### PR TITLE
Reader: Only link to Discover for en users

### DIFF
--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -43,6 +43,10 @@ var userUtils = {
 
 		// Forward user to WordPress.com to be logged out
 		location.href = logoutUrl;
+	},
+
+	getLocaleSlug: function() {
+		return user.get().localeSlug;
 	}
 };
 

--- a/client/reader/discover/helper.jsx
+++ b/client/reader/discover/helper.jsx
@@ -5,7 +5,18 @@ var find = require( 'lodash/collection/find' ),
 	get = require( 'lodash/object/get' ),
 	url = require( 'url' );
 
+/**
+ * Internal Dependencies
+ */
+var config = require( 'config' ),
+	userUtils = require( 'lib/user/utils' );
+
 module.exports = {
+	isEnabled: function() {
+		return config.isEnabled( 'reader/discover' ) &&
+			userUtils.getLocaleSlug() === 'en';
+	},
+
 	isDiscoverPost: function( post ) {
 		return !! post.discover_metadata;
 	},

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -1,7 +1,8 @@
 var React = require( 'react' );
 
 var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' );
+	stats = require( 'reader/stats' ),
+	discoverHelper = require( 'reader/discover/helper' );
 
 var FeedEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -19,11 +20,12 @@ var FeedEmptyContent = React.createClass( {
 	},
 
 	render: function() {
-		var action = (
+		var action = discoverHelper.isEnabled()
+		? (
 			<a
 				className="empty-content__action button is-primary"
 				onClick={ this.recordAction }
-				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ),
+				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null,
 			secondaryAction = (
 				<a
 					className="empty-content__action button"

--- a/client/reader/following-stream/empty.jsx
+++ b/client/reader/following-stream/empty.jsx
@@ -1,7 +1,6 @@
 var React = require( 'react' );
 
 var EmptyContent = require( 'components/empty-content' ),
-	ExternalLink = require( 'components/external-link' ),
 	stats = require( 'reader/stats' );
 
 var FollowingEmptyContent = React.createClass( {

--- a/client/reader/following-stream/empty.jsx
+++ b/client/reader/following-stream/empty.jsx
@@ -1,7 +1,8 @@
 var React = require( 'react' );
 
 var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' );
+	stats = require( 'reader/stats' ),
+	discoverHelper = require( 'reader/discover/helper' );
 
 var FollowingEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -19,11 +20,12 @@ var FollowingEmptyContent = React.createClass( {
 	},
 
 	render: function() {
-		var action = (
+		var action = discoverHelper.isEnabled()
+		? (
 			<a
 				className="empty-content__action button is-primary"
 				onClick={ this.recordAction }
-				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ),
+				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null,
 			secondaryAction = (
 				<a
 					className="empty-content__action button"

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -1,7 +1,6 @@
 var React = require( 'react' );
 
 var EmptyContent = require( 'components/empty-content' ),
-	ExternalLink = require( 'components/external-link' ),
 	stats = require( 'reader/stats' );
 
 var TagEmptyContent = React.createClass( {

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -1,7 +1,8 @@
 var React = require( 'react' );
 
 var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' );
+	stats = require( 'reader/stats' ),
+	discoverHelper = require( 'reader/discover/helper' );
 
 var TagEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -23,10 +24,11 @@ var TagEmptyContent = React.createClass( {
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
 			href="/">{ this.translate( 'Back to Following' ) }</a> ),
-			secondaryAction = ( <a
+			secondaryAction = discoverHelper.isEnabled()
+			? ( <a
 				className="empty-content__action button"
 				onClick={ this.recordSecondaryAction }
-				href="/discover">{ this.translate( 'Explore Discover' ) }</a> );
+				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
 
 		return ( <EmptyContent
 			title={ this.translate( 'No Likes Yet' ) }

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -1,7 +1,8 @@
 var React = require( 'react' );
 
 var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' );
+	stats = require( 'reader/stats' ),
+	discoverHelper = require( 'reader/discover/helper' );
 
 var ListEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -23,10 +24,11 @@ var ListEmptyContent = React.createClass( {
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
 			href="/">{ this.translate( 'Back to Following' ) }</a> ),
-			secondaryAction = ( <a
+			secondaryAction = discoverHelper.isEnabled()
+			? ( <a
 				className="empty-content__action button"
 				onClick={ this.recordSecondaryAction }
-				href="/discover">{ this.translate( 'Explore Discover' ) }</a> );
+				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
 
 		return ( <EmptyContent
 			title={ this.translate( 'No recent posts…' ) }

--- a/client/reader/sidebar/sidebar.jsx
+++ b/client/reader/sidebar/sidebar.jsx
@@ -25,7 +25,8 @@ const layoutFocus = require( 'lib/layout-focus' ),
 	SidebarActions = require( 'lib/reader-sidebar/actions' ),
 	stats = require( 'reader/stats' ),
 	Gridicon = require( 'components/gridicon' ),
-	config = require( 'config' );
+	config = require( 'config' ),
+	discoverHelper = require( 'reader/discover/helper' );
 
 module.exports = React.createClass( {
 	displayName: 'ReaderSidebar',
@@ -283,7 +284,7 @@ module.exports = React.createClass( {
 						{ this.renderTeams() }
 
 						{
-							config.isEnabled( 'reader/discover' )
+							discoverHelper.isEnabled()
 							? (
 									<li className={ this.itemLinkClass( '/discover', { 'sidebar-streams__discover': true } ) }>
 										<a href="/discover">

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -1,7 +1,6 @@
 var React = require( 'react' );
 
 var EmptyContent = require( 'components/empty-content' ),
-	ExternalLink = require( 'components/external-link' ),
 	stats = require( 'reader/stats' );
 
 var SiteEmptyContent = React.createClass( {

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -1,7 +1,8 @@
 var React = require( 'react' );
 
 var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' );
+	stats = require( 'reader/stats' ),
+	discoverHelper = require( 'reader/discover/helper' );
 
 var SiteEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -19,11 +20,12 @@ var SiteEmptyContent = React.createClass( {
 	},
 
 	render: function() {
-		var action = (
+		var action = discoverHelper.isEnabled()
+		? (
 			<a
 				className="empty-content__action button is-primary"
 				onClick={ this.recordAction }
-				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ),
+				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null,
 			secondaryAction = (
 				<a
 					className="empty-content__action button"

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -1,7 +1,6 @@
 var React = require( 'react' );
 
 var EmptyContent = require( 'components/empty-content' ),
-	ExternalLink = require( 'components/external-link' ),
 	stats = require( 'reader/stats' );
 
 var TagEmptyContent = React.createClass( {

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -1,7 +1,8 @@
 var React = require( 'react' );
 
 var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' );
+	stats = require( 'reader/stats' ),
+	discoverHelper = require( 'reader/discover/helper' );
 
 var TagEmptyContent = React.createClass( {
 	shouldComponentUpdate: function() {
@@ -19,10 +20,11 @@ var TagEmptyContent = React.createClass( {
 	},
 
 	render: function() {
-		var action = ( <a
+		var action = discoverHelper.isEnabled()
+			? ( <a
 			className="empty-content__action button"
 			onClick={ this.recordSecondaryAction }
-			href="/discover">{ this.translate( 'Explore Discover' ) }</a> );
+			href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
 
 		return ( <EmptyContent
 			title={ this.translate( 'No recent posts…' ) }


### PR DESCRIPTION
Hides Discover links for non-`en` users since the content is currently only in English.

## To Test

- Set interface language to English from Me > Account Settings.
- Go to Reader.
- Make sure "Discover" shows in sidebar.

- Switch language to something not English.
- Go to Reader.
- Make sure "Discover" is no longer visible in sidebar