### PR TITLE
Themes: correct position of search panel on scroll

### DIFF
--- a/client/components/sticky-panel/index.jsx
+++ b/client/components/sticky-panel/index.jsx
@@ -72,7 +72,7 @@ module.exports = React.createClass( {
 		if ( this.state.isSticky ) {
 			// Offset to account for Master Bar by finding body visual top
 			// relative the current scroll position
-			offset = document.getElementById( 'primary' ).getBoundingClientRect().top;
+			offset = document.getElementById( 'content' ).getBoundingClientRect().top;
 
 			return {
 				top: offset + window.pageYOffset,


### PR DESCRIPTION
Fix the showcase search panel so that it sticks to the masterbar rather than hovering below.

**Before**
<img width="506" alt="screen shot 2015-12-14 at 11 52 21" src="https://cloud.githubusercontent.com/assets/7767559/11780357/4331c1d2-a259-11e5-80d5-31a92a1cfa0b.png">

**After**
<img width="505" alt="screen shot 2015-12-14 at 11 51 23" src="https://cloud.githubusercontent.com/assets/7767559/11780364/4d2e4142-a259-11e5-9c67-aaba561d417c.png">


Use the #content instead of #primary div for calculating the sticky-panel
offset from top of page. Unlike #primary, #content has a consistent
layout across the editor and showcase pages, meaning it will have
the desired effect in both places.

**To Test**
* `<StickyPanel />` is used for the publish panel in the editor, so check that the behaviour there remains the same (see #528 for test instructions)
* Go to http://calypso.localhost:3000/design and scroll the page
