### PR TITLE
Reader: Use SectionHeading on Manage Followed Sites

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -40,7 +40,8 @@ module.exports = React.createClass( {
 		onKeyDown: React.PropTypes.func,
 		disableAutocorrect: React.PropTypes.bool,
 		onBlur: React.PropTypes.func,
-		searching: React.PropTypes.bool
+		searching: React.PropTypes.bool,
+		forceCloseButton: React.PropTypes.bool
 	},
 
 	getInitialState: function() {
@@ -60,7 +61,8 @@ module.exports = React.createClass( {
 			onSearchClose: noop,
 			onKeyDown: noop,
 			disableAutocorrect: false,
-			searching: false
+			searching: false,
+			forceCloseButton: false
 		};
 	},
 
@@ -275,7 +277,7 @@ module.exports = React.createClass( {
 					aria-hidden={ ! isOpenUnpinnedOrQueried }
 					autoCapitalize="none"
 					{...autocorrect } />
-				{ ( searchValue || this.state.isOpen ) ? this.closeButton() : null }
+				{ ( this.props.forceCloseButton || searchValue || this.state.isOpen ) ? this.closeButton() : null }
 			</div>
 		);
 	},

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -41,12 +41,13 @@ module.exports = React.createClass( {
 		disableAutocorrect: React.PropTypes.bool,
 		onBlur: React.PropTypes.func,
 		searching: React.PropTypes.bool,
-		forceCloseButton: React.PropTypes.bool
+		isOpen: React.PropTypes.bool
 	},
 
 	getInitialState: function() {
 		return {
-			keyword: this.props.initialValue || ''
+			keyword: this.props.initialValue || '',
+			isOpen: this.props.isOpen || false
 		};
 	},
 
@@ -62,7 +63,7 @@ module.exports = React.createClass( {
 			onKeyDown: noop,
 			disableAutocorrect: false,
 			searching: false,
-			forceCloseButton: false
+			isOpen: false
 		};
 	},
 
@@ -178,7 +179,7 @@ module.exports = React.createClass( {
 
 		this.setState( {
 			keyword: '',
-			isOpen: false
+			isOpen: this.props.isOpen || false
 		} );
 
 		input.value = ''; // will not trigger onChange
@@ -277,7 +278,7 @@ module.exports = React.createClass( {
 					aria-hidden={ ! isOpenUnpinnedOrQueried }
 					autoCapitalize="none"
 					{...autocorrect } />
-				{ ( this.props.forceCloseButton || searchValue || this.state.isOpen ) ? this.closeButton() : null }
+				{ ( searchValue || this.state.isOpen ) ? this.closeButton() : null }
 			</div>
 		);
 	},

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -47,7 +47,7 @@ module.exports = React.createClass( {
 	getInitialState: function() {
 		return {
 			keyword: this.props.initialValue || '',
-			isOpen: this.props.isOpen || false
+			isOpen: !! this.props.isOpen
 		};
 	},
 

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -39,7 +39,8 @@
 	text-transform: uppercase;
 }
 
-.section-header .button {
+.section-header__button {
+	background: none;
 	float: left;
 	margin-right: 8px;
 

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -251,6 +251,8 @@ var FollowingEdit = React.createClass( {
 	},
 
 	handleNewSubscriptionSearchClose: function() {
+		this.toggleAddSite();
+
 		if ( this.state.lastError && this.state.lastError.errorType === FeedSubscriptionErrorTypes.UNABLE_TO_FOLLOW ) {
 			this.setState( { isAttemptingFollow: false } );
 			FeedSubscriptionActions.dismissError( this.state.lastError );
@@ -258,6 +260,7 @@ var FollowingEdit = React.createClass( {
 	},
 
 	handleFollow: function() {
+		this.toggleAddSite();
 		this.setState( { isAttemptingFollow: true } );
 	},
 
@@ -310,6 +313,10 @@ var FollowingEdit = React.createClass( {
 		this.setState( {
 			isAddingOpen: ! this.state.isAddingOpen
 		} );
+
+		if ( ! this.state.isAddingOpen ) {
+			document.getElementById( 'search-component-1' ).focus();
+		}
 	},
 
 	render: function() {

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -312,6 +312,10 @@ var FollowingEdit = React.createClass( {
 		this.setState( {
 			isAddingOpen: ! this.state.isAddingOpen
 		} );
+
+		if ( ! this.state.isAddingOpen ) {
+			this.refs['feed-search'].focus();
+		}
 	},
 
 	render: function() {
@@ -365,12 +369,12 @@ var FollowingEdit = React.createClass( {
 					</SectionHeaderButton>
 				</SectionHeader>
 
-				{ this.state.isAddingOpen &&
-					<FollowingEditSubscribeForm
-						onSearch={ this.handleNewSubscriptionSearch }
-						onSearchClose={ this.handleNewSubscriptionSearchClose }
-						onFollow={ this.handleFollow }
-						initialSearchString={ this.props.initialFollowUrl } /> }
+				<FollowingEditSubscribeForm
+					onSearch={ this.handleNewSubscriptionSearch }
+					onSearchClose={ this.handleNewSubscriptionSearchClose }
+					onFollow={ this.handleFollow }
+					initialSearchString={ this.props.initialFollowUrl }
+					ref="feed-search" />
 
 				<Search
 					key="existingFeedSearch"

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -337,7 +337,8 @@ var FollowingEdit = React.createClass( {
 				{ this.renderUnfollowError() }
 
 				<SectionHeader label={ this.translate( 'Sites' ) } count={ 2 }>
-					<SectionHeaderButton>Sort By</SectionHeaderButton>
+					<FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
+
 					<SectionHeaderButton onClick={ function() {
 						console.log( 'Clicked Add button' );
 					} }>
@@ -350,7 +351,7 @@ var FollowingEdit = React.createClass( {
 					onSearchClose={ this.handleNewSubscriptionSearchClose }
 					onFollow={ this.handleFollow }
 					initialSearchString={ this.props.initialFollowUrl } />
-				<FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
+
 				<Search
 					key="existingFeedSearch"
 					autoFocus={ false }

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -26,7 +26,9 @@ const Main = require( 'components/main' ),
 	smartSetState = require( 'lib/react-smart-set-state' ),
 	escapeRegexp = require( 'escape-string-regexp' ),
 	FollowingEditSortControls = require( './sort-controls' ),
-	FollowingEditHelper = require( 'reader/following-edit/helper' );
+	FollowingEditHelper = require( 'reader/following-edit/helper' ),
+	SectionHeader = require( 'components/section-header' ),
+	SectionHeaderButton = require( 'components/section-header/button' );
 
 const initialLoadFeedCount = 20;
 
@@ -333,6 +335,16 @@ var FollowingEdit = React.createClass( {
 				</MobileBackToSidebar>
 				{ this.renderFollowError() }
 				{ this.renderUnfollowError() }
+
+				<SectionHeader label={ this.translate( 'Sites' ) } count={ 2 }>
+					<SectionHeaderButton>Sort By</SectionHeaderButton>
+					<SectionHeaderButton onClick={ function() {
+						console.log( 'Clicked Add button' );
+					} }>
+						{ this.translate( 'Add Site' ) }
+					</SectionHeaderButton>
+				</SectionHeader>
+
 				<FollowingEditSubscribeForm
 					onSearch={ this.handleNewSubscriptionSearch }
 					onSearchClose={ this.handleNewSubscriptionSearchClose }

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -3,7 +3,9 @@ const React = require( 'react' ),
 	times = require( 'lodash/utility/times' ),
 	trimLeft = require( 'lodash/string/trimLeft' ),
 	Immutable = require( 'immutable' ),
-	debounce = require( 'lodash/function/debounce' );
+	debounce = require( 'lodash/function/debounce' ),
+	classnames = require( 'classnames' ),
+	assign = require( 'lodash/object/assign' );
 
 // Internal dependencies
 const Main = require( 'components/main' ),
@@ -28,7 +30,8 @@ const Main = require( 'components/main' ),
 	FollowingEditSortControls = require( './sort-controls' ),
 	FollowingEditHelper = require( 'reader/following-edit/helper' ),
 	SectionHeader = require( 'components/section-header' ),
-	SectionHeaderButton = require( 'components/section-header/button' );
+	SectionHeaderButton = require( 'components/section-header/button' ),
+	Gridicon = require( 'components/gridicon' );
 
 const initialLoadFeedCount = 20;
 
@@ -42,7 +45,9 @@ var FollowingEdit = React.createClass( {
 	},
 
 	getInitialState: function() {
-		return this.getStateFromStores();
+		return assign( {
+			isAddingOpen: false
+		}, this.getStateFromStores() );
 	},
 
 	getDefaultProps: function() {
@@ -301,6 +306,12 @@ var FollowingEdit = React.createClass( {
 		);
 	},
 
+	toggleAddSite: function() {
+		this.setState( {
+			isAddingOpen: ! this.state.isAddingOpen
+		} );
+	},
+
 	render: function() {
 		let subscriptions = this.state.subscriptions,
 			subscriptionsToDisplay = [],
@@ -328,20 +339,26 @@ var FollowingEdit = React.createClass( {
 			searchPlaceholder = this.translate( 'Search' );
 		}
 
+		var containerClasses = classnames( {
+			'is-adding': this.state.isAddingOpen
+		}, 'following-edit' );
+
 		return (
-			<Main className="following-edit">
+			<Main className={ containerClasses }>
 				<MobileBackToSidebar>
 					<h1>{ this.translate( 'Manage Followed Sites' ) }</h1>
 				</MobileBackToSidebar>
 				{ this.renderFollowError() }
 				{ this.renderUnfollowError() }
 
-				<SectionHeader label={ this.translate( 'Sites' ) } count={ 2 }>
+				<SectionHeader className="following-edit-header" label={ this.translate( 'Sites' ) } count={ 2 }>
+					<div className="following-edit__more-options">
+						<Gridicon icon="ellipsis" />
+					</div>
+
 					<FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
 
-					<SectionHeaderButton onClick={ function() {
-						console.log( 'Clicked Add button' );
-					} }>
+					<SectionHeaderButton onClick={ this.toggleAddSite }>
 						{ this.translate( 'Add Site' ) }
 					</SectionHeaderButton>
 				</SectionHeader>
@@ -361,7 +378,8 @@ var FollowingEdit = React.createClass( {
 				{ this.state.isAttemptingFollow && ! this.state.lastError ? <SubscriptionPlaceholder key={ 'placeholder-add-feed' } /> : null }
 				{ subscriptionsToDisplay.length === 0 && this.props.search ?
 					<NoResults text={ this.translate( 'No subscriptions match that search.' ) } /> :
-				<InfiniteList role="main"
+
+				<InfiniteList role="main" className="followed-sites-list"
 					items={ subscriptionsToDisplay }
 					lastPage={ this.state.isLastPage }
 					fetchingNextPage={ this.state.isLoading }

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -366,7 +366,7 @@ var FollowingEdit = React.createClass( {
 					<FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
 
 					<SectionHeaderButton onClick={ this.toggleAddSite }>
-						{ this.translate( 'Add Site' ) }
+						{ this.translate( 'Add' ) }
 					</SectionHeaderButton>
 				</SectionHeader>
 

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -358,7 +358,7 @@ var FollowingEdit = React.createClass( {
 				{ this.renderFollowError() }
 				{ this.renderUnfollowError() }
 
-				<SectionHeader className="following-edit-header" label={ this.translate( 'Sites' ) } count={ 2 }>
+				<SectionHeader className="following-edit-header" label={ this.translate( 'Sites' ) } count={ this.state.totalSubscriptions }>
 					<div className="following-edit__more-options">
 						<Gridicon icon="ellipsis" />
 					</div>

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -4,8 +4,7 @@ const React = require( 'react' ),
 	trimLeft = require( 'lodash/string/trimLeft' ),
 	Immutable = require( 'immutable' ),
 	debounce = require( 'lodash/function/debounce' ),
-	classnames = require( 'classnames' ),
-	assign = require( 'lodash/object/assign' );
+	classnames = require( 'classnames' );
 
 // Internal dependencies
 const Main = require( 'components/main' ),
@@ -45,7 +44,7 @@ var FollowingEdit = React.createClass( {
 	},
 
 	getInitialState: function() {
-		return assign( {
+		return Object.assign( {
 			isAddingOpen: false
 		}, this.getStateFromStores() );
 	},
@@ -313,10 +312,6 @@ var FollowingEdit = React.createClass( {
 		this.setState( {
 			isAddingOpen: ! this.state.isAddingOpen
 		} );
-
-		if ( ! this.state.isAddingOpen ) {
-			document.getElementById( 'search-component-1' ).focus();
-		}
 	},
 
 	render: function() {
@@ -346,7 +341,7 @@ var FollowingEdit = React.createClass( {
 			searchPlaceholder = this.translate( 'Search' );
 		}
 
-		var containerClasses = classnames( {
+		const containerClasses = classnames( {
 			'is-adding': this.state.isAddingOpen
 		}, 'following-edit' );
 
@@ -370,11 +365,12 @@ var FollowingEdit = React.createClass( {
 					</SectionHeaderButton>
 				</SectionHeader>
 
-				<FollowingEditSubscribeForm
-					onSearch={ this.handleNewSubscriptionSearch }
-					onSearchClose={ this.handleNewSubscriptionSearchClose }
-					onFollow={ this.handleFollow }
-					initialSearchString={ this.props.initialFollowUrl } />
+				{ this.state.isAddingOpen &&
+					<FollowingEditSubscribeForm
+						onSearch={ this.handleNewSubscriptionSearch }
+						onSearchClose={ this.handleNewSubscriptionSearchClose }
+						onFollow={ this.handleFollow }
+						initialSearchString={ this.props.initialFollowUrl } /> }
 
 				<Search
 					key="existingFeedSearch"

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -19,7 +19,7 @@ const Main = require( 'components/main' ),
 	SubscriptionListItem = require( './list-item' ),
 	Notice = require( 'components/notice' ),
 	stats = require( 'reader/stats' ),
-	Search = require( 'components/search' ),
+	SearchCard = require( 'components/search-card' ),
 	URLSearch = require( 'lib/mixins/url-search' ),
 	FollowingEditSubscribeForm = require( './subscribe-form' ),
 	FeedSubscriptionErrorTypes = require( 'lib/reader-feed-subscriptions/constants' ).error,
@@ -376,9 +376,9 @@ var FollowingEdit = React.createClass( {
 					initialSearchString={ this.props.initialFollowUrl }
 					ref="feed-search" />
 
-				<Search
+				<SearchCard
 					key="existingFeedSearch"
-					autoFocus={ false }
+					autoFocus={ true }
 					additionalClasses="following-edit__existing-feed-search"
 					placeholder={ searchPlaceholder }
 					onSearch={ this.doSearch } initialValue={ this.props.search } delaySearch={ true } ref="url-search" />

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -29,8 +29,7 @@ const Main = require( 'components/main' ),
 	FollowingEditSortControls = require( './sort-controls' ),
 	FollowingEditHelper = require( 'reader/following-edit/helper' ),
 	SectionHeader = require( 'components/section-header' ),
-	Button = require( 'components/button' ),
-	Gridicon = require( 'components/gridicon' );
+	Button = require( 'components/button' );
 
 const initialLoadFeedCount = 20;
 
@@ -358,10 +357,6 @@ var FollowingEdit = React.createClass( {
 				{ this.renderUnfollowError() }
 
 				<SectionHeader className="following-edit__header" label={ this.translate( 'Sites' ) } count={ this.state.totalSubscriptions }>
-					<div className="following-edit__more-options">
-						<Gridicon icon="ellipsis" />
-					</div>
-
 					<FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
 
 					<Button compact onClick={ this.toggleAddSite }>

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -381,7 +381,10 @@ var FollowingEdit = React.createClass( {
 					autoFocus={ true }
 					additionalClasses="following-edit__existing-feed-search"
 					placeholder={ searchPlaceholder }
-					onSearch={ this.doSearch } initialValue={ this.props.search } delaySearch={ true } ref="url-search" />
+					onSearch={ this.doSearch }
+					initialValue={ this.props.search }
+					delaySearch={ true }
+					ref="url-search" />
 				{ this.state.isAttemptingFollow && ! this.state.lastError ? <SubscriptionPlaceholder key={ 'placeholder-add-feed' } /> : null }
 				{ subscriptionsToDisplay.length === 0 && this.props.search ?
 					<NoResults text={ this.translate( 'No subscriptions match that search.' ) } /> :

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -359,8 +359,8 @@ const FollowingEdit = React.createClass( {
 				<SectionHeader className="following-edit__header" label={ this.translate( 'Sites' ) } count={ this.state.totalSubscriptions }>
 					<FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
 
-					<Button compact onClick={ this.toggleAddSite }>
-						{ this.translate( 'Add' ) }
+					<Button compact primary onClick={ this.toggleAddSite }>
+						{ this.translate( 'Follow Site' ) }
 					</Button>
 				</SectionHeader>
 

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -1,39 +1,39 @@
 // External dependencies
-const React = require( 'react' ),
-	times = require( 'lodash/utility/times' ),
-	trimLeft = require( 'lodash/string/trimLeft' ),
-	Immutable = require( 'immutable' ),
-	debounce = require( 'lodash/function/debounce' ),
-	classnames = require( 'classnames' );
+import React from 'react';
+import times from 'lodash/utility/times';
+import trimLeft from 'lodash/string/trimLeft';
+import Immutable from 'immutable';
+import debounce from 'lodash/function/debounce';
+import classnames from 'classnames';
 
 // Internal dependencies
-const Main = require( 'components/main' ),
-	FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' ),
-	SiteStore = require( 'lib/reader-site-store' ),
-	FeedStore = require( 'lib/feed-store' ),
-	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' ),
-	EmptyContent = require( 'components/empty-content' ),
-	NoResults = require( 'my-sites/no-results' ),
-	InfiniteList = require( 'components/infinite-list' ),
-	SubscriptionPlaceholder = require( './placeholder' ),
-	SubscriptionListItem = require( './list-item' ),
-	Notice = require( 'components/notice' ),
-	stats = require( 'reader/stats' ),
-	SearchCard = require( 'components/search-card' ),
-	URLSearch = require( 'lib/mixins/url-search' ),
-	FollowingEditSubscribeForm = require( './subscribe-form' ),
-	FeedSubscriptionErrorTypes = require( 'lib/reader-feed-subscriptions/constants' ).error,
-	MobileBackToSidebar = require( 'components/mobile-back-to-sidebar' ),
-	smartSetState = require( 'lib/react-smart-set-state' ),
-	escapeRegexp = require( 'escape-string-regexp' ),
-	FollowingEditSortControls = require( './sort-controls' ),
-	FollowingEditHelper = require( 'reader/following-edit/helper' ),
-	SectionHeader = require( 'components/section-header' ),
-	Button = require( 'components/button' );
+import Main from 'components/main';
+import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
+import SiteStore from 'lib/reader-site-store';
+import FeedStore from 'lib/feed-store';
+import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
+import EmptyContent from 'components/empty-content';
+import NoResults from 'my-sites/no-results';
+import InfiniteList from 'components/infinite-list';
+import SubscriptionPlaceholder from './placeholder';
+import SubscriptionListItem from './list-item';
+import Notice from 'components/notice';
+import SearchCard from 'components/search-card';
+import URLSearch from 'lib/mixins/url-search';
+import FollowingEditSubscribeForm from './subscribe-form';
+import { error as FeedSubscriptionErrorTypes } from 'lib/reader-feed-subscriptions/constants';
+import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
+import smartSetState from 'lib/react-smart-set-state';
+import escapeRegexp from 'escape-string-regexp';
+import FollowingEditSortControls from './sort-controls';
+import FollowingEditHelper from 'reader/following-edit/helper';
+import SectionHeader from 'components/section-header';
+import Button from 'components/button';
+const stats = require( 'reader/stats' );
 
 const initialLoadFeedCount = 20;
 
-var FollowingEdit = React.createClass( {
+const FollowingEdit = React.createClass( {
 
 	mixins: [ URLSearch ],
 

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -29,7 +29,7 @@ const Main = require( 'components/main' ),
 	FollowingEditSortControls = require( './sort-controls' ),
 	FollowingEditHelper = require( 'reader/following-edit/helper' ),
 	SectionHeader = require( 'components/section-header' ),
-	SectionHeaderButton = require( 'components/section-header/button' ),
+	Button = require( 'components/button' ),
 	Gridicon = require( 'components/gridicon' );
 
 const initialLoadFeedCount = 20;
@@ -364,9 +364,9 @@ var FollowingEdit = React.createClass( {
 
 					<FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
 
-					<SectionHeaderButton onClick={ this.toggleAddSite }>
+					<Button compact onClick={ this.toggleAddSite }>
 						{ this.translate( 'Add' ) }
-					</SectionHeaderButton>
+					</Button>
 				</SectionHeader>
 
 				<FollowingEditSubscribeForm

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -357,7 +357,7 @@ var FollowingEdit = React.createClass( {
 				{ this.renderFollowError() }
 				{ this.renderUnfollowError() }
 
-				<SectionHeader className="following-edit-header" label={ this.translate( 'Sites' ) } count={ this.state.totalSubscriptions }>
+				<SectionHeader className="following-edit__header" label={ this.translate( 'Sites' ) } count={ this.state.totalSubscriptions }>
 					<div className="following-edit__more-options">
 						<Gridicon icon="ellipsis" />
 					</div>
@@ -386,7 +386,7 @@ var FollowingEdit = React.createClass( {
 				{ subscriptionsToDisplay.length === 0 && this.props.search ?
 					<NoResults text={ this.translate( 'No subscriptions match that search.' ) } /> :
 
-				<InfiniteList role="main" className="followed-sites-list"
+				<InfiniteList className="following-edit__sites"
 					items={ subscriptionsToDisplay }
 					lastPage={ this.state.isLastPage }
 					fetchingNextPage={ this.state.isLoading }

--- a/client/reader/following-edit/sort-controls.jsx
+++ b/client/reader/following-edit/sort-controls.jsx
@@ -34,8 +34,8 @@ const FollowingEditSortControls = React.createClass( {
 			<div className="following-edit-sort-controls">
 				<label htmlFor="sort-control-select">{ this.translate( 'Sort by' ) }</label>
 				<select id="sort-control-select" ref="sortControlSelect" className="is-compact" onChange={ this.handleSelectChange } value={ sortOrder }>
-					<option value="date-followed">{ this.translate( 'Recently Followed' ) }</option>
-					<option value="alpha">{ this.translate( 'Alphabetical' ) }</option>
+					<option value="date-followed">{ this.translate( 'By Date' ) }</option>
+					<option value="alpha">{ this.translate( 'By Name' ) }</option>
 				</select>
 			</div>
 		);

--- a/client/reader/following-edit/sort-controls.jsx
+++ b/client/reader/following-edit/sort-controls.jsx
@@ -34,7 +34,7 @@ const FollowingEditSortControls = React.createClass( {
 			<div className="following-edit-sort-controls">
 				<label htmlFor="sort-control-select">{ this.translate( 'Sort by' ) }</label>
 				<select id="sort-control-select" ref="sortControlSelect" className="is-compact" onChange={ this.handleSelectChange } value={ sortOrder }>
-					<option value="date-followed">{ this.translate( 'Date followed' ) }</option>
+					<option value="date-followed">{ this.translate( 'Recently Followed' ) }</option>
 					<option value="alpha">{ this.translate( 'Alphabetical' ) }</option>
 				</select>
 			</div>

--- a/client/reader/following-edit/sort-controls.jsx
+++ b/client/reader/following-edit/sort-controls.jsx
@@ -31,7 +31,7 @@ const FollowingEditSortControls = React.createClass( {
 		const sortOrder = this.props.sortOrder;
 
 		return (
-			<div className="following-edit-sort-controls">
+			<div className="following-edit__sort-controls">
 				<label htmlFor="sort-control-select">{ this.translate( 'Sort by' ) }</label>
 				<select id="sort-control-select" ref="sortControlSelect" className="is-compact" onChange={ this.handleSelectChange } value={ sortOrder }>
 					<option value="date-followed">{ this.translate( 'By Date' ) }</option>

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -68,6 +68,10 @@
 		position: relative;
 			top: 2px;
 		cursor: pointer;
+
+		&:hover {
+			fill: $blue-medium;
+		}
 	}
 }
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -116,6 +116,8 @@
 	}
 }
 
+
+// Add to Following
 .following-edit__subscribe-form {
 	.search {
 		margin-bottom: 0;

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -216,10 +216,6 @@
 		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 			0 1px 2px lighten( $gray, 30% );
 	}
-
-	.noticon-close-alt {
-		right: 191px;
-	}
 }
 
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -37,56 +37,31 @@
 }
 
 
-// Add to Following
-.following-edit__subscribe-form {
-	.search {
-		margin-bottom: 0;
+.section-header.following-edit-header {
+	margin-bottom: 24px;
+
+	.section-header__actions {
+		transition: all 0.15s ease-in-out;
 	}
 
-	.search__input[type="search"] {
-		height: 38px;
-		padding-left: 33px;
-		border: 1px solid #c8d7e1;
-
-		&:focus {
-			border-color: #0087be;
- 			box-shadow: 0 0 0 2px #78dcfa;
+	.is-adding & {
+		.section-header__actions {
+			transform: translateX( -30px );
 		}
-	}
-
-	position: relative;
-
-	.noticon {
-		display: none;
-	}
-
-	.gridicons-add-outline {
-		position: absolute;
-		top: 7px;
-		left: 6px;
-		fill: #12b0df;
-		z-index: 40;
-	}
-
-	.noticon-close-alt {
-		top: -12px;
-		right: -8px;
-		color: $gray;
 	}
 }
 
 
-// Search Followed Sites
-.following-edit__existing-feed-search {
-	margin-bottom: 0;
-	margin-left: -1px;
+// More Options
+.following-edit__more-options {
+	float: left;
+	margin-right: 16px;
 
-	.search__input[type="search"] {
-		box-shadow: inset 0 0 0 1px lighten( $gray, 20% );
-	}
-
-	.noticon-close-alt {
-		right: 191px;
+	.gridicon {
+		fill: $gray;
+		position: relative;
+			top: 2px;
+		cursor: pointer;
 	}
 }
 
@@ -106,6 +81,7 @@
 		padding-top: 2px;
 		padding-bottom: 2px;
 		padding-left: 10px;
+		margin: 0;
 
 		&:hover {
 			border-color: #a8bece;
@@ -113,6 +89,95 @@
 		}
 	}
 }
+
+
+// Add to Following
+.following-edit__subscribe-form {
+	overflow: hidden;
+	position: absolute;
+		top: 0;
+		right: 0;
+		left: 0;
+	opacity: 0;
+	pointer-events: none;
+	transition: all 0.15s ease-in-out;
+	
+	.search {
+		margin-bottom: 0;
+	}
+
+	.search__input[type="search"] {
+		height: 50px;
+
+		&:focus {
+			border-color: $blue-wordpress;
+			box-shadow: 0 0 0 2px $blue-light;
+		}
+	}
+
+	.noticon {
+		display: none;
+	}
+
+	.gridicons-add-outline {
+		position: absolute;
+			top: 13px;
+			left: 18px;
+		fill: $blue-medium;
+		z-index: 23; // Higher than <Search>'s z-index: 22;
+	}
+
+	.noticon-close-alt {
+		top: -4px;
+		right: -2px;
+		color: $gray;
+	}
+
+	.search__input[type="search"],
+	.gridicons-add-outline,
+	.noticon-close-alt {
+		transform: translateX( 30px );
+		transition: all 0.15s ease-in-out;
+	}
+
+	.is-adding & {
+		opacity: 1;
+		//pointer-events: auto;
+
+		.search__input[type="search"],
+		.gridicons-add-outline,
+		.noticon-close-alt {
+			transform: translateX( 0 );
+		}
+	}
+}
+
+
+// Search Followed Sites
+.following-edit__existing-feed-search {
+	margin-bottom: 0;
+
+	.search__input[type="search"] {
+		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
+			0 1px 2px lighten( $gray, 30% );
+	}
+
+	.noticon-close-alt {
+		right: 191px;
+	}
+}
+
+
+// Followed Sites
+.followed-sites-list,
+.following-edit__existing-feed-search {
+	transition: all 0.1s ease-in-out;
+
+	.is-adding & {
+		opacity: 0.3;
+	}
+}
+
 
 .following-edit .reader-list-item__card {
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -151,7 +151,7 @@
 		pointer-events: auto;
 
 		.gridicons-add-outline {
-			transform: translateX( 0 );
+			transform: translateX( 0 ) rotate( 180deg );
 		}
 	}
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -37,7 +37,7 @@
 }
 
 
-.section-header.following-edit-header {
+.section-header.following-edit__header {
 	margin-bottom: 24px;
 
 	@include breakpoint( "<480px" ) {
@@ -77,7 +77,7 @@
 
 
 // Sort Controls
-.following-edit-sort-controls {
+.following-edit__sort-controls {
 	float: left;
 	margin-right: 8px;
 
@@ -220,7 +220,7 @@
 
 
 // Search Results Placeholder
-.subscribe-form__blank {
+.following-edit__subscribe-form-blank {
 	position: absolute;
 		top: 68px;
 	width: 100%;
@@ -240,7 +240,7 @@
 
 
 // Followed Sites and Search Transitions
-.followed-sites-list,
+.following-edit__sites,
 .following-edit__existing-feed-search {
 	transition: all 0.2s ease-in-out;
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -40,6 +40,10 @@
 .section-header.following-edit-header {
 	margin-bottom: 24px;
 
+	@include breakpoint( "<480px" ) {
+		margin-bottom: 8px;
+	}
+
 	.section-header__actions {
 		transition: all 0.15s ease-in-out;
 	}
@@ -103,6 +107,10 @@
 	pointer-events: none;
 	transition: all 0.15s ease-in-out;
 
+	@include breakpoint( "<480px" ) {
+		top: 62px;
+	}
+
 	.search {
 		margin-bottom: 0;
 	}
@@ -153,9 +161,13 @@
 
 	.card.is-search-result {
 		position: absolute;
+			top: 68px;
 		width: 100%;
-		top: 68px;
 		z-index: 35;
+
+		@include breakpoint( "<480px" ) {
+			top: 59px;
+		}
 
 		.gridicon__follow {
 			fill: lighten( $gray, 20% );
@@ -219,6 +231,11 @@
 	color: darken( $gray, 10 );
 	background: lighten( $gray, 30 );
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20 ), .5 );
+
+	@include breakpoint( "<480px" ) {
+		padding: 16px 42px 0 42px;
+		top: 59px;
+	}
 }
 
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -36,6 +36,84 @@
 	}
 }
 
+
+// Add to Following
+.following-edit__subscribe-form {
+	.search {
+		margin-bottom: 0;
+	}
+
+	.search__input[type="search"] {
+		height: 38px;
+		padding-left: 33px;
+		border: 1px solid #c8d7e1;
+
+		&:focus {
+			border-color: #0087be;
+ 			box-shadow: 0 0 0 2px #78dcfa;
+		}
+	}
+
+	position: relative;
+
+	.noticon {
+		display: none;
+	}
+
+	.gridicons-add-outline {
+		position: absolute;
+		top: 7px;
+		left: 6px;
+		fill: #12b0df;
+		z-index: 40;
+	}
+
+	.noticon-close-alt {
+		top: -12px;
+		right: -8px;
+		color: $gray;
+	}
+}
+
+
+// Search Followed Sites
+.following-edit__existing-feed-search {
+	margin-bottom: 0;
+	margin-left: -1px;
+
+	.search__input[type="search"] {
+		box-shadow: inset 0 0 0 1px lighten( $gray, 20% );
+	}
+
+	.noticon-close-alt {
+		right: 191px;
+	}
+}
+
+
+// Sort Controls
+.following-edit-sort-controls {
+	float: left;
+	margin-right: 8px;
+
+	label {
+		display: none;
+	}
+
+	select {
+		font-size: 12px;
+		color: $gray;
+		padding-top: 2px;
+		padding-bottom: 2px;
+		padding-left: 10px;
+
+		&:hover {
+			border-color: #a8bece;
+			color: #2e4453;
+		}
+	}
+}
+
 .following-edit .reader-list-item__card {
 
 	&.is-placeholder {
@@ -115,46 +193,6 @@
 		z-index: z-index( '.following-edit', '.following-edit .reader-list-item__card.is-search-result' );
 	}
 }
-
-
-// Add to Following
-.following-edit__subscribe-form {
-	.search {
-		margin-bottom: 0;
-	}
-
-	.search__input[type="search"] {
-		height: 38px;
-		padding-left: 33px;
-		border: 1px solid #c8d7e1;
-
-		&:focus {
-			border-color: #0087be;
-			box-shadow: 0 0 0 2px #78dcfa;
-		}
-	}
-
-	position: relative;
-
-	.search-open__icon {
-		display: none;
-	}
-
-	.gridicons-add-outline {
-		position: absolute;
-		top: 7px;
-		left: 6px;
-		fill: #12b0df;
-		z-index: z-index( '.following-edit', '.following-edit__subscribe-form .gridicons-add-outline' );
-	}
-
-	.search-close__icon {
-		top: 20px;
-		right: -8px;
-		color: $gray;
-	}
-}
-
 
 .following-edit-navigation {
 	min-height: 25px;
@@ -239,46 +277,6 @@
 
 .following-edit__notification-settings-error {
 	margin-top: 12px;
-}
-
-.following-edit__existing-feed-search {
-	margin-bottom: 0;
-	margin-left: -1px;
-
-	.search__input[type="search"] {
-		box-shadow: inset 0 0 0 1px lighten( $gray, 20% );
-	}
-
-	.noticon-close-alt {
-		right: 191px;
-	}
-}
-
-.following-edit-sort-controls {
-	position: absolute;
-		right: -1px;
-	z-index: z-index( '.following-edit', '.following-edit-sort-controls' );
-	background-color: $gray-light;
-	padding: 13px 8px 0 16px;
-	box-shadow: inset 0px 0px 0px 1px lighten( $gray, 20% );
-	min-height: 51px;
-	box-sizing: border-box;
-
-	label {
-		vertical-align: middle;
-		color: $gray;
-		display: inline-block;
-		font-size: 13px;
-		font-weight: 600;
-		margin-top: -1px;
-		margin-right: 6px;
-	}
-
-	select {
-		vertical-align: middle;
-		min-width: 100px;
-		display: inline;
-	}
 }
 
 @include breakpoint( ">660px" ) {

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -1,6 +1,12 @@
 .following-edit {
 	position: relative;
 
+	&.is-adding {
+		.search-card {
+			display: none;
+		}
+	}
+
 	ul {
 		list-style-type: none;
 		margin: 0;
@@ -129,7 +135,7 @@
 		}
 	}
 
-	.noticon {
+	.search-open__icon {
 		display: none;
 	}
 
@@ -141,14 +147,7 @@
 		z-index: 23; // Higher than <Search>'s z-index: 22;
 	}
 
-	.noticon-close-alt {
-		top: -2px;
-		right: -2px;
-		color: $gray;
-	}
-
-	.gridicons-add-outline,
-	.noticon-close-alt {
+	.gridicons-add-outline {
 		transform: translateX( 30px );
 		transition: all 0.15s ease-in-out;
 	}
@@ -157,8 +156,7 @@
 		opacity: 1;
 		pointer-events: auto;
 
-		.gridicons-add-outline,
-		.noticon-close-alt {
+		.gridicons-add-outline {
 			transform: translateX( 0 );
 		}
 	}
@@ -199,10 +197,6 @@
 				margin-top: 8px;
 				margin-bottom: 11px;
 			}
-		}
-
-		.reader-list-item__icon .noticon {
-			display: block;
 		}
 	}
 }
@@ -369,6 +363,7 @@
 .following-edit__notification-settings-error {
 	margin-top: 12px;
 }
+
 
 @include breakpoint( ">660px" ) {
 	.following-edit {

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -209,13 +209,8 @@
 
 
 // Search Followed Sites
-.following-edit__existing-feed-search {
-	margin-bottom: 0;
-
-	.search__input[type="search"] {
-		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
-			0 1px 2px lighten( $gray, 30% );
-	}
+.following-edit .search-card {
+	margin-bottom: 1px;
 }
 
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -1,12 +1,6 @@
 .following-edit {
 	position: relative;
 
-	&.is-adding {
-		.search-card {
-			display: none;
-		}
-	}
-
 	ul {
 		list-style-type: none;
 		margin: 0;
@@ -230,13 +224,15 @@
 
 // Followed Sites and Search Transitions
 .following-edit__sites,
-.following-edit__existing-feed-search {
+.following-edit .search-card {
 	transition: all 0.2s ease-in-out;
+}
 
-	.is-adding & {
-		opacity: 0.3;
-		transform: translateY( 85px );
-	}
+.is-adding .following-edit__sites,
+.following-edit.is-adding .search-card {
+	opacity: 0.3;
+	transform: translateY( 85px );
+	pointer-events: none;
 }
 
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -45,6 +45,8 @@
 	}
 
 	.is-adding & {
+		pointer-events: none;
+
 		.section-header__actions {
 			transform: translateX( -30px );
 		}
@@ -93,7 +95,6 @@
 
 // Add to Following
 .following-edit__subscribe-form {
-	overflow: hidden;
 	position: absolute;
 		top: 0;
 		right: 0;
@@ -101,13 +102,14 @@
 	opacity: 0;
 	pointer-events: none;
 	transition: all 0.15s ease-in-out;
-	
+
 	.search {
 		margin-bottom: 0;
 	}
 
 	.search__input[type="search"] {
 		height: 50px;
+		border: 1px solid transparent;
 
 		&:focus {
 			border-color: $blue-wordpress;
@@ -128,12 +130,11 @@
 	}
 
 	.noticon-close-alt {
-		top: -4px;
+		top: -2px;
 		right: -2px;
 		color: $gray;
 	}
 
-	.search__input[type="search"],
 	.gridicons-add-outline,
 	.noticon-close-alt {
 		transform: translateX( 30px );
@@ -142,12 +143,50 @@
 
 	.is-adding & {
 		opacity: 1;
-		//pointer-events: auto;
+		pointer-events: auto;
 
-		.search__input[type="search"],
 		.gridicons-add-outline,
 		.noticon-close-alt {
 			transform: translateX( 0 );
+		}
+	}
+
+	.card.is-search-result {
+		position: absolute;
+		width: 100%;
+		top: 68px;
+		z-index: 35;
+
+		.gridicon__follow {
+			fill: lighten( $gray, 20% );
+		}
+
+		.follow-button {
+			cursor: default;
+			color: lighten( $gray, 20% );
+		}
+
+		&.is-valid {
+			.gridicon__follow {
+				fill: $blue-medium;
+			}
+
+			.follow-button {
+				cursor: pointer;
+			}
+
+			.follow-button__label {
+				color: $blue-medium;
+			}
+
+			.following-edit__list-title {
+				margin-top: 8px;
+				margin-bottom: 11px;
+			}
+		}
+
+		.reader-list-item__icon .noticon {
+			display: block;
 		}
 	}
 }
@@ -168,17 +207,34 @@
 }
 
 
-// Followed Sites
+// Search Results Placeholder
+.subscribe-form__blank {
+	position: absolute;
+		top: 68px;
+	width: 100%;
+	height: 75px;
+	box-sizing: border-box;
+	padding: 26px 32px 0 32px;
+	text-align: center;
+	color: darken( $gray, 10 );
+	background: lighten( $gray, 30 );
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20 ), .5 );
+}
+
+
+// Followed Sites and Search Transitions
 .followed-sites-list,
 .following-edit__existing-feed-search {
-	transition: all 0.1s ease-in-out;
+	transition: all 0.2s ease-in-out;
 
 	.is-adding & {
 		opacity: 0.3;
+		transform: translateY( 85px );
 	}
 }
 
 
+// Followed Site Cards
 .following-edit .reader-list-item__card {
 
 	&.is-placeholder {
@@ -214,48 +270,6 @@
 	.reader-list-item__icon {
 		top: 14px;
 		left: 40px;
-	}
-
-	&.is-search-result {
-		.gridicon__follow {
-			fill: lighten( $gray, 20% );
-		}
-
-		.follow-button {
-			cursor: default;
-			color: lighten( $gray, 20% );
-		}
-
-		&.is-valid {
-			.gridicon__follow {
-				fill: #12b0df;
-			}
-
-			.follow-button {
-				cursor: pointer;
-			}
-
-			.follow-button__label {
-				color: #12b0df;
-			}
-
-			.following-edit__list-title {
-				margin-top: 8px;
-				margin-bottom: 11px;
-			}
-		}
-
-		.reader-list-item__icon .noticon {
-			display: block;
-		}
-
-		border-radius: 5px;
-		box-shadow: 0 0 0 2px #78dcfa;
-		position: absolute;
-		width: 100%;
-		top: 44px;
-		border: 1px solid #0087be;
-		z-index: z-index( '.following-edit', '.following-edit .reader-list-item__card.is-search-result' );
 	}
 }
 

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -39,6 +39,10 @@ var FollowingEditSubscribeForm = React.createClass( {
 		this.verifySearchString( this.props.initialSearchString );
 	},
 
+	focus: function() {
+		this.refs.followingEditSubscriptionSearch.focus();
+	},
+
 	handleFollowToggle: function() {
 		FeedSubscriptionActions.follow( this.state.searchString, true );
 		this.setState( { previousSearchString: this.state.searchString } );

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -110,8 +110,12 @@ var FollowingEditSubscribeForm = React.createClass( {
 		return true;
 	},
 
+	blankSearch: function() {
+		return ( <div className="subscribe-form__blank">{ this.translate( "Follow any site by adding it's URL above." ) }</div> );
+	},
+
 	render: function() {
-		var searchResult = null,
+		var searchResult = this.blankSearch(),
 			handleFollowToggle = noop;
 
 		const searchString = this.state.searchString,
@@ -143,7 +147,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 					ref="followingEditSubscriptionSearch"
 					onKeyDown={ this.handleKeyDown }
 					disableAutocorrect={ true }
-					autoFocus={ true }
+					autoFocus={ false }
 					initialValue={ this.props.initialSearchString }
 					forceCloseButton={ true }
 				/>

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -111,7 +111,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 	},
 
 	blankSearch: function() {
-		return ( <div className="subscribe-form__blank">{ this.translate( "Follow any site by adding it's URL above." ) }</div> );
+		return ( <div className="subscribe-form__blank">{ this.translate( 'Follow any site by adding its URL above.' ) }</div> );
 	},
 
 	render: function() {
@@ -147,7 +147,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 					ref="followingEditSubscriptionSearch"
 					onKeyDown={ this.handleKeyDown }
 					disableAutocorrect={ true }
-					autoFocus={ false }
+					autoFocus={ true }
 					initialValue={ this.props.initialSearchString }
 					forceCloseButton={ true }
 				/>

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -145,6 +145,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 					disableAutocorrect={ true }
 					autoFocus={ true }
 					initialValue={ this.props.initialSearchString }
+					forceCloseButton={ true }
 				/>
 				{ searchResult }
 			</div>

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -143,6 +143,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 			<div className="following-edit__subscribe-form">
 				<Gridicon icon="add-outline" onClick={ this.handleFollowIconClick } />
 				<Search
+					forceCloseButton={ true }
 					key="newSubscriptionSearch"
 					onSearch={ this.handleSearch }
 					onSearchClose={ this.handleSearchClose }

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -151,9 +151,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 					ref="followingEditSubscriptionSearch"
 					onKeyDown={ this.handleKeyDown }
 					disableAutocorrect={ true }
-					autoFocus={ true }
 					initialValue={ this.props.initialSearchString }
-					isOpen={ true }
 				/>
 				{ searchResult }
 			</div>

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -143,7 +143,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 			<div className="following-edit__subscribe-form">
 				<Gridicon icon="add-outline" onClick={ this.handleFollowIconClick } />
 				<Search
-					forceCloseButton={ true }
+					isOpen={ true }
 					key="newSubscriptionSearch"
 					onSearch={ this.handleSearch }
 					onSearchClose={ this.handleSearchClose }

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -115,7 +115,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 	},
 
 	blankSearch: function() {
-		return ( <div className="subscribe-form__blank">{ this.translate( 'Follow any site by adding its URL above.' ) }</div> );
+		return ( <div className="following-edit__subscribe-form-blank">{ this.translate( 'Follow any site by adding its URL above.' ) }</div> );
 	},
 
 	render: function() {
@@ -153,7 +153,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 					disableAutocorrect={ true }
 					autoFocus={ true }
 					initialValue={ this.props.initialSearchString }
-					forceCloseButton={ true }
+					isOpen={ true }
 				/>
 				{ searchResult }
 			</div>


### PR DESCRIPTION
Here's what follow management looks like on `master`:

![screen shot 2015-12-08 at 2 12 06 pm](https://cloud.githubusercontent.com/assets/191598/11665536/da9fdf3e-9db5-11e5-8798-c1f6f3301006.png)

![screen shot 2015-12-08 at 2 12 11 pm](https://cloud.githubusercontent.com/assets/191598/11665539/dd0fb9c4-9db5-11e5-86cd-222ee3940408.png)

The double input is really obnoxious, and I often find myself mixing up the add and search inputs. Also, the search result is a little loud.

Lets bring in the `<SectionHeading>` component and clean things up a bit:

![screen shot 2015-12-08 at 2 11 22 pm](https://cloud.githubusercontent.com/assets/191598/11665563/11c2555a-9db6-11e5-9b5f-eb1ad092a3e1.png)

We bring back the once-upon-a-time subscription count, and hide the add input behind a button. Clicking/tapping the add button transitions to show a placeholder and the focused add input:

![screen shot 2015-12-08 at 2 11 24 pm](https://cloud.githubusercontent.com/assets/191598/11665594/3981b0a4-9db6-11e5-85e3-7734f7184baa.png)

Type a URL and you get the preview:

![screen shot 2015-12-08 at 2 11 32 pm](https://cloud.githubusercontent.com/assets/191598/11665606/4ab8e93c-9db6-11e5-96f2-6b3796365276.png)

Hitting follow (or enter) adds a placeholder to your list, which is then replaced by the actual site:

![screen shot 2015-12-08 at 2 11 37 pm](https://cloud.githubusercontent.com/assets/191598/11665620/5d35a442-9db6-11e5-9866-a9e495ea38e4.png)

There's also a new ellipsis icon which can be use to open a `<Popover>` with Import, Export, and Delivery Settings options that @blowery is working on.

@bluefuton I'd love it if you could take a look at this.