### PR TITLE
Editor: Display field for copying media item URL

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -15,6 +15,7 @@
 @import 'components/button-group/style';
 @import 'components/card/style';
 @import 'components/chart/style';
+@import 'components/clipboard-button-input/style';
 @import 'components/comment-button/style';
 @import 'components/count/style';
 @import 'components/date-picker/style';

--- a/client/components/clipboard-button-input/README.md
+++ b/client/components/clipboard-button-input/README.md
@@ -1,0 +1,43 @@
+Clipboard Button Input
+======================
+
+Clipboard Button Input is a React component used to display a text input field containing a button for copying the value of the input to a user's clipboard. It makes use of the [Clipboard Button component](../forms/clipboard-button), which leverages [Clipboard.js](https://github.com/zenorocha/clipboard.js) for non-Flash based copy behavior.
+
+## Usage
+
+In most cases, the component can be treated much like any other text input element. Pass a `value` to be used as the input text to be copied.
+
+```jsx
+import React from 'react';
+import ClipboardButtonInput from 'components/clipboard-button-input';
+
+export default function MyComponent() {
+	return (
+		<ClipboardButtonInput value="https://example.wordpress.com/" />
+	);
+};
+```
+
+## Props
+
+The following props can be passed to the ClipboardButtonInput component. With the exception of `className`, all props, including those not listed below, will be passed to the child `<input />` element.
+
+### `value`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>""</code></td></tr>
+</table>
+
+The value of the `<input />` element, and the text to be copied when clicking the copy button.
+
+### `disabled`
+
+<table>
+	<tr><td>Type</td><td>Boolean</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>false</code></td></tr>
+</table>
+
+Whether the children `<input />` and `<button />` should be rendered as `disabled`.

--- a/client/components/clipboard-button-input/docs/example.jsx
+++ b/client/components/clipboard-button-input/docs/example.jsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react/addons';
+
+/**
+ * Internal dependencies
+ */
+import ClipboardButtonInput from '../';
+
+export default React.createClass( {
+	displayName: 'ClipboardButtonInput',
+
+	mixins: [ React.addons.PureRenderMixin ],
+
+	render: function() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/design/clipboard-button-input">Clipboard Button Input</a>
+				</h2>
+				<ClipboardButtonInput value="https://example.wordpress.com/" />
+			</div>
+		);
+	}
+} );

--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classnames from 'classnames';
+import omit from 'lodash/object/omit';
+
+/**
+ * Internal dependencies
+ */
+import ClipboardButton from 'components/forms/clipboard-button';
+import FormTextInput from 'components/forms/form-text-input';
+
+export default React.createClass( {
+	displayName: 'ClipboardButtonInput',
+
+	propTypes: {
+		value: PropTypes.string,
+		className: PropTypes.string
+	},
+
+	getInitialState() {
+		return {
+			isCopied: false
+		};
+	},
+
+	getDefaultProps() {
+		return {
+			value: ''
+		};
+	},
+
+	componentWillUnmount() {
+		clearTimeout( this.confirmationTimeout );
+		delete this.confirmationTimeout;
+	},
+
+	showConfirmation() {
+		this.setState( {
+			isCopied: true
+		} );
+
+		this.confirmationTimeout = setTimeout( () => {
+			this.setState( {
+				isCopied: false
+			} );
+		}, 4000 );
+	},
+
+	render() {
+		const { value, className } = this.props;
+		const classes = classnames( 'clipboard-button-input', className );
+
+		return (
+			<span className={ classes }>
+				<FormTextInput
+					{ ...omit( this.props, 'className' ) }
+					type="text"
+					selectOnFocus
+					readOnly />
+				<ClipboardButton
+					text={ value }
+					onCopy={ this.showConfirmation }
+					compact>
+					{ this.state.isCopied
+						? this.translate( 'Copied!' )
+						: this.translate( 'Copy', { context: 'verb' } ) }
+				</ClipboardButton>
+			</span>
+		);
+	}
+} );

--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -16,12 +16,14 @@ export default React.createClass( {
 
 	propTypes: {
 		value: PropTypes.string,
+		disabled: PropTypes.bool,
 		className: PropTypes.string
 	},
 
 	getInitialState() {
 		return {
-			isCopied: false
+			isCopied: false,
+			disabled: false
 		};
 	},
 
@@ -49,7 +51,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { value, className } = this.props;
+		const { value, className, disabled } = this.props;
 		const classes = classnames( 'clipboard-button-input', className );
 
 		return (
@@ -62,6 +64,7 @@ export default React.createClass( {
 				<ClipboardButton
 					text={ value }
 					onCopy={ this.showConfirmation }
+					disabled={ disabled }
 					compact>
 					{ this.state.isCopied
 						? this.translate( 'Copied!' )

--- a/client/components/clipboard-button-input/style.scss
+++ b/client/components/clipboard-button-input/style.scss
@@ -9,7 +9,7 @@
 	transform: translateY( -50% );
 	overflow: visible;
 
-	&::before {
+	&:not( :disabled )::before {
 		@include long-content-fade( $size: 16px );
 		right: calc( 100% + 1px );
 	}

--- a/client/components/clipboard-button-input/style.scss
+++ b/client/components/clipboard-button-input/style.scss
@@ -1,0 +1,20 @@
+.clipboard-button-input {
+	position: relative;
+}
+
+.clipboard-button-input .clipboard-button {
+	position: absolute;
+		top: 50%;
+		right: 4px;
+	transform: translateY( -50% );
+	overflow: visible;
+
+	&::before {
+		@include long-content-fade( $size: 16px );
+		right: calc( 100% + 1px );
+	}
+
+	&:focus::before {
+		right: calc( 100% + 3px );
+	}
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -43,6 +43,7 @@ var SearchCard = require( 'components/search-card' ),
 	InputChrono = require( 'components/input-chrono/docs/example' ),
 	TimezoneDropdown = require( 'components/timezone-dropdown/docs/example' ),
 	ClipboardButtons = require( 'components/forms/clipboard-button/docs/example' ),
+	ClipboardButtonInput = require( 'components/clipboard-button-input/docs/example' ),
 	HeaderCake = require( 'components/header-cake' ),
 	InfoPopover = require( 'components/info-popover/docs/example' ),
 	FoldableCard = require( 'components/foldable-card/docs/example' ),
@@ -204,6 +205,7 @@ module.exports = React.createClass( {
 					<DropZones />
 					<FormFields searchKeywords="input textbox textarea radio"/>
 					<ClipboardButtons />
+					<ClipboardButtonInput />
 					<Rating />
 					<Count />
 					<Version />

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -13,6 +13,7 @@ var ReactDom = require( 'react-dom' ),
 var analytics = require( 'analytics' ),
 	MediaUtils = require( 'lib/media/utils' ),
 	MediaActions = require( 'lib/media/actions' ),
+	ClipboardButtonInput = require( 'components/clipboard-button-input' ),
 	FormTextarea = require( 'components/forms/form-textarea' ),
 	FormTextInput = require( 'components/forms/form-text-input' ),
 	TrackInputChanges = require( 'components/track-input-changes' ),
@@ -134,6 +135,9 @@ module.exports = React.createClass( {
 					<TrackInputChanges onNewValue={ this.bumpStat.bind( this, 'description' ) }>
 						<FormTextInput name="description" value={ this.getItemValue( 'description' ) } onChange={ this.onChange } />
 					</TrackInputChanges>
+				</EditorMediaModalFieldset>
+				<EditorMediaModalFieldset legend={ this.translate( 'URL' ) }>
+					<ClipboardButtonInput value={ MediaUtils.url( this.props.item ) } />
 				</EditorMediaModalFieldset>
 			</div>
 		);


### PR DESCRIPTION
Closes #1051

This pull request seeks to add a new `<ClipboardButtonInput />` component for displaying a read-only text field with copy button. It also includes this component in the post editor media modal, enabling a user to copy the media item's URL.

![image](https://cloud.githubusercontent.com/assets/1779930/11730196/6f67d106-9f61-11e5-9dea-0ef88d2392b7.png)

__Testing instructions:__

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click the media button in the editor toolbar
4. Hover a media item and click the edit button
5. Note that a URL field is shown in the detail sidebar
6. Click the Copy button in the URL field
7. Note that the media item URL is copied to your clipboard