### PR TITLE
Signup: Matches signup footer padding with card

### DIFF
--- a/client/signup/logged-out-form/style.scss
+++ b/client/signup/logged-out-form/style.scss
@@ -7,11 +7,11 @@
 	background: lighten( $gray, 34% );
 	border-top: 1px solid lighten( $gray, 30% );
 	margin: 16px -16px -16px -16px;
-	padding: 24px 16px;
+	padding: 16px;
 
 	@include breakpoint( ">480px" ) {
 		margin: 40px -24px -24px -24px;
-		padding: 30px 40px;
+		padding: 24px;
 	}
 
 	.button.is-primary {


### PR DESCRIPTION
In a Slack chat, @rickybanister suggested that the signup form footer's padding match that of the `Card` above. This PR does that.

cc @fabianapsimoes as someone from NUX who has also worked in this file

To test:
- Checkout `update/logged-out-form-footer-padding`
- Go to `/start/account/user`

After:

![screen shot 2](https://cloud.githubusercontent.com/assets/1126811/11571374/950ea1f0-99c1-11e5-9d85-2b4ddc27c92c.png)
![screen shot 3](https://cloud.githubusercontent.com/assets/1126811/11571373/950e95ca-99c1-11e5-96cd-a216757c2e11.png)
