### PR TITLE
Signup: DSS: Improve Tracks stats for DSS.

### DIFF
--- a/client/lib/dss/image-store.js
+++ b/client/lib/dss/image-store.js
@@ -9,6 +9,7 @@ import get from 'lodash/object/get'
  */
 import { createReducerStore } from 'lib/store';
 import { action as ActionTypes } from 'lib/dss/constants';
+import analytics from 'analytics';
 
 const debug = debugFactory( 'calypso:dss:image-store' );
 const initialState = {
@@ -38,10 +39,16 @@ export default createReducerStore( ( state, { action } ) => {
 			if ( images.length < 1 ) {
 				// TODO: notify the user of the error
 				debug( 'error getting dynamic-screenshots images', action );
+
+				analytics.tracks.recordEvent( 'calypso_dss_fetch_error', { searchterm: action.searchTerm } );
+
 				return Object.assign( {}, state, { isLoading: false } );
 			}
 			debug( 'saving image results for', action.searchTerm );
 			const imageResultsByKey = Object.assign( {}, state.imageResultsByKey, { [ action.searchTerm ]: images[0] } );
+
+			analytics.tracks.recordEvent( 'calypso_dss_fetch_images', Object.assign( {}, { searchterm: action.searchTerm }, imageResultsByKey[ action.searchTerm ] ) );
+
 			return Object.assign( {}, state, { isLoading: false, lastKey: action.searchTerm, imageResultsByKey } );
 	}
 	return state;

--- a/client/signup/steps/dss/theme-thumbnail.jsx
+++ b/client/signup/steps/dss/theme-thumbnail.jsx
@@ -23,15 +23,11 @@ export default React.createClass( {
 	handleSubmit() {
 		const { lastKey, imageResultsByKey } = DSSImageStore.get();
 		const dssImage = imageResultsByKey[ lastKey ] ? imageResultsByKey[ lastKey ] : undefined;
-		const eventProps = {
-			theme: this.props.themeRepoSlug,
-			headstart: true,
-			images: dssImage ? JSON.stringify( dssImage ) : undefined,
-			searchterms: Object.keys( imageResultsByKey ).join( ',' ),
-			selectedterm: lastKey
-		};
 
-		analytics.tracks.recordEvent( 'calypso_signup_theme_select', eventProps );
+		analytics.tracks.recordEvent( 'calypso_dss_select_theme', {
+			theme: this.props.themeRepoSlug,
+			search_term: lastKey
+		} );
 
 		SignupActions.submitSignupStep( { stepName: this.props.stepName }, null, {
 			theme: this.props.themeRepoSlug,


### PR DESCRIPTION
Collecting all the props we can for DSS into the existing `calypso_signup_theme_select` event makes it difficult to pull out search results data. Instead, we can use:

* `calypso_dss_fetch_images` for every successful API search result, including image data
* `calypso_dss_fetch_error` for every empty result returned
* `calypso_dss_select_theme` to track selected themes, and the last successful search