### PR TITLE
Reader comments: fix escaping of comments without a state property

### DIFF
--- a/client/reader/comments/post-comment-content.jsx
+++ b/client/reader/comments/post-comment-content.jsx
@@ -7,12 +7,12 @@ const PostCommentContent = React.createClass( {
 
 	propTypes: {
 		content: PropTypes.string.isRequired,
-		state: PropTypes.string.isRequired,
+		state: PropTypes.string,
 	},
 
 	render() {
 		// Don't trust comment content unless it was provided by the API
-		if ( this.props.state !== CommentConstants.state.COMPLETE ) {
+		if ( this.props.state === CommentConstants.state.PENDING ) {
 			return <div className="comment__content">{ this.props.content }</div>;
 		}
 


### PR DESCRIPTION
An earlier PR (#620) started escaping the output of Reader comments when the comment.state was not _COMPLETED_.

Unfortunately, the comment store does not apply this status on existing comments, so legitimate comments from the API were being escaped (e.g. http://wordpress.com/read/post/feed/26771/873202123):

![screen shot 2015-11-25 at 20 42 10](https://cloud.githubusercontent.com/assets/17325/11409013/053287b6-93b5-11e5-9c28-052a6d5ef3db.png)
