### PR TITLE
Documentation: Fix line alignment in style.scss

### DIFF
--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -38,8 +38,8 @@
 @import 'sections/domain-search';              // Domain Search styles
 @import 'sections/menus';                      // menus page styles
 @import 'sections/keyboard-shortcuts';         // keyboard shortcuts menu
-@import 'sections/plugins';
-@import 'sections/translator';
+@import 'sections/plugins';                    // manage plugins for Jetpack sites
+@import 'sections/translator';                 // community translator
 @import 'sections/devdocs';                    // developer documentation at /devdocs
 @import 'sections/nux-welcome';                // persistent welcome for new users
 

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -1,47 +1,47 @@
 // Shared
-@import 'shared/reset';                  				// css reset before the rest of the styles are defined
-@import 'shared/functions';              				// functions that we've used from Compass, ported over
-@import 'shared/colors';                 				// import all of our wpcom colors
-@import 'shared/utilities';              				// Helper classes
-@import 'shared/typography';             				// all the typographic rules, variables, etc.
-@import 'shared/mixins/mixins';                 				// sass mixins for gradients, bordius radii, etc.
-@import 'shared/extends';                				// sass extends for commonly used styles
-@import 'shared/animation';              				// all UI animation
-@import 'shared/forms';                  				// form styling
-@import 'shared/dropdowns';              				// dropdown styling
-@import 'shared/toolbar-bulk';           				// The toolbar used for bulk actions including bulk selecting and deselecting
-@import 'shared/livechat';               				// styles for the popup livechat box
-@import 'shared/welcome';                				// welcome messages
-@import 'shared/infinite-scroll-end';    				// Last page marker once infinite scroll has reached end
+@import 'shared/reset';                        // css reset before the rest of the styles are defined
+@import 'shared/functions';                    // functions that we've used from Compass, ported over
+@import 'shared/colors';                       // import all of our wpcom colors
+@import 'shared/utilities';                    // Helper classes
+@import 'shared/typography';                   // all the typographic rules, variables, etc.
+@import 'shared/mixins/mixins';                // sass mixins for gradients, bordius radii, etc.
+@import 'shared/extends';                      // sass extends for commonly used styles
+@import 'shared/animation';                    // all UI animation
+@import 'shared/forms';                        // form styling
+@import 'shared/dropdowns';                    // dropdown styling
+@import 'shared/toolbar-bulk';                 // The toolbar used for bulk actions including bulk selecting and deselecting
+@import 'shared/livechat';                     // styles for the popup livechat box
+@import 'shared/welcome';                      // welcome messages
+@import 'shared/infinite-scroll-end';          // Last page marker once infinite scroll has reached end
 
 // Layouts
-@import 'layout/main';                   				// global layout and responsive styles
-@import 'layout/masterbar';              				// masterbar styles
-@import 'layout/sidebar';                				// sidebar styles, shared across most pages
-@import 'layout/overlay';                				// overlay UX styling
-@import 'layout/detail-page';             				// detail page styles
+@import 'layout/main';                         // global layout and responsive styles
+@import 'layout/masterbar';                    // masterbar styles
+@import 'layout/sidebar';                      // sidebar styles, shared across most pages
+@import 'layout/overlay';                      // overlay UX styling
+@import 'layout/detail-page';                  // detail page styles
 
 // Sections
-@import 'sections/sites';                				// sites section styles
-@import 'sections/manage';               				// manage section styles
-@import 'sections/posts';                				// posts section styles
-@import 'sections/updated-confirmation'; 				// confirmation boxes for posts/pages
-@import 'sections/posts-controls';       				// posts controls styles
-@import 'sections/post-relative-time-status';   // post relative time styles
-@import 'sections/stats';                				// stats page styles
-@import 'sections/upgrades';             				// upgrades page styles
-@import 'sections/sharing';              				// sharing page styles
-@import 'sections/site-settings';        				// blog setting styles
-@import 'sections/notifications';        				// notifications styles
-@import 'sections/checkout';             				// Checkout styles
-@import 'sections/billing-history';      				// Billing History styles
-@import 'sections/domain-search';        				// Domain Search styles
-@import 'sections/menus';                				// menus page styles
-@import 'sections/keyboard-shortcuts';   				// keyboard shortcuts menu
+@import 'sections/sites';                      // sites section styles
+@import 'sections/manage';                     // manage section styles
+@import 'sections/posts';                      // posts section styles
+@import 'sections/updated-confirmation';       // confirmation boxes for posts/pages
+@import 'sections/posts-controls';             // posts controls styles
+@import 'sections/post-relative-time-status';  // post relative time styles
+@import 'sections/stats';                      // stats page styles
+@import 'sections/upgrades';                   // upgrades page styles
+@import 'sections/sharing';                    // sharing page styles
+@import 'sections/site-settings';              // blog setting styles
+@import 'sections/notifications';              // notifications styles
+@import 'sections/checkout';                   // Checkout styles
+@import 'sections/billing-history';            // Billing History styles
+@import 'sections/domain-search';              // Domain Search styles
+@import 'sections/menus';                      // menus page styles
+@import 'sections/keyboard-shortcuts';         // keyboard shortcuts menu
 @import 'sections/plugins';
 @import 'sections/translator';
-@import 'sections/devdocs';              				// developer documentation at /devdocs
-@import 'sections/nux-welcome';                         // persistent welcome for new users
+@import 'sections/devdocs';                    // developer documentation at /devdocs
+@import 'sections/nux-welcome';                // persistent welcome for new users
 
 // Components
 @import 'components';


### PR DESCRIPTION
Thanks to @HugoGiraudel (#570) and @jonathanp (#580) for independently noticing and submitting fixes towards this.  We should only use spaces in the middle of lines for alignment, this way the document will appear correctly at all editor tab sizes.

Also from our [JavaScript guidelines](https://github.com/Automattic/wp-calypso/blob/1c4d008/docs/coding-guidelines/javascript.md):

> Spaces may align code within documentation blocks or within a line, but only tabs should be used at the start of a line