### PR TITLE
Docs: Spaces VS Spacing

### DIFF
--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -3,7 +3,7 @@ JavaScript Coding Guidelines
 
 ## Spacing
 
-Use spaces liberally throughout your code. “When in doubt, space it out.”
+Use spacing liberally throughout your code. “When in doubt, space it out.”
 
 These rules encourage liberal spacing for improved developer readability. The minification process creates a file that is optimized for browsers to read and process.
 


### PR DESCRIPTION
"Use spaces" can confuse a user about if the recommendation is using spaces over tabs or vertical spaces for code readability. So, I switched it with `spacing`.