### PR TITLE
Me: Adds ability to generate new backup codes for 2fa

### DIFF
--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -36,12 +36,14 @@ module.exports = React.createClass( {
 			printed: printed,
 			verified: printed,
 			showPrompt: ! printed,
-			backupCodes: []
+			backupCodes: [],
+			generatingCodes: false
 		};
 	},
 
 	onGenerate: function() {
 		this.setState( {
+			generatingCodes: true,
 			verified: false,
 			showPrompt: true
 		} );
@@ -58,7 +60,8 @@ module.exports = React.createClass( {
 		}
 
 		this.setState( {
-			backupCodes: data.codes
+			backupCodes: data.codes,
+			generatingCodes: false
 		} );
 	},
 
@@ -120,10 +123,6 @@ module.exports = React.createClass( {
 	},
 
 	renderList: function() {
-		if ( ! this.state.backupCodes || ! this.state.backupCodes.length ) {
-			return;
-		}
-
 		return (
 			<Security2faBackupCodesList
 				backupCodes={ this.state.backupCodes }
@@ -134,30 +133,46 @@ module.exports = React.createClass( {
 		);
 	},
 
+	renderPrompt: function() {
+		return (
+			<div>
+				<p>
+					{
+						this.translate(
+							'Backup codes let you access your account if your phone is ' +
+							'lost, stolen, or if you run it through the washing ' +
+							'machine and the bag of rice trick doesn\'t work.'
+						)
+					}
+				</p>
+
+				<p className="security-2fa-backup-codes__status">{ this.renderStatus() }</p>
+
+				{ this.state.showPrompt &&
+					<Security2faBackupCodesPrompt onSuccess={ this.onVerified } />
+				}
+			</div>
+		);
+	},
+
 	render: function() {
 		return (
 			<div className="security-2fa-backup-codes">
 				<SectionHeader label={ this.translate( 'Backup Codes' ) }>
-					<Button compact onClick={ this.recordClickEvent( 'Generate New Backup Codes Button', this.onGenerate ) }>
+					<Button
+						compact
+						disabled={ this.state.generatingCodes || this.state.backupCodes.length }
+						onClick={ this.recordClickEvent( 'Generate New Backup Codes Button', this.onGenerate ) }
+					>
 						{ this.translate( 'Generate New Backup Codes' ) }
 					</Button>
 				</SectionHeader>
 				<Card>
-					<p>
-						{
-							this.translate(
-								'Backup codes let you access your account if your phone is ' +
-								'lost, stolen, or if you run it through the washing ' +
-								'machine and the bag of rice trick doesn\'t work.'
-							)
-						}
-					</p>
-
-					<p className="security-2fa-backup-codes__status">{ this.renderStatus() }</p>
-
-					{ this.state.showPrompt ? <Security2faBackupCodesPrompt onSuccess={ this.onVerified }/> : null }
-
-					{ this.renderList() }
+					{
+						this.state.generatingCodes || this.state.backupCodes.length
+						? this.renderList()
+						: this.renderPrompt()
+					}
 				</Card>
 			</div>
 		);

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -161,7 +161,7 @@ module.exports = React.createClass( {
 				<SectionHeader label={ this.translate( 'Backup Codes' ) }>
 					<Button
 						compact
-						disabled={ this.state.generatingCodes || this.state.backupCodes.length }
+						disabled={ this.state.generatingCodes || !! this.state.backupCodes.length }
 						onClick={ this.recordClickEvent( 'Generate New Backup Codes Button', this.onGenerate ) }
 					>
 						{ this.translate( 'Generate New Backup Codes' ) }

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -7,11 +7,19 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var Security2faBackupCodesPrompt = require( 'me/security-2fa-backup-codes-prompt' );
+var Security2faBackupCodesPrompt = require( 'me/security-2fa-backup-codes-prompt' ),
+	SectionHeader = require( 'components/section-header' ),
+	Button = require( 'components/button' ),
+	Card = require( 'components/card' ),
+	eventRecorder = require( 'me/event-recorder' ),
+	twoStepAuthorization = require( 'lib/two-step-authorization' ),
+	Security2faBackupCodesList = require( 'me/security-2fa-backup-codes-list' );
 
 module.exports = React.createClass( {
 
 	displayName: 'Security2faBackupCodes',
+
+	mixins: [ eventRecorder ],
 
 	componentDidMount: function() {
 		debug( this.constructor.displayName + ' React component is mounted.' );
@@ -27,37 +35,46 @@ module.exports = React.createClass( {
 		return {
 			printed: printed,
 			verified: printed,
-			showPrompt: ! printed
+			showPrompt: ! printed,
+			backupCodes: []
 		};
 	},
 
 	onGenerate: function() {
-		this.setState(
-			{
-				verified: false,
-				showPrompt: true
-			}
-		);
+		this.setState( {
+			verified: false,
+			showPrompt: true
+		} );
+
+		twoStepAuthorization.backupCodes( this.onRequestComplete );
+	},
+
+	onRequestComplete: function( error, data ) {
+		if ( error ) {
+			this.setState( {
+				lastError: this.translate( 'Unable to obtain backup codes.  Please try again later.' )
+			} );
+			return;
+		}
+
+		this.setState( {
+			backupCodes: data.codes
+		} );
 	},
 
 	onNextStep: function() {
-		this.setState(
-			{
-				printed: true,
-				verified: false,
-				showPrompt: true
-			}
-		);
+		this.setState( {
+			backupCodes: [],
+			printed: true,
+		} );
 	},
 
 	onVerified: function() {
-		this.setState(
-			{
-				printed: true,
-				verified: true,
-				showPrompt: false
-			}
-		);
+		this.setState( {
+			printed: true,
+			verified: true,
+			showPrompt: false
+		} );
 	},
 
 	renderStatus: function() {
@@ -78,7 +95,7 @@ module.exports = React.createClass( {
 		if ( ! this.state.verified ) {
 			return (
 				this.translate(
-					'{{verify}}Backup Codes have just been printed, but need to be verified. ' +
+					'{{verify}}New backup Codes have just been generated, but need to be verified. ' +
 					'Please enter one of them below for verification.{{/verify}}',
 					{
 						components: {
@@ -102,22 +119,46 @@ module.exports = React.createClass( {
 		);
 	},
 
+	renderList: function() {
+		if ( ! this.state.backupCodes || ! this.state.backupCodes.length ) {
+			return;
+		}
+
+		return (
+			<Security2faBackupCodesList
+				backupCodes={ this.state.backupCodes }
+				onNextStep={ this.onNextStep }
+				userSettings={ this.props.userSettings }
+				showList
+			/>
+		);
+	},
+
 	render: function() {
 		return (
-			<div>
-				<p>
-					{
-						this.translate(
-							'Backup codes let you access your account if your phone is ' +
-							'lost, stolen, or if you run it through the washing ' +
-							'machine and the bag of rice trick doesn\'t work.'
-						)
-					}
-				</p>
+			<div className="security-2fa-backup-codes">
+				<SectionHeader label={ this.translate( 'Backup Codes' ) }>
+					<Button compact onClick={ this.recordClickEvent( 'Generate New Backup Codes Button', this.onGenerate ) }>
+						{ this.translate( 'Generate New Backup Codes' ) }
+					</Button>
+				</SectionHeader>
+				<Card>
+					<p>
+						{
+							this.translate(
+								'Backup codes let you access your account if your phone is ' +
+								'lost, stolen, or if you run it through the washing ' +
+								'machine and the bag of rice trick doesn\'t work.'
+							)
+						}
+					</p>
 
-				<p className="security-2fa-backup-codes__status">{ this.renderStatus() }</p>
+					<p className="security-2fa-backup-codes__status">{ this.renderStatus() }</p>
 
-				{ this.state.showPrompt ? <Security2faBackupCodesPrompt onSuccess={ this.onVerified }/> : null }
+					{ this.state.showPrompt ? <Security2faBackupCodesPrompt onSuccess={ this.onVerified }/> : null }
+
+					{ this.renderList() }
+				</Card>
 			</div>
 		);
 	}

--- a/client/me/security-2fa-backup-codes/style.scss
+++ b/client/me/security-2fa-backup-codes/style.scss
@@ -1,5 +1,5 @@
 .security-2fa-backup-codes__status {
-		margin-top: 20px;
+	margin-top: 20px;
 }
 
 .security-2fa-backup-codes__status-heading {
@@ -21,4 +21,8 @@
 	text-transform: uppercase;
 	color: green;
 	font-weight: bold;
+}
+
+.security-2fa-backup-codes .security-2fa-backup-codes-list {
+	margin-top: 16px;
 }

--- a/client/me/security-2fa-backup-codes/style.scss
+++ b/client/me/security-2fa-backup-codes/style.scss
@@ -22,7 +22,3 @@
 	color: green;
 	font-weight: bold;
 }
-
-.security-2fa-backup-codes .security-2fa-backup-codes-list {
-	margin-top: 16px;
-}

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -25,10 +25,31 @@ module.exports = React.createClass( {
 
 	componentDidMount: function() {
 		debug( this.constructor.displayName + ' React component is mounted.' );
+		twoStepAuthorization.backupCodes( this.onRequestComplete );
 	},
 
 	componentWillUnmount: function() {
 		debug( this.constructor.displayName + ' React component will unmount.' );
+	},
+
+	getInitialState: function() {
+		return {
+			backupCodes: [],
+			lastError: false
+		};
+	},
+
+	onRequestComplete: function( error, data ) {
+		if ( error ) {
+			this.setState( {
+				lastError: this.translate( 'Unable to obtain backup codes.  Please try again later.' ),
+			} );
+			return;
+		}
+
+		this.setState( {
+			backupCodes: data.codes,
+		} );
 	},
 
 	onFinished: function() {
@@ -37,7 +58,7 @@ module.exports = React.createClass( {
 
 	possiblyRenderError: function() {
 		var errorMessage;
-		if ( twoStepAuthorization.getBackupCodes().length ) {
+		if ( ! this.state.lastError ) {
 			return;
 		}
 
@@ -66,16 +87,13 @@ module.exports = React.createClass( {
 	},
 
 	renderList: function() {
-		var backupCodes = twoStepAuthorization.getBackupCodes();
-
-		// This shouldn't happen. If we've enabled 2fa, there should be backup codes.
-		if ( ! backupCodes.length ) {
-			return;
+		if ( this.state.lastError ) {
+			return null;
 		}
 
 		return (
 			<Security2faBackupCodesList
-				backupCodes={ backupCodes }
+				backupCodes={ this.state.backupCodes }
 				onNextStep={ this.onFinished }
 				showList
 			/>

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -18,8 +18,7 @@ var MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	Security2faSetup = require( 'me/security-2fa-setup' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	SecuritySectionNav = require( 'me/security-section-nav' ),
-	Main = require( 'components/main' ),
-	SectionHeader = require( 'components/section-header' );
+	Main = require( 'components/main' );
 
 module.exports = React.createClass( {
 
@@ -49,12 +48,10 @@ module.exports = React.createClass( {
 		}
 
 		if ( ! this.state.initialized ) {
-			this.setState(
-				{
-					initialized: true,
-					doingSetup: ! this.props.userSettings.isTwoStepEnabled()
-				}
-			);
+			this.setState( {
+				initialized: true,
+				doingSetup: ! this.props.userSettings.isTwoStepEnabled()
+			} );
 			return;
 		}
 
@@ -137,12 +134,7 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<div>
-				<SectionHeader label={ this.translate( 'Backup Codes' ) } />
-				<Card className="me-security-backup-codes">
-					<Security2faBackupCodes userSettings={ this.props.userSettings } />
-				</Card>
-			</div>
+			<Security2faBackupCodes userSettings={ this.props.userSettings } />
 		);
 	},
 

--- a/shared/lib/wpcom-undocumented/lib/me.js
+++ b/shared/lib/wpcom-undocumented/lib/me.js
@@ -184,6 +184,15 @@ UndocumentedMe.prototype.storedCardDelete = function( card, callback ) {
 	return this.wpcom.req.post( args, callback );
 };
 
+UndocumentedMe.prototype.backupCodes = function( callback ) {
+	var args = {
+		apiVersion: '1.1',
+		path: '/me/two-step/backup-codes/new'
+	};
+
+	return this.wpcom.req.post( args, callback );
+};
+
 UndocumentedMe.prototype.blockSite = function( site, callback ) {
 	var args = {
 		path: '/me/block/sites/' + encodeURIComponent( site ) + '/new',


### PR DESCRIPTION
The ability to generate new backup codes was previously removed from the `/me` section. This PR adds back that functionality.

To test:
- Checkout `add/me-backup-codes` branch
- Go to `/me/security/two-step`
- Enable 2fa
- Do you get backup codes at the end of activating 2fa?
- Go to `/me/security/two-step` with 2fa enabled
- Are you able to generate new backup codes?

cc @rickybanister for design review and @beaulebens or @mjangda for a code review.

After screenshots:

![screen shot](https://cloud.githubusercontent.com/assets/1126811/11487139/d4ddd828-9782-11e5-83c3-a523027052de.png)
![screen shot 1](https://cloud.githubusercontent.com/assets/1126811/11487138/d4dd48d6-9782-11e5-98e3-bb4f9cfe160e.png)
![screen shot 2](https://cloud.githubusercontent.com/assets/1126811/11487140/d4e0201a-9782-11e5-8011-4b05504c6680.png)
![screen shot 3](https://cloud.githubusercontent.com/assets/1126811/11487141/d4e53046-9782-11e5-9bb3-63ec5b7d5fac.png)