### PR TITLE
Signup: Add first draft of "Triforce" flow

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -302,6 +302,7 @@
 @import 'signup/step-header/style';
 @import 'signup/steps/domains/style';
 @import 'signup/steps/survey/style';
+@import 'signup/steps/design-type/style';
 @import 'signup/steps/plans/style';
 @import 'signup/steps/site-creation/style';
 @import 'signup/validation-fieldset/style';

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -135,6 +135,13 @@ const flows = {
 		lastModified: '2015-11-13'
 	},
 
+	'layout': {
+		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
+		destination: getCheckoutDestination,
+		description: 'Theme trifurcation flow',
+		lastModified: '2015-12-14'
+	},
+
 	developer: {
 		steps: [ 'themes', 'site', 'user' ],
 		destination: '/devdocs/welcome',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -6,6 +6,7 @@ var EmailSignupComponent = require( 'signup/steps/email-signup-form' ),
 	ThemeSelectionComponent = require( 'signup/steps/theme-selection' ),
 	PlansStepComponent = require( 'signup/steps/plans' ),
 	DomainsStepComponent = require( 'signup/steps/domains' ),
+	DesignTypeComponent = require( 'signup/steps/design-type' ),
 	DSSStepComponent = require( 'signup/steps/dss' ),
 	SurveyStepComponent = require( 'signup/steps/survey' ),
 	config = require( 'config' );
@@ -22,5 +23,6 @@ module.exports = {
 	'survey-user': EmailSignupComponent,
 	'domains-with-theme': DomainsStepComponent,
 	'theme-dss': DSSStepComponent,
+	'design-type': DesignTypeComponent,
 	'jetpack-user': EmailSignupComponent
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -25,6 +25,11 @@ module.exports = {
 		providesDependencies: [ 'theme', 'images' ]
 	},
 
+	'design-type': {
+		stepName: 'design-type',
+		providesDependencies: [ 'themes' ]
+	},
+
 	site: {
 		stepName: 'site',
 		apiRequestFunction: stepActions.createSite,

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -65,6 +65,9 @@ export default React.createClass( {
 
 	handleNextStep( designType ) {
 		const themes = getThemes( designType );
+
+		analytics.tracks.recordEvent( 'calypso_triforce_select_design', { category: designType } );
+
 		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { themes } );
 		this.props.goToNextStep();
 	}

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import SignupActions from 'lib/signup/actions';
+import analytics from 'analytics';
+import getThemes from './themes-map';
+import Card from 'components/card';
+
+export default React.createClass( {
+	displayName: 'DesignType',
+
+	getChoices() {
+		return [
+			{ type: 'blog', label: this.translate( 'A list of my latest posts' ), image: '/calypso/images/signup/design-type/design-type-latest.svg' },
+			{ type: 'page', label: this.translate( 'A welcome page for my site' ), image: '/calypso/images/signup/design-type/design-type-welcome.svg' },
+			{ type: 'grid', label: this.translate( 'A grid of my latest posts' ), image: '/calypso/images/signup/design-type/design-type-grid.svg' },
+		];
+	},
+
+	renderChoice( choice ) {
+		return (
+			<Card className="design-type__choice" key={ choice.type }>
+				<a className="design-type__choice__link" href="#" onClick={ ( event ) => this.handleChoiceClick( event, choice.type ) }>
+					<img src={ choice.image } />
+					<h2>{ choice.label }</h2>
+				</a>
+			</Card>
+		);
+	},
+
+	renderChoices() {
+		return (
+			<div className="design-type__list">
+				{ this.getChoices().map( this.renderChoice ) }
+			</div>
+		);
+	},
+
+	render() {
+		return (
+			<div className="design-type__section-wrapper">
+				<StepWrapper
+					flowName={ this.props.flowName }
+					stepName={ this.props.stepName }
+					positionInFlow={ this.props.positionInFlow }
+					headerText={ this.translate( 'What would you like your homepage to look like?' ) }
+					subHeaderText={ this.translate( 'This will help us figure out what kinds of designs to show you.' ) }
+					signupProgressStore={ this.props.signupProgressStore }
+					stepContent={ this.renderChoices() } />
+			</div>
+		);
+	},
+
+	handleChoiceClick( event, type ) {
+		event.preventDefault();
+		event.stopPropagation();
+		this.handleNextStep( type );
+	},
+
+	handleNextStep( designType ) {
+		const themes = getThemes( designType );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { themes } );
+		this.props.goToNextStep();
+	}
+} );

--- a/client/signup/steps/design-type/style.scss
+++ b/client/signup/steps/design-type/style.scss
@@ -1,0 +1,28 @@
+.design-type__list {
+	display: flex;
+	flex-flow: row wrap;
+}
+
+.design-type__choice {
+	padding: 0;
+	margin: 0 10px 20px 10px;
+	width: 230px;
+	flex-grow: 1;
+	transition: all 100ms ease-in-out;
+
+	a, img {
+		display: block;
+	}
+
+	h2 {
+		color: #000;
+		padding-left: 15px;
+		border-top: 1px solid transparentize( lighten( $gray, 20% ), .5 );
+		font-weight: bold;
+		line-height: 54px;
+	}
+
+	&:hover {
+		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
+	}
+}

--- a/client/signup/steps/design-type/themes-map.js
+++ b/client/signup/steps/design-type/themes-map.js
@@ -1,0 +1,41 @@
+import shuffle from 'lodash/collection/shuffle';
+
+const map = {
+	blog: [
+		{ name: 'Button', slug: 'button' },
+		{ name: 'Franklin', slug: 'franklin' },
+		{ name: 'Sapor', slug: 'sapor' },
+		{ name: 'Colinear', slug: 'colinear' },
+		{ name: 'Minnow', slug: 'minnow' },
+		{ name: 'Eighties', slug: 'eighties' },
+		{ name: 'Libre', slug: 'libre' },
+		{ name: 'Penscratch', slug: 'penscratch' },
+		{ name: 'Libretto', slug: 'libretto' },
+	],
+	page: [
+		{ name: 'Gateway', slug: 'gateway' },
+		{ name: 'Edin', slug: 'edin' },
+		{ name: 'Sequential', slug: 'sequential' },
+		{ name: 'Goran', slug: 'goran' },
+		{ name: 'Sela', slug: 'sela' },
+		{ name: 'Motif', slug: 'motif' },
+		{ name: 'Big Brother', slug: 'big-brother' },
+		{ name: 'Argent', slug: 'argent' },
+		{ name: 'Harmonic', slug: 'harmonic' },
+	],
+	grid: [
+		{ name: 'Dyad', slug: 'dyad' },
+		{ name: 'Blask', slug: 'blask' },
+		{ name: 'Cubic', slug: 'cubic' },
+		{ name: 'Illustratr', slug: 'illustratr' },
+		{ name: 'Snaps', slug: 'snaps' },
+		{ name: 'Sketch', slug: 'sketch' },
+		{ name: 'Gazette', slug: 'gazette' },
+		{ name: 'Apostrophe', slug: 'apostrophe' },
+		{ name: 'Pictorico', slug: 'pictorico' },
+	]
+};
+
+export default function getThemes( key ) {
+	return shuffle( map[ key ] || [] );
+}

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -64,9 +64,13 @@ module.exports = React.createClass( {
 		this.props.goToNextStep();
 	},
 
+	getThemes() {
+		return this.props.signupDependencies.themes || this.props.themes;
+	},
+
 	renderThemesList: function() {
 		var actionLabel = this.translate( 'Pick' ),
-			themes = this.props.themes.map( function( theme ) {
+			themes = this.getThemes().map( function( theme ) {
 				return {
 					id: theme.slug,
 					name: theme.name,

--- a/public/images/signup/design-type/design-type-grid.svg
+++ b/public/images/signup/design-type/design-type-grid.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 310 230" enable-background="new 0 0 310 230" xml:space="preserve">
+<rect x="15" y="15" fill="#E8F0F5" width="280" height="40"/>
+<rect x="114" y="70" fill="#C3EF96" width="82" height="65"/>
+<rect x="15" y="70" fill="#C3EF96" width="82" height="65"/>
+<rect x="213" y="70" fill="#C3EF96" width="82" height="65"/>
+<rect x="114" y="150" fill="#C3EF96" width="82" height="65"/>
+<rect x="15" y="150" fill="#C3EF96" width="82" height="65"/>
+<rect x="213" y="150" fill="#C3EF96" width="82" height="65"/>
+</svg>

--- a/public/images/signup/design-type/design-type-latest.svg
+++ b/public/images/signup/design-type/design-type-latest.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 310 230" enable-background="new 0 0 310 230" xml:space="preserve">
+<rect x="15" y="15" fill="#E8F0F5" width="280" height="70"/>
+<rect x="15" y="98" fill="#C3EF96" width="194" height="85"/>
+<rect x="15" y="195" fill="#C3EF96" width="194" height="35"/>
+</svg>

--- a/public/images/signup/design-type/design-type-welcome.svg
+++ b/public/images/signup/design-type/design-type-welcome.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 310 230" enable-background="new 0 0 310 230" xml:space="preserve">
+<rect fill="#E8F0F5" width="310" height="110"/>
+<rect x="114" y="205" fill="#E8F0F5" width="82" height="25"/>
+<rect x="15" y="205" fill="#E8F0F5" width="82" height="25"/>
+<rect x="213" y="205" fill="#E8F0F5" width="82" height="25"/>
+<rect x="15" y="36" fill="#D2DEE6" width="153" height="13"/>
+<rect x="15" y="59" fill="#D2DEE6" width="113" height="13"/>
+<rect x="15" y="82" fill="#C3EF96" width="30" height="13"/>
+<rect x="15" y="125" fill="#C3EF96" width="280" height="65"/>
+</svg>


### PR DESCRIPTION
Initial draft of the "Triforce" design selection flow. You can access it currently by visiting http://calypso.localhost:3000/start/layout 

<img width="967" alt="screen shot 2015-12-14 at 6 56 26 pm" src="https://cloud.githubusercontent.com/assets/2036909/11797928/6ce07cea-a294-11e5-937a-57b91401e36d.png">

Still to do:

- [x] Add stats collection
- [x] Add images to choices
- [x] Make sure theme mapping is what we want
- [x] Decide what to name the flow (currently `/start/triforce`, but probably should be something else)
- [x] Clean up / polish the styles

## Testing

1. Visit http://calypso.localhost:3000/start/layout and make sure that the first step of the signup flow is the "triforce" screen (pictured above). 
2. Try each layout choice to be sure the listed themes on the next page are different from other layout choices (beware: the theme order is randomized). 
3. Complete the signup flow with one of the theme choices and be sure that A) there are no javascript errors (at least, ones not in `master`) and B) the created site has the theme chosen.