### PR TITLE
SiteSelectorModal: Use SitesDropdown

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -61,6 +61,7 @@
 @import 'components/select-dropdown/style';
 @import 'components/site-icon/style';
 @import 'components/site-selector/style';
+@import 'components/site-selector-modal/style';
 @import 'components/sites-dropdown/style';
 @import 'components/sites-popover/style';
 @import 'components/spinner/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -61,7 +61,6 @@
 @import 'components/select-dropdown/style';
 @import 'components/site-icon/style';
 @import 'components/site-selector/style';
-@import 'components/site-selector-modal/style';
 @import 'components/sites-dropdown/style';
 @import 'components/sites-popover/style';
 @import 'components/spinner/style';

--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -36,9 +36,9 @@ var SiteSelectorModal = React.createClass( {
 
 	getInitialState: function() {
 		return ( {
-			site: sitesList.getPrimary().jetpack ?
-				sitesList.get().filter( this.props.filter )[0] :
-				sitesList.getPrimary()
+			site: sitesList.getPrimary().jetpack
+				? sitesList.get().filter( this.props.filter )[0]
+				: sitesList.getPrimary()
 		} );
 	},
 
@@ -58,9 +58,9 @@ var SiteSelectorModal = React.createClass( {
 	getMainLink: function() {
 		var url = this.props.getMainUrl && this.props.getMainUrl( this.state.site );
 
-		return url ?
-			<a href={ url } className="button is-primary">{ this.props.mainActionLabel }</a> :
-			{ action: 'mainAction', label: this.props.mainActionLabel, isPrimary: true };
+		return url
+			? <a href={ url } className="button is-primary">{ this.props.mainActionLabel }</a>
+			: { action: 'mainAction', label: this.props.mainActionLabel, isPrimary: true };
 	},
 
 	render: function() {

--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -9,6 +9,7 @@ var React = require( 'react/addons' ),
  * Internal dependencies
  */
 var Dialog = require( 'components/dialog' ),
+	Button = require( 'components/button' ),
 	SitesDropdown = require( 'components/sites-dropdown' ),
 	sitesList = require( 'lib/sites-list' )();
 
@@ -67,7 +68,7 @@ var SiteSelectorModal = React.createClass( {
 		var url = this.props.getMainUrl && this.props.getMainUrl( this.state.site );
 
 		return url
-			? <a href={ url } className="button is-primary">{ this.props.mainActionLabel }</a>
+			? <Button primary href={ url }>{ this.props.mainActionLabel }</Button>
 			: { action: 'mainAction', label: this.props.mainActionLabel, isPrimary: true };
 	},
 

--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -8,7 +8,7 @@ var React = require( 'react/addons' ),
  * Internal dependencies
  */
 var Dialog = require( 'components/dialog' ),
-	SelectSite = require( 'me/select-site' ),
+	SitesDropdown = require( 'components/sites-dropdown' ),
 	sitesList = require( 'lib/sites-list' )();
 
 /**
@@ -42,8 +42,8 @@ var SiteSelectorModal = React.createClass( {
 		} );
 	},
 
-	setSite: function( event ) {
-		var site = sitesList.getSite( parseInt( event.target.value ) );
+	setSite: function( slug ) {
+		var site = sitesList.getSite( slug );
 		this.setState( { site: site } );
 	},
 
@@ -79,12 +79,10 @@ var SiteSelectorModal = React.createClass( {
 				<div className="site-selector-modal__content">
 					{ this.props.children }
 				</div>
-				<SelectSite className="site-selector-modal__dropdown"
-					sites={ sitesList }
-					value={ this.state.site && this.state.site.ID }
-					onChange={ this.setSite }
+				<SitesDropdown
+					onSiteSelect={ this.setSite }
+					selected={ this.state.site.slug }
 					filter={ this.props.filter } />
-
 			</Dialog>
 		);
 	}

--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var React = require( 'react/addons' ),
-	classnames = require( 'classnames' );
+	classnames = require( 'classnames' ),
+	includes = require( 'lodash/collection/includes' );
 
 /**
  * Internal dependencies
@@ -35,11 +36,18 @@ var SiteSelectorModal = React.createClass( {
 	},
 
 	getInitialState: function() {
-		return ( {
-			site: sitesList.getPrimary().jetpack
-				? sitesList.get().filter( this.props.filter )[0]
-				: sitesList.getPrimary()
-		} );
+		const primarySite = sitesList.getPrimary();
+		let filteredSites = sitesList.getVisible();
+
+		if ( this.props.filter ) {
+			filteredSites = filteredSites.filter( this.props.filter );
+		}
+
+		return {
+			site: includes( filteredSites, primarySite )
+				? primarySite
+				: filteredSites[0]
+		};
 	},
 
 	setSite: function( slug ) {

--- a/client/components/site-selector-modal/style.scss
+++ b/client/components/site-selector-modal/style.scss
@@ -1,8 +1,3 @@
 .site-selector-modal__content {
 	padding-bottom: 15px;
 }
-
-.site-selector-modal__dropdown {
-	width: 100%;
-	margin-bottom: 20px;
-}

--- a/client/components/site-selector-modal/style.scss
+++ b/client/components/site-selector-modal/style.scss
@@ -1,0 +1,3 @@
+.site-selector-modal .sites-dropdown .site-selector {
+	max-height: 20vh;
+}

--- a/client/components/site-selector-modal/style.scss
+++ b/client/components/site-selector-modal/style.scss
@@ -1,3 +1,0 @@
-.site-selector-modal__content {
-	padding-bottom: 15px;
-}

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -27,7 +27,8 @@ module.exports = React.createClass( {
 		autoFocus: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
 		selected: React.PropTypes.string,
-		hideSelected: React.PropTypes.bool
+		hideSelected: React.PropTypes.bool,
+		filter: React.PropTypes.func
 	},
 
 	getDefaultProps: function() {
@@ -144,6 +145,10 @@ module.exports = React.createClass( {
 			sites = this.props.sites.search( this.state.search );
 		} else {
 			sites = this.props.sites.getVisible();
+		}
+
+		if ( this.props.filter ) {
+			sites = sites.filter( this.props.filter );
 		}
 
 		// Render sites

--- a/client/components/sites-dropdown/README.md
+++ b/client/components/sites-dropdown/README.md
@@ -16,3 +16,16 @@ render() {
 	);
 }
 ```
+
+#### Props
+
+(All optional)
+* `selected` (`number|string`) — Index or slug of the initial selection
+* `showAllSites` (`bool`) — `true` to display the _All My Sites_ option
+* `indicator` (`bool`) — `true` to show the status indicator badge against each site
+* `autoFocus` (`bool`) — `true` to set focus in search box
+* `onClose` (`function`) — called on site selection
+* `onSiteSelect` (`function`) - called with the site `slug` on site selection
+* `filter` (`function`) - If present, passed to `sites.filter()` to display a subset of sites. Return `true` to display a site.
+
+

--- a/client/components/sites-dropdown/README.md
+++ b/client/components/sites-dropdown/README.md
@@ -22,8 +22,6 @@ render() {
 (All optional)
 * `selected` (`number|string`) — Index or slug of the initial selection
 * `showAllSites` (`bool`) — `true` to display the _All My Sites_ option
-* `indicator` (`bool`) — `true` to show the status indicator badge against each site
-* `autoFocus` (`bool`) — `true` to set focus in search box
 * `onClose` (`function`) — called on site selection
 * `onSiteSelect` (`function`) - called with the site `slug` on site selection
 * `filter` (`function`) - If present, passed to `sites.filter()` to display a subset of sites. Return `true` to display a site.

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -27,8 +27,6 @@ export default React.createClass( {
 			React.PropTypes.string
 		] ),
 		showAllSites: React.PropTypes.bool,
-		indicator: React.PropTypes.bool,
-		autoFocus: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
 		onSiteSelect: React.PropTypes.func,
 		filter: React.PropTypes.func
@@ -37,7 +35,6 @@ export default React.createClass( {
 	getDefaultProps() {
 		return {
 			showAllSites: false,
-			indicator: false,
 			onClose: noop,
 			onSiteSelect: noop
 		};

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -46,7 +46,6 @@ export default React.createClass( {
 	getInitialState() {
 		const primary = sites.getPrimary();
 		return {
-			search: '',
 			selected: this.props.selected || primary && primary.slug
 		};
 	},

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -30,7 +30,8 @@ export default React.createClass( {
 		indicator: React.PropTypes.bool,
 		autoFocus: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
-		onSiteSelect: React.PropTypes.func
+		onSiteSelect: React.PropTypes.func,
+		filter: React.PropTypes.func
 	},
 
 	getDefaultProps() {
@@ -84,6 +85,7 @@ export default React.createClass( {
 							onSiteSelect={ this.selectSite }
 							selected={ this.state.selected }
 							hideSelected={ true }
+							filter={ this.props.filter }
 						/>
 					}
 				</div>

--- a/shared/my-sites/themes/style.scss
+++ b/shared/my-sites/themes/style.scss
@@ -33,7 +33,7 @@
 }
 
 .themes__site-selector-modal {
-	padding: 15px;
+	padding-bottom: 24px;
 
 	.site-selector-modal__content {
 		.theme {


### PR DESCRIPTION
Use @mtias' `SitesDropdown` component inside `SiteSelectorModal` (instead of `me/select-site`).

Changes include:
* Added filter props to some components in the hierarchy, in order to remove Jetpack sites from the dropdown.
* Generalization of the logic that sets the pre-selected site (bb739e1d16bacb00fd2627d1833984e98bd10c88) @seear 
* Some cleanup (ESLint, obsolete SASS, obsolete attribute in `SiteDropdown`'s `initialState`)

To test:
* Go to calypso.localhost:3000/design
* Click on any theme's '...' menu and select 'Activate'
* Verify that your primary site is pre-selected in the dropdown.
* Verify that no Jetpack sites are shown in that dropdown.
* Select a test site of yours and activate the theme on it.
* Check that you're shown the 'Thanks' modal, and that the theme really has been activated on the selected site.
* Edge case -- primary site is a Jetpack site:
 * Try setting your primary site to a Jetpack site. Verify that instead of that JP site, the (alphabetically) first of your wpcom-hosted sites is pre-selected in the dropdown.

Before:

![before](https://cloud.githubusercontent.com/assets/96308/11821812/ad558a90-a36b-11e5-8d6d-30fabeb32f6b.png)

After:

![after](https://cloud.githubusercontent.com/assets/96308/11821837/c8419aa6-a36b-11e5-834d-05857f888d58.png)
