### PR TITLE
WordAds: Add Config flag for Jetpack Sites to manage ads.

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -12,7 +12,10 @@ module.exports = {
 	 */
 	canAccessWordads: site => {
 		if ( config.isEnabled( 'manage/ads' ) ) {
-			return site.options && site.options.wordads && site.user_can_manage && ! site.jetpack;
+			return site.options &&
+				site.options.wordads &&
+				site.user_can_manage &&
+				( ! site.jetpack || config.isEnabled( 'manage/ads/jetpack' ) );
 		}
 
 		return false;

--- a/config/development.json
+++ b/config/development.json
@@ -98,6 +98,7 @@
 		"manage/customize": true,
 
 		"manage/ads": true,
+		"manage/ads/jetpack": true,
 
 		"vip": false,
 		"vip/deploys": true,


### PR DESCRIPTION
Adding a flag in config to roll out Jetpack site access to WordAds. Just development for now.