### PR TITLE
Stats: track superProps when logged out

### DIFF
--- a/client/analytics/super-props.js
+++ b/client/analytics/super-props.js
@@ -14,7 +14,7 @@ module.exports = {
 			siteProps = {},
 			defaultProps = {
 				environment: config( 'env' ),
-				site_count: sites.data.length,
+				site_count: sites.data ? sites.data.length : 0,
 				site_id_label: 'wpcom',
 				client: config( 'tracks_client_prop' )
 			};

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -169,6 +169,8 @@ function boot() {
 			translatorInvitation: translatorInvitation
 		} ), document.getElementById( 'wpcom' ) );
 	} else {
+		analytics.setSuperProps( superProps );
+
 		if ( config.isEnabled( 'oauth' ) ) {
 			LoggedOutLayout = require( 'layout/logged-out-oauth' );
 		} else {


### PR DESCRIPTION
When logged out the `superProps` are not added to any recorded events. This means that the `client` property will be missing.

This PR ensures that the `client` event prop is recorded even when logged out.

To test:
- Visit `/start` when logged out and confirm that the super props are included with tracked events.