### PR TITLE
Signup: Verticals: Add back the vertical survey AB test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -16,6 +16,15 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
+	verticalSurvey: {
+		datestamp: '20151210',
+		variations: {
+			noSurvey: 12,
+			oneStep: 44,
+			twoStep: 44
+		},
+		defaultVariation: 'noSurvey'
+	},
 	translatorInvitation: {
 		datestamp: '20150910',
 		variations: {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -103,6 +103,8 @@ module.exports = {
 				ab_test_variations: getSavedVariations(),
 				validate: false,
 				signup_flow_name: flowName,
+				nux_q_site_type: dependencies.surveySiteType,
+				nux_q_question_primary: dependencies.surveyQuestion,
 				jetpack_redirect: queryArgs.jetpackRedirect
 			}
 		), ( error, response ) => {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -66,6 +66,13 @@ const flows = {
 		lastModified: '2015-09-22'
 	},
 
+	verticals: {
+		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
+		destination: getCheckoutDestination,
+		description: 'Categorizing blog signups for Verticals Survey',
+		lastModified: '2015-12-10'
+	},
+
 	headstart: {
 		steps: [ 'theme-headstart', 'domains-with-theme', 'plans', 'user' ],
 		destination: getCheckoutDestination,
@@ -146,6 +153,11 @@ function removeUserStepFromFlow( flow ) {
 }
 
 function getCurrentFlowNameFromTest( currentURL ) {
+	// Assign the user to the verticals survey test if appropriate.
+	if ( '/start/vert-blog' === currentURL || '/start/vert-site' === currentURL ) {
+		return ( 'noSurvey' === abtest( 'verticalSurvey' ) ) ? 'main' : 'verticals';
+	}
+
 	// Only consider users from the general /start path.
 	if ( '/start/en?ref=homepage' === currentURL && 'dss' === abtest( 'dss' ) ) {
 		return 'dss';

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -7,6 +7,7 @@ var EmailSignupComponent = require( 'signup/steps/email-signup-form' ),
 	PlansStepComponent = require( 'signup/steps/plans' ),
 	DomainsStepComponent = require( 'signup/steps/domains' ),
 	DSSStepComponent = require( 'signup/steps/dss' ),
+	SurveyStepComponent = require( 'signup/steps/survey' ),
 	config = require( 'config' );
 
 module.exports = {
@@ -17,6 +18,8 @@ module.exports = {
 	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
 	plans: PlansStepComponent,
 	domains: DomainsStepComponent,
+	survey: SurveyStepComponent,
+	'survey-user': EmailSignupComponent,
 	'domains-with-theme': DomainsStepComponent,
 	'theme-dss': DSSStepComponent,
 	'jetpack-user': EmailSignupComponent

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -1,5 +1,12 @@
+/**
+ * External dependencies
+ */
+import { current } from 'page';
+
+/**
+* Internal dependencies
+*/
 import stepActions from 'lib/signup/step-actions';
-import { abtest } from 'lib/abtest';
 import i18n from 'lib/mixins/i18n';
 
 module.exports = {
@@ -33,6 +40,22 @@ module.exports = {
 
 	test: {
 		stepName: 'test',
+	},
+
+	'survey-user': {
+		stepName: 'survey-user',
+		apiRequestFunction: stepActions.createAccount,
+		dependencies: [ 'surveySiteType', 'surveyQuestion' ],
+		providesToken: true,
+		providesDependencies: [ 'bearer_token', 'username' ]
+	},
+
+	survey: {
+		stepName: 'survey',
+		props: {
+			surveySiteType: ( '/start/vert-blog' === current ) ? 'blog' : 'site'
+		},
+		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
 	},
 
 	plans: {

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -14,6 +14,11 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import BackButton from 'components/header-cake';
 import Gridicon from 'components/gridicon';
+import { getABTestVariation } from 'lib/abtest';
+
+function isSurveyOneStep() {
+	return 'oneStep' === getABTestVariation( 'verticalSurvey' );
+}
 
 export default React.createClass( {
 	displayName: 'SurveyStep',
@@ -26,7 +31,7 @@ export default React.createClass( {
 	getDefaultProps() {
 		return {
 			surveySiteType: 'site',
-			isOneStep: false
+			isOneStep: isSurveyOneStep()
 		}
 	},
 


### PR DESCRIPTION
Re-add the verticals survey AB test from #1145.

Changes from #1145 involve assigning the test to only those users that have come from the two vertical survey buttons (`/start/vert-blog` and `/start/vert-site`), and simplifying the signup to just one flow with one survey step.