### PR TITLE
Editor: Remove inner box shadow on Excerpt textarea

### DIFF
--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -43,6 +43,7 @@
 	font-size: 13px;
 	font-family: $serif;
 	resize: vertical;
+	-webkit-appearance: none;
 }
 
 .editor-drawer .editor-delete-post::before {


### PR DESCRIPTION
The Excerpt textarea has an inner shadow in mobile Safari. 

Before:
<img width="363" alt="screen shot 2015-11-25 at 12 02 36 pm" src="https://cloud.githubusercontent.com/assets/5835847/11403748/75245002-936c-11e5-8323-da597324074e.png">

After: 
<img width="362" alt="screen shot 2015-11-25 at 12 02 27 pm" src="https://cloud.githubusercontent.com/assets/5835847/11403749/75249ff8-936c-11e5-8a12-9245313c4372.png">

To test it go to /post, choose a site, press Actions button on the top, and expand More Options.