### PR TITLE
Plugin-icon update to es6

### DIFF
--- a/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
@@ -1,20 +1,25 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	Gridicon = require( 'components/gridicon' );
+import React from 'react'
+import classNames from 'classnames'
+import Gridicon from 'components/gridicon'
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'PluginIcon',
 
-	render: function() {
-		var className = classNames( {
-			'plugin-icon': true,
-			'is-placeholder': this.props.isPlaceholder,
-			'is-fallback': ! this.props.image
-		} ),
+	propTypes: {
+		image: React.PropTypes.string,
+		isPlaceholder: React.PropTypes.bool
+	},
+
+	render() {
+		const className = classNames( {
+				'plugin-icon': true,
+				'is-placeholder': this.props.isPlaceholder,
+				'is-fallback': ! this.props.image
+			} ),
 		avatar = ( this.props.isPlaceholder || ! this.props.image ) ? <Gridicon icon="plugins" /> : <img className="plugin-icon__img" src={ this.props.image } />;
 
 		return (


### PR DESCRIPTION
Not much to say... add missing proptypes and updates `plugin-icon` to es6.

how to test
========
1. Go to http://calypso.dev:3000/plugins/akismet and make sure the plugin icon keeps being there