### PR TITLE
Framework: update `wpcom-undocumented`

### DIFF
--- a/shared/lib/wp/browser.js
+++ b/shared/lib/wp/browser.js
@@ -1,25 +1,27 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:wp' );
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:wp' );
 
 /**
  * Internal dependencies
  */
-var WPCOM = require( 'lib/wpcom-undocumented' ),
-	config = require( 'config' );
+import wpcomUndocumented from 'lib/wpcom-undocumented';
+import config from 'config';
 
-var wpcom;
+let wpcom;
 
 if ( config.isEnabled( 'oauth' ) ) {
-	let oAuthToken = require( 'lib/oauth-token' );
-
-	wpcom = WPCOM( oAuthToken.getToken(), require( 'lib/wpcom-xhr-wrapper' ) );
+	wpcom = wpcomUndocumented(
+		require( 'lib/oauth-token' ),
+		require( 'lib/wpcom-xhr-wrapper' )
+	);
 } else {
 	// Set proxy request handler
-	wpcom = WPCOM( require( 'wpcom-proxy-request' ) );
+	wpcom = wpcomUndocumented( require( 'wpcom-proxy-request' ) );
 
-	//Upgrade to "access all users blogs" mode
+	// Upgrade to "access all users blogs" mode
 	wpcom.request( {
 		metaAPI: { accessAllUsersBlogs: true }
 	}, function( error ) {

--- a/shared/lib/wpcom-undocumented/index.js
+++ b/shared/lib/wpcom-undocumented/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var WPCOM = require( 'wpcom-unpublished' ),
+var wpcomFactory = require( 'wpcom-unpublished' ),
 	inherits = require( 'inherits' ),
 	assign = require( 'lodash/object/assign' ),
 	debug = require( 'debug' )( 'calypso:wpcom-undocumented' );
@@ -14,13 +14,13 @@ var Undocumented = require( './lib/undocumented' );
 /**
  * Add special methods to WPCOM class
  *
- * @param {String} [token]
- * @param {Function} [reqHandler]
- * @api public
+ * @param {String} [token] - oauth token
+ * @param {Function} [reqHandler] - request handler
+ * @return {NUll} null
  */
-function WPCOMPlus( token, reqHandler ) {
-	if ( ! ( this instanceof WPCOMPlus ) ) {
-		return new WPCOMPlus( token, reqHandler );
+function WPCOMUndocumented( token, reqHandler ) {
+	if ( ! ( this instanceof WPCOMUndocumented ) ) {
+		return new WPCOMUndocumented( token, reqHandler );
 	}
 
 	if ( 'function' === typeof token ) {
@@ -30,25 +30,31 @@ function WPCOMPlus( token, reqHandler ) {
 		this.loadToken( token );
 	}
 
-	WPCOM.call( this, token, function( params, fn ) {
+	wpcomFactory.call( this, token, function( params, fn ) {
 		if ( this.isTokenLoaded() ) {
-			// authToken is used in wpcom-xhr-request, which is used for the signup flow in the REST Proxy
-			params = assign( {}, params, { authToken: this._token, token: this._token } );
+			// authToken is used in wpcom-xhr-request,
+			// which is used for the signup flow in the REST Proxy
+			params = assign(
+				{},
+				params,
+				{ authToken: this._token, token: this._token }
+			);
 		}
 
 		return reqHandler( params, fn );
 	} );
+
 	debug( 'Extending wpcom with undocumented endpoints.' );
 }
 
-inherits( WPCOMPlus, WPCOM );
+inherits( WPCOMUndocumented, wpcomFactory );
 
 /**
  * Get `Undocumented` object instance
  *
- * @api public
+ * @return {Undocumented} Undocumented instance
  */
-WPCOM.prototype.undocumented = function() {
+wpcomFactory.prototype.undocumented = function() {
 	return new Undocumented( this );
 };
 
@@ -56,20 +62,22 @@ WPCOM.prototype.undocumented = function() {
  * Add a token to this instance of WPCOM.
  * When loaded, the token is applied to the param object of each subsequent request.
  *
- * @param {String} [token]
+ * @param {String} [token] - oauth token
  */
-WPCOM.prototype.loadToken = function( token ) {
+wpcomFactory.prototype.loadToken = function( token ) {
 	this._token = token;
 };
 
 /**
  * Returns a boolean representing whether or not the token has been loaded.
+ *
+ * @return {String} oauth token
  */
-WPCOM.prototype.isTokenLoaded = function() {
+wpcomFactory.prototype.isTokenLoaded = function() {
 	return this._token !== undefined;
 };
 
 /**
- * Expose `WPCOMPlus`
+ * Expose `WPCOMUndocumented`
  */
-module.exports = WPCOMPlus;
+module.exports = WPCOMUndocumented;

--- a/shared/lib/wpcom-undocumented/index.js
+++ b/shared/lib/wpcom-undocumented/index.js
@@ -1,18 +1,21 @@
 /**
  * External dependencies
  */
-var wpcomFactory = require( 'wpcom-unpublished' ),
-	inherits = require( 'inherits' ),
-	assign = require( 'lodash/object/assign' ),
-	debug = require( 'debug' )( 'calypso:wpcom-undocumented' );
+import wpcomFactory from 'wpcom-unpublished';
+import inherits from 'inherits';
+import assign from 'lodash/object/assign';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-var Undocumented = require( './lib/undocumented' );
+import Undocumented from './lib/undocumented';
+
+const debug = debugFactory( 'calypso:wpcom-undocumented' );
 
 /**
- * Add special methods to WPCOM class
+ * Class inherited from `WPCOMUnpublished` class and adds
+ * specific methods useful for wp-calypso.
  *
  * @param {String} [token] - oauth token
  * @param {Function} [reqHandler] - request handler
@@ -54,7 +57,7 @@ inherits( WPCOMUndocumented, wpcomFactory );
  *
  * @return {Undocumented} Undocumented instance
  */
-wpcomFactory.prototype.undocumented = function() {
+WPCOMUndocumented.prototype.undocumented = function() {
 	return new Undocumented( this );
 };
 
@@ -73,11 +76,11 @@ wpcomFactory.prototype.loadToken = function( token ) {
  *
  * @return {String} oauth token
  */
-wpcomFactory.prototype.isTokenLoaded = function() {
+WPCOMUndocumented.prototype.isTokenLoaded = function() {
 	return this._token !== undefined;
 };
 
 /**
  * Expose `WPCOMUndocumented`
  */
-module.exports = WPCOMUndocumented;
+export default WPCOMUndocumented;

--- a/shared/lib/wpcom-undocumented/lib/me.js
+++ b/shared/lib/wpcom-undocumented/lib/me.js
@@ -1,13 +1,14 @@
 /**
  * Module dependencies.
  */
-var debug = require( 'debug' )( 'calypso:wpcom-undocumented:me' );
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:wpcom-undocumented:me' );
 
 /**
  * Create an UndocumentedMe instance
  *
- * @param {WPCOM} wpcom
- * @api public
+ * @param {WPCOM} wpcom - WPCOMUndocumented instance
+ * @return {NUll} null
  */
 function UndocumentedMe( wpcom ) {
 	debug( 'UndocumentedMe' );

--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -25,7 +25,7 @@ var Site = require( './site' ),
  * so that they will be successful. This is not a sufficent measure
  * against spam as these keys are exposed publicly
  *
- * @param { object } query Add client_id and client_secret to the query.
+ * @param { object } query - Add client_id and client_secret to the query.
  */
 function restrictByOauthKeys( query ) {
 	query.client_id = config( 'wpcom_signup_id' );
@@ -35,9 +35,8 @@ function restrictByOauthKeys( query ) {
 /**
  * Create an `Undocumented` instance
  *
- * @param {WPCOM} wpcom The request handler
- * @api public
- * @returns {Undocumented} An instance of Undocumented
+ * @param {WPCOM} wpcom - The request handler
+ * @returns {Undocumented} - An instance of Undocumented
  */
 function Undocumented( wpcom ) {
 	if ( ! ( this instanceof Undocumented ) ) {


### PR DESCRIPTION
* Fix ESLINT warnings
* Use some ES6 notations, for instance, replace `require` by `import`.
* Fix wrong way adding prototypes to `WPCOM` class. They should be added to `WPCOMUndocumented` class. For instance: https://github.com/Automattic/wp-calypso/blob/master/shared/lib/wpcom-undocumented/index.js#L51
