### PR TITLE
Site Settings: Update Jetpack settings section to use SectionHeader pattern

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -219,6 +219,7 @@
 @import 'my-sites/sharing/connections/services-group';
 @import 'my-sites/sidebar-navigation/style';
 @import 'my-sites/site-indicator/style';
+@import 'my-sites/site-settings/style';
 @import 'my-sites/site-settings/action-panel/style';
 @import 'my-sites/site-settings/delete-site-options/style';
 @import 'my-sites/site-settings/delete-site/style';

--- a/assets/stylesheets/style.scss
+++ b/assets/stylesheets/style.scss
@@ -32,7 +32,6 @@
 @import 'sections/stats';                      // stats page styles
 @import 'sections/upgrades';                   // upgrades page styles
 @import 'sections/sharing';                    // sharing page styles
-@import 'sections/site-settings';              // blog setting styles
 @import 'sections/notifications';              // notifications styles
 @import 'sections/checkout';                   // Checkout styles
 @import 'sections/billing-history';            // Billing History styles

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -79,3 +79,10 @@
 .plugins__plugin-list-state {
 	white-space: nowrap;
 }
+
+.disconnect-jetpack-button {
+	margin-right: 8px;
+}
+.card.is-compact.section-header.after-compact {
+	margin-top: 16px;
+}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -225,7 +225,7 @@ module.exports = React.createClass( {
 						onClick={ this.recordEvent.bind( this, 'Clicked Site Visibility Radio Button' ) }
 					/>
 					<span>{ this.translate( 'Discourage search engines from indexing this site' ) }</span>
-					<p className="settings-explanation inside-list">
+					<p className="settings-explanation inside-list is-indented">
 						{ this.translate( 'Note: This option does not block access to your site — it is up to search engines to honor your request.' ) }
 					</p>
 				</label>
@@ -316,33 +316,10 @@ module.exports = React.createClass( {
 					<label>
 						<input name="jetpack_sync_non_public_post_stati" type="checkbox" checkedLink={ this.linkState( 'jetpack_sync_non_public_post_stati' ) }/>
 						<span>{ this.translate( 'Allow synchronization of Posts and Pages with non-public post statuses' ) }</span>
-						<p className="settings-explanation">{ this.translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }</p>
+						<p className="settings-explanation is-indented">{ this.translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }</p>
 					</label>
 				</li>
 			</ul>
-		);
-	},
-
-	jetpackOptions: function() {
-		var site = this.props.site;
-
-		if ( ! site.jetpack ) {
-			return null;
-		}
-
-		return (
-			<fieldset>
-				<legend>{ this.translate( 'Jetpack Status' ) }</legend>
-				{ this.syncNonPublicPostTypes() }
-				<p>{
-					this.translate( 'You can also {{manageLink}}manage the monitor settings{{/manageLink}} and {{migrateLink}}migrate followers{{/migrateLink}}.', {
-						components: {
-							manageLink: <a href={ '../security/' + site.slug } />,
-							migrateLink: <a href={ 'https://wordpress.com/manage/' + site.ID } />
-						}
-					} )
-				}</p>
-			</fieldset>
 		);
 	},
 
@@ -358,26 +335,11 @@ module.exports = React.createClass( {
 			context: 'Jetpack: Action user takes to disconnect Jetpack site from .com link in general site settings'
 		} );
 
-		return (
-			<fieldset>
-				<legend>{ this.translate( 'Jetpack Connection' ) }</legend>
-				<ul id="settings-jetpack-connection" className="settings-jetpack">
-					<li>
-						<label>
-							<DisconnectJetpackButton
-								site={ site }
-								text= { disconnectText }
-								redirect= "/stats"
-								linkDisplay={ false }
-							/>
-							<p className="settings-explanation inside-list">
-								{ this.translate( 'This action cannot be undone. You will need to reconnect manually from your site dashboard.' ) }
-							</p>
-						</label>
-					</li>
-				</ul>
-			</fieldset>
-		);
+		return <DisconnectJetpackButton
+				site={ site }
+				text= { disconnectText }
+				redirect= "/stats"
+				linkDisplay={ false } />;
 	},
 
 	holidaySnowOption: function() {
@@ -435,6 +397,7 @@ module.exports = React.createClass( {
 					<form onChange={ this.markChanged }>
 						{ this.siteOptions() }
 						{ this.languageOptions() }
+						{ this.holidaySnowOption() }
 					</form>
 				</Card>
 				<SectionHeader label={ this.translate( 'Address and visibility' ) }>
@@ -456,7 +419,36 @@ module.exports = React.createClass( {
 						{ this.visibilityOptions() }
 					</form>
 				</Card>
-				<SectionHeader label={ this.translate( 'Other' ) }>
+				{ this.props.site.jetpack
+					? <div>
+						<SectionHeader label={ this.translate( 'Jetpack' ) }>
+							{ this.jetpackDisconnectOption() }
+							<Button
+								compact={ true }
+								onClick={ this.submitForm }
+								primary={ true }
+								type="submit"
+								disabled={ this.state.fetchingSettings || this.state.submittingForm }>
+									{ this.state.submittingForm
+										? this.translate( 'Saving…' )
+										: this.translate( 'Save Settings' )
+									}
+							</Button>
+						</SectionHeader>
+						<Card className="is-compact">
+							<form onChange={ this.markChanged }>
+								{ this.syncNonPublicPostTypes() }
+							</form>
+						</Card>
+						<Card href={ '../security/' + site.slug } className="is-compact">
+							{ this.translate( 'View Jetpack Monitor Settings' ) }
+						</Card>
+						<Card href={ 'https://wordpress.com/manage/' + site.ID } className="is-compact">
+							{ this.translate( 'Migrate followers from another WordPress.com blog' ) }
+						</Card>
+					</div>
+					: null }
+				<SectionHeader className="after-compact" label={ this.translate( 'Related Posts' ) }>
 					<Button
 						compact={ true }
 						onClick={ this.submitForm }
@@ -471,9 +463,6 @@ module.exports = React.createClass( {
 				</SectionHeader>
 				<Card>
 					<form onChange={ this.markChanged }>
-						{ this.jetpackOptions() }
-						{ this.jetpackDisconnectOption() }
-						{ this.holidaySnowOption() }
 						{ this.relatedPostsOptions() }
 					</form>
 				</Card>

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -69,6 +69,9 @@
 		font-style: italic;
 		font-weight: 400;
 		color: $gray;
+		&.is-indented {
+			margin-left: 24px;
+		}
 	}
 
 	p.settings-alert {


### PR DESCRIPTION
Currently, the area for Jetpack settings looks like this, and is grouped in with Related Posts under an "Other" section:

<img width="810" alt="screen shot 2015-12-10 at 3 04 00 pm" src="https://cloud.githubusercontent.com/assets/1084656/11730011/95aadbb8-9f4f-11e5-8586-bb3d63cb1ea8.png">

This PR proposes that we do the following to make this whole thing clearer:
- Separate Jetpack and Related Posts into two sections.
- Use the SectionHeader pattern better here by moving the Disconnect button up next to Save
- Clean up the content by using the clickable Card pattern for Monitor Settings and Migrate Followers
- Clean up the form label descriptions for indented items by adding an 'is-indented` class to the italicized descriptions that are for labels with checkboxes in front of them

Making the aforementioned changes results in this:

<img width="809" alt="screen shot 2015-12-10 at 3 04 09 pm" src="https://cloud.githubusercontent.com/assets/1084656/11730077/03bc8a34-9f50-11e5-89a9-cf905750e1b1.png">
