### PR TITLE
Reader: turn on recommendations in production and horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -57,6 +57,7 @@
 		"reader/share": true,
 		"reader/following-edit": true,
 		"reader/discover": true,
+		"reader/recommendations": true,
 
 		"upgrades/checkout": true,
 		"upgrades/purchases/cancel": true,

--- a/config/production.json
+++ b/config/production.json
@@ -78,6 +78,7 @@
 		"reader/share": true,
 		"reader/following-edit": true,
 		"reader/discover": true,
+		"reader/recommendations": true,
 		"ad-tracking": true,
 		"mailing-lists/unsubscribe": true
 	},


### PR DESCRIPTION
Release the current recommendations as is.

This will require a corresponding update to atlas and routing rules.
