### PR TITLE
WordAds: Turn on WordAds for Jetpack in staging, wpcalypso, and horizon.

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,6 +21,7 @@
 		"editor-drafts": true,
 
 		"manage/ads": true,
+		"manage/ads/jetpack": true,
 		"manage/stats": true,
 		"manage/stats/insights": true,
 		"manage/jetpack": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,6 +19,7 @@
 		"post-editor/pages": true,
 		"editor-drafts": true,
 		"manage/ads": true,
+		"manage/ads/jetpack": true,
 		"manage/customize": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -21,6 +21,7 @@
 		"editor-drafts": true,
 
 		"manage/ads": true,
+		"manage/ads/jetpack": true,
 		"manage/stats": true,
 		"manage/stats/insights": true,
 		"manage/jetpack": true,


### PR DESCRIPTION
Simple config update, see title.