### PR TITLE
Desktop: globally check for invalid oauth token

### DIFF
--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -1,13 +1,29 @@
+/**
+ * External dependencies
+ */
 import xhr from 'wpcom-xhr-request';
+import debugModule from 'debug';
+
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:wpcom-xhr-wrapper' );
 
 export default function( params, callback ) {
 	return xhr( params, function( error, response ) {
-		if ( error && error.response && typeof error.response.body ) {
-			// Extend the error object in a way to match wpcom-proxy-request
-			error.httpMessage = error.message;
-			error.message = error.response.body.message;
-			error.error = error.response.body.error;
-			error.statusCode = error.status;
+		if ( error ) {
+			if ( error.response && typeof error.response.body ) {
+				// Extend the error object in a way to match wpcom-proxy-request
+				error.httpMessage = error.message;
+				error.message = error.response.body.message;
+				error.error = error.response.body.error;
+				error.statusCode = error.status;
+			}
+
+			if ( error.error === 'invalid_token' ) {
+				debug( 'Invalid token error detected, authorisation probably revoked - logging out' );
+				require( 'lib/user/utils' ).logout();
+			}
 		}
 
 		callback( error, response );


### PR DESCRIPTION
When using OAuth if the token is revoked we should log the user out as soon as possible.

This PR uses the `wpcom-xhr-wrapper` to add a global check for invalid tokens. Although it links the wrapper directly to the user library I think it's the best place without introducing more complications.