### PR TITLE
Reader: Switch to ExternalLink, add icon to timestamp on full post.

### DIFF
--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -17,6 +17,7 @@ var analytics = require( 'analytics' ),
 	CommentStore = require( 'lib/comment-store/comment-store' ),
 	Dialog = require( 'components/dialog' ),
 	DISPLAY_TYPES = require( 'lib/feed-post-store/display-types' ),
+	ExternalLink = require( 'components/external-link' ),
 	LikeButton = require( 'reader/like-button' ),
 	PostByline = require( 'reader/post-byline' ),
 	PostCommentHelper = require( 'reader/comments/helper' ),
@@ -161,9 +162,9 @@ FullPostView = React.createClass( {
 							<img src={ this.props.post.canonical_image.uri } height={ this.props.post.canonical_image.height } width={ this.props.post.canonical_image.width } />
 						</div> : null }
 
-					{ post.title ? <h1 className="reader__post-title" onClick={ this.handlePermalinkClick }><a className="reader__post-title-link" href={ post.URL } target="_blank">{ post.title }</a></h1> : null }
+					{ post.title ? <h1 className="reader__post-title" onClick={ this.handlePermalinkClick }><ExternalLink className="reader__post-title-link" href={ post.URL } target="_blank" icon={ false }>{ post.title }</ExternalLink></h1> : null }
 
-					<PostByline post={ post } site={ site } />
+					<PostByline post={ post } site={ site } icon={ true }/>
 
 					<div className="reader__full-post-content" dangerouslySetInnerHTML={{ __html: postContent }}></div>
 

--- a/client/reader/post-byline/_style.scss
+++ b/client/reader/post-byline/_style.scss
@@ -49,11 +49,14 @@
 }
 
 .reader-post-byline__tag .gridicon {
-		color: #C8D7E1;
+		color: lighten( $gray, 20% );
 		position: relative;
 			top: 4px;
 }
 
 .reader-post-byline__date-link .gridicon {
-	color: $gray;
+	color: inherit;
+	position: relative;
+	top: 2px;
+	margin-left: 2px;
 }

--- a/client/reader/post-byline/_style.scss
+++ b/client/reader/post-byline/_style.scss
@@ -53,3 +53,7 @@
 		position: relative;
 			top: 4px;
 }
+
+.reader-post-byline__date-link .gridicon {
+	color: $gray;
+}

--- a/client/reader/post-byline/index.jsx
+++ b/client/reader/post-byline/index.jsx
@@ -6,7 +6,8 @@ var React = require( 'react' );
 /**
  * Internal Dependencies
  */
-var Gravatar = require( 'components/gravatar' ),
+var ExternalLink = require( 'components/external-link' ),
+	Gravatar = require( 'components/gravatar' ),
 	Gridicon = require( 'components/gridicon' ),
 	PostTime = require( 'reader/post-time' ),
 	utils = require( 'reader/utils' ),
@@ -44,10 +45,10 @@ var PostByline = React.createClass( {
 		}
 
 		return (
-			<a href={ post.author.URL } target="_blank" onClick={ this.recordAuthorClick }>
+			<ExternalLink href={ post.author.URL } target="_blank" onClick={ this.recordAuthorClick }>
 				{ gravatar }
 				{ authorName }
-			</a>
+			</ExternalLink>
 		);
 	},
 
@@ -72,7 +73,8 @@ var PostByline = React.createClass( {
 					<a className="reader-post-byline__date-link"
 						onClick={ this.recordDateClick }
 						href={ post.URL }
-						target="_blank"><PostTime date={ post.date } /></a>
+						target="_blank"
+						icon={ true }><PostTime date={ post.date } />{ this.props.icon ? <Gridicon icon="external" size={ 14 } /> : null }</a>
 				</li> : null }
 			{ primaryTag ?
 				<li className="reader-post-byline__tag">

--- a/client/reader/post-byline/index.jsx
+++ b/client/reader/post-byline/index.jsx
@@ -73,8 +73,7 @@ var PostByline = React.createClass( {
 					<a className="reader-post-byline__date-link"
 						onClick={ this.recordDateClick }
 						href={ post.URL }
-						target="_blank"
-						icon={ true }><PostTime date={ post.date } />{ this.props.icon ? <Gridicon icon="external" size={ 14 } /> : null }</a>
+						target="_blank"><PostTime date={ post.date } />{ this.props.icon ? <Gridicon icon="external" size={ 14 } /> : null }</a>
 				</li> : null }
 			{ primaryTag ?
 				<li className="reader-post-byline__tag">

--- a/client/reader/post-permalink/index.jsx
+++ b/client/reader/post-permalink/index.jsx
@@ -4,7 +4,8 @@
 var React = require( 'react' );
 
 // Internal Dependencies
-var stats = require( 'reader/stats' );
+var ExternalLink = require( 'components/external-link' ),
+	stats = require( 'reader/stats' );
 
 var PostPermalink = React.createClass( {
 
@@ -25,9 +26,9 @@ var PostPermalink = React.createClass( {
 
 		return (
 			<li className="post-permalink" onClick={ this.recordClick }>
-				<a href={ this.props.postUrl } rel="external" target="_blank">
+				<ExternalLink href={ this.props.postUrl } rel="external" target="_blank">
 					{ this.translate( 'Visit', { comment: 'Visit the post on the original site' } ) }
-				</a>
+				</ExternalLink>
 			</li>
 		);
 	}


### PR DESCRIPTION
This patch switches a number of external links in the reader to use the ExternalLink component. In one case, it does not (the timestamp in PostByline) because the default ExternalLink forces an icon size of 18, which doesn't work in the 14px byline.

We could add a size param to ExternalLink, but this patch is simpler without it.

cc @johngodley 