### PR TITLE
Pages: do not show clock icon in placeholder

### DIFF
--- a/client/my-sites/pages/placeholder.jsx
+++ b/client/my-sites/pages/placeholder.jsx
@@ -29,8 +29,7 @@ module.exports = {
 		render: function() {
 			return (
 				<div className="page-list__header is-placeholder">
-					<span className="noticon noticon-time" />
-					<span className="placeholder-text">{ this.translate( "Loading time marker…" ) }</span>
+					<span>&nbsp;</span>
 				</div>
 			);
 		}


### PR DESCRIPTION
Fixes #11 to not display the clock icon when pages are loading.

Before:
<img width="669" alt="2011d41c-8d28-11e5-9749-69a39b4ec4d4" src="https://cloud.githubusercontent.com/assets/1270189/11759127/844a49aa-a029-11e5-8119-5f90e3c025f0.png">

After:
![loading](https://cloud.githubusercontent.com/assets/1270189/11790813/818d2662-a252-11e5-9369-1aa99b6814be.gif)

## Testing Instructions
1. Navigate to http://calypso.localhost:3000/pages

Check to see if the page placeholder render without the clock icon or the pulsing loading bar.

cc @mtias @alisterscott 