### PR TITLE
Purchases: Add `CancelPurchasePlaceholder`

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -146,6 +146,7 @@
 @import 'me/profile-links/style';
 @import 'me/purchases/cancel-private-registration/style';
 @import 'me/purchases/cancel-purchase/style';
+@import 'me/purchases/cancel-purchase-placeholder/style';
 @import 'me/purchases/confirm-cancel-purchase/style';
 @import 'me/purchases/list/item/style';
 @import 'me/purchases/list/site/style';

--- a/client/components/data/purchases/manage-purchase/index.jsx
+++ b/client/components/data/purchases/manage-purchase/index.jsx
@@ -35,7 +35,9 @@ const ManagePurchaseData = React.createClass( {
 		component: React.PropTypes.func.isRequired,
 		purchaseId: React.PropTypes.string.isRequired,
 		sites: React.PropTypes.object.isRequired,
-		destinationType: React.PropTypes.string
+		destinationType: React.PropTypes.string,
+		loadingPlaceholder: React.PropTypes.func,
+		isDataLoading: React.PropTypes.func
 	},
 
 	mixins: [ observe( 'sites' ) ],
@@ -48,6 +50,8 @@ const ManagePurchaseData = React.createClass( {
 		return (
 			<StoreConnection
 				component={ this.props.component }
+				isDataLoading={ this.props.isDataLoading }
+				loadingPlaceholder={ this.props.loadingPlaceholder }
 				stores={ stores }
 				getStateFromStores={ getStateFromStores }
 				purchaseId={ this.props.purchaseId }

--- a/client/components/loading-placeholder/index.jsx
+++ b/client/components/loading-placeholder/index.jsx
@@ -15,7 +15,7 @@ const LoadingPlaceholder = React.createClass( {
 	propTypes: {
 		className: React.PropTypes.string,
 		path: React.PropTypes.string,
-		title: React.PropTypes.string.required
+		title: React.PropTypes.string.isRequired
 	},
 
 	goBack() {

--- a/client/me/purchases/cancel-purchase-placeholder/index.jsx
+++ b/client/me/purchases/cancel-purchase-placeholder/index.jsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import CompactCard from 'components/card/compact';
+import Button from 'components/button';
+import LoadingPlaceholder from 'components/loading-placeholder';
+import { managePurchase } from 'me/purchases/paths';
+
+const CancelPurchasePlaceholder = React.createClass( {
+	propTypes: {
+		purchaseId: React.PropTypes.string.isRequired,
+		selectedSite: React.PropTypes.object.isRequired
+	},
+
+	render() {
+		return (
+			<LoadingPlaceholder
+				title={ this.translate( 'Cancel Purchase' ) }
+				path={ managePurchase( this.props.selectedSite.slug, this.props.purchaseId ) }>
+				<Card className="cancel-purchase-placeholder__card">
+					<h2 className="cancel-purchase-placeholder__header" />
+					<div className="cancel-purchase-placeholder__subheader" />
+					<div className="cancel-purchase-placeholder__reason" />
+					<div className="cancel-purchase-placeholder__reason" />
+				</Card>
+				<CompactCard>
+					<Button className="cancel-purchase-placeholder__cancel-button" />
+				</CompactCard>
+			</LoadingPlaceholder>
+		);
+	}
+} );
+
+export default CancelPurchasePlaceholder;

--- a/client/me/purchases/cancel-purchase-placeholder/style.scss
+++ b/client/me/purchases/cancel-purchase-placeholder/style.scss
@@ -1,0 +1,32 @@
+.cancel-purchase-placeholder__cancel-button {
+	width: 30%;
+}
+
+.cancel-purchase-placeholder__header,
+.cancel-purchase-placeholder__subheader,
+.cancel-purchase-placeholder__reason {
+	@include placeholder( 23% );
+}
+
+.cancel-purchase-placeholder__header {
+	height: 36px;
+	margin-bottom: 15px;
+	width: 70%;
+}
+
+.cancel-purchase-placeholder__reason {
+	height: 12px;
+	margin-bottom: 5px;
+	width: 60%;
+}
+
+.cancel-purchase-placeholder__card {
+	margin: 0;
+}
+
+.cancel-purchase-placeholder__subheader {
+	height: 24px;
+	margin-bottom: 10px;
+	width: 50%;
+}
+

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import analytics from 'analytics';
 import ConfirmCancelPurchase from './confirm-cancel-purchase';
 import CancelPurchase from './cancel-purchase';
+import CancelPurchasePlaceholder from './cancel-purchase-placeholder';
 import CancelPrivateRegistration from './cancel-private-registration';
 import EditCardDetails from './payment/edit-card-details';
 import EditCardDetailsData from 'components/data/purchases/edit-card-details';
@@ -25,6 +26,7 @@ import PurchasesList from './list';
 import sitesFactory from 'lib/sites-list';
 import titleActions from 'lib/screen-title/actions';
 import userFactory from 'lib/user';
+import { isDataLoading } from './utils';
 
 const sites = sitesFactory();
 const user = userFactory();
@@ -69,6 +71,8 @@ export default {
 		renderPage(
 			<ManagePurchaseData
 				component={ CancelPurchase }
+				isDataLoading={ isDataLoading }
+				loadingPlaceholder={ CancelPurchasePlaceholder }
 				purchaseId={ context.params.purchaseId }
 				sites={ sites } />
 		);

--- a/shared/components/data/store-connection/index.jsx
+++ b/shared/components/data/store-connection/index.jsx
@@ -59,7 +59,7 @@ const StoreConnection = React.createClass( {
 
 	render() {
 		if ( this.isDataLoading() ) {
-			return React.createElement( this.props.loadingPlaceholder );
+			return React.createElement( this.props.loadingPlaceholder, this.state );
 		}
 
 		if ( this.props.component ) {


### PR DESCRIPTION
This PR adds `CancelPurchasePlaceholder` and updates the cancel purchase page to render this placeholder when purchases are fetching.

I added this component to `me/purchases/cancel-purchase-placeholder/` instead of `me/purchases/cancel-purchase/placeholder.jsx` so that it can be reused as the fetching state of `ConfirmCancelPurchase`, as the placeholder design is identical. `ConfirmCancelPurchase` has two loading phases (fetching `/purchases`, then fetching the endpoint cancel form), and further, non-trivial changes are required to overwrite the 'Loading..' text with `CancelPurchasePlaceholder` on that page.

Fixes #275 (not entirely, but I want to link this to that issue).

**Testing**
- Visit http://calypso.localhost:3000/purchases
- Click on a purchase.
- Click 'Cancel and Refund [purchase]'.
- Refresh the page.
- Assert that the fetching state contains a placeholder like in the design in #275.

- [x] QA review
- [x] Code review