### PR TITLE
[Experimental] Add super rudimentary support for plugins

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -199,4 +199,8 @@ if ( config.isEnabled( 'mailing-lists/unsubscribe' ) ) {
 	} );
 }
 
+if ( config( 'plugins' ) ) {
+	sections = sections.concat( config( 'plugins' ) );
+}
+
 module.exports = sections;

--- a/config/development.json
+++ b/config/development.json
@@ -168,6 +168,13 @@
 		"pub/hexa",
 		"pub/harmonic"
 	],
+	"plugins": [
+		{
+			"name": "hello-world",
+			"paths": [ "/hello-world" ],
+			"module": "hello-world"
+		}
+	],
 	"languages": [
 		{ "value": 2, "langSlug": "af", "name": "af - Afrikaans" },
 		{ "value": 418, "langSlug": "als", "name": "als - Alemannisch" },

--- a/plugins/hello-world/components/hello/index.jsx
+++ b/plugins/hello-world/components/hello/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default React.createClass( {
+	render() {
+		return (
+			<div>
+				<h3>Hello, World!</h3>
+			</div>
+		);
+	}
+} )
+

--- a/plugins/hello-world/controller.js
+++ b/plugins/hello-world/controller.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import Hello from './components/hello';
+
+export default function helloController() {
+	React.render(
+		<Hello />,
+		document.getElementById( 'primary' )
+	);
+}

--- a/plugins/hello-world/index.js
+++ b/plugins/hello-world/index.js
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import controller from './controller';
+
+export default function helloWorld() {
+	page( '/hello-world', controller );
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,7 @@ webpackConfig = {
 	},
 	resolve: {
 		extensions: [ '', '.json', '.js', '.jsx' ],
-		modulesDirectories: [ 'node_modules', path.join( __dirname, 'client' ), path.join( __dirname, 'shared' ) ]
+		modulesDirectories: [ 'node_modules', path.join( __dirname, 'client' ), path.join( __dirname, 'shared' ), path.join( __dirname, 'plugins' ) ]
 	},
 	node: {
 		console: false,


### PR DESCRIPTION
At WordCamp US, there has been some discussion around the potential for Calypso to support plugins. This PR is just a quick example that illustrates how the code chunking and dynamic route definition could be utilized to make it possible for plugins to add routes. 

The basic idea is that plugins are a directory in a top-level `plugins` directory. In this form, the plugin is a section, which while neat isn't ideal long-term because there will need to be a need for both the ability to define new sections and for code to be loaded elsewhere so that the route can be linked to from elsewhere via some way of hooking in.