### PR TITLE
SiteStatsStickyLink: remove shouldComponentUpdate

### DIFF
--- a/client/components/site-stats-sticky-link/index.jsx
+++ b/client/components/site-stats-sticky-link/index.jsx
@@ -26,18 +26,6 @@ var SiteStatsStickyLink = React.createClass( {
 		siteStatsStickyTabStore.off( 'change', this.handleStatsStickyTabChange );
 	},
 
-	shouldComponentUpdate: function( nextProps, nextState ) {
-		if (
-			nextState.url !== this.state.url ||
-			nextProps.onClick !== this.props.onClick ||
-			nextProps.title !== this.props.title
-		) {
-			return true;
-		}
-
-		return false;
-	},
-
 	handleStatsStickyTabChange: function() {
 		var url = siteStatsStickyTabStore.getUrl();
 


### PR DESCRIPTION
# Why?

Because shouldComponentUpdate was bound to url, onClick and title,
the whole children subtree was not changed even if props changed there

The problem that occured in #473 was that after creating SECOND site in an account, the masterbar button was still 'My Site'
![Screenshot](https://cldup.com/xTIFs7xtgN-3000x3000.png)

# What consequences does it have?

SiteStatsStickyLink is not so widely used, 
the performance shouldnt hit us:
```
Searching 32113 files for "SiteStatsStickyLink" (case sensitive)

/Users/Artpi/GIT/calypso/client/components/site-stats-sticky-link/index.jsx:
    6  var siteStatsStickyTabStore = require( 'lib/site-stats-sticky-tab/store' );
    7  
    8: var SiteStatsStickyLink = React.createClass( {
    9  
   10  	propTypes: {
   ..
   46  } );
   47  
   48: module.exports = SiteStatsStickyLink;
   49  

/Users/Artpi/GIT/calypso/client/components/site-stats-sticky-link/README.md:
   10  ### usage:
   11  ```jsx
   12: var SiteStatsStickyLink = require( 'components/site-stats-sticky-link' );
   13  
   14  /* ...inside component render method: */
   15: <SiteStatsStickyLink
   16  	onClick={ callback }
   17  	title={ localizedTitle }>{
   18  		localizedLinkTextAndOrImagesAsChildNodes
   19: }</SiteStatsStickyLink>
   20  ```
   21  

/Users/Artpi/GIT/calypso/client/layout/masterbar-sections-menu.jsx:
   12  	MasterbarNewPost = require( 'layout/masterbar-new-post' ),
   13  	layoutFocus = require( 'lib/layout-focus' ),
   14: 	SiteStatsStickyLink = require( 'components/site-stats-sticky-link' ),
   15  	Gravatar = require( 'components/gravatar' );
   16  
   ..
  109  				<ul className="sections-menu">
  110  					<li className={ this.itemLinkClass( 'sites', { 'my-sites': true } ) }>
  111: 						<SiteStatsStickyLink onClick={ this.focusSidebar } title={ this.translate( 'View a list of your sites and access their dashboards', { textOnly: true } ) }>
  112  							{ this.wordpressIcon() }
  113  							<span className="section-label">
  ...
  118  								}
  119  							</span>
  120: 						</SiteStatsStickyLink>
  121  					</li>
  122  					<li className={ this.itemLinkClass( 'reader', { home: true, reader: true } ) }>

/Users/Artpi/GIT/calypso/client/my-sites/sidebar/sidebar.jsx:
   16  	CurrentSite = require( 'my-sites/current-site' ),
   17  	PublishMenu = require( './publish-menu' ),
   18: 	SiteStatsStickyLink = require( 'components/site-stats-sticky-link' ),
   19  	productsValues = require( 'lib/products-values' ),
   20  	getCustomizeUrl = require( 'lib/themes/helpers' ).getCustomizeUrl,
   ..
  113  		return (
  114  			<li className={ this.itemLinkClass( '/stats', 'stats' ) }>
  115: 				<SiteStatsStickyLink onClick={ this.onNavigate }>
  116  					<Gridicon icon="stats-alt" size={ 24 } />
  117  					<span className="menu-link-text">{ this.translate( 'Stats' ) }</span>
  118: 				</SiteStatsStickyLink>
  119  			</li>
  120  		);
```

# Testing
1. Log into account that has only 1 site (or register a new one)
2. Click "Create new WordPress"
3. Go through NUX until plan choice
4. Just after clicking "Free Plan" notice My Site -> My Sites