### PR TITLE
Devdocs : # links not working 

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -73,7 +73,7 @@ var devdocs = {
 			React.createElement( SingleDocComponent, {
 				path: context.params.path,
 				term: context.query.term,
-				sectionId: '' + Object.keys( context.hash )[0]
+				sectionId: Object.keys( context.hash )[0]
 			} ),
 			document.getElementById( 'primary' )
 		);

--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -73,7 +73,7 @@ var devdocs = {
 			React.createElement( SingleDocComponent, {
 				path: context.params.path,
 				term: context.query.term,
-				sectionId: context.hash
+				sectionId: '' + Object.keys( context.hash )[0]
 			} ),
 			document.getElementById( 'primary' )
 		);


### PR DESCRIPTION
Fixes #611, 
Context stores hash value in an object  - for 
```
For #link

context.hash = {
   link: ""
}
```
and app is expecting String
Reacts generates warnings:
```
Warning: Failed propType: Invalid prop `sectionId` of type `object` supplied to `SingleDocument`, expected `string`.
```
and scrolling to proper section does not work
I casted the context hash value to String

I am not sure this is the proper way to go.
Hash is treated like a queryString, I have no idea why it is so.
I have searched the codebase for `#links`, but apparently I cannot find any.

# Testing
- fire up Calypso `devdocs/docs/guide/index.md`
- assert lack of react warnings
- `devdocs/docs/guide/hello-world.md#4-register-section` - see that it scrolls
