### PR TITLE
Purchases: Make domain cancel and refund form work properly

### DIFF
--- a/client/me/purchases/confirm-cancel-purchase/index.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/index.jsx
@@ -58,10 +58,7 @@ const ConfirmCancelPurchase = React.createClass( {
 
 	handleSubmit( error, response ) {
 		if ( error ) {
-			notices.error( this.translate(
-				'There was a problem canceling this purchase. ' +
-				'Please try again later or contact support.'
-			) );
+			notices.error( error.message );
 			return;
 		}
 

--- a/client/me/purchases/confirm-cancel-purchase/load-endpoint-form.js
+++ b/client/me/purchases/confirm-cancel-purchase/load-endpoint-form.js
@@ -89,8 +89,9 @@ function getFormData( { form, selectedPurchase, selectedSite } ) {
 	return inputs;
 }
 
-function initializeDomainCancelForm( { form } ) {
-	const domainCancelReason = form.querySelector( '#domain_cancel_reason' ),
+function initializeDomainCancelForm( options ) {
+	const { form } = options,
+		domainCancelReason = form.querySelector( '#domain_cancel_reason' ),
 		confirmCheckbox = form.querySelector( '#confirm' ),
 		submitButton = form.querySelector( 'input[type=submit]' );
 

--- a/client/me/purchases/confirm-cancel-purchase/load-endpoint-form.js
+++ b/client/me/purchases/confirm-cancel-purchase/load-endpoint-form.js
@@ -134,6 +134,9 @@ function showDomainReasonDetail( { form, selectValue } ) {
 		case 'transfer':
 			selected = '#div_transfer';
 			break;
+		case 'misspelled':
+			selected = '#div_misspelled';
+			break;
 		case 'expectations':
 		case 'wanted_free':
 		case 'other':


### PR DESCRIPTION
Fixes error found in #465.

This change makes domain cancellation working properly.

### Testing
Apply patch `fe3b-pb`.
1. Go to http://calypso.localhost:3000/purchases.
2. Find domain purchase which is cancelable (within 48h period from purchase date).
3. Click `Cancel and Refund` link.
4. You should see cancellation flow going smoothly, including cancel information and cancel confirmation page (form).

/cc @fabianapsimoes, @scruffian 

### Review
* [x] Code review
* [x] QA review