### PR TITLE
Framework: Use standalone shallowequal instead of react/lib's

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1226,3 +1226,28 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
+
+### https://github.com/dashed/shallowequal
+```text
+The MIT License (MIT)
+
+Copyright (c) 2015 Alberto Leal <mailforalberto@gmail.com> (github.com/dashed)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	shallowEqual = require( 'react/lib/shallowEqual' ),
+	shallowEqual = require( 'shallowequal' ),
 	config = require( 'config' );
 
 /**

--- a/client/reader/post-errors/index.jsx
+++ b/client/reader/post-errors/index.jsx
@@ -1,6 +1,6 @@
 // External dependencies
 var React = require( 'react' ),
-	shallowEqual = require( 'react/lib/shallowEqual' ),
+	shallowEqual = require( 'shallowequal' ),
 	debug = require( 'debug' )( 'calypso:reader:post-options-error' ); //eslint-disable-line no-unused-vars
 
 // Internal dependencies

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "redux-thunk": "1.0.0",
     "rtlcss": "1.6.1",
     "sanitize-html": "1.11.1",
+    "shallowequal": "0.2.2",
     "source-map": "0.1.39",
     "source-map-support": "0.3.2",
     "store": "1.3.16",


### PR DESCRIPTION
In preparation for React 0.14, cf #776 #786 #787 and friends.

To test:
Make sure the Reader still works.

CC @blowery @aduth