### PR TITLE
Media: Display placeholder block while gallery loads

### DIFF
--- a/client/components/shortcode/frame.jsx
+++ b/client/components/shortcode/frame.jsx
@@ -75,7 +75,14 @@ export default React.createClass( {
 		body: PropTypes.string,
 		scripts: PropTypes.object,
 		style: PropTypes.object,
+		onLoad: PropTypes.func,
 		className: PropTypes.string
+	},
+
+	getDefaultProps() {
+		return {
+			onLoad: () => {}
+		}
 	},
 
 	getInitialState: function() {
@@ -104,10 +111,13 @@ export default React.createClass( {
 		} );
 	},
 
-	setHtml( event ) {
+	onFrameLoad( event ) {
+		// Transmit message to assign frame markup
 		event.target.contentWindow.postMessage( JSON.stringify( {
 			content: this.state.html
 		} ), '*' );
+
+		this.props.onLoad( event );
 	},
 
 	render() {
@@ -125,11 +135,11 @@ export default React.createClass( {
 		return (
 			<ResizableIframe
 				key={ key }
+				{ ...omit( this.props, 'body', 'scripts', 'style' ) }
 				src="https://wpcomwidgets.com/render/"
-				onLoad={ this.setHtml }
+				onLoad={ this.onFrameLoad }
 				frameBorder="0"
 				sandbox="allow-scripts"
-				{ ...omit( this.props, 'body', 'scripts', 'style' ) }
 				className={ classes } />
 		);
 	}

--- a/client/post-editor/media-modal/gallery/preview-individual.jsx
+++ b/client/post-editor/media-modal/gallery/preview-individual.jsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import markup from '../markup';
+
+export default React.createClass( {
+	displayName: 'EditorMediaModalGalleryPreviewIndividual',
+
+	propTypes: {
+		items: PropTypes.arrayOf( PropTypes.object )
+	},
+
+	render() {
+		const items = this.props.items.map( ( item ) => {
+			const caption = markup.caption( item );
+
+			if ( null === caption ) {
+				return <div key={ item.ID } dangerouslySetInnerHTML={ { __html: markup.get( item ) } } />;
+			}
+
+			return React.cloneElement( caption, { key: item.ID } );
+		} );
+
+		return (
+			<div className="editor-media-modal-gallery__preview-individual">
+				<div className="editor-media-modal-gallery__preview-individual-content">
+					{ items }
+				</div>
+			</div>
+		);
+	}
+
+} );

--- a/client/post-editor/media-modal/gallery/preview-shortcode.jsx
+++ b/client/post-editor/media-modal/gallery/preview-shortcode.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import some from 'lodash/collection/some';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { generateGalleryShortcode } from 'lib/media/utils';
+import GalleryShortcode from 'components/gallery-shortcode';
+
+export default React.createClass( {
+	displayName: 'EditorMediaModalGalleryPreviewShortcode',
+
+	propTypes: {
+		siteId: PropTypes.number,
+		settings: PropTypes.object
+	},
+
+	getInitialState() {
+		return {
+			isLoading: true,
+			shortcode: generateGalleryShortcode( this.props.settings )
+		};
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		const shortcode = generateGalleryShortcode( nextProps.settings );
+		if ( this.state.shortcode === shortcode ) {
+			return;
+		}
+
+		this.setState( {
+			isLoading: true,
+			shortcode
+		} );
+	},
+
+	setLoaded() {
+		if ( ! this.isMounted() ) {
+			return;
+		}
+
+		this.setState( {
+			isLoading: false
+		} );
+	},
+
+	render() {
+		const { siteId, settings } = this.props;
+		const { isLoading, shortcode } = this.state;
+		const classes = classNames( 'editor-media-modal-gallery__preview-shortcode', {
+			'is-loading': isLoading || some( settings.items, 'transient' )
+		} );
+
+		return (
+			<div className={ classes }>
+				<GalleryShortcode siteId={ siteId } onLoad={ this.setLoaded }>
+					{ shortcode }
+				</GalleryShortcode>
+			</div>
+		);
+	}
+
+} );

--- a/client/post-editor/media-modal/gallery/preview.jsx
+++ b/client/post-editor/media-modal/gallery/preview.jsx
@@ -26,7 +26,7 @@ export default React.createClass( {
 
 	getInitialState() {
 		return {
-			isOrdering: false
+			isEditing: false
 		};
 	},
 
@@ -43,13 +43,13 @@ export default React.createClass( {
 		return (
 			<SegmentedControl className="editor-media-modal-gallery__preview-toggle" compact={ true }>
 				<SegmentedControlItem
-					selected={ ! this.state.isOrdering }
-					onClick={ () => this.setState( { isOrdering: false } ) }>
+					selected={ ! this.state.isEditing }
+					onClick={ () => this.setState( { isEditing: false } ) }>
 					{ this.translate( 'Preview' ) }
 				</SegmentedControlItem>
 				<SegmentedControlItem
-					selected={ this.state.isOrdering }
-					onClick={ () => this.setState( { isOrdering: true } ) }>
+					selected={ this.state.isEditing }
+					onClick={ () => this.setState( { isEditing: true } ) }>
 					{ this.translate( 'Edit' ) }
 				</SegmentedControlItem>
 			</SegmentedControl>
@@ -63,7 +63,7 @@ export default React.createClass( {
 			return;
 		}
 
-		if ( this.state.isOrdering ) {
+		if ( this.state.isEditing ) {
 			return (
 				<EditorMediaModalGalleryEdit
 					site={ site }

--- a/client/post-editor/media-modal/gallery/preview.jsx
+++ b/client/post-editor/media-modal/gallery/preview.jsx
@@ -7,11 +7,11 @@ import React, { PropTypes } from 'react';
  * Internal dependencies
  */
 import SimpleNotice from 'notices/simple-notice';
-import GalleryShortcode from 'components/gallery-shortcode';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
-import markup from '../markup';
 import EditorMediaModalGalleryEdit from './edit';
+import EditorMediaModalGalleryPreviewShortcode from './preview-shortcode';
+import EditorMediaModalGalleryPreviewIndividual from './preview-individual';
 
 export default React.createClass( {
 	displayName: 'EditorMediaModalGalleryPreview',
@@ -72,34 +72,17 @@ export default React.createClass( {
 			);
 		}
 
-		if ( settings && 'individual' === settings.type ) {
+		if ( 'individual' === settings.type ) {
 			return (
-				<div className="editor-media-modal-gallery__preview-individual">
-					<div className="editor-media-modal-gallery__preview-individual-content">
-						{ settings.items.map( ( item ) => {
-							const caption = markup.caption( item );
-
-							if ( null === caption ) {
-								return <div key={ item.ID } dangerouslySetInnerHTML={ { __html: markup.get( item ) } } />;
-							}
-
-							return React.cloneElement( caption, { key: item.ID } );
-						} ) }
-					</div>
-				</div>
+				<EditorMediaModalGalleryPreviewIndividual
+					items={ settings.items } />
 			);
 		}
 
 		return (
-			<GalleryShortcode
+			<EditorMediaModalGalleryPreviewShortcode
 				siteId={ site.ID }
-				items={ settings.items }
-				type={ settings.type }
-				columns={ settings.columns }
-				orderBy={ settings.orderBy }
-				link={ settings.link }
-				size={ settings.size }
-				className="editor-media-modal-gallery__preview-iframe" />
+				settings={ settings } />
 		);
 	},
 

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -136,22 +136,69 @@ input.editor-media-modal-gallery__caption[type="text"] {
 }
 
 .editor-media-modal-gallery__preview-wrapper {
+	position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
 	box-sizing: border-box;
 	overflow-y: auto;
 	padding: 16px;
+}
 
-	@include breakpoint( ">660px" ) {
-		position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
+.editor-media-modal-gallery__preview-shortcode {
+	&,
+	& .shortcode-frame {
+		width: 100%;
+		height: 100%;
 	}
 }
 
-.editor-media-modal-gallery__preview-iframe {
-	width: 100%;
-	height: 100%;
+.editor-media-modal-gallery__preview-shortcode {
+	&.is-loading {
+		animation: loading-fade 0.8s ease-in-out infinite;
+	}
+
+	&::before,
+	&::after {
+		content: "";
+		position: absolute;
+			left: 50%;
+		display: block;
+		width: 90%;
+		margin-left: -45%;
+		transition: 0.2s opacity cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
+		opacity: 0;
+
+		@include breakpoint( ">660px" ) {
+			width: 75%;
+			margin-left: -37.5%;
+		}
+	}
+
+	&::before {
+		top: 16px;
+		height: 130px;
+		background: linear-gradient(
+			to right,
+			lighten( $gray, 25% ),
+			lighten( $gray, 25% ) 40%,
+			transparent 40%,
+			transparent 42%,
+			lighten( $gray, 20% ) 42%
+		);
+	}
+
+	&::after {
+		top: calc( 146px + 2% );
+		height: 240px;
+		background: lighten( $gray, 10% );
+	}
+
+	&.is-loading::before,
+	&.is-loading::after {
+		opacity: 1;
+	}
 }
 
 .editor-media-modal-gallery__fields .for-setting-type {


### PR DESCRIPTION
This pull request seeks to display a loading placeholder block in the editor media modal gallery preview while the gallery is loading. A gallery is considered to be loading while its shortcode rendering is being performed, or while media in the selected set is still being uploaded.

![placeholder](https://cloud.githubusercontent.com/assets/1779930/11369826/dc639900-928e-11e5-9600-586fff6e8433.gif)

__Testing instructions:__

Verify that the placeholder displays well on desktop and on mobile devices. Ensure that rendering of the preview, including "Individual Images", is not impacted.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click the media button in the editor toolbar
4. Drop two images from your computer on to the media modal
 - Choose images large enough to give you enough time to complete step 5
5. Before the images finish uploading, click Continue in the dialog action bar
6. Note that a placeholder block is shown until the images finish uploading, at which point the placeholder is replaced with the preview rendering
7. Change the gallery Layout
8. Note that, for all types aside from Individual Images, the placeholder is shown while the preview loads.