### PR TITLE
Signup: Fix TOS URL for other locales

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -25,6 +25,7 @@ import notices from 'notices'
 import Notice from 'notices/notice'
 import LoggedOutForm from 'signup/logged-out-form'
 import formState from 'lib/form-state'
+import i18n from 'lib/mixins/i18n'
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -317,6 +318,11 @@ export default React.createClass( {
 		)
 	},
 
+	getTermsOfServiceUrl() {
+		// locales where we don't have translated TOS will simply show the English one
+		return 'https://' + i18n.getLocaleSlug() + '.wordpress.com/tos/';
+	},
+
 	termsOfServiceLink() {
 		return (
 			<p className='signup-form__terms-of-service-link'>{
@@ -325,7 +331,7 @@ export default React.createClass( {
 					{
 						components: {
 							a: <a
-								href="https://en.wordpress.com/tos/"
+								href={ this.getTermsOfServiceUrl() }
 								onClick={ this.handleOnClickTos }
 								target="_blank" />
 						}


### PR DESCRIPTION
Fixes #723: Signup: Localize the link to Terms of Service

Please review the list of locales and the respective URLs.