### PR TITLE
Plugins: Update plugins list bulk management headers

### DIFF
--- a/client/components/bulk-select/docs/example.jsx
+++ b/client/components/bulk-select/docs/example.jsx
@@ -36,7 +36,7 @@ module.exports = React.createClass( {
 	},
 
 	renderElements() {
-		return this.state.elements.map( (element, index) => {
+		return this.state.elements.map( ( element, index ) => {
 			const onClick = function() {
 				element.selected = ! element.selected;
 				this.forceUpdate();
@@ -57,7 +57,9 @@ module.exports = React.createClass( {
 					<a href="/devdocs/design/bulk-selects">BulkSelects</a>
 				</h2>
 				<Card>
-					<BulkSelect totalElements={ this.state.elements.length } selectedElements={ this.getSelectedElementsNumber() } onToggle={ this.handleToggleAll } />
+					<div>
+						<BulkSelect totalElements={ this.state.elements.length } selectedElements={ this.getSelectedElementsNumber() } onToggle={ this.handleToggleAll } />
+					</div>
 					{ this.renderElements() }
 				</Card>
 			</div>

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -40,11 +40,13 @@ export default React.createClass( {
 
 	render() {
 		return (
-			<div className="bulk-select" onClick={ this.handleToggleAll }>
-				<input type="checkbox" className="bulk-select__box" checked={ this.hasAllElementsSelected() } readOnly />
-				<Count count={ this.props.selectedElements } />
-				{ this.getStateIcon() }
-			</div>
+			<span className="bulk-select" onClick={ this.handleToggleAll }>
+				<span className="bulk-select__container">
+					<input type="checkbox" className="bulk-select__box" checked={ this.hasAllElementsSelected() } readOnly />
+					<Count count={ this.props.selectedElements } />
+					{ this.getStateIcon() }
+				</span>
+			</span>
 		);
 	}
 } );

--- a/client/components/bulk-select/style.scss
+++ b/client/components/bulk-select/style.scss
@@ -1,16 +1,20 @@
 .bulk-select {
-	position: relative;
+	display: inline-block;
+}
+
+.bulk-select__container {
+	cursor: pointer;
 	display: flex;
 		align-items: center;
-	cursor: pointer;
+	position: relative;
 
 	.gridicon {
-		width: 16px;
-		height: 16px;
 		color: $blue-medium;
+		height: 16px;
 		position: absolute;
 			left: 0px;
 			top: 0px;
+		width: 16px;
 	}
 
 	> .count {
@@ -19,10 +23,10 @@
 }
 
 input[type=checkbox].bulk-select__box {
+	appearance: none;
 	height: 16px;
 	margin: 0;
+	min-width: 16px;
 	padding: 0;
 	width: 16px;
-	min-width: 16px;
-	appearance: none;
 }

--- a/client/components/button-group/style.scss
+++ b/client/components/button-group/style.scss
@@ -38,6 +38,10 @@
 		border-bottom-right-radius: 4px;
 	}
 
+	.section-header & .button {
+		margin-right: 0;
+	}
+
 	&.example {
 		margin-bottom: 16px;
 		display: inline-block;

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -25,9 +25,10 @@ var SelectDropdownItem = React.createClass( {
 	},
 
 	render: function() {
-		var optionClassName = classNames( {
+		var optionClassName = classNames( this.props.className, {
 			'select-dropdown__item': true,
-			'is-selected': this.props.selected
+			'is-selected': this.props.selected,
+			'is-disabled': this.props.disabled
 		} );
 
 		return (
@@ -36,12 +37,11 @@ var SelectDropdownItem = React.createClass( {
 					ref="itemLink"
 					href={ this.props.path }
 					className={ optionClassName }
-					onClick={ this.props.onClick }
+					onClick={ this.props.disabled ? null : this.props.onClick }
 					data-bold-text={ this.props.value || this.props.children }
 					role="menuitem"
 					tabIndex={ 0 }
-					aria-selected={ this.props.selected }
-				>
+					aria-selected={ this.props.selected } >
 					<span className="select-dropdown__item-text">
 						{ this.props.children }
 						{

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -162,6 +162,14 @@
 		color: $white;
 	}
 
+	&.is-disabled {
+		background-color: $white;
+		color: $gray;
+		cursor: default;
+		opacity: .5;
+	}
+
+
 	.notouch & {
 		// Make sure :visited links stay blue
 		&:hover {

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -4,6 +4,10 @@
 
 .select-dropdown {
 	height: 43px;
+
+	&.is-compact {
+		height: 28px;
+	}
 }
 
 .select-dropdown__container {

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -173,7 +173,6 @@
 		opacity: .5;
 	}
 
-
 	.notouch & {
 		// Make sure :visited links stay blue
 		&:hover {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -398,9 +398,12 @@ export default React.createClass( {
 		return ( this.props.sites.selected || this.props.sites.get().length === 1 ) ? '/' + this.props.sites.selected : '';
 	},
 
-	placeholders() {
+	renderPlaceholders() {
 		const placeholderCount = 16;
-		return [ ... Array( placeholderCount ).keys() ].map( i => <PluginItem key={ 'placeholder-' + i } /> );
+		return [
+			<SectionHeader label="Jetpack Plugins" className="plugins__section-actions is-placeholder" />,
+			[ ... Array( placeholderCount ).keys() ].map( i => <PluginItem key={ 'placeholder-' + i } /> )
+		];
 	},
 
 	formatPlugins( plugins, disableManage ) {
@@ -710,7 +713,7 @@ export default React.createClass( {
 			<div className="plugins__lists">
 				{ this.renderPluginList( this.getWpcomPlugins(), this.translate( 'WordPress.com Plugins' ) ) }
 				{ this.renderPluginList( this.getJetpackPlugins(), this.translate( 'Jetpack Plugins' ) ) }
-				{ ! this.state.plugins && this.placeholders() }
+				{ ! this.state.plugins && this.renderPlaceholders() }
 			</div>
 		);
 	},

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -606,7 +606,7 @@ export default React.createClass( {
 
 			options.push( <DropdownSeparator key="plugin__actions_separator_3" /> );
 			options.push( <DropdownItem key="plugin__actions_remove" className="plugins__actions_remove_item" disabled={ ! needsRemoveButton } onClick={ this.removePluginNotice } >{ this.translate( 'Remove' ) }</DropdownItem> );
-			actions.push( <SelectDropdown className="plugins__actions_dropdown" selectedText="Actions">{ options }</SelectDropdown> );
+			actions.push( <SelectDropdown compact className="plugins__actions_dropdown" selectedText="Actions">{ options }</SelectDropdown> );
 		}
 		return actions;
 	},

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -518,32 +518,9 @@ export default React.createClass( {
 		let activateButtons = [];
 		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
 		const isJetpackSelected = this.state.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
-
-
-		if ( this.areSelected( 'inactive' ) ) { // needs activate button
-			leftSideButtons.push( <Button compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
-		}
-
-		if ( this.areSelected( 'active' ) ) {
-			let deactivateButton = isJetpackSelected
-				? <Button compact onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</Button>
-				: <Button compact onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</Button>;
-			leftSideButtons.push( deactivateButton )
-		}
-
-		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && this.areSelected() ) { // needs autoupdates
-			updateButtons.push( <Button compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
-			updateButtons.push( <Button compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
-		}
-
-		leftSideButtons.push( <ButtonGroup>{ updateButtons }</ButtonGroup> );
-
-		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && config.isEnabled( 'manage/plugins/browser' ) && ! isJetpackSelected ) {  // needs remove
-			leftSideButtons.push( <ButtonGroup><Button compact scary onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
-		}
+		const needsRemoveButton = this.getSelected().length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
 
 		if( ! this.state.bulkManagement ) {
-
 			if ( 0 < this.state.pluginUpdateCount ) {
 				rightSideButtons.push(
 					<ButtonGroup>
@@ -557,8 +534,22 @@ export default React.createClass( {
 			rightSideButtons.push(
 				<ButtonGroup><Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>{ this.translate( 'Bulk Edit', { context: 'button label' } ) }</Button></ButtonGroup>
 			);
-
 		} else {
+			activateButtons.push( <Button disabled={ ! this.areSelected( 'inactive' ) } compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
+			let deactivateButton = isJetpackSelected
+				? <Button disabled={ ! this.areSelected( 'active' )  } compact onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</Button>
+				: <Button disabled={ ! this.areSelected( 'active' )  } compact onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</Button>;
+			activateButtons.push( deactivateButton )
+
+			updateButtons.push( <Button disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
+			updateButtons.push( <Button disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
+
+			leftSideButtons.push( <ButtonGroup>{ activateButtons }</ButtonGroup> );
+			leftSideButtons.push( <ButtonGroup>{ updateButtons }</ButtonGroup> );
+
+
+			leftSideButtons.push( <ButtonGroup><Button disabled={ ! needsRemoveButton } compact scary onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
+
 			rightSideButtons.push(
 				<ButtonGroup>
 					<button className="plugins__section-actions-close" onClick={ this.toggleBulkManagement }>

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -41,7 +41,8 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page'
 import PlanNudge from 'components/plans/plan-nudge'
 import FeatureExample from 'components/feature-example'
 import SectionHeader from 'components/section-header'
-import SectionHeaderButton from 'components/section-header/button'
+import ButtonGroup from 'components/button-group'
+import Button from 'components/button'
 
 /**
  * Module variables
@@ -434,7 +435,7 @@ export default React.createClass( {
 		} );
 
 		headerMarkup = (
-			<SectionHeader label={ header }>
+			<SectionHeader label={ header } className="plugins__section-actions">
 				{ disableManage ? null : this.getCurrentActionButtons() }
 			</SectionHeader>
 		);
@@ -506,49 +507,59 @@ export default React.createClass( {
 
 	getCurrentActionButtons() {
 		let buttons = [];
+		let updateButtons = [];
+		let activateButtons = [];
 		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
 		const isJetpackSelected = this.state.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
 
 		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && this.areSelected( 'updates' ) ) { // needs updates
-			buttons.push( <SectionHeaderButton onClick={ this.updateSelected }>{ this.translate( 'Update' ) }</SectionHeaderButton> );
-		}
-
-		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && config.isEnabled( 'manage/plugins/browser' ) && ! isJetpackSelected ) {  // needs remove
-			buttons.push( <SectionHeaderButton onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</SectionHeaderButton> );
+			updateButtons.push( <Button compact onClick={ this.updateSelected }>{ this.translate( 'Update' ) }</Button> );
 		}
 
 		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && this.areSelected() ) { // needs autoupdates
-			buttons.push( <SectionHeaderButton onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</SectionHeaderButton> );
-			buttons.push( <SectionHeaderButton onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Manually update' ) }</SectionHeaderButton> );
+			updateButtons.push( <Button compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
+			updateButtons.push( <Button compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Manually update' ) }</Button> );
+		}
+
+		buttons.push( <ButtonGroup>{ updateButtons }</ButtonGroup> );
+
+		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && config.isEnabled( 'manage/plugins/browser' ) && ! isJetpackSelected ) {  // needs remove
+			buttons.push( <ButtonGroup><Button compact onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
 		}
 
 		if ( this.areSelected( 'inactive' ) ) { // needs activate button
-			buttons.push( <SectionHeaderButton onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</SectionHeaderButton> )
+			activateButtons.push( <Button compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
 		}
 
 		if ( this.areSelected( 'active' ) ) {
 			let deactivateButton = isJetpackSelected
-				? <SectionHeaderButton onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</SectionHeaderButton>
-				: <SectionHeaderButton onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</SectionHeaderButton>;
-			buttons.push( deactivateButton )
+				? <Button compact onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</Button>
+				: <Button compact onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</Button>;
+			activateButtons.push( deactivateButton )
 		}
+
+		buttons.push( <ButtonGroup>{ activateButtons }</ButtonGroup> );
 
 		if ( this.props && this.props.filter === 'updates' ) {
 			buttons.push(
-				<SectionHeaderButton onClick={ this.updateAllPlugins } >
-					{ this.translate( 'Update All', { context: 'button label' } ) }
-				</SectionHeaderButton>
+				<ButtonGroup>
+					<Button compact onClick={ this.updateAllPlugins } >
+						{ this.translate( 'Update All', { context: 'button label' } ) }
+					</Button>
+				</ButtonGroup>
 			);
 		}
 
 		buttons.push(
-			<SectionHeaderButton onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>
-					{
-						this.state.bulkManagement ?
-						this.translate( 'Done', { context: 'button label' } ) :
-						this.translate( 'Bulk Edit', { context: 'button label' } )
-					}
-			</SectionHeaderButton>
+			<ButtonGroup>
+				<Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>
+						{
+							this.state.bulkManagement
+							? this.translate( 'Done', { context: 'button label' } )
+							: this.translate( 'Bulk Edit', { context: 'button label' } )
+						}
+				</Button>
+			</ButtonGroup>
 		);
 		return buttons;
 	},
@@ -649,16 +660,15 @@ export default React.createClass( {
 					illustration={ emptyContentData.illustration }
 					actionURL={ emptyContentData.actionURL }
 					action={ emptyContentData.action } />
-			);;
-		} else {
-			return (
-				<div className="plugins__lists">
-					{ this.renderPluginList( this.getWpcomPlugins(), this.translate( 'WordPress.com Plugins' ), true ) }
-					{ this.renderPluginList( this.getJetpackPlugins(), this.translate( 'Jetpack Plugins' ) ) }
-					{ ! this.state.plugins && this.placeholders() }
-				</div>
 			);
 		}
+		return (
+			<div className="plugins__lists">
+				{ this.renderPluginList( this.getWpcomPlugins(), this.translate( 'WordPress.com Plugins' ), true ) }
+				{ this.renderPluginList( this.getJetpackPlugins(), this.translate( 'Jetpack Plugins' ) ) }
+				{ ! this.state.plugins && this.placeholders() }
+			</div>
+		);
 	},
 
 	getMockPluginItems() {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -43,6 +43,7 @@ import FeatureExample from 'components/feature-example'
 import SectionHeader from 'components/section-header'
 import ButtonGroup from 'components/button-group'
 import Button from 'components/button'
+import Gridicon from 'components/gridicon'
 
 /**
  * Module variables
@@ -434,6 +435,10 @@ export default React.createClass( {
 			'is-bulk-editing': this.state.bulkManagement && ! disableManage
 		} );
 
+		if( this.state.bulkManagement ) {
+			header = null;
+		}
+
 		headerMarkup = (
 			<SectionHeader label={ header } className="plugins__section-actions">
 				{ disableManage ? null : this.getCurrentActionButtons() }
@@ -507,6 +512,8 @@ export default React.createClass( {
 
 	getCurrentActionButtons() {
 		let buttons = [];
+		let rightSideButtons = [];
+		let leftSideButtons = [];
 		let updateButtons = [];
 		let activateButtons = [];
 		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
@@ -514,52 +521,57 @@ export default React.createClass( {
 
 
 		if ( this.areSelected( 'inactive' ) ) { // needs activate button
-			activateButtons.push( <Button compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
+			leftSideButtons.push( <Button compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
 		}
 
 		if ( this.areSelected( 'active' ) ) {
 			let deactivateButton = isJetpackSelected
 				? <Button compact onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</Button>
 				: <Button compact onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</Button>;
-			activateButtons.push( deactivateButton )
+			leftSideButtons.push( deactivateButton )
 		}
-
-		buttons.push( <ButtonGroup>{ activateButtons }</ButtonGroup> );
 
 		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && this.areSelected() ) { // needs autoupdates
 			updateButtons.push( <Button compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
 			updateButtons.push( <Button compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
 		}
 
-		buttons.push( <ButtonGroup>{ updateButtons }</ButtonGroup> );
+		leftSideButtons.push( <ButtonGroup>{ updateButtons }</ButtonGroup> );
 
 		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && config.isEnabled( 'manage/plugins/browser' ) && ! isJetpackSelected ) {  // needs remove
-			buttons.push( <ButtonGroup><Button compact onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
+			leftSideButtons.push( <ButtonGroup><Button compact scary onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
 		}
 
-		debugger;
+		if( ! this.state.bulkManagement ) {
 
-		if ( this.props && this.props.filter === 'updates' ) {
-			buttons.push(
+			if ( 0 < this.state.pluginUpdateCount ) {
+				rightSideButtons.push(
+					<ButtonGroup>
+						<Button compact primary onClick={ this.updateAllPlugins } >
+							{ this.translate( 'Update All', { context: 'button label' } ) }
+						</Button>
+					</ButtonGroup>
+				);
+			}
+
+			rightSideButtons.push(
+				<ButtonGroup><Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>{ this.translate( 'Bulk Edit', { context: 'button label' } ) }</Button></ButtonGroup>
+			);
+
+		} else {
+			rightSideButtons.push(
 				<ButtonGroup>
-					<Button compact onClick={ this.updateAllPlugins } >
-						{ this.translate( 'Update All', { context: 'button label' } ) }
-					</Button>
+					<button className="plugins__section-actions-close" onClick={ this.toggleBulkManagement }>
+						<span className="screen-reader-text">{ this.translate( 'Close' ) }</span>
+						<Gridicon icon="cross" />
+					</button>
 				</ButtonGroup>
 			);
 		}
 
-		buttons.push(
-			<ButtonGroup>
-				<Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>
-						{
-							this.state.bulkManagement
-							? this.translate( 'Done', { context: 'button label' } )
-							: this.translate( 'Bulk Edit', { context: 'button label' } )
-						}
-				</Button>
-			</ButtonGroup>
-		);
+		buttons.push( <span className="plugins__action-buttons">{ leftSideButtons }</span> );
+		buttons.push( <span className="plugins__mode-buttons">{ rightSideButtons }</span> );
+
 		return buttons;
 	},
 

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -512,20 +512,6 @@ export default React.createClass( {
 		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
 		const isJetpackSelected = this.state.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
 
-		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && this.areSelected( 'updates' ) ) { // needs updates
-			updateButtons.push( <Button compact onClick={ this.updateSelected }>{ this.translate( 'Update' ) }</Button> );
-		}
-
-		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && this.areSelected() ) { // needs autoupdates
-			updateButtons.push( <Button compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
-			updateButtons.push( <Button compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Manually update' ) }</Button> );
-		}
-
-		buttons.push( <ButtonGroup>{ updateButtons }</ButtonGroup> );
-
-		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && config.isEnabled( 'manage/plugins/browser' ) && ! isJetpackSelected ) {  // needs remove
-			buttons.push( <ButtonGroup><Button compact onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
-		}
 
 		if ( this.areSelected( 'inactive' ) ) { // needs activate button
 			activateButtons.push( <Button compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
@@ -539,6 +525,19 @@ export default React.createClass( {
 		}
 
 		buttons.push( <ButtonGroup>{ activateButtons }</ButtonGroup> );
+
+		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && this.areSelected() ) { // needs autoupdates
+			updateButtons.push( <Button compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
+			updateButtons.push( <Button compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
+		}
+
+		buttons.push( <ButtonGroup>{ updateButtons }</ButtonGroup> );
+
+		if ( ! hasWpcomPlugins && this.canUpdatePlugins() && config.isEnabled( 'manage/plugins/browser' ) && ! isJetpackSelected ) {  // needs remove
+			buttons.push( <ButtonGroup><Button compact onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
+		}
+
+		debugger;
 
 		if ( this.props && this.props.filter === 'updates' ) {
 			buttons.push(

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -46,6 +46,7 @@ import Gridicon from 'components/gridicon'
 import SelectDropdown from 'components/select-dropdown'
 import DropdownItem from 'components/select-dropdown/item'
 import DropdownSeparator from 'components/select-dropdown/separator'
+import BulkSelect from 'components/bulk-select';
 
 /**
  * Module variables
@@ -448,6 +449,7 @@ export default React.createClass( {
 
 		headerMarkup = (
 			<SectionHeader label={ header } className={ headerClasses }>
+				{ disableManage || ! this.state.bulkManagement ? null : <BulkSelect totalElements={ this.state.plugins.length } selectedElements={ this.getSelected().length } onToggle={ this.unselectOrSelectAll } /> }
 				{ disableManage ? null : this.getCurrentActionDropdown() }
 				{ disableManage ? null : this.getCurrentActionButtons() }
 			</SectionHeader>
@@ -585,7 +587,7 @@ export default React.createClass( {
 		const needsRemoveButton = !! this.getSelected().length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
 
 		if ( this.state.bulkManagement ) {
-			options.push( <DropdownItem key="plugin__actions_title" selected={ true } value="Actions">{ this.translate( 'Actions' ) }</DropdownItem> );
+			options.push( <DropdownItem key="plugin__actions_title" selected={ true } v1alue="Actions">{ this.translate( 'Actions' ) }</DropdownItem> );
 			options.push( <DropdownSeparator key="plugin__actions_separator_1" /> );
 
 			options.push( <DropdownItem key="plugin__actions_activate" disabled={ ! this.areSelected( 'inactive' ) } onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</DropdownItem> );
@@ -601,7 +603,6 @@ export default React.createClass( {
 
 			options.push( <DropdownSeparator key="plugin__actions_separator_3" /> );
 			options.push( <DropdownItem key="plugin__actions_remove" className="plugins__actions_remove_item" disabled={ ! needsRemoveButton } onClick={ this.removePluginNotice } >{ this.translate( 'Remove' ) }</DropdownItem> );
-
 			actions.push( <SelectDropdown className="plugins__actions_dropdown" selectedText="Actions">{ options }</SelectDropdown> );
 		}
 		return actions;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -1,51 +1,51 @@
 /**
  * External dependencies
  */
-import React from 'react/addons'
-import debugModule from 'debug'
-import titleCase from 'to-title-case'
-import classNames from 'classnames'
-import some from 'lodash/collection/some'
-import find from 'lodash/collection/find'
-import filter from 'lodash/collection/filter'
-import reject from 'lodash/collection/reject'
-import assign from 'lodash/object/assign'
-import property from 'lodash/utility/property'
-import isEmpty from 'lodash/lang/isEmpty'
+import React from 'react/addons';
+import debugModule from 'debug';
+import titleCase from 'to-title-case';
+import classNames from 'classnames';
+import some from 'lodash/collection/some';
+import find from 'lodash/collection/find';
+import filter from 'lodash/collection/filter';
+import reject from 'lodash/collection/reject';
+import assign from 'lodash/object/assign';
+import property from 'lodash/utility/property';
+import isEmpty from 'lodash/lang/isEmpty';
 
 /**
  * Internal dependencies
  */
-import acceptDialog from 'lib/accept'
-import analytics from 'analytics'
-import { abtest } from 'lib/abtest'
-import Main from 'components/main'
-import SidebarNavigation from 'my-sites/sidebar-navigation'
-import pluginsAccessControl from 'my-sites/plugins/access-control'
-import { isBusiness } from 'lib/products-values'
-import PluginItem from './plugin-item/plugin-item'
-import SectionNav from 'components/section-nav'
-import NavTabs from 'components/section-nav/tabs'
-import NavItem from 'components/section-nav/item'
-import Search from 'components/search'
-import URLSearch from 'lib/mixins/url-search'
-import EmptyContent from 'components/empty-content'
-import DisconnectJetpackDialog from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog'
-import PluginsActions from 'lib/plugins/actions'
-import PluginsLog from 'lib/plugins/log-store'
-import PluginsStore from 'lib/plugins/store'
-import PluginsDataStore from 'lib/plugins/wporg-data/store'
-import PluginNotices from 'lib/plugins/notices'
-import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page'
-import PlanNudge from 'components/plans/plan-nudge'
-import FeatureExample from 'components/feature-example'
-import SectionHeader from 'components/section-header'
-import ButtonGroup from 'components/button-group'
-import Button from 'components/button'
-import Gridicon from 'components/gridicon'
-import SelectDropdown from 'components/select-dropdown'
-import DropdownItem from 'components/select-dropdown/item'
-import DropdownSeparator from 'components/select-dropdown/separator'
+import acceptDialog from 'lib/accept';
+import analytics from 'analytics';
+import { abtest } from 'lib/abtest';
+import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import pluginsAccessControl from 'my-sites/plugins/access-control';
+import { isBusiness } from 'lib/products-values';
+import PluginItem from './plugin-item/plugin-item';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import Search from 'components/search';
+import URLSearch from 'lib/mixins/url-search';
+import EmptyContent from 'components/empty-content';
+import DisconnectJetpackDialog from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog';
+import PluginsActions from 'lib/plugins/actions';
+import PluginsLog from 'lib/plugins/log-store';
+import PluginsStore from 'lib/plugins/store';
+import PluginsDataStore from 'lib/plugins/wporg-data/store';
+import PluginNotices from 'lib/plugins/notices';
+import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import PlanNudge from 'components/plans/plan-nudge';
+import FeatureExample from 'components/feature-example';
+import SectionHeader from 'components/section-header';
+import ButtonGroup from 'components/button-group';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import SelectDropdown from 'components/select-dropdown';
+import DropdownItem from 'components/select-dropdown/item';
+import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
 
 /**
@@ -401,7 +401,7 @@ export default React.createClass( {
 	renderPlaceholders() {
 		const placeholderCount = 16;
 		return [
-			<SectionHeader label="Jetpack Plugins" className="plugins__section-actions is-placeholder" />,
+			<SectionHeader key="plugins__section-placeholder" label="Jetpack Plugins" className="plugins__section-actions is-placeholder" />,
 			[ ... Array( placeholderCount ).keys() ].map( i => <PluginItem key={ 'placeholder-' + i } /> )
 		];
 	},
@@ -433,6 +433,7 @@ export default React.createClass( {
 
 	renderPluginList( plugins, header, disableManage ) {
 		let headerMarkup;
+		const slug = header.replace( / /g, '' );
 
 		if ( isEmpty( plugins ) ) {
 			return;
@@ -451,15 +452,15 @@ export default React.createClass( {
 		}
 
 		headerMarkup = (
-			<SectionHeader label={ header } className={ headerClasses }>
-				{ disableManage || ! this.state.bulkManagement ? null : <BulkSelect totalElements={ this.state.plugins.length } selectedElements={ this.getSelected().length } onToggle={ this.unselectOrSelectAll } /> }
+			<SectionHeader label={ header } className={ headerClasses } key={ 'plugins__section-header-' + slug } >
+				{ disableManage || ! this.state.bulkManagement ? null : <BulkSelect key="plugins__bulk-select" totalElements={ this.state.plugins.length } selectedElements={ this.getSelected().length } onToggle={ this.unselectOrSelectAll } /> }
 				{ disableManage ? null : this.getCurrentActionDropdown() }
 				{ disableManage ? null : this.getCurrentActionButtons() }
 			</SectionHeader>
 		);
 
 		return (
-			<span>
+			<span key={ 'plugins__header-' + slug }>
 				{ headerMarkup }
 				<div className={ itemListClasses }>{ this.formatPlugins( plugins, disableManage ) }</div>
 			</span>
@@ -529,8 +530,6 @@ export default React.createClass( {
 		let leftSideButtons = [];
 		let updateButtons = [];
 		let activateButtons = [];
-		let GroupComponent = ButtonGroup;
-		let ButtonComponent = Button;
 
 		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
 		const isJetpackSelected = this.state.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
@@ -539,44 +538,42 @@ export default React.createClass( {
 		if ( ! this.state.bulkManagement ) {
 			if ( 0 < this.state.pluginUpdateCount ) {
 				rightSideButtons.push(
-					<GroupComponent>
-						<ButtonComponent compact primary onClick={ this.updateAllPlugins } >
+					<ButtonGroup key="plugins__buttons-update-all">
+						<Button compact primary onClick={ this.updateAllPlugins } >
 							{ this.translate( 'Update All', { context: 'button label' } ) }
-						</ButtonComponent>
-					</GroupComponent>
+						</Button>
+					</ButtonGroup>
 				);
 			}
 
 			rightSideButtons.push(
-				<GroupComponent><ButtonComponent compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>{ this.translate( 'Bulk Edit', { context: 'button label' } ) }</ButtonComponent></GroupComponent>
+				<ButtonGroup key="plugins__buttons-bulk-management"><Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>{ this.translate( 'Bulk Edit', { context: 'button label' } ) }</Button></ButtonGroup>
 			);
 		} else {
-			activateButtons.push( <ButtonComponent disabled={ ! this.areSelected( 'inactive' ) } compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</ButtonComponent> )
+			activateButtons.push( <Button key="plugins__buttons-activate" disabled={ ! this.areSelected( 'inactive' ) } compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
 			let deactivateButton = isJetpackSelected
-				? <ButtonComponent disabled={ ! this.areSelected( 'active' ) } compact onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</ButtonComponent>
-				: <ButtonComponent disabled={ ! this.areSelected( 'active' ) } compact onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</ButtonComponent>;
+				? <Button key="plugins__buttons-deactivate" disabled={ ! this.areSelected( 'active' ) } compact onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</Button>
+				: <Button key="plugins__buttons-disable" disabled={ ! this.areSelected( 'active' ) } compact onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</Button>;
 			activateButtons.push( deactivateButton )
 
-			updateButtons.push( <ButtonComponent disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</ButtonComponent> );
-			updateButtons.push( <ButtonComponent disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</ButtonComponent> );
+			updateButtons.push( <Button key="plugins__buttons-autoupdate-on" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
+			updateButtons.push( <Button key="plugins__buttons-autoupdate-off" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
 
-			leftSideButtons.push( <GroupComponent>{ activateButtons }</GroupComponent> );
-			leftSideButtons.push( <GroupComponent>{ updateButtons }</GroupComponent> );
+			leftSideButtons.push( <ButtonGroup key="plugins__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
+			leftSideButtons.push( <ButtonGroup key="plugins__buttons-update-buttons">{ updateButtons }</ButtonGroup> );
 
-			leftSideButtons.push( <GroupComponent><ButtonComponent disabled={ ! needsRemoveButton } compact scary onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</ButtonComponent></GroupComponent> );
+			leftSideButtons.push( <ButtonGroup key="plugins__buttons-remove-button"><Button disabled={ ! needsRemoveButton } compact scary onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
 
 			rightSideButtons.push(
-				<GroupComponent>
-					<button className="plugins__section-actions-close" onClick={ this.toggleBulkManagement }>
-						<span className="screen-reader-text">{ this.translate( 'Close' ) }</span>
-						<Gridicon icon="cross" />
-					</button>
-				</GroupComponent>
+				<button key="plugins__buttons-close-button" className="plugins__section-actions-close" onClick={ this.toggleBulkManagement }>
+					<span className="screen-reader-text">{ this.translate( 'Close' ) }</span>
+					<Gridicon icon="cross" />
+				</button>
 			);
 		}
 
-		buttons.push( <span className="plugins__action-buttons">{ leftSideButtons }</span> );
-		buttons.push( <span className="plugins__mode-buttons">{ rightSideButtons }</span> );
+		buttons.push( <span key="plugins__buttons-action-buttons" className="plugins__action-buttons">{ leftSideButtons }</span> );
+		buttons.push( <span key="plugins__buttons-global-buttons" className="plugins__mode-buttons">{ rightSideButtons }</span> );
 
 		return buttons;
 	},
@@ -606,7 +603,7 @@ export default React.createClass( {
 
 			options.push( <DropdownSeparator key="plugin__actions_separator_3" /> );
 			options.push( <DropdownItem key="plugin__actions_remove" className="plugins__actions_remove_item" disabled={ ! needsRemoveButton } onClick={ this.removePluginNotice } >{ this.translate( 'Remove' ) }</DropdownItem> );
-			actions.push( <SelectDropdown compact className="plugins__actions_dropdown" selectedText="Actions">{ options }</SelectDropdown> );
+			actions.push( <SelectDropdown compact className="plugins__actions_dropdown" key="plugins__actions_dropdown" selectedText="Actions">{ options }</SelectDropdown> );
 		}
 		return actions;
 	},
@@ -696,7 +693,7 @@ export default React.createClass( {
 		this.recordEvent( 'Clicked Update all Plugins', true );
 	},
 
-	getPluginsContent() {
+	renderPluginsContent() {
 		const plugins = this.state.plugins || [];
 
 		if ( isEmpty( plugins ) && ( this.props.search || 'inactive' === this.props.filter || 'updates' === this.props.filter ) ) {
@@ -828,7 +825,7 @@ export default React.createClass( {
 						placeholder={ this.getSearchPlaceholder() }
 					/>
 				</SectionNav>
-				{ this.getPluginsContent() }
+				{ this.renderPluginsContent() }
 				<DisconnectJetpackDialog ref="dialog" site={ this.props.site } sites={ this.props.sites } redirect="/plugins" />
 			</Main>
 		);

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -128,13 +128,6 @@
 	}
 }
 
-.plugins__lists .is-compact {
-	margin-bottom: 1px;
-}
-.plugins__lists .is-compact:last-child {
-	margin-bottom: 8px;
-}
-
 // Last updated, version, whatever
 .plugin-item__meta {
 	display: block;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -1,3 +1,13 @@
 .plugin__installed-on {
 	margin-bottom: 16px;
 }
+
+.plugins__section-actions {
+	.section-header__actions {
+		height: 24px;
+	}
+
+	.button-group {
+		margin-left: 8px;
+	}
+}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -4,10 +4,14 @@
 
 .plugins__section-actions {
 	.section-header__actions {
-		height: 24px;
 		flex-grow: 1;
 		display: flex;
 		justify-content: space-between;
+		align-items: center;
+	}
+
+	.bulk-select {
+		margin-right: 16px;
 	}
 
 	&.is-bulk-editing .section-header__label {
@@ -20,8 +24,9 @@
 }
 
 .plugins__action-buttons {
+	align-items: center;
+	display: flex;
 	flex-grow: 1;
-	display: inline-block;
 
 	@include breakpoint( "<960px" ) {
 		display: none;
@@ -29,6 +34,8 @@
 }
 
 .plugins__mode-buttons {
+	display: flex;
+		justify-content: flex-end;
 	flex-grow: 1;
 	text-align: right;
 }
@@ -36,20 +43,12 @@
 
 .plugins__section-actions-close {
 	cursor: pointer;
+	display: flex;
+		align-items: center;
 }
 
 .plugins__actions_dropdown {
 	display: none;
-	position: relative;
-		top: -11px;
-
-	.select-dropdown__header {
-		border: 0;
-	}
-
-	.select-dropdown__header {
-		line-height: 26px;
-	}
 
 	@include breakpoint( "<960px" ) {
 		display: inline-block;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -5,9 +5,26 @@
 .plugins__section-actions {
 	.section-header__actions {
 		height: 24px;
+		flex-grow: 1;
+		display: flex;
+		justify-content: space-between;
 	}
 
 	.button-group {
 		margin-left: 8px;
 	}
+}
+
+.plugins__action-buttons {
+	flex-grow: 1;
+}
+
+.plugins__mode-buttons {
+	flex-grow: 1;
+	text-align: right;
+}
+
+
+.plugins__section-actions-close {
+	cursor: pointer;
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -2,6 +2,8 @@
 	margin-bottom: 16px;
 }
 
+
+
 .plugins__section-actions {
 	.section-header__actions {
 		flex-grow: 1;
@@ -12,6 +14,12 @@
 
 	.bulk-select {
 		margin-right: 16px;
+	}
+
+	&.is-placeholder {
+		.section-header__label span {
+			@include placeholder(23%);
+		}
 	}
 
 	&.is-bulk-editing .section-header__label {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -10,6 +10,10 @@
 		justify-content: space-between;
 	}
 
+	&.is-bulk-editing .section-header__label {
+		display: none;
+	}
+
 	.button-group {
 		margin-left: 8px;
 	}
@@ -17,6 +21,11 @@
 
 .plugins__action-buttons {
 	flex-grow: 1;
+	display: inline-block;
+
+	@include breakpoint( "<960px" ) {
+		display: none;
+	}
 }
 
 .plugins__mode-buttons {
@@ -27,4 +36,30 @@
 
 .plugins__section-actions-close {
 	cursor: pointer;
+}
+
+.plugins__actions_dropdown {
+	display: none;
+	position: relative;
+		top: -11px;
+
+	.select-dropdown__header {
+		border: 0;
+	}
+
+	.select-dropdown__header {
+		line-height: 26px;
+	}
+
+	@include breakpoint( "<960px" ) {
+		display: inline-block;
+	}
+}
+
+.plugins__actions_remove_item {
+	color: $alert-red;
+
+	&.is-disabled {
+		color: lighten( $alert-red, 30% );
+	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -2,9 +2,9 @@
 	margin-bottom: 16px;
 }
 
+.plugins__section-actions.section-header.card {
+	padding-right: 16px;
 
-
-.plugins__section-actions {
 	.section-header__actions {
 		flex-grow: 1;
 		display: flex;
@@ -53,6 +53,11 @@
 	cursor: pointer;
 	display: flex;
 		align-items: center;
+
+	&:focus {
+		border-color: $blue-medium;
+		box-shadow: 0 0 0 2px $blue-light;
+	}
 }
 
 .plugins__actions_dropdown {


### PR DESCRIPTION
fixes https://github.com/Automattic/wp-calypso/issues/912

This PR changes the way we bulk manage plugins in the plugins list. Until now, the plugins list header showed a "manage" button, that once clicked, it would change the view to edition mode and add a second level bar with the available actions for the selected plugins.

That secondary actions bar dissapears and the 'manage' button is now integrated in a <SectionHeader> component that is always shown on top of the differnt lists of plugins. The actions are also embed in there.

Before:
![image](https://cloud.githubusercontent.com/assets/1554855/11477993/d0193dd4-978a-11e5-963c-d2419d683a72.png)

![image](https://cloud.githubusercontent.com/assets/1554855/11477948/9fa29592-978a-11e5-91e1-54070602c963.png)

After:
![image](https://cloud.githubusercontent.com/assets/1554855/11477965/ae56455c-978a-11e5-8744-ed6d32c041ae.png)
![image](https://cloud.githubusercontent.com/assets/1554855/11477926/8810d66e-978a-11e5-9a03-a3efa0936b61.png)




