### PR TITLE
Checkout: Block removal of Private Registration from cart only when renewing

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -24,6 +24,18 @@ function applyCoupon( coupon ) {
 	};
 }
 
+function canRemoveFromCart( cart, cartItem ) {
+	if ( productsValues.isCredits( cartItem ) ) {
+		return false;
+	}
+
+	if ( cartItems.hasRenewalItem( cart ) && productsValues.isPrivateRegistration( cartItem ) ) {
+		return false;
+	}
+
+	return true;
+}
+
 /**
  * Compare two different cart objects and get the messages of newest one
  *
@@ -112,13 +124,14 @@ function isPayPalExpressEnabled( cart ) {
 
 module.exports = {
 	applyCoupon,
+	canRemoveFromCart,
 	cartItems,
+	emptyCart,
 	fillInAllCartItemAttributes,
 	fillInSingleCartItemAttributes,
 	getNewMessages,
 	getRefundPolicy,
 	isFree,
 	isPaidForFullyInCredits,
-	isPayPalExpressEnabled,
-	emptyCart
+	isPayPalExpressEnabled
 };

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -244,16 +244,7 @@ function isSpaceUpgrade( product ) {
 		'100gb_space_upgrade' === product.product_slug;
 }
 
-function canRemoveFromCart( product ) {
-	if ( isPrivateRegistration( product ) || isCredits( product ) ) {
-		return false;
-	}
-
-	return true;
-}
-
 module.exports = {
-	canRemoveFromCart,
 	formatProduct,
 	isFreePlan: isFreePlan,
 	isPremium: isPremium,

--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -56,18 +56,10 @@ module.exports = React.createClass( {
 	},
 
 	getFreeTrialPrice: function() {
-		var freeTrialText, renewalPrice;
+		var freeTrialText;
 
 		freeTrialText = this.translate( 'Free %(days)s Day Trial', {
 			args: { days: '14' }
-		} );
-
-		renewalPrice = this.translate( '(%(cost)s %(currency)s/%(billingPeriod)s)', {
-			args: {
-				cost: this.props.cartItem.orig_cost,
-				currency: this.props.cartItem.currency,
-				billingPeriod: 'year'
-			}
 		} );
 
 		return (

--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -7,7 +7,7 @@ var React = require( 'react' );
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
-	canRemoveFromCart = require( 'lib/products-values' ).canRemoveFromCart,
+	canRemoveFromCart = require( 'lib/cart-values' ).canRemoveFromCart,
 	cartItems = require( 'lib/cart-values' ).cartItems,
 	getIncludedDomain = cartItems.getIncludedDomain,
 	isCredits = require( 'lib/products-values' ).isCredits,
@@ -158,7 +158,7 @@ module.exports = React.createClass( {
 	},
 
 	removeButton: function() {
-		if ( canRemoveFromCart( this.props.cartItem ) ) {
+		if ( canRemoveFromCart( this.props.cart, this.props.cartItem ) ) {
 			return <button className="remove-item noticon noticon-close" onClick={ this.removeFromCart }></button>;
 		}
 	}


### PR DESCRIPTION
Fixes #1410.

Steps to reproduce:
1. Go to http://calypso.localhost:3000/domains/manage.
2. Select a Site.
3. Select a Domain without Private Registration.
4. Navigate to Contacts and Privacy page.
5. Navigate to Privacy Protection page.
6. Click Add Privacy Protection button.
7. Checkout page will load and you won't be able to remove this upgrade from the cart (remove icon is missing):
### Testing
1. Do (1)-(6) from steps to reproduce.
2. You should be able to remove Private Registration from the cart.
3. Go to http://calypso.localhost:3000/purchases.
4. Select a Domain purchase with Private Registration that is expiring.
5. Click Renew button.
6. You shouldn't be able to remove Private Registration from the cart. Domain needs to be renewed together with Private Registration.
