### PR TITLE
Manage: Fix/single sites permission to update files for single sites

### DIFF
--- a/client/lib/site/test/test-utils.js
+++ b/client/lib/site/test/test-utils.js
@@ -16,19 +16,19 @@ describe( 'Site Utils', function() {
 			assert.isFunction( SiteUtils.canUpdateFiles );
 		} );
 
-		it( 'CanUpdateFiles should return false when no site object is passed in.', function() {
+		it( 'Should return false when no site object is passed in.', function() {
 			assert.isFalse( SiteUtils.canUpdateFiles() );
 		} );
 
-		it( 'CanUpdateFiles should return false when passed an empty object.', function() {
+		it( 'Should return false when passed an empty object.', function() {
 			assert.isFalse( SiteUtils.canUpdateFiles( {} ) );
 		} );
 
-		it( 'CanUpdateFiles should return false when passed an object without options.', function() {
+		it( 'Should return false when passed an object without options.', function() {
 			assert.isFalse( SiteUtils.canUpdateFiles( { hello: 'not important' } ) );
 		} );
 
-		it( 'CanUpdateFiles should return false when passed an site object that has something value in the file_mod_option.', function() {
+		it( 'Should return false when passed an site object that has something value in the file_mod_option.', function() {
 			const site = {
 				hasMinimumJetpackVersion: true,
 				options: {
@@ -41,7 +41,7 @@ describe( 'Site Utils', function() {
 			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
 		} );
 
-		it( 'CanUpdateFiles should return false when passed a multi site when unmapped_url and main_network_site are not equal.', function() {
+		it( 'Should return false when passed a multi site when unmapped_url and main_network_site are not equal.', function() {
 			const site = {
 				hasMinimumJetpackVersion: true,
 				is_multisite: true,
@@ -55,7 +55,7 @@ describe( 'Site Utils', function() {
 			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
 		} );
 
-		it( 'CanUpdateFiles should return true when passed a site a single site even though the unmapped_url is not the same as main_network_site.', function() {
+		it( 'Should return true when passed a site a single site even though the unmapped_url is not the same as main_network_site.', function() {
 			const site = {
 				hasMinimumJetpackVersion: true,
 				is_multisite: false,
@@ -69,7 +69,7 @@ describe( 'Site Utils', function() {
 			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
 		} );
 
-		it( 'CanUpdateFiles should return true when passed a site data with that has different protocolls for unmapped_url and main_network_site.', function() {
+		it( 'Should return true when passed a site that has different protocolls for unmapped_url and main_network_site.', function() {
 			const site = {
 				hasMinimumJetpackVersion: true,
 				is_multisite: true,
@@ -83,7 +83,7 @@ describe( 'Site Utils', function() {
 			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
 		} );
 
-		it( 'CanUpdateFiles should return false when passed a site data with that has compares ftp to http protocolls for unmapped_url and main_network_site.', function() {
+		it( 'Should return false when passed a site  that has compares ftp to http protocolls for unmapped_url and main_network_site.', function() {
 			const site = {
 				hasMinimumJetpackVersion: true,
 				is_multisite: true,
@@ -97,7 +97,7 @@ describe( 'Site Utils', function() {
 			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
 		} );
 
-		it( 'CanUpdateFiles should return true when passed a site data has all the right settings permissions to be able to update files.', function() {
+		it( 'Should return true when passed a site that has all the right settings permissions to be able to update files.', function() {
 			const site = {
 				hasMinimumJetpackVersion: true,
 				is_multisite: true,
@@ -109,6 +109,77 @@ describe( 'Site Utils', function() {
 				}
 			}
 			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
+		} );
+	} );
+
+	describe( 'isMainNetworkSite', function() {
+		it( 'Should have a method isMainNetworkSite.', function() {
+			assert.isFunction( SiteUtils.isMainNetworkSite );
+		} );
+
+		it( 'Should return false when no site object is passed in.', function() {
+			assert.isFalse( SiteUtils.isMainNetworkSite() );
+		} );
+
+		it( 'Should return false when passed an empty object.', function() {
+			assert.isFalse( SiteUtils.isMainNetworkSite( {} ) );
+		} );
+
+		it( 'Should return false when passed an object without options.', function() {
+			assert.isFalse( SiteUtils.isMainNetworkSite( { hello: 'not important' } ) );
+		} );
+
+		it( 'Should return false when passed a multi site when unmapped_url and main_network_site are not equal.', function() {
+			const site = {
+				is_multisite: true,
+				options: {
+					unmapped_url: 'someurl',
+					main_network_site: 'someurl-different',
+				}
+			}
+			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
+		} );
+
+		it( 'Should return true when passed a site a single site even though the unmapped_url is not the same as main_network_site.', function() {
+			const site = {
+				is_multisite: false,
+				options: {
+					unmapped_url: 'someurl',
+					main_network_site: 'someurl-different',
+				}
+			}
+			assert.isTrue( SiteUtils.isMainNetworkSite( site ) );
+		} );
+
+		it( 'Should return false when passed a site that a part of a multi network.', function() {
+			const site = {
+				options: {
+					is_multi_network: true,
+				}
+			}
+			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
+		} );
+
+		it( 'Should return true when passed a site that has different protocolls for unmapped_url and main_network_site.', function() {
+			const site = {
+				is_multisite: true,
+				options: {
+					unmapped_url: 'http://someurl',
+					main_network_site: 'https://someurl',
+				}
+			}
+			assert.isTrue( SiteUtils.isMainNetworkSite( site ) );
+		} );
+
+		it( 'Should return false when passed a site that has compares ftp to http protocolls for unmapped_url and main_network_site.', function() {
+			const site = {
+				is_multisite: true,
+				options: {
+					unmapped_url: 'http://someurl',
+					main_network_site: 'ftp://someurl',
+				}
+			}
+			assert.isFalse( SiteUtils.isMainNetworkSite( site ) );
 		} );
 	} );
 } );

--- a/client/lib/site/test/test-utils.js
+++ b/client/lib/site/test/test-utils.js
@@ -41,6 +41,34 @@ describe( 'Site Utils', function() {
 			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
 		} );
 
+		it( 'CanUpdateFiles should return false when passed a multi site when unmapped_url and main_network_site are not equal.', function() {
+			const site = {
+				hasMinimumJetpackVersion: true,
+				is_multisite: true,
+				options: {
+					unmapped_url: 'someurl',
+					main_network_site: 'someurl-different',
+					is_multi_network: false,
+					file_mod_disabled: false
+				}
+			}
+			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
+		} );
+
+		it( 'CanUpdateFiles should return true when passed a site a single site even though the unmapped_url is not the same as main_network_site.', function() {
+			const site = {
+				hasMinimumJetpackVersion: true,
+				is_multisite: false,
+				options: {
+					unmapped_url: 'someurl',
+					main_network_site: 'someurl-different',
+					is_multi_network: false,
+					file_mod_disabled: false
+				}
+			}
+			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
+		} );
+
 		it( 'CanUpdateFiles should return true when passed a site data has all the right settings permissions to be able to update files.', function() {
 			const site = {
 				hasMinimumJetpackVersion: true,

--- a/client/lib/site/test/test-utils.js
+++ b/client/lib/site/test/test-utils.js
@@ -69,9 +69,38 @@ describe( 'Site Utils', function() {
 			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
 		} );
 
+		it( 'CanUpdateFiles should return true when passed a site data with that has different protocolls for unmapped_url and main_network_site.', function() {
+			const site = {
+				hasMinimumJetpackVersion: true,
+				is_multisite: true,
+				options: {
+					unmapped_url: 'http://someurl',
+					main_network_site: 'https://someurl',
+					is_multi_network: false,
+					file_mod_disabled: false
+				}
+			}
+			assert.isTrue( SiteUtils.canUpdateFiles( site ) );
+		} );
+
+		it( 'CanUpdateFiles should return false when passed a site data with that has compares ftp to http protocolls for unmapped_url and main_network_site.', function() {
+			const site = {
+				hasMinimumJetpackVersion: true,
+				is_multisite: true,
+				options: {
+					unmapped_url: 'http://someurl',
+					main_network_site: 'ftp://someurl',
+					is_multi_network: false,
+					file_mod_disabled: false
+				}
+			}
+			assert.isFalse( SiteUtils.canUpdateFiles( site ) );
+		} );
+
 		it( 'CanUpdateFiles should return true when passed a site data has all the right settings permissions to be able to update files.', function() {
 			const site = {
 				hasMinimumJetpackVersion: true,
+				is_multisite: true,
 				options: {
 					unmapped_url: 'someurl',
 					main_network_site: 'someurl',

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -109,7 +109,7 @@ export default {
 			return false;
 		}
 
-		if ( site.is_multisite && ( site.options && site.options.unmapped_url !== site.options.main_network_site ) ) {
+		if ( site.is_multisite && ( site.options && site.options.unmapped_url.replace( /^https?:\/\//, '' ) !== site.options.main_network_site.replace( /^https?:\/\//, '' ) ) ) {
 			return false;
 		}
 

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -109,7 +109,7 @@ export default {
 			return false;
 		}
 
-		if ( site.options && site.options.unmapped_url !== site.options.main_network_site ) {
+		if ( site.is_multisite && ( site.options && site.options.unmapped_url !== site.options.main_network_site ) ) {
 			return false;
 		}
 

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -109,7 +109,7 @@ export default {
 			return false;
 		}
 
-		if ( site.is_multisite && ( site.options && site.options.unmapped_url.replace( /^https?:\/\//, '' ) !== site.options.main_network_site.replace( /^https?:\/\//, '' ) ) ) {
+		if ( ! this.isMainNetworkSite( site ) ) {
 			return false;
 		}
 
@@ -122,5 +122,28 @@ export default {
 		}
 
 		return true;
+	},
+
+	isMainNetworkSite( site ) {
+		if ( ! site ) {
+			return false;
+		}
+
+		if ( site.options && site.options.is_multi_network ) {
+			return false;
+		}
+
+		if ( site.is_multisite === false ) {
+			return true;
+		}
+
+		if ( site.is_multisite ) {
+			// Compare unmapped_url with the main_network_site to see if is the main network site.
+			return ! ( site.options &&
+				site.options.unmapped_url.replace( /^https?:\/\//, '' ) !== site.options.main_network_site.replace( /^https?:\/\//, '' )
+			);
+		}
+
+		return false;
 	}
 };

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -68,7 +68,7 @@ module.exports = React.createClass( {
 			} );
 		}
 
-		if ( this.props.site.options.unmapped_url !== this.props.site.options.main_network_site ) {
+		if ( ! utils.isMainNetworkSite( this.props.site ) ) {
 			return this.translate( 'Only the main site on a multi-site installation can enable autoupdates for plugins.', {
 				args: { site: this.props.site.title }
 			} );


### PR DESCRIPTION
Currently if a site has  FORCE_SSL_ADMIN constant defined as true. 
`define( 'FORCE_SSL_ADMIN', true );` and the main siteurl is not on ssl then we get an error where the site is not able to update files. 

This is implemented in order for us to prevent sub sites from updating the network and only allow the main site to update the files. 

This change checks performs this check only on multi sites and allows single sites to update files even if they have the constant set and the main network site url is different from the site url. 

**To test:**
Run the test in `/client/lib/site` and run `make test` 
cc: @johnHackworth, @lezama 

Does this fix the issue in some of your cases @macmanx2?