### PR TITLE
Editor: Always send string value for featured_image

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -94,12 +94,6 @@ function normalizeApiAttributes( attributes ) {
 		delete attributes.categories;
 	}
 
-	// The API doesn't like false/null, which wpcom-xhr-request sends when removing the featured_image.
-	// Force the value to an empty string instead.
-	if ( attributes.hasOwnProperty( 'featured_image' ) && !attributes.featured_image ) {
-		attributes.featured_image = '';
-	}
-
 	return attributes;
 }
 

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -94,6 +94,12 @@ function normalizeApiAttributes( attributes ) {
 		delete attributes.categories;
 	}
 
+	// The API doesn't like false/null, which wpcom-xhr-request sends when removing the featured_image.
+	// Force the value to an empty string instead.
+	if ( attributes.hasOwnProperty( 'featured_image' ) && !attributes.featured_image ) {
+		attributes.featured_image = '';
+	}
+
 	return attributes;
 }
 

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -59,7 +59,7 @@ var EditorFeaturedImage = React.createClass( {
 
 	removeImage: function() {
 		PostActions.edit( {
-			featured_image: null
+			featured_image: ''
 		} );
 
 		stats.recordStat( 'featured_image_removed' );


### PR DESCRIPTION
The API doesn't like false/null, which `wpcom-xhr-request` sends when removing the featured image (making it impossible to remove a featured image from the Desktop app, for example).

To be safe, we should force the value to an empty string when removing the image.

## To Test

- Add new post
- Set a Featured Image
- Save
- Remove the Featured Image
- Save
- Verify the save is successful

Repeat repro steps in a desktop build.