### PR TITLE
Signup: Replace usage of ThemeThumbnail for ThemesList component on Theme Selection Signup Step

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -298,7 +298,6 @@
 @import 'signup/steps/survey/style';
 @import 'signup/steps/plans/style';
 @import 'signup/steps/site-creation/style';
-@import 'signup/steps/theme-selection/style';
 @import 'signup/validation-fieldset/style';
 @import 'vip/vip-logs/style';
 @import 'signup/steps/dss/style';

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -1,12 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	noop = require( 'lodash/utility/noop' );
 
 /**
  * Internal dependencies
  */
-var ThemeThumbnail = require( './theme-thumbnail' ),
+var analytics = require( 'analytics' ),
+	SignupActions = require( 'lib/signup/actions' ),
+	ThemesList = require( 'components/themes-list' ),
+	ThemeHelper = require( 'lib/themes/helpers' ),
 	StepWrapper = require( 'signup/step-wrapper' );
 
 module.exports = React.createClass( {
@@ -30,28 +34,55 @@ module.exports = React.createClass( {
 		};
 	},
 
-	renderThemes: function() {
+	handleScreenshotClick: function( theme ) {
+		var themeSlug = theme.id;
+
+		if ( true === this.props.useHeadstart && themeSlug ) {
+			analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: true } );
+
+			SignupActions.submitSignupStep( { stepName: this.props.stepName }, null, {
+				theme: 'pub/' + themeSlug,
+				images: undefined
+			} );
+		} else {
+			analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: false } );
+
+			SignupActions.submitSignupStep( {
+				stepName: this.props.stepName,
+				processingMessage: this.translate( 'Adding your theme' ),
+				themeSlug
+			} );
+		}
+
+		this.props.goToNextStep();
+	},
+
+	renderThemesList: function() {
+		var themes = this.props.themes.map( function( t ) {
+			return {
+				id: ThemeHelper.getSlugFromName( t ),
+				name: t,
+				screenshot: 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + ThemeHelper.getSlugFromName( t ) + '/screenshot.png?w=660'
+			}
+		} );
 		return (
-			<div>
-				{ this.props.themes.map( function( theme ) {
-					return <ThemeThumbnail
-						key={ theme }
-						theme={ theme }
-						{ ...this.props }/>;
-				}.bind( this ) ) }
-			</div>
+			<ThemesList
+				getButtonOptions= { noop }
+				onScreenshotClick= { this.handleScreenshotClick }
+				onMoreButtonClick= { noop }
+				{ ...this.props }
+				themes= { themes } />
 		);
 	},
 
 	render: function() {
 		const defaultDependencies = this.props.useHeadstart ? { theme: 'pub/twentyfifteen', images: null } : undefined;
-
 		return (
 			<StepWrapper
 				fallbackHeaderText={ this.translate( 'Choose a theme.' ) }
 				fallbackSubHeaderText={ this.translate( 'No need to overthink it. You can always switch to a different theme\u00a0later.' ) }
 				subHeaderText={ this.translate( 'Choose a theme. You can always switch to a different theme\u00a0later.' ) }
-				stepContent={ this.renderThemes() }
+				stepContent={ this.renderThemesList() }
 				defaultDependencies={ defaultDependencies }
 				{ ...this.props } />
 		);

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -58,13 +58,15 @@ module.exports = React.createClass( {
 	},
 
 	renderThemesList: function() {
-		var themes = this.props.themes.map( function( t ) {
-			return {
-				id: ThemeHelper.getSlugFromName( t ),
-				name: t,
-				screenshot: 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + ThemeHelper.getSlugFromName( t ) + '/screenshot.png?w=660'
-			}
-		} );
+		var actionLabel = this.translate( 'Pick' ),
+			themes = this.props.themes.map( function( theme ) {
+				return {
+					id: ThemeHelper.getSlugFromName( theme ),
+					name: theme,
+					screenshot: 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + ThemeHelper.getSlugFromName( theme ) + '/screenshot.png?w=660',
+					actionLabel: actionLabel
+				}
+			} );
 		return (
 			<ThemesList
 				getButtonOptions= { noop }

--- a/client/signup/steps/theme-selection/style.scss
+++ b/client/signup/steps/theme-selection/style.scss
@@ -1,8 +1,0 @@
-.themes-list .theme__active-focus {
-	opacity: 0.0;
-
-	&:hover {
-		opacity: 0.0; // Override Theme default behaviour for showing 'Preview'
-	}
-
-}

--- a/client/signup/steps/theme-selection/style.scss
+++ b/client/signup/steps/theme-selection/style.scss
@@ -1,44 +1,8 @@
-.theme-thumbnail__name {
-	background-color: $gray-light;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
-	display: block;
-	font-size: 16px;
-	padding: 12px 0;
-	text-align: center;
+.themes-list .theme__active-focus {
+	opacity: 0.0;
 
-	@include breakpoint( ">660px" ) {
-		font-size: 14px;
-		padding: 10px 8px;
-		text-align: left;
-	}
-}
-
-.theme-thumbnail__theme {
-	background: white;
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ), 0 1px 2px lighten( $gray, 30% );
-	box-sizing: border-box;
-	margin: 10px 0;
-	position: relative;
-	transition: all 0.2s ease-in-out 0s;
-	width: 100%;
-	cursor: pointer;
-
-	@include breakpoint( ">660px" ) {
-		float: left;
-		margin: 0 0 2% 2%;
-		width: 32%;
-
-		&:nth-child( 3n + 1 ) {
-			margin-left: 0;
-		}
+	&:hover {
+		opacity: 0.0; // Override Theme default behaviour for showing 'Preview'
 	}
 
-	img {
-		display: block;
-		width: 100%;
-
-		@include breakpoint( ">960px" ) {
-			height: 230px;
-		}
-	}
 }

--- a/shared/components/theme/index.jsx
+++ b/shared/components/theme/index.jsx
@@ -47,14 +47,17 @@ var Theme = React.createClass( {
 				action: React.PropTypes.func,
 			} )
 		),
-		index: React.PropTypes.number
+		index: React.PropTypes.number,
+		// Label to show on screenshot hover.
+		actionLabel: React.PropTypes.string
 	},
 
 	getDefaultProps: function() {
 		return ( {
 			isPlaceholder: false,
 			buttonContents: [],
-			onMoreButtonClick: noop
+			onMoreButtonClick: noop,
+			actionLabel: ''
 		} );
 	},
 
@@ -67,16 +70,16 @@ var Theme = React.createClass( {
 	},
 
 	renderHover: function() {
-		var actionLabel = '';
+		var actionLabel = this.translate( 'Preview', {
+			context: 'appears on hovering a single theme thumbnail, opens the theme demo site preview'
+		} );
 
 		if ( this.props.active ) {
 			actionLabel = this.translate( 'Customize', {
 				context: 'appears on hovering the active single theme thumbnail, opens the customizer'
 			} );
 		} else {
-			actionLabel = this.translate( 'Preview', {
-				context: 'appears on hovering a single theme thumbnail, opens the theme demo site preview'
-			} );
+			actionLabel = this.props.actionLabel || actionLabel;
 		}
 
 		if ( this.props.screenshotClickUrl || this.props.onScreenshotClick ) {


### PR DESCRIPTION
ThemesList is a reusable component appropriate for the function that ThemeSelection Step is providing.

ThemeThumbnail will no longer be necessary. The theme selection step still handles a headStart flow providing {theme: 'pub/twentyfifteen'} as a default dependency.

See #256 and #674 .

cc @scruffian 

## Testing instructions

### Regular theme selection

* Load http://calypso.localhost:3000/start (you'll be redirected to /start/themes)
* Select a theme.
* Follow domain registration (and user signup if testing anonymously). 
* After completing registration, go to switch sites, find your new site.
* Go to themes and check the theme you selected is the one active for your new site.

### Headstart flow

* Load http://calypso.localhost:3000/start/headstart (you'll be redirected to /start/themes)
* Don't select any theme and click the `Skip` button. (This way, theme `twentyfifteen` will be selected by default.
* Follow domain registration (and user signup if testing anonymously). 
* After completing registration, go to switch sites, find your new site.
* Go to themes and check the active theme for your new site is `Twenty Fifteen`.

### /design theme selection for existing sites

* Once logged in, go to switch sites, find one of your sites.
* On sidebar, click Themes under _Personalize_. 
* The new theme gallery is using `ThemesList` and thus, the updated `Theme` component. There shouldn't be any differences with its current behaviour and appearance as the default `Theme` behaviour is used here. 