### PR TITLE
Purchases: Don't open links to product info pages in a new tab

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -14,7 +14,6 @@ import Card from 'components/card';
 import { cartItems } from 'lib/cart-values';
 import { domainManagementEdit } from 'my-sites/upgrades/paths';
 import { googleAppsSettingsUrl } from 'lib/google-apps';
-import Gridicon from 'components/gridicon';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import NoticeAction from 'components/notice/notice-action';
@@ -291,8 +290,8 @@ const ManagePurchase = React.createClass( {
 
 		if ( url && text ) {
 			return (
-				<a href={ url } target="_blank">
-					{ text } <Gridicon size={ 14 } icon="external" />
+				<a href={ url }>
+					{ text }
 				</a>
 			);
 		}


### PR DESCRIPTION
Since Calypso is a single page app, and these links all point to Calypso, we shouldn't open them in a new window.

@fabianapsimoes - what do you think? Does this change make sense?

**Testing**

1. `git checkout update/remove-external-links`
2. Open http://calypso.localhost:3000/purchases
3. Open an individual purchase
4. Click on the product info link beneath the title:
<img width="333" alt="screenshot 2015-12-05 20 46 37" src="https://cloud.githubusercontent.com/assets/275961/11610124/4d5f1a98-9b91-11e5-8c0e-65bb85554841.png">

5. Assert that the link opens in the same tab

- [x] Code review
- [x] QA review