### PR TITLE
Sidebar: add icon to WP Admin item and move to bottom.

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -452,8 +452,9 @@ module.exports = React.createClass( {
 		return (
 			<li className="wp-admin">
 				<a onClick={ this.trackWpadminClick } href={ site.options.admin_url } target="_blank">
+					<Gridicon icon="my-sites" size={ 24 } />
 					<span className="menu-link-text">{ this.translate( 'WP Admin' ) }</span>
-					<span className="noticon noticon-external"></span>
+					<span className="noticon noticon-external" />
 				</a>
 			</li>
 		);
@@ -603,7 +604,6 @@ module.exports = React.createClass( {
 				<li className="sidebar-menu">
 					<ul>
 						{ this.homepage() }
-						{ this.wpAdmin() }
 						{ this.stats() }
 						{ this.ads() }
 						{ this.plan() }
@@ -650,6 +650,7 @@ module.exports = React.createClass( {
 						{ this.plugins() }
 						{ this.upgrades() }
 						{ this.siteSettings() }
+						{ this.wpAdmin() }
 					</ul>
 				</li>
 				: null }


### PR DESCRIPTION
Add gridicon to the sidebar item for "WP Admin" and place it at the bottom.
