### PR TITLE
String: Rename barcode to code

### DIFF
--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -202,7 +202,7 @@ module.exports = React.createClass( {
 				<p className="security-2fa-enable__qr-instruction">
 					{
 						this.translate(
-							"Scan this QR code with your mobile app. {{toggleMethodLink}}Can't scan the barcode?{{/toggleMethodLink}}", {
+							"Scan this QR code with your mobile app. {{toggleMethodLink}}Can't scan the code?{{/toggleMethodLink}}", {
 								components: {
 									toggleMethodLink: this.getToggleLink()
 								}
@@ -225,7 +225,7 @@ module.exports = React.createClass( {
 				<p className="security-2fa-enable__time-instruction">
 					{
 						this.translate(
-							'Enter this time code into your mobile app. {{toggleMethodLink}}Prefer to scan the barcode?{{/toggleMethodLink}}', {
+							'Enter this time code into your mobile app. {{toggleMethodLink}}Prefer to scan the code?{{/toggleMethodLink}}', {
 								components: {
 									toggleMethodLink: this.getToggleLink()
 								}


### PR DESCRIPTION
As discovered by @iqatrophie, a QR code is not a barcode, therefore we should just call it code.

cc @allendav because the string is orginally from you: any objections?