### PR TITLE
Update/information box typography

### DIFF
--- a/client/components/version/README.md
+++ b/client/components/version/README.md
@@ -24,7 +24,7 @@ The following props can be passed to the Version component:
 ### `version`
 
 <table>
-	<tr><td>Type</td><td>Number</td></tr>
+	<tr><td>Type</td><td>String</td></tr>
 	<tr><td>Required</td><td>Yes</td></tr>
 </table>
 

--- a/client/components/version/index.jsx
+++ b/client/components/version/index.jsx
@@ -13,7 +13,7 @@ export default React.createClass( {
 	displayName: 'Version',
 
 	propTypes: {
-		version: React.PropTypes.number.isRequired,
+		version: React.PropTypes.string.isRequired,
 		icon: React.PropTypes.string
 	},
 

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -9,6 +9,7 @@ import i18n from 'lib/mixins/i18n';
  */
 
 import Gridicon from 'components/gridicon';
+import ExternalLink from 'components/external-link';
 import Rating from 'components/rating';
 import PluginVersion from 'my-sites/plugins/plugin-version';
 import PluginRatings from 'my-sites/plugins/plugin-ratings/';
@@ -43,16 +44,14 @@ export default React.createClass( {
 		}
 
 		return (
-			<div>
-				<a
-					className="plugin-information__external-link"
-					target="_blank"
-					onClick={ analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked Plugin Homepage Link', 'Plugin Name', this.props.plugin.slug ) }
-					href={ this.props.plugin.plugin_url }
-				>
-					<Gridicon size={ 12 } icon="external" />{ this.translate( 'Plugin homepage' ) }
-				</a>
-			</div>
+			<ExternalLink
+				icon={ true }
+				href={ this.props.plugin.plugin_url }
+				onClick={ analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked Plugin Homepage Link', 'Plugin Name', this.props.plugin.slug ) }
+				className="plugin-information__external-link"
+			>
+				{ this.translate( 'Plugin homepage' ) }
+			</ExternalLink>
 		);
 	},
 
@@ -61,16 +60,14 @@ export default React.createClass( {
 			return;
 		}
 		return (
-			<div>
-				<a
-					className="plugin-information__external-link"
-					target="_blank"
-					onClick={ analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked wp.org Plugin Link', 'Plugin Name', this.props.plugin.slug ) }
-					href={ 'https://' + this._WPORG_PLUGINS_URL + this.props.plugin.slug + '/' }
-				>
-					<Gridicon size={ 12 } icon="external" />{ this.translate( 'WordPress.org Plugin page' ) }
-				</a>
-			</div>
+			<ExternalLink
+				icon={ true }
+				href={ 'https://' + this._WPORG_PLUGINS_URL + this.props.plugin.slug + '/' }
+				onClick={ analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked wp.org Plugin Link', 'Plugin Name', this.props.plugin.slug ) }
+				className="plugin-information__external-link"
+			>
+				{ this.translate( 'WordPress.org Plugin page' ) }
+			</ExternalLink>
 		);
 	},
 
@@ -80,14 +77,14 @@ export default React.createClass( {
 		}
 
 		return (
-			<a
-				className="plugin-information__external-link"
-				target="_blank"
-				onClick={ analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked Plugin Homepage Link', 'Plugin Name', this.props.plugin.slug ) }
+			<ExternalLink
+				icon={ true }
 				href={ this.props.plugin.support_URL }
+				onClick={ analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked Plugin Homepage Link', 'Plugin Name', this.props.plugin.slug ) }
+				className="plugin-information__external-link"
 			>
-				<Gridicon size={ 12 } icon="external" />{ this.translate( 'Learn More' ) }
-			</a>
+				{ this.translate( 'Learn More' ) }
+			</ExternalLink>
 		);
 	},
 

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -8,11 +8,11 @@ import i18n from 'lib/mixins/i18n';
  * Internal dependencies
  */
 
-import Gridicon from 'components/gridicon';
 import ExternalLink from 'components/external-link';
-import Rating from 'components/rating';
-import PluginVersion from 'my-sites/plugins/plugin-version';
+import Gridicon from 'components/gridicon';
+import Version from 'components/version';
 import PluginRatings from 'my-sites/plugins/plugin-ratings/';
+import versionCompare from 'lib/version-compare';
 import analytics from 'analytics';
 
 export default React.createClass( {
@@ -88,41 +88,56 @@ export default React.createClass( {
 		);
 	},
 
-	renderStarRating() {
-		return (
-			<div>
-				<div className="plugin-information__rating-stars"><Rating rating={ this.props.plugin.rating } /></div>
-				<div className="plugin-information__rating-text">
-					{ this.translate( 'Based on %(ratingsNumber)s rating', 'Based on %(ratingsNumber)s ratings', {
-						count: this.props.plugin.num_ratings,
-						args: { ratingsNumber: this.props.plugin.num_ratings }
-					} ) }
-				</div>
-			</div>
-		);
-	},
-
 	renderLastUpdated() {
 		if ( this.props.plugin && this.props.plugin.last_updated ) {
-			let dateFromNow = i18n.moment.utc( this.props.plugin.last_updated, 'YYYY-MM-DD hh:mma' ).fromNow();
-			return <div className="plugin-information__last-updated">{ this.translate( 'Latest release %(dateFromNow)s', { args: { dateFromNow: dateFromNow } } ) }</div>;
+			const dateFromNow = i18n.moment.utc( this.props.plugin.last_updated, 'YYYY-MM-DD hh:mma' ).fromNow();
+			const syncIcon = this.props.hasUpdate ? <Gridicon icon="sync" size={ 18 } /> : null;
+
+			return <div className="plugin-information__last-updated">
+				{ this.translate( 'Released %(dateFromNow)s', { args: { dateFromNow } } ) }
+				{ syncIcon }
+			</div>;
 		}
+	},
+
+	renderSiteVersion() {
+		return this.props.siteVersion
+			? <Version version={ this.props.siteVersion } icon="my-sites" className="plugin-information__version" />
+			: null;
 	},
 
 	renderLimits() {
 		const limits = this.getCompatibilityLimits();
 		let versionView;
-
+		let versionCheck = null;
+		if ( this.props.siteVersion && limits.maxVersion ) {
+			if ( versionCompare( this.props.siteVersion, limits.maxVersion, '<=' ) ) {
+				versionCheck = <Gridicon icon="checkmark" size={ 18 } />;
+			} else {
+				versionCheck = <Gridicon icon="cross-small" size={ 18 } />;
+			}
+		}
 		if ( limits.minVersion && limits.maxVersion && limits.minVersion !== limits.maxVersion ) {
 			versionView = <div className="plugin-information__version-limit">
-				{ this.translate( 'Compatible with WordPress version %(minVersion)s to %(maxVersion)s',
-					{ args: { minVersion: limits.minVersion, maxVersion: limits.maxVersion } }
+				{ this.translate( '{{wpIcon/}}  Compatible with %(minVersion)s to %(maxVersion)s {{versionCheck/}}',
+					{
+						args: { minVersion: limits.minVersion, maxVersion: limits.maxVersion },
+						components: {
+							wpIcon: this.props.siteVersion ? null : <Gridicon icon="my-sites" size={ 18 } />,
+							versionCheck
+						}
+					}
 				) }
 			</div>;
 		}
 		if ( limits.minVersion && limits.maxVersion && limits.minVersion === limits.maxVersion ) {
 			versionView = <div className="plugin-information__version-limit">
-				{ this.translate( 'Compatible with WordPress version %(maxVersion)s', { args: { maxVersion: limits.maxVersion } } ) }
+				{ this.translate( '{{icon/}} Compatible with %(maxVersion)s',
+					{
+						args: { maxVersion: limits.maxVersion },
+						components: { wpIcon: this.props.siteVersion ? null : <Gridicon icon="my-sites" size={ 18 } /> }
+					}
+				) }
 			</div>;
 		}
 		return (
@@ -130,10 +145,6 @@ export default React.createClass( {
 				{ versionView }
 			</div>
 		);
-	},
-
-	renderRatingsDetail() {
-		return <PluginRatings plugin={ this.props.plugin } />;
 	},
 
 	getCompatibilityLimits() {
@@ -151,13 +162,26 @@ export default React.createClass( {
 			<div className="plugin-information is-placeholder">
 					<div className="plugin-information__wrapper">
 						<div className="plugin-information__version-info">
-							{ this.renderLastUpdated() }
-							<PluginVersion plugin={ this.props.plugin } />
-							{ this.renderLimits() }
+							<div className="plugin-information__version-shell">
+								{ this.props.pluginVersion
+									? <Version version={ this.props.pluginVersion } icon="plugins" className="plugin-information__version" />
+									: null
+								}
+								{ this.renderLastUpdated() }
+							</div>
+							<div className="plugin-information__version-shell">
+								{ this.renderSiteVersion() }
+								{ this.renderLimits() }
+							</div>
 						</div>
 						<div className="plugin-information__rating-info">
-							{ this.renderStarRating() }
-							{ this.renderRatingsDetail() }
+							<PluginRatings
+								rating={ this.props.plugin.rating }
+								ratings={ this.props.plugin.ratings }
+								downloaded={ this.props.plugin.downloaded }
+								numRatings={ this.props.plugin.num_ratings }
+								slug={ this.props.plugin.slug }
+								placeholder={ true } />
 						</div>
 						<div className="plugin-information__links">
 							{ this.renderWporgLink() }
@@ -184,13 +208,22 @@ export default React.createClass( {
 			<div className="plugin-information">
 					<div className="plugin-information__wrapper">
 						<div className="plugin-information__version-info">
-							{ this.renderLastUpdated() }
-							<PluginVersion plugin={ this.props.plugin } />
-							{ this.renderLimits() }
+							<div className="plugin-information__version-shell">
+								<Version version={ this.props.pluginVersion } icon="plugins" className="plugin-information__version" />
+								{ this.renderLastUpdated() }
+							</div>
+							<div className="plugin-information__version-shell">
+								{ this.renderSiteVersion() }
+								{ this.renderLimits() }
+							</div>
 						</div>
 						<div className="plugin-information__rating-info">
-							{ this.renderStarRating() }
-							{ this.renderRatingsDetail() }
+							<PluginRatings
+								rating={ this.props.plugin.rating }
+								ratings={ this.props.plugin.ratings }
+								downloaded={ this.props.plugin.downloaded }
+								numRatings={ this.props.plugin.num_ratings }
+								slug={ this.props.plugin.slug } />
 						</div>
 						<div className="plugin-information__links">
 							{ this.renderWporgLink() }

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -177,20 +177,19 @@ export default React.createClass( {
 								{ this.renderLimits() }
 							</div>
 						</div>
-						<div className="plugin-information__rating-info">
-							<PluginRatings
-								rating={ this.props.plugin.rating }
-								ratings={ this.props.plugin.ratings }
-								downloaded={ this.props.plugin.downloaded }
-								numRatings={ this.props.plugin.num_ratings }
-								slug={ this.props.plugin.slug }
-								placeholder={ true } />
-						</div>
 						<div className="plugin-information__links">
 							{ this.renderWporgLink() }
 							{ this.renderHomepageLink() }
 						</div>
 					</div>
+					<PluginRatings
+						rating={ this.props.plugin.rating }
+						ratings={ this.props.plugin.ratings }
+						downloaded={ this.props.plugin.downloaded }
+						numRatings={ this.props.plugin.num_ratings }
+						slug={ this.props.plugin.slug }
+						placeholder={ true }
+					/>
 			</div>
 		);
 	},
@@ -226,19 +225,18 @@ export default React.createClass( {
 								{ this.renderLimits() }
 							</div>
 						</div>
-						<div className="plugin-information__rating-info">
-							<PluginRatings
-								rating={ this.props.plugin.rating }
-								ratings={ this.props.plugin.ratings }
-								downloaded={ this.props.plugin.downloaded }
-								numRatings={ this.props.plugin.num_ratings }
-								slug={ this.props.plugin.slug } />
-						</div>
 						<div className="plugin-information__links">
 							{ this.renderWporgLink() }
 							{ this.renderHomepageLink() }
 						</div>
 					</div>
+					<PluginRatings
+						rating={ this.props.plugin.rating }
+						ratings={ this.props.plugin.ratings }
+						downloaded={ this.props.plugin.downloaded }
+						numRatings={ this.props.plugin.num_ratings }
+						slug={ this.props.plugin.slug }
+					/>
 			</div>
 		);
 	},

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 import i18n from 'lib/mixins/i18n';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -108,8 +109,9 @@ export default React.createClass( {
 
 	renderLimits() {
 		const limits = this.getCompatibilityLimits();
-		let versionView;
+		let versionView = null;
 		let versionCheck = null;
+
 		if ( this.props.siteVersion && limits.maxVersion ) {
 			if ( versionCompare( this.props.siteVersion, limits.maxVersion, '<=' ) ) {
 				versionCheck = <Gridicon icon="checkmark" size={ 18 } />;
@@ -118,12 +120,13 @@ export default React.createClass( {
 			}
 		}
 		if ( limits.minVersion && limits.maxVersion && limits.minVersion !== limits.maxVersion ) {
-			versionView = <div className="plugin-information__version-limit">
-				{ this.translate( '{{wpIcon/}}  Compatible with %(minVersion)s to %(maxVersion)s {{versionCheck/}}',
+			versionView = <div className="plugin-information__version-limit" >
+				{ this.translate( '{{wpIcon/}}  Compatible with %(minVersion)s to {{span}} %(maxVersion)s {{versionCheck/}}{{/span}}',
 					{
 						args: { minVersion: limits.minVersion, maxVersion: limits.maxVersion },
 						components: {
 							wpIcon: this.props.siteVersion ? null : <Gridicon icon="my-sites" size={ 18 } />,
+							span: <span className="plugin-information__version-limit-state" />,
 							versionCheck
 						}
 					}
@@ -195,24 +198,30 @@ export default React.createClass( {
 	renderWpcom() {
 		return (
 			<div className="plugin-information">
-					<p className="plugin-information__description">
-						{ this.props.plugin.description }
-					</p>
+				<p className="plugin-information__description">
+					{ this.props.plugin.description }
+				</p>
+				<div className="plugin-information__links">
 					{ this.renderWPCOMPluginSupportLink() }
-			</div>
+				</div>
+		</div>
 		);
 	},
 
 	renderWporg() {
+		const classes = classNames( {
+			'plugin-information__version-info': true,
+			'is-singlesite': !! this.props.siteVersion
+		} );
 		return (
 			<div className="plugin-information">
 					<div className="plugin-information__wrapper">
-						<div className="plugin-information__version-info">
+						<div className={ classes }>
 							<div className="plugin-information__version-shell">
 								<Version version={ this.props.pluginVersion } icon="plugins" className="plugin-information__version" />
 								{ this.renderLastUpdated() }
 							</div>
-							<div className="plugin-information__version-shell">
+							<div className="plugin-information__version-shell plugin-information__site-version-shell">
 								{ this.renderSiteVersion() }
 								{ this.renderLimits() }
 							</div>

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -220,7 +220,7 @@ export default React.createClass( {
 								<Version version={ this.props.pluginVersion } icon="plugins" className="plugin-information__version" />
 								{ this.renderLastUpdated() }
 							</div>
-							<div className="plugin-information__version-shell plugin-information__site-version-shell">
+							<div className="plugin-information__version-shell">
 								{ this.renderSiteVersion() }
 								{ this.renderLimits() }
 							</div>

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -1,19 +1,18 @@
 /**
  * External dependencies
  */
-import React from 'react/addons'
-import i18n from 'lib/mixins/i18n'
+import React from 'react/addons';
+import i18n from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
  */
-import Card from 'components/card'
-import Gridicon from 'components/gridicon'
-import Rating from 'components/rating'
-import PluginVersion from 'my-sites/plugins/plugin-version'
-import PluginRatings from 'my-sites/plugins/plugin-ratings/'
-import SectionHeader from 'components/section-header'
-import analytics from 'analytics'
+
+import Gridicon from 'components/gridicon';
+import Rating from 'components/rating';
+import PluginVersion from 'my-sites/plugins/plugin-version';
+import PluginRatings from 'my-sites/plugins/plugin-ratings/';
+import analytics from 'analytics';
 
 export default React.createClass( {
 	_WPORG_PLUGINS_URL: 'wordpress.org/plugins/',
@@ -153,8 +152,6 @@ export default React.createClass( {
 	renderPlaceholder() {
 		return (
 			<div className="plugin-information is-placeholder">
-				<SectionHeader text={ this.translate( 'Plugin Information' ) } />
-				<Card>
 					<div className="plugin-information__wrapper">
 						<div className="plugin-information__version-info">
 							{ this.renderLastUpdated() }
@@ -170,7 +167,6 @@ export default React.createClass( {
 							{ this.renderHomepageLink() }
 						</div>
 					</div>
-				</Card>
 			</div>
 		);
 	},
@@ -178,13 +174,10 @@ export default React.createClass( {
 	renderWpcom() {
 		return (
 			<div className="plugin-information">
-				<SectionHeader label={ this.translate( 'Plugin Information' ) } />
-				<Card>
 					<p className="plugin-information__description">
 						{ this.props.plugin.description }
 					</p>
 					{ this.renderWPCOMPluginSupportLink() }
-				</Card>
 			</div>
 		);
 	},
@@ -192,8 +185,6 @@ export default React.createClass( {
 	renderWporg() {
 		return (
 			<div className="plugin-information">
-				<SectionHeader label={ this.translate( 'Plugin Information' ) } />
-				<Card>
 					<div className="plugin-information__wrapper">
 						<div className="plugin-information__version-info">
 							{ this.renderLastUpdated() }
@@ -209,7 +200,6 @@ export default React.createClass( {
 							{ this.renderHomepageLink() }
 						</div>
 					</div>
-				</Card>
 			</div>
 		);
 	},

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -4,22 +4,66 @@ $plugin-information-rating-size: 160px;
 		margin-right: $plugin-information-rating-size + 24;
 	}
 }
+.plugin-information {
+	border-top: 1px solid #E9EFF3;
+	margin-top: 16px;
+	padding-top: 16px;
+	position: relative;
+	overflow: hidden;
+}
 
-.plugin-information__version-info {
+.plugin-information__version-shell {
+	margin-bottom: 16px;
+	text-align: left;
 	@include breakpoint( '>480px' ) {
 		float: left;
 		width: 100%;
+		position: relative;
+		overflow: hidden;
 	}
 }
 
-.plugin-information__last-updated {
-	font-size: 16px;
+.plugin-information__version-info {
+	font-size: 11px;
+	color: $gray;
+	text-transform: uppercase;
+	float: left;
+}
 
-	@include breakpoint( '<480px' ) {
-		display: inline-block;
-		color: $gray;
-		font-size: 11px;
-		text-transform: uppercase;
+.plugin-information__version-info .version {
+	@include breakpoint( '>480px' ) {
+		min-width: 150px;
+		margin-right: 8px;
+		float: left;
+	}
+}
+
+.plugin-information__last-updated,
+.plugin-information__versions {
+	@include breakpoint( '>480px' ) {
+		line-height: 18px;
+		min-width: 200px;
+		float: left;
+	}
+}
+.plugin-information__last-updated .gridicons-sync {
+	vertical-align: text-bottom;
+	color: $alert-yellow;
+	margin-left: 8px;
+}
+
+.plugin-information__versions {
+	.gridicons-my-sites {
+		float: left;
+		margin-right: 4px;
+	}
+	.gridicons-cross-small {
+		vertical-align: bottom;
+		color: $alert-red;
+	}
+	.gridicons-checkmark {
+		vertical-align: text-bottom;
+		color: $alert-green;
 	}
 }
 
@@ -39,39 +83,9 @@ $plugin-information-rating-size: 160px;
 	}
 }
 
-.plugin-information__rating-text {
-	@include breakpoint( '<480px' ) {
-		display: inline;
-	}
-}
-
-.plugin-information__rating-stars {
-	font-size: 24px;
-
-	@include breakpoint( '<480px' ) {
-		display: inline-block;
-		margin-right: 8px;
-		font-size: 16px;
-	}
-}
-
-.plugin-information__versions {
-	margin-top: 16px;
-}
-
-.plugin-information__version-limit {
-	margin-bottom: 4px;
-
-	&:before {
-		@include noticon( '\f418', 20px );
-		line-height: 14px;
-		color: $alert-green;
-	}
-}
-
 .plugin-information__links {
 	margin-top: 14px;
-
+	clear: left;
 	@include breakpoint( '>480px' ) {
 		float: left;
 	}
@@ -81,25 +95,11 @@ $plugin-information-rating-size: 160px;
 	display: block;
 	margin-top: 16px;
 }
-.plugin-information .plugin-version {
-	font-size: 11px;
-}
-.plugin-information__rating-text,
-.plugin-information__version-limit {
-	color: $gray;
-	font-size: 11px;
-	text-transform: uppercase;
-	white-space: pre;
-	text-overflow: ellipsis;
-	overflow: hidden;
-}
 
 .plugin-information.is-placeholder {
-	.plugin-information__description,
-	.plugin-information__version-info,
-	.plugin-information__last-updated,
-	.plugin-information__rating-text,
-	.plugin-card-header__text {
+	.plugin-information__version-shell,
+	.plugin-information__external-link,
+	.version {
 		@include placeholder();
 	}
 

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -1,13 +1,13 @@
 $plugin-information-rating-size: 160px;
 .plugin-information__wrapper {
 	@include breakpoint( '>480px' ) {
-		margin-left: $plugin-information-rating-size + 24;
+		margin-right: $plugin-information-rating-size + 24;
 	}
 }
 
 .plugin-information__version-info {
 	@include breakpoint( '>480px' ) {
-		float: right;
+		float: left;
 		width: 100%;
 	}
 }
@@ -25,9 +25,9 @@ $plugin-information-rating-size: 160px;
 
 .plugin-information__rating-info {
 	@include breakpoint( '>480px' ) {
-		float: left;
+		float: right;
 		width: $plugin-information-rating-size;
-		margin-left: -1 * $plugin-information-rating-size - 24;
+		margin-right: -1 * $plugin-information-rating-size - 24;
 	}
 
 	@include breakpoint( '<480px' ) {
@@ -78,14 +78,8 @@ $plugin-information-rating-size: 160px;
 }
 
 .plugin-information__external-link {
-	font-size: 11px;
-
-	.gridicons-external {
-		color: lighten( $gray, 10% );
-		margin-right: 8px;
-		top: 2px;
-		position: relative;
-	}
+	display: block;
+	margin-top: 16px;
 }
 .plugin-information .plugin-version {
 	font-size: 11px;

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -12,40 +12,58 @@ $plugin-information-rating-size: 160px;
 	overflow: hidden;
 }
 
+plugin-information__description {
+	margin-bottom: 0;
+}
+
 .plugin-information__version-shell {
-	margin-bottom: 16px;
 	text-align: left;
-	@include breakpoint( '>480px' ) {
-		float: left;
-		width: 100%;
-		position: relative;
-		overflow: hidden;
-	}
+	position: relative;
+	overflow: hidden;
+}
+
+.plugin-information__version-shell .version{
+	float: left;
+	width: 50%;
+	padding-bottom: 8px;
+}
+
+.plugin-information__last-updated {
+	line-height: 18px;
+	padding-bottom: 8px;
 }
 
 .plugin-information__version-info {
 	font-size: 11px;
 	color: $gray;
 	text-transform: uppercase;
-	float: left;
+	width: 100%;
+
+	@include breakpoint( '>480px' ) {
+		float: left;
+	}
+}
+
+.plugin-information__version-info.is-singlesite {
+	display: table;
+
+	.plugin-information__version-shell {
+		display: table-row;
+	}
+
+	.plugin-information__last-updated,
+	.plugin-information__versions,
+	.version {
+		display: table-cell;
+		float: none;
+		padding-bottom: 8px;
+	}
 }
 
 .plugin-information__version-info .version {
-	@include breakpoint( '>480px' ) {
-		min-width: 150px;
-		margin-right: 8px;
-		float: left;
-	}
+	padding-right: 8px;
 }
 
-.plugin-information__last-updated,
-.plugin-information__versions {
-	@include breakpoint( '>480px' ) {
-		line-height: 18px;
-		min-width: 200px;
-		float: left;
-	}
-}
 .plugin-information__last-updated .gridicons-sync {
 	vertical-align: text-bottom;
 	color: $alert-yellow;
@@ -83,8 +101,11 @@ $plugin-information-rating-size: 160px;
 	}
 }
 
+.plugin-information__version-limit-state {
+	white-space: nowrap;
+}
+
 .plugin-information__links {
-	margin-top: 14px;
 	clear: left;
 	@include breakpoint( '>480px' ) {
 		float: left;

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -1,10 +1,6 @@
-$plugin-information-rating-size: 160px;
-.plugin-information__wrapper {
-	@include breakpoint( '>480px' ) {
-		margin-right: $plugin-information-rating-size + 24;
-	}
-}
 .plugin-information {
+	display: flex;
+	flex-wrap: wrap;
 	border-top: 1px solid #E9EFF3;
 	margin-top: 16px;
 	padding-top: 16px;
@@ -12,25 +8,36 @@ $plugin-information-rating-size: 160px;
 	overflow: hidden;
 }
 
-plugin-information__description {
+.plugin-information__description {
 	margin-bottom: 0;
 }
 
+.plugin-information__wrapper {
+	flex-grow: 1;
+
+	@include breakpoint( '>480px' ) {
+
+	}
+}
+
 .plugin-information__version-shell {
-	text-align: left;
-	position: relative;
-	overflow: hidden;
+	@include clear-fix;
 }
 
 .plugin-information__version-shell .version{
 	float: left;
-	width: 50%;
-	padding-bottom: 8px;
+	margin: 0 16px 8px 0;
 }
 
 .plugin-information__last-updated {
 	line-height: 18px;
-	padding-bottom: 8px;
+	margin-bottom: 8px;
+}
+
+.plugin-information__last-updated .gridicons-sync {
+	vertical-align: text-bottom;
+	color: $alert-yellow;
+	margin-left: 8px;
 }
 
 .plugin-information__version-info {
@@ -45,59 +52,49 @@ plugin-information__description {
 }
 
 .plugin-information__version-info.is-singlesite {
-	display: table;
+	// display: table;
 
 	.plugin-information__version-shell {
-		display: table-row;
 	}
 
 	.plugin-information__last-updated,
 	.plugin-information__versions,
 	.version {
-		display: table-cell;
-		float: none;
-		padding-bottom: 8px;
+		float: left;
+		margin-bottom: 8px;
 	}
 }
 
-.plugin-information__version-info .version {
-	padding-right: 8px;
-}
-
-.plugin-information__last-updated .gridicons-sync {
-	vertical-align: text-bottom;
-	color: $alert-yellow;
-	margin-left: 8px;
-}
-
 .plugin-information__versions {
+	line-height: 18px;
+	white-space: nowrap;
+
 	.gridicons-my-sites {
 		float: left;
 		margin-right: 4px;
 	}
+
 	.gridicons-cross-small {
-		vertical-align: bottom;
+		float: right;
+		margin-left: 4px;
 		color: $alert-red;
 	}
+
 	.gridicons-checkmark {
-		vertical-align: text-bottom;
+		float: right;
+		margin-left: 4px;
 		color: $alert-green;
 	}
 }
 
-.plugin-information__rating-info {
+.plugin-information .plugin-ratings {
+	flex-grow: 1;
+	margin-top: 16px;
+
 	@include breakpoint( '>480px' ) {
-		float: right;
-		width: $plugin-information-rating-size;
-		margin-right: -1 * $plugin-information-rating-size - 24;
-	}
-
-	@include breakpoint( '<480px' ) {
-		margin-top: 16px;
-
-		& .gridicon {
-			font-size: 12px;
-		}
+		flex-grow: 0;
+		width: 160px;
+		margin-top: 0;
 	}
 }
 
@@ -107,6 +104,7 @@ plugin-information__description {
 
 .plugin-information__links {
 	clear: left;
+
 	@include breakpoint( '>480px' ) {
 		float: left;
 	}
@@ -118,6 +116,7 @@ plugin-information__description {
 }
 
 .plugin-information.is-placeholder {
+
 	.plugin-information__version-shell,
 	.plugin-information__external-link,
 	.version {

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -117,10 +117,17 @@
 
 .plugin-information.is-placeholder {
 
-	.plugin-information__version-shell,
+	.plugin-information__last-updated,
+	.plugin-information__version-limit,
 	.plugin-information__external-link,
 	.version {
 		@include placeholder();
+	}
+
+	.plugin-information__version-limit,
+	.plugin-information__last-updated {
+		width: 99%;
+		margin-top:8px;
 	}
 
 	.rating {

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -117,11 +117,15 @@
 
 .plugin-information.is-placeholder {
 
-	.plugin-information__last-updated,
-	.plugin-information__version-limit,
-	.plugin-information__external-link,
-	.version {
+	.plugin-information__wrapper {
 		@include placeholder();
+		@include breakpoint( '>480px' ) {
+			margin-right: 16px;
+		}
+	}
+	.plugin-information__external-link,
+	.version{
+		color: transparent;
 	}
 
 	.plugin-information__version-limit,

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -1,14 +1,15 @@
 /**
  * External dependencies
  */
-import React from 'react/addons'
-import classNames from 'classnames'
-import i18n from 'lib/mixins/i18n'
-import _some from 'lodash/collection/some'
+import React from 'react/addons';
+import classNames from 'classnames';
+import i18n from 'lib/mixins/i18n';
+import _some from 'lodash/collection/some';
 
 /**
  * Internal dependencies
  */
+<<<<<<< HEAD
 import analytics from 'analytics'
 import Card from 'components/card'
 import Gridicon from 'components/gridicon'
@@ -24,6 +25,23 @@ import NoticeAction from 'components/notice/notice-action';
 import PluginVersion from 'my-sites/plugins/plugin-version'
 import PluginInstallButton from 'my-sites/plugins/plugin-install-button'
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button'
+=======
+import analytics from 'analytics';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
+import PluginsActions from 'lib/plugins/actions';
+import PluginsLog from 'lib/plugins/log-store';
+import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
+import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
+import safeProtocolUrl from 'lib/safe-protocol-url';
+import config from 'config';
+import Notice from 'notices/notice';
+import PluginVersion from 'my-sites/plugins/plugin-version';
+import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
+import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
+import PluginInformation from 'my-sites/plugins/plugin-information';
+>>>>>>> 5012847... Plugin: Update information box
 
 export default React.createClass( {
 	OUT_OF_DATE_YEARS: 2,
@@ -257,7 +275,7 @@ export default React.createClass( {
 						</div>
 						{ this.renderActions() }
 					</div>
-
+					<PluginInformation plugin={ this.props.plugin } isPlaceholder={ this.props.isPlaceholder } />
 				</Card>
 				{ this.getVersionWarning() }
 				{ this.getUpdateWarning() }

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 import classNames from 'classnames';
 import i18n from 'lib/mixins/i18n';
 import _some from 'lodash/collection/some';
@@ -14,6 +14,7 @@ import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
+import Gridicon from 'components/gridicon';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginsActions from 'lib/plugins/actions';
 import PluginsLog from 'lib/plugins/log-store';
@@ -47,13 +48,7 @@ export default React.createClass( {
 	},
 
 	renderActions() {
-		const site = this.props.sites && this.props.sites[ 0 ] ? this.props.sites[ 0 ] : false;
-
-		/*
-		 * Do not show actions if we are not on a single site view or
-		 * if the plugin is not installed on any sites
-		 */
-		if ( ( ! this.props.siteUrl || ! site ) && this.isInstalledOnSite( this.props.selectedSite ) ) {
+		if ( ! this.props.selectedSite ) {
 			return;
 		}
 
@@ -97,7 +92,7 @@ export default React.createClass( {
 				href={ this.props.plugin.wp_admin_settings_page_url }
 				target="_blank">
 				{ this.translate( 'Setup' ) }
-				<Gridicon size={ 14 } icon="external" />
+				<Gridicon size={ 18 } icon="external" />
 			</a>
 		);
 	},

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -9,26 +9,11 @@ import _some from 'lodash/collection/some';
 /**
  * Internal dependencies
  */
-<<<<<<< HEAD
-import analytics from 'analytics'
-import Card from 'components/card'
-import Gridicon from 'components/gridicon'
-import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon'
-import PluginsActions from 'lib/plugins/actions'
-import PluginsLog from 'lib/plugins/log-store'
-import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle'
-import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle'
-import safeProtocolUrl from 'lib/safe-protocol-url'
-import config from 'config'
-import Notice from 'components/notice'
-import NoticeAction from 'components/notice/notice-action';
-import PluginVersion from 'my-sites/plugins/plugin-version'
-import PluginInstallButton from 'my-sites/plugins/plugin-install-button'
-import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button'
-=======
 import analytics from 'analytics';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
+import NoticeAction from 'components/notice/notice-action';
+import Notice from 'components/notice';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginsActions from 'lib/plugins/actions';
 import PluginsLog from 'lib/plugins/log-store';
@@ -36,12 +21,9 @@ import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
 import safeProtocolUrl from 'lib/safe-protocol-url';
 import config from 'config';
-import Notice from 'notices/notice';
-import PluginVersion from 'my-sites/plugins/plugin-version';
 import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
 import PluginInformation from 'my-sites/plugins/plugin-information';
->>>>>>> 5012847... Plugin: Update information box
 
 export default React.createClass( {
 	OUT_OF_DATE_YEARS: 2,
@@ -57,7 +39,7 @@ export default React.createClass( {
 	},
 
 	displayBanner() {
-		if ( this.props.plugin.banners && ( this.props.plugin.banners.high || this.props.plugin.banners.low ) ) {
+		if ( this.props.plugin && this.props.plugin.banners && ( this.props.plugin.banners.high || this.props.plugin.banners.low ) ) {
 			return <div className="plugin-meta__banner">
 						<img className="plugin-meta__banner-image" src={ this.props.plugin.banners.high || this.props.plugin.banners.low }/>
 					</div>;
@@ -134,12 +116,13 @@ export default React.createClass( {
 		if ( ! this.props.plugin || ! ( this.props.plugin.author_url && this.props.plugin.author_name ) ) {
 			return;
 		}
+		const linkToAuthor = <a className="plugin-meta__author" href={ safeProtocolUrl( this.props.plugin.author_url ) }>{ this.props.plugin.author_name }</a>;
 
-		return (
-			<a className="plugin-meta__author" href={ safeProtocolUrl( this.props.plugin.author_url ) }>
-				{ this.props.plugin.author_name }
-			</a>
-		);
+		return this.translate( 'By {{linkToAuthor/}}', {
+			components: {
+				linkToAuthor
+			}
+		} );
 	},
 
 	isInstalledOnSite( site ) {
@@ -157,7 +140,7 @@ export default React.createClass( {
 	},
 
 	isOutOfDate() {
-		if ( this.props.plugin.last_updated ) {
+		if ( this.props.plugin && this.props.plugin.last_updated ) {
 			let lastUpdated = this.moment( this.props.plugin.last_updated, 'YYYY-MM-DD' );
 			return this.moment().diff( lastUpdated, 'years' ) >= this.OUT_OF_DATE_YEARS;
 		}
@@ -186,10 +169,11 @@ export default React.createClass( {
 		if ( newVersion ) {
 			return (
 				<Notice
-					className="plugin-meta__version-notice"
-					text={ i18n.translate( 'A new version is available.' ) }
 					status="is-warning"
-					showDismiss={ false } >
+					className="plugin-meta__version-notice"
+					showDismiss={ false }
+					icon="sync"
+					text={ i18n.translate( 'A new version is available.' ) }>
 					<NoticeAction onClick={ this.handlePluginUpdates }>
 						{ i18n.translate( 'Update to %(newPluginVersion)s', { args: { newPluginVersion: newVersion } } ) }
 					</NoticeAction>
@@ -258,6 +242,7 @@ export default React.createClass( {
 			'has-site': !! this.props.selectedSite,
 			'is-placeholder': !! this.props.isPlaceholder
 		} );
+
 		const plugin = this.props.selectedSite && this.props.sites[ 0 ] ? this.props.sites[ 0 ].plugin : this.props.plugin;
 
 		return (
@@ -266,16 +251,22 @@ export default React.createClass( {
 					{ this.displayBanner() }
 					<div className={ cardClasses } >
 						<div className="plugin-meta__detail">
-							<PluginIcon image={ this.props.plugin.icon } isPlaceholder={ this.props.isPlaceholder } />
+							<PluginIcon image={ this.props.plugin && this.props.plugin.icon } isPlaceholder={ this.props.isPlaceholder } />
 							{ this.renderName() }
 							<div className="plugin-meta__meta">
 								{ this.renderAuthorUrl() }
-								<PluginVersion plugin={ plugin } site={ this.props.selectedSite } notices={ this.props.notices } />
 							</div>
 						</div>
 						{ this.renderActions() }
 					</div>
-					<PluginInformation plugin={ this.props.plugin } isPlaceholder={ this.props.isPlaceholder } />
+					<PluginInformation
+						plugin={ this.props.plugin }
+						isPlaceholder={ this.props.isPlaceholder }
+						site={ this.props.selectedSite }
+						pluginVersion={ plugin && plugin.version }
+						siteVersion={ this.props.selectedSite && this.props.selectedSite.options.software_version }
+						hasUpdate={ this.getAvailableNewVersion() } />
+
 				</Card>
 				{ this.getVersionWarning() }
 				{ this.getUpdateWarning() }

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -14,7 +14,6 @@ import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
-import Gridicon from 'components/gridicon';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginsActions from 'lib/plugins/actions';
 import PluginsLog from 'lib/plugins/log-store';

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -67,6 +67,7 @@
 	}
 
 	.is-placeholder & {
+		width: 200px;
 		@include placeholder();
 	}
 }
@@ -93,18 +94,19 @@
 }
 
 .plugin-meta__meta {
-	font-size: 11px;
 	color: $gray;
 	white-space: pre;
 	text-overflow: ellipsis;
+	float: left;
 
-	a, a:visited {
-		color: $gray;
+	.is-placeholder & {
+		width: 120px;
+		@include placeholder();
 	}
+}
 
-	@include breakpoint( '>480px' ) {
-		text-transform: uppercase;
-	}
+.is-placeholder .plugin-meta__author {
+	color: transparent !important;
 }
 
 .plugin-meta__actions {

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -169,12 +169,17 @@ a.plugin-meta__settings-link {
 	display: block;
 	font-size: 11px;
 	line-height: 16px;
-	margin: 8px 9px 0 0;
+	margin: 16px 9px 0 0;
 	text-transform: uppercase;
+
+	@include breakpoint( '>480px' ) {
+		display: inline-block;
+	}
 
 	.gridicon {
 		float: right;
 		position: relative;
-			left: 9px;
+			left: 7px;
+			top: -3px;
 	}
 }

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -1,12 +1,13 @@
 /**
  * External depe;ndencies
  */
-var React = require( 'react' );
+import React from 'react';
 /**
  * Internal dependencies
  */
-var ProgressBar = require( 'components/progress-bar' ),
-	analytics = require( 'analytics' );
+import ProgressBar from 'components/progress-bar';
+import Rating from 'components/rating';
+import analytics from 'analytics';
 
 /**
  * Constants
@@ -14,27 +15,43 @@ var ProgressBar = require( 'components/progress-bar' ),
 const REVIEW_URL = 'https://wordpress.org/support/view/plugin-reviews/';
 
 module.exports = React.createClass( {
+	displayName: 'PluginRatings',
+
+	propTypes: {
+		rating: React.PropTypes.number,
+		ratings: React.PropTypes.object,
+		downloaded: React.PropTypes.number,
+		slug: React.PropTypes.string,
+		numRatings: React.PropTypes.number,
+	},
 
 	ratingTiers: [ 5, 4, 3, 2, 1 ],
-
-	displayName: 'PluginRatings',
 
 	getDefaultProps: function() {
 		return { barWidth: 88 };
 	},
 
+	renderPlaceholder: function() {
+		return (
+		<div className="plugin-ratings is-placeholder">
+			<div className="plugin-ratings__rating-stars"><Rating rating={ 0 } /></div>
+			<div className="plugin-ratings__rating-text">Based on</div>
+		</div>
+		);
+	},
+
 	renderRatingTier: function( ratingTier ) {
-		var amountOfRatings = ( this.props.plugin.ratings && this.props.plugin.ratings[ ratingTier ] ) ? this.props.plugin.ratings[ ratingTier ] : 0;
+		var numberOfRatings = ( this.props.ratings && this.props.ratings[ ratingTier ] ) ? this.props.ratings[ ratingTier ] : 0;
 		return (
 			<div className="plugin-ratings__rating-tier" key={ 'plugins-ratings__tier-' + ratingTier }>
 				<a className="plugin-ratings__rating-container" target="_blank"
-					onClick={ analytics.ga.recordEvent.bind( this, 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', this.props.pluginSlug ) }
-					href={ REVIEW_URL + this.props.plugin.slug }>
+					onClick={ analytics.ga.recordEvent.bind( this, 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', this.props.slug ) }
+					href={ REVIEW_URL + this.props.slug }>
 					<span className="plugin-ratings__rating-tier-text"> { this.translate( '%(ratingTier)s stars', { args: { ratingTier: ratingTier } } ) } </span>
 					<span className="plugin_ratings__bar">
-						<ProgressBar value={ amountOfRatings }
-									total={ this.props.plugin.num_ratings }
-									title={ this.translate( '%(numberOfRatings)s ratings', { args: { numberOfRatings: amountOfRatings } } ) } />
+						<ProgressBar value={ numberOfRatings }
+							total={ this.props.numRatings }
+							title={ this.translate( '%(numberOfRatings)s ratings', { args: { numberOfRatings } } ) } />
 					</span>
 				</a>
 			</div>
@@ -42,7 +59,7 @@ module.exports = React.createClass( {
 	},
 
 	renderDownloaded: function() {
-		var downloaded = this.props.plugin.downloaded;
+		var downloaded = this.props.downloaded;
 		if ( downloaded > 100000 ) {
 			downloaded = this.numberFormat( Math.floor( downloaded / 10000 ) * 10000 ) + '+';
 		} else if ( downloaded > 10000 ) {
@@ -51,12 +68,17 @@ module.exports = React.createClass( {
 			downloaded = this.numberFormat( downloaded );
 		}
 
-		return <div className="plugin-ratings__downloads"> { this.translate( '%(installs)s downloads', { args: { installs: downloaded } } ) } </div>;
+		return <div className="plugin-ratings__downloads">{ this.translate( '%(installs)s downloads', { args: { installs: downloaded } } ) }</div>;
 	},
 
 	render: function() {
 		var tierViews;
-		if ( ! this.props.plugin.ratings ) {
+
+		if ( this.props.placeholder ) {
+			return this.renderPlaceholder();
+		}
+
+		if ( ! this.props.ratings ) {
 			return null;
 		}
 
@@ -65,6 +87,13 @@ module.exports = React.createClass( {
 		}, this );
 		return (
 			<div className="plugin-ratings">
+				<div className="plugin-ratings__rating-stars"><Rating rating={ this.props.rating } /></div>
+				<div className="plugin-ratings__rating-text">
+					{ this.translate( 'Based on %(ratingsNumber)s rating', 'Based on %(ratingsNumber)s ratings', {
+						count: this.props.numRatings,
+						args: { ratingsNumber: this.props.numRatings }
+					} ) }
+				</div>
 				{ tierViews }
 				{ this.renderDownloaded() }
 			</div>

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -1,9 +1,36 @@
-.plugin-ratings {
-	margin-top: 12px;
+.plugin-ratings.is-placeholder {
+	.plugin-ratings__rating-text {
+		@include placeholder();
+	}
+
+	.rating {
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}
+}
+
+.plugin-ratings__rating-stars {
+	font-size: 24px;
+
+	@include breakpoint( '<480px' ) {
+		display: inline-block;
+		margin-right: 8px;
+		font-size: 16px;
+	}
 }
 
 .plugin-ratings__rating-tier {
 	line-height: 18px;
+}
+
+.plugin-ratings__rating-text {
+	font-size: 11px;
+	color: $gray;
+	text-transform: uppercase;
+	margin-bottom: 16px;
+
+	@include breakpoint( '<480px' ) {
+		display: inline;
+	}
 }
 
 .plugin-ratings__rating-container {

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -14,7 +14,6 @@
 	@include breakpoint( '<480px' ) {
 		display: inline-block;
 		margin-right: 8px;
-		font-size: 16px;
 	}
 }
 
@@ -30,6 +29,8 @@
 
 	@include breakpoint( '<480px' ) {
 		display: inline;
+		line-height: 24px;
+    vertical-align: top;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -30,7 +30,7 @@
 	@include breakpoint( '<480px' ) {
 		display: inline;
 		line-height: 24px;
-    vertical-align: top;
+	vertical-align: top;
 	}
 }
 

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -143,7 +143,7 @@ module.exports = React.createClass( {
 				disabledInfo={ getDisabledInfo }
 				className="plugin-remove-button__remove-link"
 			>
-				<a onClick={ this.removeAction } >
+				<a onClick={ this.removeAction } className="plugin-remove-button__remove-icon" >
 					<Gridicon icon="trash" size={ 18 } />
 				</a>
 			</PluginAction>

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -11,7 +11,10 @@
 	margin-top: 0;
 	padding: 16px;
 }
-.plugin-remove-button__remove-link {
+.plugin-remove-button__remove-icon {
+	display: block;
+	margin-top: -1px;
+
 	.gridicons-trash {
 		color: $gray;
 		cursor: pointer;
@@ -19,5 +22,4 @@
 			color: $alert-red;
 		}
 	}
-
 }

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -18,7 +18,6 @@ import analytics from 'analytics';
 import PluginSiteList from 'my-sites/plugins/plugin-site-list';
 import HeaderCake from 'components/header-cake';
 import PluginMeta from 'my-sites/plugins/plugin-meta';
-import PluginInformation from 'my-sites/plugins/plugin-information';
 import PluginsStore from 'lib/plugins/store';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginsDataStore from 'lib/plugins/wporg-data/store';
@@ -239,7 +238,6 @@ export default React.createClass( {
 						siteUrl={ this.props.siteUrl }
 						sites={ this.state.sites }
 						selectedSite={ this.props.sites.getSelectedSite() } />
-					<PluginInformation isPlaceholder />
 				</div>
 			</MainComponent>
 		);
@@ -251,7 +249,7 @@ export default React.createClass( {
 			canUpdateFiles: true,
 			name: 'Not a real site',
 			options: {
-				'software_version': 1
+				software_version: 1
 			}
 		}
 		return (
@@ -329,7 +327,6 @@ export default React.createClass( {
 						sites={ this.state.sites }
 						selectedSite={ selectedSite }
 						isInstalling={ installInProgress } />
-					<PluginInformation plugin={ this.state.plugin } />
 					<PluginSections plugin={ this.state.plugin } />
 					{ this.renderSitesList() }
 				</div>


### PR DESCRIPTION
Fixes #953

After:
Placeholder 
![screen shot 2015-12-15 at 15 30 00](https://cloud.githubusercontent.com/assets/115071/11827402/e1f94a8c-a340-11e5-91ae-9345ace295e9.png)

Multi site view.
![screen shot 2015-12-15 at 16 12 27](https://cloud.githubusercontent.com/assets/115071/11828153/c126f3da-a346-11e5-95a1-60812683554e.png)

Single site view.
![screen shot 2015-12-15 at 15 30 16](https://cloud.githubusercontent.com/assets/115071/11827404/e4280ece-a340-11e5-95af-93f851421124.png)

Mobile view
![screen shot 2015-12-15 at 16 25 03](https://cloud.githubusercontent.com/assets/115071/11828338/a513f83a-a348-11e5-8bb3-823050c801b4.png)

Mobile view:
![screen shot 2015-12-15 at 16 24 47](https://cloud.githubusercontent.com/assets/115071/11828343/a8940f7c-a348-11e5-99bb-d27fa05ac650.png)

Single Site view:
A plugin that doesn't have much info.
![screen shot 2015-12-15 at 16 13 01](https://cloud.githubusercontent.com/assets/115071/11828156/c457dfd8-a346-11e5-865f-8756aa4404b8.png)

Business Plugin:
![screen shot 2015-12-15 at 16 31 25](https://cloud.githubusercontent.com/assets/115071/11828425/7f678254-a349-11e5-8d3e-39082b33e443.png)


![screen shot 2015-12-15 at 16 08 51](https://cloud.githubusercontent.com/assets/115071/11828108/5de2ad64-a346-11e5-9242-c323f6d1f34b.png)




**To test**
Visit a single plugin page. For example 
http://calypso.localhost:3000/plugins/akismet and also http://calypso.localhost:3000/plugins/akismet/example.com

Browse plugins single plugin pages that have comptible versions with wp. 
Haven't been updated in a long time. 
Need an update.
Etc. 
Does it look and function as expected? 

cc: @rickybanister, @johnHackworth  and @lezama 