### PR TITLE
Framework: replace `wpcom-private` by `wpcom-unpublished`

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "walk": "2.3.4",
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom-private": "https://cldup.com/uCVC3inECmP/GHgpcP.tgz#3.6.0",
+    "wpcom-unpublished": "1.0.3",
     "wpcom-proxy-request": "1.0.4",
     "wpcom-xhr-request": "0.3.1",
     "xgettext-js": "0.2.0"

--- a/shared/lib/wpcom-undocumented/index.js
+++ b/shared/lib/wpcom-undocumented/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var WPCOM = require( 'wpcom-private' ),
+var WPCOM = require( 'wpcom-unpublished' ),
 	inherits = require( 'inherits' ),
 	assign = require( 'lodash/object/assign' ),
 	debug = require( 'debug' )( 'calypso:wpcom-undocumented' );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,7 +85,7 @@ webpackConfig = {
 if ( CALYPSO_ENV === 'desktop' || CALYPSO_ENV === 'desktop-mac-app-store' ) {
 	webpackConfig.output.filename = '[name].js';
 } else {
-	webpackConfig.entry.vendor = [ 'react', 'store', 'page', 'wpcom-private', 'jed', 'debug' ];
+	webpackConfig.entry.vendor = [ 'react', 'store', 'page', 'wpcom-unpublished', 'jed', 'debug' ];
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( 'vendor', '[name].[hash].js' ) );
 	webpackConfig.plugins.push( new ChunkFileNamePlugin() );
 }


### PR DESCRIPTION
We had to rollback this https://github.com/Automattic/wp-calypso/pull/305 because we were using Promises in `wpcom.js` and it isn't supported by IE.
So I've updated `wpcom-unpublished` bumping a previous version of wpcom.js to avoid Promises.

cc @rralian @aduth 
