### PR TITLE
Checkout: Send request type to Paygate configuration endpoint

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -136,7 +136,7 @@ TransactionFlow.prototype._paymentHandlers = {
 TransactionFlow.prototype._createPaygateToken = function( callback ) {
 	this._pushStep({ name: 'submitting-payment-key-request' });
 
-	createPaygateToken( this._initialData.payment.newCardDetails, function( error, paygateToken ) {
+	createPaygateToken( 'new_purchase', this._initialData.payment.newCardDetails, function( error, paygateToken ) {
 		if ( error ) {
 			return this._pushStep({
 				name: 'received-payment-key-response',
@@ -178,8 +178,8 @@ TransactionFlow.prototype._submitWithPayment = function( payment ) {
 	}.bind( this ) );
 };
 
-function createPaygateToken( cardDetails, callback ) {
-	wpcom.paygateConfiguration( function ( error, configuration ) {
+function createPaygateToken( requestType, cardDetails, callback ) {
+	wpcom.paygateConfiguration( { request_type: requestType }, function ( error, configuration ) {
 		if ( error ) {
 			callback( error );
 			return;

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -141,7 +141,7 @@ const EditCardDetails = React.createClass( {
 			{ product_slug: getPurchase( this.props ).productSlug }
 		);
 
-		createPaygateToken( cardDetails, ( paygateError, token ) => {
+		createPaygateToken( 'card_update', cardDetails, ( paygateError, token ) => {
 			if ( paygateError ) {
 				notices.error( paygateError.message );
 				return;

--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -925,10 +925,10 @@ Undocumented.prototype.updateCreditCard = function( params, fn ) {
  * @param {Function} fn The callback function
  * @api public
  */
-Undocumented.prototype.paygateConfiguration = function( fn ) {
+Undocumented.prototype.paygateConfiguration = function( data, fn ) {
 	debug( '/me/paygate-configuration query' );
 
-	this.wpcom.req.get( '/me/paygate-configuration', fn );
+	this.wpcom.req.get( '/me/paygate-configuration', data, fn );
 };
 
 /**


### PR DESCRIPTION
We need different configuration for card updates and new purchases.

To test, make a new credit card purchase, and check in dev tools that `paygate_request_type` parameter of `/me/paygate-configration` endpoint call is `new_purchase`.

Than, go to `/purchases`, and update a credit card. Check that `paygate_request_type` field of the paygate configuration request is `card_update `.