### PR TITLE
Plugins: Update/remove link with info popover

### DIFF
--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -22,14 +22,14 @@ module.exports = React.createClass( {
 		}
 	},
 
-	renderLabel: function( id ) {
+	renderLabel: function() {
 		if ( this.props.label ) {
 			return (
 				<label
 					className="plugin-action__label"
 					ref="disabledInfoLabel"
 					onClick={ this.handleAction }
-					htmlFor={ id }
+					htmlFor={ this.props.htmlFor }
 					>
 					{ this.props.label }
 				</label>
@@ -38,53 +38,62 @@ module.exports = React.createClass( {
 		return null;
 	},
 
-	renderToggle: function( id ) {
-		if ( this.props.disabledInfo ) {
-			return (
-				<div className="plugin-action__disabled-info">
-					<InfoPopover
-						position="bottom left"
-						popoverName={ 'Plugin Action Disabled' + this.props.label }
-						gaEventCategory="Plugins"
-						ref="infoPopover"
-						ignoreContext={ this.refs && this.refs.disabledInfoLabel }
-						>
-						{ this.props.disabledInfo }
-					</InfoPopover>
-					{ this.renderLabel( id ) }
-				</div>
-			);
-		}
+	renderDisabledInfo: function() {
+		return (
+			<div className="plugin-action__disabled-info">
+				<InfoPopover
+					position="bottom left"
+					popoverName={ 'Plugin Action Disabled' + this.props.label }
+					gaEventCategory="Plugins"
+					ref="infoPopover"
+					ignoreContext={ this.refs && this.refs.disabledInfoLabel }
+					>
+					{ this.props.disabledInfo }
+				</InfoPopover>
+				{ this.renderLabel() }
+			</div>
+		);
+	},
+
+	renderToggle: function() {
 		return (
 			<CompactToggle
 				onChange={ this.props.action }
 				checked={ this.props.status }
 				toggling={ this.props.inProgress }
 				disabled={ this.props.disabled }
-				id={ id }
+				id={ this.props.htmlFor }
 			>
-				{ this.renderLabel( id ) }
+				{ this.renderLabel() }
 			</CompactToggle>
 		);
 	},
 
-	renderChildren: function( id ) {
+	renderChildren: function() {
 		return (
 			<div>
 				<span className="plugin-action__children">{ this.props.children }</span>
-				{ this.renderLabel( id ) }
+				{ this.renderLabel() }
 			</div>
 		);
 	},
 
+	renderInner: function() {
+		if ( this.props.disabledInfo ) {
+			return this.renderDisabledInfo();
+		}
+
+		if ( 0 < React.Children.count( this.props.children ) ) {
+			return this.renderChildren();
+		}
+
+		return this.renderToggle();
+	},
+
 	render: function() {
-		var id = this.props.htmlFor;
 		return (
 			<div className={ classNames( 'plugin-action', this.props.className ) }>
-				{ 0 < React.Children.count( this.props.children )
-					? this.renderChildren( id )
-					: this.renderToggle( id )
-				}
+				{ this.renderInner() }
 			</div>
 		);
 	}

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -30,6 +30,7 @@ module.exports = React.createClass( {
 					ref="disabledInfoLabel"
 					onClick={ this.handleAction }
 					htmlFor={ this.props.htmlFor }
+					key="renderDisabledInfoLabel"
 					>
 					{ this.props.label }
 				</label>
@@ -39,9 +40,9 @@ module.exports = React.createClass( {
 	},
 
 	renderDisabledInfo: function() {
-		return (
-			<div className="plugin-action__disabled-info">
-				<InfoPopover
+		return [ <InfoPopover
+					key="renderDisabledInfoPopOver"
+					className="plugin-action__disabled-info"
 					position="bottom left"
 					popoverName={ 'Plugin Action Disabled' + this.props.label }
 					gaEventCategory="Plugins"
@@ -49,10 +50,7 @@ module.exports = React.createClass( {
 					ignoreContext={ this.refs && this.refs.disabledInfoLabel }
 					>
 					{ this.props.disabledInfo }
-				</InfoPopover>
-				{ this.renderLabel() }
-			</div>
-		);
+				</InfoPopover>, this.renderLabel() ];
 	},
 
 	renderToggle: function() {

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -43,7 +43,7 @@
 .plugin-action__children .noticon {
 	margin-left: 8px;
 }
-.plugin-action__disabled-info .info-popover {
+.plugin-action__disabled-info.info-popover {
 	float: right;
 	margin: 0 3px;
 }

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -1,45 +1,43 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	config = require( 'config' );
+import React from 'react';
+import config from 'config';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'analytics' ),
-	accept = require( 'lib/accept' ),
-	Gridicon = require( 'components/gridicon' ),
-	PluginsLog = require( 'lib/plugins/log-store' ),
-	PluginAction = require( 'my-sites/plugins/plugin-action/plugin-action' ),
-	PluginsActions = require( 'lib/plugins/actions' ),
-	ExternalLink = require( 'components/external-link' ),
-	analytics = require( 'analytics' ),
-	utils = require( 'lib/site/utils' );
+import analytics from 'analytics';
+import accept from 'lib/accept';
+import Gridicon from 'components/gridicon';
+import PluginsLog from 'lib/plugins/log-store';
+import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
+import PluginsActions from 'lib/plugins/actions';
+import ExternalLink from 'components/external-link';
+import utils from 'lib/site/utils';
 
 module.exports = React.createClass( {
 
 	displayName: 'PluginRemoveButton',
 
-	removeAction: function() {
-		accept(
-			this.translate( 'Are you sure you want to remove {{strong}}%(pluginName)s{{/strong}} from %(siteName)s? {{br /}} {{em}}This will deactivate the plugin and delete all associated files and data.{{/em}}', {
-				components: {
-					em: <em />,
-					br: <br />,
-					strong: <strong />
-				},
-				args: {
-					pluginName: this.props.plugin.name,
-					siteName: this.props.site.title
-				}
-			} ),
+	removeAction() {
+		accept( this.translate( 'Are you sure you want to remove {{strong}}%(pluginName)s{{/strong}} from %(siteName)s? {{br /}} {{em}}This will deactivate the plugin and delete all associated files and data.{{/em}}', {
+			components: {
+				em: <em />,
+				br: <br />,
+				strong: <strong />
+			},
+			args: {
+				pluginName: this.props.plugin.name,
+				siteName: this.props.site.title
+			}
+		} ),
 			this.processRemovalConfirmation,
 			this.translate( 'Remove' )
 		);
 	},
 
-	processRemovalConfirmation: function( accepted ) {
+	processRemovalConfirmation( accepted ) {
 		if ( accepted ) {
 			PluginsActions.removePluginsNotices( this.props.notices.completed.concat( this.props.notices.errors ) );
 			PluginsActions.removePlugin( this.props.site, this.props.plugin );
@@ -60,7 +58,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	getDisabledInfo: function() {
+	getDisabledInfo() {
 		if ( ! this.props.site ) { // we don't have enough info
 			return null;
 		}
@@ -87,7 +85,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( ! this.props.site.canUpdateFiles && this.props.site.options.file_mod_disabled ) {
-			let reasons = utils.getSiteFileModDisableReason( this.props.site );
+			const reasons = utils.getSiteFileModDisableReason( this.props.site );
 			let html = [];
 
 			if ( reasons.length > 1 ) {
@@ -100,20 +98,17 @@ module.exports = React.createClass( {
 				html.push( <ul className="plugin-action__disabled-info-list" key="reason-shell-list">{ list }</ul> );
 			} else {
 				html.push(
-					<p key="reason-shell">{
-						this.translate( '%(pluginName)s cannot be removed. %(reason)s', {
-							args: { pluginName: this.props.plugin.name, reason: reasons[0] }
-						} )
-					}</p> );
+					<p key="reason-shell">
+						{ this.translate( '%(pluginName)s cannot be removed. %(reason)s', { args: { pluginName: this.props.plugin.name, reason: reasons[0] } } ) }
+					</p>
+				);
 			}
 			html.push(
 				<ExternalLink
 					key="external-link"
-					onClick={
-						analytics.ga.recordEvent.bind( this, 'Plugins', 'Clicked How do I fix diabled plugin removal.' )
-					}
+					onClick={ analytics.ga.recordEvent.bind( this, 'Plugins', 'Clicked How do I fix diabled plugin removal.' ) }
 					href="https://jetpack.me/support/site-management/#file-update-disabled"
-					>
+				>
 					{ this.translate( 'How do I fix this?' ) }
 				</ExternalLink>
 			);
@@ -123,14 +118,16 @@ module.exports = React.createClass( {
 		return null;
 	},
 
-	renderButton: function() {
-		var inProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, [ 'REMOVE_PLUGIN' ] ),
-			getDisabledInfo = this.getDisabledInfo(),
-			label = getDisabledInfo
-				? this.translate( 'Removal Disabled', {
-					context: 'this goes next to an icon that displays if site is in a state where it can\'t modify has "Removal Disabled" '
-				} )
-				: this.translate( 'Remove', { context: 'Verb. Presented to user as a label for a button.' } );
+	renderButton() {
+		const inProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, [
+			'REMOVE_PLUGIN'
+		] );
+		const getDisabledInfo = this.getDisabledInfo();
+		const label = getDisabledInfo
+			? this.translate( 'Removal Disabled', {
+				context: 'this goes next to an icon that displays if site is in a state where it can\'t modify has "Removal Disabled" '
+			} )
+			: this.translate( 'Remove', { context: 'Verb. Presented to user as a label for a button.' } );
 		if ( inProgress ) {
 			return (
 				<span className="plugin-action plugin-remove-button__remove">
@@ -140,20 +137,20 @@ module.exports = React.createClass( {
 		}
 		return (
 			<PluginAction
-					label={ label }
-					htmlFor={ 'remove-plugin-' + this.props.site.ID }
-					action={ this.removeAction }
-					disabledInfo={ getDisabledInfo }
-					className="plugin-remove-button__remove-link"
-					>
-						<a onClick={ this.removeAction } >
-							<Gridicon icon="trash" size={ 18 } />
-						</a>
-				</PluginAction>
+				label={ label }
+				htmlFor={ 'remove-plugin-' + this.props.site.ID }
+				action={ this.removeAction }
+				disabledInfo={ getDisabledInfo }
+				className="plugin-remove-button__remove-link"
+			>
+				<a onClick={ this.removeAction } >
+					<Gridicon icon="trash" size={ 18 } />
+				</a>;
+			</PluginAction>
 		);
 	},
 
-	render: function() {
+	render() {
 		if ( ! this.props.site.jetpack ) {
 			return null;
 		}


### PR DESCRIPTION
Update the remove action to also who the reason why a plugin can't be removed from a site.

Before: 
<img width="739" alt="screen shot 2015-11-25 at 12 12 38 pm" src="https://cloud.githubusercontent.com/assets/115071/11408436/f20dcf34-936d-11e5-84e6-e125da52ae86.png">
After:
<img width="839" alt="screen shot 2015-11-25 at 11 51 48 am" src="https://cloud.githubusercontent.com/assets/115071/11408438/f40b17d8-936d-11e5-87e2-e251175ef5f7.png">

<img width="853" alt="screen_shot_2015-12-02_at_12_48_41" src="https://cloud.githubusercontent.com/assets/115071/11543730/208915f0-98f3-11e5-8c35-fc76375349eb.png">


**To test** remove the ability to update files on a site 
via 
``` 
 define( 'FS_METHOD', 'ssh2' );
 define( 'DISALLOW_FILE_MODS',true );
 define( 'WP_AUTO_UPDATE_CORE', false );
 define( 'AUTOMATIC_UPDATER_DISABLED', true );
```

Visit the single plugin: 
For example https://wordpress.com/plugins/akismet
or the single plugin view for a site. 
https://wordpress.com/plugins/akismet/example.com