### PR TITLE
Reader tags: remove formatting from tag title in stream header on /tag/:tag

### DIFF
--- a/client/reader/tag-stream/index.jsx
+++ b/client/reader/tag-stream/index.jsx
@@ -1,5 +1,4 @@
-var React = require( 'react' ),
-	toTitleCase = require( 'to-title-case' );
+var React = require( 'react' );
 
 var FollowingStream = require( 'reader/following-stream' ),
 	EmptyContent = require( './empty' ),
@@ -50,8 +49,8 @@ var FeedStream = React.createClass( {
 			ReaderTagActions.fetchTag( this.props.tag );
 			return this.translate( 'Loading Tag' );
 		}
-		// this crazy statement deals with strings that fail toTitleCase, like Japanese
-		return toTitleCase( tag.title || tag.slug ) || tag.title;
+
+		return tag.title || tag.slug;
 	},
 
 	isSubscribed: function() {


### PR DESCRIPTION
This PR removes `toTitleCase` from the tag title in StreamHeader. This sometimes caused undesirable results such as the formatting of the WordPress tag as 'Word Press'.

The tag title in the stream header should now match the tag title in the Reader sidebar.

Fixes https://github.com/Automattic/wp-calypso/issues/1548.

<img width="751" alt="screen shot 2015-12-15 at 14 36 34" src="https://cloud.githubusercontent.com/assets/17325/11801385/48503046-a339-11e5-8344-76c651e11575.png">

### To test

Navigate to a tag stream (e.g. http://calypso.localhost:3000/tag/wordpress) and ensure the tag title in the header matches the tag title in the sidebar.