### PR TITLE
Update `wpcom-xhr-request` to 0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "webpack-dev-middleware": "1.2.0",
     "wpcom-unpublished": "1.0.3",
     "wpcom-proxy-request": "1.0.4",
-    "wpcom-xhr-request": "0.3.1",
+    "wpcom-xhr-request": "0.3.3",
     "xgettext-js": "0.2.0"
   },
   "engines": {


### PR DESCRIPTION
To update yet another `ms` down the dependency chain to 0.7.1,
fixing https://nodesecurity.io/advisories/46.

Upstream ChangeLog: https://github.com/Automattic/wpcom-xhr-request/blob/master/History.md
