### PR TITLE
Me: Select correct nav when password updated

### DIFF
--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -44,6 +44,11 @@ module.exports = React.createClass( {
 	getSelectedText: function() {
 		var text = '',
 			found = find( this.props.tabs, function( tab ) {
+
+				if ( this.props.path === '/me/security?updated=password' ) {
+					this.props.path = '/me/security';
+				}
+
 				return this.props.path === tab.path;
 			}, this );
 

--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -41,15 +41,15 @@ module.exports = React.createClass( {
 		};
 	},
 
+	getFilteredPath: function() {
+		var paramIndex = this.props.path.indexOf( '?' );
+		return ( paramIndex < 0 ) ? this.props.path : this.props.path.substring( 0, paramIndex );
+	},
+
 	getSelectedText: function() {
 		var text = '',
 			found = find( this.props.tabs, function( tab ) {
-
-				if ( this.props.path === '/me/security?updated=password' ) {
-					this.props.path = '/me/security';
-				}
-
-				return this.props.path === tab.path;
+				return this.getFilteredPath() === tab.path;
 			}, this );
 
 		if ( 'undefined' !== typeof found ) {
@@ -73,7 +73,7 @@ module.exports = React.createClass( {
 								key={ tab.path }
 								onClick={ this.onClick }
 								path={ tab.path }
-								selected={ tab.path === this.props.path }
+								selected={ tab.path === this.getFilteredPath() }
 							>
 								{ tab.title }
 							</NavItem>


### PR DESCRIPTION
This is a potential fix for #399. When the password is updated, match this.props.path to 'me/security' so the Password menu item is highlighted.

Here's a snapshot of this in action:

<img width="1002" alt="initial" src="https://cloud.githubusercontent.com/assets/7240478/11603700/40802218-9aa1-11e5-81db-2dea5853d52a.png">

After updating:

<img width="987" alt="updated" src="https://cloud.githubusercontent.com/assets/7240478/11603704/48c8a922-9aa1-11e5-94ca-3d4d746b52d4.png">

Confirmed this doesn't interfere with clicking on any other elements after updating a password. Other nav items work as expected.