### PR TITLE
Framework: Move the bug badge out of the way

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -454,7 +454,7 @@ body.newdash div.wordpress-com-extension-promo {
 		pointer-events: none;
 		min-width: 100%;
 		transition: all 0.15s ease-in-out;
-		transition-delay: 0.5s;
+		transition-delay: 0.25s;
 
 		a {
 			display: block;
@@ -462,6 +462,7 @@ body.newdash div.wordpress-com-extension-promo {
 			margin-top: 6px;
 			background: $white;
 			border-radius: 3px;
+			box-shadow: inset 0 0 0 1px rgba( $gray, 0.2 );
 		}
 	}
 
@@ -477,10 +478,6 @@ body.newdash div.wordpress-com-extension-promo {
 		.is-bug-report {
 			opacity: 1;
 			pointer-events: auto;
-			
-			a {
-				box-shadow: 0 1px 2px rgba( darken( $gray, 30 ), 0.4 );
-			}
 		}
 	}
 }

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -398,8 +398,8 @@ body.newdash div.wordpress-com-extension-promo {
 
 .environment-badge {
 	position: fixed;
-		bottom: 16px;
-		left: 289px;
+		top: 9px;
+		right: 216px;
 	z-index: z-index( 'root', '.environment-badge' );
 	backface-visibility: hidden;
 	transition: opacity 0.1s ease-in-out;

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -397,25 +397,64 @@ body.newdash div.wordpress-com-extension-promo {
 }
 
 .environment-badge {
-	opacity: 0.4;
+	//opacity: 0.4;
 	position: fixed;
-		top: 47px + 12;
-		right: 12px;
+		top: 11px;
+		right: 210px;
 	backface-visibility: hidden;
 	height: 28px;
 	z-index: z-index( 'root', '.environment-badge' );
 	transition: all 0.15s ease-in-out;
-	transition-delay: 0.25s;
+	//transition-delay: 0.25s;
+
+	.detail-page-open & {
+		opacity: 0;
+		transform: translateX( -30px );
+		pointer-events: none;
+	}
 
 	.environment {
 		float: right;
-		clear: both;
 		box-sizing: border-box;
 		position: relative;
 		z-index: 1000;
 		font-size: 12px;
 		font-weight: bold;
 		transition: all 0.1s ease-in-out;
+
+		&:nth-child( 3 ) a {
+			margin-top: 11px;
+		}
+
+		&:last-child a {
+			border-bottom-right-radius: 3px;
+			border-bottom-left-radius: 3px;
+		}
+	}
+
+	.is-branch-name {
+		opacity: 0.4;
+		border-radius: 3px;
+		padding: 4px 12px 3px 8px;
+		box-shadow: inset 0 0 0 1px rgba( black, 0.1 );
+		background: $white;
+		cursor: default;
+		clear: none;
+		background: $gray-dark;
+		color: $white;
+		font-weight: normal;
+		float: left;
+		position: relative;
+			right: -4px;
+		max-width: 340px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		transition: all 0.15s ease-in-out;
+
+		@include breakpoint( "<960px" ) {
+			max-width: 181px;
+		}
 	}
 
 	.is-staging,
@@ -425,7 +464,7 @@ body.newdash div.wordpress-com-extension-promo {
 	.is-feedback {
 		border-radius: 3px;
 		padding: 4px 8px 3px 8px;
-		box-shadow: inset 0 0 0 1px rgba( black, 0.1 );
+		box-shadow: inset 0 0 0 1px rgba( black, 0.2 );
 		background: $white;
 		cursor: default;
 	}
@@ -435,7 +474,8 @@ body.newdash div.wordpress-com-extension-promo {
 	}
 	
 	.is-wpcalypso {
-		background: #B1EED0;
+		background: $alert-green;
+		color: $white;
 	}
 	
 	.is-dev {
@@ -445,35 +485,35 @@ body.newdash div.wordpress-com-extension-promo {
 	
 	.is-horizon,
 	.is-feedback {
-		background: $blue-light;
+		background: $blue-dark;
+		color: $white;
 	}
 
 	.is-docs,
 	.is-bug-report {
+		clear: both;
 		opacity: 0;
+		min-width: 80%;
 		pointer-events: none;
-		min-width: 100%;
 		transition: all 0.15s ease-in-out;
 		transition-delay: 0.25s;
 
 		a {
 			display: block;
-			padding: 4px 8px;
-			margin-top: 6px;
+			padding: 8px 12px;
 			background: $white;
-			border-radius: 3px;
-			box-shadow: inset 0 0 0 1px rgba( $gray, 0.2 );
+			border-left: 1px solid lighten( $gray, 20% );
+			border-right: 1px solid lighten( $gray, 20% );
+			border-bottom: 1px solid lighten( $gray, 20% );
 		}
 	}
 
 	&:hover {
-		opacity: 1;
+		//opacity: 1;
 		width: auto;
 		overflow: visible;
 
-		.environment {
-		}
-
+		.is-branch-name,
 		.is-docs,
 		.is-bug-report {
 			opacity: 1;
@@ -482,7 +522,7 @@ body.newdash div.wordpress-com-extension-promo {
 	}
 }
 
-@include breakpoint( "<960px" ) {
+@include breakpoint( "<660px" ) {
 	// Don't show environment badge on smaller screens. It just gets in the way.
 	.environment-badge {
 		display: none;

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -399,7 +399,7 @@ body.newdash div.wordpress-com-extension-promo {
 .environment-badge {
 	position: fixed;
 		bottom: 16px;
-		left: 16px;
+		left: 289px;
 	z-index: z-index( 'root', '.environment-badge' );
 	backface-visibility: hidden;
 

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -397,102 +397,89 @@ body.newdash div.wordpress-com-extension-promo {
 }
 
 .environment-badge {
+	opacity: 0.4;
 	position: fixed;
-		top: 9px;
-		right: 216px;
-	z-index: z-index( 'root', '.environment-badge' );
+		top: 47px + 12;
+		right: 12px;
 	backface-visibility: hidden;
-	transition: opacity 0.1s ease-in-out;
-
-	.detail-page-active & {
-		opacity: 0;
-		pointer-events: none;
-	}
-
-	.bug-report {
-		position: relative;
-		display: inline-block;
-		width: 26px;
-		height: 26px;
-		background-color: $white;
-		border: solid 1px $gray-dark;
-		border-radius: 50%;
-		color: $gray-dark;
-		text-decoration: none;
-		text-align: center;
-		z-index: z-index( '.environment-badge', '.environment-badge .bug-report' );
-		transition: border-radius 0.2s ease-out;
-		&:before {
-			@include noticon( '\f50a', 14px );
-			vertical-align: middle;
-		}
-	}
+	height: 28px;
+	z-index: z-index( 'root', '.environment-badge' );
+	transition: all 0.15s ease-in-out;
+	transition-delay: 0.25s;
 
 	.environment {
+		float: right;
+		clear: both;
+		box-sizing: border-box;
 		position: relative;
-		display: inline-block;
-		font-size: 9px;
-		font-weight: 600;
-		line-height: 1;
-		text-transform: uppercase;
-		padding: 4px 7px 4px 6px;
-		vertical-align: middle;
-		transition: all 0.2s ease-out;
-		&:before {
-			content: '';
-			position: absolute;
-				left: -1px;
-				right: 0;
-				top: 0;
-				bottom: 0;
-			z-index: z-index( '.environment-badge', '.environment-badge .environment::before' );
-			background-color: $white;
-			border: solid 1px $gray-dark;
-		}
-		&:first-of-type:before {
-			left: -4px;
-		}
-		a {
-			text-decoration: none;
-			display: inline-block;
-			color: black;
+		z-index: 1000;
+		font-size: 12px;
+		font-weight: bold;
+		transition: all 0.1s ease-in-out;
+	}
 
-			&:hover {
-				transform: scale( 1.1 );
-			}
-		}
-		&.is-staging {
-			&:before {
-				background-color: $alert-yellow;
-			}
-		}
-		&.is-wpcalypso {
-			&:before {
-				background-color: #B1EED0;
-			}
-		}
-		&.is-dev {
-			&:before {
-				background-color: $alert-red;
-			}
-		}
-		&.is-horizon,
-		&.is-feedback {
-			&:before {
-				background-color: $blue-light;
-			}
-		}
-		&.branch-name {
-			text-transform: inherit;
-			background-color: #272727;
-			color: #F1F1F1;
+	.is-staging,
+	.is-wpcalypso,
+	.is-dev,
+	.is-horizon,
+	.is-feedback {
+		border-radius: 3px;
+		padding: 4px 8px 3px 8px;
+		box-shadow: inset 0 0 0 1px rgba( black, 0.1 );
+		background: $white;
+		cursor: default;
+	}
+
+	.is-staging {
+		background: $alert-yellow;
+	}
+	
+	.is-wpcalypso {
+		background: #B1EED0;
+	}
+	
+	.is-dev {
+		color: $white;
+		background: $alert-red;
+	}
+	
+	.is-horizon,
+	.is-feedback {
+		background: $blue-light;
+	}
+
+	.is-docs,
+	.is-bug-report {
+		opacity: 0;
+		pointer-events: none;
+		min-width: 100%;
+		transition: all 0.15s ease-in-out;
+		transition-delay: 0.5s;
+
+		a {
+			display: block;
+			padding: 4px 8px;
+			margin-top: 6px;
+			background: $white;
+			border-radius: 3px;
 		}
 	}
 
-	.notouch & {
-		.bug-report {
-			&:hover {
-				border-radius: 4px;
+	&:hover {
+		opacity: 1;
+		width: auto;
+		overflow: visible;
+
+		.environment {
+		}
+
+		.is-docs,
+		.is-bug-report {
+			opacity: 1;
+			pointer-events: auto;
+			
+			a {
+				box-shadow: 0 1px 2px rgba( darken( $gray, 30 ), 0.4 );
 			}
 		}
 	}

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -402,6 +402,12 @@ body.newdash div.wordpress-com-extension-promo {
 		left: 289px;
 	z-index: z-index( 'root', '.environment-badge' );
 	backface-visibility: hidden;
+	transition: opacity 0.1s ease-in-out;
+
+	.detail-page-active & {
+		opacity: 0;
+		pointer-events: none;
+	}
 
 	.bug-report {
 		position: relative;

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -49,14 +49,14 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			.wpcom-site__logo.noticon.noticon-wordpress
 		if badge
 			div.environment-badge
-				span(class=['environment', 'is-' + badge])=badge
 				if branchName && branchName !== 'master'
-					span(class=['environment', 'branch-name'])=branchName
+					span(class=['environment', 'is-branch-name'])=branchName
+				span(class=['environment', 'is-' + badge])=badge
 				if devDocs
 					span(class=['environment', 'is-docs'])
-						a(href=devDocsURL title='DevDocs') docs
+						a(href=devDocsURL title='DevDocs') Developer Docs
 				span(class=['environment', 'is-bug-report'])
-					a(href=feedbackURL, title='Report an issue', target='_blank') bug?
+					a(href=feedbackURL, title='Report an issue', target='_blank') Found a bug?
 
 		script.
 			(function() {

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -49,13 +49,14 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			.wpcom-site__logo.noticon.noticon-wordpress
 		if badge
 			div.environment-badge
-				a(class='bug-report', href=feedbackURL, title='Report an issue', target='_blank')
 				span(class=['environment', 'is-' + badge])=badge
 				if branchName && branchName !== 'master'
 					span(class=['environment', 'branch-name'])=branchName
 				if devDocs
 					span(class=['environment', 'is-docs'])
 						a(href=devDocsURL title='DevDocs') docs
+				span(class=['environment', 'is-bug-report'])
+					a(href=feedbackURL, title='Report an issue', target='_blank') bug?
 
 		script.
 			(function() {


### PR DESCRIPTION
Moving the bug badge to it doesn’t obscure the sidebar. Here's what it looks like on `master`:

![screen shot 2015-12-07 at 11 01 58 am](https://cloud.githubusercontent.com/assets/191598/11631822/fc5e5360-9cd1-11e5-8bbe-380a81d15cb4.png)

This PR moves the badge so it doesn't overlap the sidebar:

![screen shot 2015-12-07 at 11 02 21 am](https://cloud.githubusercontent.com/assets/191598/11631859/1fa54504-9cd2-11e5-9d99-a5353f8d935f.png)
