### PR TITLE
Update/update step module names to match step names

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -306,7 +306,7 @@
 @import 'signup/steps/survey/style';
 @import 'signup/steps/design-type/style';
 @import 'signup/steps/plans/style';
-@import 'signup/steps/site-creation/style';
+@import 'signup/steps/site/style';
 @import 'signup/validation-fieldset/style';
 @import 'vip/vip-logs/style';
 @import 'signup/steps/dss/style';

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-var EmailSignupComponent = require( 'signup/steps/email-signup-form' ),
+var UserSignupComponent = require( 'signup/steps/user' ),
 	SiteCreationComponent = require( 'signup/steps/site-creation' ),
 	ThemeSelectionComponent = require( 'signup/steps/theme-selection' ),
 	PlansStepComponent = require( 'signup/steps/plans' ),
@@ -15,14 +15,14 @@ module.exports = {
 	themes: ThemeSelectionComponent,
 	'theme-headstart': ThemeSelectionComponent,
 	site: SiteCreationComponent,
-	user: EmailSignupComponent,
+	user: UserSignupComponent,
 	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
 	plans: PlansStepComponent,
 	domains: DomainsStepComponent,
 	survey: SurveyStepComponent,
-	'survey-user': EmailSignupComponent,
+	'survey-user': UserSignupComponent,
 	'domains-with-theme': DomainsStepComponent,
 	'theme-dss': DSSStepComponent,
 	'design-type': DesignTypeComponent,
-	'jetpack-user': EmailSignupComponent
+	'jetpack-user': UserSignupComponent
 };

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 var UserSignupComponent = require( 'signup/steps/user' ),
-	SiteCreationComponent = require( 'signup/steps/site-creation' ),
+	SiteComponent = require( 'signup/steps/site' ),
 	ThemeSelectionComponent = require( 'signup/steps/theme-selection' ),
 	PlansStepComponent = require( 'signup/steps/plans' ),
 	DomainsStepComponent = require( 'signup/steps/domains' ),
@@ -14,7 +14,7 @@ var UserSignupComponent = require( 'signup/steps/user' ),
 module.exports = {
 	themes: ThemeSelectionComponent,
 	'theme-headstart': ThemeSelectionComponent,
-	site: SiteCreationComponent,
+	site: SiteComponent,
 	user: UserSignupComponent,
 	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
 	plans: PlansStepComponent,

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -34,7 +34,7 @@ var siteUrlsSearched = [],
 	timesValidationFailed = 0;
 
 module.exports = React.createClass( {
-	displayName: 'SiteCreation',
+	displayName: 'Site',
 
 	getInitialState: function() {
 		return {
@@ -235,7 +235,7 @@ module.exports = React.createClass( {
 			<FormTextInput
 				autoFocus={ true }
 				autoCapitalize={ 'off' }
-				className='site-creation__site-url'
+				className='site-signup-step__site-url'
 				disabled={ fieldDisabled }
 				type='text'
 				name='site'
@@ -244,7 +244,7 @@ module.exports = React.createClass( {
 				isValid={ formState.isFieldValid( this.state.form, 'site' ) }
 				onBlur={ this.handleBlur }
 				onChange={ this.handleChangeEvent } />
-			<span className='site-creation__wordpress-domain-suffix'>.wordpress.com</span>
+			<span className='site-signup-step__wordpress-domain-suffix'>.wordpress.com</span>
 		</ValidationFieldset>;
 	},
 

--- a/client/signup/steps/site/style.scss
+++ b/client/signup/steps/site/style.scss
@@ -1,8 +1,8 @@
-.site-creation__site-url.form-text-input {
+.site-signup-step__site-url.form-text-input {
 	padding-right: 122px;
 }
 
-.site-creation__wordpress-domain-suffix {
+.site-signup-step__wordpress-domain-suffix {
 	color: $gray;
 	line-height: 40px;
 	margin-left: -122px;

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -16,7 +16,7 @@ import { getABTestVariation } from 'lib/abtest';
 
 export default React.createClass( {
 
-	displayName: 'EmailSignupForm',
+	displayName: 'User',
 
 	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.step && 'invalid' === nextProps.step.status ) {


### PR DESCRIPTION
Updates email-signup-form and site-creation signup steps directories and require statements to use these names for consistency as proposed by #767 : 

`client/signup/steps/email-signup-form` -> `client/signup/steps/user`
`client/signup/steps/site-creation -> `client/signup/steps/site`

### Testing instructions

* While logged out, go to http://calypso.localhost:3000/start/developer
* Make sure the signup flow lets you reach the site selection and user registration steps.
* Make sure that input padding and suffix styles for the site selection step was not affected