### PR TITLE
Validate .tld for new feed URLs

### DIFF
--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -3,7 +3,8 @@
 // External dependencies
 const React = require( 'react' ),
 	url = require( 'url' ),
-	noop = require( 'lodash/utility/noop' );
+	noop = require( 'lodash/utility/noop' ),
+	last = require( 'lodash/array/last' );
 
 // Internal dependencies
 const Search = require( 'components/search' ),
@@ -56,7 +57,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 
 	handleKeyDown: function( event ) {
 		// Use Enter to submit
-		if ( event.keyCode === 13 && this.state.searchString.length > minSearchLength  && this.state.isWellFormedFeedUrl ) {
+		if ( event.keyCode === 13 && this.state.searchString.length > minSearchLength && this.state.isWellFormedFeedUrl ) {
 			event.preventDefault();
 			this.handleFollowToggle();
 		}
@@ -98,11 +99,17 @@ var FollowingEditSubscribeForm = React.createClass( {
 	},
 
 	isWellFormedFeedUrl: function( parsedUrl ) {
-		if ( parsedUrl.hostname && parsedUrl.hostname.indexOf( '.' ) !== -1 ) {
-			return true;
+		if ( ! parsedUrl.hostname ) {
+			return false;
 		}
 
-		return false;
+		// Check for a valid-looking TLD
+		const lastHostnameSegment = last( parsedUrl.hostname.split( '.' ) );
+		if ( ! lastHostnameSegment || lastHostnameSegment.length < 2 ) {
+			return false;
+		}
+
+		return true;
 	},
 
 	render: function() {

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -99,7 +99,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 	},
 
 	isWellFormedFeedUrl: function( parsedUrl ) {
-		if ( ! parsedUrl.hostname ) {
+		if ( ! parsedUrl.hostname || parsedUrl.hostname.indexOf( '.' ) === -1 ) {
 			return false;
 		}
 

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -3,8 +3,7 @@
 // External dependencies
 const React = require( 'react' ),
 	url = require( 'url' ),
-	noop = require( 'lodash/utility/noop' ),
-	last = require( 'lodash/array/last' );
+	noop = require( 'lodash/utility/noop' );
 
 // Internal dependencies
 const Search = require( 'components/search' ),
@@ -104,8 +103,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 		}
 
 		// Check for a valid-looking TLD
-		const lastHostnameSegment = last( parsedUrl.hostname.split( '.' ) );
-		if ( ! lastHostnameSegment || lastHostnameSegment.length < 2 ) {
+		if ( parsedUrl.hostname.lastIndexOf( '.' ) > ( parsedUrl.hostname.length - 3 ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Ensure that new feed URLs have a valid .tld before allowing the user to follow the feed.

![dfbc6e9c-8eb5-11e5-8bec-c09eb793c6cd](https://cloud.githubusercontent.com/assets/17325/11335353/8f9e1f52-91d3-11e5-8787-faece62ef4ce.png)

Fixes Automattic/wp-calypso#96.