### PR TITLE
Update `wpcom-proxy-request` to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",
     "wpcom-unpublished": "1.0.3",
-    "wpcom-proxy-request": "1.0.4",
+    "wpcom-proxy-request": "1.0.5",
     "wpcom-xhr-request": "0.3.3",
     "xgettext-js": "0.2.0"
   },


### PR DESCRIPTION
To update yet another `ms` down the dependency chain to 0.7.1,
fixing https://nodesecurity.io/advisories/46.

Upstream HISTORY: https://github.com/Automattic/wpcom-proxy-request/blob/master/History.md

(The debug version bump is literally the only change since the 1.0.4.)
