### PR TITLE
Help: Use <ExternalLink /> component to add help links

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -11,6 +11,7 @@ var Main = require( 'components/main' ),
 	FormSectionHeading = require( 'components/forms/form-section-heading' ),
 	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	HelpSearch = require( './help-search' ),
+	ExternalLink = require( 'components/external-link' ),
 	Card = require( 'components/card' );
 
 module.exports = React.createClass( {
@@ -23,13 +24,13 @@ module.exports = React.createClass( {
 			<Card>
 				<div className="help__support-link">
 					<h2 className="help__support-link-title">
-						<a href="https://support.wordpress.com/" target="__blank">{ this.translate( 'Support docs' ) }</a>
+						<ExternalLink icon={ true } href="https://support.wordpress.com/" target="__blank">{ this.translate( 'Support docs' ) }</ExternalLink>
 					</h2>
 					<p className="help__support-link-content">{ this.translate( 'Looking to learn more about a feature? Our docs have all the details.' ) }</p>
 				</div>
 				<div className="help__support-link">
 					<h2 className="help__support-link-title">
-						<a href="https://dailypost.wordpress.com/" target="__blank">{ this.translate( 'The daily post' ) }</a>
+						<ExternalLink icon={ true } href="https://dailypost.wordpress.com/" target="__blank">{ this.translate( 'The daily post' ) }</ExternalLink>
 					</h2>
 					<p className="help__support-link-content">{ this.translate( 'Get daily tips for your blog and connect with others to share your journey.' ) }</p>
 				</div>

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -30,7 +30,7 @@ module.exports = React.createClass( {
 				</div>
 				<div className="help__support-link">
 					<h2 className="help__support-link-title">
-						<ExternalLink icon={ true } href="https://dailypost.wordpress.com/" target="__blank">{ this.translate( 'The daily post' ) }</ExternalLink>
+						<ExternalLink icon={ true } href="https://dailypost.wordpress.com/" target="__blank">{ this.translate( 'The Daily Post' ) }</ExternalLink>
 					</h2>
 					<p className="help__support-link-content">{ this.translate( 'Get daily tips for your blog and connect with others to share your journey.' ) }</p>
 				</div>


### PR DESCRIPTION
### Fixes
https://github.com/Automattic/wp-calypso/issues/1092

### Changes by this PR
This PR replaces help links to use `<ExternalLink/>` component

Desktop version
<img width="754" alt="screen shot 2015-12-03 at 5 03 55 pm" src="https://cloud.githubusercontent.com/assets/581008/11559580/1c66e96e-99e0-11e5-99f9-f066b94de760.png">

Mobile
<img width="464" alt="screen shot 2015-12-03 at 5 04 29 pm" src="https://cloud.githubusercontent.com/assets/581008/11559584/21efa876-99e0-11e5-8fa5-4c206135168c.png">
 version


### Testing instructions
Go to http://calypso.localhost:3000/help. See the external links now have an icon that signals the user of non-calypso pages. Try different resolutions and see it fits well