### PR TITLE
Revert "Signup: Free trials: Only show free trials on signup in the dev environment"

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -27,7 +27,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( this.props.isInSignup ) {
-			return config.isEnabled( 'upgrades/free-trials' ) ? this.newPlanActions() : this.upgradeActions();
+			return this.signUpActions();
 		}
 
 		if ( this.siteHasThisPlan() ) {
@@ -144,6 +144,26 @@ module.exports = React.createClass( {
 
 		return (
 			<div onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'button' ) } className={ classes } />
+		);
+	},
+
+	signUpActions: function() {
+		if ( isFreePlan( this.props.plan ) ) {
+			return <div>
+				<button className="button is-primary plan-actions__upgrade-button"
+					onClick={ this.handleAddToCart.bind( null, null, 'button' ) }>
+					{ this.translate( 'Select Free Plan' ) }
+				</button>
+			</div>;
+		}
+
+		return (
+			<div>
+				<button className="button is-primary plan-actions__upgrade-button"
+					onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'button' ) }>
+						{ this.translate( 'Upgrade Now', { context: 'Store action' } ) }
+				</button>
+			</div>
 		);
 	},
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#1423