### PR TITLE
Checkout: PayPal Express can be disabled for cart

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -106,6 +106,10 @@ function getRefundPolicy( cart ) {
 	return 'genericRefund';
 }
 
+function isPayPalExpressEnabled( cart ) {
+	return cart.allowed_payment_methods.indexOf( 'WPCOM_Billing_PayPal_Express' ) >= 0;
+}
+
 module.exports = {
 	emptyCart: emptyCart,
 	applyCoupon: applyCoupon,
@@ -115,5 +119,6 @@ module.exports = {
 	isFree: isFree,
 	fillInAllCartItemAttributes: fillInAllCartItemAttributes,
 	fillInSingleCartItemAttributes: fillInSingleCartItemAttributes,
-	getRefundPolicy: getRefundPolicy
+	getRefundPolicy: getRefundPolicy,
+	isPayPalExpressEnabled: isPayPalExpressEnabled
 };

--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -12,7 +12,7 @@ var PayButton = require( './pay-button' ),
 	TermsOfService = require( './terms-of-service' ),
 	PaymentBox = require( './payment-box' ),
 	analytics = require( 'analytics' ),
-	cartItems = require( 'lib/cart-values' ).cartItems;
+	cartValues = require( 'lib/cart-values' );
 
 var CreditCardPaymentBox = React.createClass( {
 	getInitialState: function() {
@@ -44,7 +44,7 @@ var CreditCardPaymentBox = React.createClass( {
 						cart={ this.props.cart }
 						transactionStep={ this.props.transactionStep } />
 
-					{ ! cartItems.hasFreeTrial( cart ) ?
+					{ cartValues.isPayPalExpressEnabled( cart ) ?
 						<a className="credit-card-payment-box__switch-link" href="" onClick={ this.handleToggle }>{ this.translate( 'or use PayPal' ) }</a>
 					: null }
 				</div>


### PR DESCRIPTION
D541-code adds `allowed_payment_methods` field to `/sites/:site/shopping-cart` endpoint.

Only PayPal Express is currently returned in that field. Support for other payment methods in that field will follow in other PRs.

To test:

- go to checkout using Jetpack site, confirm there is no "or use PayPal" link
- go to checkout using WordPress.com site, confirm PayPal link is there

![image](https://cloud.githubusercontent.com/assets/203105/11370765/7f67a26e-92c5-11e5-9de9-1ea35f31b95f.png)
