### PR TITLE
Domain Management: DNS: Minor improvements to SRV Record form

### DIFF
--- a/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
@@ -43,7 +43,7 @@ const SrvRecord = React.createClass( {
 		return (
 			<div className={ classes }>
 				<FormFieldset>
-					<FormLabel>{ this.translate( 'Value', { context: 'Dns Record' } ) }</FormLabel>
+					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError="true" /> : null }
 					<FormTextInput
 						name="name"

--- a/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
@@ -21,7 +21,8 @@ const SrvRecord = React.createClass( {
 			aux: 10,
 			weight: 10,
 			target: '',
-			port: ''
+			port: '',
+			protocol: 'tcp'
 		}
 	},
 
@@ -65,7 +66,9 @@ const SrvRecord = React.createClass( {
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Protocol', { context: 'Dns Record' } ) }</FormLabel>
 
-					<FormSelect onChange={ this.props.onChange( 'protocol' ) } value={ protocol }>
+					<FormSelect name="protocol"
+							onChange={ this.props.onChange( 'protocol' ) }
+							value={ protocol }>
 						{ options }
 					</FormSelect>
 				</FormFieldset>


### PR DESCRIPTION
- Fix a bug where the form would return a server-side error if the Protocol select box was left in it's default state.
- Change the "Value" field to "Name" to make the purpose more clear.

### Testing

1. Go to http://calypso.localhost:3000/domains/manage
2. Click on a domain registration or mapping and select "DNS Editor"
3. Try to add a SRV record but *do not* change the Protocol option
4. The SRV record should get added successfully.