### PR TITLE
Plans: Add missing space to `PlansNudge`

### DIFF
--- a/client/components/plans/plan-nudge/index.jsx
+++ b/client/components/plans/plan-nudge/index.jsx
@@ -83,6 +83,7 @@ export default React.createClass( {
 					</h4>
 					<div>
 						{ this.translate( 'WordPress.com has many powerful plugins already built in and free to use. Additional ecommerce plugins (Shopify, Ecwid, Gumroad) are available with WordPress.com Business.') }
+						{ ' ' }
 						<a href="http://support.wordpress.com/plugins/" target="_blank">
 							{ this.translate( 'Learn more about plugins.') }
 						</a>


### PR DESCRIPTION
Fixes #1414. I added a space using the JSX syntax (`{ ' ' }`) – what do you think, @sirjonathan?

[Before](https://cloudup.com/ch4NTjR6iOe) / [After](https://cloudup.com/cb9ZUDeUAmT)

**Testing**
- Enter `localStorage.setItem( 'ABTests', '{"businessPluginsNudge_20151119":"nudge"}' );` in local storage.
- Visit http://calypso.localhost:3000/plugins/:site for a .com site without the business plan.
- Assert that the space is no longer missing.

cc @fabianapsimoes