### PR TITLE
Purchases: Add notice to `PurchasesList` after a purchase is canceled

### DIFF
--- a/client/components/data/purchases/index.jsx
+++ b/client/components/data/purchases/index.jsx
@@ -17,13 +17,17 @@ import userFactory from 'lib/user';
 const stores = [ PurchasesStore ],
 	user = userFactory();
 
-function getStateFromStores() {
-	return { purchases: PurchasesStore.getByUser( user.get().ID ) };
+function getStateFromStores( props ) {
+	return {
+		noticeType: props.noticeType,
+		purchases: PurchasesStore.getByUser( user.get().ID )
+	};
 }
 
 const PurchasesData = React.createClass( {
 	propTypes: {
-		component: React.PropTypes.func.isRequired
+		component: React.PropTypes.func.isRequired,
+		noticeType: React.PropTypes.string
 	},
 
 	componentDidMount() {
@@ -34,6 +38,7 @@ const PurchasesData = React.createClass( {
 		return (
 			<StoreConnection
 				component={ this.props.component }
+				noticeType={ this.props.noticeType }
 				stores={ stores }
 				getStateFromStores={ getStateFromStores } />
 		);

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -65,6 +65,13 @@ export default function() {
 			controller.purchases.noSitesMessage,
 			controller.purchases.list
 		);
+
+		page(
+			paths.purchases.listNotice(),
+			controller.sidebar,
+			controller.purchases.noSitesMessage,
+			controller.purchases.list
+		);
 	}
 
 	if ( config.isEnabled( 'upgrades/purchases/manage' ) ) {

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -163,7 +163,7 @@ export default {
 		);
 	},
 
-	list() {
+	list( context ) {
 		setTitle();
 
 		recordPageView(
@@ -172,7 +172,8 @@ export default {
 
 		renderPage(
 			<PurchasesData
-				component={ PurchasesList } />
+				component={ PurchasesList }
+				noticeType={ context.params.noticeType } />
 		);
 	},
 

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -13,8 +13,48 @@ import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import PurchasesHeader from './header';
 import PurchasesSite from './site';
+import SimpleNotice from 'notices/simple-notice';
 
 const PurchasesList = React.createClass( {
+	renderNotice() {
+		const { noticeType } = this.props;
+
+		if ( ! noticeType ) {
+			return null;
+		}
+
+		let message, status;
+
+		if ( 'cancel-success' === noticeType ) {
+			message = this.translate(
+				'Your purchase was canceled and refunded. The refund may take up to ' +
+				'7 days to appear in your PayPal/bank/credit card account.'
+			);
+
+			status = 'is-success';
+		}
+
+		if ( 'cancel-problem' === noticeType ) {
+			message = this.translate(
+				'There was a problem canceling your purchase. ' +
+				'Please {{a}}contact support{{/a}} for more information.',
+				{
+					components: {
+						a: <a href="https://support.wordpress.com/" />
+					}
+				}
+			);
+
+			status = 'is-error';
+		}
+
+		return (
+			<SimpleNotice showDismiss={ false } status={ status }>
+				{ message }
+			</SimpleNotice>
+		);
+	},
+
 	render() {
 		let content;
 
@@ -54,11 +94,14 @@ const PurchasesList = React.createClass( {
 		}
 
 		return (
-			<Main className="purchases-list">
-				<MeSidebarNavigation />
-				<PurchasesHeader section={ 'purchases' } />
-				{ content }
-			</Main>
+			<span>
+				{ this.renderNotice() }
+				<Main className="purchases-list">
+					<MeSidebarNavigation />
+					<PurchasesHeader section={ 'purchases' } />
+					{ content }
+				</Main>
+			</span>
 		);
 	}
 } );

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -11,9 +11,9 @@ import EmptyContent from 'components/empty-content';
 import { getPurchasesBySite } from 'lib/purchases';
 import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
+import Notice from 'components/notice';
 import PurchasesHeader from './header';
 import PurchasesSite from './site';
-import SimpleNotice from 'notices/simple-notice';
 
 const PurchasesList = React.createClass( {
 	renderNotice() {
@@ -49,9 +49,9 @@ const PurchasesList = React.createClass( {
 		}
 
 		return (
-			<SimpleNotice showDismiss={ false } status={ status }>
+			<Notice showDismiss={ false } status={ status }>
 				{ message }
-			</SimpleNotice>
+			</Notice>
 		);
 	},
 

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -2,6 +2,10 @@ function list() {
 	return '/purchases';
 }
 
+function listNotice( noticeType = ':noticeType' ) {
+	return list() + `/${ noticeType }`;
+}
+
 function managePurchase( siteName = ':site', purchaseId = ':purchaseId' ) {
 	return list() + `/${ siteName }/${ purchaseId }`;
 }
@@ -37,6 +41,7 @@ export default {
 	editCardDetails,
 	editPaymentMethod,
 	list,
+	listNotice,
 	managePurchase,
 	managePurchaseDestination
 };


### PR DESCRIPTION
This adds a success and error notice to `PurchasesList`, which users will be redirected to after clicking the link in the email they receive when asked to confirm a purchase cancelation.

Requires patch `D-573`.

Fixes #257.

**Testing**
You can test the notices by visiting these URLs:
- http://calypso.localhost:3000/purchases/cancel-problem
- http://calypso.localhost:3000/purchases/cancel-success

The conditions for redirecting to these URLs are handled by the patch. An unsuccessful cancelation can be triggered by opening the cancelation link from the confirmation email in a browser window that is not logged in to the user that requested the cancelation.

- [x] QA review
- [x] Code review