### PR TITLE
Reader: Fixes the issue with text going underneath the help icon

### DIFF
--- a/client/reader/post-excerpt-link/style.scss
+++ b/client/reader/post-excerpt-link/style.scss
@@ -1,7 +1,7 @@
 .post-excerpt-link {
 	background: $gray-light;
 	color: darken( $gray, 20 );
-	padding: 16px 32px 16px 24px;
+	padding: 16px 48px 16px 24px;
 	margin: 20px -24px 8px -24px;
 	position: relative;
 
@@ -9,7 +9,6 @@
 		margin-left: -16px;
 		margin-right: -16px;
 		padding-left: 16px;
-		padding-right: 24px;
 	}
 
 	.gridicon {


### PR DESCRIPTION
Adds more padding from the right side so the text will not go
underneath the help icon.

Fixes #950
Fixes #709 

Replaces #1103 