### PR TITLE
People: Invites: Redirect and display notice on invite dismiss

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -40,7 +40,7 @@ export default React.createClass( {
 						}
 					</div>
 					<div className="invite-accept-logged-in__button-bar">
-						<Button href={ window.location.origin + '?invite_declined' }>
+						<Button onClick={ this.props.decline }>
 							{ this.translate( 'Decline', { context: 'button' } ) }
 						</Button>
 						<Button primary onClick={ () => acceptInvite( this.props.invite ) } href={ this.props.redirectTo } >

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -11,33 +11,30 @@ import Card from 'components/card';
 import Gravatar from 'components/gravatar';
 import Button from 'components/button';
 import config from 'config';
-import userModule from 'lib/user';
 import InviteFormHeader from 'my-sites/invites/invite-form-header';
 import { acceptInvite } from 'lib/invites/actions';
-
-const user = userModule();
 
 export default React.createClass( {
 
 	displayName: 'InviteAcceptLoggedIn',
 
 	render() {
-		let userObject = user.get(),
+		const { user } = this.props,
 			signInLink = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
 
 		return (
 			<div className={ classNames( 'logged-in-accept', this.props.className ) } >
 				<Card>
-					<InviteFormHeader { ...this.props } user={ user.get() } />
+					<InviteFormHeader { ...this.props } />
 					<div className="invite-accept-logged-in__join-as">
-						<Gravatar user={ userObject } size={ 72 } />
+						<Gravatar user={ user } size={ 72 } />
 						{
 							this.translate( 'Join as {{usernameWrap}}%(username)s{{/usernameWrap}}', {
 								components: {
 									usernameWrap: <span className="invite-accept-logged-in__join-as-username" />
 								},
 								args: {
-									username: userObject && userObject.display_name
+									username: user && user.display_name
 								}
 							} )
 						}

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -55,7 +55,7 @@ export default React.createClass( {
 			<WpcomLoginForm
 				log={ userData.username }
 				authorization={ 'Bearer ' + bearerToken }
-				redirectTo={ this.props.redirectTo }
+				redirectTo={ window.location.origin + this.props.redirectTo + '?invite_accepted=' + this.props.invite.blog_id }
 			/>
 		)
 	},

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -20,7 +20,7 @@ import EmptyContent from 'components/empty-content';
  * Module variables
  */
 const debug = new Debug( 'calypso:invite-accept' );
-const user = userModule();
+const user = userModule().get();
 
 export default React.createClass( {
 
@@ -81,9 +81,9 @@ export default React.createClass( {
 			return null;
 		}
 		debug( 'Rendering invite' );
-		return user.get()
-			? <LoggedIn { ...this.state.invite } redirectTo={ this.getRedirectTo() } />
 			: <LoggedOut { ...this.state.invite } redirectTo={ this.getRedirectTo() } />;
+		return user
+			? <LoggedIn { ...this.state.invite } user={ user } />
 	},
 
 	renderError() {

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import Debug from 'debug';
 import classNames from 'classnames';
+import page from 'page';
 
 /**
  * Internal Dependencies
@@ -12,7 +13,7 @@ import InviteHeader from 'my-sites/invites/invite-header';
 import LoggedIn from 'my-sites/invites/invite-accept-logged-in';
 import LoggedOut from 'my-sites/invites/invite-accept-logged-out';
 import userModule from 'lib/user';
-import { fetchInvite } from 'lib/invites/actions';
+import { fetchInvite, displayInviteDeclined } from 'lib/invites/actions';
 import InvitesStore from 'lib/invites/stores/invites-validation';
 import EmptyContent from 'components/empty-content';
 
@@ -62,17 +63,21 @@ export default React.createClass( {
 		);
 	},
 
-	getRedirectTo() {
+	getRedirectAfterAccept() {
 		const { invite } = this.state.invite;
-		let redirectTo = window.location.origin;
 		switch ( invite.meta.role ) {
 			case 'viewer':
 			case 'follower':
+				return '/';
 				break;
 			default:
-				redirectTo += '/posts/' + invite.blog_id;
+				return '/posts/' + invite.blog_id;
 		}
-		return redirectTo += '?invite_accepted=' + invite.blog_id;
+	},
+
+	decline() {
+		page( '/' );
+		displayInviteDeclined();
 	},
 
 	renderForm() {
@@ -81,9 +86,9 @@ export default React.createClass( {
 			return null;
 		}
 		debug( 'Rendering invite' );
-			: <LoggedOut { ...this.state.invite } redirectTo={ this.getRedirectTo() } />;
 		return user
-			? <LoggedIn { ...this.state.invite } user={ user } />
+			? <LoggedIn { ...this.state.invite } decline={ this.decline } user={ user } />
+			: <LoggedOut { ...this.state.invite } redirectTo={ this.getRedirectAfterAccept() } decline={ this.decline } />;
 	},
 
 	renderError() {

--- a/client/my-sites/invites/invite-message/index.jsx
+++ b/client/my-sites/invites/invite-message/index.jsx
@@ -53,7 +53,7 @@ export default React.createClass( {
 		}
 		if ( declined ) {
 			return (
-				<Notice status="is-success" onClick={ dismissInviteDeclined }>
+				<Notice status="is-info" onClick={ dismissInviteDeclined }>
 					<h3>
 						{ this.translate( 'You declined to join.' ) }
 					</h3>

--- a/client/my-sites/invites/invite-message/index.jsx
+++ b/client/my-sites/invites/invite-message/index.jsx
@@ -55,7 +55,7 @@ export default React.createClass( {
 			return (
 				<Notice status="is-success" onClick={ dismissInviteDeclined }>
 					<h3>
-						{ this.translate( 'You declined to join' ) }
+						{ this.translate( 'You declined to join.' ) }
 					</h3>
 				</Notice>
 			);


### PR DESCRIPTION
Fixes #1146

This PR displays a notice when declining and invite and redirects the user to the reader

![image](https://cloud.githubusercontent.com/assets/104869/11532563/56304d50-98e3-11e5-82cd-7028e52e6dd4.png)

__To test__
- Checkout `update/invites-redirect-and-notice-on-dismiss `

__Decline Invite__
- Create an invite at `$site/wp-admin/users.php?page=wpcom-invite-users`
- In the invite email, make note of the invitation key
- While logged in, go to `/accept-invite/$site/$invite_key`
- Dismiss the notice.
- Do you get redirected to the reader?
- Do you get the dismiss notice?


cc @ebinnion 