### PR TITLE
DevDocs: Fix a bunch of broken links

### DIFF
--- a/client/devdocs/service.js
+++ b/client/devdocs/service.js
@@ -11,7 +11,7 @@ function fetchDocsEndpoint( endpoint, params, callback ) {
 			if ( res.ok ) {
 				callback( null, ( res.body || res.text ) ); // this conditional is to capture both JSON and text/html responses
 			} else {
-				callback( "Error invoking /devdocs/" + endpoint + ": " + error.text, null );
+				callback( 'Error invoking /devdocs/' + endpoint + ': ' + res.text, null );
 			}
 		});
 }

--- a/server/devdocs/Makefile
+++ b/server/devdocs/Makefile
@@ -1,0 +1,12 @@
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared:$(BASE_DIR)/server
+COMPILERS ?= js:babel/register
+REPORTER ?= spec
+UI ?= bdd
+
+test:
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers $(COMPILERS) --reporter $(REPORTER) --ui $(UI)
+
+.PHONY: test

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -30,7 +30,7 @@ var DEFAULT_SNIPPET_LENGTH = 100;
  * and also because lunr.js is designed to be memory resident
  */
 function queryDocs( query ) {
-	var results = docsIndex.search( query ).map( function ( result ) {
+	var results = docsIndex.search( query ).map( function( result ) {
 		var doc = documents[result.ref],
 			snippet = makeSnippet( doc, query );
 
@@ -39,7 +39,7 @@ function queryDocs( query ) {
 			title: doc.title,
 			snippet: snippet
 		};
-	});
+	} );
 
 	return results;
 }
@@ -48,13 +48,12 @@ function queryDocs( query ) {
  * Return an array of results based on the provided filenames
  */
 function listDocs( filePaths ) {
-
-	var results = filePaths.map( function ( path ) {
-		var doc = find( documents, function ( entry ) {
+	var results = filePaths.map( function( path ) {
+		var doc = find( documents, function( entry ) {
 			return entry.path === path;
-		});
+		} );
 
-		if( doc ) {
+		if ( doc ) {
 			return {
 				path: path,
 				title: doc.title,
@@ -67,8 +66,7 @@ function listDocs( filePaths ) {
 				snippet: ''
 			};
 		}
-
-	});
+	} );
 	return results;
 }
 
@@ -78,25 +76,22 @@ function listDocs( filePaths ) {
  * We look for up to 3 matches in a document and concatenate them.
  */
 function makeSnippet( doc, query ) {
-
 	// generate a regex of the form /[^a-zA-Z](term1|term2)/ for the query "term1 term2"
-	var termRegexMatchers = lunr.tokenizer( query ).
-		map( function ( term ) {
+	const termRegexMatchers = lunr.tokenizer( query )
+		.map( function( term ) {
 			return escapeRegexString( term );
 		} );
-
-	var termRegexString = '[^a-zA-Z](' + termRegexMatchers.join( '|' ) + ')';
-
-	var termRegex = new RegExp( termRegexString, 'gi' );
-
-	var match, snippets = [];
+	const termRegexString = '[^a-zA-Z](' + termRegexMatchers.join( '|' ) + ')';
+	const termRegex = new RegExp( termRegexString, 'gi' );
+	const snippets = [];
+	let match;
 
 	// find up to 4 matches in the document and extract snippets to be joined together
 	// TODO: detect when snippets overlap and merge them.
-	while( ( match = termRegex.exec( doc.body ) ) !== null && snippets.length < 4) {
-		var matchStr = match[1],
+	while ( ( match = termRegex.exec( doc.body ) ) !== null && snippets.length < 4 ) {
+		const matchStr = match[1],
 			index = match.index + 1,
-			before = doc.body.substring( index-SNIPPET_PAD_LENGTH, index ),
+			before = doc.body.substring( index - SNIPPET_PAD_LENGTH, index ),
 			after = doc.body.substring( index + matchStr.length, index + matchStr.length + SNIPPET_PAD_LENGTH );
 
 		snippets.push( before +
@@ -105,8 +100,8 @@ function makeSnippet( doc, query ) {
 		);
 	}
 
-	if( snippets.length ) {
-		return '...' + snippets.join(' ... ') + '...';
+	if ( snippets.length ) {
+		return '...' + snippets.join( ' ... ' ) + '...';
 	} else {
 		return defaultSnippet( doc );
 	}
@@ -115,35 +110,35 @@ function makeSnippet( doc, query ) {
 function escapeRegexString( str ) {
 	// taken from: https://github.com/sindresorhus/escape-string-regexp/blob/master/index.js
 	var matchOperatorsRe = /[|\\{}()[\]^$+*?.]/g;
-	return str.replace( matchOperatorsRe,  '\\$&' );
+	return str.replace( matchOperatorsRe, '\\$&' );
 }
 
 function defaultSnippet( doc ) {
 	var content = doc.body.substring( 0, DEFAULT_SNIPPET_LENGTH );
-	return escapeHTML( content )+'&hellip;';
+	return escapeHTML( content ) + '&hellip;';
 }
 
 module.exports = function() {
 	var app = express();
 
 	// this middleware enforces access control
-	app.use( '/devdocs/service', function ( request, response, next ) {
+	app.use( '/devdocs/service', function( request, response, next ) {
 		if ( ! config.isEnabled( 'devdocs' ) ) {
 			response.status( 404 );
-			next("Not found");
+			next( 'Not found' );
 		} else {
 			next();
 		}
 	} );
 
 	// search the documents using a search phrase "q"
-	app.get( '/devdocs/service/search', function ( request, response ) {
+	app.get( '/devdocs/service/search', function( request, response ) {
 		var query = request.query.q;
 
-		if( ! query ) {
-			response.
-				status( 400 ).
-				json( {
+		if ( ! query ) {
+			response
+				.status( 400 )
+				.json( {
 					message: 'Missing required "q" parameter'
 				} );
 			return;
@@ -153,29 +148,29 @@ module.exports = function() {
 	} );
 
 	// return a listing of documents from filenames supplied in the "files" parameter
-	app.get( '/devdocs/service/list', function ( request, response ) {
+	app.get( '/devdocs/service/list', function( request, response ) {
 		var files = request.query.files;
 
-		if( ! files ) {
-			response.
-				status( 400 ).
-				json( {
+		if ( ! files ) {
+			response
+				.status( 400 )
+				.json( {
 					message: 'Missing required "files" parameter'
 				} );
 			return;
 		}
 
-		response.json( listDocs( files.split(',') ) );
+		response.json( listDocs( files.split( ',' ) ) );
 	} );
 
 	// return the HTML content of a document (assumes that the document is in markdown format)
-	app.get( '/devdocs/service/content', function ( request, response ) {
-		var path = request.query.path;
+	app.get( '/devdocs/service/content', function( request, response ) {
+		let path = request.query.path;
 
 		if ( ! path ) {
-			response.
-				status( 400 ).
-				send( 'Need to provide a file path (e.g. path=client/devdocs/README.md)' );
+			response
+				.status( 400 )
+				.send( 'Need to provide a file path (e.g. path=client/devdocs/README.md)' );
 			return;
 		}
 
@@ -190,13 +185,13 @@ module.exports = function() {
 		}
 
 		if ( ! path || path.substring( 0, root.length + 1 ) !== root + '/' ) {
-			response.
-				status( 404 ).
-				send( 'File does not exist' );
+			response
+				.status( 404 )
+				.send( 'File does not exist' );
 			return;
 		}
 
-		var fileContents = fs.readFileSync( path, { encoding: 'utf8' });
+		const fileContents = fs.readFileSync( path, { encoding: 'utf8' } );
 
 		response.send( marked( fileContents ) );
 	} );

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -13,7 +13,7 @@ var express = require( 'express' ),
  * Internal dependencies
  */
 var	config = require( 'config' ),
-	root = fspath.join( __dirname, '..', '..' ),
+	root = fs.realpathSync( fspath.join( __dirname, '..', '..' ) ),
 	searchIndex = require( 'devdocs/search-index' ),
 	docsIndex = lunr.Index.load( searchIndex.index ),
 	documents = searchIndex.documents;
@@ -172,28 +172,31 @@ module.exports = function() {
 	app.get( '/devdocs/service/content', function ( request, response ) {
 		var path = request.query.path;
 
-		if( ! path ) {
+		if ( ! path ) {
 			response.
 				status( 400 ).
 				send( 'Need to provide a file path (e.g. path=client/devdocs/README.md)' );
 			return;
-		} else if ( ! /\.md$/.test( path ) ) {
-			response.
-				status( 422 ).
-				send( 'Filename must end with .md (e.g. path=client/devdocs/README.md)' );
-			return;
 		}
 
-		var fullPath = fspath.join( root, path );
+		if ( ! /\.md$/.test( path ) ) {
+			path = fspath.join( path, 'README.md' );
+		}
 
-		if( ! fs.existsSync( fullPath ) ) {
+		try {
+			path = fs.realpathSync( fspath.join( root, path ) );
+		} catch ( err ) {
+			path = null;
+		}
+
+		if ( ! path || path.substring( 0, root.length + 1 ) !== root + '/' ) {
 			response.
 				status( 404 ).
 				send( 'File does not exist' );
 			return;
 		}
 
-		var fileContents = fs.readFileSync( fullPath, { encoding: 'utf8' });
+		var fileContents = fs.readFileSync( path, { encoding: 'utf8' });
 
 		response.send( marked( fileContents ) );
 	} );

--- a/server/devdocs/test/index.js
+++ b/server/devdocs/test/index.js
@@ -10,19 +10,27 @@ import { expect } from 'chai';
 /**
  * Test setup
  */
-mockery.registerMock( 'config', {
-	isEnabled: function() {
-		return true;
-	}
+mockery.enable( {
+	warnOnReplace: false,
+	warnOnUnregistered: false
 } );
-mockery.registerMock( 'server/devdocs/search-index', {
-	index: {} // for speed - the real search index is very large
+mockery.registerMock( 'config', {
+	isEnabled: () => true
+} );
+// for speed - the real search index is very large
+mockery.registerMock( 'devdocs/search-index', {
+	index: {}
+} );
+mockery.registerMock( 'lunr', {
+	Index: {
+		load: () => null
+	}
 } );
 
 /**
  * Internal dependencies
  */
-import devdocs from '../';
+const devdocs = require( '../' );
 
 /**
  * Module variables
@@ -51,6 +59,8 @@ describe( 'devdocs server', () => {
 	} );
 
 	after( done => {
+		mockery.deregisterAll();
+		mockery.disable();
 		server.close( done );
 	} );
 

--- a/server/devdocs/test/index.js
+++ b/server/devdocs/test/index.js
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import fs from 'fs';
+import fspath from 'path';
+import request from 'superagent';
+import mockery from 'mockery';
+import { expect } from 'chai';
+
+/**
+ * Test setup
+ */
+mockery.registerMock( 'config', {
+	isEnabled: function() {
+		return true;
+	}
+} );
+mockery.registerMock( 'server/devdocs/search-index', {
+	index: {} // for speed - the real search index is very large
+} );
+
+/**
+ * Internal dependencies
+ */
+import devdocs from '../';
+
+/**
+ * Module variables
+ */
+function getDocument( base, path, cb ) {
+	if ( typeof path === 'function' ) {
+		cb = path;
+		path = base;
+	} else {
+		// This mimics what the browser does in this situation
+		path = fspath.join( base, path );
+	}
+	request.get( 'http://localhost:9993/devdocs/service/content' )
+		.query( { path: path } )
+		.end( ( error, res ) => {
+			cb( error, res );
+		} );
+}
+
+describe( 'devdocs server', () => {
+	let app, server;
+
+	before( done => {
+		app = devdocs();
+		server = app.listen( 9993, done );
+	} );
+
+	after( done => {
+		server.close( done );
+	} );
+
+	it( 'should return documents', done => {
+		getDocument(
+			'README.md',
+			( err, res ) => {
+				expect( err ).to.be.null;
+				expect( res.statusCode ).to.equal( 200 );
+				expect( res.text ).to.contain( '<a href="CONTRIBUTING.md">' );
+				done();
+			} );
+	} );
+
+	it( 'should return documents with relative paths', done => {
+		getDocument(
+			'client/components/infinite-list',
+			'../../lib/mixins/infinite-scroll/README.md',
+			( err, res ) => {
+				expect( err ).to.be.null;
+				expect( res.statusCode ).to.equal( 200 );
+				expect( res.text ).to.contain( '<h1 id="infinite-scroll">' );
+				done();
+			} );
+	} );
+
+	it( 'should return the README.md by default', done => {
+		getDocument(
+			'client/lib/mixins/infinite-scroll',
+			( err, res ) => {
+				expect( err ).to.be.null;
+				expect( res.statusCode ).to.equal( 200 );
+				expect( res.text ).to.contain( '<h1 id="infinite-scroll">' );
+				done();
+			} );
+	} );
+
+	it( 'should not allow viewing files outside the Calypso repo', done => {
+		const pathOutsideCalypso = fspath.join( __dirname, '..', '..', '..', '..', 'outside-calypso.md' );
+		fs.writeFileSync( pathOutsideCalypso, 'oh no' );
+		getDocument(
+			'../outside-calypso.md',
+			( err, res ) => {
+				fs.unlinkSync( pathOutsideCalypso );
+				expect( err ).not.to.be.null;
+				expect( res.statusCode ).to.equal( 404 );
+				expect( res.text ).to.equal( 'File does not exist' );
+				done();
+			} );
+	} );
+
+	it( 'should not allow viewing JavaScript files', done => {
+		getDocument(
+			'index.js',
+			( err, res ) => {
+				expect( err ).not.to.be.null;
+				expect( res.statusCode ).to.equal( 422 );
+				expect( res.text ).to.match( /Filename must end with \.md/ );
+				done();
+			} );
+	} );
+} );

--- a/server/devdocs/test/index.js
+++ b/server/devdocs/test/index.js
@@ -107,8 +107,8 @@ describe( 'devdocs server', () => {
 			'index.js',
 			( err, res ) => {
 				expect( err ).not.to.be.null;
-				expect( res.statusCode ).to.equal( 422 );
-				expect( res.text ).to.match( /Filename must end with \.md/ );
+				expect( res.statusCode ).to.equal( 404 );
+				expect( res.text ).to.equal( 'File does not exist' );
 				done();
 			} );
 	} );


### PR DESCRIPTION
This PR seeks to fix 3 different issues with the devdocs code for retrieving content files that I noticed while investigating #600 / #601.

**First**, fixes this broken error message when loading a nonexistent file:

![image](https://cloud.githubusercontent.com/assets/227022/11377187/2ff267ac-92aa-11e5-949d-1523901540c4.png)

**Second**, the current devdocs content retrieval code requires the requested path to have a `.md` file extension.  However, we have 55 links in `.md` files in the codebase that do not match this pattern:  https://gist.github.com/nylen/44ae53d8d0e5d18b64ca

This PR modifies this logic to append `README.md` to repository paths that look like a directory name, like GitHub does.  Of the 55 links above, this should fix 38 of them (assuming that all of the linked paths are correct).  The remaining 17 are links directly to `.js` or `.jsx` files which we still do not serve via devdocs.

**Third**, the current code has a minor security issue that allows traversing outside of the Calypso repository.  However, we decided this PR was OK for the public repo: the practical implications of this issue are minimal, because the code successfully limits users to only requesting `.md` files.

In  769fd5d I also reformatted one of the files I touched to better conform to our [coding guidelines](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md).  As a result, it may be easier to review this PR one commit at a time.

### Testing instructions

1. Go to a URL like http://calypso.localhost:3000/devdocs/some/nonexistent/thing and confirm that an appropriate error message is shown.
2. Go to a readme document that contains a link to another document without the `README.md` suffix.  For example, http://calypso.localhost:3000/devdocs/client/components/infinite-list/README.md and click the "infinite list" link.  (Or just go [here](http://calypso.localhost:3000/devdocs/client/lib/mixins/infinite-scroll)).
3. Verify that you cannot access files outside of the Calypso repo.  Because of the security implications of making changes to this code, the PR includes a test suite which is sufficient to verify this.  Additionally, you can run the following shell commands on `master` and on this branch:

```sh
echo 'oh no' > "$(git rev-parse --show-toplevel)/../bad.md"
curl 'calypso.localhost:3000/devdocs/service/content?path=../bad.md'
```