### PR TITLE
Signup: Verticals Survey: Disable the Verticals Survey

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -16,15 +16,6 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
-	verticalSurvey: {
-		datestamp: '20151202',
-		variations: {
-			noSurvey: 12,
-			oneStep: 44,
-			twoStep: 44
-		},
-		defaultVariation: 'noSurvey'
-	},
 	translatorInvitation: {
 		datestamp: '20150910',
 		variations: {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -103,8 +103,6 @@ module.exports = {
 				ab_test_variations: getSavedVariations(),
 				validate: false,
 				signup_flow_name: flowName,
-				nux_q_site_type: dependencies.surveySiteType,
-				nux_q_question_primary: dependencies.surveyQuestion,
 				jetpack_redirect: queryArgs.jetpackRedirect
 			}
 		), ( error, response ) => {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -9,7 +9,6 @@ var assign = require( 'lodash/object/assign' ),
 */
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
-	abtest = require( 'lib/abtest' ).abtest,
 	user = require( 'lib/user' )();
 
 function getCheckoutDestination( dependencies ) {
@@ -63,20 +62,6 @@ const flows = {
 		destination: '/me/next/welcome',
 		description: 'This flow is used to test the site step.',
 		lastModified: '2015-09-22'
-	},
-
-	'vert-blog': {
-		steps: abtest( 'verticalSurvey' ) === 'noSurvey' ? [ 'themes', 'domains', 'plans', 'user' ] : [ 'survey-blog', 'themes', 'domains', 'plans', 'survey-user' ],
-		destination: getCheckoutDestination,
-		description: 'Categorizing blog signups for Verticals Survey',
-		lastModified: null
-	},
-
-	'vert-site': {
-		steps: abtest( 'verticalSurvey' ) === 'noSurvey' ? [ 'themes', 'domains', 'plans', 'user' ] : [ 'survey-site', 'themes', 'domains', 'plans', 'survey-user' ],
-		destination: getCheckoutDestination,
-		description: 'Categorizing site signups for Verticals Survey',
-		lastModified: null
 	},
 
 	headstart: {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -7,7 +7,6 @@ var EmailSignupComponent = require( 'signup/steps/email-signup-form' ),
 	PlansStepComponent = require( 'signup/steps/plans' ),
 	DomainsStepComponent = require( 'signup/steps/domains' ),
 	DSSStepComponent = require( 'signup/steps/dss' ),
-	SurveyStepComponent = require( 'signup/steps/survey' ),
 	config = require( 'config' );
 
 module.exports = {
@@ -18,9 +17,6 @@ module.exports = {
 	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
 	plans: PlansStepComponent,
 	domains: DomainsStepComponent,
-	'survey-blog': SurveyStepComponent,
-	'survey-site': SurveyStepComponent,
-	'survey-user': EmailSignupComponent,
 	'domains-with-theme': DomainsStepComponent,
 	'theme-dss': DSSStepComponent,
 	'jetpack-user': EmailSignupComponent

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -35,32 +35,6 @@ module.exports = {
 		stepName: 'test',
 	},
 
-	'survey-user': {
-		stepName: 'survey-user',
-		apiRequestFunction: stepActions.createAccount,
-		dependencies: [ 'surveySiteType', 'surveyQuestion' ],
-		providesToken: true,
-		providesDependencies: [ 'bearer_token', 'username' ]
-	},
-
-	'survey-blog': {
-		stepName: 'survey-blog',
-		props: {
-			surveySiteType: 'blog',
-			isOneStep: abtest( 'verticalSurvey' ) === 'oneStep'
-		},
-		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
-	},
-
-	'survey-site': {
-		stepName: 'survey-site',
-		props: {
-			surveySiteType: 'site',
-			isOneStep: abtest( 'verticalSurvey' ) === 'oneStep'
-		},
-		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
-	},
-
 	plans: {
 		stepName: 'plans',
 		apiRequestFunction: stepActions.addPlanToCart,


### PR DESCRIPTION
There were some bugs around stats collection and some strange behavior in
Firefox and iOS Chrome. We are disabling the test for now and will re-start when
things are working correctly again.

Firefox/iOS Chrome bug is #1310 

As noted in other places, the first part of the Verticals Survey is a home page variation for new users. Disabling that variation should happen first and is outside Calypso.