### PR TITLE
Update `component-tip` to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "commander": "2.3.0",
     "component-classes": "1.2.1",
     "component-closest": "0.1.4",
-    "component-tip": "2.3.0",
+    "component-tip": "2.5.0",
     "component-uid": "0.0.2",
     "cookie": "0.1.2",
     "cookie-parser": "1.3.2",


### PR DESCRIPTION
To update another `ms` down the dependency chain to 0.7.1,
fixing https://nodesecurity.io/advisories/46.
