### PR TITLE
Reader: Fix positioning of update notice on mobile

### DIFF
--- a/client/reader/update-notice/_style.scss
+++ b/client/reader/update-notice/_style.scss
@@ -3,6 +3,7 @@
 .reader-update-notice {
 	position: fixed;
 		top: ( 47px + 8px );
+		right: 8px;
 	background: rgba( $orange-jazzy, 0.96 );
 	padding: 6px 18px 6px 34px;
 	border-radius: 24px;
@@ -17,10 +18,6 @@
 
 	@include breakpoint( ">480px" ) {
 		right: 16px;
-	}
-
-	@include breakpoint( "<480px" ) {
-		right: 8px;
 	}
 
 	&:hover {

--- a/client/reader/update-notice/_style.scss
+++ b/client/reader/update-notice/_style.scss
@@ -2,8 +2,7 @@
 // Slides in when there are new posts available
 .reader-update-notice {
 	position: fixed;
-		top: 16px;
-		right: 16px;
+		top: ( 47px + 8px );
 	background: rgba( $orange-jazzy, 0.96 );
 	padding: 6px 18px 6px 34px;
 	border-radius: 24px;
@@ -16,8 +15,12 @@
 	pointer-events: none;
 	transition: background 0.15s ease-in-out, transform 0.20s cubic-bezier( 0.175, 0.885, 0.320, 1.275 );
 
-	@include breakpoint( ">660px" ) {
-		top: ( 47px + 8px ); // Make way for the sticky Masterbar
+	@include breakpoint( ">480px" ) {
+		right: 16px;
+	}
+
+	@include breakpoint( "<480px" ) {
+		right: 8px;
 	}
 
 	&:hover {
@@ -29,6 +32,10 @@
 		transform: translateY( 0 );
 		pointer-events: auto;
 		cursor: pointer;
+
+		&.is-at-top {
+			transform: translateY( -46px );
+		}
 	}
 }
 

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -10,7 +10,8 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var titleActions = require( 'lib/screen-title/actions' ),
-	Gridicon = require( 'components/gridicon' );
+	Gridicon = require( 'components/gridicon' ),
+	viewport = require( 'lib/viewport' );
 
 var UpdateNotice = React.createClass( {
 	mixins: [ PureRenderMixin ],
@@ -24,8 +25,20 @@ var UpdateNotice = React.createClass( {
 		return { onClick: noop };
 	},
 
+	getInitialState: function() {
+		return {
+			isAtTop: false
+		}
+	},
+
 	componentDidMount: function() {
 		this.setCount();
+		this.threshold = React.findDOMNode( this ).offsetTop;
+		window.addEventListener( 'scroll', this.onWindowScroll );
+	},
+
+	componentWillUnmount: function() {
+		window.removeEventListener( 'scroll', this.onWindowScroll );
 	},
 
 	componentDidUpdate: function() {
@@ -40,10 +53,17 @@ var UpdateNotice = React.createClass( {
 		return this.props.count >= 40 ? '40+' : ( '' + this.props.count );
 	},
 
+	onWindowScroll: function() {
+		if ( viewport.isMobile() ) {
+			return this.setState( { isAtTop: window.pageYOffset > this.threshold } );
+		}
+	},
+
 	render: function() {
 		var counterClasses = classnames( {
 			'reader-update-notice': true,
-			'is-active': this.props.count > 0
+			'is-active': this.props.count > 0,
+			'is-at-top': this.state.isAtTop
 		} );
 
 		return (


### PR DESCRIPTION
In `master` the update notice is shown _under_ the Masterbar on mobile:

![02b37064-9670-11e5-89a6-2cc891225505](https://cloud.githubusercontent.com/assets/191598/11515526/6bd5fe4e-984c-11e5-9933-68264e68f8d6.PNG)

This branch fixes this by checking the scroll position of the window. So on page load, the notice shows below the Masterbar:

![screen shot 2015-12-01 at 4 55 31 pm](https://cloud.githubusercontent.com/assets/191598/11515557/8b40271e-984c-11e5-9740-41b563a256d5.png)

As you scroll, it transitions to the top of the viewport:

![screen shot 2015-12-01 at 4 55 49 pm](https://cloud.githubusercontent.com/assets/191598/11515571/934fcb9e-984c-11e5-8cb2-dee7952f5e32.png)

You can force the update notice to display by tricking Reader with the following code changes:

1) Replace line 66 of `client/lib/feed-stream-store/feed-stream.js` with `interval: 10,`
2) Add `params.before = "2015-11-01T00:00:00";` below line 25 in `client/lib/feed-stream-store/actions.js`

Fixes #947