### PR TITLE
Help: Preserve scroll position of chat conversations

### DIFF
--- a/client/components/olark-chatbox/index.jsx
+++ b/client/components/olark-chatbox/index.jsx
@@ -105,8 +105,14 @@ module.exports = React.createClass( {
 			return;
 		}
 
+		const conversationDiv = document.getElementById( 'habla_conversation_div' );
+		const scrollTop = conversationDiv.scrollTop;
+
 		// Return the olark widget to its original DOM node
 		this.originalDOMParent.appendChild( this.olarkDOMNode );
+
+		// The conversation scroll position gets lost when changing the dom parent so lets set it to what it was before.
+		conversationDiv.scrollTop = scrollTop;
 
 		debug( 'release the olark chat widget' );
 	},


### PR DESCRIPTION
## Preserve scroll position of chat conversations

The goal of this pull request is to preserve the scroll position of chat conversations when going from an inline chat to the widget.

**How to test**
1. Navigate to http://calypso.localhost:3000/help/contact
2. Start a chat.
3. Enter many lines of text so that it scrolls.
4. Scroll to the middle of the conversation.
5. Click the back link on the contact form.
6. Notice that your still at the same scroll location.

**What to expect**
![screen shot 2015-12-15 at 2 51 58 am](https://cloud.githubusercontent.com/assets/1854440/11805110/3d5738e0-a2d7-11e5-932b-b7994272562e.png)

![screen shot 2015-12-15 at 2 52 14 am](https://cloud.githubusercontent.com/assets/1854440/11805117/443ac500-a2d7-11e5-9b60-ecd8477a0740.png)

*Note: the preservation of the scroll position is currently one directional because of the olark state changes that occur while inlining the chat.* 

Fixes #1504 