### PR TITLE
Me: Fix missing cancel button on email change notice

### DIFF
--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -33,7 +33,8 @@ var LanguageSelector = require( 'components/forms/language-selector' ),
 	ReauthRequired = require( 'me/reauth-required' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	user = require( 'lib/user' )(),
-	Notice = require( 'notices/notice' ),
+	Notice = require( 'components/notice' ),
+	NoticeAction = require( 'components/notice/notice-action' ),
 	notices = require( 'notices' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	eventRecorder = require( 'me/event-recorder' ),
@@ -248,9 +249,7 @@ module.exports = React.createClass( {
 
 		return (
 			<Notice
-				button={ this.translate( 'Cancel' ) }
 				isCompact={ true }
-				onClick={ this.cancelEmailChange }
 				showDismiss={ false }
 				status="is-info"
 				text={
@@ -259,7 +258,11 @@ module.exports = React.createClass( {
 							email: this.props.userSettings.getSetting( 'new_user_email' )
 						}
 					} )
-				} />
+				}>
+				<NoticeAction onClick={ this.cancelEmailChange }>
+					{ this.translate( 'Cancel' ) }
+				</NoticeAction>
+			</Notice>
 		);
 	},
 

--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -33,7 +33,7 @@ var LanguageSelector = require( 'components/forms/language-selector' ),
 	ReauthRequired = require( 'me/reauth-required' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	user = require( 'lib/user' )(),
-	Notice = require( 'components/notice' ),
+	Notice = require( 'notices/notice' ),
 	notices = require( 'notices' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	eventRecorder = require( 'me/event-recorder' ),
@@ -252,6 +252,7 @@ module.exports = React.createClass( {
 				isCompact={ true }
 				onClick={ this.cancelEmailChange }
 				showDismiss={ false }
+				status="is-info"
 				text={
 					this.translate( 'There is a pending change of your email to %(email)s. Please check your inbox for a confirmation link.', {
 						args: {


### PR DESCRIPTION
Fix https://github.com/Automattic/wp-calypso/issues/1271

(probably related with the chanegs in notices) we were missing the 'cancel' button in the 'email changed, waiting for confirmation' notice:
![image](https://cloud.githubusercontent.com/assets/1554855/11593164/07b75b48-9aa3-11e5-8f08-2bca99a67629.png)

This PR adds the button again:
![image](https://cloud.githubusercontent.com/assets/1554855/11593136/e5d3a8e2-9aa2-11e5-945e-dda389e813d0.png)

ping @aduth @ebinnion 

ping @mtias & @artpi , because this bug could be related with the changes in notices?
