### PR TITLE
Adds a new action-only poller

### DIFF
--- a/client/lib/interval/Makefile
+++ b/client/lib/interval/Makefile
@@ -1,0 +1,11 @@
+REPORTER ?= spec
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := $(BASE_DIR)/client:$(BASE_DIR)/shared
+
+test:
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers js:babel/register --reporter $(REPORTER) --ui bdd
+
+.PHONY: test
+

--- a/client/lib/interval/README.md
+++ b/client/lib/interval/README.md
@@ -1,0 +1,43 @@
+# Interval
+
+An interface into a global timer coalescing interval runner.
+
+_**An interface**_ because this component handles registering and un-registering the given `onTick` action with the global runner.
+
+_**timer coalescing**_ because the global runner will run at the same time all of the actions registered for a given interval period. For example, if four actions are registered for running once per minute, they will all run at one point in time every minute instead of having four different run times, each time repeating every minute. This is better for things like battery life because it allows for longer and deeper periods of sleep between actions.
+
+_**interval runner**_ because the global runner will execute the given action every interval on the interval.
+
+This component can be used to easily trigger a polling, looping, or interval action in the background. Such usages could include polling an API endpoint for updates, sweeping over user input such as in the post editor at intervals, or updating an on-screen timer.
+
+It only requires two inputs: an action to perform and an interval between which runs of the action should occur. The action is simply a function and the interval is a named constant representing the interval period. These interval periods are intentionally limited to prevent sprawl of timers.
+
+The action will only be executed as long as the React component is mounted, as the component un-registers the action on unmount. Additionally, the default behavior is to stop executing the action when the browser document is hidden, though this can be overwritten. "Hidden" means that another browser tab is selected or the browser is minimized.
+
+Wrapped components will be transferred all additional props not consumed by the `<Interval />` itself.
+
+## Usage
+
+```jsx
+import Interval, { EVERY_FIVE_SECONDS, EVERY_MINUTE } from 'lib/interval';
+
+<Interval onTick={ doSomething } period={ EVERY_FIVE_SECONDS } />
+
+// Wrapping a component
+<Interval onTick={ fetchNewReaderPosts } period={ EVERY_MINUTE }>
+	<Reader {...readerProps} />
+</Interval>
+
+// Wrapping passes down props
+const CounterDisplay = counter => <div>{ counter }</div>;
+
+<Interval onTick={ updateCounter } period={ EVERY_MINUTE } counter={ counter }>
+	<CounterDisplay />
+</Interval>
+```
+
+## Props
+
+ - `onTick`: Function to run on interval, _required_
+ - `period`: Constant specifying interval period, _required_
+ - `pauseWhenHidden`: _[true]_ Boolean indicating whether or not to stop executing the action when the browser document is hidden from view.

--- a/client/lib/interval/index.js
+++ b/client/lib/interval/index.js
@@ -1,0 +1,98 @@
+import React, { PropTypes } from 'react';
+import omit from 'lodash/object/omit';
+
+import {
+	add, remove,
+	EVERY_SECOND,
+	EVERY_FIVE_SECONDS,
+	EVERY_TEN_SECONDS,
+	EVERY_THIRTY_SECONDS,
+	EVERY_MINUTE
+} from './runner';
+
+export {
+	EVERY_SECOND,
+	EVERY_FIVE_SECONDS,
+	EVERY_TEN_SECONDS,
+	EVERY_THIRTY_SECONDS,
+	EVERY_MINUTE
+};
+
+/**
+ * Calls a given function on a given interval
+ */
+export default React.createClass( {
+	displayName: 'Interval',
+
+	propTypes: {
+		onTick: PropTypes.func.isRequired,
+		period: PropTypes.oneOf( [
+			EVERY_SECOND,
+			EVERY_FIVE_SECONDS,
+			EVERY_TEN_SECONDS,
+			EVERY_THIRTY_SECONDS,
+			EVERY_MINUTE
+		] ).isRequired,
+		pauseWhenHidden: PropTypes.bool,
+		children: PropTypes.element
+	},
+
+	getDefaultProps: () => ( {
+		pauseWhenHidden: true
+	} ),
+
+	getInitialState: () => ( {
+		id: null
+	} ),
+
+	componentDidMount() {
+		this.start();
+
+		document.addEventListener( 'visibilitychange', this.handleVisibilityChange, false );
+	},
+
+	componentWillUnmount() {
+		document.removeEventListener( 'visibilitychange', this.handleVisibilityChange, false );
+
+		this.stop();
+	},
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.period === this.props.period && prevProps.onTick === this.props.onTick ) {
+			return;
+		}
+
+		this.start();
+	},
+
+	handleVisibilityChange() {
+		const { id } = this.state;
+		const { pauseWhenHidden } = this.props;
+
+		if ( document.hidden && id && pauseWhenHidden ) {
+			return this.stop();
+		}
+
+		if ( ! document.hidden && ! id && pauseWhenHidden ) {
+			this.start();
+		}
+	},
+
+	start() {
+		const { period, onTick } = this.props;
+
+		if ( this.state.id ) {
+			remove( this.state.id );
+		}
+		this.setState( { id: add( period, onTick ) } );
+	},
+
+	stop() {
+		remove( this.state.id );
+		this.setState( { id: null } );
+	},
+
+	render() {
+		return this.props.children ? React.cloneElement( this.props.children, omit( this.props, [ 'onTick', 'period', 'pauseWhenHidden', 'children' ] ) ) : null;
+	}
+} );

--- a/client/lib/interval/runner.js
+++ b/client/lib/interval/runner.js
@@ -1,0 +1,149 @@
+/**
+ *  Global interval action runner
+ *
+ *  This module contains both a store for keeping track of
+ *  actions that need to run at intervals and the code used
+ *  to execute those actions.
+ *
+ *  Note: this is not a Flux or a Redux model and the store
+ *  of actions here isn't intended to be exported higher up
+ *  in the application. This module is a singleton that should
+ *  work concurrently for multiple callers from the `<Interval />`
+ *  component.
+ *
+ *  # Basic operation
+ *
+ *  The store keeps track of actions as they are added and removed.
+ *  Every time an action is added to the store a unique id is
+ *  returned much in the same way as with `setTimeout`. This id
+ *  can be used to reference that particular action for later
+ *  removal.
+ *
+ *      const id = add( EVERY_SECOND, doSomething );
+ *      remove( id );
+ *
+ *  Instead of employing any long-running process to manage
+ *  executing the actions, we instead guarantee that a timeout gets
+ *  set whenever a new action is added.  If there are no actions
+ *  stored for a given interval, that timeout gets cleared to make
+ *  sure we don't run for that period.
+ *
+ *  The scheduling logic all takes place in `scheduleNextRun()`
+ *  which is a safe function to call at any time, meaning that it
+ *  won't overlap timers or break things if we called it needlessly.
+ */
+
+import { fromJS } from 'immutable';
+
+export const EVERY_SECOND = 1000;
+export const EVERY_FIVE_SECONDS = 5 * 1000;
+export const EVERY_TEN_SECONDS = 10 * 1000;
+export const EVERY_THIRTY_SECONDS = 30 * 1000;
+export const EVERY_MINUTE = 60 * 1000;
+
+const initialState = fromJS( {
+	nextId: 1,
+	periodTimers: {
+		EVERY_SECOND: null,
+		EVERY_FIVE_SECONDS: null,
+		EVERY_TEN_SECONDS: null,
+		EVERY_THIRTY_SECONDS: null,
+		EVERY_MINUTE: null
+	},
+	actions: []
+} );
+let state = initialState;
+
+const increment = a => a + 1;
+const addToList = item => list => list.push( item );
+const removeFromList = id => list => list.filterNot( o => o.get( 'id' ) === id );
+
+/**
+ * Resets action store and clears timers
+ *
+ * Please don't use in production. This is only
+ * intended to help with testing code.
+ */
+export const resetForTesting = () => {
+	state
+		.get( 'periodTimers' )
+		.forEach( clearTimeout );
+
+	state = initialState;
+};
+
+/**
+ * Adds an action to the queue on the given interval period
+ *
+ * @param period one of the constants defining interval periods
+ * @param {function} onTick the action to run
+ * @returns {number} unique identifier to use to remove action
+ */
+export function add( period, onTick ) {
+	const id = state.get( 'nextId' );
+
+	storeNewAction( { id, period, onTick } );
+	scheduleNextRun();
+
+	return id;
+}
+
+function storeNewAction( { id, period, onTick } ) {
+	state = state
+		.update( 'actions', addToList( fromJS( { id, period, onTick } ) ) )
+		.update( 'nextId', increment );
+}
+
+/**
+ * Removes an action from the queue
+ *
+ * @see add
+ *
+ * @param {number} id identifier returned by add()
+ */
+export function remove( id ) {
+	removeFromQueue( id );
+	scheduleNextRun();
+}
+
+function removeFromQueue( id ) {
+	state = state.update( 'actions', removeFromList( id ) );
+}
+
+function getPeriodActions( period ) {
+	return state
+		.get( 'actions' )
+		.filter( a => a.get( 'period' ) === period );
+}
+
+function hasPeriodActions( period ) {
+	return state
+		.get( 'actions' )
+		.some( a => a.get( 'period' ) === period );
+}
+
+function executePeriodActions( period ) {
+	// Make sure we don't return `false` or it will
+	// halt the iteration in `forEach`
+	const callAction = a => a.get( 'onTick' ).call() || true;
+
+	getPeriodActions( period ).forEach( callAction );
+
+	state = state.setIn( [ 'periodTimers', period ], null );
+	scheduleNextRun();
+}
+
+function scheduleNextRun() {
+	[ EVERY_SECOND, EVERY_FIVE_SECONDS, EVERY_TEN_SECONDS, EVERY_THIRTY_SECONDS, EVERY_MINUTE ]
+		.forEach( p => {
+			if ( ! hasPeriodActions( p ) ) {
+				state = state.updateIn( [ 'periodTimers', p ], clearTimeout );
+				return;
+			}
+
+			if ( ! state.get( 'periodTimers' ).get( p ) ) {
+				// Note that the second `p` in the call here gets passed as an arg to `executePeriodActions`
+				state = state.setIn( [ 'periodTimers', p ], setTimeout( executePeriodActions, p, p ) );
+			}
+		} );
+}

--- a/client/lib/interval/test/component.js
+++ b/client/lib/interval/test/component.js
@@ -1,0 +1,117 @@
+require( 'lib/react-test-env-setup' )();
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Interval, { EVERY_SECOND, EVERY_MINUTE } from '../index';
+import { add, resetForTesting as reset } from '../runner';
+
+const noop = () => null;
+const nudgeObject = ( o, v ) => () => ( o.counter += v );
+
+describe( 'Interval', function() {
+	before( function() {
+		this.clock = sinon.useFakeTimers();
+	} );
+
+	after( function() {
+		this.clock.restore();
+	} );
+
+	describe( 'Rendering and children', function() {
+		it( 'Should render an empty span with no children', function() {
+			const wrapper = shallow( <Interval onTick={ noop } period={ EVERY_SECOND }/> );
+
+			assert( '' === wrapper.text() );
+		} );
+
+		it( 'Should render children', function() {
+			const wrapper = shallow( <Interval onTick={ noop } period={ EVERY_SECOND }><div>test</div></Interval> );
+
+			assert( wrapper.contains( <div>test</div> ) );
+		} );
+
+		it( 'Should pass props to children', function() {
+			const PropConsumer = React.createClass( { render() { return <div>{ this.props.prop }</div>; } } );
+			const wrapper = shallow( <Interval prop={ 42 } onTick={ noop } period={ EVERY_SECOND }><PropConsumer /></Interval> );
+
+			assert( 42 === wrapper.find( PropConsumer ).prop( 'prop' ) );
+		} );
+	} );
+
+	describe( 'Running actions', function() {
+		beforeEach( function() {
+			reset();
+		} );
+
+		it( 'Should add the given action', function() {
+			const id = add( EVERY_MINUTE, noop );
+			mount( <Interval onTick={ noop } period={ EVERY_SECOND }><div /></Interval> );
+
+			// verifies that the nextId incremented, signalling that the action was added
+			assert( id + 2 === add( EVERY_MINUTE, noop ) );
+		} );
+
+		it( 'Runs onTick()', function() {
+			const o = { counter: 0 };
+			mount( <Interval onTick={ nudgeObject( o, 1 ) } period={ EVERY_SECOND }><div /></Interval> );
+
+			assert( 0 === o.counter );
+
+			this.clock.tick( 1000 );
+			assert( 1 === o.counter );
+		} );
+
+		it( 'Changes the callback on prop changes', function() {
+			const o = { counter: 0 };
+			const wrapper = mount( <Interval onTick={ nudgeObject( o, 1 ) } period={ EVERY_SECOND }><div /></Interval> );
+
+			this.clock.tick( 1000 );
+			wrapper.setProps( { period: EVERY_MINUTE } );
+
+			this.clock.tick( 1000 );
+			assert( 1 === o.counter );
+
+			this.clock.tick( 1000 * 60 );
+			assert( 2 === o.counter );
+
+			wrapper.setProps( { onTick: noop } );
+			this.clock.tick( 1000 * 60 );
+			assert( 2 === o.counter );
+		} );
+
+		it( 'Adds the action when mounted', function() {
+			const o = { counter: 0 };
+			const wrapper = mount( <div></div> );
+
+			this.clock.tick( 1000 );
+			assert( 0 === o.counter );
+
+			wrapper.setProps( { children: <Interval onTick={ nudgeObject( o, 1 ) } period={ EVERY_SECOND }><div /></Interval> } );
+
+			this.clock.tick( 1000 );
+			assert( 1 === o.counter );
+		} );
+
+		it( 'Removes the action when unMounted', function() {
+			const o = { counter: 0 };
+			const wrapper = mount( <div><Interval onTick={ nudgeObject( o, 1 ) } period={ EVERY_SECOND }><div /></Interval></div> );
+
+			this.clock.tick( 1000 );
+			assert( 1 === o.counter );
+
+			wrapper.setProps( { children: null } );
+
+			this.clock.tick( 1000 );
+			assert( 1 === o.counter );
+		} );
+	} );
+} );

--- a/client/lib/interval/test/runner.js
+++ b/client/lib/interval/test/runner.js
@@ -1,0 +1,151 @@
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+
+import {
+	add, remove,
+	resetForTesting as reset,
+	EVERY_SECOND,
+	EVERY_FIVE_SECONDS,
+	EVERY_TEN_SECONDS,
+	EVERY_THIRTY_SECONDS,
+	EVERY_MINUTE
+} from '../runner';
+
+const noop = () => null;
+const nudgeObject = ( o, value ) => () => ( o.counter += value );
+
+describe( 'Interval Runner', function() {
+	before( function() {
+		this.clock = sinon.useFakeTimers();
+	} );
+
+	after( function() {
+		this.clock.restore();
+	} );
+
+	beforeEach( function() {
+		reset();
+	} );
+
+	describe( 'Adding actions', function() {
+		it( 'Should return the appropriate id', function() {
+			const o = { counter: 0 };
+			const id = add( EVERY_SECOND, nudgeObject( o, 42 ) );
+
+			assert( 1 === id );
+			assert( 0 === o.counter );
+
+			this.clock.tick( 1000 );
+			assert( 42 === o.counter );
+		} );
+
+		it( 'Should increment the next id after adding an action', function() {
+			[1, 2, 3, 4, 5, 6, 7, 8, 9].forEach( () => add( EVERY_SECOND, noop ) );
+
+			assert( 10 === add( EVERY_FIVE_SECONDS, noop ) );
+		} );
+
+		it( 'Should add an action to the proper slot', function() {
+			const o = { counter: 0 };
+			add( EVERY_TEN_SECONDS, nudgeObject( o, 42 ) );
+
+			// plus 1 second
+			this.clock.tick( 1000 );
+			assert( 0 === o.counter );
+
+			// plus 5 seconds
+			this.clock.tick( 1000 * 4 );
+			assert( 0 === o.counter );
+
+			// plus 10 seconds
+			this.clock.tick( 1000 * 5 );
+			assert( 42 === o.counter );
+		} );
+
+		it( 'Should add two actions of the same interval to the same slot', function() {
+			const o = { counter: 0 };
+
+			add( EVERY_TEN_SECONDS, nudgeObject( o, 3 ) );
+			add( EVERY_FIVE_SECONDS, nudgeObject( o, 5 ) );
+			add( EVERY_TEN_SECONDS, nudgeObject( o, 7 ) );
+
+			assert( 0 === o.counter );
+
+			// plus 5 seconds
+			this.clock.tick( 1000 * 5 );
+			assert( 5 === o.counter );
+
+			// plus 10 seconds
+			this.clock.tick( 1000 * 5 );
+			assert( 5 + 5 + 3 + 7 === o.counter );
+		} );
+	} );
+
+	describe( 'Removing actions', function() {
+		it( 'Should remove an action by id', function() {
+			const o = { counter: 0 };
+			const id = add( EVERY_SECOND, nudgeObject( o, 42 ) );
+
+			this.clock.tick( 1000 );
+			assert( 42 === o.counter );
+
+			remove( id );
+			this.clock.tick( 1000 );
+			assert( 42 === o.counter );
+		} );
+
+		it( 'Should not decrement the next id after removing an action', function() {
+			add( EVERY_SECOND, noop );
+			add( EVERY_FIVE_SECONDS, noop );
+
+			const id = add( EVERY_TEN_SECONDS, noop );
+			remove( id );
+
+			assert( 4 === add( EVERY_THIRTY_SECONDS, noop ) );
+		} );
+	} );
+
+	describe( 'Running actions', function() {
+		it( 'Should run all actions for a given period when called', function() {
+			const o = { counter: 0 };
+
+			add( EVERY_SECOND, nudgeObject( o, 3 ) );
+			add( EVERY_SECOND, nudgeObject( o, 5 ) );
+
+			this.clock.tick( 1000 );
+
+			assert( 3 + 5 === o.counter );
+		} );
+
+		it( 'Should only execute actions for the given period', function() {
+			const o = { counter: 0 };
+
+			add( EVERY_SECOND, nudgeObject( o, 3 ) );
+			add( EVERY_MINUTE, nudgeObject( o, 5 ) );
+
+			// plus 1 second
+			this.clock.tick( 1000 );
+			assert( 3 === o.counter );
+
+			// plus 1 minute
+			this.clock.tick( 1000 * 59 );
+			assert( 3 * 60 + 5 === o.counter );
+		} );
+
+		it( 'Should only execute actions that remain after removal', function() {
+			const o = { counter: 0 };
+
+			const id = add( EVERY_SECOND, nudgeObject( o, 3 ) );
+
+			this.clock.tick( 1000 );
+			assert( 3 === o.counter );
+
+			this.clock.tick( 1000 );
+			assert( 6 === o.counter );
+
+			remove( id );
+			this.clock.tick( 1000 );
+			assert( 6 === o.counter );
+		} );
+	} );
+} );

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "blanket": "1.1.6",
     "chai": "2.0.0",
     "chai-immutable": "^1.4.0",
+    "enzyme": "1.1.0",
     "esformatter": "0.7.3",
     "esformatter-braces": "1.2.1",
     "esformatter-collapse-objects-a8c": "0.1.0",


### PR DESCRIPTION
This polling component can wrap another component in a polling mechanism
that runs a given function at a given interval and will optionally stop
polling if the component enters a hidden visibility state to save on
bandwidth.

If specified to pause when hidden, there is an optional parameter
describing whether or not the action should fire immediately upon coming
back into view. If not, it will fire after the given interval.

This component was inspired by the data-poller component but attempts to
be a more lightweight and readable component.