### PR TITLE
Checkout: Panic mode disable credit cards

### DIFF
--- a/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
@@ -158,8 +158,9 @@ module.exports = React.createClass( {
 						</button>
 						<SubscriptionText cart={ this.props.cart } />
 					</div>
-					
-					<a href="" className="credit-card-payment-box__switch-link" onClick={ this.handleToggle }>{ this.translate( 'or use a credit card', { context: 'Upgrades: PayPal checkout screen', comment: '"Checkout with PayPal -- or use a credit card"' } ) }</a>
+
+					{ false &&
+						<a href="" className="credit-card-payment-box__switch-link" onClick={ this.handleToggle }>{ this.translate( 'or use a credit card', { context: 'Upgrades: PayPal checkout screen', comment: '"Checkout with PayPal -- or use a credit card"' } ) }</a> }
 				</div>
 			</form>
 		);

--- a/client/my-sites/upgrades/checkout/secure-payment-form.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form.jsx
@@ -51,7 +51,8 @@ var SecurePaymentForm = React.createClass( {
 			return this.state.userSelectedPaymentBox;
 		} else {
 			// Default state
-			return 'credit-card';
+			//return 'credit-card';
+			return 'paypal';
 		}
 	},
 


### PR DESCRIPTION
Currently cc payments are failing with "This transaction cannot be processed due to an invalid merchant configuration."

This change shows only PayPal Express form, which seems to work.