### PR TITLE
Support suggesting domain through /domains/add path

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -40,7 +40,8 @@ var RegisterDomainStep = React.createClass( {
 		onDomainsAvailabilityChange: React.PropTypes.func,
 		products: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.object, React.PropTypes.bool ] ),
-		basePath: React.PropTypes.string.isRequired
+		basePath: React.PropTypes.string.isRequired,
+		suggestion: React.PropTypes.string,
 	},
 
 	getDefaultProps: function() {
@@ -51,14 +52,16 @@ var RegisterDomainStep = React.createClass( {
 	},
 
 	getInitialState: function() {
+		const suggestion = this.props.suggestion ? getFixedDomainSearch( this.props.suggestion ) : '';
+
 		return {
 			clickedExampleSuggestion: false,
-			lastQuery: null,
+			lastQuery: suggestion,
 			searchResults: null,
 			defaultSuggestions: null,
 			lastDomainSearched: null,
 			lastDomainError: null,
-			loadingResults: false,
+			loadingResults: Boolean( suggestion ),
 			notice: null
 		};
 	},

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -23,7 +23,8 @@ module.exports = React.createClass( {
 	propTypes: {
 		sites: React.PropTypes.object.isRequired,
 		productsList: React.PropTypes.object.isRequired,
-		basePath: React.PropTypes.string.isRequired
+		basePath: React.PropTypes.string.isRequired,
+		context: React.PropTypes.object.isRequired,
 	},
 
 	getInitialState: function() {
@@ -80,6 +81,7 @@ module.exports = React.createClass( {
 
 					<RegisterDomainStep
 						path={ this.props.context.path }
+						suggestion={ this.props.context.params.suggestion }
 						onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
 						cart={ this.props.cart }
 						selectedSite={ selectedSite }

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -206,6 +206,15 @@ module.exports = function() {
 			upgradesController.domainSearch
 		);
 
+		page( '/domains/add/suggestion/:suggestion/:domain',
+			adTracking.retarget,
+			controller.siteSelection,
+			controller.navigation,
+			upgradesController.redirectIfNoSite( '/domains/add' ),
+			controller.jetPackWarning,
+			upgradesController.domainSearch
+		);
+
 		page( '/domains/add/:registerDomain/google-apps/:domain',
 			adTracking.retarget,
 			controller.siteSelection,


### PR DESCRIPTION
In wp-admin the user was suggested a domain in a tip (or if the domain was prefilled when buying a bundle) and could follow a link to register that domain. This PR extends the existing `/domains/add` path to support an optional `suggestion` parameter that will prefill the search field, if present. This will allow a smoother transition from wp-admin to calypso.

Testing:

1. Visit `http://calypso.localhost:3000/domains/add/yourtestblog.wordpress.com` - everything should be as it was before, empty search field with default domain suggestions based on your `*.wordpress.com` domain.
2. Visit `http://calypso.localhost:3000/domains/add/gryffins/yourtestblog.wordpress.com` and verify that `gryffins` is in the search field and different TLDs for that search query are present.
3. Visit `http://calypso.localhost:3000/domains/add/gryffins4life.biz/yourtestblog.wordpress.com` and verify that `gryffins4life.biz` is in the search field, different TLDs for that search query are present and a green box allowing you to add this domain is present.

cc @dzver