### PR TITLE
Me: Adds ability to toggle holiday snow

### DIFF
--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -198,6 +198,36 @@ module.exports = React.createClass( {
 		}.bind( this ) );
 	},
 
+	renderHolidaySnow() {
+		let today = this.moment(),
+			thisYear = today.year();
+
+		// Now, let's get the start and end date for the holiday snow feature.
+		// Note that the isBetween() method does not seem to be inclusive, so we use
+		// 11-30 and 1-5 for the cut-off dates.
+		let startDate = this.moment( '2015-11-30' ).year( thisYear ),
+			endDate = this.moment( '2015-01-05' ).year( thisYear + 1 );
+
+		if ( ! today.isBetween( startDate, endDate, 'day' ) ) {
+			return;
+		}
+
+		return (
+			<FormFieldset>
+				<FormLegend>{ this.translate( 'Holiday Snow' ) }</FormLegend>
+				<FormLabel>
+					<FormCheckbox
+						checkedLink={ this.valueLink( 'holidaysnow' ) }
+						disabled={ this.getDisabledState() }
+						id="holidaysnow"
+						name="holidaysnow"
+						onClick={ this.recordCheckboxEvent( 'Holiday Snow' ) } />
+					<span>{ this.translate( 'Show snowfall on WordPress.com sites.' ) }</span>
+				</FormLabel>
+			</FormFieldset>
+		);
+	},
+
 	renderJoinDate: function() {
 		var dateMoment = i18n.moment( user.get().date );
 
@@ -381,18 +411,7 @@ module.exports = React.createClass( {
 					</FormLabel>
 				</FormFieldset>
 
-				<FormFieldset>
-					<FormLegend>{ this.translate( 'Holiday Snow' ) }</FormLegend>
-					<FormLabel>
-						<FormCheckbox
-							checkedLink={ this.valueLink( 'holidaysnow' ) }
-							disabled={ this.getDisabledState() }
-							id="holidaysnow"
-							name="holidaysnow"
-							onClick={ this.recordCheckboxEvent( 'Holiday Snow' ) } />
-						<span>{ this.translate( 'Show snowfall on WordPress.com sites.' ) }</span>
-					</FormLabel>
-				</FormFieldset>
+				{ this.renderHolidaySnow() }
 
 				<FormButton
 					isSubmitting={ this.state.submittingForm }

--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -381,6 +381,19 @@ module.exports = React.createClass( {
 					</FormLabel>
 				</FormFieldset>
 
+				<FormFieldset>
+					<FormLegend>{ this.translate( 'Holiday Snow' ) }</FormLegend>
+					<FormLabel>
+						<FormCheckbox
+							checkedLink={ this.valueLink( 'holidaysnow' ) }
+							disabled={ this.getDisabledState() }
+							id="holidaysnow"
+							name="holidaysnow"
+							onClick={ this.recordCheckboxEvent( 'Holiday Snow' ) } />
+						<span>{ this.translate( 'Show snowfall on WordPress.com sites.' ) }</span>
+					</FormLabel>
+				</FormFieldset>
+
 				<FormButton
 					isSubmitting={ this.state.submittingForm }
 					disabled={ ! this.props.userSettings.hasUnsavedSettings() || this.getDisabledState() }


### PR DESCRIPTION
In #1123, @jeherve reported that the holiday snow option was not displayed within `/me`. This PR allows a user to toggle holiday snow.

Since holiday snow only displays from 12-1 to 1-4, we could also feature flag or time flag this option.

Instead of presenting a checkbox that allowed a user to "disable", as opposed to "enable" a feature, I modified the `/me/settings` endpoint in r127611-wpcom to reverse the logic for holiday snow.

To test:
- Checkout `update/me-holiday-snow`
- On a WordPress.com site, go to `$site/wp-admin/options-general.php` and ensure holiday snow is turned on
- Go to `/me/account`
- Toggle the checkbox for holiday snow a few times and ensure that the holiday snow displays accordingly