### PR TITLE
Devdocs: use <SearchCard> for the standalone search box.

### DIFF
--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -10,7 +10,7 @@ var React = require( 'react' ),
  */
 var DocService = require( './service' ),
 	Main = require( 'components/main' ),
-	Search = require( 'components/search' );
+	SearchCard = require( 'components/search-card' );
 
 var DEFAULT_FILES = [
 		'docs/guide/index.md',
@@ -146,7 +146,7 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 			<Main className="devdocs">
-				<Search
+				<SearchCard
 					autoFocus
 					placeholder="Search documentation…"
 					analyticsGroup="Docs"


### PR DESCRIPTION
`SearchCard` is meant to be used instead of `Search` for these standalone search cards.

Before:
![image](https://cloud.githubusercontent.com/assets/548849/11338332/bea589b4-91f3-11e5-8d90-ca52905354e2.png)

After:
![image](https://cloud.githubusercontent.com/assets/548849/11338326/b5fdb00c-91f3-11e5-86d6-a6ead9b35a54.png)
