### PR TITLE
OSS: OnBoarding: welcome an wait terminal messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,18 @@ export NODE_PATH := server:shared:.
 
 .DEFAULT_GOAL := install
 
+welcome:
+	@echo "\033[36m    ___ __ _| |_   _ _ __  ___  ___       "
+	@echo "\033[36m  / __/ _\\\` | | | | | '_ \/ __|/ _ \\\  "
+	@echo "\033[36m  | (_| (_| | | |_| | |_) \__ \ (_) |     "
+	@echo "\033[36m   \___\__,_|_|\__, | .__/|___/\___/      "
+	@echo "\033[36m               |___/|_|                   "
+	@echo "\033[m"
+
 install: node_modules
 
 # Simply running `make run` will spawn the Node.js server instance.
-run: githooks-commit install build
+run: welcome githooks-commit install build
 	@$(NODE) build/bundle-$(CALYPSO_ENV).js
 
 # a helper rule to ensure that a specific module is installed,

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
  * External dependencies.
  */
 var boot = require( 'boot' ),
-	http = require( 'http' );
+	http = require( 'http' ),
+	chalk = require( 'chalk' );
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ var start = Date.now(),
 	hotReloader;
 
 console.log( '%s booted in %dms - port: %s', pkg.name, ( Date.now() ) - start, port );
+console.info( chalk.cyan( '\nGetting bundles ready, hold on...' ) );
 server = http.createServer( app );
 server.listen( port );
 

--- a/server/bundler/index.js
+++ b/server/bundler/index.js
@@ -35,9 +35,9 @@ function middleware( app ) {
 			process.nextTick( function() {
 				if ( beforeFirstCompile ) {
 					beforeFirstCompile = false;
-					console.info( chalk.blue( 'READY! You can load http://calypso.localhost:3000/ now. Have fun!' ) );
+					console.info( chalk.cyan( '\nReady! You can load http://calypso.localhost:3000/ now. Have fun!' ) );
 				} else {
-					console.info( chalk.blue( 'READY! All assets are re-compiled. Have fun!' ) );
+					console.info( chalk.cyan( '\nReady! All assets are re-compiled. Have fun!' ) );
 				}
 			} );
 		} );
@@ -48,7 +48,7 @@ function middleware( app ) {
 			return next();
 		}
 
-		console.info( 'Compiling assets... Wait until you see READY! and then try http://calypso.localhost:3000/ again.' );
+		console.info( 'Compiling assets... Wait until you see Ready! and then try http://calypso.localhost:3000/ again.' );
 
 		// a special message for newcomers, because seeing a blank page is confusing
 		if ( request.url === '/' ) {


### PR DESCRIPTION
Partially addressing #1034.

Specifically fixes:

* Terminal: No startup message. Not a big deal, but would be nice to show something.
* Terminal: No wait message. This is rather important since in the test it was causing some confusion. 

These are the things this PR adds / changes:

![screen shot 2015-11-30 at 15 02 30](https://cloud.githubusercontent.com/assets/4389/11475306/94caa2d8-9774-11e5-810c-8fc23ceaad0d.png)

![screen shot 2015-11-30 at 15 11 16](https://cloud.githubusercontent.com/assets/4389/11475317/a1a3fb4e-9774-11e5-9452-0e8cdcb8c8fd.png)

![screen shot 2015-11-30 at 15 11 33](https://cloud.githubusercontent.com/assets/4389/11475326/ace5e06c-9774-11e5-9d30-34f29282530d.png)



To test:

* `make run`
* Check that the initial message, instantly after run, is there
* Check the wait message once the server is ready.
* Check the ready message once done.