### PR TITLE
Signup: Don't show error

### DIFF
--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -65,7 +65,11 @@ const olark = {
 	},
 
 	handleError: function( error ) {
-		notices.error( error.message );
+		// error.error === 'authorization_required' when the user is logged out
+		// when https://github.com/Automattic/wp-calypso/issues/289 is fixed then we can remove this condition
+		if ( error.error !== 'authorization_required' ) {
+			notices.error( error.message );
+		}
 	},
 
 	getOlarkConfiguration: function() {


### PR DESCRIPTION
Olark was showing an error notice in /start when the user was logged out.

This is because we make requests to endpoints that we don't have credentials for when the user is logged out. We should fix this in https://github.com/Automattic/wp-calypso/issues/289, but until then we can just catch this case and not show the error.

**Testing**
1. `git checkout fix/error-on-signup`
2. Open http://calypso.dev:3000/start in an incognito window
3. Assert that you don't see a big red notice saying:

> An active access token must be used to query information about the current user.

<img width="1256" alt="screenshot 2015-11-20 23 04 14" src="https://cloud.githubusercontent.com/assets/275961/11314167/0da09c7c-8fdb-11e5-8e55-c01f597a82ec.png">

cc @rralian 
