### PR TITLE
Purchases: Button state for cancelling Private Registration

### DIFF
--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -21,7 +21,8 @@ import { goToManagePurchase, isDataLoading, recordPageView } from '../utils';
 const CancelPrivateRegistration = React.createClass( {
 	getInitialState() {
 		return {
-			disabled: false
+			disabled: false,
+			cancelling: false
 		};
 	},
 
@@ -33,14 +34,22 @@ const CancelPrivateRegistration = React.createClass( {
 		recordPageView( 'cancel_private_registration', this.props, nextProps );
 	},
 
-	cancel() {
+	cancel( event ) {
+		// We call blur on the cancel button to remove the blue outline that shows up when you click on the button
+		event.target.blur();
+
 		const { domain, id } = this.props.selectedPurchase.data;
 
 		this.setState( {
-			disabled: true
+			disabled: true,
+			cancelling: true
 		} );
 
 		cancelPrivateRegistration( id, canceledSuccessfully => {
+			this.setState( {
+				cancelling: false,
+				disabled: false
+			} );
 			if ( canceledSuccessfully ) {
 				page( paths.managePurchaseDestination( domain, id, 'canceled-private-registration' ) );
 			}
@@ -87,7 +96,10 @@ const CancelPrivateRegistration = React.createClass( {
 				onClick={ this.cancel }
 				className="cancel-private-registration__cancel-button"
 				disabled={ this.state.disabled }>
-				{ this.translate( 'Cancel Private Registration' ) }
+				{
+					this.state.cancelling
+						? this.translate( 'Processing…' )
+						: this.translate( 'Cancel Private Registration' ) }
 			</Button>
 		);
 	},

--- a/client/me/purchases/cancel-private-registration/style.scss
+++ b/client/me/purchases/cancel-private-registration/style.scss
@@ -23,4 +23,8 @@
 
 .cancel-private-registration__cancel-button {
 	margin-top: 10px;
+
+	&[disabled] {
+		color: $gray;
+	}
 }


### PR DESCRIPTION
Fixes #195.

This PR adds a cancelling state to the button when cancelling Private Registration.
It changes the button label to "Processing..." on click.

It also blurs the button on click to get rid of the blue outline after clicking the button. I opted to keep the css for the focus state since that helps with accessibility, but after clicking the outline is gone.

Testing:
---

1. Go to `/purchases`
2. Select a domain with Private Registration
3. Go ahead and cancel it
4. Verify that the text changes to "Processing..."
5. Verify that the blue outline goes away.

/cc: @fabianapsimoes