### PR TITLE
Purchases: Edit card form not loading

### DIFF
--- a/client/components/data/purchases/edit-card-details/index.jsx
+++ b/client/components/data/purchases/edit-card-details/index.jsx
@@ -32,7 +32,7 @@ function getStateFromStores( props ) {
 
 function isDataLoading( state ) {
 	return (
-		! state.card ||
+		state.card.isFetching ||
 		! state.selectedPurchase.hasLoadedFromServer ||
 		! state.selectedSite
 	);

--- a/client/lib/purchases/stored-cards/store.js
+++ b/client/lib/purchases/stored-cards/store.js
@@ -14,7 +14,7 @@ const StoredCardsStore = createReducerStore( reducer, getInitialState() );
 
 assign( StoredCardsStore, {
 	getByCardId( cardId ) {
-		return find( this.get().list, { id: cardId } );
+		return assign( {}, this.get(), { data: find( this.get().list, { id: cardId } ) } );
 	}
 } );
 

--- a/client/lib/purchases/stored-cards/test/store-test.js
+++ b/client/lib/purchases/stored-cards/test/store-test.js
@@ -66,7 +66,7 @@ describe( 'Stored Cards Store', () => {
 	} );
 
 	it( 'should return an object with a card for a specific id', () => {
-		expect( StoredCardsStore.getByCardId( 12345 ) ).to.be.eql( {
+		expect( StoredCardsStore.getByCardId( 12345 ).data ).to.be.eql( {
 			id: 12345,
 			expiry: '2016-11-30',
 			number: 2596,

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -71,7 +71,10 @@ const EditCardDetails = React.createClass( {
 	componentWillMount() {
 		recordPageView( 'edit_card_details', this.props );
 
-		const fields = this.mergeCard( this.props.card, formState.createNullFieldValues( this.fieldNames ) );
+		let fields = formState.createNullFieldValues( this.fieldNames );
+		if ( this.props.card.data ) {
+			fields = this.mergeCard( this.props.card.data, fields );
+		}
 
 		this.formStateController = formState.Controller( {
 			initialFields: fields,


### PR DESCRIPTION
When we have the ID of a stored card in the purchases endpoint, but the same card doesn't exist in the stored cards endpoint, we just show the placeholders forever. This changes that loading state so that now we still load the edit form even if the card data doesn't exist.

This PR solves the problem by just showing an empty form to users in this situation, but we should probably also investigate how a purchase gets into this situation in the first place - why is there no corresponding record for the stored card ID in the purchases endpoint?

Fixes #1264

There are several cases to test:

- [x] - user has a no payment information - don't show a link to edit: to reproduce this use credits to purchase something.
- [x] - user has payment information in the purchases endpoint and stored cards endpoint: in this case we should show the edit link, and load the stored payment name
- [x] - user has a stored card ID but no data in the stored-cards endpoint: in this case we should show a link to edit the payment data, but there will be nothing in the payment name field. To reproduce this case find a purchase with a stored card, and then delete that card from /me/billing.

- [x] Code review
- [x] Product review