### PR TITLE
WordAds: Replace missing WordAds icon.

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -129,11 +129,13 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<li className={ this.itemLinkClass( '/ads', 'ads' ) }>
-				<a onClick={ this.onNavigate } href={ adsLink }>
-					<span className="menu-link-text">{ site.jetpack ? 'AdControl' : 'WordAds' }</span>
-				</a>
-			</li>
+			<SidebarMenuItem
+				label={ site.jetpack ? 'AdControl' : 'WordAds' }
+				className={ this.itemLinkClass( '/ads', 'ads' ) }
+				link={ adsLink }
+				onNavigate={ this.onNavigate }
+				icon={ 'speaker' }
+			/>
 		);
 	},
 


### PR DESCRIPTION
WordAds icon got chomped in sidebar update, updating with new ‘gridicons-speaker’ icon and updating to use SidebarMenuItem component.

To test:
* Have site w/ WordAds or AdControl.
* Icon should show up in sidebar.

<img width="258" alt="screen shot 2015-12-04 at 8 56 41 am" src="https://cloud.githubusercontent.com/assets/273708/11595579/08ccb7b4-9a65-11e5-816d-479f5e271b35.png">
