### PR TITLE
Signup: Add autofill for username when available. [feedback wanted]. Implements #753

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -80,5 +80,13 @@ module.exports = {
 			notTested: 20
 		},
 		defaultVariation: 'main'
+	},
+	autoFillUsernameSignup: {
+		datestamp: '20151201',
+		variations: {
+			autoFill: 50,
+			dontAutoFill: 50
+		},
+		defaultVariation: 'dontAutoFill'
 	}
 };

--- a/client/signup/test/utils-test.js
+++ b/client/signup/test/utils-test.js
@@ -124,3 +124,41 @@ describe( 'utils.getValidPath - currentFlowName === defaultFlowName', function()
 	} );
 } );
 
+describe( 'utils.getValueFromProgressStore', function() {
+	const testStore = [ { stepName: 'empty' }, { stepName: 'site', site: 'calypso' } ];
+	const config = {
+		stepName: 'site',
+		fieldName: 'site',
+		signupProgressStore: testStore
+	};
+
+	it( 'should return the value of the field if it exists', function() {
+		assert.equal( utils.getValueFromProgressStore( config ), 'calypso' );
+	} );
+
+	it( 'should return null if the field is not present', function() {
+		delete testStore[1].site;
+		assert.equal( utils.getValueFromProgressStore( config ), null );
+	} );
+} );
+
+describe( 'utils.mergeFormWithValue', function() {
+	const config = {
+		fieldName: 'username',
+		fieldValue: 'calypso'
+	};
+
+	it( 'should return the form with the field added if the field doesn\'t have a value', function() {
+		const form = { username: {} };
+		config.form = form;
+		assert.deepEqual( utils.mergeFormWithValue( config ), {
+			username: { value: 'calypso' }
+		} );
+	} );
+
+	it( 'should return the form unchanged if there is already a value in the form', function() {
+		const form = { username: { value: 'wordpress' } };
+		config.form = form;
+		assert.equal( utils.mergeFormWithValue( config ), form );
+	} );
+} );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -4,7 +4,8 @@
 var isEmpty = require( 'lodash/lang/isEmpty' ),
 	find = require( 'lodash/collection/find' ),
 	indexOf = require( 'lodash/array/indexOf' ),
-	pick = require( 'lodash/object/pick' );
+	pick = require( 'lodash/object/pick' ),
+	merge = require( 'lodash/object/merge' );
 
 /**
  * Internal dependencies
@@ -12,7 +13,8 @@ var isEmpty = require( 'lodash/lang/isEmpty' ),
 var i18nUtils = require( 'lib/i18n-utils' ),
 	steps = require( 'signup/config/steps' ),
 	flows = require( 'signup/config/flows' ),
-	defaultFlowName = require( 'signup/config/flows' ).defaultFlowName;
+	defaultFlowName = require( 'signup/config/flows' ).defaultFlowName,
+	formState = require( 'lib/form-state' );
 
 function getFlowName( parameters ) {
 	var currentFlowName = flows.currentFlowName;
@@ -93,6 +95,23 @@ function getNextStepName( flowName, currentStepName ) {
 	return flow.steps[ indexOf( flow.steps, currentStepName ) + 1 ];
 }
 
+function getValueFromProgressStore( { signupProgressStore, stepName, fieldName } ) {
+	const siteStepProgress = find(
+		signupProgressStore,
+		step => step.stepName === stepName
+	);
+	return siteStepProgress ? siteStepProgress[fieldName] : null;
+}
+
+function mergeFormWithValue( { form, fieldName, fieldValue} ) {
+	if ( ! formState.getFieldValue( form, fieldName ) ) {
+		return merge( form, {
+			[fieldName]: { value: fieldValue }
+		} );
+	}
+	return form;
+}
+
 module.exports = {
 	getFlowName: getFlowName,
 	getStepName: getStepName,
@@ -101,5 +120,7 @@ module.exports = {
 	getStepUrl: getStepUrl,
 	getValidPath: getValidPath,
 	getPreviousStepName: getPreviousStepName,
-	getNextStepName: getNextStepName
+	getNextStepName: getNextStepName,
+	getValueFromProgressStore: getValueFromProgressStore,
+	mergeFormWithValue: mergeFormWithValue
 };


### PR DESCRIPTION
This PR adds the feature in #753. In the signup flow, if the user has set a site name and registered it while signing up, upon reaching the account creation form the username field will already be filled in with the site name chosen. 

Here are images of the feature.
http://zippy.gfycat.com/SoulfulCourteousAnole.gif

I am fairly new to React so I do have a question, I feel like this code should be abstracted more and not be implemented SignupForm. Is there a better place to check if a site name has been checked? Thanks in advanced.