### PR TITLE
Plugins: Add 'update all' button

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -633,6 +633,36 @@ export default React.createClass( {
 		return some( this.props.sites.getSelectedOrAllWithPlugins(), site => site && site.jetpack && site.canUpdateFiles );
 	},
 
+	updateAllPlugins: function() {
+		PluginsActions.removePluginsNotices( this.state.notices.completed.concat( this.state.notices.errors ) );
+		this.state.plugins.forEach( plugin => {
+			plugin.sites.forEach( site => PluginsActions.updatePlugin( site, site.plugin ) );
+		} );
+		this.recordEvent( 'Clicked Update all Plugins', true );
+	},
+
+	getNavItems() {
+		let navItems = [];
+
+		if ( this.props && this.props.filter === 'updates' ) {
+			navItems.push(
+				<NavItem onClick={ this.updateAllPlugins } >
+					{ this.translate( 'Update All', { context: 'button label' } ) }
+				</NavItem>
+			);
+		}
+
+		navItems.push( <NavItem onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>
+				{
+					this.state.bulkManagement ?
+					this.translate( 'Done', { context: 'button label' } ) :
+					this.translate( 'Manage', { context: 'button label' } )
+				}
+			</NavItem>
+		);
+		return navItems;
+	},
+
 	render() {
 		if ( this.state.accessError ) {
 			return (
@@ -674,13 +704,7 @@ export default React.createClass( {
 			toolbarSelect = this.toolbarSelect();
 			manageLink = (
 				<NavSegmented>
-					<NavItem onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>
-						{
-							this.state.bulkManagement ?
-							this.translate( 'Done', { context: 'button label' } ) :
-							this.translate( 'Manage', { context: 'button label' } )
-						}
-					</NavItem>
+					{ this.getNavItems() }
 				</NavSegmented>
 			);
 		}

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -251,7 +251,7 @@ export default React.createClass( {
 		this.recordEvent( 'Clicked Deactivate Plugin(s)', true );
 	},
 
-	deactiveAndDisconnectSelected: function() {
+	deactiveAndDisconnectSelected() {
 		var waitForDeactivate = false;
 
 		this.doActionOverSelected( 'deactivating', ( site, plugin ) => {
@@ -528,9 +528,9 @@ export default React.createClass( {
 			needsAutoUpdates = ! hasWpcomPlugins && sitesCanUpdateFiles && this.areSelected(),
 			needsActivateLink = this.areSelected( 'inactive' ),
 			needsDeactivateLink = this.areSelected( 'active' ),
-			deactivateLink = isJetpackSelected ?
-				<a onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</a> :
-				<a onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</a>;
+			deactivateLink = isJetpackSelected
+			? <a onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</a>
+			: <a onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</a>;
 
 		return (
 			<div className={ bulkActionOptionsClasses }>
@@ -633,7 +633,7 @@ export default React.createClass( {
 		return some( this.props.sites.getSelectedOrAllWithPlugins(), site => site && site.jetpack && site.canUpdateFiles );
 	},
 
-	updateAllPlugins: function() {
+	updateAllPlugins() {
 		PluginsActions.removePluginsNotices( this.state.notices.completed.concat( this.state.notices.errors ) );
 		this.state.plugins.forEach( plugin => {
 			plugin.sites.forEach( site => PluginsActions.updatePlugin( site, site.plugin ) );
@@ -641,7 +641,7 @@ export default React.createClass( {
 		this.recordEvent( 'Clicked Update all Plugins', true );
 	},
 
-	getNavItems() {
+	renderNavItems() {
 		let navItems = [];
 
 		if ( this.props && this.props.filter === 'updates' ) {
@@ -654,9 +654,9 @@ export default React.createClass( {
 
 		navItems.push( <NavItem onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>
 				{
-					this.state.bulkManagement ?
-					this.translate( 'Done', { context: 'button label' } ) :
-					this.translate( 'Manage', { context: 'button label' } )
+					this.state.bulkManagement
+					? this.translate( 'Done', { context: 'button label' } )
+					: this.translate( 'Manage', { context: 'button label' } )
 				}
 			</NavItem>
 		);
@@ -704,7 +704,7 @@ export default React.createClass( {
 			toolbarSelect = this.toolbarSelect();
 			manageLink = (
 				<NavSegmented>
-					{ this.getNavItems() }
+					{ this.renderNavItems() }
 				</NavSegmented>
 			);
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/948

Currently, when users have several plugins in their "update" tab, they need to manually click in every "update" button to update them all. This PR adds a new button in the top bar to allow updating everything with a single click:

![image](https://cloud.githubusercontent.com/assets/1554855/11471608/3edffa92-9767-11e5-9469-9a3d90478ef7.png)

I'm aware that we are moving the buttons out of the top bar, but this was an easy addition and well... we can move the new button too once we tackle that issue :)

Video:
https://cloudup.com/cg6S9avpJev

How to test:
1. Go to http://calypso.dev:3000/plugins/
2. Click on updates
3. You must see an "update all" button
4. Click it and wait for all the plugins to get updated

cc/ @enejb @rickybanister 
