### PR TITLE
Purchases: Add cancel/remove option for expired domain registrations and mappings

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -57,12 +57,16 @@ function hasPrivateRegistration( purchase ) {
 }
 
 function isCancelable( purchase ) {
-	if ( isRefundable( purchase ) ) {
-		return true;
-	}
-
 	if ( isIncludedWithPlan( purchase ) ) {
 		return false;
+	}
+
+	if ( isExpired( purchase ) ) {
+		return false;
+	}
+
+	if ( isRefundable( purchase ) ) {
+		return true;
 	}
 
 	return purchase.canDisableAutoRenew;
@@ -99,6 +103,14 @@ function isRedeemable( purchase ) {
 
 function isRefundable( purchase ) {
 	return purchase.isRefundable;
+}
+
+function isRemovable( purchase ) {
+	if (  isIncludedWithPlan( purchase ) ) {
+		return false;
+	}
+
+	return ( isExpired( purchase ) && purchase.isCancelable );
 }
 
 function isRenewable( purchase ) {
@@ -184,6 +196,7 @@ export {
 	isOneTimePurchase,
 	isRedeemable,
 	isRefundable,
+	isRemovable,
 	isRenewable,
 	isRenewing,
 	paymentLogoType,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -9,7 +9,7 @@ import moment from 'moment';
  * Internal dependencies
  */
 import i18n from 'lib/mixins/i18n';
-import { isDomainRegistration, isTheme, isPlan } from 'lib/products-values';
+import { isDomainMapping, isDomainRegistration, isTheme, isPlan } from 'lib/products-values';
 
 /**
  * Returns an array of sites objects, each of which contains an array of purchases.
@@ -106,11 +106,14 @@ function isRefundable( purchase ) {
 }
 
 function isRemovable( purchase ) {
-	if (  isIncludedWithPlan( purchase ) ) {
+	if ( isIncludedWithPlan( purchase ) ) {
 		return false;
 	}
 
-	return ( isExpired( purchase ) && purchase.isCancelable );
+	return (
+		( isDomainRegistration( purchase ) || isDomainMapping( purchase ) ) &&
+		isExpired( purchase )
+	);
 }
 
 function isRenewable( purchase ) {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -56,6 +56,15 @@ function hasPrivateRegistration( purchase ) {
 	return purchase.hasPrivateRegistration;
 }
 
+/**
+ * Checks if a purchase can be cancelled.
+ * Returns true for purchases that aren't expired
+ * Also returns true for purchases whether or not they are after the refund period.
+ * Purchases included with a plan can't be cancelled.
+ *
+ * @param {Object} purchase
+ * @return {boolean}
+ */
 function isCancelable( purchase ) {
 	if ( isIncludedWithPlan( purchase ) ) {
 		return false;
@@ -101,10 +110,27 @@ function isRedeemable( purchase ) {
 	return purchase.isRedeemable;
 }
 
+/**
+ * Checks if a purchase can be canceled and refunded.
+ * Purchases usually can be refunded up to 30 days after purchase.
+ * Domains and domain mappings can be refunded up to 48 hours.
+ * Purchases included with plan can't be refunded.
+ *
+ * @param {Object} purchase
+ * @return {boolean}
+ */
 function isRefundable( purchase ) {
 	return purchase.isRefundable;
 }
 
+/**
+ * Checks if an expired purchase can be removed from a user account.
+ * Only domains and domain mappings can be removed.
+ * Purchases included with plan can't be removed.
+ *
+ * @param {Object} purchase
+ * @return {boolean}
+ */
 function isRemovable( purchase ) {
 	if ( isIncludedWithPlan( purchase ) ) {
 		return false;

--- a/client/lib/purchases/test/data/index.js
+++ b/client/lib/purchases/test/data/index.js
@@ -1,0 +1,50 @@
+const DOMAIN_PURCHASE = {
+	expiryStatus: 'active',
+	id: 10001,
+	isDomainRegistration: true,
+	meta: 'foo.com',
+	productName: 'Domain Registration',
+	productSlug: 'domain_reg'
+};
+
+const DOMAIN_PURCHASE_EXPIRED = Object.assign( {}, DOMAIN_PURCHASE, {
+	expiryStatus: 'expired',
+	id: 10002
+} );
+
+const DOMAIN_MAPPING_PURCHASE = {
+	expiryStatus: 'active',
+	id: 20001,
+	isDomainRegistration: false,
+	meta: 'boo.com',
+	productName: 'Domain Mapping',
+	productSlug: 'domain_map'
+};
+
+const DOMAIN_MAPPING_PURCHASE_EXPIRED = Object.assign( {}, DOMAIN_MAPPING_PURCHASE, {
+	expiryStatus: 'expired',
+	id: 20002
+} );
+
+const SITE_REDIRECT_PURCHASE = {
+	expiryStatus: 'active',
+	id: 30001,
+	isDomainRegistration: false,
+	meta: '',
+	productName: 'Site Redirect',
+	productSlug: 'offsite_redirect'
+};
+
+const SITE_REDIRECT_PURCHASE_EXPIRED = Object.assign( {}, SITE_REDIRECT_PURCHASE, {
+	expiryStatus: 'expired',
+	id: 30002
+} );
+
+export default {
+	DOMAIN_PURCHASE,
+	DOMAIN_PURCHASE_EXPIRED,
+	DOMAIN_MAPPING_PURCHASE,
+	DOMAIN_MAPPING_PURCHASE_EXPIRED,
+	SITE_REDIRECT_PURCHASE,
+	SITE_REDIRECT_PURCHASE_EXPIRED
+}

--- a/client/lib/purchases/test/index-test.js
+++ b/client/lib/purchases/test/index-test.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	DOMAIN_PURCHASE,
+	DOMAIN_PURCHASE_EXPIRED,
+	DOMAIN_MAPPING_PURCHASE_EXPIRED,
+	SITE_REDIRECT_PURCHASE_EXPIRED
+} from 'data';
+import { isRemovable } from '../index';
+
+describe( 'Purchases Utils', () => {
+	describe( 'isRemovable', () => {
+		it( 'should not be removable when domain purchase is not expired', () => {
+			expect( isRemovable( DOMAIN_PURCHASE ) ).to.be.false;
+		} );
+
+		it( 'should not be removable when non-domain and non-domain mapping purchase is expired', () => {
+			expect( isRemovable( SITE_REDIRECT_PURCHASE_EXPIRED ) ).to.be.false;
+		} );
+
+		it( 'should be removable when domain purchase is expired', () => {
+			expect( isRemovable( DOMAIN_PURCHASE_EXPIRED ) ).to.be.true;
+		} );
+
+		it( 'should be removable when domain mapping purchase is expired', () => {
+			expect( isRemovable( DOMAIN_MAPPING_PURCHASE_EXPIRED ) ).to.be.true;
+		} );
+	} );
+} );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -432,6 +432,31 @@ const ManagePurchase = React.createClass( {
 		}
 	},
 
+	renderRemovePurchaseInformation() {
+		const purchase = getPurchase( this.props ),
+			contactSupportUrl = 'https://support.wordpress.com/';
+
+		if ( ! isRemovable( purchase ) ) {
+			return null;
+		}
+
+		return (
+			<div className="manage-purchase__remove-information">
+				<em>{ this.translate(
+					'Looking to remove this purchase? Please {{a}}contact support{{/a}} to remove %(purchaseName) from your account.',
+					{
+						args: {
+							purchaseName: getName( purchase )
+						},
+						components: {
+							a: <a href={ contactSupportUrl } target="_blank" />
+						}
+					}
+				) }</em>
+			</div>
+		);
+	},
+
 	renderEditPaymentMethodNavItem() {
 		const purchase = getPurchase( this.props ),
 			{ domain, id, payment } = purchase;
@@ -497,6 +522,7 @@ const ManagePurchase = React.createClass( {
 			price,
 			renewsOrExpiresOnLabel,
 			renewsOrExpiresOn,
+			removePurchaseInformation,
 			renewButton,
 			expiredRenewNotice,
 			editPaymentMethodNavItem,
@@ -520,12 +546,13 @@ const ManagePurchase = React.createClass( {
 			productLink = this.renderProductLink();
 			price = this.renderPrice();
 			renewsOrExpiresOnLabel = this.renderRenewsOrExpiresOnLabel();
+			renewsOrExpiresOn = this.renderRenewsOrExpiresOn();
+			removePurchaseInformation = this.renderRemovePurchaseInformation();
 			renewButton = this.renderRenewButton();
 			expiredRenewNotice = this.renderExpiredRenewNotice();
 			editPaymentMethodNavItem = this.renderEditPaymentMethodNavItem();
 			cancelPurchaseNavItem = this.renderCancelPurchaseNavItem();
 			cancelPrivateRegistrationNavItem = this.renderCancelPrivateRegistration();
-			renewsOrExpiresOn = this.renderRenewsOrExpiresOn();
 		}
 
 		return (
@@ -555,6 +582,7 @@ const ManagePurchase = React.createClass( {
 						</li>
 						{ this.renderPaymentDetails() }
 					</ul>
+					{ removePurchaseInformation }
 					{ renewButton }
 				</Card>
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -441,15 +441,16 @@ const ManagePurchase = React.createClass( {
 		}
 
 		return (
-			<div className="manage-purchase__remove-information">
-				<em>{ this.translate(
-					'Looking to remove this purchase? Please {{a}}contact support{{/a}} to remove %(purchaseName) from your account.',
+			<div className="manage-purchase__remove-box">
+				<em className="manage-purchase__remove-text">{ this.translate(
+					'{{strong}}Looking to remove this purchase?{{/strong}} Please {{a}}contact support{{/a}} to remove %(purchaseName)s from your account.',
 					{
 						args: {
 							purchaseName: getName( purchase )
 						},
 						components: {
-							a: <a href={ contactSupportUrl } target="_blank" />
+							a: <a href={ contactSupportUrl } target="_blank" />,
+							strong: <strong />
 						}
 					}
 				) }</em>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -36,6 +36,7 @@ import {
 	isPaidWithCreditCard,
 	isRedeemable,
 	isRefundable,
+	isRemovable,
 	isRenewable,
 	isRenewing,
 	isIncludedWithPlan,
@@ -450,7 +451,7 @@ const ManagePurchase = React.createClass( {
 		const purchase = getPurchase( this.props ),
 			{ domain, id } = purchase;
 
-		if ( isExpired( purchase ) || ! isCancelable( purchase ) ) {
+		if ( ! isCancelable( purchase ) ) {
 			return null;
 		}
 
@@ -466,6 +467,23 @@ const ManagePurchase = React.createClass( {
 					: this.translate( 'Cancel %(purchaseName)s', translateArgs )
 				}
 			</VerticalNavItem>
+		);
+	},
+
+	renderRemovePurchaseNavItem() {
+		const purchase = this.getPurchase(),
+				{ domain, id } = purchase;
+
+		if ( ! isRemovable( purchase ) ) {
+			return null;
+		}
+
+		return (
+				<VerticalNavItem path={ paths.confirmCancelPurchase( domain, id ) }>
+					{ this.translate( 'Remove %(purchaseName)s from my site', {
+						args: { purchaseName: getName( purchase ) }
+					} )}
+				</VerticalNavItem>
 		);
 	},
 
@@ -500,6 +518,7 @@ const ManagePurchase = React.createClass( {
 			expiredRenewNotice,
 			editPaymentMethodNavItem,
 			cancelPurchaseNavItem,
+			removePurchaseNavItem,
 			cancelPrivateRegistrationNavItem;
 
 		if ( isDataLoading( this.props ) || this.isDataFetchingAfterRenewal() ) {
@@ -523,6 +542,7 @@ const ManagePurchase = React.createClass( {
 			expiredRenewNotice = this.renderExpiredRenewNotice();
 			editPaymentMethodNavItem = this.renderEditPaymentMethodNavItem();
 			cancelPurchaseNavItem = this.renderCancelPurchaseNavItem();
+			removePurchaseNavItem = this.renderRemovePurchaseNavItem();
 			cancelPrivateRegistrationNavItem = this.renderCancelPrivateRegistration();
 			renewsOrExpiresOn = this.renderRenewsOrExpiresOn();
 		}
@@ -561,6 +581,7 @@ const ManagePurchase = React.createClass( {
 
 				{ editPaymentMethodNavItem }
 				{ cancelPurchaseNavItem }
+				{ removePurchaseNavItem }
 				{ cancelPrivateRegistrationNavItem }
 			</div>
 		);

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -470,23 +470,6 @@ const ManagePurchase = React.createClass( {
 		);
 	},
 
-	renderRemovePurchaseNavItem() {
-		const purchase = this.getPurchase(),
-				{ domain, id } = purchase;
-
-		if ( ! isRemovable( purchase ) ) {
-			return null;
-		}
-
-		return (
-				<VerticalNavItem path={ paths.confirmCancelPurchase( domain, id ) }>
-					{ this.translate( 'Remove %(purchaseName)s from my site', {
-						args: { purchaseName: getName( purchase ) }
-					} )}
-				</VerticalNavItem>
-		);
-	},
-
 	renderCancelPrivateRegistration() {
 		const purchase = getPurchase( this.props ),
 			{ domain, id } = purchase;
@@ -518,7 +501,6 @@ const ManagePurchase = React.createClass( {
 			expiredRenewNotice,
 			editPaymentMethodNavItem,
 			cancelPurchaseNavItem,
-			removePurchaseNavItem,
 			cancelPrivateRegistrationNavItem;
 
 		if ( isDataLoading( this.props ) || this.isDataFetchingAfterRenewal() ) {
@@ -542,7 +524,6 @@ const ManagePurchase = React.createClass( {
 			expiredRenewNotice = this.renderExpiredRenewNotice();
 			editPaymentMethodNavItem = this.renderEditPaymentMethodNavItem();
 			cancelPurchaseNavItem = this.renderCancelPurchaseNavItem();
-			removePurchaseNavItem = this.renderRemovePurchaseNavItem();
 			cancelPrivateRegistrationNavItem = this.renderCancelPrivateRegistration();
 			renewsOrExpiresOn = this.renderRenewsOrExpiresOn();
 		}
@@ -581,7 +562,6 @@ const ManagePurchase = React.createClass( {
 
 				{ editPaymentMethodNavItem }
 				{ cancelPurchaseNavItem }
-				{ removePurchaseNavItem }
 				{ cancelPrivateRegistrationNavItem }
 			</div>
 		);

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -434,7 +434,7 @@ const ManagePurchase = React.createClass( {
 
 	renderRemovePurchaseInformation() {
 		const purchase = getPurchase( this.props ),
-			contactSupportUrl = 'https://support.wordpress.com/';
+			contactSupportUrl = 'https://support.wordpress.com/contact/';
 
 		if ( ! isRemovable( purchase ) ) {
 			return null;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -14,7 +14,8 @@
 		.manage-purchase__detail-label,
 		.manage-purchase__settings-link,
 		.manage-purchase__title,
-		.manage-purchase__subtitle {
+		.manage-purchase__subtitle,
+		.manage-purchase__remove-text {
 			opacity: .6;
 		}
 	}
@@ -165,6 +166,13 @@
 			text-decoration: none;
 		}
 	}
+}
+
+.manage-purchase__remove-box {
+	border-top: 1px solid lighten($gray, 30%);
+	margin-top: 15px;
+	overflow: auto;
+	padding-top: 16px;
 }
 
 .manage-purchase__detail-label {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -9,7 +9,6 @@
 
 	&.is-expired {
 		background: $gray-light;
-		margin-bottom: 0;
 
 		.manage-purchase__detail,
 		.manage-purchase__detail-label,
@@ -17,6 +16,14 @@
 		.manage-purchase__title,
 		.manage-purchase__subtitle {
 			opacity: .6;
+		}
+	}
+
+	&.is-expired + .notice {
+		margin-top: -10px;
+
+		@include breakpoint ( ">480px" ) {
+			margin-top: -16px;
 		}
 	}
 


### PR DESCRIPTION
Fixes #241.

This PR adds remove information on `Manage Purchase` page for purchases that are expired and can be cancelled.

Expected view:
![screen shot 2015-11-26 at 09 08 58](https://cloud.githubusercontent.com/assets/699132/11418161/afe93764-941d-11e5-8cde-ab1878be5ad5.png)

### Testing
1. Go to http://calypso.localhost:3000/purchases.
2. Selected expired domain or domain mapping purchase.
3. You should see remove information presented above.