### PR TITLE
Framework: i18n fall back to language code

### DIFF
--- a/shared/lib/i18n-utils/Makefile
+++ b/shared/lib/i18n-utils/Makefile
@@ -1,9 +1,13 @@
+UI ?= bdd
 REPORTER ?= spec
-NODE_BIN := $(shell npm bin)
+COMPILERS ?= js:babel/register
+NODE_BIN := ../../../node_modules/.bin
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
 
+# In order to simply stub modules, add test to the NODE_PATH
 test:
-	@NODE_ENV=test NODE_PATH=$(BASE_DIR)/client $(MOCHA) --reporter $(REPORTER)
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers $(COMPILERS) --reporter $(REPORTER) --ui $(UI)
 
 .PHONY: test

--- a/shared/lib/i18n-utils/test/utils-test.js
+++ b/shared/lib/i18n-utils/test/utils-test.js
@@ -1,27 +1,57 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:i18n-utils:test' ), // eslint-disable-line no-unused-vars
-	assert = require( 'assert' );
+const debug = require( 'debug' )( 'calypso:i18n-utils:test' ); // eslint-disable-line no-unused-vars
+import assert from 'assert';
+import { expect } from 'chai';
 
 /**
  * Internal dependencies
  */
-var removeLocaleFromPath = require( '../utils.js' ).removeLocaleFromPath;
+import { removeLocaleFromPath, getLanguage } from 'lib/i18n-utils';
 
-describe( 'removeLocaleFromPath', function() {
-	it( 'should remove the :lang part of the URL', function() {
-		assert.equal( removeLocaleFromPath( '/start/fr' ), '/start' );
-		assert.equal( removeLocaleFromPath( '/start/flow/fr' ), '/start/flow' );
-		assert.equal( removeLocaleFromPath( '/start/flow/step' ), '/start/flow/step' );
+describe( 'i18n-utils', function() {
+	describe( 'removeLocaleFromPath', function() {
+		it( 'should remove the :lang part of the URL', function() {
+			assert.equal( removeLocaleFromPath( '/start/fr' ), '/start' );
+			assert.equal( removeLocaleFromPath( '/start/flow/fr' ), '/start/flow' );
+			assert.equal( removeLocaleFromPath( '/start/flow/step' ), '/start/flow/step' );
+		} );
+
+		it( 'should not remove the :flow part of the URL', function() {
+			assert.equal( removeLocaleFromPath( '/start' ), '/start' );
+			assert.equal( removeLocaleFromPath( '/start/flow' ), '/start/flow' );
+		} );
+
+		it( 'should not remove the :step part of the URL', function() {
+			assert.equal( removeLocaleFromPath( '/start/flow/step' ), '/start/flow/step' );
+		} );
 	} );
+	describe( 'getLanguage', function() {
+		it( 'should return a language', function() {
+			expect( getLanguage( 'ja' ).langSlug ).to.equal( 'ja' );
+		} );
 
-	it( 'should not remove the :flow part of the URL', function() {
-		assert.equal( removeLocaleFromPath( '/start' ), '/start' );
-		assert.equal( removeLocaleFromPath( '/start/flow' ), '/start/flow' );
-	} );
+		it( 'should return a language with a country code', function() {
+			expect( getLanguage( 'pt-br' ).langSlug ).to.equal( 'pt-br' );
+		} );
 
-	it( 'should not remove the :step part of the URL', function() {
-		assert.equal( removeLocaleFromPath( '/start/flow/step' ), '/start/flow/step' );
+		it( 'should fall back to the language code when a country code is not available', function() {
+			expect( getLanguage( 'fr-zz' ).langSlug ).to.equal( 'fr' );
+		} );
+
+		it( 'should return undefined when no arguments are given', function() {
+			//note that removeLocaleFromPath is dependant on getLanguage returning undefined in this case.
+			expect( getLanguage() ).to.equal( undefined );
+		} );
+
+		it( 'should return undefined when the locale is invalid', function() {
+			//note that removeLocaleFromPath is dependant on getLanguage returning undefined in this case.
+			expect( getLanguage( 'zz' ) ).to.equal( undefined );
+		} );
+
+		it( 'should return undefined when we lookup random words', function() {
+			expect( getLanguage( 'themes' ) ).to.equal( undefined );
+		} );
 	} );
 } );

--- a/shared/lib/i18n-utils/utils.js
+++ b/shared/lib/i18n-utils/utils.js
@@ -1,16 +1,24 @@
 /**
  * External dependencies
  */
-var find = require( 'lodash/collection/find' );
+import find from 'lodash/collection/find';
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' );
+import config from 'config';
 
-var i18nUtils = {
+const localeRegex = /^[A-Z]{2}$/i;
+const localeWithRegionRegex = /^[A-Z]{2}-[A-Z]{2}$/i;
+
+const i18nUtils = {
 	getLanguage: function( langSlug ) {
-		return find( config( 'languages' ), { langSlug: langSlug } );
+		let language;
+		if ( localeRegex.test( langSlug ) || localeWithRegionRegex.test( langSlug ) ) {
+			language = find( config( 'languages' ), { langSlug: langSlug } ) ||
+				find( config( 'languages' ), { langSlug: langSlug.substring( 0, 2 ) } );
+		}
+		return language;
 	},
 
 	setUpLocale: function( parameters ) {
@@ -42,4 +50,4 @@ var i18nUtils = {
 		} );
 	}
 };
-module.exports = i18nUtils;
+export default i18nUtils;


### PR DESCRIPTION
Fixes #92. Users can set locales with country codes (`en-gb`) that that are not supported in the calypso config. This is fixed in this PR by falling back to using the language code (`en`) if possible.

### Testing Instructions
- Visit https://your-site/wp-admin/users.php?page=grofiles-user-settings
- Change your Interface Language to en-gb
- Now attempt to add a new site via calypso, and after selecting the free plan ( or any plan ). In prod this throws a js error and will get stuck.

Expected: you should be able to finish setting up a new site, and you are not stuck in any redirect loops.

cc @hoverduck @rralian 