### PR TITLE
Stats: fix misaligned numbers in Insights modules

### DIFF
--- a/assets/stylesheets/sections/_stats.scss
+++ b/assets/stylesheets/sections/_stats.scss
@@ -573,7 +573,9 @@ ul.module-tabs {
 			@include breakpoint( "<480px" ) {
 				clear: none;
 				float: right;
+				font-size: 16px;
 				margin-right: 24px;
+				padding: 0;
 			}
 		}
 

--- a/client/my-sites/stats/all-time/style.scss
+++ b/client/my-sites/stats/all-time/style.scss
@@ -107,13 +107,14 @@
 	}
 
 	@include breakpoint( "<480px" ) {
-		width: auto;
 		clear: none;
-		float: right;
-		margin-right: 24px;
-		text-align: right;
-		font-size: 16px;
 		display: inline-table; // fixes "Best" section moving down the next line when resizing screen
+		float: right;
+		font-size: 16px;
+		margin-right: 24px;
+		padding: 0;
+		text-align: right;
+		width: auto;
 	}
 }
 


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/270

**Before:**
![screenshot 2015-12-08 10 01 21](https://cloud.githubusercontent.com/assets/4924246/11663955/c955fcd0-9d93-11e5-85fa-825e8660600d.png)

**After:**
![screenshot 2015-12-08 09 59 56](https://cloud.githubusercontent.com/assets/4924246/11663969/d907abd8-9d93-11e5-8855-878bfad59674.png)
