### PR TITLE
Redirect logged out /discover to Discover site

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -385,6 +385,16 @@ module.exports = function() {
 		} );
 	}
 
+	if ( config.isEnabled( 'reader/discover' ) ) {
+		app.get( '/discover', function( req, res ) {
+			if ( req.cookies.wordpress_logged_in ) {
+				renderLoggedInRoute( req, res );
+			} else {
+				res.redirect( 'https://discover.wordpress.com' );
+			}
+		} );
+	}
+
 	// catchall path to serve shell for all non-static-file requests (other than auth routes)
 	app.get( '*', renderLoggedInRoute );
 


### PR DESCRIPTION
Currently we show a login page, which is not great. Logged-in users still pass-through to Calypso. Logged-out users go to https://discover.wordpress.com.