### PR TITLE
Signup: Verticals Survey: Update category list to match taxonomy updates

### DIFF
--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -2,9 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import debugFactory from 'debug';
-import shuffle from 'lodash/collection/shuffle';
-import find from 'lodash/collection/find';
 
 /**
  * Internal dependencies
@@ -17,8 +14,6 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import BackButton from 'components/header-cake';
 import Gridicon from 'components/gridicon';
-
-const debug = debugFactory( 'calypso:steps:survey' );
 
 export default React.createClass( {
 	displayName: 'SurveyStep',
@@ -38,25 +33,8 @@ export default React.createClass( {
 	getInitialState() {
 		return {
 			stepOne: null,
-			verticalList: shuffle( verticals.get() )
+			verticalList: verticals.get()
 		}
-	},
-
-	/**
-	 * Shuffle an array of verticals, but put the General vertical last.
-	 *
-	 * @param {Array} elements - the array of vertical elements to shuffle.
-	 * @returns {Array} the shuffled array of elements.
-	*/
-	shuffleVerticals( elements ) {
-		const newVerticals = shuffle( elements );
-		const general = find( newVerticals, vertical => vertical.isGeneral );
-		newVerticals.splice( newVerticals.indexOf( general ), 1 );
-		if ( general ) {
-			newVerticals.push( general );
-		}
-		debug( 'shuffling elements', elements, 'becomes', newVerticals );
-		return newVerticals;
 	},
 
 	renderStepTwoVertical( vertical ) {
@@ -83,7 +61,7 @@ export default React.createClass( {
 			return (
 				<div>
 					<BackButton isCompact className="survey-step__title" onClick={ this.showStepOne }>{ this.state.stepOne.label }</BackButton>
-					{ this.shuffleVerticals( this.state.stepOne.stepTwo ).map( this.renderStepTwoVertical ) }
+					{ this.state.stepOne.stepTwo.map( this.renderStepTwoVertical ) }
 				</div>
 			);
 		}

--- a/client/signup/steps/survey/verticals.js
+++ b/client/signup/steps/survey/verticals.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import shuffle from 'lodash/collection/shuffle';
+import find from 'lodash/collection/find';
 import { translate } from 'lib/mixins/i18n';
 
 const verticals = [
@@ -68,8 +73,29 @@ const verticals = [
 	] },
 ];
 
+/**
+ * Shuffle a multi-dimensional array of verticals, but put the General vertical last.
+ *
+ * @param {Array} elements - the array of vertical elements to shuffle.
+ * @returns {Array} the shuffled array of elements.
+ */
+function shuffleVerticals( elements ) {
+	const newVerticals = shuffle( elements ).map( ( vertical ) => {
+		if ( vertical.stepTwo ) {
+			return Object.assign( {}, vertical, { stepTwo: shuffleVerticals( vertical.stepTwo ) } );
+		}
+		return vertical;
+	} );
+	const general = find( newVerticals, vertical => vertical.isGeneral );
+	if ( general ) {
+		newVerticals.splice( newVerticals.indexOf( general ), 1 );
+		newVerticals.push( general );
+	}
+	return newVerticals;
+};
+
 export default {
 	get() {
-		return verticals;
+		return shuffleVerticals( verticals );
 	}
 }

--- a/client/signup/steps/survey/verticals.js
+++ b/client/signup/steps/survey/verticals.js
@@ -25,8 +25,9 @@ const verticals = [
 		{ value: 'a8c.3.0.4', label: translate( 'Communications' ) },
 	] },
 
-	{ value: 'a8c.6', label: translate( 'Family, Home, & Lifestyle' ), icon: 'house', stepTwo: [
-		{ value: 'a8c.6', label: translate( 'Family & Parenting' ), isGeneral: true },
+	{ value: 'a8c.9', label: translate( 'Family, Home, & Lifestyle' ), icon: 'house', stepTwo: [
+		{ value: 'a8c.9', label: translate( 'General Family, Home, & Lifestyle' ), isGeneral: true },
+		{ value: 'a8c.6', label: translate( 'Family & Parenting' ) },
 		{ value: 'a8c.14.7', label: translate( 'Events & Weddings' ) },
 		{ value: 'a8c.10', label: translate( 'Home & Garden' ) },
 		{ value: 'a8c.8', label: translate( 'Food & Drink' ) },
@@ -48,12 +49,11 @@ const verticals = [
 
 	{ value: 'a8c.7', label: translate( 'Health & Wellness' ), icon: 'heart', stepTwo: [
 		{ value: 'a8c.7', label: translate( 'General Health & Wellness' ), isGeneral: true },
-		{ value: 'a8c.7.18', label: translate( 'Depression' ) },
-		{ value: 'a8c.7.42', label: translate( 'Substance Abuse' ) },
+		{ value: 'a8c.7.37.1', label: translate( 'Mental Health' ) },
 		{ value: 'a8c.7.1.1', label: translate( 'Exercise / Weight Loss' ) },
 		{ value: 'a8c.7.31', label: translate( 'Men\'s Health' ) },
 		{ value: 'a8c.7.45', label: translate( 'Women\'s Health' ) },
-		{ value: 'a8c.7.37', label: translate( 'Psychology/Psychiatry' ) },
+		{ value: 'a8c.7.37', label: translate( 'Psychology / Psychiatry' ) },
 		{ value: 'a8c.7.32', label: translate( 'Nutrition' ) },
 	] },
 

--- a/client/signup/steps/survey/verticals.js
+++ b/client/signup/steps/survey/verticals.js
@@ -12,7 +12,7 @@ const verticals = [
 		{ value: 'a8c.17', label: translate( 'Sports & Recreation' ) },
 	] },
 
-	{ value: 'a8c.3', label: translate( 'Business & Services' ), icon: 'bookmark', stepTwo: [
+	{ value: 'a8c.3', label: translate( 'Business & Services' ), icon: 'briefcase', stepTwo: [
 		{ value: 'a8c.3', label: translate( 'General Business & Services' ), isGeneral: true },
 		{ value: 'a8c.3.0.1', label: translate( 'Finance & Law' ) },
 		{ value: 'a8c.3.0.2', label: translate( 'Consulting & Coaching' ) },
@@ -36,7 +36,7 @@ const verticals = [
 		{ value: 'a8c.16', label: translate( 'Pets' ) },
 	] },
 
-	{ value: 'a8c.5', label: translate( 'Education & Organizations' ), icon: 'clipboard', stepTwo: [
+	{ value: 'a8c.5', label: translate( 'Education & Organizations' ), icon: 'institution', stepTwo: [
 		{ value: 'a8c.5', label: translate( 'General Education & Organizations' ), isGeneral: true },
 		{ value: 'a8c.3.0.6', label: translate( 'Communities & Associations' ) },
 		{ value: 'a8c.3.0.5', label: translate( 'Non-Profit' ) },
@@ -57,7 +57,7 @@ const verticals = [
 		{ value: 'a8c.7.32', label: translate( 'Nutrition' ) },
 	] },
 
-	{ value: 'a8c.1.1', label: translate( 'Writing & Books' ), icon: 'create', stepTwo: [
+	{ value: 'a8c.1.1', label: translate( 'Writing & Books' ), icon: 'book', stepTwo: [
 		{ value: 'a8c.1.1', label: translate( 'General Writing & Books' ), isGeneral: true },
 		{ value: 'a8c.1.1.1', label: translate( 'Book Reviews & Clubs' ) },
 		{ value: 'a8c.1.4', label: translate( 'Humor' ) },


### PR DESCRIPTION
To do:

- [x] Update spacing in "Psychology / Psychiatry"
- [x] Add "General Family, Home, & Lifestyle" category
- [x] Combine "Substance Abuse" and "Depression" into "Mental Health"
- [x] Update Gridicons to use new icons for Business, Education, and Writing categories


## New Gridicons

<img width="600" alt="screen shot 2015-11-30 at 6 02 28 pm" src="https://cloud.githubusercontent.com/assets/2036909/11491959/da1f544c-97b4-11e5-9e7d-63f94c36c45c.png">

## Testing

1. Visit calypso.localhost:3000/start/vert-site/ in this branch
2. Make sure the icons are as shown in the above screenshot (category order will be different as it is random), particularly the icons for Education, Business, and Writing.
3. Under "Family, Home and Lifestyle", be sure the last item is "General Family, Home and Lifestyle".
4. Under "Health and Wellness", be sure there is no "Depression" subcategory, no "Substance Abuse", and that instead, there is a subcategory of "Mental Health".

