### PR TITLE
Desktop App: Fix broken oauth token access when booting Desktop App

### DIFF
--- a/shared/lib/wp/browser.js
+++ b/shared/lib/wp/browser.js
@@ -13,13 +13,14 @@ import config from 'config';
 let wpcom;
 
 if ( config.isEnabled( 'oauth' ) ) {
-	wpcom = wpcomUndocumented(
-		require( 'lib/oauth-token' ),
-		require( 'lib/wpcom-xhr-wrapper' )
-	);
+	const oauthToken = require( 'lib/oauth-token' ),
+		requestHandler = require( 'lib/wpcom-xhr-wrapper' );
+
+	wpcom = wpcomUndocumented( oauthToken.getToken(), requestHandler );
 } else {
-	// Set proxy request handler
-	wpcom = wpcomUndocumented( require( 'wpcom-proxy-request' ) );
+	const requestHandler = require( 'wpcom-proxy-request' );
+
+	wpcom = wpcomUndocumented( requestHandler );
 
 	// Upgrade to "access all users blogs" mode
 	wpcom.request( {


### PR DESCRIPTION
When I try to run Desktop App in development mode I get the following error:

![screen shot 2015-12-07 at 14 22 57](https://cloud.githubusercontent.com/assets/699132/11627921/67c78326-9cee-11e5-93f4-58d87d670e29.png)

This PR fixes that issue.

### Testing
Apply this Calypso patch and try to run Desktop App in development mode.