### PR TITLE
Me: Fixes logic for gated security checkup nav tab

### DIFF
--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -18,27 +18,30 @@ module.exports = React.createClass( {
 		path: React.PropTypes.string.isRequired
 	},
 
-	getDefaultProps: function() {
-		return {
-			tabs: [
-				{
-					title: i18n.translate( 'Password', { textOnly: true } ),
-					path: '/me/security',
-				},
-				{
-					title: i18n.translate( 'Two-Step Authentication', { textOnly: true } ),
-					path: '/me/security/two-step',
-				},
-				{
-					title: i18n.translate( 'Connected Applications', { textOnly: true } ),
-					path: '/me/security/connected-applications',
-				},
-				config.isEnabled( 'me/security/checkup' ) ? {
-					title: i18n.translate( 'Checkup', { textOnly: true } ),
-					path: '/me/security/checkup',
-				} : false
-			]
-		};
+	getNavtabs: function() {
+		var tabs = [
+			{
+				title: i18n.translate( 'Password', { textOnly: true } ),
+				path: '/me/security',
+			},
+			{
+				title: i18n.translate( 'Two-Step Authentication', { textOnly: true } ),
+				path: '/me/security/two-step',
+			},
+			{
+				title: i18n.translate( 'Connected Applications', { textOnly: true } ),
+				path: '/me/security/connected-applications',
+			}
+		];
+
+		if ( config.isEnabled( 'me/security/checkup' ) ) {
+			tabs.push( {
+				title: i18n.translate( 'Checkup', { textOnly: true } ),
+				path: '/me/security/checkup',
+			} );
+		}
+
+		return tabs;
 	},
 
 	getFilteredPath: function() {
@@ -48,7 +51,7 @@ module.exports = React.createClass( {
 
 	getSelectedText: function() {
 		var text = '',
-			found = find( this.props.tabs, function( tab ) {
+			found = find( this.getNavtabs(), function( tab ) {
 				return this.getFilteredPath() === tab.path;
 			}, this );
 
@@ -67,7 +70,7 @@ module.exports = React.createClass( {
 		return (
 			<SectionNav selectedText={ this.getSelectedText() }>
 				<NavTabs>
-					{ this.props.tabs.map( function( tab ) {
+					{ this.getNavtabs().map( function( tab ) {
 						return (
 							<NavItem
 								key={ tab.path }


### PR DESCRIPTION
Fixes #24

Now that the `/me/security/checkup` section has launched, the spacing issue not seem to exist anymore. But, I believe the issue was due to how we were adding the checkup nav tab, specifically that the condition returned false if the feature flag wasn't turned on.

Since there were no instances of calling of a component passing tabs into `<SecuritySectionNav>`, I opted to repurpose `getDefaultProps()` to dynamically create an array of objects. This will allow us to easily add/remove sections later when we modify feature flags.

cc @mjangda 

To test:
- Checkout `fix/me-checkup-section-nav`
- Go to `/me/security`
- Ensure that all 4 tabs show.
- Shrink to mobile and open mobile nav. 
- Ensure all 4 tabs open=
- In `config/development.json`, set `me/security/checkup` to `false` 
- Restart server.
- Follow steps above, except you should now see 3 nav tabs