### PR TITLE
Me: Fixes 2fa progress indicator layout on mobile

### DIFF
--- a/client/me/security-2fa-progress/style.scss
+++ b/client/me/security-2fa-progress/style.scss
@@ -1,5 +1,9 @@
 .security-2fa-progress__container {
-	margin: 0 -24px 24px;
+	margin: 0 -16px 16px;
+
+	@include breakpoint( ">480px" ) {
+		margin: 0 -24px 24px;
+	}
 
 	.security-2fa-progress__inner-container {
 		display: flex;


### PR DESCRIPTION
Fixes #1440

Previously, the blue line on the 2fa progress indicator would expand outside of the gray lines of the card :scream: This PR fixes that.

cc @rickybanister and @enejb for what should be a quick review.

__After screenshots:__
![screen shot 4](https://cloud.githubusercontent.com/assets/1126811/11699072/ef7e12f4-9e87-11e5-9314-7cc02a7f06e0.png)
![screen shot 5](https://cloud.githubusercontent.com/assets/1126811/11699073/ef9366fe-9e87-11e5-8bcc-7427d25edbb6.png)

__Before screenshot:__
![3e8ef07a-9e74-11e5-8337-78c8869e446f](https://cloud.githubusercontent.com/assets/1126811/11699078/f7dc2382-9e87-11e5-95fe-72621fa0f526.png)
