### PR TITLE
Site Settings: Add stopPropagation to SELECT onClick events

### DIFF
--- a/client/my-sites/site-settings/form-base.js
+++ b/client/my-sites/site-settings/form-base.js
@@ -62,6 +62,11 @@ module.exports = {
 
 	},
 
+	recordClickEventAndStop: function( recordObject, clickEvent ) {
+		this.recordEvent( recordObject );
+		clickEvent.preventDefault();
+	},
+
 	recordEvent: function( eventAction ) {
 		analytics.ga.recordEvent( 'Site Settings', eventAction );
 	},

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -178,7 +178,7 @@ module.exports = React.createClass( {
 								name="thread_comments_depth"
 								valueLink={ this.linkState( 'thread_comments_depth' ) }
 								disabled={ this.state.fetchingSettings }
-								onClick={ this.recordEvent.bind( this, 'Selected Comment Nesting Level' ) }
+								onClick={ this.recordClickEventAndStop.bind( this, 'Selected Comment Nesting Level' ) }
 								>
 									<option value="2">2</option>
 									<option value="3">3</option>
@@ -223,7 +223,7 @@ module.exports = React.createClass( {
 								name="default_comments_page"
 								valueLink={ this.linkState( 'default_comments_page' ) }
 								disabled={ this.state.fetchingSettings }
-								onClick={ this.recordEvent.bind( this, 'Selected Comment Page Display Default' ) }
+								onClick={ this.recordClickEventAndStop.bind( this, 'Selected Comment Page Display Default' ) }
 								>
 									<option value="newest">{ this.translate( 'last' ) }</option>
 									<option value="oldest">{ this.translate( 'first' ) }</option>


### PR DESCRIPTION
# What?
While nested in `LABEL`, `SELECT` `onClick` event was propagating
onClick was propagating to label, triggering click events higher
in DOM tree in Safari. Fixes #86

## Problem
(Copied from #86 )
![d176b8a4-cbc6-11e4-9899-d19b1c557455](https://cloud.githubusercontent.com/assets/7233112/11245421/aca7a65a-8de0-11e5-846f-72cc5cfe21d3.gif)

My Sites > Settings > Discussion

Click on a select element, and it toggles the checkbox.  Looks like it only affects Safari, not Chrome or Firefox.  IE untested.

# Testing
1. Open Safari
2. Go to My Sites > Settings > Discussion
3. Change nested comments dopth
4. Notice that toggle doesent switch
