### PR TITLE
Editor: Show proper path in page permalink

### DIFF
--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -59,6 +59,22 @@ describe( 'PostUtils', function() {
 		} );
 	} );
 
+	describe( '#getPagePath', function() {
+		it( 'should return undefined when no post is supplied', function() {
+			assert( postUtils.getPagePath() === undefined );
+		} );
+
+		it( 'should return post.URL without slug when page is published', function() {
+			var path = postUtils.getPagePath( { status: 'publish', URL: 'http://zo.mg/a/permalink/' } );
+			assert( path === 'http://zo.mg/a/' );
+		} );
+
+		it( 'should use permalink_URL when not published and present', function() {
+			var path = postUtils.getPagePath( { status: 'draft', other_URLs: { permalink_URL: 'http://zo.mg/a/permalink/%post_name%/' } } );
+			assert( path === 'http://zo.mg/a/permalink/' );
+		} );
+	} );
+
 	describe( '#getFeaturedImageId()', function() {
 		it( 'should return undefined when no post is specified', function() {
 			assert( postUtils.getFeaturedImageId() === undefined );

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -166,6 +166,17 @@ var utils = {
 		return this.removeSlug( path );
 	},
 
+	getPagePath: function( post ) {
+		if ( ! post ) {
+			return;
+		}
+		if ( ! this.isPublished( post ) ) {
+			return this.getPermalinkBasePath( post );
+		}
+
+		return this.removeSlug( post.URL );
+	},
+
 	removeSlug: function( path ) {
 		if ( ! path ) {
 			return;

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -367,7 +367,7 @@ var PostEditor = React.createClass( {
 								{ this.state.post && isPage ?
 									<EditorPageSlug
 										slug={ this.state.post.slug }
-										path={ site.URL + '/' }
+										path={ this.state.post.URL ? utils.getPagePath( this.state.post ) : site.URL + '/' }
 									/> :
 									null
 								}


### PR DESCRIPTION
Fixes #1439 - Currently when viewing a page in the editor, the permalink path is not properly displayed for pages that have a parent set.  This branch adds a new utility method for extracting the proper base path from a page so the full path is properly shown.

__To Test__
Three distinct states should be tested out on this branch:

- Open a new page in the post editor - note that the site URL should be shown underneath the title
- Add in a title for the new page, and some content, and wait for an autosave.  Ensure the suggested slug is now shown at the end of the permalink path
- While the page is still a draft, if you sent the page parent, the base method we are using to generate the `permalink_URL` in the API does not return the full path including the parent's slug.  So set the page parent, and note that the permalink path does not change
- Publish the page, and note after the page is published the full path including the parent is shown
