### PR TITLE
Framework: Upgrade to node 0.12.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN     apt-get -y update && apt-get -y install \
           make \
           build-essential
 
-ENV NODE_VERSION 0.12.6
+ENV NODE_VERSION 0.12.9
 
 RUN     wget https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz && \
           tar -zxf node-v$NODE_VERSION-linux-x64.tar.gz -C /usr/local && \


### PR DESCRIPTION
Upgrade `node` to the current 0.12 LTS release: https://nodejs.org/en/blog/release/v0.12.9/

To test (needs a working vagrant setup):
- `make distclean`
- `vagrant up`/`vagrant reload`
- Check there are no build errors, and the image works.