### PR TITLE
Editor: Fix Post Format Rendering

### DIFF
--- a/client/post-editor/editor-post-formats/accordion.jsx
+++ b/client/post-editor/editor-post-formats/accordion.jsx
@@ -4,7 +4,8 @@
 var React = require( 'react' ),
 	pick = require( 'lodash/object/pick' ),
 	find = require( 'lodash/collection/find' ),
-	classNames = require( 'classnames' );
+	classNames = require( 'classnames' ),
+	isEmpty = require( 'lodash/lang/isEmpty' );
 
 /**
  * Internal dependencies
@@ -61,7 +62,7 @@ module.exports = React.createClass( {
 			'is-loading': ! this.props.post || ! this.props.postFormats
 		} );
 
-		if ( ! this.props.postFormats || this.props.postFormats.length <= 1 ) {
+		if ( isEmpty( this.props.postFormats ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
Currently, the post format box isn't loading when a theme (like Dyad) has one post format. I <em>think</em> we can use isEmpty() on this.props.postFormats instead of the current conditional. I couldn't find a reason we would need `! this.props.postFormats` as well. Thoughts?

TIL: It's a bit difficult to find a theme without post formats! Tested with Dyad (1 post format):

![screen shot 2015-12-06 at 5 14 24 pm](https://cloud.githubusercontent.com/assets/7240478/11616620/d4910dae-9c3c-11e5-8537-1817fa667743.png)

For no formats, I tested with <a href="https://theme.wordpress.com/themes/strange-little-town/">Strange Little Town</a> and <a href="https://theme.wordpress.com/themes/sunspot/">Sunspot</a>.

![screen shot 2015-12-06 at 5 15 47 pm](https://cloud.githubusercontent.com/assets/7240478/11616629/1a365012-9c3d-11e5-87c9-9158d100102d.png)

Fix for #1107