### PR TITLE
Devdocs: fix a few remaining React warnings

### DIFF
--- a/client/components/bulk-select/docs/example.jsx
+++ b/client/components/bulk-select/docs/example.jsx
@@ -36,13 +36,13 @@ module.exports = React.createClass( {
 	},
 
 	renderElements() {
-		return this.state.elements.map( element => {
+		return this.state.elements.map( (element, index) => {
 			const onClick = function() {
 				element.selected = ! element.selected;
 				this.forceUpdate();
 			}.bind( this );
 			return (
-				<label >
+				<label key={ index }>
 					<input type="checkbox" onClick={ onClick } checked={ element.selected } />
 					{ element.title }
 				</label>

--- a/client/components/bulk-select/docs/example.jsx
+++ b/client/components/bulk-select/docs/example.jsx
@@ -43,7 +43,7 @@ module.exports = React.createClass( {
 			}.bind( this );
 			return (
 				<label key={ index }>
-					<input type="checkbox" onClick={ onClick } checked={ element.selected } />
+					<input type="checkbox" onClick={ onClick } checked={ element.selected } readOnly />
 					{ element.title }
 				</label>
 			);

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -41,7 +41,7 @@ export default React.createClass( {
 	render() {
 		return (
 			<div className="bulk-select" onClick={ this.handleToggleAll }>
-				<input type="checkbox" className="bulk-select__box" checked={ this.hasAllElementsSelected() } />
+				<input type="checkbox" className="bulk-select__box" checked={ this.hasAllElementsSelected() } readOnly />
 				<Count count={ this.props.selectedElements } />
 				{ this.getStateIcon() }
 			</div>

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -24,12 +24,6 @@ export default React.createClass( {
 	},
 
 	render() {
-		let children = [];
-		children.push( this.props.children );
-		if ( this.props.icon ) {
-			children.push( <Gridicon icon="external" size={ 18 } /> );
-		}
-
 		const classes = classnames( 'external-link', this.props.className, {
 			'has-icon': !! this.props.icon,
 		} );
@@ -38,6 +32,12 @@ export default React.createClass( {
 			className: classes,
 			rel: 'external'
 		} );
-		return React.createElement( 'a', props, children );
+
+		return (
+			<a { ...props }>
+				{ this.props.children }
+				{ this.props.icon ? <Gridicon icon="external" size={ 18 } /> : null }
+			</a>
+		);
 	}
 } );

--- a/shared/components/card/index.jsx
+++ b/shared/components/card/index.jsx
@@ -24,17 +24,20 @@ module.exports = React.createClass( {
 		var element = this.props.tagName || 'div',
 			linkClassName = this.props.href ? 'is-card-link' : null,
 			props = assign( {}, this.props, { className: joinClasses( this.props.className, 'card', linkClassName ) } ),
-			children = [ this.props.children ];
+			linkIndicator = null;
 
 		if ( this.props.href ) {
 			element = 'a';
-			children.unshift(
-				<Gridicon
-					className='card__link-indicator'
-					icon={ this.props.target ? 'external' : 'chevron-right' } />
-			);
+			linkIndicator = <Gridicon
+				className='card__link-indicator'
+				icon={ this.props.target ? 'external' : 'chevron-right' } />;
 		}
 
-		return React.createElement( element, props, children );
+		return React.createElement(
+			element,
+			props,
+			this.props.href ? linkIndicator : null,
+			this.props.children
+		);
 	}
 } );


### PR DESCRIPTION
When looking at the "UI Components" page in the Calypso Docs, there are a few warnings from React: 

![screen shot 2015-11-23 at 11 14 53 am](https://cloud.githubusercontent.com/assets/23619/11334265/4382e412-91d4-11e5-8b7f-d328030d95a2.png)

Some are issues in the reusable components themselves, some need to be fixed in the example code. 

- [x] unique key warning, `Card`
- [x] unique key warning, `ExternalLink`
- [x] failed propType warning, `BulkSelects`
- [x] unique key warning, `BulkSelects`
- [x] discuss whether method of generating keys using in 6f8fadb8cc701178f114ccc9f2bf2b2556d95afc is appropriate
