### PR TITLE
Community translator: fix icon background on the invitation

### DIFF
--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -20,7 +20,7 @@
 	}
 	.gridicons-globe {
 		// copied from noticons styling
-		background-color: lighten( $gray, 30% );
+		background-color: $gray-light;
 		color: $gray;
 		height: 22px;
 		margin-left: -11px;


### PR DESCRIPTION
I noticed that the icon background on the separator under the Translate invitation had a darker color than the page's background:

![image](https://cloud.githubusercontent.com/assets/820374/11689787/ce0a7750-9e93-11e5-9eaa-9b207061da1f.png)

I changed the color so it matches the new bg color.

![image](https://cloud.githubusercontent.com/assets/820374/11689817/ea701ae4-9e93-11e5-8d7d-d6ee9dca6973.png)
