### PR TITLE
Notifications: update grammar to be consistent with "your comments"

### DIFF
--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -6,7 +6,7 @@ export const streamLabels = {
 };
 
 export const settingLabels = {
-	comment_like: () => i18n.translate( 'Likes on my comments' ),
+	comment_like: () => i18n.translate( 'Likes on your comments' ),
 	comment_reply: () => i18n.translate( 'Replies to your comments' ),
 
 	new_comment: () => i18n.translate( 'New Comment' ),


### PR DESCRIPTION
Reported by @ryanboren 

Should “my comments” be “your comments”?

![my-comments](https://cloud.githubusercontent.com/assets/66797/11697613/99de8ae6-9e77-11e5-8b41-f3f3c6721795.png)
