### PR TITLE
Framework: Make disabled text field readable in Safari iOS

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -43,6 +43,7 @@
 		background: $gray-light;
 		border-color: lighten( $gray, 30% );
 		color: lighten( $gray, 10% );
+		-webkit-text-fill-color: lighten( $gray, 10% );
 
 		&:hover {
 			cursor: default;


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/177 (Props @v18)

Effects disabled text fields in Safari iOS. 

Before:
<img width="678" alt="screen shot 2015-12-11 at 12 56 26 pm" src="https://cloud.githubusercontent.com/assets/5835847/11753271/cf2c85a2-a009-11e5-92da-ef585ed137a2.png">

After:
<img width="687" alt="screen shot 2015-12-11 at 12 56 17 pm" src="https://cloud.githubusercontent.com/assets/5835847/11753279/d740e38c-a009-11e5-8784-a15faec511d7.png">

Now comparable to Mac 'n Chrome, for example:
<img width="693" alt="screen shot 2015-12-11 at 1 07 11 pm" src="https://cloud.githubusercontent.com/assets/5835847/11753282/da958768-a009-11e5-8e74-6fb9025e90d6.png">