### PR TITLE
Site Settings: Adds holidaysnow to general site settings

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -113,20 +113,24 @@ module.exports = React.createClass( {
 		}
 
 		if ( config.isEnabled( 'upgrades/domain-search' ) ) {
-			customAddress = <a
-								href={ '/domains/add/' + site.slug  }
-								className="button"
-								onClick={ this.trackUpgradeClick }>{ this.translate( 'Add a custom address', { context: 'Site address, domain' } ) }
-							</a>;
+			customAddress = (
+				<a
+					href={ '/domains/add/' + site.slug }
+					className="button"
+					onClick={ this.trackUpgradeClick }
+				>
+					{ this.translate( 'Add a custom address', { context: 'Site address, domain' } ) }
+				</a>
+			);
 
 			addressDescription =
 				<p className="settings-explanation">
 					{
 						this.translate( 'Buy a {{domainSearchLink}}custom domain{{/domainSearchLink}}, {{mapDomainLink}}map{{/mapDomainLink}} a domain you already own, or {{redirectLink}}redirect{{/redirectLink}} this site.', {
 							components: {
-								domainSearchLink: <a href={ '/domains/add/' + site.slug  } onClick={ this.trackUpgradeClick } />,
-								mapDomainLink: <a href={ '/domains/add/mapping/' + site.slug  } onClick={ this.trackUpgradeClick } />,
-								redirectLink: <a href={ '/domains/add/site-redirect/' + site.slug  } onClick={ this.trackUpgradeClick } />
+								domainSearchLink: <a href={ '/domains/add/' + site.slug } onClick={ this.trackUpgradeClick } />,
+								mapDomainLink: <a href={ '/domains/add/mapping/' + site.slug } onClick={ this.trackUpgradeClick } />,
+								redirectLink: <a href={ '/domains/add/site-redirect/' + site.slug } onClick={ this.trackUpgradeClick } />
 							}
 						} )
 					}
@@ -237,7 +241,7 @@ module.exports = React.createClass( {
 					</p>
 				</label>
 
-				{ ! site.jetpack ?
+				{ ! site.jetpack &&
 					<label>
 						<input
 							type="radio"
@@ -250,14 +254,13 @@ module.exports = React.createClass( {
 						/>
 						<span>{ this.translate( 'I would like my site to be private, visible only to users I choose' ) }</span>
 					</label>
-				: null }
+				}
 
 			</fieldset>
 		);
 	},
 
 	relatedPostsOptions: function() {
-
 		if ( ! this.state.jetpack_relatedposts_allowed ) {
 			return null;
 		}
@@ -312,7 +315,6 @@ module.exports = React.createClass( {
 				</ul>
 			</fieldset>
 		);
-
 	},
 
 	syncNonPublicPostTypes: function() {
@@ -346,7 +348,7 @@ module.exports = React.createClass( {
 				<p>{
 					this.translate( 'You can also {{manageLink}}manage the monitor settings{{/manageLink}} and {{migrateLink}}migrate followers{{/migrateLink}}.', {
 						components: {
-							manageLink: <a href={ '../security/' + site.slug  } />,
+							manageLink: <a href={ '../security/' + site.slug } />,
 							migrateLink: <a href={ 'https://wordpress.com/manage/' + site.ID } />
 						}
 					} )
@@ -387,7 +389,6 @@ module.exports = React.createClass( {
 				</ul>
 			</fieldset>
 		);
-
 	},
 
 	render: function() {

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -188,24 +188,7 @@ module.exports = React.createClass( {
 	},
 
 	visibilityOptions: function() {
-		var site = this.props.site,
-			privateSiteOption;
-
-		if ( ! this.props.site.jetpack ) {
-			privateSiteOption =
-				<label>
-					<input
-						type="radio"
-						name="blog_public"
-						value="-1"
-						checked={ - 1 === parseInt( this.state.blog_public, 10 ) }
-						onChange={ this.handleRadio }
-						disabled={ this.state.fetchingSettings }
-						onClick={ this.recordEvent.bind( this, 'Clicked Site Visibility Radio Button' ) }
-					/>
-					<span>{ this.translate( 'I would like my site to be private, visible only to users I choose' ) }</span>
-				</label>;
-		}
+		var site = this.props.site;
 
 		return (
 			<fieldset>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -45,6 +45,10 @@ module.exports = React.createClass( {
 				settings.jetpack_relatedposts_show_headline = site.settings.jetpack_relatedposts_show_headline;
 				settings.jetpack_relatedposts_show_thumbnails = site.settings.jetpack_relatedposts_show_thumbnails;
 			}
+
+			if ( site.settings.holidaysnow ) {
+				settings.holidaysnow = site.settings.holidaysnow;
+			}
 		}
 
 		return settings;
@@ -70,7 +74,8 @@ module.exports = React.createClass( {
 			jetpack_relatedposts_enabled: false,
 			jetpack_relatedposts_show_headline: false,
 			jetpack_relatedposts_show_thumbnails: false,
-			jetpack_sync_non_public_post_stati: false
+			jetpack_sync_non_public_post_stati: false,
+			holidaysnow: false
 		} );
 	},
 
@@ -374,6 +379,36 @@ module.exports = React.createClass( {
 		);
 	},
 
+	holidaySnowOption: function() {
+		// Note that years and months below are zero indexed
+		let site = this.props.site,
+			today = this.moment(),
+			startDate = this.moment( { year: today.year(), month: 11, day: 1 } ),
+			endDate = this.moment( { year: today.year(), month: 0, day: 4 } );
+
+		if ( site.jetpack && site.versionCompare( '4.0', '<' ) ) {
+			return null;
+		}
+
+		if ( today.isBefore( startDate, 'day' ) && today.isAfter( endDate, 'day' ) ) {
+			return null;
+		}
+
+		return (
+			<fieldset>
+				<legend>{ this.translate( 'Holiday Snow' ) }</legend>
+				<ul>
+					<li>
+						<label>
+							<input name="holidaysnow" type="checkbox" checkedLink={ this.linkState( 'holidaysnow' ) }/>
+							<span>{ this.translate( 'Show falling snow on my blog until January 4th.' ) }</span>
+						</label>
+					</li>
+				</ul>
+			</fieldset>
+		);
+	},
+
 	render: function() {
 		var site = this.props.site;
 		if ( site.jetpack && ! site.hasMinimumJetpackVersion ) {
@@ -437,6 +472,7 @@ module.exports = React.createClass( {
 					<form onChange={ this.markChanged }>
 						{ this.jetpackOptions() }
 						{ this.jetpackDisconnectOption() }
+						{ this.holidaySnowOption() }
 						{ this.relatedPostsOptions() }
 					</form>
 				</Card>


### PR DESCRIPTION
Closes #1123

@jeherve reported in #1123 that the holiday snow options weren't ported to Calypso. In #1138, I added the holiday snow override to `/me` and this PR adds the holiday snow site setting to the `/settings/general/$site`.

__Note:__ The first two commits are ESLint fixes. So, if you'd like to see the changeset to add `holidaysnow`, see the third commit.

To test:
- Checkout `add/site-settings-holiday-snow` branch
- Go to `/me/account` and ensure you have holiday snow enabled
- Go to `/settings/general/$site` where `$site` is a WP.com site and ensure that snow is enabled
- Go to `$site`. Do you see snow? Good
- Go to `/settings/general/$site` and disable snow.
- Go to `$site`. You should not see snow.
- Go to `/settings/general/$site` where `$site` is a Jetpack site. You should not see the holiday snow option yet. Since this requires an API change, it is unlikely that holiday snow will be changeable via the API until 4.0 (late January 2016)

cc @lancewillett who pointed the issue out to me and @lezama who has done some work in `form-general`.

__WP.com site__
![screen shot 1](https://cloud.githubusercontent.com/assets/1126811/11546315/1a325e4a-9912-11e5-83c8-e871b6cd52cd.png)

__Jetpack site__
![screen shot](https://cloud.githubusercontent.com/assets/1126811/11546314/1a2b6568-9912-11e5-873e-7368bd216601.png)
