### PR TITLE
Components: Adds LoggedOutFormContainer component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -41,6 +41,7 @@
 @import 'components/infinite-list/style';
 @import 'components/info-popover/style';
 @import 'components/input-chrono/style';
+@import 'components/logged-out-form-container/style';
 @import 'components/like-button/style';
 @import 'components/loading-placeholder/style';
 @import 'components/main/style';

--- a/client/components/logged-out-form-container/footer-link.jsx
+++ b/client/components/logged-out-form-container/footer-link.jsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import omit from 'lodash/object/omit';
+
+module.exports = React.createClass( {
+	displayName: 'LoggedOutFormContainerFooterLink',
+
+	render: function() {
+		return (
+			<a
+				{ ...omit( this.props, 'classNames' ) }
+				className={ classnames( 'logged-out-form-container__footer-link', this.props.className ) }
+			>
+				{ this.props.children }
+			</a>
+		);
+	}
+} );

--- a/client/components/logged-out-form-container/footer.jsx
+++ b/client/components/logged-out-form-container/footer.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+
+module.exports = React.createClass( {
+	displayName: 'LoggedOutFormContainerFooter',
+
+	render: function() {
+		return (
+			<Card className={ classnames( 'logged-out-form-container__footer', this.props.className ) } >
+				{ this.props.children }
+			</Card>
+		);
+	}
+} );

--- a/client/components/logged-out-form-container/form.jsx
+++ b/client/components/logged-out-form-container/form.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import omit from 'lodash/object/omit';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+
+module.exports = React.createClass( {
+	displayName: 'LoggedOutFormContainerForm',
+
+	render: function() {
+		return (
+			<Card className={ classnames( 'logged-out-form-container__form', this.props.className ) }>
+				<form { ...omit( this.props.className ) }>
+					{ this.props.children }
+				</form>
+			</Card>
+		);
+	}
+} );

--- a/client/components/logged-out-form-container/index.jsx
+++ b/client/components/logged-out-form-container/index.jsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+module.exports = React.createClass( {
+	displayName: 'LoggedOutFormContainer',
+
+	render: function() {
+		return (
+			<div className={ classnames( 'logged-out-form-container', this.props.className ) } >
+				{ this.props.children }
+			</div>
+		);
+	}
+} );

--- a/client/components/logged-out-form-container/style.scss
+++ b/client/components/logged-out-form-container/style.scss
@@ -1,0 +1,42 @@
+.logged-out-form-container {
+	margin: 0 auto;
+	max-width: 400px;
+}
+
+.logged-out-form-container__footer {
+	background: lighten( $gray, 34% );
+	margin-top: -16px;
+
+	.button.is-primary {
+		float: none;
+		margin: 0;
+		width: 100%;
+	}
+}
+
+.logged-out-form-container__footer-link {
+	border-top: 1px solid lighten( $gray, 20% );
+	color: $gray;
+	display: block;
+	font-family: $sans;
+	font-size: 14px;
+	line-height: 21px;
+	padding: 16px 0 16px 16px;
+
+	@include breakpoint( ">480px" ) {
+		padding-left: 24px;
+	}
+
+	&:first-of-type {
+		margin-top: 16px;
+		padding-top: 0;
+	}
+
+	&:visited {
+		color: $gray;
+	}
+
+	&:hover {
+		color: $blue-medium;
+	}
+}

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -1,31 +1,32 @@
 /**
  * External dependencies
  */
-import React from 'react'
-import map from 'lodash/collection/map'
-import forEach from 'lodash/collection/forEach'
-import first from 'lodash/array/first'
-import includes from 'lodash/collection/includes'
-import keys from 'lodash/object/keys'
-import debugModule from 'debug'
+import React from 'react';
+import map from 'lodash/collection/map';
+import forEach from 'lodash/collection/forEach';
+import first from 'lodash/array/first';
+import includes from 'lodash/collection/includes';
+import keys from 'lodash/object/keys';
+import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp'
-import config from 'config'
-import analytics from 'analytics'
-import ValidationFieldset from 'signup/validation-fieldset'
-import FormLabel from 'components/forms/form-label'
-import FormPasswordInput from 'components/forms/form-password-input'
-import FormSettingExplanation from 'components/forms/form-setting-explanation'
-import FormTextInput from 'components/forms/form-text-input'
-import FormButton from 'components/forms/form-button'
-import notices from 'notices'
-import Notice from 'components/notice'
-import LoggedOutForm from 'signup/logged-out-form'
-import formState from 'lib/form-state'
-import i18n from 'lib/mixins/i18n'
+import wpcom from 'lib/wp';
+import config from 'config';
+import analytics from 'analytics';
+import ValidationFieldset from 'signup/validation-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormPasswordInput from 'components/forms/form-password-input';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormTextInput from 'components/forms/form-text-input';
+import FormButton from 'components/forms/form-button';
+import notices from 'notices';
+import Notice from 'components/notice';
+import LoggedOutForm from 'signup/logged-out-form';
+import formState from 'lib/form-state';
+import i18n from 'lib/mixins/i18n';
+import LoggedOutFormContainerLink from 'components/logged-out-form-container/footer-link';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
 	debug = debugModule( 'calypso:signup-form:form' );
@@ -398,11 +399,16 @@ export default React.createClass( {
 		if ( this.props.positionInFlow !== 0 ) {
 			return;
 		}
+
 		let logInUrl = this.localizeUrlWithSubdomain( config( 'login_url' ) );
 		if ( config.isEnabled( 'login' ) ) {
 			logInUrl = this.localizeUrlWithLastSlug( '/log-in' );
 		}
-		return <a href={ logInUrl } className="logged-out-form__link">{ this.translate( 'Already have a WordPress.com account? Log in now.' ) }</a>;
+		return (
+			<LoggedOutFormContainerLink href={ logInUrl }>
+				{ this.translate( 'Already have a WordPress.com account? Log in now.' ) }
+			</LoggedOutFormContainerLink>
+		);
 	},
 
 	render() {

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -14,6 +14,8 @@ import Button from 'components/button';
 import config from 'config';
 import InviteFormHeader from 'my-sites/invites/invite-form-header';
 import { acceptInvite } from 'lib/invites/actions';
+import LoggedOutFormContainer from 'components/logged-out-form-container';
+import LoggedOutFormContainerLink from 'components/logged-out-form-container/footer-link';
 
 export default React.createClass( {
 
@@ -33,7 +35,7 @@ export default React.createClass( {
 			signInLink = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
 
 		return (
-			<div className={ classNames( 'logged-in-accept', this.props.className ) } >
+			<LoggedOutFormContainer className={ classNames( 'invite-accept-logged-in', this.props.className ) }>
 				<Card>
 					<InviteFormHeader { ...this.props } />
 					<div className="invite-accept-logged-in__join-as">
@@ -58,10 +60,11 @@ export default React.createClass( {
 						</Button>
 					</div>
 				</Card>
-				<a className="logged-in-accept__sign-in" href={ signInLink }>
+
+				<LoggedOutFormContainerLink href={ signInLink }>
 					{ this.translate( 'Sign in as a different user' ) }
-				</a>
-			</div>
+				</LoggedOutFormContainerLink>
+			</LoggedOutFormContainer>
 		);
 	}
 } );

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -12,6 +12,7 @@ import InviteFormHeader from 'my-sites/invites/invite-form-header'
 import { createAccount, acceptInvite } from 'lib/invites/actions'
 import WpcomLoginForm from 'signup/wpcom-login-form'
 import config from 'config'
+import LoggedOutFormContainerLink from 'components/logged-out-form-container/footer-link';
 
 export default React.createClass( {
 
@@ -78,9 +79,9 @@ export default React.createClass( {
 		let logInUrl = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
 		return (
 			<div>
-				<a href={ logInUrl } className="logged-out-form__link">
+				<LoggedOutFormContainerLink href={ logInUrl }>
 					{ this.translate( 'Already have a WordPress.com account? Log in now.' ) }
-				</a>
+				</LoggedOutFormContainerLink>
 				{ this.renderEmailOnlySubscriptionLink() }
 			</div>
 		);
@@ -92,9 +93,9 @@ export default React.createClass( {
 		}
 
 		return (
-			<a onClick={ this.subscribeUserByEmailOnly } className="logged-out-form__link">
+			<LoggedOutFormContainerLink onClick={ this.subscribeUserByEmailOnly }>
 				{ this.translate( 'Follow by email subscription only.' ) }
-			</a>
+			</LoggedOutFormContainerLink>
 		);
 	},
 

--- a/client/signup/log-in-form/index.jsx
+++ b/client/signup/log-in-form/index.jsx
@@ -15,7 +15,8 @@ var wpcom = require( 'lib/wp' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormTextInput = require( 'components/forms/form-text-input' ),
 	WpcomLoginForm = require( 'signup/wpcom-login-form' ),
-	LoggedOutForm = require( 'signup/logged-out-form' );
+	LoggedOutForm = require( 'signup/logged-out-form' ),
+	LoggedOutFormContainerLink = require( 'components/logged-out-form-container/footer-link' );
 
 module.exports = React.createClass( {
 	displayName: 'LoginForm',
@@ -238,7 +239,11 @@ module.exports = React.createClass( {
 	footerLink: function() {
 		var startUrl = this.props.locale ? '/start/' + this.props.locale : '/start';
 
-		return <a href={ startUrl } className="logged-out-form__link">{ this.translate( 'New to WordPress.com? Sign up now.' ) }</a>;
+		return (
+			<LoggedOutFormContainerLink href={ startUrl }>
+				{ this.translate( 'New to WordPress.com? Sign up now.' ) }
+			</LoggedOutFormContainerLink>
+		);
 	},
 
 	render: function() {

--- a/client/signup/logged-out-form/index.jsx
+++ b/client/signup/logged-out-form/index.jsx
@@ -2,38 +2,36 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	classnames = require( 'classnames' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' );
+var LoggedoutFormContainer = require( 'components/logged-out-form-container' ),
+	LoggedoutFormContainerFooter = require( 'components/logged-out-form-container/footer' ),
+	LoggedoutFormContainerForm = require( 'components/logged-out-form-container/form' );
 
 module.exports = React.createClass( {
 	displayName: 'LoggedOutForm',
 
 	render: function() {
-		var classes = classNames( { 'logged-out-form': true, } );
-
 		return (
-			<div className={ classnames( this.props.className, classes ) } >
-				<Card>
-					<form onSubmit={ this.props.onSubmit } noValidate={ true }>
-						{ this.props.formHeader &&
-							<header className="logged-out-form__header">
-								{ this.props.formHeader }
-							</header>
-						}
-						{ this.props.formFields }
-						<footer className="logged-out-form__footer">
-							{ this.props.formFooter }
-						</footer>
-					</form>
-				</Card>
+			<LoggedoutFormContainer>
+				<LoggedoutFormContainerForm onSubmit={ this.props.onSubmit } noValidate={ true }>
+					{ this.props.formHeader &&
+						<header className="logged-out-form__header">
+							{ this.props.formHeader }
+						</header>
+					}
+					{ this.props.formFields }
+				</LoggedoutFormContainerForm>
+
+				<LoggedoutFormContainerFooter>
+					{ this.props.formFooter }
+				</LoggedoutFormContainerFooter>
+
 				{ this.props.footerLink }
-			</div>
+			</LoggedoutFormContainer>
 		);
 	}
 } );

--- a/client/signup/logged-out-form/style.scss
+++ b/client/signup/logged-out-form/style.scss
@@ -1,26 +1,3 @@
-.logged-out-form {
-	margin: 0 auto;
-	max-width: 400px;
-}
-
-.logged-out-form__footer {
-	background: lighten( $gray, 34% );
-	border-top: 1px solid lighten( $gray, 30% );
-	margin: 16px -16px -16px -16px;
-	padding: 16px;
-
-	@include breakpoint( ">480px" ) {
-		margin: 40px -24px -24px -24px;
-		padding: 24px;
-	}
-
-	.button.is-primary {
-		float: none;
-		margin: 0;;
-		width: 100%;
-	}
-}
-
 .logged-out-form__link {
 	display: block;
 	font-size: 12px;


### PR DESCRIPTION
In an effort to factor the logged out link that shows at the bottom of the form at `/start/account/user` and to allow reuse of the logged out form styles, this PR refactors the `signup/logged-out-form` component and brings much of its functionality to `client/components/logged-out-form-container` component.

At this point, I would like to solicit feedback from designers (cc @rickybanister) as well as devs ( cc @scruffian, @drewblaisdell, @lezama, @roccotripaldi  ) to get feedback.

Questions:
- I'm not sure I like `logged-out-form-container` for a component name. Do you have other suggestions?
- What are your thoughts on this approach? Should we scrap and go another route, or is this on the right path?
- The links are now left-aligned, which matches @rickybanister's people management mocks. This looks a bit off to me with a single link (ex. the `login-form` screenshot). Should single links be center aligned?


While this PR is working, it __should not be merged__ as it is a __try__ PR and will require other work before it is ready to merge.

After screenshots:

![screen shot 4](https://cloud.githubusercontent.com/assets/1126811/11602115/56ac5a38-9a9d-11e5-8d44-f952ee6c273c.png)
![screen shot 3](https://cloud.githubusercontent.com/assets/1126811/11602111/56a2ec50-9a9d-11e5-8395-cb3ebb415276.png)
![screen shot 2](https://cloud.githubusercontent.com/assets/1126811/11602112/56a3fef6-9a9d-11e5-8cbe-92d1c35b476f.png)
![screen shot 1](https://cloud.githubusercontent.com/assets/1126811/11602114/56a669e8-9a9d-11e5-94f7-1ab39fd02941.png)
![screen shot](https://cloud.githubusercontent.com/assets/1126811/11602113/56a64e0e-9a9d-11e5-883e-1a290bead930.png)
