### PR TITLE
Purchases: Add analytics to renew now button

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 /**
  * Internal Dependencies
  */
+import analytics from 'analytics';
 import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
@@ -173,6 +174,12 @@ const ManagePurchase = React.createClass( {
 			cartItem = cartItems.getRenewalItemFromProduct( purchase, {
 				domain: purchase.meta
 			} );
+
+		// Track the renew now submit
+		analytics.tracks.recordEvent(
+			'calypso_purchases_renew_now_click',
+			{ product_slug: purchase.productSlug }
+		);
 
 		upgradesActions.addItem( cartItem );
 


### PR DESCRIPTION
Adds a `calypso_purchases_click_renew_now` event to the renew now button on the manage purchase page.

Fixes #271 (part of it)

**Testing**

1. `git checkout add/analytics-to-renew-now-button`
2. Open http://calypso.dev:3000/purchases
3. Add `calypso:analytics` to the debugger so you see analytics calls in your console
4. Open a purchase that has auto renew disabled
5. Click the renew now message
4. Assert that you see this event: `calypso_purchases_click_renew_now` with the `product_slug` property

- [x] Code review
- [x] QA review