### PR TITLE
Build: Restart server on file change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install: node_modules
 
 # Simply running `make run` will spawn the Node.js server instance.
 run: welcome githooks-commit install build
-	@$(NODEMON) --watch build build/bundle-$(CALYPSO_ENV).js
+	@$(NODEMON) --watch server --watch shared  --exec "CALYPSO_ENV=$(CALYPSO_ENV) $(SERVER_BUILD_COMMAND); $(NODE)" build/bundle-$(CALYPSO_ENV).js
 
 # a helper rule to ensure that a specific module is installed,
 # without relying on a generic `npm install` command
@@ -120,14 +120,11 @@ builddir:
 build-server: install builddir
 	@CALYPSO_ENV=$(CALYPSO_ENV) $(SERVER_BUILD_COMMAND)
 
-build-and-watch-server: install builddir
-	@CALYPSO_ENV=$(CALYPSO_ENV) $(SERVER_BUILD_COMMAND) --watch &
-
 build: install build-$(CALYPSO_ENV)
 
 build-css: public/style.css public/style-rtl.css public/style-debug.css public/editor.css
 
-build-development: build-and-watch-server $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
+build-development: install builddir $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
 
 build-wpcalypso: build-server $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
 	@$(BUNDLER)

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ NODE_BIN := $(THIS_DIR)/node_modules/.bin
 
 # applications
 NODE ?= node
+NODEMON ?= $(NODE_BIN)/nodemon
 NPM ?= $(NODE) $(shell which npm)
 BUNDLER ?= $(BIN)/bundler
 SASS ?= $(NODE_BIN)/node-sass --include-path 'client:shared'
@@ -35,6 +36,8 @@ CLIENT_CONFIG_FILE := client/config/index.js
 NODE_ENV ?= development
 CALYPSO_ENV ?= $(NODE_ENV)
 
+SERVER_BUILD_COMMAND ?= $(NODE_BIN)/webpack --display-error-details --config webpack.config.node.js
+
 export NODE_ENV := $(NODE_ENV)
 export CALYPSO_ENV := $(CALYPSO_ENV)
 export NODE_PATH := server:shared:.
@@ -53,7 +56,7 @@ install: node_modules
 
 # Simply running `make run` will spawn the Node.js server instance.
 run: welcome githooks-commit install build
-	@$(NODE) build/bundle-$(CALYPSO_ENV).js
+	@$(NODEMON) --watch build build/bundle-$(CALYPSO_ENV).js
 
 # a helper rule to ensure that a specific module is installed,
 # without relying on a generic `npm install` command
@@ -111,15 +114,20 @@ public/editor.css: node_modules $(SASS_FILES)
 server/devdocs/search-index.js: $(MD_FILES) $(ALL_DEVDOCS_JS)
 	@$(ALL_DEVDOCS_JS) $(MD_FILES)
 
-build-server: install
+builddir:
 	@mkdir -p build
-	@CALYPSO_ENV=$(CALYPSO_ENV) $(NODE_BIN)/webpack --display-error-details --config webpack.config.node.js
+
+build-server: install builddir
+	@CALYPSO_ENV=$(CALYPSO_ENV) $(SERVER_BUILD_COMMAND)
+
+build-and-watch-server: install builddir
+	@CALYPSO_ENV=$(CALYPSO_ENV) $(SERVER_BUILD_COMMAND) --watch &
 
 build: install build-$(CALYPSO_ENV)
 
 build-css: public/style.css public/style-rtl.css public/style-debug.css public/editor.css
 
-build-development: build-server $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
+build-development: build-and-watch-server $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
 
 build-wpcalypso: build-server $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js build-css
 	@$(BUNDLER)

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "mocha": "2.3.4",
     "mockery": "1.4.0",
     "nock": "2.17.0",
+    "nodemon": "1.8.1",
     "react-hot-loader": "1.3.0",
     "rewire": "2.3.3",
     "sinon": "1.12.2",


### PR DESCRIPTION
At the moment, changes to a file used on the server, including shared modules, requires the Node server to be restarted. Now that we are starting to use more shared modules, an automatic compile/restart becomes more important.

This PR changes the run target so that it:

Runs webpack --watch on server files in the background to compile on change.
Uses nodemon to restart server after compilation.

**To Test**
`make clean`
`make run`
Make a change to any file used on the server and check that the server restarts and picks up the change
