### PR TITLE
Live Chat: Hide the X link that lets people close the chat box.

### DIFF
--- a/assets/stylesheets/shared/_livechat.scss
+++ b/assets/stylesheets/shared/_livechat.scss
@@ -648,18 +648,7 @@
 }
 
 #habla_window_div #habla_closebutton_a {
-
-	&:before {
-		display: inline-block;
-		width: 16px;
-		height: 16px;
-		font: 16px/1 Noticons;
-		content: '\f405';
-	}
-}
-
-#habla_window_div #habla_closebutton_a:hover {
-	background-color: rgba(255, 255, 255, 0.15);
+	display: none;
 }
 
 #habla_window_div #habla_popout_a {


### PR DESCRIPTION
When you click this, the chat goes away for the remainder of your session and there's not a good way to get it back. We've overridden the standard Olark UI to make the floating box less obtrusive anyway, so the need to X out is rendered unnecessary by the unobtrusive UI we now show when you click the little inverted carat to minimize the chat box.

This change makes it harder for users to accidentally dismiss the chat box for the duration of their session and have difficulty initiating or resuming a chat.

Here's what it looked like previously:

![screen shot 2015-12-01 at 8 35 23 am](https://cloud.githubusercontent.com/assets/2738252/11502621/f41f6a62-9809-11e5-8e08-85c57a24bbc4.png)

And with the change:

![screen shot 2015-12-01 at 8 57 23 am](https://cloud.githubusercontent.com/assets/2738252/11502624/fbd23726-9809-11e5-893d-49cb87d4900e.png)

To test:

1. Go to http://calypso.localhost:3000/help/contact/
2. Initiate a chat (you'll need to make sure an operator is online -- the button will say "Chat with us" if an operator is available).
3. Navigate to a different screen.
4. Observe the chat box at lower right.
5. Expand, minify, resize the browser window.
