### PR TITLE
Plugins: font-size scrub from 10px to 11px

### DIFF
--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -24,9 +24,9 @@
 
 .plugin-action__label {
 	color: $gray;
-	font-size: 10px;
+	font-size: 11px;
 	line-height: 16px;
-	margin-right: 10px;
+	margin-right: 8px;
 	vertical-align: top;
 	text-transform: uppercase;
 	cursor: pointer;

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -1,7 +1,9 @@
 .plugin-activate-toggle .disconnect-jetpack-button {
-	font-size: 10px;
+	font-size: 11px;
+	color: $alert-red;
 	text-transform: uppercase;
 }
+
 .plugin-activate-toggle .plugin-action__children {
 	float: none;
 }

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -135,8 +135,7 @@
 // Last updated, version, whatever
 .plugin-item__meta {
 	display: block;
-	margin-top: -3px;
-	font-size: 10px;
+	font-size: 11px;
 	color: $gray;
 	white-space: pre;
 	text-overflow: ellipsis;

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -91,7 +91,7 @@
 }
 
 .plugin-meta__meta {
-	font-size: 10px;
+	font-size: 11px;
 	color: $gray;
 	white-space: pre;
 	text-overflow: ellipsis;
@@ -163,7 +163,7 @@
 a.plugin-meta__settings-link {
 	color: $gray;
 	display: block;
-	font-size: 10px;
+	font-size: 11px;
 	line-height: 16px;
 	margin: 8px 9px 0 0;
 	text-transform: uppercase;

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -1,5 +1,5 @@
 .plugin-ratings {
-	margin-top: 13px;
+	margin-top: 12px;
 }
 
 .plugin-ratings__rating-tier {
@@ -14,9 +14,8 @@
 
 .plugin-ratings__rating-tier-text,
 .plugin-ratings__downloads {
-	font-size: 10px;
-	font-weight: bold;
-	color: #87a6bc;
+	font-size: 11px;
+	color: $gray;
 	white-space: pre;
 	text-overflow: ellipsis;
 	text-transform: uppercase;
@@ -37,6 +36,8 @@
 	flex-grow: 1;
 
 	.progress-bar {
+		position: relative;
+		top: -2px;
 		border-radius: 0;
 		height: 8px;
 		background-color: lighten( $gray, 20% );
@@ -44,6 +45,6 @@
 
 	.progress-bar__progress {
 		border-radius: 0;
-		background-color: lighten( $blue-dark, 10% );
+		background-color: $blue-medium;
 	}
 }

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -1,6 +1,6 @@
 .plugin-remove-button__remove {
 	color: $gray;
-	font-size: 10px;
+	font-size: 11px;
 	line-height: 16px;
 	margin-right: 10px;
 	vertical-align: top;

--- a/client/my-sites/plugins/plugin-version/style.scss
+++ b/client/my-sites/plugins/plugin-version/style.scss
@@ -1,12 +1,13 @@
 .plugin-version {
-	font-size: 10px;
-	color: #87a6bc;
+	font-size: 11px;
+	color: $gray;
 	white-space: pre;
 	text-overflow: ellipsis;
 	text-transform: uppercase;
 	margin-top: 2px;
 	word-spacing: 2px;
 }
+
 .plugin-version__plugin {
 	margin-right:16px;
 
@@ -16,6 +17,7 @@
 		padding: 3px 4px;
 		border-radius: 2px;
 	}
+
 	.gridicon {
 		vertical-align: bottom;
 	}


### PR DESCRIPTION
- I worked through the plugins css to remove a bunch of instances of `font-size: 10px;` and replacing it with 11px (our minimum size for text)
- I made tweaks to align things that moved due to the change to 11px.
- I noticed while doing this that there were styles that had broken related to the Jetpack Disconnect button.
- I found references to colors that weren't using the scss variables, I took care of those.

**Before:**
<img width="760" alt="screen shot 2015-11-20 at 4 31 04 pm" src="https://cloud.githubusercontent.com/assets/437258/11312447/29fd5856-8fa4-11e5-8415-31209aae4260.png">

<img width="773" alt="screen shot 2015-11-20 at 4 29 44 pm" src="https://cloud.githubusercontent.com/assets/437258/11312449/2e5b6906-8fa4-11e5-80d0-d4f0a0aa30ce.png">

**After:**

<img width="755" alt="screen shot 2015-11-20 at 4 30 56 pm" src="https://cloud.githubusercontent.com/assets/437258/11312455/341996d8-8fa4-11e5-8f04-bf63147078da.png">

<img width="784" alt="screen shot 2015-11-20 at 4 29 09 pm" src="https://cloud.githubusercontent.com/assets/437258/11312462/3b36d444-8fa4-11e5-8ac6-433d475fb22c.png">

cc @MichaelArestad 
