### PR TITLE
Reader comments: only trust comment content from the API

### DIFF
--- a/client/lib/comment-store/comment-store.js
+++ b/client/lib/comment-store/comment-store.js
@@ -132,7 +132,7 @@ function confirmComment( siteId, postId, commentPlaceholderId, confirmedComment 
 	}
 
 	// Replace the comment with the new one and set the state to complete
-	confirmedComment.state = States.CONFIRMED;
+	confirmedComment.state = States.COMPLETE;
 
 	// If the comment can be published immediately (i.e. doesn't require moderation), increment the comment count
 	if ( confirmedComment.status === 'approved' ) {

--- a/client/reader/comments/index.jsx
+++ b/client/reader/comments/index.jsx
@@ -12,7 +12,8 @@ var Gravatar = require( 'components/gravatar' ),
 	PostTime = require( 'reader/post-time' ),
 	PostCommentForm = require( './form' ),
 	CommentLikeButtonContainer = require( './comment-likes' ),
-	stats = require( 'reader/stats' );
+	stats = require( 'reader/stats' ),
+	PostCommentContent = require( './post-comment-content' );
 
 var PostComment = React.createClass( {
 
@@ -146,12 +147,11 @@ var PostComment = React.createClass( {
 					</small>
 				</div>
 
-				{ comment.status && comment.status === 'unapproved' ?
-					<p className="comment__moderation">{ this.translate( 'Your comment is awaiting moderation.' ) }</p>
+				{ comment.status && comment.status === 'unapproved'
+					? <p className="comment__moderation">{ this.translate( 'Your comment is awaiting moderation.' ) }</p>
 					: null }
 
-				<div className="comment__content" dangerouslySetInnerHTML={{ __html: comment.content }}>
-				</div>
+				<PostCommentContent content={ comment.content } state={ comment.state } />
 
 				{ this.renderCommentActions( comment ) }
 				{ this.renderCommentForm() }

--- a/client/reader/comments/post-comment-content.jsx
+++ b/client/reader/comments/post-comment-content.jsx
@@ -1,0 +1,23 @@
+import React, { PropTypes } from 'react';
+import CommentConstants from 'lib/comment-store/constants';
+
+const PostCommentContent = React.createClass( {
+	propTypes: {
+		content: PropTypes.string.isRequired,
+		state: PropTypes.string.isRequired,
+	},
+
+	render() {
+		// Don't trust comment content unless it was provided by the API
+		if ( this.props.state !== CommentConstants.state.COMPLETE ) {
+			return <div className="comment__content">{ this.props.content }</div>;
+		}
+
+		return (
+			<div className="comment__content" dangerouslySetInnerHTML={{ __html: this.props.content }}>
+			</div>
+		);
+	}
+} );
+
+export default PostCommentContent;

--- a/client/reader/comments/post-comment-content.jsx
+++ b/client/reader/comments/post-comment-content.jsx
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React, { PropTypes } from 'react/addons';
 import CommentConstants from 'lib/comment-store/constants';
 
 const PostCommentContent = React.createClass( {

--- a/client/reader/comments/post-comment-content.jsx
+++ b/client/reader/comments/post-comment-content.jsx
@@ -2,6 +2,9 @@ import React, { PropTypes } from 'react';
 import CommentConstants from 'lib/comment-store/constants';
 
 const PostCommentContent = React.createClass( {
+
+	mixins: [ React.addons.PureRenderMixin ],
+
 	propTypes: {
 		content: PropTypes.string.isRequired,
 		state: PropTypes.string.isRequired,


### PR DESCRIPTION
We currently render all Reader comment content using `dangerouslySetInnerHtml`, including previews.

To benefit from React's in-built escaping, I've created a new `PostCommentContent` component which only uses `dangerouslySetInnerHtml` on trusted comment content received from the REST API.
