### PR TITLE
Domain Search: Update Google Apps tracking to use generic path string

### DIFF
--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -115,8 +115,7 @@ module.exports = {
 
 	googleAppsWithRegistration: function( context ) {
 		var CartData = require( 'components/data/cart' ),
-			GoogleApps = require( 'components/upgrades/google-apps' ),
-			basePath = route.sectionify( context.path );
+			GoogleApps = require( 'components/upgrades/google-apps' );
 
 		titleActions.setTitle(
 			i18n.translate( 'Register %(domain)s', {
@@ -140,7 +139,7 @@ module.exports = {
 			page( '/checkout/' + sites.getSelectedSite().slug );
 		};
 
-		analytics.pageView.record( basePath, 'Domain Search > Domain Registration > Google Apps' );
+		analytics.pageView.record( '/domains/add/:site/google-apps', 'Domain Search > Domain Registration > Google Apps' );
 
 		ReactDom.render(
 			(


### PR DESCRIPTION
We are currently passing the full URL in the page view tracking for Google Apps:

`Record event "calypso_page_view" called with props {"path":"/domains/add/sometestdomainexample.com/google-apps"}`

This PR removes the dynamic domain name from the path so we can properly segment this step in funnels:

`Record event "calypso_page_view" called with props {"path":"/domains/add/google-apps"}`