### PR TITLE
Signup: DSS: Properly send image data to new site

### DIFF
--- a/client/signup/steps/dss/theme-thumbnail.jsx
+++ b/client/signup/steps/dss/theme-thumbnail.jsx
@@ -22,11 +22,11 @@ export default React.createClass( {
 
 	handleSubmit() {
 		const { lastKey, imageResultsByKey } = DSSImageStore.get();
-		const dssImage = imageResultsByKey[ lastKey ] ? JSON.stringify( imageResultsByKey[ lastKey ] ) : undefined;
-		var eventProps = {
+		const dssImage = imageResultsByKey[ lastKey ] ? imageResultsByKey[ lastKey ] : undefined;
+		const eventProps = {
 			theme: this.props.themeRepoSlug,
 			headstart: true,
-			images: dssImage,
+			images: dssImage ? JSON.stringify( dssImage ) : undefined,
 			searchterms: Object.keys( imageResultsByKey ).join( ',' ),
 			selectedterm: lastKey
 		};
@@ -35,7 +35,7 @@ export default React.createClass( {
 
 		SignupActions.submitSignupStep( { stepName: this.props.stepName }, null, {
 			theme: this.props.themeRepoSlug,
-			images: eventProps.images
+			images: dssImage ? [ dssImage ] : undefined
 		} );
 
 		this.props.goToNextStep();


### PR DESCRIPTION
In a previous commit, the image data being sent to `submitSignupStep` was turned
into a string accidentally (it was changed to fix the stats).
## Testing
1. Visit http://calypso.localhost:3000/start/dss/ and go through the flow (search for something, select a screenshot with an image, complete the flow to create a new site).
2. Visit the new site and make sure the image you chose is being used as the header image.
