### PR TITLE
Web preview: remove fake placeholder in favour of <Spinner>.

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -11,6 +11,7 @@ import debugModule from 'debug';
 import Toolbar from './toolbar';
 import touchDetect from 'lib/touch-detect';
 import { isMobile } from 'lib/viewport';
+import Spinner from 'components/spinner';
 
 const debug = debugModule( 'calypso:web-preview' );
 
@@ -33,9 +34,7 @@ const WebPreview = React.createClass( {
 		// Elements to render on the right side of the toolbar
 		children: React.PropTypes.node,
 		// Called when the preview is closed, either via the 'X' button or the escape key
-		onClose: React.PropTypes.func,
-		// Loading message to display along with placeholder
-		loadingMessage: React.PropTypes.string,
+		onClose: React.PropTypes.func
 	},
 
 	mixins: [ React.addons.PureRenderMixin ],
@@ -44,8 +43,7 @@ const WebPreview = React.createClass( {
 		return {
 			showExternal: true,
 			showDeviceSwitcher: true,
-			previewUrl: 'about:blank',
-			loadingMessage: ''
+			previewUrl: 'about:blank'
 		}
 	},
 
@@ -158,7 +156,7 @@ const WebPreview = React.createClass( {
 						showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
 					/>
 					<div className="web-preview__placeholder">
-						{ ! this.state.loaded && this.props.loadingMessage }
+						{ ! this.state.loaded && <Spinner /> }
 						{ this.shouldRenderIframe() &&
 							<iframe
 								className="web-preview__frame"

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -34,7 +34,9 @@ const WebPreview = React.createClass( {
 		// Elements to render on the right side of the toolbar
 		children: React.PropTypes.node,
 		// Called when the preview is closed, either via the 'X' button or the escape key
-		onClose: React.PropTypes.func
+		onClose: React.PropTypes.func,
+		// Optional loading message to display during loading
+		loadingMessage: React.PropTypes.string
 	},
 
 	mixins: [ React.addons.PureRenderMixin ],
@@ -156,7 +158,16 @@ const WebPreview = React.createClass( {
 						showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
 					/>
 					<div className="web-preview__placeholder">
-						{ ! this.state.loaded && <Spinner /> }
+						{ ! this.state.loaded &&
+							<div>
+								<Spinner />
+								{ this.props.loadingMessage &&
+									<span className="web-preview__loading-message">
+										{ this.props.loadingMessage }
+									</span>
+								}
+							</div>
+						}
 						{ this.shouldRenderIframe() &&
 							<iframe
 								className="web-preview__frame"

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -140,38 +140,13 @@
 }
 
 .web-preview__placeholder {
-	animation: loading-fade 0.8s ease-in-out infinite;
 	width: 100%;
 	height: 100%;
+}
 
-	line-height: 160px;
-	font-size: 16px;
-	color: $white;
-	text-align: center;
-
-	background:
-		linear-gradient(to bottom, lighten( $gray, 20% ) 160px, transparent 160px, transparent),
-		linear-gradient(to bottom, lighten( $gray, 20% ) 40px, lighten( $gray, 20% ) ),
-		linear-gradient(to bottom, lighten( $gray, 20% ) 40px, lighten( $gray, 20% ) ),
-		linear-gradient(to bottom, lighten( $gray, 20% ) 40px, lighten( $gray, 20% ) ),
-		linear-gradient(to bottom, lighten( $gray, 20% ) 40px, lighten( $gray, 20% ) );
-
-	background-position:
-		0% 0%,
-		20px 200px,
-		20px 268px,
-		20px 316px,
-		20px 366px;
-	background-size:
-		100% 100%,
-		200px 48px,
-		82% 26px,
-		87% 26px,
-		55% 26px;
-
-	background-repeat: no-repeat;
-
-	.is-loaded & {
-		animation: none;
-	}
+.web-preview .spinner {
+	margin-left: -10px;
+	position: absolute;
+		top: 45%;
+		left: 50%;
 }

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -46,11 +46,16 @@
 	.is-phone & {
 		width: 460px;
 	}
+}
 
+.web-preview.is-computer .web-preview__content,
+.web-preview.is-tablet .web-preview__content,
+.web-preview.is-phone .web-preview__content {
 	@include breakpoint( "<660px" ) {
 		left: 0;
 		right: 0;
 		top: 0;
+		width: 100%;
 	}
 }
 
@@ -117,6 +122,10 @@
 	&.is-active {
 		color: $gray-dark;
 	}
+
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
 }
 
 .web-preview__toolbar-tray {
@@ -149,6 +158,10 @@
 	position: absolute;
 		top: 45%;
 		left: 50%;
+
+	@include breakpoint( "<660px" ) {
+		top: 20%;
+	}
 }
 
 .web-preview__loading-message {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -150,3 +150,12 @@
 		top: 45%;
 		left: 50%;
 }
+
+.web-preview__loading-message {
+	color: $gray;
+	font-size: 18px;
+	font-weight: 300;
+	text-align: center;
+	display: block;
+	margin: 48px 0;
+}

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -86,7 +86,6 @@ const EditorPreview = React.createClass( {
 				defaultViewportDevice="tablet"
 				onClose={ this.props.onClose }
 				previewUrl={ this.state.iframeUrl }
-				loadingMessage="Beep beep boop…"
 			/>
 		);
 	}

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -86,6 +86,7 @@ const EditorPreview = React.createClass( {
 				defaultViewportDevice="tablet"
 				onClose={ this.props.onClose }
 				previewUrl={ this.state.iframeUrl }
+				loadingMessage="Beep beep boop…"
 			/>
 		);
 	}


### PR DESCRIPTION
We had previously discussed the fake placeholders were not the best solution since they won't conform at all to the theme. This replaces it with a `<Spinner>`. (Also removes the placeholder message `prop` since it's no longer needed.)