### PR TITLE
Editor: Fix Safari inability to right-click text

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -4,14 +4,11 @@
 		left: 0;
 		right: 0;
 	margin: 0 auto;
-	height: 100%;
-	opacity: 1;
-	pointer-events: none;
-	z-index: 200;
-
-	&.is-touch {
-		z-index: -1; // Prevents 10332-gh-calypso-pre-oss
-	}
+	height: 0;
+	overflow: hidden;
+	z-index: 100200; // Above TinyMCE dialogs
+	opacity: 0;
+	transition: 0s 0.2s height, 0.2s opacity cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
 }
 
 .web-preview__backdrop {
@@ -22,8 +19,6 @@
 		right: 0;
 		bottom: 0;
 	display: block;
-	opacity: 0;
-	transition: all 0.2s cubic-bezier(0.25, 0.5, 0.5, 0.9);
 }
 
 .web-preview__content {
@@ -37,10 +32,8 @@
 		bottom: 0;
 	margin: 0 auto;
 	transform: scale( 0.96 );
-	opacity: 0;
-	transition: all 0.1s cubic-bezier(0.25, 0.5, 0.5, 0.9);
+	transition: 0.1s transform cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
 	background: lighten( $gray, 30% );
-	z-index: 100200; // try to ensure that dialogs are on top of everything else (match TinyMCE dialog styles)
 
 	.is-computer & {
 		width: 100%;
@@ -62,19 +55,12 @@
 }
 
 .web-preview.is-visible {
-	pointer-events: auto;
-
-	&.is-touch {
-		z-index: 200;
-	}
+	height: 100%;
+	opacity: 1;
+	transition: 0s height, 0.2s opacity cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
 
 	.web-preview__content {
 		transform: scale( 1 );
-		opacity: 1;
-	}
-
-	.web-preview__backdrop {
-		opacity: 1;
 	}
 }
 


### PR DESCRIPTION
Fixes 12499-gh-calypso-pre-oss
Fixes #327

This pull request seeks to resolve an issue where right-clicking text in the post editor would present the user with a set of options related to using the post preview iframe in Safari.

__Before:__

![image](https://cloud.githubusercontent.com/assets/1779930/11339813/4657714a-91c9-11e5-8a0e-a446aeee1eb3.png)

__After:__

![image](https://cloud.githubusercontent.com/assets/1779930/11339806/3831836c-91c9-11e5-9583-d48fb56565a0.png)

__Implementation notes:__

The key change here was to set the height of the preview to zero, only to be restored to `100%` as the preview is visible. A delay is added to the height transition in the default state to ensure that the "fade out" transition has time to be shown to the user.

Some styles were shifted around to manage `z-index` and `opacity` in the `.web-preview` styles.

__Testing instructions:__

Verify that right-click presents the correct text formatting options in Safari and in your preferred browser. Ensure that transitions still occurs as expected when previewing the post. Also check that previous issues with iOS Safari editor usability are not reintroduced here (10332-gh-calypso-pre-oss).

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Add some text to the post editor
4. Right click the text
5. Note that the formatting options right-click dialog is shown
6. Click Preview
7. Note that the preview is shown and transitions with opacity effects
8. Dismiss the preview
9. Note that the preview is hidden and transitions with opacity effects

__Caveats:__

Without text in the post editor area, a right-click may show the iframe options. These are the options for the TinyMCE frame and is expected when there is no text occupying that area of the editor.