### PR TITLE
Signup: DSS: Add DSS AB test i2.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -45,4 +45,13 @@ module.exports = {
 		},
 		defaultVariation: 'drake'
 	},
+	dss: {
+		datestamp: '20151210',
+		variations: {
+			main: 15,
+			dss: 15,
+			notTested: 70
+		},
+		defaultVariation: 'main'
+	}
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -2,14 +2,16 @@
  * External dependencies
  */
 var assign = require( 'lodash/object/assign' ),
-	reject = require( 'lodash/collection/reject' );
+	reject = require( 'lodash/collection/reject' ),
+	page = require( 'page' );
 
 /**
 * Internal dependencies
 */
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
-	user = require( 'lib/user' )();
+	user = require( 'lib/user' )(),
+	abtest = require( 'lib/abtest' ).abtest;
 
 function getCheckoutDestination( dependencies ) {
 	if ( dependencies.cartItem || dependencies.domainItem ) {
@@ -143,8 +145,17 @@ function removeUserStepFromFlow( flow ) {
 	} );
 }
 
+function getCurrentFlowNameFromTest( currentURL ) {
+	// Only consider users from the general /start path.
+	if ( '/start' === currentURL && 'dss' === abtest( 'dss' ) ) {
+		return 'dss';
+	}
+
+	return 'main';
+}
+
 module.exports = {
-	currentFlowName: 'main',
+	currentFlowName: getCurrentFlowNameFromTest( page.current ),
 
 	defaultFlowName: 'main',
 


### PR DESCRIPTION
This PR is a retake of the DSS AB test i2, which was launched and then reverted from #1219 .

By first checking the current URL is the general `/start` URL for signup, users won't be assigned to this test when already involved in the verticals survey tests, or any other flow that's being accesssed directly (such as `/start/headstart`).

### Testing

* Change `active-tests.js` L61 (the `dss` weight) and set it to a high number, to force `dss` variaiton assignments.
* Open the inspector to the Resources tab, with `localStorage` showing for your local dev URL.
* Try different signup URLs and be sure the DSS test is only assigned on `/start`.
* Clear localStorage before every new URL for a fresh assignment.