### PR TITLE
Editor: Fix iOS 8.4 Focus Issues

### DIFF
--- a/assets/stylesheets/sections/_notifications.scss
+++ b/assets/stylesheets/sections/_notifications.scss
@@ -22,10 +22,7 @@
 	&.wpnt-closed {
 		opacity: 0;
 		pointer-events: none;
-
-		@include breakpoint( "<480px" ) {
-			display: none;
-		}
+		display: none;
 	}
 }
 


### PR DESCRIPTION
A user reported having issues using the editor on an iPad Air2 running iOS 8.4.  Upon testing, it was clear something was intercepting clicks from TinyMCE and even at times the title field.  I discovered that the notifications panel, much like the `<EditorPreview />`, was using an `opacity: 0` to hide itself when not active.

The issue happens in iOS 9 as well - but does _not_ happen on smaller viewports due to an existing css rule that uses `display: none` when the screen is `<480px`.  The screen grab below shows the positioning of the notifications iframe over the editor, and how only a very small slice is not covered, and as such is clickable:

![ios-notif](https://cloud.githubusercontent.com/assets/22080/11299361/03cd1914-8f3b-11e5-99a6-ad49ebe716cf.gif)

This click intercept happens in areas outside of the editor as well.  Any place where the notifications drawer covers clickable elements, the iframe is intercepting clicks.  For example visit a site post list and try to click "...More" under a post card, or clicking the "Comments" tab in the stats chart.

The fix in this branch is to simply apply `display: none` regardless of viewport size.

**To Test**
Use an iOS device, preferably running iOS 8.4, or a simulator
- Open the post editor
- Ensure you can click focus into the title and TinyMCE editor areas
