### PR TITLE
Me: Sidebar: Decode entities for User's display name on /me profile sidebar

### DIFF
--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -8,6 +8,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var Gravatar = require( 'components/gravatar' ),
+	formatting = require( 'lib/formatting' ),
 	eventRecorder = require( 'me/event-recorder' );
 
 module.exports = React.createClass( {
@@ -40,7 +41,7 @@ module.exports = React.createClass( {
 					</span>
 				</a>
 
-				<h2 className="profile-gravatar__user-display-name">{ this.props.user.display_name }</h2>
+				<h2 className="profile-gravatar__user-display-name">{ formatting.decodeEntities( this.props.user.display_name ) }</h2>
 
 				<div className="profile-gravatar__user-secondary-info">
 					<a href={ profileURL }>@{ this.props.user.username }</a>


### PR DESCRIPTION
Display names that used a special char, for example, an ampersand were shown like &amp; on the h2 that shows the display name under the gravatar.

It used to look like this
![Entities not decoded on /me display name](https://cldup.com/1KacnQadRa-3000x3000.png)

Now it shows just the ampersand.

cc @ebinnion 
