### PR TITLE
Framework: make <CurrentSite> in sidebar a link to the front end.

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -3,7 +3,6 @@
  */
 var React = require( 'react/addons' ),
 	debug = require( 'debug' )( 'calypso:my-sites:current-site' ),
-	analytics = require( 'analytics' ),
 	url = require( 'url' );
 
 /**
@@ -11,6 +10,7 @@ var React = require( 'react/addons' ),
  */
 var AllSites = require( 'my-sites/all-sites' ),
 	AddNewButton = require( 'components/add-new-button' ),
+	analytics = require( 'analytics' ),
 	Card = require( 'components/card' ),
 	SiteNotice = require( 'notices/site-notice' ),
 	layoutFocus = require( 'lib/layout-focus' ),
@@ -143,6 +143,10 @@ module.exports = React.createClass( {
 		);
 	},
 
+	trackHomepageClick: function() {
+		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
+	},
+
 	render: function() {
 		var site,
 			hasOneSite = this.props.siteCount === 1;
@@ -183,7 +187,14 @@ module.exports = React.createClass( {
 							{ this.translate( 'Switch Site' ) }
 						</span>
 				}
-				{ this.props.sites.selected ? <Site site={ site }/> : <AllSites sites={ this.props.sites }/> }
+				{ this.props.sites.selected
+					? <Site
+						site={ site }
+						href={ site.URL }
+						externalLink={ true }
+						onSelect={ this.trackHomepageClick } />
+					: <AllSites sites={ this.props.sites } />
+				}
 				{ this.getSiteNotices( site ) }
 			</Card>
 		);

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -439,23 +439,6 @@ module.exports = React.createClass( {
 		);
 	},
 
-	homepage: function() {
-		var site = this.getSelectedSite();
-
-		if ( ! this.isSingle() ) {
-			return null;
-		}
-
-		return (
-			<li className={ this.itemLinkClass( '/homepage', 'homepage' ) }>
-				<a onClick={ this.trackHomepageClick } href={ site.URL }>
-					<Gridicon icon="house" size={ 24 } />
-					<span className="menu-link-text">{ this.translate( 'View Site' ) }</span>
-				</a>
-			</li>
-		);
-	},
-
 	trackHomepageClick: function() {
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
 	},
@@ -634,7 +617,6 @@ module.exports = React.createClass( {
 
 				<li className="sidebar-menu">
 					<ul>
-						{ this.homepage() }
 						{ this.stats() }
 						{ this.ads() }
 						{ this.plan() }


### PR DESCRIPTION
Also removes sidebar item for home page making it leaner:

![image](https://cloud.githubusercontent.com/assets/548849/11719566/a49f348c-9f5b-11e5-9196-3ee4400970fc.png)

-----

### Thoughts

* Should we add a hover effect?
* Should we add a `<Tooltip>`?
* What if clicking on it opened a `WebPreview` instance? It may be neat for the desktop app, allowing to quickly check out the site inside the app.