### PR TITLE
Invites: Centers logged in accept invite

### DIFF
--- a/client/accept-invite/controller.js
+++ b/client/accept-invite/controller.js
@@ -15,6 +15,7 @@ export default {
 		titleActions.setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) );
 
 		React.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+		context.layout.setState( { noSidebar: true } );
 
 		React.render(
 			React.createElement( Main, context.params ),


### PR DESCRIPTION
Now that #302 is in, we can center the logged in accept invite flow. __Note:__ This does not handle centering the logged out invite flow, which is still off center.

![invite-centered](https://cloud.githubusercontent.com/assets/1126811/11449415/a34bafb0-9539-11e5-87a3-41749a475ed0.png)


To test:
- Create an invite in the wp-admin area of a WordPress.com invite
- In the invite email that you get, make note of the invitation key
- Go to `/accept-invite/$site/$invite_key`
- Is it centered?