### PR TITLE
Invites: Filter invite object and decode entities

### DIFF
--- a/client/lib/invites/reducers/invites-validation.js
+++ b/client/lib/invites/reducers/invites-validation.js
@@ -2,22 +2,39 @@
  * External dependencies
  */
 import { fromJS } from 'immutable';
+import mapValues from 'lodash/object/mapValues';
+import pick from 'lodash/object/pick';
 
 /**
  * Internal dependencies
  */
 import { action as ActionTypes } from 'lib/invites/constants';
+import { decodeEntities } from 'lib/formatting';
 
 const initialState = fromJS( {
 	list: {},
 	errors: {}
 } );
 
+function filterObjectProperties( object ) {
+	return mapValues( object, value => {
+		if ( 'object' === typeof value ) {
+			return filterObjectProperties( value );
+		}
+
+		return value ? decodeEntities( value ) : value;
+	} );
+}
+
+function filterInvite( invite ) {
+	return mapValues( pick( invite, [ 'invite', 'inviter', 'blog_details' ] ), filterObjectProperties );
+}
+
 const reducer = ( state = initialState, payload ) => {
 	const { action } = payload;
 	switch ( action.type ) {
 		case ActionTypes.RECEIVE_INVITE:
-			return state.setIn( [ 'list', action.siteId, action.inviteKey ], action.data );
+			return state.setIn( [ 'list', action.siteId, action.inviteKey ], filterInvite( action.data ) );
 		case ActionTypes.RECEIVE_INVITE_ERROR:
 			return state.setIn( [ 'errors', action.siteId, action.inviteKey ], action.error );
 	}


### PR DESCRIPTION
This PR filters an invite and ensures that all value are decoded. Addresses #1086

To test:
- Checkout `update/invites-html-entities`
- Invite a test user by going to `$site/wp-admin/users.php?page=wpcom-invite-users`
- In the invitation email that you get, make note of the `$invite_key`
- Change the title of your site to include an entity of some sort ( ex. &)
- Go to `/accept-invite/$site/$invite_key` where `$site` has an entity in its name
- Is your site's title decoded properly?

__Note:__ Decoding the user object is now taking place in #1257, so the entities showing in the below screenshot are OK.

![screen shot 4](https://cloud.githubusercontent.com/assets/1126811/11578632/ccb3f508-99ec-11e5-9cb7-2560e0155884.png)