### PR TITLE
Framework: <GlobalNotices> visual design update

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -35,6 +35,7 @@
 @import 'components/foldable-card/style';
 @import 'components/follow-button/style';
 @import 'components/gauge/style';
+@import 'components/global-notices/style';
 @import 'components/gravatar/style';
 @import 'components/gridicon/style';
 @import 'components/header-cake/style';

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
 import debugModule from 'debug';
 
 /**
@@ -12,7 +11,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import notices from 'notices';
 import observe from 'lib/mixins/data-observe';
-import DeleteSiteNotices from './delete-site-notices';
+import DeleteSiteNotices from 'notices/delete-site-notices';
 
 const debug = debugModule( 'calypso:notices' );
 
@@ -104,14 +103,9 @@ export default React.createClass( {
 			return null;
 		}
 		return (
-			<div>
-				<div id={ this.props.id } className={ classNames( 'notices-list', { 'is-pinned': this.state.pinned } ) }>
-					<DeleteSiteNotices />
-					{ noticesList }
-				</div>
-				{ this.state.pinned && ! this.props.forcePinned
-					? <div className="notices-list__whitespace" />
-					: null }
+			<div id={ this.props.id } className="global-notices">
+				<DeleteSiteNotices />
+				{ noticesList }
 			</div>
 		);
 	}

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -1,0 +1,21 @@
+.global-notices {
+	overflow: hidden;
+
+	z-index: 180;
+	position: fixed;
+		top: 47px + 32px;
+		right: 48px;
+
+	@include breakpoint( "<960px" ) {
+	}
+
+	@include breakpoint( "<660px" ) {
+		top: 16px;
+	}
+}
+
+.global-notices .notice {
+	border-radius: 50px;
+	display: inline-flex;
+	z-index: 180;
+}

--- a/client/components/overlay/overlay.jsx
+++ b/client/components/overlay/overlay.jsx
@@ -9,7 +9,7 @@ var React = require( 'react/addons' ),
  * Internal dependencies
  */
 var Toolbar = require( './toolbar' ),
-	NoticesList = require( 'notices/notices-list' ),
+	NoticesList = require( 'components/global-notices' ),
 	notices = require( 'notices' ),
 	page = require( 'page' ),
 	TitleData = require( 'components/data/screen-title' );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -11,7 +11,7 @@ var React = require( 'react' ),
  */
 var Masterbar = require( './masterbar' ),
 	observe = require( 'lib/mixins/data-observe' ),
-	NoticesList = require( 'notices/notices-list' ),
+	GlobalNotices = require( 'components/global-notices' ),
 	notices = require( 'notices' ),
 	translator = require( 'lib/translator-jumpstart' ),
 	TranslatorInvitation = require( './community-translator/invitation' ),
@@ -110,7 +110,7 @@ module.exports = React.createClass( {
 					</Welcome>
 					<InviteMessage sites={ this.props.sites }/>
 					<EmailVerificationNotice user={ this.props.user } />
-					<NoticesList id="notices" notices={ notices.list } forcePinned={ 'post' === this.state.section } />
+					<GlobalNotices id="notices" notices={ notices.list } forcePinned={ 'post' === this.state.section } />
 					<TranslatorInvitation isVisible={ showInvitation } />
 					<div id="primary" className="wp-primary wp-section" />
 					<div id="secondary" className="wp-secondary" />

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -8,7 +8,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var Masterbar = require( './masterbar' ),
-	NoticesList = require( 'notices/notices-list' ),
+	GlobalNotices = require( 'components/global-notices' ),
 	notices = require( 'notices' );
 
 module.exports = React.createClass( {
@@ -31,7 +31,7 @@ module.exports = React.createClass( {
 			<div className={ classes }>
 				<Masterbar />
 				<div id="content" className="wp-content">
-					<NoticesList id="notices" notices={ notices.list } />
+					<GlobalNotices id="notices" notices={ notices.list } />
 					<div id="primary" className="wp-primary wp-section" />
 					<div id="secondary" className="wp-secondary" />
 				</div>

--- a/client/my-sites/site-settings/form-base.js
+++ b/client/my-sites/site-settings/form-base.js
@@ -153,7 +153,7 @@ module.exports = {
 				}
 				this.setState( { submittingForm: false } );
 			} else {
-				notices.success( this.translate( 'Settings saved successfully!' ) );
+				notices.success( this.translate( 'Settings saved!' ) );
 				this.markSaved();
 				//for dirtyFields, see lib/mixins/dirty-linked-state
 				this.setState( { submittingForm: false, dirtyFields: [] } );

--- a/client/notices/style.scss
+++ b/client/notices/style.scss
@@ -1,33 +1,3 @@
-.notices-list {
-	overflow: hidden;
-
-	&.is-pinned {
-		width: calc( 100% - 272px - 32px - 32px );
-		z-index: 180;
-		position: fixed;
-			top: 47px + 32px;
-
-		.notice {
-			z-index: 180;
-		}
-
-		@include breakpoint( "<960px" ) {
-			width: calc( 100% - 228px - 24px - 24px );
-		}
-
-		@include breakpoint( "<660px" ) {
-			top: 16px;
-			width: calc( 100% - 16px );
-		}
-	}
-}
-
-.notices-list__whitespace {
-	height: 71px;
-	width: 100%;
-	display: block;
-}
-
 .site-notice {
 	display: block;
 	line-height: 1.8;


### PR DESCRIPTION
This in-progress work finalizes the component cleanup of notices-list, with `components/global-notices` used in `layout`. It adjusts the design to the pill-shape notices. It still uses `notice` as the core component.

![image](https://cloud.githubusercontent.com/assets/548849/11688481/394ac152-9e8d-11e5-9212-5e54470aa0e5.png)
