### PR TITLE
Invites: Updates strings in invite header and form header

### DIFF
--- a/client/accept-invite/invite-form-header/index.jsx
+++ b/client/accept-invite/invite-form-header/index.jsx
@@ -50,7 +50,7 @@ export default React.createClass( {
 		switch ( this.getRole() ) {
 			case 'administrator':
 				title = this.translate(
-					'Sign up to become an administrator of {{siteLink/}}.', {
+					'Sign up to start managing {{siteLink/}}.', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -59,7 +59,7 @@ export default React.createClass( {
 				break;
 			case 'editor':
 				title = this.translate(
-					'Sign up to become an editor of {{siteLink/}}.', {
+					'Sign up to start editing {{siteLink/}}.', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -68,7 +68,7 @@ export default React.createClass( {
 				break;
 			case 'author':
 				title = this.translate(
-					'Sign up to become an author of {{siteLink/}}.', {
+					'Sign up to start writing for {{siteLink/}}.', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -77,7 +77,7 @@ export default React.createClass( {
 				break;
 			case 'contributor':
 				title = this.translate(
-					'Sign up to become a contributor to {{siteLink/}}.', {
+					'Sign up to start contributing to {{siteLink/}}.', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -86,7 +86,7 @@ export default React.createClass( {
 				break;
 			case 'subscriber':
 				title = this.translate(
-					'Sign up to become a subscriber of {{siteLink/}}.', {
+					'Sign up to start your subscription to {{siteLink/}}.', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -95,7 +95,7 @@ export default React.createClass( {
 				break;
 			case 'follower':
 				title = this.translate(
-					'Sign up to become a follower of {{siteLink/}}.', {
+					'Sign up to start following {{siteLink/}} in the WordPress.com reader.', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -104,7 +104,7 @@ export default React.createClass( {
 				break;
 			default:
 				title = this.translate(
-					'Sign up to join {{siteLink/}} with a role of: {{strong}}%(siteRole)s{{/strong}}.', {
+					'Sign up to join {{siteLink/}} as: {{strong}}%(siteRole)s{{/strong}}.', {
 						args: {
 							siteRole: this.getRole()
 						},
@@ -125,7 +125,7 @@ export default React.createClass( {
 		switch ( this.getRole() ) {
 			case 'administrator':
 				title = this.translate(
-					'Would you like to become an administrator of {{siteLink/}}?', {
+					'Would you like to start managing {{siteLink/}}?', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -134,7 +134,7 @@ export default React.createClass( {
 				break;
 			case 'editor':
 				title = this.translate(
-					'Would you like to become an editor of {{siteLink/}}?', {
+					'Would you like to start editing {{siteLink/}}?', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -143,7 +143,7 @@ export default React.createClass( {
 				break;
 			case 'author':
 				title = this.translate(
-					'Would you like to become an author of {{siteLink/}}?', {
+					'Would you like to start writing for {{siteLink/}}?', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -152,7 +152,7 @@ export default React.createClass( {
 				break;
 			case 'contributor':
 				title = this.translate(
-					'Would you like to become a contributor to {{siteLink/}}?', {
+					'Would you like to start contributing to {{siteLink/}}?', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -161,7 +161,7 @@ export default React.createClass( {
 				break;
 			case 'subscriber':
 				title = this.translate(
-					'Would you like to become a subscriber of {{siteLink/}}?', {
+					'Would you like to start following {{siteLink/}} in the WordPress.com reader?', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -179,7 +179,7 @@ export default React.createClass( {
 				break;
 			default:
 				title = this.translate(
-					'Would you like to join {{siteLink/}} with a role of: {{strong}}%(siteRole)s{{/strong}}?', {
+					'Would you like to join {{siteLink/}} as: {{strong}}%(siteRole)s{{/strong}}?', {
 						args: {
 							siteRole: this.getRole()
 						},

--- a/client/accept-invite/invite-form-header/index.jsx
+++ b/client/accept-invite/invite-form-header/index.jsx
@@ -95,7 +95,7 @@ export default React.createClass( {
 				break;
 			case 'follower':
 				title = this.translate(
-					'Sign up to start following {{siteLink/}} in the WordPress.com reader.', {
+					'Sign up to start following {{siteLink/}} in the WordPress.com Reader.', {
 						components: {
 							siteLink: this.getSiteLink()
 						}
@@ -161,7 +161,7 @@ export default React.createClass( {
 				break;
 			case 'subscriber':
 				title = this.translate(
-					'Would you like to start following {{siteLink/}} in the WordPress.com reader?', {
+					'Would you like to start following {{siteLink/}} in the WordPress.com Reader?', {
 						components: {
 							siteLink: this.getSiteLink()
 						}

--- a/client/accept-invite/invite-header/index.jsx
+++ b/client/accept-invite/invite-header/index.jsx
@@ -33,10 +33,12 @@ export default React.createClass( {
 			</strong>
 		);
 
-		switch ( get( this.props, 'invite.meta.role' ) ) {
+		const role = get( this.props, 'invite.meta.role' );
+
+		switch ( role ) {
 			case 'administrator':
 				text = this.translate(
-					'{{inviterName/}} invited you to manage:', {
+					'{{inviterName/}} invited you to be an administrator on:', {
 						components: {
 							inviterName: inviterName
 						}
@@ -45,7 +47,7 @@ export default React.createClass( {
 				break;
 			case 'editor':
 				text = this.translate(
-					'{{inviterName/}} invited you to edit:', {
+					'{{inviterName/}} invited you to be an editor on:', {
 						components: {
 							inviterName: inviterName
 						}
@@ -63,7 +65,7 @@ export default React.createClass( {
 				break;
 			case 'contributor':
 				text = this.translate(
-					'{{inviterName/}} invited you to contribute to:', {
+					'{{inviterName/}} invited you to be a contributor on:', {
 						components: {
 							inviterName: inviterName
 						}
@@ -90,7 +92,10 @@ export default React.createClass( {
 				break
 			default:
 				text = this.translate(
-					'{{inviterName/}} invited you to join:', {
+					'{{inviterName/}} invited you to be: %(invitedRole)s on:', {
+						args: {
+							invitedRole: role
+						},
 						components: {
 							inviterName: inviterName
 						}


### PR DESCRIPTION
Closes #664 by updating the strings as suggested.

<img width="422" alt="screen shot" src="https://cloud.githubusercontent.com/assets/1126811/11384212/9ffb2e2a-92d3-11e5-98b1-c21c2f5f5440.png">

To test: 
- Checkout `update/invite-strings` branch
- Create an invite
- In the invitation email, get the invitation key
- Go to `/accept-invite/$site/$invite_key`
- Check that there are no errors
- Invite the same user to another role
- Refresh Calypso and check that the string changed

cc @rickybanister for design review and @lezama for code review