### PR TITLE
Update `express` to 4.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "escape-string-regexp": "1.0.3",
     "events": "1.0.2",
     "exports-loader": "0.6.2",
-    "express": "4.12.3",
+    "express": "4.13.3",
     "flux": "2.1.1",
     "he": "0.5.0",
     "html-loader": "0.2.3",


### PR DESCRIPTION
To update `ms` down the dependency chain to 0.7.1, fixing
https://nodesecurity.io/advisories/46.

cc @mcsf 
