### PR TITLE
Component (header cake): gridicon support

### DIFF
--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -7,7 +7,8 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' );
+var Card = require( 'components/card' ),
+	Gridicon = require( 'components/gridicon' );
 
 module.exports = React.createClass( {
 	displayName: 'HeaderCake',
@@ -40,7 +41,7 @@ module.exports = React.createClass( {
 			<Card className={ classes }>
 				<div className="header-cake__corner">
 					<a className="header-cake__back" onClick={ this.props.onClick }>
-						<span className="noticon noticon-collapse" />
+						<Gridicon icon="chevron-left" size={ 16 } />
 						<span className="header-cake__back-text">{ this.props.backText || this.translate( 'Back' ) }</span>
 					</a>
 				</div>

--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -39,10 +39,10 @@
 	color: darken( $gray, 20% );
 	cursor: pointer;
 
-	.noticon {
-		margin-top: 1px;
+	.gridicon {
+		display: inline-block;
+		vertical-align: middle;
 		opacity: 0.6;
-		transform: rotate( -90deg );
 	}
 }
 


### PR DESCRIPTION
### Changes in PR

Updates chevron icon in the "back" link to use `Gridicon` component instead of relying on `noticon` font.

##### Before
![screen shot 2015-12-04 at 2 17 32 pm](https://cloud.githubusercontent.com/assets/1427136/11598769/d660bf00-9a91-11e5-8f60-5cc43e58be8f.png)

##### After
![screen shot 2015-12-04 at 2 17 42 pm](https://cloud.githubusercontent.com/assets/1427136/11598776/dec878fe-9a91-11e5-974c-30f65f8ca32d.png)

*Note: the icon visually appears slightly larger in the after screenshot because the it aligns itself to the baseline grid more strictly than the `noticon` font does.*

---

### Testing

Visit any page that uses the "header cake" component and check that the back chevron icon is visible at the top left of the component, some easy ones are any subpage of the `/devdocs/design/*` route.

---

/cc @rickybanister (noticon removal cleanup)