### PR TITLE
Purchases: Thank you page off-center and too wide

### DIFF
--- a/assets/stylesheets/sections/_checkout.scss
+++ b/assets/stylesheets/sections/_checkout.scss
@@ -762,6 +762,23 @@
 	text-align: center;
 	width: 100%;
 
+	&.main.is-full {
+		@include breakpoint( ">660px" ) {
+			max-width: none;
+			width: calc( 100% + 224px);
+		}
+		@include breakpoint( ">960px" ) {
+			width: calc( 100% + 272px);
+		}
+	}
+
+	.get-support,
+	.card {
+		margin-left: auto;
+	    margin-right: auto;
+	    max-width: 960px;
+	}
+
 	.thank-you-message {
 		padding-bottom: 20px;
 
@@ -915,8 +932,10 @@
 
 	.get-support {
 		border-top: 1px solid lighten( $gray, 20% );
+		box-sizing: border-box;
 		color: darken($gray, 10%);
 		font-size: 14px;
+
 
 		> h3 {
 			font-weight: 600;


### PR DESCRIPTION
The recent sidebar changes caused the thank you page to render off-center and wider than intended on desktop:

https://cloudup.com/cAsNh_rr15D
![image](https://cloud.githubusercontent.com/assets/12596797/11311029/3bf6ea9e-8f9b-11e5-86df-791f07a93221.png)
