### PR TITLE
Desktop: remove wpcom-xhr-request error check

### DIFF
--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -108,7 +108,7 @@ User.prototype.fetch = function() {
 
 	me.get( { meta: 'flags' }, function( error, data ) {
 		if ( error ) {
-			if ( ! config( 'wpcom_user_bootstrap' ) && ( error.error === 'authorization_required' || error.status === 403 ) ) {
+			if ( ! config( 'wpcom_user_bootstrap' ) && error.error === 'authorization_required' ) {
 				/**
 				 * if the user bootstrap is disabled (in development), we need to rely on a request to
 				 * /me to determine if the user is logged in.


### PR DESCRIPTION
An additional error check was previously added to work around a difference in error handling between `wpcom-proxy-request` and `wpcom-xhr-request`.

This extra check was no longer needed when `lib/wpcom-xhr-wrapper` was introduced. This PR removes the extra check.
