### PR TITLE
Domains: Cleanup Domain Management data components

### DIFF
--- a/client/components/data/domain-management/README.md
+++ b/client/components/data/domain-management/README.md
@@ -35,11 +35,10 @@ const MyComponent = React.createClass( {
 	render() {
 		return (
 			<DomainManagementData
+				component={ MyChildComponent }
 				context={ context }
 				productsList={ productsList }
-				sites={ sites }>
-				{ MyChildComponent }
-			</DomainManagementData>
+				sites={ sites } />
 		);
 	}
 } );
@@ -51,12 +50,14 @@ The component expects to receive all listed props:
 
 * `context` - a request context
 * `productsList` - a collection of all the products users can have on WordPress.com
+* `selectedDomainName` - the domain name currently selected (optional)
 * `sites` - a list of user sites 
 
 The child component should receive processed props defined during the render:
 
 * `context` - a request context
 * `products` - a collection of all the products users can have on WordPress.com
+* `selectedDomainName` - the domain name currently selected (optional)
 * `selectedSite` - the site currently selected 
 
 As well as:

--- a/client/components/data/domain-management/dns/index.jsx
+++ b/client/components/data/domain-management/dns/index.jsx
@@ -66,9 +66,7 @@ module.exports = React.createClass( {
 				stores={ stores }
 				getStateFromStores={ getStateFromStores }
 				selectedDomainName={ this.props.selectedDomainName }
-				selectedSite={ this.props.sites.getSelectedSite() }>
-				{ this.props.children }
-			</StoreConnection>
+				selectedSite={ this.props.sites.getSelectedSite() } />
 		);
 	}
 } );

--- a/client/components/data/domain-management/email-forwarding/index.jsx
+++ b/client/components/data/domain-management/email-forwarding/index.jsx
@@ -47,9 +47,7 @@ const EmailForwardingData = React.createClass( {
 				stores={ [ EmailForwardingStore ] }
 				getStateFromStores={ getStateFromStores }
 				selectedDomainName={ this.props.selectedDomainName }
-				selectedSite={ this.props.sites.getSelectedSite() }>
-				{ this.props.children }
-			</StoreConnection>
+				selectedSite={ this.props.sites.getSelectedSite() } />
 		);
 	}
 } );

--- a/client/components/data/domain-management/email/README.md
+++ b/client/components/data/domain-management/email/README.md
@@ -23,8 +23,7 @@ const MyComponent = React.createClass( {
 				productsList={ productsList }
 				selectedDomainName={ selectedDomainName }
 				context={ context }
-				sites={ sites }
-				user={ user.get() } />
+				sites={ sites } />
 		);
 	}
 } );
@@ -39,7 +38,6 @@ The component expects to receive all listed props:
 * `productsList` - a collection of all the products users can have on WordPress.com
 * `selectedDomainName` - the domain name currently selected 
 * `sites` - a list of user sites 
-* `user` - a current user object 
 
 The child component should receive processed props defined during the render:
 

--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -80,9 +80,7 @@ module.exports = React.createClass( {
 				selectedDomainName={ this.props.selectedDomainName }
 				selectedSite={ this.props.sites.getSelectedSite() }
 				context={ this.props.context }
-				user={ this.props.user }>
-				{ this.props.children }
-			</StoreConnection>
+				user={ this.props.user } />
 		);
 	}
 } );

--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -11,7 +11,10 @@ var StoreConnection = require( 'components/data/store-connection' ),
 	GoogleAppsUsersStore = require( 'lib/domains/google-apps-users/store' ),
 	CartStore = require( 'lib/cart/store' ),
 	observe = require( 'lib/mixins/data-observe' ),
-	upgradesActions = require( 'lib/upgrades/actions' );
+	upgradesActions = require( 'lib/upgrades/actions' ),
+	userFactory = require( 'lib/user' );
+
+const user = userFactory();
 
 var stores = [
 	DomainsStore,
@@ -34,7 +37,7 @@ function getStateFromStores( props ) {
 		googleAppsUsers: GoogleAppsUsersStore.getByDomainName( props.selectedDomainName ),
 		selectedDomainName: props.selectedDomainName,
 		selectedSite: props.selectedSite,
-		user: props.user
+		user: user.get()
 	};
 }
 
@@ -46,8 +49,7 @@ module.exports = React.createClass( {
 		context: React.PropTypes.object.isRequired,
 		productsList: React.PropTypes.object.isRequired,
 		selectedDomainName: React.PropTypes.string,
-		sites: React.PropTypes.object.isRequired,
-		user: React.PropTypes.object.isRequired
+		sites: React.PropTypes.object.isRequired
 	},
 
 	mixins: [ observe( 'productsList' ) ],
@@ -79,8 +81,7 @@ module.exports = React.createClass( {
 				products={ this.props.productsList.get() }
 				selectedDomainName={ this.props.selectedDomainName }
 				selectedSite={ this.props.sites.getSelectedSite() }
-				context={ this.props.context }
-				user={ this.props.user } />
+				context={ this.props.context } />
 		);
 	}
 } );

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -23,6 +23,7 @@ function getStateFromStores( props ) {
 		context: props.context,
 		domains: ( props.selectedSite ? DomainsStore.getBySite( props.selectedSite.ID ) : null ),
 		products: props.products,
+		selectedDomainName: props.selectedDomainName,
 		selectedSite: props.selectedSite
 	};
 }
@@ -33,6 +34,7 @@ module.exports = React.createClass( {
 	propTypes: {
 		context: React.PropTypes.object.isRequired,
 		productsList: React.PropTypes.object.isRequired,
+		selectedDomainName: React.PropTypes.string,
 		sites: React.PropTypes.object.isRequired
 	},
 
@@ -57,13 +59,13 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 			<StoreConnection
+				component={ this.props.component }
 				stores={ stores }
 				getStateFromStores={ getStateFromStores }
 				products={ this.props.productsList.get() }
+				selectedDomainName={ this.props.selectedDomainName }
 				selectedSite={ this.props.sites.getSelectedSite() }
-				context={ this.props.context }>
-				{ this.props.children }
-			</StoreConnection>
+				context={ this.props.context } />
 		);
 	}
 } );

--- a/client/components/data/domain-management/nameservers/index.jsx
+++ b/client/components/data/domain-management/nameservers/index.jsx
@@ -72,9 +72,7 @@ const NameserversData = React.createClass( {
 				stores={ stores }
 				getStateFromStores={ getStateFromStores }
 				selectedDomainName={ this.props.selectedDomainName }
-				selectedSite={ this.props.sites.getSelectedSite() }>
-				{ this.props.children }
-			</StoreConnection>
+				selectedSite={ this.props.sites.getSelectedSite() } />
 		);
 	}
 } );

--- a/client/components/data/domain-management/primary-domain/index.jsx
+++ b/client/components/data/domain-management/primary-domain/index.jsx
@@ -46,9 +46,7 @@ export default React.createClass( {
 				stores={ stores }
 				getStateFromStores={ getStateFromStores }
 				selectedDomainName={ this.props.selectedDomainName }
-				selectedSite={ this.props.sites.getSelectedSite() }>
-				{ this.props.children }
-			</StoreConnection>
+				selectedSite={ this.props.sites.getSelectedSite() } />
 		);
 	}
 } );

--- a/client/components/data/domain-management/site-redirect/index.jsx
+++ b/client/components/data/domain-management/site-redirect/index.jsx
@@ -40,9 +40,7 @@ module.exports = React.createClass( {
 				stores={ stores }
 				getStateFromStores={ getStateFromStores }
 				selectedDomainName={ this.props.selectedDomainName }
-				selectedSite={ this.props.sites.getSelectedSite() }>
-				{ this.props.children }
-			</StoreConnection>
+				selectedSite={ this.props.sites.getSelectedSite() } />
 		);
 	}
 } );

--- a/client/components/data/domain-management/whois/index.jsx
+++ b/client/components/data/domain-management/whois/index.jsx
@@ -80,9 +80,7 @@ module.exports = React.createClass( {
 				products={ this.props.productsList.get() }
 				selectedDomainName={ this.props.selectedDomainName }
 				selectedSite={ this.props.sites.getSelectedSite() }
-				context={ this.props.context }>
-				{ this.props.children }
-			</StoreConnection>
+				context={ this.props.context } />
 		);
 	}
 } );

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -21,7 +21,6 @@ import ProductsList from 'lib/products-list';
 import SiteRedirectData from 'components/data/domain-management/site-redirect';
 import SitesList from 'lib/sites-list';
 import TransferData from 'components/data/domain-management/transfer';
-import User from 'lib/user';
 import WhoisData from 'components/data/domain-management/whois';
 import titleActions from 'lib/screen-title/actions';
 
@@ -147,8 +146,6 @@ module.exports = {
 	},
 
 	domainManagementEmail( context ) {
-		const user = new User();
-
 		setTitle(
 			i18n.translate( 'Domain Management › Email' ),
 			context
@@ -165,8 +162,7 @@ module.exports = {
 				productsList={ productsList }
 				selectedDomainName={ context.params.domain }
 				context={ context }
-				sites={ sites }
-				user={ user.get() } />
+				sites={ sites } />
 		);
 	},
 

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -56,11 +56,10 @@ module.exports = {
 
 		renderPage(
 			<DomainManagementData
+				component={ DomainManagement.List }
 				context={ context }
 				productsList={ productsList }
-				sites={ sites }>
-				<DomainManagement.List />
-			</DomainManagementData>
+				sites={ sites } />
 		);
 	},
 
@@ -77,13 +76,11 @@ module.exports = {
 
 		renderPage(
 			<DomainManagementData
+				component={ DomainManagement.Edit }
 				context={ context }
 				productsList={ productsList }
-				sites={ sites }>
-				<DomainManagement.Edit
-					selectedSite={ sites.getSelectedSite() }
-					selectedDomainName={ context.params.domain } />
-			</DomainManagementData>
+				selectedDomainName={ context.params.domain }
+				sites={ sites } />
 		);
 	},
 
@@ -263,14 +260,11 @@ module.exports = {
 
 		renderPage(
 			<DomainManagementData
+				component={ DomainManagement.AddGoogleApps }
 				context={ context }
 				productsList={ productsList }
-				sites={ sites }>
-				<DomainManagement.AddGoogleApps
-					productsList={ productsList }
-					selectedSite={ sites.getSelectedSite() }
-					selectedDomainName={ context.params.domain } />
-			</DomainManagementData>
+				selectedDomainName={ context.params.domain }
+				sites={ sites } />
 		);
 	},
 


### PR DESCRIPTION
This PR makes cleanup in Domain Management data components. It makes sure there is only one way to pass child component to data component. It also moves user dependency from controller to data component.

Initially I wanted also to move `productList` and `sites` from controller to data components, but there is legacy `observe` mixin logic involved. I'm leaving it for further refactoring.

### Testing
There is really nothing special to test it. All Domain Management pages should work without any visible changes.

/cc @stephanethomas - we talked about those kind of changes a few weeks ago :)