### PR TITLE
Purchases: Remove the navigation to Manage Purchases from upgrades pages

### DIFF
--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -19,12 +19,10 @@ var React = require( 'react/addons' ),
 var SectionNav = require( 'components/section-nav' ),
 	NavTabs = require( 'components/section-nav/tabs' ),
 	NavItem = require( 'components/section-nav/item' ),
-	config = require( 'config' ),
 	upgradesPaths = require( 'my-sites/upgrades/paths' ),
 	viewport = require( 'lib/viewport' ),
 	upgradesActionTypes = require( 'lib/upgrades/constants' ).action,
 	PopoverCart = require( 'my-sites/upgrades/cart/popover-cart' ),
-	purchasesPaths = require( 'me/purchases/paths' ),
 	i18n = require( 'lib/mixins/i18n' );
 
 // The first path acts as the primary path that the button will link to. The
@@ -56,12 +54,6 @@ var NAV_ITEMS = {
 		paths: [ '/domains/add' ],
 		label: i18n.translate( 'Add a Domain' ),
 		allSitesPath: false
-	},
-
-	'My Purchases': {
-		paths: [ purchasesPaths.list() ],
-		label: i18n.translate( 'Manage Purchases' ),
-		allSitesPath: true
 	}
 };
 
@@ -118,9 +110,9 @@ var UpgradesNavigation = React.createClass( {
 		var items;
 
 		if ( this.props.selectedSite.jetpack ) {
-			items = [ 'Plans', 'My Purchases' ];
+			items = [ 'Plans' ];
 		} else {
-			items = [ 'Plans', 'Domains', 'Email', 'My Purchases' ];
+			items = [ 'Plans', 'Domains', 'Email' ];
 		}
 
 		return items.map( propertyOf( NAV_ITEMS ) );


### PR DESCRIPTION
Remove the navigation to Manage Purchases from upgrades pages.

Fixes #1270

**Testing**

1. `git checkout fix/1270-remove-purchase-from-navigation`
2. Open http://calypso.localhost:3000/plans/:site
3. Assert that there is no link to Manage Purchases from the header cake

- [x] Code review
- [x] QA review