### PR TITLE
Documentation: Code attribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,3 +122,10 @@ We encourage you to ask for help at any point. We want your first experience wit
 ## License
 
 Calypso is licensed under [GNU General Public License v2 (or later)](./LICENSE.md).
+
+All materials contributed should be compatible with the GPLv2. This means that if you own the material, you agree to license it under the GPLv2 license. If you are contributing code that is not your own, such as adding a component from another Open Source project, or adding an `npm` package, you need to make sure you follow these steps:
+
+1. Check that the code has a license. If you can't find one, you can try to contact the original author and get permission to use, or ask them to release under a compatible Open Source license.
+2. Check the license is compatible with [GPLv2](http://www.gnu.org/licenses/license-list.en.html#GPLCompatibleLicenses), note that the Apache 2.0 license is *not* compatible.
+3. Add the code source URL (e.g. a GitHub URL), the files where it's used in `wp-calypso` and the full license terms to [`CREDITS.md`](/CREDITS.md)
+4. Add attribution to the code, if applicable. This line should include the copyright notice of the source, and a reference to the license contained in [`CREDITS.md`](/CREDITS.md)

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later).\n\n"
+echo "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see CONTRIBUTING.md for details.\n\n"
 
 files=$(git diff --cached --name-only --diff-filter=ACM | grep ".jsx*$")
 if [ "$files" = "" ]; then

--- a/bin/pre-push
+++ b/bin/pre-push
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-echo "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later).\n\n"
+echo "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see CONTRIBUTING.md for details.\n\n"
+
 echo "\nRunning tests ...\n"
 make test
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
@pesieminski asks: "Our credits file is looking good, but when we open up the repo for contributions - from within and outside Automattic - how do we ensure that new third party OSS components are properly credited and referenced?"

This PR adds:
- Some basic guidelines on how to attribute code to `CONTRIBUTING.md`
- A compatibility notice to the `pre-commit` `githook`

Let's see if we can make these clearer, and more friendly.

/cc @rralian