### PR TITLE
Reader: fix sidebar list highlight

### DIFF
--- a/client/reader/sidebar/sidebar.jsx
+++ b/client/reader/sidebar/sidebar.jsx
@@ -4,14 +4,14 @@
 const assign = require( 'lodash/object/assign' ),
 	classnames = require( 'classnames' ),
 	closest = require( 'component-closest' ),
-	endsWith = require( 'lodash/string/endsWith' ),
 	map = require( 'lodash/collection/map' ),
 	some = require( 'lodash/collection/some' ),
 	startsWith = require( 'lodash/string/startsWith' ),
 	ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	page = require( 'page' ),
-	url = require( 'url' );
+	url = require( 'url' ),
+	last = require( 'lodash/array/last' );
 
 /**
  * Internal Dependencies
@@ -190,10 +190,11 @@ module.exports = React.createClass( {
 			const listManagementUrls = [
 				listRelativeUrl + '/tags',
 				listRelativeUrl + '/edit',
-				listRelativeUrl + '/feeds',
+				listRelativeUrl + '/sites',
 			];
 
-			const isCurrentList = this.pathStartsWithOneOf( [ listRelativeUrl ] ) && endsWith( this.props.path.toLowerCase(), list.slug.toLowerCase() );
+			const lastPathSegment = last( this.props.path.split( '/' ) );
+			const isCurrentList = lastPathSegment && lastPathSegment.toLowerCase() === list.slug.toLowerCase();
 			const isActionButtonSelected = this.pathStartsWithOneOf( listManagementUrls );
 
 			const classes = classnames(

--- a/client/reader/sidebar/sidebar.jsx
+++ b/client/reader/sidebar/sidebar.jsx
@@ -252,25 +252,7 @@ module.exports = React.createClass( {
 		}, this );
 	},
 
-	getFollowingEditLink: function() {
-		var followingEditUrl = '/following/edit',
-			followingEditRel;
-
-		// If Calypso following/edit isn't yet enabled, use the Atlas version
-		if ( ! config.isEnabled( 'reader/following-edit' ) ) {
-			followingEditUrl = 'https://wordpress.com'.concat( followingEditUrl );
-			followingEditRel = 'external';
-		}
-
-		return {
-			url: followingEditUrl,
-			rel: followingEditRel
-		};
-	},
-
 	render: function() {
-		let followingEditLink = this.getFollowingEditLink();
-
 		return (
 			<ul className="wpcom-sidebar sidebar reader-sidebar" onClick={ this.handleClick }>
 				<li className="sidebar-menu sidebar-streams">
@@ -281,7 +263,7 @@ module.exports = React.createClass( {
 								<Gridicon icon="checkmark-circle" size={ 24 } />
 								<span className="menu-link-text">{ this.translate( 'Followed Sites' ) }</span>
 							</a>
-							<a href={ followingEditLink.url } rel={ followingEditLink.rel } className="add-new">{ this.translate( 'Manage' ) }</a>
+							<a href="/following/edit" className="add-new">{ this.translate( 'Manage' ) }</a>
 						</li>
 
 						{ this.renderTeams() }

--- a/client/reader/sidebar/sidebar.jsx
+++ b/client/reader/sidebar/sidebar.jsx
@@ -4,7 +4,7 @@
 const assign = require( 'lodash/object/assign' ),
 	classnames = require( 'classnames' ),
 	closest = require( 'component-closest' ),
-	debug = require( 'debug' )( 'calypso:reader:sidebar' ),
+	endsWith = require( 'lodash/string/endsWith' ),
 	map = require( 'lodash/collection/map' ),
 	some = require( 'lodash/collection/some' ),
 	startsWith = require( 'lodash/string/startsWith' ),
@@ -31,10 +31,6 @@ const layoutFocus = require( 'lib/layout-focus' ),
 
 module.exports = React.createClass( {
 	displayName: 'ReaderSidebar',
-
-	componentWillMount: function() {
-		debug( 'Mounting the reader sidebar React component.' );
-	},
 
 	itemLinkClass: function( path, additionalClasses ) {
 		var basePathLowerCase = this.props.path.split( '?' )[0].replace( /\/edit$/, '' ).toLowerCase(),
@@ -192,15 +188,19 @@ module.exports = React.createClass( {
 			}
 
 			const listManagementUrls = [
-				listRelativeUrl + '/followers',
+				listRelativeUrl + '/tags',
 				listRelativeUrl + '/edit',
-				listRelativeUrl + '/description/edit',
+				listRelativeUrl + '/feeds',
 			];
 
+			const isCurrentList = this.pathStartsWithOneOf( [ listRelativeUrl ] ) && endsWith( this.props.path.toLowerCase(), list.slug.toLowerCase() );
+			const isActionButtonSelected = this.pathStartsWithOneOf( listManagementUrls );
+
 			const classes = classnames(
-				this.itemLinkClassStartsWithOneOf( [ listRelativeUrl ], { 'sidebar-dynamic-menu__list has-buttons': true } ),
 				{
-					'is-action-button-selected': this.pathStartsWithOneOf( listManagementUrls )
+					'sidebar-dynamic-menu__list has-buttons': true,
+					selected: isCurrentList || isActionButtonSelected,
+					'is-action-button-selected': isActionButtonSelected
 				}
 			);
 


### PR DESCRIPTION
Ensure that only the current list is highlighted in the Reader sidebar. 

Previously, it was possible for multiple lists to be highlighted at the same time if they shared the same beginning to their URL (fixes #1523).

<img width="280" alt="screen shot 2015-12-14 at 14 05 46" src="https://cloud.githubusercontent.com/assets/17325/11772026/037ee660-a26c-11e5-9ed7-b93224f54f96.png">
<img width="283" alt="screen shot 2015-12-14 at 14 05 41" src="https://cloud.githubusercontent.com/assets/17325/11772025/037a06ae-a26c-11e5-9586-408115f17b18.png">

### To test

Create two Reader lists with a common start to their name (e.g. giraffe1 and giraffe2). 

Choose the list in the sidebar, and ensure that only the chosen list is highlighted.

Then choose the Manage button for your chosen list, again ensuring that only the chosen list is highlighted.