### PR TITLE
Domain Management: DNS: Allow underscores in CNAME and MX records

### DIFF
--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-const includes = require( 'lodash/collection/includes' ),
-	mapValues = require( 'lodash/object/mapValues' );
+import includes from 'lodash/collection/includes';
+import mapValues from 'lodash/object/mapValues';
+import clone from 'lodash/lang/clone';
 
 function validateAllFields( fieldValues ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {
@@ -55,7 +56,7 @@ function isValidData( data, type ) {
 }
 
 function getNormalizedData( fieldValues, selectedDomainName ) {
-	var data = fieldValues;
+	const data = clone( fieldValues );
 
 	data.data = getFieldWithDot( data.data );
 
@@ -77,11 +78,17 @@ function removeTrailingDomain( domain, trailing ) {
 }
 
 function getFieldWithDot( field ) {
+	if ( ! typeof field === 'string' ) {
+		return null;
+	}
+
 	// something that looks like domain but doesn't end with a dot
-	return ( typeof field === 'string' && field.match( /^([a-z0-9-]+\.)+\.?[a-z]+$/i ) ) ? field + '.' : field;
+	const pattern = /^([a-z0-9-]+\.)+\.?[a-z]+$/i;
+
+	return field.match( pattern ) ? field + '.' : field;
 }
 
-module.exports = {
+export {
 	validateAllFields,
 	getNormalizedData
 };

--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -37,7 +37,7 @@ function validateField( { name, value, type } ) {
 }
 
 function isValidName( name ) {
-	return /^([\da-z-]+\.)+[\da-z-]+$/i.test( name );
+	return /^([\da-z-_]+\.)+[\da-z-_]+$/i.test( name );
 }
 
 function isValidData( data, type ) {


### PR DESCRIPTION
This allows underscores to be valid characters in domain names in the DNS editor. Reported in `p2MSmN-3Uq-p2`.

### Testing

1. Go to http://calypso.localhost:3000/domains/manage
2. Click a registered or mapped domain and select "DNS Records"
3. Click "Add a New DNS Record"
4. Select "CNAME" as the type
5. Enter a domain with an underscore, e.g. `foo_.example.com`.
6. The field should be valid.