### PR TITLE
Profile Link: Update styling to match

### DIFF
--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -8,6 +8,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var ActionRemove = require( 'me/action-remove' ),
+	safeProtocolUrl = require( 'lib/safe-protocol-url' ),
 	eventRecorder = require( 'me/event-recorder' );
 
 module.exports = React.createClass( {
@@ -47,22 +48,28 @@ module.exports = React.createClass( {
 				'profile-link': true,
 				'is-placeholder': this.props.isPlaceholder
 			} ),
-			imageSrc = '//s1.wp.com/mshots/v1/' + encodeURIComponent( this.props.url ) + '?w=' + this.props.imageSize,
-			linkHref = this.props.isPlaceholder ? null : this.props.url;
+			imageSrc = '//s1.wp.com/mshots/v1/' + encodeURIComponent( this.props.url ) + '?w=' + this.props.imageSize + '&h=64',
+			linkHref = this.props.isPlaceholder ? null : safeProtocolUrl( this.props.url );
 
 		return (
 			<li className={ classes }>
 				{
 					this.props.isPlaceholder
-					? <div className="profile-link__image" />
-					: <img className="profile-link__image" src={ imageSrc } />
+					? <div className="profile-link__image-link" />
+					: <a
+						href={ linkHref }
+						className="profile-link__image-link" target="_blank"
+						onClick={ this.recordClickEvent( 'Profile Links Site Images Link' ) }
+					>
+						<img className="profile-link__image" src={ imageSrc } />
+					</a>
 				}
 				<a href={ linkHref } target="_blank" onClick={ this.recordClickEvent( 'Profile Links Site Link' ) }>
 					<span className="profile-link__title">
 						{ this.props.title }
 					</span>
 					<span className="profile-link__url">
-						{ this.props.url }
+						{ this.props.url.replace( /^https?:\/\//, '' ) }
 					</span>
 				</a>
 

--- a/client/me/profile-link/style.scss
+++ b/client/me/profile-link/style.scss
@@ -1,11 +1,11 @@
 .profile-link {
 	margin-bottom: 15px;
 	position: relative;
-	padding-left: 60px;
+	padding-left: 62px;
 	height: 50px;
 
 	&.is-placeholder {
-		.profile-link__image,
+		.profile-link__image-link,
 		.profile-link__title,
 		.profile-link__url,
 		.profile-link__remove {
@@ -15,7 +15,8 @@
 		}
 
 		.profile-link__title {
-			height: 15px;
+			height: 18px;
+			margin-bottom: 2px;
 		}
 
 		.profile-link__url {
@@ -32,13 +33,14 @@
 	}
 }
 
-.profile-link__image {
+.profile-link__image-link {
 	display: block;
-	height: 50px;
+	height: 32px;
 	width: 50px;
 	position: absolute;
 	top: 0;
 	left: 0;
+	border: 1px solid lighten( $gray, 30% );
 }
 
 .profile-link__link {
@@ -46,12 +48,13 @@
 }
 
 .profile-link__title {
-	display: block;
-	font-size: 15px;
+	float: left;
+	font-size: 13px;
+	line-height: 1.4;
 	text-decoration: underline;
-	font-weight: bold;
 	overflow: hidden;
 	white-space: nowrap;
+	text-decoration: none;
 
 	&:after {
 		@include long-content-fade( $size: 45% );
@@ -59,7 +62,10 @@
 }
 
 .profile-link__url {
-	display: block;
-	font-size: 12px;
+	font-size: 11px;
+	font-style: italic;
+	line-height: 1.4;
 	color: $gray;
+	float: left;
+	clear: left;
 }


### PR DESCRIPTION
Update for consistant with the rest of calypso when showing a url/domain. 

Fixes https://github.com/Automattic/wp-calypso/issues/1006

Before:
![screen shot 2015-12-09 at 11 37 40](https://cloud.githubusercontent.com/assets/115071/11696481/58eb1d64-9e69-11e5-9b68-9266beaf35aa.png)

After:
![screen shot 2015-12-09 at 13 08 19](https://cloud.githubusercontent.com/assets/115071/11698883/f87f1126-9e75-11e5-92c9-05aaf8de6ec4.png)


Also update the placeholders to look like this:
![screen shot 2015-12-09 at 11 56 32](https://cloud.githubusercontent.com/assets/115071/11696956/fb5c1894-9e6b-11e5-93a2-b0efec4eec4c.png)

Things to notice. 
- I also added links to the image. ( since I was expecting to be able to click on it)
- the site image is not square any more since before it was being stretched. 
- as a precaution I added safeUrlProtocal. 
- I made the links not be display: block any more. 

Since the link area kind of overlapped the 

To test visit 
http://calypso.localhost:3000/me

cc: @ebinnion, @rickybanister, @MichaelArestad 