### PR TITLE
Notices: Fix whitespace in global notices

### DIFF
--- a/client/notices/notices-list.jsx
+++ b/client/notices/notices-list.jsx
@@ -100,6 +100,9 @@ export default React.createClass( {
 				);
 			}, this );
 
+		if ( ! noticesRaw.length ) {
+			return null;
+		}
 		return (
 			<div>
 				<div id={ this.props.id } className={ classNames( 'notices-list', { 'is-pinned': this.state.pinned } ) }>


### PR DESCRIPTION
Empty Notices list was pushing content of every view
This reverts commit ff907696009c9c17be8b77e516b3d73e24d56d19.

# Why?
Commit ff907696009c9c17be8b77e516b3d73e24d56d19 introduced NoticeList in every page.
This became a problem because notice list scrolls with the content.

# Testing
1. Go to WordPress.com and see that if you scroll, the content shifts a bit
2. Run this PR and see that the problem is gone, everything scrolls like it was.