### PR TITLE
Framework: Create new <SitesDropdown> component.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -61,6 +61,7 @@
 @import 'components/site-icon/style';
 @import 'components/site-selector/style';
 @import 'components/site-selector-modal/style';
+@import 'components/sites-dropdown/style';
 @import 'components/sites-popover/style';
 @import 'components/spinner/style';
 @import 'components/stat-update-indicator/style';

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -289,16 +289,11 @@ $sidebar-width-min: 228px;
 }
 
 .wpcom-sidebar,
-.site-selector,
+.wp-secondary .site-selector,
 .current-site,
 .sidebar-menu {
 	transform: translateX( 0 );
 	transition: all 0.15s cubic-bezier(0.075, 0.820, 0.165, 1.000);
-}
-
-.site-selector {
-	opacity: 0;
-	pointer-events: none;
 }
 
 .focus-sites {
@@ -307,7 +302,7 @@ $sidebar-width-min: 228px;
 		pointer-events: none;
 	}
 
-	.site-selector {
+	.wp-secondary .site-selector {
 		opacity: 1;
 		transform: translateX( 272px );
 		pointer-events: auto;

--- a/assets/stylesheets/layout/_sidebar.scss
+++ b/assets/stylesheets/layout/_sidebar.scss
@@ -284,3 +284,22 @@
 		color: $blue-medium;
 	}
 }
+
+// site selector in the sidebar
+.wp-secondary .site-selector {
+	background: lighten( $gray, 30% );
+	border-right: 1px solid lighten( $gray, 25% );
+	position: fixed;
+		top: 47px;
+		bottom: 0;
+		left: -272px;
+	width: 272px;
+	overflow: hidden;
+	z-index: 10;
+	opacity: 0;
+	pointer-events: none;
+
+	.search {
+		border-bottom: 1px solid lighten( $gray, 20% );
+	}
+}

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -157,7 +157,7 @@ module.exports = React.createClass( {
 
 		if ( this.props.showAllSites && ! this.state.search && allSitesPath ) {
 			// default posts links to /posts/my when possible and /posts when not
-			postsBase = ( this.props.sites.allSingleSites ) ? '/posts' : '/posts/my';
+			const postsBase = ( this.props.sites.allSingleSites ) ? '/posts' : '/posts/my';
 			allSitesPath = allSitesPath.replace( /^\/posts\b(\/my)?/, postsBase );
 
 			// There is currently no "all sites" version of the insights page

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -38,7 +38,8 @@ module.exports = React.createClass( {
 			indicator: false,
 			hideSelected: false,
 			selected: null,
-			onClose: noop
+			onClose: noop,
+			onSiteSelect: noop
 		};
 	},
 
@@ -127,6 +128,8 @@ module.exports = React.createClass( {
 		if ( siteBasePath.match( /^\/domains\/manage\// ) ) {
 			siteBasePath = '/domains/manage';
 		}
+
+		return siteBasePath;
 	},
 
 	isSelected: function( site ) {

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -25,7 +25,9 @@ module.exports = React.createClass( {
 		showAllSites: React.PropTypes.bool,
 		indicator: React.PropTypes.bool,
 		autoFocus: React.PropTypes.bool,
-		onClose: React.PropTypes.func
+		onClose: React.PropTypes.func,
+		selected: React.PropTypes.string,
+		hideSelected: React.PropTypes.bool
 	},
 
 	getDefaultProps: function() {
@@ -34,6 +36,8 @@ module.exports = React.createClass( {
 			showAllSites: false,
 			siteBasePath: false,
 			indicator: false,
+			hideSelected: false,
+			selected: null,
 			onClose: noop
 		};
 	},
@@ -125,6 +129,10 @@ module.exports = React.createClass( {
 		}
 	},
 
+	isSelected: function( site ) {
+		return this.props.sites.selected === site.domain || this.props.selected === site.slug;
+	},
+
 	renderSiteElements: function() {
 		var allSitesPath = this.props.allSitesPath,
 			sites, siteElements;
@@ -143,6 +151,12 @@ module.exports = React.createClass( {
 				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
 			}
 
+			const isSelected = this.isSelected( site );
+
+			if ( isSelected && this.props.hideSelected ) {
+				return;
+			}
+
 			return (
 				<Site
 					site={ site }
@@ -150,7 +164,7 @@ module.exports = React.createClass( {
 					key={ 'site-' + site.ID }
 					indicator={ this.props.indicator }
 					onSelect={ this.onSiteSelect.bind( this, site.slug ) }
-					isSelected={ this.props.sites.selected === site.domain }
+					isSelected={ isSelected }
 				/>
 			);
 		}, this );

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -3,14 +3,10 @@
  * @component `selector`
  */
 .site-selector {
-	background: lighten( $gray, 30% );
-	border-right: 1px solid lighten( $gray, 25% );
-	position: fixed;
-		top: 47px;
-		bottom: 0;
-		left: -272px;
-	width: 272px;
-	overflow: hidden;
+	overflow: visible;
+	position: static;
+	pointer-events: auto;
+	border: none;
 	z-index: z-index( 'root', '.site-selector' );
 
 	&.is-large .search  {
@@ -83,7 +79,7 @@
 	width: auto;
 	height: auto;
 	padding: 8px;
-	border-bottom: 1px solid lighten( $gray, 20% );
+	border-bottom: 1px solid lighten( $gray, 30% );
 
 	.search__input[type="search"] {
 		position: relative;

--- a/client/components/sites-dropdown/README.md
+++ b/client/components/sites-dropdown/README.md
@@ -1,0 +1,18 @@
+Sites Dropdown
+==============
+
+Renders a dropdown component for selecting a site. This is the canonical site picker component for using whenever you need to offer users a site selection flow.
+
+It support searching if you have many sites, handles sites with empty titles, sites with redirects, etc.
+
+#### How to use:
+
+```js
+import SitesDropdown 'components/sites-dropdown';
+
+render() {
+	return (
+		<SitesDropdown />
+	);
+}
+```

--- a/client/components/sites-dropdown/docs/example.jsx
+++ b/client/components/sites-dropdown/docs/example.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SitesDropdown from 'components/sites-dropdown';
+
+export default React.createClass( {
+
+	displayName: 'SitesDropdownExample',
+
+	render: function() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/design/sites-dropdown">SitesDropdown</a>
+				</h2>
+				<SitesDropdown />
+			</div>
+		);
+	}
+} );

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -42,13 +42,21 @@ export default React.createClass( {
 
 	getInitialState() {
 		return {
-			search: ''
+			search: '',
+			selected: this.props.selected
 		};
 	},
 
-	getDefaultSite() {
-		return this.props.selected ? sites.getSite( this.props.selected ) : sites.getPrimary();
+	getSelectedSite() {
+		return sites.getSite( this.state.selected ) || sites.getPrimary();
 	},
+
+	selectSite( siteSlug ) {
+		this.setState( {
+			selected: siteSlug,
+			open: false
+		} );
+ 	},
 
 	render() {
 		return (
@@ -58,17 +66,17 @@ export default React.createClass( {
 					onClick={ () => this.setState( { open: ! this.state.open } ) }
 				>
 					<Site
-						site={ this.getDefaultSite() }
+						site={ this.getSelectedSite() }
 					/>
 					<Gridicon icon={ this.state.open ? 'chevron-up' : 'chevron-down' } />
 				</div>
 				{ this.state.open &&
 					<SiteSelector
 						sites={ sites }
-						siteBasePath="/post"
 						indicator={ false }
 						autoFocus={ true }
 						onClose={ this.props.onClose }
+						onSiteSelect={ this.selectSite }
 					/>
 				}
 			</div>

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+import noop from 'lodash/utility/noop';
+
+/**
+ * Internal dependencies
+ */
+import Site from 'my-sites/site';
+import SiteSelector from 'components/site-selector';
+import sitesList from 'lib/sites-list';
+import Gridicon from 'components/gridicon';
+
+const sites = sitesList();
+
+export default React.createClass( {
+
+	displayName: 'SitesDropdown',
+
+	mixins: [ React.addons.PureRenderMixin ],
+
+	propTypes: {
+		selected: React.PropTypes.oneOfType( [
+			React.PropTypes.number,
+			React.PropTypes.string
+		] ),
+		showAllSites: React.PropTypes.bool,
+		indicator: React.PropTypes.bool,
+		autoFocus: React.PropTypes.bool,
+		onClose: React.PropTypes.func
+	},
+
+	getDefaultProps() {
+		return {
+			showAllSites: false,
+			indicator: false,
+			onClose: noop
+		};
+	},
+
+	getInitialState() {
+		return {
+			search: ''
+		};
+	},
+
+	getDefaultSite() {
+		return this.props.selected ? sites.getSite( this.props.selected ) : sites.getPrimary();
+	},
+
+	render() {
+		return (
+			<div className={ classNames( 'sites-dropdown', { 'is-open': this.state.open } ) }>
+				<div
+					className="sites-dropdown__selected"
+					onClick={ () => this.setState( { open: ! this.state.open } ) }
+				>
+					<Site
+						site={ this.getDefaultSite() }
+					/>
+					<Gridicon icon={ this.state.open ? 'chevron-up' : 'chevron-down' } />
+				</div>
+				{ this.state.open &&
+					<SiteSelector
+						sites={ sites }
+						siteBasePath="/post"
+						indicator={ false }
+						autoFocus={ true }
+						onClose={ this.props.onClose }
+					/>
+				}
+			</div>
+		);
+	}
+} );

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -43,7 +43,7 @@ export default React.createClass( {
 	getInitialState() {
 		return {
 			search: '',
-			selected: this.props.selected
+			selected: this.props.selected || sites.getPrimary().slug
 		};
 	},
 
@@ -56,7 +56,7 @@ export default React.createClass( {
 			selected: siteSlug,
 			open: false
 		} );
- 	},
+	},
 
 	render() {
 		return (
@@ -73,10 +73,11 @@ export default React.createClass( {
 				{ this.state.open &&
 					<SiteSelector
 						sites={ sites }
-						indicator={ false }
 						autoFocus={ true }
 						onClose={ this.props.onClose }
 						onSiteSelect={ this.selectSite }
+						selected={ this.state.selected }
+						hideSelected={ true }
 					/>
 				}
 			</div>

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -29,14 +29,16 @@ export default React.createClass( {
 		showAllSites: React.PropTypes.bool,
 		indicator: React.PropTypes.bool,
 		autoFocus: React.PropTypes.bool,
-		onClose: React.PropTypes.func
+		onClose: React.PropTypes.func,
+		onSiteSelect: React.PropTypes.func
 	},
 
 	getDefaultProps() {
 		return {
 			showAllSites: false,
 			indicator: false,
-			onClose: noop
+			onClose: noop,
+			onSiteSelect: noop
 		};
 	},
 
@@ -48,10 +50,11 @@ export default React.createClass( {
 	},
 
 	getSelectedSite() {
-		return sites.getSite( this.state.selected ) || sites.getPrimary();
+		return sites.getSite( this.state.selected );
 	},
 
 	selectSite( siteSlug ) {
+		this.props.onSiteSelect( siteSlug );
 		this.setState( {
 			selected: siteSlug,
 			open: false

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -61,25 +61,28 @@ export default React.createClass( {
 	render() {
 		return (
 			<div className={ classNames( 'sites-dropdown', { 'is-open': this.state.open } ) }>
-				<div
-					className="sites-dropdown__selected"
-					onClick={ () => this.setState( { open: ! this.state.open } ) }
-				>
-					<Site
-						site={ this.getSelectedSite() }
-					/>
-					<Gridicon icon={ this.state.open ? 'chevron-up' : 'chevron-down' } />
+				<div className="sites-dropdown__wrapper">
+					<div
+						className="sites-dropdown__selected"
+						onClick={ () => this.setState( { open: ! this.state.open } ) }
+					>
+						<Site
+							site={ this.getSelectedSite() }
+							indicator={ false }
+						/>
+						<Gridicon icon="chevron-down" />
+					</div>
+					{ this.state.open &&
+						<SiteSelector
+							sites={ sites }
+							autoFocus={ true }
+							onClose={ this.props.onClose }
+							onSiteSelect={ this.selectSite }
+							selected={ this.state.selected }
+							hideSelected={ true }
+						/>
+					}
 				</div>
-				{ this.state.open &&
-					<SiteSelector
-						sites={ sites }
-						autoFocus={ true }
-						onClose={ this.props.onClose }
-						onSiteSelect={ this.selectSite }
-						selected={ this.state.selected }
-						hideSelected={ true }
-					/>
-				}
 			</div>
 		);
 	}

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -32,25 +32,22 @@
 }
 
 .sites-dropdown .site-selector {
-	border-top: 1px solid lighten( $gray, 20% );
 	padding: 0;
 	position: static;
 	max-height: 30vh;
 	overflow-y: auto;
 
 	&.is-large {
-		margin-top: 64px;
-		border-top: 1px solid lighten( $gray, 30 );
+		margin-top: 50px;
 	}
 }
 
 .sites-dropdown .site-selector .search {
 	position: absolute;
-		top: 69px;
-		left: 16px;
-		right: 16px;
-	margin: 16px 0;
-	background-color: $white;
+		top: 67px;
+		left: 0;
+		right: 0;
+	margin: 0;
 }
 
 .sites-dropdown .site-selector .search input {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -70,6 +70,24 @@
 			}
 		}
 	}
+
+	// Highlight selected site
+	&.is-selected,
+	.notouch &.is-selected:hover {
+		background-color: $gray-light;
+
+		.site__title {
+			color: $gray-dark;
+		}
+
+		.site__domain {
+			color: $gray;
+		}
+
+		&.is-private .site__title::before {
+			color: $gray;
+		}
+	}
 }
 
 .sites-dropdown .site-selector .site:not(.is-selected) .site-icon__img {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -1,0 +1,81 @@
+.sites-dropdown {
+	background: $white;
+	border: 1px solid lighten( $gray, 20% );
+	border-width: 1px 1px 2px;
+	border-radius: 4px;
+	margin: 24px 0;
+	position: relative;
+	width: 300px;
+
+	.gridicons-chevron-down,
+	.gridicons-chevron-up {
+		color: lighten( $gray, 10% );
+		position: absolute;
+			right: 16px;
+			top: 24px;
+	}
+}
+
+.sites-dropdown__selected {
+	cursor: pointer;
+
+	.is-open & {
+		border-bottom: 1px solid lighten( $gray, 30% );
+	}
+
+	&:hover {
+		.gridicons-chevron-down,
+		.gridicons-chevron-up {
+			color: darken( $gray, 20% );
+		}
+	}
+}
+
+.sites-dropdown .site-selector {
+	border-top: 1px solid lighten( $gray, 20% );
+	padding: 0;
+	position: static;
+	max-height: 30vh;
+	overflow-y: auto;
+
+	&.is-large {
+		margin-top: 64px;
+		border-top: 1px solid lighten( $gray, 30 );
+	}
+}
+
+.sites-dropdown .site-selector .search {
+	position: absolute;
+		top: 69px;
+		left: 16px;
+		right: 16px;
+	margin: 16px 0;
+	background-color: $white;
+}
+
+.sites-dropdown .site-selector .search input {
+	margin: 0;
+	background-color: $white;
+}
+
+.sites-dropdown .site-selector .site {
+	.notouch & {
+		&:hover {
+			background: $blue-medium;
+
+			.site__title,
+			.site__domain {
+				color: white;
+			}
+
+			.site__title:before {
+				color: white;
+			}
+		}
+	}
+}
+
+.sites-dropdown .site-selector .site:not(.is-selected) .site-icon__img {
+	opacity: 1;
+	filter: none;
+}

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -1,19 +1,32 @@
 .sites-dropdown {
+	&.is-open {
+		height: 69px;
+		.gridicons-chevron-down {
+			transform: rotate( 180deg );
+		}
+	}
+
+	.gridicons-chevron-down {
+		color: lighten( $gray, 10% );
+		position: absolute;
+			right: 16px;
+			top: 22px;
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
+	}
+}
+
+.sites-dropdown__wrapper {
 	background: $white;
 	border: 1px solid lighten( $gray, 20% );
 	border-width: 1px 1px 2px;
 	border-radius: 4px;
-	margin: 24px 0;
+	margin: 0;
 	position: relative;
 	width: 300px;
+}
 
-	.gridicons-chevron-down,
-	.gridicons-chevron-up {
-		color: lighten( $gray, 10% );
-		position: absolute;
-			right: 16px;
-			top: 24px;
-	}
+.sites-dropdown.is-open .sites-dropdown__wrapper {
+	margin: 0;
 }
 
 .sites-dropdown__selected {

--- a/client/components/sites-popover/style.scss
+++ b/client/components/sites-popover/style.scss
@@ -14,16 +14,6 @@ $sites-popover-width: 300px;
 }
 
 .sites-popover .site-selector {
-	overflow: visible;
-	position: static;
-		top: auto;
-		left: auto;
-		bottom: auto;
-	width: auto;
-	opacity: 1;
-	pointer-events: auto;
-	border: none;
-	background: transparent;
 
 	&.is-large {
 		padding-top: 50px;

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -24,6 +24,7 @@ var SearchCard = require( 'components/search-card' ),
 	SegmentedControl = require( 'components/segmented-control/docs/example' ),
 	Cards = require( 'components/card/docs/example' ),
 	Sites = require( 'lib/sites-list/docs/example' ),
+	SitesDropdown = require( 'components/sites-dropdown/docs/example' ),
 	TokenFields = require( 'components/token-field/docs/example' ),
 	CountedTextareas = require( 'components/forms/counted-textarea/docs/example' ),
 	ProgressBar = require( 'components/progress-bar/docs/example' ),
@@ -190,6 +191,7 @@ module.exports = React.createClass( {
 					<SegmentedControl />
 					<Cards />
 					<Sites />
+					<SitesDropdown />
 					<TokenFields />
 					<CountedTextareas />
 					<ProgressBar />


### PR DESCRIPTION
This should replace all usages of "me/select-site" and standardize all site selection with our core picker patterns.

![ed0199c2-8a11-11e5-9e81-b9c2dc7fed68](https://cloud.githubusercontent.com/assets/548849/11318183/8409fa0e-9047-11e5-85ed-fc16ba0c4eac.png)

### To-do

- [x] Highlight selected site in list.
- [x] Handle `onSelect` actions.
- [x] Testing.