### PR TITLE
Help: Fix contact form tool tips

### DIFF
--- a/client/components/segmented-control/README.md
+++ b/client/components/segmented-control/README.md
@@ -108,6 +108,10 @@ Boolean representing the selected visual state. `selected={ true }` creates a bl
 
 Optional URL to navigate to when option is clicked.
 
+`title`
+
+Optional title to show when hovering over segmented control options. Default will be the child content of the item.
+
 `onClick`
 
 Optional callback that will be applied when a `ControlItem` has been clicked. This could be used for updating a parent's state, tracking analytics, etc.

--- a/client/components/segmented-control/item.jsx
+++ b/client/components/segmented-control/item.jsx
@@ -13,6 +13,7 @@ var SegmentedControlItem = React.createClass( {
 		children: React.PropTypes.node.isRequired,
 		path: React.PropTypes.string,
 		selected: React.PropTypes.bool,
+		title: React.PropTypes.string,
 		onClick: React.PropTypes.func
 	},
 
@@ -35,7 +36,7 @@ var SegmentedControlItem = React.createClass( {
 					className="segmented-control__link"
 					ref="itemLink"
 					onTouchTap={ this.props.onClick }
-					title={ this.props.children }
+					title={ this.props.title || this.props.children }
 					role="radio"
 					tabIndex={ 0 }
 					aria-selected={ this.props.selected }>

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -86,6 +86,7 @@ module.exports = React.createClass( {
 				key: option.value,
 				selected: option.value === this.state[ selectionName ],
 				value: option.value,
+				title: option.label,
 				onClick: () => {
 					this.setState( { [ selectionName ]: option.value } )
 				}


### PR DESCRIPTION
This pull request fixes #1433 by allowing [`SegmentedControls`](https://github.com/Automattic/wp-calypso/tree/master/client/components/segmented-control) to use a custom title instead of the default `toString` that is implicitly called on the child nodes for each option.

**How to test:**
*This requires you be in a group that has no available operators so that you can see the kayako ticket form*
1. Navigate to http://calypso.localhost:3000/help/contact
2. Hover your mouse over one of the "How can we help" options.
3. Notice how the tool tip that appears is the same as the main text on the option.

**What to expect**
![screen shot 2015-12-10 at 12 54 39 am](https://cloud.githubusercontent.com/assets/1854440/11708018/a90be80e-9ed8-11e5-94da-d0bef4f3f516.png)

 
Fixes #1433 