### PR TITLE
DevDocs: Show login interstitial in development mode

### DIFF
--- a/assets/stylesheets/sections/_devdocs.scss
+++ b/assets/stylesheets/sections/_devdocs.scss
@@ -40,6 +40,10 @@
 	}
 }
 
+.is-section-devdocs-start .wp-primary {
+	margin-left: 0;
+}
+
 .devdocs__sidebar {
 	margin-top: 48px;
 }

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -271,6 +271,11 @@ function boot() {
 				return startsWith( context.path, validPath );
 			} );
 
+			if ( '/' === context.path && config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
+				page.redirect( '/devdocs/start' );
+				return;
+			}
+
 			if ( isValidSection ) {
 				next();
 			}

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -4,7 +4,8 @@
 var React = require( 'react' ),
 	qs = require( 'qs' ),
 	debounce = require( 'lodash/function/debounce' ),
-	page = require( 'page' );
+	page = require( 'page' ),
+	EmptyContent = require( 'components/empty-content' );
 
 /**
  * Internal dependencies
@@ -95,6 +96,25 @@ var devdocs = {
 		React.render(
 			React.createElement( FormStateExamplesComponent, {
 				component: context.params.component
+			} ),
+			document.getElementById( 'primary' )
+		);
+	},
+
+	pleaseLogIn: function( context ) {
+		context.layout.setState( { section: 'devdocs-start' } );
+
+		React.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+
+		React.render(
+			React.createElement( EmptyContent, {
+				title: 'Log In to start hacking',
+				line: 'Required to access the WordPress.com API',
+				action: 'Log In to WordPress.com',
+				actionURL: 'https://wordpress.com/login',
+				secondaryAction: 'Register',
+				secondaryActionURL: 'https://wordpress.com/start',
+				illustration: '/calypso/images/drake/drake-nosites.svg'
 			} ),
 			document.getElementById( 'primary' )
 		);

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -14,6 +14,7 @@ module.exports = function() {
 		page( '/devdocs', controller.sidebar, controller.devdocs );
 		page( '/devdocs/form-state-examples/:component?', controller.sidebar, controller.formStateExamples );
 		page( '/devdocs/design/:component?', controller.sidebar, controller.design );
+		page( '/devdocs/start', controller.pleaseLogIn );
 		page( '/devdocs/:path*', controller.sidebar, controller.singleDoc );
 	}
 };

--- a/client/sections.js
+++ b/client/sections.js
@@ -140,7 +140,8 @@ if ( config.isEnabled( 'devdocs' ) ) {
 	sections.push( {
 		name: 'devdocs',
 		paths: [ '/devdocs' ],
-		module: 'devdocs'
+		module: 'devdocs',
+		enableLoggedOut: true
 	} );
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -129,6 +129,7 @@
 		"olark" : true,
 		"olark_use_wpcom_configuration": true,
 		"devdocs": true,
+		"devdocs/redirect-loggedout-homepage": true,
 		"jetpack_core_inline_update": true,
 		"phone_signup": true,
 		"login": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -78,6 +78,7 @@
 		"olark_use_wpcom_configuration": false,
 		"community-translator": true,
 		"devdocs": true,
+		"devdocs/redirect-loggedout-homepage": false,
 		"keyboard-shortcuts": true,
 		"jetpack_core_inline_update": true,
 		"me/my-profile": true,


### PR DESCRIPTION
If a user is logged out they can’t do much, even with the dev version.

This shows them a screen inviting them to login or register:

![screen shot 2015-11-22 at 20 12 18](https://cloud.githubusercontent.com/assets/27954/11325399/5ec58e3e-9155-11e5-954a-ff6d0d19005b.png)
- [x] Show the page on `/`, only in dev environment.

cc @folletto, @mtias 
