### PR TITLE
Purchases: Fix type errors for function that retrieves the selected purchase

### DIFF
--- a/client/me/purchases/confirm-cancel-purchase/index.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/index.jsx
@@ -15,7 +15,7 @@ import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
-import { goToManagePurchase } from '../utils';
+import { getPurchase, goToManagePurchase } from '../utils';
 
 const ConfirmCancelPurchase = React.createClass( {
 	propTypes: {
@@ -68,7 +68,7 @@ const ConfirmCancelPurchase = React.createClass( {
 
 		analytics.tracks.recordEvent(
 			'calypso_purchases_cancel_form_submit',
-			{ product_slug: this.getPurchase().productSlug }
+			{ product_slug: getPurchase( this.props ).productSlug }
 		);
 
 		page.redirect( paths.list() );

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -25,7 +25,7 @@ import ValidationErrorList from 'notices/validation-error-list';
 import { createPaygateToken } from 'lib/store-transactions';
 import wpcomFactory from 'lib/wp';
 import paths from 'me/purchases/paths';
-import { goToManagePurchase, isDataLoading } from 'me/purchases/utils';
+import { getPurchase, goToManagePurchase, isDataLoading } from 'me/purchases/utils';
 
 const wpcom = wpcomFactory.undocumented();
 
@@ -119,7 +119,7 @@ const EditCardDetails = React.createClass( {
 
 		analytics.tracks.recordEvent(
 			'calypso_purchases_credit_card_form_submit',
-			{ product_slug: this.getPurchase().productSlug }
+			{ product_slug: getPurchase( this.props ).productSlug }
 		);
 
 		createPaygateToken( cardDetails, ( paygateError, token ) => {


### PR DESCRIPTION
This is a follow-up of https://github.com/Automattic/wp-calypso/pull/586 that fixes two function calls that were forgotten in this pull request.