### PR TITLE
Signup: Nux Trampoline - add Nux Trampoline AB test i2

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -62,5 +62,14 @@ module.exports = {
 			notTested: 70
 		},
 		defaultVariation: 'main'
+	},
+	nuxTrampoline: {
+		datestamp: '20151210',
+		variations: {
+			main: 25,
+			trampoline: 25,
+			notTested: 50
+		},
+		defaultVariation: 'main'
 	}
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -10,12 +10,18 @@ var assign = require( 'lodash/object/assign' ),
 */
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
-	user = require( 'lib/user' )(),
-	abtest = require( 'lib/abtest' ).abtest;
+	abtest = require( 'lib/abtest' ).abtest,
+	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
+	user = require( 'lib/user' )();
 
 function getCheckoutDestination( dependencies ) {
 	if ( dependencies.cartItem || dependencies.domainItem ) {
 		return '/checkout/' + dependencies.siteSlug;
+	}
+
+	/* NUX Trampoline A/B */
+	if ( 'trampoline' === getABTestVariation( 'nuxTrampoline' ) ) {
+		return 'https://' + dependencies.siteSlug;
 	}
 
 	return '/me/next?welcome';

--- a/client/signup/steps/email-signup-form/index.jsx
+++ b/client/signup/steps/email-signup-form/index.jsx
@@ -11,6 +11,7 @@ import StepWrapper from 'signup/step-wrapper'
 import SignupForm from 'components/signup-form'
 import signupUtils from 'signup/utils'
 import SignupActions from 'lib/signup/actions'
+import { abtest } from 'lib/abtest'
 
 export default React.createClass( {
 
@@ -42,6 +43,11 @@ export default React.createClass( {
 		} );
 
 		analytics.tracks.recordEvent( 'calypso_signup_user_step_submit', analyticsData );
+
+		// run and record before creating user, only for free and in main flow
+		if ( ! this.props.signupDependencies.cartItem && this.props.flowName === 'main' ) {
+			abtest( 'nuxTrampoline' );
+		}
 
 		SignupActions.submitSignupStep( {
 			processingMessage: this.translate( 'Creating your account' ),


### PR DESCRIPTION
## Goal
Find a teaching, front end alternative to `/me/next` with similar or better engagement metrics (customization, posting) and purchasing conversions.

**Note:** This is a second attempt at the NUX Trampoline AB i1 test (pre wp-calypso). Due to #908 and our use of the `?landing` query parameter for the Trampoline, our initial metrics can't be trusted.

## Hypothesis
Exiting non-upgrade signup on the front end of a user's site, with the 'Trampoline' guide will encourage and teach users to use the My Sites menu to customize, post, and purchase upgrades as well or better than the current `/me/next` landing page.

## Success Indicators
- Engagement: based on site customization and publishing of new posts and pages
- Purchasing Conversions: based on internal stats

## Control/Variants
- Control: exit non-upgrade signup after the default (main) flow at `/me/next`
- Variation: exit non-upgrade signup after the default flow at the front end with Trampoline

## Traffic Allocation
- Control: 25%
- Variation: 25%
- notTested*: 50%

*I've also added a `notTested` variation for future signup flow tests to use.