### PR TITLE
Framework: Avoid picking Lodash modules from root export

### DIFF
--- a/client/accept-invite/invite-form-header/index.jsx
+++ b/client/accept-invite/invite-form-header/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { get } from 'lodash';
+import get from 'lodash/object/get';
 
 /**
  * Internal dependencies

--- a/client/accept-invite/invite-header/index.jsx
+++ b/client/accept-invite/invite-header/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import { get } from 'lodash';
+import get from 'lodash/object/get';
 
 /**
  * Internal dependencies

--- a/client/accept-invite/logged-out-invite/signup-form.jsx
+++ b/client/accept-invite/logged-out-invite/signup-form.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react'
-import { get } from 'lodash'
+import get from 'lodash/object/get'
 
 /**
  * Internal dependencies

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -3,7 +3,8 @@
  */
 import React, { PropTypes } from 'react';
 import Immutable from 'immutable';
-import { zip, contains } from 'lodash';
+import zip from 'lodash/array/zip';
+import includes from 'lodash/collection/includes';
 
 /**
  * Internal dependencies
@@ -48,7 +49,7 @@ export default React.createClass( {
 
 		let counts = this.props.settings
 			.deleteIn( [ 'email', 'achievement' ] )
-			.filterNot( ( _, key ) => contains( [ 'blog_id', 'devices' ], key ) )
+			.filterNot( ( _, key ) => includes( [ 'blog_id', 'devices' ], key ) )
 			.map( sizeAndSum )
 			.toArray();
 


### PR DESCRIPTION
This pull request seeks to import Lodash modules directly from their module subpath. This is much more efficient than picking from the base Lodash export, as the latter will cause the entire Lodash module to be included in any bundle for which the import is made. Arguably this should be the task of build optimizer / uglifier in eliminating dead code, but nonetheless the effect is noticeable.

__Before:__

![Before](https://cloud.githubusercontent.com/assets/1779930/11398465/ea5cc0a2-934e-11e5-8034-094ae6654d47.png)

__After:__

![After](https://cloud.githubusercontent.com/assets/1779930/11398462/de5335f2-934e-11e5-82e5-fa4ce77709a7.png)

Notable changes are in the `me`, `help`, and `accept-invite` bundles, with savings in each averaging 0.43MB.

__Implementation notes:__

I used this opportunity to switch `contains` with `includes`, as `contains` is an alias.

__Testing instructions:__

Verify that no errors occur when visiting any one of the affected components.

`<InviteHeader />` 12496-gh-calypso-pre-oss /cc @ebinnion , @roccotripaldi 

- Invite yourself to a site
- In the email you receive, you should get an invitation key
- Checkout `update/invite-placeholders`
- Go to `/accept-invite/$site/$invitation_key`
- For both logged in and logged out, do you see placeholders?
- Do the placeholders go away?
- Are there any errors?

`<InviteFormHeader />` #369 /cc @ebinnion , @lezama 

- Invite a test user to join a WordPress.com site by going to `Users > Invite New` in `wp-admin`
- In the invitation email, make note of the invitation key
- Go to `/accept-invite/$site/$invite_key` when you are both logged in and out
- Do the strings change between logged in and logged out?
- Now, go back to the invite users UI in `wp-admin`
- Invite the same user, but with a different role this time
- Refresh the tab that has Calypso loaded
- Do the strings represent the new role?

`<LoggedOutInviteSignupForm />` #623 /cc @lezama @roccotripaldi 

* invite a user to a blog and get the key from the email
* logout
* go to `calypso.dev:3000/accept-invite/_blog_id_/_invite_key`
* confirm that the email field is being pre-populated

`<BlogSettingsHeader />` 10667-gh-calypso-pre-oss /cc @rodrigoi @dmsnell 

Changes on the Blog Settings page accessible on http://calypso.localhost:3000/me/notifications or by clicking on the _Notifications_ link on the navigation bar. These changes only affect the list and it's behaviours. There should be no side effects on other pages.
- When a user with a single blog access this page, a single `Blog` component is rendered:
- When a user has many blogs, an `InfiniteList` component is rendered with as many `Blog` components as the page allows.
- When clicking on a site, a top and bottom margin is added and the arrow on the right side points up. This is when the settings form will get rendered in the future.
- The final PR will include all the performance improvements on the settings form.