### PR TITLE
Build: Install pre-commit githook on `make run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ export NODE_PATH := server:shared:$(THIS_DIR)
 install: node_modules
 
 # Simply running `make run` will spawn the Node.js server instance.
-run: install build
+run: githooks-commit install build
 	@$(NODE) build/bundle-$(CALYPSO_ENV).js
 
 # a helper rule to ensure that a specific module is installed,


### PR DESCRIPTION
The rationale for this is that we'd like more exposure for the GPLv2 contribution notice. Installing them on `make run` seems like a good way to do this.

The way that `bin/pre-commit` is set up now, this will also force the running of i18nlint and eslint checks. Which is a Good Thing in any case.

Of course, these checks can be bypassed using `git commit --no-verify`

To test:
- Delete the existing symlink: `rm .git/hooks/pre-commit`
- Restart `make run`, check that the `.git/hooks/pre-commit` symlink is reinstated

/cc @rralian 
