### PR TITLE
Editor: Prevent featured image drag from triggering Drop Zone (Firefox)

### DIFF
--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -45,13 +45,26 @@ module.exports = React.createClass( {
 	},
 
 	isValidTransfer: function( transfer ) {
+		if ( ! transfer ) {
+			return false;
+		}
+
+		// Firefox will claim that images dragged from within the same page are
+		// files, but will also identify them with a `mozSourceNode` attribute.
+		// This value will be `null` for files dragged from outside the page.
+		//
+		// See: https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/mozSourceNode
+		if ( transfer.mozSourceNode ) {
+			return false;
+		}
+
 		// `types` is a DOMStringList, which is treated as an array in Chrome,
 		// but as an array-like object in Firefox. Therefore, we call `indexOf`
 		// using the Array prototype. Safari may pass types as `null` which
 		// makes detection impossible, so we err on allowing the transfer.
 		//
 		// See: http://www.w3.org/html/wg/drafts/html/master/editing.html#the-datatransfer-interface
-		return transfer && ( ! transfer.types || -1 !== Array.prototype.indexOf.call( transfer.types, 'Files' ) );
+		return ! transfer.types || -1 !== Array.prototype.indexOf.call( transfer.types, 'Files' );
 	},
 
 	render: function() {


### PR DESCRIPTION
Fixes #591 

This pull request seeks to resolve an issue where dragging the featured image in Firefox will trigger the media drop zone to activate on the page.

__Implementation notes:__

Validation is performed to ensure that the dragged file is in-fact a file. In non-Firefox browsers, this `types` Array-like structure will not include the "Files" string unless the file is dragged from off the page. Firefox still includes this value for elements dragged from within the same page, but will also assign a [`mozSourceNode`](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/mozSourceNode) property. By checking for the existence of this property, we can detect whether the drag was initiated from on the same page. Since this property is non-standard, we should monitor Firefox for future changes to the property or behavior, or seek an alternative solution (likely manual tracking of the node from which a drag is initiated). The behavior implemented here is considered a workaround for a browser quirk.

__Testing instructions:__

Verify that dragging an image only initiates the drop zone if dragged from off-screen, especially in Firefox, but also in your preferred browser.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Drag an item from your Finder on to the page
4. Note that the drop zone is activated and will accept the file on drop
5. Assign a featured image to the post
6. Attempt to drag the assigned featured image
7. Note that the drop zone is not activated