### PR TITLE
Signup: Verticals Survey: Add verticalSurvey test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -16,6 +16,15 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
+	verticalSurvey: {
+		datestamp: '20151201',
+		variations: {
+			noSurvey: 12,
+			oneStep: 44,
+			twoStep: 44
+		},
+		defaultVariation: 'noSurvey'
+	},
 	translatorInvitation: {
 		datestamp: '20150910',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -9,6 +9,7 @@ var assign = require( 'lodash/object/assign' ),
 */
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
+	abtest = require( 'lib/abtest' ).abtest,
 	user = require( 'lib/user' )();
 
 function getCheckoutDestination( dependencies ) {
@@ -65,16 +66,16 @@ const flows = {
 	},
 
 	'vert-blog': {
-		steps: [ 'survey-blog', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: abtest( 'verticalSurvey' ) === 'noSurvey' ? [ 'themes', 'domains', 'plans', 'user' ] : [ 'survey-blog', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getCheckoutDestination,
-		description: 'Categorizing blog signups',
+		description: 'Categorizing blog signups for Verticals Survey',
 		lastModified: null
 	},
 
 	'vert-site': {
-		steps: [ 'survey-site', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: abtest( 'verticalSurvey' ) === 'noSurvey' ? [ 'themes', 'domains', 'plans', 'user' ] : [ 'survey-site', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getCheckoutDestination,
-		description: 'Categorizing site signups',
+		description: 'Categorizing site signups for Verticals Survey',
 		lastModified: null
 	},
 

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -1,4 +1,5 @@
 import stepActions from 'lib/signup/step-actions';
+import { abtest } from 'lib/abtest';
 
 module.exports = {
 	themes: {
@@ -45,6 +46,7 @@ module.exports = {
 		stepName: 'survey-blog',
 		props: {
 			surveySiteType: 'blog',
+			isOneStep: abtest( 'verticalSurvey' ) === 'oneStep'
 		},
 		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
 	},
@@ -53,6 +55,7 @@ module.exports = {
 		stepName: 'survey-site',
 		props: {
 			surveySiteType: 'site',
+			isOneStep: abtest( 'verticalSurvey' ) === 'oneStep'
 		},
 		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
 	},


### PR DESCRIPTION
The Verticals survey is a signup test wherein a new user is asked to categorize
their soon-to-be new site using a custom taxonomy. The result of the survey does
not actually change anything in the signup flow at this time, but can be used to
make other decisions later and may eventually influence the themes offered
during signup.

This tests three variants:

For all the users directed to the `vert-blog` or `vert-site` flow (this part is
taken care of by the homepage, which is not part of Calypso):
- 12% will see no survey and will see the normal signup flow instead.
- 44% will see the Verticals survey as the first step in the signup flow, with only one tier of categories.
- 44% will see the Verticals survey as the first step in the signup flow, with two tiers of categories.

NOTE: in order for this test to run, a percentage of logged-out users must end up at the URLs http://wordpress.com/start/vert-blog/ and http://wordpress.com/start/vert-site/ That will be taken care of by a change in the home page code on wordpress.com outside of Calypso.
