### PR TITLE
Link directly to the manage page for this plan.

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -180,9 +180,10 @@ module.exports = React.createClass( {
 	},
 
 	managePlanButton: function() {
+		var link = "/purchases/" + this.props.site.domain + "/" + this.props.siteSpecificPlansDetails.ID;
 		if ( this.planHasCost() ) {
 			return (
-				<a href="https://wordpress.com/my-upgrades" rel="external" className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>
+				<a href={ link } rel="external" className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>
 			);
 		}
 	},

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -12,7 +12,8 @@ var analytics = require( 'analytics' ),
 	isFreePlan = productsValues.isFreePlan,
 	isBusiness = productsValues.isBusiness,
 	isEnterprise = productsValues.isEnterprise,
-	cartItems = require( 'lib/cart-values' ).cartItems;
+	cartItems = require( 'lib/cart-values' ).cartItems,
+	puchasesPaths = require( 'me/purchases/paths' );
 
 module.exports = React.createClass( {
 	displayName: 'PlanActions',
@@ -180,7 +181,7 @@ module.exports = React.createClass( {
 	},
 
 	managePlanButton: function() {
-		var link = '/purchases/' + this.props.site.domain + '/' + this.props.siteSpecificPlansDetails.id;
+		var link = puchasesPaths.managePurchase( this.props.site.domain, this.props.siteSpecificPlansDetails.id );
 		if ( this.planHasCost() ) {
 			return (
 				<a href={ link } className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -181,8 +181,9 @@ module.exports = React.createClass( {
 	},
 
 	managePlanButton: function() {
-		var link = puchasesPaths.managePurchase( this.props.site.domain, this.props.siteSpecificPlansDetails.id );
+		var link;
 		if ( this.planHasCost() ) {
+			link = puchasesPaths.managePurchase( this.props.site.slug, this.props.siteSpecificPlansDetails.id );
 			return (
 				<a href={ link } className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>
 			);

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -183,7 +183,7 @@ module.exports = React.createClass( {
 		var link = '/purchases/' + this.props.site.domain + '/' + this.props.siteSpecificPlansDetails.id;
 		if ( this.planHasCost() ) {
 			return (
-				<a href={ link } rel="external" className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>
+				<a href={ link } className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>
 			);
 		}
 	},

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -180,7 +180,7 @@ module.exports = React.createClass( {
 	},
 
 	managePlanButton: function() {
-		var link = "/purchases/" + this.props.site.domain + "/" + this.props.siteSpecificPlansDetails.ID;
+		var link = '/purchases/' + this.props.site.domain + '/' + this.props.siteSpecificPlansDetails.id;
 		if ( this.planHasCost() ) {
 			return (
 				<a href={ link } rel="external" className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>

--- a/client/me/billing-history/index.jsx
+++ b/client/me/billing-history/index.jsx
@@ -55,10 +55,10 @@ module.exports = React.createClass( {
 						<p>
 							{
 								this.translate(
-									'A complete history of all billing transactions for your WordPress.com account. If you are looking to add or cancel a plan go to {{link}}My Upgrades{{/link}}.',
+									'A complete history of all billing transactions for your WordPress.com account. If you are looking to add or cancel a plan go to {{link}}Manage Purchases{{/link}}.',
 									{
 										components: {
-											link: <a href="/purchases" onClick={ this.recordClickEvent( 'My Upgrades Link on Billing History' ) }/>
+											link: <a href="/purchases" onClick={ this.recordClickEvent( 'Manage Purchases Link on Billing History' ) }/>
 										}
 									}
 								)

--- a/client/me/billing-history/index.jsx
+++ b/client/me/billing-history/index.jsx
@@ -58,7 +58,7 @@ module.exports = React.createClass( {
 									'A complete history of all billing transactions for your WordPress.com account. If you are looking to add or cancel a plan go to {{link}}My Upgrades{{/link}}.',
 									{
 										components: {
-											link: <a href="//wordpress.com/my-upgrades/" rel="external" onClick={ this.recordClickEvent( 'My Upgrades Link on Billing History' ) }/>
+											link: <a href="/purchases" onClick={ this.recordClickEvent( 'My Upgrades Link on Billing History' ) }/>
 										}
 									}
 								)

--- a/client/me/billing-history/index.jsx
+++ b/client/me/billing-history/index.jsx
@@ -18,7 +18,8 @@ var observe = require( 'lib/mixins/data-observe' ),
 	PurchasesHeader = require( '../purchases/list/header' ),
 	BillingHistoryTable = require( './billing-history-table' ),
 	UpcomingChargesTable = require( './upcoming-charges-table' ),
-	SectionHeader = require( 'components/section-header' );
+	SectionHeader = require( 'components/section-header' ),
+	puchasesPaths = require( 'me/purchases/paths' );
 
 module.exports = React.createClass( {
 	displayName: 'BillingHistory',
@@ -55,13 +56,12 @@ module.exports = React.createClass( {
 						<p>
 							{
 								this.translate(
-									'A complete history of all billing transactions for your WordPress.com account. If you are looking to add or cancel a plan go to {{link}}Manage Purchases{{/link}}.',
-									{
-										components: {
-											link: <a href="/purchases" onClick={ this.recordClickEvent( 'Manage Purchases Link on Billing History' ) }/>
-										}
+									'A complete history of all billing transactions for your WordPress.com account. If you are looking to add or cancel a plan go to {{link}}Manage Purchases{{/link}}.', {
+									components: {
+										link: <a href={ puchasesPaths.list() }
+											onClick={ this.recordClickEvent( 'Manage Purchases Link on Billing History' ) } />
 									}
-								)
+								} )
 							}
 						</p>
 					</div>

--- a/client/me/billing-history/index.jsx
+++ b/client/me/billing-history/index.jsx
@@ -8,7 +8,6 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var observe = require( 'lib/mixins/data-observe' ),
-	FormSectionHeading = require( 'components/forms/form-section-heading' ),
 	Card = require( 'components/card' ),
 	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	config = require( 'config' ),
@@ -57,11 +56,12 @@ module.exports = React.createClass( {
 							{
 								this.translate(
 									'A complete history of all billing transactions for your WordPress.com account. If you are looking to add or cancel a plan go to {{link}}Manage Purchases{{/link}}.', {
-									components: {
-										link: <a href={ puchasesPaths.list() }
-											onClick={ this.recordClickEvent( 'Manage Purchases Link on Billing History' ) } />
+										components: {
+											link: <a href={ puchasesPaths.list() }
+												onClick={ this.recordClickEvent( 'Manage Purchases Link on Billing History' ) } />
+										}
 									}
-								} )
+								)
 							}
 						</p>
 					</div>

--- a/client/me/billing-history/index.jsx
+++ b/client/me/billing-history/index.jsx
@@ -24,7 +24,7 @@ var observe = require( 'lib/mixins/data-observe' ),
 module.exports = React.createClass( {
 	displayName: 'BillingHistory',
 
-	mixins: [ observe( 'billingData' ), eventRecorder ],
+	mixins: [ observe( 'billingData', 'sites' ), eventRecorder ],
 
 	componentWillMount: function() {
 		classes( document.body ).add( 'billing-history-page' );
@@ -71,7 +71,7 @@ module.exports = React.createClass( {
 
 				<SectionHeader label={ this.translate( 'Upcoming Charges' ) } />
 				<Card id="upcoming-charges">
-					<UpcomingChargesTable transactions={ data.upcomingCharges } />
+					<UpcomingChargesTable sites={ this.props.sites } transactions={ data.upcomingCharges } />
 				</Card>
 
 				{ this.renderManageCards() }

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -51,6 +51,10 @@ var TransactionsTable = React.createClass( {
 	filterTransactions: function( filter ) {
 		var newFilter, newTransactions;
 
+		if ( ! this.props.transactions ) {
+			return;
+		}
+
 		if ( filter.search ) {
 			// In this case the user is typing in the search box. We remove any other
 			// filter parameters besides the text we're searching for.

--- a/client/me/billing-history/upcoming-charges-table.jsx
+++ b/client/me/billing-history/upcoming-charges-table.jsx
@@ -22,7 +22,7 @@ module.exports = React.createClass( {
 					return (
 						<div className="transaction-links">
 							<a href={ link }>
-								{ this.translate( 'Manage Upgrade' ) }
+								{ this.translate( 'Manage Purchase' ) }
 							</a>
 						</div>
 					);

--- a/client/me/billing-history/upcoming-charges-table.jsx
+++ b/client/me/billing-history/upcoming-charges-table.jsx
@@ -6,7 +6,8 @@ var React = require( 'react' );
 /**
  * Internal Dependencies
  */
-var	TransactionsTable = require( './transactions-table' );
+var	purchasesPaths = require( 'me/purchases/paths' ),
+	TransactionsTable = require( './transactions-table' );
 
 module.exports = React.createClass( {
 
@@ -18,10 +19,9 @@ module.exports = React.createClass( {
 				{ ...this.props }
 				initialFilter={ { date: { newest: 20 } } }
 				description={ function( { domain, id } = transaction ) {
-					const link = '/purchases/' + domain + '/' + id
 					return (
 						<div className="transaction-links">
-							<a href={ link }>
+							<a href={ purchasesPaths.managePurchase( domain, id ) }>
 								{ this.translate( 'Manage Purchase' ) }
 							</a>
 						</div>

--- a/client/me/billing-history/upcoming-charges-table.jsx
+++ b/client/me/billing-history/upcoming-charges-table.jsx
@@ -17,10 +17,11 @@ module.exports = React.createClass( {
 			<TransactionsTable
 				{ ...this.props }
 				initialFilter={ { date: { newest: 20 } } }
-				description={ function() {
+				description={ function( { domain, id } = transaction ) {
+					const link = '/purchases/' + domain + '/' + id
 					return (
 						<div className="transaction-links">
-							<a href="/my-upgrades">
+							<a href={ link }>
 								{ this.translate( 'Manage Upgrade' ) }
 							</a>
 						</div>

--- a/client/me/billing-history/upcoming-charges-table.jsx
+++ b/client/me/billing-history/upcoming-charges-table.jsx
@@ -14,19 +14,28 @@ module.exports = React.createClass( {
 	displayName: 'UpcomingChargesTable',
 
 	render: function() {
+		var transactions = null;
+
+		if ( this.props.sites.initialized ) {
+			// `TransactionsTable` will render a loading state until the transactions are present
+			transactions = this.props.transactions;
+		}
+
 		return (
 			<TransactionsTable
-				{ ...this.props }
+				transactions={ transactions }
 				initialFilter={ { date: { newest: 20 } } }
-				description={ function( { domain, id } = transaction ) {
+				description={ function( transaction ) {
+					var siteSlug = this.props.sites.getSite( Number( transaction.blog_id ) ).slug;
+
 					return (
 						<div className="transaction-links">
-							<a href={ purchasesPaths.managePurchase( domain, id ) }>
+							<a href={ purchasesPaths.managePurchase( siteSlug, transaction.id ) }>
 								{ this.translate( 'Manage Purchase' ) }
 							</a>
 						</div>
 					);
-				} }
+				}.bind( this ) }
 			/>
 		);
 	}

--- a/client/me/billing-history/upcoming-charges-table.jsx
+++ b/client/me/billing-history/upcoming-charges-table.jsx
@@ -26,15 +26,17 @@ module.exports = React.createClass( {
 				transactions={ transactions }
 				initialFilter={ { date: { newest: 20 } } }
 				description={ function( transaction ) {
-					var siteSlug = this.props.sites.getSite( Number( transaction.blog_id ) ).slug;
+					var site = this.props.sites.getSite( Number( transaction.blog_id ) );
 
-					return (
-						<div className="transaction-links">
-							<a href={ purchasesPaths.managePurchase( siteSlug, transaction.id ) }>
-								{ this.translate( 'Manage Purchase' ) }
-							</a>
-						</div>
-					);
+					if ( site ) {
+						return (
+							<div className="transaction-links">
+								<a href={ purchasesPaths.managePurchase( site.slug, transaction.id ) }>
+									{ this.translate( 'Manage Purchase' ) }
+								</a>
+							</div>
+						);
+					}
 				}.bind( this ) }
 			/>
 		);

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -274,7 +274,7 @@ export default {
 		titleActions.setTitle( i18n.translate( 'Billing History', { textOnly: true } ) );
 
 		React.render(
-			React.createElement( BillingHistoryComponent, { billingData: billingData } ),
+			React.createElement( BillingHistoryComponent, { billingData: billingData, sites: sites } ),
 			document.getElementById( 'primary' )
 		);
 

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -80,7 +80,7 @@ module.exports = React.createClass( {
 		dialogButtons = [
 			{ action: 'dismiss', label: this.translate( 'Dismiss' ) },
 			<a className="button is-primary" href={ '/purchases' }>{
-				this.translate( 'Manage Upgrades', { context: 'button label' } )
+				this.translate( 'Manage Purchases', { context: 'button label' } )
 			}</a>
 		];
 

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -9,6 +9,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var CompactCard = require( 'components/card/compact' ),
+	purchasesPaths = require( 'me/purchases/paths' ),
 	PurchasesStore = require( 'lib/purchases/store' ),
 	UpgradesActions = require( 'lib/upgrades/actions' ),
 	pollers = require( 'lib/data-poller' ),
@@ -79,7 +80,7 @@ module.exports = React.createClass( {
 
 		dialogButtons = [
 			{ action: 'dismiss', label: this.translate( 'Dismiss' ) },
-			<a className="button is-primary" href={ '/purchases' }>{
+			<a className="button is-primary" href={ purchasesPaths.list() }>{
 				this.translate( 'Manage Purchases', { context: 'button label' } )
 			}</a>
 		];

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -79,7 +79,7 @@ module.exports = React.createClass( {
 
 		dialogButtons = [
 			{ action: 'dismiss', label: this.translate( 'Dismiss' ) },
-			<a className="button is-primary" href={ 'https://wordpress.com/my-upgrades' }>{
+			<a className="button is-primary" href={ '/purchases' }>{
 				this.translate( 'Manage Upgrades', { context: 'button label' } )
 			}</a>
 		];

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -20,10 +20,8 @@ const debug = _debug( 'calypso:domain-warnings' );
 const allAboutDomainsLink = <a href="https://support.wordpress.com/all-about-domains/" target="_blank"/>,
 	domainsLink = <a href="https://support.wordpress.com/domains/" target="_blank" />,
 	pNode = <p />,
-	renewLinkSingle = <a href="/purchases"
-													target="_blank">{ i18n.translate( 'Renew it now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>,
-	renewLinkPlural = <a href="/purchases"
-													target="_blank">{ i18n.translate( 'Renew them now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>;
+	renewLinkSingle = <a href="/purchases">{ i18n.translate( 'Renew it now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>,
+	renewLinkPlural = <a href="/purchases">{ i18n.translate( 'Renew them now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>;
 
 export default React.createClass( {
 	displayName: 'DomainWarnings',

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -20,9 +20,9 @@ const debug = _debug( 'calypso:domain-warnings' );
 const allAboutDomainsLink = <a href="https://support.wordpress.com/all-about-domains/" target="_blank"/>,
 	domainsLink = <a href="https://support.wordpress.com/domains/" target="_blank" />,
 	pNode = <p />,
-	renewLinkSingle = <a href="/my-upgrades"
+	renewLinkSingle = <a href="/purchases"
 													target="_blank">{ i18n.translate( 'Renew it now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>,
-	renewLinkPlural = <a href="/my-upgrades"
+	renewLinkPlural = <a href="/purchases"
 													target="_blank">{ i18n.translate( 'Renew them now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>;
 
 export default React.createClass( {

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -9,8 +9,8 @@ import intersection from 'lodash/array/intersection';
 /**
  * Internal Dependencies
  **/
-
 import Notice from 'components/notice';
+import purchasesPaths from 'me/purchases/paths';
 import domainConstants from 'lib/domains/constants';
 import i18n from 'lib/mixins/i18n';
 
@@ -20,8 +20,8 @@ const debug = _debug( 'calypso:domain-warnings' );
 const allAboutDomainsLink = <a href="https://support.wordpress.com/all-about-domains/" target="_blank"/>,
 	domainsLink = <a href="https://support.wordpress.com/domains/" target="_blank" />,
 	pNode = <p />,
-	renewLinkSingle = <a href="/purchases">{ i18n.translate( 'Renew it now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>,
-	renewLinkPlural = <a href="/purchases">{ i18n.translate( 'Renew them now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>;
+	renewLinkSingle = <a href={ purchasesPaths.list() }>{ i18n.translate( 'Renew it now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>,
+	renewLinkPlural = <a href={ purchasesPaths.list() }>{ i18n.translate( 'Renew them now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>;
 
 export default React.createClass( {
 	displayName: 'DomainWarnings',

--- a/client/my-sites/upgrades/domain-management/edit/card/subscription-settings.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/card/subscription-settings.jsx
@@ -12,7 +12,6 @@ const SubscriptionSettings = React.createClass( {
 		return (
 			<a className="domain-details-card__subscription-settings-button button"
 				href="/purchases"
-				target="_blank"
 				onClick={ this.props.onClick }>
 				{ this.translate( 'Payment Settings' ) }
 			</a>

--- a/client/my-sites/upgrades/domain-management/edit/card/subscription-settings.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/card/subscription-settings.jsx
@@ -11,7 +11,7 @@ const SubscriptionSettings = React.createClass( {
 	render() {
 		return (
 			<a className="domain-details-card__subscription-settings-button button"
-				href="/my-upgrades"
+				href="/purchases"
 				target="_blank"
 				onClick={ this.props.onClick }>
 				{ this.translate( 'Payment Settings' ) }

--- a/client/my-sites/upgrades/domain-management/edit/card/subscription-settings.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/card/subscription-settings.jsx
@@ -3,6 +3,11 @@
  */
 const React = require( 'react' );
 
+/**
+ * Internal dependencies
+ */
+import purchasesPaths from 'me/purchases/paths';
+
 const SubscriptionSettings = React.createClass( {
 	propTypes: {
 		onClick: React.PropTypes.func.isRequired
@@ -11,7 +16,7 @@ const SubscriptionSettings = React.createClass( {
 	render() {
 		return (
 			<a className="domain-details-card__subscription-settings-button button"
-				href="/purchases"
+				href={ purchasesPaths.list() }
 				onClick={ this.props.onClick }>
 				{ this.translate( 'Payment Settings' ) }
 			</a>

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -33,13 +33,13 @@ var NAV_ITEMS = {
 	Plans: {
 		paths: [ '/plans' ],
 		label: i18n.translate( 'Plans' ),
-		external: false
+		allSitesPath: false
 	},
 
 	Email: {
 		paths: [ upgradesPaths.domainManagementEmail() ],
 		label: i18n.translate( 'Email' ),
-		external: false
+		allSitesPath: false
 	},
 
 	Domains: {
@@ -48,25 +48,19 @@ var NAV_ITEMS = {
 			'/domains/add'
 		],
 		label: i18n.translate( 'Domains' ),
-		external: false
+		allSitesPath: false
 	},
 
 	'Add a Domain': {
 		paths: [ '/domains/add' ],
 		label: i18n.translate( 'Add a Domain' ),
-		external: false
+		allSitesPath: false
 	},
 
-	'My Domains': {
-		paths: [ '/my-domains' ],
-		label: i18n.translate( 'My Domains' ),
-		external: true
-	},
-
-	'My Upgrades': {
+	'My Purchases': {
 		paths: [ '/purchases' ],
 		label: i18n.translate( 'Manage Purchases' ),
-		external: true
+		allSitesPath: true
 	}
 };
 
@@ -123,14 +117,12 @@ var UpgradesNavigation = React.createClass( {
 		var items;
 
 		if ( this.props.selectedSite.jetpack ) {
-			items = [ 'Plans', 'My Upgrades' ];
-		} else if ( config.isEnabled( 'upgrades/domain-management/list' ) ) {
-			items = [ 'Plans', 'Domains', 'Email', 'My Upgrades' ];
+			items = [ 'Plans', 'My Purchases' ];
+		} else {
+			items = [ 'Plans', 'Domains', 'Email', 'My Purchases' ];
 			if ( config.isEnabled( 'upgrades/purchases/list' ) ) {
 				items = [ 'Plans', 'Domains', 'Email' ];
 			}
-		} else {
-			items = [ 'Plans', 'Add a Domain', 'My Domains', 'My Upgrades' ];
 		}
 
 		return items.map( propertyOf( NAV_ITEMS ) );
@@ -151,21 +143,21 @@ var UpgradesNavigation = React.createClass( {
 	},
 
 	navItem: function( itemData ) {
-		var { paths, external, label } = itemData,
+		var { paths, allSitesPath, label } = itemData,
 			slug = this.props.selectedSite ? this.props.selectedSite.slug : null,
 			selectedNavItem = this.getSelectedNavItem(),
 			primaryPath = paths[ 0 ],
 			fullPath;
 
-		if ( external ) {
-			fullPath = `https://wordpress.com${primaryPath}`;
+		if ( allSitesPath ) {
+			fullPath = primaryPath;
 		} else {
 			fullPath = slug ? `${ primaryPath }/${ slug }` : primaryPath;
 		}
 
 		return (
 			<NavItem path={ fullPath }
-					isExternalLink={ external }
+					isExternalLink={ false }
 					key={ fullPath }
 					selected={ selectedNavItem && ( selectedNavItem.label === label ) }>
 				{ label }

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -65,7 +65,7 @@ var NAV_ITEMS = {
 
 	'My Upgrades': {
 		paths: [ '/purchases' ],
-		label: i18n.translate( 'My Upgrades' ),
+		label: i18n.translate( 'Manage Purchases' ),
 		external: true
 	}
 };

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -24,6 +24,7 @@ var SectionNav = require( 'components/section-nav' ),
 	viewport = require( 'lib/viewport' ),
 	upgradesActionTypes = require( 'lib/upgrades/constants' ).action,
 	PopoverCart = require( 'my-sites/upgrades/cart/popover-cart' ),
+	purchasesPaths = require( 'me/purchases/paths' ),
 	i18n = require( 'lib/mixins/i18n' );
 
 // The first path acts as the primary path that the button will link to. The
@@ -58,7 +59,7 @@ var NAV_ITEMS = {
 	},
 
 	'My Purchases': {
-		paths: [ '/purchases' ],
+		paths: [ purchasesPaths.list() ],
 		label: i18n.translate( 'Manage Purchases' ),
 		allSitesPath: true
 	}

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -64,7 +64,7 @@ var NAV_ITEMS = {
 	},
 
 	'My Upgrades': {
-		paths: [ '/my-upgrades' ],
+		paths: [ '/purchases' ],
 		label: i18n.translate( 'My Upgrades' ),
 		external: true
 	}

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -158,7 +158,6 @@ var UpgradesNavigation = React.createClass( {
 
 		return (
 			<NavItem path={ fullPath }
-					isExternalLink={ false }
 					key={ fullPath }
 					selected={ selectedNavItem && ( selectedNavItem.label === label ) }>
 				{ label }

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -121,9 +121,6 @@ var UpgradesNavigation = React.createClass( {
 			items = [ 'Plans', 'My Purchases' ];
 		} else {
 			items = [ 'Plans', 'Domains', 'Email', 'My Purchases' ];
-			if ( config.isEnabled( 'upgrades/purchases/list' ) ) {
-				items = [ 'Plans', 'Domains', 'Email' ];
-			}
 		}
 
 		return items.map( propertyOf( NAV_ITEMS ) );


### PR DESCRIPTION
Fixes #543 

Testing

0. Apply this patch: `D593-code`
1. `git checkout update/Link-directly-to-manage-purchase`
2. Browse to http://calypso.localhost:3000/plans
3. Select a site with a plan
4. Clicking on manage purchase takes you to the correct `/purchases/` page for this plan
5. Visit `Billing History` and verify that the `Manage Purchases` link takes you to `purchases`
6. Make sure that the `Manage Purchase` links for upcoming charges takes you to the correct purchase.

Also test:
1. The link at the top of /me/billing
2. The `Payment Settings` link on http://calypso.localhost:3000/domains/manage/:site/edit/:domain
3. The "Renew them now." link which appears when you have a domain warning
4. The "Manage Purchases" link shown when you want to delete a site.

- [x] Code review
- [x] QA review