### PR TITLE
Framework: Use warn module in place of react/lib/warn

### DIFF
--- a/client/lib/warn/index.js
+++ b/client/lib/warn/index.js
@@ -1,16 +1,13 @@
 /**
  * Internal Dependencies
  */
-var config = require( 'config' );
+import config from 'config';
 
-function warn() {
-	if ( config( 'env' ) !== 'production' ) {
-		try {
-			window.console.warn.apply( window.console, arguments );
-		} catch ( e ) {
-			// Squelch
-		}
-	}
+let warn;
+if ( config( 'env' ) !== 'production' && 'function' === typeof console.warn ) {
+	warn = console.warn.bind( console );
+} else {
+	warn = () => {};
 }
 
-module.exports = warn;
+export default warn;

--- a/client/lib/warn/index.js
+++ b/client/lib/warn/index.js
@@ -5,9 +5,11 @@ var config = require( 'config' );
 
 function warn() {
 	if ( config( 'env' ) !== 'production' ) {
-		try{
+		try {
 			window.console.warn.apply( window.console, arguments );
-		} catch( e ) {}
+		} catch ( e ) {
+			// Squelch
+		}
 	}
 }
 

--- a/shared/lib/formatting/index.js
+++ b/shared/lib/formatting/index.js
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 var trim = require( 'lodash/string/trim' ),
-	warning = require( 'react/lib/warning' );
+	warn = require( 'lib/warn' );
 
 /**
  * Internal Dependencies
@@ -11,7 +11,7 @@ var decode = require( './decode-entities' );
 
 function decodeEntities( text ) {
 	if ( text === undefined || text === false || text === null ) {
-		warning( false, 'Don\'t call `decodeEntities` with an `undefined`, `false`, or `null` value.' );
+		warn( 'Don\'t call `decodeEntities` with an `undefined`, `false`, or `null` value.' );
 		return text;
 	}
 


### PR DESCRIPTION
Related: #786, #776

This pull request seeks to replace existing usage of the `react/lib/warn` module with our own existing [`warn` module](https://github.com/Automattic/wp-calypso/tree/master/client/lib/warn). This is a prerequisite for upgrading to React 0.14. Facebook has moved library modules to a separate package, which they warn against using.

>Note: If you are consuming the code here and you are not also a Facebook project, be prepared for a bad time. APIs may appear or disappear and we may not follow semver strictly, though we will do our best to. This library is being published with our use cases in mind and is not necessarily meant to be consumed by the broader public.

https://github.com/facebook/fbjs

__Testing instructions:__

Ensure that no references remain for `react/lib/warn`.

/cc @blowery 11943-gh-calypso-pre-oss