### PR TITLE
Purchases: Domain cancellation: confirm button enabled before user co…

### DIFF
--- a/client/me/purchases/confirm-cancel-purchase/load-endpoint-form.js
+++ b/client/me/purchases/confirm-cancel-purchase/load-endpoint-form.js
@@ -92,35 +92,33 @@ function getFormData( { form, selectedPurchase, selectedSite } ) {
 function initializeDomainCancelForm( options ) {
 	const { form } = options,
 		domainCancelReason = form.querySelector( '#domain_cancel_reason' ),
-		confirmCheckbox = form.querySelector( '#confirm' ),
-		submitButton = form.querySelector( 'input[type=submit]' );
+		reasonsDiv = form.querySelector( '#domain_cancel_reasons' );
 
-	submitButton.disabled = ! form.querySelector( '#confirm' ).checked;
+	domainCancelReason.addEventListener( 'change', ( event ) => {
+		showDomainCancelReasonDetail( reasonsDiv, event.target.value );
+	} );
+
+	toArray( reasonsDiv.children ).forEach( ( div ) => {
+		const confirmCheckbox = div.querySelector( 'input[type=checkbox]' ),
+			submitButton = div.querySelector( 'input[type=submit]' );
+
+		if ( confirmCheckbox && submitButton ) {
+			submitButton.disabled = ! confirmCheckbox.checked;
+
+			confirmCheckbox.addEventListener( 'click', ( event ) => {
+				submitButton.disabled = ! event.target.checked;
+			} );
+		}
+	} );
 
 	form.addEventListener( 'submit', ( event ) => {
 		event.preventDefault();
 
-		if ( ! form.querySelector( '#confirm' ).checked ) {
-			return;
-		}
-
 		submitForm( options );
-	} );
-
-	domainCancelReason.addEventListener( 'change', ( event ) => {
-		showDomainReasonDetail( {
-			form,
-			selectValue: event.target.value
-		} );
-	} );
-
-	confirmCheckbox.addEventListener( 'click', ( event ) => {
-		submitButton.disabled = ! event.target.checked;
 	} );
 }
 
-function showDomainReasonDetail( { form, selectValue } ) {
-	const reasonsDiv = form.querySelector( '#domain_cancel_reasons' );
+function showDomainCancelReasonDetail( reasonsDiv, selectValue ) {
 	toArray( reasonsDiv.children ).forEach( ( div ) => div.className = 'hidden' );
 
 	let selected;


### PR DESCRIPTION
…nfirmed understanding terms

When cancelling a domain, if I select "The service isn't what I expected" / "I meant to get a free blog" / "Something not listed here" in the Confirm Cancellation screen, the Cancel Domain button is enabled right away.

It should only be enabled once the user has checked "I understand that canceling means that I may lose this domain forever".

### Testing
1. Go to http://calypso.localhost:3000/purchases.
2. Select domain purchased in last 48h.
3. Go to `Cancel and Refund` page.
4. Go to `Confirm Cancel Purchase` page.
5. Submit button should only be enabled once the user has checked "I understand that canceling means that I may lose this domain forever".

**Note:** When you send one request to Cancel Domain Purchase mail is sent. When you go again to Cancel Confirmation page the following message is displayed:
This upgrade cannot be cancelled.

### Testing
* [x] Code review
* [x] QA review

/cc @fabianapsimoes 