### PR TITLE
Media: Prevent title from overlapping back button in detail view

### DIFF
--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -18,7 +18,7 @@
 		left: 50%;
 	transform: translate( -50%, -50% );
 	width: 200px;
-	width: calc( 100vw - 150px );
+	width: calc( 100vw - 175px );
 	word-break: normal;
 	white-space: nowrap;
 	overflow: hidden;


### PR DESCRIPTION
Before:
<img width="369" alt="screen shot 2015-11-25 at 9 08 17 am" src="https://cloud.githubusercontent.com/assets/5835847/11399260/1fe2631c-9354-11e5-8675-d1fd98f09fe0.png">

After: 
<img width="529" alt="screen shot 2015-11-25 at 9 07 35 am" src="https://cloud.githubusercontent.com/assets/5835847/11399261/1fe36960-9354-11e5-8978-87f3775c155c.png">

To test: 
Most noticeable on a phone (iPhone 6+ or similar/smaller size) 

Go to /post, choose a site, press the Add Media button, select a photo and press the edit button that overlays the photo. Notice the `< Library` button is no longer being obscured by the title input. 