### PR TITLE
Add some help to the gridicons automatic checker error message

### DIFF
--- a/bin/gridiconFormatChecker
+++ b/bin/gridiconFormatChecker
@@ -43,7 +43,8 @@ fs.readFile( filename, 'utf8', function ( err, data ) {
 
 	if ( result !== '' ) {
 		console.error( result );
-		console.log( '\033[m=== Valid gridiconsizes are ' + validIconSizes.join( 'px, ' ) + 'px ===\n' );
+		console.log( '\033[mValid gridiconsizes are ' + validIconSizes.join( 'px, ' ) + 'px' );
+		console.log( '\033[mIf you need any of those Gridicons to have a non-standard size, please, add \'nonStandardSize\' as a property. See https://github.com/Automattic/wp-calypso/tree/master/shared/components/gridicon#props \n' );
 		process.exit( 1 );
 	} else {
 		process.exit( 0 );


### PR DESCRIPTION
This PR adds a suggestion to the non-standard gridicons pre-commit error message, for those of us who didn't read about the new gridicons automatic checker:

![image](https://cloud.githubusercontent.com/assets/1554855/11740813/56bc94f4-9ff5-11e5-81e2-64f81ea90ce0.png)

How to test
=========
1. Modify any gridicon to use not standard size
2. Try to commit the change. You should get an error message like the one in the screencap above