### PR TITLE
Framework: Contrast and gridicon update to full screen site picker

### DIFF
--- a/assets/stylesheets/sections/_sites.scss
+++ b/assets/stylesheets/sections/_sites.scss
@@ -24,15 +24,13 @@
 }
 
 .site-card__add-new {
-	.noticon {
-		font-size: 64px;
-		height: 65px;
-		margin-top: 20px;
+	.gridicon {
+		margin: 28px 0 4px;
 		color: darken( $gray, 10% );
 		transition: all 0.1s ease-in-out;
 	}
 
-	a:hover .noticon {
+	a:hover .gridicon {
 		color: $blue-medium;
 	}
 
@@ -42,7 +40,7 @@
 		background: none;
 		box-shadow: none;
 		border: 2px dashed lighten( $gray, 20% );
-		padding-top: 25px;
+		padding-top: 24px;
 
 		.site-card__title {
 			color: darken( $gray, 10% );

--- a/assets/stylesheets/sections/_sites.scss
+++ b/assets/stylesheets/sections/_sites.scss
@@ -200,7 +200,7 @@
 
 	// Banner image
 	.site-card__header {
-		background-color: $gray-light;
+		background-color: lighten( $gray, 30% );
 		background-size: cover;
 		position: absolute;
 			top: 0;

--- a/client/my-sites/sites/sites.jsx
+++ b/client/my-sites/sites/sites.jsx
@@ -9,6 +9,7 @@ var React = require( 'react' ),
  */
 var SiteCard = require( './site-card' ),
 	SearchCard = require( 'components/search-card' ),
+	Gridicon = require( 'components/gridicon' ),
 	infiniteScroll = require( 'lib/mixins/infinite-scroll' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	config = require( 'config' );
@@ -83,7 +84,7 @@ module.exports = React.createClass( {
 			<div className="site-card site-card__add-new" key="new-site-box">
 				<a href={ config( 'signup_url' ) + '?ref=calypso-sites' }>
 					<div className="site-card__content">
-						<span className="noticon noticon-plus" />
+						<Gridicon icon="add-outline" size={ 48 } />
 						<h3 className="site-card__title">{ this.translate( 'Start a New WordPress' ) }</h3>
 					</div>
 				</a>


### PR DESCRIPTION
When the recent background color change, the site cards with empty headers were fading into the background:

<img width="1242" alt="screen shot 2015-11-20 at 3 48 29 pm" src="https://cloud.githubusercontent.com/assets/5835847/11314052/a2cbd11a-8fa7-11e5-86e7-839a252827a4.png">

I updated the color and replaced the noticon in the 'Start A New WordPress' card to a gridicon.

<img width="1240" alt="screen shot 2015-11-20 at 4 38 28 pm" src="https://cloud.githubusercontent.com/assets/5835847/11314056/a64a0852-8fa7-11e5-9db5-b2258f5b429d.png">

To test, visit `/post`. 