### PR TITLE
Add translate calls to strings in SectionHeader docs

### DIFF
--- a/client/components/section-header/README.md
+++ b/client/components/section-header/README.md
@@ -14,7 +14,7 @@ render: function() {
 	return (
 		<SectionHeader label={ this.translate( 'Team' ) }>
 			<Button compact>
-				this.translate( 'Manage' ) }
+				{ this.translate( 'Manage' ) }
 			</Button>
 			<Button
 				compact

--- a/client/components/section-header/README.md
+++ b/client/components/section-header/README.md
@@ -14,7 +14,7 @@ render: function() {
 	return (
 		<SectionHeader label={ this.translate( 'Team' ) }>
 			<Button compact>
-				Manage
+				this.translate( 'Manage' ) }
 			</Button>
 			<Button
 				compact
@@ -22,7 +22,7 @@ render: function() {
 					console.log( 'Clicked Add button' );
 				} }
 			>
-				Add
+				{ this.translate( 'Add' ) }
 			</Button>
 		</SectionHeader>
 	);

--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -8,7 +8,7 @@ var React = require( 'react' );
  */
 var SectionHeader = require( 'components/section-header' ),
 	Button = require( 'components/button' );
-	
+
 var Cards = React.createClass( {
 	displayName: 'SectionHeader',
 
@@ -21,12 +21,12 @@ var Cards = React.createClass( {
 					<a href="/devdocs/design/section-header">Section Header</a>
 				</h2>
 
-				<SectionHeader label="Team" count={ 10 }>
+				<SectionHeader label={ this.translate( 'Team' ) } count={ 10 }>
 					<Button compact primary>
-						Primary Action
+						{ this.translate( 'Primary Action' ) }
 					</Button>
 					<Button compact>
-						Manage
+						{ this.translate( 'Manage' ) }
 					</Button>
 					<Button
 						compact
@@ -34,7 +34,7 @@ var Cards = React.createClass( {
 							alert( 'Clicked add button' );
 						} }
 					>
-						Add
+						{ this.translate( 'Add' ) }
 					</Button>
 				</SectionHeader>
 			</div>


### PR DESCRIPTION
This PR adds translate() calls to strings in SectionHeader, as suggested in #1468

You can see the example with the translate calls works at http://calypso.localhost:3000/devdocs/design/section-header and you can check that the strings won't go out to translators by running `make translate` and then checking `calypso-strings.php` both from the top directory of calypso.

@ebinnion: I've opened this PR because I feel bad about being away and missing the other PR, not to be pushy.  If you feel like the example stands better without the changes, feel free to comment to that effect and close