### PR TITLE
Plans: Replace compare plans Noticon with Gridicon

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -45,7 +45,7 @@ module.exports = React.createClass( {
 
 		return (
 			<a href={ url } className="compare-plans-link" onClick={ this.recordComparePlansClick }>
-				<Gridicon icon="clipboard" size="16" />
+				<Gridicon icon="clipboard" size="18" />
 				{ this.translate( 'Compare Plans' ) }
 			</a>
 		);

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -11,7 +11,8 @@ var analytics = require( 'analytics' ),
 	PlanList = require( 'components/plans/plan-list' ),
 	siteSpecificPlansDetailsMixin = require( 'components/plans/site-specific-plan-details-mixin' ),
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	UpgradesNavigation = require( 'my-sites/upgrades/navigation' );
+	UpgradesNavigation = require( 'my-sites/upgrades/navigation' ),
+	Gridicon = require( 'components/gridicon' );
 
 module.exports = React.createClass( {
 	displayName: 'Plans',
@@ -42,7 +43,12 @@ module.exports = React.createClass( {
 			url += '/' + selectedSite.slug;
 		}
 
-		return <a href={ url } className="compare-plans-link" onClick={ this.recordComparePlansClick }>{ this.translate( 'Compare Plans' ) }</a>;
+		return (
+			<a href={ url } className="compare-plans-link" onClick={ this.recordComparePlansClick }>
+				<Gridicon icon="clipboard" size="16" />
+				{ this.translate( 'Compare Plans' ) }
+			</a>
+		);
 	},
 
 	sidebarNavigation: function() {

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -6,11 +6,9 @@
 		margin: 20px 0 0 0;
 		text-align: center;
 
-		&:before {
-			@include noticon( '\f425', 16px );
-			color: $blue-medium;
+		.gridicon {
+			margin: -2px 3px 0 0;
 			vertical-align: middle;
-			margin: -2px 5px 0 0;
 		}
 	}
 }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -92,7 +92,7 @@ module.exports = React.createClass( {
 					href={ this.comparePlansUrl() }
 					className='plans-step__compare-plans-link'
 					onClick={ this.handleComparePlansLinkClick.bind( null, 'footer' ) }>
-						<Gridicon icon="clipboard" size="16" />
+						<Gridicon icon="clipboard" size="18" />
 						{ this.translate( 'Compare Plans' ) }
 				</a>
 			</div>

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -15,7 +15,8 @@ var productsList = require( 'lib/products-list' )(),
 	PlanList = require( 'components/plans/plan-list' ),
 	PlansCompare = require( 'components/plans/plans-compare' ),
 	SignupActions = require( 'lib/signup/actions' ),
-	StepWrapper = require( 'signup/step-wrapper' );
+	StepWrapper = require( 'signup/step-wrapper' ),
+	Gridicon = require( 'components/gridicon' );
 
 module.exports = React.createClass( {
 	displayName: 'PlansStep',
@@ -91,7 +92,8 @@ module.exports = React.createClass( {
 					href={ this.comparePlansUrl() }
 					className='plans-step__compare-plans-link'
 					onClick={ this.handleComparePlansLinkClick.bind( null, 'footer' ) }>
-					{ this.translate( 'Compare Plans' ) }
+						<Gridicon icon="clipboard" size="16" />
+						{ this.translate( 'Compare Plans' ) }
 				</a>
 			</div>
 		);

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -10,11 +10,9 @@
 	margin: 20px 0 0 0;
 	text-align: center;
 
-	&:before {
-		@include noticon( '\f425', 16px );
-		color: $blue-medium;
+	.gridicon {
+		margin: -2px 3px 0 0;
 		vertical-align: middle;
-		margin: -2px 5px 0 0;
 	}
 }
 


### PR DESCRIPTION
Before | After
------------ | -------------
<img width="133" alt="screen shot 2015-12-04 at 11 24 32 am" src="https://cloud.githubusercontent.com/assets/3011211/11599075/a4a49d3c-9a79-11e5-88f8-4a47729f5021.png"> | <img width="130" alt="screen shot 2015-12-04 at 11 22 04 am" src="https://cloud.githubusercontent.com/assets/3011211/11599074/a4925168-9a79-11e5-814d-f233b0e89214.png">

Side note: This should probably be componentized. cc: @scruffian 