### PR TITLE
Buttons: fixed up Scary styles

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -145,44 +145,6 @@ button {
 	}
 }
 
-// ==========================================================================
-// Deprecated styles
-//
-// `button.is-destructive` and ``.button.is-dangerous` are also deprecated
-// ==========================================================================
-
-.button.is-link {
-	background: transparent;
-	border: none;
-	border-radius: 0;
-	padding: 0;
-	color: $blue-medium;
-	font-weight: 400;
-	font-size: inherit;
-	line-height: 1.65;
-
-	&:hover,
-	&:focus,
-	&:active {
-		color: $link-highlight;
-		box-shadow: none;
-	}
-}
-
-// Positions and resets font styles of noticons applied to buttons
-.button.noticon {
-	line-height: inherit;
-
-	&:before {
-		display: inline-block;
-		vertical-align: middle;
-		margin-top: -2px;
-		font-size: 16px;
-		font-style: normal;
-		font-weight: normal;
-	}
-}
-
 .button.is-borderless {
 	border: none;
 	color: darken( $gray, 10% );
@@ -265,4 +227,40 @@ button {
 	border-style: solid none;
 	border-color: transparent;
 	padding: 0
+}
+
+// ==========================================================================
+// Deprecated styles
+// ==========================================================================
+
+.button.is-link {
+	background: transparent;
+	border: none;
+	border-radius: 0;
+	padding: 0;
+	color: $blue-medium;
+	font-weight: 400;
+	font-size: inherit;
+	line-height: 1.65;
+
+	&:hover,
+	&:focus,
+	&:active {
+		color: $link-highlight;
+		box-shadow: none;
+	}
+}
+
+// Positions and resets font styles of noticons applied to buttons
+.button.noticon {
+	line-height: inherit;
+
+	&:before {
+		display: inline-block;
+		vertical-align: middle;
+		margin-top: -2px;
+		font-size: 16px;
+		font-style: normal;
+		font-weight: normal;
+	}
 }

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -100,7 +100,8 @@ button {
 		border-color: $blue-dark;
 		color: $white;
 	}
-	&[disabled] {
+	&[disabled],
+	&:disabled {
 		background: tint( $blue-light, 50% );
 		border-color: tint( $blue-wordpress, 55% );
 		color: $white;
@@ -111,13 +112,9 @@ button {
 }
 
 // Scary buttons
-.button.is-scary,
-.button.is-dangerous {
+.button.is-scary {
 	color: $alert-red;
 
-	&[disabled] {
-		color: lighten( $alert-red, 30% );
-	}
 	&:hover,
 	&:focus {
 		border-color: $alert-red;
@@ -125,19 +122,24 @@ button {
 	&:focus {
 		box-shadow: 0 0 0 2px lighten( $alert-red, 20% );
 	}
+	&[disabled],
+	&:disabled {
+		color: lighten( $alert-red, 30% );
+		border-color: lighten( $gray, 30% );
+	}
 }
 
-.button.is-primary.is-scary,
-.button.is-destructive {
+.button.is-primary.is-scary {
 	background: $alert-red;
 	border-color: darken( $alert-red, 20% );
 	color: $white;
 
 	&:hover,
 	&:focus {
-		border-color: darken( $alert-red, 30% );
+		border-color: darken( $alert-red, 40% );
 	}
-	&[disabled] {
+	&[disabled],
+	&:disabled {
 		background: lighten( $alert-red, 20% );
 		border-color: tint( $alert-red, 30% );
 	}
@@ -211,6 +213,11 @@ button {
 	}
 	&.is-scary {
 		color: $alert-red;
+
+		&:hover,
+		&:focus {
+			color: darken( $alert-red, 20% );
+		}
 
 		&[disabled] {
 			color: lighten( $alert-red, 30% );

--- a/client/my-sites/site-settings/action-panel/style.scss
+++ b/client/my-sites/site-settings/action-panel/style.scss
@@ -72,12 +72,7 @@ a.settings-action-panel__body-text-link {
 	}
 }
 
-.settings-action-panel__footer-button-icon {
-	vertical-align: top;
-	margin: 3px 4px 0 0;
-	color: $gray;
-
-	&:last-child {
-		margin: 3px 0 0 4px;
-	}
+.settings-action-panel__export-button .gridicon,
+.settings-action-panel__support-button .gridicon {
+	margin-left: 8px;
 }

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -15,8 +15,10 @@ var HeaderCake = require( 'components/header-cake' ),
 	ActionPanelBody = require( 'my-sites/site-settings/action-panel/body' ),
 	ActionPanelFigure = require( 'my-sites/site-settings/action-panel/figure' ),
 	ActionPanelFooter = require( 'my-sites/site-settings/action-panel/footer' ),
+	Button = require( 'components/button' ),
 	Dialog = require( 'components/dialog' ),
 	config = require( 'config' ),
+	Gridicon = require ( 'components/gridicon' ),
 	SiteListActions = require( 'lib/sites-list/actions' );
 
 module.exports = React.createClass( {
@@ -51,17 +53,17 @@ module.exports = React.createClass( {
 			deleteButtons, strings;
 
 		deleteButtons = [
-			<button
-				className="button"
+			<Button
 				onClick={ this._closeDialog }>{
 					this.translate( 'Cancel' )
-			}</button>,
-			<button
-				className="button is-destructive"
+			}</Button>,
+			<Button
+				primary
+				scary
 				disabled={ deleteDisabled }
 				onClick={ this._deleteSite }>{
 					this.translate( 'Delete this Site' )
-			}</button>
+			}</Button>
 		];
 
 		strings = {
@@ -94,15 +96,13 @@ module.exports = React.createClass( {
 						}</p>
 					</ActionPanelBody>
 					<ActionPanelFooter>
-						<a
-							className="button"
+						<Button
 							disabled={ ! this.state.site }
 							onClick={ this._checkSiteLoaded }
 							href={ exportLink }
 							target={ exportTarget }>
 							{ strings.exportContent }
-							<span className="noticon noticon-external settings-action-panel__footer-button-icon"></span>
-						</a>
+						</Button>
 					</ActionPanelFooter>
 				</ActionPanel>
 				<ActionPanel>
@@ -144,13 +144,13 @@ module.exports = React.createClass( {
 						<p><a className="settings-action-panel__body-text-link" href="https://en.support.wordpress.com/contact" target="_blank">{ strings.contactSupport }</a></p>
 					</ActionPanelBody>
 					<ActionPanelFooter>
-						<button
-							className="button is-dangerous"
+						<Button
+							scary
 							disabled={ ! this.state.site }
 							onClick={ this._showDialog }>
-							<span className="noticon noticon-trash settings-action-panel__footer-button-icon"></span>
+							<Gridicon icon="trash" />
 							{ strings.deleteSite }
-						</button>
+						</Button>
 					</ActionPanelFooter>
 
 					<Dialog isVisible={ this.state.showDialog } buttons={ deleteButtons } className="delete-site__confirm-dialog">

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -97,11 +97,13 @@ module.exports = React.createClass( {
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						<Button
+							className="settings-action-panel__export-button"
 							disabled={ ! this.state.site }
 							onClick={ this._checkSiteLoaded }
 							href={ exportLink }
 							target={ exportTarget }>
 							{ strings.exportContent }
+							<Gridicon icon="external" />
 						</Button>
 					</ActionPanelFooter>
 				</ActionPanel>

--- a/client/my-sites/site-settings/start-over/index.jsx
+++ b/client/my-sites/site-settings/start-over/index.jsx
@@ -13,7 +13,9 @@ var HeaderCake = require( 'components/header-cake' ),
 	ActionPanelTitle = require( 'my-sites/site-settings/action-panel/title' ),
 	ActionPanelBody = require( 'my-sites/site-settings/action-panel/body' ),
 	ActionPanelFigure = require( 'my-sites/site-settings/action-panel/figure' ),
-	ActionPanelFooter = require( 'my-sites/site-settings/action-panel/footer' );
+	ActionPanelFooter = require( 'my-sites/site-settings/action-panel/footer' ),
+	Button = require ( 'components/button' ),
+	Gridicon = require ( 'components/gridicon' );
 
 module.exports = React.createClass( {
 
@@ -57,7 +59,13 @@ module.exports = React.createClass( {
 						}</p>
 					</ActionPanelBody>
 					<ActionPanelFooter>
-						<a className="button" href="https://en.support.wordpress.com/contact" target="_blank">{ strings.contactSupport }<span className="noticon noticon-external settings-action-panel__footer-button-icon"></span></a>
+						<Button
+							className="settings-action-panel__support-button"
+							href="https://en.support.wordpress.com/contact"
+							target="_blank">
+							{ strings.contactSupport }
+							<Gridicon icon="external" />
+						</Button>
 					</ActionPanelFooter>
 				</ActionPanel>
 			</div>


### PR DESCRIPTION
* I started out just trying to fix the hover state for a disabled scary button—it was showing a red border on hover despite being disabled.
* I then noticed a bunch of deprecated styles in the buttons css so I removed them. They affected site-settings delete site stuff, so I also updated that page to use the `Button` component properly, removed noticons, and used the new `scary` prop instead of the old `is-destructive` and `is-dangerous` classes.
* I also made the border color darker for primary scary buttons when hovering
* I also added a hover style for borderless scary buttons

**Before:**

<img width="994" alt="screen shot 2015-12-08 at 10 42 46 am" src="https://cloud.githubusercontent.com/assets/437258/11659880/75464a64-9d98-11e5-885a-5baafcc3e868.png">
<img width="217" alt="screen shot 2015-12-08 at 10 43 27 am" src="https://cloud.githubusercontent.com/assets/437258/11659900/8d515888-9d98-11e5-81b9-654a6c295abb.png">

**After:**

<img width="249" alt="screen shot 2015-12-08 at 10 39 52 am" src="https://cloud.githubusercontent.com/assets/437258/11659853/5c11e986-9d98-11e5-95a6-be30fc8c542f.png">
<img width="293" alt="screen shot 2015-12-08 at 10 39 59 am" src="https://cloud.githubusercontent.com/assets/437258/11659852/5c10c826-9d98-11e5-8f26-d96386aaef4b.png">
<img width="813" alt="screen shot 2015-12-08 at 10 40 40 am" src="https://cloud.githubusercontent.com/assets/437258/11659854/5c11e3c8-9d98-11e5-91d6-bc0ecef049d6.png">
<img width="257" alt="screen shot 2015-12-08 at 10 41 34 am" src="https://cloud.githubusercontent.com/assets/437258/11659855/5c1734cc-9d98-11e5-8372-d02225c53a38.png">
<img width="465" alt="screen shot 2015-12-08 at 10 41 40 am" src="https://cloud.githubusercontent.com/assets/437258/11659856/5c189d44-9d98-11e5-865f-90c40338b6db.png">

cc @adambbecker since you did the original work on settings
cc @mtias 

- [ ] Add external icon back to the Export Button, but conditionalize it so it disappears when export launches