### PR TITLE
Signup: pointing to the proper developer welcome page

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -112,7 +112,7 @@ var devdocs = {
 				title: 'Log In to start hacking',
 				line: 'Required to access the WordPress.com API',
 				action: 'Log In to WordPress.com',
-				actionURL: 'https://wordpress.com/wp-login.php?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000',
+				actionURL: 'https://wordpress.com/wp-login.php?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000/devdocs/welcome',
 				secondaryAction: 'Register',
 				secondaryActionURL: '/start/developer',
 				illustration: '/calypso/images/drake/drake-nosites.svg'

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -128,7 +128,7 @@ const flows = {
 
 	developer: {
 		steps: [ 'themes', 'site', 'user' ],
-		destination: '/me/next?welcome',
+		destination: '/devdocs/welcome',
 		description: 'Signup flow for developers in developer environment',
 		lastModified: '2015-11-23'
 	}


### PR DESCRIPTION
The signup/register work was done separate from the devdocs/welcome work, so we need to wire it up.

## Testing
@nb could you give this a runthrough? Test both register and login and make sure it takes you to the proper /devdocs/start page.