### PR TITLE
Media: Allow gallery captioned to be emptied

### DIFF
--- a/client/post-editor/media-modal/gallery/caption.jsx
+++ b/client/post-editor/media-modal/gallery/caption.jsx
@@ -24,7 +24,7 @@ export default React.createClass( {
 	},
 
 	getValue() {
-		if ( this.state.caption ) {
+		if ( null !== this.state.caption ) {
 			return this.state.caption;
 		}
 


### PR DESCRIPTION
This pull request seeks to resolve an issue where it was previously not possible to remove all text from an image caption in the media modal gallery edit panel. Without these changes, when a user would try to remove all text from the caption field, it would immediately reset to the original value.

**Before:**

![before](https://cloud.githubusercontent.com/assets/1779930/11337348/52a6de0e-91ba-11e5-9241-39be52474ae9.gif)

**After;**

![after](https://cloud.githubusercontent.com/assets/1779930/11337351/5687d9a6-91ba-11e5-9141-549cd77ec181.gif)

**Testing instructions:**

Verify that you can remove all characters from the gallery caption field to remove the caption from an image.
1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click the media button in the editor toolbar
4. Select two or more images from your media library
   - At least one of which should already have a caption. You can add a caption by clicking the Edit button before proceeding to the gallery screen
5. Click Continue in the modal action bar
6. Change to the gallery Edit tab
7. Remove all characters from the captioned field
8. Note that you can remove all characters from the field
9. Insert the gallery to the post or click the Preview tab
10. Note that the caption removal persists through insertion/preview
