### PR TITLE
Oauth Login: Hide notice icons

### DIFF
--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -46,8 +46,8 @@ html.is-desktop {
 		padding: 0;
 	}
 
-	.notice.is-info:before {
-		content: none;
+	.notice.is-info .notice__icon {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
The oauth login screen uses the "notices" component in a slightly unusual way to adhere to login screen design standards. Text is centered, and icons are hidden.

This PR updates the login screen to accomodate the recent notices change from noticons to gridicons.

Screenshot:

![screen shot 2015-12-11 at 11 46 21](https://cloud.githubusercontent.com/assets/1204802/11742036/29bd673c-9ffd-11e5-915c-9b9cb77651f4.png)
