### PR TITLE
Purchases: Use `/sites/:site_slug/purchases` endpoint in `UpgradesActions`

### DIFF
--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -88,7 +88,7 @@ function fetchSitePurchases( siteId ) {
 		siteId
 	} );
 
-	wpcom.siteUpgrades( siteId, ( error, data ) => {
+	wpcom.sitePurchases( siteId, ( error, data ) => {
 		debug( error, data );
 
 		if ( error ) {
@@ -100,7 +100,7 @@ function fetchSitePurchases( siteId ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.PURCHASES_SITE_FETCH_COMPLETED,
 				siteId,
-				purchases: purchasesAssembler.createPurchasesArray( data.upgrades )
+				purchases: purchasesAssembler.createPurchasesArray( data )
 			} );
 		}
 	} );

--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -1643,9 +1643,9 @@ Undocumented.prototype.changeTheme = function( siteSlug, data, fn ) {
 	}, fn );
 };
 
-Undocumented.prototype.siteUpgrades = function( siteId, fn ) {
-	debug( '/site/:site_id/upgrades' );
-	this.wpcom.req.get( { path: '/sites/' + siteId + '/upgrades' }, fn );
+Undocumented.prototype.sitePurchases = function( siteId, fn ) {
+	debug( '/site/:site_id/purchases' );
+	this.wpcom.req.get( { path: '/sites/' + siteId + '/purchases' }, fn );
 };
 
 Undocumented.prototype.googleAppsListAll = function( domainName, fn ) {


### PR DESCRIPTION
Disparity between the site upgrades and user purchases endpoints (specifically, the lack of a `renew_date` property) is causing issues when a user visits the delete site component before visiting `/purchases`. This PR/patch will update `fetchSitePurchases` to fetch actual purchase objects through a new endpoint.

Requires patch `D-587`, which adds the new endpoint.

**Testing**
- Visit `/settings/general/:site` for a site with active subscriptions and click 'Delete Site'.
- Assert that you are prompted to remove your subscriptions before the site can be deleted.
- Visit `/settings/general/:site` for a site with no active subscriptions and click 'Delete Site'.
- Assert that you are prompted to enter the site slug and can successfully delete your site.

- [x] QA review
- [x] Code review

Props to @scruffian for noticing this.