### PR TITLE
Framework: Add Scrolling Indicator to Sidebar

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -53,6 +53,7 @@
 @import 'components/post-excerpt/style';
 @import 'components/pulsing-dot/style';
 @import 'components/rating/style';
+@import 'components/scrollable-container/style';
 @import 'components/search/style';
 @import 'components/search-card/style';
 @import 'components/section-nav/style';

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -397,7 +397,6 @@ body.newdash div.wordpress-com-extension-promo {
 }
 
 .environment-badge {
-	display: none;
 	position: fixed;
 		bottom: 16px;
 		left: 16px;

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -397,6 +397,7 @@ body.newdash div.wordpress-com-extension-promo {
 }
 
 .environment-badge {
+	display: none;
 	position: fixed;
 		bottom: 16px;
 		left: 16px;

--- a/assets/stylesheets/layout/_sidebar.scss
+++ b/assets/stylesheets/layout/_sidebar.scss
@@ -2,7 +2,7 @@
 .sidebar,
 .secondary-cart { // This selects the sidebar on /checkout
 	overflow: auto;
-	padding: 0;
+	padding: 0 0 40px 0;
 	background: lighten( $gray, 30% );
 	position: fixed;
 		top: 47px;
@@ -35,6 +35,51 @@
 
 		.focus-sites & {
 			transform: translateX( 100vw );
+		}
+	}
+}
+
+.scroll-indicator {
+	display: none;
+}
+
+// Fade Overlay
+.is-scrollable {
+	.scroll-indicator {
+		display: block;
+		pointer-events: none;
+		z-index: 2;
+		position: fixed;
+			bottom: 8px;
+			left: 0;
+		height: 24px;
+		text-align: center;
+		width: $sidebar-width-max;
+		transition: all 0.15s ease-in-out;
+
+		.gridicon {
+			fill: $gray;
+		}
+	}
+
+	&:after {
+		pointer-events: none;
+		z-index: 1;
+		position: fixed;
+			bottom: 0;
+			left: 0;
+		display: block;
+		content: '';
+		height: 56px;
+		width: $sidebar-width-max;
+		background: linear-gradient( to bottom, rgba( lighten( $gray, 30% ), 0 ) 0%, rgba( lighten( $gray, 30% ), 1 ) 70% );
+		transition: all 0.15s ease-in-out;
+	}
+
+	&.is-scrolled {
+		.scroll-indicator,
+		&:after {
+			opacity: 0;
 		}
 	}
 }

--- a/assets/stylesheets/layout/_sidebar.scss
+++ b/assets/stylesheets/layout/_sidebar.scss
@@ -39,51 +39,6 @@
 	}
 }
 
-.scroll-indicator {
-	display: none;
-}
-
-// Fade Overlay
-.is-scrollable {
-	.scroll-indicator {
-		display: block;
-		pointer-events: none;
-		z-index: 2;
-		position: fixed;
-			bottom: 8px;
-			left: 0;
-		height: 24px;
-		text-align: center;
-		width: $sidebar-width-max;
-		transition: all 0.15s ease-in-out;
-
-		.gridicon {
-			fill: $gray;
-		}
-	}
-
-	&:after {
-		pointer-events: none;
-		z-index: 1;
-		position: fixed;
-			bottom: 0;
-			left: 0;
-		display: block;
-		content: '';
-		height: 56px;
-		width: $sidebar-width-max;
-		background: linear-gradient( to bottom, rgba( lighten( $gray, 30% ), 0 ) 0%, rgba( lighten( $gray, 30% ), 1 ) 70% );
-		transition: all 0.15s ease-in-out;
-	}
-
-	&.is-scrolled {
-		.scroll-indicator,
-		&:after {
-			opacity: 0;
-		}
-	}
-}
-
 
 // Clearing out the sidebar list styles
 .wpcom-sidebar {

--- a/client/components/scrollable-container/index.jsx
+++ b/client/components/scrollable-container/index.jsx
@@ -25,18 +25,22 @@ import smartSetState from 'lib/react-smart-set-state';
 		window.addEventListener( 'resize', this.checkScrollable );
 		this.checkScrollable();
 
-		document.getElementById( 'wp-sidebar' ).addEventListener( 'scroll', this.checkScrolled );
+		React.findDOMNode( this.refs[ 'sidebar-container' ] ).addEventListener( 'scroll', this.checkScrolled );
 		this.checkScrolled();
+
+		console.log( 'componentDidMount' );
 	},
 
 	componentWillUnmount: function() {
 		window.removeEventListener( 'resize', this.checkScrollable );
-		document.getElementById( 'wp-sidebar' ).removeEventListener( 'scroll', this.checkScrolled );
+		React.findDOMNode( this.refs[ 'sidebar-container' ] ).removeEventListener( 'scroll', this.checkScrolled );
 	},
 
 	componentDidUpdate: function() {
 		this.checkScrollable();
 		this.checkScrolled();
+
+		console.log( 'componentDidUpdate' );
 	},
 
 	/**
@@ -45,7 +49,7 @@ import smartSetState from 'lib/react-smart-set-state';
 	 */
 	checkScrollable: function() {
 		var windowHeight = window.innerHeight,
-			sidebar = document.getElementById( 'wp-sidebar' ),
+			sidebar = React.findDOMNode( this.refs[ 'sidebar-container' ] ),
 			sidebarHeight = sidebar.scrollHeight;
 
 		if ( sidebarHeight > ( windowHeight ) ) {
@@ -60,7 +64,7 @@ import smartSetState from 'lib/react-smart-set-state';
 	 * This is used to hide/show the chevron Gridicon as needed.
 	 */
 	checkScrolled: function() {
-		var sidebar = document.getElementById( 'wp-sidebar' ),
+		var sidebar = React.findDOMNode( this.refs[ 'sidebar-container' ] ),
 			isAtBottom = ( sidebar.scrollTop === ( sidebar.scrollHeight - sidebar.offsetHeight ) );
 
 		if ( isAtBottom ) {
@@ -71,7 +75,8 @@ import smartSetState from 'lib/react-smart-set-state';
 	},
 
 	render() {
-		let containerClasses;
+		let containerClasses,
+			child = React.cloneElement( React.Children.only( this.props.children ), { ref: 'sidebar-container' } );
 
 		containerClasses = classnames( {
 			'is-scrollable': this.state.isScrollable,
@@ -80,7 +85,7 @@ import smartSetState from 'lib/react-smart-set-state';
 
 		return (
 			<div className={ containerClasses }>
-				{ this.props.children }
+				{ child }
 
 				<div className="scroll-indicator"><Gridicon icon="chevron-down" /></div>
 			</div>

--- a/client/components/scrollable-container/index.jsx
+++ b/client/components/scrollable-container/index.jsx
@@ -42,6 +42,7 @@ import smartSetState from 'lib/react-smart-set-state';
 		this.checkScrollable();
 		this.checkScrolledToBottom();
 		this.scrollLock();
+		console.log( React.findDOMNode( this.refs[ 'scrollable-content' ] ).offsetWidth - React.findDOMNode( this.refs[ 'scrollable-content' ] ).clientWidth );
 	},
 
 	/**
@@ -51,9 +52,14 @@ import smartSetState from 'lib/react-smart-set-state';
 	checkScrollable: function() {
 		var windowHeight = window.innerHeight,
 			content = React.findDOMNode( this.refs[ 'scrollable-content' ] ),
-			contentHeight = content.scrollHeight;
+			contentHeight = content.scrollHeight,
+			scrollbarWidth = content.offsetWidth - content.clientWidth,
+			isScrollbarVisible = false;
 
-		if ( contentHeight > ( windowHeight ) ) {
+		if ( scrollbarWidth > 1 )
+			isScrollbarVisible = true;
+
+		if ( ( contentHeight > ( windowHeight ) ) && !isScrollbarVisible ) {
 			this.smartSetState( { isScrollable: true } );
 		} else {
 			this.smartSetState( { isScrollable: false } );

--- a/client/components/scrollable-container/index.jsx
+++ b/client/components/scrollable-container/index.jsx
@@ -27,16 +27,21 @@ import smartSetState from 'lib/react-smart-set-state';
 
 		React.findDOMNode( this.refs[ 'scrollable-content' ] ).addEventListener( 'scroll', this.checkScrolledToBottom );
 		this.checkScrolledToBottom();
+
+		this.scrollLock();
 	},
 
 	componentWillUnmount: function() {
 		window.removeEventListener( 'resize', this.checkScrollable );
 		React.findDOMNode( this.refs[ 'scrollable-content' ] ).removeEventListener( 'scroll', this.checkScrolledToBottom );
+
+		this.scrollRelease();
 	},
 
 	componentDidUpdate: function() {
 		this.checkScrollable();
 		this.checkScrolledToBottom();
+		this.scrollLock();
 	},
 
 	/**
@@ -69,6 +74,45 @@ import smartSetState from 'lib/react-smart-set-state';
 			this.smartSetState( { isScrolledToBottom: false } );
 		}
 	},
+
+    scrollLock: function () {
+		var content = React.findDOMNode( this.refs[ 'scrollable-content' ] );
+		if ( content ) {
+			content.addEventListener( 'wheel', this.onScrollHandler );
+		}
+    },
+
+	scrollRelease: function () {
+		var content = React.findDOMNode( this.refs[ 'scrollable-content' ] );
+		if ( content ) {
+			content.removeEventListener( 'wheel', this.onScrollHandler );
+		}
+	},
+
+    cancelScrollEvent: function ( event ) {
+		event.stopImmediatePropagation();
+		event.preventDefault();
+		event.returnValue = false;
+		return false;
+    },
+
+    onScrollHandler: function ( event ) {
+		var content = React.findDOMNode( this.refs[ 'scrollable-content' ] );
+		var scrollTop = content.scrollTop;
+		var scrollHeight = content.scrollHeight;
+		var height = content.clientHeight;
+		var wheelDelta = event.deltaY;
+		var isDeltaPositive = wheelDelta > 0;
+
+		if ( isDeltaPositive && wheelDelta > scrollHeight - height - scrollTop ) {
+			content.scrollTop = scrollHeight;
+			return this.cancelScrollEvent( event );
+		}
+		else if ( ! isDeltaPositive && -wheelDelta > scrollTop ) {
+			content.scrollTop = 0;
+			return this.cancelScrollEvent( event );
+		}
+    },
 
 	render() {
 		let containerClasses,

--- a/client/components/scrollable-container/index.jsx
+++ b/client/components/scrollable-container/index.jsx
@@ -17,7 +17,7 @@ import smartSetState from 'lib/react-smart-set-state';
 	getInitialState: function() {
 		return {
 			isScrollable: false,
-			isScrolled: false
+			isScrolledToBottom: false
 		}
 	},
 
@@ -25,22 +25,18 @@ import smartSetState from 'lib/react-smart-set-state';
 		window.addEventListener( 'resize', this.checkScrollable );
 		this.checkScrollable();
 
-		React.findDOMNode( this.refs[ 'sidebar-container' ] ).addEventListener( 'scroll', this.checkScrolled );
-		this.checkScrolled();
-
-		console.log( 'componentDidMount' );
+		React.findDOMNode( this.refs[ 'scrollable-content' ] ).addEventListener( 'scroll', this.checkScrolledToBottom );
+		this.checkScrolledToBottom();
 	},
 
 	componentWillUnmount: function() {
 		window.removeEventListener( 'resize', this.checkScrollable );
-		React.findDOMNode( this.refs[ 'sidebar-container' ] ).removeEventListener( 'scroll', this.checkScrolled );
+		React.findDOMNode( this.refs[ 'scrollable-content' ] ).removeEventListener( 'scroll', this.checkScrolledToBottom );
 	},
 
 	componentDidUpdate: function() {
 		this.checkScrollable();
-		this.checkScrolled();
-
-		console.log( 'componentDidUpdate' );
+		this.checkScrolledToBottom();
 	},
 
 	/**
@@ -49,10 +45,10 @@ import smartSetState from 'lib/react-smart-set-state';
 	 */
 	checkScrollable: function() {
 		var windowHeight = window.innerHeight,
-			sidebar = React.findDOMNode( this.refs[ 'sidebar-container' ] ),
-			sidebarHeight = sidebar.scrollHeight;
+			content = React.findDOMNode( this.refs[ 'scrollable-content' ] ),
+			contentHeight = content.scrollHeight;
 
-		if ( sidebarHeight > ( windowHeight ) ) {
+		if ( contentHeight > ( windowHeight ) ) {
 			this.smartSetState( { isScrollable: true } );
 		} else {
 			this.smartSetState( { isScrollable: false } );
@@ -63,24 +59,24 @@ import smartSetState from 'lib/react-smart-set-state';
 	 * Check to see if the div is scrolled to it's bottom.
 	 * This is used to hide/show the chevron Gridicon as needed.
 	 */
-	checkScrolled: function() {
-		var sidebar = React.findDOMNode( this.refs[ 'sidebar-container' ] ),
-			isAtBottom = ( sidebar.scrollTop === ( sidebar.scrollHeight - sidebar.offsetHeight ) );
+	checkScrolledToBottom: function() {
+		var content = React.findDOMNode( this.refs[ 'scrollable-content' ] ),
+			isAtBottom = ( content.scrollTop === ( content.scrollHeight - content.offsetHeight ) );
 
 		if ( isAtBottom ) {
-			this.smartSetState( { isScrolled: true } );
+			this.smartSetState( { isScrolledToBottom: true } );
 		} else {
-			this.smartSetState( { isScrolled: false } );
+			this.smartSetState( { isScrolledToBottom: false } );
 		}
 	},
 
 	render() {
 		let containerClasses,
-			child = React.cloneElement( React.Children.only( this.props.children ), { ref: 'sidebar-container' } );
+			child = React.cloneElement( React.Children.only( this.props.children ), { ref: 'scrollable-content' } );
 
 		containerClasses = classnames( {
 			'is-scrollable': this.state.isScrollable,
-			'is-scrolled': this.state.isScrolled
+			'is-scrolled-to-bottom': this.state.isScrolledToBottom
 		}, this.props.className, 'scrollable-container' );
 
 		return (

--- a/client/components/scrollable-container/index.jsx
+++ b/client/components/scrollable-container/index.jsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import React from 'react/addons';
+import classnames from 'classnames';
+import smartSetState from 'lib/react-smart-set-state';
+
+/**
+ * Internal dependencies
+ */
+ import Gridicon from 'components/gridicon';
+
+ export default React.createClass( {
+	displayName: 'ScrollableContainer',
+	smartSetState: smartSetState,
+
+	getInitialState: function() {
+		return {
+			isScrollable: false,
+			isScrolled: false
+		}
+	},
+
+	componentDidMount: function() {
+		window.addEventListener( 'resize', this.checkScrollable );
+		this.checkScrollable();
+
+		document.getElementById( 'wp-sidebar' ).addEventListener( 'scroll', this.checkScrolled );
+		this.checkScrolled();
+	},
+
+	componentWillUnmount: function() {
+		window.removeEventListener( 'resize', this.checkScrollable );
+		document.getElementById( 'wp-sidebar' ).removeEventListener( 'scroll', this.checkScrolled );
+	},
+
+	componentDidUpdate: function() {
+		this.checkScrollable();
+		this.checkScrolled();
+	},
+
+	/**
+	 * Check to see if the div is scrollable, that is, if the
+	 * div is taller than the window's height.
+	 */
+	checkScrollable: function() {
+		var windowHeight = window.innerHeight,
+			sidebar = document.getElementById( 'wp-sidebar' ),
+			sidebarHeight = sidebar.scrollHeight;
+
+		if ( sidebarHeight > ( windowHeight ) ) {
+			this.smartSetState( { isScrollable: true } );
+		} else {
+			this.smartSetState( { isScrollable: false } );
+		}
+	},
+
+	/**
+	 * Check to see if the div is scrolled to it's bottom.
+	 * This is used to hide/show the chevron Gridicon as needed.
+	 */
+	checkScrolled: function() {
+		var sidebar = document.getElementById( 'wp-sidebar' ),
+			isAtBottom = ( sidebar.scrollTop === ( sidebar.scrollHeight - sidebar.offsetHeight ) );
+
+		if ( isAtBottom ) {
+			this.smartSetState( { isScrolled: true } );
+		} else {
+			this.smartSetState( { isScrolled: false } );
+		}
+	},
+
+	render() {
+		let containerClasses;
+
+		containerClasses = classnames( {
+			'is-scrollable': this.state.isScrollable,
+			'is-scrolled': this.state.isScrolled
+		}, this.props.className, 'scrollable-container' );
+
+		return (
+			<div className={ containerClasses }>
+				{ this.props.children }
+
+				<div className="scroll-indicator"><Gridicon icon="chevron-down" /></div>
+			</div>
+		);
+	}
+} );

--- a/client/components/scrollable-container/index.jsx
+++ b/client/components/scrollable-container/index.jsx
@@ -8,9 +8,9 @@ import smartSetState from 'lib/react-smart-set-state';
 /**
  * Internal dependencies
  */
- import Gridicon from 'components/gridicon';
+import Gridicon from 'components/gridicon';
 
- export default React.createClass( {
+export default React.createClass( {
 	displayName: 'ScrollableContainer',
 	smartSetState: smartSetState,
 
@@ -81,12 +81,12 @@ import smartSetState from 'lib/react-smart-set-state';
 		}
 	},
 
-    scrollLock: function () {
+	scrollLock: function () {
 		var content = React.findDOMNode( this.refs[ 'scrollable-content' ] );
 		if ( content ) {
 			content.addEventListener( 'wheel', this.onScrollHandler );
 		}
-    },
+	},
 
 	scrollRelease: function () {
 		var content = React.findDOMNode( this.refs[ 'scrollable-content' ] );
@@ -95,14 +95,14 @@ import smartSetState from 'lib/react-smart-set-state';
 		}
 	},
 
-    cancelScrollEvent: function ( event ) {
+	cancelScrollEvent: function ( event ) {
 		event.stopImmediatePropagation();
 		event.preventDefault();
 		event.returnValue = false;
 		return false;
-    },
+	},
 
-    onScrollHandler: function ( event ) {
+	onScrollHandler: function ( event ) {
 		var content = React.findDOMNode( this.refs[ 'scrollable-content' ] );
 		var scrollTop = content.scrollTop;
 		var scrollHeight = content.scrollHeight;
@@ -118,7 +118,7 @@ import smartSetState from 'lib/react-smart-set-state';
 			content.scrollTop = 0;
 			return this.cancelScrollEvent( event );
 		}
-    },
+	},
 
 	render() {
 		let containerClasses,

--- a/client/components/scrollable-container/style.scss
+++ b/client/components/scrollable-container/style.scss
@@ -45,7 +45,7 @@
 		}
 	}
 
-	&.is-scrolled {
+	&.is-scrolled-to-bottom {
 		.scroll-indicator,
 		&:after {
 			opacity: 0;

--- a/client/components/scrollable-container/style.scss
+++ b/client/components/scrollable-container/style.scss
@@ -23,7 +23,7 @@
 		}
 
 		.gridicon {
-			fill: $gray;
+			fill: lighten( $gray, 10 );
 		}
 	}
 

--- a/client/components/scrollable-container/style.scss
+++ b/client/components/scrollable-container/style.scss
@@ -5,6 +5,7 @@
 
 // Fade Overlay
 .is-scrollable {
+
 	.scroll-indicator {
 		display: block;
 		pointer-events: none;
@@ -14,8 +15,12 @@
 			left: 0;
 		height: 24px;
 		text-align: center;
-		width: $sidebar-width-max;
+		width: $sidebar-width-min;
 		transition: all 0.15s ease-in-out;
+
+		@include breakpoint( ">960px" ) {
+			width: $sidebar-width-max;
+		}
 
 		.gridicon {
 			fill: $gray;
@@ -31,15 +36,29 @@
 		display: block;
 		content: '';
 		height: 56px;
-		width: $sidebar-width-max;
+		width: $sidebar-width-min;
 		background: linear-gradient( to bottom, rgba( lighten( $gray, 30% ), 0 ) 0%, rgba( lighten( $gray, 30% ), 1 ) 70% );
 		transition: all 0.15s ease-in-out;
+
+		@include breakpoint( ">960px" ) {
+			width: $sidebar-width-max;
+		}
 	}
 
 	&.is-scrolled {
 		.scroll-indicator,
 		&:after {
 			opacity: 0;
+		}
+	}
+}
+
+// Don't show the indicator on mobile
+@include breakpoint( "<660px" ) {
+	.is-scrollable {
+		.scroll-indicator,
+		&:after {
+			display: none;
 		}
 	}
 }

--- a/client/components/scrollable-container/style.scss
+++ b/client/components/scrollable-container/style.scss
@@ -1,0 +1,45 @@
+
+.scroll-indicator {
+	display: none;
+}
+
+// Fade Overlay
+.is-scrollable {
+	.scroll-indicator {
+		display: block;
+		pointer-events: none;
+		z-index: 2;
+		position: fixed;
+			bottom: 16px;
+			left: 0;
+		height: 24px;
+		text-align: center;
+		width: $sidebar-width-max;
+		transition: all 0.15s ease-in-out;
+
+		.gridicon {
+			fill: $gray;
+		}
+	}
+
+	&:after {
+		pointer-events: none;
+		z-index: 1;
+		position: fixed;
+			bottom: 0;
+			left: 0;
+		display: block;
+		content: '';
+		height: 56px;
+		width: $sidebar-width-max;
+		background: linear-gradient( to bottom, rgba( lighten( $gray, 30% ), 0 ) 0%, rgba( lighten( $gray, 30% ), 1 ) 70% );
+		transition: all 0.15s ease-in-out;
+	}
+
+	&.is-scrolled {
+		.scroll-indicator,
+		&:after {
+			opacity: 0;
+		}
+	}
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -73,6 +73,7 @@ module.exports = React.createClass( {
 		PollerPool.remove( this._sitesPoller );
 		this._sitesPoller = null;
 	},
+
 	closeWelcome: function() {
 		this.props.nuxWelcome.closeWelcome();
 		analytics.ga.recordEvent( 'Welcome Box', 'Clicked Close Button' );

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -13,7 +13,8 @@ var MenuItem = require( './sidebar-item' ),
 	eventRecorder = require( 'me/event-recorder' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	FormButton = require( 'components/forms/form-button' ),
-	userUtilities = require( 'lib/user/utils' );
+	userUtilities = require( 'lib/user/utils' ),
+	ScrollableContainer = require( 'components/scrollable-container' );
 
 module.exports = React.createClass( {
 
@@ -55,7 +56,7 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<div className="me-sidebar__menu">
+			<ScrollableContainer>
 				<ul className="wpcom-sidebar sidebar">
 
 					<ProfileGravatar user={ this.props.user.get() } />
@@ -123,7 +124,7 @@ module.exports = React.createClass( {
 						</ul>
 					</li>
 				</ul>
-			</div>
+			</ScrollableContainer>
 		);
 	},
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -20,7 +20,8 @@ var config = require( 'config' ),
 	getCustomizeUrl = require( 'lib/themes/helpers' ).getCustomizeUrl,
 	SidebarMenuItem = require( './sidebar-menu-item' ),
 	AdsUtils = require( 'lib/ads/utils' ),
-	Gridicon = require( 'components/gridicon' );
+	Gridicon = require( 'components/gridicon' ),
+	ScrollableContainer = require( 'components/scrollable-container' );
 
 module.exports = React.createClass( {
 	displayName: 'MySitesSidebar',
@@ -629,64 +630,66 @@ module.exports = React.createClass( {
 			vip = !! this.vip();
 
 		return (
-			<ul className="wpcom-sidebar sidebar">
-				<CurrentSite sites={ this.props.sites } siteCount={ this.props.user.get().visible_site_count } />
+			<ScrollableContainer>
+				<ul className="wpcom-sidebar sidebar">
+					<CurrentSite sites={ this.props.sites } siteCount={ this.props.user.get().visible_site_count } />
 
-				<li className="sidebar-menu">
-					<ul>
-						{ this.homepage() }
-						{ this.stats() }
-						{ this.ads() }
-						{ this.plan() }
-					</ul>
-				</li>
+					<li className="sidebar-menu">
+						<ul>
+							{ this.homepage() }
+							{ this.stats() }
+							{ this.ads() }
+							{ this.plan() }
+						</ul>
+					</li>
 
-				{ vip ?
-				<li className="sidebar-menu wordpress-utilities">
-					<h2 className="sidebar-heading">VIP</h2>
-					<ul>
-						{ this.vip() }
-						{ this.vipDeploys() }
-						{ this.vipBilling() }
-						{ this.vipSupport() }
-						{ this.vipBackups() }
-						{ this.vipLogs() }
-					</ul>
-				</li>
-				: null }
+					{ vip ?
+					<li className="sidebar-menu wordpress-utilities">
+						<h2 className="sidebar-heading">VIP</h2>
+						<ul>
+							{ this.vip() }
+							{ this.vipDeploys() }
+							{ this.vipBilling() }
+							{ this.vipSupport() }
+							{ this.vipBackups() }
+							{ this.vipLogs() }
+						</ul>
+					</li>
+					: null }
 
-				{ publish ?
-				<li className="sidebar-menu wordpress-content">
-					<h2 className="sidebar-heading">{ this.translate( 'Publish' ) }</h2>
-					{ this.publish() }
-				</li>
-				: null }
+					{ publish ?
+					<li className="sidebar-menu wordpress-content">
+						<h2 className="sidebar-heading">{ this.translate( 'Publish' ) }</h2>
+						{ this.publish() }
+					</li>
+					: null }
 
-				{ appearance ?
-				<li className="sidebar-menu wordpress-appearance">
-					<h2 className="sidebar-heading">{ this.translate( 'Personalize' ) }</h2>
-					<ul>
-						{ this.themes() }
-						{ this.menus() }
-					</ul>
-				</li>
-				: null }
+					{ appearance ?
+					<li className="sidebar-menu wordpress-appearance">
+						<h2 className="sidebar-heading">{ this.translate( 'Personalize' ) }</h2>
+						<ul>
+							{ this.themes() }
+							{ this.menus() }
+						</ul>
+					</li>
+					: null }
 
-				{ configuration ?
-				<li className="sidebar-menu wordpress-utilities">
-					<h2 className="sidebar-heading">{ this.translate( 'Configure' ) }</h2>
-					<ul>
-						{ this.sharing() }
-						{ this.users() }
-						{ this.plugins() }
-						{ this.upgrades() }
-						{ this.siteSettings() }
-						{ this.wpAdmin() }
-					</ul>
-				</li>
-				: null }
+					{ configuration ?
+					<li className="sidebar-menu wordpress-utilities">
+						<h2 className="sidebar-heading">{ this.translate( 'Configure' ) }</h2>
+						<ul>
+							{ this.sharing() }
+							{ this.users() }
+							{ this.plugins() }
+							{ this.upgrades() }
+							{ this.siteSettings() }
+							{ this.wpAdmin() }
+						</ul>
+					</li>
+					: null }
 
-			</ul>
+				</ul>
+			</ScrollableContainer>
 		);
 	}
 } );

--- a/client/reader/sidebar/sidebar.jsx
+++ b/client/reader/sidebar/sidebar.jsx
@@ -80,6 +80,30 @@ module.exports = React.createClass( {
 		ReaderLists.on( 'change', this.updateState );
 		ReaderLists.on( 'create', this.highlightNewList );
 		ReaderTeams.on( 'change', this.updateState );
+		window.addEventListener( 'resize', this.checkSidebarScrollable );
+	},
+
+	checkSidebarScrollable: function() {
+		var windowHeight = window.innerHeight,
+			sidebar = React.findDOMNode( this.refs.sidebar ),
+			sidebarHeight = sidebar.scrollHeight;
+
+		if ( sidebarHeight > ( windowHeight ) ) {
+			this.setState( { isSidebarScrollable: true } );
+		} else {
+			this.setState( { isSidebarScrollable: false } );
+		}
+	},
+
+	checkSidebarScrolled: function() {
+		var sidebar = React.findDOMNode( this.refs.sidebar ),
+			isAtBottom = ( sidebar.scrollTop === ( sidebar.scrollHeight - sidebar.offsetHeight ) );
+
+		if ( isAtBottom ) {
+			this.setState( { isSidebarScrolled: true } );
+		} else {
+			this.setState( { isSidebarScrolled: false } );
+		}
 	},
 
 	componentWillUnmount: function() {
@@ -88,10 +112,15 @@ module.exports = React.createClass( {
 		ReaderLists.off( 'change', this.updateState );
 		ReaderLists.off( 'create', this.highlightNewList );
 		ReaderTeams.off( 'change', this.updateState );
+
+		window.removeEventListener( 'resize', this.adjustOverflowOverlay );
 	},
 
 	getInitialState: function() {
-		return this.getStateFromStores();
+		return assign( {
+			isSidebarScrollable: false,
+			isSidebarScrolled: false
+		}, this.getStateFromStores() );
 	},
 
 	getStateFromStores: function() {
@@ -112,6 +141,7 @@ module.exports = React.createClass( {
 
 	updateState: function() {
 		this.setState( this.getStateFromStores() );
+		this.checkSidebarScrollable();
 	},
 
 	followTag: function( event ) {
@@ -270,79 +300,90 @@ module.exports = React.createClass( {
 	render: function() {
 		let followingEditLink = this.getFollowingEditLink();
 
+		var containerClasses = classnames( {
+			'is-scrollable': this.state.isSidebarScrollable,
+			'is-scrolled': this.state.isSidebarScrolled
+		}, 'wp-sidebar-container' );
+
+		var sidebarClasses = classnames( 'wpcom-sidebar', 'sidebar', 'reader-sidebar' );
+
 		return (
-			<ul className="wpcom-sidebar sidebar reader-sidebar" onClick={ this.handleClick }>
-				<li className="sidebar-menu sidebar-streams">
-					<h2 className="sidebar-heading">{ this.translate( 'Streams' ) }</h2>
-					<ul>
-						<li className={ this.itemLinkClass( '/', { 'sidebar-streams__following': true } ) }>
-							<a href="/">
-								<Gridicon icon="checkmark-circle" size={ 24 } />
-								<span className="menu-link-text">{ this.translate( 'Followed Sites' ) }</span>
-							</a>
-							<a href={ followingEditLink.url } rel={ followingEditLink.rel } className="add-new">{ this.translate( 'Manage' ) }</a>
-						</li>
+			<div className={ containerClasses }>
+				<ul id="wp-sidebar" className={ sidebarClasses } onClick={ this.handleClick } onScroll={ this.checkSidebarScrolled } ref="sidebar">
+					<li className="sidebar-menu sidebar-streams">
+						<h2 className="sidebar-heading">{ this.translate( 'Streams' ) }</h2>
+						<ul>
+							<li className={ this.itemLinkClass( '/', { 'sidebar-streams__following': true } ) }>
+								<a href="/">
+									<Gridicon icon="checkmark-circle" size={ 24 } />
+									<span className="menu-link-text">{ this.translate( 'Followed Sites' ) }</span>
+								</a>
+								<a href={ followingEditLink.url } rel={ followingEditLink.rel } className="add-new">{ this.translate( 'Manage' ) }</a>
+							</li>
 
-						{ this.renderTeams() }
+							{ this.renderTeams() }
 
-						{
-							discoverHelper.isEnabled()
-							? (
-									<li className={ this.itemLinkClass( '/discover', { 'sidebar-streams__discover': true } ) }>
-										<a href="/discover">
-											<Gridicon icon="my-sites" />
-											<span className="menu-link-text">{ this.translate( 'Discover' ) }</span>
-										</a>
-									</li>
-								) : null
+							{
+								discoverHelper.isEnabled()
+								? (
+										<li className={ this.itemLinkClass( '/discover', { 'sidebar-streams__discover': true } ) }>
+											<a href="/discover">
+												<Gridicon icon="my-sites" />
+												<span className="menu-link-text">{ this.translate( 'Discover' ) }</span>
+											</a>
+										</li>
+									) : null
+							}
+
+							{
+								config.isEnabled( 'reader/recommendations' )
+								? ( <li className={ this.itemLinkClassStartsWithOneOf( [ '/recommendations', '/tags' ], { 'sidebar-streams__recommendations': true } ) }>
+									<a href="/recommendations">
+										<svg className="gridicon menu-link-icon" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 24 24"><g><path d="M7.189,12.664l0.624-0.046l0.557-0.409l0.801-1.115l0.578-1.228l0.357-0.91l0.223-0.523l0.267-0.432 l0.49-0.409l0.578-0.5l0.445-0.682l0.267-1.046l0.29-1.934V3.159L12.931,3l0.467,0.046l0.534,0.227l0.49,0.363L14.8,4.25 l0.177,0.75V5.66l-0.088,0.865l-0.223,0.615l-0.378,0.75l-0.2,0.5l-0.246,0.546l-0.133,0.5v0.432l0.111,0.273l2.38-0.023 l1.135,0.069l0.823,0.113l0.49,0.159l0.288,0.319l0.424,0.523l0.156,0.454v0.319l-0.09,0.296l-0.2,0.227l-0.29,0.5l0.111,0.296 l0.223,0.409l0.201,0.204l0.111,0.364l-0.09,0.273l-0.267,0.296l-0.267,0.34l-0.111,0.364l0.088,0.319l0.157,0.363l0.11,0.342v0.25 l-0.11,0.363l-0.223,0.273l-0.313,0.296l-0.223,0.273l-0.088,0.273v0.319l0.023,0.409l-0.111,0.25l-0.313,0.342l-0.4,0.363 c0,0-0.156,0.137-0.378,0.25c-0.223,0.114-0.868,0.273-0.868,0.273l-0.846,0.091l-1.868-0.023l-1.937-0.091l-1.379-0.159 l-2.916-0.523L7.189,12.664z M3,13.986c0-0.939,0.761-1.7,1.702-1.7c0.939,0,1.702,0.762,1.702,1.7v4.596 c0,0.939-0.762,1.7-1.702,1.7C3.761,20.283,3,19.52,3,18.582V13.986z"/></g></svg>
+										<span className="menu-link-text">{ this.translate( 'Recommendations' ) }</span>
+									</a>
+							</li> )
+							: ( <li className={ this.itemLinkClass( '/recommendations', { 'sidebar-streams__recommendations': true } ) }>
+								<a href="https://wordpress.com/recommendations/" rel="external">
+									<Gridicon icon="star-outline" />
+									<span className="menu-link-text">{ this.translate( 'Recommended Blogs' ) }</span>
+								</a>
+							</li> )
 						}
 
-						{
-							config.isEnabled( 'reader/recommendations' )
-							? ( <li className={ this.itemLinkClassStartsWithOneOf( [ '/recommendations', '/tags' ], { 'sidebar-streams__recommendations': true } ) }>
-								<a href="/recommendations">
-									<svg className="gridicon menu-link-icon" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 24 24"><g><path d="M7.189,12.664l0.624-0.046l0.557-0.409l0.801-1.115l0.578-1.228l0.357-0.91l0.223-0.523l0.267-0.432 l0.49-0.409l0.578-0.5l0.445-0.682l0.267-1.046l0.29-1.934V3.159L12.931,3l0.467,0.046l0.534,0.227l0.49,0.363L14.8,4.25 l0.177,0.75V5.66l-0.088,0.865l-0.223,0.615l-0.378,0.75l-0.2,0.5l-0.246,0.546l-0.133,0.5v0.432l0.111,0.273l2.38-0.023 l1.135,0.069l0.823,0.113l0.49,0.159l0.288,0.319l0.424,0.523l0.156,0.454v0.319l-0.09,0.296l-0.2,0.227l-0.29,0.5l0.111,0.296 l0.223,0.409l0.201,0.204l0.111,0.364l-0.09,0.273l-0.267,0.296l-0.267,0.34l-0.111,0.364l0.088,0.319l0.157,0.363l0.11,0.342v0.25 l-0.11,0.363l-0.223,0.273l-0.313,0.296l-0.223,0.273l-0.088,0.273v0.319l0.023,0.409l-0.111,0.25l-0.313,0.342l-0.4,0.363 c0,0-0.156,0.137-0.378,0.25c-0.223,0.114-0.868,0.273-0.868,0.273l-0.846,0.091l-1.868-0.023l-1.937-0.091l-1.379-0.159 l-2.916-0.523L7.189,12.664z M3,13.986c0-0.939,0.761-1.7,1.702-1.7c0.939,0,1.702,0.762,1.702,1.7v4.596 c0,0.939-0.762,1.7-1.702,1.7C3.761,20.283,3,19.52,3,18.582V13.986z"/></g></svg>
-									<span className="menu-link-text">{ this.translate( 'Recommendations' ) }</span>
+							<li className={ this.itemLinkClass( '/activities/likes', { 'sidebar-activity__likes': true } ) }>
+								<a href="/activities/likes">
+									<Gridicon icon="star" size={ 24 } />
+									<span className="menu-link-text">{ this.translate( 'My Likes' ) }</span>
 								</a>
-						</li> )
-						: ( <li className={ this.itemLinkClass( '/recommendations', { 'sidebar-streams__recommendations': true } ) }>
-							<a href="https://wordpress.com/recommendations/" rel="external">
-								<Gridicon icon="star-outline" />
-								<span className="menu-link-text">{ this.translate( 'Recommended Blogs' ) }</span>
-							</a>
-						</li> )
-					}
+							</li>
+						</ul>
+					</li>
 
-						<li className={ this.itemLinkClass( '/activities/likes', { 'sidebar-activity__likes': true } ) }>
-							<a href="/activities/likes">
-								<Gridicon icon="star" size={ 24 } />
-								<span className="menu-link-text">{ this.translate( 'My Likes' ) }</span>
-							</a>
-						</li>
-					</ul>
-				</li>
+					<li className="sidebar-menu sidebar-dynamic-menu">
+						<h2 className="sidebar-heading">{ this.translate( 'Lists' ) }</h2>
+						<ul>
+							{ this.renderLists() }
 
-				<li className="sidebar-menu sidebar-dynamic-menu">
-					<h2 className="sidebar-heading">{ this.translate( 'Lists' ) }</h2>
-					<ul>
-						{ this.renderLists() }
+							<li className="sidebar-dynamic-menu__add" key="add-list">
+								<input className="sidebar-dynamic-menu__add-input" type="text" placeholder={ this.translate( 'New List' ) } ref="addListInput" onKeyDown={ this.handleCreateListKeyDown } />
+							</li>
+						</ul>
+					</li>
 
-						<li className="sidebar-dynamic-menu__add" key="add-list">
-							<input className="sidebar-dynamic-menu__add-input" type="text" placeholder={ this.translate( 'New List' ) } ref="addListInput" onKeyDown={ this.handleCreateListKeyDown } />
-						</li>
-					</ul>
-				</li>
+					<li className="sidebar-menu sidebar-dynamic-menu">
+						<h2 className="sidebar-heading">{ this.translate( 'Tags' ) }</h2>
+						<ul>
+							{ this.renderTags() }
+							<li className="sidebar-dynamic-menu__add" key="add-tag">
+								<input className="sidebar-dynamic-menu__add-input" type="text" placeholder={ this.translate( 'Follow a Tag' ) } ref="addTagInput" onKeyDown={ this.handleFollowTagKeyDown } />
+							</li>
+						</ul>
+					</li>
+				</ul>
 
-				<li className="sidebar-menu sidebar-dynamic-menu">
-					<h2 className="sidebar-heading">{ this.translate( 'Tags' ) }</h2>
-					<ul>
-						{ this.renderTags() }
-						<li className="sidebar-dynamic-menu__add" key="add-tag">
-							<input className="sidebar-dynamic-menu__add-input" type="text" placeholder={ this.translate( 'Follow a Tag' ) } ref="addTagInput" onKeyDown={ this.handleFollowTagKeyDown } />
-						</li>
-					</ul>
-				</li>
-			</ul>
+				<div className="scroll-indicator"><Gridicon icon="chevron-down" /></div>
+			</div>
 		);
 	}
 } );

--- a/client/reader/sidebar/sidebar.jsx
+++ b/client/reader/sidebar/sidebar.jsx
@@ -275,7 +275,7 @@ module.exports = React.createClass( {
 
 		return (
 			<ScrollableContainer>
-				<ul id="wp-sidebar" className={ sidebarClasses } onClick={ this.handleClick } ref="sidebar">
+				<ul className={ sidebarClasses } onClick={ this.handleClick } ref="sidebar">
 					<li className="sidebar-menu sidebar-streams">
 						<h2 className="sidebar-heading">{ this.translate( 'Streams' ) }</h2>
 						<ul>

--- a/client/reader/sidebar/sidebar.jsx
+++ b/client/reader/sidebar/sidebar.jsx
@@ -27,7 +27,8 @@ const layoutFocus = require( 'lib/layout-focus' ),
 	stats = require( 'reader/stats' ),
 	Gridicon = require( 'components/gridicon' ),
 	config = require( 'config' ),
-	discoverHelper = require( 'reader/discover/helper' );
+	discoverHelper = require( 'reader/discover/helper' ),
+	ScrollableContainer = require( 'components/scrollable-container' );
 
 module.exports = React.createClass( {
 	displayName: 'ReaderSidebar',
@@ -80,30 +81,6 @@ module.exports = React.createClass( {
 		ReaderLists.on( 'change', this.updateState );
 		ReaderLists.on( 'create', this.highlightNewList );
 		ReaderTeams.on( 'change', this.updateState );
-		window.addEventListener( 'resize', this.checkSidebarScrollable );
-	},
-
-	checkSidebarScrollable: function() {
-		var windowHeight = window.innerHeight,
-			sidebar = React.findDOMNode( this.refs.sidebar ),
-			sidebarHeight = sidebar.scrollHeight;
-
-		if ( sidebarHeight > ( windowHeight ) ) {
-			this.setState( { isSidebarScrollable: true } );
-		} else {
-			this.setState( { isSidebarScrollable: false } );
-		}
-	},
-
-	checkSidebarScrolled: function() {
-		var sidebar = React.findDOMNode( this.refs.sidebar ),
-			isAtBottom = ( sidebar.scrollTop === ( sidebar.scrollHeight - sidebar.offsetHeight ) );
-
-		if ( isAtBottom ) {
-			this.setState( { isSidebarScrolled: true } );
-		} else {
-			this.setState( { isSidebarScrolled: false } );
-		}
 	},
 
 	componentWillUnmount: function() {
@@ -112,15 +89,10 @@ module.exports = React.createClass( {
 		ReaderLists.off( 'change', this.updateState );
 		ReaderLists.off( 'create', this.highlightNewList );
 		ReaderTeams.off( 'change', this.updateState );
-
-		window.removeEventListener( 'resize', this.adjustOverflowOverlay );
 	},
 
 	getInitialState: function() {
-		return assign( {
-			isSidebarScrollable: false,
-			isSidebarScrolled: false
-		}, this.getStateFromStores() );
+		return this.getStateFromStores();
 	},
 
 	getStateFromStores: function() {
@@ -141,7 +113,6 @@ module.exports = React.createClass( {
 
 	updateState: function() {
 		this.setState( this.getStateFromStores() );
-		this.checkSidebarScrollable();
 	},
 
 	followTag: function( event ) {
@@ -300,16 +271,11 @@ module.exports = React.createClass( {
 	render: function() {
 		let followingEditLink = this.getFollowingEditLink();
 
-		var containerClasses = classnames( {
-			'is-scrollable': this.state.isSidebarScrollable,
-			'is-scrolled': this.state.isSidebarScrolled
-		}, 'wp-sidebar-container' );
-
 		var sidebarClasses = classnames( 'wpcom-sidebar', 'sidebar', 'reader-sidebar' );
 
 		return (
-			<div className={ containerClasses }>
-				<ul id="wp-sidebar" className={ sidebarClasses } onClick={ this.handleClick } onScroll={ this.checkSidebarScrolled } ref="sidebar">
+			<ScrollableContainer>
+				<ul id="wp-sidebar" className={ sidebarClasses } onClick={ this.handleClick } ref="sidebar">
 					<li className="sidebar-menu sidebar-streams">
 						<h2 className="sidebar-heading">{ this.translate( 'Streams' ) }</h2>
 						<ul>
@@ -381,9 +347,7 @@ module.exports = React.createClass( {
 						</ul>
 					</li>
 				</ul>
-
-				<div className="scroll-indicator"><Gridicon icon="chevron-down" /></div>
-			</div>
+			</ScrollableContainer>
 		);
 	}
 } );


### PR DESCRIPTION
Its not always obvious that the sidebar is scrollable. At many window heights the sidebar simply looks "finished," and unless you have scrollbars on (off by default on OS X) there's no indication of additional items in the menu:

![screen shot 2015-12-09 at 4 17 04 pm](https://cloud.githubusercontent.com/assets/191598/11699070/4c673d12-9e90-11e5-8296-f2a4e8bcb892.png)

This PR adds a new component called `<ScrollableContainer>` which tracks the height of it's child and displays a scroll indicator accordingly:

![screen shot 2015-12-09 at 4 14 46 pm](https://cloud.githubusercontent.com/assets/191598/11699100/7eb92b86-9e90-11e5-8bf0-6f55e8d8430d.png)

When you reach the bottom of the container, the indicator fades away:

![screen shot 2015-12-09 at 4 15 00 pm](https://cloud.githubusercontent.com/assets/191598/11699105/89bc9e78-9e90-11e5-9b5c-2c10904fc705.png)

The indicator (and the padding the comes along with it) only appears when needed. That is, if the container can fully fit within the window, then we don't do anything special.

The new `<ScrollableContainer>` component also adds a scroll locking behavior. This means that scrolling within the container doesn't affect the scrolling of the page. So now when you scroll to the bottom of the sidebar, the page doesn't start scrolling down.