### PR TITLE
Desktop: remove app badge

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -153,12 +153,6 @@ function getDefaultContext( request ) {
 		context.faviconURL = '/calypso/images/favicons/favicon-staging.ico';
 	}
 
-	if ( CALYPSO_ENV === 'desktop' ) {
-		context.badge = 'desktop';
-		context.feedbackURL = 'https://github.com/Automattic/wordpress-desktop/issues';
-		context.faviconURL = '/calypso/images/favicons/favicon-wpcalypso.ico';
-	}
-
 	if ( CALYPSO_ENV === 'development' ) {
 		context.badge = 'dev';
 		context.devDocs = true;


### PR DESCRIPTION
This removes the badge for the desktop app - it doesn't make sense inside the app anymore.