### PR TITLE
Editor: Assign directionality for user RTL preference

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -185,6 +185,7 @@ module.exports = React.createClass( {
 			content_css: CONTENT_CSS.join( ',' ),
 			language: user.get() ? user.get().localeSlug : 'en',
 			language_url: DUMMY_LANG_URL,
+			directionality: user.isRTL() ? 'rtl' : 'ltr',
 			formats: {
 				alignleft: [
 					{


### PR DESCRIPTION
Fixes #501

This pull request seeks to resolve an issue where the post editor would not assign directionality, thus causing users with RTL language preferences to see the editor as configured for LTR editing.

See related WordPress core configuration: https://github.com/WordPress/WordPress/blob/4.3.1/wp-includes/functions.php#L2903-L2934

__Before:__

![Before](https://cloud.githubusercontent.com/assets/1779930/11340878/ff88000e-91cd-11e5-9519-1204fa79fa4e.png)

__After:__

![After](https://cloud.githubusercontent.com/assets/1779930/11340862/f11084ce-91cd-11e5-998b-ff13cbc1725c.png)

__Testing instructions:__

Verify that the correctly directionality is assigned for both an RTL and LTR language preference.

For changing between languages, ensure that you stop the existing `make run` process, change the `config/development.json` `RTL` value, then restart `make run`. For accurate testing, you should also assign an RTL language (e.g. Hebrew) from [the account settings page](http://calypso.localhost:3000/me/account).

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Focus the post editor editable region
4. Note that the alignment of the cursor matches the current RTL preference