### PR TITLE
People: Removes use of mock data in logged in accept

### DIFF
--- a/client/accept-invite/logged-in-accept/index.jsx
+++ b/client/accept-invite/logged-in-accept/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,35 +17,12 @@ import InviteFormHeader from '../invite-form-header';
 
 const user = userModule();
 
-const mockData = {
-	invite: {
-		invite_slug: 'asdf2345',
-		blog_id: 1234,
-		user_id: 1234,
-		invited_id: 5678,
-		signed_up: '0000-00-00 00:00:00',
-		invite_date: '2015-11-03 16:45:37',
-		meta: {
-			role: 'editor'
-		}
-	},
-	blog_details: {
-		domain: 'example.com',
-		title: 'Example WordPress website',
-		icon: {
-			img: 'https://secure.gravatar.com/blavatar',
-			ico: 'https://secure.gravatar.com/blavatar'
-		}
-	}
-};
-
 export default React.createClass( {
 
 	displayName: 'LoggedInAccept',
 
 	getInviteRole() {
-		let meta = mockData.invite && mockData.invite.meta ? mockData.invite.meta : false;
-		return meta && meta.role ? meta.role : false;
+		return get( this.props, 'invite.meta.role', '' );
 	},
 
 	render() {
@@ -58,11 +36,11 @@ export default React.createClass( {
 						title={
 							this.translate( 'Would you like to become an %(siteRole)s on {{siteNameLink}}%(siteName)s{{/siteNameLink}}?', {
 								args: {
-									siteName: mockData.blog_details.title,
+									siteName: get( this.props, 'blog_details.title', '' ),
 									siteRole: this.getInviteRole()
 								},
 								components: {
-									siteNameLink: <a href={ mockData.blog_details.domain } className="logged-in-accept__site-name" />
+									siteNameLink: <a href={ get( this.props, 'blog_details.domain', null ) } className="logged-in-accept__site-name" />
 								}
 							} )
 						}


### PR DESCRIPTION
Now that we are validating invitations before sending the invitation to the logged in/out accept flows, we should get rid of the mock data.

This PR removes the mock data from the `logged-in-accept` component and uses the invite data from the API.

To test:
- Checkout `update/people-remove-mock-data`
- On a WordPress.com site, create an invitation
- Make note of the site that you created the invite for and the invite key
- Go to `/accept-invite/$site/$invite_key`
- Does the information populate correctly?

cc @roccotripaldi for review
