### PR TITLE
Framework: preload all the things

### DIFF
--- a/client/components/site-stats-sticky-link/index.jsx
+++ b/client/components/site-stats-sticky-link/index.jsx
@@ -4,6 +4,7 @@ var React = require( 'react' );
 
 // Internal dependencies
 var siteStatsStickyTabStore = require( 'lib/site-stats-sticky-tab/store' );
+var sections = require( 'sections' );
 
 var SiteStatsStickyLink = React.createClass( {
 
@@ -11,6 +12,8 @@ var SiteStatsStickyLink = React.createClass( {
 		title: React.PropTypes.string,
 		onClick: React.PropTypes.func
 	},
+
+	_preloaded: false,
 
 	getInitialState: function() {
 		return {
@@ -36,11 +39,23 @@ var SiteStatsStickyLink = React.createClass( {
 		}
 	},
 
+	preload: function() {
+		if ( ! this._preloaded ) {
+			this._preloaded = true;
+			sections.preload( 'stats' );
+		}
+	},
+
 	render: function() {
 		return (
-			<a href={ this.state.url } onClick={ this.props.onClick } title={ this.props.title }>{
-				this.props.children
-			}</a>
+			<a
+				href={ this.state.url }
+				onClick={ this.props.onClick }
+				title={ this.props.title }
+				onMouseEnter={ this.preload }
+			>
+				{ this.props.children }
+			</a>
 		);
 	}
 } );

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import noop from 'lodash/utility/noop';
+import isFunction from 'lodash/lang/isFunction';
 
 /**
  * Internal dependencies
@@ -22,8 +23,7 @@ export default React.createClass( {
 		icon: React.PropTypes.string,
 		className: React.PropTypes.string,
 		isActive: React.PropTypes.bool,
-		preloadSectionName: React.PropTypes.string,
-		sections: React.PropTypes.object
+		preloadSection: React.PropTypes.func
 	},
 
 	_preloaded: false,
@@ -36,9 +36,9 @@ export default React.createClass( {
 	},
 
 	preload() {
-		if ( ! this._preloaded && this.props.preloadSectionName ) {
+		if ( ! this._preloaded && isFunction( this.props.preloadSection ) ) {
 			this._preloaded = true;
-			this.props.sections.preload( this.props.preloadSectionName );
+			this.props.preloadSection();
 		}
 	},
 

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -18,12 +18,15 @@ export default React.createClass( {
 	propTypes: {
 		url: React.PropTypes.string,
 		onClick: React.PropTypes.func,
-		onPreload: React.PropTypes.func,
 		tooltip: React.PropTypes.string,
 		icon: React.PropTypes.string,
 		className: React.PropTypes.string,
-		isActive: React.PropTypes.bool
+		isActive: React.PropTypes.bool,
+		preloadSectionName: React.PropTypes.string,
+		sections: React.PropTypes.object
 	},
+
+	_preloaded: false,
 
 	getDefaultProps() {
 		return {
@@ -32,13 +35,26 @@ export default React.createClass( {
 		};
 	},
 
+	preload() {
+		if ( ! this._preloaded && this.props.preloadSectionName ) {
+			this._preloaded = true;
+			this.props.sections.preload( this.props.preloadSectionName );
+		}
+	},
+
 	render() {
 		const itemClasses = classNames( 'masterbar__item', this.props.className, {
 			'is-active': this.props.isActive,
 		} );
 
 		return (
-			<a href={ this.props.url } onClick={ this.props.onClick } title={ this.props.tooltip } className={ itemClasses } onTouchStart={ this.props.onPreload } onMouseEnter={ this.props.onPreload }>
+			<a
+				href={ this.props.url }
+				onClick={ this.props.onClick }
+				title={ this.props.tooltip }
+				className={ itemClasses }
+				onTouchStart={ this.preload }
+				onMouseEnter={ this.preload }>
 				{ !! this.props.icon &&
 					<Gridicon icon={ this.props.icon } size={ 24 } />
 				}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -67,8 +67,7 @@ export default React.createClass( {
 					onClick={ this.clickMySites }
 					isActive={ this.isActive( 'sites' ) }
 					tooltip={ this.translate( 'View a list of your sites and access their dashboards', { textOnly: true } ) }
-					preloadSectionName="stats"
-					sections={ sections }
+					preloadSection={ () => sections.preload( 'stats' ) }
 				>
 					{ this.props.user.get().visible_site_count > 1
 						? this.translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
@@ -81,8 +80,7 @@ export default React.createClass( {
 					onClick={ this.clickReader }
 					isActive={ this.isActive( 'reader' ) }
 					tooltip={ this.translate( 'Read the blogs and topics you follow', { textOnly: true } ) }
-					preloadSectionName="reader"
-					sections={ sections }
+					preloadSection={ () => sections.preload( 'reader' ) }
 				>
 					{ this.translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 				</Item>
@@ -101,8 +99,7 @@ export default React.createClass( {
 					isActive={ this.isActive( 'me' ) }
 					className="masterbar__item-me"
 					tooltip={ this.translate( 'Update your profile, personal settings, and more', { textOnly: true } ) }
-					preloadSectionName="me"
-					sections={ sections }
+					preloadSection={ () => sections.preload( 'me' ) }
 				>
 					<Gravatar user={ this.props.user.get() } alt="Me" size={ 18 } />
 					<span className="masterbar__item-me-label">

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -14,6 +14,7 @@ import Notifications from './notifications';
 import Gravatar from 'components/gravatar';
 import layoutFocus from 'lib/layout-focus';
 import config from 'config';
+import sections from 'sections';
 
 export default React.createClass( {
 	displayName: 'Masterbar',
@@ -66,6 +67,8 @@ export default React.createClass( {
 					onClick={ this.clickMySites }
 					isActive={ this.isActive( 'sites' ) }
 					tooltip={ this.translate( 'View a list of your sites and access their dashboards', { textOnly: true } ) }
+					preloadSectionName="stats"
+					sections={ sections }
 				>
 					{ this.props.user.get().visible_site_count > 1
 						? this.translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
@@ -78,10 +81,11 @@ export default React.createClass( {
 					onClick={ this.clickReader }
 					isActive={ this.isActive( 'reader' ) }
 					tooltip={ this.translate( 'Read the blogs and topics you follow', { textOnly: true } ) }
+					preloadSectionName="reader"
+					sections={ sections }
 				>
 					{ this.translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 				</Item>
-
 				<Publish
 					sites={ this.props.sites }
 					user={ this.props.user }
@@ -97,6 +101,8 @@ export default React.createClass( {
 					isActive={ this.isActive( 'me' ) }
 					className="masterbar__item-me"
 					tooltip={ this.translate( 'Update your profile, personal settings, and more', { textOnly: true } ) }
+					preloadSectionName="me"
+					sections={ sections }
 				>
 					<Gravatar user={ this.props.user.get() } alt="Me" size={ 18 } />
 					<span className="masterbar__item-me-label">

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -12,11 +12,10 @@ import config from 'config';
 import SitesPopover from 'components/sites-popover';
 import paths from 'lib/paths';
 import viewport from 'lib/viewport';
+import sections from 'sections';
 
 export default React.createClass( {
 	displayName: 'MasterbarItemNew',
-
-	_preloaded: false,
 
 	propTypes: {
 		user: React.PropTypes.object,
@@ -57,14 +56,6 @@ export default React.createClass( {
 		}
 	},
 
-	onPreload() {
-		if ( ! this._preloaded && config.isEnabled( 'post-editor' ) ) {
-			this._preloaded = true;
-			// preload the post editor chunk
-			require.ensure( [ 'post-editor' ], () => {}, 'post-editor' );
-		}
-	},
-
 	getPopoverPosition() {
 		if ( viewport.isMobile() ) {
 			return 'bottom';
@@ -88,10 +79,11 @@ export default React.createClass( {
 				url={ newPostPath }
 				icon="create"
 				onClick={ this.onClick }
-				onPreload={ this.onPreload }
+				preloadSectionName="post-editor"
 				isActive={ this.props.isActive }
 				tooltip={ this.props.tooltip }
 				className={ classes }
+				sections={ sections }
 			>
 				{ this.props.children }
 				<SitesPopover

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -79,11 +79,10 @@ export default React.createClass( {
 				url={ newPostPath }
 				icon="create"
 				onClick={ this.onClick }
-				preloadSectionName="post-editor"
 				isActive={ this.props.isActive }
 				tooltip={ this.props.tooltip }
 				className={ classes }
-				sections={ sections }
+				preloadSection={ () => sections.preload( 'post-editor' ) }
 			>
 				{ this.props.children }
 				<SitesPopover

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -146,10 +146,14 @@ var PublishMenu = React.createClass( {
 			link = menuItem.link + this.props.siteSuffix;
 		}
 
+		let preload;
+
 		if ( menuItem.name === 'post' ) {
 			icon = 'posts';
+			preload = 'posts-pages';
 		} else if ( menuItem.name === 'page' ) {
 			icon = 'pages';
+			preload = 'posts-pages';
 		} else if ( menuItem.name === 'jetpack-portfolio' ) {
 			icon = 'folder';
 		} else if ( menuItem.name === 'jetpack-testimonial' ) {
@@ -166,6 +170,7 @@ var PublishMenu = React.createClass( {
 				buttonLink={ menuItem.buttonLink }
 				onNavigate={ this.props.onNavigate }
 				icon={ icon }
+				preload={ preload }
 			/>
 		);
 	},

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -170,7 +170,7 @@ var PublishMenu = React.createClass( {
 				buttonLink={ menuItem.buttonLink }
 				onNavigate={ this.props.onNavigate }
 				icon={ icon }
-				preload={ preload }
+				preloadSectionName={ preload }
 			/>
 		);
 	},

--- a/client/my-sites/sidebar/sidebar-menu-item.jsx
+++ b/client/my-sites/sidebar/sidebar-menu-item.jsx
@@ -7,7 +7,8 @@ var React = require( 'react' );
  * Internal dependencies
  */
 var isExternal = require( 'lib/url' ).isExternal,
-	Gridicon = require( 'components/gridicon' );
+	Gridicon = require( 'components/gridicon' ),
+	sections = require( 'sections' );
 
 /**
  * Component
@@ -21,7 +22,10 @@ var SidebarMenuItem = React.createClass( {
 		buttonLabel: React.PropTypes.string,
 		onNavigate: React.PropTypes.func,
 		icon: React.PropTypes.string,
+		preload: React.PropTypes.string
 	},
+
+	_preloaded: false,
 
 	renderButton: function( link ) {
 		if ( ! link ) {
@@ -40,12 +44,24 @@ var SidebarMenuItem = React.createClass( {
 		);
 	},
 
+	preload: function() {
+		if ( ! this._preloaded && this.props.preload ) {
+			this._preloaded = true;
+			sections.preload( this.props.preload );
+		}
+	},
+
 	render: function() {
 		const isExternalLink = isExternal( this.props.link );
 
 		return (
 			<li className={ this.props.className }>
-				<a onClick={ this.props.onNavigate } href={ this.props.link } target={ isExternalLink ? '_blank' : null }>
+				<a
+					onClick={ this.props.onNavigate }
+					href={ this.props.link }
+					target={ isExternalLink ? '_blank' : null }
+					onMouseEnter={ this.preload }
+				>
 					<Gridicon icon={ this.props.icon } size={ 24 } />
 					<span className="menu-link-text">{ this.props.label }</span>
 					{ isExternalLink ? <span className="noticon noticon-external" /> : null }

--- a/client/my-sites/sidebar/sidebar-menu-item.jsx
+++ b/client/my-sites/sidebar/sidebar-menu-item.jsx
@@ -22,7 +22,7 @@ var SidebarMenuItem = React.createClass( {
 		buttonLabel: React.PropTypes.string,
 		onNavigate: React.PropTypes.func,
 		icon: React.PropTypes.string,
-		preload: React.PropTypes.string
+		preloadSectionName: React.PropTypes.string
 	},
 
 	_preloaded: false,
@@ -45,9 +45,9 @@ var SidebarMenuItem = React.createClass( {
 	},
 
 	preload: function() {
-		if ( ! this._preloaded && this.props.preload ) {
+		if ( ! this._preloaded && this.props.preloadSectionName ) {
 			this._preloaded = true;
-			sections.preload( this.props.preload );
+			sections.preload( this.props.preloadSectionName );
 		}
 	},
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -177,6 +177,7 @@ module.exports = React.createClass( {
 				buttonLabel={ this.translate( 'Customize' ) }
 				onNavigate={ this.onNavigate }
 				icon={ 'themes' }
+				preload={ 'themes' }
 			/>
 		);
 	},

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -177,7 +177,7 @@ module.exports = React.createClass( {
 				buttonLabel={ this.translate( 'Customize' ) }
 				onNavigate={ this.onNavigate }
 				icon={ 'themes' }
-				preload={ 'themes' }
+				preloadSectionName="themes"
 			/>
 		);
 	},

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -3,6 +3,7 @@ var config = require( 'config' ),
 
 function getSectionsModule( sections ) {
 	var dependencies = '',
+		loadSection = '',
 		sectionLoaders = '';
 
 	if ( config.isEnabled( 'code-splitting' ) ) {
@@ -17,6 +18,7 @@ function getSectionsModule( sections ) {
 		].join( '\n' );
 
 		sections.forEach( function( section ) {
+			loadSection += singleEnsure( section.name );
 			section.paths.forEach( function( path ) {
 				sectionLoaders += splitTemplate( path, section.module, section.name );
 			} );
@@ -33,6 +35,11 @@ function getSectionsModule( sections ) {
 		'	},',
 		'	load: function() {',
 		'		' + sectionLoaders,
+		'	},',
+		'	preload: function( section ) {',
+		'		switch ( section ) {',
+		'		' + loadSection,
+		'		}',
 		'	}',
 		'};'
 	].join( '\n' );
@@ -90,6 +97,16 @@ function splitTemplate( path, module, chunkName ) {
 
 function requireTemplate( module ) {
 	return 'require( ' + JSON.stringify( module ) + ' )();\n';
+}
+
+function singleEnsure( chunkName ) {
+	var result = [
+		'case ' + JSON.stringify( chunkName ) + ':',
+		'	return require.ensure([], function() {}, ' + JSON.stringify( chunkName ) + ' );',
+		'	break;\n'
+	];
+
+	return result.join( '\n' );
 }
 
 module.exports = function( content ) {


### PR DESCRIPTION
This PR works with webpack to expose a `preload( section )` function that components can use to trigger early loading of chunks, making the app feel much more responsive.

-------

I've hooked it up with a few items — "My Sites" in masterbar, posts/pages/themes items in sidebar — so if you hover any of these items for a moment and then click on them you should see no loading indicator for the chunk.

In my experience less than a second is enough to retrieve the chunk, so hover works quite well.

cc @ehg for the webpack bits and sanity check.