### PR TITLE
Framework: ImagePreloader: Add onLoad prop for additional onload events

### DIFF
--- a/client/components/image-preloader/README.md
+++ b/client/components/image-preloader/README.md
@@ -39,3 +39,17 @@ A React element to render while the image `src` is being loaded.
 - __Required:__ No
 
 If a child is passed, it will be used as substitute content in the case that the image fails to load.
+
+### `onLoad`
+
+- __Type:__ function
+- __Required:__ No
+
+A custom function to call when the image loading is complete.
+
+### `onError`
+
+- __Type:__ function
+- __Required:__ No
+
+A custom function to call if the image loading fails.

--- a/client/components/image-preloader/index.jsx
+++ b/client/components/image-preloader/index.jsx
@@ -21,7 +21,9 @@ module.exports = React.createClass( {
 	propTypes: {
 		src: React.PropTypes.string.isRequired,
 		placeholder: React.PropTypes.element.isRequired,
-		children: React.PropTypes.node
+		children: React.PropTypes.node,
+		onLoad: React.PropTypes.func,
+		onError: React.PropTypes.func
 	},
 
 	getInitialState: function() {
@@ -72,8 +74,18 @@ module.exports = React.createClass( {
 	onLoadComplete: function( event ) {
 		this.destroyLoader();
 
-		this.setState( {
-			status: 'load' === event.type ? LoadStatus.LOADED : LoadStatus.FAILED
+		if ( event.type !== 'load' ) {
+			return this.setState( { status: LoadStatus.FAILED }, () => {
+				if ( this.props.onError ) {
+					this.props.onError( event );
+				}
+			} );
+		}
+
+		this.setState( { status: LoadStatus.LOADED }, () => {
+			if ( this.props.onLoad ) {
+				this.props.onLoad( event );
+			}
 		} );
 	},
 


### PR DESCRIPTION
Even though the `ImagePreloader` component docs read:

> All props will be transferred to the rendered `<img />` element, with the exception of `placeholder`.

that's not quite true, because the `onload` prop on the `img` is already being used by the component for its own purposes.

This PR adds `onLoad` and `onError` props that will be called after the `ImagePreloader` handler is complete, allowing any parent component to include a custom callback for when the image has completed loading.