### PR TITLE
Signup: DSS: Show loading overlay during image preloading

### DIFF
--- a/client/signup/steps/dss/index.jsx
+++ b/client/signup/steps/dss/index.jsx
@@ -104,9 +104,10 @@ export default React.createClass( {
 	},
 
 	renderImageLoader() {
-		if ( ! this.state.renderComplete ) {
-			debug( 'preloading image', this.state.dssImage.url );
+		if ( this.state.renderComplete ) {
+			return '';
 		}
+		debug( 'preloading image', this.state.dssImage.url );
 		const placeholder = <div>…</div>;
 		return (
 			<ImagePreloader

--- a/client/signup/steps/dss/index.jsx
+++ b/client/signup/steps/dss/index.jsx
@@ -126,6 +126,7 @@ export default React.createClass( {
 					<SearchCard id="dss-theme-selection__search__field"
 						autoFocus={ true }
 						delaySearch={ true }
+						delayTimeout={ 450 }
 						placeholder={ this.translate( 'e.g., games' ) }
 						onSearch={ this.handleSearch }
 					/>

--- a/client/signup/steps/dss/index.jsx
+++ b/client/signup/steps/dss/index.jsx
@@ -51,13 +51,13 @@ export default React.createClass( {
 
 	componentWillMount() {
 		ThemePreviewStore.on( 'change', this.updateMarkup );
-		DSSImageStore.on( 'change', this.updateScreenshot );
+		DSSImageStore.on( 'change', this.updateScreenshots );
 		this.loadThemePreviews();
 	},
 
 	componentWillUnmount() {
 		ThemePreviewStore.off( 'change', this.updateMarkup );
-		DSSImageStore.off( 'change', this.updateScreenshot );
+		DSSImageStore.off( 'change', this.updateScreenshots );
 	},
 
 	componentWillReceiveProps() {
@@ -73,13 +73,14 @@ export default React.createClass( {
 		this.setState( { markupAndStyles: ThemePreviewStore.get() } );
 	},
 
-	updateScreenshot() {
+	updateScreenshots() {
 		const { isLoading, lastKey, imageResultsByKey } = DSSImageStore.get();
+		// If there is no search currently happening or no results for a current search...
 		if ( ! imageResultsByKey[ lastKey ] ) {
 			return this.setState( { isLoading, renderComplete: false, dssImage: null } );
 		}
 		const dssImage = imageResultsByKey[ lastKey ];
-		this.setState( { isLoading, dssImage } );
+		this.setState( { isLoading, dssImage, renderComplete: false } );
 	},
 
 	dssImageLoaded() {
@@ -100,7 +101,9 @@ export default React.createClass( {
 	},
 
 	renderImageLoader() {
-		debug( 'preloading image', this.state.dssImage.url );
+		if ( ! this.state.renderComplete ) {
+			debug( 'preloading image', this.state.dssImage.url );
+		}
 		const placeholder = <div>…</div>;
 		return (
 			<ImagePreloader

--- a/client/signup/steps/dss/index.jsx
+++ b/client/signup/steps/dss/index.jsx
@@ -89,10 +89,13 @@ export default React.createClass( {
 	},
 
 	handleSearch( searchString ) {
-		debug( 'processing search for', searchString );
 		if ( ! searchString ) {
 			return DynamicScreenshotsActions.resetScreenshots();
 		}
+		if ( searchString.length < 3 ) {
+			return;
+		}
+		debug( 'processing search for', searchString );
 		const { imageResultsByKey } = DSSImageStore.get();
 		if ( imageResultsByKey[ searchString ] ) {
 			return DynamicScreenshotsActions.updateScreenshotsFor( searchString );

--- a/client/signup/steps/dss/screenshot.jsx
+++ b/client/signup/steps/dss/screenshot.jsx
@@ -30,6 +30,18 @@ export default React.createClass( {
 		renderComplete: React.PropTypes.bool
 	},
 
+	shouldShowLoadingIndicator() {
+		// If the store is waiting on results, show loading.
+		if ( this.props.isLoading ) {
+			return true;
+		}
+		// If the image is preloading, show loading.
+		if ( this.props.dssImage && ! this.props.renderComplete ) {
+			return true;
+		}
+		return false;
+	},
+
 	getAdditionalStyles( imageUrl ) {
 		return `#theme-${this.props.themeSlug} .hero.with-featured-image{background-image:url(${imageUrl});}`;
 	},
@@ -49,8 +61,8 @@ export default React.createClass( {
 	render() {
 		const { markup, styles } = this.props.markupAndStyles || { markup: null, styles: null };
 		const containerClassNames = classnames( 'dss-screenshot', {
-			'is-loading': this.props.isLoading,
-			'is-preview-ready': markup && styles && this.props.renderComplete
+			'is-loading': this.shouldShowLoadingIndicator(), // show the white overlay
+			'is-preview-ready': markup && styles && this.props.renderComplete // show the dynamic screenshot
 		} );
 
 		if ( markup && styles ) {

--- a/client/signup/steps/dss/screenshot.jsx
+++ b/client/signup/steps/dss/screenshot.jsx
@@ -62,7 +62,7 @@ export default React.createClass( {
 		const { markup, styles } = this.props.markupAndStyles || { markup: null, styles: null };
 		const containerClassNames = classnames( 'dss-screenshot', {
 			'is-loading': this.shouldShowLoadingIndicator(), // show the white overlay
-			'is-preview-ready': markup && styles && this.props.renderComplete // show the dynamic screenshot
+			'is-preview-ready': markup && styles && this.props.dssImage // show the dynamic screenshot
 		} );
 
 		if ( markup && styles ) {

--- a/client/signup/steps/dss/style.scss
+++ b/client/signup/steps/dss/style.scss
@@ -53,16 +53,16 @@
 
 // Center themes, regardless of how many columns.
 .dss-theme-selection__screenshots__themes {
-       margin: 0 auto;
-       width: 300px;
+	margin: 0 auto;
+	width: 300px;
 
-       @include breakpoint( ">660px" ) {
-               width: 640px;
-       }
+	@include breakpoint( ">660px" ) {
+		width: 640px;
+	}
 
-       @include breakpoint( ">960px" ) {
-               width: 960px;
-       }
+	@include breakpoint( ">960px" ) {
+		width: 960px;
+	}
 }
 
 // Show the original screenshot image when the screenshot markup is loading.


### PR DESCRIPTION
Fixes #1163 

## Testing

Load http://calypso.localhost:3000/start/dss/ and try searching for words. Make sure that the images load correctly and with very little or no flicker of unstyled previews.

Try the following types of search events to look for strange behavior:

1. Type a search very slowly.
2. After typing a multi-word search, press backspace several times to delete the last word.
3. Clear the search field either with the 'X' or with select-all + backspace.
4. Slowly type a search for one word (e.g., "favorite") and then add another word (e.g, "favorite meal").
5. Search for one word, then search for a different word.
6. Search for one word, then search for a different word, then repeat the search for the first word again.
7. Search for one noun (e.g., "game"), then pluralize it (e.g., "games").
8. Search for something that returns no results (e.g., "asdasdlkjasdljs").