### PR TITLE
Reader: Add inbox view

### DIFF
--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -264,46 +264,79 @@
 
 // Condensed View
 .is-condensed {
-	.reader__card {
-		margin-bottom: 0;
+
+	// Hide a bunch of stuff
+	.reader__card.card .site-icon,
+	.site__domain,
+	.reader-post-byline,
+	.reader__post-featured-image,
+	.reader__post-featured-video,
+	//.post-excerpt,
+	.reader__card .reader__full-post-content,
+	.reader-post-images,
+	.reader__post-footer {
+		display: none;
 	}
 
-	.reader__card.card .site-icon {
-		display: none;
+	.reader__card {
+		padding: 16px;
+		margin-bottom: 0;
+		overflow-x: hidden;
+
+		&:after {
+			content: '';
+			text-align: right;
+			position: absolute;
+				top: 0;
+				right: 0;
+				bottom: 0;
+			width: 10%;
+			background: linear-gradient(to right, rgba(255, 255, 255, 0), #ffffff 50%);
+		    visibility: visible;
+    		height: 100%;
+		}
+
+		&:hover {
+			background: $gray-light;
+			cursor: pointer;
+			box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+
+			&:after {
+				background: linear-gradient( to right, rgba( $gray-light, 0 ), $gray-light 50% );
+			}
+		}
 	}
 
 	.reader__card.card  .site__title {
 		color: $gray;
-	}
-
-	.site__domain {
-		display: none;
-	}
-
-	.reader-post-byline {
-		display: none;
-	}
-
-	.reader__post-featured-image,
-	.reader__post-featured-video {
-		display: none;
+		font-size: 13px;
 	}
 
 	.reader__post-title {
-		font-size: 15px;
-		margin: 4px 0 0 0;
+		display: inline;
+		font-size: 16px;
+		margin: 8px 0 0 0;
+		white-space: nowrap;
 	}
 	
 	.reader__post-header {
 		margin-bottom: 0;
 	}
 
-	.post-excerpt,
-	.reader__card .reader__full-post-content {
-		display: none;
-	}
+	.post-excerpt {
+		display: inline;
+		padding-left: 8px;
 
-	.reader__post-footer {
-		display: none;
+		.post-excerpt__text {
+			font-size: 14px;
+			white-space: nowrap;
+			color: darken( $gray, 20 );
+			line-height: 1;
+			display: inline;
+
+			&.is-long:after {
+				display: none;
+			}
+		}
 	}
 }

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -300,10 +300,54 @@
 				//background: linear-gradient( to right, rgba( $gray-light, 0 ), $gray-light 50% );
 			}
 		}
+	}
 
-		&.has-featured-image {
-			//padding-left: 104px;
+	.reader__card.has-featured-image {
+		.reader__post-featured-image {
+			display: none;
 		}
+
+		&.is-photo-only {
+			.reader__post-featured-image {
+				display: block;
+				position: absolute;
+					top: auto;
+					right: 16px;
+					bottom: 32px;
+					left: 64px;
+				width: auto;
+				height: 200px;
+				z-index: 1;
+				border-radius: 3px;
+
+				/*
+				display: none;
+				position: absolute;
+					top: 8px;
+					left: 8px;
+					bottom: 8px;
+				border-radius: 3px;
+				width: 80px;
+				height: calc( 100% - 16px ) !important;
+				margin: 0;
+				overflow: hidden;
+				
+				img {
+					max-height: 100%;
+					max-width: none;
+				}
+				*/
+			}
+
+			.reader__post-footer {
+				margin-top: 224px;
+			}
+		}
+	}
+
+	// Hide x-posts for now. They need some thinking.
+	.reader__card.is-x-post {
+		display: none;
 	}
 
 	.reader__post-header {
@@ -319,50 +363,16 @@
 			overflow: visible;
 
 			.site__title {
-				position: absolute;
-					top: 24px;
-					left: -4px;
-				box-shadow: 0 0 0 1px rgba( $white, 0.8 );
-				background: lighten( $gray, 30 );
-				border: 1px solid lighten( $gray, 20 );
-				color: $gray-dark;
+				color: darken( $gray, 20 );
 				font-size: 13px;
-				margin: 4px 0 8px 0;
-				padding: 4px 8px;
-				border-radius: 3px;
-				z-index: 1;
-				opacity: 0;
-				transition: all 0.15s ease-in-out;
+				overflow: visible;
+				margin: 0 0 0 10px;
 			}
-		}
-
-		&:hover {
-			.site__content .site__title {
-				opacity: 1;
-			}
-		}
-	}
-
-	.reader__post-featured-image {
-		display: none;
-		position: absolute;
-			top: 8px;
-			left: 8px;
-			bottom: 8px;
-		border-radius: 3px;
-		width: 80px;
-		height: calc( 100% - 16px ) !important;
-		margin: 0;
-		overflow: hidden;
-		
-		img {
-			max-height: 100%;
-			max-width: none;
 		}
 	}
 
 	.reader__post-title {
-		margin: 0 0 2px 0;
+		margin: 22px 0 2px 0;
 		font-size: 16px;
 		white-space: nowrap;
 	}

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -134,7 +134,7 @@
 		top: 0;
 		left: -16px;
 	margin-bottom: 16px;
-	border-bottom: 1px solid lighten( $gray, 20 );
+	border-bottom: 1px solid lighten( $gray, 30 );
 	box-shadow: inset 0 0 2px 2px rgba( lighten( $gray, 10 ), 0.1 );
 	background: rgba( lighten( $gray, 30 ), 0.3 );
 
@@ -316,6 +316,7 @@
 				width: calc( 100% + 80px );
 				max-height: 320px;
 				margin: 0 0 16px 0;
+				border-top: 1px solid lighten( $gray, 30 );
 
 				/*
 				position: absolute;

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -260,3 +260,50 @@
 	font-size: 12px;
 	line-height: 1;
 }
+
+
+// Condensed View
+.is-condensed {
+	.reader__card {
+		margin-bottom: 0;
+	}
+
+	.reader__card.card .site-icon {
+		display: none;
+	}
+
+	.reader__card.card  .site__title {
+		color: $gray;
+	}
+
+	.site__domain {
+		display: none;
+	}
+
+	.reader-post-byline {
+		display: none;
+	}
+
+	.reader__post-featured-image,
+	.reader__post-featured-video {
+		display: none;
+	}
+
+	.reader__post-title {
+		font-size: 15px;
+		margin: 4px 0 0 0;
+	}
+	
+	.reader__post-header {
+		margin-bottom: 0;
+	}
+
+	.post-excerpt,
+	.reader__card .reader__full-post-content {
+		display: none;
+	}
+
+	.reader__post-footer {
+		display: none;
+	}
+}

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -313,18 +313,17 @@
 }
 
 .is-condensed {
-	margin: 0;
 
 	// Hide a bunch of stuff
 	.site__domain,
-	.reader-post-byline,
 	.reader__post-featured-video,
-	.reader-post-images {
+	.reader-post-images,
+	.post-excerpt-link {
 		display: none;
 	}
 
 	.reader__card {
-		padding: 16px 24px;
+		padding: 16px 24px 16px 64px;
 		overflow: hidden;
 		margin-bottom: 1px;
 
@@ -346,7 +345,7 @@
 		}
 
 		.follow-button {
-			top: -18px;
+			display: none;
 		}
 	}
 
@@ -418,13 +417,12 @@
 		.reader__full-post-content {
 			font-size: 14px;
 			color: darken( $gray, 20 );
-			max-height: 22px;
-			overflow: hidden;
 		}
 	}
 
 	.reader__post-header {
 		margin: 0;
+		left: -48px;
 
 		&:after {
 			display: none;
@@ -432,12 +430,12 @@
 	}
 
 	.site {
-		margin: 0 0 8px 0;
+		margin: 0 0 4px 0;
 
 		.site__content {
 			display: block;
 			overflow: visible;
-			padding-left: 24px;
+			padding-left: 48px;
 
 			.site-icon {
 				margin: 0;
@@ -445,16 +443,6 @@
 					top: 0;
 					left: 0;
 				z-index: 2; // "Above" the featured image
-
-				// Overriding some inline styles from the <Site> component
-				height: 16px !important;
-				width: 16px !important;
-				line-height: 16px !important;
-
-				img {
-					height: 16px;
-					width: 16px;
-				}
 			}
 
 			.site__title {
@@ -474,7 +462,20 @@
 		margin: 0 0 2px 0;
 		font-size: 18px;
 	}
-	
+
+	.reader__card.card .reader-post-byline {
+		margin: 0;
+
+		.gravatar {
+			display: none;
+		}
+
+		li,
+		li a {
+			color: lighten( $gray, 10 );
+		}
+	}
+
 	.reader__post-header {
 		margin-bottom: 0;
 	}
@@ -482,14 +483,8 @@
 	.post-excerpt {
 		.post-excerpt__text {
 			font-size: 14px;
-			white-space: nowrap;
 			color: darken( $gray, 20 );
-			line-height: 1;
-			display: inline;
-
-			&.is-long:after {
-				display: none;
-			}
+			line-height: 1.8;
 		}
 	}
 

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -266,22 +266,18 @@
 .is-condensed {
 
 	// Hide a bunch of stuff
-	.reader__card.card .site-icon,
 	.site__domain,
 	.reader-post-byline,
-	.reader__post-featured-image,
 	.reader__post-featured-video,
-	//.post-excerpt,
 	.reader__card .reader__full-post-content,
-	.reader-post-images,
-	.reader__post-footer {
+	.reader-post-images {
 		display: none;
 	}
 
 	.reader__card {
-		padding: 16px;
+		padding: 16px 16px 16px 64px;
+		overflow: hidden;
 		margin-bottom: 0;
-		overflow-x: hidden;
 
 		&:after {
 			content: '';
@@ -289,33 +285,85 @@
 			position: absolute;
 				top: 0;
 				right: 0;
-				bottom: 0;
 			width: 10%;
 			background: linear-gradient(to right, rgba(255, 255, 255, 0), #ffffff 50%);
 		    visibility: visible;
-    		height: 100%;
+    		height: calc( 100% - 40px );
 		}
 
 		&:hover {
-			background: $gray-light;
-			cursor: pointer;
+			//background: $gray-light;
+			//cursor: pointer;
 			box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
 
 			&:after {
-				background: linear-gradient( to right, rgba( $gray-light, 0 ), $gray-light 50% );
+				//background: linear-gradient( to right, rgba( $gray-light, 0 ), $gray-light 50% );
+			}
+		}
+
+		&.has-featured-image {
+			//padding-left: 104px;
+		}
+	}
+
+	.reader__post-header {
+		margin: 0;
+	}
+
+	.site {
+		position: absolute;
+		top: 0;
+		left: -49px;
+
+		.site__content {
+			overflow: visible;
+
+			.site__title {
+				position: absolute;
+					top: 24px;
+					left: -4px;
+				box-shadow: 0 0 0 1px rgba( $white, 0.8 );
+				background: lighten( $gray, 30 );
+				border: 1px solid lighten( $gray, 20 );
+				color: $gray-dark;
+				font-size: 13px;
+				margin: 4px 0 8px 0;
+				padding: 4px 8px;
+				border-radius: 3px;
+				z-index: 1;
+				opacity: 0;
+				transition: all 0.15s ease-in-out;
+			}
+		}
+
+		&:hover {
+			.site__content .site__title {
+				opacity: 1;
 			}
 		}
 	}
 
-	.reader__card.card  .site__title {
-		color: $gray;
-		font-size: 13px;
+	.reader__post-featured-image {
+		display: none;
+		position: absolute;
+			top: 8px;
+			left: 8px;
+			bottom: 8px;
+		border-radius: 3px;
+		width: 80px;
+		height: calc( 100% - 16px ) !important;
+		margin: 0;
+		overflow: hidden;
+		
+		img {
+			max-height: 100%;
+			max-width: none;
+		}
 	}
 
 	.reader__post-title {
-		display: inline;
+		margin: 0 0 2px 0;
 		font-size: 16px;
-		margin: 8px 0 0 0;
 		white-space: nowrap;
 	}
 	
@@ -324,9 +372,6 @@
 	}
 
 	.post-excerpt {
-		display: inline;
-		padding-left: 8px;
-
 		.post-excerpt__text {
 			font-size: 14px;
 			white-space: nowrap;
@@ -337,6 +382,16 @@
 			&.is-long:after {
 				display: none;
 			}
+		}
+	}
+
+	.reader__post-footer {
+		margin-top: 8px;
+
+		.comment-button .gridicon__comments,
+		.like-button .gridicon {
+			height: 18px;
+			top: 6px;
 		}
 	}
 }

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -307,9 +307,17 @@
 			display: none;
 		}
 
-		&.is-photo-only {
+		&.is-photo-only,
+		&.is-large-banner {
 			.reader__post-featured-image {
 				display: block;
+				z-index: 1;
+				left: -64px;
+				width: calc( 100% + 80px );
+				max-height: 320px;
+				margin: 0 0 16px 0;
+
+				/*
 				position: absolute;
 					top: auto;
 					right: 16px;
@@ -320,7 +328,7 @@
 				z-index: 1;
 				border-radius: 3px;
 
-				/*
+
 				display: none;
 				position: absolute;
 					top: 8px;
@@ -340,7 +348,7 @@
 			}
 
 			.reader__post-footer {
-				margin-top: 224px;
+				//margin-top: 224px;
 			}
 		}
 	}
@@ -352,28 +360,43 @@
 
 	.reader__post-header {
 		margin: 0;
+
+		&:after {
+			display: none;
+		}
 	}
 
 	.site {
-		position: absolute;
-		top: 0;
-		left: -49px;
+		margin: 0 0 8px 0;
 
 		.site__content {
+			display: block;
 			overflow: visible;
+
+			.site-icon {
+				margin: 0;
+				position: absolute;
+					top: 0;
+					left: -48px;
+				z-index: 2; // "Above" the featured image
+			}
 
 			.site__title {
 				color: darken( $gray, 20 );
 				font-size: 13px;
 				overflow: visible;
-				margin: 0 0 0 10px;
+				margin: 0;
+			}
+
+			.site__info {
+				width: auto;
 			}
 		}
 	}
 
 	.reader__post-title {
-		margin: 22px 0 2px 0;
-		font-size: 16px;
+		margin: 0 0 2px 0;
+		font-size: 18px;
 		white-space: nowrap;
 	}
 	

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -262,11 +262,17 @@
 }
 
 
+// Section Header
+.wp-primary .section-header__following-stream {
+	margin-bottom: 16px;
+}
+
+
 // Condensed View
 .view-toggle {
-	position: fixed;
-		top: 50px;
-		left: 236px;
+	position: absolute;
+		top: -2px;
+		left: -12px;
 	z-index: 1;
 	height: 34px;
 	width: 34px;

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -263,6 +263,23 @@
 
 
 // Condensed View
+.view-toggle {
+	text-align: right;
+	padding: 0 16px 16px 0;
+
+	.view-toggle__label {
+		color: darken( $gray, 30 );
+		margin-left: 8px;
+		font-size: 13px;
+	}
+
+	&:after {
+		content: "";
+		display: table;
+		clear: both;
+	}
+}
+
 .is-condensed {
 
 	// Hide a bunch of stuff

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -309,13 +309,15 @@
 		}
 
 		&:hover {
-			//background: $gray-light;
-			//cursor: pointer;
-			box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5), 0 1px 2px #e9eff3;
+			box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5),
+				0 1px 2px lighten( $gray, 30% ),
+				inset 6px 0 0 lighten( $gray, 30 );
+		}
 
-			&:after {
-				//background: linear-gradient( to right, rgba( $gray-light, 0 ), $gray-light 50% );
-			}
+		&.is-selected {
+			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+				0 1px 2px lighten( $gray, 30% ),
+				inset 6px 0 0 $blue-wordpress;
 		}
 	}
 
@@ -324,8 +326,7 @@
 			display: none;
 		}
 
-		&.is-photo-only,
-		&.is-large-banner {
+		&.is-photo-only {
 			.reader__post-featured-image {
 				display: block;
 				z-index: 1;
@@ -336,7 +337,7 @@
 				border-radius: 3px;
 
 				img {
-					margin-top: -16%;
+					margin-top: -24%;
 				}
 			}
 		}

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -264,13 +264,31 @@
 
 // Condensed View
 .view-toggle {
-	text-align: right;
-	padding: 0 16px 16px 0;
+	position: fixed;
+		top: 50px;
+		left: 236px;
+	z-index: 1;
+	height: 34px;
+	width: 34px;
+	box-sizing: border-box;
+	border-radius: 3px;
+	cursor: pointer;
 
-	.view-toggle__label {
-		color: darken( $gray, 30 );
-		margin-left: 8px;
-		font-size: 13px;
+	@include breakpoint( "<960px" ) {
+		left: 192px;
+	}
+
+	.gridicon {
+		fill: $gray;
+		padding: 5px;
+		position: absolute;
+			top: 0;
+			left: 0;
+		transition: all 0.15s ease-in-out;
+	}
+
+	.view-toggle__inbox {
+		opacity: 0;
 	}
 
 	&:after {
@@ -278,14 +296,28 @@
 		display: table;
 		clear: both;
 	}
+
+	&:hover {
+		background: rgba( $gray-dark, 0.05 );
+	}
+
+	&.is-inbox {
+		.gridicon {
+			fill: darken( $gray, 20 );
+		}
+
+		.view-toggle__inbox {
+			opacity: 1;
+		}
+
+		.view-toggle__card {
+			opacity: 0;
+		}
+	}
 }
 
 .is-condensed {
-	margin: 0 -32px;
-
-	@include breakpoint( "<660px" ) {
-		margin: -8px;
-	}
+	margin: 0;
 
 	// Hide a bunch of stuff
 	.site__domain,
@@ -298,7 +330,7 @@
 	.reader__card {
 		padding: 16px 24px;
 		overflow: hidden;
-		margin-bottom: 0;
+		margin-bottom: 1px;
 
 		@include breakpoint( "<660px" ) {
 			padding: 16px;
@@ -315,20 +347,6 @@
 			background: linear-gradient(to right, rgba(255, 255, 255, 0), #ffffff 50%);
 		    visibility: visible;
     		height: 30px;
-		}
-
-		&:hover {
-			box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5),
-				0 1px 2px lighten( $gray, 30% ),
-				inset 0 1px 0 0 $gray,
-				inset 0 -1px 0 0 $gray;
-		}
-
-		&.is-selected {
-			box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5),
-				0 1px 2px lighten( $gray, 30% ),
-				inset 0 -1px 0 0 $gray,
-				inset 0 3px 0 0 $blue-wordpress;
 		}
 
 		.follow-button {
@@ -382,12 +400,6 @@
 		box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5),
 			0 1px 2px lighten( $gray, 30% );
 
-		&:hover {
-			box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5),
-				0 1px 2px lighten( $gray, 30% ),
-				inset 6px 0 0 lighten( $gray, 30 );
-		}
-
 		&:after {
 			display: none;
 		}
@@ -410,6 +422,8 @@
 		.reader__full-post-content {
 			font-size: 14px;
 			color: darken( $gray, 20 );
+			max-height: 22px;
+			overflow: hidden;
 		}
 	}
 

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -281,6 +281,11 @@
 }
 
 .is-condensed {
+	margin: 0 -32px;
+
+	@include breakpoint( "<660px" ) {
+		margin: -8px;
+	}
 
 	// Hide a bunch of stuff
 	.site__domain,
@@ -291,32 +296,39 @@
 	}
 
 	.reader__card {
-		padding: 16px 16px 16px 64px;
+		padding: 16px 24px;
 		overflow: hidden;
 		margin-bottom: 0;
+
+		@include breakpoint( "<660px" ) {
+			padding: 16px;
+
+		}
 
 		&:after {
 			content: '';
 			text-align: right;
 			position: absolute;
-				top: 0;
 				right: 0;
+				bottom: 40px;
 			width: 10%;
 			background: linear-gradient(to right, rgba(255, 255, 255, 0), #ffffff 50%);
 		    visibility: visible;
-    		height: calc( 100% - 40px );
+    		height: 30px;
 		}
 
 		&:hover {
 			box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5),
 				0 1px 2px lighten( $gray, 30% ),
-				inset 6px 0 0 lighten( $gray, 30 );
+				inset 0 1px 0 0 $gray,
+				inset 0 -1px 0 0 $gray;
 		}
 
 		&.is-selected {
-			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+			box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5),
 				0 1px 2px lighten( $gray, 30% ),
-				-6px 0 0 $blue-wordpress;
+				inset 0 -1px 0 0 $gray,
+				inset 0 3px 0 0 $blue-wordpress;
 		}
 
 		.follow-button {
@@ -327,7 +339,6 @@
 	.reader__card.has-featured-image {
 		&.is-photo-only {
 			.reader__post-featured-image {
-				//display: block;
 				z-index: 1;
 				left: 0;
 				width: 100%;
@@ -343,7 +354,7 @@
 
 		&:not( .is-photo-only ) {
 			.reader__post-featured-image {
-				//display: block;
+				display: none;
 				position: absolute;
 					top: 0;
 					left: 0;
@@ -396,10 +407,6 @@
 			display: none;
 		}
 
-		.reader__post-title {
-			white-space: normal;
-		}
-
 		.reader__full-post-content {
 			font-size: 14px;
 			color: darken( $gray, 20 );
@@ -420,13 +427,24 @@
 		.site__content {
 			display: block;
 			overflow: visible;
+			padding-left: 24px;
 
 			.site-icon {
 				margin: 0;
 				position: absolute;
 					top: 0;
-					left: -48px;
+					left: 0;
 				z-index: 2; // "Above" the featured image
+
+				// Overriding some inline styles from the <Site> component
+				height: 16px !important;
+				width: 16px !important;
+				line-height: 16px !important;
+
+				img {
+					height: 16px;
+					width: 16px;
+				}
 			}
 
 			.site__title {
@@ -445,7 +463,6 @@
 	.reader__post-title {
 		margin: 0 0 2px 0;
 		font-size: 18px;
-		white-space: nowrap;
 	}
 	
 	.reader__post-header {
@@ -469,7 +486,7 @@
 	.reader__post-footer {
 		margin-top: 0;
 
-		.comment-button .gridicon__comments,
+		.comment-button .gridicon,
 		.like-button .gridicon {
 			height: 18px;
 			top: 6px;

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -329,44 +329,15 @@
 			.reader__post-featured-image {
 				display: block;
 				z-index: 1;
-				left: -64px;
-				width: calc( 100% + 80px );
-				max-height: 320px;
+				left: 0;
+				width: 100%;
+				max-height: 112px;
 				margin: 0 0 16px 0;
-				border-top: 1px solid lighten( $gray, 30 );
-
-				/*
-				position: absolute;
-					top: auto;
-					right: 16px;
-					bottom: 32px;
-					left: 64px;
-				width: auto;
-				height: 200px;
-				z-index: 1;
 				border-radius: 3px;
 
-
-				display: none;
-				position: absolute;
-					top: 8px;
-					left: 8px;
-					bottom: 8px;
-				border-radius: 3px;
-				width: 80px;
-				height: calc( 100% - 16px ) !important;
-				margin: 0;
-				overflow: hidden;
-				
 				img {
-					max-height: 100%;
-					max-width: none;
+					margin-top: -16%;
 				}
-				*/
-			}
-
-			.reader__post-footer {
-				//margin-top: 224px;
 			}
 		}
 	}
@@ -437,7 +408,7 @@
 	}
 
 	.reader__post-footer {
-		margin-top: 8px;
+		margin-top: 0;
 
 		.comment-button .gridicon__comments,
 		.like-button .gridicon {

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -322,13 +322,9 @@
 	}
 
 	.reader__card.has-featured-image {
-		.reader__post-featured-image {
-			display: none;
-		}
-
 		&.is-photo-only {
 			.reader__post-featured-image {
-				display: block;
+				//display: block;
 				z-index: 1;
 				left: 0;
 				width: 100%;
@@ -338,6 +334,30 @@
 
 				img {
 					margin-top: -24%;
+				}
+			}
+		}
+
+		&:not( .is-photo-only ) {
+			.reader__post-featured-image {
+				//display: block;
+				position: absolute;
+					top: 0;
+					left: 0;
+					bottom: 0;
+				height: 100%;
+				width: 32px;
+
+				img {
+					max-height: 100%;
+					max-width: none;
+					transition: opacity 0.1s ease-in-out;
+				}
+			}
+
+			&:hover {
+				.reader__post-featured-image img {
+					opacity: 0.4;
 				}
 			}
 		}

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -343,9 +343,29 @@
 		}
 	}
 
-	// Hide x-posts for now. They need some thinking.
 	.reader__card.is-x-post {
-		display: none;
+		background: rgba( $white, 0.5 );
+		box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5),
+			0 1px 2px lighten( $gray, 30% );
+
+		&:hover {
+			box-shadow: 0 0 0 1px rgba(200, 215, 225, 0.5),
+				0 1px 2px lighten( $gray, 30% ),
+				inset 6px 0 0 lighten( $gray, 30 );
+		}
+
+		&:after {
+			display: none;
+		}
+
+		.reader__site-and-author-icon {
+			left: -8px;
+		}
+
+		.reader__post-title {
+			font-size: 15px;
+			font-weight: normal;
+		}
 	}
 
 	.reader__post-header {

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -302,10 +302,6 @@
 	}
 
 	&.is-inbox {
-		.gridicon {
-			fill: darken( $gray, 20 );
-		}
-
 		.view-toggle__inbox {
 			opacity: 1;
 		}

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -268,47 +268,45 @@
 }
 
 
-// Condensed View
+// List View
 .view-toggle {
-	position: absolute;
-		top: -2px;
-		left: -12px;
-	z-index: 1;
-	height: 34px;
-	width: 34px;
-	box-sizing: border-box;
-	border-radius: 3px;
-	cursor: pointer;
+	position: relative;
+	line-height: 24px;
+	font-size: 14px;
+	color: $gray;
 
-	@include breakpoint( "<960px" ) {
-		left: 192px;
+	&:hover {
+		color: darken( $gray, 30 );
+		cursor: pointer;
+
+		.gridicon {
+			fill: darken( $gray, 30 );
+		}
 	}
 
 	.gridicon {
-		fill: $gray;
-		padding: 5px;
 		position: absolute;
 			top: 0;
 			left: 0;
-		transition: all 0.15s ease-in-out;
+		fill: $gray;
 	}
 
-	.view-toggle__inbox {
+	.view-toggle__card,
+	.view-toggle__list {
+		position: absolute;
+			top: 2px;
+			right: -8px;
+		min-width: 70px;
+		padding-left: 28px;
+		transition: all 0.05s ease-in-out;
+	}
+
+	.view-toggle__list {
 		opacity: 0;
 	}
 
-	&:after {
-		content: "";
-		display: table;
-		clear: both;
-	}
-
-	&:hover {
-		background: rgba( $gray-dark, 0.05 );
-	}
-
-	&.is-inbox {
-		.view-toggle__inbox {
+	&.is-list {
+		.view-toggle__list {
 			opacity: 1;
 		}
 
@@ -318,7 +316,7 @@
 	}
 }
 
-.is-condensed {
+.is-list {
 
 	// Hide a bunch of stuff
 	.site__domain,

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -286,7 +286,6 @@
 	.site__domain,
 	.reader-post-byline,
 	.reader__post-featured-video,
-	.reader__card .reader__full-post-content,
 	.reader-post-images {
 		display: none;
 	}
@@ -317,7 +316,11 @@
 		&.is-selected {
 			box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 				0 1px 2px lighten( $gray, 30% ),
-				inset 6px 0 0 $blue-wordpress;
+				-6px 0 0 $blue-wordpress;
+		}
+
+		.follow-button {
+			top: -18px;
 		}
 	}
 
@@ -385,6 +388,21 @@
 		.reader__post-title {
 			font-size: 15px;
 			font-weight: normal;
+		}
+	}
+
+	.reader__card.is-one-liner {
+		&:after {
+			display: none;
+		}
+
+		.reader__post-title {
+			white-space: normal;
+		}
+
+		.reader__full-post-content {
+			font-size: 14px;
+			color: darken( $gray, 20 );
 		}
 	}
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -76,7 +76,7 @@ module.exports = React.createClass( {
 		//return this.getStateFromStores();
 		return assign(
 			this.getStateFromStores(), {
-			viewInbox: false
+			viewInbox: true
 		} );
 	},
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -75,7 +75,7 @@ module.exports = React.createClass( {
 		//return this.getStateFromStores();
 		return assign(
 			this.getStateFromStores(), {
-			viewInbox: false
+			viewInbox: true
 		} );
 	},
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -3,6 +3,7 @@
  */
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
+	assign = require( 'lodash/object/assign' ),
 	noop = require( 'lodash/utility/noop' ),
 	times = require( 'lodash/utility/times' );
 
@@ -75,7 +76,7 @@ module.exports = React.createClass( {
 		//return this.getStateFromStores();
 		return assign(
 			this.getStateFromStores(), {
-			viewInbox: true
+			viewInbox: false
 		} );
 	},
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -410,7 +410,7 @@ module.exports = React.createClass( {
 		} else {
 			body = ( <InfiniteList
 			ref={ ( c ) => this._list = c }
-			className="reader__content"
+			className="reader__content is-condensed"
 			items={ this.state.posts }
 			lastPage={ this.props.store.isLastPage()}
 			fetchingNextPage={ this.props.store.isFetchingNextPage()}

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -33,7 +33,7 @@ var Main = require( 'components/main' ),
 	KeyboardShortcuts = require( 'lib/keyboard-shortcuts' ),
 	scrollTo = require( 'lib/scroll-to' ),
 	XPostHelper = require( 'reader/xpost-helper' ),
-	FormToggle = require( 'components/forms/form-toggle' );
+	Gridicon = require( 'components/gridicon' );
 
 const GUESSED_POST_HEIGHT = 600,
 	HEADER_OFFSET_TOP = 46;
@@ -415,9 +415,14 @@ module.exports = React.createClass( {
 	render: function() {
 		var store = this.props.store,
 			hasNoPosts = store.isLastPage() && ( ( ! this.state.posts ) || this.state.posts.length === 0 ),
-			body;
+			body,
+			contentClasses,
+			viewToggleClass = classnames( {
+				'view-toggle': true,
+				'is-inbox': this.state.viewInbox,
+			} );
 
-		var contentClasses = classnames( {
+		contentClasses = classnames( {
 			'reader__content': true,
 			'is-condensed': this.state.viewInbox,
 		} );
@@ -447,15 +452,9 @@ module.exports = React.createClass( {
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.handleUpdateClick } />
 
-				<div className="view-toggle">
-					<FormToggle
-						checked={ this.state.viewInbox }
-						//toggling={ this.props.toggling }
-						//disabled={ this.props.disabled }
-						onChange={ this.handleView }
-						id={ 'view-toggle__inbox' }
-					/>
-					<span className="view-toggle__label">Condensed View</span>
+				<div className={ viewToggleClass } onClick={ this.handleView }>
+					<Gridicon icon="align-justify" className="view-toggle__inbox" />
+					<Gridicon icon="align-image-center" className="view-toggle__card" />
 				</div>
 
 				{ this.props.children }

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -34,7 +34,8 @@ var Main = require( 'components/main' ),
 	KeyboardShortcuts = require( 'lib/keyboard-shortcuts' ),
 	scrollTo = require( 'lib/scroll-to' ),
 	XPostHelper = require( 'reader/xpost-helper' ),
-	Gridicon = require( 'components/gridicon' );
+	Gridicon = require( 'components/gridicon' ),
+	SectionHeader = require( 'components/section-header' );
 
 const GUESSED_POST_HEIGHT = 600,
 	HEADER_OFFSET_TOP = 46;
@@ -453,10 +454,12 @@ module.exports = React.createClass( {
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.handleUpdateClick } />
 
-				<div className={ viewToggleClass } onClick={ this.handleView }>
-					<Gridicon icon="align-justify" className="view-toggle__inbox" />
-					<Gridicon icon="align-image-center" className="view-toggle__card" />
-				</div>
+				<SectionHeader label={ this.translate( 'Following' ) } className={ "section-header__following-stream" }>
+					<div className={ viewToggleClass } onClick={ this.handleView }>
+						<Gridicon icon="align-justify" className="view-toggle__inbox" />
+						<Gridicon icon="align-image-center" className="view-toggle__card" />
+					</div>
+				</SectionHeader>
 
 				{ this.props.children }
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -454,14 +454,14 @@ module.exports = React.createClass( {
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.handleUpdateClick } />
 
-				<SectionHeader label={ this.translate( 'Following' ) } className={ "section-header__following-stream" }>
+				{ this.props.children }
+
+				<SectionHeader label={ this.translate( "Latest Posts" ) } className={ "section-header__following-stream" }>
 					<div className={ viewToggleClass } onClick={ this.handleView }>
 						<Gridicon icon="align-justify" className="view-toggle__inbox" />
 						<Gridicon icon="align-image-center" className="view-toggle__card" />
 					</div>
 				</SectionHeader>
-
-				{ this.props.children }
 
 				{ body }
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -35,6 +35,7 @@ var Main = require( 'components/main' ),
 	scrollTo = require( 'lib/scroll-to' ),
 	XPostHelper = require( 'reader/xpost-helper' ),
 	Gridicon = require( 'components/gridicon' ),
+	Button = require( 'components/button' ),
 	SectionHeader = require( 'components/section-header' );
 
 const GUESSED_POST_HEIGHT = 600,
@@ -62,7 +63,7 @@ module.exports = React.createClass( {
 		showFollowInHeader: React.PropTypes.bool,
 		onUpdatesShown: React.PropTypes.func,
 		emptyContent: React.PropTypes.object,
-		viewInbox: React.PropTypes.bool
+		viewList: React.PropTypes.bool
 	},
 
 	getDefaultProps: function() {
@@ -77,12 +78,12 @@ module.exports = React.createClass( {
 		//return this.getStateFromStores();
 		return assign(
 			this.getStateFromStores(), {
-			viewInbox: true
+			viewList: true
 		} );
 	},
 
 	handleView: function() {
-		this.setState( { viewInbox: ! this.state.viewInbox } );
+		this.setState( { viewList: ! this.state.viewList } );
 	},
 
 	getStateFromStores: function( store ) {
@@ -421,12 +422,12 @@ module.exports = React.createClass( {
 			contentClasses,
 			viewToggleClass = classnames( {
 				'view-toggle': true,
-				'is-inbox': this.state.viewInbox,
+				'is-list': this.state.viewList,
 			} );
 
 		contentClasses = classnames( {
 			'reader__content': true,
-			'is-condensed': this.state.viewInbox,
+			'is-list': this.state.viewList,
 		} );
 
 		if ( hasNoPosts ) {
@@ -458,8 +459,14 @@ module.exports = React.createClass( {
 
 				<SectionHeader label={ this.translate( "Latest Posts" ) } className={ "section-header__following-stream" }>
 					<div className={ viewToggleClass } onClick={ this.handleView }>
-						<Gridicon icon="align-justify" className="view-toggle__inbox" />
-						<Gridicon icon="align-image-center" className="view-toggle__card" />
+						<div className="view-toggle__card">
+							<Gridicon icon="align-image-center" />
+							<span className="view-toggle__label">Card View</span>
+						</div>
+						<div className="view-toggle__list">
+							<Gridicon icon="align-justify" />
+							<span className="view-toggle__label">List View</span>
+						</div>
 					</div>
 				</SectionHeader>
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -23,6 +23,7 @@ var Main = require( 'components/main' ),
 	Post = require( './post' ),
 	CrossPost = require( './x-post' ),
 	page = require( 'page' ),
+	classnames = require( 'classnames' ),
 	PostUnavailable = require( './post-unavailable' ),
 	PostPlaceholder = require( './post-placeholder' ),
 	PostStore = require( 'lib/feed-post-store' ),
@@ -31,7 +32,8 @@ var Main = require( 'components/main' ),
 	CommentStore = require( 'lib/comment-store/comment-store' ),
 	KeyboardShortcuts = require( 'lib/keyboard-shortcuts' ),
 	scrollTo = require( 'lib/scroll-to' ),
-	XPostHelper = require( 'reader/xpost-helper' );
+	XPostHelper = require( 'reader/xpost-helper' ),
+	FormToggle = require( 'components/forms/form-toggle' );
 
 const GUESSED_POST_HEIGHT = 600,
 	HEADER_OFFSET_TOP = 46;
@@ -57,27 +59,37 @@ module.exports = React.createClass( {
 		suppressSiteNameLink: React.PropTypes.bool,
 		showFollowInHeader: React.PropTypes.bool,
 		onUpdatesShown: React.PropTypes.func,
-		emptyContent: React.PropTypes.object
+		emptyContent: React.PropTypes.object,
+		viewInbox: React.PropTypes.bool
 	},
 
 	getDefaultProps: function() {
 		return {
 			suppressSiteNameLink: false,
 			showFollowInHeader: false,
-			onShowUpdates: noop
+			onShowUpdates: noop,
 		};
 	},
 
 	getInitialState: function() {
-		return this.getStateFromStores();
+		//return this.getStateFromStores();
+		return assign(
+			this.getStateFromStores(), {
+			viewInbox: false
+		} );
+	},
+
+	handleView: function() {
+		this.setState( { viewInbox: ! this.state.viewInbox } );
 	},
 
 	getStateFromStores: function( store ) {
 		store = store || this.props.store;
+
 		return {
 			posts: store.get(),
 			updateCount: store.getUpdateCount(),
-			selectedIndex: store.getSelectedIndex()
+			selectedIndex: store.getSelectedIndex(),
 		};
 	},
 
@@ -405,12 +417,17 @@ module.exports = React.createClass( {
 			hasNoPosts = store.isLastPage() && ( ( ! this.state.posts ) || this.state.posts.length === 0 ),
 			body;
 
+		var contentClasses = classnames( {
+			'reader__content': true,
+			'is-condensed': this.state.viewInbox,
+		} );
+
 		if ( hasNoPosts ) {
 			body = this.props.emptyContent || ( <EmptyContent /> );
 		} else {
 			body = ( <InfiniteList
 			ref={ ( c ) => this._list = c }
-			className="reader__content is-condensed"
+			className={ contentClasses }
 			items={ this.state.posts }
 			lastPage={ this.props.store.isLastPage()}
 			fetchingNextPage={ this.props.store.isFetchingNextPage()}
@@ -429,6 +446,17 @@ module.exports = React.createClass( {
 				</MobileBackToSidebar>
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.handleUpdateClick } />
+
+				<div className="view-toggle">
+					<FormToggle
+						checked={ this.state.viewInbox }
+						//toggling={ this.props.toggling }
+						//disabled={ this.props.disabled }
+						onChange={ this.handleView }
+						id={ 'view-toggle__inbox' }
+					/>
+					<span className="view-toggle__label">Condensed View</span>
+				</div>
 
 				{ this.props.children }
 


### PR DESCRIPTION
cc @shaunandrews 

This PR adds a toggle which lets you switch between the normal, Magazine view and a new Condensed view.

Here's the current Magazine view that's in `master`:

![screen shot 2015-11-11 at 4 29 20 pm](https://cloud.githubusercontent.com/assets/191598/11103604/6c110054-8891-11e5-9ad1-4edf30031de5.png)

And here's what the new Condensed view looks like:

![screen shot 2015-11-11 at 4 29 23 pm](https://cloud.githubusercontent.com/assets/191598/11103608/74b58dce-8891-11e5-9e95-c674d1bb53c9.png)

A few todos:
- [ ] Where should this view toggle live in the UI? I'm not super keen with it at the top of the stream.
- [ ] Mobile needs some updates with padding/spacing.
- [ ] The view state should be remembered between refreshes and views
- [ ] Maybe a keyboard shortcut for toggling between views?
- [ ] There's some performance issues with scrolling (maybe infinite scroll?)