### PR TITLE
Me: Use FormTelInput instead of FormTextInput

### DIFF
--- a/client/me/constants.js
+++ b/client/me/constants.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import i18n from 'lib/mixins/i18n';
+
+export default {
+	sixDigit2faPlaceholder: i18n.translate( 'e.g. 123456', {
+		context: '6 digit two factor code placeholder.',
+		textOnly: true
+	} ),
+	sevenDigit2faPlaceholder: i18n.translate( 'e.g. 1234567', {
+		context: '7 digit two factor code placeholder.',
+		textOnly: true
+	} ),
+	eightDigitBackupCodePlaceholder: i18n.translate( 'e.g. 12345678', {
+		context: '8 digit two factor backup code placeholder.',
+		textOnly: true
+	} )
+};

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -18,7 +18,8 @@ var Dialog = require( 'components/dialog' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	Notice = require( 'components/notice' ),
 	eventRecorder = require( 'me/event-recorder' ),
-	userUtilities = require( 'lib/user/utils' );
+	userUtilities = require( 'lib/user/utils' ),
+	constants = require( 'me/constants' );
 
 module.exports = React.createClass( {
 
@@ -152,17 +153,9 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var codePlaceholder = this.translate( 'e.g. 123456', {
-			context: '6 digit two factor code placeholder.',
-			textOnly: true
-		} );
-
-		if ( this.props.twoStepAuthorization.isTwoStepSMSEnabled() ) {
-			codePlaceholder = this.translate( 'e.g. 1234567', {
-				context: '7 digit two factor code placeholder.',
-				textOnly: true
-			} );
-		}
+		var codePlaceholder = this.props.twoStepAuthorization.isTwoStepSMSEnabled()
+			? constants.sevenDigit2faPlaceholder
+			: constants.sixDigit2faPlaceholder;
 
 		return (
 			<Dialog

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -13,7 +13,8 @@ var FormButton = require( 'components/forms/form-button' ),
 	FormTelInput = require( 'components/forms/form-tel-input' ),
 	Notice = require( 'components/notice' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	analytics = require( 'analytics' );
+	analytics = require( 'analytics' ),
+	constants = require( 'me/constants' );
 
 module.exports = React.createClass( {
 
@@ -129,7 +130,7 @@ module.exports = React.createClass( {
 						disabled={ this.state.submittingCode }
 						name="backup-code-entry"
 						autoComplete="off"
-						placeholder="12345678"
+						placeholder={ constants.eightDigitBackupCodePlaceholder }
 						valueLink={ this.linkState( 'backupCodeEntry' ) }
 						onFocus={ function() {
 							analytics.ga.recordEvent( 'Me', 'Focused On 2fa Backup Codes Confirm Printed Backup Codes Input' );

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -10,7 +10,7 @@ var React = require( 'react' ),
 var FormButton = require( 'components/forms/form-button' ),
 	FormFieldset = require( 'components/forms/form-fieldset' ),
 	FormLabel = require( 'components/forms/form-label' ),
-	FormTextInput = require( 'components/forms/form-text-input' ),
+	FormTelInput = require( 'components/forms/form-tel-input' ),
 	Notice = require( 'components/notice' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	analytics = require( 'analytics' );
@@ -125,10 +125,9 @@ module.exports = React.createClass( {
 			<form className="security-2fa-backup-codes-prompt" onSubmit={ this.onVerify }>
 				<FormFieldset>
 					<FormLabel htmlFor="backup-code-entry">{ this.translate( 'Type a Backup Code' ) }</FormLabel>
-					<FormTextInput
+					<FormTelInput
 						disabled={ this.state.submittingCode }
 						name="backup-code-entry"
-						type="text"
 						autoComplete="off"
 						placeholder="12345678"
 						valueLink={ this.linkState( 'backupCodeEntry' ) }

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -11,7 +11,7 @@ var FormButton = require( 'components/forms/form-button' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormFieldset = require( 'components/forms/form-fieldset' ),
 	FormSettingExplanation = require( 'components/forms/form-setting-explanation' ),
-	FormTextInput = require( 'components/forms/form-text-input' ),
+	FormTelInput = require( 'components/forms/form-tel-input' ),
 	Notice = require( 'components/notice' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	analytics = require( 'analytics' );
@@ -197,11 +197,10 @@ module.exports = React.createClass( {
 			<form className="security-2fa-code-prompt" onSubmit={ this.onSubmit }>
 				<FormFieldset>
 					<FormLabel htmlFor="verification-code">{ this.translate( 'Verification Code' ) }</FormLabel>
-					<FormTextInput
+					<FormTelInput
 						className="security-2fa-code-prompt__verification-code"
 						disabled={ this.state.submittingForm }
 						name="verification-code"
-						type="text"
 						autoComplete="off"
 						valueLink={ this.linkState( 'verificationCode' ) }
 						onFocus={ function() {

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -14,7 +14,8 @@ var FormButton = require( 'components/forms/form-button' ),
 	FormTelInput = require( 'components/forms/form-tel-input' ),
 	Notice = require( 'components/notice' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	analytics = require( 'analytics' );
+	analytics = require( 'analytics' ),
+	constants = require( 'me/constants' );
 
 module.exports = React.createClass( {
 
@@ -193,14 +194,20 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
+		var codePlaceholder = twoStepAuthorization.isTwoStepSMSEnabled()
+			? constants.sevenDigit2faPlaceholder
+			: constants.sixDigit2faPlaceholder;
+
 		return (
 			<form className="security-2fa-code-prompt" onSubmit={ this.onSubmit }>
 				<FormFieldset>
 					<FormLabel htmlFor="verification-code">{ this.translate( 'Verification Code' ) }</FormLabel>
 					<FormTelInput
+						autoFocus
 						className="security-2fa-code-prompt__verification-code"
 						disabled={ this.state.submittingForm }
 						name="verification-code"
+						placeholder={ codePlaceholder }
 						autoComplete="off"
 						valueLink={ this.linkState( 'verificationCode' ) }
 						onFocus={ function() {

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -12,7 +12,7 @@ var React = require( 'react' ),
 var FormButton = require( 'components/forms/form-button' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormSettingExplanation = require( 'components/forms/form-setting-explanation' ),
-	FormTextInput = require( 'components/forms/form-text-input' ),
+	FormTelInput = require( 'components/forms/form-tel-input' ),
 	Notice = require( 'components/notice' ),
 	Security2faProgress = require( 'me/security-2fa-progress' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
@@ -332,12 +332,11 @@ module.exports = React.createClass( {
 		return (
 			<div className="security-2fa-enable__next">
 				{ this.renderInputHelp() }
-				<FormTextInput
+				<FormTelInput
 					autoComplete="off"
 					disabled={ this.state.submittingForm }
 					name="verification-code"
 					placeholder="123456"
-					type="text"
 					valueLink={ this.linkState( 'verificationCode' ) }
 					onFocus={ function() {
 						analytics.ga.recordEvent( 'Me', 'Focused On 2fa Enable Verification Code Input' );

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -16,7 +16,8 @@ var FormButton = require( 'components/forms/form-button' ),
 	Notice = require( 'components/notice' ),
 	Security2faProgress = require( 'me/security-2fa-progress' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	analytics = require( 'analytics' );
+	analytics = require( 'analytics' ),
+	constants = require( 'me/constants' );
 
 module.exports = React.createClass( {
 
@@ -334,9 +335,10 @@ module.exports = React.createClass( {
 				{ this.renderInputHelp() }
 				<FormTelInput
 					autoComplete="off"
+					autoFocus
 					disabled={ this.state.submittingForm }
 					name="verification-code"
-					placeholder="123456"
+					placeholder={ 'sms' === this.state.method ? constants.sevenDigit2faPlaceholder : constants.sixDigit2faPlaceholder }
 					valueLink={ this.linkState( 'verificationCode' ) }
 					onFocus={ function() {
 						analytics.ga.recordEvent( 'Me', 'Focused On 2fa Enable Verification Code Input' );


### PR DESCRIPTION
Fixes #28 

This PR replaces the `FormTextInput` components that were being used throughout 2fa with `FormTelInput` which should show a number keyboard on mobile devices.

While working on that fix, I also updated placeholders to be consistent with #1386

cc @rickybanister for design review and @johnHackworth for code review.

__After screenshots__ (Note: mobile layout will be worked on in other PRs):

To test: 
- Checkout `fix/me-2fa-number-input` branch
- Connect your mobile device to the Calypso that is running on your desktop. [Charles](https://www.charlesproxy.com/) is recommended.
- Go to `/me/security/two-step` and enable/disable 2fa for a test account.
- Do you get the number keyboard? 

__Note:__ In the below screenshots the label and button in the application passwords section header seems off. I'm not sure what to do there, but it is unrelated to this PR.

__After screenshots:__

![2015-12-09 16 26 24](https://cloud.githubusercontent.com/assets/1126811/11700873/0a7f8844-9e92-11e5-845d-e620998cdbcf.png)
![2015-12-09 16 26 58](https://cloud.githubusercontent.com/assets/1126811/11700874/0a8035b4-9e92-11e5-8116-0443ffc52d23.png)
![2015-12-09 16 27 13](https://cloud.githubusercontent.com/assets/1126811/11700875/0a81a002-9e92-11e5-892e-45e4805a9fb3.png)
![2015-12-09 16 26 14](https://cloud.githubusercontent.com/assets/1126811/11700877/0ca36988-9e92-11e5-983d-6a420ad42531.png)

