### PR TITLE
Editor: Fix publish panel pinning when navigating from My Sites

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -67,11 +67,15 @@ module.exports = React.createClass( {
 	},
 
 	getBlockStyle: function() {
+		var offset;
+
 		if ( this.state.isSticky ) {
 			// Offset to account for Master Bar by finding body visual top
 			// relative the current scroll position
+			offset = document.getElementById( 'primary' ).getBoundingClientRect().top;
+
 			return {
-				top: document.body.getBoundingClientRect().top + window.pageYOffset,
+				top: offset + window.pageYOffset,
 				width: this.state.blockWidth
 			};
 		}


### PR DESCRIPTION
Fixes #368 

This pull request seeks to resolve an issue where the publish panel would be incorrectly pinned when navigating to the My Sites section prior to visiting the post editor.

**Before:**

![Before](https://cloud.githubusercontent.com/assets/1779930/11343084/7453887c-91d8-11e5-964a-f1fe195e8499.png)

**After:**

![After](https://cloud.githubusercontent.com/assets/1779930/11343104/85c7b1c8-91d8-11e5-85b9-82cdc4038abe.png)

**Implementation notes:**

This is admittedly a bit of a stop-gap fix, and is one we should revisit in the future. It's not ideal for us to be pulling offsets directly from the DOM from within a React component. That said, the behavior here should match the intention of the working behavior, i.e. to adjust the `top` attribute to account for the height of the master bar. It was previously working intermittently because the `getBoundingClientRect` of the `<body>` element would change when navigating to the My Sites section. The `#content` element is more reliable in this regard.

**Testing instructions:**

Verify that the publish panel scroll pinning behaves as expected in the following flow.
1. Navigate to the [Reader](http://calypso.localhost:3000/post)
2. Click My Sites in the master bar
3. Click the New Post (pencil) button in the master bar
4. Select a site, if prompted
5. Scroll the page enough to cause the publish panel to be pinned
6. Note that the publish panel is pinned to the bottom of the master bar, not the top of the page
