### PR TITLE
New Jetpack user signup flow

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -97,7 +97,7 @@ module.exports = {
 		SignupCart.addToCart( siteSlug, cartItem, callback );
 	},
 
-	createAccount( callback, dependencies, { userData, flowName } ) {
+	createAccount( callback, dependencies, { userData, flowName, queryArgs } ) {
 		return wpcom.undocumented().usersNew( assign(
 			{}, userData, {
 				ab_test_variations: getSavedVariations(),
@@ -105,7 +105,7 @@ module.exports = {
 				signup_flow_name: flowName,
 				nux_q_site_type: dependencies.surveySiteType,
 				nux_q_question_primary: dependencies.surveyQuestion,
-				jetpack_redirect: dependencies.jetpackRedirect
+				jetpack_redirect: queryArgs.jetpackRedirect
 			}
 		), ( error, response ) => {
 			var errors = error && error.error ? [ { error: error.error, message: error.message } ] : undefined,

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -105,6 +105,7 @@ module.exports = {
 				signup_flow_name: flowName,
 				nux_q_site_type: dependencies.surveySiteType,
 				nux_q_question_primary: dependencies.surveyQuestion,
+				jetpack_redirect: dependencies.jetpackRedirect
 			}
 		), ( error, response ) => {
 			var errors = error && error.error ? [ { error: error.error, message: error.message } ] : undefined,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -140,8 +140,12 @@ const flows = {
 		destination: '/devdocs/welcome',
 		description: 'Signup flow for developers in developer environment',
 		lastModified: '2015-11-23'
-	}
+	},
 
+	'jetpack': {
+		steps: [ 'jetpack-user' ],
+		destination: '/'
+	}
 };
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -23,4 +23,5 @@ module.exports = {
 	'survey-user': EmailSignupComponent,
 	'domains-with-theme': DomainsStepComponent,
 	'theme-dss': DSSStepComponent,
+	'jetpack-user': EmailSignupComponent
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -1,5 +1,6 @@
 import stepActions from 'lib/signup/step-actions';
 import { abtest } from 'lib/abtest';
+import i18n from 'lib/mixins/i18n';
 
 module.exports = {
 	themes: {
@@ -90,5 +91,17 @@ module.exports = {
 		},
 		dependencies: [ 'siteSlug' ],
 		providesDependencies: [ 'theme', 'images' ]
+	},
+
+	'jetpack-user': {
+		stepName: 'jetpack-user',
+		apiRequestFunction: stepActions.createAccount,
+		providesToken: true,
+		props: {
+			headerText: i18n.translate( 'Create an account for Jetpack' ),
+			subHeaderText: i18n.translate( 'You\'re moments away from connecting Jetpack.' )
+		},
+		dependencies: [ 'jetpackRedirect' ],
+		providesDependencies: [ 'bearer_token', 'username', 'jetpackRedirect' ]
 	}
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -101,7 +101,6 @@ module.exports = {
 			headerText: i18n.translate( 'Create an account for Jetpack' ),
 			subHeaderText: i18n.translate( 'You\'re moments away from connecting Jetpack.' )
 		},
-		dependencies: [ 'jetpackRedirect' ],
-		providesDependencies: [ 'bearer_token', 'username', 'jetpackRedirect' ]
+		providesDependencies: [ 'bearer_token', 'username' ]
 	}
 };

--- a/client/signup/config/test/lib/mixins/i18n.js
+++ b/client/signup/config/test/lib/mixins/i18n.js
@@ -1,0 +1,12 @@
+/**
+ * Stub i18n
+ */
+
+function I18n() {
+}
+
+I18n.translate = function( string ) {
+	return string;
+};
+
+module.exports = I18n;

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import page from 'page';
 import qs from 'qs';
+import isEmpty from 'lodash/lang/isEmpty';
 
 /**
  * Internal Dependencies
@@ -27,7 +28,7 @@ const basePageTitle = 'Signup'; // used for analytics, doesn't require translati
 /**
  * Module variables
  */
-let refParameter;
+let refParameter, queryObject;
 
 export default {
 	redirectWithoutLocaleIfLoggedIn( context, next ) {
@@ -51,6 +52,14 @@ export default {
 	saveRefParameter( context, next ) {
 		if ( context.query.ref ) {
 			refParameter = context.query.ref;
+		}
+
+		next();
+	},
+
+	saveQueryObject( context, next ) {
+		if ( ! isEmpty( context.query ) ) {
+			queryObject = context.query;
 		}
 
 		next();
@@ -86,6 +95,7 @@ export default {
 			React.createElement( SignupComponent, {
 				path: context.path,
 				refParameter,
+				queryObject,
 				locale: utils.getLocale( context.params ),
 				flowName: flowName,
 				stepName: stepName,

--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -19,6 +19,7 @@ module.exports = function() {
 		'/start/:flowName?/:stepName?/:stepSectionName?/:lang?',
 		adTracking.retarget,
 		controller.saveRefParameter,
+		controller.saveQueryObject,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,
 		controller.start

--- a/client/signup/steps/email-signup-form/index.jsx
+++ b/client/signup/steps/email-signup-form/index.jsx
@@ -30,7 +30,12 @@ export default React.createClass( {
 	},
 
 	submitForm( form, userData, analyticsData ) {
-		let flowName = this.props.flowName;
+		let flowName = this.props.flowName,
+			dependencies = {};
+
+		if ( this.props.queryObject && this.props.queryObject.jetpack_redirect ) {
+			dependencies.jetpackRedirect = this.props.queryObject.jetpack_redirect;
+		}
 
 		const formWithoutPassword = Object.assign( {}, form, {
 			password: Object.assign( {}, form.password, { value: '' } )
@@ -44,7 +49,9 @@ export default React.createClass( {
 			userData,
 			stepName: this.props.stepName,
 			form: formWithoutPassword
-		} );
+		}, null,
+			dependencies
+		);
 
 		this.props.goToNextStep();
 	},
@@ -106,6 +113,8 @@ export default React.createClass( {
 			<StepWrapper
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
+				headerText={ this.props.headerText }
+				subHeaderText={ this.props.subHeaderText }
 				positionInFlow={ this.props.positionInFlow }
 				fallbackHeaderText={ this.translate( 'Create your account.' ) }
 				signupProgressStore={ this.props.signupProgressStore }

--- a/client/signup/steps/email-signup-form/index.jsx
+++ b/client/signup/steps/email-signup-form/index.jsx
@@ -31,10 +31,10 @@ export default React.createClass( {
 
 	submitForm( form, userData, analyticsData ) {
 		let flowName = this.props.flowName,
-			dependencies = {};
+			queryArgs = {};
 
 		if ( this.props.queryObject && this.props.queryObject.jetpack_redirect ) {
-			dependencies.jetpackRedirect = this.props.queryObject.jetpack_redirect;
+			queryArgs.jetpackRedirect = this.props.queryObject.jetpack_redirect;
 		}
 
 		const formWithoutPassword = Object.assign( {}, form, {
@@ -48,10 +48,9 @@ export default React.createClass( {
 			flowName,
 			userData,
 			stepName: this.props.stepName,
-			form: formWithoutPassword
-		}, null,
-			dependencies
-		);
+			form: formWithoutPassword,
+			queryArgs
+		} );
 
 		this.props.goToNextStep();
 	},

--- a/client/signup/test/lib/mixins/i18n.js
+++ b/client/signup/test/lib/mixins/i18n.js
@@ -1,0 +1,12 @@
+/**
+ * Stub i18n
+ */
+
+function I18n() {
+}
+
+I18n.translate = function( string ) {
+	return string;
+};
+
+module.exports = I18n;


### PR DESCRIPTION
Creates a new signup flow `start/jetpack` for users coming from Jetpack.  

![screen shot 2015-11-12 at 4 18 58 pm](https://cloud.githubusercontent.com/assets/7129409/11131572/4f013d12-8959-11e5-854f-29a19b44e037.png)

**Requires phab diff D472-code**

**Set up Environment**:
- Sign out of your wordpress.com account.
- Unlink/disconnect Jetpack from your .org site.
- Modify host files to make sure both `public-api.wordpress.com` and `signup.wordpress.com` are pointing to your sandbox
- Also point the API base of your .org jetpack plugin to point to your sandbox https://github.com/Automattic/jetpack/blob/master/jetpack.php#L26
- Apply dotcom patch `D472-code` to your sandbox

**Begin actual testing**:
- Click "Connect Jetpack" in your .org site's Jetpack Admin page.  This will take you to a Jetpack Auth page. If you're logged out of wpcom, you should see a link to create a new account.  Click it.
- This will bring you to the new signup flow for jetpack at calypso.dev:3000/start/jetpack
- Sign up as a new user
- Validate your account via the email link sent by WordPress.  This should immediately redirect you back to the Jetpack Auth screen.  You should be logged in, and able to hit "accept", which will connect your Jetpack site and redirect you back into wp-admin.

cc @scruffian @richardmuscat 