### PR TITLE
Editor: Fix color button RTL alignment

### DIFF
--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -707,7 +707,7 @@ div.mce-path {
 .mce-panel .mce-btn i.mce-caret {
 	top: 5px;
 	right: 18px;
-	margin: 2px 0 0 -13px;
+	margin: 2px 0 0 -13px #{"/*rtl:ignore*/"};
 	border: none;
 	color: $gray;
 	&::before {


### PR DESCRIPTION
Fixes #497 

This pull request seeks to fix the alignment of the color button when the user has an RTL language preference.

**Before:**

![Before](https://cloud.githubusercontent.com/assets/1779930/11341346/2601cfd8-91d0-11e5-8519-0427e3885170.png)

**After:**

![After](https://cloud.githubusercontent.com/assets/1779930/11341356/2dce2590-91d0-11e5-9310-a38275d551a8.png)

**Testing instructions:**

Verify that the alignment of the color button caret is correct in both RTL and LTR language preferences.

For changing between languages, ensure that you stop the existing `make run` process, change the `config/development.json` `RTL` value, then restart `make run`. For accurate testing, you should also assign an RTL language (e.g. Hebrew) from [the account settings page](http://calypso.localhost:3000/me/account).
1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Expand the editor "kitchen sink" secondary action bar using the ellipses, if not already shown
4. Note that the color button caret is aligned correctly and is clickable
