### PR TITLE
Additional Troubleshooting tips for `ulimit` on Versions of OS X

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,13 +27,13 @@ If that's the case, you can work around this by running
 sudo launchctl limit maxfiles 65536
 ```
 
-This command will temporarily (until your next system reboot) change the maximum number of files you're allows to set with commands like `ulimit`.  After running the above, try running `ulimit` again 
+This command will temporarily (until your next system reboot) change the maximum number of files you're allowed to set with commands like `ulimit`.  After running the above, try running `ulimit` again 
 
 ```
 sudo ulimit -n 16384
 ```
 
-There is also more permanent solution described here: http://docs.basho.com/riak/latest/ops/tuning/open-files-limit/#Mac-OS-X
+There is also more a permanent solution described here: http://docs.basho.com/riak/latest/ops/tuning/open-files-limit/#Mac-OS-X
 
 ### Run as administrator
 Sometimes, usually during the first build, you can see a message similar to `Please try running again as an administrator`. 


### PR DESCRIPTION
When I tried to do my initial `make run` on OS X, I ran into a few `EMFILE` errors.  Additionally, when I tried to set a new ulimit, OS X told me I couldn't do that. It turns out on Yosemite that `launchctl limit maxfiles` controls the maximum number of files **you're allows to set** with commands like `ulimit`.  

This pull requests contains a documentation change with additional context and tips for working around this problem. 