### PR TITLE
Reader: Add Featured component to SiteStream

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -284,6 +284,7 @@
 @import 'reader/share/style';
 @import 'reader/sidebar/style';
 @import 'reader/site-and-author-icon/style';
+@import 'reader/site-stream/style';
 @import 'reader/style';
 @import 'reader/stream-header/style';
 @import 'reader/update-notice/style';

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -108,6 +108,21 @@ function getStoreForSite( storeId ) {
 	} );
 }
 
+function getStoreForFeatured( storeId ) {
+	var siteId = storeId.split( ':' )[ 1 ],
+		fetcher = function( query, callback ) {
+			wpcomUndoc.readSiteFeatured( siteId, callback );
+		};
+
+	return new FeedStream( {
+		id: storeId,
+		fetcher: fetcher,
+		keyMaker: siteKeyMaker,
+		onGapFetch: limitSiteParams,
+		onUpdateFetch: limitSiteParams
+	} );
+}
+
 function feedStoreFactory( storeId ) {
 	var store = FeedStreamCache.get( storeId );
 
@@ -146,6 +161,8 @@ function feedStoreFactory( storeId ) {
 		store = getStoreForList( storeId );
 	} else if ( storeId.indexOf( 'site:' ) === 0 ) {
 		store = getStoreForSite( storeId );
+	} else if ( storeId.indexOf( 'featured:' ) === 0 ) {
+		store = getStoreForFeatured( storeId );
 	} else {
 		throw new Error( 'Unknown feed store ID' );
 	}

--- a/client/lib/reader-site-store/index.js
+++ b/client/lib/reader-site-store/index.js
@@ -30,6 +30,8 @@ function setSite( attributes ) {
 		attributes.state = State.COMPLETE;
 	}
 
+	attributes.has_featured = !!attributes.meta.links.featured;
+
 	attributes = omit( attributes, [ 'meta', '_headers' ] );
 
 	if ( attributes.URL ) {

--- a/client/lib/reader-site-store/index.js
+++ b/client/lib/reader-site-store/index.js
@@ -2,7 +2,8 @@
 
 // External Dependencies
 var Immutable = require( 'immutable' ),
-	omit = require( 'lodash/object/omit' );
+	omit = require( 'lodash/object/omit' ),
+	has = require( 'lodash/object/has' );
 
 // Internal Dependencies
 var Dispatcher = require( 'dispatcher' ),
@@ -30,9 +31,7 @@ function setSite( attributes ) {
 		attributes.state = State.COMPLETE;
 	}
 
-	if ( attributes.meta && attributes.meta.links ) {
-		attributes.has_featured = !!attributes.meta.links.featured;
-	}
+	attributes.has_featured = has( attributes, 'meta.links.featured' );
 
 	attributes = omit( attributes, [ 'meta', '_headers' ] );
 

--- a/client/lib/reader-site-store/index.js
+++ b/client/lib/reader-site-store/index.js
@@ -30,7 +30,9 @@ function setSite( attributes ) {
 		attributes.state = State.COMPLETE;
 	}
 
-	attributes.has_featured = !!attributes.meta.links.featured;
+	if ( attributes.meta && attributes.meta.links ) {
+		attributes.has_featured = !!attributes.meta.links.featured;
+	}
 
 	attributes = omit( attributes, [ 'meta', '_headers' ] );
 

--- a/client/lib/reader-site-store/test/reader-site-store-tests.js
+++ b/client/lib/reader-site-store/test/reader-site-store-tests.js
@@ -3,7 +3,8 @@
  */
 var expect = require( 'chai' ).expect,
 	mockery = require( 'mockery' ),
-	sinon = require( 'sinon' );
+	sinon = require( 'sinon' ),
+	assign = require( 'lodash/object/assign' );
 
 var State = require( '../constants' ).state,
 	SiteStore, SiteStoreActions;
@@ -15,6 +16,94 @@ var readSiteStub,
 			return { readSite: readSiteStub };
 		}
 	};
+
+var SiteExample = {
+	ID: 77203074,
+	name: 'Just You Wait',
+	description: 'Sweet little tests all in a Box',
+	URL: 'https://testonesite2014.wordpress.com',
+	jetpack: false,
+	post_count: 1,
+	subscribers_count: 1,
+	lang: 'en',
+	logo: {
+		id: 0,
+		sizes: [],
+		url: ''
+	},
+	visible: true,
+	is_private: false,
+	is_following: false,
+	options: {
+		timezone: '',
+		gmt_offset: 0,
+		videopress_enabled: false,
+		upgraded_filetypes_enabled: false,
+		login_url: 'https://testonesite2014.wordpress.com/wp-login.php',
+		admin_url: 'https://testonesite2014.wordpress.com/wp-admin/',
+		is_mapped_domain: false,
+		is_redirect: false,
+		unmapped_url: 'https://testonesite2014.wordpress.com',
+		featured_images_enabled: false,
+		theme_slug: 'pub/penscratch',
+		header_image: {
+			attachment_id: 28,
+			url: 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg',
+			thumbnail_url: 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg',
+			height: 1280,
+			width: 850
+		},
+		background_color: false,
+		image_default_link_type: 'file',
+		image_thumbnail_width: 150,
+		image_thumbnail_height: 150,
+		image_thumbnail_crop: 0,
+		image_medium_width: 300,
+		image_medium_height: 300,
+		image_large_width: 1024,
+		image_large_height: 1024,
+		permalink_structure: '/%year%/%monthnum%/%day%/%postname%/',
+		post_formats: [],
+		default_post_format: '0',
+		default_category: 1,
+		allowed_file_types: [
+			'jpg',
+			'jpeg',
+			'png',
+			'gif',
+			'pdf',
+			'doc',
+			'ppt',
+			'odt',
+			'pptx',
+			'docx',
+			'pps',
+			'ppsx',
+			'xls',
+			'xlsx',
+			'key'
+		],
+		show_on_front: 'posts',
+		default_likes_enabled: true,
+		default_sharing_status: true,
+		default_comment_status: true,
+		default_ping_status: true,
+		software_version: '4.4-alpha-33842',
+		created_at: '2014-10-18T17:14:52+00:00',
+		wordads: false,
+		publicize_permanently_disabled: false
+	},
+	meta: {
+		links: {
+			self: 'https://public-api.wordpress.com/rest/v1.1/sites/77203074',
+			help: 'https://public-api.wordpress.com/rest/v1.1/sites/77203074/help',
+			posts: 'https://public-api.wordpress.com/rest/v1.1/sites/77203074/posts/',
+			comments: 'https://public-api.wordpress.com/rest/v1.1/sites/77203074/comments/',
+			xmlrpc: 'https://testonesite2014.wordpress.com/xmlrpc.php'
+		}
+	},
+	user_can_manage: true
+};
 
 describe( 'SiteStore', function() {
 	before( function() {
@@ -49,94 +138,8 @@ describe( 'SiteStore', function() {
 	} );
 
 	it( 'should accept a good response', function() {
-		var Site, SiteFromStore;
-		Site = {
-			ID: 77203074,
-			name: 'Just You Wait',
-			description: 'Sweet little tests all in a Box',
-			URL: 'https://testonesite2014.wordpress.com',
-			jetpack: false,
-			post_count: 1,
-			subscribers_count: 1,
-			lang: 'en',
-			logo: {
-				id: 0,
-				sizes: [],
-				url: ''
-			},
-			visible: true,
-			is_private: false,
-			is_following: false,
-			options: {
-				timezone: '',
-				gmt_offset: 0,
-				videopress_enabled: false,
-				upgraded_filetypes_enabled: false,
-				login_url: 'https://testonesite2014.wordpress.com/wp-login.php',
-				admin_url: 'https://testonesite2014.wordpress.com/wp-admin/',
-				is_mapped_domain: false,
-				is_redirect: false,
-				unmapped_url: 'https://testonesite2014.wordpress.com',
-				featured_images_enabled: false,
-				theme_slug: 'pub/penscratch',
-				header_image: {
-					attachment_id: 28,
-					url: 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg',
-					thumbnail_url: 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg',
-					height: 1280,
-					width: 850
-				},
-				background_color: false,
-				image_default_link_type: 'file',
-				image_thumbnail_width: 150,
-				image_thumbnail_height: 150,
-				image_thumbnail_crop: 0,
-				image_medium_width: 300,
-				image_medium_height: 300,
-				image_large_width: 1024,
-				image_large_height: 1024,
-				permalink_structure: '/%year%/%monthnum%/%day%/%postname%/',
-				post_formats: [],
-				default_post_format: '0',
-				default_category: 1,
-				allowed_file_types: [
-					'jpg',
-					'jpeg',
-					'png',
-					'gif',
-					'pdf',
-					'doc',
-					'ppt',
-					'odt',
-					'pptx',
-					'docx',
-					'pps',
-					'ppsx',
-					'xls',
-					'xlsx',
-					'key'
-				],
-				show_on_front: 'posts',
-				default_likes_enabled: true,
-				default_sharing_status: true,
-				default_comment_status: true,
-				default_ping_status: true,
-				software_version: '4.4-alpha-33842',
-				created_at: '2014-10-18T17:14:52+00:00',
-				wordads: false,
-				publicize_permanently_disabled: false
-			},
-			meta: {
-				links: {
-					self: 'https://public-api.wordpress.com/rest/v1.1/sites/77203074',
-					help: 'https://public-api.wordpress.com/rest/v1.1/sites/77203074/help',
-					posts: 'https://public-api.wordpress.com/rest/v1.1/sites/77203074/posts/',
-					comments: 'https://public-api.wordpress.com/rest/v1.1/sites/77203074/comments/',
-					xmlrpc: 'https://testonesite2014.wordpress.com/xmlrpc.php'
-				}
-			},
-			user_can_manage: true
-		};
+		var Site = assign( {}, SiteExample ),
+			SiteFromStore;
 
 		readSiteStub.callsArgWith( 1, null, Site );
 
@@ -178,5 +181,19 @@ describe( 'SiteStore', function() {
 		expect( SiteFromStore ).to.be.ok;
 		expect( SiteFromStore.get( 'state' ) ).to.equal( State.ERROR );
 		expect( SiteFromStore.get( 'error' ) ).to.equal( error );
+	} );
+
+	it( 'should set has_featured with meta link', function() {
+		var Site = assign( {}, SiteExample ),
+			SiteFromStore;
+
+		Site.meta.links.featured = 'https://public-api.wordpress.com/rest/v1.1/read/sites/77203074/featured';
+
+		readSiteStub.callsArgWith( 1, null, Site );
+
+		SiteStoreActions.fetch( 77203074 );
+		SiteFromStore = SiteStore.get( 77203074 );
+
+		expect( SiteFromStore.toJS().has_featured ).to.be.true;
 	} );
 } );

--- a/client/reader/site-stream/_style.scss
+++ b/client/reader/site-stream/_style.scss
@@ -1,0 +1,73 @@
+// Featured Posts Area
+
+.reader__featured-card {
+	padding: 16px 24px 0;
+	margin-bottom: 24px;
+}
+
+.reader__featured-header {
+	margin-bottom: 16px;
+}
+
+.reader__featured-title {
+	color: $gray-dark;
+	display: block;
+	font-size: 14px;
+	line-height: 1.6;
+}
+
+.reader__featured-description {
+	font-size: 13px;
+	color: $gray;
+}
+
+.reader__featured-posts {
+	position: relative;
+	left: -24px;
+	width: calc( 100% + 48px );
+	background-color: $gray-dark;
+
+	// Break into 3 columns on larger screens
+	@include breakpoint( ">960px" ) {
+		display: flex;
+	}
+}
+
+.reader__featured-post {
+	position: relative;
+	min-height: 52px;
+	padding: 32px 24px;
+	background-color: $gray-dark;
+	transition: all 0.1s ease-in-out;
+	cursor: pointer;
+	
+	// Break into 3 columns on larger screens
+	@include breakpoint( ">960px" ) {
+		flex: 1;
+		min-height: 152px;
+
+		&:hover {
+			background-color: darken( $gray, 30% );
+		}
+	}
+}
+
+.reader__featured-post-image {
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	background-size: cover;
+	background-position: center;
+	opacity: 0.3;
+}
+
+.reader__featured-post-title {
+	position: relative;
+	font-family: Merriweather, Georgia, "Times New Roman", Times, serif;
+	font-weight: 700;
+	font-size: 18px;
+	color: $white;
+	z-index: 1;
+}

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -82,8 +82,8 @@ export default React.createClass( {
 		return (
 			<Card className="reader__featured-card">
 				<div className="reader__featured-header">
-					<div className="reader__featured-title">{ this.translate( 'Featured' ) }</div>
-					<div className="reader__featured-description">{ this.translate( 'Stories, interviews, and more from the editors at WordPress.com.' ) }</div>
+					<div className="reader__featured-title">{ this.translate( 'Highlights' ) }</div>
+					<div className="reader__featured-description">{ this.translate( 'What we’re reading this week.' ) }</div>
 				</div>
 
 				<div className="reader__featured-posts">

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -65,9 +65,9 @@ export default React.createClass( {
 						<div
 							key={ post.ID }
 							className="reader__featured-post"
-							onClick={ this.handleClick.bind( this, post ) }
-							style={ style }>
-							<h2>{ post.title }</h2>
+							onClick={ this.handleClick.bind( this, post ) }>
+							<div className="reader__featured-post-image" style={ style }></div>
+							<h2 className="reader__featured-post-title">{ post.title }</h2>
 						</div>
 					);
 			}
@@ -80,10 +80,10 @@ export default React.createClass( {
 		}
 
 		return (
-			<Card>
+			<Card className="reader__featured-card">
 				<div className="reader__featured-header">
 					<div className="reader__featured-title">{ this.translate( 'Featured' ) }</div>
-					<div className="reader__featured-description">{ this.translate( 'Stories interviews, and more from the editors at WordPress.com.' ) }</div>
+					<div className="reader__featured-description">{ this.translate( 'Stories, interviews, and more from the editors at WordPress.com.' ) }</div>
 				</div>
 
 				<div className="reader__featured-posts">

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -1,0 +1,95 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import Card from 'components/card';
+import page from 'page';
+import PostStore from 'lib/feed-post-store';
+import FeedPostStoreActions from 'lib/feed-post-store/actions';
+
+export default React.createClass( {
+	displayName: 'FeedFeatured',
+
+	getInitialState() {
+		return this.getStateFromStores();
+	},
+
+	getStateFromStores( store ) {
+		store = store || this.props.store;
+		return {
+			posts: store.get()
+		};
+	},
+
+	updateState( store ) {
+		this.setState( this.getStateFromStores( store ) );
+	},
+
+	componentDidMount() {
+		this.props.store.on( 'change', this.updateState );
+		PostStore.on( 'change', this.updateState );
+	},
+
+	componentWillUnmount() {
+		this.props.store.off( 'change', this.updateState );
+		PostStore.off( 'change', this.updateState );
+	},
+
+	handleClick( post ) {
+		page( '/read/post/id/' + post.site_ID + '/' + post.ID );
+	},
+
+	renderPosts() {
+		return this.state.posts.map( postKey => {
+			let post = PostStore.get( postKey );
+			let postState = post._state;
+			if ( ! post || postState === 'minimal' ) {
+				FeedPostStoreActions.fetchPost( postKey );
+				postState = 'pending';
+			}
+
+			switch ( postState ) {
+				case 'pending':
+				case 'error':
+					break;
+				default:
+					let style = {
+						backgroundImage: post.canonical_image && post.canonical_image.uri ? 'url(' + post.canonical_image.uri + ')' : null
+					};
+
+					return (
+						<div
+							key={ post.ID }
+							className="reader__featured-post"
+							onClick={ this.handleClick.bind( this, post ) }
+							style={ style }>
+							<h2>{ post.title }</h2>
+						</div>
+					);
+			}
+		} );
+	},
+
+	render() {
+		if ( ! this.state.posts ) {
+			return null;
+		}
+
+		return (
+			<Card>
+				<div className="reader__featured-header">
+					<div className="reader__featured-title">{ this.translate( 'Featured' ) }</div>
+					<div className="reader__featured-description">{ this.translate( 'Stories interviews, and more from the editors at WordPress.com.' ) }</div>
+				</div>
+
+				<div className="reader__featured-posts">
+					{ this.renderPosts() }
+				</div>
+			</Card>
+		);
+	}
+} );

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -10,6 +10,7 @@ import Card from 'components/card';
 import page from 'page';
 import PostStore from 'lib/feed-post-store';
 import FeedPostStoreActions from 'lib/feed-post-store/actions';
+import stats from 'reader/stats';
 
 export default React.createClass( {
 	displayName: 'FeedFeatured',
@@ -40,6 +41,8 @@ export default React.createClass( {
 	},
 
 	handleClick( post ) {
+		stats.recordAction( 'clicked_featured_post' );
+		stats.recordGaEvent( 'Clicked Featured Post' );
 		page( '/read/post/id/' + post.site_ID + '/' + post.ID );
 	},
 

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -15,6 +15,8 @@ import stats from 'reader/stats';
 export default React.createClass( {
 	displayName: 'FeedFeatured',
 
+	mixins: [ React.addons.PureRenderMixin ],
+
 	getInitialState() {
 		return this.getStateFromStores();
 	},

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -40,6 +40,12 @@ export default React.createClass( {
 		PostStore.off( 'change', this.updateState );
 	},
 
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.store !== this.props.store ) {
+			this.updateState();
+		}
+	},
+
 	handleClick( post ) {
 		stats.recordTrack( 'calypso_reader_clicked_featured_post', { blog_id: post.site_ID, post_id: post.ID } )
 		stats.recordAction( 'clicked_featured_post' );

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -41,8 +41,10 @@ export default React.createClass( {
 	},
 
 	handleClick( post ) {
+		stats.recordTrack( 'calypso_reader_clicked_featured_post', { blog_id: post.site_ID, post_id: post.ID } )
 		stats.recordAction( 'clicked_featured_post' );
 		stats.recordGaEvent( 'Clicked Featured Post' );
+
 		page( '/read/post/id/' + post.site_ID + '/' + post.ID );
 	},
 

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -1,12 +1,15 @@
 var React = require( 'react' );
 
 var FeedHeader = require( 'reader/feed-header' ),
+	FeedFeatured = require( './featured' ),
 	EmptyContent = require( './empty' ),
 	FollowingStream = require( 'reader/following-stream' ),
 	SiteStore = require( 'lib/reader-site-store' ),
 	SiteStoreActions = require( 'lib/reader-site-store/actions' ),
 	SiteState = require( 'lib/reader-site-store/constants' ).state,
-	FeedError = require( 'reader/feed-error' );
+	FeedError = require( 'reader/feed-error' ),
+	FeedStreamStoreActions = require( 'lib/feed-stream-store/actions' ),
+	feedStreamFactory = require( 'lib/feed-stream-store' );
 
 var SiteStream = React.createClass( {
 
@@ -71,7 +74,9 @@ var SiteStream = React.createClass( {
 	render: function() {
 		var site = this.state.site,
 			title = this.state.title,
-			emptyContent = ( <EmptyContent /> );
+			emptyContent = ( <EmptyContent /> ),
+			featuredStore = null,
+			featuredContent = null;
 
 		if ( ! title ) {
 			title = this.translate( 'Loading Site' );
@@ -85,9 +90,16 @@ var SiteStream = React.createClass( {
 			return <FeedError listName={ title } />;
 		}
 
+		if ( site && site.get( 'has_featured' ) ) {
+			featuredStore = feedStreamFactory( 'featured:' + site.get( 'ID' ) );
+			setTimeout( () => FeedStreamStoreActions.fetchNextPage( featuredStore.id ), 0 ); // timeout to prevent invariant violations
+			featuredContent = ( <FeedFeatured store={ featuredStore } /> );
+		}
+
 		return (
 			<FollowingStream { ...this.props } listName={ title } emptyContent={ emptyContent }>
 				<FeedHeader site={ this.state.site } />
+				{ featuredContent }
 			</FollowingStream>
 
 		);

--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -1149,6 +1149,11 @@ Undocumented.prototype.readSite = function( query, fn ) {
 	this.wpcom.req.get( '/read/sites/' + query.site, params, fn );
 };
 
+Undocumented.prototype.readSiteFeatured = function( siteId, fn ) {
+	debug( '/read/sites/:site/featured' );
+	this.wpcom.req.get( '/read/sites/' + siteId + '/featured', null, fn );
+};
+
 Undocumented.prototype.readSitePosts = function( query, fn ) {
 	var params = omit( query, 'site' );
 	debug( '/read/sites/:site/posts' );


### PR DESCRIPTION
Displayed for any sites that return a `featured` meta link but is only enabled for Discover right now. The component relies on a new FeedStream Store which pings the `/featured` endpoint but reuses all other post storage mechanisms.

## To Test

- Load up Calypso
- Go to Discover from the sidebar
- Verify that the "Highlights" section is displayed
- Go to another site stream
- Verify that the "Highlights" section does not show up
- Bonus: verify that on non-Discover site streams that we're not making calls to the `/featured` endpoint