### PR TITLE
Signup: Verticals Survey: Use appropriate 'blog'/'site' in survey language

### DIFF
--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -65,10 +65,12 @@ export default React.createClass( {
 				</div>
 			);
 		}
+		const blogLabel = this.translate( 'What is your blog about?' );
+		const siteLabel = this.translate( 'What is your website about?' );
 		return (
 			<div>
 				<CompactCard className="survey-step__title">
-					<label className="survey-step__label">{ this.translate( 'What is your website about?' ) }</label>
+					<label className="survey-step__label">{ this.props.surveySiteType === 'blog' ? blogLabel : siteLabel }</label>
 				</CompactCard>
 				{ this.state.verticalList.map( this.renderStepOneVertical ) }
 			</div>
@@ -76,13 +78,15 @@ export default React.createClass( {
 	},
 
 	render() {
+		const blogHeaderText = this.translate( 'Create your blog today!' );
+		const siteHeaderText = this.translate( 'Create your site today!' );
 		return (
 			<div className="survey-step__section-wrapper">
 				<StepWrapper
 					flowName={ this.props.flowName }
 					stepName={ this.props.stepName }
 					positionInFlow={ this.props.positionInFlow }
-					headerText={ this.translate( 'Create your site today!' ) }
+					headerText={ this.props.surveySiteType === 'blog' ? blogHeaderText : siteHeaderText }
 					subHeaderText={ this.translate( 'WordPress.com is the best place for your WordPress blog or website.' ) }
 					signupProgressStore={ this.props.signupProgressStore }
 					stepContent={ this.renderOptionList() } />


### PR DESCRIPTION
There are two versions of the Verticals Survey step in signup (if the user is in that test). Previously both "blog" and "site" versions had the same language in the header:

<img width="561" alt="screen shot 2015-12-01 at 4 02 25 pm" src="https://cloud.githubusercontent.com/assets/2036909/11514154/104fd894-9845-11e5-84e8-2a81d32ff68b.png">

With this PR the "blog" version has its own language:

<img width="554" alt="screen shot 2015-12-01 at 4 02 38 pm" src="https://cloud.githubusercontent.com/assets/2036909/11514198/1d2fca74-9845-11e5-9303-a1278af09306.png">

## Testing

Validate the language is different at http://calypso.localhost:3000/start/vert-blog/ and http://calypso.localhost:3000/start/vert-site/