### PR TITLE
Sticky panel: add event listener for resizing to update measurements.

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	throttle = require( 'lodash/function/throttle' ),
 	raf = require( 'raf' ),
 	classNames = require( 'classnames' );
 
@@ -25,15 +26,16 @@ module.exports = React.createClass( {
 		// Determine and cache vertical threshold from rendered element's
 		// offset relative the document
 		this.threshold = React.findDOMNode( this ).offsetTop;
+		this.throttleOnResize = throttle( this.onWindowResize, 200 );
 
 		window.addEventListener( 'scroll', this.onWindowScroll );
-		window.addEventListener( 'resize', this.onWindowResize );
+		window.addEventListener( 'resize', this.throttleOnResize );
 		this.updateIsSticky();
 	},
 
 	componentWillUnmount: function() {
 		window.removeEventListener( 'scroll', this.onWindowScroll );
-		window.removeEventListener( 'resize', this.onWindowResize );
+		window.removeEventListener( 'resize', this.throttleOnResize );
 		raf.cancel( this.rafHandle );
 	},
 


### PR DESCRIPTION
Also removes sticky state when mobile viewport is detected, otherwise components like EditorGroundControl could get stuck in an incorrect state. (Obscuring the UI.)
### Testing
- Scroll a bit on the editor window to trigger the sticky behaviour; resize window and see that the component always fits.
- Scroll a bit on the editor, now resize to the smallest window possible (to trigger `isMobile` checks), then scroll up in mobile view, then resize back to regular window size.

@jasmussen do you mind taking a look at this?
