### PR TITLE
Signup: DSS: Only show previews when images are loaded

### DIFF
--- a/client/signup/steps/dss/screenshot.jsx
+++ b/client/signup/steps/dss/screenshot.jsx
@@ -33,7 +33,8 @@ export default React.createClass( {
 	propTypes: {
 		screenshotUrl: React.PropTypes.string.isRequired,
 		themeRepoSlug: React.PropTypes.string.isRequired,
-		themeSlug: React.PropTypes.string.isRequired
+		themeSlug: React.PropTypes.string.isRequired,
+		renderComplete: React.PropTypes.bool
 	},
 
 	getInitialState() {
@@ -41,7 +42,6 @@ export default React.createClass( {
 			isLoading: false,
 			markup: '',
 			styles: '',
-			renderComplete: false,
 			dssImage: null
 		};
 	},
@@ -76,23 +76,20 @@ export default React.createClass( {
 		const dssImage = imageResultsByKey[ lastKey ];
 		debug( 'replacing images in ' + this.props.themeRepoSlug + ' screenshot with', dssImage.url );
 		const { markup, styles } = this.getMarkupAndStyles();
-		// Give styles time to render. Note this only happens on first markup
-		// render. Subsequent changes don't flicker unstyled markup.
-		setTimeout( () => this.setState( { renderComplete: true } ), 250 );
 		return this.setState( { dssImage, markup, styles, isLoading } );
 	},
 
 	render() {
 		const containerClassNames = classnames( 'dss-screenshot', {
 			'is-loading': this.state.isLoading,
-			'is-preview-ready': this.state.markup && this.state.styles && this.state.renderComplete
+			'is-preview-ready': this.state.markup && this.state.styles && this.props.renderComplete
 		} );
 
 		if ( this.state.markup && this.state.styles ) {
 			return (
 				<div className={ containerClassNames }>
 					<div className="dss-screenshot__original">
-						<img src={ this.props.screenshotUrl } alt={ this.translate( 'Loading...' ) } />
+						<img src={ this.props.screenshotUrl } alt={ this.translate( 'Loading…' ) } />
 					</div>
 					<div className="dss-screenshot__dynamic">
 						<style dangerouslySetInnerHTML={{ __html: this.state.styles }} />
@@ -107,7 +104,7 @@ export default React.createClass( {
 		return (
 			<div className={ containerClassNames }>
 				<div className="dss-screenshot__original">
-					<img src={ this.props.screenshotUrl } alt={ this.translate( 'Loading...' ) } />
+					<img src={ this.props.screenshotUrl } alt={ this.translate( 'Loading…' ) } />
 				</div>
 			</div>
 		);

--- a/client/signup/steps/dss/style.scss
+++ b/client/signup/steps/dss/style.scss
@@ -143,3 +143,7 @@
 	padding: 0 20px;
 	text-align: center;
 }
+
+.dss-theme-selection__image-preloader {
+	display: none;
+}

--- a/client/signup/steps/dss/theme-thumbnail.jsx
+++ b/client/signup/steps/dss/theme-thumbnail.jsx
@@ -51,7 +51,9 @@ export default React.createClass( {
 				<Screenshot
 					themeSlug={ this.props.themeSlug }
 					themeRepoSlug={ this.props.themeRepoSlug }
-					screenshotUrl={ this.getThumbnailUrl() } />
+					screenshotUrl={ this.getThumbnailUrl() }
+					renderComplete={ this.props.renderComplete }
+				/>
 				<span className="dss-theme-thumbnail__name">{ this.props.themeName }</span>
 			</div>
 		);


### PR DESCRIPTION
Right now DSS images load slowly. We try to handle this by waiting ~250ms before showing the preview, but depending on the browser and the connection speed, that may not be enough. It would be nice to avoid this guessing game.

Part of fixing #1163 

Here we use a hidden `ImagePreloader` to load the image onto the page and track when it is complete. Once the image has been loaded by the browser, then we update the images in the previews.
## Testing

Load http://calypso.localhost:3000/start/dss/ and try searching for words. Make sure that the images load correctly and with very little or no flicker of unstyled previews (the amount of DOM changes still may cause a short flicker).
