### PR TITLE
Framework: Use key-mirror in place of react/lib/keyMirror

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1213,3 +1213,16 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
+
+### https://github.com/wmira/key-mirror
+```text
+The MIT License (MIT)
+
+Copyright (c) 2015 Warren Mira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/client/lib/comment-like-store/constants.js
+++ b/client/lib/comment-like-store/constants.js
@@ -1,5 +1,5 @@
 // External Dependencies
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	LIKE_COMMENT: null,

--- a/client/lib/comment-store/constants.js
+++ b/client/lib/comment-store/constants.js
@@ -1,5 +1,5 @@
 // External Dependencies
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	ADD_COMMENT: null,

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -1,4 +1,4 @@
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.type = keyMirror( {
 	MAPPED: null,

--- a/client/lib/dss/constants.js
+++ b/client/lib/dss/constants.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'key-mirror';
 
 /**
  * Module variables

--- a/client/lib/feed-post-store/constants.js
+++ b/client/lib/feed-post-store/constants.js
@@ -1,3 +1,3 @@
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports = { action: keyMirror( { FETCH_FEED_POST: null, RECEIVE_FEED_POST: null } ) };

--- a/client/lib/happiness-engineers/constants.js
+++ b/client/lib/happiness-engineers/constants.js
@@ -1,4 +1,4 @@
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	SET_HAPPPINESS_ENGINEERS: null

--- a/client/lib/help-search/constants.js
+++ b/client/lib/help-search/constants.js
@@ -1,4 +1,4 @@
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	SET_HELP_LINKS: null

--- a/client/lib/invites/constants.js
+++ b/client/lib/invites/constants.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'key-mirror';
 
 /**
  * Module variables

--- a/client/lib/media/constants.js
+++ b/client/lib/media/constants.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'key-mirror';
 
 /**
  * An enum set of possible media validation errors.

--- a/client/lib/oauth-store/constants.js
+++ b/client/lib/oauth-store/constants.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'key-mirror';
 
 module.exports = {
 	actions: keyMirror( {

--- a/client/lib/olark-store/constants.js
+++ b/client/lib/olark-store/constants.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'key-mirror';
 
 /**
  * Module variables

--- a/client/lib/reader-comment-email-subscriptions/constants.js
+++ b/client/lib/reader-comment-email-subscriptions/constants.js
@@ -1,5 +1,5 @@
 // External Dependencies
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	SUBSCRIBE_TO_COMMENT_EMAILS: null,

--- a/client/lib/reader-feed-subscriptions/constants.js
+++ b/client/lib/reader-feed-subscriptions/constants.js
@@ -1,5 +1,5 @@
 // External Dependencies
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	FOLLOW_READER_FEED: null,

--- a/client/lib/reader-post-email-subscriptions/constants.js
+++ b/client/lib/reader-post-email-subscriptions/constants.js
@@ -1,5 +1,5 @@
 // External Dependencies
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	SUBSCRIBE_TO_POST_EMAILS: null,

--- a/client/lib/reader-site-blocks/constants.js
+++ b/client/lib/reader-site-blocks/constants.js
@@ -1,5 +1,5 @@
 // External Dependencies
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	BLOCK_SITE: null,

--- a/client/lib/reader-teams/constants.js
+++ b/client/lib/reader-teams/constants.js
@@ -1,5 +1,5 @@
 // External Dependencies
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	RECEIVE_TEAMS: null,

--- a/client/lib/security-checkup/constants.js
+++ b/client/lib/security-checkup/constants.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 /**
  * Internal dependencies

--- a/client/lib/terms/constants.js
+++ b/client/lib/terms/constants.js
@@ -1,5 +1,5 @@
 // External Dependencies
-var keyMirror = require( 'react/lib/keyMirror' );
+var keyMirror = require( 'key-mirror' );
 
 module.exports.MAX_TAGS = 1000;
 module.exports.MAX_TAGS_SUGGESTIONS = 20;

--- a/client/lib/upgrades/constants.js
+++ b/client/lib/upgrades/constants.js
@@ -1,4 +1,4 @@
-const keyMirror = require( 'react/lib/keyMirror' );
+const keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	ADD_CART_ITEM: null,

--- a/client/me/security-checkup/manage-contact.jsx
+++ b/client/me/security-checkup/manage-contact.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	keyMirror = require( 'react/lib/keyMirror' ),
+	keyMirror = require( 'key-mirror' ),
 	assign = require( 'lodash/object/assign' );
 
 /**

--- a/client/post-editor/media-modal/constants.js
+++ b/client/post-editor/media-modal/constants.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'key-mirror';
 
 export const Views = keyMirror( {
 	LIST: null,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jed": "1.0.2",
     "json-loader": "0.5.1",
     "jstimezonedetect": "1.0.5",
+    "key-mirror": "1.0.1",
     "keymaster": "1.6.2",
     "lodash": "3.10.1",
     "lunr": "0.5.7",
@@ -89,8 +90,8 @@
     "walk": "2.3.4",
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom-unpublished": "1.0.5",
     "wpcom-proxy-request": "1.0.5",
+    "wpcom-unpublished": "1.0.5",
     "wpcom-xhr-request": "0.3.3",
     "xgettext-js": "0.2.0"
   },

--- a/shared/lib/screen-title/constants.js
+++ b/shared/lib/screen-title/constants.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'key-mirror';
 
 const actionTypes = keyMirror( {
 	SET_TITLE: null,

--- a/shared/lib/themes/constants.js
+++ b/shared/lib/themes/constants.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var assign = require( 'lodash/object/assign' ),
-	keyMirror = require( 'react/lib/keyMirror' );
+	keyMirror = require( 'key-mirror' );
 
 module.exports = assign( keyMirror( {
 


### PR DESCRIPTION
Related: #786, #787

This pull request seeks to replace existing usage of the `react/lib/keyMirror` module with the standalone [`key-mirror` package](https://github.com/wmira/key-mirror). This is a prerequisite for upgrading to React 0.14. Facebook has moved library modules to a separate package, which they warn against using.

>Note: If you are consuming the code here and you are not also a Facebook project, be prepared for a bad time. APIs may appear or disappear and we may not follow semver strictly, though we will do our best to. This library is being published with our use cases in mind and is not necessarily meant to be consumed by the broader public.

https://github.com/facebook/fbjs

__Testing instructions:__

Ensure that no references remain for `react/lib/keyMirror`. Verify also that the application continues to load, especially for pages making use of `key-mirror` functionality.

/cc @blowery 11943-gh-calypso-pre-oss