### PR TITLE
Framework: Use ES6's Object.assign instead of react/lib's

### DIFF
--- a/client/components/single-child-css-transition-group/index.js
+++ b/client/components/single-child-css-transition-group/index.js
@@ -1,7 +1,5 @@
 var React = require( 'react' );
 
-var assign = require( 'react/lib/Object.assign' );
-
 var ReactTransitionGroup = React.createFactory(
 	require( 'react/lib/ReactTransitionGroup' )
 );
@@ -47,7 +45,7 @@ var SingleChildCSSTransitionGroup = React.createClass( {
 
 	render: function() {
 		return ReactTransitionGroup( // eslint-disable-line
-			assign( {}, this.props, {
+			Object.assign( {}, this.props, {
 				childFactory: this._wrapChild
 			} )
 		);

--- a/client/lib/cart/store/Makefile
+++ b/client/lib/cart/store/Makefile
@@ -7,9 +7,9 @@ NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
 
 # In order to simply stub modules, add test to the NODE_PATH
 test:
-	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers js:babel/register-without-polyfill --reporter $(REPORTER)
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers js:babel/register --reporter $(REPORTER)
 
 integration:
-	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers js:babel/register-without-polyfill --reporter $(REPORTER) test/integration
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers js:babel/register --reporter $(REPORTER) test/integration
 
 .PHONY: test integration

--- a/client/lib/comment-like-store/Makefile
+++ b/client/lib/comment-like-store/Makefile
@@ -6,9 +6,9 @@ NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
 
 # In order to simply stub modules, add test to the NODE_PATH
 test:
-	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --reporter $(REPORTER)
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers js:babel/register --reporter $(REPORTER)
 
 test-w:
-	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --reporter min --watch --growl -b
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers js:babel/register --reporter min --watch --growl -b
 
 .PHONY: test

--- a/client/lib/feed-stream-store/Makefile
+++ b/client/lib/feed-stream-store/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/like-store/Makefile
+++ b/client/lib/like-store/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/olark-store/Makefile
+++ b/client/lib/olark-store/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/people/Makefile
+++ b/client/lib/people/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/post-formats/Makefile
+++ b/client/lib/post-formats/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/preferences/Makefile
+++ b/client/lib/preferences/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/reader-comment-email-subscriptions/Makefile
+++ b/client/lib/reader-comment-email-subscriptions/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/reader-feed-subscriptions/Makefile
+++ b/client/lib/reader-feed-subscriptions/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/reader-post-email-subscriptions/Makefile
+++ b/client/lib/reader-post-email-subscriptions/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/reader-site-blocks/Makefile
+++ b/client/lib/reader-site-blocks/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/reader-site-store/Makefile
+++ b/client/lib/reader-site-store/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/reader-teams/Makefile
+++ b/client/lib/reader-teams/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/recommended-sites-store/Makefile
+++ b/client/lib/recommended-sites-store/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/signup/Makefile
+++ b/client/lib/signup/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= jsx:babel/register-without-polyfill
+COMPILERS ?= jsx:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/site-roles/Makefile
+++ b/client/lib/site-roles/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/sites-list/Makefile
+++ b/client/lib/sites-list/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/stats/stats-list/Makefile
+++ b/client/lib/stats/stats-list/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/terms/Makefile
+++ b/client/lib/terms/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/lib/viewers/Makefile
+++ b/client/lib/viewers/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= js:babel/register-without-polyfill
+COMPILERS ?= js:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/Makefile
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/Makefile
@@ -2,7 +2,7 @@ NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
-COMPILERS ?= jsx:babel/register-without-polyfill
+COMPILERS ?= jsx:babel/register
 REPORTER ?= spec
 UI ?= bdd
 

--- a/shared/dispatcher/index.js
+++ b/shared/dispatcher/index.js
@@ -1,8 +1,7 @@
 var Dispatcher = require( 'flux' ).Dispatcher,
-	assign = require( 'react/lib/Object.assign' ),
 	debug = require( 'debug' )( 'calypso:dispatcher' );
 
-var AppDispatcher = assign( new Dispatcher(), {
+var AppDispatcher = Object.assign( new Dispatcher(), {
 	handleViewAction: function( action ) {
 		debug( 'Dispatching view action %s: %o', action.type, action );
 		this.dispatch( {


### PR DESCRIPTION
Related: #776 #786 #787 

Prerequisite for upgrading to React 0.14. Facebook has moved library modules to a separate package, which they warn against using.

>Note: If you are consuming the code here and you are not also a Facebook project, be prepared for a bad time. APIs may appear or disappear and we may not follow semver strictly, though we will do our best to. This library is being published with our use cases in mind and is not necessarily meant to be consumed by the broader public.

https://github.com/facebook/fbjs

`Object.assign` is already widely used in the Calypso project and behaves the same as `react/lib/object-assign` when passed a number of argument objects.

__Testing instructions:__

Ensure that no references remain for `react/lib/Object.assign`. Verify also that the application continues to work, especially for sections making use of `Object.assign` functionality (only used via `shared/dispatcher/index.js` and the `SingleChildCSSTransitionGroup` component, which is used for `Dialog`s, i.e. modals.) 

/cc @blowery @aduth 11943-gh-calypso-pre-oss