### PR TITLE
Help: Increase font size in Happiness Engineer text

### DIFF
--- a/client/me/help/help-happiness-engineers/style.scss
+++ b/client/me/help/help-happiness-engineers/style.scss
@@ -13,11 +13,10 @@
 
 .help-happiness-engineers__description {
 	margin: -16px 0px 12px 0px;
-	font: 11px/16px $sans;
+	font: 14px/21px $sans;
 	color: darken( $gray, 10% );
 	@include breakpoint( ">660px" ) {
 		margin: -16px 0px 20px 0px;
-		font: 14px/21px $sans;
 	}
 }
 


### PR DESCRIPTION
The font size is a little small at narrower widths, and this makes it a little friendlier to read at smaller screen sizes.

Repro:

1. Visit http://calypso.localhost:3000/help/
2. Observe the list of Happiness Engineers at the bottom
3. Reduce screen size to a width narrower than 660px.
4. Observe the font size of the text underneath "We care about your happiness"

This would fix #1390. Before the fix:

![screen shot](https://cloud.githubusercontent.com/assets/426388/11665459/d72b3d62-9de7-11e5-89e4-4d2fb221fb3a.png)

With the fix:

![screen shot 2015-12-14 at 4 12 32 pm](https://cloud.githubusercontent.com/assets/2738252/11794095/8a48851e-a27d-11e5-913c-9a85c694fc5b.png)

