### PR TITLE
Reader: Try to pull retina images when we can for the reader.

### DIFF
--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -12,7 +12,7 @@ var postNormalizer = require( 'lib/post-normalizer' ),
 /**
  * Module vars
  */
-var READER_CONTENT_WIDTH = 653, // 68% of our 960 fixed width. Might need to bump if / when we go fluid.
+const READER_CONTENT_WIDTH = 720,
 	PHOTO_ONLY_MIN_WIDTH = READER_CONTENT_WIDTH * 0.8,
 	ONE_LINER_THRESHOLD = ( 20 * 10 ); // roughly 10 lines of words
 

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -52,6 +52,8 @@ function stripAutoPlays( query ) {
 const DEFAULT_PHOTON_QUALITY = 80, // 80 was chosen after some heuristic testing as the best blend of size and quality
 	READING_WORDS_PER_SECOND = 250 / 60; // Longreads says that people can read 250 words per minute. We want the rate in words per second.
 
+const imageScaleFactor = ( typeof window !== 'undefined' && window.devicePixelRatio && window.devicePixelRatio > 1 ) ? 2 : 1;
+
 /**
  * Asynchronously normalizes an object shaped like a post. Works on a copy of the post and does not mutate the original post.
  * @param  {object} post A post shaped object, generally returned by the API
@@ -107,7 +109,7 @@ function maxWidthPhotonishURL( imageURL, width ) {
 	} );
 
 	sizeParam = isGravatar ? 's' : 'w';
-	parsedURL.query[ sizeParam ] = width;
+	parsedURL.query[ sizeParam ] = width * imageScaleFactor;
 
 	if ( ! isGravatar ) {
 		// gravatar doesn't support these, only photon / files.wordpress


### PR DESCRIPTION
Detect the devicePixelRatio and double the width we request.

To test, try a device that has hi dpi and notice that images in the stream are asking for a width of 1440, not 720. You can fake the dpi setting using chrome dev tools.

Fixes #693