### PR TITLE
Editor: Add PostListStoreFactory

### DIFF
--- a/client/lib/posts/post-counts-store.js
+++ b/client/lib/posts/post-counts-store.js
@@ -11,7 +11,7 @@ var sum = require( 'lodash/math/sum' ),
  * Internal dependencies
  */
 var emitter = require( 'lib/mixins/emitter' ),
-	PostListStore = require( './post-list-store' ),
+	PostListStore = require( './post-list-store-factory' )(),
 	PostsStore = require( './posts-store' ),
 	sites = require( 'lib/sites-list' )(),
 	postUtils = require( 'lib/posts/utils' ),

--- a/client/lib/posts/post-list-cache-store.js
+++ b/client/lib/posts/post-list-cache-store.js
@@ -100,7 +100,7 @@ var PostsListCache = {
 
 PostsListCache.dispatchToken = Dispatcher.register( function( payload ) {
 	var action = payload.action,
-		PostListStore = require( './post-list-store' );
+		PostListStore = require( './post-list-store-factory' )();
 
 	Dispatcher.waitFor( [ PostListStore.dispatchToken ] );
 

--- a/client/lib/posts/post-list-store-factory.js
+++ b/client/lib/posts/post-list-store-factory.js
@@ -10,15 +10,10 @@ const _postListStores = {};
 
 export default function( storeId ) {
 	const postStoreId = storeId || 'default';
-	let postListStore = _postListStores[ postStoreId ];
 
-	if ( postListStore ) {
-		return postListStore;
+	if ( ! _postListStores[ postStoreId ] ) {
+		_postListStores[ postStoreId ] = new PostListStore( postStoreId );
 	}
 
-	postListStore = new PostListStore( postStoreId );
-
-	_postListStores[ postStoreId ] = postListStore;
-
-	return postListStore;
+	return _postListStores[ postStoreId ];
 }

--- a/client/lib/posts/post-list-store-factory.js
+++ b/client/lib/posts/post-list-store-factory.js
@@ -1,0 +1,24 @@
+/**
+ * Internal Dependencies
+ **/
+import PostListStore from './post-list-store';
+
+/**
+ * Module variables
+ **/
+const _postListStores = {};
+
+export default function( storeId ) {
+	const postStoreId = storeId || 'default';
+	let postListStore = _postListStores[ postStoreId ];
+
+	if ( postListStore ) {
+		return postListStore;
+	}
+
+	postListStore = new PostListStore( postStoreId );
+
+	_postListStores[ postStoreId ] = postListStore;
+
+	return postListStore;
+}

--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:posts-list' );
+import debugModule from 'debug';
 import clone from 'lodash/lang/clone';
 import assign from 'lodash/object/assign';
 import transform from 'lodash/object/transform';
@@ -34,9 +33,11 @@ const _defaultQuery = {
 	perPage: 20
 };
 
+const debug = debugModule( 'calypso:posts-list' );
+
 let _nextId = 0;
 
-module.exports = function( id ) {
+export default function( id ) {
 	if ( ! id ) {
 		throw new Error( 'must supply a post-list-store id' );
 	}

--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -1,24 +1,29 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:posts-list' ),
-	clone = require( 'lodash/lang/clone' ),
-	some = require( 'lodash/collection/some' ),
-	assign = require( 'lodash/object/assign' ),
-	transform = require( 'lodash/object/transform' ),
-	difference = require( 'lodash/array/difference' ),
-	last = require( 'lodash/array/last' ),
-	max = require( 'lodash/collection/max' );
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:posts-list' );
+import clone from 'lodash/lang/clone';
+import assign from 'lodash/object/assign';
+import transform from 'lodash/object/transform';
+import difference from 'lodash/array/difference';
+import last from 'lodash/array/last';
+import max from 'lodash/collection/max';
+import { EventEmitter } from 'events/';
+import some from 'lodash/collection/some'
 
 /**
  * Internal dependencies
  */
-var Emitter = require( 'lib/mixins/emitter' ),
-	Dispatcher = require( 'dispatcher' ),
-	treeConvert = require( 'lib/tree-convert' )( 'ID' ),
-	PostsStore = require( './posts-store' );
+import Dispatcher from 'dispatcher';
+import treeConvert from 'lib/tree-convert';
+import PostsStore from './posts-store';
+import PostListCacheStore from './post-list-cache-store';
 
-var _defaultQuery = {
+/**
+ * Module Variables
+ */
+const _defaultQuery = {
 	siteID: false,
 	type: 'post',
 	status: 'publish',
@@ -29,355 +34,361 @@ var _defaultQuery = {
 	perPage: 20
 };
 
-var _activeList = {
-	postIds: [],
-	errors: [],
-	query: clone( _defaultQuery ),
-	page: 0,
-	nextPageHandle: false,
-	isLastPage: false,
-	isFetchingNextPage: false,
-	isFetchingUpdated: false
-};
+let _nextId = 0;
 
-var _nextId = 0;
-var PostListStore;
-
-function queryPosts( options ) {
-	var query = assign( {}, _defaultQuery, options ),
-		cache = require( './post-list-cache-store' ),
-		list;
-
-	if ( query.siteID && typeof query.siteID === 'string' ) {
-		query.siteID = query.siteID.replace( /::/g, '/' );
+module.exports = function( id ) {
+	if ( ! id ) {
+		throw new Error( 'must supply a post-list-store id' );
 	}
 
-	if ( query.status === 'draft,pending' ) {
-		query.orderBy = 'modified';
-	}
+	let _activeList = {
+		postIds: [],
+		errors: [],
+		query: clone( _defaultQuery ),
+		page: 0,
+		nextPageHandle: false,
+		isLastPage: false,
+		isFetchingNextPage: false,
+		isFetchingUpdated: false
+	};
 
-	list = cache.get( query );
+	function queryPosts( options ) {
+		let query = assign( {}, _defaultQuery, options );
 
-	if ( list ) {
-		_activeList = list;
-	} else {
-		_activeList = {
-			id: _nextId,
-			postIds: [],
-			errors: [],
-			query: query,
-			page: 0,
-			isLastPage: false,
-			isFetchingNextPage: false,
-			isFetchingUpdated: false
-		};
-
-		_nextId++;
-	}
-
-	PostListStore.emit( 'change' );
-}
-
-/**
- * Remove any keys from the params that are null or undefined
- *
- * We do this to avoid sending empty values along.
- * Returns a new object representing the clean params.
- * The original params is unmodified.
- *
- * @param  {string} params The params to clean
- * @return {object} The cleaned params object.
- */
-function cleanParams( params ) {
-	return transform( params, function( result, value, key ) {
-		if ( value != null ) {
-			result[ key ] = value;
+		if ( query.siteID && typeof query.siteID === 'string' ) {
+			query.siteID = query.siteID.replace( /::/g, '/' );
 		}
-	}, {} );
-}
 
-/**
- * Sort the active list
- **/
-function sort() {
-	var key = _activeList.query.orderBy;
-
-	_activeList.postIds.sort( function( a, b ) {
-		var postA = PostsStore.get( a ),
-			postB = PostsStore.get( b ),
-			timeA = postA[ key ],
-			timeB = postB[ key ];
-
-		if ( timeA === timeB ) {
-			if ( postA.title === postB.title ) {
-				return 0;
-			} else {
-				return postA.title > postB.title ? 1 : -1;
-			}
+		if ( query.status === 'draft,pending' ) {
+			query.orderBy = 'modified';
 		}
-		// reverse-chronological
-		return timeA > timeB ? -1 : 1;
-	} );
-}
 
-/**
- * Process a new page of data and concatenate to the end of the list
- **/
-function receivePage( id, error, data ) {
-	var found = data && data.found,
-		posts,
-		postIds;
+		let list = PostListCacheStore.get( query );
 
-	if ( id !== _activeList.id ) {
-		return;
-	}
+		if ( list ) {
+			_activeList = list;
+		} else {
+			_activeList = {
+				id: _nextId,
+				postIds: [],
+				errors: [],
+				query: query,
+				page: 0,
+				isLastPage: false,
+				isFetchingNextPage: false,
+				isFetchingUpdated: false
+			};
 
-	_activeList.isFetchingNextPage = false;
-
-	if ( error ) {
-		debug( 'Error fetching PostsList from api:', error );
-		error.timestamp = Date.now();
-		_activeList.errors.push( error );
-		PostListStore.emit( 'change' );
-		return;
-	}
-
-	if ( ! found ) {
-		_activeList.isLastPage = true;
-		PostListStore.emit( 'change' );
-		return;
-	}
-
-	// if we got a next page handle, cache it for the next page
-	_activeList.nextPageHandle = data.meta && data.meta.next_page;
-
-	if ( ! _activeList.nextPageHandle ) {
-		_activeList.isLastPage = true;
-	}
-
-	posts = data.posts;
-
-	postIds = posts.map( function( post ) {
-		return post.global_ID;
-	} );
-
-	if ( postIds.length ) {
-		// did we actually find any new posts?
-		postIds = difference( postIds, _activeList.postIds );
-		if ( postIds.length ) {
-			_activeList.postIds = _activeList.postIds.concat( postIds );
-			_activeList.page++;
+			_nextId++;
 		}
 	}
-
-	PostListStore.emit( 'change' );
-}
-
-/**
- * Merge updated posts
- **/
-function receiveUpdates( id, error, data ) {
-	var posts, postIds, newPostIds;
-
-	if ( error ) {
-		debug( 'An error occurred while fetching updated posts %o', error );
-		return;
-	}
-
-	if ( id !== _activeList.id ) {
-		return;
-	}
-
-	if ( ! data.posts.length ) {
-		return;
-	}
-
-	posts = data.posts;
-
-	debug( 'Fetched updated posts:', posts );
-
-	postIds = posts.map( function( post ) {
-		return post.global_ID;
-	} );
-
-	newPostIds = difference( postIds, _activeList.postIds );
-
-	if ( newPostIds.length ) {
-		_activeList.postIds = _activeList.postIds.concat( newPostIds );
-		sort( _activeList.postIds );
-	}
-
-	PostListStore.emit( 'change' );
-}
-
-PostListStore = {
-
-	get: function() {
-		return _activeList;
-	},
-
-	getID: function() {
-		return _activeList.id;
-	},
-
-	getSiteID: function() {
-		return _activeList.query.siteID;
-	},
 
 	/**
-	* Get list of posts from current object
-	*/
-	getAll: function() {
-		return _activeList.postIds.map( function( globalID ) {
-			return PostsStore.get( globalID );
+	 * Remove any keys from the params that are null or undefined
+	 *
+	 * We do this to avoid sending empty values along.
+	 * Returns a new object representing the clean params.
+	 * The original params is unmodified.
+	 *
+	 * @param  {string} params The params to clean
+	 * @return {object} The cleaned params object.
+	 */
+	function cleanParams( params ) {
+		return transform( params, function( result, value, key ) {
+			if ( value != null ) {
+				result[ key ] = value;
+			}
+		}, {} );
+	}
+
+	/**
+	 * Sort the active list
+	 **/
+	function sort() {
+		var key = _activeList.query.orderBy;
+
+		_activeList.postIds.sort( function( a, b ) {
+			var postA = PostsStore.get( a ),
+				postB = PostsStore.get( b ),
+				timeA = postA[ key ],
+				timeB = postB[ key ];
+
+			if ( timeA === timeB ) {
+				if ( postA.title === postB.title ) {
+					return 0;
+				}
+
+				return postA.title > postB.title ? 1 : -1;
+			}
+			// reverse-chronological
+			return timeA > timeB ? -1 : 1;
 		} );
-	},
+	}
 
-	getTree: function() {
-		var sortedPosts = [];
+	// Process a new page of data and concatenate to the end of the list
+	function receivePage( listId, error, data ) {
+		const found = data && data.found;
+		let posts;
+		let postIds;
 
-		// clone objects to prevent mutating store data, set parent to number
-		_activeList.postIds.forEach( function( globalID ) {
-			var post = clone( PostsStore.get( globalID ) );
-			post.parent = post.parent ? post.parent.ID : 0;
-			sortedPosts.push( post );
+		if ( listId !== _activeList.id ) {
+			return;
+		}
+
+		_activeList.isFetchingNextPage = false;
+
+		if ( error ) {
+			debug( 'Error fetching PostsList from api:', error );
+			error.timestamp = Date.now();
+			_activeList.errors.push( error );
+			return;
+		}
+
+		if ( ! found ) {
+			_activeList.isLastPage = true;
+			return;
+		}
+
+		// if we got a next page handle, cache it for the next page
+		_activeList.nextPageHandle = data.meta && data.meta.next_page;
+
+		if ( ! _activeList.nextPageHandle ) {
+			_activeList.isLastPage = true;
+		}
+
+		posts = data.posts;
+
+		postIds = posts.map( function( post ) {
+			return post.global_ID;
 		} );
 
-		return treeConvert.treeify( sortedPosts );
-	},
-
-	getPost: function( globalID ) {
-		if ( _activeList.postIds.indexOf( globalID ) > -1 ) {
-			return PostsStore.get( globalID );
+		if ( postIds.length ) {
+			// did we actually find any new posts?
+			postIds = difference( postIds, _activeList.postIds );
+			if ( postIds.length ) {
+				_activeList.postIds = _activeList.postIds.concat( postIds );
+				_activeList.page++;
+			}
 		}
-	},
+	}
 
-	getPage: function() {
-		return _activeList.page;
-	},
+	// Merge updated posts
+	function receiveUpdates( listId, error, data ) {
+		let posts;
+		let postIds;
+		let newPostIds;
 
-	isLastPage: function() {
-		return _activeList.isLastPage;
-	},
+		if ( error ) {
+			debug( 'An error occurred while fetching updated posts %o', error );
+			return;
+		}
 
-	isFetchingNextPage: function() {
-		return _activeList.isFetchingNextPage;
-	},
+		if ( listId !== _activeList.id ) {
+			return;
+		}
 
-	// Have we received an error recently?
-	hasRecentError: function() {
-		const recentTimeIntervalSeconds = 30;
-		const dateNow = Date.now();
+		if ( ! data.posts.length ) {
+			return;
+		}
 
-		return some( _activeList.errors, function( error ) {
-			return ( dateNow - error.timestamp ) < ( recentTimeIntervalSeconds * 1000 );
+		posts = data.posts;
+
+		debug( 'Fetched updated posts:', posts );
+
+		postIds = posts.map( function( post ) {
+			return post.global_ID;
 		} );
-	},
 
-	getNextPageParams: function() {
-		var params = {},
-			query = _activeList.query;
+		newPostIds = difference( postIds, _activeList.postIds );
 
-		params.status = query.status;
-		params.order_by = query.orderBy;
-		params.order = query.order;
-		params.author = query.author;
-		params.number = query.perPage;
-		params.type = query.type;
-		params.page_handle = _activeList.nextPageHandle;
-		params.exclude_tree = query.exclude_tree;
-		params.number = query.number;
-		params.before = query.before;
-		params.after = query.after;
+		if ( newPostIds.length ) {
+			_activeList.postIds = _activeList.postIds.concat( newPostIds );
+			sort( _activeList.postIds );
+		}
+	}
 
-		if ( query.search ) {
-			params.search = query.search;
+	return new class extends EventEmitter {
+		constructor() {
+			super();
+			this.id = id;
+			this.dispatchToken = Dispatcher.register( this.handlePayload.bind( this ) );
 		}
 
-		if ( ! params.siteID ) {
-			// Only query from visible sites
-			params.site_visibility = 'visible';
+		get() {
+			return _activeList;
 		}
 
-		if ( query.meta ) {
-			params.meta = query.meta;
+		getID() {
+			return _activeList.id;
 		}
 
-		return cleanParams( params );
-	},
-
-	getUpdatesParams: function() {
-		var params = {},
-			query = _activeList.query;
-
-		params.status = query.status;
-		params.author = query.author;
-		params.type = query.type;
-
-		if ( query.search ) {
-			params.search = query.search;
+		getSiteID() {
+			return _activeList.query.siteID;
 		}
 
-		if ( ! params.siteID ) {
-			// Only query from visible sites
-			params.site_visibility = 'visible';
+		// Get list of posts from current object
+		getAll() {
+			return _activeList.postIds.map( function( globalID ) {
+				return PostsStore.get( globalID );
+			} );
 		}
 
-		if ( query.meta ) {
-			params.meta = query.meta;
+		getTree() {
+			const sortedPosts = [];
+
+			// clone objects to prevent mutating store data, set parent to number
+			_activeList.postIds.forEach( function( globalID ) {
+				let post = clone( PostsStore.get( globalID ) );
+				post.parent = post.parent ? post.parent.ID : 0;
+				sortedPosts.push( post );
+			} );
+
+			return treeConvert( 'ID' ).treeify( sortedPosts );
 		}
 
-		if ( _activeList.postIds.length ) {
-			params.modified_after = max( PostListStore.getAll(), function( post ) {
-				return new Date( post.modified ).getTime();
-			} ).modified;
-
-			// For situations where the list ordered by publish date, we want to
-			// only get updates that should show up in the list to avoid creating
-			// a gap in our paging
-			if ( query.orderBy !== 'modified' && ! _activeList.isLastPage ) {
-				params.after = PostListStore.getPost( last( _activeList.postIds ) ).date;
+		getPost( globalID ) {
+			if ( _activeList.postIds.indexOf( globalID ) > -1 ) {
+				return PostsStore.get( globalID );
 			}
 		}
 
-		return cleanParams( params );
-	}
+		getPage() {
+			return _activeList.page;
+		}
 
-};
+		off( event, method ) {
+			this.removeListener( event, method );
+		}
 
-Emitter( PostListStore );
+		isLastPage() {
+			return _activeList.isLastPage;
+		}
 
-PostListStore.dispatchToken = Dispatcher.register( function( payload ) {
-	var action = payload.action;
+		isFetchingNextPage() {
+			return _activeList.isFetchingNextPage;
+		}
 
-	Dispatcher.waitFor( [ PostsStore.dispatchToken ] );
+		// Have we received an error recently?
+		hasRecentError() {
+			const recentTimeIntervalSeconds = 30;
+			const dateNow = Date.now();
 
-	switch( action.type ) {
-		case 'QUERY_POSTS':
-			queryPosts( action.options );
-			break;
-		case 'FETCH_NEXT_POSTS_PAGE':
-			_activeList.isFetchingNextPage = true;
-			PostListStore.emit( 'change' );
-			break;
-		case 'RECEIVE_POSTS_PAGE':
-			receivePage( action.id, action.error, action.data );
-			break;
+			return some( _activeList.errors, function( error ) {
+				return ( dateNow - error.timestamp ) < ( recentTimeIntervalSeconds * 1000 );
+			} );
+		}
 
-		case 'RECEIVE_UPDATED_POSTS':
-			receiveUpdates( action.id, action.error, action.data );
-			break;
+		getNextPageParams() {
+			let params = {};
+			const query = _activeList.query;
 
-		case 'RECEIVE_UPDATED_POST':
-			if ( action.post ) {
-				if ( _activeList.postIds.indexOf( action.post.global_ID ) > -1 ) {
-					PostListStore.emit( 'change' );
+			params.status = query.status;
+			params.order_by = query.orderBy;
+			params.order = query.order;
+			params.author = query.author;
+			params.number = query.perPage;
+			params.type = query.type;
+			params.page_handle = _activeList.nextPageHandle;
+			params.exclude_tree = query.exclude_tree;
+			params.number = query.number;
+			params.before = query.before;
+			params.after = query.after;
+
+			if ( query.search ) {
+				params.search = query.search;
+			}
+
+			if ( ! params.siteID ) {
+				// Only query from visible sites
+				params.site_visibility = 'visible';
+			}
+
+			if ( query.meta ) {
+				params.meta = query.meta;
+			}
+
+			return cleanParams( params );
+		}
+
+		getUpdatesParams() {
+			let params = {};
+			const query = _activeList.query;
+
+			params.status = query.status;
+			params.author = query.author;
+			params.type = query.type;
+
+			if ( query.search ) {
+				params.search = query.search;
+			}
+
+			if ( ! params.siteID ) {
+				// Only query from visible sites
+				params.site_visibility = 'visible';
+			}
+
+			if ( query.meta ) {
+				params.meta = query.meta;
+			}
+
+			if ( _activeList.postIds.length ) {
+				params.modified_after = max( this.getAll(), function( post ) {
+					return new Date( post.modified ).getTime();
+				} ).modified;
+
+				// For situations where the list ordered by publish date, we want to
+				// only get updates that should show up in the list to avoid creating
+				// a gap in our paging
+				if ( query.orderBy !== 'modified' && ! _activeList.isLastPage ) {
+					params.after = this.getPost( last( _activeList.postIds ) ).date;
 				}
 			}
-			break;
 
-	}
+			return cleanParams( params );
+		}
 
-} );
+		handlePayload( payload ) {
+			const action = payload.action;
 
-module.exports = PostListStore;
+			// If this action does not match this post-list-store.id return, but always evaluate RECEIVE_UPDATED_POST regardless
+			if ( ( action.postListStoreId && action.postListStoreId !== this.id ) &&
+					'RECEIVE_UPDATED_POST' !== action.type
+			) {
+				return;
+			}
+
+			Dispatcher.waitFor( [ PostsStore.dispatchToken ] );
+
+			switch ( action.type ) {
+				case 'QUERY_POSTS':
+					debug( 'QUERY_POSTS', action );
+					queryPosts( action.options );
+					this.emit( 'change' );
+					break;
+				case 'FETCH_NEXT_POSTS_PAGE':
+					debug( 'FETCH_NEXT_POSTS_PAGE', action );
+					_activeList.isFetchingNextPage = true;
+					this.emit( 'change' );
+					break;
+				case 'RECEIVE_POSTS_PAGE':
+					debug( 'receivePage', action );
+					receivePage( action.id, action.error, action.data );
+					this.emit( 'change' );
+					break;
+
+				case 'RECEIVE_UPDATED_POSTS':
+					receiveUpdates( action.id, action.error, action.data );
+					this.emit( 'change' );
+					break;
+
+				case 'RECEIVE_UPDATED_POST':
+					if ( action.post ) {
+						if ( _activeList.postIds.indexOf( action.post.global_ID ) > -1 ) {
+							this.emit( 'change' );
+						}
+					}
+					break;
+			}
+		}
+	}();
+};

--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -10,7 +10,7 @@ import difference from 'lodash/array/difference';
 import last from 'lodash/array/last';
 import max from 'lodash/collection/max';
 import { EventEmitter } from 'events/';
-import some from 'lodash/collection/some'
+import some from 'lodash/collection/some';
 
 /**
  * Internal dependencies

--- a/client/lib/posts/test/post-list-store.js
+++ b/client/lib/posts/test/post-list-store.js
@@ -1,17 +1,16 @@
-/* eslint-disable vars-on-top */
-require( 'lib/react-test-env-setup' )();
-
 /**
  * External dependencies
  */
-var rewire = require( 'rewire' ),
-	assert = require( 'chai' ).assert,
-	Dispatcher = require( 'dispatcher' );
+import rewire from 'rewire';
+import { assert } from 'chai';
+import Dispatcher from 'dispatcher';
+import isPlainObject from 'lodash/lang/isPlainObject';
+import isArray from 'lodash/lang/isArray';
 
 /**
  * Mock Data
  */
-var TWO_POST_PAYLOAD = {
+const TWO_POST_PAYLOAD = {
 	found: 2,
 	posts: [ {
 		global_ID: 778
@@ -19,10 +18,10 @@ var TWO_POST_PAYLOAD = {
 		global_ID: 779
 	} ]
 };
-var DEFAULT_POST_LIST_ID = 'default';
+const DEFAULT_POST_LIST_ID = 'default';
 
 function dispatchReceivePostsPage( id, postListStoreId, data ) {
-	var mockData = {
+	const mockData = {
 		found: 1,
 		posts: [ {
 			global_ID: 777
@@ -45,46 +44,47 @@ function dispatchQueryPosts( postListStoreId, options ) {
 	} );
 }
 
-describe( 'post-list-store', function() {
-	var postListStoreFactory, defaultPostListStore;
-	before( function() {
+describe( 'post-list-store', () => {
+	let postListStoreFactory;
+	let defaultPostListStore;
+	before( () => {
 		postListStoreFactory = rewire( '../post-list-store-factory' );
 	} );
 
-	beforeEach( function() {
+	beforeEach( () => {
 		postListStoreFactory.__set__( '_postListStores', {} );
 		defaultPostListStore = postListStoreFactory();
 	} );
 
-	afterEach( function() {
+	afterEach( () => {
 		if ( defaultPostListStore.dispatchToken ) {
 			Dispatcher.unregister( defaultPostListStore.dispatchToken );
 		}
 	} );
 
-	describe( 'postListStoreId', function() {
-		it( 'should set the default postListStoreId', function() {
+	describe( 'postListStoreId', () => {
+		it( 'should set the default postListStoreId', () => {
 			assert.equal( defaultPostListStore.id, DEFAULT_POST_LIST_ID );
 		} );
 	} );
 
-	describe( 'dispatcher', function() {
-		it( 'should have a dispatch token', function() {
+	describe( 'dispatcher', () => {
+		it( 'should have a dispatch token', () => {
 			assert.typeOf( defaultPostListStore.dispatchToken, 'string' );
 		} );
 	} );
 
-	describe( '#get', function() {
-		it( 'should return an object', function() {
-			assert.instanceOf( defaultPostListStore.get(), Object );
+	describe( '#get', () => {
+		it( 'should return an object', () => {
+			assert.isTrue( isPlainObject( defaultPostListStore.get() ) );
 		} );
 
-		it( 'should return the correct default values', function() {
-			var postList = defaultPostListStore.get();
-			assert.instanceOf( postList.postIds, Array );
+		it( 'should return the correct default values', () => {
+			const postList = defaultPostListStore.get();
+			assert.isTrue( isArray( postList.postIds ) );
 			assert.equal( postList.postIds.length, 0 );
-			assert.instanceOf( postList.errors, Array );
-			assert.instanceOf( postList.query, Object );
+			assert.isTrue( isArray( postList.errors ) );
+			assert.isTrue( isPlainObject( postList.query ) );
 			assert.equal( postList.errors.length, 0 );
 			assert.equal( postList.page, 0 );
 			assert.isFalse( postList.nextPageHandle );
@@ -94,146 +94,151 @@ describe( 'post-list-store', function() {
 		} );
 	} );
 
-	describe( '#getId', function() {
-		it( 'should the return list ID', function() {
+	describe( '#getId', () => {
+		it( 'should the return list ID', () => {
 			assert.equal( defaultPostListStore.getID(), defaultPostListStore.get().id );
+		} );
+
+		it( 'should globally increment ids across all stores', () => {
+			const anotherPostListStore = postListStoreFactory( 'post-lists-nom' );
+			dispatchQueryPosts( defaultPostListStore.id );
+			dispatchQueryPosts( anotherPostListStore.id );
+			assert.equal( defaultPostListStore.getID() + 1, anotherPostListStore.getID() );
 		} );
 	} );
 
-	describe( '#getSiteID', function() {
-		it( 'should the return site ID', function() {
+	describe( '#getSiteID', () => {
+		it( 'should the return site ID', () => {
 			assert.equal( defaultPostListStore.getSiteID(), defaultPostListStore.get().query.siteID );
 		} );
 	} );
 
-	describe( '#getAll', function() {
-		it( 'should return an array of posts', function() {
-			var allPosts = defaultPostListStore.getAll();
-			assert.instanceOf( allPosts, Array );
+	describe( '#getAll', () => {
+		it( 'should return an array of posts', () => {
+			const allPosts = defaultPostListStore.getAll();
+			assert.isTrue( isArray( allPosts ) );
 			assert.equal( allPosts.length, 0 );
 		} );
 	} );
 
-	describe( '#getTree', function() {
-		it( 'should return a tree-ified array of posts', function() {
-			var treePosts = defaultPostListStore.getTree();
-			assert.instanceOf( treePosts, Array );
+	describe( '#getTree', () => {
+		it( 'should return a tree-ified array of posts', () => {
+			const treePosts = defaultPostListStore.getTree();
+			assert.isTrue( isArray( treePosts ) );
 			assert.equal( treePosts.length, 0 );
 		} );
 	} );
 
-	describe( '#getPage', function() {
-		it( 'should return the page number', function() {
+	describe( '#getPage', () => {
+		it( 'should return the page number', () => {
 			assert.equal( defaultPostListStore.getPage(), defaultPostListStore.get().page );
 		} );
 	} );
 
-	describe( '#isLastPage', function() {
-		it( 'should return isLastPage boolean', function() {
+	describe( '#isLastPage', () => {
+		it( 'should return isLastPage boolean', () => {
 			assert.equal( defaultPostListStore.isLastPage(), defaultPostListStore.get().isLastPage );
 		} );
 	} );
 
-	describe( '#isFetchingNextPage', function() {
-		it( 'should return isFetchingNextPage boolean', function() {
+	describe( '#isFetchingNextPage', () => {
+		it( 'should return isFetchingNextPage boolean', () => {
 			assert.equal( defaultPostListStore.isFetchingNextPage(), defaultPostListStore.get().isFetchingNextPage );
 		} );
 	} );
 
-	describe( '#getNextPageParams', function() {
-		it( 'should return an object of params', function() {
-			assert.instanceOf( defaultPostListStore.getNextPageParams(), Object );
+	describe( '#getNextPageParams', () => {
+		it( 'should return an object of params', () => {
+			assert.isTrue( isPlainObject( defaultPostListStore.getNextPageParams() ) );
 		} );
 	} );
 
-	describe( '#getUpdatesParams', function() {
-		it( 'should return an object of params', function() {
-			assert.instanceOf( defaultPostListStore.getUpdatesParams(), Object );
+	describe( '#getUpdatesParams', () => {
+		it( 'should return an object of params', () => {
+			assert.isTrue( isPlainObject( defaultPostListStore.getUpdatesParams() ) );
 		} );
 	} );
 
-	describe( 'RECEIVE_POSTS_PAGE', function() {
-		it( 'should add post ids for matching postListStore', function() {
+	describe( 'RECEIVE_POSTS_PAGE', () => {
+		it( 'should add post ids for matching postListStore', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
 			assert.equal( defaultPostListStore.getAll().length, 1 );
 		} );
 
-		it( 'should add additional post ids for matching postListStore', function() {
+		it( 'should add additional post ids for matching postListStore', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
 			assert.equal( defaultPostListStore.getAll().length, 1 );
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id, TWO_POST_PAYLOAD );
 			assert.equal( defaultPostListStore.getAll().length, 3 );
 		} );
 
-		it( 'should add only unique post.global_IDs postListStore', function() {
+		it( 'should add only unique post.global_IDs postListStore', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
 			assert.equal( defaultPostListStore.getAll().length, 1 );
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
 			assert.equal( defaultPostListStore.getAll().length, 1 );
 		} );
 
-		it( 'should not update if cached store id does not match', function() {
+		it( 'should not update if cached store id does not match', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
 			assert.equal( defaultPostListStore.getAll().length, 1 );
 			dispatchReceivePostsPage( 999, defaultPostListStore.id );
 			assert.equal( defaultPostListStore.getAll().length, 1 );
 		} );
 
-		it( 'should not add post ids if postListStore does not match', function() {
+		it( 'should not add post ids if postListStore does not match', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), 'some-other-post-list-store' );
 			assert.equal( defaultPostListStore.getAll().length, 0 );
 		} );
 
-		it( 'should set isLastPage true if no next page handle returned', function() {
+		it( 'should set isLastPage true if no next page handle returned', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
 			assert.isTrue( defaultPostListStore.isLastPage() );
 		} );
 	} );
 
-	describe( 'QUERY_POSTS', function() {
-		it( 'should not change cached list if query does not change', function() {
-			var currentCacheId = defaultPostListStore.getID();
+	describe( 'QUERY_POSTS', () => {
+		it( 'should not change cached list if query does not change', () => {
+			dispatchQueryPosts( DEFAULT_POST_LIST_ID, {} );
+			const currentCacheId = defaultPostListStore.getID();
 			dispatchQueryPosts( DEFAULT_POST_LIST_ID, {} );
 			assert.equal( currentCacheId, defaultPostListStore.getID() );
 		} );
 
-		it( 'should change the active query and id when query options change', function() {
-			var currentCacheId = defaultPostListStore.getID();
+		it( 'should change the active query and id when query options change', () => {
+			const currentCacheId = defaultPostListStore.getID();
 			dispatchQueryPosts( DEFAULT_POST_LIST_ID, { type: 'page' } );
 			assert.notEqual( currentCacheId, defaultPostListStore.getID() );
 		} );
 
-		it( 'should set site_visibility if no siteID is present', function() {
+		it( 'should set site_visibility if no siteID is present', () => {
 			dispatchQueryPosts( DEFAULT_POST_LIST_ID, { type: 'page' } );
 			assert.equal( defaultPostListStore.getNextPageParams().site_visibility, 'visible' );
 		} );
 
-		it( 'should set query options passed in', function() {
-			var params;
+		it( 'should set query options passed in', () => {
 			dispatchQueryPosts( DEFAULT_POST_LIST_ID, {
 				type: 'page',
 				order: 'ASC'
 			} );
-			params = defaultPostListStore.getNextPageParams();
+			const params = defaultPostListStore.getNextPageParams();
 			assert.equal( params.type, 'page' );
 			assert.equal( params.order, 'ASC' );
 		} );
 
-		it( 'should remove null query options passed in', function() {
-			var params;
+		it( 'should remove null query options passed in', () => {
 			dispatchQueryPosts( DEFAULT_POST_LIST_ID, {
 				type: 'page',
 				order: 'ASC',
 				search: null
 			} );
-			params = defaultPostListStore.getNextPageParams();
+			const params = defaultPostListStore.getNextPageParams();
 			assert.isUndefined( params.search );
 		} );
 
-		it( 'should not set query options on a different postListStore instance', function() {
-			var params;
+		it( 'should not set query options on a different postListStore instance', () => {
 			dispatchQueryPosts( 'some-other-post-list-store', { type: 'page' } );
-			params = defaultPostListStore.getNextPageParams();
+			const params = defaultPostListStore.getNextPageParams();
 			assert.equal( params.type, 'post' );
 			assert.equal( params.order, 'DESC' );
 		} );

--- a/client/lib/posts/test/post-list-store.js
+++ b/client/lib/posts/test/post-list-store.js
@@ -23,11 +23,11 @@ var DEFAULT_POST_LIST_ID = 'default';
 
 function dispatchReceivePostsPage( id, postListStoreId, data ) {
 	var mockData = {
-			found: 1,
-			posts: [ {
-				global_ID: 777
-			} ]
-		};
+		found: 1,
+		posts: [ {
+			global_ID: 777
+		} ]
+	};
 	Dispatcher.handleServerAction( {
 		type: 'RECEIVE_POSTS_PAGE',
 		id: id,

--- a/client/lib/posts/test/post-list-store.js
+++ b/client/lib/posts/test/post-list-store.js
@@ -101,8 +101,14 @@ describe( 'post-list-store', () => {
 
 		it( 'should globally increment ids across all stores', () => {
 			const anotherPostListStore = postListStoreFactory( 'post-lists-nom' );
-			dispatchQueryPosts( defaultPostListStore.id );
-			dispatchQueryPosts( anotherPostListStore.id );
+			dispatchQueryPosts( defaultPostListStore.id, {
+				type: 'page',
+				order: 'ASC'
+			} );
+			dispatchQueryPosts( anotherPostListStore.id, {
+				type: 'page',
+				order: 'ASC'
+			} );
 			assert.equal( defaultPostListStore.getID() + 1, anotherPostListStore.getID() );
 		} );
 	} );

--- a/client/lib/posts/test/post-list-store.js
+++ b/client/lib/posts/test/post-list-store.js
@@ -165,6 +165,26 @@ describe( 'post-list-store', () => {
 		} );
 	} );
 
+	describe( '#hasRecentError', () => {
+		it( 'should return false if there are no errors', () => {
+			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );
+			assert.isFalse( defaultPostListStore.hasRecentError() );
+		} );
+
+		it( 'should return true if recent payload had error', () => {
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_POSTS_PAGE',
+				id: defaultPostListStore.getID(),
+				postListStoreId: defaultPostListStore.id,
+				data: null,
+				error: {
+					omg: 'error!'
+				}
+			} );
+			assert.isTrue( defaultPostListStore.hasRecentError() );
+		} );
+	} );
+
 	describe( 'RECEIVE_POSTS_PAGE', () => {
 		it( 'should add post ids for matching postListStore', () => {
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id );

--- a/client/lib/posts/test/post-list-store.js
+++ b/client/lib/posts/test/post-list-store.js
@@ -6,18 +6,17 @@ require( 'lib/react-test-env-setup' )();
  */
 var rewire = require( 'rewire' ),
 	assert = require( 'chai' ).assert,
-	includes = require( 'lodash/collection/includes' ),
 	Dispatcher = require( 'dispatcher' );
 
 describe( 'post-list-store', function() {
-	var PostListStoreFactory, defaultPostListStore;
+	var postListStoreFactory, defaultPostListStore;
 	before( function() {
-		PostListStoreFactory = rewire( '../post-list-store-factory' );
+		postListStoreFactory = rewire( '../post-list-store-factory' );
 	} );
 
 	beforeEach( function() {
-		PostListStoreFactory.__set__( '_postListStores', {} );
-		defaultPostListStore = PostListStoreFactory();
+		postListStoreFactory.__set__( '_postListStores', {} );
+		defaultPostListStore = postListStoreFactory();
 	} );
 
 	afterEach( function() {
@@ -43,7 +42,7 @@ describe( 'post-list-store', function() {
 			assert.instanceOf( defaultPostListStore.get(), Object );
 		} );
 
-		it( 'should return the correct default values', function(){
+		it( 'should return the correct default values', function() {
 			var postList = defaultPostListStore.get();
 			assert.instanceOf( postList.postIds, Array );
 			assert.equal( postList.postIds.length, 0 );

--- a/client/lib/posts/test/post-list-store.js
+++ b/client/lib/posts/test/post-list-store.js
@@ -1,0 +1,118 @@
+/* eslint-disable vars-on-top */
+require( 'lib/react-test-env-setup' )();
+
+/**
+ * External dependencies
+ */
+var rewire = require( 'rewire' ),
+	assert = require( 'chai' ).assert,
+	includes = require( 'lodash/collection/includes' ),
+	Dispatcher = require( 'dispatcher' );
+
+describe( 'post-list-store', function() {
+	var PostListStoreFactory, defaultPostListStore;
+	before( function() {
+		PostListStoreFactory = rewire( '../post-list-store-factory' );
+	} );
+
+	beforeEach( function() {
+		PostListStoreFactory.__set__( '_postListStores', {} );
+		defaultPostListStore = PostListStoreFactory();
+	} );
+
+	afterEach( function() {
+		if ( defaultPostListStore.dispatchToken ) {
+			Dispatcher.unregister( defaultPostListStore.dispatchToken );
+		}
+	} );
+
+	describe( 'postListStoreId', function() {
+		it( 'should set the default postListStoreId', function() {
+			assert.equal( defaultPostListStore.id, 'default' );
+		} );
+	} );
+
+	describe( 'dispatcher', function() {
+		it( 'should have a dispatch token', function() {
+			assert.typeOf( defaultPostListStore.dispatchToken, 'string' );
+		} );
+	} );
+
+	describe( '#get', function() {
+		it( 'should return an object', function() {
+			assert.instanceOf( defaultPostListStore.get(), Object );
+		} );
+
+		it( 'should return the correct default values', function(){
+			var postList = defaultPostListStore.get();
+			assert.instanceOf( postList.postIds, Array );
+			assert.equal( postList.postIds.length, 0 );
+			assert.instanceOf( postList.errors, Array );
+			assert.instanceOf( postList.query, Object );
+			assert.equal( postList.errors.length, 0 );
+			assert.equal( postList.page, 0 );
+			assert.isFalse( postList.nextPageHandle );
+			assert.isFalse( postList.isLastPage );
+			assert.isFalse( postList.isFetchingNextPage );
+			assert.isFalse( postList.isFetchingUpdated );
+		} );
+	} );
+
+	describe( '#getId', function() {
+		it( 'should the return list ID', function() {
+			assert.equal( defaultPostListStore.getID(), defaultPostListStore.get().id );
+		} );
+	} );
+
+	describe( '#getSiteID', function() {
+		it( 'should the return site ID', function() {
+			assert.equal( defaultPostListStore.getSiteID(), defaultPostListStore.get().query.siteID );
+		} );
+	} );
+
+	describe( '#getAll', function() {
+		it( 'should return an array of posts', function() {
+			var allPosts = defaultPostListStore.getAll();
+			assert.instanceOf( allPosts, Array );
+			assert.equal( allPosts.length, 0 );
+		} );
+	} );
+
+	describe( '#getTree', function() {
+		it( 'should return a tree-ified array of posts', function() {
+			var treePosts = defaultPostListStore.getTree();
+			assert.instanceOf( treePosts, Array );
+			assert.equal( treePosts.length, 0 );
+		} );
+	} );
+
+	describe( '#getPage', function() {
+		it( 'should return the page number', function() {
+			assert.equal( defaultPostListStore.getPage(), defaultPostListStore.get().page );
+		} );
+	} );
+
+	describe( '#isLastPage', function() {
+		it( 'should return isLastPage boolean', function() {
+			assert.equal( defaultPostListStore.isLastPage(), defaultPostListStore.get().isLastPage );
+		} );
+	} );
+
+	describe( '#isFetchingNextPage', function() {
+		it( 'should return isFetchingNextPage boolean', function() {
+			assert.equal( defaultPostListStore.isFetchingNextPage(), defaultPostListStore.get().isFetchingNextPage );
+		} );
+	} );
+
+	describe( '#getNextPageParams', function() {
+		it( 'should return an object of params', function() {
+			assert.instanceOf( defaultPostListStore.getNextPageParams(), Object );
+		} );
+	} );
+
+	describe( '#getUpdatesParams', function() {
+		it( 'should return an object of params', function() {
+			assert.instanceOf( defaultPostListStore.getUpdatesParams(), Object );
+		} );
+	} );
+} );

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -9,7 +9,7 @@ var React = require( 'react/addons' ),
  * Internal dependencies
  */
 var Card = require( 'components/card' ),
-	PostListStore = require( 'lib/posts/post-list-store' ),
+	PostListStore = require( 'lib/posts/post-list-store-factory' )(),
 	PostStatsStore = require( 'lib/post-stats/store' ),
 	Emojify = require( 'components/emojify' ),
 	actions = require( 'lib/posts/actions' ),


### PR DESCRIPTION
Part of #303 - In order to have multiple components in a given view that need to interact with distinct query options of a `post-list-store` - the current `post-list-store` needs to be abstracted into a factory akin to the `category-store`.

__Background__
While building the "Parent Page Selector" in the editor - both the parent page selector and the post scheduler were modifying the `post-list-store` query options, and as such the query results.  This lead to some odd behavior between the two, and ultimately was fixed by disabling the post scheduler when editing pages.

By moving to a factory setup, components like the `post-list-fetcher` can create their own instance of a `post-list-store` to ensure query options and results are not polluted by other components on the page.

This branch indeed got a bit larger then I typically like, but a large amount of the new lines are in the form of tests.  Additionally, reading the diff of `post-list-store` might be a bit difficult and is probably best read outside of the diff viewer.  I did not change any logic within the `post-list-store`, just restructured it to flow with the factory setup, and ES6-ified it.

__To Test__
Test coverage for the `post-list-store` has been added in this branch.  The tests can be executed by performing `cd client/lib/posts && make`.

Additionally, the `post-list-store` acts as a data provider for the following components.  All should be interacted with during testing to ensure no odd behavior is encountered

- `my-sites/drafts/draft-list.jsx` Can be tested by using the "Drafts Drawer" in the editor
- `my-sites/menus/item-options/post-list.jsx` Test via the menu builder by adding menu options for both a page and a post.  Interact with the search box here as well and validate the search filter still operates as expected
- `my-sites/pages/page-list.jsx` View a page list for a site.  Interact with the filter bar by toggling between Drafts and Trash.  Filter pages using search
- `my-sites/post-selector/index.jsx` Open a page in the editor, interact with the parent page selector in the sidebar.
- `my-sites/posts/post-list.jsx` Open a sites posts list.  Interact with the filterbar and search.
- `post-editor/editor-ground-control/index.jsx` Inside the post editor, expand the post scheduler.  Ensure calendar items are circled as expected for dates where posts have been published.
- Stats Insights Page - The "Latest Post Summary" on the insights tab of the stats page also uses the `post-list-store`.  Validate that data shows up as expected inside this module