### PR TITLE
Pages: check for recent errors, add placeholder for errored requests.

### DIFF
--- a/client/components/post-list-fetcher/index.jsx
+++ b/client/components/post-list-fetcher/index.jsx
@@ -59,7 +59,8 @@ function getPostsState() {
 		postImages: PostContentImagesStore.getAll(),
 		page: PostListStore.getPage(),
 		lastPage: PostListStore.isLastPage(),
-		loading: PostListStore.isFetchingNextPage()
+		loading: PostListStore.isFetchingNextPage(),
+		hasRecentError: PostListStore.hasRecentError()
 	};
 }
 

--- a/client/lib/posts/post-counts-store.js
+++ b/client/lib/posts/post-counts-store.js
@@ -102,13 +102,13 @@ PostCountsStore.dispatchToken = Dispatcher.register( function( payload ) {
 	switch ( action.type ) {
 		case 'RECEIVE_UPDATED_POSTS':
 		case 'RECEIVE_POSTS_PAGE':
-			if ( data.meta && data.meta.data && data.meta.data.counts ) {
+			if ( data && data.meta && data.meta.data && data.meta.data.counts ) {
 				setPostCounts( data.meta.data.counts );
 			}
 			break;
 
 		case 'RECEIVE_POST_COUNTS':
-			if ( data.counts && action.siteId ) {
+			if ( data && data.counts && action.siteId ) {
 				setPostCounts( data, action.siteId );
 			}
 			break;

--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -3,6 +3,7 @@
  */
 var debug = require( 'debug' )( 'calypso:posts-list' ),
 	clone = require( 'lodash/lang/clone' ),
+	some = require( 'lodash/collection/some' ),
 	assign = require( 'lodash/object/assign' ),
 	transform = require( 'lodash/object/transform' ),
 	difference = require( 'lodash/array/difference' ),
@@ -135,6 +136,7 @@ function receivePage( id, error, data ) {
 
 	if ( error ) {
 		debug( 'Error fetching PostsList from api:', error );
+		error.timestamp = Date.now();
 		_activeList.errors.push( error );
 		PostListStore.emit( 'change' );
 		return;
@@ -260,6 +262,16 @@ PostListStore = {
 
 	isFetchingNextPage: function() {
 		return _activeList.isFetchingNextPage;
+	},
+
+	// Have we received an error recently?
+	hasRecentError: function() {
+		const recentTimeIntervalSeconds = 30;
+		const dateNow = Date.now();
+
+		return some( _activeList.errors, function( error ) {
+			return ( dateNow - error.timestamp ) < ( recentTimeIntervalSeconds * 1000 );
+		} );
 	},
 
 	getNextPageParams: function() {

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -59,13 +59,15 @@ var Pages = React.createClass({
 		search: React.PropTypes.string,
 		siteID: React.PropTypes.any,
 		sites: React.PropTypes.object.isRequired,
-		trackScrollPage: React.PropTypes.func.isRequired
+		trackScrollPage: React.PropTypes.func.isRequired,
+		hasRecentError: React.PropTypes.bool.isRequired
 	},
 
 	getDefaultProps: function() {
 		return {
 			perPage: 20,
 			loading: false,
+			hasRecentError: false,
 			lastPage: false,
 			page: 0,
 			posts: [],
@@ -74,7 +76,7 @@ var Pages = React.createClass({
 	},
 
 	fetchPages: function( options ) {
-		if ( this.props.loading || this.props.lastPage ) {
+		if ( this.props.loading || this.props.lastPage || this.props.hasRecentError ) {
 			return;
 		}
 		if ( options.triggeredByScroll ) {
@@ -135,37 +137,44 @@ var Pages = React.createClass({
 				newPageLink = selectedSite ? '//wordpress.com/page/' + selectedSite.ID + '/new' : '//wordpress.com/page';
 			}
 
-			const status = this.props.status || 'published';
-			switch ( status ) {
-				case 'drafts':
-					attributes = {
-						title: this.translate( 'You don\'t have any drafts.' ),
-						line: this.translate( 'Would you like to create one?' ),
-						action: this.translate( 'Start a Page' ),
-						actionURL: newPageLink
-					};
-					break;
-				case 'scheduled':
-					attributes = {
-						title: this.translate( 'You don\'t have any scheduled pages yet.' ),
-						line: this.translate( 'Would you like to create one?' ),
-						action: this.translate( 'Start a Page' ),
-						actionURL: newPageLink
-					};
-					break;
-				case 'trashed':
-					attributes = {
-						title: this.translate( 'You don\'t have any pages in your trash folder.' ),
-						line: this.translate( 'Everything you write is solid gold.' )
-					};
-					break;
-				default:
-					attributes = {
-						title: this.translate( 'You haven\'t published any pages yet.' ),
-						line: this.translate( 'Would you like to publish your first page?' ),
-						action: this.translate( 'Start a Page' ),
-						actionURL: newPageLink
-					};
+			if ( this.props.hasRecentError ) {
+				attributes = {
+					title: this.translate( 'Oh, no! We couldn\'t fetch your pages.' ),
+					line: this.translate( 'Please check your internet connection.' )
+				};
+			} else {
+				const status = this.props.status || 'published';
+				switch ( status ) {
+					case 'drafts':
+						attributes = {
+							title: this.translate( 'You don\'t have any drafts.' ),
+							line: this.translate( 'Would you like to create one?' ),
+							action: this.translate( 'Start a Page' ),
+							actionURL: newPageLink
+						};
+						break;
+					case 'scheduled':
+						attributes = {
+							title: this.translate( 'You don\'t have any scheduled pages yet.' ),
+							line: this.translate( 'Would you like to create one?' ),
+							action: this.translate( 'Start a Page' ),
+							actionURL: newPageLink
+						};
+						break;
+					case 'trashed':
+						attributes = {
+							title: this.translate( 'You don\'t have any pages in your trash folder.' ),
+							line: this.translate( 'Everything you write is solid gold.' )
+						};
+						break;
+					default:
+						attributes = {
+							title: this.translate( 'You haven\'t published any pages yet.' ),
+							line: this.translate( 'Would you like to publish your first page?' ),
+							action: this.translate( 'Start a Page' ),
+							actionURL: newPageLink
+						};
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #358, where after losing internet connection, the pages placeholder would glitch between a loading placeholder and an empty placeholder. This PR adds a method hasRecentError to the store, so the we can limit the number of actions dispatched from the view when the store enters that state. This also adds a simple errored placeholder to pages. 

## Testing instructions:
1. In a fresh browser tab, open: http://calypso.localhost:3000/posts
2. Select a site if prompted
3. Turn off your wifi
4. Click on the Pages sidebar link

Before:
![glitch](https://cloud.githubusercontent.com/assets/1270189/11575424/c811c7f4-99c5-11e5-80e8-a7b4db202273.gif)
After: 
<img width="740" alt="after" src="https://cloud.githubusercontent.com/assets/1270189/11575427/ccad7394-99c5-11e5-886b-0a8c631d3423.png">

cc @rralian @rickybanister 