### PR TITLE
Plugins: Fix Plugin Banner to be more responsive and work better on desktop

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -32,7 +32,6 @@ module.exports = React.createClass( {
 	displayBanner: function() {
 		if ( this.props.plugin.banners && ( this.props.plugin.banners.high || this.props.plugin.banners.low ) ) {
 			return <div className="plugin-meta__banner">
-						<div className="plugin-meta__banner-background"></div>
 						<img className="plugin-meta__banner-image" src={ this.props.plugin.banners.high || this.props.plugin.banners.low }/>
 					</div>;
 		}
@@ -69,9 +68,9 @@ module.exports = React.createClass( {
 
 	renderSettingsLink: function() {
 		if ( ! this.props.plugin ||
-			! this.props.plugin.wp_admin_settings_page_url ||
-			! this.props.plugin.active ||
-			! this.props.selectedSite ) {
+				! this.props.plugin.wp_admin_settings_page_url ||
+				! this.props.plugin.active ||
+				! this.props.selectedSite ) {
 			return;
 		}
 

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -1,30 +1,28 @@
+
 .plugin-meta__banner {
-	margin-bottom: 0;
-}
-
-.plugin-meta__banner-background {
 	position: relative;
-	top: -24px;
-	left: -24px;
-	display: inline-block;
-	width: calc(100% + 46px);
-
-	@include breakpoint( "<480px" ) {
-		top: -16px;
+		top: 0;
 		left: -16px;
-		max-width: calc(100% + 32px);
+	width: calc( 100% + 32px );
+	overflow: hidden;
+	margin-top: -16px;
+	margin-bottom: 16px;
+	box-shadow: inset 0 0 2px 2px rgba( lighten( $gray, 10 ), 0.1 );
+	background: rgba( lighten( $gray, 30 ), 0.3 );
+
+	@include breakpoint( ">480px" ) {
+		left: -24px;
+		width: calc( 100% + 48px );
+		margin-top: -24px;
+		margin-bottom: 24px;
 	}
-}
 
-.plugin-meta__banner-background {
-	padding-bottom: 34.8%;
-	background: lighten( $gray, 20 );
-}
-
-.plugin-meta__banner-image {
-	position: absolute;
-	top: 0;
-	left: 0;
+	img {
+		display: block;
+		width: auto;
+		max-height: 70vh;
+		margin: 0 auto;
+	}
 }
 
 .plugin-meta__information {


### PR DESCRIPTION
This implementation is based on the code by the Reader since it seems to work really well there. 

This is how it looks like if there is no banner
![screen shot 2015-11-17 at 4 46 17 pm](https://cloud.githubusercontent.com/assets/115071/11229523/02799610-8d4b-11e5-8367-2ff6e2bd8259.png)

When there is a banner ( Should be the same as now )
![screen shot 2015-11-17 at 4 46 32 pm](https://cloud.githubusercontent.com/assets/115071/11229521/02777592-8d4b-11e5-874e-e79751e6d226.png)

If the width of the main div is larger then the size of the image. 
![screen shot 2015-11-17 at 4 46 51 pm](https://cloud.githubusercontent.com/assets/115071/11229522/0278ebfc-8d4b-11e5-9c2e-9c8349181ef5.png)

To test go to a single plugins in calypso.Check that the banner looks as expected.

cc: @MichaelArestad