### PR TITLE
Purchases: Fix Credit Card Info Alignment

### DIFF
--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -215,6 +215,12 @@
 	}
 }
 
-.manage-purchase__payment-info .payment-logo {
-	margin-right: 5px;
+.manage-purchase__payment-info {
+	@include breakpoint( "<660px" ) {
+		float: right;
+	}
+
+	.payment-logo {
+		margin-right: 5px;
+	}
 }


### PR DESCRIPTION
- Added a breakpoint in manage-purchase/style.scss to float info right on smaller than 660px

Small tweak for #200 

Tested on iPhone 6 portrait:

![iphonepor](https://cloud.githubusercontent.com/assets/7240478/11321108/345f097c-906f-11e5-8099-7913e073525e.png)

iPhone 6 landscape:

![iphoneland](https://cloud.githubusercontent.com/assets/7240478/11321110/3e57c63a-906f-11e5-8df1-b085e5f5f5bc.png)

320px wide (like original report):

![320](https://cloud.githubusercontent.com/assets/7240478/11321111/5266d616-906f-11e5-9e1d-8be9a2164bd6.png)

Confirmed it also looks fine for no payment info ("None") and PayPal.