### PR TITLE
Checkout: Fix errors when removing item from sidebar cart

### DIFF
--- a/client/my-sites/upgrades/checkout/free-trial-confirmation-box.js
+++ b/client/my-sites/upgrades/checkout/free-trial-confirmation-box.js
@@ -3,23 +3,25 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	classNames = require( 'classnames' );
+	classNames = require( 'classnames' ),
+	find = require( 'lodash/collection/find' );
 
 /**
  * Internal dependencies
  */
-var PayButton = require( './pay-button' ),
+var isPlan = require( 'lib/products-values' ).isPlan,
+	PayButton = require( './pay-button' ),
 	PaymentBox = require( './payment-box' ),
 	TermsOfService = require( './terms-of-service' );
 
-var FreeTrialConfirmationBox = React.createClass( {
-	content: function() {
+const FreeTrialConfirmationBox = React.createClass( {
+	content() {
 		return (
 			<form onSubmit={ this.props.onSubmit }>
 				<div className="payment-box-section">
 					<h6>
 					{
-						this.translate( 'Get started with %(productName)s', { args: { productName: this.props.cart.products[0].product_name } } )
+						this.translate( 'Get started with %(productName)s', { args: { productName: this.getProductName() } } )
 					}
 					</h6>
 
@@ -40,8 +42,14 @@ var FreeTrialConfirmationBox = React.createClass( {
 		);
 	},
 
-	render: function() {
-		var classSet = classNames( {
+	getProductName() {
+		const planProduct = find( this.props.cart.products, isPlan );
+
+		return ( planProduct && planProduct.product_name ) || '';
+	},
+
+	render() {
+		const classSet = classNames( {
 			'credits-payment-box': true,
 			selected: this.props.selected === true
 		} );


### PR DESCRIPTION
Fixes #1286.

To reproduce before this change:

1. Add an upgrade to your cart for a new site or an existing one. e.g.: visit the plans page for an existing site (https://wordpress.com/plans/example.wordpress.com) and click "Upgrade Now".
2. Click the "x" next to the upgrade in the Checkout page sidebar.
3. The page hangs on a loading screen and errors appear in the console.
4. The error persists upon reloading the Checkout page.

I was able to reproduce it only when I had **free credit** assigned to my account.

<img width="1072" alt="screen shot 2015-12-04 at 5 51 52 pm" src="https://cloud.githubusercontent.com/assets/2036909/11603460/d39dad14-9aaf-11e5-9732-2a25114a5349.png">

### Testing
1. Assign free credits to your account.
2. Try to reproduce this error.
