### PR TITLE
Framework: Display the name of the current branch with the environment badge

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -481,6 +481,11 @@ body.newdash div.wordpress-com-extension-promo {
 				background-color: $blue-light;
 			}
 		}
+		&.branch-name {
+			text-transform: inherit;
+			background-color: #272727;
+			color: #F1F1F1;
+		}
 	}
 
 	.notouch & {

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -51,6 +51,8 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			div.environment-badge
 				a(class='bug-report', href=feedbackURL, title='Report an issue', target='_blank')
 				span(class=['environment', 'is-' + badge])=badge
+				if branchName && branchName !== 'master'
+					span(class=['environment', 'branch-name'])=branchName
 				if devDocs
 					span(class=['environment', 'is-docs'])
 						a(href=devDocsURL title='DevDocs') docs

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -132,8 +132,7 @@ function getDefaultContext( request ) {
 		jsFile: 'build',
 		faviconURL: '//s1.wp.com/i/favicon.ico',
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
-		devDocsURL: '/devdocs',
-		branchName: getCurrentBranchName()
+		devDocsURL: '/devdocs'
 	};
 
 	context.app = {
@@ -168,6 +167,7 @@ function getDefaultContext( request ) {
 		context.devDocs = true;
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/new';
 		context.faviconURL = '/calypso/images/favicons/favicon-development.ico';
+		context.branchName = getCurrentBranchName();
 	}
 
 	if ( config.isEnabled( 'code-splitting' ) ) {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -2,6 +2,7 @@ var express = require( 'express' ),
 	fs = require( 'fs' ),
 	crypto = require( 'crypto' ),
 	qs = require( 'qs' ),
+	execSync = require( 'child_process' ).execSync,
 	cookieParser = require( 'cookie-parser' ),
 	i18nUtils = require( 'lib/i18n-utils' ),
 	debug = require( 'debug' )( 'calypso:pages' );
@@ -107,6 +108,14 @@ function getChunk( path ) {
 	}
 }
 
+function getCurrentBranchName() {
+	try {
+		return execSync('git rev-parse --abbrev-ref HEAD');
+	} catch(err) {
+		return undefined;
+	}
+}
+
 function getDefaultContext( request ) {
 	var context, chunk;
 
@@ -123,7 +132,8 @@ function getDefaultContext( request ) {
 		jsFile: 'build',
 		faviconURL: '//s1.wp.com/i/favicon.ico',
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
-		devDocsURL: '/devdocs'
+		devDocsURL: '/devdocs',
+		branchName: getCurrentBranchName()
 	};
 
 	context.app = {


### PR DESCRIPTION
The idea is that it is useful to be remembered of the current branch when you are testing.

This is what it looks like:

<img width="989" alt="cloudup-08a1b31a-7023-4396-a76d-864ef226fa22" src="https://cloud.githubusercontent.com/assets/230230/11762831/2a9c4d60-a0f4-11e5-910e-a87b83864f9d.png">


Branch name is not displayed when:
- Git is not available
- The project is not a git repository
- The current branch is master

Also, this is going to be really useful for [a multiple versions application](https://github.com/Automattic/calypso-live-branches) of calypso.