### PR TITLE
Plugins: Add browser button to the section header

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 import debugModule from 'debug';
 import titleCase from 'to-title-case';
 import classNames from 'classnames';
@@ -47,6 +47,7 @@ import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
+import AddNewButton from 'components/add-new-button';
 
 /**
  * Module variables
@@ -223,6 +224,10 @@ export default React.createClass( {
 			PluginsActions.removePluginsNotices( this.state.notices.completed.concat( this.state.notices.errors ) );
 			this.recordEvent( 'Clicked Manage Done' );
 		}
+	},
+
+	goToBrowser() {
+		this.recordEvent( 'Clicked Add New Plugins' );
 	},
 
 	togglePluginSelection( plugin ) {
@@ -539,6 +544,8 @@ export default React.createClass( {
 		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
 		const isJetpackSelected = this.state.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
 		const needsRemoveButton = this.getSelected().length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
+		const selectedSite = this.props.sites.getSelectedSite();
+		const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
 
 		if ( ! this.state.bulkManagement ) {
 			if ( 0 < this.state.pluginUpdateCount ) {
@@ -554,6 +561,10 @@ export default React.createClass( {
 			rightSideButtons.push(
 				<ButtonGroup key="plugins__buttons-bulk-management"><Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>{ this.translate( 'Edit All', { context: 'button label' } ) }</Button></ButtonGroup>
 			);
+			rightSideButtons.push(
+				<ButtonGroup key="plugins__buttons-browser"><Button compact href={ browserUrl } onClick={ this.goToBrowser } className="plugins__browser-button"><Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } /></Button></ButtonGroup>
+			);
+
 		} else {
 			activateButtons.push( <Button key="plugins__buttons-activate" disabled={ ! this.areSelected( 'inactive' ) } compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
 			let deactivateButton = isJetpackSelected

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -226,7 +226,7 @@ export default React.createClass( {
 		}
 	},
 
-	goToBrowser() {
+	onBrowserLinkClick() {
 		this.recordEvent( 'Clicked Add New Plugins' );
 	},
 
@@ -535,9 +535,7 @@ export default React.createClass( {
 				return !! selectedSite.jetpack;
 			}
 
-			return this.props.sites.get().some( function( site ) {
-				return site.jetpack;
-			} );
+			return this.props.sites.getJetpack().length > 0;
 		}
 		return false;
 	},
@@ -576,7 +574,7 @@ export default React.createClass( {
 				const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
 
 				rightSideButtons.push(
-					<ButtonGroup key="plugins__buttons-browser"><Button compact href={ browserUrl } onClick={ this.goToBrowser } className="plugins__browser-button"><Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } /></Button></ButtonGroup>
+					<ButtonGroup key="plugins__buttons-browser"><Button compact href={ browserUrl } onClick={ this.onBrowserLinkClick } className="plugins__browser-button"><Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } /></Button></ButtonGroup>
 				);
 			}
 		} else {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -530,11 +530,7 @@ export default React.createClass( {
 
 	canAddNewPlugins() {
 		if ( config.isEnabled( 'manage/plugins/browser' ) ) {
-			const selectedSite = this.props.sites.getSelectedSite();
-			if ( selectedSite ) {
-				return !! selectedSite.jetpack;
-			}
-			return this.props.sites.getJetpack().length > 0;
+			return this.hasJetpackSelectedSites();
 		}
 		return false;
 	},
@@ -543,6 +539,14 @@ export default React.createClass( {
 		return this.state.plugins
 			.filter( plugin => plugin.selected )
 			.some( plugin => plugin.sites.some( site => site.canUpdateFiles ) );
+	},
+
+	hasJetpackSelectedSites() {
+		const selectedSite = this.props.sites.getSelectedSite();
+		if ( selectedSite ) {
+			return !! selectedSite.jetpack;
+		}
+		return this.props.sites.getJetpack().length > 0;
 	},
 
 	getCurrentActionButtons( isWpCom ) {
@@ -582,14 +586,15 @@ export default React.createClass( {
 				? <Button key="plugins__buttons-deactivate" disabled={ ! this.areSelected( 'active' ) } compact onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</Button>
 				: <Button key="plugins__buttons-disable" disabled={ ! this.areSelected( 'active' ) } compact onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</Button>;
 			activateButtons.push( deactivateButton )
-
-			updateButtons.push( <Button key="plugins__buttons-autoupdate-on" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
-			updateButtons.push( <Button key="plugins__buttons-autoupdate-off" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
-
 			leftSideButtons.push( <ButtonGroup key="plugins__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
-			leftSideButtons.push( <ButtonGroup key="plugins__buttons-update-buttons">{ updateButtons }</ButtonGroup> );
 
-			leftSideButtons.push( <ButtonGroup key="plugins__buttons-remove-button"><Button disabled={ ! needsRemoveButton } compact scary onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
+			if ( this.hasJetpackSelectedSites() ) {
+				updateButtons.push( <Button key="plugins__buttons-autoupdate-on" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
+				updateButtons.push( <Button key="plugins__buttons-autoupdate-off" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
+
+				leftSideButtons.push( <ButtonGroup key="plugins__buttons-update-buttons">{ updateButtons }</ButtonGroup> );
+				leftSideButtons.push( <ButtonGroup key="plugins__buttons-remove-button"><Button disabled={ ! needsRemoveButton } compact scary onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
+			}
 
 			rightSideButtons.push(
 				<button key="plugins__buttons-close-button" className="plugins__section-actions-close" onClick={ this.toggleBulkManagement }>
@@ -624,12 +629,15 @@ export default React.createClass( {
 				: <DropdownItem key="plugin__actions_deactivate" disabled={ ! this.areSelected( 'active' ) } onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</DropdownItem>;
 			options.push( deactivateAction );
 
-			options.push( <DropdownSeparator key="plugin__actions_separator_2" /> );
-			options.push( <DropdownItem key="plugin__actions_autoupdate" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</DropdownItem> );
-			options.push( <DropdownItem key="plugin__actions_disable_autoupdate" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</DropdownItem> );
+			if ( this.hasJetpackSelectedSites() ) {
+				options.push( <DropdownSeparator key="plugin__actions_separator_2" /> );
+				options.push( <DropdownItem key="plugin__actions_autoupdate" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</DropdownItem> );
+				options.push( <DropdownItem key="plugin__actions_disable_autoupdate" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</DropdownItem> );
 
-			options.push( <DropdownSeparator key="plugin__actions_separator_3" /> );
-			options.push( <DropdownItem key="plugin__actions_remove" className="plugins__actions_remove_item" disabled={ ! needsRemoveButton } onClick={ this.removePluginNotice } >{ this.translate( 'Remove' ) }</DropdownItem> );
+				options.push( <DropdownSeparator key="plugin__actions_separator_3" /> );
+				options.push( <DropdownItem key="plugin__actions_remove" className="plugins__actions_remove_item" disabled={ ! needsRemoveButton } onClick={ this.removePluginNotice } >{ this.translate( 'Remove' ) }</DropdownItem> );
+			}
+
 			actions.push( <SelectDropdown compact className="plugins__actions_dropdown" key="plugins__actions_dropdown" selectedText="Actions">{ options }</SelectDropdown> );
 		}
 		return actions;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -588,7 +588,7 @@ export default React.createClass( {
 			activateButtons.push( deactivateButton )
 			leftSideButtons.push( <ButtonGroup key="plugins__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
 
-			if ( this.hasJetpackSelectedSites() ) {
+			if ( this.hasJetpackSelectedSites() && ! isWpCom ) {
 				updateButtons.push( <Button key="plugins__buttons-autoupdate-on" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
 				updateButtons.push( <Button key="plugins__buttons-autoupdate-off" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
 

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -12,6 +12,7 @@ import reject from 'lodash/collection/reject';
 import assign from 'lodash/object/assign';
 import property from 'lodash/utility/property';
 import isEmpty from 'lodash/lang/isEmpty';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -47,7 +48,6 @@ import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
-import AddNewButton from 'components/add-new-button';
 
 /**
  * Module variables
@@ -528,6 +528,20 @@ export default React.createClass( {
 		}
 	},
 
+	canAddNewPlugins() {
+		if ( config.isEnabled( 'manage/plugins/browser' ) ) {
+			let selectedSite = this.props.sites.getSelectedSite();
+			if ( selectedSite ) {
+				return !! selectedSite.jetpack;
+			}
+
+			return this.props.sites.get().some( function( site ) {
+				return site.jetpack;
+			} );
+		}
+		return false;
+	},
+
 	canUpdatePlugins() {
 		return this.state.plugins
 			.filter( plugin => plugin.selected )
@@ -544,9 +558,6 @@ export default React.createClass( {
 		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
 		const isJetpackSelected = this.state.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
 		const needsRemoveButton = this.getSelected().length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
-		const selectedSite = this.props.sites.getSelectedSite();
-		const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
-
 		if ( ! this.state.bulkManagement ) {
 			if ( 0 < this.state.pluginUpdateCount ) {
 				rightSideButtons.push(
@@ -557,14 +568,17 @@ export default React.createClass( {
 					</ButtonGroup>
 				);
 			}
-
 			rightSideButtons.push(
 				<ButtonGroup key="plugins__buttons-bulk-management"><Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>{ this.translate( 'Edit All', { context: 'button label' } ) }</Button></ButtonGroup>
 			);
-			rightSideButtons.push(
-				<ButtonGroup key="plugins__buttons-browser"><Button compact href={ browserUrl } onClick={ this.goToBrowser } className="plugins__browser-button"><Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } /></Button></ButtonGroup>
-			);
+			if ( this.canAddNewPlugins() ) {
+				const selectedSite = this.props.sites.getSelectedSite();
+				const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
 
+				rightSideButtons.push(
+					<ButtonGroup key="plugins__buttons-browser"><Button compact href={ browserUrl } onClick={ this.goToBrowser } className="plugins__browser-button"><Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } /></Button></ButtonGroup>
+				);
+			}
 		} else {
 			activateButtons.push( <Button key="plugins__buttons-activate" disabled={ ! this.areSelected( 'inactive' ) } compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
 			let deactivateButton = isJetpackSelected

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -16,6 +16,23 @@
 		margin-right: 16px;
 	}
 
+	.button {
+		position: relative;
+	}
+
+	.button-group {
+		margin-left: 8px;
+	}
+
+	.gridicons-plus-small {
+		height: 12px;
+		left: 4px;
+		margin-left: 0;
+		position: absolute;
+		top: 8px;
+		width: 12px;
+	}
+
 	&.is-placeholder {
 		.section-header__label span {
 			@include placeholder(23%);
@@ -81,6 +98,9 @@
 	}
 }
 
+.plugins__browser-button.button.is-compact {
+	padding-left: 12px;
+}
 .plugins__plugin-list-state {
 	white-space: nowrap;
 }


### PR DESCRIPTION
Adds a button to allow going to the plugins browser from the section header. 

![image](https://cloud.githubusercontent.com/assets/1554855/11809045/618281be-a324-11e5-866d-474bf086cbde.png)

How to test:
1. You need to have at least one jetpack site
2. Go to http://calypso.dev:3000/plugins
3. You should see the 'add new plugins' button. Click it and check that it takes you to http://calypso.dev:3000/plugins/browse
4. Go back to your plugins list. Select a business .com site. You should not see the button up there.
5. Select a jetpack site. You should see the button again. 
6. Click the add new plugins button. You should be in the plugins browser, again, but this time you should still have your jetpack site selected.