### PR TITLE
Editor: Cast category IDs to strings for compat reasons

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -89,7 +89,9 @@ function normalizeApiAttributes( attributes ) {
 	}
 
 	if ( attributes.categories ) {
-		attributes.categories_by_id = attributes.categories;
+		// Force category IDs to strings to work with ctype_digit in some versions of the API.
+		// (ctype_digit returns false for integers between -128 and 255).
+		attributes.categories_by_id = attributes.categories.map( category => category.toString() );
 		delete attributes.category_ids;
 		delete attributes.categories;
 	}


### PR DESCRIPTION
Some versions of the API use `ctype_digit` to validate numbers. `ctype_digit` returns false for integers between -128 and 255. Some versions of Calypso (namely Desktop app) send category IDs as integers which means that if the category ID is between 1 and 255, it will always fail to be added to the post.

By forcing it to a string, we can make it always work.

## To Test

Repeat the following with a Jetpack blog and a WP.com blog:

- Add new post
- Set a category
- Save
- Make sure category sticks
- Try setting a category where ID <= 255
- Make sure it sticks

Repeat the above by checking about the branch in the desktop app as well.