### PR TITLE
OSS: adds new developer login/register

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -111,9 +111,9 @@ var devdocs = {
 				title: 'Log In to start hacking',
 				line: 'Required to access the WordPress.com API',
 				action: 'Log In to WordPress.com',
-				actionURL: 'https://wordpress.com/login',
+				actionURL: 'https://wordpress.com/wp-login.php?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000',
 				secondaryAction: 'Register',
-				secondaryActionURL: 'https://wordpress.com/start',
+				secondaryActionURL: '/start/developer',
 				illustration: '/calypso/images/drake/drake-nosites.svg'
 			} ),
 			document.getElementById( 'primary' )

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -124,6 +124,13 @@ const flows = {
 		destination: getCheckoutDestination,
 		description: 'Dynamic Screenshots and Headstart flow',
 		lastModified: '2015-11-13'
+	},
+
+	developer: {
+		steps: [ 'themes', 'site', 'user' ],
+		destination: '/me/next?welcome',
+		description: 'Signup flow for developers in developer environment',
+		lastModified: '2015-11-23'
 	}
 
 };


### PR DESCRIPTION
Addresses #472. Adding new login and signup flows for developers in the development environment that is a little more tailored to their experience. The prior experience would take them out of the developer flow and drop them into production.
## Testing

Log out of WordPress (or open a new incognito window) and go to http://calypso.localhost:3000. Try both the register flow and the login flow and make sure they keep you in the development environment once you are through the flows.

Once https://github.com/Automattic/wp-calypso/issues/474 is completed, we should point the login and register flows to that new welcome screen.

/cc @scruffian @nb 
