### PR TITLE
Documentation: Declare React External Dependency

### DIFF
--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -49,6 +49,11 @@ touch client/my-sites/hello-world/controller.js
 There you'll write your controller with a function called `helloWorld`:
 
 ```javascript
+/**
+ * External Dependencies
+ */
+var React = require( 'react' );
+
 const Controller = {
 	helloWorld() {
 		console.log( 'Hello, world?' );


### PR DESCRIPTION
Following the "Hello World" guide produces the following error:

```Uncaught ReferenceError: React is not defined```

External React dependency needs to be declared.