### PR TITLE
Reader: Fix action layout in full post view on mobile

### DIFF
--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -40,6 +40,7 @@ module.exports = React.createClass( {
 		return {
 			// onSelect callback
 			onSelect: noop,
+			onClick: noop,
 			// mouse event callbacks
 			onMouseEnter: noop,
 			onMouseLeave: noop,
@@ -65,7 +66,8 @@ module.exports = React.createClass( {
 		onMouseEnter: React.PropTypes.func,
 		onMouseLeave: React.PropTypes.func,
 		isSelected: React.PropTypes.bool,
-		site: React.PropTypes.object.isRequired
+		site: React.PropTypes.object.isRequired,
+		onClick: React.PropTypes.func
 	},
 
 	onSelect: function( event ) {
@@ -74,7 +76,7 @@ module.exports = React.createClass( {
 		}
 
 		this.props.onSelect( event );
-		event.preventDefault();
+		event.preventDefault(); // this doesn't actually do anything...
 	},
 
 	render: function() {
@@ -102,6 +104,7 @@ module.exports = React.createClass( {
 					target={ this.props.externalLink && '_blank' }
 					title={ this.props.homeLink ? this.translate( 'Visit "%(title)s"', { args: { title: site.title } } ) : site.title }
 					onTouchTap={ this.onSelect }
+					onClick={ this.props.onClick }
 					onMouseEnter={ this.props.onMouseEnter }
 					onMouseLeave={ this.props.onMouseLeave }
 					aria-label={ this.translate( 'Open site %(domain)s in new tab', { args: { domain: site.domain } } ) }

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -44,7 +44,8 @@ var Card = require( 'components/card' ),
 	DiscoverHelper = require( 'reader/discover/helper' ),
 	FeedPostStore = require( 'lib/feed-post-store' ),
 	FollowButton = require( 'reader/follow-button' ),
-	Gridicon = require( 'components/gridicon' );
+	Gridicon = require( 'components/gridicon' ),
+	smartSetState = require( 'lib/react-smart-set-state' );
 
 var Post = React.createClass( {
 
@@ -59,6 +60,8 @@ var Post = React.createClass( {
 		additionalClasses: React.PropTypes.object,
 		handleClick: React.PropTypes.func.isRequired
 	},
+
+	smartSetState: smartSetState,
 
 	getMaxFeaturedWidthSize: function() {
 		return ReactDom.findDOMNode( this ).offsetWidth;
@@ -112,6 +115,7 @@ var Post = React.createClass( {
 
 		return {
 			site: site,
+			siteish: utils.siteishFromSiteAndPost( site, post ),
 			originalPost: originalPost,
 			isDiscoverPost: isDiscoverPost,
 			isDiscoverSitePick: isDiscoverSitePick
@@ -138,7 +142,7 @@ var Post = React.createClass( {
 	updateState: function( props ) {
 		var newState = this.getStateFromStores( props );
 		if ( newState.site !== this.state.site ) {
-			this.setState( newState );
+			this.smartSetState( newState );
 		}
 	},
 
@@ -299,7 +303,7 @@ var Post = React.createClass( {
 
 	render: function() {
 		var post = this.props.post,
-			site = utils.siteishFromSiteAndPost( this.state.site, post ),
+			site = this.state.siteish,
 			featuredImage = this.featuredImageComponent( post ),
 			shouldShowComments = PostCommentHelper.shouldShowComments( post ),
 			shouldShowLikes = LikeHelper.shouldShowLikes( post ),

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -51,6 +51,14 @@
 		display: none;
 	}
 
+	.site {
+		.site__content {
+			padding: 0;
+			border-radius: 0;
+			text-decoration: none;
+		}
+	}
+
 	.reader__post-time {
 		.reader__post-time-link, .reader__post-time-link:hover {
 			color: inherit;
@@ -61,10 +69,10 @@
 	.reader__post-title {
 		font-size: 36px;
 		line-height: 1.258;
-		margin: 8px 0 0 0;
+		margin: 16px 0 0 0;
 
 		@include breakpoint( "<480px" ) {
-			font-size: 24px;
+			font-size: 28px;
 		}
 
 		a {
@@ -92,7 +100,7 @@
 }
 
 .full-post__featured-image {
-	margin: -15px -32px 24px -32px;
+	margin: 8px -32px;
 	max-width: calc(100% + 64px);
 	text-align: center;
 	background: $gray-light;
@@ -101,50 +109,6 @@
 		display: block;
 		width: 100%;
 		object-fit: cover;
-	}
-}
-
-// Full Post Site
-// Lives inside the Dialog's action-bar area.
-.full-post__site {
-	position: absolute;
-		top: 0;
-		left: 44px;
-		bottom: 0;
-	line-height: 48px;
-	padding: 0 12px;
-	border-left: 1px solid lighten( $gray, 30 );
-	font-size: 13px;
-	text-align: left;
-	color: lighten( $gray, 10 );
-	max-width: 110px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-
-	@include breakpoint( ">480px" ) {
-			left: 48px;
-		padding: 0 16px;
-		font-size: 15px;
-		max-width: 450px;
-	}
-
-	.site-icon {
-		display: none;
-	}
-
-	.full-post__site-name {
-		position: relative;
-
-		a {
-			color: $blue-medium;
-			text-decoration: none;
-			font-weight: bold;
-
-			&:hover {
-				color: $blue-light;
-			}
-		}
 	}
 }
 

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -7,7 +7,7 @@
 	margin: 0 auto;
 
 	@include breakpoint( ">660px" ) {
-		padding-top: calc( 56px + 12vh );
+		padding-top: calc( 56px + 6vh );
 		padding-bottom: calc( 48px + 6vh );
 	}
 

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -19,7 +19,9 @@
 		.reader__post-byline,
 		.reader__post-byline a,
 		.reader__post-read-time,
-		.reader__full-post-content p {
+		.reader__full-post-content p,
+		.site__info,
+		.site__title {
 			pointer-events: none;
 			user-select: none;
 			color: transparent;

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -9,7 +9,8 @@ var ReactDom = require( 'react-dom' ),
 	debug = require( 'debug' )( 'calypso:reader-full-post' ), //eslint-disable-line no-unused-vars
 	moment = require( 'moment' ),
 	omit = require( 'lodash/object/omit' ),
-	twemoji = require( 'twemoji' );
+	twemoji = require( 'twemoji' ),
+	page = require( 'page' );
 
 /**
  * Internal Dependencies
@@ -38,7 +39,8 @@ var analytics = require( 'analytics' ),
 	PostExcerptLink = require( 'reader/post-excerpt-link' ),
 	ShareButton = require( 'reader/share' ),
 	DiscoverHelper = require( 'reader/discover/helper' ),
-	DiscoverVisitLink = require( 'reader/discover/visit-link' );
+	DiscoverVisitLink = require( 'reader/discover/visit-link' ),
+	readerRoute = require( 'reader/route' );
 
 var loadingPost = {
 		URL: '',
@@ -121,9 +123,25 @@ FullPostView = React.createClass( {
 		stats.recordPermalinkClick( 'full_post_title' );
 	},
 
+	pickSite: function( event ) {
+		if ( utils.isSpecialClick( event ) ) {
+			return;
+		}
+
+		const url = readerRoute.getStreamUrlFromPost( this.props.post );
+		page.show( url );
+	},
+
+	handleSiteClick: function( event ) {
+		if ( ! utils.isSpecialClick( event ) ) {
+			event.preventDefault();
+		}
+	},
+
 	render: function() {
 		var post = this.props.post,
 			site = this.props.site,
+			siteish = utils.siteishFromSiteAndPost( site, post ),
 			hasFeaturedImage = post &&
 				! ( post.display_type & DISPLAY_TYPES.CANONICAL_IN_CONTENT ) &&
 				post.canonical_image &&
@@ -178,7 +196,10 @@ FullPostView = React.createClass( {
 
 					<PostErrors post={ post } />
 
-					<Site site={ site.toJS() } href={ post.site_URL } />
+					<Site site={ siteish }
+						href={ post.site_URL }
+						onSelect={ this.pickSite }
+						onClick={ this.handleSiteClick } />
 
 					{ hasFeaturedImage
 						? <div className="full-post__featured-image test">

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -28,6 +28,7 @@ var analytics = require( 'analytics' ),
 	PostErrors = require( 'reader/post-errors' ),
 	PostStore = require( 'lib/feed-post-store' ),
 	PostStoreActions = require( 'lib/feed-post-store/actions' ),
+	Site = require( 'my-sites/site' ),
 	SiteState = require( 'lib/reader-site-store/constants' ).state,
 	SiteStore = require( 'lib/reader-site-store' ),
 	SiteStoreActions = require( 'lib/reader-site-store/actions' ),
@@ -176,6 +177,8 @@ FullPostView = React.createClass( {
 				<article className={ articleClasses } id="modal-full-post" ref="article">
 
 					<PostErrors post={ post } />
+
+					<Site site={ site.toJS() } href={ post.site_URL } />
 
 					{ hasFeaturedImage
 						? <div className="full-post__featured-image test">

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -28,8 +28,6 @@ var analytics = require( 'analytics' ),
 	PostErrors = require( 'reader/post-errors' ),
 	PostStore = require( 'lib/feed-post-store' ),
 	PostStoreActions = require( 'lib/feed-post-store/actions' ),
-	SiteIcon = require( 'components/site-icon' ),
-	SiteLink = require( 'reader/site-link' ),
 	SiteState = require( 'lib/reader-site-store/constants' ).state,
 	SiteStore = require( 'lib/reader-site-store' ),
 	SiteStoreActions = require( 'lib/reader-site-store/actions' ),
@@ -277,24 +275,11 @@ FullPostDialog = React.createClass( {
 					action: 'close',
 					isPrimary: true
 				}
-			], siteName, siteLink;
-
-		siteName = utils.siteNameFromSiteAndPost( site, post );
-
-		siteLink = this.props.suppressSiteNameLink
-			? siteName
-			: ( <SiteLink post={ post }>{ siteName }</SiteLink> );
+			];
 
 		if ( post && ! post._state ) {
 			shouldShowComments = PostCommentHelper.shouldShowComments( post );
 			shouldShowLikes = LikeHelper.shouldShowLikes( post );
-
-			buttons.push(
-				<div className="full-post__site" key="site-name">
-					<SiteIcon site={ site && site.toJS() } size={ 24 } />
-					<span className="full-post__site-name">{ siteLink }</span>
-				</div>
-			);
 
 			buttons.push( <PostOptions key="post-options" post={ post } site={ site } onBlock={ this.props.onClose } /> );
 

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -1,27 +1,61 @@
-var url = require( 'url' );
+const url = require( 'url' );
 
-var
-	i18n = require( 'lib/mixins/i18n' ),
-	SiteState = require( 'lib/reader-site-store/constants' ).state;
+const i18n = require( 'lib/mixins/i18n' ),
+	SiteState = require( 'lib/reader-site-store/constants' ).state,
+	FeedDisplayHelper = require( 'reader/lib/feed-display-helper' );
+
+function siteNameFromSiteAndPost( site, post ) {
+	var siteName;
+
+	if ( site && site.get( 'state' ) === SiteState.COMPLETE ) {
+		siteName = site.get( 'title' ) || site.get( 'domain' );
+	} else if ( post ) {
+		if ( post.site_name ) {
+			siteName = post.site_name;
+		} else if ( post.site_URL ) {
+			siteName = url.parse( post.site_URL ).hostname;
+		}
+	}
+
+	if ( ! siteName ) {
+		siteName = i18n.translate( '(no title)' );
+	}
+
+	return siteName;
+}
+
+/**
+ * Creates a site-like object from a site and a post.
+ *
+ * Compliant with what things like the <Site /> object expects
+ * @param  {Immutable.Map} site A Reader site (Immutable)
+ * @param  {Object} post A Reader post
+ * @return {Object}      A site like object
+ */
+function siteishFromSiteAndPost( site, post ) {
+	if ( site ) {
+		return site.toJS();
+	}
+
+	if ( post ) {
+		return {
+			title: siteNameFromSiteAndPost( site, post ),
+			domain: FeedDisplayHelper.formatUrlForDisplay( post.site_URL )
+		};
+	}
+
+	return {
+		title: '',
+		domain: ''
+	}
+}
+
+function isSpecialClick( event ) {
+	return event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey;
+}
 
 module.exports = {
-	siteNameFromSiteAndPost: function( site, post ) {
-		var siteName;
-
-		if ( site && site.get( 'state' ) === SiteState.COMPLETE ) {
-			siteName = site.get( 'title' ) || site.get( 'domain' );
-		} else if ( post ) {
-			if ( post.site_name ) {
-				siteName = post.site_name;
-			} else if ( post.site_URL ) {
-				siteName = url.parse( post.site_URL ).hostname;
-			}
-		}
-
-		if ( ! siteName ) {
-			siteName = i18n.translate( '(no title)' );
-		}
-
-		return siteName;
-	}
+	siteNameFromSiteAndPost,
+	siteishFromSiteAndPost,
+	isSpecialClick
 };


### PR DESCRIPTION
The action bar on the top of the full post view in Reader is getting crowded, and causing issues like this:
![72ba5de2-560f-11e5-8b17-75ab3ab64c0b](https://cloud.githubusercontent.com/assets/191598/10827576/1af1bbbe-7e46-11e5-8c39-a3346b523bef.png)

This PR moves the site title out of the action bar and above the feature image (or title, if no image exists):

![screen shot 2015-10-29 at 2 01 59 pm](https://cloud.githubusercontent.com/assets/191598/10827590/38ae9c76-7e46-11e5-9aa4-48d9ae291cf2.png)

![screen shot 2015-10-29 at 2 02 35 pm](https://cloud.githubusercontent.com/assets/191598/10827594/3aef0dcc-7e46-11e5-8ee0-cf8d6a10277e.png)

Fixes #545