### PR TITLE
Signup: Remove `nuxTrampoline` a/b test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -37,15 +37,6 @@ module.exports = {
 		},
 		defaultVariation: 'originalA'
 	},
-	nuxTrampoline: {
-		datestamp: '20151113',
-		variations: {
-			main: 10,
-			'landing-main': 10,
-			notTested: 80
-		},
-		defaultVariation: 'main'
-	},
 	businessPluginsNudge: {
 		datestamp: '20151119',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -9,17 +9,11 @@ var assign = require( 'lodash/object/assign' ),
 */
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
-	user = require( 'lib/user' )(),
-	abtest = require( 'lib/abtest' ).abtest;
+	user = require( 'lib/user' )();
 
 function getCheckoutDestination( dependencies ) {
 	if ( dependencies.cartItem || dependencies.domainItem ) {
 		return '/checkout/' + dependencies.siteSlug;
-	}
-
-	/* NUX Trampoline A/B */
-	if ( 'landing-main' === abtest( 'nuxTrampoline' ) ) {
-		return 'https://' + dependencies.siteSlug + '/?landing';
 	}
 
 	return '/me/next?welcome';


### PR DESCRIPTION
This test was never removed, but was supposed to end on 11/20. Also, we discovered an issue where users with Olark chat enabled (i.e., users with the business plan) were not properly redirected to their site `foobar.wordpress.com/?landing` (issue forthcoming).

**Testing**
- Assert that you can complete signup and land in checkout (by selecting a plan/domain).
- Assert that you can complete signup and land on `/me/next/welcome`.

cc @kwight @mattwiebe 