### PR TITLE
Framework: Add mixedindentlint target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ node_modules: package.json
 test: build
 	@$(BIN)/run-all-tests
 
-lint: node_modules/eslint node_modules/eslint-plugin-react node_modules/babel-eslint
+lint: node_modules/eslint node_modules/eslint-plugin-react node_modules/babel-eslint mixedindentlint
 	@$(NODE_BIN)/eslint --quiet $(JS_FILES)
 
 eslint: lint
@@ -84,6 +84,10 @@ eslint-branch: node_modules/eslint node_modules/eslint-plugin-react node_modules
 # ignore functionality
 i18n-lint:
 	@echo "$(JS_FILES)" | sed 's/\([^ ]*\/test\/[^ ]* *\)//g' | xargs -n1 $(I18NLINT)
+
+# Skip files that are auto-generated
+mixedindentlint: node_modules/mixedindentlint
+	@echo "$(JS_FILES)\n$(SASS_FILES)" | xargs $(NODE_BIN)/mixedindentlint --ignore-comments --exclude="client/config/index.js" --exclude="shared/components/gridicon/index.jsx"
 
 # keep track of the current CALYPSO_ENV so that it can be used as a
 # prerequisite for other rules

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "jsdom": "3.1.2",
     "localStorage": "1.0.2",
     "lodash-deep": "1.5.3",
+    "mixedindentlint": "1.1.1",
     "mocha": "2.3.4",
     "mockery": "1.4.0",
     "nock": "2.17.0",


### PR DESCRIPTION
Scans the JS and SASS files for mixed indentation.

Also added as a dependency to the `lint` target.

## Testing

Run `make lint` in the Calypso directory. You should ~~see output like~~ NOT see any errors, now that #1476 is merged. Try editing a file and changing the tab indentation to spaces on a line, then running `make lint` again and you should see warnings like this:

```
Line 702 in "assets/stylesheets/sections/_stats.scss" has indentation that differs from the rest of the file.
Line 703 in "assets/stylesheets/sections/_stats.scss" has indentation that differs from the rest of the file.
```
