### PR TITLE
Editor: fix small gap between masterbar and content.

### DIFF
--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -14,7 +14,7 @@
 	align-items: center;
 	justify-content: center;
 	// remove normal #content padding
-	margin-top: -28px;
+	margin-top: -32px;
 
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
This was caused by the recent layout update, and the editor is still using the old value.

![image](https://cloud.githubusercontent.com/assets/548849/11336676/96164314-91e7-11e5-8884-93d34530f64e.png)
