### PR TITLE
Update .editorconfig to show tabs as two spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 
 [*]
 indent_style = tab
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
This is more like most JS out there and changes how GitHub displays code. See https://github.com/isaacs/github/issues/170#issuecomment-150489692

Refs #558