### PR TITLE
Editor: Allow parent page to be removed.

### DIFF
--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -25,7 +25,8 @@ export default React.createClass( {
 		selected: PropTypes.number,
 		excludeTree: PropTypes.number,
 		orderBy: PropTypes.oneOf( [ 'title', 'date', 'modified', 'comment_count', 'ID' ] ),
-		order: PropTypes.oneOf( [ 'ASC', 'DESC' ] )
+		order: PropTypes.oneOf( [ 'ASC', 'DESC' ] ),
+		postListStoreId: PropTypes.string
 	},
 
 	getDefaultProps() {
@@ -35,7 +36,8 @@ export default React.createClass( {
 			multiple: false,
 			onChange: noop,
 			orderBy: 'title',
-			order: 'ASC'
+			order: 'ASC',
+			postListStoreId: 'post-selector'
 		};
 	},
 
@@ -61,6 +63,7 @@ export default React.createClass( {
 				excludeTree={ this.props.excludeTree }
 				orderBy={ this.props.orderBy }
 				order={ this.props.order }
+				postListStoreId={ this.props.postListStoreId }
 			>
 				<Selector
 					{ ...omit( this.props, 'children' ) }

--- a/client/post-editor/editor-page-parent/index.jsx
+++ b/client/post-editor/editor-page-parent/index.jsx
@@ -24,7 +24,7 @@ export default React.createClass( {
 	},
 
 	updatePageParent( item ) {
-		const parentId = item ? item.ID : null;
+		const parentId = item && item.ID ? item.ID : null;
 		postActions.edit( {
 			parent: parentId
 		} );

--- a/client/post-editor/editor-page-parent/index.jsx
+++ b/client/post-editor/editor-page-parent/index.jsx
@@ -10,7 +10,7 @@ import AccordionSection from 'components/accordion/section';
 import PostSelector from 'my-sites/post-selector';
 import postActions from 'lib/posts/actions';
 import FormLabel from 'components/forms/form-label';
-import FormCheckbox from 'components/forms/form-checkbox';
+import FormToggle from 'components/forms/form-toggle/compact';
 
 export default React.createClass( {
 	displayName: 'EditorPageParent',
@@ -44,9 +44,15 @@ export default React.createClass( {
 				<FormLabel>
 					<span className="editor-page-parent__label-text">{ this.translate( 'Parent Page' ) }</span>
 				</FormLabel>
-				<FormLabel>
-					<FormCheckbox ref="topLevel" checked={ ! this.props.parent } onChange={ this.updatePageParent } />
-					{ this.translate( 'Top level page', { context: 'Categories: New category being created is top level i.e. has no parent' } ) }
+				<FormLabel className="editor-page-parent__top-level">
+					<span className="editor-page-parent__top-level-label">
+						{ this.translate( 'Top level page', { context: 'Editor: Page being edited is top level i.e. has no parent' } ) }
+					</span>
+					<FormToggle
+						checked={ ! this.props.parent }
+						onChange={ this.updatePageParent }
+						aria-label={ this.translate( 'Toggle to set page as top level' ) }
+					/>
 				</FormLabel>
 				<PostSelector
 					type="page"

--- a/client/post-editor/editor-page-parent/index.jsx
+++ b/client/post-editor/editor-page-parent/index.jsx
@@ -9,6 +9,8 @@ import AccordionSection from 'components/accordion/section';
  */
 import PostSelector from 'my-sites/post-selector';
 import postActions from 'lib/posts/actions';
+import FormLabel from 'components/forms/form-label';
+import FormCheckbox from 'components/forms/form-checkbox';
 
 export default React.createClass( {
 	displayName: 'EditorPageParent',
@@ -22,25 +24,30 @@ export default React.createClass( {
 	},
 
 	updatePageParent( item ) {
+		const parentId = item ? item.ID : null;
 		postActions.edit( {
-			parent: item.ID
+			parent: parentId
 		} );
 	},
 
 	getEmptyMessage() {
 		if ( this.props.postId ) {
 			return this.translate( 'You have no other pages yet.' );
-		} else {
-			return this.translate( 'You have no pages yet.' );
 		}
+
+		return this.translate( 'You have no pages yet.' );
 	},
 
 	render() {
 		return (
 			<AccordionSection className="editor-page-parent">
-				<label>
+				<FormLabel>
 					<span className="editor-page-parent__label-text">{ this.translate( 'Parent Page' ) }</span>
-				</label>
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox ref="topLevel" checked={ ! this.props.parent } onChange={ this.updatePageParent } />
+					{ this.translate( 'Top level page', { context: 'Categories: New category being created is top level i.e. has no parent' } ) }
+				</FormLabel>
 				<PostSelector
 					type="page"
 					siteId={ this.props.siteId }

--- a/client/post-editor/editor-page-parent/style.scss
+++ b/client/post-editor/editor-page-parent/style.scss
@@ -46,3 +46,20 @@
 	margin-bottom: 4px;
 	text-transform: uppercase;
 }
+
+.editor-page-parent__top-level-label {
+	color: darken( $gray, 10% );
+	font-size: 13px;
+	line-height: 1.7;
+}
+
+.editor-page-parent__top-level {
+	align-content: center;
+	display: flex;
+	justify-content: space-between;
+
+	.gridicon {
+		margin-left: 4px;
+		vertical-align: middle;
+	}
+}

--- a/client/post-editor/editor-page-parent/style.scss
+++ b/client/post-editor/editor-page-parent/style.scss
@@ -57,9 +57,4 @@
 	align-content: center;
 	display: flex;
 	justify-content: space-between;
-
-	.gridicon {
-		margin-left: 4px;
-		vertical-align: middle;
-	}
 }


### PR DESCRIPTION
Fixes #741

Currently in the editor there is no way to remove a page parent if one is currently set.  This branch adds a checkbox above the Parent Page Selector, much like we show in the Add Category screen, to allow removing the parent page option, or setting it back to a "Top level page.".

![edit_page_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/11444772/62dd0310-94db-11e5-9b5e-889a3ab98aad.png)

__To Test__
- Open up a new page in the editor
- Expand the Page Options accordion, note that "Top level page" is checked
- Add a title and some content
- Select a page parent, note the checkbox is un-checked
- Save the page, and do a hard refresh, check that your parent page selection is persisted
- Check the Top Level Page checkbox, note that the parent page radio is de-selected
- Save the page, hard refresh and note that the page is still set to Top Level