### PR TITLE
Framework: Allow for a sans-sidebar layout and adjust accordingly 

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -237,30 +237,29 @@ html.iframed {
 
 /* =General Layout
 ----------------------------------------------- */
+$sidebar-width-max: 272px;
+$sidebar-width-min: 228px;
+
 .wp-content {
 	@include clear-fix;
 	position: relative;
-	width: 100%;
-	margin: 47px auto 0;
+	margin: 47px 0 0 0;
+	padding: 32px 32px 32px ( $sidebar-width-max + 32px );
 	box-sizing: border-box;
 	overflow: hidden;
 }
 
-.wp-primary {
-	padding: 32px;
-	margin-left: 272px;
-}
-
 // Tablets
 @include breakpoint( "<960px" ) {
-	.wp-primary {
-		margin-left: 224px;
+	.wp-content {
+		padding: 24px;
+		padding-left: ( $sidebar-width-min + 24px );
 	}
 }
 
 // Mobile (Full Width)
 @include breakpoint( "<660px" ) {
-	.wp-primary {
+	.wp-content {
 		margin-left: 0;
 		padding: 8px;
 

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -248,7 +248,7 @@ $sidebar-width-min: 228px;
 	box-sizing: border-box;
 	overflow: hidden;
 
-	.sidebar-off & {
+	.has-no-sidebar & {
 		padding-left: 32px;
 	}
 }
@@ -259,7 +259,7 @@ $sidebar-width-min: 228px;
 		padding: 24px;
 		padding-left: ( $sidebar-width-min + 24px );
 
-		.sidebar-off & {
+		.has-no-sidebar & {
 			padding-left: 24px;
 		}
 	}
@@ -271,7 +271,7 @@ $sidebar-width-min: 228px;
 		margin-left: 0;
 		padding: 8px;
 
-		.sidebar-off & {
+		.has-no-sidebar & {
 			padding-left: 8px;
 		}
 

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -247,6 +247,10 @@ $sidebar-width-min: 228px;
 	padding: 32px 32px 32px ( $sidebar-width-max + 32px );
 	box-sizing: border-box;
 	overflow: hidden;
+
+	.sidebar-off & {
+		padding-left: 32px;
+	}
 }
 
 // Tablets
@@ -254,6 +258,10 @@ $sidebar-width-min: 228px;
 	.wp-content {
 		padding: 24px;
 		padding-left: ( $sidebar-width-min + 24px );
+
+		.sidebar-off & {
+			padding-left: 24px;
+		}
 	}
 }
 
@@ -262,6 +270,10 @@ $sidebar-width-min: 228px;
 	.wp-content {
 		margin-left: 0;
 		padding: 8px;
+
+		.sidebar-off & {
+			padding-left: 8px;
+		}
 
 		.focus-sidebar & {
 			transform: translateX( 100vw );

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -275,10 +275,6 @@ $sidebar-width-min: 228px;
 			padding-left: 8px;
 		}
 
-		.focus-sidebar & {
-			transform: translateX( 100vw );
-		}
-
 		.focus-sidebar.is-section-post & {
 			transform: translateX( 0 );
 		}

--- a/assets/stylesheets/layout/_sidebar.scss
+++ b/assets/stylesheets/layout/_sidebar.scss
@@ -7,16 +7,16 @@
 	position: fixed;
 		top: 47px;
 		bottom: 0;
+		left: 0;
 
 	@include breakpoint( "<960px" ) {
 		border-right: 1px solid lighten( $gray, 25% );
-		width: 224px;
+		width: $sidebar-width-min;
 	}
 
 	@include breakpoint( ">960px" ) {
 		border-right: 1px solid lighten( $gray, 25% );
-		left: 0;
-		width: 272px;
+		width: $sidebar-width-max;
 	}
 
 	@include breakpoint( "<660px" ) {

--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -16,6 +16,10 @@ module.exports = {
 		if ( OAuthToken.getToken() ) {
 			page( '/' );
 		} else {
+
+			// We don't need the sidebar on the login screen
+			context.layout.setState( { noSidebar: true } );
+			
 			React.render(
 				React.createElement( LoginComponent, {} ),
 				document.getElementById( 'primary' )

--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -16,9 +16,6 @@ module.exports = {
 		if ( OAuthToken.getToken() ) {
 			page( '/' );
 		} else {
-
-			// We don't need the sidebar on the login screen
-			context.layout.setState( { noSidebar: true } );
 			
 			React.render(
 				React.createElement( LoginComponent, {} ),

--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -16,7 +16,6 @@ module.exports = {
 		if ( OAuthToken.getToken() ) {
 			page( '/' );
 		} else {
-			
 			React.render(
 				React.createElement( LoginComponent, {} ),
 				document.getElementById( 'primary' )

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -96,7 +96,7 @@ module.exports = React.createClass( {
 		const { requires2fa, inProgress, errorMessage, errorLevel } = this.state;
 
 		return (
-			<Main className="auth is-full">
+			<Main className="auth">
 				<WordPressLogo />
 				<form className="auth__form" onSubmit={ this.submitForm }>
 					<FormFieldset>

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -3,27 +3,9 @@
 	max-width: 720px;
 	z-index: 20;
 
-	// Some screens (like /sites) don't have a sidebar.
-	// @todo: This kinda sucks. I think the full-width class
-	// should be moved to .wp-primary, and we can just remove
-	// the margin, instead of overriding it here. -shaun
-	&.is-full {
-		margin-left: -272px;
-		max-width: calc( 100% + 272px );
-
-		// Tablets
-		@include breakpoint( "<960px" ) {
-			margin-left: -224px;
-		}
-
-		@include breakpoint( "<660px" ) {
-			margin-left: 0;
-			max-width: 100%;
-		}
-	}
-
 	// Themes is a great example of using all this new space ;)
-	&.themes {
+	&.themes,
+	&.sites {
 		max-width: 100%;
 	}
 

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -50,7 +50,10 @@ var devdocs = {
 				false );
 		}
 
-		context.layout.setState( { section: 'devdocs' } );
+		context.layout.setState( {
+			section: 'devdocs',
+			noSidebar: true
+		} );
 
 		React.render(
 			React.createElement( DocsComponent, {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -95,7 +95,7 @@ module.exports = React.createClass( {
 			} );
 
 		if ( this.state.noSidebar ) {
-			sectionClass += ' sidebar-off';
+			sectionClass += ' has-no-sidebar';
 		}
 
 		return (

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -59,7 +59,8 @@ module.exports = React.createClass( {
 	getInitialState: function() {
 		return {
 			section: false,
-			isLoading: false
+			isLoading: false,
+			noSidebar: false
 		};
 	},
 
@@ -92,6 +93,10 @@ module.exports = React.createClass( {
 				layout__loader: true,
 				'is-active': this.state.isLoading
 			} );
+
+		if ( this.state.noSidebar ) {
+			sectionClass += ' sidebar-off';
+		}
 
 		return (
 			<div className={ sectionClass }>

--- a/client/mailing-lists/controller.js
+++ b/client/mailing-lists/controller.js
@@ -11,10 +11,9 @@ import MainComponent from './main';
 
 export default {
 	unsubscribe( context ) {
-		
 		// We don't need the sidebar here.
 		context.layout.setState( {
-			section: 'mailing-lists',
+			section: 'me',
 			noSidebar: true }
 		);
 

--- a/client/mailing-lists/controller.js
+++ b/client/mailing-lists/controller.js
@@ -11,6 +11,13 @@ import MainComponent from './main';
 
 export default {
 	unsubscribe( context ) {
+		
+		// We don't need the sidebar here.
+		context.layout.setState( {
+			section: 'mailing-lists',
+			noSidebar: true }
+		);
+
 		React.render(
 			React.createElement( MainComponent, {
 				email: context.query.email,

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -299,6 +299,7 @@ export default {
 
 		if ( isWelcome ) {
 			React.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+			context.layout.setState( { noSidebar: true } );
 		}
 
 		analytics.tracks.recordEvent( 'calypso_me_next_view', { is_welcome: isWelcome } );

--- a/client/me/next-steps/next-steps.scss
+++ b/client/me/next-steps/next-steps.scss
@@ -1,19 +1,5 @@
-.next-steps.is-single-page {
-	box-sizing: border-box;
-	margin: 0 0 0 -227px;
-	max-width: inherit;
-
-	.next-steps__intro,
-	.next-steps__steps,
-	.next-steps__outro {
-		max-width: 640px;
-		margin-left: auto;
-		margin-right: auto;
-	}
-
-	@include breakpoint( "<660px" ) {
-		margin-left: 0;
-	}
+.sidebar-off .next-steps {
+	max-width: 640px;
 }
 
 .next-steps__title {

--- a/client/me/next-steps/next-steps.scss
+++ b/client/me/next-steps/next-steps.scss
@@ -1,4 +1,4 @@
-.sidebar-off .next-steps {
+.has-no-sidebar .next-steps {
 	max-width: 640px;
 }
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -251,7 +251,10 @@ module.exports = {
 		 * Sites is rendered on #primary but it doesn't expect a sidebar to exist
 		 * so section needs to be set explicitly and #secondary cleaned up
 		 */
-		context.layout.setState( { section: 'sites' } );
+		context.layout.setState( {
+			section: 'sites',
+			noSidebar: true
+		} );
 		React.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		layoutFocus.set( 'content' );
 

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -195,7 +195,7 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<div className="main main-column sites is-full" role="main">
+			<div className="main main-column sites" role="main">
 				<h2 className="sites__select-heading">{ siteSelectionHeaderText }</h2>
 				{ this.getSiteCount() > 1 ?
 					<SearchCard onSearch={ this.doSearch } analyticsGroup="Sites" />

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -112,7 +112,7 @@ var CheckoutThankYou = React.createClass( {
 		}
 
 		return (
-			<Main className="checkout-thank-you is-full">
+			<Main className="checkout-thank-you">
 				<Card>
 					<div className="thank-you-message">
 						<span className="receipt-icon"></span>

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -200,6 +200,7 @@ module.exports = {
 			basePath = route.sectionify( context.path );
 
 		analytics.pageView.record( basePath, 'Checkout Thank You' );
+		context.layout.setState( { noSidebar: true } );
 
 		if ( ! lastTransaction ) {
 			page.redirect( '/plans' );

--- a/client/notices/style.scss
+++ b/client/notices/style.scss
@@ -245,8 +245,8 @@
 		}
 
 		@include breakpoint( "<480px" ) {
-			top: 0;
-			left: 0;
+			top: 16px;
+			width: calc( 100% - 16px );
 		}
 	}
 }

--- a/client/notices/style.scss
+++ b/client/notices/style.scss
@@ -240,11 +240,11 @@
 			z-index: 180;
 		}
 
-		@include breakpoint( "<660px" ) {
+		@include breakpoint( "<960px" ) {
 			width: calc( 100% - 228px - 24px - 24px );
 		}
 
-		@include breakpoint( "<480px" ) {
+		@include breakpoint( "<660px" ) {
 			top: 16px;
 			width: calc( 100% - 16px );
 		}

--- a/client/notices/style.scss
+++ b/client/notices/style.scss
@@ -13,9 +13,12 @@
 	.notice__text {
 		flex-grow: 1;
 		flex-basis: 100px;
-		max-width: 680px; // For line-length sanity
-
 		padding: 11px 24px;
+
+		& > span,
+		& > div {
+			max-width: 680px;
+		}
 
 		@include breakpoint( ">660px" ) {
 			padding: 13px 48px;
@@ -78,14 +81,7 @@
 	// Email Verification Notice
 	&.is-email-verification {
 		background: $white;
-		margin-left: 273px;
-		margin-bottom: 0;
 		box-shadow: 0 0 0 1px lighten( $gray, 20 );
-
-		// The signup screens don't have the sidebar
-		.is-section-signup & {
-			margin-left: 0;
-		}
 	}
 }
 
@@ -232,24 +228,20 @@
 }
 
 .notices-list {
-	@include breakpoint( ">660px" ) {
-		margin-left: 273px;
-	}
-
-	.notice {
-		margin-bottom: 0;
-	}
+	overflow: hidden;
 
 	&.is-pinned {
-		width: 100%;
-			min-width: 320px;
-			max-width: 960px;
+		width: calc( 100% - 272px - 32px - 32px );
 		z-index: 180;
 		position: fixed;
-			top: 47px;
+			top: 47px + 32px;
 
 		.notice {
 			z-index: 180;
+		}
+
+		@include breakpoint( "<660px" ) {
+			width: calc( 100% - 228px - 24px - 24px );
 		}
 
 		@include breakpoint( "<480px" ) {

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -1,7 +1,9 @@
-.is-section-post .wp-primary {
+.is-section-post .wp-content {
 	// We don't need the space for a sidebar
 	margin-left: 0;
 	padding-bottom: 0;
+	padding-left: 0;
+	padding-right: 0;
 
 	// Lets go full width on smaller screens
 	@include breakpoint( "<660px" ) {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -77,7 +77,10 @@ export default {
 
 		titleActions.setTitle( i18n.translate( 'Create an account' ) );
 
-		context.layout.setState( { section: 'signup' } );
+		context.layout.setState( {
+			section: 'signup',
+			noSidebar: true
+		} );
 
 		React.render(
 			React.createElement( SignupComponent, {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -3,11 +3,6 @@
 	margin: 0 auto;
 }
 
-// We don't need the space for a sidebar
-.is-section-signup .wp-primary {
-	margin-left: 0;
-}
-
 .signup__step {
 	margin: 0 24px;
 	position: absolute;


### PR DESCRIPTION
This PR aims to address two things:

1) Broken notice's. Specifically notices that break the layout of the page.
2) Broken layouts where there is no sidebar. Sometimes screens decide to hide the sidebar.

These are bugs that were introduce with the recent docked sidebar update, so I'm trying my best to get them fixed.

The solution to broken notices was to move all the layout-related CSS from `.wp-primary` to `.wp-content` — which contains notices. This means no more funky layouts when you see a notice.

Once I made that change (and after hearing a few reports of busted layouts) I noticed that notices were still broken on screens without a sidebar. Moreover, screens without a sidebar were busted in general. So, I worked to fix the broken layouts (and notices in the process) by creating a new state for layout: `context.layout.setState( { noSidebar: true } );` will now remove any extra padding/margin so you don't have to. This should replace any negative margins or the `.is-full` class.

You can check the notices by submitting a blank payment form at `/checkout` or (if you're like me) looking at a Jetpack site that has connection issues.

The noSidebar stuff is scattered throughout, including `/login`, `/me/next/welcome`, `/checkout/thank-you`, '/devdocs`, and `/sites`.