### PR TITLE
Editor: Contact Form - Basic TinyMCE plugin and create/edit dialog.

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -36,6 +36,7 @@ require( './plugins/wpcom-tabindex/plugin' )();
 require( './plugins/touch-scroll-toolbar/plugin' )();
 require( './plugins/editor-button-analytics/plugin' )();
 require( './plugins/calypso-alert/plugin' )();
+require( './plugins/contact-form/plugin' )();
 
 /**
  * Internal Dependencies
@@ -43,7 +44,8 @@ require( './plugins/calypso-alert/plugin' )();
 const formatting = require( 'lib/formatting' ),
 	user = require( 'lib/user' )(),
 	i18n = require( './i18n' ),
-	viewport = require( 'lib/viewport' );
+	viewport = require( 'lib/viewport' ),
+	config = require( 'config' );
 
 /**
  * Internal Variables
@@ -94,6 +96,7 @@ const PLUGINS = [
 	'wpcom/editorbuttonanalytics',
 	'wpcom/calypsoalert',
 	'wpcom/tabindex',
+	'wpcom/contactform'
 ];
 
 const CONTENT_CSS = [
@@ -177,6 +180,11 @@ module.exports = React.createClass( {
 
 		this.localize();
 
+		let toolbar1 = [ 'wpcom_add_media', 'formatselect', 'bold', 'italic', 'bullist', 'numlist', 'link', 'blockquote', 'alignleft', 'aligncenter', 'alignright', 'spellchecker', 'wp_more', 'wpcom_advanced' ];
+		if ( config.isEnabled( 'post-editor/contact-form' ) ) {
+			toolbar1.splice( 1, 0, 'wpcom_add_contact_form' );
+		}
+
 		tinymce.init( {
 			selector: '#' + this._id,
 			skin_url: '//s1.wp.com/wp-includes/js/tinymce/skins/lightgray',
@@ -231,14 +239,14 @@ module.exports = React.createClass( {
 			// Limit the preview styles in the menu/toolbar
 			preview_styles: 'font-family font-size font-weight font-style text-decoration text-transform',
 			end_container_on_empty_block: true,
-			plugins: PLUGINS.join( ',' ),
+			plugins: PLUGINS.join(),
 			statusbar: false,
 			resize: false,
 			menubar: false,
 			indent: false,
 
 			autoresize_min_height: document.documentElement.clientHeight,
-			toolbar1: 'wpcom_add_media,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced',
+			toolbar1: toolbar1.join(),
 			toolbar2: 'strikethrough,underline,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
 			toolbar3: '',
 			toolbar4: '',

--- a/client/components/tinymce/plugins/contact-form/dialog.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog.jsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Shortcode from 'lib/shortcode';
+import Dialog from 'components/dialog';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormButton from 'components/forms/form-button';
+
+/**
+ * object constants
+ */
+const fieldTypes = {
+	name: 'name',
+	email: 'email',
+	url: 'url',
+	checkbox: 'checkbox',
+	dropdown: 'dropdown',
+	radio: 'radio',
+	text: 'text',
+	textarea: 'textarea',
+	website: 'website'
+};
+
+const defaultForm = [
+	{ label: 'Name', type: fieldTypes.name, required: true },
+	{ label: 'Email', type: fieldTypes.email, required: true },
+	{ label: 'Website', type: fieldTypes.url },
+	{ label: 'Comment', type: fieldTypes.textarea, required: true }
+];
+
+export default React.createClass( {
+	displayName: 'ContactFormDialog',
+
+	propTypes: {
+		onClose: PropTypes.func.isRequired,
+		onInsertMedia: PropTypes.func.isRequired,
+		showDialog: PropTypes.bool.isRequired
+	},
+
+	render() {
+		const buttons = [
+			<FormButton
+				key="save"
+				onClick={ () => {
+					const fields = defaultForm.map( field => {
+						return Shortcode.stringify( {
+							tag: 'contact-field',
+							type: 'self-closing',
+							attrs: {
+								label: field.label,
+								type: field.type,
+								required: field.required ? 1 : 0
+							}
+						} );
+					} ).join( '' );
+
+					const shortcode = Shortcode.stringify( {
+						tag: 'contact-form',
+						type: 'closed',
+						content: fields,
+						attrs: {
+							to: 'user@example.com',
+							subject: 'this is a contact form'
+						}
+					} );
+
+					this.props.onInsertMedia( shortcode );
+				} }
+			>
+				{ this.translate( 'Save' ) }
+			</FormButton>,
+			<FormButton
+				key="cancel"
+				isPrimary={ false }
+				onClick={ this.props.onClose }
+			>
+				{ this.translate( 'Cancel' ) }
+			</FormButton>
+		];
+
+		return (
+			<Dialog
+				isVisible={ this.props.showDialog }
+				onClose={ this.props.onClose }
+				buttons={ buttons }
+				additionalClassNames="contact-form__dialog"
+			>
+				<FormFieldset>
+					<FormLabel>
+						<span>Here be dragons. Click Save to add a generic contact form...</span>
+					</FormLabel>
+				</FormFieldset>
+			</Dialog>
+		);
+	}
+} );

--- a/client/components/tinymce/plugins/contact-form/plugin.js
+++ b/client/components/tinymce/plugins/contact-form/plugin.js
@@ -1,0 +1,67 @@
+/**
+ * External Dependencies
+ */
+import tinymce from 'tinymce/tinymce';
+import i18n from 'lib/mixins/i18n';
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import Gridicon from 'components/gridicon';
+import ContactFormDialog from './dialog';
+
+const contactForm = editor => {
+	let node;
+
+	editor.on( 'init', () => {
+		node = editor.getContainer().appendChild(
+			document.createElement( 'div' )
+		);
+	} );
+
+	editor.on( 'remove', () => {
+		React.unmountComponentAtNode( node );
+		node.parentNode.removeChild( node );
+		node = null;
+	} );
+
+	editor.addCommand( 'WP_ContactForm', () => {
+		function onClose() {
+			editor.focus();
+			renderModal( 'hide' );
+		};
+
+		function renderModal( visibility = 'show' ) {
+			React.render(
+				React.createElement( ContactFormDialog, {
+					showDialog: visibility === 'show',
+					onClose,
+					onInsertMedia( markup ) {
+						editor.execCommand( 'mceInsertContent', false, markup );
+					}
+				} ),
+				node
+			);
+		};
+
+		renderModal();
+	} );
+
+	editor.addButton( 'wpcom_add_contact_form', {
+		classes: 'btn wpcom-button contact-form',
+		title: i18n.translate( 'Add Contact Form' ),
+		cmd: 'WP_ContactForm',
+		onPostRender() {
+			this.innerHtml( React.renderToStaticMarkup(
+				<button type="button" role="presentation">
+					<Gridicon icon="grid" size={ 20 } />
+				</button>
+			) );
+		}
+	} );
+};
+
+export default () => {
+	tinymce.PluginManager.add( 'wpcom/contactform', contactForm );
+}

--- a/client/components/tinymce/plugins/wpcom-view/contact-form-view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/contact-form-view.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependecies
+ */
+import shortcodeUtils from 'lib/shortcode';
+
+export default React.createClass( {
+	statics: {
+		match( content ) {
+			const match = shortcodeUtils.next( 'contact-form', content );
+
+			if ( match ) {
+				return {
+					index: match.index,
+					content: match.content,
+					options: {
+						shortcode: match.shortcode
+					}
+				};
+			}
+		},
+
+		serialize( content ) {
+			return encodeURIComponent( content );
+		},
+
+		edit( editor, content ) {
+			editor.execCommand( 'WP_ContactForm', content );
+		}
+	},
+	render() {
+		return (
+			<div className="wpview-content wpview-type-contact-form">
+				<p>This is a placeholder for the form preview.</p>
+			</div>
+		);
+	}
+} );

--- a/client/components/tinymce/plugins/wpcom-view/views.js
+++ b/client/components/tinymce/plugins/wpcom-view/views.js
@@ -10,16 +10,22 @@ import values from 'lodash/object/values';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import GalleryView from './gallery-view';
 import EmbedViewManager from './views/embed';
+import ContactFormView from './contact-form-view';
 
 /**
  * Module variables
  */
-const views = {
+let views = {
 	gallery: GalleryView,
 	embed: new EmbedViewManager()
 };
+
+if ( config.isEnabled( 'post-editor/contact-form' ) ) {
+	views.contact = ContactFormView;
+}
 
 const components = mapValues( views, ( view ) => {
 	if ( 'function' === typeof view.getComponent ) {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -158,6 +158,7 @@
 	vertical-align: middle;
 }
 
+.mce-toolbar .mce-wpcom-button.mce-contact-form button,
 .mce-toolbar .mce-wpcom-button.mce-media button {
 	height: 38px;
 	padding: 0 8px;
@@ -178,21 +179,25 @@
 	font-size: 13px;
 }
 
+.mce-toolbar .mce-wpcom-button.mce-contact-form:hover span,
 .mce-toolbar .mce-wpcom-button.mce-media:hover span {
 	color: $gray-dark;
 }
 
+.mce-toolbar .mce-wpcom-button.mce-contact-form svg,
 .mce-toolbar .mce-wpcom-button.mce-media svg {
 	fill: darken( $gray, 20% );
 	width: 20px;
 	margin-right: 4px;
 }
 
+.mce-toolbar .mce-wpcom-button.mce-contact-form:hover svg,
 .mce-toolbar .mce-wpcom-button.mce-media:hover svg {
 	fill: $gray-dark;
 }
 
 // Position media button at the beginning of the toolbar
+.mce-toolbar .mce-wpcom-button.mce-btn.mce-contact-form,
 .mce-toolbar .mce-wpcom-button.mce-btn.mce-media {
 	margin: 0;
 	border: 0;

--- a/config/development.json
+++ b/config/development.json
@@ -43,6 +43,7 @@
 		"post-editor/pages": true,
 		"post-editor-github-link": false,
 		"post-editor/post-type-switch": false,
+		"post-editor/contact-form": true,
 
 		"manage/media": true,
 		"manage/posts": true,

--- a/public/tinymce/skins/wordpress/wp-content.css
+++ b/public/tinymce/skins/wordpress/wp-content.css
@@ -416,6 +416,13 @@ audio {
     clear: both;
 }
 
+.wpview-type-contact-form {
+	border: 1px solid #87a6bc;
+	border-radius: 3px;
+	padding: 20px;
+	text-align: center;
+}
+
 .gallery img[data-mce-selected]:focus {
 	outline: none;
 }


### PR DESCRIPTION
This is the starting point for building a new contact form builder for Calypso's editor. This first incremental update includes a new `contact-form-view` for `wpcom-view` that will handle the contact form preview and a new `contact-form` TinyMCE plugin, to handle the create/edit dialog, state, serialization and deserialization.

![contact-form-dialog](https://cloud.githubusercontent.com/assets/233601/11694182/6036003e-9e87-11e5-8948-8201bda15f6a.gif)

#### Changes include:

Added a new feature flag, `post-editor/contact-from`, so this feature is only available in development mode. All the changes involving the feature flag will be reverted once this feature is production ready.

Changes on `client/components/tinymce/index.jsx` to add the new `contact-form` plugin and a new toolbar button.

Changes on `client/components/tinymce/plugins/wpcom-view/views.js` to load the new `contact-form-view` when `[contact-form]` is found.

Tentative styling of the toolbar button is on `client/components/tinymce/style.scss` and basic layout for the preview is on `public/tinymce/skins/wordpress/wp-content.css`.

#### what is new

A new component, `contact-form-view`, was created to render the form preview and lives on `wpcom-view`. It implements a series of static methods to match the `[contact-form]` shortcode, serialize it for the _HTML_ view of the editor and handle the `edit` command.

A new TinyMCE plugin, `contact-form`, is in charge of setting up the editor and render the dialog to build and manage the form settings.

#### what is missing

To keep the size of this pull request small, the dialog just creates a default form. Also, the form preview is missing. Some placeholder messages are not being translated.