### PR TITLE
Reader: Update the post time more frequently

### DIFF
--- a/client/lib/react-smart-set-state/index.js
+++ b/client/lib/react-smart-set-state/index.js
@@ -4,7 +4,7 @@
  */
 export default function smartSetState( newState ) {
 	const hasNewValues = Object.keys( newState ).some( function( key ) {
-		return ( ! this.state.hasOwnProperty( key ) || ( this.state[ key ] !== newState[ key ] ) );
+		return ( ! ( this.state && this.state.hasOwnProperty( key ) ) || ( this.state[ key ] !== newState[ key ] ) );
 	}, this );
 	if ( hasNewValues ) {
 		this.setState( newState );

--- a/client/lib/ticker/index.js
+++ b/client/lib/ticker/index.js
@@ -24,9 +24,11 @@ ticker._start = function() {
 		return;
 	}
 
+	debug( '%d listeners active', ticker.listeners( 'tick' ).length );
+
 	if ( ! ticker.interval ) {
 		debug( 'starting interval' );
-		ticker.interval = setInterval( ticker.tick, 60000 );
+		ticker.interval = setInterval( ticker.tick, 10000 );
 	}
 };
 

--- a/client/reader/post-time/index.jsx
+++ b/client/reader/post-time/index.jsx
@@ -1,5 +1,7 @@
 var debug = require( 'debug' )( 'calyso:reader:post-time' ),
-	React = require( 'react/addons' ),
+	React = require( 'react/addons' );
+
+const smartSetState = require( 'lib/react-smart-set-state' ),
 	ticker = require( 'lib/ticker' ),
 	humanDate = require( 'lib/human-date' );
 
@@ -24,9 +26,11 @@ var PostTime = React.createClass( {
 		ticker.off( 'tick', this._update );
 	},
 
+	smartSetState: smartSetState,
+
 	_update: function( date ) {
 		date = date || this.props.date;
-		this.setState( { ago: humanDate( date ) } );
+		this.smartSetState( { ago: humanDate( date ) } );
 	},
 
 	render: function() {


### PR DESCRIPTION
Prior, we updated the time every 60s, which doesn't work well for posts that are very recent. This drops the update time to 10s.

In addition, we moved to only setting the state if it has changed, to avoid unnecessary rerenders.