### PR TITLE
Purchases: Add analytics to the contact support links 

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -60,7 +60,7 @@ const CancelPurchase = React.createClass( {
 					</h2>
 
 					<div className="cancel-purchase__info">
-						<CancelPurchaseSupportBox />
+						<CancelPurchaseSupportBox purchase={ purchase } />
 
 						<div className="cancel-purchase__content">
 							<div className="cancel-purchase__section">

--- a/client/me/purchases/cancel-purchase/support-box.jsx
+++ b/client/me/purchases/cancel-purchase/support-box.jsx
@@ -3,7 +3,27 @@
  */
 import React from 'react';
 
+/**
+ * Internal Dependencies
+ */
+import analytics from 'analytics';
+
 const CancelPurchaseSupportBox = React.createClass( {
+	propTypes: {
+		purchase: React.PropTypes.object.isRequired,
+	},
+
+	trackClickContactSupport() {
+		if ( ! this.props.purchase ) {
+			return;
+		}
+
+		analytics.tracks.recordEvent(
+			'calypso_purchases_click_contact_support',
+			{ product_slug: this.props.purchase.productSlug }
+		);
+	},
+
 	render() {
 		const contactSupportUrl = 'https://support.wordpress.com/';
 
@@ -20,7 +40,7 @@ const CancelPurchaseSupportBox = React.createClass( {
 						'If you are unsure about canceling or have any questions about this purchase, please {{a}}contact support{{/a}}.',
 						{
 							components: {
-								a: <a href={ contactSupportUrl } target="_blank" />
+								a: <a href={ contactSupportUrl } target="_blank" onClick={ this.trackClickContactSupport } />
 							}
 						}
 					) }
@@ -28,6 +48,7 @@ const CancelPurchaseSupportBox = React.createClass( {
 
 				<a href={ contactSupportUrl }
 					target="_blank"
+					onClick={ this.trackClickContactSupport }
 					className="button is-primary">
 					{ this.translate( 'Contact Support' ) }
 				</a>

--- a/client/me/purchases/cancel-purchase/support-box.jsx
+++ b/client/me/purchases/cancel-purchase/support-box.jsx
@@ -14,10 +14,6 @@ const CancelPurchaseSupportBox = React.createClass( {
 	},
 
 	trackClickContactSupport() {
-		if ( ! this.props.purchase ) {
-			return;
-		}
-
 		analytics.tracks.recordEvent(
 			'calypso_purchases_click_contact_support',
 			{ product_slug: this.props.purchase.productSlug }

--- a/client/me/purchases/confirm-cancel-purchase/index.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/index.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 /**
  * Internal Dependencies
- **/
+ */
 import analytics from 'analytics';
 import Card from 'components/card';
 import loadEndpointForm from './load-endpoint-form';


### PR DESCRIPTION
Adds a `calypso_purchases_click_contact_support` event to the contact support links on the cancel purchase page.

Fixes #271 (part of it)

**Testing**

1. `git checkout fix/12207-analytics`
2. Open http://calypso.dev:3000/purchases
3. Add `calypso:analytics` to the debugger so you see analytics calls in your console
4. Open a purchase and go to the cancel page
5. Click the "contact support" links (there are two)
4. Assert that you see this event: `calypso_purchases_click_contact_support` with the `product_slug` property.

- [x] Code review
- [x] QA review