### PR TITLE
Site Utils: Added canUpdateFiles method to site utils

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -13,6 +13,7 @@ var wpcom = require( 'lib/wp' ),
 	notices = require( 'notices' ),
 	i18n = require( 'lib/mixins/i18n' ),
 	versionCompare = require( 'lib/version-compare' ),
+	SiteUtils = require( 'lib/site/utils' ),
 	config = require( 'config' );
 
 inherits( JetpackSite, Site );
@@ -31,7 +32,7 @@ JetpackSite.prototype.updateComputedAttributes = function() {
 	// unmapped_url is more likely to equal main_network_site because they should both be set to siteurl option
 	// is_multi_network checks to see that a site is not part of a multi network
 	// Since there is no primary network we disable updates for that case
-	this.canUpdateFiles = this.hasMinimumJetpackVersion && this.options.unmapped_url === this.options.main_network_site && ! this.options.is_multi_network && ! this.options.file_mod_disabled;
+	this.canUpdateFiles = SiteUtils.canUpdateFiles( this );
 	this.hasJetpackMenus = versionCompare( this.options.jetpack_version, '3.5-alpha' ) >= 0;
 	this.hasJetpackThemes = versionCompare( this.options.jetpack_version, '3.7-beta' ) >= 0;
 };

--- a/client/lib/site/test/test-utils.js
+++ b/client/lib/site/test/test-utils.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import chai from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import SiteUtils from 'lib/site/utils';
+
+const assert = chai.assert;
+
+describe( 'Site Utils', function() {
+	describe( 'canUpdateFiles', function() {
+		it( 'should have a method canUpdateFiles', function() {
+			assert.isFunction( SiteUtils.canUpdateFiles );
+		} );
+
+		it( 'canUpdateFiles should return false when passed an empty object', function() {
+			assert.isFalse( SiteUtils.canUpdateFiles( {} ) );
+		} );
+
+		it( 'canUpdateFiles should return false when passed an object without options', function() {
+			assert.isFalse( SiteUtils.canUpdateFiles( { hello: 'not important' } ) );
+		} );
+
+		it( 'canUpdateFiles should return true when passed a site data that will ', function() {
+			const site = {
+				hasMinimumJetpackVersion: true,
+				options: {
+					unmapped_url: 'someurl',
+					main_network_site: 'someurl',
+					is_multi_network: false,
+					file_mod_disabled: false
+				}
+			}
+			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
+		} );
+
+		it( 'canUpdateFiles should return false when passed an site object that has something value in the file_mod_option', function() {
+			const site = {
+				hasMinimumJetpackVersion: true,
+				options: {
+					unmapped_url: 'someurl',
+					main_network_site: 'someurl',
+					is_multi_network: false,
+					file_mod_disabled: [ 'something else' ]
+				}
+			}
+			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
+		} );
+	} );
+} );

--- a/client/lib/site/test/test-utils.js
+++ b/client/lib/site/test/test-utils.js
@@ -12,32 +12,23 @@ const assert = chai.assert;
 
 describe( 'Site Utils', function() {
 	describe( 'canUpdateFiles', function() {
-		it( 'should have a method canUpdateFiles', function() {
+		it( 'Should have a method canUpdateFiles.', function() {
 			assert.isFunction( SiteUtils.canUpdateFiles );
 		} );
 
-		it( 'canUpdateFiles should return false when passed an empty object', function() {
+		it( 'CanUpdateFiles should return false when no site object is passed in.', function() {
+			assert.isFalse( SiteUtils.canUpdateFiles() );
+		} );
+
+		it( 'CanUpdateFiles should return false when passed an empty object.', function() {
 			assert.isFalse( SiteUtils.canUpdateFiles( {} ) );
 		} );
 
-		it( 'canUpdateFiles should return false when passed an object without options', function() {
+		it( 'CanUpdateFiles should return false when passed an object without options.', function() {
 			assert.isFalse( SiteUtils.canUpdateFiles( { hello: 'not important' } ) );
 		} );
 
-		it( 'canUpdateFiles should return true when passed a site data that will ', function() {
-			const site = {
-				hasMinimumJetpackVersion: true,
-				options: {
-					unmapped_url: 'someurl',
-					main_network_site: 'someurl',
-					is_multi_network: false,
-					file_mod_disabled: false
-				}
-			}
-			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
-		} );
-
-		it( 'canUpdateFiles should return false when passed an site object that has something value in the file_mod_option', function() {
+		it( 'CanUpdateFiles should return false when passed an site object that has something value in the file_mod_option.', function() {
 			const site = {
 				hasMinimumJetpackVersion: true,
 				options: {
@@ -48,6 +39,19 @@ describe( 'Site Utils', function() {
 				}
 			}
 			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
+		} );
+
+		it( 'CanUpdateFiles should return true when passed a site data has all the right settings permissions to be able to update files.', function() {
+			const site = {
+				hasMinimumJetpackVersion: true,
+				options: {
+					unmapped_url: 'someurl',
+					main_network_site: 'someurl',
+					is_multi_network: false,
+					file_mod_disabled: false
+				}
+			}
+			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
 		} );
 	} );
 } );

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -91,11 +91,6 @@ export default {
 						i18n.translate( 'Core autoupdates are explicitly disabled by a site administrator.' )
 					);
 					break
-				case 'disallow_file_edit':
-					reasons.push(
-						i18n.translate( 'File edits are explicitly disabled by a site administrator.' )
-					);
-					break;
 				case 'disallow_file_mods':
 					reasons.push(
 						i18n.translate( 'File modifications are explicitly disabled by a site administrator.' )

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -102,7 +102,10 @@ export default {
 	},
 
 	canUpdateFiles( site ) {
-		if ( site && ! site.hasMinimumJetpackVersion ) {
+		if ( ! site ) {
+			return false;
+		}
+		if ( ! site.hasMinimumJetpackVersion ) {
 			return false;
 		}
 

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -104,5 +104,25 @@ export default {
 			}
 		}
 		return reasons;
+	},
+
+	canUpdateFiles( site ) {
+		if ( site && ! site.hasMinimumJetpackVersion ) {
+			return false;
+		}
+
+		if ( site.options && site.options.unmapped_url !== site.options.main_network_site ) {
+			return false;
+		}
+
+		if ( site.options.is_multi_network ) {
+			return false;
+		}
+
+		if ( site.options.file_mod_disabled ) {
+			return false;
+		}
+
+		return true;
 	}
 };


### PR DESCRIPTION
This PR just adds test for `canUpdateFiles` method on site utils. 
And removed a deprecated reason for why a site file updates are disabled.

**To test**
run the tests via make test in the `/client/lib/site/` directory via `make test` command.

cc: @johnHackworth, @lezama, @ebinnion