### PR TITLE
Notices: Fixes warning from invalid propType check in NoticeAction

### DIFF
--- a/client/components/notice/notice-action.jsx
+++ b/client/components/notice/notice-action.jsx
@@ -14,7 +14,13 @@ export default React.createClass( {
 	propTypes: {
 		href: React.PropTypes.string,
 		onClick: React.PropTypes.func,
-		external: false
+		external: React.PropTypes.bool
+	},
+
+	getDefaultProps() {
+		return {
+			external: false
+		};
 	},
 
 	render() {


### PR DESCRIPTION
While working in development today, I noticed the following warning in my console:

![screen shot 4](https://cloud.githubusercontent.com/assets/1126811/11550094/d19a116c-9931-11e5-9431-65e9e7c6912e.png)

I was able to narrow this down to a default value being placed in the `propTypes` object instead of the `getDefaultProps()` lifecycle method for the `NoticeAction` component.

cc @mtias for review

To test:
- Checkout `fix/notice-action-external-proptype` branch
- Go to `/post/$site` in development
- Publish a post on a test site
- Check the console
- You shouldn't see a warning

![screen shot 5](https://cloud.githubusercontent.com/assets/1126811/11550129/335c2610-9932-11e5-84d1-db82ad8bbc61.png)
