### PR TITLE
Plugin single view feature gate

### DIFF
--- a/client/components/feature-example/style.scss
+++ b/client/components/feature-example/style.scss
@@ -1,5 +1,5 @@
 .feature-example {
-	height: 300px;
+	height: 400px;
 	margin-top: 36px;
 	position: relative;
 	overflow: hidden;
@@ -8,7 +8,7 @@
 .feature-example__gradient {
 	position: absolute;
 		top: 0;
-	height: 300px;
+	height: 100%;
 	width: 100%;
 	background: linear-gradient( to bottom, rgba(243, 246, 248, 0.4), rgba( 243, 246, 248, 1) );
 }

--- a/client/my-sites/plugins/plugin-meta/README.md
+++ b/client/my-sites/plugins/plugin-meta/README.md
@@ -24,3 +24,4 @@ render: function() {
 * `siteURL` : (string) The URL of the selected site. Used to determine if this is a single or all sites view.
 * `sites` : (array) An array of the sites that current plugin is installed on.
 * `isPlaceholder`: (boolean) Whether the component is being rendered in placeholder mode
+* `isMock`: a boolean indicating if the toggle should not launch any real action when interacted

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -66,9 +66,9 @@ export default React.createClass( {
 
 		return (
 			<div className="plugin-meta__actions">
-				<PluginActivateToggle plugin={ this.props.plugin } site={ this.props.selectedSite } notices={ this.props.notices } />
-				<PluginAutoupdateToggle plugin={ this.props.plugin } site={ this.props.selectedSite } notices={ this.props.notices } wporg={ this.props.plugin.wporg } />
-				<PluginRemoveButton plugin={ this.props.plugin } site={ this.props.selectedSite } notices={ this.props.notices } />
+				<PluginActivateToggle { ...this.props } site={ this.props.selectedSite } />
+				<PluginAutoupdateToggle { ...this.props } site={ this.props.selectedSite } wporg={ this.props.plugin.wporg } />
+				<PluginRemoveButton { ...this.props } site={ this.props.selectedSite } />
 				{ this.renderSettingsLink() }
 			</div>
 		);

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -66,9 +66,9 @@ export default React.createClass( {
 
 		return (
 			<div className="plugin-meta__actions">
-				<PluginActivateToggle { ...this.props } site={ this.props.selectedSite } />
-				<PluginAutoupdateToggle { ...this.props } site={ this.props.selectedSite } wporg={ this.props.plugin.wporg } />
-				<PluginRemoveButton { ...this.props } site={ this.props.selectedSite } />
+				<PluginActivateToggle plugin={ this.props.plugin } site={ this.props.selectedSite } notices={ this.props.notices } isMock={ this.props.isMock } />
+				<PluginAutoupdateToggle plugin={ this.props.plugin } site={ this.props.selectedSite } notices={ this.props.notices } wporg={ this.props.plugin.wporg } isMock={ this.props.isMock } />
+				<PluginRemoveButton plugin={ this.props.plugin } site={ this.props.selectedSite } notices={ this.props.notices } isMock={ this.props.isMock } />
 				{ this.renderSettingsLink() }
 			</div>
 		);

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -305,8 +305,8 @@ export default React.createClass( {
 					<JetpackManageErrorPage
 						template="optInManage"
 						site={ this.props.site }
-						actionURL={ selectedSite.getRemoteManagementURL() }
-						illustration= '/calypso/images/drake/drake-jetpack.svg'
+						actionURL={ selectedSite.getRemoteManagementURL() + '&section=plugings' }
+						illustration= '/calypso/images/jetpack/jetpack-manage.svg'
 						featureExample={ this.getMockPlugin() } />
 				</MainComponent>
 			);

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -244,6 +244,31 @@ export default React.createClass( {
 		);
 	},
 
+	getMockPlugin() {
+		const selectedSite = {
+			slug: 'no-slug',
+			canUpdateFiles: true,
+			name: 'Not a real site',
+			options: {
+				'software_version': 1
+			}
+		}
+		return (
+			<MainComponent>
+				<div className="plugin__page">
+					{ this.displayHeader() }
+					<PluginMeta
+						notices={ [] }
+						plugin={ this.state.plugin }
+						siteUrl={ 'no-real-url' }
+						sites={ [ selectedSite ] }
+						selectedSite={ selectedSite }
+						isMock={ true } />
+				</div>
+			</MainComponent>
+		);
+	},
+
 	render() {
 		const selectedSite = this.props.sites.getSelectedSite(),
 			classes = classNames( 'plugin__page', { 'is-wpcom': this.props.isWpcomPlugin } );
@@ -280,8 +305,9 @@ export default React.createClass( {
 					<JetpackManageErrorPage
 						template="optInManage"
 						site={ this.props.site }
-						actionURL={ selectedSite.getRemoteManagementURL() + '&section=plugins' }
-						illustration= '/calypso/images/drake/drake-jetpack.svg' />
+						actionURL={ selectedSite.getRemoteManagementURL() }
+						illustration= '/calypso/images/drake/drake-jetpack.svg'
+						featureExample={ this.getMockPlugin() } />
 				</MainComponent>
 			);
 		}


### PR DESCRIPTION
This PR depends on the `FeatureExample` component and the changes introduced at https://github.com/Automattic/wp-calypso/pull/838, so until that PR is merged, this would be unmergeable. Also, the changeset includes the commits on #838, so it will be more easily revieweable once that one is in master.

Plugin single view not-manage error page didn't containt a feature example. This PR adds it:

Before:
![image](https://cloud.githubusercontent.com/assets/1554855/11439146/edcf3556-94f9-11e5-9dc2-22c386295533.png)


After:
![image](https://cloud.githubusercontent.com/assets/1554855/11439140/e4976288-94f9-11e5-8c06-91a89b485157.png)

How to test
=========

1. You need a jetpack site with manage off
2. Go to http://calypso.dev:3000/plugins/akismet
3. Select your site
4. You should see the error screen