### PR TITLE
Add site names on sites-list error notices

### DIFF
--- a/client/lib/sites-list/notices.js
+++ b/client/lib/sites-list/notices.js
@@ -50,15 +50,19 @@ module.exports = {
 	},
 
 	getMessage: function( logs, messageFunction ) {
-		var sampleLog, translateArg;
-		sampleLog = logs[ 0 ];
-		translateArg = {
-			count: logs.length,
-			args: {
-				siteName: sampleLog.site.title,
-				numberOfSites: logs.length
-			}
-		};
+		const sampleLog = logs[ 0 ],
+			sites = logs.map( function( log ) {
+				return log.site && log.site.title;
+			} ),
+			translateArg = {
+				count: logs.length,
+				args: {
+					siteName: sampleLog.site.title,
+					siteNames: sites.join( ', ' ),
+					numberOfSites: sites.length
+				}
+			};
+
 		return messageFunction( sampleLog.action, translateArg, sampleLog );
 	},
 
@@ -110,8 +114,8 @@ module.exports = {
 					return this.translate( 'Error fetching plugins on %(siteName)s.', translateArg );
 				}
 				return this.translate(
-					'Error fetching plugins on %(numberOfSites)d site.',
-					'Error fetching plugins on %(numberOfSites)d sites.',
+					'Error fetching plugins on %(numberOfSites)d site: %(siteNames)s.',
+					'Error fetching plugins on %(numberOfSites)d sites: %(siteNames)s.',
 					translateArg );
 
 			case 'DISCONNECT_SITE':
@@ -122,8 +126,8 @@ module.exports = {
 							return this.translate( 'You don\'t have permission to disconnect %(siteName)s.', translateArg );
 						}
 						return this.translate(
-							'You don\'t have permission to disconnect %(numberOfSites)d site.',
-							'You don\'t have permission to disconnect %(numberOfSites)d sites.',
+							'You don\'t have permission to disconnect %(numberOfSites)d site: %(siteNames)s.',
+							'You don\'t have permission to disconnect %(numberOfSites)d sites: %(siteNames)s.',
 							translateArg );
 
 					default:
@@ -131,8 +135,8 @@ module.exports = {
 							return this.translate( 'Error disconnecting %(siteName)s.', translateArg );
 						}
 						return this.translate(
-							'Error disconnecting %(numberOfSites)d site.',
-							'Error disconnecting %(numberOfSites)d sites.',
+							'Error disconnecting %(numberOfSites)d site: %(siteNames)s.',
+							'Error disconnecting %(numberOfSites)d sites: %(siteNames)s.',
 							translateArg );
 				}
 


### PR DESCRIPTION
Until now, each time you got an error message related with your site list that affected more than one site, you only could see that the error were affecting N sites, but not which sites those were.

![image](https://cloud.githubusercontent.com/assets/1554855/11335854/6e20b396-91e0-11e5-9ed8-4d5c7b9f59e2.png)

This PR adds the name of the sites to the error message:

![image](https://cloud.githubusercontent.com/assets/1554855/11335862/850abade-91e0-11e5-8581-340e56ad8ed0.png)


How to test
=========

1. If you have any jetpack site, force an error message (for example, stopping the server)
2. Go to http://calypso.localhost:3000/plugins
3. You should get a error notice, which should contain a list of the sites currently down