### PR TITLE
Me: 2fa Reauth Required Improvements

### DIFF
--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -152,10 +152,16 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var codePlaceholder = '123456';
+		var codePlaceholder = this.translate( 'e.g. 123456', {
+			context: '6 digit two factor code placeholder.',
+			textOnly: true
+		} );
 
 		if ( this.props.twoStepAuthorization.isTwoStepSMSEnabled() ) {
-			codePlaceholder = '1234567';
+			codePlaceholder = this.translate( 'e.g. 1234567', {
+				context: '7 digit two factor code placeholder.',
+				textOnly: true
+			} );
 		}
 
 		return (

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -97,6 +97,10 @@ module.exports = React.createClass( {
 		} );
 	},
 
+	preValidateAuthCode: function() {
+		return this.state.code.length && this.state.code.length > 5;
+	},
+
 	renderSendSMSButton: function() {
 		var button;
 		if ( this.props.twoStepAuthorization.isTwoStepSMSEnabled() ) {
@@ -204,7 +208,10 @@ module.exports = React.createClass( {
 					{ this.renderSMSResendThrottled() }
 
 					<FormButtonsBar>
-						<FormButton disabled={ this.state.validatingCode } onClick={ this.recordClickEvent( 'Submit Validation Code on Reauth Required' ) } >
+						<FormButton
+							disabled={ this.state.validatingCode || ! this.preValidateAuthCode() }
+							onClick={ this.recordClickEvent( 'Submit Validation Code on Reauth Required' ) }
+						>
 							{ this.translate( 'Verify' ) }
 						</FormButton>
 

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -156,6 +156,7 @@ module.exports = React.createClass( {
 
 		return (
 			<Dialog
+				autoFocus={ false }
 				className="reauth-required__dialog"
 				isFullScreen={ false }
 				isVisible={ this.props.twoStepAuthorization.isReauthRequired() }
@@ -177,11 +178,13 @@ module.exports = React.createClass( {
 					<FormFieldset>
 						<FormLabel htmlFor="code">{ this.translate( 'Verification Code' ) }</FormLabel>
 						<FormTelInput
+							autoFocus={ true }
 							id="code"
 							isError={ this.props.twoStepAuthorization.codeValidationFailed() }
 							name="code"
 							placeholder={ codePlaceholder }
 							onFocus={ this.recordFocusEvent( 'Reauth Required Verification Code Field' ) }
+							ref="code"
 							valueLink={ this.linkState( 'code' ) } />
 
 						{ this.renderFailedValidationMsg() }


### PR DESCRIPTION
Fixes #401
Fixes #400

This PR allows auto focusing of the 2fa code input when the reauth required dialog opens in `/me`.

![reauth-autofocus](https://cloud.githubusercontent.com/assets/1126811/11664424/498707e2-9da7-11e5-9794-985ee785b0de.gif)

cc @v18 and @lezama for review

To test:
- Checkout `fix/me-reauth-autofocus`
- Make sure to test with an account that has 2fa enabled
- Go to WordPress.com
- Delete `twostep_auth` cookie
- Go to `/me` in Calypso
- In the dialog that pops up, the input should focus automagically