### PR TITLE
Invites: Fixes typo in invites list reducer

### DIFF
--- a/client/lib/invites/reducers/invites-list.js
+++ b/client/lib/invites/reducers/invites-list.js
@@ -24,7 +24,7 @@ const reducer = ( state = initialState, payload ) => {
 	const { action } = payload;
 	switch ( action.type ) {
 		case ActionTypes.FETCH_INVITES:
-			return state.setIn( [ 'fetchingInvites', actions.siteId ], true );
+			return state.setIn( [ 'fetchingInvites', action.siteId ], true );
 		case ActionTypes.RECEIVE_INVITES:
 			return state
 				.setIn( [ 'fetchingInvites', action.siteId ], false )


### PR DESCRIPTION
While working on another issue, I noticed that there was a typo in the invites reducer. This PR fixes that.

To test:
- Checkout `fix/invites-undefined` branch
- `cd client/lib/invites && make test`
- Send an invitation to yourself at `$site/wp-admin/users.php?page=wpcom-invite-users`
- In the invitation email, get the invitation key
- Test that fetching an invitation still works properly by going to `/accept-invite/$site/$invitation_key`

Note: We currently do not have test coverage for the `fetchingInvites` part of the reducer. We should consider getting more test coverage in this store. That being said, I lean towards addressing that in a separate issue.

cc @lezama for review