### PR TITLE
 Purchases: Fill credit card form with card holder name upon loading Edit Card Details page

### DIFF
--- a/client/components/data/purchases/edit-card-details/index.jsx
+++ b/client/components/data/purchases/edit-card-details/index.jsx
@@ -7,20 +7,23 @@ import React from 'react';
  * Internal dependencies
  */
 import CountriesList from 'lib/countries-list';
-import { fetchUserPurchases } from 'lib/upgrades/actions';
+import { fetchStoredCards, fetchUserPurchases } from 'lib/upgrades/actions';
 import observe from 'lib/mixins/data-observe';
 import PurchasesStore from 'lib/purchases/store';
 import StoreConnection from 'components/data/store-connection';
+import StoredCardsStore from 'lib/purchases/stored-cards/store';
 
 /**
  * Module variables
  */
 const stores = [
-	PurchasesStore
+	PurchasesStore,
+	StoredCardsStore
 ];
 
 function getStateFromStores( props ) {
 	return {
+		card: StoredCardsStore.getByCardId( parseInt( props.cardId, 10 ) ),
 		countriesList: CountriesList.forPayments(),
 		selectedPurchase: PurchasesStore.getByPurchaseId( parseInt( props.purchaseId, 10 ) ),
 		selectedSite: props.selectedSite
@@ -38,6 +41,7 @@ const EditCardDetailsData = React.createClass( {
 	mixins: [ observe( 'sites' ) ],
 
 	componentWillMount() {
+		fetchStoredCards();
 		fetchUserPurchases();
 	},
 

--- a/client/lib/purchases/stored-cards/store.js
+++ b/client/lib/purchases/stored-cards/store.js
@@ -1,7 +1,21 @@
 /**
+ * External Dependencies
+ */
+import assign from 'lodash/object/assign';
+import find from 'lodash/collection/find';
+
+/**
  * Internal dependencies
  */
 import { createReducerStore } from 'lib/store';
 import { getInitialState, reducer } from './reducer';
 
-export default createReducerStore( reducer, getInitialState() );
+const StoredCardsStore = createReducerStore( reducer, getInitialState() );
+
+assign( StoredCardsStore, {
+	getByCardId( cardId ) {
+		return find( this.get().list, { id: cardId } );
+	}
+} );
+
+export default StoredCardsStore;

--- a/client/lib/purchases/stored-cards/test/store-test.js
+++ b/client/lib/purchases/stored-cards/test/store-test.js
@@ -65,6 +65,16 @@ describe( 'Stored Cards Store', () => {
 		} );
 	} );
 
+	it( 'should return an object with a card for a specific id', () => {
+		expect( StoredCardsStore.getByCardId( 12345 ) ).to.be.eql( {
+			id: 12345,
+			expiry: '2016-11-30',
+			number: 2596,
+			type: 'amex',
+			name: 'Jane Doe'
+		} );
+	} );
+
 	it( 'should return an object with the previous list of cards and fetching disabled when fetching failed', () => {
 		Dispatcher.handleViewAction( {
 			type: ActionTypes.STORED_CARDS_FETCH_FAILED,

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -46,7 +46,6 @@ const EditCardDetails = React.createClass( {
 	},
 
 	fieldNames: [
-		'id',
 		'name',
 		'number',
 		'cvv',

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import extend from 'lodash/object/assign';
 import page from 'page';
 
 /**
@@ -31,6 +32,7 @@ const wpcom = wpcomFactory.undocumented();
 
 const EditCardDetails = React.createClass( {
 	propTypes: {
+		card: React.PropTypes.object.isRequired,
 		countriesList: React.PropTypes.object.isRequired,
 		selectedPurchase: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.object.isRequired
@@ -53,12 +55,43 @@ const EditCardDetails = React.createClass( {
 		'postalCode'
 	],
 
+	componentWillReceiveProps( nextProps ) {
+		// Updates the form once with the stored credit card data as soon as they are available
+		if ( nextProps.card && ( ! this.props.card || ( nextProps.card.id !== this.props.card.id ) ) ) {
+			this.setState( {
+				form: formState.initializeFields( this.state.form, this.mergeCard( nextProps.card ) )
+			} );
+		}
+	},
+
+	/**
+	 * Merges the specified card object returned by the StoredCards store into a new object with only properties that
+	 * should be used to prefill the credit card form, and with keys matching the corresponding field names.
+	 *
+	 * @param card
+	 * @param fields
+	 */
+	mergeCard( card, fields: {} ) {
+		return extend( {}, fields, {
+			name: card.name
+		} );
+	},
+
 	componentWillMount() {
-		this.formStateController = formState.Controller( {
-			fieldNames: this.fieldNames,
+		const options = {
 			validatorFunction: this.validate,
 			onNewState: this.setFormState
-		} );
+		};
+
+		if ( this.props.card ) {
+			const fields = formState.createNullFieldValues( this.fieldNames );
+
+			options.initialState = formState.createInitialFormState( this.mergeCard( this.props.card, fields ) );
+		} else {
+			options.fieldNames = this.fieldNames;
+		}
+
+		this.formStateController = formState.Controller( options );
 
 		this.setState( { form: this.formStateController.getInitialState() } );
 	},
@@ -75,7 +108,7 @@ const EditCardDetails = React.createClass( {
 		const messages = formState.getErrorMessages( form );
 
 		if ( messages.length > 0 ) {
-			const notice = notices.error( <ValidationErrorList messages={ messages }/> );
+			const notice = notices.error( <ValidationErrorList messages={ messages } /> );
 
 			this.setState( {
 				form,


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/193 partially by updating the `Edit Card Details` page to display the name attached to the stored credit card associated to the current purchase when it loads:

![screenshot](https://cloud.githubusercontent.com/assets/594356/11335858/8024316c-91e0-11e5-8097-a0cbaa3c939c.png)

It makes use of the [`Stored Cards` store](https://github.com/Automattic/wp-calypso/tree/f102e287020ea3189f48db35b0fbb2126e0c6b5c/client/lib/purchases/stored-cards) that relies on the `/me/stored-cards` API endpoint. We only fill in the form with the card holder name for the time being but we should probably display the country and the postal code as well - these are probably the only fields that won't be updated by users in 95% of the cases. It doesn't make sense to display the last four digits as well as the expiration date for the opposite reason.

This pull request doesn't address disabling of input fields - this is handled as a separate issue in https://github.com/Automattic/wp-calypso/issues/260.

#### Testing instructions

1. Get a new test account and blog
2. Enable the store sandbox
3. Select a plan by clicking the `Upgrade Now` button on the [`Plans` page](http://calypso.localhost:3000/plans)
4. Submit the form on the `Secure Payment` page with fake credit card information
5. Check that the purchase was successful
6. Head to the [`Purchases` page](http://calypso.localhost:3000/purchases)
7. Click the new plan to display the corresponding `Manage Purchase` page
8. Check that the `Payment Method` section shows the right credit card logo and last digits
9. Click the `Edit Payment Method` navigation link to display the `Edit Card Details` page
10. Check that card holder name entered during checkout appears in the form
11. Enter new credit card information and click the `Update Card` button
12. Check that the update was successful
13. Check that the [`Manage Purchase` page](http://calypso.localhost:3000/purchases/:site/:purchaseId) reflects these changes
14. Check that the new stored credit card appears at the bottom of the [`Billing History` page](http://calypso.localhost:3000/me/billing)

#### Notes

I think we should remove the country and postal code returned with the payment data in the `/me/purchases` endpoint and update the `/me/stored-cards` endpoint to return it. That way everything is located in the `Stored Cards` store. What do you think?