### PR TITLE
Don't allow private registration to be removed from the cart

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -244,7 +244,16 @@ function isSpaceUpgrade( product ) {
 		'100gb_space_upgrade' === product.product_slug;
 }
 
+function canRemoveFromCart( product ) {
+	if ( isPrivateRegistration( product ) || isCredits( product ) ) {
+		return false;
+	}
+
+	return true;
+}
+
 module.exports = {
+	canRemoveFromCart,
 	formatProduct,
 	isFreePlan: isFreePlan,
 	isPremium: isPremium,

--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -7,6 +7,7 @@ var React = require( 'react' );
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
+	canRemoveFromCart = require( 'lib/products-values' ).canRemoveFromCart,
 	cartItems = require( 'lib/cart-values' ).cartItems,
 	getIncludedDomain = cartItems.getIncludedDomain,
 	isCredits = require( 'lib/products-values' ).isCredits,
@@ -94,8 +95,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var cartItem = this.props.cartItem,
-			name = this.getProductName();
+		var name = this.getProductName();
 
 		return (
 			<li className="cart-item">
@@ -108,7 +108,7 @@ module.exports = React.createClass( {
 					<span className="product-price">
 						{ this.price() }
 					</span>
-					{ isCredits( cartItem ) ? null : this.removeButton() }
+					{ this.removeButton() }
 				</div>
 			</li>
 		);
@@ -159,6 +159,8 @@ module.exports = React.createClass( {
 	},
 
 	removeButton: function() {
-		return <button className="remove-item noticon noticon-close" onClick={ this.removeFromCart }></button>;
+		if ( canRemoveFromCart( this.props.cartItem ) ) {
+			return <button className="remove-item noticon noticon-close" onClick={ this.removeFromCart }></button>;
+		}
 	}
 } );


### PR DESCRIPTION
Fixes #273 

Testing

---
1. `git checkout update/keep-private-registration-in-cart`
2. Add a domain with private registration to your cart
3. Verify that you cannot remove it.

![screen shot 2015-11-19 at 1 34 24 pm](https://cloud.githubusercontent.com/assets/363753/11280198/c00136a2-8ec2-11e5-8a71-7cfd33b35f45.png)
- [x] Code review
- [x] QA review
