### PR TITLE
Me: Fixes 2fa via app layout

### DIFF
--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -3,7 +3,8 @@
  */
 var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:me:security:2fa-enable' ),
-	QRCode = require( 'qrcode.react' );
+	QRCode = require( 'qrcode.react' ),
+	classNames = require( 'classnames' );
 
 /**
  * Internal dependencies
@@ -191,6 +192,10 @@ module.exports = React.createClass( {
 	},
 
 	renderQRCode: function() {
+		var qrClasses = classNames( 'security-2fa-enable__qr-code', {
+			'is-placeholder': ! this.state.otpAuthUri
+		} );
+
 		return (
 			<div className="security-2fa-enable__qr-code-block">
 				<p className="security-2fa-enable__qr-instruction">
@@ -204,7 +209,7 @@ module.exports = React.createClass( {
 						)
 					}
 				</p>
-				<div className="security-2fa-enable__qr-code">
+				<div className={ qrClasses }>
 					{ this.state.otpAuthUri &&
 						<QRCode value={ this.state.otpAuthUri } size={ 150 } />
 					}

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -184,8 +184,8 @@ module.exports = React.createClass( {
 			<a
 				className="security-2fa-enable__toggle"
 				onClick={ function( event ) {
-					analytics.ga.recordEvent( 'Me', 'Clicked On Barcode Toggle Link', 'current-method', this.state.method );
 					this.toggleMethod( event );
+					analytics.ga.recordEvent( 'Me', 'Clicked On Barcode Toggle Link', 'current-method', this.state.method );
 				}.bind( this ) }
 			/>
 		);

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -178,22 +178,54 @@ module.exports = React.createClass( {
 		}
 	},
 
+	getToggleLink: function() {
+		return (
+			<a
+				className="security-2fa-enable__toggle"
+				onClick={ function( event ) {
+					analytics.ga.recordEvent( 'Me', 'Clicked On Barcode Toggle Link', 'current-method', this.state.method );
+					this.toggleMethod( event );
+				}.bind( this ) }
+			/>
+		);
+	},
+
 	renderQRCode: function() {
 		return (
-			<div>
-				<p>
-					{ this.translate( 'Scan this QR code with your mobile app:' ) }
+			<div className="security-2fa-enable__qr-code-block">
+				<p className="security-2fa-enable__qr-instruction">
+					{
+						this.translate(
+							"Scan this QR code with your mobile app. {{toggleMethodLink}}Can't scan the barcode?{{/toggleMethodLink}}", {
+								components: {
+									toggleMethodLink: this.getToggleLink()
+								}
+							}
+						)
+					}
 				</p>
-				{ this.state.otpAuthUri ? <QRCode value={ this.state.otpAuthUri } size={ 150 } /> : null }
+				<div className="security-2fa-enable__qr-code">
+					{ this.state.otpAuthUri &&
+						<QRCode value={ this.state.otpAuthUri } size={ 150 } />
+					}
+				</div>
 			</div>
 		);
 	},
 
 	renderTimeCode: function() {
 		return (
-			<div>
-				<p>
-					{ this.translate( 'Enter this time code into your mobile app:' ) }
+			<div className="security-2fa-enable__time-code-block">
+				<p className="security-2fa-enable__time-instruction">
+					{
+						this.translate(
+							'Enter this time code into your mobile app. {{toggleMethodLink}}Prefer to scan the barcode?{{/toggleMethodLink}}', {
+								components: {
+									toggleMethodLink: this.getToggleLink()
+								}
+							}
+						)
+					}
 				</p>
 				<p className="security-2fa-enable__time-code">
 					{ this.state.timeCode }
@@ -208,11 +240,8 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<div className="security-2fa-enable__first">
-				<p className="security-2fa-enable__first-label">
-					{ this.translate( 'First', { context: 'The first thing we want the user to do for Two-Step setup.' } ) }
-				</p>
-				{ ( 'scan' === this.state.method ) ? this.renderQRCode() : this.renderTimeCode() }
+			<div className="security-2fa-enable__code-block">
+				{ 'scan' === this.state.method ? this.renderQRCode() : this.renderTimeCode() }
 			</div>
 		);
 	},
@@ -226,11 +255,7 @@ module.exports = React.createClass( {
 
 		return (
 			<p>
-				{
-					'scan' === this.state.method
-					? this.translate( 'Enter the code your app gives you after scanning:' )
-					: this.translate( 'Enter the code your app gives you after entering the time code:' )
-				}
+				{ this.translate( 'Then enter the six digit code provided by the app:' ) }
 			</p>
 		);
 	},
@@ -275,17 +300,6 @@ module.exports = React.createClass( {
 						)
 					}
 				</p>
-				<p>
-					<a
-						className="security-2fa-enable__toggle"
-						onClick={ function( event ) {
-							analytics.ga.recordEvent( 'Me', 'Clicked On Barcode Toggle Link', 'current-method', this.state.method );
-							this.toggleMethod( event );
-						}.bind( this ) }
-					>
-						{ 'scan' === this.state.method ? this.translate( "Can't scan the barcode?" ) : this.translate( 'Prefer to scan the barcode?' ) }
-					</a>
-				</p>
 			</div>
 		);
 	},
@@ -312,15 +326,6 @@ module.exports = React.createClass( {
 	renderInputBlock: function() {
 		return (
 			<div className="security-2fa-enable__next">
-				{
-					'sms' !== this.state.method
-					? (
-						<p className="security-2fa-enable__next-label">
-							{ this.translate( 'Next', { context: 'The next thing we want the user to do for Two-Step setup.' } ) }
-						</p>
-					)
-					: null
-				}
 				{ this.renderInputHelp() }
 				<FormTextInput
 					autoComplete="off"
@@ -355,7 +360,7 @@ module.exports = React.createClass( {
 
 	renderButtons: function() {
 		return (
-			<div>
+			<div className="security-2fa-enable__buttons-bar">
 				<FormButton
 					className="security-2fa-enable__verify"
 					disabled={ this.getFormDisabled() }

--- a/client/me/security-2fa-enable/style.scss
+++ b/client/me/security-2fa-enable/style.scss
@@ -1,31 +1,16 @@
-.security-2fa-enable__inner {
-	@include clear-fix;
-	display: flex;
-	margin-bottom: 20px;
-}
-
 .security-2fa-enable .security-2fa-enable__cancel {
 	float: left;
 	margin-left: 0;
 }
 
-.security-2fa-enable__first {
-	flex: 1;
-	margin-right: 20px;
+.security-2fa-enable__code-block {
+	margin-bottom: 16px;
 }
 
-.security-2fa-enable__first-label {
-	font-weight: bold;
-	margin-bottom: 0;
-}
-
-.security-2fa-enable__next {
-	flex: 2;
-}
-
-.security-2fa-enable__next-label {
-	font-weight: bold;
-	margin-bottom: 0;
+.security-2fa-enable__qr-code {
+	height: 150px;
+	width: 150px;
+	margin: 0 auto;
 }
 
 .security-2fa-enable__app-options {
@@ -42,8 +27,14 @@
 
 .security-2fa-enable__toggle {
 	cursor: pointer;
+	display: block;
 }
 
 .security-2fa-enable .notice {
 	margin: 5px 0 0 0;
+}
+
+.security-2fa-enable__buttons-bar {
+	@include clear-fix;
+	margin-top: 16px;
 }

--- a/client/me/security-2fa-enable/style.scss
+++ b/client/me/security-2fa-enable/style.scss
@@ -11,6 +11,10 @@
 	height: 150px;
 	width: 150px;
 	margin: 0 auto;
+
+	&.is-placeholder {
+		@include placeholder( 23% );
+	}
 }
 
 .security-2fa-enable__app-options {


### PR DESCRIPTION
Fixes #232 

Previously, the 2fa via app flow layout was essentially broken on mobile :disappointed:. This PR fixes that.

cc @rickybanister for design review and @enejb for code review.

To test:
- Checkout `fix/me-2fa-layout` branch
- Go to `/me/security/two-step` while logged in to a test account
- Test that activating/deactivating 2fa is still functional
- Test that the layout functions well for both mobile and desktop users

__After screenshots:__

![screen shot 1](https://cloud.githubusercontent.com/assets/1126811/11697469/5da58d6a-9e7f-11e5-93a1-80638de64738.png)
![screen shot](https://cloud.githubusercontent.com/assets/1126811/11697468/5d9fdc1c-9e7f-11e5-863e-972b6cff811f.png)

![screen shot 2](https://cloud.githubusercontent.com/assets/1126811/11697565/c0dd1902-9e7f-11e5-9b96-19e953ff70af.png)
![screen shot 3](https://cloud.githubusercontent.com/assets/1126811/11697566/c0df2738-9e7f-11e5-90b9-6c77780da52e.png)

__Before screenshot:__
![71db0742-8ecb-11e5-840d-fc8e9743d672](https://cloud.githubusercontent.com/assets/1126811/11697502/7524fe26-9e7f-11e5-8049-c30a93518d73.png)
