### PR TITLE
Help: fix blank options in site selector

### DIFF
--- a/client/me/select-site.jsx
+++ b/client/me/select-site.jsx
@@ -27,7 +27,7 @@ module.exports = React.createClass( {
 				{
 					sites.map( function( site ) {
 						return (
-							<option value={ site.ID } key={ site.ID }>{ site.name }</option>
+							<option value={ site.ID } key={ site.ID }>{ site.title }</option>
 						);
 					} )
 				}


### PR DESCRIPTION
This pull request does a quick fix for an issue brought up in #1529. The solution here was to use `site.title` instead of `site.name` which can be blank sometimes.

**How to verify**
*You must have more than one site for your account and you must be eligible to chat*
1. Go to /wp-admin/options-general.php for your test site
2. Clear the `Site Title` field.
3. Save.
4. Go to http://calypso.localhost:3000/help/contact
5. Notice that the title for that site is no longer blank. It should be something like "example.wordpress.com"

**Notes**
I know we need to stop using this component so I've created another pull request, #1588, which replaces it and may take longer to get merged since it requires more review.

Fixes #1529