### PR TITLE
Help: Handle chat ineligible users with the support forums

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -156,25 +156,23 @@ module.exports = React.createClass( {
 
 		return (
 			<div className="help-contact-form">
-				{ formDescription ? (
-					<p>{ formDescription }</p>
-				) : null }
+				{ formDescription && ( <p>{ formDescription }</p> ) }
 
-				{ showHowCanWeHelpField ? (
+				{ showHowCanWeHelpField && (
 					<div>
 						<FormLabel>{ this.translate( 'How can we help?' ) }</FormLabel>
 						{ this.renderFormSelection( 'howCanWeHelp', howCanWeHelpOptions ) }
 					</div>
-				) : null }
+				) }
 
-				{ showHowYouFeelField ? (
+				{ showHowYouFeelField && (
 					<div>
 						<FormLabel>{ this.translate( 'Mind sharing how you feel?' ) }</FormLabel>
 						{ this.renderFormSelection( 'howYouFeel', howYouFeelOptions ) }
 					</div>
-				) : null }
+				) }
 
-				{ showSiteField ? (
+				{ showSiteField && (
 					<div>
 						<FormLabel>{ this.translate( 'Which site do you need help with?' ) }</FormLabel>
 						<SelectSite
@@ -184,14 +182,14 @@ module.exports = React.createClass( {
 							value={ this.state.site.ID }
 							onChange={ this.setSite } />
 					</div>
-				) : null }
+				) }
 
-				{ showSubjectField ? (
+				{ showSubjectField && (
 					<div className="help-contact-form__subject">
 						<FormLabel>{ this.translate( 'Subject' ) }</FormLabel>
 						<FormTextInput valueLink={ this.linkState( 'subject' ) } />
 					</div>
-				) : null }
+				) }
 
 				<FormLabel>{ this.translate( 'What are you trying to do?' ) }</FormLabel>
 				<FormTextarea valueLink={ this.linkState( 'message' ) } placeholder={ this.translate( 'Please be descriptive' ) }></FormTextarea>

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -139,9 +139,9 @@ module.exports = React.createClass( {
 	 */
 	render: function() {
 		var howCanWeHelpOptions = [
-				{ value: 'gettingStarted', label: this.translate( 'Help getting started' ), subtext: this.translate( 'Can you show me how to...' ) },
-				{ value: 'somethingBroken', label: this.translate( 'Something is broken' ), subtext: this.translate( 'Can you check this out...' ) },
-				{ value: 'suggestion', label: this.translate( 'I have a suggestion' ), subtext: this.translate( 'I think it would be cool if...' ) }
+				{ value: 'gettingStarted', label: this.translate( 'Help getting started' ), subtext: this.translate( 'Can you show me how to…' ) },
+				{ value: 'somethingBroken', label: this.translate( 'Something is broken' ), subtext: this.translate( 'Can you check this out…' ) },
+				{ value: 'suggestion', label: this.translate( 'I have a suggestion' ), subtext: this.translate( 'I think it would be cool if…' ) }
 			],
 			howYouFeelOptions = [
 				{ value: 'unspecified', label: this.translate( "I'd rather not" ) },

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -22,6 +22,7 @@ module.exports = React.createClass( {
 	mixins: [ React.addons.LinkedStateMixin, React.addons.PureRenderMixin ],
 
 	propTypes: {
+		formDescription: React.PropTypes.node,
 		buttonLabel: React.PropTypes.string.isRequired,
 		onSubmit: React.PropTypes.func.isRequired,
 		showHowCanWeHelpField: React.PropTypes.bool,
@@ -35,6 +36,7 @@ module.exports = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
+			formDescription: '',
 			showHowCanWeHelpField: false,
 			showHowYouFeelField: false,
 			showSubjectField: false,
@@ -150,10 +152,14 @@ module.exports = React.createClass( {
 				{ value: 'panicked', label: this.translate( 'Panicked' ) }
 			];
 
-		const { buttonLabel, showHowCanWeHelpField, showHowYouFeelField, showSubjectField, showSiteField, siteList, siteFilter } = this.props;
+		const { formDescription, buttonLabel, showHowCanWeHelpField, showHowYouFeelField, showSubjectField, showSiteField, siteList, siteFilter } = this.props;
 
 		return (
 			<div className="help-contact-form">
+				{ formDescription ? (
+					<p>{ formDescription }</p>
+				) : null }
+
 				{ showHowCanWeHelpField ? (
 					<div>
 						<FormLabel>{ this.translate( 'How can we help?' ) }</FormLabel>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -124,8 +124,10 @@ module.exports = React.createClass( {
 			this.setState( {
 				isSubmitting: false,
 				confirmation: {
-					title: this.translate( "We're on it!" ),
-					message: this.translate( "We've received your message, and you'll hear back from one of our Happiness Engineers shortly." )
+					title: this.translate( 'We\'re on it!' ),
+					message: this.translate(
+						'We\'ve received your message, and you\'ll hear back from ' +
+						'one of our Happiness Engineers shortly.' )
 				}
 			} );
 		} );
@@ -149,7 +151,15 @@ module.exports = React.createClass( {
 				isSubmitting: false,
 				confirmation: {
 					title: this.translate( 'Got it!' ),
-					message: this.translate( 'Your message has been submitted to our {{a}}community forums{{/a}}', { components: { a: <a href={ data.topic_URL } /> } } )
+					message: this.translate(
+						'Your message has been submitted to our ' +
+						'{{a}}community forums{{/a}}',
+						{
+							components: {
+								a: <a href={ data.topic_URL } />
+							}
+						}
+					)
 				}
 			} );
 		} );
@@ -258,7 +268,12 @@ module.exports = React.createClass( {
 
 	getPublicForumsForm: function() {
 		const { isSubmitting } = this.state;
-		const formDescription = this.translate( 'Post a new question in our {{strong}}public forums{{/strong}}, where it may be answered by helpful community members, by submitting the form below. {{strong}}Please do not{{/strong}} provide financial or contact information when submitting this form.',
+		const formDescription = this.translate(
+			'Post a new question in our {{strong}}public forums{{/strong}}, ' +
+			'where it may be answered by helpful community members, ' +
+			'by submitting the form below. ' +
+			'{{strong}}Please do not{{/strong}} provide financial or ' +
+			'contact information when submitting this form.',
 			{
 				components: {
 					strong: <strong />

--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -1763,6 +1763,13 @@ Undocumented.prototype.getOlarkConfiguration = function( fn ) {
 	}, fn );
 };
 
+Undocumented.prototype.submitSupportForumsTopic = function( subject, message, fn ) {
+	this.wpcom.req.post( {
+		path: '/help/forums/support/topics/new',
+		body: { subject, message }
+	}, fn );
+};
+
 /**
  * Expose `Undocumented` module
  */


### PR DESCRIPTION
Handle chat ineligible users with the support forums
=======================================

We aim to implement a contact form in calypso that will allow users to contact us either through livechat, support ticket or via a support forums post.

#### Goals of this PR
* Allow a user to create a topic on the support forums when they are ineligible for live chat.

#### Whats changed
* Made the contact form generic so that we could reuse code and css.
* Added a subject field to the contact form
* Added a method to the wpcom undocumented lib to allow posting to the forums
* Modified the `help-contact` component so that ineligible users can submit a question to the forums.

#### How to test
This test requires you to login in with a user that is ineligible for chat. This is generally someone who does not have any paid upgrades. Be aware that there are some business rules around new users being occasionally made eligible when there is available HE bandwidth. 

1. Navigate to http://calypso.localhost:3000/help/contact
2. Enter a  subject and description.
3. Click "Ask in the forums".
4. Notice that the main button is now disabled and the text has changed to "Asking in the forums"
5. You should see a confirmation page when the forum is finished submitting.
6. Go to https://en.forums.wordpress.com/. You should see your topic posted.
7. Login and delete the test forums topic you created.

#### What to expect
![screen shot 2015-11-11 at 10 06 58 pm](https://cloud.githubusercontent.com/assets/1854440/11109663/e1114c68-88c0-11e5-8a4f-774ff6a2407b.png)

![screen shot 2015-11-11 at 10 07 28 pm](https://cloud.githubusercontent.com/assets/1854440/11109665/e43c122e-88c0-11e5-9156-c45a7c80cbbc.png)

