### PR TITLE
Purchases: Fix partial domain+plan cancellations

### DIFF
--- a/client/me/purchases/confirm-cancel-purchase/load-endpoint-form.js
+++ b/client/me/purchases/confirm-cancel-purchase/load-endpoint-form.js
@@ -77,6 +77,9 @@ function submitForm( { form, onSubmit, selectedPurchase, selectedSite } ) {
 function getFormData( { form, selectedPurchase, selectedSite } ) {
 	const inputs = zipObject(
 		toArray( form.elements )
+			.filter( ( element ) => {
+				return ( element.type === 'radio' ) ? element.checked : true;
+			} )
 			.map( ( element ) => [ element.name, element.value ] )
 	);
 


### PR DESCRIPTION
Fixes #466. The form data for choosing the cancellation type was not working properly because we were ignoring whether the `option` was selected or not. This changes the endpoint form to only get the value of options that are checked.

### Testing

1. Go to http://calypso.localhost:3000/purchases and click a plan that includes a domain
2. Click "Cancel WordPress.com [Plan Type]"
3. Click "Cancel WordPress.com [Plan Type]" again
4. Choose the option to cancel only the plan and keep the domain
5. The email you receive should show a partial refund of $81 rather than $99
6. When you click the cancellation link in the email, the domain should still be available on your account but the plan should be gone.