### PR TITLE
Notifications: Control Center Configuration Settings

### DIFF
--- a/client/me/index.js
+++ b/client/me/index.js
@@ -108,12 +108,8 @@ export default function() {
 		page( '/me/find-friends', controller.findFriendsRedirect );
 	}
 
-	if ( config.isEnabled( 'me/notifications-control-panel' ) ) {
-		page( '/me/notifications', controller.sidebar, controller.notifications );
-		page( '/me/notifications/comments', controller.sidebar, controller.comments );
-		page( '/me/notifications/updates', controller.sidebar, controller.updates );
-		page( '/me/notifications/subscriptions', controller.sidebar, controller.notificationSubscriptions );
-	} else {
-		page( '/me/notifications', controller.sidebar, controller.notificationSubscriptions );
-	}
+	page( '/me/notifications', controller.sidebar, controller.notifications );
+	page( '/me/notifications/comments', controller.sidebar, controller.comments );
+	page( '/me/notifications/updates', controller.sidebar, controller.updates );
+	page( '/me/notifications/subscriptions', controller.sidebar, controller.notificationSubscriptions );
 };

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import protectForm from 'lib/mixins/protect-form';
 import formBase from 'me/form-base';
@@ -44,53 +43,16 @@ module.exports = React.createClass( {
 		);
 	},
 
-	renderNotificationsControlPanel() {
-		return (
-			<div>
-				<FormSectionHeading className="is-primary">
-					{ this.translate( 'Notification Emails' ) }
-				</FormSectionHeading>
-
-				<FormFieldset>
-					<FormLegend>{ this.translate( '"Like" Comments' ) }</FormLegend>
-					<FormLabel>
-						<FormCheckbox
-							checkedLink={ this.valueLink( 'comment_like_notification' ) }
-							disabled={ this.getDisabledState() }
-							id="comment_like_notification"
-							name="comment_like_notification"
-							onClick={ this.recordCheckboxEvent( 'Comment Like Notifications' ) } />
-							{ this.translate( 'Email me when someone Likes one of my comments.' ) }
-					</FormLabel>
-				</FormFieldset>
-
-				<FormFieldset>
-					<FormLegend>{ this.translate( 'Mentions' ) }</FormLegend>
-					<FormLabel>
-						<FormCheckbox
-							checkedLink={ this.valueLink( 'mentions_notification' ) }
-							disabled={ this.getDisabledState() }
-							id="mentions_notification"
-							name="mentions_notification"
-							onClick={ this.recordCheckboxEvent( 'Mention Notifications' ) } />
-							{ this.translate( 'Email me when someone mentions my username.' ) }
-					</FormLabel>
-				</FormFieldset>
-			</div>
-		);
-	},
-
 	render() {
 		return (
 			<Main className="notifications">
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 
-				{ config.isEnabled( 'me/notifications-control-panel' ) ? <Navigation path={ this.props.path } /> : null }
+				<Navigation path={ this.props.path } />
 
 				<Card className="me-notification-settings">
 					<form id="notification-settings" onChange={ this.markChanged } onSubmit={ this.submitForm } >
-						{ config.isEnabled( 'me/notifications-control-panel' ) ? null : this.renderNotificationsControlPanel() }
 						<FormSectionHeading>{ this.translate( 'Subscriptions Delivery' ) }</FormSectionHeading>
 						<p>
 							{ this.translate( '{{readerLink}}Use the Reader{{/readerLink}} to adjust delivery settings for your existing subscriptions.',

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -92,7 +92,6 @@
 		"me/security": true,
 		"me/security/checkup": true,
 		"me/notifications": true,
-		"me/notifications-control-panel": true,
 		"me/next-steps": false,
 		"me/credit-cards": false,
 		"me/find-friends": false,

--- a/config/development.json
+++ b/config/development.json
@@ -117,7 +117,6 @@
 		"me/security": true,
 		"me/security/checkup": true,
 		"me/notifications": true,
-		"me/notifications-control-panel": true,
 		"me/next-steps": true,
 		"me/credit-cards": true,
 		"me/find-friends": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -79,7 +79,6 @@
 		"me/billing-history": true,
 		"me/security": true,
 		"me/notifications": true,
-		"me/notifications-control-panel": false,
 		"me/next-steps": true,
 		"me/credit-cards": true,
 		"me/find-friends": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -56,7 +56,6 @@
 		"me/account": true,
 		"help": false,
 		"me/notifications": true,
-		"me/notifications-control-panel": true,
 		"upgrades/checkout": true,
 		"upgrades/domain-management/contacts-privacy": true,
 		"upgrades/domain-management/email": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -88,7 +88,6 @@
 		"me/security": true,
 		"me/security/checkup": true,
 		"me/notifications": true,
-		"me/notifications-control-panel": true,
 		"me/next-steps": true,
 		"me/credit-cards": true,
 		"me/find-friends": false,


### PR DESCRIPTION
In order to make this feature available to all environments, the `me/notifications-control-panel` configuration flag is no longer needed.

This change includes the removal of the configuration flag and some code no longer needed.