### PR TITLE
Help: Autofill the subject field of the contact form when olark operators become unavailable

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import isEqual from 'lodash/lang/isEqual';
 
 /**
  * Internal dependencies
@@ -37,7 +38,11 @@ module.exports = React.createClass( {
 		showSiteField: React.PropTypes.bool,
 		siteFilter: React.PropTypes.func,
 		siteList: React.PropTypes.object,
-		disabled: React.PropTypes.bool
+		disabled: React.PropTypes.bool,
+		valueLink: React.PropTypes.shape( {
+			value: React.PropTypes.any,
+			requestChange: React.PropTypes.func.isRequired
+		} ),
 	},
 
 	getDefaultProps: function() {
@@ -47,7 +52,11 @@ module.exports = React.createClass( {
 			showHowYouFeelField: false,
 			showSubjectField: false,
 			showSiteField: false,
-			disabled: false
+			disabled: false,
+			valueLink: {
+				value: null,
+				requestChange: () => {}
+			}
 		}
 	},
 
@@ -58,13 +67,25 @@ module.exports = React.createClass( {
 	getInitialState: function() {
 		const site = sites.getLastSelectedSite() || sites.getPrimary();
 
-		return {
+		return this.props.valueLink.value || {
 			howCanWeHelp: 'gettingStarted',
 			howYouFeel: 'unspecified',
 			message: '',
 			subject: '',
 			siteSlug: site ? site.slug : null
 		};
+	},
+
+	componentWillReceiveProps: function( nextProps ) {
+		if ( isEqual( nextProps.valueLink.value, this.state ) ) {
+			return;
+		}
+
+		this.setState( nextProps.valueLink.value );
+	},
+
+	componentDidUpdate: function() {
+		this.props.valueLink.requestChange( this.state );
 	},
 
 	setSite: function( siteSlug ) {


### PR DESCRIPTION
## Autofill subject field when operators become unavailable

This pull request aims to fix the issue outlined in #1338. The simplest solution here was to autofill the subject field when operators become unavailable. 

**Whats changed**
I introduced `valueLink` to the `HelpContactForm` component so that its state could be transferred upstream to its parent for saving/manipulating. Because the state is being transferred upstream for saving it also fixes #516.

**How to test**
*Target a group where you are the only operator*
1. In Olark set yourself as "Available".
2. In another tab navigate to http://calypso.localhost:3000/help/contact
3. Enter some text in the message field.
4. In the Olark tab, set yourself as "Away".
5. In the Calypso tab verify that when the form switches to the Kayako version that the subject contains the first five words of your original message followed by an ellipses.

**What to expect**
![screen shot 2015-12-14 at 9 22 48 pm](https://cloud.githubusercontent.com/assets/1854440/11800256/dec62378-a2a8-11e5-90b0-00936652307d.png)

![screen shot 2015-12-14 at 9 21 50 pm](https://cloud.githubusercontent.com/assets/1854440/11800244/c5aa32da-a2a8-11e5-9fed-370ba10895c4.png)

Fixes #1338 
Fixes #516