### PR TITLE
Domain Search: DNS editor cleanup, fixes #604

### DIFF
--- a/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
@@ -3,6 +3,11 @@
  */
 var React = require( 'react' );
 
+/**
+ * Internal dependencies
+ */
+import RemoveButton from "components/remove-button";
+
 var DnsRecord = React.createClass( {
 	propTypes: {
 		deleteDns: React.PropTypes.func.isRequired,
@@ -96,7 +101,7 @@ var DnsRecord = React.createClass( {
 				</div>
 				<div className="dns__list-remove">
 					{ ! this.props.dnsRecord.protected_field || 'MX' === this.props.dnsRecord.type ?
-						<button className="remove" onClick={ this.deleteDns }>{ this.translate( 'Delete' ) }</button> : null }
+						<RemoveButton icon="trash" onClick={ this.deleteDns } /> : null }
 				</div>
 			</li>
 		);

--- a/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
@@ -87,11 +87,17 @@ var DnsRecord = React.createClass( {
 	render: function() {
 		return (
 			<li>
-				<label>{ this.props.dnsRecord.type }</label>
-				{ ! this.props.dnsRecord.protected_field || 'MX' === this.props.dnsRecord.type ?
-					<button className="remove" onClick={ this.deleteDns }>{ this.translate( 'Delete' ) }</button> : null }
-				<strong>{ this.getName() }</strong>
-				<em>{ this.handledBy() }</em>
+				<div className="dns__list-type">
+					<label>{ this.props.dnsRecord.type }</label>
+				</div>
+				<div className="dns__list-info">
+					<strong>{ this.getName() }</strong>
+					<em>{ this.handledBy() }</em>
+				</div>
+				<div className="dns__list-remove">
+					{ ! this.props.dnsRecord.protected_field || 'MX' === this.props.dnsRecord.type ?
+						<button className="remove" onClick={ this.deleteDns }>{ this.translate( 'Delete' ) }</button> : null }
+				</div>
 			</li>
 		);
 	}

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -936,6 +936,7 @@ ul.dns__list {
 
 	.dns__list-info {
 		width: 100%;
+		word-break: break-all;
 	}
 
 	.dns__list-remove {

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -901,6 +901,8 @@ ul.dns__list {
 
 	li {
 		border-top: 1px solid $gray-light;
+		display: flex;
+		justify-content: space-between;
 		overflow: auto;
 		padding: 10px 0;
 		position: relative;
@@ -915,12 +917,11 @@ ul.dns__list {
 			background: #87a6bc;
 			border-radius: 2px;
 			color: $white;
-			float: left;
+			display: block;
 			font-size: 12px;
 			margin: 0 10px 0 0;
 			padding: 10px 5px;
 			text-align: center;
-			width: 60px;
 		}
 
 		strong {
@@ -928,16 +929,29 @@ ul.dns__list {
 			font-weight: normal;
 		}
 	}
-	.remove {
-		background-color: #87a6bc;
-		border-radius: 2px;
-		color: #FFF;
-		cursor: pointer;
-		display: inline-block;
-		float: right;
-		font-size: 9px;
-		padding: 3px 8px;
-		text-transform: uppercase;
+
+	.dns__list-type {
+		min-width: 60px;
+	}
+
+	.dns__list-info {
+		width: 100%;
+	}
+
+	.dns__list-remove {
+		text-align: right;
+		width: 100px;
+
+		.remove {
+			background-color: #87a6bc;
+			border-radius: 2px;
+			color: #FFF;
+			cursor: pointer;
+			display: inline-block;
+			font-size: 9px;
+			padding: 3px 8px;
+			text-transform: uppercase;
+		}
 	}
 }
 

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -941,17 +941,6 @@ ul.dns__list {
 	.dns__list-remove {
 		text-align: right;
 		width: 100px;
-
-		.remove {
-			background-color: #87a6bc;
-			border-radius: 2px;
-			color: #FFF;
-			cursor: pointer;
-			display: inline-block;
-			font-size: 9px;
-			padding: 3px 8px;
-			text-transform: uppercase;
-		}
 	}
 }
 


### PR DESCRIPTION
This PR:
- Converts DNS editor floats to flexbox (fixes https://github.com/Automattic/wp-calypso/issues/604)
- Replaces the non-standard delete button with the new `RemoveButton` component

Before:
<img width="671" alt="screen_shot_2015-12-04_at_10_52_20_am" src="https://cloud.githubusercontent.com/assets/3011211/11598203/58fb28aa-9a75-11e5-8c2d-fe1698fa426b.png">

After:
<img width="679" alt="screen_shot_2015-12-04_at_10_51_42_am" src="https://cloud.githubusercontent.com/assets/3011211/11598205/5af8a2fe-9a75-11e5-9cd3-87ee163f690c.png">
