### PR TITLE
Reader: Stop opening summary-only posts in a new tab

### DIFF
--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -250,13 +250,6 @@ var Post = React.createClass( {
 			return;
 		}
 
-		if ( this.props.post.use_excerpt && ! event.defaultPrevented ) {
-			event.preventDefault();
-			stats.recordPermalinkClick( 'summary_card' );
-			stats.recordGaEvent( 'Clicked Post Summary Card' );
-			window.open( postUrl );
-		}
-
 		// For Discover posts (but not site picks), open the original post in full post view
 		if ( this.state.originalPost ) {
 			postToOpen = this.state.originalPost;


### PR DESCRIPTION
Currently, Reader treats summary only posts (that is, posts from site’s who’s setting only allow us to show a summary) in a new tab. This PR reverts this behavior to open the post in Reader’s full post view.

The current behavior (new tab) breaks your flow and is unexpected.
## Current Behavior

![old-summary-behavior](https://cloud.githubusercontent.com/assets/14350/11319845/22f5842a-9053-11e5-945e-6aa989d42c4d.gif)
## New Behavior

![new-summary-behavior-rmall](https://cloud.githubusercontent.com/assets/14350/11319869/28c43cec-9054-11e5-8eff-cba23f83b498.gif)
