### PR TITLE
Editor: Prevent media inline toolbar from bleeding through when viewing the sidebar

### DIFF
--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -104,6 +104,7 @@
 		margin: 0;
 		padding: 0 20%;
 		position: absolute;
+		z-index: 100100; /* Same as the other TinyMCE "panels" */
 		transform: translateX( -100vw );
 		transition: all 0.15s cubic-bezier(0.770, 0.000, 0.175, 1.000);
 


### PR DESCRIPTION
Occurs in screen sizes smaller than 660px wide. (Mobile device or an emulator) 

This fix assigns the same z-index TinyMCE to the sidebar as uses for its panels.

To test: Go to /post, choose a site, insert an image, select the image so the inline toolbar appears and press the Actions bar on the top of the page to open the sidebar. Ensure that the toolbar is no longer bleeding through: 

<img width="361" alt="screen shot 2015-11-25 at 10 39 44 am" src="https://cloud.githubusercontent.com/assets/5835847/11401520/e5ab9ce2-9360-11e5-803b-cedf2807cc1e.png">