### PR TITLE
Purchases: Individual purchases not loading on sites with Site Redirect

### DIFF
--- a/client/components/data/purchases/index.jsx
+++ b/client/components/data/purchases/index.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { fetchUserPurchases } from 'lib/upgrades/actions';
+import observe from 'lib/mixins/data-observe';
 import PurchasesStore from 'lib/purchases/store';
 import StoreConnection from 'components/data/store-connection';
 import userFactory from 'lib/user';
@@ -20,15 +21,19 @@ const stores = [ PurchasesStore ],
 function getStateFromStores( props ) {
 	return {
 		noticeType: props.noticeType,
-		purchases: PurchasesStore.getByUser( user.get().ID )
+		purchases: PurchasesStore.getByUser( user.get().ID ),
+		sites: props.sites
 	};
 }
 
 const PurchasesData = React.createClass( {
 	propTypes: {
 		component: React.PropTypes.func.isRequired,
-		noticeType: React.PropTypes.string
+		noticeType: React.PropTypes.string,
+		sites: React.PropTypes.object.isRequired
 	},
+
+	mixins: [ observe( 'sites' ) ],
 
 	componentDidMount() {
 		fetchUserPurchases();
@@ -39,6 +44,7 @@ const PurchasesData = React.createClass( {
 			<StoreConnection
 				component={ this.props.component }
 				noticeType={ this.props.noticeType }
+				sites={ this.props.sites }
 				stores={ stores }
 				getStateFromStores={ getStateFromStores } />
 		);

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -15,9 +15,10 @@ import { isDomainMapping, isDomainRegistration, isTheme, isPlan } from 'lib/prod
  * Returns an array of sites objects, each of which contains an array of purchases.
  *
  * @param {array} purchases An array of purchase objects.
+ * @param {SitesList} sites SitesList instance
  * @return {array} An array of sites with purchases attached.
  */
-function getPurchasesBySite( purchases ) {
+function getPurchasesBySite( purchases, sites ) {
 	return purchases.reduce( ( result, currentValue ) => {
 		const site = find( result, { id: currentValue.siteId } );
 		if ( site ) {
@@ -27,6 +28,7 @@ function getPurchasesBySite( purchases ) {
 				domain: currentValue.domain,
 				id: currentValue.siteId,
 				name: currentValue.siteName,
+				slug: sites.getSite( currentValue.siteId ).slug,
 				title: currentValue.siteName ? currentValue.siteName : currentValue.domain,
 				purchases: [ currentValue ]
 			} );

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -24,11 +24,16 @@ function getPurchasesBySite( purchases, sites ) {
 		if ( site ) {
 			site.purchases = site.purchases.concat( currentValue );
 		} else {
+			const siteObject = find( sites, { ID: currentValue.siteId } );
+
 			result = result.concat( {
 				domain: currentValue.domain,
 				id: currentValue.siteId,
 				name: currentValue.siteName,
-				slug: find( sites, { ID: currentValue.siteId } ).slug,
+				/* if the purchase is attached to a deleted site,
+				 * there will be no site with this ID in `sites`, so
+				 * we fall back on the domain. */
+				slug: siteObject ? siteObject.slug : currentValue.domain,
 				title: currentValue.siteName ? currentValue.siteName : currentValue.domain,
 				purchases: [ currentValue ]
 			} );

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -28,7 +28,7 @@ function getPurchasesBySite( purchases, sites ) {
 				domain: currentValue.domain,
 				id: currentValue.siteId,
 				name: currentValue.siteName,
-				slug: sites.getSite( currentValue.siteId ).slug,
+				slug: find( sites, { ID: currentValue.siteId } ).slug,
 				title: currentValue.siteName ? currentValue.siteName : currentValue.domain,
 				purchases: [ currentValue ]
 			} );

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -15,7 +15,7 @@ import { isDomainMapping, isDomainRegistration, isTheme, isPlan } from 'lib/prod
  * Returns an array of sites objects, each of which contains an array of purchases.
  *
  * @param {array} purchases An array of purchase objects.
- * @param {SitesList} sites SitesList instance
+ * @param {array} sites An array of site objects
  * @return {array} An array of sites with purchases attached.
  */
 function getPurchasesBySite( purchases, sites ) {

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -173,7 +173,8 @@ export default {
 		renderPage(
 			<PurchasesData
 				component={ PurchasesList }
-				noticeType={ context.params.noticeType } />
+				noticeType={ context.params.noticeType }
+				sites={ sites } />
 		);
 	},
 

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -14,6 +14,9 @@ import MeSidebarNavigation from 'me/sidebar-navigation';
 import Notice from 'components/notice';
 import PurchasesHeader from './header';
 import PurchasesSite from './site';
+import sitesFactory from 'lib/sites-list';
+
+const sites = sitesFactory();
 
 const PurchasesList = React.createClass( {
 	renderNotice() {
@@ -67,12 +70,12 @@ const PurchasesList = React.createClass( {
 		}
 
 		if ( this.props.purchases.hasLoadedFromServer && this.props.purchases.data.length ) {
-			content = getPurchasesBySite( this.props.purchases.data ).map(
+			content = getPurchasesBySite( this.props.purchases.data, sites ).map(
 				site => (
 					<PurchasesSite
 						key={ site.id }
 						name={ site.title }
-						domain={ site.domain }
+						slug={ site.slug }
 						purchases={ site.purchases } />
 				)
 			);

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -75,7 +75,7 @@ const PurchasesList = React.createClass( {
 		}
 
 		if ( this.props.purchases.hasLoadedFromServer && this.props.purchases.data.length ) {
-			content = getPurchasesBySite( this.props.purchases.data, this.props.sites ).map(
+			content = getPurchasesBySite( this.props.purchases.data, this.props.sites.get() ).map(
 				site => (
 					<PurchasesSite
 						key={ site.id }

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -14,9 +14,6 @@ import MeSidebarNavigation from 'me/sidebar-navigation';
 import Notice from 'components/notice';
 import PurchasesHeader from './header';
 import PurchasesSite from './site';
-import sitesFactory from 'lib/sites-list';
-
-const sites = sitesFactory();
 
 const PurchasesList = React.createClass( {
 	renderNotice() {
@@ -58,19 +55,27 @@ const PurchasesList = React.createClass( {
 		);
 	},
 
+	isDataLoading() {
+		if ( this.props.purchases.isFetching && ! this.props.purchases.hasLoadedFromServer ) {
+			return true;
+		}
+
+		if ( ! this.props.sites.initialized ) {
+			return true;
+		}
+
+		return false;
+	},
+
 	render() {
 		let content;
 
-		if ( ! this.props.purchases.isFetching && ! this.props.purchases.hasLoadedFromServer ) {
-			return null;
-		}
-
-		if ( this.props.purchases.isFetching && ! this.props.purchases.hasLoadedFromServer ) {
+		if ( this.isDataLoading() ) {
 			content = <PurchasesSite isPlaceholder />;
 		}
 
 		if ( this.props.purchases.hasLoadedFromServer && this.props.purchases.data.length ) {
-			content = getPurchasesBySite( this.props.purchases.data, sites ).map(
+			content = getPurchasesBySite( this.props.purchases.data, this.props.sites ).map(
 				site => (
 					<PurchasesSite
 						key={ site.id }

--- a/client/me/purchases/list/item/index.jsx
+++ b/client/me/purchases/list/item/index.jsx
@@ -23,7 +23,7 @@ import {
 
 const PurchaseItem = React.createClass( {
 	propTypes: {
-		domain: React.PropTypes.string,
+		slug: React.PropTypes.string,
 		purchase: React.PropTypes.object,
 		isPlaceholder: React.PropTypes.bool
 	},
@@ -131,7 +131,7 @@ const PurchaseItem = React.createClass( {
 
 		if ( ! isPlaceholder ) {
 			props = {
-				href: paths.managePurchase( this.props.domain, this.props.purchase.id ),
+				href: paths.managePurchase( this.props.slug, this.props.purchase.id ),
 				onClick: this.scrollToTop
 			};
 		}

--- a/client/me/purchases/list/site/index.jsx
+++ b/client/me/purchases/list/site/index.jsx
@@ -12,7 +12,7 @@ import PurchaseItem from '../item';
 
 const PurchasesSite = React.createClass( {
 	propTypes: {
-		domain: React.PropTypes.string,
+		slug: React.PropTypes.string,
 		name: React.PropTypes.string,
 		purchases: React.PropTypes.array,
 		isPlaceholder: React.PropTypes.bool
@@ -39,7 +39,7 @@ const PurchasesSite = React.createClass( {
 					this.props.purchases.map( purchase => (
 						<PurchaseItem
 							key={ purchase.id }
-							domain={ this.props.domain }
+							slug={ this.props.slug }
 							purchase={ purchase } />
 						)
 					)


### PR DESCRIPTION
This fixes the issue of individual purchases not loading on site with Site Redirect record set as primary domain. (Fixes #122)

It changes the use of `domain` property from purchases data to getting the site slug from `SitesList`. This will the URLs will behave the same as in store.

**Testing**
- Assert that a site with a site redirect appears properly in `/purchases`.
- Assert that two sites that redirect to the same site appear properly in `/purchases`.

- [x] QA review
- [x] Code review