### PR TITLE
Framework: Add new component: RemoveButton

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -102,6 +102,7 @@
 @import 'components/plans/plan-price/style';
 @import 'components/plans/plans-compare/style';
 @import 'components/post-schedule/style';
+@import 'components/remove-button/style';
 @import 'components/section-header/style';
 @import 'components/signup-form/style';
 @import 'components/tooltip/style';

--- a/client/components/remove-button/README.md
+++ b/client/components/remove-button/README.md
@@ -6,7 +6,7 @@ This component is used to implement dang sweet remove/trash/delete/disconnect/de
 #### How to use:
 
 ```js
-var Button = require( 'components/remove-button' );
+var RemoveButton = require( 'components/remove-button' );
 
 render: function() {
 	return (

--- a/client/components/remove-button/README.md
+++ b/client/components/remove-button/README.md
@@ -1,0 +1,23 @@
+RemoveButton
+=========
+
+This component is used to implement dang sweet remove/trash/delete/disconnect/deactivate buttons.
+
+#### How to use:
+
+```js
+var Button = require( 'components/remove-button' );
+
+render: function() {
+	return (
+		<RemoveButton compact scary disabled icon={ 'remove | trash | delete | deactivate | disconnect' } >Delete me!</RemoveButton>
+	);
+}
+```
+
+#### Props
+
+* `compact`: (bool) whether the button is compact or not.
+* `scary`: (bool) whether the button has modified styling to warn users (red text & icon).
+* `disabled`: (bool) whether the button should be in the disabled state.
+* `icon`: (string) a text identifier for what kind of button you want to show. Displays `remove` by default. Accepts `remove`, `trash`, `delete`, `disconnect`, `deactivate`.

--- a/client/components/remove-button/docs/example.jsx
+++ b/client/components/remove-button/docs/example.jsx
@@ -9,7 +9,7 @@ var React = require( 'react' );
 var RemoveButton = require( 'components/remove-button' ),
 	Card = require( 'components/card' );
 
-var Buttons = React.createClass( {
+var RemoveButtons = React.createClass( {
 	displayName: 'RemoveButtons',
 
 	getInitialState: function() {
@@ -24,7 +24,7 @@ var Buttons = React.createClass( {
 		return (
 			<div className="design-assets__group">
 				<h2>
-					<a href="/devdocs/design/buttons">RemoveButton</a>
+					<a href="/devdocs/design/removebuttons">RemoveButton</a>
 					<a className="design-assets__toggle button" onClick={ this.toggleButtons }>{ toggleButtonsText }</a>
 				</h2>
 				{ this.renderButtons() }
@@ -46,7 +46,7 @@ var Buttons = React.createClass( {
 					</div>
 					<div className="design-assets__button-row">
 						<RemoveButton></RemoveButton>
-						<RemoveButton disabled ></RemoveButton>		
+						<RemoveButton disabled ></RemoveButton>
 						<RemoveButton icon="trash"></RemoveButton>
 						<RemoveButton icon="disconnect"></RemoveButton>
 
@@ -104,4 +104,4 @@ var Buttons = React.createClass( {
 	}
 } );
 
-module.exports = Buttons;
+module.exports = RemoveButtons;

--- a/client/components/remove-button/docs/example.jsx
+++ b/client/components/remove-button/docs/example.jsx
@@ -33,70 +33,40 @@ var RemoveButtons = React.createClass( {
 	},
 
 	renderButtons: function() {
-		if ( ! this.state.compactButtons ) {
-			return (
-				<Card>
-					<div className="design-assets__button-row">
-						<RemoveButton>Remove</RemoveButton>
-						<RemoveButton icon="trash">Trash</RemoveButton>
-						<RemoveButton icon="delete">Delete</RemoveButton>
-            <RemoveButton icon="disconnect">Disconnect</RemoveButton>
-            <RemoveButton icon="deactivate">Deactivate</RemoveButton>
-						<RemoveButton disabled >Remove Disabled</RemoveButton>
-					</div>
-					<div className="design-assets__button-row">
-						<RemoveButton></RemoveButton>
-						<RemoveButton disabled ></RemoveButton>
-						<RemoveButton icon="trash"></RemoveButton>
-						<RemoveButton icon="disconnect"></RemoveButton>
-
-					</div>
-          <div className="design-assets__button-row">
-						<RemoveButton scary>Remove</RemoveButton>
-						<RemoveButton scary icon="trash">Trash</RemoveButton>
-						<RemoveButton scary icon="delete">Delete</RemoveButton>
-            <RemoveButton scary icon="disconnect">Disconnect</RemoveButton>
-            <RemoveButton scary icon="deactivate">Deactivate</RemoveButton>
-						<RemoveButton scary disabled >Remove Disabled</RemoveButton>
-					</div>
-					<div className="design-assets__button-row">
-						<RemoveButton scary></RemoveButton>
-						<RemoveButton scary disabled ></RemoveButton>
-						<RemoveButton scary icon="trash"></RemoveButton>
-            <RemoveButton scary icon="disconnect"></RemoveButton>
-					</div>
-				</Card>
-			);
-		} else {
-			return (
-				<Card>
-          <div className="design-assets__button-row">
-            <RemoveButton compact>Remove Compact</RemoveButton>
-            <RemoveButton compact icon="trash">Trash</RemoveButton>
-            <RemoveButton compact icon="delete">Delete</RemoveButton>
-            <RemoveButton compact icon="disconnect">Disconnect</RemoveButton>
-            <RemoveButton compact icon="deactivate">Deactivate</RemoveButton>
-            <RemoveButton compact disabled >Remove Disabled</RemoveButton>
-          </div>
-          <div className="design-assets__button-row">
-						<RemoveButton compact scary>Remove Scary Compact</RemoveButton>
-						<RemoveButton compact scary icon="trash">Trash</RemoveButton>
-						<RemoveButton compact scary icon="delete">Delete</RemoveButton>
-            <RemoveButton compact scary icon="disconnect">Disconnect</RemoveButton>
-            <RemoveButton compact scary icon="deactivate">Deactivate</RemoveButton>
-						<RemoveButton compact scary disabled >Remove Disabled</RemoveButton>
-					</div>
-					<div className="design-assets__button-row">
-						<RemoveButton compact scary></RemoveButton>
-						<RemoveButton compact scary icon="trash"></RemoveButton>
-						<RemoveButton compact scary icon="delete"></RemoveButton>
-						<RemoveButton compact scary icon="disconnect"></RemoveButton>
-						<RemoveButton compact scary icon="deactivate"></RemoveButton>
-						<RemoveButton compact scary disabled ></RemoveButton>
-					</div>
-				</Card>
-			);
-		}
+		return (
+			<Card>
+				<div className="design-assets__button-row">
+					<RemoveButton compact={ this.state.compactButtons }>
+						{ this.state.compactButtons ? 'Remove Compact' : 'Remove' }
+					</RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } icon="trash">Trash</RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } icon="delete">Delete</RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } icon="disconnect">Disconnect</RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } icon="deactivate">Deactivate</RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } disabled >Remove Disabled</RemoveButton>
+				</div>
+				<div className="design-assets__button-row">
+					<RemoveButton compact={ this.state.compactButtons }></RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } disabled ></RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } icon="trash"></RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } icon="disconnect"></RemoveButton>
+				</div>
+				<div className="design-assets__button-row">
+					<RemoveButton compact={ this.state.compactButtons } scary>Remove</RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } scary icon="trash">Trash</RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } scary icon="delete">Delete</RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } scary icon="disconnect">Disconnect</RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } scary icon="deactivate">Deactivate</RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } scary disabled >Remove Disabled</RemoveButton>
+				</div>
+				<div className="design-assets__button-row">
+					<RemoveButton compact={ this.state.compactButtons } scary></RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } scary disabled ></RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } scary icon="trash"></RemoveButton>
+					<RemoveButton compact={ this.state.compactButtons } scary icon="disconnect"></RemoveButton>
+				</div>
+			</Card>
+		);
 	},
 
 	toggleButtons: function() {

--- a/client/components/remove-button/docs/example.jsx
+++ b/client/components/remove-button/docs/example.jsx
@@ -44,6 +44,13 @@ var Buttons = React.createClass( {
             <RemoveButton icon="deactivate">Deactivate</RemoveButton>
 						<RemoveButton disabled >Remove Disabled</RemoveButton>
 					</div>
+					<div className="design-assets__button-row">
+						<RemoveButton></RemoveButton>
+						<RemoveButton disabled ></RemoveButton>		
+						<RemoveButton icon="trash"></RemoveButton>
+						<RemoveButton icon="disconnect"></RemoveButton>
+
+					</div>
           <div className="design-assets__button-row">
 						<RemoveButton scary>Remove</RemoveButton>
 						<RemoveButton scary icon="trash">Trash</RemoveButton>
@@ -51,6 +58,12 @@ var Buttons = React.createClass( {
             <RemoveButton scary icon="disconnect">Disconnect</RemoveButton>
             <RemoveButton scary icon="deactivate">Deactivate</RemoveButton>
 						<RemoveButton scary disabled >Remove Disabled</RemoveButton>
+					</div>
+					<div className="design-assets__button-row">
+						<RemoveButton scary></RemoveButton>
+						<RemoveButton scary disabled ></RemoveButton>
+						<RemoveButton scary icon="trash"></RemoveButton>
+            <RemoveButton scary icon="disconnect"></RemoveButton>
 					</div>
 				</Card>
 			);
@@ -72,6 +85,14 @@ var Buttons = React.createClass( {
             <RemoveButton compact scary icon="disconnect">Disconnect</RemoveButton>
             <RemoveButton compact scary icon="deactivate">Deactivate</RemoveButton>
 						<RemoveButton compact scary disabled >Remove Disabled</RemoveButton>
+					</div>
+					<div className="design-assets__button-row">
+						<RemoveButton compact scary></RemoveButton>
+						<RemoveButton compact scary icon="trash"></RemoveButton>
+						<RemoveButton compact scary icon="delete"></RemoveButton>
+						<RemoveButton compact scary icon="disconnect"></RemoveButton>
+						<RemoveButton compact scary icon="deactivate"></RemoveButton>
+						<RemoveButton compact scary disabled ></RemoveButton>
 					</div>
 				</Card>
 			);

--- a/client/components/remove-button/docs/example.jsx
+++ b/client/components/remove-button/docs/example.jsx
@@ -1,0 +1,86 @@
+/**
+* External dependencies
+*/
+var React = require( 'react' );
+
+/**
+ * Internal dependencies
+ */
+var RemoveButton = require( 'components/remove-button' ),
+	Card = require( 'components/card' );
+
+var Buttons = React.createClass( {
+	displayName: 'RemoveButtons',
+
+	getInitialState: function() {
+		return {
+			compactButtons: false
+		};
+	},
+
+	render: function() {
+		var toggleButtonsText = this.state.compactButtons ? 'Normal Buttons' : 'Compact Buttons';
+
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/design/buttons">RemoveButton</a>
+					<a className="design-assets__toggle button" onClick={ this.toggleButtons }>{ toggleButtonsText }</a>
+				</h2>
+				{ this.renderButtons() }
+			</div>
+		);
+	},
+
+	renderButtons: function() {
+		if ( ! this.state.compactButtons ) {
+			return (
+				<Card>
+					<div className="design-assets__button-row">
+						<RemoveButton>Remove</RemoveButton>
+						<RemoveButton icon="trash">Trash</RemoveButton>
+						<RemoveButton icon="delete">Delete</RemoveButton>
+            <RemoveButton icon="disconnect">Disconnect</RemoveButton>
+            <RemoveButton icon="deactivate">Deactivate</RemoveButton>
+						<RemoveButton disabled >Remove Disabled</RemoveButton>
+					</div>
+          <div className="design-assets__button-row">
+						<RemoveButton scary>Remove</RemoveButton>
+						<RemoveButton scary icon="trash">Trash</RemoveButton>
+						<RemoveButton scary icon="delete">Delete</RemoveButton>
+            <RemoveButton scary icon="disconnect">Disconnect</RemoveButton>
+            <RemoveButton scary icon="deactivate">Deactivate</RemoveButton>
+						<RemoveButton scary disabled >Remove Disabled</RemoveButton>
+					</div>
+				</Card>
+			);
+		} else {
+			return (
+				<Card>
+          <div className="design-assets__button-row">
+            <RemoveButton compact>Remove Compact</RemoveButton>
+            <RemoveButton compact icon="trash">Trash</RemoveButton>
+            <RemoveButton compact icon="delete">Delete</RemoveButton>
+            <RemoveButton compact icon="disconnect">Disconnect</RemoveButton>
+            <RemoveButton compact icon="deactivate">Deactivate</RemoveButton>
+            <RemoveButton compact disabled >Remove Disabled</RemoveButton>
+          </div>
+          <div className="design-assets__button-row">
+						<RemoveButton compact scary>Remove Scary Compact</RemoveButton>
+						<RemoveButton compact scary icon="trash">Trash</RemoveButton>
+						<RemoveButton compact scary icon="delete">Delete</RemoveButton>
+            <RemoveButton compact scary icon="disconnect">Disconnect</RemoveButton>
+            <RemoveButton compact scary icon="deactivate">Deactivate</RemoveButton>
+						<RemoveButton compact scary disabled >Remove Disabled</RemoveButton>
+					</div>
+				</Card>
+			);
+		}
+	},
+
+	toggleButtons: function() {
+		this.setState( { compactButtons: ! this.state.compactButtons } );
+	}
+} );
+
+module.exports = Buttons;

--- a/client/components/remove-button/index.jsx
+++ b/client/components/remove-button/index.jsx
@@ -12,14 +12,14 @@ export default React.createClass( {
 	displayName: 'RemoveButton',
 
 	propTypes: {
-  	icon: React.PropTypes.string,
-  	disabled: React.PropTypes.bool,
+		icon: React.PropTypes.string,
+		disabled: React.PropTypes.bool,
 		onClick: React.PropTypes.func
 	},
 
 	getDefaultProps() {
 		return {
-      icon: 'remove',
+			icon: 'remove',
 			disabled: false,
 			compact: false,
 			scary: false,

--- a/client/components/remove-button/index.jsx
+++ b/client/components/remove-button/index.jsx
@@ -53,7 +53,7 @@ export default React.createClass( {
 		}
 
 		return(
-			<button disabled={ this.props.disabled } className={ classNames( this.props.className, buttonClasses ) }>
+			<button onClick={ this.props.onClick } disabled={ this.props.disabled } className={ classNames( this.props.className, buttonClasses ) }>
 				<Gridicon icon={ buttonIcons[ this.props.icon ] } size={ iconSize } />
 				{ this.props.children }
 			</button>

--- a/client/components/remove-button/index.jsx
+++ b/client/components/remove-button/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import assign from 'lodash/object/assign';
 import classNames from 'classnames';
 import noop from 'lodash/utility/noop';
 import Gridicon from 'components/gridicon';
@@ -27,18 +26,13 @@ export default React.createClass( {
 		};
 	},
 
-	getIconAssignments(){
-
-	},
-
 	render() {
-		const element = 'button';
 		const buttonIcons = {
-			'remove': 		'cross',
-			'trash': 			'trash',
-			'disconnect':	'link-break',
-			'deactivate':	'cross',
-			'delete':			'trash',
+			remove: 'cross',
+			trash: 'trash',
+			disconnect: 'link-break',
+			deactivate: 'cross',
+			delete: 'trash',
 		};
 		const buttonClasses = classNames( this.props.className, {
 			'button-remove': true,
@@ -46,15 +40,9 @@ export default React.createClass( {
 			'is-scary': this.props.scary
 		} );
 
-		if( this.props.compact ){
-			var iconSize = 12;
-		} else {
-			var iconSize = 24;
-		}
-
 		return(
 			<button onClick={ this.props.onClick } disabled={ this.props.disabled } className={ buttonClasses }>
-				<Gridicon icon={ buttonIcons[this.props.icon] } size={ iconSize } />
+				<Gridicon icon={ buttonIcons[this.props.icon] } size={ this.props.compact ? 12 : 24 } />
 				{ this.props.children }
 			</button>
 		);

--- a/client/components/remove-button/index.jsx
+++ b/client/components/remove-button/index.jsx
@@ -40,7 +40,7 @@ export default React.createClass( {
 			'deactivate':	'cross',
 			'delete':			'trash',
 		};
-		const buttonClasses = classNames( {
+		const buttonClasses = classNames( this.props.className, {
 			'button-remove': true,
 			'is-compact': this.props.compact,
 			'is-scary': this.props.scary
@@ -53,8 +53,8 @@ export default React.createClass( {
 		}
 
 		return(
-			<button onClick={ this.props.onClick } disabled={ this.props.disabled } className={ classNames( this.props.className, buttonClasses ) }>
-				<Gridicon icon={ buttonIcons[ this.props.icon ] } size={ iconSize } />
+			<button onClick={ this.props.onClick } disabled={ this.props.disabled } className={ buttonClasses }>
+				<Gridicon icon={ buttonIcons[this.props.icon] } size={ iconSize } />
 				{ this.props.children }
 			</button>
 		);

--- a/client/components/remove-button/index.jsx
+++ b/client/components/remove-button/index.jsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import assign from 'lodash/object/assign';
+import classNames from 'classnames';
+import noop from 'lodash/utility/noop';
+import Gridicon from 'components/gridicon';
+
+export default React.createClass( {
+
+	displayName: 'RemoveButton',
+
+	propTypes: {
+  	icon: React.PropTypes.string,
+  	disabled: React.PropTypes.bool,
+		onClick: React.PropTypes.func
+	},
+
+	getDefaultProps() {
+		return {
+      icon: 'remove',
+			disabled: false,
+			compact: false,
+			scary: false,
+			onClick: noop
+		};
+	},
+
+	getIconAssignments(){
+
+	},
+
+	render() {
+		const element = 'button';
+		const buttonIcons = {
+			'remove': 		'cross',
+			'trash': 			'trash',
+			'disconnect':	'link-break',
+			'deactivate':	'cross',
+			'delete':			'trash',
+		};
+		const buttonClasses = classNames( {
+			'button-remove': true,
+			'is-compact': this.props.compact,
+			'is-scary': this.props.scary
+		} );
+
+		if( this.props.compact ){
+			var iconSize = 12;
+		} else {
+			var iconSize = 24;
+		}
+
+		return(
+			<button disabled={ this.props.disabled } className={ classNames( this.props.className, buttonClasses ) }>
+				<Gridicon icon={ buttonIcons[ this.props.icon ] } size={ iconSize } />
+				{ this.props.children }
+			</button>
+		);
+	}
+} );

--- a/client/components/remove-button/style.scss
+++ b/client/components/remove-button/style.scss
@@ -1,0 +1,109 @@
+// ==========================================================================
+// Buttons
+// ==========================================================================
+
+.button-remove {
+	color: darken( $gray, 10% );;
+	cursor: pointer;
+	display: inline-block;
+	margin: 0;
+	outline: 0;
+	overflow: hidden;
+	font-weight: 600;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: top;
+	box-sizing: border-box;
+	font-size: 14px;
+	line-height: 21px;
+	border-radius: 4px;
+	padding: 7px 14px 9px;
+	-webkit-appearance: none;
+	appearance: none;
+
+	&:hover {
+		border-color: lighten( $gray, 10% );
+		color: $gray-dark;
+	}
+	&:active {
+		border-width: 2px 1px 1px;
+	}
+	&:visited {
+		color: $gray-dark;
+	}
+	&[disabled],
+	&:disabled {
+		color: lighten( $gray, 30% );
+		background: $white;
+		cursor: default;
+
+		&:active {
+			border-width: 1px 1px 2px;
+		}
+	}
+	&:focus {
+		border-color: $blue-medium;
+		box-shadow: 0 0 0 2px $blue-light;
+	}
+	&.hidden {
+		display: none;
+	}
+  &.is-compact {
+		padding: 7px;
+		color: darken( $gray, 10% );
+		font-size: 11px;
+		line-height: 1;
+		text-transform: uppercase;
+
+		&:disabled {
+			color: lighten( $gray, 30% );
+		}
+		.gridicon {
+			top: 4px;
+			margin-top: -2px;
+			width: 20px;
+			height: 16px;
+			text-align: right;
+		}
+	}
+	.gridicon {
+		position: relative;
+		top: 7px;
+		margin-top: -2px;
+		width: 28px;
+		height: 24px;
+	}
+}
+
+// Scary buttons
+.button-remove.is-scary,
+.button-remove.is-dangerous {
+	color: $alert-red;
+
+	&[disabled] {
+		color: lighten( $alert-red, 30% );
+	}
+	&:hover,
+	&:focus {
+		border-color: $alert-red;
+	}
+	&:focus {
+		box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
+	}
+}
+
+.button.is-primary.is-scary,
+.button.is-destructive {
+	background: $alert-red;
+	border-color: darken( $alert-red, 20% );
+	color: $white;
+
+	&:hover,
+	&:focus {
+		border-color: darken( $alert-red, 30% );
+	}
+	&[disabled] {
+		background: lighten( $alert-red, 20% );
+		border-color: tint( $alert-red, 30% );
+	}
+}

--- a/client/components/remove-button/style.scss
+++ b/client/components/remove-button/style.scss
@@ -21,8 +21,6 @@
 	-webkit-appearance: none;
 	appearance: none;
 
-	border: 1px $alert-red solid;
-
 	&:hover {
 		border-color: lighten( $gray, 10% );
 		color: $gray-dark;

--- a/client/components/remove-button/style.scss
+++ b/client/components/remove-button/style.scss
@@ -48,7 +48,7 @@
 	&.hidden {
 		display: none;
 	}
-  &.is-compact {
+	&.is-compact {
 		padding: 7px 14px 9px 10px;
 		color: darken( $gray, 10% );
 		font-size: 11px;

--- a/client/components/remove-button/style.scss
+++ b/client/components/remove-button/style.scss
@@ -17,9 +17,11 @@
 	font-size: 14px;
 	line-height: 21px;
 	border-radius: 4px;
-	padding: 7px 14px 9px;
+	padding: 7px 14px 9px 10px;
 	-webkit-appearance: none;
 	appearance: none;
+
+	border: 1px $alert-red solid;
 
 	&:hover {
 		border-color: lighten( $gray, 10% );
@@ -49,7 +51,7 @@
 		display: none;
 	}
   &.is-compact {
-		padding: 7px;
+		padding: 7px 14px 9px 10px;
 		color: darken( $gray, 10% );
 		font-size: 11px;
 		line-height: 1;
@@ -60,7 +62,7 @@
 		}
 		.gridicon {
 			top: 4px;
-			margin-top: -2px;
+			margin-top: -4px;
 			width: 20px;
 			height: 16px;
 			text-align: right;
@@ -68,8 +70,8 @@
 	}
 	.gridicon {
 		position: relative;
-		top: 7px;
-		margin-top: -2px;
+		top: 6px;
+		margin-top: -6px;
 		width: 28px;
 		height: 24px;
 	}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -14,6 +14,7 @@ var SearchCard = require( 'components/search-card' ),
 	Typography = require( 'components/typography/docs/example' ),
 	Notices = require( 'components/notices/docs/example' ),
 	Buttons = require( 'components/button/docs/example' ),
+	RemoveButtons = require( 'components/remove-button/docs/example' ),
 	ButtonGroups = require( 'components/button-group/docs/example' ),
 	AddNewButtons = require( 'components/add-new-button/docs/example' ),
 	CommentButtons = require( 'components/comment-button/docs/example' ),
@@ -180,6 +181,7 @@ module.exports = React.createClass( {
 					<Typography />
 					<Notices />
 					<Buttons />
+					<RemoveButtons />
 					<ButtonGroups />
 					<AddNewButtons />
 					<CommentButtons />


### PR DESCRIPTION
<img width="1007" alt="screen shot 2015-11-09 at 2 51 52 pm" src="https://cloud.githubusercontent.com/assets/1084656/11047784/7c35ff1c-86f1-11e5-9aff-485f15d81a2f.png">

<img width="1017" alt="screen shot 2015-11-09 at 2 51 58 pm" src="https://cloud.githubusercontent.com/assets/1084656/11047798/80eb9d3c-86f1-11e5-890e-aa79cf226ee7.png">


As part of the process of standardizing the Trash, Remove, Delete, Disconnect, & Deactivate actions into one cohesive pattern, I've built a new basic component to handle the display of the buttons themselves. The documentation I've written for this component looks like this:

RemoveButton
=========

This component is used to implement dang sweet remove/trash/delete/disconnect/deactivate buttons.

#### How to use:

```js
var RemoveButton = require( 'components/remove-button' );

render: function() {
	return (
		<RemoveButton compact scary disabled icon={ 'remove | trash | delete | deactivate | disconnect' } >Delete me!</RemoveButton>
	);
}
```

#### Props

* `compact`: (bool) whether the button is compact or not.
* `scary`: (bool) whether the button has modified styling to warn users (red text & icon).
* `disabled`: (bool) whether the button should be in the disabled state.
* `icon`: (string) a text identifier for what kind of button you want to show. Displays `remove` by default. Accepts `remove`, `trash`, `delete`, `disconnect`, `deactivate`.


Some considerations & caveats:
- The naming convention for the `icon` prop is probably not correct. Type was too generic and got forwarded verbatim into the HTML anyway. This is just a pass-through to Gridicon for the most part, with a mapping of the words we use on the screen to the correct icon names. This way the correct icon is handled for the developer/designer if the action is Remove.
- This button has mostly the same props as the `Button` component with the exceptions of `href` and `is-link` because they didn't seem valuable to me. They could be easily re-implemented.
- This is the first step toward me being able to implement this in various place. I was planning on starting with `/me` because it seemed like low-hanging fruit and Mercury people could perhaps support code-reviews on that.
- I didn't extend the actual `Button` component per @MichaelArestad's advice to implement a new component instead. This allowed me to simplify the icon parameters that the button expects, but since I implemented similar usage patterns (compact, scary, disabled, etc) it should be easy to adopt.
- If no text is given in the Component tag, it'll simply render the icon. I don't figure that the icon-less version of this is useful to anyone since it's not part of the Remove pattern anyway_ *Just use a regular Button with `scary` on it for an icon-less remove button, since we want an outline there *_
- If an outer button style is desired, simply use `<Button scary />`