### PR TITLE
Update Stats empty-state modules to use the correct background color and update the RGBA values to use color variables

### DIFF
--- a/client/my-sites/stats/nux/style.scss
+++ b/client/my-sites/stats/nux/style.scss
@@ -7,7 +7,7 @@
 	// to hide module's default border
 	width: 101%;
 	left: -1px;
-	background: linear-gradient(to bottom, rgba( lighten( $gray, 30% ), 0 ), rgba( lighten( $gray, 30% ), 0.3 ), $gray-light 95%);
+	background: linear-gradient(to bottom, rgba( $gray-light, 0 ), rgba( $gray-light, 0.3 ), $gray-light 95%);
 
 	@include breakpoint( "<660px" ) {
 		// hide module's bottom border that's showing on mobile

--- a/client/my-sites/stats/nux/style.scss
+++ b/client/my-sites/stats/nux/style.scss
@@ -7,7 +7,7 @@
 	// to hide module's default border
 	width: 101%;
 	left: -1px;
-	background: linear-gradient(to bottom, rgba(233,239,243,0), rgba(233,239,243,0.3), rgba(233,239,243,1) 95%);
+	background: linear-gradient(to bottom, rgba( lighten( $gray, 30% ), 0 ), rgba( lighten( $gray, 30% ), 0.3 ), $gray-light 95%);
 
 	@include breakpoint( "<660px" ) {
 		// hide module's bottom border that's showing on mobile


### PR DESCRIPTION
The style was using the old background color, which meant the module wasn’t actually reaching transparency at the bottom.

Before:

<img width="747" alt="screen shot 2015-12-11 at 12 09 40 pm" src="https://cloud.githubusercontent.com/assets/2846578/11750197/19d94f2c-a000-11e5-9bb3-42eff7e5e7af.png">

After:

<img width="760" alt="screen shot 2015-12-11 at 12 19 21 pm" src="https://cloud.githubusercontent.com/assets/2846578/11750450/736291c4-a001-11e5-89ad-fc854913e33e.png">

To test: 

Go to or create an empty site. Once you make it through signup, opt to go straight to your dashboard. You'll see the empty site call-to-action.