### PR TITLE
Components: Add `isCompact` prop to `PaymentLogo`

### DIFF
--- a/client/components/payment-logo/README.md
+++ b/client/components/payment-logo/README.md
@@ -1,0 +1,25 @@
+PaymentLogo
+====
+
+## Usage
+
+```js
+import PaymentLogo from 'components/payment-logo';
+
+<PaymentLogo type="amex" />
+
+<PaymentLogo type="paypal" />
+
+<PaymentLogo type="paypal" isCompact />
+
+```
+
+## Required props
+
+* `type` – String that determines which type of logo is displayed. Currently accepts:
+   * amex
+   * discover
+   * mastercard
+   * visa
+   * paypal
+* `isCompact` (optional) – Boolean that determines if the compact PayPal logo is rendered.

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PaymentLogo from '../index';
+
+const PaymentLogoExamples = React.createClass( {
+	mixins: [ React.addons.PureRenderMixin ],
+
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>PaymentLogo</h2>
+				<div>
+					<PaymentLogo type="amex" /> { ' ' }
+					<PaymentLogo type="discover" /> { ' ' }
+					<PaymentLogo type="mastercard" /> { ' ' }
+					<PaymentLogo type="visa" /> { ' ' }
+					<PaymentLogo type="paypal" isCompact /> { ' ' }
+					<PaymentLogo type="paypal" />
+				</div>
+			</div>
+		);
+	}
+} );
+
+module.exports = PaymentLogoExamples;

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -1,15 +1,19 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import React from 'react';
 
 const PaymentLogo = React.createClass( {
 	propTypes: {
-		type: React.PropTypes.string.isRequired
+		type: React.PropTypes.string.isRequired,
+		isCompact: React.PropTypes.bool
 	},
 
 	render: function() {
-		const classes = `payment-logo is-${ this.props.type }`;
+		const classes = classNames( 'payment-logo', `is-${ this.props.type }`, {
+			'is-compact': this.props.isCompact
+		} );
 
 		return (
 			<div className={ classes } />

--- a/client/components/payment-logo/style.scss
+++ b/client/components/payment-logo/style.scss
@@ -27,5 +27,9 @@
 		background-image: url( '/calypso/images/upgrades/paypal.svg' );
 		background-size: 70px;
 		width: 70px;
+
+		&.is-compact {
+			width: 16px;
+		}
 	}
 }

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -48,6 +48,7 @@ var SearchCard = require( 'components/search-card' ),
 	FoldableCard = require( 'components/foldable-card/docs/example' ),
 	SectionHeader = require( 'components/section-header/docs/example' ),
 	Flag = require( 'components/flag/docs/example' ),
+	PaymentLogo = require( 'components/payment-logo/docs/example' ),
 	Count = require( 'components/count/docs/example' ),
 	Version = require( 'components/version/docs/example' ),
 	BulkSelect = require( 'components/bulk-select/docs/example' ),
@@ -214,6 +215,7 @@ module.exports = React.createClass( {
 					<TimezoneDropdown />
 					<FoldableCard />
 					<Flag />
+					<PaymentLogo />
 					<BulkSelect />
 					<SectionHeader />
 					<SectionNav />


### PR DESCRIPTION
Addresses part of #272.

![screen shot 2015-11-24 at 4 28 41 pm](https://cloud.githubusercontent.com/assets/1130674/11384880/96536bfe-92c8-11e5-8c80-4c1b72c6be4f.png)

This PR:

- Adds a README for `PaymentLogo`.
- Adds `PaymentLogo` to `/devdocs/design`
- Adds an `isCompact` prop to `PaymentLogo` to determine if just the 'P' is displayed when the logo is a paypal logo.

**Testing**
- Assert that the README is sensible.
- Assert that `PaymentLogo` appears in `/devdocs/design`.

- [x] QA review
- [x] Code review