### PR TITLE
People: Invites: Fix call to accept invite endpoint

### DIFF
--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -290,8 +290,8 @@ Undocumented.prototype.getInvite = function( siteId, inviteKey, fn ) {
 };
 
 Undocumented.prototype.acceptInvite = function( siteId, inviteKey, fn ) {
-	debug( '/sites/:site_id:/invites/ query' );
-	this.wpcom.req.post( { path: '/sites/' + siteId + '/invites/' }, {}, { invite_key: inviteKey }, fn );
+	debug( '/sites/:site_id:/invites/:inviteKey:/accept query' );
+	this.wpcom.req.get( '/sites/' + siteId + '/invites/' + inviteKey + '/accept', fn );
 };
 
 /**


### PR DESCRIPTION
### How to test ###

* pull `fix/invites-accept-invite-call`
* invite a user to a blog and get the key from the email
* go to `calypso.dev:3000/accept-invite/_blog_id_/_invite_key`
* accept the invite and confirm that everything flows

Closes #548