### PR TITLE
Purchases: Add an is_renewal property to the calypso checkout page view

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -32,22 +32,20 @@ module.exports = React.createClass( {
 			return;
 		}
 
-		window.scrollTo( 0, 0 );
 		if ( this.props.cart.hasLoadedFromServer ) {
-			this.trackPageView( this.props.cart );
+			this.trackPageView();
 		}
+
+		window.scrollTo( 0, 0 );
+
 		upgradesActions.resetTransaction();
 	},
 
 	componentWillUpdate: function( nextProps ) {
-		if ( this.props.cart.hasLoadedFromServer ) {
-			return;
+		if ( ! this.props.cart.hasLoadedFromServer && nextProps.cart.hasLoadedFromServer ) {
+			this.trackPageView();
 		}
-
-		if ( this.props.cart.hasLoadedFromServer !== nextProps.cart.hasLoadedFromServer ) {
-			this.trackPageView( nextProps.cart );
-		}
-  	},
+	},
 
 	componentDidUpdate: function() {
 		var previousCart, nextCart;
@@ -64,11 +62,11 @@ module.exports = React.createClass( {
 		}
 	},
 
-	trackPageView: function ( cart ) {
+	trackPageView: function() {
 		analytics.tracks.recordEvent( 'calypso_checkout_page_view', {
 			saved_cards: this.props.cards.get().length,
-			is_renewal: cartItems.hasRenewalItem( cart )
-		});
+			is_renewal: cartItems.hasRenewalItem( this.props.cart )
+		} );
 	},
 
 	redirectIfEmptyCart: function() {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -33,9 +33,21 @@ module.exports = React.createClass( {
 		}
 
 		window.scrollTo( 0, 0 );
-		analytics.tracks.recordEvent( 'calypso_checkout_page_view', { saved_cards: this.props.cards.get().length } );
+		if ( this.props.cart.hasLoadedFromServer ) {
+			this.trackPageView( this.props.cart );
+		}
 		upgradesActions.resetTransaction();
 	},
+
+	componentWillUpdate: function( nextProps ) {
+		if ( this.props.cart.hasLoadedFromServer ) {
+			return;
+		}
+
+		if ( this.props.cart.hasLoadedFromServer !== nextProps.cart.hasLoadedFromServer ) {
+			this.trackPageView( nextProps.cart );
+		}
+  	},
 
 	componentDidUpdate: function() {
 		var previousCart, nextCart;
@@ -50,6 +62,13 @@ module.exports = React.createClass( {
 			this.redirectIfEmptyCart();
 			this.setState( { previousCart: nextCart } );
 		}
+	},
+
+	trackPageView: function ( cart ) {
+		analytics.tracks.recordEvent( 'calypso_checkout_page_view', {
+			saved_cards: this.props.cards.get().length,
+			is_renewal: cartItems.hasRenewalItem( cart )
+		});
 	},
 
 	redirectIfEmptyCart: function() {

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -41,9 +41,10 @@ module.exports = React.createClass( {
 		upgradesActions.resetTransaction();
 	},
 
-	componentWillUpdate: function( nextProps ) {
+	componentWillReceiveProps: function( nextProps ) {
 		if ( ! this.props.cart.hasLoadedFromServer && nextProps.cart.hasLoadedFromServer ) {
-			this.trackPageView();
+			// if the cart hadn't loaded when this mounted, record the page view when it loads
+			this.trackPageView( nextProps );
 		}
 	},
 
@@ -62,10 +63,12 @@ module.exports = React.createClass( {
 		}
 	},
 
-	trackPageView: function() {
+	trackPageView: function( props ) {
+		props = props || this.props;
+
 		analytics.tracks.recordEvent( 'calypso_checkout_page_view', {
-			saved_cards: this.props.cards.get().length,
-			is_renewal: cartItems.hasRenewalItem( this.props.cart )
+			saved_cards: props.cards.get().length,
+			is_renewal: cartItems.hasRenewalItem( props.cart )
 		} );
 	},
 


### PR DESCRIPTION
Adds an `is_renewal` property to the `calypso_checkout_page_view` event.

Fixes #271 (part of it)

**Testing**

1. `git checkout add/analytics-to-renew-now-button`
2. Open http://calypso.dev:3000/purchases
3. Add `calypso:analytics` to the debugger so you see analytics calls in your console
4. Open a purchase that has auto renew disabled
5. Click the renew now message
4. Assert that you see this event in the checkout: `calypso_checkout_page_view` with the `is_renewal` property.
5. Reload the page and assert that the event fires again.

- [x] Code review
- [ ] QA review