### PR TITLE
Auth Code Request Store: Use standalone key-mirror

### DIFF
--- a/client/lib/auth-code-request-store/constants.js
+++ b/client/lib/auth-code-request-store/constants.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'key-mirror';
 
 export const actions = keyMirror( {
 	// Sending a request for an SMS auth code

--- a/client/lib/auth-code-request-store/index.js
+++ b/client/lib/auth-code-request-store/index.js
@@ -1,6 +1,6 @@
 import { createReducerStore } from 'lib/store'
 import { actions as ActionTypes } from './constants'
-import keyMirror from 'react/lib/keyMirror';
+import keyMirror from 'key-mirror';
 
 export const requestState = keyMirror( {
 	READY: null,


### PR DESCRIPTION
We're trying to move away from react/lib dependencies in preparation
for our move to React 0.14.

@beaucollins see #776

CC @aduth @blowery 