### PR TITLE
Framework: Fixes uncentered logged-out layouts with no sidebar

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	classNames = require( 'classnames' );
 
 /**
  * Internal dependencies
@@ -15,15 +16,19 @@ module.exports = React.createClass( {
 
 	getInitialState: function() {
 		return {
-			section: undefined
+			section: undefined,
+			noSidebar: false
 		};
 	},
 
 	render: function() {
-		var sectionClass = 'wp' + ( this.state.section ? ' is-section-' + this.state.section : '' );
+		var sectionClass = this.state.section ? ' is-section-' + this.state.section : '',
+			classes = classNames( 'wp', sectionClass, {
+				'has-no-sidebar': this.state.noSidebar
+			} );
 
 		return (
-			<div className={ sectionClass }>
+			<div className={ classes }>
 				<Masterbar />
 				<div id="content" className="wp-content">
 					<NoticesList id="notices" notices={ notices.list } />


### PR DESCRIPTION
Fixes #1077 and #901

In #1077, I reported that logged out layouts without a sidebar were still off-center even after #302. After looking into this more, it looks like it was because there's a `client/layout/logged-out.jsx` component that wasn't updated to add the `has-no-sidebar` class. This PR fixes that.

cc @shaunandrews @scruffian for review

To test:
- Checkout `fix/logged-out-sidebar-layout` branch
- While logged out (easiest in incognito), go to `/start`.
- Does everything look centered?
- Now, go to `$site/wp-admin/users.php?page=wpcom-invite-users` and send an invitation to an email you have access to me
- In the invitation email, make note of the `$invitation_key`
- While logged out, go to `/accept-invite/$site/$invitation_key`
- Is everything centered properly.

After screenshots:

![screen shot 1](https://cloud.githubusercontent.com/assets/1126811/11566750/66277140-99a9-11e5-82e8-0dfc5ac956f8.png)
![screen shot](https://cloud.githubusercontent.com/assets/1126811/11566760/704e34ce-99a9-11e5-80a2-55bfad905a7e.png)
