### PR TITLE
Notices: absorb <Flag> component as compact <Notice>.

### DIFF
--- a/assets/stylesheets/sections/_devdocs.scss
+++ b/assets/stylesheets/sections/_devdocs.scss
@@ -181,7 +181,3 @@
 	float: right;
 	margin-top: -120px;
 }
-
-.design-assets .notice.is-compact {
-	margin-bottom: 8px;
-}

--- a/assets/stylesheets/sections/_devdocs.scss
+++ b/assets/stylesheets/sections/_devdocs.scss
@@ -181,3 +181,7 @@
 	float: right;
 	margin-top: -120px;
 }
+
+.design-assets .notice.is-compact {
+	margin-bottom: 8px;
+}

--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -28,40 +28,54 @@ var Notices = React.createClass( {
 					<a className="design-assets__toggle button" onClick={ this.toggleNotices }>{ toggleNoticesText }</a>
 				</h2>
 
-				<Notice
-					text="I'm a notice with no status."
-					showDismiss={ false }
-					isCompact={ this.state.compactNotices ? true : null } />
-				<Notice
-					status="is-info"
-					text="I'm an `is-info` notice with custom icon."
-					icon="heart"
-					isCompact={ this.state.compactNotices ? true : null } />
-				<Notice status="is-success" text="I'm an `is-success` notice." isCompact={ this.state.compactNotices ? true : null } />
-				<Notice status="is-error" text="I'm an `is-error` notice." isCompact={ this.state.compactNotices ? true : null } />
-				<Notice
-					status="is-warning"
-					icon="mention"
-					text="I'm an `is-warning` notice with custom icon."
-					isCompact={ this.state.compactNotices ? true : null } />
-				<Notice
-					status="is-warning"
-					isCompact={ this.state.compactNotices ? true : null }
-					showDismiss={ false }
-					text={ "I'm an `is-warning` notice with an action." }>
-					<NoticeAction href="#">
-						{ "Update" }
-					</NoticeAction>
-				</Notice>
-				<Notice
-					status="is-success"
-					isCompact={ this.state.compactNotices ? true : null }
-					showDismiss={ false }
-					text={ "I'm an `is-success` notice with an arrow link." }>
-					<NoticeAction href="#" external={ true }>
-						{ "Preview" }
-					</NoticeAction>
-				</Notice>
+				<div>
+					<Notice
+						text="I'm a notice with no status."
+						showDismiss={ false }
+						isCompact={ this.state.compactNotices ? true : null } />
+				</div>
+				<div>
+					<Notice
+						status="is-info"
+						text="I'm an `is-info` notice with custom icon."
+						icon="heart"
+						isCompact={ this.state.compactNotices ? true : null } />
+				</div>
+				<div>
+					<Notice status="is-success" text="I'm an `is-success` notice." isCompact={ this.state.compactNotices ? true : null } />
+				</div>
+				<div>
+					<Notice status="is-error" text="I'm an `is-error` notice." isCompact={ this.state.compactNotices ? true : null } />
+				</div>
+				<div>
+					<Notice
+						status="is-warning"
+						icon="mention"
+						text="I'm an `is-warning` notice with custom icon."
+						isCompact={ this.state.compactNotices ? true : null } />
+				</div>
+				<div>
+					<Notice
+						status="is-warning"
+						isCompact={ this.state.compactNotices ? true : null }
+						showDismiss={ false }
+						text={ "I'm an `is-warning` notice with an action." }>
+						<NoticeAction href="#">
+							{ "Update" }
+						</NoticeAction>
+					</Notice>
+				</div>
+				<div>
+					<Notice
+						status="is-success"
+						isCompact={ this.state.compactNotices ? true : null }
+						showDismiss={ false }
+						text={ "I'm an `is-success` notice with an arrow link." }>
+						<NoticeAction href="#" external={ true }>
+							{ "Preview" }
+						</NoticeAction>
+					</Notice>
+				</div>
 			</div>
 		);
 	},

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -155,19 +155,20 @@
 .notice.is-compact {
 	border-radius: 2px;
 	color: $white;
-	display: inline-block;
-	line-height: 20px;
-	margin: 0;
+	display: inline-flex;
+	min-height: 20px;
+	margin: 8px;
 	padding: 0;
 	text-decoration: none;
 
 	.notice__text {
 		font-size: 12px;
-		padding: 2px 8px;
-		line-height: 24px;
+		padding: 8px;
+		line-height: 1;
 	}
 
 	.notice__icon {
+		align-self: center;
 		padding: 0 0 0 8px;
 		width: 14px;
 		height: 14px;
@@ -183,7 +184,7 @@
 		display: inline-block;
 		font-size: 11px;
 		font-weight: 600;
-		line-height: 20px;
+		align-self: center;
 		margin-left: 16px;
 		padding: 0 8px;
 		text-decoration: underline;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -153,24 +153,55 @@
 
 // Compact notices
 .notice.is-compact {
-	margin-bottom: 8px;
-	font-size: 14px;
+	border-radius: 2px;
+	color: $white;
+	display: inline-block;
+	line-height: 24px;
+	margin: 0;
+	padding: 0;
+	text-decoration: none;
 
 	.notice__text {
-		padding: 11px 24px 11px 16px;
+		font-size: 12px;
+		padding: 2px 8px;
+		line-height: 24px;
 	}
 
 	.notice__icon {
-		display: none;
+		padding: 0 0 0 8px;
+		width: 18px;
+		height: 18px;
+		vertical-align: middle;
 	}
 
 	.notice__dismiss {
-		padding: 9px 16px;
+		display: none;
 	}
 
-	a.notice__action .gridicon {
-		width: 18px;
-		height: 18px;
+	a.notice__action {
+		background: transparent;
+		display: inline-block;
+		font-size: 11px;
+		font-weight: 600;
+		line-height: 20px;
+		margin-left: 16px;
+		padding: 0 8px;
+		text-decoration: underline;
+		text-transform: uppercase;
+
+		&:hover,
+		&:active,
+		&:focus {
+			background: transparent;
+			text-decoration: none;
+		}
+
+		.gridicon {
+			margin-left: 8px;
+			width: 18px;
+			height: 18px;
+			vertical-align: top;
+		}
 	}
 }
 
@@ -199,9 +230,4 @@
 	&:focus {
 		background: rgba( 255, 255, 255, 0.2 );
 	}
-}
-
-// For site notices
-.current-site.card .notice.is-compact {
-	margin-bottom: 0px
 }

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -156,7 +156,7 @@
 	border-radius: 2px;
 	color: $white;
 	display: inline-block;
-	line-height: 24px;
+	line-height: 20px;
 	margin: 0;
 	padding: 0;
 	text-decoration: none;
@@ -169,8 +169,8 @@
 
 	.notice__icon {
 		padding: 0 0 0 8px;
-		width: 18px;
-		height: 18px;
+		width: 14px;
+		height: 14px;
 		vertical-align: middle;
 	}
 
@@ -198,9 +198,10 @@
 
 		.gridicon {
 			margin-left: 8px;
-			width: 18px;
-			height: 18px;
-			vertical-align: top;
+			width: 14px;
+			height: 14px;
+			vertical-align: sub;
+			opacity: 1;
 		}
 	}
 }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -102,7 +102,7 @@ module.exports = React.createClass( {
 			<Notice
 				showDismiss={ false }
 				isCompact={ true }
-				text={ this.translate( 'The site redirects to {{a}}%(url)s{{/a}}', {
+				text={ this.translate( 'Redirects to {{a}}%(url)s{{/a}}', {
 					args: { url: hostname },
 					components: { a: <a href={ site.URL }/> }
 				} ) }>


### PR DESCRIPTION
This PR converts current `<Flag>` component into a `<Notice compact={ true }>` to reduce duplication.

-----

Flag:

![image](https://cloud.githubusercontent.com/assets/548849/11812164/886c4218-a33a-11e5-8d88-d0d7e0177a83.png)

Compact notice:

![image](https://cloud.githubusercontent.com/assets/548849/11812157/7e475b92-a33a-11e5-9f0d-05f90a403edd.png)

-----

Notices support arbitrary icons as well.

cc @scruffian @rickybanister @folletto 