### PR TITLE
Framework: Make sure sections with sidebar declare it.

### DIFF
--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -36,7 +36,10 @@ export default {
 			document.getElementById( 'secondary' )
 		);
 
-		context.layout.setState( { section: 'me' } );
+		context.layout.setState( {
+			section: 'me',
+			noSidebar: false
+		} );
 
 		next();
 	},

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -24,7 +24,10 @@ var user = require( 'lib/user' )(),
  * the site selector list and the sidebar section items
  */
 function renderNavigation( context, allSitesPath, siteBasePath ) {
-	context.layout.setState( { section: 'sites' } );
+	context.layout.setState( {
+		section: 'sites',
+		noSidebar: false
+	} );
 
 	// Render the My Sites navigation in #secondary
 	React.render(

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -82,7 +82,10 @@ module.exports = {
 	sidebar: function( context, next ) {
 		var ReaderSidebarComponent = require( 'reader/sidebar' );
 
-		context.layout.setState( { section: 'reader' } );
+		context.layout.setState( {
+			section: 'reader',
+			noSidebar: false
+		} );
 
 		React.render(
 			React.createElement( ReaderSidebarComponent, { path: context.path } ),


### PR DESCRIPTION
This fixes issues when the user navigates from a sidebar-less section, to one that has a sidebar, as layout.state persists.

An example was navigating from `/start` to a section in the masterbar that had a sidebar. The layout wasn't appropriately set.

#### Testing:

Load `calypso.localhost:3000/start` and click on the masterbar for My Sites. The layout should be correct.

cc @scruffian 