### PR TITLE
Pages: show scheduled pages and fix empty placeholders

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -18,7 +18,9 @@ var PageList = require( './page-list' ),
 	config = require( 'config' ),
 	notices = require( 'notices' );
 
-module.exports = React.createClass({
+const statuses = [ 'published', 'drafts', 'scheduled', 'trashed' ];
+
+module.exports = React.createClass( {
 
 	displayName: 'Pages',
 
@@ -49,57 +51,56 @@ module.exports = React.createClass({
 	},
 
 	render: function() {
-		var siteFilter = this.props.sites.selected ? '/' + this.props.sites.selected : '',
-			statusSlug = this.props.status,
-			searchPlaceholder, selectedText, filterStrings;
-
-		filterStrings = {
-			drafts: this.translate( 'Drafts', { context: 'Filter label for pages list' } ),
+		const status = this.props.status || 'published';
+		const filterStrings = {
 			published: this.translate( 'Published', { context: 'Filter label for pages list' } ),
-			trashed: this.translate( 'Trash', { context: 'Filter label for pages list' } ),
-			status: this.translate( 'Status' )
+			drafts: this.translate( 'Drafts', { context: 'Filter label for pages list' } ),
+			scheduled: this.translate( 'Scheduled', { context: 'Filter label for pages list' } ),
+			trashed: this.translate( 'Trash', { context: 'Filter label for pages list' } )
 		};
-
-
-
-		switch( statusSlug ) {
-			case 'drafts':
-				searchPlaceholder = this.translate( 'Search drafts…', { context: 'Search placeholder for pages list', textOnly: true } );
-				selectedText = filterStrings.drafts;
-				break;
-			case 'trashed':
-				searchPlaceholder = this.translate( 'Search trash…', { context: 'Search placeholder for pages list', textOnly: true } );
-				selectedText = filterStrings.trashed;
-				break;
-			default:
-				searchPlaceholder = this.translate( 'Search published…', { context: 'Search placeholder for pages list', textOnly: true } );
-				selectedText = filterStrings.published;
-				break;
-		}
-
+		const searchStrings = {
+			published: this.translate( 'Search published…', { context: 'Search placeholder for pages list', textOnly: true } ),
+			drafts: this.translate( 'Search drafts…', { context: 'Search placeholder for pages list', textOnly: true } ),
+			scheduled: this.translate( 'Search scheduled…', { context: 'Search placeholder for pages list', textOnly: true } ),
+			trashed: this.translate( 'Search trash…', { context: 'Search placeholder for pages list', textOnly: true } )
+		};
 		return (
 			<div className="main main-column pages" role="main">
 				<SidebarNavigation />
-
-				<SectionNav selectedText={ selectedText }>
-					<NavTabs label={ filterStrings.status }>
-						<NavItem path={ '/pages' + siteFilter } selected={ ! statusSlug }>{ filterStrings.published }</NavItem>
-						<NavItem path={ '/pages/drafts' + siteFilter } selected={ statusSlug === 'drafts' } >{ filterStrings.drafts }</NavItem>
-						<NavItem path={ '/pages/trashed' + siteFilter } selected={ statusSlug === 'trashed' } >{ filterStrings.trashed }</NavItem>
+				<SectionNav selectedText={ filterStrings[ status ] }>
+					<NavTabs label={ this.translate( 'Status', { context: 'Filter page group label for tabs' } ) }>
+						{ this.getNavItems( filterStrings, status ) }
 					</NavTabs>
 					<Search
 						pinned={ true }
 						onSearch={ this.doSearch }
 						initialValue={ this.props.search }
-						placeholder={ searchPlaceholder }
+						placeholder={ searchStrings[ status ] }
 						analyticsGroup="Pages"
 						delaySearch={ true }
 					/>
 				</SectionNav>
-
 				<PageList { ...this.props } />
 			</div>
 		);
+	},
+
+	getNavItems( filterStrings, currentStatus ) {
+		const siteFilter = this.props.sites.selected ? '/' + this.props.sites.selected : '';
+		return statuses.map( function( status ) {
+			let path = `/pages${ siteFilter }`;
+			if ( status !== 'publish' ) {
+				path = `/pages/${ status }${ siteFilter }`;
+			}
+			return (
+				<NavItem
+					path={ path }
+					selected={ currentStatus === status }
+					key={ `page-filter-${ status }` }>
+					{ filterStrings[ status ] }
+				</NavItem>
+			);
+		} );
 	},
 
 	_setWarning( selectedSite ) {
@@ -110,4 +111,4 @@ module.exports = React.createClass({
 			);
 		}
 	}
-});
+} );

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -26,7 +26,6 @@ var PageList = React.createClass( {
 		context: React.PropTypes.object,
 		search: React.PropTypes.string,
 		sites: React.PropTypes.object,
-		statusSlug: React.PropTypes.string,
 		siteID: React.PropTypes.any
 	},
 
@@ -60,7 +59,6 @@ var Pages = React.createClass({
 		search: React.PropTypes.string,
 		siteID: React.PropTypes.any,
 		sites: React.PropTypes.object.isRequired,
-		statusSlug: React.PropTypes.string,
 		trackScrollPage: React.PropTypes.func.isRequired
 	},
 
@@ -137,10 +135,19 @@ var Pages = React.createClass({
 				newPageLink = selectedSite ? '//wordpress.com/page/' + selectedSite.ID + '/new' : '//wordpress.com/page';
 			}
 
-			switch( this.props.statusSlug ) {
+			const status = this.props.status || 'published';
+			switch ( status ) {
 				case 'drafts':
 					attributes = {
 						title: this.translate( 'You don\'t have any drafts.' ),
+						line: this.translate( 'Would you like to create one?' ),
+						action: this.translate( 'Start a Page' ),
+						actionURL: newPageLink
+					};
+					break;
+				case 'scheduled':
+					attributes = {
+						title: this.translate( 'You don\'t have any scheduled pages yet.' ),
 						line: this.translate( 'Would you like to create one?' ),
 						action: this.translate( 'Start a Page' ),
 						actionURL: newPageLink


### PR DESCRIPTION
Fixes #452, to display scheduled pages.

## Testing Instructions:
1. Navigate to http://calypso.localhost:3000/page
2. Add some content to the page editor
3. Schedule the page to be published in the future by clicking on the calendar icon, selecting a future date, and clicking 'Schedule'
4. Navigate to http://calypso.localhost:3000/pages
5. Scheduled tab should be visible
6. Clicking on the Scheduled tab should display your scheduled pages 

Before:
<img width="775" alt="screen shot 2015-12-01 at 11 31 59 am" src="https://cloud.githubusercontent.com/assets/1270189/11514361/e8a1798c-982c-11e5-9e87-a0dd243f27a5.png">

After:
<img width="796" alt="screen shot 2015-12-01 at 12 44 24 pm" src="https://cloud.githubusercontent.com/assets/1270189/11514369/f36668be-982c-11e5-8fea-31a7a563bb31.png">
<img width="775" alt="screen shot 2015-12-01 at 12 44 44 pm" src="https://cloud.githubusercontent.com/assets/1270189/11514370/f3681e98-982c-11e5-9fe9-aea980f98a31.png">

cc @alisterscott @rralian 