### PR TITLE
Search: Trigger search when no keyword change, but site change

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -94,7 +94,7 @@ module.exports = React.createClass( {
 			this.focus();
 		}
 
-		if ( this.state.keyword === prevState.keyword ) {
+		if ( this.state.keyword === prevState.keyword && prevProps.initialValue === this.props.initialValue ) {
 			return;
 		}
 		// if there's a keyword change: trigger search

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -94,7 +94,11 @@ module.exports = React.createClass( {
 			this.focus();
 		}
 
-		if ( this.state.keyword === prevState.keyword && prevProps.initialValue === this.props.initialValue ) {
+		if (
+			this.state.keyword === prevState.keyword &&
+			this.props.initialValue === prevProps.initialValue &&
+			this.props.siteID === prevProps.siteID
+		) {
 			return;
 		}
 		// if there's a keyword change: trigger search

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -122,6 +122,9 @@ module.exports = React.createClass( {
 		if ( this.props.autoFocus ) {
 			this.focus();
 		}
+		if ( this.props.initialValue ) {
+			this.onSearch( this.props.initialValue );
+		}
 	},
 
 	focus: function() {

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -89,7 +89,7 @@ module.exports = React.createClass({
 					</NavTabs>
 					<Search
 						pinned={ true }
-						siteID = { this.props.siteID }
+						siteID={ this.props.siteID }
 						onSearch={ this.doSearch }
 						initialValue={ this.props.search }
 						placeholder={ searchPlaceholder }

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -89,6 +89,7 @@ module.exports = React.createClass({
 					</NavTabs>
 					<Search
 						pinned={ true }
+						siteID = { this.props.siteID }
 						onSearch={ this.doSearch }
 						initialValue={ this.props.search }
 						placeholder={ searchPlaceholder }

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -4,6 +4,7 @@
 var page = require( 'page' ),
 	React = require( 'react' ),
 	qs = require( 'querystring' ),
+	url = require( 'url' ),
 	debug = require( 'debug' )( 'calypso:my-sites:posts' );
 
 /**
@@ -29,6 +30,11 @@ module.exports = {
 			basePath = route.sectionify( context.path ),
 			analyticsPageTitle = 'Blog Posts',
 			baseAnalyticsPath;
+
+		if ( !search && context.prevPath ) {
+			//Guessing search parameters from previous url
+			search = qs.parse( url.parse( context.prevPath ).query ).s;
+		}
 
 		function shouldRedirectMyPosts( author, sites ) {
 			var selectedSite = sites.getSelectedSite() || {};

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -134,7 +134,7 @@ export default React.createClass( {
 				}
 				<Search
 					pinned={ true }
-					siteID = { this.props.siteID }
+					siteID={ this.props.siteID }
 					onSearch={ this.doSearch }
 					initialValue={ this.props.search }
 					placeholder={ 'Search ' + statusTabs.selectedText + '...' }

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -134,6 +134,7 @@ export default React.createClass( {
 				}
 				<Search
 					pinned={ true }
+					siteID = { this.props.siteID }
 					onSearch={ this.doSearch }
 					initialValue={ this.props.search }
 					placeholder={ 'Search ' + statusTabs.selectedText + '...' }


### PR DESCRIPTION
Fixes #453 and #1062. 

This PR makes search term 'persistent' between site switches

# What changed?
- Component is now reacting to both siteID change and search term change
- siteID is passed to component
- If site posts were not browsed during this session (and thus new URL is loaded), previous search terms are deduced from previous URL

# Testing
1. Go to My Sites
2. Click on a site and click "Blog Posts"
3. Click the search icon at top right to open search bar, type in "test", and hit Enter to search
4. Click on "Switch Site" and pick a different site
5. Notice that search term is still there and search is returning results from other site
6. Repeat the same for pages
7. Open Safari and input http://calypso.localhost:3000/posts/my/?s=potato - should behave like in chrome (wasnt searching before)