### PR TITLE
Email Forwarding: Changed trash icon remove button to RemoveButton component

### DIFF
--- a/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-item.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import analyticsMixin from 'lib/mixins/analytics';
 import notices from 'notices';
 import * as upgradesActions from 'lib/upgrades/actions';
+import RemoveButton from "components/remove-button";
 
 const EmailForwardingItem = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'emailForwarding' ) ],
@@ -34,10 +35,11 @@ const EmailForwardingItem = React.createClass( {
 	render: function() {
 		return (
 			<li>
-				<button
+				<RemoveButton
+					icon="trash"
 					disabled={ this.props.emailData.temporary }
 					onClick={ this.deleteItem }
-					className="noticon noticon-trash button" />
+					/>
 				<span>{ this.translate( '{{strong1}}%(email)s{{/strong1}} {{em}}forwards to{{/em}} {{strong2}}%(forwardTo)s{{/strong2}}',
 					{
 						components: {

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -625,7 +625,7 @@ ul.email-forwarding__list {
 			}
 		}
 
-		.button {
+		.button-remove {
 			float: right;
 			margin-top: -2px;
 		}


### PR DESCRIPTION
Currently, the email forwarding interface looks like this:
<img width="751" alt="screen shot 2015-12-02 at 1 46 38 pm" src="https://cloud.githubusercontent.com/assets/1084656/11543656/26ca3900-98fb-11e5-9f0a-ee26db3d91f8.png">

That trash icon button is a little non-standard there so I went and used the first instance of the new RemoveButton component:

<img width="738" alt="screen shot 2015-12-02 at 1 47 40 pm" src="https://cloud.githubusercontent.com/assets/1084656/11543677/45f4baf8-98fb-11e5-8b1d-c9c063954798.png">

Is this super groundbreaking? Not really. It just takes a sort-of-weird button and starts to implement a new standard for removing list items from Calypso. The HTML for this used to be a regular `<button>` tag with classNames set for its appearance. Now it's using a standard component that will be implementable everywhere without setting classNames etc.

Pinging @mikeshelton1503 and @breezyskies for a design review.