### PR TITLE
People: Ensures form header strings are translated properly

### DIFF
--- a/client/accept-invite/invite-form-header/index.jsx
+++ b/client/accept-invite/invite-form-header/index.jsx
@@ -218,7 +218,7 @@ export default React.createClass( {
 				break;
 			case 'contributor':
 				explanation = this.translate(
-					'As a contributor, you will be able to write and manage your own posts, but you will not be able to publish on your own.'
+					'As a contributor, you will be able to write and manage your own posts, but you will not be able to publish.'
 				);
 				break;
 			case 'subscriber':

--- a/client/accept-invite/invite-form-header/index.jsx
+++ b/client/accept-invite/invite-form-header/index.jsx
@@ -29,94 +29,87 @@ export default React.createClass( {
 		return get( this.props, 'blog_details.domain' );
 	},
 
+	getSiteLink() {
+		const siteName = this.getSiteName();
+		const siteDomain = this.getSiteDomain();
+
+		if ( ! siteName || ! siteDomain ) {
+			return null;
+		}
+
+		return (
+			<a href={ siteDomain } className="invite-header__site-link">
+				{ siteName }
+			</a>
+		);
+	},
+
 	getLoggedOutTitleForInvite() {
 		let title = '';
-		let siteLink = (
-			<a href={ this.getSiteDomain() } className="invite-header__site-link" />
-		);
 
 		switch ( this.getRole() ) {
 			case 'administrator':
 				title = this.translate(
-					'Sign up to become an administrator of {{siteLink}}%(siteName)s{{/siteLink}}.', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Sign up to become an administrator of {{siteLink/}}.', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			case 'editor':
 				title = this.translate(
-					'Sign up to become an editor of {{siteLink}}%(siteName)s{{/siteLink}}.', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Sign up to become an editor of {{siteLink/}}.', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			case 'author':
 				title = this.translate(
-					'Sign up to become an author of {{siteLink}}%(siteName)s{{/siteLink}}.', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Sign up to become an author of {{siteLink/}}.', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			case 'contributor':
 				title = this.translate(
-					'Sign up to become a contributor to {{siteLink}}%(siteName)s{{/siteLink}}.', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Sign up to become a contributor to {{siteLink/}}.', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			case 'subscriber':
 				title = this.translate(
-					'Sign up to become a subscriber of {{siteLink}}%(siteName)s{{/siteLink}}.', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Sign up to become a subscriber of {{siteLink/}}.', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			case 'follower':
 				title = this.translate(
-					'Sign up to become a follower of {{siteLink}}%(siteName)s{{/siteLink}}.', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Sign up to become a follower of {{siteLink/}}.', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			default:
 				title = this.translate(
-					'Sign up to join {{siteLink}}%(siteName)s{{/siteLink}} with a role of: {{strong}}%(siteRole)s{{/strong}}.', {
+					'Sign up to join {{siteLink/}} with a role of: {{strong}}%(siteRole)s{{/strong}}.', {
 						args: {
-							siteName: this.getSiteName(),
 							siteRole: this.getRole()
 						},
 						components: {
-							siteLink: siteLink,
+							siteLink: this.getSiteLink(),
 							strong: <strong />
 						}
 					}
@@ -128,91 +121,70 @@ export default React.createClass( {
 
 	getLoggedInTitleForInvite() {
 		let title = '';
-		let siteLink = (
-			<a href={ this.getSiteDomain() } className="invite-header__site-link" />
-		);
 
 		switch ( this.getRole() ) {
 			case 'administrator':
 				title = this.translate(
-					'Would you like to become an administrator of {{siteLink}}%(siteName)s{{/siteLink}}?', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Would you like to become an administrator of {{siteLink/}}?', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			case 'editor':
 				title = this.translate(
-					'Would you like to become an editor of {{siteLink}}%(siteName)s{{/siteLink}}?', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Would you like to become an editor of {{siteLink/}}?', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			case 'author':
 				title = this.translate(
-					'Would you like to become an author of {{siteLink}}%(siteName)s{{/siteLink}}?', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Would you like to become an author of {{siteLink/}}?', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			case 'contributor':
 				title = this.translate(
-					'Would you like to become a contributor to {{siteLink}}%(siteName)s{{/siteLink}}?', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Would you like to become a contributor to {{siteLink/}}?', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			case 'subscriber':
 				title = this.translate(
-					'Would you like to become a subscriber of {{siteLink}}%(siteName)s{{/siteLink}}?', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Would you like to become a subscriber of {{siteLink/}}?', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			case 'follower':
 				title = this.translate(
-					'Would you like to become a follower of {{siteLink}}%(siteName)s{{/siteLink}}?', {
-						args: {
-							siteName: this.getSiteName()
-						},
+					'Would you like to become a follower of {{siteLink/}}?', {
 						components: {
-							siteLink: siteLink
+							siteLink: this.getSiteLink()
 						}
 					}
 				);
 				break;
 			default:
 				title = this.translate(
-					'Would you like to join {{siteLink}}%(siteName)s{{/siteLink}} with a role of: {{strong}}%(siteRole)s{{/strong}}?', {
+					'Would you like to join {{siteLink/}} with a role of: {{strong}}%(siteRole)s{{/strong}}?', {
 						args: {
 							siteRole: this.getRole()
 						},
 						components: {
-							siteLink: siteLink,
+							siteLink: this.getSiteLink(),
 							strong: <strong />
 						}
 					}

--- a/client/accept-invite/invite-form-header/index.jsx
+++ b/client/accept-invite/invite-form-header/index.jsx
@@ -1,20 +1,287 @@
 /**
  * External dependencies
  */
-import React from 'react'
+import React from 'react';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import userModule from 'lib/user';
+
+/**
+ * Module variables
+ */
+const user = userModule();
 
 export default React.createClass( {
 	displayName: 'InviteFormHeader',
 
+	getRole() {
+		return get( this.props, 'invite.meta.role' );
+	},
+
+	getSiteName() {
+		return get( this.props, 'blog_details.title' );
+	},
+
+	getSiteDomain() {
+		return get( this.props, 'blog_details.domain' );
+	},
+
+	getLoggedOutTitleForInvite() {
+		let title = '';
+		let siteLink = (
+			<a href={ this.getSiteDomain() } className="invite-header__site-link" />
+		);
+
+		switch ( this.getRole() ) {
+			case 'administrator':
+				title = this.translate(
+					'Sign up to become an administrator of {{siteLink}}%(siteName)s{{/siteLink}}.', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			case 'editor':
+				title = this.translate(
+					'Sign up to become an editor of {{siteLink}}%(siteName)s{{/siteLink}}.', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			case 'author':
+				title = this.translate(
+					'Sign up to become an author of {{siteLink}}%(siteName)s{{/siteLink}}.', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			case 'contributor':
+				title = this.translate(
+					'Sign up to become a contributor to {{siteLink}}%(siteName)s{{/siteLink}}.', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			case 'subscriber':
+				title = this.translate(
+					'Sign up to become a subscriber of {{siteLink}}%(siteName)s{{/siteLink}}.', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			case 'follower':
+				title = this.translate(
+					'Sign up to become a follower of {{siteLink}}%(siteName)s{{/siteLink}}.', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			default:
+				title = this.translate(
+					'Sign up to join {{siteLink}}%(siteName)s{{/siteLink}} with a role of: {{strong}}%(siteRole)s{{/strong}}.', {
+						args: {
+							siteName: this.getSiteName(),
+							siteRole: this.getRole()
+						},
+						components: {
+							siteLink: siteLink,
+							strong: <strong />
+						}
+					}
+				);
+		}
+
+		return title;
+	},
+
+	getLoggedInTitleForInvite() {
+		let title = '';
+		let siteLink = (
+			<a href={ this.getSiteDomain() } className="invite-header__site-link" />
+		);
+
+		switch ( this.getRole() ) {
+			case 'administrator':
+				title = this.translate(
+					'Would you like to become an administrator of {{siteLink}}%(siteName)s{{/siteLink}}?', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			case 'editor':
+				title = this.translate(
+					'Would you like to become an editor of {{siteLink}}%(siteName)s{{/siteLink}}?', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			case 'author':
+				title = this.translate(
+					'Would you like to become an author of {{siteLink}}%(siteName)s{{/siteLink}}?', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			case 'contributor':
+				title = this.translate(
+					'Would you like to become a contributor to {{siteLink}}%(siteName)s{{/siteLink}}?', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			case 'subscriber':
+				title = this.translate(
+					'Would you like to become a subscriber of {{siteLink}}%(siteName)s{{/siteLink}}?', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			case 'follower':
+				title = this.translate(
+					'Would you like to become a follower of {{siteLink}}%(siteName)s{{/siteLink}}?', {
+						args: {
+							siteName: this.getSiteName()
+						},
+						components: {
+							siteLink: siteLink
+						}
+					}
+				);
+				break;
+			default:
+				title = this.translate(
+					'Would you like to join {{siteLink}}%(siteName)s{{/siteLink}} with a role of: {{strong}}%(siteRole)s{{/strong}}?', {
+						args: {
+							siteRole: this.getRole()
+						},
+						components: {
+							siteLink: siteLink,
+							strong: <strong />
+						}
+					}
+				);
+		}
+
+		return title;
+	},
+
+	getExplanationForInvite() {
+		let explanation = '';
+		switch ( this.getRole() ) {
+			case 'administrator':
+				explanation = this.translate(
+					'As an administrator, you will be able to manage all aspects of %(siteName)s.', {
+						args: {
+							siteName: this.getSiteName()
+						}
+					}
+				);
+				break;
+			case 'editor':
+				explanation = this.translate(
+					'As an editor, you will be able to publish and manage your own posts and the posts of others, as well as upload media.'
+				);
+				break;
+			case 'author':
+				explanation = this.translate(
+					'As an author, you will be able to publish and edit your own posts as well as upload media.'
+				);
+				break;
+			case 'contributor':
+				explanation = this.translate(
+					'As a contributor, you will be able to write and manage your own posts, but you will not be able to publish on your own.'
+				);
+				break;
+			case 'subscriber':
+				explanation = this.translate(
+					'As a subscriber, you will be able to manage your profile on %(siteName)s', {
+						args: {
+							siteName: this.getSiteName()
+						}
+					}
+				);
+				break;
+			case 'follower':
+				explanation = this.translate(
+					'As a follower, you will receive updates every time there is a new post on %(siteName)s', {
+						args: {
+							siteName: this.getSiteName()
+						}
+					}
+				);
+				break
+		}
+
+		return explanation;
+	},
+
 	render() {
+		let roleExplanation = this.getExplanationForInvite();
 		return (
 			<div className="invite-form-header">
 				<h3 className="invite-form-header__title">
-					{ this.props.title }
+					{ user.get() ? this.getLoggedInTitleForInvite() : this.getLoggedOutTitleForInvite() }
 				</h3>
-				{ this.props.explanation &&
+				{ roleExplanation &&
 					<p className="invite-form-header__explanation">
-						{ this.props.explanation }
+						{ roleExplanation }
 					</p>
 				}
 			</div>

--- a/client/accept-invite/logged-in-accept/index.jsx
+++ b/client/accept-invite/logged-in-accept/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,10 +20,6 @@ export default React.createClass( {
 
 	displayName: 'LoggedInAccept',
 
-	getInviteRole() {
-		return get( this.props, 'invite.meta.role', '' );
-	},
-
 	render() {
 		let userObject = user.get(),
 			signInLink = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
@@ -32,28 +27,7 @@ export default React.createClass( {
 		return (
 			<div className={ classNames( 'logged-in-accept', this.props.className ) } >
 				<Card>
-					<InviteFormHeader
-						title={
-							this.translate( 'Would you like to become an %(siteRole)s on {{siteNameLink}}%(siteName)s{{/siteNameLink}}?', {
-								args: {
-									siteName: get( this.props, 'blog_details.title', '' ),
-									siteRole: this.getInviteRole()
-								},
-								components: {
-									siteNameLink: <a href={ get( this.props, 'blog_details.domain', null ) } className="logged-in-accept__site-name" />
-								}
-							} )
-						}
-						explanation={
-							this.translate(
-								'As an %(siteRole)s you will be able to publish and edit your own posts as well as upload media.', {
-									args: {
-										siteRole: this.getInviteRole()
-									}
-								}
-							)
-						}
-					/>
+					<InviteFormHeader { ...this.props } />
 					<div className="logged-in-accept__join-as">
 						<Gravatar user={ userObject } size={ 72 } />
 						{

--- a/client/accept-invite/logged-out-invite/signup-form.jsx
+++ b/client/accept-invite/logged-out-invite/signup-form.jsx
@@ -45,28 +45,7 @@ export default React.createClass( {
 
 	getFormHeader() {
 		return (
-			<InviteFormHeader
-				title={
-					this.translate( 'Sign up to become an %(siteRole)s on {{siteNameLink}}%(siteName)s{{/siteNameLink}}?', {
-						args: {
-							siteName: this.props.blog_details.title,
-							siteRole: get( this.props, 'invite.meta.role' )
-						},
-						components: {
-							siteNameLink: <a href={ this.props.blog_details.domain } className="logged-in-accept__site-name" />
-						}
-					} )
-				}
-				explanation={
-					this.translate(
-						'As an %(siteRole)s you will be able to publish and edit your own posts as well as upload media.', {
-							args: {
-								siteRole: get( this.props, 'invite.meta.role' )
-							}
-						}
-					)
-				}
-			/>
+			<InviteFormHeader { ...this.props } />
 		);
 	},
 


### PR DESCRIPTION
Addresses part of #138

Previously, the form header title and description were incorrect for a role. The title did not take into account the user of `a` or `an` and the explanation was the same for every role.

This PR changes that.

Currently, it is quite verbose, so ping @deBhal for advice on trimming it down a bit.

To test:
- Checkout `update/invite-translations` branch
- Invite a test user to join a WordPress.com site by going to `Users > Invite New` in `wp-admin`
- In the invitation email, make note of the invitation key
- Go to `/accept-invite/$site/$invite_key` when you are both logged in and out
- Do the strings change between logged in and logged out?
- Now, go back to the invite users UI in `wp-admin`
- Invite the same user, but with a different role this time
- Refresh the tab that has Calypso loaded
- Do the strings represent the new role?

cc @lezama for an early review