### PR TITLE
Domains: Standardize store and module getters

### DIFF
--- a/client/components/data/domain-management/README.md
+++ b/client/components/data/domain-management/README.md
@@ -62,6 +62,6 @@ The child component should receive processed props defined during the render:
 As well as:
 
 * `cart` - products added to the cart, it's the result of a call to `CartStore.get`  
-* `domains` - a list of domains, it's the result of a call to `DomainsStore.getForSite` for the current site
+* `domains` - a list of domains, it's the result of a call to `DomainsStore.getBySite` for the current site
 
 It's updated whenever CartStore`, `DomainStore`, `productsList` or `sites` changes.

--- a/client/components/data/domain-management/dns/README.md
+++ b/client/components/data/domain-management/dns/README.md
@@ -42,7 +42,7 @@ The child component should receive processed props defined during the render:
 
 As well as:
 
-* `domains` - a list of domains, it's the result of a call to `DomainsStore.getForSite` for the current site
+* `domains` - a list of domains, it's the result of a call to `DomainsStore.getBySite` for the current site
 * `dns` - DNS records, it's the result of a call to `DnsStore.getByDomainName` for the current domain  
 
 It's updated whenever `DomainsStore`, `DnsStore` or `sites` changes.

--- a/client/components/data/domain-management/dns/index.jsx
+++ b/client/components/data/domain-management/dns/index.jsx
@@ -21,7 +21,7 @@ function getStateFromStores( props ) {
 	let domains;
 
 	if ( props.selectedSite ) {
-		domains = DomainsStore.getForSite( props.selectedSite.ID );
+		domains = DomainsStore.getBySite( props.selectedSite.ID );
 	}
 
 	return {

--- a/client/components/data/domain-management/email/README.md
+++ b/client/components/data/domain-management/email/README.md
@@ -52,7 +52,7 @@ The child component should receive processed props defined during the render:
 As well as:
 
 * `cart` - products added to the cart, it's the result of a call to `CartStore.get`  
-* `domains` - a list of domains, it's the result of a call to `DomainsStore.getForSite` for the current site
+* `domains` - a list of domains, it's the result of a call to `DomainsStore.getBySite` for the current site
 * `googleAppsUsers` - Google Apps users, it's the result of a call to `GoogleAppsUsersStore.getByDomainName` for the current domain
 
 It's updated whenever `CartStore`, `DomainsStore`, `GoogleAppsUsersStore`, `productsList` or `sites` changes.

--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -23,7 +23,7 @@ function getStateFromStores( props ) {
 	let domains;
 
 	if ( props.selectedSite ) {
-		domains = DomainsStore.getForSite( props.selectedSite.ID );
+		domains = DomainsStore.getBySite( props.selectedSite.ID );
 	}
 
 	return {

--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -21,7 +21,7 @@ function getStateFromStores( props ) {
 	return {
 		cart: CartStore.get(),
 		context: props.context,
-		domains: ( props.selectedSite ? DomainsStore.getForSite( props.selectedSite.ID ) : null ),
+		domains: ( props.selectedSite ? DomainsStore.getBySite( props.selectedSite.ID ) : null ),
 		products: props.products,
 		selectedSite: props.selectedSite
 	};

--- a/client/components/data/domain-management/nameservers/README.md
+++ b/client/components/data/domain-management/nameservers/README.md
@@ -42,7 +42,7 @@ The child component should receive processed props defined during the render:
 
 As well as:
 
-* `domains` - a list of domains, it's the result of a call to `DomainsStore.getForSite` for the current site
+* `domains` - a list of domains, it's the result of a call to `DomainsStore.getBySite` for the current site
 * `nameservers` - nameservers data, it's the result of a call to `NameserversStore.getByDomainName` for the current domain  
 
 It's updated whenever `DomainsStore`, `NameserversStore` or `sites` changes.

--- a/client/components/data/domain-management/nameservers/index.jsx
+++ b/client/components/data/domain-management/nameservers/index.jsx
@@ -21,7 +21,7 @@ function getStateFromStores( props ) {
 	let domains;
 
 	if ( props.selectedSite ) {
-		domains = DomainsStore.getForSite( props.selectedSite.ID );
+		domains = DomainsStore.getBySite( props.selectedSite.ID );
 	}
 
 	return {

--- a/client/components/data/domain-management/primary-domain/README.md
+++ b/client/components/data/domain-management/primary-domain/README.md
@@ -42,6 +42,6 @@ The child component should receive processed props defined during the render:
 
 As well as:
 
-* `domains` - a list of domains, it's the result of a call to `DomainsStore.getForSite` for the current site
+* `domains` - a list of domains, it's the result of a call to `DomainsStore.getBySite` for the current site
 
 It's updated whenever `DomainsStore` or `sites` changes.

--- a/client/components/data/domain-management/primary-domain/index.jsx
+++ b/client/components/data/domain-management/primary-domain/index.jsx
@@ -18,7 +18,7 @@ function getStateFromStores( props ) {
 	let domains;
 
 	if ( props.selectedSite ) {
-		domains = DomainsStore.getForSite( props.selectedSite.ID );
+		domains = DomainsStore.getBySite( props.selectedSite.ID );
 	}
 
 	return {

--- a/client/components/data/domain-management/transfer/README.md
+++ b/client/components/data/domain-management/transfer/README.md
@@ -42,7 +42,7 @@ The child component should receive processed props defined during the render:
 
 As well as:
 
-* `domains` - a list of domains, it's the result of a call to `DomainsStore.getForSite` for the current site
+* `domains` - a list of domains, it's the result of a call to `DomainsStore.getBySite` for the current site
 * `wapiDomainInfo` - Wapi domain info, it's the result of a call to `WapiDomainInfoStore.getForSite` for the current site  
 
 It's updated whenever `DomainsStore`, `WapiDomainInfoStore` or `sites` changes.

--- a/client/components/data/domain-management/transfer/README.md
+++ b/client/components/data/domain-management/transfer/README.md
@@ -43,6 +43,6 @@ The child component should receive processed props defined during the render:
 As well as:
 
 * `domains` - a list of domains, it's the result of a call to `DomainsStore.getBySite` for the current site
-* `wapiDomainInfo` - Wapi domain info, it's the result of a call to `WapiDomainInfoStore.getForSite` for the current site  
+* `wapiDomainInfo` - Wapi domain info, it's the result of a call to `WapiDomainInfoStore.getByDomainName` for the current domain  
 
 It's updated whenever `DomainsStore`, `WapiDomainInfoStore` or `sites` changes.

--- a/client/components/data/domain-management/transfer/index.jsx
+++ b/client/components/data/domain-management/transfer/index.jsx
@@ -20,7 +20,7 @@ function getStateFromStores( props ) {
 	let domains;
 
 	if ( props.selectedSite ) {
-		domains = DomainsStore.getForSite( props.selectedSite.ID );
+		domains = DomainsStore.getBySite( props.selectedSite.ID );
 	}
 
 	return {

--- a/client/components/data/domain-management/whois/README.md
+++ b/client/components/data/domain-management/whois/README.md
@@ -48,7 +48,7 @@ The child component should receive processed props defined during the render:
 
 As well as:
 
-* `domains` - a list of domains, it's the result of a call to `DomainsStore.getForSite` for the current site
+* `domains` - a list of domains, it's the result of a call to `DomainsStore.getBySite` for the current site
 * `whois` - WHOIS contact information, it's the result of a call to `WhoisStore.getByDomainName` for the current domain  
 
 It's updated whenever `DomainsStore`, `WhoisStore`, `productsList` or `sites` changes.

--- a/client/components/data/domain-management/whois/index.jsx
+++ b/client/components/data/domain-management/whois/index.jsx
@@ -21,7 +21,7 @@ function getStateFromStores( props ) {
 	let domains;
 
 	if ( props.selectedSite ) {
-		domains = DomainsStore.getForSite( props.selectedSite.ID );
+		domains = DomainsStore.getBySite( props.selectedSite.ID );
 	}
 
 	return {

--- a/client/lib/domains/README.md
+++ b/client/lib/domains/README.md
@@ -18,13 +18,13 @@ It is modelled as a [Flux](https://facebook.github.io/flux/docs/overview.html) s
 
 ## Usage
 
-The store is a singleton object which offers `get` and `getForSite` methods to retrieve data:
+The store is a singleton object which offers `get` and `getBySite` methods to retrieve data:
 
 ```js
 import DomainsStore from 'lib/domains/store';
 
 DomainsStore.get()
-DomainsStore.getForSite( 'example.wordpress.com' )
+DomainsStore.getBySite( 'example.wordpress.com' )
 ```
 
 To interact with the store, use the actions made available in [`domain-management.js`](../../upgrades/actions/domain-management.js):

--- a/client/lib/domains/reducer.js
+++ b/client/lib/domains/reducer.js
@@ -94,7 +94,7 @@ function reducer( state, payload ) {
 
 		case UpgradesActionTypes.DOMAIN_TRANSFER_CODE_REQUEST_COMPLETED:
 			domainData = getSelectedDomain( {
-				domains: getForSite( state, action.siteId ),
+				domains: getBySite( state, action.siteId ),
 				selectedDomainName: action.domainName
 			} );
 			privateDomain = ( ! action.disablePrivacy ) && domainData.privateDomain;
@@ -108,12 +108,12 @@ function reducer( state, payload ) {
 	}
 }
 
-function getForSite( state, siteId ) {
+function getBySite( state, siteId ) {
 	return state[ siteId ];
 }
 
 export {
-	getForSite,
+	getBySite,
 	initialState,
 	reducer
 };

--- a/client/lib/domains/store.js
+++ b/client/lib/domains/store.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import { createReducerStore } from 'lib/store';
-import { getForSite, initialState, reducer } from './reducer';
+import { getBySite, initialState, reducer } from './reducer';
 
 const DomainsStore = createReducerStore( reducer, initialState );
 
-DomainsStore.getForSite = siteId => getForSite( DomainsStore.get(), siteId );
+DomainsStore.getBySite = siteId => getBySite( DomainsStore.get(), siteId );
 
 export default DomainsStore;

--- a/client/lib/domains/wapi-domain-info/reducer.js
+++ b/client/lib/domains/wapi-domain-info/reducer.js
@@ -65,7 +65,7 @@ function reducer( state, payload ) {
 		case UpgradesActionTypes.DOMAIN_TRANSFER_CODE_REQUEST_COMPLETED:
 			const { data } = state[ action.domainName ],
 				domainData = getSelectedDomain( {
-					domains: DomainsStore.getForSite( action.siteId ),
+					domains: DomainsStore.getBySite( action.siteId ),
 					selectedDomainName: action.domainName
 				} ),
 				locked = ( ! action.unlock ) && data.locked,

--- a/client/lib/states-list/README.md
+++ b/client/lib/states-list/README.md
@@ -19,7 +19,7 @@ The following public methods are available:
 
 This fetches the corresponding list of states from the server. The list is cached in the store upon retrieval.
 
-### `getForCountry( countryCode )`
+### `getByCountry( countryCode )`
 
 This retrieves the list of states as a set of key and value pairs. The list is loaded from the store and then fetched once from the server to update any stale data.
 

--- a/client/lib/states-list/index.js
+++ b/client/lib/states-list/index.js
@@ -82,7 +82,7 @@ StatesList.prototype.fetchForCountry = function( countryCode ) {
  * @param {string} countryCode - country code
  * @returns {object} the list of states
  */
-StatesList.prototype.getForCountry = function( countryCode ) {
+StatesList.prototype.getByCountry = function( countryCode ) {
 	var data;
 
 	if ( ! this.data ) {

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -108,7 +108,7 @@ module.exports = React.createClass( {
 	},
 
 	getDomainExpirationNotices: function() {
-		let domainStore = this.state.domainsStore.getForSite( this.getSelectedSite().ID ),
+		let domainStore = this.state.domainsStore.getBySite( this.getSelectedSite().ID ),
 			domains = domainStore && domainStore.list || [];
 		return (
 			<DomainWarnings

--- a/client/my-sites/upgrades/components/form/state-select.jsx
+++ b/client/my-sites/upgrades/components/form/state-select.jsx
@@ -31,7 +31,7 @@ module.exports = React.createClass( {
 				focus: this.state.focus,
 				invalid: this.props.invalid
 			} ),
-			statesList = this.props.statesList.getForCountry( this.props.countryCode ),
+			statesList = this.props.statesList.getByCountry( this.props.countryCode ),
 			options = [];
 
 		if ( isEmpty( statesList ) ) {


### PR DESCRIPTION
This pull request seeks to standardize the few access methods that weren't following the *de facto* naming convention in Flux stores (used in the domains management section) as well as in a module (used in the checkout). The logic didn't change and everything should work as before.

#### Testing instructions

##### Checkout

1. Navigate to the [`Domains Search` page](http://calypso.localhost:3000/domains/add)
2. Click on any `Add` button to add a domain to the shopping cart
3. Click on the `No thanks, I don't need email or will use another provider.` link on the next page
4. Select a country on the `Domain Registration Details` page that triggers the list of states (e.g. Spain)
5. Fill in and submit the form
6. Submit the form on the `Secure Payment` page and check that the purchase was successful

##### Domains Management

1. Navigate to the [`Domains` page](http://calypso.localhost:3000/domains/add)
2. Click on the new domain registration to open the corresponding `Domain Settings` page
3. Check that you can still perform any operation such as:
  * Making the domain primary
  * Adding an email forward
  * Adding a DNS record
  * Updating name servers