### PR TITLE
Notices: convert icons to gridicons.

### DIFF
--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -32,10 +32,18 @@ var Notices = React.createClass( {
 					text="I'm a notice with no status."
 					showDismiss={ false }
 					isCompact={ this.state.compactNotices ? true : null } />
-				<Notice status="is-info" text="I'm an `is-info` notice." isCompact={ this.state.compactNotices ? true : null } />
+				<Notice
+					status="is-info"
+					text="I'm an `is-info` notice with custom icon."
+					icon="heart"
+					isCompact={ this.state.compactNotices ? true : null } />
 				<Notice status="is-success" text="I'm an `is-success` notice." isCompact={ this.state.compactNotices ? true : null } />
 				<Notice status="is-error" text="I'm an `is-error` notice." isCompact={ this.state.compactNotices ? true : null } />
-				<Notice status="is-warning" text="I'm an `is-warning` notice." isCompact={ this.state.compactNotices ? true : null } />
+				<Notice
+					status="is-warning"
+					icon="mention"
+					text="I'm an `is-warning` notice with custom icon."
+					isCompact={ this.state.compactNotices ? true : null } />
 				<Notice
 					status="is-warning"
 					isCompact={ this.state.compactNotices ? true : null }

--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -28,7 +28,10 @@ var Notices = React.createClass( {
 					<a className="design-assets__toggle button" onClick={ this.toggleNotices }>{ toggleNoticesText }</a>
 				</h2>
 
-				<Notice text="I'm a notice with no status." isCompact={ this.state.compactNotices ? true : null } />
+				<Notice
+					text="I'm a notice with no status."
+					showDismiss={ false }
+					isCompact={ this.state.compactNotices ? true : null } />
 				<Notice status="is-info" text="I'm an `is-info` notice." isCompact={ this.state.compactNotices ? true : null } />
 				<Notice status="is-success" text="I'm an `is-success` notice." isCompact={ this.state.compactNotices ? true : null } />
 				<Notice status="is-error" text="I'm an `is-error` notice." isCompact={ this.state.compactNotices ? true : null } />

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -51,6 +51,30 @@ export default React.createClass( {
 		return content;
 	},
 
+	getIcon() {
+		let icon;
+
+		switch ( this.props.status ) {
+			case 'is-info':
+				icon = 'info';
+				break;
+			case 'is-success':
+				icon = 'checkmark';
+				break;
+			case 'is-error':
+				icon = 'notice';
+				break;
+			case 'is-warning':
+				icon = 'notice';
+				break;
+			default:
+				icon = 'info';
+				break;
+		}
+
+		return icon;
+	},
+
 	render() {
 		let dismiss;
 
@@ -76,6 +100,7 @@ export default React.createClass( {
 
 		return (
 			<div className={ classnames( this.props.className, noticeClass ) }>
+				<Gridicon className="notice__icon" icon={ this.getIcon() } size={ 24 } />
 				{ this.renderChildren() }
 				{ dismiss }
 			</div>

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -31,6 +31,7 @@ export default React.createClass( {
 			React.PropTypes.string,
 			React.PropTypes.object
 		] ),
+		icon: React.PropTypes.string,
 		className: React.PropTypes.string
 	},
 
@@ -100,7 +101,7 @@ export default React.createClass( {
 
 		return (
 			<div className={ classnames( this.props.className, noticeClass ) }>
-				<Gridicon className="notice__icon" icon={ this.getIcon() } size={ 24 } />
+				<Gridicon className="notice__icon" icon={ this.props.icon || this.getIcon() } size={ 24 } />
 				{ this.renderChildren() }
 				{ dismiss }
 			</div>

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -160,7 +160,7 @@
 		padding: 11px 24px 11px 16px;
 	}
 
-	&::before {
+	.notice__icon {
 		display: none;
 	}
 

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -11,55 +11,34 @@
 
 	@include breakpoint( ">660px" ) {
 		font-size: inherit;
-
-		&::before {
-			@extend %noticon;
-			content: '\f456';
-			position: absolute;
-				top: 26px;
-				left: 20px;
-			margin: -12px 0px 0 -8px;
-			font-size: 24px;
-			line-height: 1;
-		}
 	}
 
 	// Success!
 	&.is-success {
 		background: $alert-green;
-
-		@include breakpoint( ">660px" ) {
-			&:before {
-				content: '\f418';
-			}
-		}
 	}
 
 	// Warning
 	&.is-warning {
 		background: $alert-yellow;
-
-		&:before {
-		}
 	}
 
 	// Error! OHNO!
 	&.is-error {
 		background: $alert-red;
-
-		&:before {
-		}
 	}
 
-	// Information
+	// General notice
 	&.is-info {
 		background: $blue-wordpress;
+	}
+}
 
-		@include breakpoint( ">660px" ) {
-			&:before {
-				content: '\f455';
-			}
-		}
+.notice__icon {
+	padding: 13px 0 13px 16px;
+
+	@include breakpoint( "<660px" ) {
+		display: none;
 	}
 }
 
@@ -75,7 +54,7 @@
 	}
 
 	@include breakpoint( ">660px" ) {
-		padding: 13px 48px;
+		padding: 13px;
 	}
 }
 


### PR DESCRIPTION
Converts notices to use gridicons, cleans the CSS, and adds support for custom icons.

Before:
![image](https://cloud.githubusercontent.com/assets/548849/11658236/dda5bc9c-9dc1-11e5-823b-6429ae3e69ee.png)

After:
![image](https://cloud.githubusercontent.com/assets/548849/11658353/707c8064-9dc2-11e5-9387-c5705cb62254.png)
