### PR TITLE
Signup: Verticals: Fix mobile styling for the verticals survey.

### DIFF
--- a/client/signup/steps/survey/style.scss
+++ b/client/signup/steps/survey/style.scss
@@ -1,6 +1,6 @@
 .survey-step__section-wrapper {
 	margin: 0 auto 2em;
-	width: 500px;
+	max-width: 500px;
 }
 
 .survey-step__label {
@@ -17,7 +17,6 @@
 	margin-bottom: 0;
 	font-size: 14px;
 	font-weight: 600;
-	height: 50px;
 }
 
 .survey-step__vertical .survey-step__label {


### PR DESCRIPTION
Fixes #1305. Allowing variable rather than a fixed width ensures the survey stays onscreen at mobile sizes. Removing the fixed height of `survey-step__title` allows proper padding at narrow widths, if the title breaks to two lines.