### PR TITLE
Editor: Media Modal: Fix right-click to translate (Fixes #481)

### DIFF
--- a/assets/stylesheets/sections/_translator.scss
+++ b/assets/stylesheets/sections/_translator.scss
@@ -53,6 +53,7 @@ body {
 	padding: 0;
 	text-align: inherit;
 	border-color: lighten( $gray, 20% );
+	z-index: 100300; // Appear above dialog
 
 	.webui-popover-title {
 	  background-color: lighten( $gray, 20% );


### PR DESCRIPTION
Increased the translator pop-up z-index to 100300 up from the default of 100000 so that it appears above the dialogs (100200).

Fixes #481

<img width="861" alt="screen shot 2015-11-24 at 1 35 41 pm" src="https://cloud.githubusercontent.com/assets/2380669/11376897/32935122-92b1-11e5-93d8-194df1d703e6.png">
