### PR TITLE
Editor: Try moving token-field remove icon to left

### DIFF
--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -67,13 +67,13 @@ input[type="text"].token-field__input {
 }
 
 .token-field__token-text {
-	border-radius: 4px 0 0 4px;
-	padding: 0 4px 0 6px;
+	border-radius: 0 4px 4px 0;
+	padding: 0 6px 0 4px;
 }
 
 .token-field__remove-token {
 	cursor: pointer;
-	border-radius: 0 4px 4px 0;
+	border-radius: 4px 0 0 4px;
 	padding: 0 6px;
 	font-size: 10px;
 	color: lighten( $gray, 20% );

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -22,12 +22,12 @@ var Token = React.createClass( {
 	render: function() {
 		return (
 			<span className="token-field__token" tabIndex="-1">
-				<span className="token-field__token-text">
-					{ this.props.valueTransform( this.props.value ) }
-				</span>
 				<span
 					className="token-field__remove-token noticon noticon-close-alt"
 					onClick={ this._onClickRemove } />
+				<span className="token-field__token-text">
+					{ this.props.valueTransform( this.props.value ) }
+				</span>
 			</span>
 		);
 	},


### PR DESCRIPTION
Based off of feedback in #918 - this branch is testing out how things would look and function if the remove (x) span inside `token-field`s is moved to the left side.  Currently, on longer tags, the remove (x) is not displayed due to the flex-box used in the token-field area.

One option would be to allow longer tags to flow across multiple lines, but that could be visually confusing too.

<img width="251" alt="edit_post_ _testingtimmy2_wordpress_com_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/11664346/1e2f1104-9d96-11e5-8bd5-b1db3c96bb71.png">

/cc @nylen 

__To Test__
- Open up the editor
- Add a very long tag