### PR TITLE
Missing focus state to overwrite base styles.

### DIFF
--- a/assets/stylesheets/layout/_detail-page.scss
+++ b/assets/stylesheets/layout/_detail-page.scss
@@ -87,7 +87,8 @@
 			color: $gray;
 		}
 
-		&:hover {
+		&:hover,
+		&:focus {
 			color: $blue-medium;
 		}
 


### PR DESCRIPTION
This PR fixes #1490.

The button inherits the base styles from `.button.is-primary`, and the `:focus` pseudo-class needs to overwrite the inherited color. This PR adds this missing pseudo-class.

cc @johngodley