### PR TITLE
removes all non-shortcode links to the old codebase

### DIFF
--- a/assets/stylesheets/README.md
+++ b/assets/stylesheets/README.md
@@ -7,4 +7,4 @@ Calypso uses SASS to build its CSS and compile it to `public/style.css`. Remembe
 
 If you are adding a new SASS file to `assets/stylesheets` you will need to reference the file in `assets/stylesheets/style.scss` for it to load. We have three directories to organize the respective files: layout, sections, and shared. If you are adding a new file you are likely adding it to `sections`.
 
-Check [our styleguide](https://github.com/Automattic/calypso-pre-oss/blob/master/docs/coding-guidelines/css.md) for more information on how we use SASS.
+Check [our styleguide](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md) for more information on how we use SASS.

--- a/client/components/README.md
+++ b/client/components/README.md
@@ -1,6 +1,6 @@
 Components
 ==========
 
-This place harbors shared React components used for composing the UI of Calypso. Components come with their own styles defined [according to our guidelines](https://github.com/Automattic/calypso-pre-oss/blob/master/docs/coding-guidelines/css.md), and manually loaded from the [styles assets folder](https://github.com/Automattic/calypso-pre-oss/blob/master/assets/stylesheets/_components.scss). Structuring the user interface with these building blocks has several benefits — like allowing to quickly construct a view that is visually consistent with the rest of Calypso, and easier to iterate on.
+This place harbors shared React components used for composing the UI of Calypso. Components come with their own styles defined [according to our guidelines](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md), and manually loaded from the [styles assets folder](https://github.com/Automattic/wp-calypso/blob/master/assets/stylesheets/_components.scss). Structuring the user interface with these building blocks has several benefits — like allowing to quickly construct a view that is visually consistent with the rest of Calypso, and easier to iterate on.
 
 Some of these components can be seen in action in our [DevDocs: Design](https://wpcalypso.wordpress.com/devdocs/design) section.

--- a/client/components/shortcode/README.md
+++ b/client/components/shortcode/README.md
@@ -58,4 +58,4 @@ Function to override default render result. Passed the original result of the [s
 
 ## Resources
 
-You may find it convenient to use the [`Shortcode` conversion library](https://github.com/Automattic/calypso-pre-oss/tree/master/client/lib/shortcode) in conjunction with this component to help with generating shortcode strings.
+You may find it convenient to use the [`Shortcode` conversion library](https://github.com/Automattic/wp-calypso/tree/master/client/lib/shortcode) in conjunction with this component to help with generating shortcode strings.

--- a/client/components/spinner/README.md
+++ b/client/components/spinner/README.md
@@ -5,7 +5,7 @@ Spinner is a React component for rendering a loading indicator.
 
 <img src="https://cldup.com/H27NKdxFBN.gif" alt="Demo" />
 
-__Please exercise caution in deciding to use a spinner in your component.__ A lone spinner is a poor user-experience and conveys little context to what the user should expect from the page. Refer to [the _Reactivity and Loading States_ guide](https://github.com/Automattic/calypso-pre-oss/blob/master/docs/reactivity.md) for more information on building fast interfaces and making the most of data already available to use.
+__Please exercise caution in deciding to use a spinner in your component.__ A lone spinner is a poor user-experience and conveys little context to what the user should expect from the page. Refer to [the _Reactivity and Loading States_ guide](https://github.com/Automattic/wp-calypso/blob/master/docs/reactivity.md) for more information on building fast interfaces and making the most of data already available to use.
 
 ## Usage
 

--- a/client/config/README.md
+++ b/client/config/README.md
@@ -1,7 +1,7 @@
 client/config
 =============
 
-The `index.js` file is generated on startup by `regenerate.js`. Based on the environment, data is read from the appropriate .json file in the root config directory, for example, `/config/development.json`. The data is then compared against a whitelist in `/config/client.json`, and whitelisted items are added to the data object in `/client/config/index.js`. You can read more about how to use `config` in the [main documentation](https://github.com/Automattic/calypso-pre-oss#config).
+The `index.js` file is generated on startup by `regenerate.js`. Based on the environment, data is read from the appropriate .json file in the root config directory, for example, `/config/development.json`. The data is then compared against a whitelist in `/config/client.json`, and whitelisted items are added to the data object in `/client/config/index.js`. You can read more about how to use `config` in the [main documentation](https://github.com/Automattic/wp-calypso#config).
 
 Feature Flags API
 -----------------

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -85,7 +85,7 @@ module.exports = React.createClass( {
 
 	render: function() {
 
-		var editURL = encodeURI( 'https://github.com/Automattic/calypso-pre-oss/edit/master/' + this.props.path ) +
+		var editURL = encodeURI( 'https://github.com/Automattic/wp-calypso/edit/master/' + this.props.path ) +
 			'?message=Documentation: <title>&description=What did you change and why&target_branch=update/docs-your-title';
 
 		return (

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -164,7 +164,6 @@ const MainComponent = React.createClass( {
 				{ this.renderCategoryAndEmail() }
 				<button className="button is-primary" onClick={ this.onResubscribeClick }>{ this.translate( 'Resubscribe' ) }</button>
 				{/* Hide link to manage all updates until that page is live.
-					See https://github.com/Automattic/calypso-pre-oss/pull/10771
 				<p></p>
 				<button className="button is-link" onClick={ this.onManageUpdatesClick }>{ this.translate( 'Manage all your updates from WordPress.com' ) }</button>
 				*/}

--- a/client/my-sites/jetpack-manage-error-page/README.md
+++ b/client/my-sites/jetpack-manage-error-page/README.md
@@ -1,12 +1,12 @@
 Jetpack Manage Error Pages
 ==========================
 
-This component is used to catch Jetpack management errors at a high level, 
+This component is used to catch Jetpack management errors at a high level,
 and render an appropriate error page before any management tools are rendered.
 
 This component is an extension of the [EmptyContent component][1], and it accepts
 the same properties.
-[1]: https://github.com/Automattic/calypso-pre-oss/tree/master/shared/components/empty-content
+[1]: https://github.com/Automattic/wp-calypso/tree/master/shared/components/empty-content
 
 Additionally, this component accepts a `template` property which will render some pre-defined
 templates. Here are acceptable values for `template` along with examples of how to use them.

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -77,7 +77,7 @@ handleSubmit: function( event ) {
 - (optional) `providedDependencies`, an object describing the data added by the step to the Dependency Store. Use this only for data that does not come from API requests.
 - (optional) `processingMessage`, a message that is displayed at the end of the flow while the user waits for the apiRequestFunction to process. For example, "Creating your account" or "Setting up your site", depending on what your step does.
 
-Some background on `providedDependencies` and the Dependency Store: submitted steps are saved in the Progress Store, where they wait to have their dependencies met. For example, a step that creates a site needs to wait until a user account is created. Once that happens, the step is processed and its result is saved in the Dependency Store, so other steps can use it. You can read more about this [here](https://github.com/Automattic/calypso-pre-oss/tree/master/client/lib/signup).
+Some background on `providedDependencies` and the Dependency Store: submitted steps are saved in the Progress Store, where they wait to have their dependencies met. For example, a step that creates a site needs to wait until a user account is created. Once that happens, the step is processed and its result is saved in the Dependency Store, so other steps can use it. You can read more about this [here](https://github.com/Automattic/wp-calypso/tree/master/client/lib/signup).
 
 ### apiRequestFunction
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "calypso-pre-oss",
+  "name": "wp-calypso",
   "version": "0.17.0",
   "description": "A pure REST-API and JS based version of the WordPress.com admin",
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/Automattic/calypso-pre-oss.git"
+    "url": "https://github.com/Automattic/wp-calypso.git"
   },
   "main": "index.js",
   "dependencies": {

--- a/server/i18n/index.js
+++ b/server/i18n/index.js
@@ -96,7 +96,7 @@ function buildPhpOutput( data, arrayName ) {
 	// prepend the matches array with this content to open the php file
 	matches.unshift( [
 		'<?php',
-		'\n/* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. SEE https://github.com/Automattic/calypso-pre-oss/tree/develop/server/i18n */',
+		'\n/* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. SEE https://github.com/Automattic/wp-calypso/tree/master/server/i18n */',
 		'\n$' + arrayName + ' = array('
 	].join( '' ) );
 
@@ -191,4 +191,3 @@ function readFile( outputFile, arrayName, inputFiles, done ) {
 }
 
 module.exports = readFile;
-

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -135,7 +135,7 @@ function getDefaultContext( request ) {
 
 	if ( CALYPSO_ENV === 'wpcalypso' ) {
 		context.badge = CALYPSO_ENV;
-		context.feedbackURL = 'https://github.com/Automattic/calypso-pre-oss/issues/new';
+		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/new';
 		context.faviconURL = '/calypso/images/favicons/favicon-wpcalypso.ico';
 	}
 
@@ -147,7 +147,7 @@ function getDefaultContext( request ) {
 
 	if ( CALYPSO_ENV === 'stage' ) {
 		context.badge = 'staging';
-		context.feedbackURL = 'https://github.com/Automattic/calypso-pre-oss/issues/new';
+		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/new';
 		context.faviconURL = '/calypso/images/favicons/favicon-staging.ico';
 	}
 


### PR DESCRIPTION
There were a number of places where we linked to the old codebase. Updating here. Test by trying out the links. I confirmed with @rodrigoi that we can remove the link in `client/mailing-lists/main.jsx`.
