### PR TITLE
Me: Decode entities for /me form inputs.

### DIFF
--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -3,7 +3,9 @@
  */
 var debug = require( 'debug' )( 'calypso:user:settings' ),
 	merge = require( 'lodash/object/merge' ),
+	assign = require( 'lodash/object/assign' ),
 	keys = require( 'lodash/object/keys' ),
+	decodeEntities = require( 'lib/formatting' ).decodeEntities,
 	isEmpty = require( 'lodash/lang/isEmpty' );
 
 /**
@@ -13,6 +15,19 @@ var Emitter = require( 'lib/mixins/emitter' ),
 	wpcom = require( 'lib/wp' ).undocumented(),
 	user = require( 'lib/user' )();
 
+/**
+ * Decodes entities in those specific user settings properties
+ * that the REST API returns already HTML-encoded
+ */
+function decodeUserSettingsEntities( data ) {
+	let decodedValues = {
+			display_name: data.display_name && decodeEntities( data.display_name ),
+			description: data.description && decodeEntities( data.description ),
+			user_URL: data.user_URL && decodeEntities( data.user_URL )
+	};
+
+	return assign( {}, data, decodedValues );
+}
 /**
  * Initialize UserSettings with defaults
  */
@@ -44,7 +59,6 @@ UserSettings.prototype.getSettings = function() {
 	if ( ! this.settings ) {
 		this.fetchSettings();
 	}
-
 	return this.settings;
 };
 
@@ -60,7 +74,7 @@ UserSettings.prototype.fetchSettings = function() {
 	debug( 'Fetching user settings' );
 	wpcom.me().settings( function( error, data ) {
 		if ( ! error ) {
-			this.settings = data;
+			this.settings = decodeUserSettingsEntities ( data );
 			this.initialized = true;
 			this.emit( 'change' );
 		}
@@ -86,7 +100,7 @@ UserSettings.prototype.saveSettings = function( callback, settingsOverride ) {
 	debug( 'Saving settings: ' + JSON.stringify( settings ) );
 	wpcom.me().saveSettings( settings, function( error, data ) {
 		if ( ! error ) {
-			this.settings = merge( this.settings, data );
+			this.settings = decodeUserSettingsEntities( merge( this.settings, data ) );
 
 			// Do not reset unsaved settings if settingsOverride was passed
 			if ( ! settingsOverride ) {

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -15,19 +15,20 @@ var Emitter = require( 'lib/mixins/emitter' ),
 	wpcom = require( 'lib/wp' ).undocumented(),
 	user = require( 'lib/user' )();
 
-/**
+/*
  * Decodes entities in those specific user settings properties
  * that the REST API returns already HTML-encoded
  */
 function decodeUserSettingsEntities( data ) {
 	let decodedValues = {
-			display_name: data.display_name && decodeEntities( data.display_name ),
-			description: data.description && decodeEntities( data.description ),
-			user_URL: data.user_URL && decodeEntities( data.user_URL )
+		display_name: data.display_name && decodeEntities( data.display_name ),
+		description: data.description && decodeEntities( data.description ),
+		user_URL: data.user_URL && decodeEntities( data.user_URL )
 	};
 
 	return assign( {}, data, decodedValues );
 }
+
 /**
  * Initialize UserSettings with defaults
  */


### PR DESCRIPTION
Decode the HTML entities present in user settings REST API response. 

See #625  and [#625 concerns comment ](https://github.com/Automattic/wp-calypso/pull/625#issuecomment-159354498) by @ebinnion.


The API takes care of encoding characters but React components are re-encoding those characters on render.

Regarding previously mentioned concerns, it seems the API does a good job filtering HTML tags.

### Steps to currently recreate the issue fixed here:

1. Go to your profile.
2. Set a display name, description or Web Address with an ampersand character.
3. Reload the page (full browser reload).
4. Look at the display name input having the `&amp` there.

It seems there's also an issue after updating the description field and saving.

### Before:
![Before decoding fix](https://cldup.com/eMxsEdKp9F-3000x3000.png)
![Before decoding fix](https://cldup.com/Xpk_gIB0w7-3000x3000.png)

### After:
![After decoding fix](https://cldup.com/JdnVYjeMfa-1200x1200.png)
![After decoding fix](https://cldup.com/3Jth8pSnRE.png)
