### PR TITLE
Editor: Open window with previewUrl if it failed

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -628,8 +628,12 @@ var PostEditor = React.createClass( {
 		}
 
 		previewPost = function() {
-			this._previewWindow.location = this.state.previewUrl;
-			this._previewWindow.focus();
+			if ( this._previewWindow ) {
+				this._previewWindow.location = this.state.previewUrl;
+				this._previewWindow.focus();
+			} else {
+				this._previewWindow = window.open( this.state.previewUrl, 'WordPress.com Post Preview' );
+			}
 		}.bind( this );
 
 		if ( status === 'publish' ) {


### PR DESCRIPTION
In the desktop app `window.open( 'about:blank' )` causes issues, and the Jetpack preview fails.

This PR adds a check for `_previewWindow`. If it doesn't exist when displaying the `previewUrl` then directly open the window with the `previewUrl`.

Note: it may be possible to just create the window here in the first place but I am not sure if it is split for a reason