### PR TITLE
DevDocs/Contributing: Add tips for choosing a code reviewer in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,14 @@ Code reviews are an important part of the Calypso workflow. They help to keep co
 
 Every PR should be reviewed and approved by someone other than the author, even if the author has write access. Fresh eyes can find problems that can hide in the open if you’ve been working on the code for a while.
 
+The recommended way of finding an appropriate person to review your code is by [blaming](https://help.github.com/articles/using-git-blame-to-trace-changes-in-a-file/) one of the files you are updating and looking at who was responsible for previous commits on that file.
+
+Then, you may ask that person to review your code by mentioning his/her GitHub username on the PR comments like this:
+
+```
+ cc @username
+```
+
 *Everyone* is encouraged to review PRs and add feedback and ask questions, even people who are new to Calypso. Also, don’t just review PRs about what you’re working on. Reading other people’s code is a great way to learn new techniques, and seeing code outside of your own feature helps you to see patterns across the project. It’s also helpful to see the feedback other contributors are getting on their PRs.
 
 ### Coding Standards & Guidelines


### PR DESCRIPTION
Adds recommendations about mentioning a user for review and how to choose the appropriate previous contributor for choosing him as reviewer

cc @nb  