### PR TITLE
Framework: Update Me.Settings() undocumented stuff

### DIFF
--- a/client/lib/preferences/actions.js
+++ b/client/lib/preferences/actions.js
@@ -49,7 +49,7 @@ PreferencesActions.fetch = function() {
 		} );
 	}
 
-	wpcom.me().settings( function( error, data ) {
+	wpcom.me().settings().get( function( error, data ) {
 		if ( ! error && data ) {
 			mergePreferencesToLocalStorage( data[ PreferencesConstants.USER_SETTING_KEY ] );
 		}

--- a/client/lib/preferences/actions.js
+++ b/client/lib/preferences/actions.js
@@ -77,7 +77,7 @@ PreferencesActions.set = function( key, value ) {
 	mergePreferencesToLocalStorage( preferences );
 
 	_pendingUpdates++;
-	wpcom.me().saveSettings( JSON.stringify( settings ), function( error, data ) {
+	wpcom.me().settings().update( JSON.stringify( settings ), function( error, data ) {
 		if ( --_pendingUpdates ) {
 			return;
 		}

--- a/client/lib/preferences/test/actions.js
+++ b/client/lib/preferences/test/actions.js
@@ -42,8 +42,12 @@ describe( 'PreferencesActions', function() {
 				return {
 					me: function() {
 						return {
-							settings: getSettings,
-							saveSettings: postSettings
+							settings: function() {
+								return {
+									get: getSettings,
+									update: postSettings
+								}
+							}
 						};
 					}
 				};

--- a/client/lib/preferences/test/actions.js
+++ b/client/lib/preferences/test/actions.js
@@ -46,7 +46,7 @@ describe( 'PreferencesActions', function() {
 								return {
 									get: getSettings,
 									update: postSettings
-								}
+								};
 							}
 						};
 					}

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -11,7 +11,7 @@ var debug = require( 'debug' )( 'calypso:user:settings' ),
 /**
  * Internal dependencies
  */
-var Emitter = require( 'lib/mixins/emitter' ),
+var emitterClass = require( 'lib/mixins/emitter' ),
 	wpcom = require( 'lib/wp' ).undocumented(),
 	user = require( 'lib/user' )();
 
@@ -31,6 +31,8 @@ function decodeUserSettingsEntities( data ) {
 
 /**
  * Initialize UserSettings with defaults
+ *
+ * @return {Null} null
  */
 function UserSettings() {
 	if ( ! ( this instanceof UserSettings ) ) {
@@ -44,10 +46,12 @@ function UserSettings() {
 	this.unsavedSettings = {};
 }
 
-Emitter( UserSettings.prototype );
+emitterClass( UserSettings.prototype );
 
 /**
  * Returns a boolean signifying whether there are settings or not
+ *
+ * @return {Boolean} true is the user has settings object
  */
 UserSettings.prototype.hasSettings = function() {
 	return !! this.settings;
@@ -55,6 +59,8 @@ UserSettings.prototype.hasSettings = function() {
 
 /**
  * Get user settings. If not already initialized, then fetch settings
+ *
+ * @return {Object} user setting object
  */
 UserSettings.prototype.getSettings = function() {
 	if ( ! this.settings ) {
@@ -75,7 +81,7 @@ UserSettings.prototype.fetchSettings = function() {
 	debug( 'Fetching user settings' );
 	wpcom.me().settings().get( function( error, data ) {
 		if ( ! error ) {
-			this.settings = decodeUserSettingsEntities ( data );
+			this.settings = decodeUserSettingsEntities( data );
 			this.initialized = true;
 			this.emit( 'change' );
 		}
@@ -83,15 +89,19 @@ UserSettings.prototype.fetchSettings = function() {
 		this.fetchingSettings = false;
 
 		debug( 'Settings successfully retrieved' );
-
 	}.bind( this ) );
 };
 
 /**
  * Post settings to WordPress.com API at /me/settings endpoint
+ *
+ * @param {Function} callback - callback function
+ * @param {Object} settingsOverride - default settings object
+ * @return {Null} null
  */
 UserSettings.prototype.saveSettings = function( callback, settingsOverride ) {
 	var settings = settingsOverride ? settingsOverride : this.unsavedSettings;
+
 	if ( isEmpty( settings ) ) {
 		debug( 'There are no settings to save.' );
 		callback( null );
@@ -99,6 +109,7 @@ UserSettings.prototype.saveSettings = function( callback, settingsOverride ) {
 	}
 
 	debug( 'Saving settings: ' + JSON.stringify( settings ) );
+
 	wpcom.me().saveSettings( settings, function( error, data ) {
 		if ( ! error ) {
 			this.settings = decodeUserSettingsEntities( merge( this.settings, data ) );
@@ -138,6 +149,9 @@ UserSettings.prototype.cancelPendingEmailChange = function( callback ) {
 
 /**
  * Given a settingName, returns that original setting if it exists or null
+ *
+ * @param {String} settingName - setting name
+ * @return {*} setting key value
  */
 UserSettings.prototype.getOriginalSetting = function( settingName ) {
 	var setting = null;
@@ -150,6 +164,8 @@ UserSettings.prototype.getOriginalSetting = function( settingName ) {
 
 /**
  * Is two-step enabled for the current user?
+ *
+ * @return {Boolean} return true if two-step is enabled
  */
 UserSettings.prototype.isTwoStepEnabled = function() {
 	return this.settings ? this.settings.two_step_enabled : false;
@@ -157,6 +173,8 @@ UserSettings.prototype.isTwoStepEnabled = function() {
 
 /**
  * Is two-step sms enabled for the current user?
+ *
+ * @return {Boolean} return true if two-step sms is enabled
  */
 UserSettings.prototype.isTwoStepSMSEnabled = function() {
 	return this.settings ? this.settings.two_step_sms_enabled : false;
@@ -164,6 +182,8 @@ UserSettings.prototype.isTwoStepSMSEnabled = function() {
 
 /**
  * Returns true if there is a pending email change, false if not.
+ *
+ * @return {Boolean} pending email state
  */
 UserSettings.prototype.isPendingEmailChange = function() {
 	if ( this.settings ) {
@@ -175,13 +195,18 @@ UserSettings.prototype.isPendingEmailChange = function() {
 
 /**
  * Given a settingName, returns that setting if it exists or null
+ *
+ * @param {String}  settingName - setting name
+ * @return {*} setting name value
  */
 UserSettings.prototype.getSetting = function( settingName ) {
 	var setting = null;
 
 	// If we haven't fetched settings, or if the setting doesn't exist return null
 	if ( this.settings && 'undefined' !== typeof this.settings[ settingName ] ) {
-		setting = ( 'undefined' !== typeof this.unsavedSettings[ settingName ] ) ? this.unsavedSettings[ settingName ] : this.settings[ settingName ];
+		setting = ( 'undefined' !== typeof this.unsavedSettings[ settingName ] )
+			? this.unsavedSettings[ settingName ]
+			: this.settings[ settingName ];
 	}
 
 	return setting;
@@ -190,10 +215,13 @@ UserSettings.prototype.getSetting = function( settingName ) {
 /**
  * Handles the storage and removal of changed setting that are pending
  * being saved to the WPCOM API.
+ *
+ * @param {String} settingName - setting name
+ * @param {*} value - setting value
+ * @return {Boolean} updating successful response
  */
 UserSettings.prototype.updateSetting = function( settingName, value ) {
 	if ( this.settings && 'undefined' !== typeof this.settings[ settingName ] ) {
-
 		this.unsavedSettings[ settingName ] = value;
 
 		/*
@@ -201,8 +229,11 @@ UserSettings.prototype.updateSetting = function( settingName, value ) {
 		 * user_login is a special case since the logic for validating and saving a username
 		 * is more complicated.
 		 */
-		if ( this.settings[ settingName ] === this.unsavedSettings[ settingName ] && 'user_login' !== settingName ) {
-			debug( 'Removing ' + settingName + ' from changed settings.'  );
+		if (
+			this.settings[ settingName ] === this.unsavedSettings[ settingName ] &&
+			'user_login' !== settingName
+		) {
+			debug( 'Removing ' + settingName + ' from changed settings.' );
 			delete this.unsavedSettings[ settingName ];
 		}
 

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -73,7 +73,7 @@ UserSettings.prototype.fetchSettings = function() {
 
 	this.fetchingSettings = true;
 	debug( 'Fetching user settings' );
-	wpcom.me().settings( function( error, data ) {
+	wpcom.me().settings().get( function( error, data ) {
 		if ( ! error ) {
 			this.settings = decodeUserSettingsEntities ( data );
 			this.initialized = true;

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -110,7 +110,7 @@ UserSettings.prototype.saveSettings = function( callback, settingsOverride ) {
 
 	debug( 'Saving settings: ' + JSON.stringify( settings ) );
 
-	wpcom.me().saveSettings( settings, function( error, data ) {
+	wpcom.me().settings().update( settings, function( error, data ) {
 		if ( ! error ) {
 			this.settings = decodeUserSettingsEntities( merge( this.settings, data ) );
 
@@ -136,7 +136,7 @@ UserSettings.prototype.saveSettings = function( callback, settingsOverride ) {
 };
 
 UserSettings.prototype.cancelPendingEmailChange = function( callback ) {
-	wpcom.me().saveSettings( { user_email_change_pending: false }, function( error, data ) {
+	wpcom.me().settings().update( { user_email_change_pending: false }, function( error, data ) {
 		if ( ! error ) {
 			this.settings = merge( this.settings, data );
 			this.emit( 'change' );

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -32,7 +32,7 @@ function decodeUserSettingsEntities( data ) {
 /**
  * Initialize UserSettings with defaults
  *
- * @return {Null} null
+ * @return {Undefined} undefined
  */
 function UserSettings() {
 	if ( ! ( this instanceof UserSettings ) ) {

--- a/client/lib/user-settings/test/lib/wp.js
+++ b/client/lib/user-settings/test/lib/wp.js
@@ -3,16 +3,20 @@ module.exports = {
 		return {
 			me: function() {
 				return {
-					settings: function( callback ) {
-						callback( false, {
-							test: false,
-							lang_id: false
-						} );
-					},
-					saveSettings: function( settings, callback ) {
-						setTimeout( function() {
-							callback( null, settings );
-						} );
+					settings: function() {
+						return {
+							get: function( callback ) {
+								callback( false, {
+									test: false,
+									lang_id: false
+								} );
+							},
+							update: function( settings, callback ) {
+								setTimeout( function() {
+									callback( null, settings );
+								} );
+							}
+						};
 					}
 				};
 			}

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "walk": "2.3.4",
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom-unpublished": "1.0.7",
+    "wpcom-unpublished": "1.0.8",
     "wpcom-proxy-request": "1.0.5",
     "wpcom-xhr-request": "0.3.3",
     "xgettext-js": "0.2.0"

--- a/shared/lib/wpcom-undocumented/lib/me.js
+++ b/shared/lib/wpcom-undocumented/lib/me.js
@@ -34,13 +34,6 @@ UndocumentedMe.prototype.purchases = function( callback ) {
 	return this.wpcom.req.get( '/me/purchases', callback );
 };
 
-UndocumentedMe.prototype.settings = function( callback ) {
-	return this.wpcom.req.get( {
-		apiVersion: '1.1',
-		path: '/me/settings'
-	}, callback );
-};
-
 UndocumentedMe.prototype.saveSettings = function( settings, callback ) {
 	var args = {
 		apiVersion: '1.1',

--- a/shared/lib/wpcom-undocumented/lib/me.js
+++ b/shared/lib/wpcom-undocumented/lib/me.js
@@ -41,16 +41,6 @@ UndocumentedMe.prototype.purchases = function( callback ) {
 	return this.wpcom.req.get( '/me/purchases', callback );
 };
 
-UndocumentedMe.prototype.saveSettings = function( settings, callback ) {
-	var args = {
-		apiVersion: '1.1',
-		path: '/me/settings',
-		body: settings
-	};
-
-	return this.wpcom.req.post( args, callback );
-};
-
 UndocumentedMe.prototype.getConnectedApplications = function( callback ) {
 	var args = {
 		apiVersion: '1.1',

--- a/shared/lib/wpcom-undocumented/lib/me.js
+++ b/shared/lib/wpcom-undocumented/lib/me.js
@@ -1,6 +1,8 @@
 /**
  * Module dependencies.
  */
+import Me from 'wpcom-unpublished/dist/lib/me';
+import inherits from 'inherits';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:wpcom-undocumented:me' );
 
@@ -17,6 +19,11 @@ function UndocumentedMe( wpcom ) {
 	}
 	this.wpcom = wpcom;
 }
+
+/**
+ * Inherits from Me class
+ */
+inherits( UndocumentedMe, Me );
 
 UndocumentedMe.prototype.billingHistory = function( callback ) {
 	return this.wpcom.req.get( '/me/billing-history', callback );


### PR DESCRIPTION
* Update to [`wpcom-unpublished@1.0.8`](https://github.com/Automattic/wpcom-unpublished/blob/master/History.md#108--2015-12-10)
* Remove those methods from `wpcom-undocumented` that are already implemented either in `wpcom-unpublished` as `wpcom.js`

The main changes in wpcom-unpublished@1.08 are tied to the [wpcom@4.8.3 changes](https://github.com/Automattic/wpcom.js/blob/master/History.md#483--2015-12-10).

