### PR TITLE
Security: if phone already set, don't disable submit

### DIFF
--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -42,9 +42,20 @@ module.exports = React.createClass( {
 	verifyByApp: null,
 
 	getInitialState: function() {
+		let phoneNumber = null;
+		let storedCountry = this.props.userSettings.getSetting( 'two_step_sms_country' );
+		let storedNumber = this.props.userSettings.getSetting( 'two_step_sms_phone_number' );
+		if ( storedCountry && storedNumber ) {
+			phoneNumber = {
+				countryCode: storedCountry,
+				phoneNumber: storedNumber,
+				isValid: true
+			}
+		}
+
 		return {
 			lastError: false,
-			phoneNumber: null
+			phoneNumber
 		};
 	},
 
@@ -96,14 +107,21 @@ module.exports = React.createClass( {
 		}
 
 		this.props.userSettings.updateSetting( 'two_step_sms_phone_number', phoneNumber.phoneNumber );
-		this.props.userSettings.updateSetting( 'two_step_sms_country', phoneNumber.countryData.code );
+		this.props.userSettings.updateSetting( 'two_step_sms_country', phoneNumber.countryCode );
 
 		this.setState( { submittingForm: true } );
 		this.props.userSettings.saveSettings( this.onSubmitResponse );
 	},
 
 	onChangePhoneInput: function( phoneNumber ) {
-		this.setState( { phoneNumber } );
+		this.setState( {
+			phoneNumber: {
+				phoneNumber: phoneNumber.phoneNumber,
+				countryCode: phoneNumber.countryData.code,
+				isValid: phoneNumber.isValid,
+				validation: phoneNumber.validation
+			}
+		} );
 	},
 
 	onSubmitResponse: function( error ) {


### PR DESCRIPTION
When a user already has an SMS number stored, we shouldn't disable the submit button in the 2fa flow by default. We do this by initializing the sms settings component state with the phone number data from userSettings.

### To Test

- Start with a user account with 2fa disabled and no phone number set (can delete from Security > Checkup)
- Go to Security > Two Step
- Tap "Get Started"
- Verify the phone fields are empty and buttons are disabled
- Enter incorrect values and submit. Check for validation errors.
- Enter a valid phone number and submit
- Verify that you were bumped to the next step in the flow
- Tap "Cancel"
- Refresh
- Tap "Get Started"
- Verify the phone fields are populated and the buttons are enabled

/cc @ebinnion 