### PR TITLE
Editor: enable drafts drawer in production.

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -53,6 +53,7 @@
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/pages": true,
+		"editor-drafts": true,
 		"help": false,
 		"upgrades/checkout": true,
 		"upgrades/domain-management/contacts-privacy": true,


### PR DESCRIPTION
To display drafts drawer inside the editor. Not currently enabled.