### PR TITLE
Invites: Fixes invalid propType in LoggedInAccept caused by passing string to Gravatar

### DIFF
--- a/client/accept-invite/logged-in-accept/index.jsx
+++ b/client/accept-invite/logged-in-accept/index.jsx
@@ -55,7 +55,7 @@ export default React.createClass( {
 						}
 					/>
 					<div className="logged-in-accept__join-as">
-						<Gravatar user={ userObject } size="72"/>
+						<Gravatar user={ userObject } size={ 72 } />
 						{
 							this.translate( 'Join as {{usernameWrap}}%(username)s{{/usernameWrap}}', {
 								components: {


### PR DESCRIPTION
Previously, we passed the string `72` to the `Gravatar` component, which caused the following warning:

> Warning: Failed propType: Invalid prop `size` of type `string` supplied to `Gravatar`, expected `number`. Check the render method of `LoggedInAccept`.

This PR ensures that we pass an integer to `Gravatar`.

To test:
- Checkout `people/invite-grav-int` branch
- Create an invite to a WordPress.com site
- In the invitation email that you receive, get the invitation key from the URL
- Go to `/accept-invite/$site/$invite_key`
- Check the console
- You shouldn't see an invalid `propType` message. 

cc @lezama for review