### PR TITLE
Site settings: only update clean fields with updated poll data

### DIFF
--- a/client/lib/mixins/dirty-linked-state/Makefile
+++ b/client/lib/mixins/dirty-linked-state/Makefile
@@ -1,0 +1,13 @@
+UI ?= bdd
+REPORTER ?= spec
+COMPILERS ?= js:babel/register
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
+
+# In order to simply stub modules, add test to the NODE_PATH
+test:
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers $(COMPILERS) --reporter $(REPORTER) --ui $(UI)
+
+.PHONY: test

--- a/client/lib/mixins/dirty-linked-state/README.md
+++ b/client/lib/mixins/dirty-linked-state/README.md
@@ -1,0 +1,46 @@
+Dirty Linked State
+============
+This mixin works like [React Linked State Mixin](https://facebook.github.io/react/docs/two-way-binding-helpers.html), 
+but also updates a dirtyFields array on the state object. This array lets us know if any fields have been
+modified by the user. This is useful when we don't want to wipe out user changes on polling updates. 
+See `client/my-sites/site-settings/form-base.js` for an example of this in action.
+
+Usage
+-----
+
+Enable this per component by adding it to its `mixins`:
+
+```
+import dirtyLinkedState from ("lib/mixins/dirty-linked-state");
+app.TodoItem = React.createClass( {
+    mixins: [ dirtyLinkedState ],
+    render() {
+      return ( 
+      	<input type="text" valueLink={ this.linkState( 'blogname' ) } />
+      	<input type="text" valueLink={ this.linkState( 'blogdescription' ) } /> 
+      );
+    }
+```
+
+Example
+-----
+Before the user types in the field the state object might look like:
+
+```
+{ 
+	blogname: 'default title',
+	blogdescription: 'default description'
+}
+```
+
+After typing:
+
+```
+{
+	blogname: 'new title',
+	blogdescription: 'default description',
+	dirtyFields[ 'blogname' ]
+}
+```
+
+

--- a/client/lib/mixins/dirty-linked-state/index.js
+++ b/client/lib/mixins/dirty-linked-state/index.js
@@ -1,0 +1,16 @@
+export default {
+	linkState( key ) {
+		let link = {};
+		link.value = this.state[ key ];
+		link.requestChange = ( newValue ) => {
+			let newState = {};
+			newState[ key ] = newValue;
+			const dirtyFields = this.state.dirtyFields || [];
+			if ( dirtyFields.indexOf( key ) === -1 ) {
+				newState.dirtyFields = [ ...dirtyFields, key ];
+			}
+			this.setState( newState );
+		};
+		return link;
+	}
+}

--- a/client/lib/mixins/dirty-linked-state/test/test.js
+++ b/client/lib/mixins/dirty-linked-state/test/test.js
@@ -1,0 +1,77 @@
+require( 'lib/react-test-env-setup' )();
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import React from 'react/addons';
+
+/**
+ * Internal dependencies
+ */
+import dirtyLinkedState from 'lib/mixins/dirty-linked-state';
+
+describe( 'Dirty Linked State Mixin', function() {
+	const TestUtils = React.addons.TestUtils;
+	const DirtyLinkedForm = React.createClass( {
+		mixins: [ dirtyLinkedState ],
+		getInitialState() {
+			return {
+				foo: 'default foo',
+				bar: 'default bar'
+			};
+		},
+		render() {
+			return (
+				<form>
+					<input type="text" className='foo' valueLink={ this.linkState( 'foo' ) } />
+					<input type="text" className='bar' valueLink={ this.linkState( 'bar' ) } />
+				</form>
+			);
+		}
+	} );
+	var form, fooInput, barInput;
+	beforeEach( function() {
+		form = React.render( <DirtyLinkedForm />, document.body );
+		fooInput = React.findDOMNode( form ).querySelector( '.foo' );
+		barInput = React.findDOMNode( form ).querySelector( '.bar' );
+	} );
+
+	afterEach( function() {
+		React.unmountComponentAtNode( document.body );
+	} );
+
+	it( 'initially has default state', function( ) {
+		expect( form.state ).to.deep.equal( { foo: 'default foo', bar: 'default bar' } );
+	} );
+
+	it( 'adds a modified field to dirtyFields', function() {
+		TestUtils.Simulate.change( fooInput, { target: { value: 'new value' } } );
+		expect( form.state ).to.deep.equal( {
+			foo: 'new value',
+			bar: 'default bar',
+			dirtyFields: [ 'foo' ]
+		} );
+	} );
+
+	it( 'when a field is modified multiple times, the dirty field is only added once', function() {
+		TestUtils.Simulate.change( fooInput, { target: { value: 'new value' } } );
+		TestUtils.Simulate.change( fooInput, { target: { value: 'updated value' } } );
+		expect( form.state ).to.deep.equal( {
+			foo: 'updated value',
+			bar: 'default bar',
+			dirtyFields: [ 'foo' ]
+		} );
+	} );
+
+	it( 'can have multiple dirty fields', function() {
+		TestUtils.Simulate.change( fooInput, { target: { value: 'new value' } } );
+		TestUtils.Simulate.change( fooInput, { target: { value: 'updated value' } } );
+		TestUtils.Simulate.change( barInput, { target: { value: 'so many bars' } } );
+		expect( form.state ).to.deep.equal( {
+			foo: 'updated value',
+			bar: 'so many bars',
+			dirtyFields: [ 'foo', 'bar' ]
+		} );
+	} );
+} );

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -8,13 +8,14 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var formBase = require( './form-base' ),
-	protectForm = require( 'lib/mixins/protect-form' );
+	protectForm = require( 'lib/mixins/protect-form' ),
+	dirtyLinkedState = require( 'lib/mixins/dirty-linked-state' );
 
 module.exports = React.createClass( {
 
 	displayName: 'SiteSettingsFormDiscussion',
 
-	mixins: [ React.addons.LinkedStateMixin, protectForm.mixin, formBase ],
+	mixins: [ dirtyLinkedState, protectForm.mixin, formBase ],
 
 	discussionAttributes: [
 		'default_pingback_flag',

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -16,13 +16,14 @@ var Card = require( 'components/card' ),
 	config = require( 'config' ),
 	protectForm = require( 'lib/mixins/protect-form' ),
 	notices = require( 'notices' ),
-	analytics = require( 'analytics' );
+	analytics = require( 'analytics' ),
+	dirtyLinkedState = require( 'lib/mixins/dirty-linked-state' );
 
 module.exports = React.createClass( {
 
 	displayName: 'SiteSettingsFormGeneral',
 
-	mixins: [ React.addons.LinkedStateMixin, protectForm.mixin, formBase ],
+	mixins: [ dirtyLinkedState, protectForm.mixin, formBase ],
 
 	getSettingsFromSite: function( site ) {
 		var settings;

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -16,14 +16,14 @@ var config = require( 'config' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	formBase = require( './form-base' ),
 	SettingsCardFooter = require( './settings-card-footer' ),
-	notices = require( 'notices' );
-
+	notices = require( 'notices' ),
+	dirtyLinkedState = require( 'lib/mixins/dirty-linked-state' );
 
 module.exports = React.createClass( {
 
 	displayName: 'SiteSettingsFormJetpackMonitor',
 
-	mixins: [ React.addons.LinkedStateMixin, protectForm.mixin, formBase ],
+	mixins: [ dirtyLinkedState, protectForm.mixin, formBase ],
 
 	getSettingsFromSite: function( site ) {
 		var settings = {};

--- a/client/my-sites/site-settings/form-jetpack-protect.jsx
+++ b/client/my-sites/site-settings/form-jetpack-protect.jsx
@@ -16,13 +16,14 @@ var formBase = require( './form-base' ),
 	FormLegend = require( 'components/forms/form-legend' ),
 	FormTextarea = require( 'components/forms/form-textarea' ),
 	FormButton = require( 'components/forms/form-button' ),
-	SettingsCardFooter = require( './settings-card-footer' );
+	SettingsCardFooter = require( './settings-card-footer' ),
+	dirtyLinkedState = require( 'lib/mixins/dirty-linked-state' );
 
 module.exports = React.createClass( {
 
 	displayName: 'SiteSettingsFormJetpackProtect',
 
-	mixins: [ React.addons.LinkedStateMixin, protectForm.mixin, formBase ],
+	mixins: [ dirtyLinkedState, protectForm.mixin, formBase ],
 
 	getSettingsFromSite: function( site ) {
 		var settings = {};

--- a/client/my-sites/site-settings/form-jetpack-scan.jsx
+++ b/client/my-sites/site-settings/form-jetpack-scan.jsx
@@ -20,13 +20,14 @@ var formBase = require( 'my-sites/site-settings/form-base' ),
 	SettingsCardFooter = require( 'my-sites/site-settings/settings-card-footer' ),
 	ProgressIndicator = require( 'components/progress-indicator' ),
 	FormInputValidation = require( 'components/forms/form-input-validation' ),
-	notices = require( 'notices' );
+	notices = require( 'notices' ),
+	dirtyLinkedState = require( 'lib/mixins/dirty-linked-state' );
 
 module.exports = React.createClass( {
 
 	displayName: 'SiteSettingsFormJetpackScan',
 
-	mixins: [ React.addons.LinkedStateMixin, protectForm.mixin, formBase ],
+	mixins: [ dirtyLinkedState, protectForm.mixin, formBase ],
 
 	settingsTimer: false,
 

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -9,13 +9,14 @@ var React = require( 'react' );
 var formBase = require( './form-base' ),
 	protectForm = require( 'lib/mixins/protect-form' ),
 	config = require( 'config' ),
-	PressThisLink = require( './press-this-link' );
+	PressThisLink = require( './press-this-link' ),
+	dirtyLinkedState = require( 'lib/mixins/dirty-linked-state' );
 
 module.exports = React.createClass( {
 
 	displayName: 'SiteSettingsFormWriting',
 
-	mixins: [ React.addons.LinkedStateMixin, protectForm.mixin, formBase ],
+	mixins: [ dirtyLinkedState, protectForm.mixin, formBase ],
 
 	getSettingsFromSite: function( site ) {
 		var writingAttributes = [


### PR DESCRIPTION
Fixes #43 #40 and #42 where unsaved changes to site settings could be wiped out on rerender. This is triggered by SitesList polling periodically via the /me/sites endpoint. Note that this affects all settings, not just the site tagline.

## Testing Instructions
1. Navigate to: http://calypso.localhost:3000/settings/
2. Select a site when prompted
3. Update some site settings
4. Wait around 30 seconds for SitesList to update

Expected: Your unsaved changes are still there.

cc @hoverduck @rralian 
