### PR TITLE
Domains: Remove recurring boilerplate in reducers

### DIFF
--- a/client/lib/domains/reducer.js
+++ b/client/lib/domains/reducer.js
@@ -16,6 +16,7 @@ const initialState = {};
 
 function updateSiteState( state, siteId, attributes ) {
 	return React.addons.update( state, {
+		// TODO: remove boilerplate around siteId part of updated state
 		[ siteId ]: {
 			$apply: ( value ) => Object.assign( {}, value, attributes )
 		}


### PR DESCRIPTION
This PR addresses comment from @ockham 

> aI've noticed that recurring boilerplate of modifying data for a given `domainName`,

> ```js
function doSomething( state, domainName, data ) {
	/* Do something with data to get newValue */
	command = {
		[ domainName ]: {
			something: { $set: newValue }
		}
	}
	return React.addons.update( state, command );
}
```

> The recurring part is that we're pretty much always only reading and writing `state[ domainName ]` -- we don't need any other parts of `state` (or the contents of the `domainName` parameter, for that matter).

> So especially with Redux and its hierarchical stores and state, what about just acting on the `state[ domainName ]` substate, e.g. dropping the `domainName` argument altogether, and rewriting functions like so:

> ```js
function doSomething( state, data ) {
	/* Do something with data to get newValue */
	command = {
		something: { $set: newValue }
	}
	return React.addons.update( state, command );
}
```

> ...and consequently, invoking these functions inside the reducers like

> ```js
state = React.addons.update( state, {
	[ action.domainName ]: {
		$apply: domainState => updateDomainState( domainState, someData )
	}
} );
```

> (See http://rackt.org/redux/docs/basics/Reducers.html#splitting-reducers)