### PR TITLE
Editor: Disable drafts button when no drafts exist

### DIFF
--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -36,7 +36,9 @@ export default React.createClass( {
 				aria-label={ this.translate( 'View all drafts' ) }
 			>
 				<span>{ this.translate( 'Drafts' ) }</span>
-				{ this.props.count && this.props.count > 0 && <Count count={ this.props.count } /> }
+				{ this.props.count ?
+					<Count count={ this.props.count } />
+				: null }
 			</button>
 		);
 	}

--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -1,31 +1,43 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { PropTypes } from 'react';
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	Count = require( 'components/count' );
+import Count from 'components/count';
 
-var DraftsButton = React.createClass( {
+export default React.createClass( {
+	displayName: 'EditorDraftsButton',
 
-	render: function() {
-		if ( ! config.isEnabled( 'editor-drafts' ) || ! this.props.site ) {
+	propTypes: {
+		site: PropTypes.object,
+		count: PropTypes.number,
+		onClick: PropTypes.func
+	},
+
+	getDefaultProps() {
+		return {
+			count: 0,
+			onClick: () => {}
+		};
+	},
+
+	render() {
+		if ( ! this.props.site ) {
 			return null;
 		}
 
 		return (
-			<button className="drafts-button" onClick={ this.props.onClick } aria-label={ this.translate( 'View all drafts' ) }>
+			<button className="drafts-button"
+				onClick={ this.props.onClick }
+				disabled={ ! this.props.count }
+				aria-label={ this.translate( 'View all drafts' ) }
+			>
 				<span>{ this.translate( 'Drafts' ) }</span>
-				{ this.props.count ?
-					<Count count={ this.props.count } />
-				: null }
+				{ this.props.count && <Count count={ this.props.count } /> }
 			</button>
 		);
 	}
-
 } );
-
-module.exports = DraftsButton;

--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -36,7 +36,7 @@ export default React.createClass( {
 				aria-label={ this.translate( 'View all drafts' ) }
 			>
 				<span>{ this.translate( 'Drafts' ) }</span>
-				{ this.props.count && <Count count={ this.props.count } /> }
+				{ this.props.count && this.props.count > 0 && <Count count={ this.props.count } /> }
 			</button>
 		);
 	}

--- a/client/post-editor/drafts-button/style.scss
+++ b/client/post-editor/drafts-button/style.scss
@@ -4,6 +4,11 @@
 	font-size: 11px;
 	text-transform: uppercase;
 
+	&[disabled] {
+		cursor: not-allowed;
+		color: lighten( $gray, 10% );
+	}
+
 	.count {
 		margin-left: 8px;
 	}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -288,7 +288,7 @@ var PostEditor = React.createClass( {
 				<div className="post-editor__inner">
 					<div className="post-editor__sidebar">
 						<div className="post-editor__sidebar-header">
-							{ config.isEnabled( 'editor-drafts' ) && this.state.showDrafts ?
+							{ this.state.showDrafts ?
 								<button className="post-editor__close" onClick={ this.toggleDrafts } aria-label={ this.translate( 'Close drafts list' ) }>
 									<Gridicon icon="cross" size={ 18 } />
 									<span>{ this.translate( 'Close' ) }</span>
@@ -308,7 +308,7 @@ var PostEditor = React.createClass( {
 								<span>{ this.translate( 'Write' ) }</span>
 							</button>
 						</div>
-						{ config.isEnabled( 'editor-drafts' ) && this.state.showDrafts ?
+						{ this.state.showDrafts ?
 							<DraftList { ...this.props }
 								onTitleClick={ this.toggleSidebar }
 								showAllActionsMenu={ false }

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -25,7 +25,6 @@
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/pages": true,
-		"editor-drafts": true,
 
 		"manage/ads": true,
 		"manage/stats": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -21,7 +21,6 @@
 
 		"ad-tracking": true,
 		"community-translator": true,
-		"editor-drafts": true,
 		"help": false,
 		"mailing-lists/unsubscribe": true,
 		"manage/ads": true,

--- a/config/development.json
+++ b/config/development.json
@@ -43,7 +43,6 @@
 		"post-editor/pages": true,
 		"post-editor-github-link": false,
 		"post-editor/post-type-switch": false,
-		"editor-drafts": true,
 
 		"manage/media": true,
 		"manage/posts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -18,7 +18,6 @@
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/pages": true,
-		"editor-drafts": true,
 
 		"manage/ads": true,
 		"manage/ads/jetpack": true,

--- a/config/production.json
+++ b/config/production.json
@@ -53,7 +53,6 @@
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/pages": true,
-		"editor-drafts": true,
 		"help": false,
 		"upgrades/checkout": true,
 		"upgrades/domain-management/contacts-privacy": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -17,7 +17,6 @@
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/pages": true,
-		"editor-drafts": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -18,7 +18,6 @@
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/pages": true,
-		"editor-drafts": true,
 
 		"manage/ads": true,
 		"manage/ads/jetpack": true,


### PR DESCRIPTION
Fixes #348

This branch seeks to disable the drafts sidebar button when a site has no drafts.  This prevents the "You have not posts, want to create one?" message from being shown in the sidebar.  While working in this component, I opted to sprinkle it with ES6 syntax, and clean up the old `editor-drafts` feature flag.

![no-drafts](https://cloud.githubusercontent.com/assets/22080/11446878/b331067e-94f2-11e5-9721-9ef695f22d89.gif)

__To Test__
You will need to test on a site that does not have any drafts to view the new behavior
- Open the post editor on a site that does not have any drafts
- Note that the draft sidebar button is a lighter tone of grey, and if you hover over it with your mouse, the cursor shows `disabled`
- Add a title, and some content and wait for an auto-save to occur
- Note that the drafts button now shows ( 1 ) in the counter, and you can open it.