### PR TITLE
Add a small Calypso banner on top of the HTML

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -1,4 +1,13 @@
 doctype html
+//
+	<3
+	             _
+	    ___ __ _| |_   _ _ __  ___  ___
+	  / __/ _\` | | | | | '_ \/ __|/ _ \\
+	  | (_| (_| | | |_| | |_) \__ \ (_) |
+	   \___\__,_|_|\__, | .__/|___/\___/
+	               |___/|_|
+
 html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width' : '')
 	head
 		title WordPress.com


### PR DESCRIPTION
Useful for knowing which page is Calypso and just for fun.

Props @stephanethomas who used it in `calypso-bootstrap`.

Generated by `figlet -c -w 40 "calypso”`.

Had to upgrade `jade`, otherwise parsing of the comment failed.
