### PR TITLE
Add development badge with a link to DevDocs

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -429,16 +429,29 @@ body.newdash div.wordpress-com-extension-promo {
 		text-transform: uppercase;
 		padding: 4px 7px 4px 6px;
 		vertical-align: middle;
+		transition: all 0.2s ease-out;
 		&:before {
 			content: '';
 			position: absolute;
-				left: -4px;
+				left: -1px;
 				right: 0;
 				top: 0;
 				bottom: 0;
 			z-index: -1;
 			background-color: $white;
 			border: solid 1px $gray-dark;
+		}
+		&:first-of-type:before {
+			left: -4px;
+		}
+		a {
+			text-decoration: none;
+			display: inline-block;
+			color: black;
+
+			&:hover {
+				transform: scale( 1.1 );
+			}
 		}
 		&.is-staging {
 			&:before {
@@ -448,6 +461,11 @@ body.newdash div.wordpress-com-extension-promo {
 		&.is-wpcalypso {
 			&:before {
 				background-color: #B1EED0;
+			}
+		}
+		&.is-dev {
+			&:before {
+				background-color: $alert-red;
 			}
 		}
 		&.is-horizon,

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -50,6 +50,9 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			div.environment-badge
 				a(class='bug-report', href=feedbackURL, title='Report an issue', target='_blank')
 				span(class=['environment', 'is-' + badge])=badge
+				if devDocs
+					span(class=['environment', 'is-docs'])
+						a(href=devDocsURL title='DevDocs') docs
 
 		script.
 			(function() {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -122,7 +122,8 @@ function getDefaultContext( request ) {
 		lang: config( 'i18n_default_locale_slug' ),
 		jsFile: 'build',
 		faviconURL: '//s1.wp.com/i/favicon.ico',
-		isFluidWidth: !! config.isEnabled( 'fluid-width' )
+		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
+		devDocsURL: '/devdocs'
 	};
 
 	context.app = {
@@ -135,6 +136,7 @@ function getDefaultContext( request ) {
 
 	if ( CALYPSO_ENV === 'wpcalypso' ) {
 		context.badge = CALYPSO_ENV;
+		context.devDocs = true;
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/new';
 		context.faviconURL = '/calypso/images/favicons/favicon-wpcalypso.ico';
 	}
@@ -158,6 +160,9 @@ function getDefaultContext( request ) {
 	}
 
 	if ( CALYPSO_ENV === 'development' ) {
+		context.badge = 'dev';
+		context.devDocs = true;
+		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/new';
 		context.faviconURL = '/calypso/images/favicons/favicon-development.ico';
 	}
 


### PR DESCRIPTION
We were missing a badge in the dev environment:

![screen shot 2015-11-22 at 22 21 06](https://cloud.githubusercontent.com/assets/27954/11326068/43abc164-9168-11e5-9fbe-4d177f609b05.png)

The right part links to `/devdocs`.
