### PR TITLE
Domains: Remove store dependency in WAPI Domain Info reduce

### DIFF
--- a/client/lib/domains/wapi-domain-info/reducer.js
+++ b/client/lib/domains/wapi-domain-info/reducer.js
@@ -7,6 +7,7 @@ import React from 'react/addons';
  * Internal dependencies
  */
 import { action as UpgradesActionTypes } from 'lib/upgrades/constants';
+// TODO: remove dependency
 import DomainsStore from 'lib/domains/store';
 import { getSelectedDomain } from 'lib/domains';
 


### PR DESCRIPTION
This PR address comment from @ockham:

> I've noticed that you're importing `DomainsStore` [here](https://github.com/Automattic/wp-calypso/blob/master/client/lib/domains/wapi-domain-info/reducer.js#L10), but I think ideally, you shouldn't do that inside a reducer (as we want to get rid of the old Flux stores in the long run) -- so maybe just directly `import { getForSite } from '../reducer'`?