### PR TITLE
Connected Applications: Update to FoldableCard Pattern

### DIFF
--- a/client/me/connected-application-icon/style.scss
+++ b/client/me/connected-application-icon/style.scss
@@ -7,10 +7,10 @@
 	// !important necessary here since plugin-icon uses !important as well
 	height: 40px !important;
 	width:  40px !important;
-	margin-left: 32px;
+	margin-left: 0px;
 	margin-right: 12px;
 
 	@include breakpoint( '>480px' ) {
-		margin-left: 40px;
+		margin-left: 0px;
 	}
 }

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -9,7 +9,6 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 import eventRecorder from 'me/event-recorder';
-import CompactCard from 'components/card/compact';
 import ConnectedApplicationIcon from 'me/connected-application-icon';
 import safeProtocolUrl from 'lib/safe-protocol-url';
 import analytics from 'analytics';
@@ -119,16 +118,16 @@ module.exports = React.createClass( {
 
 		if ( message ) {
 			return (
-				<li className="connected-application-item__connection-detail">
-					<strong className="connected-application-item__connection-detail-title">
+				<div>
+					<h2>
 						{ this.translate( 'Access Scope' ) }
 						{ this.renderAccessScopeBadge() }
-					</strong>
+					</h2>
 
-					<span className="connected-application-item__connection-detail-description" >
+					<p className="connected-application-item__connection-detail-description" >
 						{ message }
-					</span>
-				</li>
+					</p>
+				</div>
 			);
 		}
 	},
@@ -140,11 +139,11 @@ module.exports = React.createClass( {
 
 		return (
 			<div>
-				<strong className="connected-application-item__connection-detail-title">
+				<h2>
 					{ this.translate( 'Application Website' ) }
-				</strong>
+				</h2>
 
-				<span className="connected-application-item__connection-detail-description">
+				<p>
 					<a
 						href={ safeProtocolUrl( this.props.connection.URL ) }
 						onClick={ this.recordClickEvent( 'Connected Application Website Link' ) }
@@ -152,33 +151,35 @@ module.exports = React.createClass( {
 					>
 						{ safeProtocolUrl( this.props.connection.URL ) }
 					</a>
-				</span>
+				</p>
 
 				{ this.translate( '{{detailTitle}}Authorized On{{/detailTitle}}{{detailDescription}}%(date)s{{/detailDescription}}', {
 					components: {
-						detailTitle: <strong className="connected-application-item__connection-detail-title" />,
-						detailDescription: <span className="connected-application-item__connection-detail-description" />
+						detailTitle: <h2 />,
+					detailDescription: <p className="connected-application-item__connection-detail-description" />
 					},
 					args: {
 						date: this.moment( this.props.connection.authorized ).format( 'MMM D, YYYY @ h:mm a' )
 					}
 				} ) }
+				<p>
+					{ this.renderScopeMessage() }
+				</p>
 
-				<strong className="connected-application-item__connection-detail-title">
+				<h2>
 					{ this.translate( 'Access Permissions' ) }
-				</strong>
-
-				{ this.renderScopeMessage() }
-
-				{ this.props.connection.permissions.map( function( permission ) {
-					return (
-						<span
-							className="connected-application-item__connection-detail-description"
-							key={ 'permission-' + permission.name } >
-							{ permission.description }
-						</span>
-					);
-				}, this ) }
+				</h2>
+				<p>
+					{ this.props.connection.permissions.map( function( permission ) {
+						return (
+							<span
+								className="connected-application-item__connection-detail-description"
+								key={ 'permission-' + permission.name } >
+								{ permission.description }
+							</span>
+						);
+					}, this ) }
+				</p>
 			</div>
 		);
 	},
@@ -199,7 +200,6 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-
 		let classes = classNames( {
 			'connected-application-item': true,
 			'is-placeholder': this.props.isPlaceholder
@@ -209,6 +209,7 @@ module.exports = React.createClass( {
 			<FoldableCard
 				header={ this.header() }
 				summary={ this.summary() }
+				expandedSummary={ this.summary() }
 				clickableHeader
 				compact
 				className={ classes }>

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -142,7 +142,6 @@ module.exports = React.createClass( {
 				<h2>
 					{ this.translate( 'Application Website' ) }
 				</h2>
-
 				<p>
 					<a
 						href={ safeProtocolUrl( this.props.connection.URL ) }
@@ -156,7 +155,7 @@ module.exports = React.createClass( {
 				{ this.translate( '{{detailTitle}}Authorized On{{/detailTitle}}{{detailDescription}}%(date)s{{/detailDescription}}', {
 					components: {
 						detailTitle: <h2 />,
-					detailDescription: <p className="connected-application-item__connection-detail-description" />
+						detailDescription: <p className="connected-application-item__connection-detail-description" />
 					},
 					args: {
 						date: this.moment( this.props.connection.authorized ).format( 'MMM D, YYYY @ h:mm a' )
@@ -169,17 +168,15 @@ module.exports = React.createClass( {
 				<h2>
 					{ this.translate( 'Access Permissions' ) }
 				</h2>
-				<p>
+				<ul className="connected-application-item__connection-detail-descriptions">
 					{ this.props.connection.permissions.map( function( permission ) {
 						return (
-							<span
-								className="connected-application-item__connection-detail-description"
-								key={ 'permission-' + permission.name } >
+							<li key={ 'permission-' + permission.name } >
 								{ permission.description }
-							</span>
+							</li>
 						);
 					}, this ) }
-				</p>
+				</ul>
 			</div>
 		);
 	},
@@ -195,7 +192,7 @@ module.exports = React.createClass( {
 
 	summary: function() {
 		return( <div>{ this.props.isPlaceholder
-		 	? ( <Button compact disabled>{ this.translate( 'Loading…' ) }</Button> )
+			? ( <Button compact disabled>{ this.translate( 'Loading…' ) }</Button> )
 			: ( <Button compact onClick={ this.disconnect }>{ this.translate( 'Disconnect' ) }</Button> ) }</div> );
 	},
 

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -8,11 +8,12 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var eventRecorder = require( 'me/event-recorder' ),
-	CompactCard = require( 'components/card/compact' ),
-	ConnectedApplicationIcon = require( 'me/connected-application-icon' ),
-	safeProtocolUrl = require( 'lib/safe-protocol-url' ),
-	analytics = require( 'analytics' );
+import eventRecorder from 'me/event-recorder';
+import CompactCard from 'components/card/compact';
+import ConnectedApplicationIcon from 'me/connected-application-icon';
+import safeProtocolUrl from 'lib/safe-protocol-url';
+import analytics from 'analytics';
+import Button from 'components/button';
 
 module.exports = React.createClass( {
 
@@ -222,11 +223,12 @@ module.exports = React.createClass( {
 						{ connection.title }
 					</div>
 
-					<span className="connected-application-item__disconnect">
-						<a onClick={ this.disconnect } className="button">
-							{ this.translate( 'Disconnect' ) }
-						</a>
-					</span>
+					<div className="connected-application-item__disconnect">
+						{ this.props.isPlaceholder
+							? <Button compact disabled>{ this.translate( 'Loading…' ) }</Button>
+							: <Button compact onClick={ this.disconnect }>{ this.translate( 'Disconnect' ) }</Button> }
+					</div>
+
 				</div>
 				{ this.renderDetail() }
 			</CompactCard>

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -41,38 +41,30 @@ module.exports = React.createClass( {
 		};
 	},
 
-	toggleDetail: function() {
-		if ( this.state.showDetail ) {
-			analytics.ga.recordEvent( 'Me', 'Collapsed Connected Application', this.props.connection.title );
-		} else {
-			analytics.ga.recordEvent( 'Me', 'Expanded Connected Application', this.props.connection.title );
-		}
-
-		this.setState( { showDetail: ! this.state.showDetail } );
-	},
-
 	disconnect: function( event ) {
 		if ( this.props.isPlaceholder ) {
 			return;
 		}
+		const { connection: { title, ID } } = this.props;
 		event.stopPropagation();
-		analytics.ga.recordEvent( 'Me', 'Clicked on Disconnect Connected Application Link', this.props.connection.title );
-		this.props.revoke( this.props.connection.ID );
+		analytics.ga.recordEvent( 'Me', 'Clicked on Disconnect Connected Application Link', title );
+		this.props.revoke( ID );
 	},
 
 	renderAccessScopeBadge: function() {
+		const { connection: { scope, site } } = this.props;
 		var meta = '';
 
 		if ( ! this.props.connection ) {
 			return;
 		}
 
-		if ( 'auth' === this.props.connection.scope ) {
+		if ( 'auth' === scope ) {
 			meta = this.translate( 'Authentication' );
-		} else if ( 'global' === this.props.connection.scope ) {
+		} else if ( 'global' === scope ) {
 			meta = this.translate( 'Global' );
-		} else if ( this.props.connection.site ) {
-			meta = this.props.connection.site.site_name;
+		} else if ( site ) {
+			meta = site.site_name;
 		}
 
 		if ( meta.length ) {
@@ -85,21 +77,22 @@ module.exports = React.createClass( {
 	},
 
 	renderScopeMessage: function() {
+		const { connection: { scope, site } } = this.props;
 		var message;
 		if ( ! this.props.connection ) {
 			return;
 		}
 
-		if ( 'global' === this.props.connection.scope ) {
+		if ( 'global' === scope ) {
 			message = this.translate(
 				'This connection is allowed to manage all of your blogs on WordPress.com, ' +
 				'including any Jetpack blogs that are connected to your WordPress.com account.'
 			);
-		} else if ( 'auth' === this.props.connection.scope ) {
+		} else if ( 'auth' === scope ) {
 			message = this.translate(
 				'This connection is not allowed to manage any of your blogs.'
 			);
-		} else if ( false !== this.props.connection.site ) {
+		} else if ( false !== site ) {
 			message = this.translate(
 				'This connection is only allowed to access {{siteLink}}%(siteName)s{{/siteLink}}', {
 					components: {
@@ -110,7 +103,7 @@ module.exports = React.createClass( {
 						/>
 					},
 					args: {
-						siteName: this.props.connection.site.site_name
+						siteName: site.site_name
 					}
 				}
 			);
@@ -133,22 +126,21 @@ module.exports = React.createClass( {
 	},
 
 	renderDetail: function() {
+		const { connection: { URL, authorized, permissions } } = this.props;
 		if ( this.props.isPlaceholder ) {
 			return;
 		}
 
 		return (
 			<div>
-				<h2>
-					{ this.translate( 'Application Website' ) }
-				</h2>
+				<h2>{ this.translate( 'Application Website' ) }</h2>
 				<p>
 					<a
-						href={ safeProtocolUrl( this.props.connection.URL ) }
+						href={ safeProtocolUrl( URL ) }
 						onClick={ this.recordClickEvent( 'Connected Application Website Link' ) }
 						target="_blank"
 					>
-						{ safeProtocolUrl( this.props.connection.URL ) }
+						{ safeProtocolUrl( URL ) }
 					</a>
 				</p>
 
@@ -158,18 +150,18 @@ module.exports = React.createClass( {
 						detailDescription: <p className="connected-application-item__connection-detail-description" />
 					},
 					args: {
-						date: this.moment( this.props.connection.authorized ).format( 'MMM D, YYYY @ h:mm a' )
+						date: this.moment( authorized ).format( 'MMM D, YYYY @ h:mm a' )
 					}
 				} ) }
-				<p>
+				<div>
 					{ this.renderScopeMessage() }
-				</p>
+				</div>
 
 				<h2>
 					{ this.translate( 'Access Permissions' ) }
 				</h2>
 				<ul className="connected-application-item__connection-detail-descriptions">
-					{ this.props.connection.permissions.map( function( permission ) {
+					{ permissions.map( function( permission ) {
 						return (
 							<li key={ 'permission-' + permission.name } >
 								{ permission.description }
@@ -191,9 +183,13 @@ module.exports = React.createClass( {
 	},
 
 	summary: function() {
-		return( <div>{ this.props.isPlaceholder
-			? ( <Button compact disabled>{ this.translate( 'Loading…' ) }</Button> )
-			: ( <Button compact onClick={ this.disconnect }>{ this.translate( 'Disconnect' ) }</Button> ) }</div> );
+		return(
+			<div>
+				{ this.props.isPlaceholder
+					? ( <Button compact disabled>{ this.translate( 'Loading…' ) }</Button> )
+					: ( <Button compact onClick={ this.disconnect }>{ this.translate( 'Disconnect' ) }</Button> )
+				}
+			</div> );
 	},
 
 	render: function() {

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -15,7 +15,7 @@ import analytics from 'analytics';
 import Button from 'components/button';
 import FoldableCard from 'components/foldable-card';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'ConnectedApplicationItem',
 
@@ -109,20 +109,22 @@ module.exports = React.createClass( {
 			);
 		}
 
-		if ( message ) {
-			return (
-				<div>
-					<h2>
-						{ this.translate( 'Access Scope' ) }
-						{ this.renderAccessScopeBadge() }
-					</h2>
-
-					<p className="connected-application-item__connection-detail-description" >
-						{ message }
-					</p>
-				</div>
-			);
+		if ( ! message ) {
+			return;
 		}
+
+		return (
+			<div>
+				<h2>
+					{ this.translate( 'Access Scope' ) }
+					{ this.renderAccessScopeBadge() }
+				</h2>
+
+				<p className="connected-application-item__connection-detail-description" >
+					{ message }
+				</p>
+			</div>
+		);
 	},
 
 	renderDetail: function() {
@@ -161,13 +163,11 @@ module.exports = React.createClass( {
 					{ this.translate( 'Access Permissions' ) }
 				</h2>
 				<ul className="connected-application-item__connection-detail-descriptions">
-					{ permissions.map( function( permission ) {
-						return (
-							<li key={ 'permission-' + permission.name } >
-								{ permission.description }
-							</li>
-						);
-					}, this ) }
+					{ permissions.map( ( { name, description } ) => (
+						<li key={ `permission-${ name }` }>
+							{ description }
+						</li>
+					) ) }
 				</ul>
 			</div>
 		);

--- a/client/me/connected-application-item/style.scss
+++ b/client/me/connected-application-item/style.scss
@@ -1,147 +1,30 @@
-.connected-application-item.card {
-	padding: 0;
+.connected-application-item__header {
 
-	@include breakpoint( '>660px' ) {
-		padding: 0;
+	display: flex;
+
+	h3 {
+		flex: 2;
+		display: block;
+		overflow: hidden;
+		margin-top: 8px;
 	}
 
-	&.is-compact {
-		margin-bottom: 1px;
+	.connected-application-icon {
+		width: 48px;
 	}
+}
 
-	&.is-compact:last-child {
-		margin-bottom: 8px;
-	}
+.connected-application-item.is-placeholder {
+	h3 {
+		color: transparent;
+		width: 36%;
+		line-height: 24px;
+		margin-top: 8px;
+		background-color: lighten( $gray, 30% );
+		animation: loading-fade 1.6s ease-in-out infinite;
 
-	&.is-open {
-		margin-bottom: 16px;
-	}
-
-	&.is-placeholder {
-		.connected-application-item__title {
-			color: transparent;
-			width: 36%;
-			line-height: 24px;
-			margin-top: 8px;
-			background-color: lighten( $gray, 30% );
-			animation: loading-fade 1.6s ease-in-out infinite;
-
-			&:before {
-				content: ' ';
-			}
+		&:before {
+			content: ' ';
 		}
 	}
-}
-
-.connected-application-item {
-	position: relative;
-	@include clear-fix;
-}
-
-.connected-application-item__header {
-	cursor: pointer;
-	display: block;
-	padding: 16px;
-
-	@include clear-fix;
-}
-
-.connected-application-item__header:hover .connected-application-item__content-toggle {
-	color: $blue-medium;
-}
-
-.connected-application-item__content-toggle {
-	position: absolute;
-		top: 24px;
-		right: 16px;
-	margin-top: 4px;
-	font-size: 16px;
-	color: $gray;
-
-	@include breakpoint( '>480px' ) {
-		margin-top: 0;
-		font-size: 24px;
-	}
-}
-
-.connected-application-item__title {
-	display: block;
-	color: $gray-dark;
-	font-size: 14px;
-	line-height: 40px;
-	white-space: pre;
-	overflow: hidden;
-
-	@include breakpoint( '>480px' ) {
-		font-size: 20px;
-	}
-}
-
-.connected-application-item__disconnect{
-	position: absolute;
-		top: 22px;
-		right: 56px;
-}
-
-.connected-application-item__content {
-	position: relative;
-	display: none;
-	padding: 15px 20px 20px 20px;
-	background: $gray-light;
-	border-top: 2px solid lighten( $gray, 30% );
-}
-
-.connected-application-item.is-open .connected-application-item__content {
-	background: $gray-light;
-	border-top: 1px solid lighten( $gray, 30% );
-	display: block;
-	padding: 16px;
-
-	@include breakpoint( '>480px' ) {
-		border-top-width: 2px;
-	}
-
-	@include breakpoint( '>660px' ) {
-		padding: 24px;
-	}
-}
-
-.connected-application-item__meta {
-	position: absolute;
-		left: 110%;
-		top: 2px;
-	font-size: 12px;
-	background-color: $gray;
-	color: $white;
-	white-space: pre;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	padding: 0 4px;
-	border-radius: 2px;
-	font-weight: normal;
-}
-
-.connected-application-item__ul {
-	list-style-type: none;
-	margin: 0;
-}
-
-.connected-application-item__connection-detail {
-	margin-bottom: 1em;
-
-	&:last-child {
-		margin-bottom: 0;
-	}
-}
-
-.connected-application-item__connection-detail-title {
-	position: relative;
-}
-
-.connected-application-item__connection-detail-description {
-	display: block;
-}
-
-.connected-application-item__content-description {
-	margin: 0 0 1em 0;
 }

--- a/client/me/connected-application-item/style.scss
+++ b/client/me/connected-application-item/style.scss
@@ -53,7 +53,7 @@
 .connected-application-item__content-toggle {
 	position: absolute;
 		top: 24px;
-		left: 16px;
+		right: 16px;
 	margin-top: 4px;
 	font-size: 16px;
 	color: $gray;
@@ -79,21 +79,8 @@
 
 .connected-application-item__disconnect{
 	position: absolute;
-		top: 16px;
-		right: 16px;
-	font-size: 14px;
-	line-height: 40px;
-	color: $alert-red;
-	margin-left: 20px;
-	background: $white;
-
-	&:hover {
-		color: lighten( $alert-red, 10% );
-	}
-
-	&:after {
-		@include stats-fade-text( $white );
-	}
+		top: 22px;
+		right: 56px;
 }
 
 .connected-application-item__content {

--- a/client/me/connected-application-item/style.scss
+++ b/client/me/connected-application-item/style.scss
@@ -45,3 +45,12 @@
 	color: $white;
 	font-weight: normal;
 }
+
+.connected-application-item__connection-detail-descriptions {
+	margin-left: 1.5em;
+	margin-top: 4px;
+
+	li {
+		padding: 0;
+	}
+}

--- a/client/me/connected-application-item/style.scss
+++ b/client/me/connected-application-item/style.scss
@@ -28,3 +28,20 @@
 		}
 	}
 }
+
+.connected-application-item {
+	h2 {
+		font-weight: bold;
+	}
+}
+
+.connected-application-item__meta {
+	font-size: 12px;
+	display: inline-block;
+	padding: 4px 8px;
+	margin-left: 8px;
+	border-radius: 4px;
+	background: $gray;
+	color: $white;
+	font-weight: normal;
+}


### PR DESCRIPTION
As part of my attempt to replace custom foldable-card style components with the standard global `FoldableCard` component, this PR takes the Connected Applications screen, which looks like this and is built with a custom set of set of components and SCSS...
<img width="738" alt="screen shot 2016-01-25 at 4 24 43 pm" src="https://cloud.githubusercontent.com/assets/1084656/12568055/34d35f7c-c380-11e5-88d3-f78ee3ffbe18.png">

...and turns it into this, which uses the standard `FoldableCard` component:
<img width="755" alt="screen shot 2016-01-26 at 10 02 27 am" src="https://cloud.githubusercontent.com/assets/1084656/12588009/f733203c-c413-11e5-809f-5250281077bc.png">

This PR brings Connected Applications into parity with the new Sharing page, PR #1474.

To test: check out the branch and head on over to `/me/security/connected-applications` and you should see the updated layout.