### PR TITLE
Signup: Free trials: Only show free trials on signup in the dev environment

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -27,7 +27,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( this.props.isInSignup ) {
-			return this.signUpActions();
+			return config.isEnabled( 'upgrades/free-trials' ) ? this.newPlanActions() : this.upgradeActions();
 		}
 
 		if ( this.siteHasThisPlan() ) {
@@ -144,26 +144,6 @@ module.exports = React.createClass( {
 
 		return (
 			<div onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'button' ) } className={ classes } />
-		);
-	},
-
-	signUpActions: function() {
-		if ( isFreePlan( this.props.plan ) ) {
-			return <div>
-				<button className="button is-primary plan-actions__upgrade-button"
-					onClick={ this.handleAddToCart.bind( null, null, 'button' ) }>
-					{ this.translate( 'Select Free Plan' ) }
-				</button>
-			</div>;
-		}
-
-		return (
-			<div>
-				<button className="button is-primary plan-actions__upgrade-button"
-					onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'button' ) }>
-						{ this.translate( 'Upgrade Now', { context: 'Store action' } ) }
-				</button>
-			</div>
 		);
 	},
 


### PR DESCRIPTION
This enables free trials in signup in dev.

Fixes #1417

**Testing**

1. `git checkout update/1417-free-trials-in-signup`
2. Open http://calypso.localhost:3000/start incognito
3. Assert that you are show the "Start free trial" button.

- [x] Code review
- [x] QA review