### PR TITLE
Pages: Standardize Trash/Delete Pattern

### DIFF
--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -195,14 +195,14 @@ module.exports = React.createClass( {
 			return (
 				<PopoverMenuItem className="page__trash-item" onClick={ this.updateStatusTrash }>
 					<Gridicon icon="trash" size={ 18 } />
-					{ this.translate( 'Send to Trash' ) }
+					{ this.translate( 'Trash' ) }
 				</PopoverMenuItem>
 			);
 		} else {
 			return (
-				<PopoverMenuItem className="page__trash-item" onClick={ this.updateStatusDelete }>
+				<PopoverMenuItem className="page__delete-item" onClick={ this.updateStatusDelete }>
 					<Gridicon icon="trash" size={ 18 } />
-					{ this.translate( 'Delete permanently' ) }
+					{ this.translate( 'Delete' ) }
 				</PopoverMenuItem>
 			);
 		}

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -91,13 +91,13 @@
 	text-align: left;
 }
 
-.page__trash-item.popover__menu-item {
+.page__delete-item.popover__menu-item {
 	&:hover,
 	&:focus {
 		background-color: $alert-red;
 		border: 0;
 		box-shadow: none;
-		color: white;
+		color: $white;
 	}
 }
 
@@ -107,4 +107,3 @@
 		display: inline;
 	}
 }
-


### PR DESCRIPTION
Currently, deleting a page looks like this:

<img width="752" alt="screen shot 2015-12-02 at 2 10 14 pm" src="https://cloud.githubusercontent.com/assets/1084656/11544305/7111a428-98fe-11e5-8f53-d8b26a022a98.png">

which then requires you to go to the Trash section and do this:

<img width="793" alt="screen shot 2015-12-02 at 2 10 53 pm" src="https://cloud.githubusercontent.com/assets/1084656/11544320/84dc64fc-98fe-11e5-8378-03d151efd5b9.png">

Since we've decided to standardize on a few things that affect this, such as:
- Wording should be standard on "Trash" for items that get sent to the trash and "Delete" for items that will be deleted permanently
- Large red backgrounds should only be used for truly destructive acts, such as permanently deleting content

This led me to the following changes:
<img width="772" alt="screen shot 2015-12-02 at 2 12 30 pm" src="https://cloud.githubusercontent.com/assets/1084656/11544371/bef8057e-98fe-11e5-90f7-73097bea5380.png">

- Changed the wording to just "Trash" form "Send to Trash"
- Removed the custom red background coloring from this stage of the delete process as it's not destructive yet (just moving to the trash)

<img width="787" alt="screen shot 2015-12-02 at 2 13 40 pm" src="https://cloud.githubusercontent.com/assets/1084656/11544410/e954a28c-98fe-11e5-9173-fc2c4690d7ce.png">

- Kept the red scary coloring here
- Changed the wording to just "Delete" from "Delete permanently"