### PR TITLE
Help: Use the ExternalLink component for help search results

### DIFF
--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
+import ExternalLink from 'components/external-link';
 
 module.exports = React.createClass( {
 	displayName: 'HelpResult',
@@ -21,23 +22,25 @@ module.exports = React.createClass( {
 
 	render: function() {
 		return (
-			<a className="help-result" href={ this.props.helpLink.link } target="__blank" onClick={ this.onClick }>
+			<div className="help-result">
 				<CompactCard className="help-result__wrapper">
-					<svg className="help-result__icon" width="24" height="24" viewBox="0 0 24 24">
-						<defs>
-							<path id="a" d="M0 0h656v92H0z" />
-						</defs>
-						<g fill="none" fill-rule="evenodd">
-							<g transform="translate(-16 -15)">
-								<use stroke="#E9EFF3" />
-								<path className="help-result__icon-path" d={ this.props.iconPathDescription } transform="translate(16 15)" mask="url(#b)" fill="#87A6BC" />
+					<ExternalLink href={ this.props.helpLink.link } icon={ true } target="__blank" onClick={ this.onClick }>
+						<svg className="help-result__icon" width="24" height="24" viewBox="0 0 24 24">
+							<defs>
+								<path id="a" d="M0 0h656v92H0z" />
+							</defs>
+							<g fill="none" fill-rule="evenodd">
+								<g transform="translate(-16 -15)">
+									<use stroke="#E9EFF3" />
+									<path className="help-result__icon-path" d={ this.props.iconPathDescription } transform="translate(16 15)" mask="url(#b)" fill="#87A6BC" />
+								</g>
 							</g>
-						</g>
-					</svg>
-					<h2 className="help-result__title">{ this.props.helpLink.title }</h2>
-					<p className="help-result__description">{ this.props.helpLink.description }</p>
+						</svg>
+						<h2 className="help-result__title">{ this.props.helpLink.title }</h2>
+						<p className="help-result__description">{ this.props.helpLink.description }</p>
+					</ExternalLink>
 				</CompactCard>
-			</a>
+			</div>
 		);
 	}
 } );

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -22,8 +22,18 @@
 }
 
 .help-result {
+	position: relative;
+
+	.gridicons-external {
+		position: absolute;
+		z-index: 1;
+		top: 16px;
+		right: 24px;
+	}
+
 	&:hover {
 		background-color: $blue-medium;
+		.gridicons-external,
 		.help-result__title,
 		.help-result__description {
 			color: $white;

--- a/client/me/help/help-search/style.scss
+++ b/client/me/help/help-search/style.scss
@@ -31,6 +31,7 @@
 	.help-results__header-text, {
 		background-color: lighten( $gray, 20% );
 	}
+	.gridicons-external,
 	.help-results__footer {
 		display: none;
 	}


### PR DESCRIPTION
## Use the ExternalLink component for help search results

This pull request modifies the help search results to use the `ExternalLink` component since all results lead to links that open a new window.

**How to test**
1. Navigate to http://calypso.localhost:3000/help
2. Enter a search term
3. Notice how the results now have an external link icon in the upper right corner of each item returned in the search results.

**Before**
![screen shot 2015-12-10 at 1 26 33 am](https://cloud.githubusercontent.com/assets/1854440/11708413/1a67bba0-9edd-11e5-9347-f168222c2e75.png)

**After**
![screen shot 2015-12-10 at 1 23 09 am](https://cloud.githubusercontent.com/assets/1854440/11708391/e49358f4-9edc-11e5-986d-84210c4a9bb5.png)

Fixes #1349 