### PR TITLE
Purchases: Fix style for fetching state in `ManagePurchase`

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -285,7 +285,11 @@ const ManagePurchase = React.createClass( {
 		}
 
 		if ( isIncludedWithPlan( purchase ) ) {
-			return this.translate( 'Included with plan' );
+			return (
+				<span className="manage-purchase__detail">
+					{ this.translate( 'Included with plan' ) }
+				</span>
+			);
 		}
 
 		if ( hasPaymentMethod( purchase ) ) {
@@ -296,7 +300,7 @@ const ManagePurchase = React.createClass( {
 			}
 
 			return (
-				<span className="manage-purchase__payment-info">
+				<span className="manage-purchase__detail">
 					<PaymentLogo type={ paymentLogoType( purchase ) } />
 					{ paymentInfo }
 				</span>

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -192,6 +192,10 @@
 		text-align: right;
 	}
 
+	.payment-logo {
+		margin-right: 5px;
+	}
+
 	a {
 		display: block;
 		font-size: 12px;
@@ -219,8 +223,4 @@
 			right: 24px;
 			top: 16px;
 	}
-}
-
-.manage-purchase__payment-info .payment-logo {
-	margin-right: 5px;
 }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -36,10 +36,6 @@
 			margin-bottom: 3px;
 		}
 
-		.manage-purchase__detail {
-			height: 40px;
-		}
-
 		.manage-purchase__detail-label {
 			margin-bottom: 3px;
 		}
@@ -54,6 +50,23 @@
 
 		.manage-purchase__title {
 			width: 60%;
+		}
+
+		@include breakpoint( ">660px" ) {
+			.manage-purchase__detail,
+			.manage-purchase__detail-label {
+				height: 40px;
+			}
+		}
+
+		@include breakpoint( "<660px" ) {
+			.manage-purchase__detail {
+				width: 25%;
+			}
+
+			.manage-purchase__detail-label {
+				width: 70%;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Switching to flex-boxes seems to have broken the mobile styles of the fetching state on `ManagePurchase`. I also included a commit to fix misaligned payment info in the same component.

[before](https://cloudup.com/ck0UKZ_3pew) / [after](https://cloudup.com/c06dVlinYzj)

Fixes #665.

**Testing**
Assert that the styles are fixed on the fetching/loaded states when viewing a purchase on `/purchases/:site/:purchase_id` in a small viewport.

- [x] QA review
- [x] Code review