### PR TITLE
Editor: Upgrade TinyMCE to 4.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "store": "1.3.16",
     "superagent": "1.2.0",
     "timeout-transition-group": "1.0.3",
-    "tinymce": "4.2.6",
+    "tinymce": "4.2.8",
     "to-title-case": "0.1.5",
     "tween.js": "16.3.1",
     "twemoji": "1.3.2",


### PR DESCRIPTION
This pull request upgrades the TinyMCE package to version 4.2.8.

See related changelog: https://github.com/tinymce/tinymce/blob/master/changelog.txt . (4.3.0 just came out today, but in my testing there are a few issues with it, so I'll open a new PR once I get those sorted out.)

Testing:

* Check out the branch and restart `make run`.
* Verify that the TinyMCE version is reported by node as 4.2.8.
* Open up the <a href="http://calypso.localhost:3000/post">editor</a> and make sure everything works as expected and there are no regressions, paying particular attention to the button styles in Visual mode.

Previously: 12248-gh-calypso-pre-oss, 11995-gh-calypso-pre-oss

See 11361-gh-calypso-pre-oss