### PR TITLE
Domain Management: loosen restrictions for resource records

### DIFF
--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -61,6 +61,11 @@ function isValidName( name, type, selectedDomainName ) {
 				isValidCname( name, selectedDomainName ) &&
 				isValidDomainName( name, type )
 			);
+		case 'SRV':
+			return (
+				name === '' ||
+				isValidDomainName( name, type )
+			);
 		default:
 			return isValidDomainName( name, type );
 	}

--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -45,12 +45,15 @@ function validateField( { name, value, type, selectedDomainName } ) {
  * and more loosely defined domain names for other records.
  */
 function isValidDomainName( name, type ) {
+	if ( name.length > 253 ) {
+		return false;
+	}
 	switch ( type ) {
 		case 'A':
 		case 'AAAA':
 			return /^([a-z0-9]([a-z0-9\-]*[a-z0-9])?\.)+[a-z0-9]([a-z0-9\-]*[a-z0-9])?\.[a-z]{2,63}$/i.test( name );
 		default:
-			return /^([a-z0-9-_]+\.)*[a-z0-9-]+\.[a-z]{2,63}$/i.test( name );
+			return /^([a-z0-9-_]{1,63}\.)*[a-z0-9-]{1,63}\.[a-z]{2,63}$/i.test( name );
 	}
 }
 

--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -75,10 +75,7 @@ function isValidName( name, type, selectedDomainName ) {
 }
 
 function isValidCname( name, selectedDomainName ) {
-	return (
-		name !== selectedDomainName &&
-		endsWith( name, selectedDomainName )
-	);
+	return endsWith( name, '.' + selectedDomainName );
 }
 
 function isValidData( data, type ) {

--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -23,7 +23,7 @@ function validateField( { name, value, type, selectedDomainName } ) {
 		case 'name':
 			return isValidName( value, type, selectedDomainName );
 		case 'target':
-			return isValidDomainName( value );
+			return isValidDomainName( value, type );
 		case 'data':
 			return isValidData( value, type );
 		case 'protocol':
@@ -39,8 +39,19 @@ function validateField( { name, value, type, selectedDomainName } ) {
 	}
 }
 
-function isValidDomainName( name ) {
-	return /^([\da-z-]+\.)+[\da-z-]+$/i.test( name );
+/*
+ * As per RFC 2181, there's actually only one restriction for DNS records - length.
+ * But to keep things sane, we only allow host names for A/AAAA records (RFC 952 and RFC 1123)
+ * and more loosely defined domain names for other records.
+ */
+function isValidDomainName( name, type ) {
+	switch ( type ) {
+		case 'A':
+		case 'AAAA':
+			return /^([a-z0-9]([a-z0-9\-]*[a-z0-9])?\.)+[a-z0-9]([a-z0-9\-]*[a-z0-9])?\.[a-z]{2,63}$/i.test( name );
+		default:
+			return /^([a-z0-9-_]+\.)*[a-z0-9-]+\.[a-z]{2,63}$/i.test( name );
+	}
 }
 
 function isValidName( name, type, selectedDomainName ) {
@@ -48,10 +59,10 @@ function isValidName( name, type, selectedDomainName ) {
 		case 'CNAME':
 			return (
 				isValidCname( name, selectedDomainName ) &&
-				isValidDomainName( name )
+				isValidDomainName( name, type )
 			);
 		default:
-			return isValidDomainName( name );
+			return isValidDomainName( name, type );
 	}
 }
 
@@ -70,7 +81,7 @@ function isValidData( data, type ) {
 			return data.match( /^[a-f0-9\:]+$/i );
 		case 'CNAME':
 		case 'MX':
-			return isValidDomainName( data );
+			return isValidDomainName( data, type );
 		case 'TXT':
 			return data.length < 256;
 	}
@@ -100,7 +111,7 @@ function removeTrailingDomain( domain, trailing ) {
 
 function getFieldWithDot( field ) {
 	// something that looks like domain but doesn't end with a dot
-	return ( typeof field === 'string' && field.match( /^([a-z0-9-]+\.)+\.?[a-z]+$/i ) ) ? field + '.' : field;
+	return ( typeof field === 'string' && field.match( /^([a-z0-9-_]+\.)+\.?[a-z]+$/i ) ) ? field + '.' : field;
 }
 
 module.exports = {


### PR DESCRIPTION
As per [RFC 2181](http://tools.ietf.org/html/rfc2181#section-11), there's actually only one restriction for DNS records - length.
But realistically speaking, we should do some sane checking.
For A/AAAA records we enforce a valid *hostname* as per [RFC 952](http://tools.ietf.org/html/rfc952) and [RFC 1123](http://tools.ietf.org/html/rfc1123).
For other resource records, we are more forgiving - e.g. we allow `-` and `_` in any position in the subdomains.

Additional reading:

 * [an informative answer](http://stackoverflow.com/a/14622263/181497) on StackOverflow on the matter

Testing:

 * `A`/`AAAA` records should have the usual strict rules for _hostnames_ - so no `_`, no `-` as the first/last character, etc.
 * other resource records (`CNAME`, `MX`, etc.) should be more permissive and allow names/targets such as `_domain.test.example.com` but not `#gryffins4life!`. Domains longer than 253 characters should not be allowed.

This change is for the frontend only. So even if the domain validates properly on the client side, you won't be able to save it because the backend will reject it. This will be fixed in a separate patch.

cc @dzver 