### PR TITLE
Reader: Add fixed table-layout to tables within full post view

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -217,6 +217,10 @@
 		}
 	}
 
+	table {
+		table-layout: fixed;
+	}
+
 	@include breakpoint( ">660px" ) {
 		.alignleft {
 			max-width: 100%;


### PR DESCRIPTION
Fixes #986 , to keep tables from overflowing within Reader's full post view in firefox

Testing instructions:

1. Publish a new post including a table with images in two 50% width colums
2. View the post in the Reader
Result: the table is not constrained to the content area when the post is viewed in the Reader using Firefox.

Before:
<img width="1436" alt="before" src="https://cloud.githubusercontent.com/assets/933450/11565939/4d3907a2-99ae-11e5-9e29-913d3947ccb5.png">
<img width="336" alt="before-mobile" src="https://cloud.githubusercontent.com/assets/933450/11565940/4f0c438c-99ae-11e5-90db-0d5c7161bde0.png">

After:
<img width="1425" alt="after" src="https://cloud.githubusercontent.com/assets/933450/11565945/52ae698e-99ae-11e5-8b3c-bfef33655669.png">
<img width="332" alt="after-mobile" src="https://cloud.githubusercontent.com/assets/933450/11565946/550655e8-99ae-11e5-9a86-0b8bd8939ea6.png">

cc: @blowery @designsimply 
