### PR TITLE
Editor: Remove unused detect-browser plugin

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -7,8 +7,7 @@ var React = require( 'react/addons' ),
 	classnames = require( 'classnames' ),
 	debounce = require( 'lodash/function/debounce' ),
 	throttle = require( 'lodash/function/throttle' ),
-	assign = require( 'lodash/object/assign' ),
-	browser = require( 'detect-browser' );
+	assign = require( 'lodash/object/assign' );
 
 /**
  * Internal dependencies

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "cookie-parser": "1.3.2",
     "creditcards": "1.1.1",
     "debug": "2.2.0",
-    "detect-browser": "1.1.1",
     "dom-scroll-into-view": "1.0.1",
     "email-validator": "1.0.1",
     "emitter-component": "1.1.1",


### PR DESCRIPTION
This is a remnant of IE10 detection, we don't need it any more.

- Remove detect-browser from package.json
- Clear up unused dependency in post-editor.jsx

To test:
- Make sure editor still works