### PR TITLE
WordAds: Change 'WordAds' to 'AdControl' for JP sites.

### DIFF
--- a/client/my-sites/ads/controller.js
+++ b/client/my-sites/ads/controller.js
@@ -25,11 +25,12 @@ function _recordPageView( context, analyticsPageTitle ) {
 }
 
 function _getLayoutTitle( context ) {
+	var title = sites.getSelectedSite().jetpack ? 'AdControl' : 'WordAds';
 	switch ( context.params.section ) {
 		case 'earnings':
-			return i18n.translate( '%(wordads)s Earnings', { args: { wordads: 'WordAds' } } );
+			return i18n.translate( '%(wordads)s Earnings', { args: { wordads: title } } );
 		case 'settings':
-			return i18n.translate( '%(wordads)s Settings', { args: { wordads: 'WordAds' } } );
+			return i18n.translate( '%(wordads)s Settings', { args: { wordads: title } } );
 	}
 }
 

--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -135,7 +135,7 @@ module.exports = React.createClass( {
 			name: '',
 			optimized_ads: false,
 			paypal: '',
-			show_to_logged_in: this.props.site.jetpack ? 'yes' : 'pause',
+			show_to_logged_in: 'yes',
 			state: '',
 			taxid_last4: '',
 			tos: 'signed',

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -131,7 +131,7 @@ module.exports = React.createClass( {
 		return (
 			<li className={ this.itemLinkClass( '/ads', 'ads' ) }>
 				<a onClick={ this.onNavigate } href={ adsLink }>
-					<span className="menu-link-text">WordAds</span>
+					<span className="menu-link-text">{ site.jetpack ? 'AdControl' : 'WordAds' }</span>
 				</a>
 			</li>
 		);


### PR DESCRIPTION
Also, show_to_logged_in defaults to ‘yes’ now to reflect auto-on status for accepted sites.

In JP site on Calypso dev:
* Need ‘blessed’ WordAds site.
* WordAds sidebar -> Settings tab
* You should see ‘AdControl’ in sidebar and page title.