### PR TITLE
Purchases: Add analytics to the purchase confirm cancellation submit button

### DIFF
--- a/client/me/purchases/confirm-cancel-purchase/index.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/index.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 /**
  * Internal Dependencies
  **/
+import analytics from 'analytics';
 import Card from 'components/card';
 import loadEndpointForm from './load-endpoint-form';
 import HeaderCake from 'components/header-cake';
@@ -64,6 +65,12 @@ const ConfirmCancelPurchase = React.createClass( {
 		}
 
 		notices.success( response.message, { persistent: true } );
+
+		analytics.tracks.recordEvent(
+			'calypso_purchases_submit_cancel_form',
+			{ product_slug: this.getPurchase().productSlug }
+		);
+
 		page.redirect( paths.list() );
 	},
 

--- a/client/me/purchases/confirm-cancel-purchase/index.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/index.jsx
@@ -67,7 +67,7 @@ const ConfirmCancelPurchase = React.createClass( {
 		notices.success( response.message, { persistent: true } );
 
 		analytics.tracks.recordEvent(
-			'calypso_purchases_submit_cancel_form',
+			'calypso_purchases_cancel_form_submit',
 			{ product_slug: this.getPurchase().productSlug }
 		);
 


### PR DESCRIPTION
Adds a `calypso_purchases_submit_cancel_form` event to the submit button form the cancel confirmation page.

Fixes #271 (part of it)

**Testing**

1. `git checkout add/analytics-submit-cancel-confirmation`
2. Open http://calypso.dev:3000/purchases
3. Add `calypso:analytics` to the debugger so you see analytics calls in your console
4. Open a purchase and go to the confirm cancel page
5. Submit the cancel button
4. Assert that you see this event: `calypso_purchases_submit_cancel_form` with the `product_slug` property

- [ ] Code review
- [x] QA review