### PR TITLE
Editor: Teardown mocks after running tests

### DIFF
--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -69,6 +69,11 @@ describe( 'PostEditor', function() {
 		sandbox.restore();
 	} );
 
+	after( function() {
+		mockery.deregisterAll();
+		mockery.disable();
+	} );
+
 	describe( 'onEditedPostChange', function() {
 		it( 'should clear content when store state transitions to isNew()', function() {
 			const tree = TestUtils.renderIntoDocument(


### PR DESCRIPTION
Looks like this got left out somehow.