### PR TITLE
Purchase: Use SectionHeader in the header of each site section in /purchases

### DIFF
--- a/client/me/purchases/list/site/index.jsx
+++ b/client/me/purchases/list/site/index.jsx
@@ -9,6 +9,7 @@ import times from 'lodash/utility/times';
  * Internal dependencies
  */
 import PurchaseItem from '../item';
+import SectionHeader from 'components/section-header';
 
 const PurchasesSite = React.createClass( {
 	propTypes: {
@@ -28,11 +29,7 @@ const PurchasesSite = React.createClass( {
 
 		return (
 			<div className={ classes }>
-				<div className="purchases-site__header">
-					<div className="purchases-site__header-text">
-						{ isPlaceholder ? this.translate( 'Loading…' ) : this.props.name }
-					</div>
-				</div>
+				<SectionHeader label={ isPlaceholder ? this.translate( 'Loading…' ) : this.props.name } />
 				{
 					isPlaceholder ?
 					this.placeholders() :

--- a/client/me/purchases/list/site/style.scss
+++ b/client/me/purchases/list/site/style.scss
@@ -1,21 +1,3 @@
 .purchases-site {
 	margin-bottom: 15px;
-
-	&.is-placeholder .purchases-site__header-text {
-		@include placeholder( 23% );
-
-		width: 50%;
-	}
-}
-
-.purchases-site__header {
-	background: white;
-	box-shadow: 0 0 0 1px lighten($gray, 20%), 0 1px 2px lighten( $gray, 30% );
-	padding: 14px 24px;
-}
-
-.purchases-site__header-text {
-	color: $gray-dark;
-	font-size: 12px;
-	text-transform: uppercase;	
 }


### PR DESCRIPTION
Before:
<img width="674" alt="screenshot 2015-12-05 19 46 14" src="https://cloud.githubusercontent.com/assets/275961/11609828/11e80b4e-9b89-11e5-973c-6a2d513a3864.png">

After:
<img width="671" alt="screenshot 2015-12-05 19 48 57" src="https://cloud.githubusercontent.com/assets/275961/11609834/418e2d42-9b89-11e5-9303-8cb07fe1a756.png">

Loading state:
<img width="663" alt="screenshot 2015-12-05 19 48 52" src="https://cloud.githubusercontent.com/assets/275961/11609835/4c4d24cc-9b89-11e5-99de-d4ff3d8fd06c.png">

Fixes #1194

**Testing**

1. `git checkout fix/1194-purchase-use-section-header`
2. Open http://calypso.localhost:3000/purchases
3. Assert that you see the text "Loading..." in the header of each site. This is a change from the previous behaviour
4. When the site have loaded, assert that the header for each site section matches /me/billing

- [x] Code review
- [x] QA review