### PR TITLE
Signup: Add second verticals survey flows and steps

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -293,6 +293,7 @@
 @import 'signup/skip-step-button/style';
 @import 'signup/step-header/style';
 @import 'signup/steps/domains/style';
+@import 'signup/steps/survey/style';
 @import 'signup/steps/plans/style';
 @import 'signup/steps/site-creation/style';
 @import 'signup/steps/theme-selection/style';

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -102,7 +102,9 @@ module.exports = {
 			{}, userData, {
 				ab_test_variations: getSavedVariations(),
 				validate: false,
-				signup_flow_name: flowName
+				signup_flow_name: flowName,
+				nux_q_site_type: dependencies.surveySiteType,
+				nux_q_question_primary: dependencies.surveyQuestion,
 			}
 		), ( error, response ) => {
 			var errors = error && error.error ? [ { error: error.error, message: error.message } ] : undefined,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -70,6 +70,20 @@ const flows = {
 		lastModified: '2015-09-22'
 	},
 
+	'vert-blog': {
+		steps: [ 'survey-blog', 'themes', 'domains', 'plans', 'survey-user' ],
+		destination: getCheckoutDestination,
+		description: 'Categorizing blog signups',
+		lastModified: null
+	},
+
+	'vert-site': {
+		steps: [ 'survey-site', 'themes', 'domains', 'plans', 'survey-user' ],
+		destination: getCheckoutDestination,
+		description: 'Categorizing site signups',
+		lastModified: null
+	},
+
 	headstart: {
 		steps: [ 'theme-headstart', 'domains-with-theme', 'plans', 'user' ],
 		destination: getCheckoutDestination,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -7,6 +7,7 @@ var EmailSignupComponent = require( 'signup/steps/email-signup-form' ),
 	PlansStepComponent = require( 'signup/steps/plans' ),
 	DomainsStepComponent = require( 'signup/steps/domains' ),
 	DSSStepComponent = require( 'signup/steps/dss' ),
+	SurveyStepComponent = require( 'signup/steps/survey' ),
 	config = require( 'config' );
 
 module.exports = {
@@ -17,6 +18,9 @@ module.exports = {
 	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
 	plans: PlansStepComponent,
 	domains: DomainsStepComponent,
+	'survey-blog': SurveyStepComponent,
+	'survey-site': SurveyStepComponent,
+	'survey-user': EmailSignupComponent,
 	'domains-with-theme': DomainsStepComponent,
-	'theme-dss': DSSStepComponent
+	'theme-dss': DSSStepComponent,
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -33,6 +33,30 @@ module.exports = {
 		stepName: 'test',
 	},
 
+	'survey-user': {
+		stepName: 'survey-user',
+		apiRequestFunction: stepActions.createAccount,
+		dependencies: [ 'surveySiteType', 'surveyQuestion' ],
+		providesToken: true,
+		providesDependencies: [ 'bearer_token', 'username' ]
+	},
+
+	'survey-blog': {
+		stepName: 'survey-blog',
+		props: {
+			surveySiteType: 'blog',
+		},
+		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
+	},
+
+	'survey-site': {
+		stepName: 'survey-site',
+		props: {
+			surveySiteType: 'site',
+		},
+		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
+	},
+
 	plans: {
 		stepName: 'plans',
 		apiRequestFunction: stepActions.addPlanToCart,

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import SignupActions from 'lib/signup/actions';
+import analytics from 'analytics';
+import verticals from './verticals';
+import Card from 'components/card';
+import CompactCard from 'components/card/compact';
+import BackButton from 'components/header-cake';
+import Gridicon from 'components/gridicon';
+
+const debug = debugFactory( 'calypso:steps:survey' );
+
+export default React.createClass( {
+	displayName: 'SurveyStep',
+
+	getInitialState() {
+		return {
+			stepOne: null
+		}
+	},
+
+	renderStepTwoVertical( vertical ) {
+		return (
+			<Card className="survey-step__vertical" key={ vertical.value } href="#" onClick={ this.handleNextStep.bind( null, vertical ) }>
+				<label className="survey-step__label">{ vertical.label }</label>
+			</Card>
+		);
+	},
+
+	renderStepOneVertical( vertical ) {
+		const icon = vertical.icon || 'user';
+		return (
+			<Card className="survey-step__vertical" key={ 'step-one-' + vertical.value } href="#" onClick={ this.showStepTwo.bind( null, vertical ) }>
+				<Gridicon icon={ icon } className="survey-step__vertical__icon"/>
+				<label className="survey-step__label">{ vertical.label }</label>
+			</Card>
+		);
+	},
+
+	renderOptionList() {
+		if ( this.state.stepOne ) {
+			return (
+				<div>
+					<BackButton isCompact className="survey-step__title" onClick={ this.showStepOne }>{ this.state.stepOne.label }</BackButton>
+					{ this.state.stepOne.stepTwo.map( this.renderStepTwoVertical ) }
+				</div>
+			);
+		}
+		return (
+			<div>
+				<CompactCard className="survey-step__title">
+					<label className="survey-step__label">{ this.translate( 'What is your website about?' ) }</label>
+				</CompactCard>
+				{ verticals.get().map( this.renderStepOneVertical ) }
+			</div>
+		);
+	},
+
+	render() {
+		debug( this.props.stepSectionName );
+		return (
+			<div className="survey-step__section-wrapper">
+				<StepWrapper
+					flowName={ this.props.flowName }
+					stepName={ this.props.stepName }
+					positionInFlow={ this.props.positionInFlow }
+					headerText={ this.translate( 'Create your site today!' ) }
+					subHeaderText={ this.translate( 'WordPress.com is the best place for your WordPress blog or website.' ) }
+					signupProgressStore={ this.props.signupProgressStore }
+					stepContent={ this.renderOptionList() } />
+			</div>
+		);
+	},
+
+	showStepOne() {
+		const { value, label } = this.state.stepOne;
+		analytics.tracks.recordEvent( 'calypso_survey_category_back_click', { category: JSON.stringify( { value, label } ) } );
+		this.setState( { stepOne: null } );
+	},
+
+	showStepTwo( stepOne ) {
+		const { value, label } = stepOne;
+		analytics.tracks.recordEvent( 'calypso_survey_category_click_level_one', { category: JSON.stringify( { value, label } ) } );
+		this.setState( { stepOne } );
+	},
+
+	handleNextStep( vertical ) {
+		analytics.tracks.recordEvent( 'calypso_survey_site_type', { type: this.props.surveySiteType } );
+		analytics.tracks.recordEvent( 'calypso_survey_category_click_level_two', { category: JSON.stringify( vertical ) } );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { surveySiteType: this.props.surveySiteType, surveyQuestion: vertical.value } );
+		this.props.goToNextStep();
+	}
+} );

--- a/client/signup/steps/survey/style.scss
+++ b/client/signup/steps/survey/style.scss
@@ -1,0 +1,43 @@
+.survey-step__section-wrapper {
+	margin: 0 auto 2em;
+	width: 500px;
+}
+
+.survey-step__label {
+	vertical-align: top;
+	display: inline-block;
+	margin-bottom: 0;
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.survey-step__title {
+	display: block;
+	width: 100%;
+	margin-bottom: 0;
+	font-size: 14px;
+	font-weight: 600;
+	height: 50px;
+}
+
+.survey-step__title .survey-step__label {
+	width: 100%;
+	text-align: center;
+	line-height: 18px;
+	color: darken( $gray, 20% );
+}
+
+.survey-step__vertical {
+	margin-bottom: 0;
+}
+
+.survey-step__vertical__icon {
+	vertical-align: bottom;
+	margin-top: -2px;
+	margin-right: 16px;
+	color: lighten( $gray, 10% );
+}
+
+.survey-step__vertical:hover .survey-step__vertical__icon {
+	color: $gray;
+}

--- a/client/signup/steps/survey/verticals.js
+++ b/client/signup/steps/survey/verticals.js
@@ -1,0 +1,75 @@
+import { translate } from 'lib/mixins/i18n';
+
+const verticals = [
+	{ value: 'a8c.1', label: translate( 'Arts & Entertainment' ), icon: 'video-camera', stepTwo: [
+		{ value: 'a8c.1', label: translate( 'General Arts & Entertainment' ) },
+		{ value: 'a8c.1.3.1', label: translate( 'Creative Arts & Design' ) },
+		{ value: 'a8c.1.3.2', label: translate( 'Entertainment & Culture' ) },
+		{ value: 'a8c.1.6', label: translate( 'Music' ) },
+		{ value: 'a8c.1.5', label: translate( 'Movies' ) },
+		{ value: 'a8c.9.23', label: translate( 'Photography' ) },
+		{ value: 'a8c.18', label: translate( 'Style & Fashion' ) },
+		{ value: 'a8c.17', label: translate( 'Sports & Recreation' ) },
+	] },
+
+	{ value: 'a8c.3', label: translate( 'Business & Services' ), icon: 'bookmark', stepTwo: [
+		{ value: 'a8c.3', label: translate( 'General Business & Services' ) },
+		{ value: 'a8c.3.0.1', label: translate( 'Finance & Law' ) },
+		{ value: 'a8c.3.0.2', label: translate( 'Consulting & Coaching' ) },
+		{ value: 'a8c.3.0.3', label: translate( 'Restaurants & Locales' ) },
+		{ value: 'a8c.3.1.1', label: translate( 'Advertising & Marketing' ) },
+		{ value: 'a8c.2', label: translate( 'Automotive' ) },
+		{ value: 'a8c.21', label: translate( 'Real Estate' ) },
+		{ value: 'a8c.19', label: translate( 'Technology & Computing' ) },
+		{ value: 'a8c.20.18.1', label: translate( 'Hotels & Vacation Rentals' ) },
+		{ value: 'a8c.3.0.4', label: translate( 'Communications' ) },
+	] },
+
+	{ value: 'a8c.6', label: translate( 'Family, Home, & Lifestyle' ), icon: 'house', stepTwo: [
+		{ value: 'a8c.6', label: translate( 'Family & Parenting' ) },
+		{ value: 'a8c.14.7', label: translate( 'Events & Weddings' ) },
+		{ value: 'a8c.10', label: translate( 'Home & Garden' ) },
+		{ value: 'a8c.8', label: translate( 'Food & Drink' ) },
+		{ value: 'a8c.9.2', label: translate( 'DIY & Crafting' ) },
+		{ value: 'a8c.20', label: translate( 'Travel' ) },
+		{ value: 'a8c.16', label: translate( 'Pets' ) },
+	] },
+
+	{ value: 'a8c.5', label: translate( 'Education & Organizations' ), icon: 'clipboard', stepTwo: [
+		{ value: 'a8c.5', label: translate( 'General Education & Organizations' ) },
+		{ value: 'a8c.3.0.6', label: translate( 'Communities & Associations' ) },
+		{ value: 'a8c.3.0.5', label: translate( 'Non-Profit' ) },
+		{ value: 'a8c.23', label: translate( 'Religion & Spirituality' ) },
+		{ value: 'a8c.5.14', label: translate( 'Special Education' ) },
+		{ value: 'a8c.5.1', label: translate( 'High School Education' ) },
+		{ value: 'a8c.5.5', label: translate( 'College Education' ) },
+		{ value: 'a8c.5.10', label: translate( 'Homeschooling' ) },
+	] },
+
+	{ value: 'a8c.7', label: translate( 'Health & Wellness' ), icon: 'heart', stepTwo: [
+		{ value: 'a8c.7', label: translate( 'General Health & Wellness' ) },
+		{ value: 'a8c.7.18', label: translate( 'Depression' ) },
+		{ value: 'a8c.7.42', label: translate( 'Substance Abuse' ) },
+		{ value: 'a8c.7.1.1', label: translate( 'Exercise / Weight Loss' ) },
+		{ value: 'a8c.7.31', label: translate( 'Men\'s Health' ) },
+		{ value: 'a8c.7.45', label: translate( 'Women\'s Health' ) },
+		{ value: 'a8c.7.37', label: translate( 'Psychology/Psychiatry' ) },
+		{ value: 'a8c.7.32', label: translate( 'Nutrition' ) },
+	] },
+
+	{ value: 'a8c.1.1', label: translate( 'Writing & Books' ), icon: 'create', stepTwo: [
+		{ value: 'a8c.1.1', label: translate( 'General Writing & Books' ) },
+		{ value: 'a8c.1.1.1', label: translate( 'Book Reviews & Clubs' ) },
+		{ value: 'a8c.1.4', label: translate( 'Humor' ) },
+		{ value: 'a8c.1.1.2', label: translate( 'Fiction & Poetry' ) },
+		{ value: 'a8c.1.1.3', label: translate( 'Author Site' ) },
+		{ value: 'a8c.9.28', label: translate( 'Screenwriting' ) },
+		{ value: 'a8c.1.1.4', label: translate( 'Non-fiction & Memoir' ) },
+	] },
+];
+
+export default {
+	get() {
+		return verticals;
+	}
+}


### PR DESCRIPTION
Adds a survey step to the beginning of the signup flow when the user visits the URLs `http://calypso.localhost:3000/start/vert-blog` or `http://calypso.localhost:3000/start/vert-site`. Both URLs provide an identical flow but record slightly different data (`blog` or `site`, respectively).

The survey asks the user to categorize the new site and has two levels of taxonomy for this purpose. (The taxonomy is based on [IAB taxonomy](http://www.iab.com/guidelines/iab-quality-assurance-guidelines-qag-taxonomy/) but modified for use here.)

<img width="558" alt="screen shot 2015-11-24 at 5 17 06 pm" src="https://cloud.githubusercontent.com/assets/2036909/11382333/3ba18b94-92cf-11e5-99a4-0cc8468d49b7.png">
<img width="408" alt="screen shot 2015-11-24 at 12 19 58 pm" src="https://cloud.githubusercontent.com/assets/2036909/11374776/cc56577a-92a5-11e5-9145-73af9dc45cf0.png">

The survey records its data in Tracks as taxonomy ID and english name (although the taxonomy labels themselves are passed through `translate`). The survey has no effect on the rest of the signup flow or the resulting site, at least for now. The goal is to gather data for use in improving theme selection.

The AB Test itself will be added in a separate PR.

## Testing

1. Visit the two URLs above. 
2. Try clicking different categories and back to be sure they all lead from the correct parent to a list of child categories, and that the `back` button works correctly.
3. Choose any category and complete the sign-up flow. Be sure the site gets created properly.