### PR TITLE
Jetpack Plugins: Fix Incorrect notice when viewing plugins with insufficient permissions

### DIFF
--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -23,7 +23,15 @@ function hasRestrictedAccess( site ) {
 
 	site = site || sites.getSelectedSite();
 
-	if ( hasErrorCondition( site, 'notMinimumJetpackVersion' ) ) {
+	// Display a 404 to users that don't have the rights to manage plugins
+	if ( hasErrorCondition( site, 'notRightsToManagePlugins' ) ) {
+		pluginPageError = {
+			title: i18n.translate( 'Not Available' ),
+			line: i18n.translate( 'The page you requested could not be found' ),
+			illustration: '/calypso/images/drake/drake-404.svg',
+			fullWidth: true
+		};
+	} else if ( hasErrorCondition( site, 'notMinimumJetpackVersion' ) ) {
 		notices.warning(
 			i18n.translate( 'Jetpack %(version)s is required to take full advantage of plugin management in %(site)s.', {
 				args: {
@@ -37,17 +45,6 @@ function hasRestrictedAccess( site ) {
 				dismissID: 'allSitesNotOnMinJetpackVersion' + config( 'jetpack_min_version' ) + '-' + site.ID
 			}
 		);
-	}
-
-	// Display a 404 to users that don't have the rights to manage plugins
-	if ( hasErrorCondition( site, 'notRightsToManagePlugins' ) &&
-			! pluginPageError ) {
-		pluginPageError = {
-			title: i18n.translate( 'Not Available' ),
-			line: i18n.translate( 'The page you requested could not be found' ),
-			illustration: '/calypso/images/drake/drake-404.svg',
-			fullWidth: true
-		};
 	}
 
 	if ( abtest( 'businessPluginsNudge' ) === 'drake' && hasErrorCondition( site, 'noBusinessPlan' ) ) {


### PR DESCRIPTION
__How to test__

* install 3.6.1 on a $site
* go to `https://calypso.dev:3000/plugins/$site` logged as a non admin user for $site

You should not get this notice anymore:

![subscriber-manage-off-3 8 0](https://cloud.githubusercontent.com/assets/11487924/11413163/f0792b0a-93b3-11e5-929e-9029ad112ed8.png)

Closes #827