### PR TITLE
Signup: determine user step by `providesToken` instead of by name

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 var assign = require( 'lodash/object/assign' ),
-	matches = require( 'lodash/utility/matches' ),
 	reject = require( 'lodash/collection/reject' );
 
 /**
 * Internal dependencies
 */
 var config = require( 'config' ),
+	stepConfig = require( './steps' ),
 	user = require( 'lib/user' )(),
 	abtest = require( 'lib/abtest' ).abtest;
 
@@ -140,7 +140,9 @@ function removeUserStepFromFlow( flow ) {
 		return;
 	}
 
-	return assign( {}, flow, { steps: reject( flow.steps, matches( 'user' ) ) } );
+	return assign( {}, flow, {
+		steps: reject( flow.steps, stepName => stepConfig[ stepName ].providesToken )
+	} );
 }
 
 module.exports = {

--- a/client/signup/test/lib/signup/step-actions.js
+++ b/client/signup/test/lib/signup/step-actions.js
@@ -1,0 +1,5 @@
+/**
+ * StepActions stub
+ */
+
+export default {};


### PR DESCRIPTION
When a user is logged-in, the `user` step of any flow is removed because the
user already has an account and does not need to create one. To do this, the
flow logic previously compared the name of the step to `user`. This can be
problematic because there are cases where a different `user` step will be used,
and the string comparison will be invalid.

This changes the logic to look for the `providesToken` property name on the step
config object, which should be present only in `user` steps.

## Testing

1. When NOT logged-in to WP.com (try an incognito/private window), run through the flow at http://calypso.localhost:3000/start/ and be sure that the last step shows a user creation form like the one below.
2. When using a logged-in WP.com user, run through the flow at http://calypso.localhost:3000/start/ and be sure that the last step creates a site rather than showing the user creation form.

<img width="523" alt="screen shot 2015-11-24 at 5 27 18 pm" src="https://cloud.githubusercontent.com/assets/2036909/11384525/80691aee-92de-11e5-8c43-0ebbc727efc3.png">
