### PR TITLE
Add site selector to the help contact form

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -14,6 +14,7 @@ import DropdownItem from 'components/select-dropdown/item';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
+import SelectSite from 'me/select-site';
 
 module.exports = React.createClass( {
 	displayName: 'HelpContactForm',
@@ -26,6 +27,9 @@ module.exports = React.createClass( {
 		showHowCanWeHelpField: React.PropTypes.bool,
 		showHowYouFeelField: React.PropTypes.bool,
 		showSubjectField: React.PropTypes.bool,
+		showSiteField: React.PropTypes.bool,
+		siteFilter: React.PropTypes.func,
+		siteList: React.PropTypes.object,
 		disabled: React.PropTypes.bool
 	},
 
@@ -34,6 +38,7 @@ module.exports = React.createClass( {
 			showHowCanWeHelpField: false,
 			showHowYouFeelField: false,
 			showSubjectField: false,
+			showSiteField: false,
 			disabled: false
 		}
 	},
@@ -43,12 +48,20 @@ module.exports = React.createClass( {
 	 * @return {Object} An object representing our initial state
 	 */
 	getInitialState: function() {
+		const { showSiteField, siteList } = this.props;
+
 		return {
 			howCanWeHelp: 'gettingStarted',
 			howYouFeel: 'unspecified',
 			message: '',
-			subject: ''
+			subject: '',
+			site: showSiteField ? siteList.getLastSelectedSite() || siteList.getPrimary() : null
 		};
+	},
+
+	setSite: function( event ) {
+		const site = this.props.siteList.getSite( parseInt( event.target.value, 10 ) );
+		this.setState( { site: site } );
 	},
 
 	/**
@@ -137,7 +150,7 @@ module.exports = React.createClass( {
 				{ value: 'panicked', label: this.translate( 'Panicked' ) }
 			];
 
-		const { buttonLabel, showHowCanWeHelpField, showHowYouFeelField, showSubjectField } = this.props;
+		const { buttonLabel, showHowCanWeHelpField, showHowYouFeelField, showSubjectField, showSiteField, siteList, siteFilter } = this.props;
 
 		return (
 			<div className="help-contact-form">
@@ -152,6 +165,18 @@ module.exports = React.createClass( {
 					<div>
 						<FormLabel>{ this.translate( 'Mind sharing how you feel?' ) }</FormLabel>
 						{ this.renderFormSelection( 'howYouFeel', howYouFeelOptions ) }
+					</div>
+				) : null }
+
+				{ showSiteField ? (
+					<div>
+						<FormLabel>{ this.translate( 'Which site do you need help with?' ) }</FormLabel>
+						<SelectSite
+							className="help-contact-form__site-selection"
+							sites={ siteList }
+							filter={ siteFilter }
+							value={ this.state.site.ID }
+							onChange={ this.setSite } />
 					</div>
 				) : null }
 

--- a/client/me/help/help-contact-form/style.scss
+++ b/client/me/help/help-contact-form/style.scss
@@ -10,11 +10,20 @@
 }
 
 .help-contact-form__subject,
+.help-contact-form__site-selection,
 .help-contact-form__selection {
 	margin-bottom: 24px;
 
 	@include breakpoint( ">960px" ) {
 		margin-bottom: 32px;
+	}
+}
+
+.help-contact-form__site-selection {
+	width: 100%;
+
+	@include breakpoint( ">960px" ) {
+		width: auto;
 	}
 }
 


### PR DESCRIPTION
This pull request adds a drop down to the contact form that will allow the user to specify which site they need help with.

### How to test

**Case 1: A user with many sites**
1. Navigate to http://calypso.localhost:3000/help/contact
2. Select a site from the "Which site do you need help with?" drop down. See this
3. Enter some text to start chatting.

**Case 2: A user with one site**
1. Navigate to http://calypso.localhost:3000/help/contact
2. Notice that the site selection is not visible since the user only has one site. See this
3. Enter some text to start chatting.

### What to expect

**Case 1**
![Case One](https://cloud.githubusercontent.com/assets/1854440/11073520/f621dacc-87b8-11e5-9dee-16a7c13dad5a.png)

**Case 2**
![Case 2](https://cloud.githubusercontent.com/assets/1854440/11073501/e5172cd2-87b8-11e5-8377-99f4abff5eaf.png)

Further details, discussion, and 12020-gh-calypso-pre-oss