### PR TITLE
Importer: Poll from `v1.1` API endpoint

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -39,7 +39,7 @@ export function fetchState( siteId ) {
 
 			Dispatcher.handleViewAction( {
 				type: actionTypes.RECEIVE_IMPORT_STATUS,
-				siteId, importerStatus
+				importerStatus
 			} );
 		} )
 		.catch( () => Dispatcher.handleViewAction( {

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -8,7 +8,7 @@ const wpcom = require( 'lib/wp' ).undocumented();
  * Internal dependencies
  */
 import { actionTypes } from './constants';
-import { toApi } from './common';
+import { fromApi, toApi } from './common';
 
 export function cancelImport( importerId ) {
 	Dispatcher.handleViewAction( {
@@ -23,6 +23,28 @@ export function failUpload( importerId, error ) {
 		importerId,
 		error
 	} );
+}
+
+export function fetchState( siteId ) {
+	Dispatcher.handleViewAction( {
+		type: actionTypes.API_REQUEST
+	} );
+
+	wpcom.fetchImporterState( siteId )
+		.then( importer => fromApi( importer ) )
+		.then( importerStatus => {
+			Dispatcher.handleViewAction( {
+				type: actionTypes.API_SUCCESS
+			} );
+
+			Dispatcher.handleViewAction( {
+				type: actionTypes.RECEIVE_IMPORT_STATUS,
+				siteId, importerStatus
+			} );
+		} )
+		.catch( () => Dispatcher.handleViewAction( {
+			type: actionTypes.API_FAILURE
+		} ) );
 }
 
 export function finishUpload( importerId, importerStatus ) {

--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -51,14 +51,15 @@ function replaceUserInfoWithIds( customData ) {
 }
 
 export function fromApi( state ) {
-	const { importId: importerId, importStatus, type, progress, customData } = state;
+	const { importId: importerId, importStatus, type, progress, customData, siteId } = state;
 
 	return {
 		importerId,
 		importerState: apiToAppState( importStatus ),
 		type: `importer-type-${ type }`,
 		progress: fromJS( progress ),
-		customData: fromJS( generateSourceAuthorIds( customData ) )
+		customData: fromJS( generateSourceAuthorIds( customData ) ),
+		site: { ID: siteId }
 	};
 }
 

--- a/client/lib/importer/constants.js
+++ b/client/lib/importer/constants.js
@@ -23,6 +23,8 @@ export const actionTypes = Object.freeze( {
 	API_FAILURE: 'importer-api-failure',
 	API_SUCCESS: 'importer-api-success',
 
+	RECEIVE_IMPORT_STATUS: 'importer-receive-import-status',
+
 	CANCEL_IMPORT: 'importer-cancel',
 	FAIL_UPLOAD: 'importer-fail-upload',
 	FINISH_UPLOAD: 'importer-finish-upload',

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -17,6 +17,7 @@ const initialState = {
 	count: 0,
 	importers: new Immutable.Map,
 	api: {
+		isHydrated: false,
 		isFetching: false,
 		retryCount: 0
 	}
@@ -92,6 +93,7 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 
 		case actionTypes.RECEIVE_IMPORT_STATUS:
 			newState = state
+				.setIn( [ 'api', 'isHydrated' ], true )
 				.setIn( [ 'importers', action.importerStatus.importerId ], Immutable.fromJS( action.importerStatus ) );
 			break;
 

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -59,7 +59,7 @@ export default React.createClass( {
 	},
 
 	getInitialState: function() {
-		return { importers: [] };
+		return getImporterState();
 	},
 
 	getSiteTitle: function() {
@@ -74,6 +74,8 @@ export default React.createClass( {
 	 * @returns {Array<Object>} ImportStatus objects
 	 */
 	getStatusFor: function( type ) {
+		const { api: { isHydrated }, importers } = this.state;
+		const { site } = this.props;
 		var disabledTypes, status;
 
 		disabledTypes = [
@@ -82,19 +84,20 @@ export default React.createClass( {
 			importerTypes.SQUARESPACE
 		];
 
-		if ( includes( disabledTypes, type ) ) {
+		if ( ! isHydrated || includes( disabledTypes, type ) ) {
 			return [ { importerState: appStates.DISABLED, type } ];
 		}
 
-		status = Object.keys( this.state.importers )
-			.map( key => this.state.importers[ key ] )
-			.filter( item => ( type === item.type ) );
+		status = Object.keys( importers )
+			.map( id => importers[ id ] )
+			.filter( importer => site.ID === importer.site.ID )
+			.filter( importer => type === importer.type );
 
 		if ( 0 === status.length ) {
-			status.push( { importerState: appStates.INACTIVE, type } );
+			return [ { importerState: appStates.INACTIVE, type } ];
 		}
 
-		return status.map( item => Object.assign( {}, item, { site: this.props.site } ) );
+		return status.map( item => Object.assign( {}, item, { site } ) );
 	},
 
 	renderImporters: function() {

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -12,9 +12,11 @@ import EmptyContent from 'components/empty-content';
 import GhostImporter from 'my-sites/importer/importer-ghost';
 import { setState as setImporterState } from 'lib/importer/actions';
 import ImporterStore, { getState as getImporterState } from 'lib/importer/store';
+import Interval, { EVERY_FIVE_SECONDS } from 'lib/interval';
 import MediumImporter from 'my-sites/importer/importer-medium';
 import SquarespaceImporter from 'my-sites/importer/importer-squarespace';
 import WordPressImporter from 'my-sites/importer/importer-wordpress';
+import { fetchState } from 'lib/importer/actions';
 import { appStates, importerTypes } from 'lib/importer/constants';
 import config from 'config';
 
@@ -185,6 +187,10 @@ export default React.createClass( {
 		setImporterState( newState );
 	},
 
+	updateFromAPI: function() {
+		fetchState( this.props.site.ID );
+	},
+
 	updateState: function() {
 		this.setState( getImporterState() );
 	},
@@ -205,6 +211,7 @@ export default React.createClass( {
 
 		return (
 			<div className="section-import">
+				<Interval onTick={ this.updateFromAPI } period={ EVERY_FIVE_SECONDS } />
 				{ this.renderCustomPropControls() }
 				<CompactCard>
 					<header>

--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -1675,9 +1675,7 @@ Undocumented.prototype.deleteEmailFollower = function( siteId, followerId, email
 Undocumented.prototype.fetchImporterState = function( siteId ) {
 	debug( `/sites/${ siteId }/importer/` );
 
-	return this.wpcom.req.get( Object.assign( {},
-		{ path: `/sites/${ siteId }/imports/` }
-	) );
+	return this.wpcom.req.get( { path: `/sites/${ siteId }/imports/` } );
 };
 
 Undocumented.prototype.updateImporter = function( siteId, importerStatus ) {

--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -1672,6 +1672,14 @@ Undocumented.prototype.deleteEmailFollower = function( siteId, followerId, email
 	}, fn );
 };
 
+Undocumented.prototype.fetchImporterState = function( siteId ) {
+	debug( `/sites/${ siteId }/importer/` );
+
+	return this.wpcom.req.get( Object.assign( {},
+		{ path: `/sites/${ siteId }/imports/` }
+	) );
+};
+
 Undocumented.prototype.updateImporter = function( siteId, importerStatus ) {
 	debug( `/sites/${ siteId }/imports/${ importerStatus.importId }` );
 


### PR DESCRIPTION
**Warning** This is a breaking build!

There are two pieces of this PR that break things:
 - The `v1.1` endpoint only exists in a patch - D398, but the `v1`
   endpoint _does_ exist but returns incompatable data. Since the
endpoints decide to send the wrong thing anyway, this will break unless
`public-api.wordpress.com` is sandboxed to a machine with the patch.
 - The polling automaticallly overwrites any local state, meaning that
   if you try to move forward with the import process your changes will
likely get wiped out before you are ready to go.

_*So what the heck is the PR for, anyhow?*_

This is here to start adding in the polling functionality without
requiring a big friendly merge. After this PR gets baked in, we should
be able to progress by intelligently merging local changes to the
importer states with those coming from the API.

**Testing**

Navigate to **My Sites** > **Settings** >> **Import** and start an
import by uploading a file. If you have previously done this, there is
likely an import waiting on the server and it will appear after about
five seconds. If not, then after your upload finishes (maybe before?)
the import from the server should appear. You should be able to navigate
away and come back and find things the same. You should be able to close
your browser session and come back and pick up where you left off (after
the delay in getting data from the API).

cc: @roundhill @fredrocious @rralian 