### PR TITLE
Domains: add missing name attribute in SRV form

### DIFF
--- a/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
@@ -21,7 +21,8 @@ const SrvRecord = React.createClass( {
 			aux: 10,
 			weight: 10,
 			target: '',
-			port: ''
+			port: '',
+			protocol: 'tcp'
 		}
 	},
 
@@ -43,7 +44,7 @@ const SrvRecord = React.createClass( {
 		return (
 			<div className={ classes }>
 				<FormFieldset>
-					<FormLabel>{ this.translate( 'Value', { context: 'Dns Record' } ) }</FormLabel>
+					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError="true" /> : null }
 					<FormTextInput
 						name="name"
@@ -65,7 +66,10 @@ const SrvRecord = React.createClass( {
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Protocol', { context: 'Dns Record' } ) }</FormLabel>
 
-					<FormSelect onChange={ this.props.onChange( 'protocol' ) } value={ protocol }>
+					<FormSelect
+							name="protocol"
+							onChange={ this.props.onChange( 'protocol' ) }
+							value={ protocol }>
 						{ options }
 					</FormSelect>
 				</FormFieldset>


### PR DESCRIPTION
The `protocol` field was missing a `name` attribute. And since it's a mandatory field, the backend did not allow saving a SRV record at all.

Interesting that no one reported this - but then again, `SRV` records are not _that_ often used.