### PR TITLE
Translator invitation: add conditional margin to avoid sidebar

### DIFF
--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -15,9 +15,20 @@
 		z-index: -1;
 		background: linear-gradient( to right, fade-out( lighten( $gray, 20% ), 1 ) 0%, lighten( $gray, 20% ) 20%, lighten( $gray, 20% ) 80%, fade-out( lighten( $gray, 20% ), 1 ) 100% );
 	}
+
+	// Allow room for the side-bar
+	@include breakpoint( ">660px" ) {
+		margin-left: 273px;
+
+		.translator-invitation__primary-content {
+			margin-left: 24px;
+		}
+	}
+
 	.close-button {
 		padding: 6px;
 	}
+
 	.gridicons-globe {
 		// copied from noticons styling
 		background-color: lighten( $gray, 30% );


### PR DESCRIPTION
This PR addresses #469

The notifications fixes this problem with a conditional hard-coded margin - https://github.com/Automattic/wp-calypso/blob/fix/469-translator-invitation-styling-with-new-sidebar/client/notices/style.scss#L236

This works, but it seems pretty fragile (not DRY enough) and I'm hoping it's wrong.

 You can show the translator invitation by setting `localStorage.calypsoTranslatorInvitationIsPending = true` and then reloading the page anywhere in "My Sites"