### PR TITLE
Framework: Search: Add an optional delayTimeout prop for the debounce

### DIFF
--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -20,7 +20,10 @@ Use this to set the initial value of the field (_not the placeholder, which is d
 `/posts?s=keyword`
 
 ### delaySearch (optional) boolean ( default false )
-Use this prop to delay the `onSearch` callback until after the user has stopped typing. If `delaySearch` is false there is no delay between keyup and the `onSearch` callback. If the filtering is done asynchronously (i.e., via ajax request) `delaySearch` should be true to avoid a request on each keypress.
+Use this prop to delay the `onSearch` callback until after the user has stopped typing. If `delaySearch` is false there is no delay between keyup and the `onSearch` callback. If the filtering is done asynchronously (i.e., via ajax request) `delaySearch` should be true to avoid a request on each keypress. The default delay is 300ms but can be customized using `delayTimeout`.
+
+### delayTimeout (optional) number ( default 300 )
+If `delaySearch` is true, this prop can be used to control the number of milliseconds used to determine when the user has stopped typing. It's a good idea to leave this at its default value unless there's a specific reason to change the timeout (e.g., a very expensive search may benefit from a longer timeout).
 
 ### pinned (optional)
 Whether to display the search input from collapsed by default and pinned to the right of its container. If not set, the search input will show as already expanded.

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -28,6 +28,7 @@ module.exports = React.createClass( {
 		placeholder: React.PropTypes.string,
 		pinned: React.PropTypes.bool,
 		delaySearch: React.PropTypes.bool,
+		delayTimeout: React.PropTypes.number,
 		onSearch: React.PropTypes.func.isRequired,
 		onSearchChange: React.PropTypes.func,
 		onSearchClose: React.PropTypes.func,
@@ -50,6 +51,7 @@ module.exports = React.createClass( {
 		return {
 			pinned: false,
 			delaySearch: false,
+			delayTimeout: SEARCH_DEBOUNCE_MS,
 			autoFocus: false,
 			disabled: false,
 			onSearchChange: noop,
@@ -64,7 +66,7 @@ module.exports = React.createClass( {
 		this.id = _instance;
 		_instance++;
 		this.onSearch = this.props.delaySearch
-			? debounce( this.props.onSearch, SEARCH_DEBOUNCE_MS )
+			? debounce( this.props.onSearch, this.props.delayTimeout )
 			: this.props.onSearch;
 	},
 
@@ -74,7 +76,7 @@ module.exports = React.createClass( {
 			nextProps.delaySearch !== this.props.delaySearch
 		) {
 			this.onSearch = this.props.delaySearch
-				? debounce( this.props.onSearch, SEARCH_DEBOUNCE_MS )
+				? debounce( this.props.onSearch, this.props.delayTimeout )
 				: this.props.onSearch;
 		}
 	},


### PR DESCRIPTION
If the prop `delaySearch` is true, the default debounce timeout is 300ms. This PR adds a prop that can be used to control the number of milliseconds used to determine when the user has stopped typing. It's a good idea to leave this at its default value but there may be specific reasons to change the timeout (e.g., a very expensive search may benefit from a longer timeout).