### PR TITLE
Checkout: Add blocked purchases error to cart messages

### DIFF
--- a/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
+++ b/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
@@ -13,14 +13,14 @@ var notices = require( 'notices' ),
 
 module.exports = {
 	componentDidMount: function() {
-		CartStore.on( 'change', this._displayCartMessages );
+		CartStore.on( 'change', this.displayCartMessages );
 	},
 
 	componentWillUnmount: function() {
-		CartStore.off( 'change', this._displayCartMessages );
+		CartStore.off( 'change', this.displayCartMessages );
 	},
 
-	_getChargebackErrorMessage: function() {
+	getChargebackErrorMessage: function() {
 		return this.translate(
 			"{{strong}}Warning:{{/strong}} One or more transactions linked to this site were refunded due to a contested charge. This may have happened because of a chargeback by the credit card holder or a PayPal investigation. Each contested charge carries a fine. To resolve the issue and re-enable posting, please {{a}}pay for the chargeback fine{{/a}}.",
 			{
@@ -32,7 +32,7 @@ module.exports = {
 		);
 	},
 
-	_getBlockedPurchaseErrorMessage: function() {
+	getBlockedPurchaseErrorMessage: function() {
 		return this.translate(
 			"Purchases are currently disabled. Please {{a}}contact us{{/a}} to re-enable purchases.",
 			{
@@ -43,28 +43,28 @@ module.exports = {
 		);
 	},
 
-	_getPrettyErrorMessages: function( messages ) {
+	getPrettyErrorMessages: function( messages ) {
 		if ( ! messages ) {
 			return [];
 		}
 
 		return messages.map( function( error ) {
 			if ( error.code === 'chargeback' ) {
-				return Object.assign( error, { message: this._getChargebackErrorMessage() } );
+				return Object.assign( error, { message: this.getChargebackErrorMessage() } );
 			} else if ( error.code === 'blocked' ) {
-				return Object.assign( error, { message: this._getBlockedPurchaseErrorMessage() } );
+				return Object.assign( error, { message: this.getBlockedPurchaseErrorMessage() } );
 			} else {
 				return error;
 			}
 		}, this );
 	},
 
-	_displayCartMessages: function() {
+	displayCartMessages: function() {
 		var newCart = this.props.cart,
 			previousCart = ( this.state ) ? this.state.previousCart : null,
 			messages = getNewMessages( previousCart, newCart );
 
-		messages.errors = this._getPrettyErrorMessages( messages.errors );
+		messages.errors = this.getPrettyErrorMessages( messages.errors );
 
 		this.setState( { previousCart: newCart } );
 

--- a/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
+++ b/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	isEmpty = require( 'lodash/lang/isEmpty' ),
-	assign = require('lodash/object/assign' );
+	isEmpty = require( 'lodash/lang/isEmpty' );
 
 /**
  * Internal dependencies
@@ -33,6 +32,17 @@ module.exports = {
 		);
 	},
 
+	_getBlockedPurchaseErrorMessage: function() {
+		return this.translate(
+			"Purchases are currently disabled. Please {{a}}contact us{{/a}} to re-enable purchases.",
+			{
+				components: {
+					a: <a href={ 'https://wordpress.com/error-report/?url=purchases@' + this.props.selectedSite.slug } />
+				}
+			}
+		);
+	},
+
 	_getPrettyErrorMessages: function( messages ) {
 		if ( ! messages ) {
 			return [];
@@ -40,7 +50,9 @@ module.exports = {
 
 		return messages.map( function( error ) {
 			if ( error.code === 'chargeback' ) {
-				return assign( {}, error, { message: this._getChargebackErrorMessage() } );
+				return Object.assign( error, { message: this._getChargebackErrorMessage() } );
+			} else if ( error.code === 'blocked' ) {
+				return Object.assign( error, { message: this._getBlockedPurchaseErrorMessage() } );
 			} else {
 				return error;
 			}

--- a/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
+++ b/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
@@ -37,7 +37,7 @@ module.exports = {
 			"Purchases are currently disabled. Please {{a}}contact us{{/a}} to re-enable purchases.",
 			{
 				components: {
-					a: <a href={ 'https://wordpress.com/error-report/?url=purchases@' + this.props.selectedSite.slug } />
+					a: <a href={ 'https://wordpress.com/error-report/?url=payment@' + this.props.selectedSite.slug } />
 				}
 			}
 		);


### PR DESCRIPTION
This adds an error to the cart messages when the user is currently blocked from making purchases on WordPress.com.

It's not ideal because it recreates the returned error in the client, but we need to provide a link to contact support and I can't think of a better way to do that here. Any ideas welcomed :)

**Testing**
1. Apply patch `fede-pb`
1. `git checkout add/blocked-purchase-error`
1. Block your account from making purchases (or ping me and I can do it for you)
1. Add a plan or domain to your cart
1. Assert that you see an error message notifying you that purchases are blocked.