### PR TITLE
Framework: dismiss soft keyboard on enter/search

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -1,19 +1,19 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	debounce = require( 'lodash/function/debounce' ),
-	noop = () => {};
+import ReactDom from 'react-dom';
+import React from 'react';
+import classNames from 'classnames';
+import debounce from 'lodash/function/debounce';
+import noop from 'lodash/utility/noop';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'analytics' ),
-	Spinner = require( 'components/spinner' ),
-	Gridicon = require( 'components/gridicon' );
-
+import analytics from 'analytics';
+import Spinner from 'components/spinner';
+import Gridicon from 'components/gridicon';
+import { isMobile } from 'lib/viewport';
 /**
  * Internal variables
  */
@@ -192,6 +192,11 @@ module.exports = React.createClass( {
 	},
 
 	keyUp: function( event ) {
+		if ( event.which === 13 && isMobile() ) {
+			//dismiss soft keyboards
+			this.blur();
+		}
+
 		if ( ! this.props.pinned ) {
 			return;
 		}

--- a/shared/my-sites/themes/themes-search-card/index.jsx
+++ b/shared/my-sites/themes/themes-search-card/index.jsx
@@ -94,7 +94,7 @@ var ThemesSearchCard = React.createClass( {
 						onSearch={ this.props.onSearch }
 						initialValue={ this.props.search }
 						ref="url-search"
-						placeholder={ this.translate( 'Search themes...' ) }
+						placeholder={ this.translate( 'Search themes…' ) }
 						analyticsGroup="Themes"
 						delaySearch={ true }
 					/>


### PR DESCRIPTION
Fixes #660, where tapping on the search button did not dismiss the android soft keyboard.

## Testing Instructions
* Setup your android emulator via android studio/android virtual device manager
* Make sure the image has enough space, and keyboard input is disabled. (You want to see the soft keyboard).
<img width="574" alt="keyboard" src="https://cloud.githubusercontent.com/assets/1270189/11481148/732bed54-9750-11e5-925d-c576a5396f14.png">
* Start the image
* Update the hosts file to point your host computer ip to calypso.localhost:
```
cd ~/Library/Android/sdk/platform-tools
# remount system
./adb remount
./adb push <yourhostfile> /system/etc
```
* To see the default browser output:
```
./adb logcat browser:V *:S
```
1. Navigate to http://calypso.localhost:3000/design
2. Using the soft keyboard, type in a search query
3. Press the Search button in the android soft keyboard
4. The keyboard should be dismissed
