### PR TITLE
Plans: Enable free trials in wpcalypso environment

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -67,6 +67,7 @@
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": true,
 		"upgrades/domain-search": true,
+	  	"upgrades/free-trials": true,
 
 		"notifications2beta": true,
 		"muse": true,


### PR DESCRIPTION
This will help us to verify that new changes don't break anything on this environment, and potentially others.