### PR TITLE
Purchases: Add a submit event to tracks when the user saves their credit card details

### DIFF
--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -7,6 +7,7 @@ import page from 'page';
 /**
  * Internal Dependencies
  */
+import analytics from 'analytics';
 import camelCase from 'lodash/string/camelCase';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
@@ -115,6 +116,11 @@ const EditCardDetails = React.createClass( {
 
 	updateCreditCard() {
 		const cardDetails = this.getCardDetails();
+
+		analytics.tracks.recordEvent(
+			'calypso_purchases_credit_card_form_submit',
+			{ product_slug: this.getPurchase().productSlug }
+		);
 
 		createPaygateToken( cardDetails, ( paygateError, token ) => {
 			if ( paygateError ) {


### PR DESCRIPTION
Adds a `calypso_purchases_submit_credit_card_form` event to the submit button form the cancel confirmation page.

Fixes #271 (part of it)

**Testing**

1. `git checkout add/purchases-analytics-edit-card-details`
2. Open http://calypso.dev:3000/purchases
3. Add `calypso:analytics` to the debugger so you see analytics calls in your console
4. Open a purchase and go to the edit payment details page
5. Enter card details and submit the form
4. Assert that you see this event: `calypso_purchases_submit_credit_card_form` with the `product_slug` property

- [ ] Code review
- [x] QA review