### PR TITLE
Checkout: Open blocked purchase support link in a new tab

### DIFF
--- a/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
+++ b/client/my-sites/upgrades/cart/cart-messages-mixin.jsx
@@ -37,7 +37,7 @@ module.exports = {
 			"Purchases are currently disabled. Please {{a}}contact us{{/a}} to re-enable purchases.",
 			{
 				components: {
-					a: <a href={ 'https://wordpress.com/error-report/?url=payment@' + this.props.selectedSite.slug } />
+					a: <a href={ 'https://wordpress.com/error-report/?url=payment@' + this.props.selectedSite.slug } target="_blank" />
 				}
 			}
 		);


### PR DESCRIPTION
Without the `target="_blank"` set the link doesn't open the support form and instead reloads the current page.

cc @gziolo 