### PR TITLE
Purchases: Always use selectedSite.slug in urls when selected site needs to be used

### DIFF
--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -39,7 +39,7 @@ const CancelPrivateRegistration = React.createClass( {
 		// We call blur on the cancel button to remove the blue outline that shows up when you click on the button
 		event.target.blur();
 
-		const { domain, id } = this.props.selectedPurchase.data;
+		const { id } = this.props.selectedPurchase.data;
 
 		this.setState( {
 			disabled: true,
@@ -53,7 +53,7 @@ const CancelPrivateRegistration = React.createClass( {
 			} );
 
 			if ( success ) {
-				page( paths.managePurchaseDestination( domain, id, 'canceled-private-registration' ) );
+				page( paths.managePurchaseDestination( this.props.selectedSite.slug, id, 'canceled-private-registration' ) );
 			}
 		} );
 	},

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -15,7 +15,8 @@ import paths from 'me/purchases/paths';
 
 const CancelPurchaseButton = React.createClass( {
 	propTypes: {
-		purchase: React.PropTypes.object.isRequired
+		purchase: React.PropTypes.object.isRequired,
+		selectedSite: React.PropTypes.object.isRequired
 	},
 
 	getInitialState() {
@@ -25,9 +26,10 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	goToCancelConfirmation() {
-		const { domain, id } = this.props.purchase;
+		const { id } = this.props.purchase,
+			{ slug } = this.props.selectedSite;
 
-		page( paths.confirmCancelPurchase( domain, id ) );
+		page( paths.confirmCancelPurchase( slug, id ) );
 	},
 
 	cancelPurchase() {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -70,49 +70,49 @@ const CancelPurchase = React.createClass( {
 		const purchase = getPurchase( this.props );
 
 		return (
-			<Main className="cancel-purchase">
-				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
-					{ titles.cancelPurchase }
-				</HeaderCake>
+				<Main className="cancel-purchase">
+					<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
+						{ titles.cancelPurchase }
+					</HeaderCake>
 
-				<Card className="cancel-purchase__card">
-					<h2>
-						{ this.translate( 'Cancel %(purchaseName)s', {
-							args: {
-								purchaseName: getName( purchase )
-							}
-						} ) }
-					</h2>
+					<Card className="cancel-purchase__card">
+						<h2>
+							{ this.translate( 'Cancel %(purchaseName)s', {
+									args: {
+											purchaseName: getName( purchase )
+											}
+									} ) }
+						</h2>
 
-					<div className="cancel-purchase__info">
-						<CancelPurchaseSupportBox purchase={ purchase } />
+						<div className="cancel-purchase__info">
+							<CancelPurchaseSupportBox purchase={ purchase } />
 
-						<div className="cancel-purchase__content">
-							<div className="cancel-purchase__section">
-								<strong className="cancel-purchase__section-header">{ this.translate( 'What am I canceling?' ) }</strong>
+							<div className="cancel-purchase__content">
+								<div className="cancel-purchase__section">
+									<strong className="cancel-purchase__section-header">{ this.translate( 'What am I canceling?' ) }</strong>
 
-								<CancelPurchaseProductInformation
-									purchase={ purchase }
-									selectedSite={ this.props.selectedSite } />
-							</div>
+									<CancelPurchaseProductInformation
+											purchase={ purchase }
+											selectedSite={ this.props.selectedSite } />
+								</div>
 
-							<hr />
+								<hr />
 
-							<div className="cancel-purchase__section">
-								<strong className="cancel-purchase__section-header">{ this.translate( 'Do I get a refund?' ) }</strong>
+								<div className="cancel-purchase__section">
+									<strong className="cancel-purchase__section-header">{ this.translate( 'Do I get a refund?' ) }</strong>
 
-								<CancelPurchaseRefundInformation
-									purchase={ purchase } />
+									<CancelPurchaseRefundInformation
+											purchase={ purchase } />
+								</div>
 							</div>
 						</div>
-					</div>
-				</Card>
+					</Card>
 
-				<CompactCard className="cancel-purchase__footer">
-					<CancelPurchaseButton
-						purchase={ purchase } />
-				</CompactCard>
-			</Main>
+					<CompactCard className="cancel-purchase__footer">
+						<CancelPurchaseButton
+								purchase={ purchase } />
+					</CompactCard>
+				</Main>
 		);
 	}
 } );

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -70,49 +70,49 @@ const CancelPurchase = React.createClass( {
 		const purchase = getPurchase( this.props );
 
 		return (
-				<Main className="cancel-purchase">
-					<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
-						{ titles.cancelPurchase }
-					</HeaderCake>
+			<Main className="cancel-purchase">
+				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
+					{ titles.cancelPurchase }
+				</HeaderCake>
 
-					<Card className="cancel-purchase__card">
-						<h2>
-							{ this.translate( 'Cancel %(purchaseName)s', {
-									args: {
-											purchaseName: getName( purchase )
-											}
-									} ) }
-						</h2>
+				<Card className="cancel-purchase__card">
+					<h2>
+						{ this.translate( 'Cancel %(purchaseName)s', {
+							args: {
+								purchaseName: getName( purchase )
+							}
+						} ) }
+					</h2>
 
-						<div className="cancel-purchase__info">
-							<CancelPurchaseSupportBox purchase={ purchase } />
+					<div className="cancel-purchase__info">
+						<CancelPurchaseSupportBox purchase={ purchase } />
 
-							<div className="cancel-purchase__content">
-								<div className="cancel-purchase__section">
-									<strong className="cancel-purchase__section-header">{ this.translate( 'What am I canceling?' ) }</strong>
+						<div className="cancel-purchase__content">
+							<div className="cancel-purchase__section">
+								<strong className="cancel-purchase__section-header">{ this.translate( 'What am I canceling?' ) }</strong>
 
-									<CancelPurchaseProductInformation
-											purchase={ purchase }
-											selectedSite={ this.props.selectedSite } />
-								</div>
+								<CancelPurchaseProductInformation
+									purchase={ purchase }
+									selectedSite={ this.props.selectedSite } />
+							</div>
 
-								<hr />
+							<hr />
 
-								<div className="cancel-purchase__section">
-									<strong className="cancel-purchase__section-header">{ this.translate( 'Do I get a refund?' ) }</strong>
+							<div className="cancel-purchase__section">
+								<strong className="cancel-purchase__section-header">{ this.translate( 'Do I get a refund?' ) }</strong>
 
-									<CancelPurchaseRefundInformation
-											purchase={ purchase } />
-								</div>
+								<CancelPurchaseRefundInformation
+									purchase={ purchase } />
 							</div>
 						</div>
-					</Card>
+					</div>
+				</Card>
 
-					<CompactCard className="cancel-purchase__footer">
-						<CancelPurchaseButton
-								purchase={ purchase } />
-					</CompactCard>
-				</Main>
+				<CompactCard className="cancel-purchase__footer">
+					<CancelPurchaseButton
+						purchase={ purchase } />
+				</CompactCard>
+			</Main>
 		);
 	}
 } );

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -110,7 +110,8 @@ const CancelPurchase = React.createClass( {
 
 				<CompactCard className="cancel-purchase__footer">
 					<CancelPurchaseButton
-						purchase={ purchase } />
+						purchase={ purchase }
+						selectedSite={ this.props.selectedSite } />
 				</CompactCard>
 			</Main>
 		);

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -23,7 +23,7 @@ const CancelPurchaseLoadingPlaceholder = React.createClass( {
 		return (
 			<LoadingPlaceholder
 				title={ titles.cancelPurchase }
-				path={ managePurchase( this.props.selectedSite.domain, this.props.purchaseId ) }>
+				path={ managePurchase( this.props.selectedSite.slug, this.props.purchaseId ) }>
 				<Card className="cancel-purchase-loading-placeholder__card">
 					<h2 className="loading-placeholder__content cancel-purchase-loading-placeholder__header" />
 					<div className="loading-placeholder__content cancel-purchase-loading-placeholder__subheader" />

--- a/client/me/purchases/cancel-purchase/product-information.jsx
+++ b/client/me/purchases/cancel-purchase/product-information.jsx
@@ -119,7 +119,7 @@ const CancelPurchaseProductInformation = React.createClass( {
 				} ) }
 				<br />
 
-				<a href={ domainManagementEdit( this.props.selectedSite.domain, domainName ) }>{ this.translate( 'Manage Domains' ) }</a>
+				<a href={ domainManagementEdit( this.props.selectedSite.slug, domainName ) }>{ this.translate( 'Manage Domains' ) }</a>
 			</p>
 		);
 	},

--- a/client/me/purchases/confirm-cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/loading-placeholder.jsx
@@ -23,7 +23,7 @@ const ConfirmCancelPurchaseLoadingPlaceholder = React.createClass( {
 		return (
 			<LoadingPlaceholder
 				title={ titles.confirmCancelPurchase }
-				path={ cancelPurchase( this.props.selectedSite.domain, this.props.purchaseId ) }>
+				path={ cancelPurchase( this.props.selectedSite.slug, this.props.purchaseId ) }>
 				<Card className="confirm-cancel-purchase-loading-placeholder__card">
 					<h2 className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__header" />
 					<div className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__subheader" />

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -215,7 +215,7 @@ const ManagePurchase = React.createClass( {
 			upgradesActions.addItem( redemptionItem );
 		}
 
-		page( '/checkout/' + this.props.selectedSite.domain );
+		page( '/checkout/' + this.props.selectedSite.slug );
 	},
 
 	renderPrice() {
@@ -254,7 +254,7 @@ const ManagePurchase = React.createClass( {
 		}
 
 		if ( isDomainProduct( purchase ) || isSiteRedirect( purchase ) ) {
-			url = domainManagementEdit( selectedSite.domain, purchase.meta );
+			url = domainManagementEdit( selectedSite.slug, purchase.meta );
 			text = this.translate( 'Domain Settings' );
 		}
 
@@ -414,7 +414,7 @@ const ManagePurchase = React.createClass( {
 
 		if ( isIncludedWithPlan( purchase ) ) {
 			const attachedPlanUrl = paths.managePurchase(
-				this.props.selectedSite.domain,
+				this.props.domain,
 				purchase.attachedToPurchaseId
 			);
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -404,17 +404,9 @@ const ManagePurchase = React.createClass( {
 	renderRenewsOrExpiresOn() {
 		const purchase = getPurchase( this.props );
 
-		if ( isRenewing( purchase ) ) {
-			return this.moment( purchase.renewDate ).format( 'LL' );
-		}
-
-		if ( isExpiring( purchase ) || isExpired( purchase ) || creditCardExpiresBeforeSubscription( purchase ) ) {
-			return this.moment( purchase.expiryDate ).format( 'LL' );
-		}
-
 		if ( isIncludedWithPlan( purchase ) ) {
 			const attachedPlanUrl = paths.managePurchase(
-				this.props.domain,
+				this.props.selectedSite.slug,
 				purchase.attachedToPurchaseId
 			);
 
@@ -426,6 +418,14 @@ const ManagePurchase = React.createClass( {
 					</a>
 				</span>
 			);
+		}
+
+		if ( isRenewing( purchase ) ) {
+			return this.moment( purchase.renewDate ).format( 'LL' );
+		}
+
+		if ( isExpiring( purchase ) || isExpired( purchase ) || creditCardExpiresBeforeSubscription( purchase ) ) {
+			return this.moment( purchase.expiryDate ).format( 'LL' );
 		}
 
 		if ( isOneTimePurchase( purchase ) ) {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -111,7 +111,7 @@ const ManagePurchase = React.createClass( {
 
 	renderCreditCardExpiringNotice() {
 		const purchase = getPurchase( this.props ),
-			{ domain, id, payment: { creditCard } } = purchase;
+			{ id, payment: { creditCard } } = purchase;
 
 		if ( isExpired( purchase ) || isOneTimePurchase( purchase ) || isIncludedWithPlan( purchase ) ) {
 			return null;
@@ -132,7 +132,7 @@ const ManagePurchase = React.createClass( {
 									cardExpiry: creditCard.expiryMoment.format( 'MMMM YYYY' )
 								},
 								components: {
-									a: <a href={ paths.editCardDetails( domain, id, creditCard.id ) } />
+									a: <a href={ paths.editCardDetails( this.props.selectedSite.slug, id, creditCard.id ) } />
 								}
 							}
 						)
@@ -341,11 +341,11 @@ const ManagePurchase = React.createClass( {
 			);
 		}
 
-		const { domain, id, payment: { creditCard } } = purchase;
+		const { id, payment: { creditCard } } = purchase;
 
 		return (
 			<li>
-				<a href={ paths.editCardDetails( domain, id, creditCard.id ) }>
+				<a href={ paths.editCardDetails( this.props.selectedSite.slug, id, creditCard.id ) }>
 					{ paymentDetails }
 				</a>
 			</li>
@@ -461,11 +461,11 @@ const ManagePurchase = React.createClass( {
 
 	renderEditPaymentMethodNavItem() {
 		const purchase = getPurchase( this.props ),
-			{ domain, id, payment } = purchase;
+			{ id, payment } = purchase;
 
 		if ( showEditPaymentDetails( purchase ) ) {
 			return (
-				<VerticalNavItem path={ paths.editCardDetails( domain, id, payment.creditCard.id ) }>
+				<VerticalNavItem path={ paths.editCardDetails( this.props.selectedSite.slug, id, payment.creditCard.id ) }>
 					{ this.translate( 'Edit Payment Method' ) }
 				</VerticalNavItem>
 			);
@@ -476,7 +476,7 @@ const ManagePurchase = React.createClass( {
 
 	renderCancelPurchaseNavItem() {
 		const purchase = getPurchase( this.props ),
-			{ domain, id } = purchase;
+			{ id } = purchase;
 
 		if ( ! isCancelable( purchase ) ) {
 			return null;
@@ -487,7 +487,7 @@ const ManagePurchase = React.createClass( {
 		};
 
 		return (
-			<VerticalNavItem path={ paths.cancelPurchase( domain, id ) }>
+			<VerticalNavItem path={ paths.cancelPurchase( this.props.selectedSite.slug, id ) }>
 				{
 					isRefundable( purchase )
 					? this.translate( 'Cancel and Refund %(purchaseName)s', translateArgs )
@@ -499,14 +499,14 @@ const ManagePurchase = React.createClass( {
 
 	renderCancelPrivateRegistration() {
 		const purchase = getPurchase( this.props ),
-			{ domain, id } = purchase;
+			{ id } = purchase;
 
 		if ( isExpired( purchase ) || ! hasPrivateRegistration( purchase ) ) {
 			return null;
 		}
 
 		return (
-			<VerticalNavItem path={ paths.cancelPrivateRegistration( domain, id ) }>
+			<VerticalNavItem path={ paths.cancelPrivateRegistration( this.props.selectedSite.slug, id ) }>
 				{ this.translate( 'Cancel Private Registration' ) }
 			</VerticalNavItem>
 		);

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -162,10 +162,9 @@ const EditCardDetails = React.createClass( {
 					persistent: true
 				} );
 
-				page( paths.managePurchase(
-					this.props.selectedSite.domain,
-					this.props.selectedPurchase.data.id
-				) );
+				const { domain, id } = getPurchase( this.props );
+
+				page( paths.managePurchase( domain, id ) );
 			} );
 		} );
 	},

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -162,9 +162,9 @@ const EditCardDetails = React.createClass( {
 					persistent: true
 				} );
 
-				const { domain, id } = getPurchase( this.props );
+				const { id } = getPurchase( this.props );
 
-				page( paths.managePurchase( domain, id ) );
+				page( paths.managePurchase( this.props.selectedSite.slug, id ) );
 			} );
 		} );
 	},

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -18,9 +18,10 @@ function getSelectedSite( props ) {
 }
 
 function goToCancelPurchase( props ) {
-	const { domain, id } = getPurchase( props );
+	const { id } = getPurchase( props ),
+		{ slug } = props.selectedSite;
 
-	page( paths.cancelPurchase( domain, id ) );
+	page( paths.cancelPurchase( slug, id ) );
 }
 
 function goToList() {
@@ -28,15 +29,17 @@ function goToList() {
 }
 
 function goToEditCardDetails( props ) {
-	const { domain, id, payment: { creditCard } } = getPurchase( props );
+	const { id, payment: { creditCard } } = getPurchase( props ),
+		{ slug } = props.selectedSite;
 
-	page( paths.editCardDetails( domain, id, creditCard.id ) );
+	page( paths.editCardDetails( slug, id, creditCard.id ) );
 }
 
 function goToManagePurchase( props ) {
-	const { domain, id } = getPurchase( props );
+	const { id } = getPurchase( props ),
+		{ slug } = props.selectedSite;
 
-	page( paths.managePurchase( domain, id ) );
+	page( paths.managePurchase( slug, id ) );
 }
 
 function isDataLoading( props ) {

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -19,7 +19,7 @@ function getSelectedSite( props ) {
 
 function goToCancelPurchase( props ) {
 	const { id } = getPurchase( props ),
-		{ slug } = props.selectedSite;
+		{ slug } = getSelectedSite( props );
 
 	page( paths.cancelPurchase( slug, id ) );
 }
@@ -30,14 +30,14 @@ function goToList() {
 
 function goToEditCardDetails( props ) {
 	const { id, payment: { creditCard } } = getPurchase( props ),
-		{ slug } = props.selectedSite;
+		{ slug } = getSelectedSite( props );
 
 	page( paths.editCardDetails( slug, id, creditCard.id ) );
 }
 
 function goToManagePurchase( props ) {
 	const { id } = getPurchase( props ),
-		{ slug } = props.selectedSite;
+		{ slug } = getSelectedSite( props );
 
 	page( paths.managePurchase( slug, id ) );
 }


### PR DESCRIPTION
This PR addresses [comment](https://github.com/Automattic/wp-calypso/pull/1036/files#r46307589) from @drewblaisdell:
> We should always be using whatever `SitesList` set to `slug` here, which is usually the domain, but switches to a `[site].wordpress.com` if there are conflicts.

It also tries to use the same style of invoking `managePurchase` url helper where possible.

### Testing
This PR affects the links on every page under `/purchases`, including the following components:

`CancelPrivateRegistration`
`CancelPurchase`
`CancelPurchaseLoadingPlaceholder`
`CancelPurchaseProductInformation`
`ConfirmCancelPurchase`
`ManagePurchase`
`EditCardDetails`

We can test this by asserting that the links from every page under `/purchases` to another page in `/purchases` are not broken, and use the site slug (either `foobar.wordpress.com` or `foobar.com`, depending on if the site has a primary domain or if there are namespace conflicts) in the URL for each link.

### Review
* [x] QA review
* [x] Code review