### PR TITLE
Plugins: Fix placeholder staying forever when there's no reachable sites

### DIFF
--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -264,9 +264,9 @@ PluginsStore = {
 			_compact(
 				plugin.sites.map( function( site ) {
 					// we create a copy of the site to avoid any possible modification down the line affecting the main list
-					let pluginSite = site.jetpack ?
-						new JetpackSite( sitesList.getSite( site.ID ) ) :
-						new Site( sitesList.getSite( site.ID ) );
+					let pluginSite = site.jetpack
+						? new JetpackSite( sitesList.getSite( site.ID ) )
+						: new Site( sitesList.getSite( site.ID ) );
 					pluginSite.plugin = site.plugin;
 					if ( site.visible ) {
 						return pluginSite;
@@ -314,7 +314,8 @@ PluginsStore.dispatchToken = Dispatcher.register( function( payload ) {
 	switch ( action.type ) {
 		case 'RECEIVE_PLUGINS':
 			if ( action.error ) {
-				// bail if there is an error since there will be nothing to update
+				updatePlugins( action.site, [] );
+				PluginsStore.emitChange();
 				return;
 			}
 

--- a/client/lib/plugins/test/test-store.js
+++ b/client/lib/plugins/test/test-store.js
@@ -183,7 +183,7 @@ describe( 'Plugins Store', function() {
 			} );
 		} );
 
-		it( 'Should not set value of the site if RECEIVE_PLUGINS errors', function() {
+		it( 'Should return an empty array if RECEIVE_PLUGINS errors', function() {
 			var UpdatedStore;
 			Dispatcher.handleServerAction( actions.fetchedError );
 			UpdatedStore = PluginsStore.getPlugins( {
@@ -191,7 +191,7 @@ describe( 'Plugins Store', function() {
 				jetpack: false,
 				plan: { product_slug: 'free_plan' }
 			} );
-			assert.isUndefined( UpdatedStore );
+			assert.equal( UpdatedStore.length, 0 );
 		} );
 
 		it( 'Should not set value of the site if NOT_ALLOWED_TO_RECEIVE_PLUGINS errors', function() {

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -63,7 +63,7 @@ JetpackSite.prototype.fetchAvailableUpdates = function() {
 			debug( 'error fetching Updates data from api', error );
 			// 403 is returned when the user does not have manage capabilities.
 			if ( 403 !== error.statusCode && ! ( this.update instanceof Object ) ) {
-				this.set( { update: 'error' } );
+				this.set( { update: 'error', unreachable: true } );
 			}
 			return;
 		}

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -57,6 +57,13 @@ module.exports = React.createClass( {
 				</div>
 			);
 		}
+		if ( this.props.selectedSite.unreachable ) {
+			return (
+				<div className="plugin-install-button__install embed has-warning">
+					<span className="plugin-install-button__warning">{ this.translate( 'Site unreachable' ) }</span>
+				</div>
+			);
+		}
 		if ( this.props.isInstalling ) {
 			return (
 				<span className="plugin-install-button__install embed">

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -42,6 +42,13 @@ module.exports = React.createClass( {
 	},
 
 	renderEmbedButton: function() {
+		if ( this.props.selectedSite.unreachable ) {
+			return (
+				<div className="plugin-install-button__install embed has-warning">
+					<span className="plugin-install-button__warning">{ this.translate( 'Site unreachable' ) }</span>
+				</div>
+			);
+		}
 		if ( ! this.props.selectedSite.canUpdateFiles ) {
 			return (
 				<div className="plugin-install-button__install embed has-warning">
@@ -54,13 +61,6 @@ module.exports = React.createClass( {
 				<div className="plugin-install-button__install embed has-warning">
 					<span className="plugin-install-button__warning">{ this.translate( 'Jetpack 3.7 is required' ) }</span>
 					<a onclick={ this.updateJetpackAction } href={ this.props.selectedSite.options.admin_url + 'plugins.php?plugin_status=upgrade' } className="plugin-install-button__link">{ this.translate( 'update', { context: 'verb, update plugin button label' } ) }</a>
-				</div>
-			);
-		}
-		if ( this.props.selectedSite.unreachable ) {
-			return (
-				<div className="plugin-install-button__install embed has-warning">
-					<span className="plugin-install-button__warning">{ this.translate( 'Site unreachable' ) }</span>
 				</div>
 			);
 		}

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -236,13 +236,13 @@ module.exports = React.createClass( {
 		return (
 			<div className={ indicatorClass }>
 				<button className="site-indicator__button" onClick={ this.toggleExpand } />
-				{ this.state.expand ?
-					<div className="site-indicator__message">
+				{ this.state.expand
+					? <div className="site-indicator__message">
 						<div className={ textClass }>
 							{ this.getText() }
 						</div>
 					</div>
-				: null }
+					: null }
 			</div>
 		);
 	}


### PR DESCRIPTION
Right now, if all your jetpack sites are unreachable and you go to a single plugin site, you get an access error notice, but the plugin view placeholder never gets dismished:

![image](https://cloud.githubusercontent.com/assets/1554855/11340181/2083e604-91fd-11e5-9b28-420f3169fbac.png)

This PR fixes that, shows the plugin info, and marks the failing sites as unreachable:

![image](https://cloud.githubusercontent.com/assets/1554855/11340202/389a1f7e-91fd-11e5-9b00-73962913eba6.png)
