### PR TITLE
Invites: Fixes error when attempting to accept follower invites

### DIFF
--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -20,6 +20,12 @@ export default React.createClass( {
 		);
 	},
 
+	getSiteName() {
+		const { site } = this.props;
+
+		return site.title || '';
+	},
+
 	getLoggedOutTitleForInvite() {
 		let title = '';
 


### PR DESCRIPTION
While testing a follower invite, I noticed that the invitation never fully loaded because of a JS error:

`Uncaught TypeError: this.getSiteName is not a function`

![screen shot 5 3 48 56 pm](https://cloud.githubusercontent.com/assets/1126811/11758183/c0e88e0e-a02d-11e5-9fed-fb928590abfc.png)

This PR fixes that by adding the method back. 

cc @lezama 

To test:
- Checkout `fix/invites-get-site-name-error` branch
- Create a `follower` invite on a __public__ WordPress.com site by going to `$site/wp-admin/users.php?page=wpcom-invite-users`
- After the page reloads, copy the link address for resending the invitation.
- Make note of the `$invitation_key`
- In the invitation email that you get, make note of the `$key` and the `$activation` parameters in the activation link
- Go to `/accept-invite/$site/$invitation_key/$activate/$key`
- Are there JS errors? No? Good.

