### PR TITLE
Invites: Improves translated string for invite header

### DIFF
--- a/client/accept-invite/invite-header/index.jsx
+++ b/client/accept-invite/invite-header/index.jsx
@@ -16,15 +16,90 @@ import Gravatar from 'components/gravatar';
 export default React.createClass( {
 	displayName: 'InviteHeader',
 
-	getInvitationVerb() {
-		switch ( get( this.props, 'invite.meta' ) ) {
-			case 'viewer':
-			case 'follower':
-				return this.translate( 'view' );
+	getInviterName() {
+		return get(
+			this.props,
+			'inviter.name',
+			this.translate( 'User', { context: 'Placeholder text while loading an invitation.' } )
+		);
+	},
+
+	getInvitedYouText() {
+		let text = '';
+
+		const inviterName = (
+			<strong className="invite-header__inviter-name">
+				{ this.getInviterName() }
+			</strong>
+		);
+
+		switch ( get( this.props, 'invite.meta.role' ) ) {
+			case 'administrator':
+				text = this.translate(
+					'{{inviterName/}} invited you to administer:', {
+						components: {
+							inviterName: inviterName
+						}
+					}
+				);
 				break;
+			case 'editor':
+				text = this.translate(
+					'{{inviterName/}} invited you to edit:', {
+						components: {
+							inviterName: inviterName
+						}
+					}
+				);
+				break;
+			case 'author':
+				text = this.translate(
+					'{{inviterName/}} invited you to author on:', {
+						components: {
+							inviterName: inviterName
+						}
+					}
+				);
+				break;
+			case 'contributor':
+				text = this.translate(
+					'{{inviterName/}} invited you to contribute to:', {
+						components: {
+							inviterName: inviterName
+						}
+					}
+				);
+				break;
+			case 'subscriber':
+				text = this.translate(
+					'{{inviterName/}} invited you to subscribe to:', {
+						components: {
+							inviterName: inviterName
+						}
+					}
+				);
+				break;
+			case 'follower':
+				text = this.translate(
+					'{{inviterName/}} invited you to follow:', {
+						components: {
+							inviterName: inviterName
+						}
+					}
+				);
+				break
 			default:
-				return this.translate( 'contribute to' );
+				text = this.translate(
+					'{{inviterName/}} invited you to join:', {
+						components: {
+							inviterName: inviterName
+						}
+					}
+				);
+				break
 		}
+
+		return text;
 	},
 
 	render() {
@@ -35,21 +110,7 @@ export default React.createClass( {
 					<div className="invite-header__inviter-info">
 						<Gravatar user={ this.props.inviter } size={ 32 } />
 						<p className="invite-header__invited-you-text">
-							{
-								this.translate( '{{strong}}%(user)s{{/strong}} invited you to %(verb)s:', {
-									args: {
-										user: get(
-											this.props,
-											'inviter.name',
-											this.translate( 'User', { context: 'Placeholder text while loading an invitation.' } )
-										),
-										verb: this.getInvitationVerb()
-									},
-									components: {
-										strong: <strong />
-									}
-								} )
-							}
+							{ this.getInvitedYouText() }
 						</p>
 					</div>
 				</CompactCard>

--- a/client/accept-invite/invite-header/index.jsx
+++ b/client/accept-invite/invite-header/index.jsx
@@ -36,7 +36,7 @@ export default React.createClass( {
 		switch ( get( this.props, 'invite.meta.role' ) ) {
 			case 'administrator':
 				text = this.translate(
-					'{{inviterName/}} invited you to administer:', {
+					'{{inviterName/}} invited you to manage:', {
 						components: {
 							inviterName: inviterName
 						}

--- a/client/accept-invite/invite-header/index.jsx
+++ b/client/accept-invite/invite-header/index.jsx
@@ -54,7 +54,7 @@ export default React.createClass( {
 				break;
 			case 'author':
 				text = this.translate(
-					'{{inviterName/}} invited you to author on:', {
+					'{{inviterName/}} invited you to be an author on:', {
 						components: {
 							inviterName: inviterName
 						}


### PR DESCRIPTION
Addresses part of #138 and related to #369

To test:
- Checkout `update/invite-header-role-strings` branch
- Invite a test user to join a WordPress.com site by going to `Users > Invite New` in `wp-admin`
- In the invitation email, make note of the invitation key
- Go to `/accept-invite/$site/$invite_key`
- Does the "invited you..." text seem appropriate for the role?
- Now, go back to the invite users UI in `wp-admin`
- Invite the same user, but with a different role this time
- Refresh the tab that has Calypso loaded
- Do the strings represent the new role?


cc @roccotripaldi for review and @rickybanister for wording review