### PR TITLE
Help: Show chat notification when chat ends.

### DIFF
--- a/client/lib/olark-events/index.js
+++ b/client/lib/olark-events/index.js
@@ -69,7 +69,7 @@ var OlarkEventEmitter = {
 		boundEvents[ event ] = true;
 
 		// Listen to the olark api event
-		olarkApi( event, () => this.olarkEventListener( event ) );
+		olarkApi( event, ( ...eventArguments ) => this.olarkEventListener( event, ...eventArguments ) );
 	},
 
 	/**
@@ -78,7 +78,7 @@ var OlarkEventEmitter = {
 	 */
 	olarkEventListener: function( event, ...eventArguments ) {
 		debug( 'Olark event: %s', event );
-		this.emit( event, eventArguments );
+		this.emit( event, ...eventArguments );
 	}
 };
 

--- a/client/lib/olark-store/actions.js
+++ b/client/lib/olark-store/actions.js
@@ -58,6 +58,10 @@ const olarkActions = {
 		olarkApi( 'api.chat.sendNotificationToOperator', { body } );
 	},
 
+	sendNotificationToVisitor( body ) {
+		olarkApi( 'api.chat.sendNotificationToVisitor', { body } );
+	},
+
 	expandBox() {
 		olarkApi( 'api.box.expand' );
 	},

--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -150,6 +150,16 @@ const olark = {
 
 		updateDetailsEvents.forEach( event => olarkEvents.on( event, olarkActions.updateDetails ) );
 
+		olarkEvents.on( 'api.chat.onCommandFromOperator', ( event ) => {
+			if ( event.command.name === 'end' ) {
+				const { email } = user.get();
+				olarkActions.sendNotificationToVisitor( i18n.translate(
+					"Your live chat has ended. We'll send a transcript to %(email)s.",
+					{ args: { email } }
+				) );
+			}
+		} );
+
 		debug( 'Olark code loaded, beginning configuration' );
 
 		this.setOlarkOptions( userData, wpcomOlarkConfig );


### PR DESCRIPTION
## Show chat notification when chat ends
This pull request aims at letting the user know that the olark operator has ended the chat and that they will be receiving a transcript. Prior to this the user had no indication that the chat has ended.

**How to test**
1. Navigate to http://calypso.localhost:3000/help/contact
2. Start a chat.
3. Have the operator end the chat using the `!end` command.
4. Notice the notification in the chat box

**What to expect**

![screen shot 2015-12-15 at 9 31 49 pm](https://cloud.githubusercontent.com/assets/1854440/11830660/38f695ae-a375-11e5-8b36-6b3d0df1646c.png)

![screen shot 2015-12-15 at 9 34 08 pm](https://cloud.githubusercontent.com/assets/1854440/11830664/3df550fe-a375-11e5-99fe-01fcf7792025.png)


*noting here that there are some CSS issues that I intend to fix in a future pull request. [this](https://github.com/Automattic/wp-calypso/blob/master/assets/stylesheets/shared/_livechat.scss#L839) line of code seems to be causing some weird wrapping if the user decides to start chatting after a notification.*

Fixes #1341 