### PR TITLE
Help: Internationalize the olark notification sent to visitors

### DIFF
--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -19,6 +19,7 @@ import olarkApi from 'lib/olark-api';
 import notices from 'notices';
 import olarkEvents from 'lib/olark-events';
 import olarkActions from 'lib/olark-store/actions';
+import i18n from 'lib/mixins/i18n';
 
 /**
  * Module variables
@@ -264,7 +265,7 @@ const olark = {
 		}
 
 		olarkApi( 'api.chat.onOperatorsAway', function() {
-			olarkApi( 'api.chat.sendNotificationToVisitor', { body: "Oops, our operators have all stepped away for a moment. If you don't hear back from us shortly, please try again later. Thanks!" } );
+			olarkApi( 'api.chat.sendNotificationToVisitor', { body: i18n.translate( "Oops, our operators have all stepped away for a moment. If you don't hear back from us shortly, please try again later. Thanks!" ) } );
 		} );
 
 		store.set( this.operatorsAvailableKey, true );
@@ -278,7 +279,7 @@ const olark = {
 		}
 
 		olarkApi( 'api.chat.onOperatorsAvailable', function() {
-			olarkApi( 'api.chat.sendNotificationToVisitor', { body: "Hey, we're back. If you don't hear from us shortly, please try your question once more. Thanks!" } );
+			olarkApi( 'api.chat.sendNotificationToVisitor', { body: i18n.translate( "Hey, we're back. If you don't hear from us shortly, please try your question once more. Thanks!" ) } );
 		} );
 
 		store.set( this.operatorsAvailableKey, false );


### PR DESCRIPTION
Internationalize the olark notification sent to visitors when operator availability changes.

**How to test**
*It is necessary to test within a group where there is only one operator in it*
1. Navigate to http://calypso.localhost:3000/help/contact
2. Begin chatting.
3. Have the operator send the `!end` command and then set them self to "Away".
4. Navigate away from the contact form so that the chat widget is showing in the lower right corner of the page.
5. Wait a while and have the operator return.
6. Notice that the notifications will appear in the chat widget.

**Screenshot of the notifications:**
![screen shot 2015-12-09 at 11 54 14 pm](https://cloud.githubusercontent.com/assets/1854440/11707299/a16584c8-9ed0-11e5-9f8e-f9bf431bd18f.png)

fixes #518