### PR TITLE
People: Invites: Pre populate email field

### DIFF
--- a/client/accept-invite/logged-out-invite/signup-form.jsx
+++ b/client/accept-invite/logged-out-invite/signup-form.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react'
+import { get } from 'lodash'
 
 /**
  * Internal dependencies
@@ -42,11 +43,6 @@ export default React.createClass( {
 		);
 	},
 
-	getInviteRole() {
-		let meta = this.props.invite && this.props.invite.meta ? this.props.invite.meta : false;
-		return meta && meta.role ? meta.role : false;
-	},
-
 	getFormHeader() {
 		return (
 			<InviteFormHeader
@@ -54,7 +50,7 @@ export default React.createClass( {
 					this.translate( 'Sign up to become an %(siteRole)s on {{siteNameLink}}%(siteName)s{{/siteNameLink}}?', {
 						args: {
 							siteName: this.props.blog_details.title,
-							siteRole: this.getInviteRole()
+							siteRole: get( this.props, 'invite.meta.role' )
 						},
 						components: {
 							siteNameLink: <a href={ this.props.blog_details.domain } className="logged-in-accept__site-name" />
@@ -65,7 +61,7 @@ export default React.createClass( {
 					this.translate(
 						'As an %(siteRole)s you will be able to publish and edit your own posts as well as upload media.', {
 							args: {
-								siteRole: this.getInviteRole()
+								siteRole: get( this.props, 'invite.meta.role' )
 							}
 						}
 					)

--- a/client/accept-invite/logged-out-invite/signup-form.jsx
+++ b/client/accept-invite/logged-out-invite/signup-form.jsx
@@ -115,6 +115,7 @@ export default React.createClass( {
 					submitForm={ this.submitForm }
 					submitButtonText={ this.submitButtonText() }
 					footerLink={ this.footerLink() }
+					email={ get( this.props, 'invite.meta.sent_to' ) }
 				/>
 				{ this.state.userData && this.loginUser() }
 			</div>

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -266,7 +266,7 @@ export default React.createClass( {
 						id="email"
 						name="email"
 						type="email"
-						value={ formState.getFieldValue( this.state.form, 'email' ) }
+						value={ formState.getFieldValue( this.state.form, 'email' ) || this.props.email }
 						isError={ formState.isFieldInvalid( this.state.form, 'email' ) }
 						isValid={ formState.isFieldValid( this.state.form, 'email' ) }
 						onBlur={ this.handleBlur }


### PR DESCRIPTION
### How to test ###

* pull `update/invites-pre-populate-email-field `
* invite a user to a blog and get the key from the email
* logout
* go to `calypso.dev:3000/accept-invite/_blog_id_/_invite_key`
* confirm that the email field is being pre-populated

Closes #367
