### PR TITLE
Invites: Ensure that user inputted data is decoded

### DIFF
--- a/client/lib/invites/reducers/invites-validation.js
+++ b/client/lib/invites/reducers/invites-validation.js
@@ -2,22 +2,39 @@
  * External dependencies
  */
 import { fromJS } from 'immutable';
+import mapValues from 'lodash/object/mapValues';
+import pick from 'lodash/object/pick';
 
 /**
  * Internal dependencies
  */
 import { action as ActionTypes } from 'lib/invites/constants';
+import { decodeEntities } from 'lib/formatting';
 
 const initialState = fromJS( {
 	list: {},
 	errors: {}
 } );
 
+function filterObject( object ) {
+	return mapValues( object, value => {
+		if ( 'object' === typeof value ) {
+			return filterObject( value );
+		}
+
+		return value ? decodeEntities( value ) : value;
+	} );
+}
+
+function filterInvite( invite ) {
+	return mapValues( pick( invite, [ 'invite', 'inviter', 'blog_details' ] ), filterObject );
+}
+
 const reducer = ( state = initialState, payload ) => {
 	const { action } = payload;
 	switch ( action.type ) {
 		case ActionTypes.RECEIVE_INVITE:
-			return state.setIn( [ 'list', action.siteId, action.inviteKey ], action.data );
+			return state.setIn( [ 'list', action.siteId, action.inviteKey ], filterInvite( action.data ) );
 		case ActionTypes.RECEIVE_INVITE_ERROR:
 			return state.setIn( [ 'errors', action.siteId, action.inviteKey ], action.error );
 	}

--- a/server/user-bootstrap/shared-utils.js
+++ b/server/user-bootstrap/shared-utils.js
@@ -57,7 +57,8 @@ module.exports = {
 			];
 
 		allowedKeys.forEach( function( key ) {
-			user[ key ] = decodeEntities( obj[ key ] );
+			// Decode if value is not falsey
+			user[ key ] = obj[ key ] ? decodeEntities( obj[ key ] ) : obj[ key ];
 		} );
 
 		return assign( user, this.getComputedAttributes( obj ) );

--- a/server/user-bootstrap/shared-utils.js
+++ b/server/user-bootstrap/shared-utils.js
@@ -6,8 +6,13 @@ var assign = require( 'lodash/object/assign' );
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	languages = config( 'languages' );
+import config from 'config';
+import { decodeEntities } from 'lib/formatting';
+
+/**
+ * Module variables
+ */
+const languages = config( 'languages' );
 
 function getLanguage( slug ) {
 	var len = languages.length,
@@ -52,7 +57,7 @@ module.exports = {
 			];
 
 		allowedKeys.forEach( function( key ) {
-			user[ key ] = obj[ key ];
+			user[ key ] = decodeEntities( obj[ key ] );
 		} );
 
 		return assign( user, this.getComputedAttributes( obj ) );

--- a/server/user-bootstrap/shared-utils.js
+++ b/server/user-bootstrap/shared-utils.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var assign = require( 'lodash/object/assign' );
+import assign from 'lodash/object/assign';
+import contains from 'lodash/collection/contains';
 
 /**
  * Internal dependencies
@@ -54,11 +55,17 @@ module.exports = {
 				'logout_URL',
 				'primary_blog_url',
 				'meta',
+			],
+			decodeWhitelist = [
+				'display_name',
+				'description',
+				'user_URL'
 			];
 
 		allowedKeys.forEach( function( key ) {
-			// Decode if value is not falsey
-			user[ key ] = obj[ key ] ? decodeEntities( obj[ key ] ) : obj[ key ];
+			user[ key ] = obj[ key ] && contains( decodeWhitelist, key )
+				? decodeEntities( obj[ key ] )
+				: obj[ key ];
 		} );
 
 		return assign( user, this.getComputedAttributes( obj ) );


### PR DESCRIPTION
Closes #1086 by decode entities for invitations.

![screen shot](https://cloud.githubusercontent.com/assets/1126811/11552594/e6bfed90-994b-11e5-9d2e-75e81ded13e6.png)

cc @roccotripaldi 

To test:
- Checkout `fix/invites-html-entities`
- Invite a test user by going to `$site/wp-admin/users.php?page=wpcom-invite-users`
- In the invitation email that you get, make note of the `$invite_key`
- Change your display name for the test user to include an `&` or other entity
- Go to `/accept-invite/$site/$invite_key` where `$site` has an entity in its name
- Are all entities decoded?