### PR TITLE
People: Ensure sign in link shows on logged out flow

### DIFF
--- a/client/accept-invite/logged-out-invite/signup-form.jsx
+++ b/client/accept-invite/logged-out-invite/signup-form.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react'
-import debugModule from 'debug';
 
 /**
  * Internal dependencies
@@ -11,11 +10,6 @@ import SignupForm from 'components/signup-form'
 import InviteFormHeader from '../invite-form-header'
 import { createAccount, acceptInvite } from '../actions'
 import WpcomLoginForm from 'signup/wpcom-login-form'
-
-/**
- * Module variables
- */
-const debug = debugModule( 'calypso:accept-invite:logged-out' );
 
 export default React.createClass( {
 
@@ -42,7 +36,7 @@ export default React.createClass( {
 				acceptInvite(
 					this.props.invite,
 					bearerToken,
-					( error, response ) => this.setState( { error, userData, bearerToken } )
+					( acceptInviteError ) => this.setState( { acceptInviteError, userData, bearerToken } )
 				)
 		);
 	},

--- a/client/accept-invite/logged-out-invite/signup-form.jsx
+++ b/client/accept-invite/logged-out-invite/signup-form.jsx
@@ -10,6 +10,7 @@ import SignupForm from 'components/signup-form'
 import InviteFormHeader from '../invite-form-header'
 import { createAccount, acceptInvite } from '../actions'
 import WpcomLoginForm from 'signup/wpcom-login-form'
+import config from 'config'
 
 export default React.createClass( {
 
@@ -97,6 +98,15 @@ export default React.createClass( {
 		)
 	},
 
+	footerLink() {
+		let logInUrl = config( 'login_url' );
+		if ( config.isEnabled( 'login' ) ) {
+			logInUrl = '/log-in';
+		}
+		logInUrl += '?redirect_to=' + encodeURIComponent( window.location.href );
+		return <a href={ logInUrl } className="logged-out-form__link">{ this.translate( 'Already have a WordPress.com account? Log in now.' ) }</a>;
+	},
+
 	render() {
 		return (
 			<div>
@@ -108,6 +118,7 @@ export default React.createClass( {
 					save={ this.save }
 					submitForm={ this.submitForm }
 					submitButtonText={ this.submitButtonText() }
+					footerLink={ this.footerLink() }
 				/>
 				{ this.state.userData && this.loginUser() }
 			</div>

--- a/client/accept-invite/logged-out-invite/signup-form.jsx
+++ b/client/accept-invite/logged-out-invite/signup-form.jsx
@@ -99,12 +99,12 @@ export default React.createClass( {
 	},
 
 	footerLink() {
-		let logInUrl = config( 'login_url' );
-		if ( config.isEnabled( 'login' ) ) {
-			logInUrl = '/log-in';
-		}
-		logInUrl += '?redirect_to=' + encodeURIComponent( window.location.href );
-		return <a href={ logInUrl } className="logged-out-form__link">{ this.translate( 'Already have a WordPress.com account? Log in now.' ) }</a>;
+		let logInUrl = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
+		return (
+			<a href={ logInUrl } className="logged-out-form__link">
+				{ this.translate( 'Already have a WordPress.com account? Log in now.' ) }
+			</a>
+		);
 	},
 
 	render() {

--- a/client/accept-invite/logged-out-invite/signup-form.jsx
+++ b/client/accept-invite/logged-out-invite/signup-form.jsx
@@ -82,7 +82,7 @@ export default React.createClass( {
 				return redirectTo;
 				break;
 			default:
-				return redirectTo + '/posts/' + invite.blog_id ;
+				return redirectTo + '/posts/' + invite.blog_id;
 		}
 	},
 

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -371,7 +371,7 @@ export default React.createClass( {
 	},
 
 	footerLink() {
-		if ( 'undefined' !== typeof this.props.positionInFlow && this.props.positionInFlow !== 0 ) {
+		if ( this.props.positionInFlow !== 0 ) {
 			return;
 		}
 		let logInUrl = this.localizeUrlWithSubdomain( config( 'login_url' ) );
@@ -388,7 +388,7 @@ export default React.createClass( {
 				formFields={ this.formFields() }
 				formFooter={ this.props.formFooter || this.formFooter() }
 				formHeader={ this.props.formHeader }
-				footerLink={ this.footerLink() }
+				footerLink={ this.props.footerLink || this.footerLink() }
 				locale={ this.props.locale }
 				onSubmit={ this.handleSubmit }
 				path={ this.props.path } />

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -371,7 +371,7 @@ export default React.createClass( {
 	},
 
 	footerLink() {
-		if ( this.props.positionInFlow !== 0 ) {
+		if ( 'undefined' !== typeof this.props.positionInFlow && this.props.positionInFlow !== 0 ) {
 			return;
 		}
 		let logInUrl = this.localizeUrlWithSubdomain( config( 'login_url' ) );


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/104869/11350204/28e6da7e-920f-11e5-97b6-63e9b176a54e.png)

### How to test ###

* pull `add/invites-logged-out-log-in-footer`
* go to `http://calypso.dev:3000/accept-invite/<blog_id>/<invitation_key>`
* test the footer link :)

Closes #363

cc @ebinnion 