### PR TITLE
Reader: Add a grid layout for My Likes

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -280,6 +280,7 @@
 @import 'reader/following-edit/style';
 @import 'reader/following-stream/style';
 @import 'reader/full-post/style';
+@import 'reader/liked-stream/style';
 @import 'reader/list-gap/style';
 @import 'reader/list-item/style';
 @import 'reader/list-management/style';

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -58,7 +58,7 @@ module.exports = React.createClass( {
 		showFollowInHeader: React.PropTypes.bool,
 		onUpdatesShown: React.PropTypes.func,
 		emptyContent: React.PropTypes.object,
-		containerClass: React.PropTypes.string
+		className: React.PropTypes.string
 	},
 
 	getDefaultProps: function() {
@@ -66,7 +66,7 @@ module.exports = React.createClass( {
 			suppressSiteNameLink: false,
 			showFollowInHeader: false,
 			onShowUpdates: noop,
-			containerClass: 'following'
+			className: 'following'
 		};
 	},
 
@@ -413,8 +413,8 @@ module.exports = React.createClass( {
 			body,
 			containerClass = 'following';
 
-		if ( this.props.containerClass ) {
-			containerClass = this.props.containerClass;
+		if ( this.props.className ) {
+			containerClass = this.props.className;
 		}
 
 		if ( hasNoPosts ) {

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -57,14 +57,16 @@ module.exports = React.createClass( {
 		suppressSiteNameLink: React.PropTypes.bool,
 		showFollowInHeader: React.PropTypes.bool,
 		onUpdatesShown: React.PropTypes.func,
-		emptyContent: React.PropTypes.object
+		emptyContent: React.PropTypes.object,
+		containerClass: React.PropTypes.string
 	},
 
 	getDefaultProps: function() {
 		return {
 			suppressSiteNameLink: false,
 			showFollowInHeader: false,
-			onShowUpdates: noop
+			onShowUpdates: noop,
+			containerClass: 'following'
 		};
 	},
 
@@ -408,7 +410,12 @@ module.exports = React.createClass( {
 	render: function() {
 		var store = this.props.store,
 			hasNoPosts = store.isLastPage() && ( ( ! this.state.posts ) || this.state.posts.length === 0 ),
-			body;
+			body,
+			containerClass = 'following';
+
+		if ( this.props.containerClass ) {
+			containerClass = this.props.containerClass;
+		}
 
 		if ( hasNoPosts ) {
 			body = this.props.emptyContent || ( <EmptyContent /> );
@@ -428,7 +435,7 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<Main className="following">
+			<Main className={ containerClass }>
 				<MobileBackToSidebar>
 					<h1>{ this.props.listName }</h1>
 				</MobileBackToSidebar>

--- a/client/reader/liked-stream/_style.scss
+++ b/client/reader/liked-stream/_style.scss
@@ -1,16 +1,13 @@
 .my-likes {
 	max-width: 100%;
 
-	.reader__content {
-		
-	}
-
 	.card.reader__card {
 		display: inline-block;
+		width: 100%;
 		height: 320px;
 		overflow: hidden;
 
-		@include breakpoint( "660px-960px" ) {
+		@media (min-width: 748px) and (max-width: 1200px) {
 			width: calc( 50% - 12px );
 			margin-right: 24px;
 
@@ -19,7 +16,7 @@
 			}
 		}
 
-		@include breakpoint( ">960px" ) {
+		@media (min-width: 1200px) and (max-width: 1350px) {
 			width: calc( 33.3% - 16px );
 			margin-right: 24px;
 			margin-bottom: 20px;
@@ -29,9 +26,8 @@
 			}
 		}
 
-		/*
-		@include breakpoint( ">1040px" ) {
-			width: calc( 25% - 16px );
+		@media (min-width: 1350px) {
+			width: calc( 25% - 18px );
 			margin-right: 24px;
 			margin-bottom: 20px;
 
@@ -39,12 +35,16 @@
 				margin-right: 0;
 			}
 		}
-		*/
+
+		@media (min-width: 1600px) {
+			width: calc( 25% - 48px );
+			margin: 24px;
+		}
 
 		&:after {
 			content: '';
 			display: block;
-			height: 48px;
+			height: 32px;
 			position: absolute;
 				right: 0;
 				bottom: 40px;
@@ -53,7 +53,7 @@
 			background: linear-gradient(
 					to bottom,
 					rgba( $white, 0 ) 0%,
-					rgba( $white, 0.7 ) 100% );
+					rgba( $white, 0.9 ) 100% );
 		}
 	}
 
@@ -61,7 +61,11 @@
 		display: none;
 	}
 
-	.site .site-icon {
+	.card.reader__card .site {
+		margin-right: auto;
+	}
+
+	.site-icon {
 		height: 16px !important; // Overriding inline styles from the Site Icon
 		width: 16px !important;
 	}
@@ -101,8 +105,8 @@
 	}
 
 	.reader__post-footer {
-		background: $gray-light;
-		border-top: 1px solid lighten( $gray, 20 );
+		background: rgba( $white, 0.98 );
+		border-top: 1px solid $gray-light;
 		position: absolute;
 			right: 0;
 			bottom: 0;
@@ -164,6 +168,13 @@
 
 		.post-excerpt {
 			display: none;
+		}
+
+		&:after {
+			background: linear-gradient(
+					to bottom,
+					rgba( $gray-dark, 0 ) 0%,
+					rgba( $gray-dark, 0.7 ) 100% );
 		}
 	}
 }

--- a/client/reader/liked-stream/_style.scss
+++ b/client/reader/liked-stream/_style.scss
@@ -42,8 +42,8 @@
 		}
 
 		@media (min-width: 1600px) {
-			width: calc( 25% - 48px );
-			margin: 24px;
+			width: calc( 25% - 32px );
+			margin: 16px;
 		}
 
 		&:after {
@@ -73,6 +73,7 @@
 	.site-icon {
 		height: 16px !important; // Overriding inline styles from the Site Icon
 		width: 16px !important;
+		line-height: 16px !important;
 	}
 
 	.site__domain {
@@ -83,16 +84,17 @@
 		max-height: 100px;
 		width: calc( 100% + 16px );
 		left: -12px;
-		box-shadow: 0 0 0 1px lighten( $gray, 10 );
+		box-shadow: 0 0 0 1px rgba( $gray, 0.2 );
+		border-bottom: 0;
 		border-radius: 3px;
+	}
+
+	.reader__post-featured-video {
+		display: none;
 	}
 
 	.reader__post-title {
 		font-size: 18px;
-	}
-
-	.reader-post-byline {
-		display: none;
 	}
 
 	.post-excerpt .post-excerpt__text,
@@ -128,58 +130,8 @@
 			margin-right: auto;
 		}
 		.post-permalink,
-		.comment-button,
 		.reader__post-options {
 			display: none;
-		}
-	}
-
-	// Photo Only Posts
-	.card.reader__card.is-photo-only {
-		.reader__post-header {
-			z-index: 2;
-			background: rgba( $white, 0.95 );
-			padding: 8px;
-			margin: -8px;
-		}
-
-		.reader__post-featured-image {
-			position: absolute;
-				top: 0;
-				right: 0;
-				bottom: 41px;
-				left: 0;
-			border-radius: 0;
-			box-shadow: none;
-			max-height: 100%;
-			margin: 0;
-
-			img {
-				height: 100% !important; // Overriding the inline styles
-				width: 100% !important;
-				object-fit: cover;
-			}
-		}
-
-		.reader__post-title {
-			background: rgba( $white, 0.95 );
-			z-index: 1;
-			position: relative;
-			padding: 2px 8px 0;
-			margin-top: 22px;
-			margin-left: -8px;
-			margin-right: -8px;
-		}
-
-		.post-excerpt {
-			display: none;
-		}
-
-		&:after {
-			background: linear-gradient(
-					to bottom,
-					rgba( $gray-dark, 0 ) 0%,
-					rgba( $gray-dark, 0.7 ) 100% );
 		}
 	}
 }

--- a/client/reader/liked-stream/_style.scss
+++ b/client/reader/liked-stream/_style.scss
@@ -1,0 +1,169 @@
+.my-likes {
+	max-width: 100%;
+
+	.reader__content {
+		
+	}
+
+	.card.reader__card {
+		display: inline-block;
+		height: 320px;
+		overflow: hidden;
+
+		@include breakpoint( "660px-960px" ) {
+			width: calc( 50% - 12px );
+			margin-right: 24px;
+
+			&:nth-of-type( 2n ) {
+				margin-right: 0;
+			}
+		}
+
+		@include breakpoint( ">960px" ) {
+			width: calc( 33.3% - 16px );
+			margin-right: 24px;
+			margin-bottom: 20px;
+
+			&:nth-of-type( 3n ) {
+				margin-right: 0;
+			}
+		}
+
+		/*
+		@include breakpoint( ">1040px" ) {
+			width: calc( 25% - 16px );
+			margin-right: 24px;
+			margin-bottom: 20px;
+
+			&:nth-of-type( 4n ) {
+				margin-right: 0;
+			}
+		}
+		*/
+
+		&:after {
+			content: '';
+			display: block;
+			height: 48px;
+			position: absolute;
+				right: 0;
+				bottom: 40px;
+				left: 0;
+			visibility: visible;
+			background: linear-gradient(
+					to bottom,
+					rgba( $white, 0 ) 0%,
+					rgba( $white, 0.7 ) 100% );
+		}
+	}
+
+	.follow-button {
+		display: none;
+	}
+
+	.site .site-icon {
+		height: 16px !important; // Overriding inline styles from the Site Icon
+		width: 16px !important;
+	}
+
+	.site__domain {
+		display: none;
+	}
+
+	.reader__post-featured-image {
+		max-height: 100px;
+		width: calc( 100% + 16px );
+		left: -12px;
+		box-shadow: 0 0 0 1px lighten( $gray, 10 );
+		border-radius: 3px;
+	}
+
+	.reader__post-title {
+		font-size: 18px;
+	}
+
+	.reader-post-byline {
+		display: none;
+	}
+
+	.post-excerpt .post-excerpt__text,
+	.reader__card .reader__full-post-content {
+		font-size: 13px;
+	}
+
+	.post-excerpt .post-excerpt__text {
+		line-height: 1.65;
+		max-height: 64px;
+	}
+
+	.post-excerpt-link {
+		display: none;
+	}
+
+	.reader__post-footer {
+		background: $gray-light;
+		border-top: 1px solid lighten( $gray, 20 );
+		position: absolute;
+			right: 0;
+			bottom: 0;
+			left: 0;
+		z-index: 1;
+		margin: 0;
+		padding: 6px 20px;
+		
+		li {
+			margin-right: 0;
+		}
+
+		.reader-share {
+			margin-right: auto;
+		}
+		.post-permalink,
+		.comment-button,
+		.reader__post-options {
+			display: none;
+		}
+	}
+
+	// Photo Only Posts
+	.card.reader__card.is-photo-only {
+		.reader__post-header {
+			z-index: 2;
+			background: rgba( $white, 0.95 );
+			padding: 8px;
+			margin: -8px;
+		}
+
+		.reader__post-featured-image {
+			position: absolute;
+				top: 0;
+				right: 0;
+				bottom: 41px;
+				left: 0;
+			border-radius: 0;
+			box-shadow: none;
+			max-height: 100%;
+			margin: 0;
+
+			img {
+				height: 100% !important; // Overriding the inline styles
+				width: 100% !important;
+				object-fit: cover;
+			}
+		}
+
+		.reader__post-title {
+			background: rgba( $white, 0.95 );
+			z-index: 1;
+			position: relative;
+			padding: 2px 8px 0;
+			margin-top: 22px;
+			margin-left: -8px;
+			margin-right: -8px;
+		}
+
+		.post-excerpt {
+			display: none;
+		}
+	}
+}

--- a/client/reader/liked-stream/_style.scss
+++ b/client/reader/liked-stream/_style.scss
@@ -1,4 +1,4 @@
-.my-likes {
+.my-likes__posts {
 	max-width: 100%;
 
 	.card.reader__card {

--- a/client/reader/liked-stream/_style.scss
+++ b/client/reader/liked-stream/_style.scss
@@ -7,6 +7,11 @@
 		height: 320px;
 		overflow: hidden;
 
+		@media (max-width: 748px) {
+			height: 220px;
+			margin-bottom: 4px;
+		}
+
 		@media (min-width: 748px) and (max-width: 1200px) {
 			width: calc( 50% - 12px );
 			margin-right: 24px;

--- a/client/reader/liked-stream/_style.scss
+++ b/client/reader/liked-stream/_style.scss
@@ -82,7 +82,7 @@
 	.reader__post-featured-image {
 		max-height: 100px;
 		width: calc( 100% + 16px );
-		left: -12px;
+		left: -8px;
 		box-shadow: 0 0 0 1px rgba( $gray, 0.2 );
 		border-bottom: 0;
 		border-radius: 3px;

--- a/client/reader/liked-stream/_style.scss
+++ b/client/reader/liked-stream/_style.scss
@@ -129,9 +129,14 @@
 		.reader-share {
 			margin-right: auto;
 		}
+
 		.post-permalink,
 		.reader__post-options {
 			display: none;
+		}
+
+		.like-button {
+			margin-left: 8px;
 		}
 	}
 }

--- a/client/reader/liked-stream/_style.scss
+++ b/client/reader/liked-stream/_style.scss
@@ -8,7 +8,6 @@
 		overflow: hidden;
 
 		@media (max-width: 748px) {
-			height: 220px;
 			margin-bottom: 4px;
 		}
 

--- a/client/reader/liked-stream/index.jsx
+++ b/client/reader/liked-stream/index.jsx
@@ -1,9 +1,11 @@
-var React = require( 'react' );
+// External dependencies
+import React from 'react' ;
 
-var FollowingStream = require( 'reader/following-stream' ),
-	EmptyContent = require( './empty' );
+// Internal dependencies
+import FollowingStream from 'reader/following-stream';
+import EmptyContent from './empty' ;
 
-var LikedStream = React.createClass( {
+const LikedStream = React.createClass( {
 
 	render: function() {
 		var title = this.translate( 'My Likes' ),
@@ -13,7 +15,7 @@ var LikedStream = React.createClass( {
 			this.props.setPageTitle( title );
 		}
 		return (
-			<FollowingStream { ...this.props } containerClass={ "my-likes" } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ true } />
+			<FollowingStream { ...this.props } containerClass={ "my-likes__posts" } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ true } />
 		);
 	}
 

--- a/client/reader/liked-stream/index.jsx
+++ b/client/reader/liked-stream/index.jsx
@@ -13,7 +13,7 @@ var LikedStream = React.createClass( {
 			this.props.setPageTitle( title );
 		}
 		return (
-			<FollowingStream { ...this.props } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ true } />
+			<FollowingStream { ...this.props } containerClass={ "my-likes" } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ true } />
 		);
 	}
 

--- a/client/reader/liked-stream/index.jsx
+++ b/client/reader/liked-stream/index.jsx
@@ -15,7 +15,7 @@ const LikedStream = React.createClass( {
 			this.props.setPageTitle( title );
 		}
 		return (
-			<FollowingStream { ...this.props } containerClass={ "my-likes__posts" } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ true } />
+			<FollowingStream { ...this.props } className={ "my-likes__posts" } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ true } />
 		);
 	}
 


### PR DESCRIPTION
The current Reader gives you a normal list of post cards based on your likes. This is all well and good, but you’ve already seen these posts. Lets make it a little easier (and quicker) to browse this collection of posts that you’ve liked.

Here's what my test account on WordPress.com looks like at a few random window sizes:

![screen shot 2015-12-21 at 3 19 25 pm](https://cloud.githubusercontent.com/assets/191598/11940383/4e67d9fe-a7f6-11e5-9e25-72bb75d796c6.png)

![screen shot 2015-12-21 at 3 19 31 pm](https://cloud.githubusercontent.com/assets/191598/11940390/538df81e-a7f6-11e5-9ccd-eb913d98b5db.png)

![screen shot 2015-12-21 at 3 19 41 pm](https://cloud.githubusercontent.com/assets/191598/11940396/5c4112b6-a7f6-11e5-9bbe-4b85966e5a6c.png)

![screen shot 2015-12-21 at 3 20 16 pm](https://cloud.githubusercontent.com/assets/191598/11940399/5ff9d9ec-a7f6-11e5-8b9e-86170075c824.png)
