### PR TITLE
Framework: Update search component (and instances) to use gridicons

### DIFF
--- a/assets/stylesheets/sections/_menus.scss
+++ b/assets/stylesheets/sections/_menus.scss
@@ -842,7 +842,7 @@
 					.gridicon {
 						position: absolute;
 						left: 0;
-						padding: 9px 9px;
+						padding: 9px 8px;
 					}
 
 					.search-box {

--- a/assets/stylesheets/sections/_menus.scss
+++ b/assets/stylesheets/sections/_menus.scss
@@ -839,7 +839,7 @@
 				.search-container {
 					position: relative;
 
-					.noticon-search {
+					.gridicon {
 						position: absolute;
 						left: 0;
 						padding: 9px 9px;

--- a/client/components/author-selector/style.scss
+++ b/client/components/author-selector/style.scss
@@ -53,10 +53,6 @@
 		height: 43px;
 		margin-bottom: 0;
 
-		&.is-open .gridicon {
-			top: 12px;
-		}
-
 		.search__input[type="search"] {
 			border-radius: 5px;
 			font-size: 14px;

--- a/client/components/author-selector/style.scss
+++ b/client/components/author-selector/style.scss
@@ -53,8 +53,8 @@
 		height: 43px;
 		margin-bottom: 0;
 
-		.is-open .noticon-search {
-			color: $gray;
+		&.is-open .gridicon {
+			top: 12px;
 		}
 
 		.search__input[type="search"] {

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -10,7 +10,8 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
-	Spinner = require( 'components/spinner' );
+	Spinner = require( 'components/spinner' ),
+	Gridicon = require( 'components/gridicon' );
 
 /**
  * Internal variables
@@ -252,7 +253,6 @@ module.exports = React.createClass( {
 				<Spinner />
 				<div
 					ref="openIcon"
-					className="noticon noticon-search"
 					onTouchTap={ enableOpenIcon ? this.openSearch : this.focus }
 					tabIndex={ enableOpenIcon ? '0' : null }
 					onKeyDown={ enableOpenIcon
@@ -260,7 +260,9 @@ module.exports = React.createClass( {
 						: null
 					}
 					aria-controls={ 'search-component-' + this.id }
-					aria-label={ this.translate( 'Open Search', { context: 'button label' } ) }/>
+					aria-label={ this.translate( 'Open Search', { context: 'button label' } ) }>
+				<Gridicon icon="search" className="search-open__icon"/>
+				</div>
 				<input
 					type="search"
 					id={ 'search-component-' + this.id }
@@ -286,12 +288,13 @@ module.exports = React.createClass( {
 	closeButton: function() {
 		return (
 			<span
-				className="noticon noticon-close-alt"
 				onTouchTap={ this.closeSearch }
 				tabIndex="0"
 				onKeyDown={ this._keyListener.bind( this, 'closeSearch' ) }
 				aria-controls={ 'search-component-' + this.id }
-				aria-label={ this.translate( 'Close Search', { context: 'button label' } ) }/>
+				aria-label={ this.translate( 'Close Search', { context: 'button label' } ) }>
+			<Gridicon icon="cross" className="search-close__icon"/>
+			</span>
 		);
 	},
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -13,10 +13,9 @@
 		width: 50px;
 	}
 
-	.noticon-search {
+	.search-open__icon {
 		position: absolute;
-			top: 0;
-			bottom: 0;
+			top: 14px;
 		width: 60px;
 		z-index: 20;
 		color: $blue-wordpress;
@@ -26,35 +25,25 @@
 			outline: dotted 1px $blue-wordpress;
 		}
 
-		&::before {
-			position: absolute;
-				left: 0;
-				right: 0;
-				top: 50%;
-			margin-top: -12px;
-			font-size: 24px;
-			text-align: center;
-		}
-
 		@include breakpoint( "<660px" ) {
 			width: 50px;
 		}
 
 	}
 
-	.noticon-search:hover {
-		color: $gray-dark;
+	.search-open__icon:hover {
+		color: darken( $gray, 30% );
 	}
 
-	.noticon-close-alt {
+	.search-close__icon {
 		position: absolute;
 			bottom: 0;
-			top: 0;
+			top: 14px;
 			right: 0;
 		width: 60px;
 		cursor: pointer;
 		z-index: 20;
-		color: $gray-dark;
+		color: darken( $gray, 30% );
 		display: none;
 		opacity: 0;
 		transition: opacity .2s ease-in;
@@ -96,7 +85,7 @@
 	// matching dropdown-selector
 	z-index: 170;
 
-	.noticon-search {
+	.search-open__icon {
 		right: 0;
 	}
 
@@ -112,7 +101,7 @@
 	top: 0;
 	padding: 0 50px 0 60px;
 	border: none;
-	background: #fff;
+	background: $white;
 	height: 51px;
 	appearance: none;
 	box-sizing: border-box;
@@ -139,17 +128,17 @@
 	margin-right: 0 !important;
 	width: 100%;
 
-	.noticon-search {
-		color: $gray-dark;
+	.search-open__icon {
+		color: darken( $gray, 30% );
 		left: 0;
 	}
 
-	.noticon-close-alt {
+	.search-close__icon {
 		display: inline-block;
 	}
 
 	.search__input,
-	.noticon-close-alt {
+	.search-close__icon{
 		opacity: 1;
 	}
 
@@ -170,7 +159,7 @@
 	}
 }
 
-.search.is-searching .noticon-search {
+.search.is-searching .search-open__icon {
 	display: none;
 }
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -15,7 +15,8 @@
 
 	.search-open__icon {
 		position: absolute;
-			top: 14px;
+			top: 50%;
+		margin-top: -12px;
 		width: 60px;
 		z-index: 20;
 		color: $blue-wordpress;
@@ -38,8 +39,9 @@
 	.search-close__icon {
 		position: absolute;
 			bottom: 0;
-			top: 14px;
+			top: 50%;
 			right: 0;
+		margin-top: -12px;
 		width: 60px;
 		cursor: pointer;
 		z-index: 20;

--- a/client/components/search/test/index.jsx
+++ b/client/components/search/test/index.jsx
@@ -11,9 +11,16 @@ import mockery from 'mockery';
 const expect = chai.expect,
 	TestUtils = React.addons.TestUtils;
 
+const EMPTY_COMPONENT = React.createClass( {
+	render: function() {
+		return <div />;
+	}
+} );
+
 describe( 'Search', function() {
 	beforeEach( function() {
 		mockery.registerMock( 'analytics', {} );
+		mockery.registerMock( 'components/gridicon', EMPTY_COMPONENT );
 		mockery.enable();
 		mockery.warnOnUnregistered( false );
 

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -1,13 +1,18 @@
 var assert = require( 'chai' ).assert,
 	sinon = require( 'sinon' ),
 	React = require( 'react/addons' ),
+	mockery = require( 'mockery' ),
 	TestUtils = React.addons.TestUtils,
 	SectionNav;
 
+var EMPTY_COMPONENT = React.createClass( {
+	render: function() {
+		return <div />;
+	}
+} );
+
 require( 'lib/react-test-env-setup' )( '<html><body><script></script><div id="container"></div></body></html>' );
 require( 'react-tap-event-plugin' )();
-
-SectionNav = require( '../' );
 
 function createComponent( component, props, children ) {
 	var shallowRenderer = React.addons.TestUtils.createRenderer();
@@ -16,74 +21,88 @@ function createComponent( component, props, children ) {
 	);
 	return shallowRenderer.getRenderOutput();
 }
-
-describe( 'Section-Nav rendering', function() {
+describe( 'section-nav', function() {
 	before( function() {
-		var selectedText = 'test';
-		var children = ( <p>mmyellow</p> );
+		mockery.registerMock( 'components/gridicon', EMPTY_COMPONENT );
+		mockery.enable();
+		mockery.warnOnUnregistered( false );
 
-		this.sectionNav = createComponent( SectionNav, {
-			selectedText: selectedText
-		}, children );
+		SectionNav = require( '../' );
+	} ),
 
-		this.panelElem = this.sectionNav.props.children[ 1 ];
-		this.headerElem = this.sectionNav.props.children[ 0 ];
-		this.headerTextElem = this.headerElem.props.children;
-		this.text = this.headerTextElem.props.children;
-	} );
+	after( function() {
+		mockery.deregisterMock( 'components/gridicon' );
+		mockery.disable();
+	} ),
 
-	it( 'should render a header and a panel', function() {
-		assert.equal( this.headerElem.props.className, 'section-nav__mobile-header' );
-		assert.equal( this.panelElem.props.className, 'section-nav__panel' );
-		assert.equal( this.headerTextElem.props.className, 'section-nav__mobile-header-text' );
-	} );
+	describe( 'rendering', function() {
+		before( function() {
+			var selectedText = 'test';
+			var children = ( <p>mmyellow</p> );
 
-	it( 'should render selectedText within mobile header', function() {
-		assert.equal( this.text, 'test' );
-	} );
+			this.sectionNav = createComponent( SectionNav, {
+				selectedText: selectedText
+			}, children );
 
-	it( 'should render children', function( done ) {
-		//React.Children.only should work here but gives an error about not being the only child
-		React.Children.map( this.panelElem.props.children, function( obj ) {
-			if ( obj.type === 'p' ) {
-				assert.equal( obj.props.children, 'mmyellow' );
-				done();
-			}
+			this.panelElem = this.sectionNav.props.children[ 1 ];
+			this.headerElem = this.sectionNav.props.children[ 0 ];
+			this.headerTextElem = this.headerElem.props.children;
+			this.text = this.headerTextElem.props.children;
+		} );
+
+		it( 'should render a header and a panel', function() {
+			assert.equal( this.headerElem.props.className, 'section-nav__mobile-header' );
+			assert.equal( this.panelElem.props.className, 'section-nav__panel' );
+			assert.equal( this.headerTextElem.props.className, 'section-nav__mobile-header-text' );
+		} );
+
+		it( 'should render selectedText within mobile header', function() {
+			assert.equal( this.text, 'test' );
+		} );
+
+		it( 'should render children', function( done ) {
+			//React.Children.only should work here but gives an error about not being the only child
+			React.Children.map( this.panelElem.props.children, function( obj ) {
+				if ( obj.type === 'p' ) {
+					assert.equal( obj.props.children, 'mmyellow' );
+					done();
+				}
+			} );
 		} );
 	} );
-} );
 
-describe( 'Section-Nav interaction', function() {
-	it( 'should call onMobileNavPanelOpen function passed as a prop when tapped', function( done ) {
-		var elem = React.createElement( SectionNav, {
-			selectedText: 'placeholder',
-			onMobileNavPanelOpen: function() {
-				done();
-			}
-		}, ( <p>placeholder</p> ) );
-		var tree = TestUtils.renderIntoDocument( elem );
-		assert( ! tree.state.mobileOpen );
-		TestUtils.Simulate.touchTap( React.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
-		assert( tree.state.mobileOpen );
-	} );
+	describe( 'interaction', function() {
+		it( 'should call onMobileNavPanelOpen function passed as a prop when tapped', function( done ) {
+			var elem = React.createElement( SectionNav, {
+				selectedText: 'placeholder',
+				onMobileNavPanelOpen: function() {
+					done();
+				}
+			}, ( <p>placeholder</p> ) );
+			var tree = TestUtils.renderIntoDocument( elem );
+			assert( ! tree.state.mobileOpen );
+			TestUtils.Simulate.touchTap( React.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
+			assert( tree.state.mobileOpen );
+		} );
 
-	it( 'should call onMobileNavPanelOpen function passed as a prop twice when tapped three times', function( done ) {
-		var spy = sinon.spy();
-		var elem = React.createElement( SectionNav, {
-			selectedText: 'placeholder',
-			onMobileNavPanelOpen: spy
-		}, ( <p>placeholder</p> ) );
-		var tree = TestUtils.renderIntoDocument( elem );
+		it( 'should call onMobileNavPanelOpen function passed as a prop twice when tapped three times', function( done ) {
+			var spy = sinon.spy();
+			var elem = React.createElement( SectionNav, {
+				selectedText: 'placeholder',
+				onMobileNavPanelOpen: spy
+			}, ( <p>placeholder</p> ) );
+			var tree = TestUtils.renderIntoDocument( elem );
 
-		assert( ! tree.state.mobileOpen );
-		TestUtils.Simulate.touchTap( React.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
-		assert( tree.state.mobileOpen );
-		TestUtils.Simulate.touchTap( React.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
-		assert( ! tree.state.mobileOpen );
-		TestUtils.Simulate.touchTap( React.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
-		assert( tree.state.mobileOpen );
+			assert( ! tree.state.mobileOpen );
+			TestUtils.Simulate.touchTap( React.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
+			assert( tree.state.mobileOpen );
+			TestUtils.Simulate.touchTap( React.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
+			assert( ! tree.state.mobileOpen );
+			TestUtils.Simulate.touchTap( React.findDOMNode( TestUtils.findRenderedDOMComponentWithClass( tree, 'section-nav__mobile-header' ) ) );
+			assert( tree.state.mobileOpen );
 
-		assert( spy.calledTwice );
-		done();
+			assert( spy.calledTwice );
+			done();
+		} );
 	} );
 } );

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -117,7 +117,7 @@
 		width: auto;
 		position: absolute;
 			left: 18px;
-			top: 16px;
+		margin-top: -8px;
 		width: 16px;
 		height: 16px;
 	}
@@ -125,8 +125,8 @@
 	&.is-open {
 		.search-close__icon {
 			color: $gray;
-			top: 16px;
 			right: 16px;
+			margin-top: -8px;
 			width: 16px;
 			height: 16px;
 		}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -117,18 +117,19 @@
 		width: auto;
 		position: absolute;
 			left: 18px;
-		margin-top: -8px;
-		width: 16px;
-		height: 16px;
+			top: 50%;
+		margin-top: -9px;
+		width: 18px;
+		height: 18px;
 	}
 
 	&.is-open {
 		.search-close__icon {
 			color: $gray;
 			right: 16px;
-			margin-top: -8px;
-			width: 16px;
-			height: 16px;
+			margin-top: -9px;
+			width: 18px;
+			height: 18px;
 		}
 	}
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -109,7 +109,7 @@
 		}
 	}
 
-	.noticon-search {
+	.search-open__icon {
 		background-color: transparent;
 		border-left: none;
 		color: $gray;
@@ -117,24 +117,18 @@
 		width: auto;
 		position: absolute;
 			left: 18px;
-			top: 7px;
-
-		&::before {
-			font-size: 16px;
-		}
+			top: 16px;
+		width: 16px;
+		height: 16px;
 	}
 
 	&.is-open {
-		.noticon-close-alt {
+		.search-close__icon {
 			color: $gray;
-			height: 36px;
-			width: 34px;
-			top: 9px;
-			right: 9px;
-
-			&:before {
-				font-size: 12px;
-			}
+			top: 16px;
+			right: 16px;
+			width: 16px;
+			height: 16px;
 		}
 	}
 }

--- a/client/my-sites/category-selector/search.jsx
+++ b/client/my-sites/category-selector/search.jsx
@@ -3,6 +3,12 @@
  */
 var React = require( 'react' );
 
+/**
+ * Internal dependencies
+ */
+var Gridicon = require( 'components/gridicon' );
+
+
 module.exports = React.createClass( {
 	displayName: 'CategorySelectorSearch',
 
@@ -14,7 +20,7 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 			<div className="category-selector__search">
-				<div className="noticon noticon-search" />
+				<Gridicon icon="search" size={ 16 } />
 				<input type="search"
 					placeholder={ this.translate( 'Search…', { textOnly: true } ) }
 					value={ this.props.searchTerm }

--- a/client/my-sites/category-selector/search.jsx
+++ b/client/my-sites/category-selector/search.jsx
@@ -20,7 +20,7 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 			<div className="category-selector__search">
-				<Gridicon icon="search" size={ 16 } />
+				<Gridicon icon="search" size={ 18 } />
 				<input type="search"
 					placeholder={ this.translate( 'Search…', { textOnly: true } ) }
 					value={ this.props.searchTerm }

--- a/client/my-sites/category-selector/search.scss
+++ b/client/my-sites/category-selector/search.scss
@@ -5,8 +5,8 @@
 
 .category-selector__search .gridicon {
 	position: absolute;
-	left: 0;
-	padding: 10px 10px;
+	left: 8px;
+	top: 9px;
 }
 
 .category-selector__search input {

--- a/client/my-sites/category-selector/search.scss
+++ b/client/my-sites/category-selector/search.scss
@@ -3,7 +3,7 @@
 	margin-bottom: 4px;
 }
 
-.category-selector__search .noticon-search {
+.category-selector__search .gridicon {
 	position: absolute;
 	left: 0;
 	padding: 10px 10px;

--- a/client/my-sites/menus/item-options/option-list.jsx
+++ b/client/my-sites/menus/item-options/option-list.jsx
@@ -31,7 +31,7 @@ var Search = React.createClass( {
 	render: function() {
 		return (
 			<div className="search-container">
-				<Gridicon icon="search" size={ 16 } />
+				<Gridicon icon="search" size={ 18 } />
 				<input type="search" className="search-box"
 					placeholder={ this.translate( 'Search…', { textOnly: true } ) }
 					value={ this.props.searchTerm }

--- a/client/my-sites/menus/item-options/option-list.jsx
+++ b/client/my-sites/menus/item-options/option-list.jsx
@@ -11,7 +11,8 @@ var React = require( 'react' ),
  */
 var MenuPanelBackButton = require( '../menu-panel-back-button' ),
 		EmptyPlaceholder = require( './empty-placeholder' ),
-		LoadingPlaceholder = require( './loading-placeholder' );
+		LoadingPlaceholder = require( './loading-placeholder' ),
+		Gridicon = require( 'components/gridicon' );
 /**
  * Constants
  */
@@ -30,7 +31,7 @@ var Search = React.createClass( {
 	render: function() {
 		return (
 			<div className="search-container">
-				<div className="noticon noticon-search" />
+				<Gridicon icon="search" size={ 16 } />
 				<input type="search" className="search-box"
 					placeholder={ this.translate( 'Search…', { textOnly: true } ) }
 					value={ this.props.searchTerm }

--- a/client/post-editor/editor-location/style.scss
+++ b/client/post-editor/editor-location/style.scss
@@ -10,21 +10,23 @@
 	margin-bottom: 1px;;
 }
 
-.editor-location__search .noticon-search {
+.editor-location__search .search-open__icon {
 	width: 40px;
+	top: 9px;
 }
 
 .editor-location__search .search,
-.editor-location__search .search__input[type="search"] {
+.editor-location__search .search__input {
 	height: 40px;
 }
 
-.editor-location__search .search__input[type="search"] {
+.editor-location__search .search__input {
 	padding: 0 40px 0 40px;
 }
 
-.editor-location__search .noticon-close-alt {
+.editor-location__search .search-close__icon {
 	width: 40px;
+	top: 9px;
 }
 
 .editor-location__search-results {

--- a/client/post-editor/editor-location/style.scss
+++ b/client/post-editor/editor-location/style.scss
@@ -12,7 +12,6 @@
 
 .editor-location__search .search-open__icon {
 	width: 40px;
-	top: 9px;
 }
 
 .editor-location__search .search,
@@ -26,7 +25,6 @@
 
 .editor-location__search .search-close__icon {
 	width: 40px;
-	top: 9px;
 }
 
 .editor-location__search-results {


### PR DESCRIPTION
This is the first step in cleaning up _all_ the searching instances: removing noticons for gridicons.

Section nav search:
(My Sites > Blog posts for example)
<img width="748" alt="section nav" src="https://cloud.githubusercontent.com/assets/5835847/11648130/4e568afc-9d36-11e5-9af7-e31d54b30e59.png">

Menu search
<img width="753" alt="menu" src="https://cloud.githubusercontent.com/assets/5835847/11648158/7f8d743c-9d36-11e5-93e8-e38a06846bff.png">

Author selector:
(Multi author site editor)
<img width="222" alt="author" src="https://cloud.githubusercontent.com/assets/5835847/11648119/27402608-9d36-11e5-8ce4-4b65ba7192af.png">

Category search:
(Category accordion in editor)
<img width="260" alt="categories" src="https://cloud.githubusercontent.com/assets/5835847/11648120/274a603c-9d36-11e5-9bfd-4cea94f656a4.png">

Location search:
(More options accordion in editor)
<img width="256" alt="location" src="https://cloud.githubusercontent.com/assets/5835847/11648121/27590c68-9d36-11e5-80ad-18c790bcf494.png">

(will squash before merging)