### PR TITLE
Reader: Pull in stores that accept actions when pre-loading.

### DIFF
--- a/client/lib/reader-feed-subscriptions/actions.js
+++ b/client/lib/reader-feed-subscriptions/actions.js
@@ -105,7 +105,9 @@ var FeedSubscriptionActions = {
 		callback = inflight.requestTracker( requestKey, function( error, data ) {
 			FeedSubscriptionStore.setIsFetching( false );
 			FeedSubscriptionActions.receiveFollowingList( error, data );
-			cb && cb( error, data );
+			if ( cb ) {
+				cb( error, data );
+			}
 		} );
 
 		FeedSubscriptionStore.setIsFetching( true );
@@ -131,12 +133,13 @@ var FeedSubscriptionActions = {
 
 	/**
 	* Fetch next page of followed feeds via the REST API
-	*/
+	*
+	* @param cb callback to invoke when complete
+	**/
 	fetchNextPage: function( cb ) {
 		var params;
 
 		if ( FeedSubscriptionStore.isLastPage() ) {
-			onComplete();
 			return;
 		}
 

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -71,6 +71,10 @@ function pageTitleSetter() {
 
 module.exports = {
 	loadSubscriptions: function( context, next ) {
+		// these three are included to ensure that the stores required have been loaded and can accept actions
+		const FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' ), // eslint-disable-line no-unused-vars
+			PostEmailSubscriptionStore = require( 'lib/reader-post-email-subscriptions' ), // eslint-disable-line no-unused-vars
+			CommentEmailSubscriptionStore = require( 'lib/reader-comment-email-subscriptions' ); // eslint-disable-line no-unused-vars
 		FeedSubscriptionActions.fetchAll();
 		next();
 	},


### PR DESCRIPTION
The Reader preloads all of a user's subscriptions when you hit any Reader URL. This works pretty well, but we have to ensure that all of the stores that want to listen for and act upon actions fired by the preload are spun up and listening.

This patch teaches the controller how to load all of those stores before kicking off the preload.

Fixes #559 