### PR TITLE
Domains: Fix site-switching issue in domain management

### DIFF
--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -50,7 +50,7 @@ module.exports = React.createClass( {
 		user: React.PropTypes.object.isRequired
 	},
 
-	mixins: [ observe( 'productsList', 'sites' ) ],
+	mixins: [ observe( 'productsList' ) ],
 
 	componentWillMount() {
 		this.loadDomains();

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -36,7 +36,7 @@ module.exports = React.createClass( {
 		sites: React.PropTypes.object.isRequired
 	},
 
-	mixins: [ observe( 'productsList', 'sites' ) ],
+	mixins: [ observe( 'productsList' ) ],
 
 	componentWillMount: function() {
 		if ( this.props.sites.getSelectedSite() ) {

--- a/client/components/data/domain-management/transfer/index.jsx
+++ b/client/components/data/domain-management/transfer/index.jsx
@@ -7,7 +7,6 @@ import React from 'react';
  * Internal dependencies
  */
 import DomainsStore from 'lib/domains/store';
-import observe from 'lib/mixins/data-observe';
 import StoreConnection from 'components/data/store-connection';
 import WapiDomainInfoStore from 'lib/domains/wapi-domain-info/store';
 import { fetchDomains, fetchWapiDomainInfo } from 'lib/upgrades/actions';
@@ -38,8 +37,6 @@ const TransferData = React.createClass( {
 		selectedDomainName: React.PropTypes.string.isRequired,
 		sites: React.PropTypes.object.isRequired
 	},
-
-	mixins: [ observe( 'sites' ) ],
 
 	componentWillMount() {
 		this.loadDomains();

--- a/client/components/data/domain-management/whois/index.jsx
+++ b/client/components/data/domain-management/whois/index.jsx
@@ -45,7 +45,7 @@ module.exports = React.createClass( {
 		sites: React.PropTypes.object.isRequired
 	},
 
-	mixins: [ observe( 'productsList', 'sites' ) ],
+	mixins: [ observe( 'productsList' ) ],
 
 	componentWillMount() {
 		this.loadDomains();


### PR DESCRIPTION
`SitesList` emits a change event when navigating to a route that isn't for the given site, or when navigating from a route that selects a site to an all-sites route. This means that the given `selectedSite` property is false for a render when going from a route that expects a site to be selected to an all-sites route. Many of the domain components currently assume `selectedSite` (and the data associated with the currently selected site) is present, and throw an error when navigating to an all-sites page (e.g. the Reader).

This PR removes the `data-observe` mixin from the following data components to ensure that a false `selectedSite` isn't passed to their children when switching sites:

- `DomainManagementData`
- `EmailData`
- `TransferData`
- `WhoisData`

We are sure that `sites` is loaded and that a site is selected when a domains component mounts in these cases, and site-switching is accompanied by a route change which triggers a re-render, so we don't need `data-observe` here.

**Testing**
- Visit the following routes:
   - `/domains/manage/:site/edit/:domain`
   - `/domains/manage/:site/email/:domain`
   - `/domains/manage/:site/add-google-apps/:domain`
   - `/domains/manage/:site/contacts-privacy/:domain`
   - `/domains/manage/:site/edit-contact-info/:domain`
   - `/domains/manage/:site/privacy-protection/:domain`
  - `/domains/manage/:site/transfer/:domain`
- Click 'Reader' in the masterbar.
- Assert that no error appears in the console and that you are taken to the Reader.

- [x] QA review
- [x] Code review

Props to @scruffian for pointing this out in #579.