### PR TITLE
Purchases: Add analytics for sections in /purchases

### DIFF
--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -16,13 +16,21 @@ import paths from '../paths';
 import { isRefundable } from 'lib/purchases';
 import { cancelPrivateRegistration } from 'lib/upgrades/actions';
 import SimpleNotice from 'notices/simple-notice';
-import { goToManagePurchase, isDataLoading } from '../utils';
+import { goToManagePurchase, isDataLoading, recordPageView } from '../utils';
 
 const CancelPrivateRegistration = React.createClass( {
 	getInitialState() {
 		return {
 			disabled: false
 		};
+	},
+
+	componentWillMount() {
+		recordPageView( 'cancel_private_registration', this.props );
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		recordPageView( 'cancel_private_registration', this.props, nextProps );
 	},
 
 	cancel() {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -17,12 +17,20 @@ import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import paths from '../paths';
 import { getName, isCancelable } from 'lib/purchases';
-import { getPurchase, goToManagePurchase, isDataLoading } from '../utils';
+import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from '../utils';
 
 const CancelPurchase = React.createClass( {
 	propTypes: {
 		selectedPurchase: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.object
+	},
+
+	componentWillMount() {
+		recordPageView( 'cancel_purchase', this.props );
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		recordPageView( 'cancel_purchase', this.props, nextProps );
 	},
 
 	componentDidMount() {

--- a/client/me/purchases/confirm-cancel-purchase/index.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/index.jsx
@@ -15,12 +15,20 @@ import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
-import { getPurchase, goToManagePurchase } from '../utils';
+import { getPurchase, goToManagePurchase, recordPageView } from '../utils';
 
 const ConfirmCancelPurchase = React.createClass( {
 	propTypes: {
 		selectedPurchase: React.PropTypes.object,
 		selectedSite: React.PropTypes.object
+	},
+
+	componentWillMount() {
+		recordPageView( 'confirm_cancel_purchase', this.props );
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		recordPageView( 'confirm_cancel_purchase', this.props, nextProps );
 	},
 
 	componentDidMount() {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -45,7 +45,7 @@ import {
 	showCreditCardExpiringWarning,
 	showEditPaymentDetails
 } from 'lib/purchases';
-import { getPurchase, goToList, isDataLoading } from '../utils';
+import { getPurchase, goToList, isDataLoading, recordPageView } from '../utils';
 
 const ManagePurchase = React.createClass( {
 	propTypes: {
@@ -53,6 +53,14 @@ const ManagePurchase = React.createClass( {
 		selectedPurchase: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.object,
 		destinationType: React.PropTypes.string
+	},
+
+	componentWillMount() {
+		recordPageView( 'manage', this.props );
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		recordPageView( 'manage', this.props, nextProps );
 	},
 
 	isDataFetchingAfterRenewal() {

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -26,7 +26,7 @@ import ValidationErrorList from 'notices/validation-error-list';
 import { createPaygateToken } from 'lib/store-transactions';
 import wpcomFactory from 'lib/wp';
 import paths from 'me/purchases/paths';
-import { getPurchase, goToManagePurchase, isDataLoading } from 'me/purchases/utils';
+import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
 
 const wpcom = wpcomFactory.undocumented();
 
@@ -55,6 +55,8 @@ const EditCardDetails = React.createClass( {
 	],
 
 	componentWillReceiveProps( nextProps ) {
+		recordPageView( 'edit_card_details', this.props, nextProps );
+
 		// Updates the form once with the stored credit card data as soon as they are available
 		if ( nextProps.card && ( ! this.props.card || ( nextProps.card.id !== this.props.card.id ) ) ) {
 			this.setState( {
@@ -77,6 +79,8 @@ const EditCardDetails = React.createClass( {
 	},
 
 	componentWillMount() {
+		recordPageView( 'edit_card_details', this.props );
+
 		const options = {
 			validatorFunction: this.validate,
 			onNewState: this.setFormState

--- a/client/me/purchases/payment/edit-payment-method/index.jsx
+++ b/client/me/purchases/payment/edit-payment-method/index.jsx
@@ -11,12 +11,20 @@ import EditPaymentMethodCreditCard from './credit-card';
 import HeaderCake from 'components/header-cake';
 import { isPaidWithCreditCard, isPaidWithPaypal } from 'lib/purchases';
 import Main from 'components/main';
-import { getPurchase, goToManagePurchase, isDataLoading } from 'me/purchases/utils';
+import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
 
 const EditPaymentMethod = React.createClass( {
 	propTypes: {
 		selectedPurchase: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.object.isRequired
+	},
+
+	componentWillMount() {
+		recordPageView( 'edit_payment_method', this.props );
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		recordPageView( 'edit_payment_method', this.props, nextProps );
 	},
 
 	render() {

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -6,6 +6,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import analytics from 'analytics';
 import paths from './paths';
 
 function getPurchase( props ) {
@@ -32,10 +33,27 @@ function isDataLoading( props ) {
 	return ( ! props.selectedSite || ! props.selectedPurchase.hasLoadedFromServer );
 }
 
+function recordPageView( trackingSlug, props, nextProps = null ) {
+	if ( isDataLoading( nextProps || props ) ) {
+		return null;
+	}
+
+	if ( nextProps &&
+		( props.selectedPurchase.hasLoadedFromServer || ! nextProps.selectedPurchase.hasLoadedFromServer ) ) {
+		// only record the page view the first time the purchase loads from the server
+		return null;
+	}
+
+	const { productSlug } = getPurchase( nextProps || props );
+
+	analytics.tracks.recordEvent( `calypso_${ trackingSlug }_purchase_view`, { product_slug: productSlug } );
+}
+
 export {
 	getPurchase,
 	goToList,
 	goToEditCardDetails,
 	goToManagePurchase,
-	isDataLoading
+	isDataLoading,
+	recordPageView
 }


### PR DESCRIPTION
Fixes #271  (well part of it)

This adds analytics calls to the single-purchase pages in `/purchases`.

**Testing**

1. `git checkout fix/12207-analytics`
2. Open http://calypso.dev:3000/purchases
3. Add `calypso:analytics` to the debugger so you see analytics calls in your console
4. Assert that you see these events:

- `calypso_cancel_private_registration_purchase_view`
- `calypso_confirm_cancel_purchase_view`
- `calypso_cancel_purchase_view`
- `edit_card_details_purchase_view`
- `calypso_manage_purchase_view`

`calypso_edit_payment_method_purchase_view` is also included in `EditPaymentMethod` in this PR, but that component doesn't appear to be linked from anywhere right now.

The events should have a `product_slug` property.
 
- [x] Code review
- [x] QA review