### PR TITLE
Business Plugins: Adds a feature example to the empty content view

### DIFF
--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -69,15 +69,12 @@ module.exports = React.createClass( {
 		if ( this.actionCallbacks[ this.props.template ] ) {
 			settings.actionCallback = this[ this.actionCallbacks[ this.props.template ] ];
 		}
+		settings.featureExample = this.props.featureExample;
 		const emptyContent = React.createElement( EmptyContent, settings );
-		const featureExample = this.props.featureExample
-			? <FeatureExample>{ this.props.featureExample }</FeatureExample>
-			: null;
 
 		return (
 			<div>
 				{ emptyContent }
-				{ featureExample }
 			</div>
 		)
 	}

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -69,12 +69,15 @@ module.exports = React.createClass( {
 		if ( this.actionCallbacks[ this.props.template ] ) {
 			settings.actionCallback = this[ this.actionCallbacks[ this.props.template ] ];
 		}
-		settings.featureExample = this.props.featureExample;
 		const emptyContent = React.createElement( EmptyContent, settings );
+		const featureExample = this.props.featureExample
+			? <FeatureExample>{ this.props.featureExample }</FeatureExample>
+			: null;
 
 		return (
 			<div>
 				{ emptyContent }
+				{ featureExample }
 			</div>
 		)
 	}

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -1,22 +1,24 @@
 /**
  * External Dependencies
  */
-var React = require( 'react' );
+import React from 'react'
 
 /**
  * Internal Dependencies
  */
- var PluginItem = require( 'my-sites/plugins/plugin-item/plugin-item' ),
-	sites = require( 'lib/sites-list' )(),
-	i18n = require( 'lib/mixins/i18n' ),
-	config = require( 'config' ),
-	analytics = require( 'analytics' ),
-	isBusiness = require( 'lib/products-values' ).isBusiness,
-	notices = require( 'notices' ),
-	abtest = require( 'lib/abtest' ).abtest;
+import PluginItem from 'my-sites/plugins/plugin-item/plugin-item'
+import sitesList from 'lib/sites-list'
+import i18n from 'lib/mixins/i18n'
+import config from 'config'
+import analytics from 'analytics'
+import { isBusiness } from 'lib/products-values'
+import notices from 'notices'
+import { abtest } from 'lib/abtest'
 
-function hasErrorCondition( site, type ) {
-	var errorConditions = {
+let sites = sitesList();
+
+const hasErrorCondition = ( site, type ) => {
+	const errorConditions = {
 		noBusinessPlan: site && ! site.jetpack && ! isBusiness( site.plan ),
 		notMinimumJetpackVersion: site && ! site.hasMinimumJetpackVersion && site.jetpack,
 		notRightsToManagePlugins: sites.initialized && ! sites.canManageSelectedOrAll()
@@ -24,7 +26,7 @@ function hasErrorCondition( site, type ) {
 	return errorConditions[ type ];
 }
 
-function getMockBusinessPluginItems() {
+const getMockBusinessPluginItems = () => {
 	const plugins = [ {
 		slug: 'ecwid',
 		name: 'Ecwid',
@@ -39,7 +41,7 @@ function getMockBusinessPluginItems() {
 		slug: 'shopify',
 		name: 'Shopify',
 		wpcom: true,
-		icon: '/calypso/images/upgrades/plugins/gumroad.png'
+		icon: '/calypso/images/upgrades/plugins/shopify-store.png'
 	} ];
 	const selectedSite = {
 		slug: 'no-slug',
@@ -59,8 +61,8 @@ function getMockBusinessPluginItems() {
 	} );
 }
 
-function hasRestrictedAccess( site ) {
-	var pluginPageError;
+const hasRestrictedAccess = ( site ) => {
+	let pluginPageError;
 
 	site = site || sites.getSelectedSite();
 
@@ -95,7 +97,7 @@ function hasRestrictedAccess( site ) {
 			action: i18n.translate( 'Upgrade Now' ),
 			actionURL: '/plans/' + site.slug,
 			illustration: '/calypso/images/drake/drake-whoops.svg',
-			actionCallback: function() {
+			actionCallback: () => {
 				analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'business_plugins' } );
 			},
 			featureExample: getMockBusinessPluginItems()
@@ -105,4 +107,4 @@ function hasRestrictedAccess( site ) {
 	return pluginPageError;
 }
 
-module.exports = { hasRestrictedAccess: hasRestrictedAccess };
+export default { hasRestrictedAccess };

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -1,7 +1,13 @@
 /**
+ * External Dependencies
+ */
+var React = require( 'react' );
+
+/**
  * Internal Dependencies
  */
-var sites = require( 'lib/sites-list' )(),
+ var PluginItem = require( 'my-sites/plugins/plugin-item/plugin-item' ),
+	sites = require( 'lib/sites-list' )(),
 	i18n = require( 'lib/mixins/i18n' ),
 	config = require( 'config' ),
 	analytics = require( 'analytics' ),
@@ -16,6 +22,41 @@ function hasErrorCondition( site, type ) {
 		notRightsToManagePlugins: sites.initialized && ! sites.canManageSelectedOrAll()
 	};
 	return errorConditions[ type ];
+}
+
+function getMockBusinessPluginItems() {
+	const plugins = [ {
+		slug: 'ecwid',
+		name: 'Ecwid',
+		wpcom: true,
+		icon: '/calypso/images/upgrades/plugins/ecwid.png'
+	}, {
+		slug: 'gumroad',
+		name: 'Gumroad',
+		wpcom: true,
+		icon: '/calypso/images/upgrades/plugins/gumroad.png'
+	}, {
+		slug: 'shopify',
+		name: 'Shopify',
+		wpcom: true,
+		icon: '/calypso/images/upgrades/plugins/gumroad.png'
+	} ];
+	const selectedSite = {
+		slug: 'no-slug',
+		canUpdateFiles: true,
+		name: 'Not a real site'
+	}
+
+	return plugins.map( plugin => {
+		return React.createElement( PluginItem, {
+			key: 'plugin-item-mock-' + plugin.slug,
+			plugin: plugin,
+			sites: [],
+			selectedSite: selectedSite,
+			progress: [],
+			isMock: true }
+		);
+	} );
 }
 
 function hasRestrictedAccess( site ) {
@@ -56,7 +97,8 @@ function hasRestrictedAccess( site ) {
 			illustration: '/calypso/images/drake/drake-whoops.svg',
 			actionCallback: function() {
 				analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'business_plugins' } );
-			}
+			},
+			featureExample: getMockBusinessPluginItems()
 		};
 	}
 

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -40,6 +40,7 @@ import PluginsDataStore from 'lib/plugins/wporg-data/store'
 import PluginNotices from 'lib/plugins/notices'
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page'
 import PlanNudge from 'components/plans/plan-nudge'
+import FeatureExample from 'components/feature-example'
 
 /**
  * Module variables
@@ -703,6 +704,7 @@ export default React.createClass( {
 			return (
 				<Main>
 					<EmptyContent { ...this.state.accessError } />
+					{ this.state.accessError.featureExample ? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample> : null }
 				</Main>
 			);
 		}

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -92,6 +92,7 @@
 	font-size: 14px;
 	font-weight: 600;
 	white-space: pre;
+	text-align: left;
 	text-overflow: ellipsis;
 	overflow: hidden;
 
@@ -140,6 +141,7 @@
 	font-size: 11px;
 	color: $gray;
 	white-space: pre;
+	text-align: left;
 	text-overflow: ellipsis;
 	overflow: hidden;
 

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -29,6 +29,7 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginSections from 'my-sites/plugins/plugin-sections';
 import pluginsAccessControl from 'my-sites/plugins/access-control';
 import EmptyContent from 'components/empty-content';
+import FeatureExample from 'components/feature-example'
 
 /**
  * Module variables
@@ -286,7 +287,12 @@ export default React.createClass( {
 		}
 
 		if ( this.state.accessError ) {
-			return <MainComponent><EmptyContent { ...this.state.accessError } /></MainComponent>;
+			return (
+				<MainComponent>
+					<EmptyContent { ...this.state.accessError } />
+					{ this.state.accessError.featureExample ? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample> : null }
+				</MainComponent>
+			);
 		}
 
 		if ( this.state.isFetching ) {

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -17,7 +17,7 @@ export default React.createClass( {
 
 	_DEFAULT_PLACEHOLDER_NUMBER: 6,
 
-	getPluginsViewList() {
+	renderPluginsViewList() {
 		let emptyCounter = 0;
 
 		let pluginsViewsList = this.props.plugins.map( ( plugin, n ) => {
@@ -25,7 +25,7 @@ export default React.createClass( {
 		} );
 
 		if ( this.props.showPlaceholders ) {
-			pluginsViewsList = pluginsViewsList.concat( this.getPlaceholdersViews() );
+			pluginsViewsList = pluginsViewsList.concat( this.renderPlaceholdersViews() );
 		}
 
 		// We need to complete the list with empty elements to keep the grid drawn.
@@ -40,21 +40,21 @@ export default React.createClass( {
 		return pluginsViewsList;
 	},
 
-	getPlaceholdersViews() {
+	renderPlaceholdersViews() {
 		return Array.apply( null, Array( this.props.size || this._DEFAULT_PLACEHOLDER_NUMBER ) ).map( ( item, i ) => {
 			return <PluginBrowserItem isPlaceholder key={ 'placeholder-plugin-' + i } />;
 		} );
 	},
 
-	getViews() {
+	renderViews() {
 		if ( this.props.plugins.length ) {
-			return this.getPluginsViewList();
+			return this.renderPluginsViewList();
 		} else if ( this.props.showPlaceholders ) {
-			return this.getPlaceholdersViews();
+			return this.renderPlaceholdersViews();
 		}
 	},
 
-	getLink() {
+	renderLink() {
 		if ( this.props.expandedListLink ) {
 			return <a className="button is-link plugins-browser-list__select-all" href={ this.props.expandedListLink + ( this.props.site || '' ) }>
 				{ this.translate( 'See All' ) }
@@ -67,10 +67,10 @@ export default React.createClass( {
 		return (
 			<div className="plugins-browser-list">
 				<SectionHeader label={ this.props.title }>
-					{ this.getLink() }
+					{ this.renderLink() }
 				</SectionHeader>
 				<Card className="plugins-browser-list__elements">
-					{ this.getViews() }
+					{ this.renderViews() }
 				</Card>
 			</div>
 		);

--- a/shared/components/empty-content/README.md
+++ b/shared/components/empty-content/README.md
@@ -43,7 +43,6 @@ render: function() {
 * <strong>actionURL</strong> — (optional) `href` value for the primary action button.
 * <strong>actionCallback</strong> — (optional) `onClick` value for the primary action button.
 * <strong>actionTarget</strong> - (optional) If ommitted, no target attribute is specified.
-* <strong>featureExample</strong> - (optional) If you initialize the component with this property, containing jsx, it will be added in the bottom of the Empty Content component as an example of what the user could be viewing if there were any content.
 
 The component also supports a secondary action. This should be used sparingly.
 

--- a/shared/components/empty-content/README.md
+++ b/shared/components/empty-content/README.md
@@ -31,7 +31,6 @@ render: function() {
 	);
 }
 
-
 ```
 
 ## Properties
@@ -44,6 +43,7 @@ render: function() {
 * <strong>actionURL</strong> — (optional) `href` value for the primary action button.
 * <strong>actionCallback</strong> — (optional) `onClick` value for the primary action button.
 * <strong>actionTarget</strong> - (optional) If ommitted, no target attribute is specified.
+* <strong>featureExample</strong> - (optional) If you initialize the component with this property, containing jsx, it will be added in the bottom of the Empty Content component as an example of what the user could be viewing if there were any content.
 
 The component also supports a secondary action. This should be used sparingly.
 

--- a/shared/components/empty-content/empty-content.jsx
+++ b/shared/components/empty-content/empty-content.jsx
@@ -5,11 +5,6 @@ var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:components:emptyContent' ),
 	classNames = require( 'classnames' );
 
-/**
- * Internal dependencies
- */
-var FeatureExample = require( 'components/feature-example' );
-
 module.exports = React.createClass( {
 
 	displayName: 'EmptyContent',
@@ -32,8 +27,7 @@ module.exports = React.createClass( {
 		secondaryActionURL: React.PropTypes.string,
 		secondaryActionCallback: React.PropTypes.func,
 		className: React.PropTypes.string,
-		isCompact: React.PropTypes.bool,
-		featureExample: React.PropTypes.element
+		isCompact: React.PropTypes.bool
 	},
 
 	componentDidMount: function() {
@@ -87,7 +81,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var action, secondaryAction, illustration, featureExample;
+		var action, secondaryAction, illustration;
 
 		if ( this.props.action ) {
 			action = this.primaryAction();
@@ -99,10 +93,6 @@ module.exports = React.createClass( {
 
 		if ( this.props.illustration ) {
 			illustration = <img src={ this.props.illustration } width={ this.props.illustrationWidth } className="empty-content__illustration" />;
-		}
-
-		if ( this.props.featureExample ) {
-			featureExample = <FeatureExample>{ this.props.featureExample }</FeatureExample>;
 		}
 
 		return (
@@ -124,8 +114,6 @@ module.exports = React.createClass( {
 				{ action }
 
 				{ secondaryAction }
-
-				{ featureExample }
 			</div>
 		);
 	}

--- a/shared/components/empty-content/empty-content.jsx
+++ b/shared/components/empty-content/empty-content.jsx
@@ -5,6 +5,11 @@ var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:components:emptyContent' ),
 	classNames = require( 'classnames' );
 
+/**
+ * Internal dependencies
+ */
+var FeatureExample = require( 'components/feature-example' );
+
 module.exports = React.createClass( {
 
 	displayName: 'EmptyContent',
@@ -27,7 +32,8 @@ module.exports = React.createClass( {
 		secondaryActionURL: React.PropTypes.string,
 		secondaryActionCallback: React.PropTypes.func,
 		className: React.PropTypes.string,
-		isCompact: React.PropTypes.bool
+		isCompact: React.PropTypes.bool,
+		featureExample: React.PropTypes.element
 	},
 
 	componentDidMount: function() {
@@ -81,7 +87,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var action, secondaryAction, illustration;
+		var action, secondaryAction, illustration, featureExample;
 
 		if ( this.props.action ) {
 			action = this.primaryAction();
@@ -95,25 +101,31 @@ module.exports = React.createClass( {
 			illustration = <img src={ this.props.illustration } width={ this.props.illustrationWidth } className="empty-content__illustration" />;
 		}
 
+		if ( this.props.featureExample ) {
+			featureExample = <FeatureExample>{ this.props.featureExample }</FeatureExample>;
+		}
+
 		return (
 			<div className={ classNames( 'empty-content', this.props.className, { 'is-compact': this.props.isCompact } ) }>
 				{ illustration }
 
 				{
-					this.props.title ?
-					<h2 className="empty-content__title">{ this.props.title }</h2> :
-					null
+					this.props.title
+					? <h2 className="empty-content__title">{ this.props.title }</h2>
+					: null
 				}
 
 				{
-					this.props.line ?
-					<h3 className="empty-content__line">{ this.props.line }</h3> :
-					null
+					this.props.line
+					? <h3 className="empty-content__line">{ this.props.line }</h3>
+					: null
 				}
 
 				{ action }
 
 				{ secondaryAction }
+
+				{ featureExample }
 			</div>
 		);
 	}


### PR DESCRIPTION
This PR adds a feature gate to the non-business sites plugins error view. 

Before:
![image](https://cloud.githubusercontent.com/assets/1554855/11531831/0eab2b04-9900-11e5-9621-16a70d13c705.png)

After:
![image](https://cloud.githubusercontent.com/assets/1554855/11531848/250df214-9900-11e5-9da1-c15d77d6f2dd.png)

Also, adds the `featureExample` prop to `EmptyContent` (and for plugins feature gate, changes render responsability from `JetpackManageError` to there) 

How to test
=========
1. Go to https://wpcalypso.wordpress.com/plugins
2. Change to a .com site without a business plan
3. You should see the 'Want to add a store to your site?' screen, with a feature example with the business plugins on the bottom

ping @drewblaisdell  @alternatekev & @enejb 