### PR TITLE
Framework: disable background scroll when dialog is visible

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -541,3 +541,8 @@ body.newdash div.wordpress-com-extension-promo {
 		display: none;
 	}
 }
+
+//added to the html element when we don't want the background content to scroll
+html.no-scroll {
+	overflow: hidden;
+}

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -6,7 +6,8 @@ var ReactDom = require( 'react-dom' ),
 	clickOutside = require( 'click-outside' ),
 	closest = require( 'component-closest' ),
 	noop = require( 'lodash/utility/noop' ),
-	classnames = require( 'classnames' );
+	classnames = require( 'classnames' ),
+	componentClasses = require( 'component-classes' );
 
 /**
  * Internal dependencies
@@ -40,6 +41,7 @@ var DialogBase = React.createClass( {
 
 			this._unbindClickHandler = clickOutside( ReactDom.findDOMNode( this.refs.dialog ), this._onBackgroundClick );
 		}.bind( this ), 10 );
+		componentClasses( document.documentElement ).add( 'no-scroll' );
 	},
 
 	componentWillUnmount: function() {
@@ -52,6 +54,7 @@ var DialogBase = React.createClass( {
 			this._unbindClickHandler();
 			this._unbindClickHandler = null;
 		}
+		componentClasses( document.documentElement ).remove( 'no-scroll' );
 	},
 
 	render: function() {

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -17,7 +17,9 @@ export default React.createClass( {
 		baseClassName: React.PropTypes.string,
 		enterTimeout: React.PropTypes.number,
 		leaveTimeout: React.PropTypes.number,
-		onClosed: React.PropTypes.func
+		transitionLeave: React.PropTypes.bool,
+		onClosed: React.PropTypes.func,
+		onClickOutside: React.PropTypes.func
 	},
 
 	getDefaultProps: function() {

--- a/client/lib/accept/test/index.js
+++ b/client/lib/accept/test/index.js
@@ -7,7 +7,8 @@ require( 'lib/react-test-env-setup' )();
 var expect = require( 'chai' ).expect,
 	TestUtils = require( 'react-addons-test-utils' ),
 	mockery = require( 'mockery' ),
-	sinon = require( 'sinon' );
+	sinon = require( 'sinon' ),
+	noop = require( 'lodash/utility/noop' );
 
 /**
  * Internal dependencies
@@ -23,6 +24,9 @@ describe( '#accept()', function() {
 		mockery.registerSubstitute( 'event', 'component-event' );
 		mockery.registerSubstitute( 'matches-selector', 'component-matches-selector' );
 		mockery.registerSubstitute( 'query', 'component-query' );
+		mockery.registerMock( 'component-classes', function() {
+			return { add: noop, toggle: noop, remove: noop }
+		} );
 		accept = require( '../' );
 		AcceptDialog = require( '../dialog' );
 		AcceptDialog.prototype.__reactAutoBindMap.translate = sinon.stub().returnsArg( 0 );

--- a/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/index.jsx
@@ -7,6 +7,7 @@ var chai = require( 'chai' ),
 	React = require( 'react' ),
 	mockery = require( 'mockery' ),
 	sinon = require( 'sinon' ),
+	noop = require( 'lodash/utility/noop' ),
 	TestUtils = require( 'react-addons-test-utils' );
 
 /**
@@ -30,6 +31,9 @@ describe( 'PluginActivateToggle', function() {
 		mockery.registerMock( 'analytics', analyticsMock );
 		mockery.registerMock( 'my-sites/plugins/plugin-action/plugin-action', mockedPluginAction );
 		mockery.registerMock( 'lib/plugins/actions', mockedActions );
+		mockery.registerMock( 'component-classes', function() {
+			return { add: noop, toggle: noop, remove: noop }
+		} );
 		mockery.registerSubstitute( 'matches-selector', 'component-matches-selector' );
 		mockery.registerSubstitute( 'query', 'component-query' );
 		mockery.enable( {

--- a/client/post-editor/editor-taxonomies/test/accordion.jsx
+++ b/client/post-editor/editor-taxonomies/test/accordion.jsx
@@ -9,6 +9,7 @@ var ReactDom = require( 'react-dom' ),
 	ReactInjection = require( 'react/lib/ReactInjection' ),
 	mockery = require( 'mockery' ),
 	expect = require( 'chai' ).expect,
+	noop = require( 'lodash/utility/noop' ),
 	TestUtils = require( 'react-addons-test-utils' );
 
 /**
@@ -32,6 +33,9 @@ mockery.enable( {
 } );
 
 mockery.registerMock( 'components/info-popover', MOCK_COMPONENT );
+mockery.registerMock( 'component-classes', function() {
+	return { add: noop, toggle: noop, remove: noop }
+} );
 mockery.registerSubstitute( 'matches-selector', 'component-matches-selector' );
 mockery.registerSubstitute( 'query', 'component-query' );
 // TODO: REDUX - add proper tests when whole post-editor is reduxified

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -9,7 +9,8 @@ const chai = require( 'chai' ),
 	TestUtils = require( 'react-addons-test-utils' ),
 	sinon = require( 'sinon' ),
 	sinonChai = require( 'sinon-chai' ),
-	mockery = require( 'mockery' );
+	mockery = require( 'mockery' ),
+	noop = require( 'lodash/utility/noop' );
 
 /**
  * Internal dependencies
@@ -38,6 +39,9 @@ mockery.enable( {
 } );
 mockery.registerSubstitute( 'matches-selector', 'component-matches-selector' );
 mockery.registerSubstitute( 'query', 'component-query' );
+mockery.registerMock( 'component-classes', function() {
+	return { add: noop, toggle: noop, remove: noop }
+} );
 mockery.registerMock( 'components/tinymce', MOCK_COMPONENT );
 mockery.registerMock( 'components/popover', MOCK_COMPONENT );
 mockery.registerMock( 'components/forms/clipboard-button', MOCK_COMPONENT );


### PR DESCRIPTION
Fixes #110 so background content cannot be scrolled on dialogs.

## Testing Instructions
1. Navigate to calypso.localhost:3000/me
2. Delete your 2-factor auth cookie `twostep_auth` under `public-api.wordpress.com`
3. Refresh the page
4. Attempt to scroll with the 2-factor auth modal displayed

Before: 
![scroll](https://cloud.githubusercontent.com/assets/1270189/11636440/fc349d78-9cd0-11e5-9136-0d50338a66e5.gif)

After (note the lack of scrollbar on the browser window):
![after](https://cloud.githubusercontent.com/assets/1270189/11636520/60e71fb6-9cd1-11e5-9c2a-cb7804923549.png)

cc @rralian @hoverduck 