### PR TITLE
Plugins: Align checkboxes in bulk edit mode

### DIFF
--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -49,7 +49,9 @@
 
 // Checkbox for multiselect purposes
 .plugin-item__checkbox[type=checkbox] {
-	margin-top: 0;
+	position: absolute;
+	top: 50%;
+	margin-top: -8px;
 
 	&:after { // Making tap area larger
 		content: '';


### PR DESCRIPTION
Added absolute positioning, set the top position to 50%, and added a negative margin of -8px (half the height of the checkbox).

Before:

![before](https://cloud.githubusercontent.com/assets/7240478/11614229/58b75082-9bf9-11e5-8ea3-323f3d34b0e9.png)

After:

![desktop](https://cloud.githubusercontent.com/assets/7240478/11614230/5de79404-9bf9-11e5-83e4-3de01ca24f47.png)

Double-checked in Firefox and also on iPhone and iPad. Fixes #1114