### PR TITLE
Components: compact mode for dropdown

### DIFF
--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -167,6 +167,10 @@ var options = [
 
 Optional string representing the initial selected option's `value`. Default will be the first option's `value`.
 
+`compact`
+
+Optional boolean indicating the dropdown will be rendered in compact mode
+
 `onSelect`
 
 Optional callback that will be run whenever a new selection has been clicked.

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -85,6 +85,50 @@ var SelectDropdownDemo = React.createClass( {
 						Trashed
 					</DropdownItem>
 				</SelectDropdown>
+
+				<h3 style={ { marginTop: 20 } }>Compact</h3>
+				<SelectDropdown
+					compact
+					onSelect={ this.onDropdownSelect }
+					selectedText={ this.state.childSelected }
+					selectedCount={ this.state.selectedCount }
+				>
+					<DropdownItem
+						count={ 10 }
+						selected={ this.state.childSelected === 'Published' }
+						onClick={ this.selectItem.bind( this, 'Published', 10 ) }
+					>
+						Published
+					</DropdownItem>
+
+					<DropdownItem
+						count={ 4 }
+						selected={ this.state.childSelected === 'Scheduled' }
+						onClick={ this.selectItem.bind( this, 'Scheduled', 4 ) }
+					>
+						Scheduled
+					</DropdownItem>
+
+					<DropdownItem
+						selected={ this.state.childSelected === 'Drafts' }
+						onClick={ this.selectItem.bind( this, 'Drafts', null ) }
+					>
+						Drafts
+					</DropdownItem>
+
+					<DropdownSeparator />
+
+					<DropdownItem
+						count={ 3 }
+						selected={ this.state.childSelected === 'Trashed' }
+						onClick={ this.selectItem.bind( this, 'Trashed', 3 ) }
+					>
+						Trashed
+					</DropdownItem>
+				</SelectDropdown>
+
+				<div className="padding" style={ { display: 'block', height: '200px' } } />
+
 			</div>
 		);
 	},

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -18,7 +18,8 @@ var SelectDropdownDemo = React.createClass( {
 	getInitialState: function() {
 		return {
 			childSelected: 'Published',
-			selectedCount: 10
+			selectedCount: 10,
+			compactButtons: false
 		};
 	},
 
@@ -34,61 +35,30 @@ var SelectDropdownDemo = React.createClass( {
 		};
 	},
 
+	toggleButtons: function() {
+		this.setState( { compactButtons: ! this.state.compactButtons } );
+	},
+
 	render: function() {
+		var toggleButtonsText = this.state.compactButtons ? 'Normal Buttons' : 'Compact Buttons';
+
 		return (
 			<div className="design-assets__group">
 				<h2>
 					<a href="/devdocs/design/select-dropdown">Select Dropdown</a>
 				</h2>
 
+				<a className="design-assets__toggle button" onClick={ this.toggleButtons }>{ toggleButtonsText }</a>
+
 				<h3>items passed as options prop</h3>
 				<SelectDropdown
+					compact={ this.state.compactButtons }
 					options={ this.props.options }
 					onSelect={ this.onDropdownSelect } />
 
 				<h3 style={ { marginTop: 20 } }>items passed as children</h3>
 				<SelectDropdown
-					onSelect={ this.onDropdownSelect }
-					selectedText={ this.state.childSelected }
-					selectedCount={ this.state.selectedCount }
-				>
-					<DropdownItem
-						count={ 10 }
-						selected={ this.state.childSelected === 'Published' }
-						onClick={ this.selectItem.bind( this, 'Published', 10 ) }
-					>
-						Published
-					</DropdownItem>
-
-					<DropdownItem
-						count={ 4 }
-						selected={ this.state.childSelected === 'Scheduled' }
-						onClick={ this.selectItem.bind( this, 'Scheduled', 4 ) }
-					>
-						Scheduled
-					</DropdownItem>
-
-					<DropdownItem
-						selected={ this.state.childSelected === 'Drafts' }
-						onClick={ this.selectItem.bind( this, 'Drafts', null ) }
-					>
-						Drafts
-					</DropdownItem>
-
-					<DropdownSeparator />
-
-					<DropdownItem
-						count={ 3 }
-						selected={ this.state.childSelected === 'Trashed' }
-						onClick={ this.selectItem.bind( this, 'Trashed', 3 ) }
-					>
-						Trashed
-					</DropdownItem>
-				</SelectDropdown>
-
-				<h3 style={ { marginTop: 20 } }>Compact</h3>
-				<SelectDropdown
-					compact
+					compact={ this.state.compactButtons }
 					onSelect={ this.onDropdownSelect }
 					selectedText={ this.state.childSelected }
 					selectedCount={ this.state.selectedCount }

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -156,6 +156,7 @@ var SelectDropdown = React.createClass( {
 	render: function() {
 		const dropdownClasses = {
 			'select-dropdown': true,
+			'is-compact': this.props.compact,
 			'is-open': this.state.isOpen
 		};
 

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -54,9 +54,28 @@
 			right: 13px;
 			top: 12px;
 
+		.is-compact & {
+			right: 4px;
+			top: 4px;
+		}
+
 		display: block;
 		line-height: 18px;
 		color: rgba( $gray, 0.5 );
+	}
+
+
+	.is-compact & {
+		padding: 7px;
+		color: darken( $gray, 10% );
+		font-size: 11px;
+		line-height: 1;
+		text-transform: uppercase;
+
+		.count {
+			position: absolute;
+				top: 5px;
+		}
 	}
 
 	.select-dropdown.is-open & {

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -91,7 +91,6 @@
 
 	.count {
 		margin-left: 8px;
-		opacity: 0.5;
 	}
 }
 
@@ -191,7 +190,6 @@
 	justify-content: space-between;
 
 	.count {
-		opacity: 0.5;
 		color: inherit;
 		border-color: inherit;
 	}

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -73,8 +73,9 @@
 		text-transform: uppercase;
 
 		.count {
-			position: absolute;
-				top: 5px;
+			border-width: 0;
+			margin-left: 0;
+			line-height: 1;
 		}
 	}
 


### PR DESCRIPTION
As discussed here https://github.com/Automattic/wp-calypso/pull/1044#issuecomment-163708869, we need to add a 'compact' mode for `Select-dropdown` .

This PR adds the styles for it, mirroring the ones we are using in `Button` compact mode:

![image](https://cloud.githubusercontent.com/assets/1554855/11743743/28960d84-a00a-11e5-82a1-b98d900f2cd6.png)

I'm not sure if for this case we want to change any of them... ping @mtias & @rickybanister for opinions

How to test
=========
1. Go to http://calypso.dev:3000/devdocs/design/select-dropdown
2. Check the compact section
...
4. Profit!