### PR TITLE
Components: header cake cleanup

### DIFF
--- a/client/components/header-cake/README.md
+++ b/client/components/header-cake/README.md
@@ -1,17 +1,19 @@
 Back Button aka Header Cake
 ===========================
 
+The "header cake" component should be used at the top of an item's detail page. It's purpose is to display a title and back link.
+
 ## Usage
 
-```
+```js
 	var HeaderCake = require( 'components/header-cake' );
 
-	<HeaderCake onClick={ callback }>Button Text</HeaderCake>
+	<HeaderCake onClick={ callback }>Item Details</HeaderCake>
 ```
 
 ## Props
 
-* `onClick` - Function to trigger when the back text is clicked
+* `onClick` - (**required**) Function to trigger when the back text is clicked
 * `onTitleClick` - Function to trigger when the title is clicked
 * `backText` - React Element or string to use in place of default "Back" text
 * `isCompact` - Optional variant of a more visually compact header cake

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ObserveWindowSizeMixin from 'lib/mixins/observe-window-resize';
+import Gridicon from 'components/gridicon';
+
+/**
+ * Module variables
+ */
+const HIDE_BACK_CRITERIA = {
+	windowWidth: 480,
+	characterLength: 8
+};
+
+export default React.createClass( {
+
+	displayName: 'HeaderCakeBack',
+
+	mixins: [ ObserveWindowSizeMixin ],
+
+	propTypes: {
+		onClick: PropTypes.func,
+		href: PropTypes.string,
+		text: PropTypes.string
+	},
+
+	getDefaultProps() {
+		return {
+			text: 'Back'
+		}
+	},
+
+	render() {
+		const { text, href, onClick } = this.props;
+		const hideText = window.innerWidth <= HIDE_BACK_CRITERIA.windowWidth && text.length >= HIDE_BACK_CRITERIA.characterLength;
+
+		return (
+			<a className="header-cake__back" href={ href } onClick={ onClick }>
+				<Gridicon icon="chevron-left" size={ 18 } />
+				{ hideText ?
+					null
+				: <span className="header-cake__back-text">{ text }</span> }
+			</a>
+		);
+	},
+
+	onWindowResize() {
+		this.forceUpdate();
+	}
+
+} );

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -26,25 +27,29 @@ export default React.createClass( {
 	propTypes: {
 		onClick: PropTypes.func,
 		href: PropTypes.string,
-		text: PropTypes.string
+		text: PropTypes.string,
+		spacer: PropTypes.bool
 	},
 
 	getDefaultProps() {
 		return {
-			text: 'Back'
-		}
+			spacer: false
+		};
 	},
 
 	render() {
-		const { text, href, onClick } = this.props;
-		const hideText = window.innerWidth <= HIDE_BACK_CRITERIA.windowWidth && text.length >= HIDE_BACK_CRITERIA.characterLength;
+		const { text = this.translate( 'Back' ), href, onClick, spacer } = this.props;
+		const windowWidth = window.innerWidth;
+		const hideText = windowWidth <= HIDE_BACK_CRITERIA.windowWidth && text.length >= HIDE_BACK_CRITERIA.characterLength || windowWidth <= 300;
+		const linkClasses = classNames( {
+			'header-cake__back': true,
+			'is-spacer': spacer
+		} );
 
 		return (
-			<a className="header-cake__back" href={ href } onClick={ onClick }>
+			<a className={ linkClasses } href={ href } onClick={ onClick }>
 				<Gridicon icon="chevron-left" size={ 18 } />
-				{ hideText ?
-					null
-				: <span className="header-cake__back-text">{ text }</span> }
+				{ ! hideText && <span className="header-cake__back-text">{ text }</span> }
 			</a>
 		);
 	},

--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -1,35 +1,34 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	Gridicon = require( 'components/gridicon' );
+import Card from 'components/card';
+import HeaderCakeBack from './back';
 
-module.exports = React.createClass( {
+export default React.createClass( {
+
 	displayName: 'HeaderCake',
 
 	propTypes: {
-		onClick: React.PropTypes.func.isRequired,
-		onTitleClick: React.PropTypes.func,
-		backText: React.PropTypes.oneOfType( [
-			React.PropTypes.element,
-			React.PropTypes.string
-		] )
+		onClick: PropTypes.func.isRequired,
+		onTitleClick: PropTypes.func,
+		backText: PropTypes.string
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			isCompact: false
 		};
 	},
 
-	render: function() {
-		var classes = classNames(
+	render() {
+		const backText = this.props.backText || this.translate( 'Back' );
+		const classes = classNames(
 			'header-cake',
 			this.props.className,
 			{
@@ -40,16 +39,16 @@ module.exports = React.createClass( {
 		return (
 			<Card className={ classes }>
 				<div className="header-cake__corner">
-					<a className="header-cake__back" onClick={ this.props.onClick }>
-						<Gridicon icon="chevron-left" size={ 16 } />
-						<span className="header-cake__back-text">{ this.props.backText || this.translate( 'Back' ) }</span>
-					</a>
+					<HeaderCakeBack text={ backText } onClick={ this.props.onClick } />
 				</div>
-				<span className="header-cake__title" onClick={ this.props.onTitleClick }>
+				<div className="header-cake__title" onClick={ this.props.onTitleClick }>
 					{ this.props.children }
-				</span>
-				<div className="header-cake__corner" />
+				</div>
+				<div className="header-cake__corner is-spacer">
+					<HeaderCakeBack text={ backText } />
+				</div>
 			</Card>
 		);
 	}
+
 } );

--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -27,7 +27,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const backText = this.props.backText || this.translate( 'Back' );
+		const { backText } = this.props;
 		const classes = classNames(
 			'header-cake',
 			this.props.className,
@@ -38,15 +38,11 @@ export default React.createClass( {
 
 		return (
 			<Card className={ classes }>
-				<div className="header-cake__corner">
-					<HeaderCakeBack text={ backText } onClick={ this.props.onClick } />
-				</div>
+				<HeaderCakeBack text={ backText } onClick={ this.props.onClick } />
 				<div className="header-cake__title" onClick={ this.props.onTitleClick }>
 					{ this.props.children }
 				</div>
-				<div className="header-cake__corner is-spacer">
-					<HeaderCakeBack text={ backText } />
-				</div>
+				<HeaderCakeBack text={ backText } spacer />
 			</Card>
 		);
 	}

--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -12,23 +12,19 @@
 	line-height: 18px;
 	padding: 0;
 
+	&::after {
+		display: none;
+	}
+
 	@include breakpoint( "<660px" ) {
 		margin-top: 10px;
 	}
 }
 
-.header-cake__corner {
+.header-cake__back {
 	flex: none;
 	display: block;
 	max-width: 33.333%;
-
-	&.is-spacer {
-		opacity: 0;
-	}
-}
-
-.header-cake__back {
-	display: block;
 	padding: 16px;
 	color: darken( $gray, 20% );
 	white-space: nowrap;
@@ -42,7 +38,8 @@
 		opacity: 0.6;
 	}
 
-	.header-cake__corner.is-spacer & {
+	&.is-spacer {
+		opacity: 0;
 		cursor: default;
 	}
 }

--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -7,36 +7,33 @@
 
 .header-cake.card {
 	display: flex;
-	align-items: stretch;
-	justify-content: center;
+	align-items: center;
 	font-size: 14px;
 	line-height: 18px;
-	padding: 16px;
+	padding: 0;
 
 	@include breakpoint( "<660px" ) {
 		margin-top: 10px;
 	}
 }
 
-.header-cake__title {
-	color: darken( $gray, 20% );
-	text-align: center;
-	word-break: break-word;
-	flex: 2 1;
-}
-
 .header-cake__corner {
-	display: flex;
-	flex: 1 0;
+	flex: none;
+	display: block;
+	max-width: 33.333%;
+
+	&.is-spacer {
+		opacity: 0;
+	}
 }
 
 .header-cake__back {
-	flex: 1 0;
 	display: block;
-	margin: -16px;
-	margin-right: 0;
-	padding: 15px 16px 16px;
+	padding: 16px;
 	color: darken( $gray, 20% );
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	cursor: pointer;
 
 	.gridicon {
@@ -44,10 +41,25 @@
 		vertical-align: middle;
 		opacity: 0.6;
 	}
+
+	.header-cake__corner.is-spacer & {
+		cursor: default;
+	}
 }
 
 .header-cake__back-text {
 	font-size: 11px;
 	font-weight: 600;
 	text-transform: uppercase;
+}
+
+.header-cake__title {
+	flex: 1 1 auto;
+	padding: 16px 0;
+	color: darken( $gray, 20% );
+	text-align: center;
+	word-break: break-word;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }

--- a/client/my-sites/upgrades/domain-management/components/header/index.jsx
+++ b/client/my-sites/upgrades/domain-management/components/header/index.jsx
@@ -12,10 +12,12 @@ const DomainManagementHeader = React.createClass( {
 	render() {
 		return (
 			<HeaderCake className="domain-management-header" onClick={ this.props.onClick }>
-				{ this.domainName() }
-				<span className="domain-management-header__children">
-					{ this.props.children }
-				</span>
+				<div className="domain-management-header__children">
+					{ this.domainName() }
+					<span className="domain-management-header__title">
+						{ this.props.children }
+					</span>
+				</div>
 			</HeaderCake>
 		);
 	},

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -1,6 +1,11 @@
 .domain-main-placeholder {
-	.header-cake__title {
+	.domain-management-header__children {
 		@include placeholder(23%);
+
+		@include breakpoint('>480px') {
+			max-width: 60%;
+			margin: 0 auto;
+		}
 	}
 }
 
@@ -47,6 +52,8 @@
 
 .domain-management-header__children {
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .domain-management-list-item__link {

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -1,24 +1,16 @@
-.editor-media-modal-detail .header-cake.card,
-.editor-media-modal-detail .header-cake__corner {
-	display: block;
-
+.editor-media-modal-detail .header-cake.card {
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 0;
 	}
 }
 
-.editor-media-modal-detail .header-cake__back {
-	display: inline-block;
+.editor-media-modal-detail .header-cake__title {
+	padding: 6px 0;
 }
 
-.editor-media-modal-detail__title .editor-media-modal-detail__title-input {
-	@extend .header-cake__title;
-	position: absolute;
-		top: 50%;
-		left: 50%;
-	transform: translate( -50%, -50% );
-	width: 200px;
-	width: calc( 100vw - 175px );
+.editor-media-modal-detail .editor-media-modal-detail__title-input {
+	width: 100%;
+	color: inherit;
 	word-break: normal;
 	white-space: nowrap;
 	overflow: hidden;
@@ -26,10 +18,6 @@
 	border-color: transparent;
 	outline: none;
 	text-align: center;
-
-	@include breakpoint( ">480px" ) {
-		width: 60%;
-	}
 
 	&[readonly]:hover,
 	&[readonly]:focus {

--- a/client/post-editor/media-modal/detail/detail-title.jsx
+++ b/client/post-editor/media-modal/detail/detail-title.jsx
@@ -81,18 +81,16 @@ export default React.createClass( {
 
 	render() {
 		return (
-			<h2 className="editor-media-modal-detail__title">
-				<TrackInputChanges onNewValue={ this.bumpStat }>
-					<FormTextInput
-						onKeyUp={ this.onKeyUp }
-						onChange={ this.onChange }
-						onBlur={ this.saveTitle }
-						value={ this.getTitleValue() }
-						placeholder={ this.translate( 'Untitled' ) }
-						readOnly={ ! userCan( 'upload_files', this.props.site ) }
-						className="editor-media-modal-detail__title-input" />
-				</TrackInputChanges>
-			</h2>
+			<TrackInputChanges onNewValue={ this.bumpStat }>
+				<FormTextInput
+					onKeyUp={ this.onKeyUp }
+					onChange={ this.onChange }
+					onBlur={ this.saveTitle }
+					value={ this.getTitleValue() }
+					placeholder={ this.translate( 'Untitled' ) }
+					readOnly={ ! userCan( 'upload_files', this.props.site ) }
+					className="editor-media-modal-detail__title-input" />
+			</TrackInputChanges>
 		);
 	}
 } );

--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -10,7 +10,6 @@ var React = require( 'react' ),
 var DetailItem = require( './detail-item' ),
 	MediaUtils = require( 'lib/media/utils' ),
 	HeaderCake = require( 'components/header-cake' ),
-	BackToLibrary = require( '../back-to-library' ),
 	EditorMediaModalDetailTitle = require( './detail-title' ),
 	preloadImage = require( '../preload-image' ),
 	ModalViews = require( '../constants' ).Views;
@@ -65,7 +64,7 @@ module.exports = React.createClass( {
 
 		return (
 			<div className="editor-media-modal-detail">
-				<HeaderCake onClick={ this.returnToList } backText={ <BackToLibrary /> }>
+				<HeaderCake onClick={ this.returnToList } backText={ this.translate( 'Media Library' ) }>
 					<EditorMediaModalDetailTitle
 						site={ this.props.site }
 						item={ items[ this.props.selectedIndex ] } />

--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -12,7 +12,6 @@ import isEqual from 'lodash/lang/isEqual';
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
-import BackToLibrary from '../back-to-library';
 import MediaStore from 'lib/media/store';
 import EditorMediaModalGalleryDropZone from './drop-zone';
 import EditorMediaModalGalleryFields from './fields';
@@ -132,7 +131,7 @@ export default React.createClass( {
 				<EditorMediaModalGalleryDropZone
 					site={ site }
 					onInvalidItemAdded={ () => this.setState( { invalidItemDropped: true } ) } />
-				<HeaderCake onClick={ this.returnToList } backText={ <BackToLibrary /> } />
+				<HeaderCake onClick={ this.returnToList } backText={ this.translate( 'Media Library' ) } />
 				<div className="editor-media-modal-gallery__content editor-media-modal__content">
 					<EditorMediaModalGalleryPreview
 						site={ site }


### PR DESCRIPTION
Cleans up the "header cake" (`client/components/header-cake`) component & fixes #143.

# Background

Over in #143, a situation arose with the current header cake component where the "back" text would wrap oddly on small screens if displayed in certain languages. After some investigation, it turns out that this situation could occur in a variety of situations as long as the text was long enough.

There was a variety of potential tweaks that were investigated (#143) and could be made in order to handle the situation. ~~This PR proposes one of them, which aligns the title to the right of the card and allows the "back" text to always remain inline with it's accompanying chevron icon.~~

**Updated: 12/14/15**

# Changes summary

This PR proposes a solution arrived at via the discussion on #143 and comments on this PR from an earlier version of it. The overall goal (visually) is to center the title text while keeping as much of the "back" text visible as possible above `480px`. Below `480px`, the "back" text will be hidden (*note: chevron still visible*) if it is 8 characters or above.

## Component structure

The component's structure is changed slightly with the introduction of a `HeaderCakeBack` sub-component whose job is just to display the "back" text/link. That sub-component also is the one that keeps track of window width and text length in order to decide if it should render just the chevron or the chevron + text.

## Visual changes

Visually, the component shouldn't be all that different from what it currently looks like (intentionally), but should be better at displaying as much of both the title and the back text as possible. This is because of a shift in the CSS where the "corners" of the header cake are no longer tied to a distributed width, but will only take up as much space as they need (with a maximum of 1/3 the container width) to display the back text which allows the title to fill all the remaining space.

The main notable visual change could occur if the back sub-component's text is over 8 characters and the window's width is below `480px`. This currently occurs in some language's translations of the word "back" as well as two other places in english: the `devdocs/design` sub-pages & in the editor's media modals' detail screens.

### Examples

##### Domain settings

`/devdocs/design/gridicons`

![screen shot 2015-12-14 at 1 23 46 pm](https://cloud.githubusercontent.com/assets/1427136/11794512/cc007a3c-a27f-11e5-879d-169c2df2c2fc.png)

![screen shot 2015-12-14 at 1 24 56 pm](https://cloud.githubusercontent.com/assets/1427136/11794588/2610a8e4-a280-11e5-8624-ba2a811d63d2.png)

##### Devdocs sub-page

`/devdocs/design/gridicons`

![screen shot 2015-12-14 at 1 24 10 pm](https://cloud.githubusercontent.com/assets/1427136/11794608/3eb6eade-a280-11e5-9da6-a5e406cee44e.png)

![screen shot 2015-12-14 at 1 24 20 pm](https://cloud.githubusercontent.com/assets/1427136/11794611/42430926-a280-11e5-88eb-c10a091f0997.png)

*Note: "back" text does away below `480px` because the string `all components` is over 8 characters*

##### Delete site

`/settings/delete-site/*`

![screen shot 2015-12-14 at 4 34 31 pm](https://cloud.githubusercontent.com/assets/1427136/11794690/9c5c9c7e-a280-11e5-8cd6-0f93fa958f8a.png)

![screen shot 2015-12-14 at 4 34 42 pm](https://cloud.githubusercontent.com/assets/1427136/11794696/aac9e6cc-a280-11e5-94b5-e662d77409d8.png)

##### Editor media modal

`/post/*` (media modal detail)

![screen shot 2015-12-14 at 4 28 00 pm](https://cloud.githubusercontent.com/assets/1427136/11794659/7c7b7f06-a280-11e5-88c6-eec2ddfee8fd.png)

![screen shot 2015-12-14 at 4 28 13 pm](https://cloud.githubusercontent.com/assets/1427136/11794661/7fe2e472-a280-11e5-975b-68fdaeede4dc.png)

## Effected implementors

The editor media modal header cake (`client/post-editor/media-modal/detail`) was the only component that initially required some tweaking, but upon further investigation, a slight refactor of the css allowed for a little cleaner implementation of the header cake itself.

Currently, the media modal header cake does some [overriding css](https://github.com/Automattic/wp-calypso/blob/a7478174b0441760c332fcb4b8c454f5b8d73dfc/client/post-editor/media-modal/detail/_style.scss#L1-L19) in order to achieve it's intended display method. With the changes to the header cake component in this PR, the media modal implementation was tweaked via cae152c so that the input no longer relies on absolute positioning in order to achieve the desired effect.

# Testing

Visit any page that contains the `HeaderCake` component and check all the text (title & back link) will no longer wrap at certain sizes. It will try to display as much text as possible, but might become ellipsis'd in certain situations.

If the "back" text is 8 characters or above and the screen size is below `480px`, only the chevron should be visible.

---

/cc @mtias, @hoverduck