### PR TITLE
Reader: Fix full post view closing when any click on popover menu

### DIFF
--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -237,6 +237,10 @@ FullPostDialog = React.createClass( {
 		this.props.onClose( action );
 	},
 
+	handleClickOutside: function( event ) {
+		event.preventDefault();
+	},
+
 	render: function() {
 		var post = this.props.post,
 			site = this.props.site,
@@ -293,6 +297,7 @@ FullPostDialog = React.createClass( {
 				buttons={ buttons }
 				baseClassName="detail-page"
 				onClose={ this.handleClose }
+				onClickOutside= { this.handleClickOutside}
 				onClosed={ this.props.onClosed } >
 				<FullPostView
 					ref="fullPost"

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -39,11 +39,11 @@ module.exports = function() {
 		page.exit( '/read/blog/feed/:feed_id', controller.resetTitle );
 
 		page( '/read/post/feed/:feed/:post', setLastRoute, controller.feedPost );
-		page.exit( '/read/post/feed/:feed/:post', controller.resetTitle );
+		page.exit( '/read/post/feed/:feed/:post', controller.resetTitle, controller.removePost );
 
 		page( '/read/blog/id/:blog_id', saveLastRoute, controller.removePost, controller.sidebar, controller.blogListing );
 		page( '/read/post/id/:blog/:post', setLastRoute, controller.blogPost );
-		page.exit( '/read/post/id/:blog/:post', controller.resetTitle );
+		page.exit( '/read/post/id/:blog/:post', controller.resetTitle, controller.removePost );
 
 		page( '/tag/:tag', saveLastRoute, controller.removePost, controller.sidebar, controller.tagListing );
 	}


### PR DESCRIPTION
Full post view is wrapped by dialog and any click on popover menu
fires clickOutside event that closes the full post view. It's because
popover view is attached on body tag.

To fix it, prevent default action of click outside event for full post view.
https://github.com/Automattic/wp-calypso/issues/686