### PR TITLE
Plugins: Align close buttons

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -3,7 +3,7 @@
 }
 
 .plugins__section-actions.section-header.card {
-	padding-right: 16px;
+	padding-right: 8px;
 
 	.section-header__actions {
 		flex-grow: 1;
@@ -29,6 +29,10 @@
 	.button-group {
 		margin-left: 8px;
 	}
+
+	@include breakpoint( '>660px' ) {
+		padding-right: 16px;
+	}
 }
 
 .plugins__action-buttons {
@@ -50,6 +54,7 @@
 
 
 .plugins__section-actions-close {
+	color: darken( $gray, 30% );
 	cursor: pointer;
 	display: flex;
 		align-items: center;


### PR DESCRIPTION
Aligns the search box and bulk edit close buttons for widths <660px. Until now, with the last changes, they were a little missaligned for small resolutions.

Before
![image](https://cloud.githubusercontent.com/assets/1554855/11807928/74977306-a31d-11e5-8fee-a4cb595a64ad.png)

After:
![image](https://cloud.githubusercontent.com/assets/1554855/11807919/61c0441a-a31d-11e5-8c79-9714f2d867fc.png)

How to test:
========
1. Go to http://calypso.dev:3000/plugins/
2. Click on "bulk edit"
3. Click on the looking glass icon
4. Resize your window so the viewport width is smaller than 660px.
5. The two 'close' buttons should be aligned
