### PR TITLE
Upgrades: fix right alignment in cancel privacy

### DIFF
--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -144,7 +144,7 @@ const CancelPrivateRegistration = React.createClass( {
 
 		return (
 
-			<Main className="manage-purchase__detail">
+			<Main>
 				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
 					{ titles.cancelPrivateRegistration }
 				</HeaderCake>


### PR DESCRIPTION
The cancel privacy page is incorrectly using a right-aligned style created for another page. It adds nothing to the look other than right alignment on mobile.

To test (on mobile):
1. Go to purchases and select a domain name with privacy.
2. Click Cancel Privacy
3. The page should not be right-aligned.