### PR TITLE
Framework: update `wpcom-unpublished` to `1.0.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "walk": "2.3.4",
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom-unpublished": "1.0.3",
+    "wpcom-unpublished": "1.0.5",
     "wpcom-proxy-request": "1.0.5",
     "wpcom-xhr-request": "0.3.3",
     "xgettext-js": "0.2.0"


### PR DESCRIPTION
Update `wpcom-unpublished` dependency to [`1.0.5`](https://github.com/Automattic/wpcom-unpublished/blob/master/History.md#105--2015-11-23)
