### PR TITLE
Plugins: Remove autoupdate toggle for non jetpack sites

### DIFF
--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -112,6 +112,10 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
+		if ( ! this.props.site.jetpack ) {
+			return null;
+		}
+
 		const inProgress = PluginsLog.isInProgressAction( this.props.site.ID, this.props.plugin.slug, [
 				'ENABLE_AUTOUPDATE_PLUGIN',
 				'DISABLE_AUTOUPDATE_PLUGIN'

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/test/fixtures.js
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/test/fixtures.js
@@ -4,7 +4,8 @@ module.exports = {
 		domain: '',
 		name: '',
 		canUpdateFiles: true,
-		options: { file_mod_disabled: false }
+		options: { file_mod_disabled: false },
+		jetpack: true
 	},
 	plugin: { slug: 'test' },
 	notices: {


### PR DESCRIPTION
Currently we show the autoupdate toggle for on non jetpack sites. 
Lets remove it for now. This fixes a regression. 

Before:
![screen shot 2015-12-07 at 10 30 24](https://cloud.githubusercontent.com/assets/115071/11635774/95677906-9ccd-11e5-807d-a4966f28923b.png)

After:
![screen shot 2015-12-07 at 10 29 30](https://cloud.githubusercontent.com/assets/115071/11635780/9e2a7034-9ccd-11e5-9f7c-563a0f3657ad.png)

Jetpack site:
![screen shot 2015-12-07 at 10 29 16](https://cloud.githubusercontent.com/assets/115071/11635786/a19916c6-9ccd-11e5-92c9-2f1771d182b6.png)
