### PR TITLE
Purchases: Fix purchase not updated upon privacy protection cancelation

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -11,77 +11,78 @@ import i18n from 'lib/mixins/i18n';
 import { isPaidWithCreditCard } from 'lib/purchases';
 import sortProducts from 'lib/products-values/sort';
 
+function createPurchaseObject( purchase ) {
+	const object = {
+		id: Number( purchase.ID ),
+		active: Boolean( purchase.active ),
+		amount: Number( purchase.amount ),
+		attachedToPurchaseId: Number( purchase.attached_to_purchase_id ),
+		canDisableAutoRenew: Boolean( purchase.can_disable_auto_renew ),
+		currencyCode: purchase.currency_code,
+		currencySymbol: purchase.currency_symbol,
+		domain: purchase.domain,
+		error: null,
+		expiryDate: purchase.expiry_date,
+		expiryMoment: purchase.expiry_date ? i18n.moment( purchase.expiry_date ) : null,
+		expiryStatus: camelCase( purchase.expiry_status ),
+		hasPrivateRegistration: Boolean( purchase.has_private_registration ),
+		includedDomain: purchase.included_domain,
+		isCancelable: Boolean( purchase.is_cancelable ),
+		isDomainRegistration: Boolean( purchase.is_domain_registration ),
+		isRedeemable: Boolean( purchase.is_redeemable ),
+		isRefundable: Boolean( purchase.is_refundable ),
+		isRenewable: Boolean( purchase.is_renewable ),
+		meta: purchase.meta,
+		priceText: `${ purchase.currency_symbol }${ purchase.amount } ${ purchase.currency_code }`,
+		payment: {
+			name: purchase.payment_name,
+			type: purchase.payment_type,
+			countryCode: purchase.payment_country_code,
+			countryName: purchase.payment_country_name
+		},
+		productId: Number( purchase.product_id ),
+		productName: purchase.product_name,
+		productSlug: purchase.product_slug,
+		refundPeriodInDays: purchase.refund_period_in_days,
+		renewDate: purchase.renew_date,
+		// only generate a moment if `renewDate` is present and positive
+		renewMoment: purchase.renew_date && purchase.renew_date > '0'
+			? i18n.moment( purchase.renew_date )
+			: null,
+		siteId: Number( purchase.blog_id ),
+		siteName: purchase.blogname,
+		subscribedDate: purchase.subscribed_date,
+		subscriptionStatus: purchase.subscription_status,
+		tagLine: purchase.tag_line,
+		userId: Number( purchase.user_id )
+	};
+
+	if ( isPaidWithCreditCard( object ) ) {
+		return merge( {}, object, {
+			payment: {
+				creditCard: {
+					id: Number( purchase.payment_card_id ),
+					type: purchase.payment_card_type,
+					number: Number( purchase.payment_details ),
+					expiryDate: purchase.payment_expiry,
+					expiryMoment: purchase.payment_expiry ? i18n.moment( purchase.payment_expiry, 'MM/YY' ) : null
+				}
+			}
+		} );
+	}
+
+	return object;
+}
+
 function createPurchasesArray( dataTransferObject ) {
 	if ( ! Array.isArray( dataTransferObject ) ) {
 		return [];
 	}
 
-	const data = dataTransferObject.map( purchase => {
-		const object = {
-			id: Number( purchase.ID ),
-			active: Boolean( purchase.active ),
-			amount: Number( purchase.amount ),
-			attachedToPurchaseId: Number( purchase.attached_to_purchase_id ),
-			canDisableAutoRenew: Boolean( purchase.can_disable_auto_renew ),
-			currencyCode: purchase.currency_code,
-			currencySymbol: purchase.currency_symbol,
-			domain: purchase.domain,
-			error: null,
-			expiryDate: purchase.expiry_date,
-			expiryMoment: purchase.expiry_date ? i18n.moment( purchase.expiry_date ) : null,
-			expiryStatus: camelCase( purchase.expiry_status ),
-			hasPrivateRegistration: Boolean( purchase.has_private_registration ),
-			includedDomain: purchase.included_domain,
-			isCancelable: Boolean( purchase.is_cancelable ),
-			isDomainRegistration: Boolean( purchase.is_domain_registration ),
-			isRedeemable: Boolean( purchase.is_redeemable ),
-			isRefundable: Boolean( purchase.is_refundable ),
-			isRenewable: Boolean( purchase.is_renewable ),
-			meta: purchase.meta,
-			priceText: `${ purchase.currency_symbol }${ purchase.amount } ${ purchase.currency_code }`,
-			payment: {
-				name: purchase.payment_name,
-				type: purchase.payment_type,
-				countryCode: purchase.payment_country_code,
-				countryName: purchase.payment_country_name
-			},
-			productId: Number( purchase.product_id ),
-			productName: purchase.product_name,
-			productSlug: purchase.product_slug,
-			refundPeriodInDays: purchase.refund_period_in_days,
-			renewDate: purchase.renew_date,
-			// only generate a moment if `renewDate` is present and positive
-			renewMoment: purchase.renew_date && purchase.renew_date > '0'
-				? i18n.moment( purchase.renew_date )
-				: null,
-			siteId: Number( purchase.blog_id ),
-			siteName: purchase.blogname,
-			subscribedDate: purchase.subscribed_date,
-			subscriptionStatus: purchase.subscription_status,
-			tagLine: purchase.tag_line,
-			userId: Number( purchase.user_id )
-		};
-
-		if ( isPaidWithCreditCard( object ) ) {
-			return merge( {}, object, {
-				payment: {
-					creditCard: {
-						id: Number( purchase.payment_card_id ),
-						type: purchase.payment_card_type,
-						number: Number( purchase.payment_details ),
-						expiryDate: purchase.payment_expiry,
-						expiryMoment: purchase.payment_expiry ? i18n.moment( purchase.payment_expiry, 'MM/YY' ) : null
-					}
-				}
-			} );
-		}
-
-		return object;
-	} );
-
-	return sortProducts( data );
+	return sortProducts( dataTransferObject.map( createPurchaseObject ) );
 }
 
 export default {
+	createPurchaseObject,
 	createPurchasesArray
 };

--- a/client/lib/purchases/store.js
+++ b/client/lib/purchases/store.js
@@ -22,24 +22,24 @@ const INITIAL_STATE = {
 };
 
 function updatePurchaseById( state, id, properties ) {
-	return assign( {}, state, { data: state.data.map( purchase => {
-		if ( id === purchase.id ) {
-			return assign( {}, purchase, properties );
-		}
-		return purchase;
-	} ) } );
+	return assign( {}, state, {
+		data: state.data.map( purchase => {
+			if ( id === purchase.id ) {
+				return assign( {}, purchase, properties );
+			}
+			return purchase;
+		} )
+	} );
 }
 
 const PurchasesStore = createReducerStore( ( state, payload ) => {
 	const { action } = payload;
 
 	switch ( action.type ) {
-		case ActionTypes.PURCHASES_SITE_FETCH_FAILED:
-		case ActionTypes.PURCHASES_USER_FETCH_FAILED:
-			return assign( {}, state, { error: action.error } );
 		case ActionTypes.PURCHASES_SITE_FETCH:
 		case ActionTypes.PURCHASES_USER_FETCH:
 			return assign( {}, state, { isFetching: true } );
+
 		case ActionTypes.PURCHASES_SITE_FETCH_COMPLETED:
 		case ActionTypes.PURCHASES_USER_FETCH_COMPLETED:
 			let { purchases } = action;
@@ -56,15 +56,22 @@ const PurchasesStore = createReducerStore( ( state, payload ) => {
 				isFetching: false,
 				hasLoadedFromServer: true
 			} );
+
+		case ActionTypes.PURCHASES_SITE_FETCH_FAILED:
+		case ActionTypes.PURCHASES_USER_FETCH_FAILED:
+			return assign( {}, state, { error: action.error } );
+
 		case ActionTypes.PURCHASES_PRIVATE_REGISTRATION_CANCEL_COMPLETED:
 			return updatePurchaseById( state, action.purchaseId, {
 				error: null,
 				hasPrivateRegistration: false
 			} );
+
 		case ActionTypes.PURCHASES_PRIVATE_REGISTRATION_CANCEL_FAILED:
 			return updatePurchaseById( state, action.purchaseId, {
 				error: action.error
 			} );
+
 		default:
 			return state;
 	}

--- a/client/lib/purchases/store.js
+++ b/client/lib/purchases/store.js
@@ -62,10 +62,7 @@ const PurchasesStore = createReducerStore( ( state, payload ) => {
 			return assign( {}, state, { error: action.error } );
 
 		case ActionTypes.PURCHASES_PRIVATE_REGISTRATION_CANCEL_COMPLETED:
-			return updatePurchaseById( state, action.purchaseId, {
-				error: null,
-				hasPrivateRegistration: false
-			} );
+			return updatePurchaseById( state, action.purchase.id, action.purchase );
 
 		case ActionTypes.PURCHASES_PRIVATE_REGISTRATION_CANCEL_FAILED:
 			return updatePurchaseById( state, action.purchaseId, {

--- a/client/lib/purchases/test/store-test.js
+++ b/client/lib/purchases/test/store-test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
+import { expect } from 'chai';
 import Dispatcher from 'dispatcher';
 import defer from 'lodash/function/defer';
 import find from 'lodash/collection/find';
@@ -13,7 +13,7 @@ import { action as actionTypes } from 'lib/upgrades/constants';
 import PurchasesStore from '../store';
 
 describe( 'Purchases Store', () => {
-	it( 'should store purchases from the site/user actions', done => {
+	it( 'should return an object with the list of purchases when fetching completed', done => {
 		Dispatcher.handleServerAction( {
 			type: actionTypes.PURCHASES_USER_FETCH_COMPLETED,
 			purchases: [ { id: 1 }, { id: 2 } ]
@@ -25,9 +25,12 @@ describe( 'Purchases Store', () => {
 				purchases: [ { id: 2 }, { id: 3 } ]
 			} );
 
-			assert( find( PurchasesStore.get().data, { id: 1 } ) );
-			assert( find( PurchasesStore.get().data, { id: 2 } ) );
-			assert( find( PurchasesStore.get().data, { id: 3 } ) );
+			expect( PurchasesStore.get() ).to.be.eql( {
+				data: [ { id: 2 }, { id: 3 }, { id: 1 } ],
+				error: null,
+				hasLoadedFromServer: true,
+				isFetching: false
+			} );
 
 			done();
 		} );

--- a/client/lib/purchases/test/store-test.js
+++ b/client/lib/purchases/test/store-test.js
@@ -61,4 +61,62 @@ describe( 'Purchases Store', () => {
 			done();
 		} );
 	} );
+
+	it( 'should return an object with original purchase when cancelation of private registration is triggered', () => {
+		Dispatcher.handleServerAction( {
+			type: actionTypes.PURCHASES_PRIVATE_REGISTRATION_CANCEL,
+			purchaseId: 2
+		} );
+
+		expect( PurchasesStore.getByPurchaseId( 2 ) ).to.be.eql( {
+			data: {
+				id: 2
+			},
+			error: null,
+			hasLoadedFromServer: true,
+			isFetching: false
+		} );
+	} );
+
+	it( 'should return an object with original purchase and error message when cancelation of private registration failed', () => {
+		Dispatcher.handleServerAction( {
+			type: actionTypes.PURCHASES_PRIVATE_REGISTRATION_CANCEL_FAILED,
+			error: 'Unable to fetch stored cards',
+			purchaseId: 2
+		} );
+
+		expect( PurchasesStore.getByPurchaseId( 2 ) ).to.be.eql( {
+			data: {
+				id: 2,
+				error: 'Unable to fetch stored cards'
+			},
+			error: null,
+			hasLoadedFromServer: true,
+			isFetching: false
+		} );
+	} );
+
+	it( 'should return an object with updated purchase when cancelation of private registration completed', () => {
+		Dispatcher.handleServerAction( {
+			type: actionTypes.PURCHASES_PRIVATE_REGISTRATION_CANCEL_COMPLETED,
+			purchase: {
+				amount: 2200,
+				error: null,
+				hasPrivateRegistration: false,
+				id: 2
+			}
+		} );
+
+		expect( PurchasesStore.getByPurchaseId( 2 ) ).to.be.eql( {
+			data: {
+				amount: 2200,
+				error: null,
+				hasPrivateRegistration: false,
+				id: 2
+			},
+			error: null,
+			hasLoadedFromServer: true,
+			isFetching: false
+		} );
+	} );
 } );

--- a/client/lib/purchases/test/store-test.js
+++ b/client/lib/purchases/test/store-test.js
@@ -13,6 +13,32 @@ import { action as actionTypes } from 'lib/upgrades/constants';
 import PurchasesStore from '../store';
 
 describe( 'Purchases Store', () => {
+	it( 'should be an object', () => {
+		expect( PurchasesStore ).to.be.an( 'object' );
+	} );
+
+	it( 'should return an object with the initial state', () => {
+		expect( PurchasesStore.get() ).to.be.eql( {
+			data: [],
+			error: null,
+			hasLoadedFromServer: false,
+			isFetching: false
+		} );
+	} );
+
+	it( 'should return an object with an empty list and fetching enabled when fetching is triggered', () => {
+		Dispatcher.handleViewAction( {
+			type: actionTypes.PURCHASES_USER_FETCH
+		} );
+
+		expect( PurchasesStore.get() ).to.be.eql( {
+			data: [],
+			error: null,
+			hasLoadedFromServer: false,
+			isFetching: true
+		} );
+	} );
+
 	it( 'should return an object with the list of purchases when fetching completed', done => {
 		Dispatcher.handleServerAction( {
 			type: actionTypes.PURCHASES_USER_FETCH_COMPLETED,

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -86,7 +86,12 @@ function deleteStoredCard( card, onComplete ) {
 }
 
 function fetchSitePurchases( siteId ) {
-	function receiveSitePurchases( error, data ) {
+	Dispatcher.handleViewAction( {
+		type: ActionTypes.PURCHASES_SITE_FETCH,
+		siteId
+	} );
+
+	wpcom.siteUpgrades( siteId, ( error, data ) => {
 		debug( error, data );
 
 		if ( error ) {
@@ -101,14 +106,7 @@ function fetchSitePurchases( siteId ) {
 				purchases: purchasesAssembler.createPurchasesArray( data.upgrades )
 			} );
 		}
-	}
-
-	Dispatcher.handleViewAction( {
-		type: ActionTypes.PURCHASES_SITE_FETCH,
-		siteId
 	} );
-
-	wpcom.siteUpgrades( siteId, receiveSitePurchases );
 }
 
 function fetchStoredCards() {

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -41,7 +41,7 @@ function cancelPrivateRegistration( purchaseId, onComplete ) {
 		if ( success ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.PURCHASES_PRIVATE_REGISTRATION_CANCEL_COMPLETED,
-				purchaseId
+				purchase: purchasesAssembler.createPurchaseObject( data.upgrade )
 			} );
 		} else {
 			Dispatcher.handleServerAction( {

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -141,10 +141,6 @@ function fetchUserPurchases() {
 	wpcom.me().purchases( ( error, data ) => {
 		debug( error, data );
 
-		const purchases = purchasesAssembler.createPurchasesArray( data );
-
-		debug( purchases );
-
 		if ( error ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.PURCHASES_USER_FETCH_FAILED,
@@ -153,7 +149,7 @@ function fetchUserPurchases() {
 		} else {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.PURCHASES_USER_FETCH_COMPLETED,
-				purchases
+				purchases: purchasesAssembler.createPurchasesArray( data )
 			} );
 		}
 	} );

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -63,6 +63,8 @@ function deleteStoredCard( card, onComplete ) {
 	} );
 
 	wpcom.me().storedCardDelete( card, ( error, data ) => {
+		debug( error, data );
+
 		let success = false;
 
 		if ( data ) {
@@ -85,6 +87,8 @@ function deleteStoredCard( card, onComplete ) {
 
 function fetchSitePurchases( siteId ) {
 	function receiveSitePurchases( error, data ) {
+		debug( error, data );
+
 		if ( error ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.PURCHASES_SITE_FETCH_FAILED,
@@ -113,6 +117,8 @@ function fetchStoredCards() {
 	} );
 
 	wpcom.getStoredCards( ( error, data ) => {
+		debug( error, data );
+
 		if ( data ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.STORED_CARDS_FETCH_COMPLETED,
@@ -133,6 +139,8 @@ function fetchUserPurchases() {
 	} );
 
 	wpcom.me().purchases( ( error, data ) => {
+		debug( error, data );
+
 		const purchases = purchasesAssembler.createPurchasesArray( data );
 
 		debug( purchases );

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -47,8 +47,7 @@ function cancelPrivateRegistration( purchaseId, onComplete ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.PURCHASES_PRIVATE_REGISTRATION_CANCEL_FAILED,
 				purchaseId,
-				error: i18n.translate( 'There was a problem canceling this private registration. ' +
-						'Please try again later or contact support.' )
+				error: error.message || i18n.translate( 'There was a problem canceling this private registration. Please try again later or contact support.' )
 			} );
 		}
 

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -36,9 +36,9 @@ function cancelPrivateRegistration( purchaseId, onComplete ) {
 	wpcom.cancelPrivateRegistration( purchaseId, ( error, data ) => {
 		debug( error, data );
 
-		const canceledSuccessfully = ! error && data.success;
+		const success = ! error && data.success;
 
-		if ( canceledSuccessfully ) {
+		if ( success ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.PURCHASES_PRIVATE_REGISTRATION_CANCEL_COMPLETED,
 				purchaseId
@@ -51,7 +51,7 @@ function cancelPrivateRegistration( purchaseId, onComplete ) {
 			} );
 		}
 
-		onComplete( canceledSuccessfully );
+		onComplete( success );
 	} );
 }
 
@@ -64,15 +64,13 @@ function deleteStoredCard( card, onComplete ) {
 	wpcom.me().storedCardDelete( card, ( error, data ) => {
 		debug( error, data );
 
-		let success = false;
+		const success = Boolean( data );
 
-		if ( data ) {
+		if ( success ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.STORED_CARDS_DELETE_COMPLETED,
 				card
 			} );
-
-			success = true;
 		} else {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.STORED_CARDS_DELETE_FAILED,

--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -46,12 +46,13 @@ const CancelPrivateRegistration = React.createClass( {
 			cancelling: true
 		} );
 
-		cancelPrivateRegistration( id, canceledSuccessfully => {
+		cancelPrivateRegistration( id, success => {
 			this.setState( {
 				cancelling: false,
 				disabled: false
 			} );
-			if ( canceledSuccessfully ) {
+
+			if ( success ) {
 				page( paths.managePurchaseDestination( domain, id, 'canceled-private-registration' ) );
 			}
 		} );

--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -1736,7 +1736,8 @@ Undocumented.prototype.cancelPrivateRegistration = function( purchaseId, fn ) {
 	debug( 'upgrades/{purchaseId}/cancel-privacy-protection' );
 
 	this.wpcom.req.post( {
-		path: `/upgrades/${purchaseId}/cancel-privacy-protection`
+		path: `/upgrades/${purchaseId}/cancel-privacy-protection`,
+		apiVersion: '1.1'
 	}, fn );
 };
 


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/189 by retrieving the domain registration purchase returned by the API when users cancel the associated private registration. The goal is to display the `Manage Purchase` page with up-to-date information as soon as the cancelation is successful:

![screenshot-wpcalypso wordpress com 2015-11-19 16-47-38](https://cloud.githubusercontent.com/assets/1248436/11275625/cfdb98bc-8ede-11e5-8cc0-87597b680ea4.png)

This pull request also fixes a small bug and refactor some code, mostly for consistency purposes.

#### Testing instructions

##### Scenario *#*1

1. Get a new test account and blog
2. Enable the store sandbox
3. Navigate to the [`Domains` page](http://calypso.localhost:3000/domains/add)
4. Click on any `Add` button to add a domain to the shopping cart
5. Click on the `No thanks, I don't need email or will use another provider.` link on the next page
6. Fill in the `Domain Registration Details` page and click on the `Add Privacy Protection` button
7. Submit the form on the `Secure Payment` page with fake credit card information
8. Head to the [`Purchases` page](http://calypso.localhost:3000/purchases)
9. Click the new domain registration to display the corresponding `Manage Purchase` page
10. Note the current price and click the `Cancel Private Registration` navigation link
11. Click the `Cancel Private Registration` on the page of the same name
12. Check that you are redirected on the `Manage Purchase` page with a success message
13. Check that the price is updated instantaneously and matches the cost of a domain registration without privacy protection