### PR TITLE
Invites: Centers text in logged in accept buttons

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-in/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-in/style.scss
@@ -26,6 +26,7 @@
 	flex-basis: 0;
 	flex-grow: 1;
 	margin: 0 4px;
+	text-align: center;
 
 	&:first-child {
 		margin-left: 0;


### PR DESCRIPTION
To test:
- Checkout `update/invites-center-button-text` branch
- Create an invite at `$site/wp-admin/users.php?page=wpcom-invite-users`
- In the invitation email that you receive, make note of the invitation key
- Go to `/accept-invite/$site/$invite_key` while you are logged in
- Is the text within the buttons centered?

cc @rickybanister for a design review

After:
![screen shot](https://cloud.githubusercontent.com/assets/1126811/11488250/bec16ef8-978a-11e5-8d39-7243fad0523a.png)


Before:
![screen shot 2](https://cloud.githubusercontent.com/assets/1126811/11488248/bd74d594-978a-11e5-8f54-62be19e62267.png)
