### PR TITLE
Me: Use $alert-red and $alert-green color variables

### DIFF
--- a/client/me/security-2fa-backup-codes/style.scss
+++ b/client/me/security-2fa-backup-codes/style.scss
@@ -8,7 +8,7 @@
 
 .security-2fa-backup-codes__status-not-verified {
 	text-transform: uppercase;
-	color: red;
+	color: $alert-red;
 	font-weight: bold;
 }
 
@@ -19,6 +19,6 @@
 
 .security-2fa-backup-codes__status-verified {
 	text-transform: uppercase;
-	color: green;
+	color: $alert-green;
 	font-weight: bold;
 }

--- a/client/me/security-2fa-status/style.scss
+++ b/client/me/security-2fa-status/style.scss
@@ -4,12 +4,12 @@
 
 .security-2fa-status__off {
 	text-transform: uppercase;
-	color: red;
+	color: $alert-red;
 	font-weight: bold;
 }
 
 .security-2fa-status__on {
 	text-transform: uppercase;
-	color: green;
+	color: $alert-green;
 	font-weight: bold;
 }


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/384 (Props @v18)

Updates `red` and `green` colors to use `$alert-red` and `$alert-green` color variables in /me/security/two-step. 

Before:
<img width="153" alt="screen shot 2015-12-09 at 5 58 35 pm" src="https://cloud.githubusercontent.com/assets/5835847/11702738/9636d534-9e9e-11e5-8c92-a59b414af4fd.png">
<img width="412" alt="screen shot 2015-12-09 at 5 58 40 pm" src="https://cloud.githubusercontent.com/assets/5835847/11702739/9637ef1e-9e9e-11e5-8645-a60b321fda78.png">

After:
<img width="365" alt="screen shot 2015-12-09 at 5 52 14 pm" src="https://cloud.githubusercontent.com/assets/5835847/11702745/9c1bd936-9e9e-11e5-8bd6-8a327efbf9c7.png">
<img width="365" alt="screen shot 2015-12-09 at 5 52 18 pm" src="https://cloud.githubusercontent.com/assets/5835847/11702746/9c1c2fa8-9e9e-11e5-9527-e1c4f0c011de.png">

Ping @rickybanister for review. 