### PR TITLE
Plugin Browser: Add feature example to business error screen

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -21,6 +21,7 @@ import EmptyContent from 'components/empty-content'
 import URLSearch from 'lib/mixins/url-search'
 import infiniteScroll from 'lib/mixins/infinite-scroll'
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page'
+import FeatureExample from 'components/feature-example'
 
 module.exports = React.createClass( {
 
@@ -213,7 +214,11 @@ module.exports = React.createClass( {
 	renderAccessError( selectedSite ) {
 		if ( this.state.accessError ) {
 			return (
-				<MainComponent><SidebarNavigation /><EmptyContent { ...this.state.accessError } /></MainComponent>
+				<MainComponent>
+					<SidebarNavigation />
+					<EmptyContent { ...this.state.accessError } />
+					{ this.state.accessError.featureExample ? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample> : null }
+				</MainComponent>
 			);
 		}
 


### PR DESCRIPTION
The plugin browser access error screen when you try to go there with a .com site selected was missing the feature example at the bottom:

Before:
![image](https://cloud.githubusercontent.com/assets/1554855/11741069/dd6cf088-9ff6-11e5-9349-b6d9cfc302a4.png)

After:
![image](https://cloud.githubusercontent.com/assets/1554855/11741038/c35d63c6-9ff6-11e5-8242-0dbb52226ac6.png)
