### PR TITLE
Framework: update wpcom.me

### DIFF
--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -25,10 +25,6 @@ function UndocumentedMe( wpcom ) {
  */
 inherits( UndocumentedMe, Me );
 
-UndocumentedMe.prototype.billingHistory = function( callback ) {
-	return this.wpcom.req.get( '/me/billing-history', callback );
-};
-
 UndocumentedMe.prototype.billingHistoryEmailReceipt = function( receiptId, callback ) {
 	var args = {
 		path: '/me/billing-history/receipt/' + receiptId + '/email'


### PR DESCRIPTION
Review and merge first #1141 

* Remove `billinHistory()` method since it's already implemented in `wpcom-unpublished`
* ~~Remove `settings()` since this name is used in `wpcom-unpublished`.~~
* ~~Update how to use `wpcom.me.settings()` method.~~

### Testing
Me#billingHistory() method is called when the user goes to `http://calypso.localhost:3000/me/billing`. You can test if the data is rightly gotten from the request on this page. Also maybe you can take a look in the `Network` tab of Developer Tools filtering by `billing-history`.

![image](https://cloud.githubusercontent.com/assets/77539/13111471/ba8f896a-d564-11e5-98cc-09449aa75067.png)


