### PR TITLE
Purchases: Show the fetching state when visiting `ManagePurchase` after renewing

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -60,6 +60,10 @@ const ManagePurchase = React.createClass( {
 	},
 
 	renderNotices() {
+		if ( isDataLoading( this.props ) || this.isDataFetchingAfterRenewal() ) {
+			return null;
+		}
+
 		return this.renderPurchaseExpiringNotice() || this.renderCreditCardExpiringNotice();
 	},
 
@@ -67,7 +71,7 @@ const ManagePurchase = React.createClass( {
 		const purchase = getPurchase( this.props );
 		let noticeStatus = 'is-info';
 
-		if ( isDataLoading( this.props ) || ! isExpiring( purchase ) ) {
+		if ( ! isExpiring( purchase ) ) {
 			return null;
 		}
 
@@ -96,10 +100,6 @@ const ManagePurchase = React.createClass( {
 	},
 
 	renderCreditCardExpiringNotice() {
-		if ( isDataLoading( this.props ) ) {
-			return null;
-		}
-
 		const purchase = getPurchase( this.props ),
 			{ domain, id, payment: { creditCard } } = purchase;
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -67,7 +67,7 @@ const ManagePurchase = React.createClass( {
 		const purchase = getPurchase( this.props );
 		let noticeStatus = 'is-info';
 
-		if ( isDataLoading( this.props ) || ! isExpiring( purchase ) || this.isDataFetchingAfterRenewal() ) {
+		if ( isDataLoading( this.props ) || ! isExpiring( purchase ) ) {
 			return null;
 		}
 
@@ -272,7 +272,7 @@ const ManagePurchase = React.createClass( {
 	renderPaymentInfo() {
 		const purchase = getPurchase( this.props );
 
-		if ( isDataLoading( this.props ) ) {
+		if ( isDataLoading( this.props ) || this.isDataFetchingAfterRenewal() ) {
 			return <span className="manage-purchase__detail" />;
 		}
 
@@ -303,22 +303,23 @@ const ManagePurchase = React.createClass( {
 	},
 
 	renderPaymentDetails() {
-		const purchase = getPurchase( this.props );
+		const purchase = getPurchase( this.props ),
+			isLoading = isDataLoading( this.props ) || this.isDataFetchingAfterRenewal();
 
-		if ( ! isDataLoading( this.props ) && isOneTimePurchase( purchase ) ) {
+		if ( ! isLoading && isOneTimePurchase( purchase ) ) {
 			return null;
 		}
 
 		let paymentDetails = (
 			<span>
 				<em className="manage-purchase__detail-label">
-					{ isDataLoading( this.props ) ? null : this.translate( 'Payment method' ) }
+					{ isLoading ? null : this.translate( 'Payment method' ) }
 				</em>
 				{ this.renderPaymentInfo() }
 			</span>
 		);
 
-		if ( isDataLoading( this.props ) || ! showEditPaymentDetails( purchase ) ) {
+		if ( isLoading || ! showEditPaymentDetails( purchase ) ) {
 			return (
 				<li>
 					{ paymentDetails }
@@ -340,7 +341,7 @@ const ManagePurchase = React.createClass( {
 	renderRenewButton() {
 		const purchase = getPurchase( this.props );
 
-		if ( ! isRenewable( purchase ) || isExpired( purchase ) || isExpiring( purchase ) || this.isDataFetchingAfterRenewal() ) {
+		if ( ! isRenewable( purchase ) || isExpired( purchase ) || isExpiring( purchase ) ) {
 			return null;
 		}
 
@@ -375,7 +376,7 @@ const ManagePurchase = React.createClass( {
 	renderRenewsOrExpiresOnLabel() {
 		const purchase = getPurchase( this.props );
 
-		if ( ! this.isDataFetchingAfterRenewal() && ( isExpiring( purchase ) || creditCardExpiresBeforeSubscription( purchase ) ) ) {
+		if ( isExpiring( purchase ) || creditCardExpiresBeforeSubscription( purchase ) ) {
 			return this.translate( 'Expires on' );
 		}
 
@@ -388,10 +389,6 @@ const ManagePurchase = React.createClass( {
 
 	renderRenewsOrExpiresOn() {
 		const purchase = getPurchase( this.props );
-
-		if ( this.isDataFetchingAfterRenewal() ) {
-			return null;
-		}
 
 		if ( isRenewing( purchase ) ) {
 			return this.moment( purchase.renewDate ).format( 'LL' );
@@ -493,7 +490,7 @@ const ManagePurchase = React.createClass( {
 			cancelPurchaseNavItem,
 			cancelPrivateRegistrationNavItem;
 
-		if ( isDataLoading( this.props ) ) {
+		if ( isDataLoading( this.props ) || this.isDataFetchingAfterRenewal() ) {
 			classes = 'manage-purchase__info is-placeholder';
 			editPaymentMethodNavItem = <VerticalNavItem isPlaceholder />;
 			cancelPurchaseNavItem = <VerticalNavItem isPlaceholder />;
@@ -510,17 +507,13 @@ const ManagePurchase = React.createClass( {
 			productLink = this.renderProductLink();
 			price = this.renderPrice();
 			renewsOrExpiresOnLabel = this.renderRenewsOrExpiresOnLabel();
-			renewsOrExpiresOn = this.renderRenewsOrExpiresOn();
 			renewButton = this.renderRenewButton();
 			expiredRenewNotice = this.renderExpiredRenewNotice();
 			editPaymentMethodNavItem = this.renderEditPaymentMethodNavItem();
 			cancelPurchaseNavItem = this.renderCancelPurchaseNavItem();
 			cancelPrivateRegistrationNavItem = this.renderCancelPrivateRegistration();
+			renewsOrExpiresOn = this.renderRenewsOrExpiresOn();
 		}
-
-		const renewsOrExpiresOnClasses = classNames( 'manage-purchase__detail', {
-			'is-placeholder': this.isDataFetchingAfterRenewal()
-		} );
 
 		return (
 			<div>
@@ -543,7 +536,7 @@ const ManagePurchase = React.createClass( {
 						</li>
 						<li>
 							<em className="manage-purchase__detail-label">{ renewsOrExpiresOnLabel }</em>
-							<span className={ renewsOrExpiresOnClasses }>
+							<span className="manage-purchase__detail">
 								{ renewsOrExpiresOn }
 							</span>
 						</li>

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -179,13 +179,6 @@
 		text-align: right;
 	}
 
-	&.is-placeholder {
-		@include placeholder( 23% );
-
-		display: block;
-		height: 25px;
-	}
-
 	a {
 		display: block;
 		font-size: 12px;


### PR DESCRIPTION
This PR updates `ManagePurchase` to render the fetching state when data is fetching after a renewal, to hide any stale data related to the pre-renewal purchase.

![screen shot 2015-11-24 at 2 51 50 pm](https://cloud.githubusercontent.com/assets/1130674/11383139/02278648-92bb-11e5-8aed-f307d372906b.png)

Previously, we attempted to just obscure the renewal date, but there are other aspects of the purchase (the price, the expired style, etc) that we would need to change temporarily as well. The simplest solution is to just hide the purchase until a new one has been fetched from the API.

Fixes #161.

**Testing**
- Visit http://calypso.localhost:3000/purchases and renew an expired purchase.
- Assert that you are redirected to the `ManagePurchase` page for the given purchase, see the success notice, and that the fetching state is displayed below for a moment instead of stale data.

- [x] QA review
- [x] Code review