### PR TITLE
User Email: Fixes #685 by disabeling and showing the new email address

### DIFF
--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -242,8 +242,20 @@ module.exports = React.createClass( {
 		);
 	},
 
+	renderEmailValueLink: function() {
+		let valueLink = this.valueLink( 'user_email' );
+		if ( this.hasPendingEmailChange() ) {
+			valueLink.value = this.props.userSettings.getSetting( 'new_user_email' );
+		}
+		return valueLink;
+	},
+
+	hasPendingEmailChange: function() {
+		return this.props.userSettings.isPendingEmailChange();
+	},
+
 	renderPendingEmailChange: function() {
-		if ( ! this.props.userSettings.isPendingEmailChange() ) {
+		if ( ! this.hasPendingEmailChange() ) {
 			return null;
 		}
 
@@ -346,11 +358,11 @@ module.exports = React.createClass( {
 				<FormFieldset>
 					<FormLabel htmlFor="email">{ this.translate( 'Email Address' ) }</FormLabel>
 					<FormTextInput
-						disabled={ this.getDisabledState() }
+						disabled={ this.getDisabledState() || this.hasPendingEmailChange() }
 						id="email"
 						name="email"
 						onFocus={ this.recordFocusEvent( 'Email Address Field' ) }
-						valueLink={ this.valueLink( 'user_email' ) } />
+						valueLink={ this.renderEmailValueLink() } />
 					{ this.renderPendingEmailChange() }
 					<FormSettingExplanation>{ this.translate( 'Will not be publicly displayed' ) }</FormSettingExplanation>
 				</FormFieldset>

--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -45,7 +45,13 @@ module.exports = React.createClass( {
 
 	displayName: 'Account',
 
-	mixins: [ formBase, React.addons.LinkedStateMixin, protectForm.mixin, observe( 'userSettings', 'username' ), eventRecorder ],
+	mixins: [
+		formBase,
+		React.addons.LinkedStateMixin,
+		protectForm.mixin,
+		observe( 'userSettings', 'username' ),
+		eventRecorder
+	],
 
 	componentWillMount: function() {
 		// Clear any username changes that were previously made
@@ -70,13 +76,9 @@ module.exports = React.createClass( {
 
 			this.props.userSettings.updateSetting( 'language', value );
 			if ( value !== originalLanguage ) {
-				this.setState( {
-					redirect: '/me/account'
-				} );
+				this.setState( { redirect: '/me/account' } );
 			} else {
-				this.setState( {
-					redirect: false
-				} );
+				this.setState( { redirect: false } );
 			}
 		}.bind( this );
 
@@ -120,9 +122,7 @@ module.exports = React.createClass( {
 
 	getOptoutText: function( website ) {
 		return this.translate( '%(website)s opt-out', {
-			args: {
-				website: website
-			},
+			args: { website: website },
 			context: 'A website address, formatted to look like "Website.com"'
 		} );
 	},
@@ -180,13 +180,9 @@ module.exports = React.createClass( {
 		var username = this.props.userSettings.getSetting( 'user_login' ),
 			action = null === this.state.usernameAction ? 'none' : this.state.usernameAction;
 
-		this.setState( {
-			submittingForm: true
-		} );
+		this.setState( { submittingForm: true } );
 		this.props.username.change( username, action, function( error ) {
-			this.setState( {
-				submittingForm: false
-			} );
+			this.setState( { submittingForm: false } );
 			if ( error ) {
 				notices.error( this.props.username.getValidationFailureMessage() );
 			} else {
@@ -202,8 +198,16 @@ module.exports = React.createClass( {
 	renderHolidaySnow() {
 		// Note that years and months below are zero indexed
 		let today = this.moment(),
-			startDate = this.moment( { year: today.year(), month: 11, day: 1 } ),
-			endDate = this.moment( { year: today.year(), month: 0, day: 4 } );
+			startDate = this.moment( {
+				year: today.year(),
+				month: 11,
+				day: 1
+			} ),
+			endDate = this.moment( {
+				year: today.year(),
+				month: 0,
+				day: 4
+			} );
 
 		if ( today.isBefore( startDate, 'day' ) && today.isAfter( endDate, 'day' ) ) {
 			return;


### PR DESCRIPTION
Fixes #685
Updated the email form field to be disabled and show the new email address in the notice. 

When the user has the email in the pending state we now disabled the email address field until the user click cancel or confirms the new email address.

Before:
![screen shot 2015-12-09 at 13 22 14](https://cloud.githubusercontent.com/assets/115071/11699256/5a0a2834-9e78-11e5-9d68-b03b008f3265.png)

After:
![screen shot 2015-12-09 at 13 24 21](https://cloud.githubusercontent.com/assets/115071/11699253/561ec1ee-9e78-11e5-85ab-50856c4a73a8.png)

*To test*

Visit http://calypso.localhost:3000/me/account 
Change your email address notice that the new email address will show up in the text field and the text field will be disabled.