### PR TITLE
Plugins: avoid single-word lines in 'all plugins up to date' message

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -616,7 +616,8 @@ export default React.createClass( {
 			emptyContentData.title = this.translate( 'All plugins on %(siteName)s are {{span}}up to date.{{/span}}', {
 				textOnly: true,
 				args: { siteName: selectedSite.title },
-				components: { span: <span className="plugins__plugin-list-state" /> }
+				components: { span: <span className="plugins__plugin-list-state" /> },
+				comment: 'The span tags prevents single words from showing on a single line.'
 			} );
 		} else {
 			emptyContentData.title = this.translate( 'All plugins are up to date.', { textOnly: true } );

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -613,9 +613,10 @@ export default React.createClass( {
 			selectedSite = this.props.sites.getSelectedSite();
 
 		if ( selectedSite ) {
-			emptyContentData.title = this.translate( 'All plugins on %(siteName)s are up to date.', {
+			emptyContentData.title = this.translate( 'All plugins on %(siteName)s are {{span}}up to date.{{/span}}', {
 				textOnly: true,
-				args: { siteName: selectedSite.title }
+				args: { siteName: selectedSite.title },
+				components: { span: <span className="plugins__plugin-list-state" /> }
 			} );
 		} else {
 			emptyContentData.title = this.translate( 'All plugins are up to date.', { textOnly: true } );

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -75,3 +75,7 @@
 		color: lighten( $alert-red, 30% );
 	}
 }
+
+.plugins__plugin-list-state {
+	white-space: nowrap;
+}


### PR DESCRIPTION
fix https://github.com/Automattic/wp-calypso/issues/420

Avoids the text of the 'all plugins up to date' view to break into a single word line:

Before
![image](https://cloud.githubusercontent.com/assets/1554855/11782033/aa7984d2-a26e-11e5-93a1-74add50cc38e.png)

After
![image](https://cloud.githubusercontent.com/assets/1554855/11781943/e0fa1d4c-a26d-11e5-9331-0a623ab7063b.png)