### PR TITLE
Help: Fix help search placeholders

### DIFF
--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -13,9 +13,15 @@ module.exports = React.createClass( {
 
 	mixins: [ React.addons.PureRenderMixin ],
 
+	onClick: function( event ) {
+		if ( this.props.helpLink.disabled ) {
+			event.preventDefault();
+		}
+	},
+
 	render: function() {
 		return (
-			<a className="help-result" href={ this.props.helpLink.link } target="__blank">
+			<a className="help-result" href={ this.props.helpLink.link } target="__blank" onClick={ this.onClick }>
 				<CompactCard className="help-result__wrapper">
 					<svg className="help-result__icon" width="24" height="24" viewBox="0 0 24 24">
 						<defs>

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -54,9 +54,10 @@ module.exports = React.createClass( {
 					<HelpResults
 						header="Dummy documentation header"
 						helpLinks={ [ {
-							title: 'Dummy titile',
-							description: 'Dummy very long description that displays an excerpt of support documentation content',
-							link: '#'
+							title: '',
+							description: '',
+							link: '#',
+							disabled: true
 						} ] }
 						footer="Dummy documentation footer"
 						iconPathDescription=""
@@ -78,19 +79,19 @@ module.exports = React.createClass( {
 				<HelpResults
 					header={ this.translate( 'WordPress.com Documentation' ) }
 					helpLinks={ this.state.helpLinks.wordpress_support_links }
-					footer={ this.translate( 'See more from WordPress.com Documentation...' ) }
+					footer={ this.translate( 'See more from WordPress.com Documentation…' ) }
 					iconPathDescription="M18.75 16.5h.75V3h-12c-1.656 0-3 1.344-3 3v12c0 1.656 1.344 3 3 3h12v-1.5h-.75c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5zm-11.25 3c-.828 0-1.5-.67-1.5-1.5s.672-1.5 1.5-1.5h9.585c-.36.4-.585.92-.585 1.5s.225 1.1.585 1.5H7.5z"
 					searchLink={ 'https://en.support.wordpress.com?s=' + this.state.searchQuery } />
 				<HelpResults
 					header={ this.translate( 'Community Answers' ) }
 					helpLinks={ this.state.helpLinks.wordpress_forum_links }
-					footer={ this.translate( 'See more from Community Forum...' ) }
+					footer={ this.translate( 'See more from Community Forum…' ) }
 					iconPathDescription="M16.5 3h-12c-1.656 0-3 1.344-3 3v4.5c0 1.656 1.344 3 3 3H6v5.25l5.25-5.25h5.25c1.656 0 3-1.344 3-3V6c0-1.656-1.344-3-3-3zM21 6v4.5c0 2.48-2.02 4.5-4.5 4.5h-4.63l-1.5 1.5h3.88l5.25 5.25V16.5H21c1.656 0 3-1.344 3-3V9c0-1.656-1.344-3-3-3z"
 					searchLink={ 'https://en.forums.wordpress.com/search.php?search=' + this.state.searchQuery } />
 				<HelpResults
 					header={ this.translate( 'Jetpack Documentation' ) }
 					helpLinks={ this.state.helpLinks.jetpack_support_links }
-					footer={ this.translate( 'See more from Jetpack Documentation...' ) }
+					footer={ this.translate( 'See more from Jetpack Documentation…' ) }
 					iconPathDescription="M12 1.5C6.15 1.5 1.5 6.15 1.5 12S6.15 22.5 12 22.5 22.5 17.85 22.5 12 17.85 1.5 12 1.5zM10.5 15l-3.45-.9c-.9-.15-1.35-1.2-.9-2.1l4.35-7.5V15zm7.35-3l-4.35 7.5V9l3.45.9c.9.15 1.35 1.2.9 2.1z"
 					searchLink="https://jetpack.me/support/" />
 			</div>


### PR DESCRIPTION
This pull request fixes the bug outlined in #1366.

To fix this I removed the dummy text and disabled clicking of the placeholder so that it no longer opens a new blank tab.

Before:
![](https://cloud.githubusercontent.com/assets/8658164/11656787/4729eee4-9daf-11e5-8b0b-23c2d5903b7f.png)

After:
![screen shot 2015-12-09 at 11 40 06 pm](https://cloud.githubusercontent.com/assets/1854440/11707148/3b929642-9ece-11e5-9629-f55198195d06.png)


fixes #1366 