### PR TITLE
Help: Replace the old site selector with the new SitesDropdown component.

### DIFF
--- a/assets/stylesheets/layout/_sidebar.scss
+++ b/assets/stylesheets/layout/_sidebar.scss
@@ -302,4 +302,10 @@
 	.search {
 		border-bottom: 1px solid lighten( $gray, 20% );
 	}
+
+	@include breakpoint( "<660px" ) {
+		width: 100vw;
+		left: -100vw;
+		-webkit-overflow-scrolling: touch;
+	}
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -12,12 +12,6 @@
 	&.is-large .search  {
 		display: block;
 	}
-
-	@include breakpoint( "<660px" ) {
-		width: 100vw;
-		left: -100vw;
-		-webkit-overflow-scrolling: touch;
-	}
 }
 
 // Styles for Site elements within the Selector

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -23,6 +23,10 @@
 	margin: 0;
 	position: relative;
 	width: 300px;
+
+	@include breakpoint( "<660px" ) {
+		width: 100%;
+	}
 }
 
 .sites-dropdown.is-open .sites-dropdown__wrapper {

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -14,7 +14,13 @@ import DropdownItem from 'components/select-dropdown/item';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
-import SelectSite from 'me/select-site';
+import SitesDropdown from 'components/sites-dropdown';
+import siteList from 'lib/sites-list';
+
+/**
+ * Module variables
+ */
+const sites = siteList();
 
 module.exports = React.createClass( {
 	displayName: 'HelpContactForm',
@@ -50,20 +56,19 @@ module.exports = React.createClass( {
 	 * @return {Object} An object representing our initial state
 	 */
 	getInitialState: function() {
-		const { showSiteField, siteList } = this.props;
+		const site = sites.getLastSelectedSite() || sites.getPrimary();
 
 		return {
 			howCanWeHelp: 'gettingStarted',
 			howYouFeel: 'unspecified',
 			message: '',
 			subject: '',
-			site: showSiteField ? siteList.getLastSelectedSite() || siteList.getPrimary() : null
+			siteSlug: site ? site.slug : null
 		};
 	},
 
-	setSite: function( event ) {
-		const site = this.props.siteList.getSite( parseInt( event.target.value, 10 ) );
-		this.setState( { site: site } );
+	setSite: function( siteSlug ) {
+		this.setState( { siteSlug } );
 	},
 
 	/**
@@ -153,7 +158,7 @@ module.exports = React.createClass( {
 				{ value: 'panicked', label: this.translate( 'Panicked' ) }
 			];
 
-		const { formDescription, buttonLabel, showHowCanWeHelpField, showHowYouFeelField, showSubjectField, showSiteField, siteList, siteFilter } = this.props;
+		const { formDescription, buttonLabel, showHowCanWeHelpField, showHowYouFeelField, showSubjectField, showSiteField } = this.props;
 
 		return (
 			<div className="help-contact-form">
@@ -174,14 +179,11 @@ module.exports = React.createClass( {
 				) }
 
 				{ showSiteField && (
-					<div>
+					<div className="help-contact-form__site-selection">
 						<FormLabel>{ this.translate( 'Which site do you need help with?' ) }</FormLabel>
-						<SelectSite
-							className="help-contact-form__site-selection"
-							sites={ siteList }
-							filter={ siteFilter }
-							value={ this.state.site.ID }
-							onChange={ this.setSite } />
+						<SitesDropdown
+							selected={ this.state.siteSlug }
+							onSiteSelect={ this.setSite } />
 					</div>
 				) }
 

--- a/client/me/help/help-contact-form/style.scss
+++ b/client/me/help/help-contact-form/style.scss
@@ -19,14 +19,6 @@
 	}
 }
 
-.help-contact-form__site-selection {
-	width: 100%;
-
-	@include breakpoint( ">960px" ) {
-		width: auto;
-	}
-}
-
 .help-contact-form__selection {
 	.select-dropdown__container {
 		// Make the dropdown span the width of the page

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -85,7 +85,8 @@ module.exports = React.createClass( {
 	},
 
 	startChat: function( contactForm ) {
-		const { message, howCanWeHelp, howYouFeel, site } = contactForm;
+		const { message, howCanWeHelp, howYouFeel, siteSlug } = contactForm;
+		const site = sites.getSite( siteSlug );
 
 		// Intentionally not translated since only HE's will see this in the olark console as a notification.
 		const notifications = [
@@ -100,12 +101,14 @@ module.exports = React.createClass( {
 	},
 
 	submitKayakoTicket: function( contactForm ) {
-		const { subject, message, howCanWeHelp, howYouFeel } = contactForm;
+		const { subject, message, howCanWeHelp, howYouFeel, siteSlug } = contactForm;
 		const { locale } = this.state.olark;
+		const site = sites.getSite( siteSlug );
 
 		const ticketMeta = [
 			'How can you help: ' + howCanWeHelp,
-			'How I feel: ' + howYouFeel
+			'How I feel: ' + howYouFeel,
+			'Site I need help with: ' + ( site ? site.URL : 'N/A' )
 		];
 
 		const kayakoMessage = [ ...ticketMeta, '\n', message ].join( '\n' );
@@ -255,9 +258,7 @@ module.exports = React.createClass( {
 				showSubjectField: showKayakoVariation || showForumsVariation,
 				showHowCanWeHelpField: showKayakoVariation || showChatVariation,
 				showHowYouFeelField: showKayakoVariation || showChatVariation,
-				showSiteField: ( showKayakoVariation || showChatVariation ) && ( sites.get().length > 1 ),
-				siteList: sites,
-				siteFilter: site => ( site.visible && ! site.jetpack )
+				showSiteField: ( showKayakoVariation || showChatVariation ) && ( sites.get().length > 1 )
 			},
 			showChatVariation && {
 				onSubmit: this.startChat,


### PR DESCRIPTION
As suggested by @mtias this pull request replaces the `me/select-site` component with the `components/sites-dropdown` component in the help contact form.

**How to test**
1. Navigate to http://calypso.localhost:3000/help/contact
2. Notice that the sites list is now the new `SitesDropdown` component.

**Before**
![screen shot 2015-12-15 at 10 11 26 pm](https://cloud.githubusercontent.com/assets/1854440/11831033/d5f27942-a378-11e5-9d26-4c903ec7eba6.png)


**After**
![screen shot 2015-12-15 at 10 08 44 pm](https://cloud.githubusercontent.com/assets/1854440/11831020/abdff77e-a378-11e5-92cf-e7e1b572c534.png)

Fixes #520