### PR TITLE
Media: vertically align chevron in Add New split button on small screens

### DIFF
--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -31,10 +31,6 @@
 		border-top-left-radius: 0;
 		border-bottom-left-radius: 0;
 
-		.gridicon {
-			margin-top: 2px;
-		}
-
 		@include breakpoint( ">660px" ) {
 			display: none;
 		}


### PR DESCRIPTION
Before:

<img width="295" alt="screen shot 2015-11-23 at 1 56 04 pm" src="https://cloud.githubusercontent.com/assets/5835847/11346297/f8cf229e-91e9-11e5-8c13-0825240636f8.png">

After: 

<img width="293" alt="screen shot 2015-11-23 at 1 55 54 pm" src="https://cloud.githubusercontent.com/assets/5835847/11346296/f8c73b24-91e9-11e5-87fc-465b9be38517.png">

Test either on your small mobile device or on a browser width of <660px. Go to /post, choose your favorite site, and open the media modal. 