### PR TITLE
Framework: Update Jade dependency to jadejs/jade#29784fd

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "immutable": "3.7.2",
     "imports-loader": "0.6.3",
     "inherits": "2.0.1",
-    "jade": "1.5.0",
+    "jade": "jadejs/jade#29784fd",
     "jed": "1.0.2",
     "json-loader": "0.5.1",
     "jstimezonedetect": "1.0.5",


### PR DESCRIPTION
To update nested dependencies on uglify to 2.6.1 which includes a
fix (mishoo/UglifyJS2@63d35f8) for https://nodesecurity.io/advisories/48.

To test:
- Restart Calypso, check that everything still works in the browser.

CC @rralian 
