### PR TITLE
Editor: Remove bottom margin on visibility dialog.

### DIFF
--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -256,6 +256,7 @@ module.exports = React.createClass( {
 					value={ value }
 					isError={ isError }
 					ref="postPassword"
+					className={ this.state.showVisibilityInfotips ? 'is-info-open' : null }
 					placeholder={ this.translate( 'Create password', { context: 'Editor: Create password for post' } ) }
 				/>
 

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -143,7 +143,7 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<FormSettingExplanation>{ infotext }</FormSettingExplanation>
+			<FormSettingExplanation className={ visibility }>{ infotext }</FormSettingExplanation>
 		);
 	},
 

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -36,6 +36,10 @@
 
 	.form-setting-explanation {
 		margin: -4px 0 8px 24px;
+
+		&.password {
+			margin-bottom: 0;
+		}
 	}
 
 	.gridicon {

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -28,6 +28,10 @@
 
 	.form-text-input {
 		font-size: 13px;
+
+		&.is-info-open {
+			margin-top: 8px;
+		}
 	}
 
 	.form-input-validation {


### PR DESCRIPTION
Fixes #374 - This removes the bottom margin on the password (i) paragraph inside the Post Visibility dialog:

__Before__
![876fdb12-8c9d-11e5-91ca-85da61317b5f](https://cloud.githubusercontent.com/assets/548849/11317949/2e0b8ab6-9040-11e5-86ba-3a59db3df48f.png)

__After__
![edit_post_ _brandnewtimmay_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/11447489/7461dea6-94fb-11e5-8dae-e7fb9ca5331c.png)