### PR TITLE
Plugin browser section header

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -10,9 +10,12 @@
 }
 
 .section-header__label {
+	display: flex;
+		align-items: center;
 	flex-grow: 1;
 	line-height: 28px;
 	position: relative;
+
 
 	&:before {
 		@include long-content-fade( $color : $white );

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -36,13 +36,12 @@
 .section-header__label,
 .section-header__button {
 	color: $gray;
-	font-size: 12px;
+	font-size: 11px;
 	text-transform: uppercase;
 }
 
 .section-header__button {
 	background: none;
-	float: let;
 	margin-right: 8px;
 	padding: 2px 8px;
 

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -7,9 +7,9 @@ import React from 'react'
  * Internal dependencies
  */
 import PluginBrowserItem from 'my-sites/plugins/plugins-browser-item'
+import Card from 'components/card'
 import Gridicon from 'components/gridicon'
 import SectionHeader from 'components/section-header'
-import SectionHeaderButton from 'components/section-header/button'
 
 export default React.createClass( {
 
@@ -69,9 +69,9 @@ export default React.createClass( {
 				<SectionHeader label={ this.props.title }>
 					{ this.getLink() }
 				</SectionHeader>
-				<div className="plugins-browser-list__elements">
+				<Card className="plugins-browser-list__elements">
 					{ this.getViews() }
-				</div>
+				</Card>
 			</div>
 		);
 	}

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -9,6 +9,7 @@ import React from 'react'
 import PluginBrowserItem from 'my-sites/plugins/plugins-browser-item'
 import Gridicon from 'components/gridicon'
 import SectionHeader from 'components/section-header'
+import SectionHeaderButton from 'components/section-header/button'
 
 export default React.createClass( {
 
@@ -65,12 +66,9 @@ export default React.createClass( {
 	render() {
 		return (
 			<div className="plugins-browser-list">
-				<div className="plugins-browser-list__header">
-					<h2 className="plugins-browser-list__title">
-						{ this.props.title }
-					</h2>
+				<SectionHeader label={ this.props.title }>
 					{ this.getLink() }
-				</div>
+				</SectionHeader>
 				<div className="plugins-browser-list__elements">
 					{ this.getViews() }
 				</div>

--- a/client/my-sites/plugins/plugins-browser-list/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-list/index.jsx
@@ -1,27 +1,27 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react'
 
 /**
  * Internal dependencies
  */
-var PluginBrowserItem = require( 'my-sites/plugins/plugins-browser-item' ),
-	Gridicon = require( 'components/gridicon' );
+import PluginBrowserItem from 'my-sites/plugins/plugins-browser-item'
+import Gridicon from 'components/gridicon'
+import SectionHeader from 'components/section-header'
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'PluginsBrowserList',
 
 	_DEFAULT_PLACEHOLDER_NUMBER: 6,
 
-	getPluginsViewList: function() {
-		var pluginsViewsList,
-			emptyCounter = 0;
+	getPluginsViewList() {
+		let emptyCounter = 0;
 
-		pluginsViewsList = this.props.plugins.map( function( plugin, n ) {
+		let pluginsViewsList = this.props.plugins.map( ( plugin, n ) => {
 			return <PluginBrowserItem site={ this.props.site } key={ plugin.slug + n } plugin={ plugin } currentSites={ this.props.currentSites } />;
-		}, this );
+		} );
 
 		if ( this.props.showPlaceholders ) {
 			pluginsViewsList = pluginsViewsList.concat( this.getPlaceholdersViews() );
@@ -39,13 +39,13 @@ module.exports = React.createClass( {
 		return pluginsViewsList;
 	},
 
-	getPlaceholdersViews: function() {
-		return Array.apply( null, Array( this.props.size || this._DEFAULT_PLACEHOLDER_NUMBER ) ).map( function( item, i ) {
+	getPlaceholdersViews() {
+		return Array.apply( null, Array( this.props.size || this._DEFAULT_PLACEHOLDER_NUMBER ) ).map( ( item, i ) => {
 			return <PluginBrowserItem isPlaceholder key={ 'placeholder-plugin-' + i } />;
 		} );
 	},
 
-	getViews: function() {
+	getViews() {
 		if ( this.props.plugins.length ) {
 			return this.getPluginsViewList();
 		} else if ( this.props.showPlaceholders ) {
@@ -53,7 +53,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	getLink: function() {
+	getLink() {
 		if ( this.props.expandedListLink ) {
 			return <a className="button is-link plugins-browser-list__select-all" href={ this.props.expandedListLink + ( this.props.site || '' ) }>
 				{ this.translate( 'See All' ) }
@@ -62,7 +62,7 @@ module.exports = React.createClass( {
 		}
 	},
 
-	render: function() {
+	render() {
 		return (
 			<div className="plugins-browser-list">
 				<div className="plugins-browser-list__header">

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -44,4 +44,5 @@
 .plugins-browser-list__elements {
 	min-height: 50px;
 	overflow: hidden; // lazy clearfix
+	padding: 0;
 }

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -17,7 +17,7 @@
 .button.plugins-browser-list__select-all,
 .plugins-browser-list__title {
 	display: inline-block;
-	padding: 6px 16px 7px;
+	padding: 6px 0px 7px;
 	color: $gray;
 	font-size: 11px;
 	line-height: 1.6;
@@ -38,7 +38,6 @@
 
 .button.plugins-browser-list__select-all {
 	float: right;
-	padding-right: 16px;
 }
 
 .plugins-browser-list__elements {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/1226
Fixes https://github.com/Automattic/wp-calypso/issues/819

Plugin browser lists were not using section headers. So when we changed the global background color to the same one they were using as background, they pretty much dissapeared as a separated box:

![image](https://cloud.githubusercontent.com/assets/1554855/11557198/c870e384-99ab-11e5-8f41-ef59f7005045.png)

This PR changes plugin-browser-list to use `Section-header`, so the header of the lists is our standard white box:

![image](https://cloud.githubusercontent.com/assets/1554855/11631467/74805b88-9d02-11e5-8d94-1f28bbfc0b48.png)


How to test:
=======
1. go to http://calypso.dev:3000/plugins/browse
2. Check the headers of each list is a Section Header
