### PR TITLE
Editor: Disable Toolbar Pin on isMobile not hasTouch

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -43,7 +43,6 @@ require( './plugins/calypso-alert/plugin' )();
 const formatting = require( 'lib/formatting' ),
 	user = require( 'lib/user' )(),
 	i18n = require( './i18n' ),
-	hasTouch = require( 'lib/touch-detect' ).hasTouch,
 	viewport = require( 'lib/viewport' );
 
 /**
@@ -170,7 +169,7 @@ module.exports = React.createClass( {
 			this.bindEditorEvents();
 			editor.on( 'SetTextAreaContent', ( event ) => this.setTextAreaContent( event.content ) );
 
-			if ( ! hasTouch() ) {
+			if ( ! viewport.isMobile() ) {
 				window.addEventListener( 'scroll', this.onScrollPinTools );
 				editor.once( 'PostRender', this.toggleEditor.bind( this, { autofocus: ! this.props.isNew } ) );
 			}

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -169,8 +169,8 @@ module.exports = React.createClass( {
 			this.bindEditorEvents();
 			editor.on( 'SetTextAreaContent', ( event ) => this.setTextAreaContent( event.content ) );
 
+			window.addEventListener( 'scroll', this.onScrollPinTools );
 			if ( ! viewport.isMobile() ) {
-				window.addEventListener( 'scroll', this.onScrollPinTools );
 				editor.once( 'PostRender', this.toggleEditor.bind( this, { autofocus: ! this.props.isNew } ) );
 			}
 		}.bind( this );


### PR DESCRIPTION
Fixes #1435 - Currently the editor toolbar being pinned as you scroll down the screen is disabled based upon 'lib/viewport/hasTouch()` - in order to prevent some sub-par experiences in mobile.  This approach though, as we discovered with other elements in the editor, led to some equally sub-par experiences on laptops with touch screens.

This branch replaces the `hasTouch` logic with `lib/viewport/isMobile`.

__To Test__
- Open up the editor in a desktop browser
- Scroll down the editor page, ensure the toolbar pins to the top as you scroll
- Ideally test this on a laptop with a touch display too
- Resize your browser window to hit the first mobile/tablet breakpoint
- Scroll down and verify that the toolbar no longer pins.