### PR TITLE
Reader: Fix icons in manage search.

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -134,7 +134,7 @@
 
 	position: relative;
 
-	.noticon {
+	.search-open__icon {
 		display: none;
 	}
 
@@ -146,8 +146,8 @@
 		z-index: 40;
 	}
 
-	.noticon-close-alt {
-		top: -12px;
+	.search-close__icon {
+		top: 20px;
 		right: -8px;
 		color: $gray;
 	}


### PR DESCRIPTION
Busted by switch to gridicons. See it at http://wordpress.com/following/edit

