### PR TITLE
Editor: Update sharing container to use selected site from Redux state

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -11,6 +11,8 @@ var page = require( 'page' ),
 var user = require( 'lib/user' )(),
 	sites = require( 'lib/sites-list' )(),
 	layoutFocus = require( 'lib/layout-focus' ),
+	sitesActions = require( 'state/sites/actions' ),
+	uiActions = require( 'state/ui/actions' ),
 	NavigationComponent = require( 'my-sites/navigation' ),
 	route = require( 'lib/route' ),
 	i18n = require( 'lib/mixins/i18n' ),
@@ -131,6 +133,13 @@ module.exports = {
 			return next();
 		}
 
+		function onSelectedSiteAvailable() {
+			var selectedSite = sites.getSelectedSite();
+			siteStatsStickyTabActions.saveFilterAndSlug( false, selectedSite.slug );
+			context.store.dispatch( sitesActions.receiveSite( selectedSite ) );
+			context.store.dispatch( uiActions.setSelectedSite( selectedSite.ID ) );
+		}
+
 		// If there's a valid site from the url path
 		// set site visibility to just that site on the picker
 		if ( ! sites.select( siteID ) ) {
@@ -146,10 +155,10 @@ module.exports = {
 					page.redirect( allSitesPath );
 				}
 
-				siteStatsStickyTabActions.saveFilterAndSlug( false, sites.getSelectedSite().slug );
+				onSelectedSiteAvailable();
 			} );
 		} else {
-			siteStatsStickyTabActions.saveFilterAndSlug( false, sites.getSelectedSite().slug );
+			onSelectedSiteAvailable();
 		}
 
 		next();

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -120,7 +120,7 @@ var EditorDrawer = React.createClass( {
 		}
 
 		return (
-			<EditorSharingContainer site={ this.props.site } currentUserID={ currentUser.ID } />
+			<EditorSharingContainer currentUserID={ currentUser.ID } />
 		);
 	},
 

--- a/client/post-editor/editor-sharing/container.jsx
+++ b/client/post-editor/editor-sharing/container.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import PostEditStore from 'lib/posts/post-edit-store';
 import { fetchConnections } from 'state/sharing/publicize/actions';
 import { getConnectionsBySiteIdAvailableToCurrentUser, hasFetchedConnections } from 'state/sharing/publicize/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import EditorSharingAccordion from './accordion';
 
 class EditorSharingContainer extends Component {
@@ -88,10 +89,12 @@ EditorSharingContainer.propTypes = {
 };
 
 export default connect(
-	( state, props ) => {
+	( state, ownProps ) => {
+		const site = getSelectedSite( state );
 		return {
-			hasFetchedConnections: props.site && hasFetchedConnections( state, props.site.ID ),
-			connections: props.site ? getConnectionsBySiteIdAvailableToCurrentUser( state, props.site.ID, props.currentUserID ) : null
+			hasFetchedConnections: site && hasFetchedConnections( state, site.ID ),
+			connections: site ? getConnectionsBySiteIdAvailableToCurrentUser( state, site.ID, ownProps.currentUserID ) : null,
+			site
 		};
 	}
 )( EditorSharingContainer );


### PR DESCRIPTION
~~Blocked by #751~~

This pull request seeks to make use of the new sites module introduced in #751 to eliminate the dependency on the `sites-list` site object passed to the `<EditorSharingContainer />` component. It also includes the necessary wiring to ensure that the selected site is assigned in the My Sites `selectedSite` middleware function, and that the sites reducers are included in the global reducer.

__Testing instructions:__

Verify that post editor Publicize connections are accurate for the site visited, that no errors are shown in the developer tools console, and that Publicize connections update upon changing the selected site in the post editor.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Note that the Sharing accordion displays with a loading indicator and is replaced with the set of Publicize connections available for that site (or blank if no Publicize connections)
4. Change the selected site from the New Post button
5. Note that the Publicize connections update to reflect the connections available for the newly selected site