### PR TITLE
Editor: Record page view via pageView analytics

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -123,7 +123,7 @@ module.exports = {
 			if ( postID ) {
 				actions.startEditingExisting( site, postID );
 				titleActions.setTitle( titleStrings.edit, { siteID: site.ID } );
-				analytics.ga.recordPageView( '/' + postType + '/:blogid/:postid', titleStrings.ga + ' > Edit' );
+				analytics.pageView.record( '/' + postType + '/:blogid/:postid', titleStrings.ga + ' > Edit' );
 			} else {
 				let postOptions = { type: postType };
 
@@ -139,7 +139,7 @@ module.exports = {
 
 				actions.startEditingNew( site, postOptions );
 				titleActions.setTitle( titleStrings.new, { siteID: site.ID } );
-				analytics.ga.recordPageView( '/' + postType, titleStrings.ga + ' > New' );
+				analytics.pageView.record( '/' + postType, titleStrings.ga + ' > New' );
 			}
 		}
 


### PR DESCRIPTION
This pull request seeks to use the `analytics.pageView` helper in place of a direct call to Google Analytics, as the `pageView.record` function also includes a bump in Tracks stats. The signature of the function is identical to `analytics.ga.recordPageView`, so it is a matter of replacing the called function.

__Testing instructions:__

1. Enable Analytics debugging by entering `localStorage.debug = 'calypso:analytics';` in your developer tools console
2. Refresh the page
3. Navigate to the post editor route (either page or post)
4. Observe two debugging statements in your console related to route tracking for the editor
 - `Record event "calypso_page_view" called with props...`
 - `Recording Page View ~ ...`

Ref: 5306-gh-calypso-pre-oss