### PR TITLE
Purchases: Perform redirect when user can't access Cancel Purchase page

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -26,12 +26,6 @@ const CancelPurchase = React.createClass( {
 		selectedSite: React.PropTypes.object.isRequired
 	},
 
-	getInitialState() {
-		return {
-			isRedirecting: false
-		};
-	},
-
 	componentWillMount() {
 		if ( this.isDataValid( this.props ) ) {
 			recordPageView( 'cancel_purchase', this.props );
@@ -43,7 +37,8 @@ const CancelPurchase = React.createClass( {
 	componentWillReceiveProps( nextProps ) {
 		if ( this.isDataValid( nextProps ) ) {
 			recordPageView( 'cancel_purchase', this.props, nextProps );
-		} else {
+		} else if ( this.isDataValid( this.props ) && ! this.isDataValid( nextProps ) ) {
+			// only redirect for invalid data once
 			this.redirect( nextProps );
 		}
 	},
@@ -56,10 +51,6 @@ const CancelPurchase = React.createClass( {
 	},
 
 	redirect( props ) {
-		if ( this.state.isRedirecting ) {
-			return;
-		}
-
 		const purchase = getPurchase( props ),
 			selectedSite = getSelectedSite( props );
 		let redirectPath = paths.list();
@@ -68,14 +59,11 @@ const CancelPurchase = React.createClass( {
 			redirectPath = paths.managePurchase( selectedSite.slug, purchase.id );
 		}
 
-		this.setState( {
-			isRedirecting: true
-		} );
 		page.redirect( redirectPath );
 	},
 
 	render() {
-		if ( this.state.isRedirecting ) {
+		if ( ! this.isDataValid( this.props ) ) {
 			return null;
 		}
 

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -13,6 +13,10 @@ function getPurchase( props ) {
 	return props.selectedPurchase.data;
 }
 
+function getSelectedSite( props ) {
+	return props.selectedSite;
+}
+
 function goToCancelPurchase( props ) {
 	const { domain, id } = getPurchase( props );
 
@@ -56,10 +60,11 @@ function recordPageView( trackingSlug, props, nextProps = null ) {
 }
 
 export {
-	goToCancelPurchase,
 	getPurchase,
-	goToList,
+	getSelectedSite,
+	goToCancelPurchase,
 	goToEditCardDetails,
+	goToList,
 	goToManagePurchase,
 	isDataLoading,
 	recordPageView


### PR DESCRIPTION
Part of #275. This should fix also issue from #1025 for Cancel Purchase page only.

Whenever user tries to access Cancel Purchase page for the purchase that has been removed from the account we should redirect to the purchases list.
Whenever user tries to access Cancel Purchase page for the purchase that can't be cancelled we should redirect to the Manage Purchase page.

### Testing.
1. Go to http://calypso.localhost:3000/purchases.
2. Select purchase that can't be cancelled.
3. When `Manage Purchase` page is loaded append `/cancel` to the url.
4. You should get redirected back to the Manage Purchase page. 
5. Repeat (3), but this time also change purchase id in the url to some random value.
6. You should get redirected to the page with purchases list.

/cc @stephanethomas 

### Review
* [x] QA review
* [x] Code review
