### PR TITLE
Build: Add /usr/local/bin to pre-commit PATH

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH="$PATH:/usr/local/bin"
+
 echo "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see CONTRIBUTING.md for details.\n\n"
 
 files=$(git diff --cached --name-only --diff-filter=ACM | grep ".jsx*$")


### PR DESCRIPTION
In some IDEs, or Git GUIs, the `i18nlint` and `eslint` checks will fail because of the PATH being set incorrectly — or being set in a login profile (`.bash_profile`).

Let's take an educated guess that `node` is going to be in `/usr/local/bin`.

@aduth this should help you with GitHub desktop.