### PR TITLE
Signup: Verticals Survey: Add tracks event for final survey choice

### DIFF
--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -109,6 +109,7 @@ export default React.createClass( {
 	handleNextStep( vertical ) {
 		const { value, label } = vertical;
 		analytics.tracks.recordEvent( 'calypso_survey_site_type', { type: this.props.surveySiteType } );
+		analytics.tracks.recordEvent( 'calypso_survey_category_chosen', { category: JSON.stringify( { value, label } ) } );
 		if ( this.state.stepOne ) {
 			analytics.tracks.recordEvent( 'calypso_survey_category_click_level_two', { category: JSON.stringify( { value, label } ) } );
 		} else {


### PR DESCRIPTION
Adds the event `calypso_survey_category_chosen` because it's difficult to
determine what category users finally choose otherwise. This is because if the
user is in the two tier test, they can click several first tier categories
before choosing one; if the user is in the one tier test, they can click only
once to choose a category. This event will represent the user's final choice.