### PR TITLE
Update Dockerfile to use HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN     apt-get -y update && apt-get -y install \
           python \
           make \
           build-essential
-RUN     wget http://nodejs.org/dist/v0.12.6/node-v0.12.6-linux-x64.tar.gz && \
+RUN     wget https://nodejs.org/dist/v0.12.6/node-v0.12.6-linux-x64.tar.gz && \
           tar -zxf node-v0.12.6-linux-x64.tar.gz -C /usr/local && \
           ln -sf node-v0.12.6-linux-x64 /usr/local/node && \
           ln -sf /usr/local/node/bin/npm /usr/local/bin/ && \


### PR DESCRIPTION
Updates the Dockerfile for the project to download Node.JS over an encrypted (HTTPS) connection instead of an unencrypted HTTP connection.  This reduces the risk of someone conducting a MITM attack and replacing the file with malicious content.