### PR TITLE
Editor: Reset title scroll position on blur

### DIFF
--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -66,6 +66,8 @@ export default React.createClass( {
 		} );
 
 		this.onChange( event );
+
+		event.target.scrollLeft = 0;
 	},
 
 	onFocus() {


### PR DESCRIPTION
Fixes #347 

This pull request seeks to resolve an issue in Firefox where, after tabbing from the editor title field after having entered a very long title, the field would not reset to the start of the field.

__Before:__

![before](https://cloud.githubusercontent.com/assets/1779930/11346010/75064b78-91e8-11e5-84a3-357cf4d0a561.gif)

__After:__

![after](https://cloud.githubusercontent.com/assets/1779930/11346032/8f4522f2-91e8-11e5-9eca-290796cc389a.gif)

__Testing instructions:__

Verify that the title resets to the show the beginning of the field value when tabbing to the editor. This should behave correctly in Firefox and in your preferred browser.

1. Navigate to the [Calypso post editor](http://caypso.localhost:3000/post)
2. Select a site, if prompted
3. Enter a long title, enough to scroll past the visible width of the editor
4. Tab from the field
5. Note that the beginning of the title field is visible