### PR TITLE
Notices: Make action buttons appear in global notices again

### DIFF
--- a/client/notices/notices-list.jsx
+++ b/client/notices/notices-list.jsx
@@ -9,6 +9,7 @@ import debugModule from 'debug';
  * Internal Dependencies
  */
 import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 import notices from 'notices';
 import observe from 'lib/mixins/data-observe';
 import DeleteSiteNotices from './delete-site-notices';
@@ -87,7 +88,15 @@ export default React.createClass( {
 						isCompact={ notice.isCompact }
 						onClick={ this.removeNotice.bind( this, notice ) }
 						showDismiss={ notice.showDismiss }
-					/>
+					>
+						{ notice.button &&
+							<NoticeAction
+								href={ notice.href }
+								onClick={ notice.onClick }
+							>
+								{ notice.button }
+							</NoticeAction> }
+						</Notice>
 				);
 			}, this );
 


### PR DESCRIPTION
Some refactoring of the global notices caused action buttons to disappear. This adds the new `NoticeAction` component to `NoticesList` when a `button` property is set in the options for a notice.