### PR TITLE
Jetpack Plugins: Add long-content-fade for long titles

### DIFF
--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -53,8 +53,12 @@
 	font-weight: 600;
 	line-height: 32px;
 	white-space: pre;
-	text-overflow: ellipsis;
 	overflow: hidden;
+	position: relative;
+
+	&:after {
+		@include long-content-fade( $size: 20% );
+	}
 
 	@include breakpoint( '>480px' ) {
 		font-size: 24px;


### PR DESCRIPTION
Plugin titles currently use an ellipsis to control overflow. This does the following:
- Removes the ellipsis
- Added a long-content-fade @ 20%

Before:

<img width="967" alt="2793f906-9087-11e5-9cc3-7f6476546632" src="https://cloud.githubusercontent.com/assets/7240478/11611226/454f6d32-9b80-11e5-8fd8-6f0261e07728.png">

After (Install) - Displays similarly when active:

![install](https://cloud.githubusercontent.com/assets/7240478/11611222/29f19aa6-9b80-11e5-91ea-8109a98670fd.png)

Attempt at fixing #411. 

Note: The main plugin menu similarly uses an ellipsis. Not sure if we want to change that as well?

![screen shot 2015-12-05 at 6 47 27 pm](https://cloud.githubusercontent.com/assets/7240478/11611234/a9a1c32a-9b80-11e5-86ad-64072554decb.png)
