### PR TITLE
Signup: Verticals Survey: Fix redirect-after-survey bug

### DIFF
--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -38,8 +38,13 @@ export default React.createClass( {
 	},
 
 	renderStepTwoVertical( vertical ) {
+		const stepTwoClickHandler = ( event ) => {
+			event.preventDefault();
+			event.stopPropagation();
+			this.handleNextStep( vertical );
+		}
 		return (
-			<Card className="survey-step__vertical" key={ vertical.value } href="#" onClick={ this.handleNextStep.bind( null, vertical ) }>
+			<Card className="survey-step__vertical" key={ vertical.value } href="#" onClick={ stepTwoClickHandler }>
 				<label className="survey-step__label">{ vertical.label }</label>
 			</Card>
 		);
@@ -47,7 +52,15 @@ export default React.createClass( {
 
 	renderStepOneVertical( vertical ) {
 		const icon = vertical.icon || 'user';
-		const stepOneClickHandler = this.props.isOneStep ? this.handleNextStep.bind( null, vertical ) : this.showStepTwo.bind( null, vertical );
+		const stepOneClickHandler = ( event ) => {
+			event.preventDefault();
+			event.stopPropagation();
+			if ( this.props.isOneStep ) {
+				this.handleNextStep( vertical )
+				return;
+			}
+			this.showStepTwo( vertical );
+		}
 		return (
 			<Card className="survey-step__vertical" key={ 'step-one-' + vertical.value } href="#" onClick={ stepOneClickHandler }>
 				<Gridicon icon={ icon } className="survey-step__vertical__icon"/>


### PR DESCRIPTION
Fixes #1310

The redirect was happening because in some browsers (iOS Chrome, Mac OS Firefox)
the `#` href in the `Card` components was redirecting the user back to the
survey step after the click handler had moved on to the next signup step. The
`#` href is necessary to force the `Card` components to display as clickable.

This fixes the issue by calling `preventDefault` and `stopPropagation` in the
click handler.

## Testing

1. You'll first have to add a signup flow to access the `survey` component, or find one in the recent history (before #1445 was merged). This may be done for you, depending on if checking out this branch works correctly.
2. Visit http://calypso.localhost:3000/start/vert-site (or whatever your flow name is) using Mac OS Firefox.
3. Make sure you're in the `oneStep` test by entering this into your console: `localStorage.setItem( 'ABTests', "{'verticalSurvey_20151202':'oneStep'}" );`. Then reload the page to make sure you see the survey.
4. Click one of the choices.
5. You should be redirected to the next step (`themes`) and stay there (previously you would be bounced back to the survey step)