### PR TITLE
Components: Prevent <Search> from stealing the focus when typing elsewhere

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -82,14 +82,8 @@ module.exports = React.createClass( {
 	},
 
 	componentDidUpdate: function( prevProps, prevState ) {
-		// Focus if we aren't disabled and have a value from user, or the
-		// search box was opened, or the autoFocus prop has changed
+		// Focus if the search box was opened or the autoFocus prop has changed
 		if (
-			(
-				! this.props.disabled &&
-				this.state.keyword &&
-				this.state.keyword !== this.props.initialValue
-			) ||
 			( this.state.isOpen && ! prevState.isOpen ) ||
 			( this.props.autoFocus && ! prevProps.autoFocus )
 		) {


### PR DESCRIPTION
This fixes #1389 where if the location field has user-entered text, it steals the focus back when typing into another text field:

![location-steals-focus](https://cloud.githubusercontent.com/assets/227022/11676067/835a8104-9df4-11e5-8a71-edb56b576596.gif)

I'm not seeing a good reason why we would want the `<Search>` component to focus itself if it has text:  in any such situation, shouldn't it already be focused?

This code or some variation of it has been present since long before OSS release.  As far as I can tell, these are the conditions needed for the bug to surface:

- A `<Search>` and another text field both present on the same screen
- A structure that causes `componentDidUpdate` to be called when the other text field changes (in the editor, this is the case, but I'm not entirely sure why)

@aduth @mtias I saw your names a lot in the history of this component, want to take a look?