### PR TITLE
Editor: Track elements for more reliable drag detection

### DIFF
--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -47,6 +47,7 @@ module.exports = React.createClass( {
 		window.addEventListener( 'drop', this.onDrop );
 		window.addEventListener( 'dragenter', this.toggleDraggingOverDocument );
 		window.addEventListener( 'dragleave', this.toggleDraggingOverDocument );
+		window.addEventListener( 'mouseup', this.resetDragState );
 	},
 
 	componentDidUpdate: function( prevProps, prevState ) {
@@ -60,7 +61,16 @@ module.exports = React.createClass( {
 		window.removeEventListener( 'drop', this.onDrop );
 		window.removeEventListener( 'dragenter', this.toggleDraggingOverDocument );
 		window.removeEventListener( 'dragleave', this.toggleDraggingOverDocument );
+		window.removeEventListener( 'mouseup', this.resetDragState );
 		this.disconnectMutationObserver();
+	},
+
+	resetDragState: function() {
+		if ( ! ( this.state.isDraggingOverDocument || this.state.isDraggingOverElement ) ) {
+			return;
+		}
+
+		this.setState( this.getInitialState() );
 	},
 
 	toggleMutationObserver: function() {


### PR DESCRIPTION
Fixes #508 
Fixes #359

This pull request seeks to resolve an issue where dragging an item could intermittently cause the drag detection to become stuck after moving the cursor away from the page.

__Implementation notes:__

In my testing, I had found that sometimes the previous implementation would incorrectly become stuck with an inaccurate "drag counter" when multiple consecutive drag incrementing (`dragenter`) events were triggered on an element. This pull request changes the implementation to track elements known to be dragged over, rather than increment a simple counter. This results in more stable tracking, as even if multiple events were fired against the same element, it would be included in the set of tracked elements only once.

__Testing instructions:__

The following cases have been observed to have sometimes caused a "stuck":

- Dragging an item across the page, then moving the cursor off the page (while the item is still dragged). This occurs more frequently when the cursor is moved quickly.
- Dragging an item from your finder immediately atop the post editor `iframe`. There is special treatment for faking a drag event atop the editor `iframe`.

Verify that drag detection is tracked correctly in your preferred browser.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Drag an item from your finder over the page
4. Note that the "drop zone" is shown in a deactivated state while the item is dragged over the page
5. Continue dragging the item over the drop zone area
6. Note that the drop zone becomes activated
7. Continue dragging the item off the drop zone area
8. Note that the drop zone becomes deactivated
9. Continue dragging the item off the page
10. Note that the drop zone area is hidden