### PR TITLE
Plugins: Fix console warnings

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -810,9 +810,18 @@ export default React.createClass( {
 							if ( 'updates' === filterItem.id && ! this.getUpdatesTabVisibility() ) {
 								return null;
 							}
-							const count = 'updates' === filterItem.id && this.state.pluginUpdateCount;
+
+							let attr = {
+								key: filterItem.id,
+								path:filterItem.path,
+								selected: filterItem.id === this.props.filter,
+							}
+
+							if ( 'updates' === filterItem.id ) {
+								attr.count = this.state.pluginUpdateCount;
+							}
 							return (
-								<NavItem key={ filterItem.id } path={ filterItem.path } selected={ filterItem.id === this.props.filter } count={ count } >
+								<NavItem { ...attr } >
 									{ filterItem.title }
 								</NavItem>
 							);

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -646,13 +646,14 @@ export default React.createClass( {
 
 		if ( this.props && this.props.filter === 'updates' ) {
 			navItems.push(
-				<NavItem onClick={ this.updateAllPlugins } >
+				<NavItem onClick={ this.updateAllPlugins } key="updatesKeyItem" >
 					{ this.translate( 'Update All', { context: 'button label' } ) }
 				</NavItem>
 			);
 		}
 
-		navItems.push( <NavItem onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>
+		navItems.push(
+			<NavItem onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement } key="bulkManage" >
 				{
 					this.state.bulkManagement
 					? this.translate( 'Done', { context: 'button label' } )
@@ -723,7 +724,7 @@ export default React.createClass( {
 					<JetpackManageErrorPage
 						template="optInManage"
 						site={ this.props.site }
-						actionURL={ selectedSite.getRemoteManagementURL() +  '&section=plugins' }
+						actionURL={ selectedSite.getRemoteManagementURL() + '&section=plugins' }
 						illustration= '/calypso/images/jetpack/jetpack-manage.svg'
 						featureExample={ this.getMockPluginItems() } />
 				</Main>
@@ -813,7 +814,7 @@ export default React.createClass( {
 
 							let attr = {
 								key: filterItem.id,
-								path:filterItem.path,
+								path: filterItem.path,
 								selected: filterItem.id === this.props.filter,
 							}
 


### PR DESCRIPTION
Fixes a couple js warnings that show up in the console when visiting /plugins
Before:
![screen shot 2015-12-04 at 15 57 47](https://cloud.githubusercontent.com/assets/115071/11604311/cd7f7256-9a9f-11e5-9bc1-382bb9ade39a.png)

After:
![screen shot 2015-12-04 at 15 57 22](https://cloud.githubusercontent.com/assets/115071/11604314/d0c51394-9a9f-11e5-8e0e-5c7f42eb39e3.png)

To test: 
Notice that we don't show any more errors. 

cc @johnHackworth, @ebinnion and @roccotripaldi 
