### PR TITLE
Purchases: Perform redirect when user can't access Manage Purchase page

### DIFF
--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -27,23 +27,24 @@ const CancelPurchase = React.createClass( {
 	},
 
 	componentWillMount() {
-		if ( this.isDataValid( this.props ) ) {
-			recordPageView( 'cancel_purchase', this.props );
-		} else {
+		if ( ! this.isDataValid() ) {
 			this.redirect( this.props );
+			return;
 		}
+
+		recordPageView( 'cancel_purchase', this.props );
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		if ( this.isDataValid( nextProps ) ) {
-			recordPageView( 'cancel_purchase', this.props, nextProps );
-		} else if ( this.isDataValid( this.props ) && ! this.isDataValid( nextProps ) ) {
-			// only redirect for invalid data once
+		if ( this.isDataValid() && ! this.isDataValid( nextProps ) ) {
 			this.redirect( nextProps );
+			return;
 		}
+
+		recordPageView( 'cancel_purchase', this.props, nextProps );
 	},
 
-	isDataValid( props ) {
+	isDataValid( props = this.props ) {
 		const purchase = getPurchase( props ),
 			selectedSite = getSelectedSite( props );
 
@@ -63,7 +64,7 @@ const CancelPurchase = React.createClass( {
 	},
 
 	render() {
-		if ( ! this.isDataValid( this.props ) ) {
+		if ( ! this.isDataValid() ) {
 			return null;
 		}
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -62,7 +62,8 @@ const ManagePurchase = React.createClass( {
 
 	componentWillMount() {
 		if ( ! this.isDataValid() ) {
-			return page.redirect( paths.list() );
+			page.redirect( paths.list() );
+			return;
 		}
 
 		recordPageView( 'manage', this.props );
@@ -70,7 +71,8 @@ const ManagePurchase = React.createClass( {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.isDataValid() && ! this.isDataValid( nextProps ) ) {
-			return page.redirect( paths.list() );
+			page.redirect( paths.list() );
+			return;
 		}
 
 		recordPageView( 'manage', this.props, nextProps );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -53,7 +53,10 @@ const ManagePurchase = React.createClass( {
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
 		selectedPurchase: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.object,
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.object,
+			React.PropTypes.bool
+		] ).isRequired,
 		destinationType: React.PropTypes.string
 	},
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -46,7 +46,7 @@ import {
 	showCreditCardExpiringWarning,
 	showEditPaymentDetails
 } from 'lib/purchases';
-import { getPurchase, goToList, isDataLoading, recordPageView } from '../utils';
+import { getPurchase, getSelectedSite, goToList, isDataLoading, recordPageView } from '../utils';
 import { isDomainProduct, isGoogleApps, isPlan, isSiteRedirect, isTheme } from 'lib/products-values';
 
 const ManagePurchase = React.createClass( {
@@ -58,15 +58,31 @@ const ManagePurchase = React.createClass( {
 	},
 
 	componentWillMount() {
+		if ( ! this.isDataValid() ) {
+			return page.redirect( paths.list() );
+		}
+
 		recordPageView( 'manage', this.props );
 	},
 
 	componentWillReceiveProps( nextProps ) {
+		if ( this.isDataValid() && ! this.isDataValid( nextProps ) ) {
+			return page.redirect( paths.list() );
+		}
+
 		recordPageView( 'manage', this.props, nextProps );
 	},
 
 	isDataFetchingAfterRenewal() {
 		return 'thank-you' === this.props.destinationType && this.props.selectedPurchase.isFetching;
+	},
+
+	isDataValid( props = this.props ) {
+		if ( isDataLoading( props ) ) {
+			return true;
+		}
+
+		return getSelectedSite( props ) && getPurchase( props );
 	},
 
 	renderNotices() {
@@ -598,8 +614,7 @@ const ManagePurchase = React.createClass( {
 	},
 
 	render() {
-		if ( this.props.selectedPurchase.hasLoadedFromServer && ! getPurchase( this.props ) ) {
-			// TODO: redirect to purchases list
+		if ( ! this.isDataValid() ) {
 			return null;
 		}
 


### PR DESCRIPTION
Fixes part of #275. I tried to follow the pattern set up by @gziolo in #1153, because we'll be using this pattern a few more times throughout `/purchases`.

**Testing**
- Visit `/purchases/:site/:purchase_id` for with an invalid `:purchase_id`.
- Assert that you are redirected to `/purchases` once the data has been fetched from the API.
- Visit `/purchases/:site/:purchase_id/cancel` for with an invalid `:purchase_id`.
- Assert that you are redirected to `/purchases` once the data has been fetched from the API.

**Review**
- [x] QA review
- [x] Code review