### PR TITLE
Editor: fix available publicize connections

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -31,7 +31,8 @@ var Accordion = require( 'components/accordion' ),
 	actions = require( 'lib/posts/actions' ),
 	stats = require( 'lib/posts/stats' ),
 	observe = require( 'lib/mixins/data-observe' ),
-	siteUtils = require( 'lib/site/utils' );
+	siteUtils = require( 'lib/site/utils' ),
+	user = require( 'lib/user' )();
 
 var EditorDrawer = React.createClass( {
 
@@ -113,8 +114,9 @@ var EditorDrawer = React.createClass( {
 	},
 
 	renderSharing: function() {
+		const currentUser = user.get();
 		return (
-			<EditorSharingContainer site={ this.props.site } />
+			<EditorSharingContainer site={ this.props.site } currentUserID={ currentUser.ID } />
 		);
 	},
 

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -115,6 +115,10 @@ var EditorDrawer = React.createClass( {
 
 	renderSharing: function() {
 		const currentUser = user.get();
+		if ( ! currentUser ) {
+			return null;
+		}
+
 		return (
 			<EditorSharingContainer site={ this.props.site } currentUserID={ currentUser.ID } />
 		);

--- a/client/post-editor/editor-sharing/container.jsx
+++ b/client/post-editor/editor-sharing/container.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  */
 import PostEditStore from 'lib/posts/post-edit-store';
 import { fetchConnections } from 'lib/sharing/publicize/actions';
-import { getConnectionsBySiteId, hasFetchedConnections } from 'lib/sharing/publicize/selectors';
+import { getConnectionsBySiteIdAvailableToCurrentUser, hasFetchedConnections } from 'lib/sharing/publicize/selectors';
 import EditorSharingAccordion from './accordion';
 
 class EditorSharingContainer extends Component {
@@ -81,6 +81,7 @@ class EditorSharingContainer extends Component {
 
 EditorSharingContainer.propTypes = {
 	site: PropTypes.object,
+	currentUserID: PropTypes.number.isRequired,
 	dispatch: PropTypes.func.isRequired,
 	hasFetchedConnections: PropTypes.bool,
 	connections: PropTypes.array
@@ -90,7 +91,7 @@ export default connect(
 	( state, props ) => {
 		return {
 			hasFetchedConnections: props.site && hasFetchedConnections( state, props.site.ID ),
-			connections: props.site ? getConnectionsBySiteId( state, props.site.ID ) : null
+			connections: props.site ? getConnectionsBySiteIdAvailableToCurrentUser( state, props.site.ID, props.currentUserID ) : null
 		};
 	}
 )( EditorSharingContainer );

--- a/shared/lib/sharing/publicize/selectors.js
+++ b/shared/lib/sharing/publicize/selectors.js
@@ -18,6 +18,23 @@ export function getConnectionsBySiteId( state, siteId ) {
 }
 
 /**
+ * Returns an array of known connections for the given site ID
+ * that are available to the current user
+ *
+ * @param  {Object} state         Global state tree
+ * @param  {Number} siteId        Site ID
+ * @param  {Number} currentUserID ID of the current user
+ * @return {Array}                Site connections
+ */
+export function getConnectionsBySiteIdAvailableToCurrentUser( state, siteId, currentUserID ) {
+	const connectionsBySiteId = getConnectionsBySiteId( state, siteId );
+
+	return connectionsBySiteId.filter( connection => {
+		return connection.shared || connection.keyring_connection_user_ID === currentUserID;
+	} );
+}
+
+/**
  * Returns true if connections have been fetched for the given site ID.
  *
  * @param  {Object} state  Global state tree

--- a/shared/lib/sharing/publicize/test/actions.js
+++ b/shared/lib/sharing/publicize/test/actions.js
@@ -81,7 +81,7 @@ describe( '#fetchConnections()', () => {
 			const action = spy.getCall( 1 ).args[ 0 ];
 			expect( action.type ).to.equal( FAIL_PUBLICIZE_CONNECTIONS_REQUEST );
 			expect( action.siteId ).to.equal( 77203074 );
-			expect( action.error.message ).to.equal( 'Forbidden' );
+			expect( action.error.message ).to.equal( 'An active access token must be used to access publicize connections.' );
 
 			done();
 		} ).catch( done );

--- a/shared/lib/sharing/publicize/test/selectors.js
+++ b/shared/lib/sharing/publicize/test/selectors.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getConnectionsBySiteId,
+	getConnectionsBySiteIdAvailableToCurrentUser,
 	hasFetchedConnections,
 	isFetchingConnections
 } from '../selectors';
@@ -44,6 +45,43 @@ describe( '#getConnectionsBySiteId()', () => {
 		expect( connections ).to.eql( [
 			{ ID: 1, site_ID: 2916284 },
 			{ ID: 2, site_ID: 2916284 }
+		] );
+	} );
+} );
+
+describe( '#getConnectionsBySiteIdAvailableToCurrentUser()', () => {
+	it( 'should return an empty array for a site which has not yet been fetched', () => {
+		const connections = getConnectionsBySiteIdAvailableToCurrentUser( {
+			sharing: {
+				publicize: {
+					connectionsBySiteId: {},
+					connections: {}
+				}
+			}
+		}, 2916284, 26957695 );
+
+		expect( connections ).to.eql( [] );
+	} );
+
+	it( 'should return an array of connection objects received for the site that are available to the current user', () => {
+		const connections = getConnectionsBySiteIdAvailableToCurrentUser( {
+			sharing: {
+				publicize: {
+					connectionsBySiteId: {
+						2916284: [ 1, 2, 3 ]
+					},
+					connections: {
+						1: { ID: 1, site_ID: 2916284, shared: true },
+						2: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695 },
+						3: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 18342963 }
+					}
+				}
+			}
+		}, 2916284, 26957695 );
+
+		expect( connections ).to.eql( [
+			{ ID: 1, site_ID: 2916284, shared: true },
+			{ ID: 2, site_ID: 2916284, keyring_connection_user_ID: 26957695 }
 		] );
 	} );
 } );


### PR DESCRIPTION
Fixes #867

Fixes available publicize connections by filtering them appropriately for the
current user context. Only shared connections or those belonging to the
current user should be available within the sharing accordion.

__Testing Instructions:__

Open the Editor for different sites with a different set of publicize connections available for each, and ensure that only shared connections or those belonging to you are offered within the sharing accordion. 