### PR TITLE
Purchases: Don't show a link to edit payment details if there is no credit card data

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -8,7 +8,6 @@ import merge from 'lodash/object/merge';
  * Internal dependencies
  */
 import i18n from 'lib/mixins/i18n';
-import { isPaidWithCreditCard } from 'lib/purchases';
 import sortProducts from 'lib/products-values/sort';
 
 function createPurchaseObject( purchase ) {
@@ -57,7 +56,7 @@ function createPurchaseObject( purchase ) {
 		userId: Number( purchase.user_id )
 	};
 
-	if ( isPaidWithCreditCard( object ) ) {
+	if ( 'credit_card' === purchase.payment_type ) {
 		return merge( {}, object, {
 			payment: {
 				creditCard: {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -158,7 +158,7 @@ function isRenewing( purchase ) {
 }
 
 function isPaidWithCreditCard( purchase ) {
-	return 'credit_card' === purchase.payment.type;
+	return 'credit_card' === purchase.payment.type && hasCreditCardData( purchase );
 }
 
 function hasCreditCardData( purchase ) {


### PR DESCRIPTION
In some circumstances a user might have paid by credit card, but not saved the credit card with us. In this case we shouldn't show the user a link to edit their payment details.