### PR TITLE
Docs: Spaces VS Vertical Spaces

### DIFF
--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -3,7 +3,7 @@ JavaScript Coding Guidelines
 
 ## Spacing
 
-Use spaces liberally throughout your code. “When in doubt, space it out.”
+Use vertical spaces liberally throughout your code. “When in doubt, space it out.”
 
 These rules encourage liberal spacing for improved developer readability. The minification process creates a file that is optimized for browsers to read and process.
 

--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -3,7 +3,7 @@ JavaScript Coding Guidelines
 
 ## Spacing
 
-Use sapcing liberally throughout your code. “When in doubt, space it out.”
+Use spacing liberally throughout your code. “When in doubt, space it out.”
 
 These rules encourage liberal spacing for improved developer readability. The minification process creates a file that is optimized for browsers to read and process.
 

--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -3,7 +3,7 @@ JavaScript Coding Guidelines
 
 ## Spacing
 
-Use vertical spaces liberally throughout your code. “When in doubt, space it out.”
+Use sapcing liberally throughout your code. “When in doubt, space it out.”
 
 These rules encourage liberal spacing for improved developer readability. The minification process creates a file that is optimized for browsers to read and process.
 


### PR DESCRIPTION
"Use spaces" can confuse a user about if the recommendation is using spaces over tabs or vertical spaces for code readability. So, I added the word "vertical".