### PR TITLE
Framework: update `wpcom-unpublished` to `1.0.7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
     "walk": "2.3.4",
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",
+    "wpcom-unpublished": "1.0.7",
     "wpcom-proxy-request": "1.0.5",
-    "wpcom-unpublished": "1.0.5",
     "wpcom-xhr-request": "0.3.3",
     "xgettext-js": "0.2.0"
   },


### PR DESCRIPTION
We've released [`wpcom-unpublished@1.0.7`](https://github.com/Automattic/wpcom-unpublished/blob/master/History.md#107--2015-11-26) and [`wpcom@4.8.2`](https://github.com/Automattic/wpcom.js/blob/master/History.md#482--2015-11-26).

There are a lot of improvements from `1.0.5` to `1.0.7`. The most importantes changes:

* Replace builder system `Browserify` by `Webpack`
* Support `Promises`

```es6
import wpcomFactory from 'wpcom-unpublished';

wpcomFactory()
    .site( '<site-id>' )
    .postsList( { number: 8 } )
        then( list => { ... } )
        catch( error => { ... } );
```

* add `runtime` in the compiling process (babel) to ensure cross-browser support (IE).

### How to test

```cli
> make clean
> make install
> make run
```

* Open the browser pointing to `http://calypso.localhost:3000/`
* If it's possible test the app under IE