### PR TITLE
Sites: fix missing margin on every 3rd card in mobile

### DIFF
--- a/assets/stylesheets/sections/_sites.scss
+++ b/assets/stylesheets/sections/_sites.scss
@@ -74,10 +74,6 @@
 
 	&:nth-child( 3n ) {
 		margin-right: 0;
-
-		@include breakpoint( "<480px" ) {
-			margin: 0;
-		}
 	}
 
 	&.has-update {


### PR DESCRIPTION
Fixes #5 by removing an unneeded media query. I've tested this in IE11, Edge, Chrome, FF but please confirm.

To test:
1) Navigate to calypso.localhost:3000/sites
2) Make sure your device has a small viewport <480px, or resize the browser window until the cards collapse to a single column
3) Make sure spacing looks correct for all cards.

Before:
<img width="386" alt="e301b9c8-8d1a-11e5-86b3-8271f573e447" src="https://cloud.githubusercontent.com/assets/1270189/11489197/f3855a72-9781-11e5-9c6c-a2662efdd49c.png">

After:
![fixed](https://cloud.githubusercontent.com/assets/1270189/11489199/f8eedcd6-9781-11e5-8bcd-43c1a9064716.png)

cc @alisterscott @mtias 