### PR TITLE
Plugins: Don't display plugins for hidden sites on multiple sites views

### DIFF
--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -183,22 +183,25 @@ PluginsStore = {
 		if ( sites.length === 0 ) {
 			return [];
 		}
-		sites.forEach( function( site ) {
-			var sitePlugins = PluginsStore.getSitePlugins( site );
+		sites.forEach( ( site ) => {
+			if ( sites.length > 1 && ! site.visible ) {
+				return;
+			}
+			const sitePlugins = PluginsStore.getSitePlugins( site );
 			if ( sitePlugins !== undefined ) {
 				fetched = true;
 			}
 			if ( ! sitePlugins ) {
 				return;
 			}
-			sitePlugins.forEach( function( plugin ) {
+			sitePlugins.forEach( ( plugin ) => {
 				if ( ! plugins[ plugin.slug ] ) {
 					plugins[ plugin.slug ] = assign( {}, plugin, { sites: [] } );
 				}
 				plugins[ plugin.slug ].sites.push( assign( {}, site, { plugin: plugin } ) );
 
 				plugins[ plugin.slug ].selected = _selectedPlugins[ plugin.slug ];
-			}, this );
+			} );
 		} );
 		if ( ! fetched ) {
 			return;


### PR DESCRIPTION
__how to test__

* checkout `update/plugins-dont-fetch-for-invisible-sites`
* hide a Jetpack site from https://wordpress.com/wp-admin/index.php?page=my-blogs
* Install a plugin that you don't have on your other sites.
* Check that the plugin is not listed under:
  * https://wordpress.com/plugins 
  * https://wordpress.com/plugins/active
  * https://wordpress.com/plugins/inactive
  * https://wordpress.com/plugins/updates

Closes #820