### PR TITLE
Site Settings: Make it impossible for users to delete a site with active subscriptions

### DIFF
--- a/client/lib/sites-list/actions.js
+++ b/client/lib/sites-list/actions.js
@@ -47,20 +47,34 @@ var SitesListActions = {
 		}
 	},
 
-	deleteSite: function( site ) {
+	deleteSite: function( site, onComplete ) {
 		Dispatcher.handleViewAction( {
 			type: 'DELETE_SITE',
 			site: site
 		} );
 
 		debug( 'Deleting site', site );
-		wpcom.deleteSite( site.ID, SitesListActions.receiveDeletedSite );
+
+		wpcom.deleteSite( site.ID, function( error ) {
+			if ( error ) {
+				Dispatcher.handleServerAction( {
+					type: 'RECEIVE_DELETED_SITE_ERROR',
+					error: error
+				} );
+			} else {
+				Dispatcher.handleServerAction( {
+					type: 'RECEIVE_DELETED_SITE',
+					site: site
+				} );
+			}
+
+			onComplete( ! error );
+		} );
 	},
 
 	receiveDeletedSite: function( error, data ) {
 		Dispatcher.handleServerAction( {
 			type: 'RECEIVE_DELETED_SITE',
-			error: error,
 			site: data
 		} );
 	},

--- a/client/lib/sites-list/delete-site-store.js
+++ b/client/lib/sites-list/delete-site-store.js
@@ -39,8 +39,11 @@ DeletedSiteStore.dispatchToken = Dispatcher.register( function( payload ) {
 		case 'DELETE_SITE':
 			storeDeletedSite( action.site );
 			break;
-		case 'RECEIVE_DELETED_SITE':
+		case 'RECEIVE_DELETED_SITE_ERROR':
 			handleDeleteSiteResponse( action.error );
+			break;
+		case 'RECEIVE_DELETED_SITE':
+			handleDeleteSiteResponse();
 			break;
 		case 'CLEAR_DELETED_SITE':
 			clearDeletedSite();

--- a/client/lib/sites-list/index.js
+++ b/client/lib/sites-list/index.js
@@ -13,7 +13,7 @@ module.exports = function() {
 			var action = payload.action;
 			switch ( action.type ) {
 				case 'DISCONNECT_SITE':
-				case 'DELETE_SITE':
+				case 'RECEIVE_DELETED_SITE':
 					_sites.removeSite( action.site );
 					break;
 

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -186,10 +186,14 @@ module.exports = React.createClass( {
 	},
 
 	_deleteSite: function() {
-		var site = this.state.site;
-		SiteListActions.deleteSite( site );
-		window.scrollTo( 0, 0 );
-		page( '/stats' );
+		this.setState( { showDialog: false } );
+
+		SiteListActions.deleteSite( this.state.site, function( success ) {
+			if ( success ) {
+				window.scrollTo( 0, 0 );
+				page( '/stats' );
+			}
+		}.bind( this ) );
 	},
 
 	_updateSite: function() {

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -190,8 +190,7 @@ module.exports = React.createClass( {
 
 		SiteListActions.deleteSite( this.state.site, function( success ) {
 			if ( success ) {
-				window.scrollTo( 0, 0 );
-				page( '/stats' );
+				page.redirect( '/stats' );
 			}
 		}.bind( this ) );
 	},

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -235,6 +235,8 @@ module.exports = {
 			statSummaryList,
 			summarySites;
 
+		window.scrollTo( 0, 0 );
+
 		titleActions.setTitle( i18n.translate( 'Stats', { textOnly: true } ) );
 
 		activeFilter = filters().filter( function( filter ) {

--- a/client/notices/notices-list.jsx
+++ b/client/notices/notices-list.jsx
@@ -100,9 +100,6 @@ export default React.createClass( {
 				);
 			}, this );
 
-		if ( ! noticesRaw.length ) {
-			return null;
-		}
 		return (
 			<div>
 				<div id={ this.props.id } className={ classNames( 'notices-list', { 'is-pinned': this.state.pinned } ) }>


### PR DESCRIPTION
Fixes #1110.

Currently, it is possible to delete a site that has active subscriptions by either:

- Visiting `/settings/general/:site` and clicking the 'Delete Site' link from `DeleteSiteOptions` before the purchases have been fetched from the API.
- Visiting `/settings/delete-site/:site` directly.

This PR addresses this by:

- Not rendering `DeleteSiteOptions` until the purchases have been loaded from the API (this is how this component used to behave).
- Returning an error from the site deletion endpoint if there are active subscriptions for the given site.
- Updating `NoticesList` so that it renders even when passed an empty array of notices, ensuring that `DeleteSiteNotices` is rendered (this is how the this component used to behave).

@johnHackworth I believe the inverse change of [this commit](https://github.com/Automattic/wp-calypso/commit/35237411d3521698e681dbfec7cebc9b62ce0d5c) was added by you a couple months ago. Do you know of any issues with removing that check in `NoticesList`?

**Testing**
- Apply the patch.
- Checkout this branch.
- Navigate to `/settings/general/:site` for a site with an active subscription (e.g. a premium plan).
- Assert that clicking the 'Delete Site' link at the bottom of the page brings up a dialog prompting you to remove your active subscription.
- Navigate to `/settings/delete-site/:site` for a site with an active subscription.
- Assert that an error notice appears when you attempt to delete a site.