### PR TITLE
Revert "Invites: Ensure that user inputted data is decoded"

### DIFF
--- a/client/lib/invites/reducers/invites-validation.js
+++ b/client/lib/invites/reducers/invites-validation.js
@@ -2,39 +2,22 @@
  * External dependencies
  */
 import { fromJS } from 'immutable';
-import mapValues from 'lodash/object/mapValues';
-import pick from 'lodash/object/pick';
 
 /**
  * Internal dependencies
  */
 import { action as ActionTypes } from 'lib/invites/constants';
-import { decodeEntities } from 'lib/formatting';
 
 const initialState = fromJS( {
 	list: {},
 	errors: {}
 } );
 
-function filterObject( object ) {
-	return mapValues( object, value => {
-		if ( 'object' === typeof value ) {
-			return filterObject( value );
-		}
-
-		return value ? decodeEntities( value ) : value;
-	} );
-}
-
-function filterInvite( invite ) {
-	return mapValues( pick( invite, [ 'invite', 'inviter', 'blog_details' ] ), filterObject );
-}
-
 const reducer = ( state = initialState, payload ) => {
 	const { action } = payload;
 	switch ( action.type ) {
 		case ActionTypes.RECEIVE_INVITE:
-			return state.setIn( [ 'list', action.siteId, action.inviteKey ], filterInvite( action.data ) );
+			return state.setIn( [ 'list', action.siteId, action.inviteKey ], action.data );
 		case ActionTypes.RECEIVE_INVITE_ERROR:
 			return state.setIn( [ 'errors', action.siteId, action.inviteKey ], action.error );
 	}

--- a/server/user-bootstrap/shared-utils.js
+++ b/server/user-bootstrap/shared-utils.js
@@ -1,19 +1,13 @@
 /**
  * External dependencies
  */
-import assign from 'lodash/object/assign';
-import contains from 'lodash/collection/contains';
+var assign = require( 'lodash/object/assign' );
 
 /**
  * Internal dependencies
  */
-import config from 'config';
-import { decodeEntities } from 'lib/formatting';
-
-/**
- * Module variables
- */
-const languages = config( 'languages' );
+var config = require( 'config' ),
+	languages = config( 'languages' );
 
 function getLanguage( slug ) {
 	var len = languages.length,
@@ -55,17 +49,10 @@ module.exports = {
 				'logout_URL',
 				'primary_blog_url',
 				'meta',
-			],
-			decodeWhitelist = [
-				'display_name',
-				'description',
-				'user_URL'
 			];
 
 		allowedKeys.forEach( function( key ) {
-			user[ key ] = obj[ key ] && contains( decodeWhitelist, key )
-				? decodeEntities( obj[ key ] )
-				: obj[ key ];
+			user[ key ] = obj[ key ];
 		} );
 
 		return assign( user, this.getComputedAttributes( obj ) );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#1222

All environments except for development seem to be broken. I believe it is related to my last pull request which modified `user-bootstrap`.