### PR TITLE
Plugins: Show disabled autoupdate info

### DIFF
--- a/client/components/info-popover/README.md
+++ b/client/components/info-popover/README.md
@@ -18,10 +18,59 @@ The `position` property can be one of the following values:
 - `left`
 - `right`
 
-### `InfoPopover` Usage
+#### `className`
+
+The `className` lets you specify the style class that the element should have.
+
+#### `gaEventCategory`
+
+The `gaEventCategory` lets you specify the Google Analyics Category that you want the toggle event to have.
+Also reqires the `popoverName` attribute.
+
+#### `popoverName`
+
+The `popoverName` lets you specify the Google Analyics Event name that you want the toggle event to have.
+Also reqires the `gaEventCategory` attribute.
+
+Turns into this even when opened:
+analytics.ga.recordEvent( gaEventCategory, 'InfoPopover: ' + popoverName + 'Opened' );
+
+#### `ignoreContext`
+
+The `ignoreContext` lets you specify a component that you want to be on the inside clickOutside context.
+So a context that you want to ignore. In most cases this is not needed but if you want to also have a label
+that can trigger the opening and closing of the InfoPopover then you need to pass in the label component as a reference.
+
+### Basic `InfoPopover` Usage
 
 ```js
 <InfoPopover position="bottom left">
     This is some informational text
 </InfoPopover>
+```
+
+
+```js
+
+handleAction( event ) {
+	this.refs && this.refs.infoPop._onClick( event );
+},
+
+render() {
+	return (
+		<div>
+			<label onClick={ this.handleAction } ref="moreInfoLabel">More Info</label>
+			<InfoPopover
+				position="bottom left"
+				ref="infoPop"
+				className="more-info"
+				gaEventCategory="Reader"
+				popoverName="More info in the reader"
+				ignoreContext={ this.refs && this.refs.moreInfoLabel } >
+				This is some informational text
+			</InfoPopover>
+		</div>
+	)
+}
+
 ```

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -19,7 +19,10 @@ export default React.createClass( {
 		position: React.PropTypes.string,
 		className: React.PropTypes.string,
 		gaEventCategory: React.PropTypes.string,
-		popoverName: React.PropTypes.string
+		popoverName: React.PropTypes.string,
+		ignoreContext: React.PropTypes.shape( {
+			getDOMNode: React.PropTypes.function
+		} ),
 	},
 
 	getDefaultProps() {
@@ -36,11 +39,12 @@ export default React.createClass( {
 
 	render() {
 		return (
-			<span onClick={ this._onClick } ref="infoPopover" className={ classNames( 'info-popover', { 'is_active': this.state.showPopover }, this.props.className ) }>
+			<span onClick={ this._onClick } ref="infoPopover" className={ classNames( 'info-popover', { is_active: this.state.showPopover }, this.props.className ) }>
 				<Gridicon icon="info-outline" size={ 18 } />
 				<Popover
 					isVisible={ this.state.showPopover }
 					context={ this.refs && this.refs.infoPopover }
+					ignoreContext={ this.props.ignoreContext }
 					position={ this.props.position }
 					onClose={ this._onClose }
 					className={ classNames( 'popover', 'info-popover__tooltip', this.props.className ) }>
@@ -67,5 +71,4 @@ export default React.createClass( {
 			analytics.ga.recordEvent( gaEventCategory, 'InfoPopover: ' + popoverName + dialogState );
 		}
 	}
-
 } );

--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -42,6 +42,12 @@ The `position` property can be one of the following values:
 - `left`
 - `right`
 
+#### `ignoreContext`
+
+The `ignoreContext` lets you specify a component that you want to be on the inside clickOutside context. 
+So a context that you want to ignore. In most cases this is not needed but if you want to also have a label 
+that can trigger the opening and closing of the Popover then you need to pass in the label component as a reference.
+
 ### `Popover` Usage
 
 ```js

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -30,7 +30,8 @@ var Popover = React.createClass( {
 	propTypes: {
 		isVisible: React.PropTypes.bool.isRequired,
 		onClose: React.PropTypes.func.isRequired,
-		position: React.PropTypes.string
+		position: React.PropTypes.string,
+		ignoreContext: React.PropTypes.shape( { getDOMNode: React.PropTypes.function } ),
 	},
 
 	getDefaultProps: function() {
@@ -117,7 +118,14 @@ var Popover = React.createClass( {
 		this._clickOutsideTimeout = setTimeout( function() {
 			this._unbindClickOutside = clickOutside( this._container, function( event ) {
 				const contextNode = React.findDOMNode( this.props.context );
-				if ( contextNode && contextNode.contains && ! contextNode.contains( event.target ) ) {
+				let shouldClose = ( contextNode && contextNode.contains && ! contextNode.contains( event.target ) );
+
+				if ( this.props.ignoreContext && shouldClose ) {
+					const ignoreContext = React.findDOMNode( this.props.ignoreContext );
+					shouldClose = shouldClose && ( ignoreContext && ignoreContext.contains && ! ignoreContext.contains( event.target ) );
+				}
+
+				if ( shouldClose ) {
 					this._close( event );
 				}
 			}.bind( this ) );

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import i18n from 'lib/mixins/i18n';
 
 export default {
 	userCan( capability, site ) {
@@ -58,5 +62,47 @@ export default {
 		if ( site.options ) {
 			return site.options.default_post_format;
 		}
+	},
+
+	getSiteFileModDisableReason( site ) {
+		if ( ! site || ! site.options || ! site.options.file_mod_disabled ) {
+			return;
+		}
+		let reasons = [];
+		for ( let clue of site.options.file_mod_disabled ) {
+			switch ( clue ) {
+				case 'is_version_controlled':
+					reasons.push(
+						i18n.translate( 'This site\'s files are under version control.' )
+					);
+					break;
+				case 'has_no_file_system_write_access':
+					reasons.push(
+						i18n.translate( 'The file permissions on this host prevent editing files.' )
+					);
+					break;
+				case 'automatic_updater_disabled':
+					reasons.push(
+						i18n.translate( 'Any autoupdates are explicitly disabled by a site administrator.' )
+					);
+					break;
+				case 'wp_auto_update_core_disabled':
+					reasons.push(
+						i18n.translate( 'Core autoupdates are explicitly disabled by a site administrator.' )
+					);
+					break
+				case 'disallow_file_edit':
+					reasons.push(
+						i18n.translate( 'File edits are explicitly disabled by a site administrator.' )
+					);
+					break;
+				case 'disallow_file_mods':
+					reasons.push(
+						i18n.translate( 'File modifications are explicitly disabled by a site administrator.' )
+					);
+					break;
+			}
+		}
+		return reasons;
 	}
 };

--- a/client/my-sites/plugins/plugin-action/README.md
+++ b/client/my-sites/plugins/plugin-action/README.md
@@ -46,3 +46,5 @@ render: function() {
 * `action`: (callback) what should be executed once the user fires the action.
 * `inProgress`: (bool) whether the action is in the middle of being performed.
 * `htmlFor`: (string) htmlFor is used for creating the for attribute on the label.
+* `disabledInfo`: ( string ) text that gets displayed in a infoPopover explaining why the action is disabled.
+

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -7,20 +7,54 @@ var React = require( 'react/addons' ),
 /**
  * Internal dependencies
  */
-var CompactToggle = require( 'components/forms/form-toggle/compact' );
+var CompactToggle = require( 'components/forms/form-toggle/compact' ),
+	InfoPopover = require( 'components/info-popover' );
 
 module.exports = React.createClass( {
 
 	displayName: 'PluginAction',
 
+	handleAction: function( event ) {
+		if ( ! this.props.disabledInfo ) {
+			this.props.action();
+		} else {
+			this.refs.infoPopover._onClick( event );
+		}
+	},
+
 	renderLabel: function( id ) {
 		if ( this.props.label ) {
-			return ( <label className="plugin-action__label" onClick={ this.props.action } htmlFor={ id }>{ this.props.label }</label> );
+			return (
+				<label
+					className="plugin-action__label"
+					ref="disabledInfoLabel"
+					onClick={ this.handleAction }
+					htmlFor={ id }
+					>
+					{ this.props.label }
+				</label>
+			);
 		}
 		return null;
 	},
 
 	renderToggle: function( id ) {
+		if ( this.props.disabledInfo ) {
+			return (
+				<div className="plugin-action__disabled-info">
+					<InfoPopover
+						position="bottom left"
+						popoverName={ 'Plugin Action Disabled' + this.props.label }
+						gaEventCategory="Plugins"
+						ref="infoPopover"
+						ignoreContext={ this.refs && this.refs.disabledInfoLabel }
+						>
+						{ this.props.disabledInfo }
+					</InfoPopover>
+					{ this.renderLabel( id ) }
+				</div>
+			);
+		}
 		return (
 			<CompactToggle
 				onChange={ this.props.action }
@@ -47,7 +81,10 @@ module.exports = React.createClass( {
 		var id = this.props.htmlFor;
 		return (
 			<div className={ classNames( 'plugin-action', this.props.className ) }>
-				{ 0 < React.Children.count( this.props.children ) ? this.renderChildren( id ) : this.renderToggle( id ) }
+				{ 0 < React.Children.count( this.props.children )
+					? this.renderChildren( id )
+					: this.renderToggle( id )
+				}
 			</div>
 		);
 	}

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -43,3 +43,11 @@
 .plugin-action__children .noticon {
 	margin-left: 8px;
 }
+.plugin-action__disabled-info .info-popover {
+	float: right;
+	margin: 0 3px;
+}
+
+.plugin-action__disabled-info-list {
+	margin-left: 16px;
+}

--- a/client/my-sites/plugins/plugin-action/test/components/info-popover/index.jsx
+++ b/client/my-sites/plugins/plugin-action/test/components/info-popover/index.jsx
@@ -1,0 +1,2 @@
+// this file is needs to be loaded in oder for the tests to pass.
+module.exports = function() {};

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -9,7 +9,9 @@ var React = require( 'react' );
 var PluginsActions = require( 'lib/plugins/actions' ),
 	PluginsLog = require( 'lib/plugins/log-store' ),
 	PluginAction = require( 'my-sites/plugins/plugin-action/plugin-action' ),
-	analytics = require( 'analytics' );
+	ExternalLink = require( 'components/external-link' ),
+	analytics = require( 'analytics' ),
+	utils = require( 'lib/site/utils' );
 
 module.exports = React.createClass( {
 
@@ -40,23 +42,92 @@ module.exports = React.createClass( {
 		}
 	},
 
-	render: function() {
-		var inProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, [
-			'ENABLE_AUTOUPDATE_PLUGIN',
-			'DISABLE_AUTOUPDATE_PLUGIN'
-		] );
+	getDisabledInfo: function() {
+		if ( ! this.props.site ) { // we don't have enough info
+			return null;
+		}
 
-		if ( this.props.site.canUpdateFiles && this.props.wporg ) {
-			return (
-				<PluginAction
-					label={ this.translate( 'Autoupdates', { context: 'this goes next to an icon that displays if the plugin has "autoupdates" active' } ) }
-					status={ this.props.plugin.autoupdate }
-					action={ this.toggleAutoupdates }
-					inProgress={ inProgress }
-					htmlFor={ 'autoupdates-' + this.props.plugin.slug + '-' + this.props.site.ID }
-				/>
+		if ( ! this.props.wporg ) {
+			return this.translate( 'This plugin is not in the WordPress.org plugin repository, so we can\'t autoupdate it.' );
+		}
+
+		if ( ! this.props.site.hasMinimumJetpackVersion ) {
+			return this.translate( '%(site)s is not running an up to date version of Jetpack', {
+				args: { site: this.props.site.title }
+			} );
+		}
+
+		if ( this.props.site.options.is_multi_network ) {
+			return this.translate( '%(site)s is part of a multi-network installation, which is not currently supported.', {
+				args: { site: this.props.site.title }
+			} );
+		}
+
+		if ( this.props.site.options.unmapped_url !== this.props.site.options.main_network_site ) {
+			return this.translate( 'Only the main site on a multi-site installation can enable autoupdates for plugins.', {
+				args: { site: this.props.site.title }
+			} );
+		}
+
+		if ( ! this.props.site.canUpdateFiles && this.props.site.options.file_mod_disabled ) {
+			let reasons = utils.getSiteFileModDisableReason( this.props.site );
+			let html = [];
+
+			if ( reasons.length > 1 ) {
+				html.push(
+					<p key="reason-shell">
+						{ this.translate( 'Autoupdates are not available for %(site)s:', { args: { site: this.props.site.title } } ) }
+					</p>
+				);
+				let list = reasons.map( ( reason, i ) => ( <li key={ 'reason-i' + i + '-' + this.props.site.ID } >{ reason }</li> ) );
+				html.push( <ul className="plugin-action__disabled-info-list" key="reason-shell-list">{ list }</ul> );
+			} else {
+				html.push(
+					<p key="reason-shell">{
+						this.translate( 'Autoupdates are not available for %(site)s. %(reason)s', {
+							args: { site: this.props.site.title, reason: reasons[0] }
+						} )
+					}</p> );
+			}
+			html.push(
+				<ExternalLink
+					key="external-link"
+					onClick={
+						analytics.ga.recordEvent.bind( this, 'Plugins', 'Clicked How do I fix disabled autoupdates' )
+					}
+					href="https://jetpack.me/support/site-management/#file-update-disabled"
+					>
+					{ this.translate( 'How do I fix this?' ) }
+				</ExternalLink>
 			);
+
+			return html;
 		}
 		return null;
+	},
+
+	render: function() {
+		const inProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, [
+				'ENABLE_AUTOUPDATE_PLUGIN',
+				'DISABLE_AUTOUPDATE_PLUGIN'
+			] ),
+			getDisabledInfo = this.getDisabledInfo(),
+			label = getDisabledInfo
+				? this.translate( 'Autoupdates disabled', {
+					context: 'this goes next to an icon that displays if the plugin has "autoupdates disabled" active'
+				} )
+				: this.translate( 'Autoupdates', {
+					context: 'this goes next to an icon that displays if the plugin has "autoupdates" active'
+				} );
+
+		return (
+			<PluginAction
+				label={ label }
+				status={ this.props.plugin.autoupdate }
+				action={ this.toggleAutoupdates }
+				inProgress={ inProgress }
+				disabledInfo={ getDisabledInfo }
+				htmlFor={ 'autoupdates-' + this.props.plugin.slug + '-' + this.props.site.ID } />
+		);
 	}
 } );

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/test/fixtures.js
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/test/fixtures.js
@@ -3,7 +3,8 @@ module.exports = {
 		slug: 'test',
 		domain: '',
 		name: '',
-		canUpdateFiles: true
+		canUpdateFiles: true,
+		options: { file_mod_disabled: false }
 	},
 	plugin: { slug: 'test' },
 	notices: {

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/test/index.jsx
@@ -56,12 +56,6 @@ describe( 'PluginAutoupdateToggle', function() {
 		expect( pluginAutoupdateToggle.length ).to.equal( 1 );
 	} );
 
-	it( 'should not render the component if the plugin is not from .org', function() {
-		var rendered = TestUtils.renderIntoDocument( <PluginAutoupdateToggle { ...fixtures } wporg={ false } /> ),
-			pluginAutoupdateToggle = TestUtils.scryRenderedDOMComponentsWithClass( rendered, 'plugin-action' );
-		expect( pluginAutoupdateToggle.length ).to.equal( 0 );
-	} );
-
 	it( 'should register an event when the subcomponent action is executed', function() {
 		var rendered = TestUtils.renderIntoDocument( <PluginAutoupdateToggle { ...fixtures } /> ),
 			pluginAutoupdateToggle = React.findDOMNode( rendered );


### PR DESCRIPTION
Uses the info popup to display info as to why there autoupdates are disabled.

<img width="289" alt="screen shot 2015-11-19 at 4 56 03 pm" src="https://cloud.githubusercontent.com/assets/115071/11289110/abd8b710-8ede-11e5-9d05-0f4d16d9c621.png">

<img width="299" alt="screen shot 2015-11-19 at 4 55 53 pm" src="https://cloud.githubusercontent.com/assets/115071/11289111/abda7cbc-8ede-11e5-8f95-d7087433637c.png">

**To test**
Go to: Plugin listing for a single site. 
http://calypso.localhost:3000/plugins/example.com

Go to: Plugin view 
http://calypso.localhost:3000/plugins/jetpack

Go to: Plugin view for a single site. 
http://calypso.localhost:3000/plugins/jetpack/example.com

Notice the plugin autoupdates disabled info bubbles. 


If your doesn't able to autoupdate 
add the following to your wp-config.php 
```
 define( 'FS_METHOD', 'ssh2' );
define( 'DISALLOW_FILE_EDIT', true );
 define( 'DISALLOW_FILE_MODS',true );
 define( 'WP_AUTO_UPDATE_CORE', false );
 define( 'AUTOMATIC_UPDATER_DISABLED', true );
```
and toggle the jetpack connection ( disconnect and connect ) 
