### PR TITLE
Editor: Prevent horizontal scroll on small screen views

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -243,7 +243,7 @@ html.iframed {
 	width: 100%;
 	margin: 47px auto 0;
 	box-sizing: border-box;
-	overflow-y: hidden;
+	overflow: hidden;
 }
 
 .wp-primary {


### PR DESCRIPTION
Fixes small horizontal scrolling that appears when editing posts on smaller browser sizes.

To test, navigate to /posts, edit a post, and resize the screen <480px wide. Notice that this horizontal scrolling is no longer occurring:

![overflow](https://cloud.githubusercontent.com/assets/5835847/11324256/8b546804-90fa-11e5-8a17-18a6abbc56de.gif)

Make sure to also test on all other pages as well, as `wp-content` is used throughout. 