### PR TITLE
Pre-commit gridicons check

### DIFF
--- a/bin/gridiconFormatChecker
+++ b/bin/gridiconFormatChecker
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+var fs = require( 'fs' );
+var readline = require( 'readline' );
+var validIconSizes = [ 12, 18, 24, 36, 48, 54, 72 ];
+
+var file = process.argv[ 2 ];
+
+function checkGridicons( filename ) {
+	var lineNumber = 0,
+		result = '';
+	readline.createInterface( {
+		input: fs.createReadStream( filename ),
+		terminal: false
+	} ).on( 'line', function( line ) {
+		var gridIconProps, onlyAttrs, size;
+
+		if ( line.indexOf( '<Gridicon' ) >= 0 ) {
+			gridIconProps = line.split( '<Gridicon' )[ 1 ];
+			if ( gridIconProps ) {
+				onlyAttrs = gridIconProps.split( '>' )[ 0 ].split( ' ' ).join( '' );
+				if ( onlyAttrs.indexOf( 'size={' ) >= 0 ) {
+					size = onlyAttrs.split( 'size={' )[ 1 ].split( '}' )[ 0 ];
+					if ( !isNaN( size ) && validIconSizes.indexOf( +size ) < 0 ) {
+						result += '\033[31mNon-standard gridicon size ( ' + size + 'px ) detected in ' + filename + ' line ' + lineNumber + '\n';
+					}
+				}
+			}
+		}
+		lineNumber++;
+	} ).on( 'close', function() {
+		if ( result !== '' ) {
+			console.error( result );
+			console.log( '\033[mValid gridiconsizes are ' + validIconSizes.join( 'px, ' ) + 'px\n' );
+			process.exit( 1 );
+		} else {
+			process.exit( 0 );
+		}
+	} );
+}
+
+checkGridicons( file );

--- a/bin/gridiconFormatChecker
+++ b/bin/gridiconFormatChecker
@@ -1,28 +1,33 @@
 #!/usr/bin/env node
 
 var fs = require( 'fs' );
-var readline = require( 'readline' );
 var validIconSizes = [ 12, 18, 24, 36, 48, 54, 72 ];
 
-var file = process.argv[ 2 ];
+var filename = process.argv[ 2 ];
 
-function checkGridicons( filename ) {
-	var lineNumber = 0,
-		result = '';
-	readline.createInterface( {
-		input: fs.createReadStream( filename ),
-		terminal: false
-	} ).on( 'line', function( line ) {
-		var gridIconProps, onlyAttrs, size, isNonStandard = false;
+fs.readFile( filename, 'utf8', function ( err, data ) {
+	var result = '',
+		splittedCode,
+		lineNumber = 1;
+	if ( err ) {
+		console.log(err);
+		process.exit( 1 );
+	}
+	data = data.toLowerCase();
+	splittedCode = data.split( '<gridicon' );
 
-		if ( line.indexOf( '<Gridicon' ) >= 0 ) {
-			gridIconProps = line.split( '<Gridicon' )[ 1 ];
-			if ( gridIconProps ) {
-				onlyAttrs = gridIconProps.split( '>' )[ 0 ].split( ' ' ).join( '' );
-				isNonStandard = onlyAttrs.indexOf( 'nonStandard' ) >= 0;
-				if ( onlyAttrs.indexOf( 'size={' ) >= 0 ) {
-					size = onlyAttrs.split( 'size={' )[ 1 ].split( '}' )[ 0 ];
+	if ( splittedCode.length > 1 ) {
+		// There are gridicon instances in this file.
+		splittedCode.forEach( function( chunk ) {
+			var gridiconAttrs, isNonStandard, size;
+			if( chunk ) {
+				// we discard all the code after the tag closing... we are only interested in the props of the gridicon.
+				gridiconAttrs = chunk.split( '>' )[ 0 ];
+				isNonStandard = gridiconAttrs.indexOf( 'nonstandard' ) >= 0;
+				if ( gridiconAttrs.indexOf( 'size={' ) >= 0 ) {
+					size = gridiconAttrs.split( 'size={' )[ 1 ].split( '}' )[ 0 ];
 					if ( !isNaN( size ) ) {
+						// We only can check if the size is standard if it is a number. If not (variables), we have no way of knowing if it's fine or not
 						if( !isNonStandard && validIconSizes.indexOf( +size ) < 0 ) {
 							result += '\033[31mNon-standard gridicon size ( ' + size + 'px ) detected in ' + filename + ' line ' + lineNumber + '\n';
 						}
@@ -31,18 +36,16 @@ function checkGridicons( filename ) {
 						}
 					}
 				}
+				lineNumber += chunk.split('\n').length - 1;
 			}
-		}
-		lineNumber++;
-	} ).on( 'close', function() {
-		if ( result !== '' ) {
-			console.error( result );
-			console.log( '\033[mValid gridiconsizes are ' + validIconSizes.join( 'px, ' ) + 'px\n' );
-			process.exit( 1 );
-		} else {
-			process.exit( 0 );
-		}
-	} );
-}
+		} );
+	}
 
-checkGridicons( file );
+	if ( result !== '' ) {
+		console.error( result );
+		console.log( '\033[m=== Valid gridiconsizes are ' + validIconSizes.join( 'px, ' ) + 'px ===\n' );
+		process.exit( 1 );
+	} else {
+		process.exit( 0 );
+	}
+} );

--- a/bin/gridiconFormatChecker
+++ b/bin/gridiconFormatChecker
@@ -13,16 +13,22 @@ function checkGridicons( filename ) {
 		input: fs.createReadStream( filename ),
 		terminal: false
 	} ).on( 'line', function( line ) {
-		var gridIconProps, onlyAttrs, size;
+		var gridIconProps, onlyAttrs, size, isNonStandard = false;
 
 		if ( line.indexOf( '<Gridicon' ) >= 0 ) {
 			gridIconProps = line.split( '<Gridicon' )[ 1 ];
 			if ( gridIconProps ) {
 				onlyAttrs = gridIconProps.split( '>' )[ 0 ].split( ' ' ).join( '' );
+				isNonStandard = onlyAttrs.indexOf( 'nonStandard' ) >= 0;
 				if ( onlyAttrs.indexOf( 'size={' ) >= 0 ) {
 					size = onlyAttrs.split( 'size={' )[ 1 ].split( '}' )[ 0 ];
-					if ( !isNaN( size ) && validIconSizes.indexOf( +size ) < 0 ) {
-						result += '\033[31mNon-standard gridicon size ( ' + size + 'px ) detected in ' + filename + ' line ' + lineNumber + '\n';
+					if ( !isNaN( size ) ) {
+						if( !isNonStandard && validIconSizes.indexOf( +size ) < 0 ) {
+							result += '\033[31mNon-standard gridicon size ( ' + size + 'px ) detected in ' + filename + ' line ' + lineNumber + '\n';
+						}
+						if( isNonStandard && validIconSizes.indexOf( +size ) >= 0 ) {
+							result += '\033[33mStandard size gridicon ( ' + size + 'px ) marked as non-standard... are you sure that is ok? in ' + filename + ' line ' + lineNumber + '\n';
+						}
 					}
 				}
 			}

--- a/bin/gridiconFormatChecker
+++ b/bin/gridiconFormatChecker
@@ -23,7 +23,7 @@ fs.readFile( filename, 'utf8', function ( err, data ) {
 			if( chunk ) {
 				// we discard all the code after the tag closing... we are only interested in the props of the gridicon.
 				gridiconAttrs = chunk.split( '>' )[ 0 ];
-				isNonStandard = gridiconAttrs.indexOf( 'nonstandard' ) >= 0;
+				isNonStandard = gridiconAttrs.indexOf( 'nonstandardsize' ) >= 0;
 				if ( gridiconAttrs.indexOf( 'size={' ) >= 0 ) {
 					size = gridiconAttrs.split( 'size={' )[ 1 ].split( '}' )[ 0 ];
 					if ( !isNaN( size ) ) {

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -38,6 +38,15 @@ done
 
 echo "\neslint validation complete\n"
 
+for file in ${files}; do
+    ./bin/gridiconFormatChecker ${file}
+        if [ $? -ne 0 ]; then
+        echo "\033[31mGridicon Format Check Failed: \033[0m${file}\n"
+        pass=false
+    fi
+done
+
+
 if ! $pass; then
     echo "\033[41mCOMMIT FAILED:\033[0m Your commit contains files that should pass validation tests but do not. Please fix the errors and try again.\n"
     exit 1

--- a/shared/components/gridicon/README.md
+++ b/shared/components/gridicon/README.md
@@ -18,3 +18,4 @@ render: function() {
 * `icon`: String - the icon name.
 * `size`: Number - (default: 24) set the size of the icon.
 * `onClick`: Function - (optional) if you need a click callback.
+* `nonStandard`: Boolean - (optional) A semantic prop to indicate (to our automatic tools and other developers) that this gridicon is not using one of the standard sizes on purpose. It must be combined with an additional comment explaining why the odd size is necesary.

--- a/shared/components/gridicon/README.md
+++ b/shared/components/gridicon/README.md
@@ -18,4 +18,4 @@ render: function() {
 * `icon`: String - the icon name.
 * `size`: Number - (default: 24) set the size of the icon.
 * `onClick`: Function - (optional) if you need a click callback.
-* `nonStandard`: Boolean - (optional) A semantic prop to indicate (to our automatic tools and other developers) that this gridicon is not using one of the standard sizes on purpose. It must be combined with an additional comment explaining why the odd size is necesary.
+* `nonStandardSize`: Boolean - (optional) A semantic prop to indicate (to our automatic tools and other contributors) that this gridicon is not using one of the standard sizes on purpose. It must be combined with an additional comment explaining why the odd size is necesary.


### PR DESCRIPTION
My hack day project: A script that gets executed in the pre-commit, checks if there's any gridicon in the commited files, and rejects it if it's using a non-standard size.

![image](https://cloud.githubusercontent.com/assets/1554855/11685936/0be25406-9e7d-11e5-94b7-506f008fe55f.png)

How to test:
=========
1. Create a test branch 
2. Modify any file to include a gridicon with a non standard size (neither 12, 18, 24, 36, 48, 54 or 72px)
3. Try to commit the change... you should not be allowed to do it and you should see an error similar to the upper screenshot (if you are doing it by command line)

ping @alternatekev @MichaelArestad @rickybanister 