### PR TITLE
Reinstate: Signup: Free trials: Only show free trials on signup in the dev environment

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -27,7 +27,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( this.props.isInSignup ) {
-			return config.isEnabled( 'upgrades/free-trials' ) ? this.newPlanActions() : this.upgradeActions();
+			return config.isEnabled( 'upgrades/free-trials' ) ? this.freeTrialActions() : this.upgradeActions();
 		}
 
 		if ( this.siteHasThisPlan() ) {
@@ -53,7 +53,7 @@ module.exports = React.createClass( {
 
 		const canStartTrial = config.isEnabled( 'upgrades/free-trials' ) ? this.props.siteSpecificPlansDetails.can_start_trial : false;
 
-		return canStartTrial ? this.newPlanActions() : this.upgradeActions();
+		return canStartTrial ? this.freeTrialActions() : this.upgradeActions();
 	},
 
 	freePlanButton: function() {
@@ -162,7 +162,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	newPlanActions: function() {
+	freeTrialActions: function() {
 		if ( isFreePlan( this.props.plan ) ) {
 			return this.freePlanButton();
 		}

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -68,6 +68,10 @@ module.exports = React.createClass( {
 	},
 
 	upgradeActions: function() {
+		if ( isFreePlan( this.props.plan ) ) {
+			return this.freePlanButton();
+		}
+
 		return (
 			<div>
 				<button className="button is-primary plan-actions__upgrade-button"

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -56,6 +56,17 @@ module.exports = React.createClass( {
 		return canStartTrial ? this.newPlanActions() : this.upgradeActions();
 	},
 
+	freePlanButton: function() {
+		return (
+			<div>
+				<button className="button is-primary plan-actions__upgrade-button"
+					onClick={ this.handleAddToCart.bind( null, null, 'button' ) }>
+					{ this.translate( 'Select Free Plan' ) }
+				</button>
+			</div>
+		);
+	},
+
 	upgradeActions: function() {
 		return (
 			<div>
@@ -149,12 +160,7 @@ module.exports = React.createClass( {
 
 	newPlanActions: function() {
 		if ( isFreePlan( this.props.plan ) ) {
-			return <div>
-				<button className="button is-primary plan-actions__upgrade-button"
-					onClick={ this.handleAddToCart.bind( null, null, 'button' ) }>
-					{ this.translate( 'Select Free Plan' ) }
-				</button>
-			</div>;
+			return this.freePlanButton();
 		}
 
 		return (

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -27,7 +27,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( this.props.isInSignup ) {
-			return this.signUpActions();
+			return config.isEnabled( 'upgrades/free-trials' ) ? this.newPlanActions() : this.upgradeActions();
 		}
 
 		if ( this.siteHasThisPlan() ) {
@@ -144,26 +144,6 @@ module.exports = React.createClass( {
 
 		return (
 			<div onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'button' ) } className={ classes } />
-		);
-	},
-
-	signUpActions: function() {
-		if ( isFreePlan( this.props.plan ) ) {
-			return <div>
-				<button className="button is-primary plan-actions__upgrade-button"
-					onClick={ this.handleAddToCart.bind( null, null, 'button' ) }>
-					{ this.translate( 'Select Free Plan' ) }
-				</button>
-			</div>;
-		}
-
-		return (
-			<div>
-				<button className="button is-primary plan-actions__upgrade-button"
-					onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'button' ) }>
-						{ this.translate( 'Upgrade Now', { context: 'Store action' } ) }
-				</button>
-			</div>
 		);
 	},
 


### PR DESCRIPTION
This change broke signups in production because we were trying to create a payment button for free plans. 

**Testing**

You should test this with the `upgrades/free-trials` flag set to both `true` and `false` in `config/development.json` and restart `make run` every time you change it.

You should be able to go through the signup flow either way; but you will not see free trials when it is false.

- [x] Code review
- [x] Product review