### PR TITLE
Invites: Fixes issues with auto-filling email

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -44,21 +44,28 @@ export default React.createClass( {
 
 	displayName: 'SignupForm',
 
-	fieldNames: [ 'email', 'username', 'password' ],
-
 	getInitialState() {
 		return {
 			notice: null,
 			submitting: false,
 			form: null,
-			signedUp: false
+			signedUp: false,
+			validationInitialized: false
 		}
+	},
+
+	getInitialFields() {
+		return {
+			email: this.props.email || null,
+			username: null,
+			password: null
+		};
 	},
 
 	componentWillMount() {
 		debug( 'Mounting the SignupForm React component.' );
 		this.formStateController = new formState.Controller( {
-			fieldNames: this.fieldNames,
+			initialFields: this.getInitialFields(),
 			sanitizerFunction: this.sanitize,
 			validatorFunction: this.validate,
 			onNewState: this.setFormState,
@@ -68,6 +75,13 @@ export default React.createClass( {
 			initialState: this.props.step ? this.props.step.form : undefined
 		} );
 		this.setState( { form: this.formStateController.getInitialState() } );
+	},
+
+	componentDidMount() {
+		// If we initialized the form with an email, we need to validate the email
+		if ( this.props.email ) {
+			this.handleBlur();
+		}
 	},
 
 	sanitizeEmail( email ) {
@@ -146,6 +160,9 @@ export default React.createClass( {
 			}
 
 			onComplete( error, messages );
+			if ( ! this.state.validationInitialized ) {
+				this.setState( { validationInitialized: true } );
+			}
 		} );
 	},
 
@@ -267,9 +284,9 @@ export default React.createClass( {
 						id="email"
 						name="email"
 						type="email"
-						value={ formState.getFieldValue( this.state.form, 'email' ) || this.props.email }
+						value={ formState.getFieldValue( this.state.form, 'email' ) }
 						isError={ formState.isFieldInvalid( this.state.form, 'email' ) }
-						isValid={ formState.isFieldValid( this.state.form, 'email' ) }
+						isValid={ this.state.validationInitialized && formState.isFieldValid( this.state.form, 'email' ) }
 						onBlur={ this.handleBlur }
 						onChange={ this.handleChangeEvent } />
 				</ValidationFieldset>

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -276,7 +276,7 @@ export default React.createClass( {
 				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'email' ) }>
 					<FormLabel htmlFor="email">{ this.translate( 'Your email address' ) }</FormLabel>
 					<FormTextInput
-						autoFocus={ true }
+						autoFocus={ ! this.props.email }
 						autoCapitalize="off"
 						autoCorrect="off"
 						className="signup-form__input"
@@ -294,6 +294,7 @@ export default React.createClass( {
 				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'username' ) }>
 					<FormLabel htmlFor="username">{ this.translate( 'Choose a username' ) }</FormLabel>
 					<FormTextInput
+						autoFocus={ ! ! this.props.email }
 						autoCapitalize="off"
 						autoCorrect="off"
 						className="signup-form__input"


### PR DESCRIPTION
Fixes #1143 and #1144 

This PR fixes a couple of issues with our auto filling of the email input by properly initializing the email value for the form.

To test:
- Checkout `fix/logged-out-prefill-email`

__Accept Invite__
- Create an invite at `$site/wp-admin/users.php?page=wpcom-invite-users`
- In the invite email, make note of the invitation key
- While logged out, go to `/accept-invite/$site/$invite_key`
- An email should be populated. If so, the email should be validated shortly after loading
- Now test that you can remove the email by backspacing all characters. If you're able to empty the input, then :+1: 
- Lastly, can you successfully create a user and accept the invite?

__Signup Framework__
- Go to `/start/account/user`
- Attempt to create a new user
- Do form fields properly validate? Are you able to successfully create a user?

cc @lezama and @scruffian for review