### PR TITLE
Build: Add /shared path to unit test runner

### DIFF
--- a/bin/run-all-tests
+++ b/bin/run-all-tests
@@ -84,4 +84,4 @@ __cleanup() {
 trap __cleanup SIGINT SIGTERM
 
 # Run all tests
-find {$BASEDIR/../client,$BASEDIR/../server} -name Makefile | run_test_fast
+find {$BASEDIR/../client,$BASEDIR/../server,$BASEDIR/../shared} -name Makefile | run_test_fast

--- a/shared/components/themes-list/Makefile
+++ b/shared/components/themes-list/Makefile
@@ -4,7 +4,7 @@ COMPILERS ?= jsx:babel/register
 NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
-NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
+NODE_PATH := test:$(BASE_DIR)/shared
 
 # In order to simply stub modules, add test to the NODE_PATH
 test:

--- a/shared/components/themes-list/test/index.jsx
+++ b/shared/components/themes-list/test/index.jsx
@@ -6,15 +6,17 @@ var assert = require( 'chai' ).assert,
 	mockery = require( 'mockery' ),
 	sinon = require( 'sinon' );
 
-var MockMoreButton = React.createClass( {
-	render: function() {
-		return <div/>;
-	}
-} );
+function mockComponent( displayName ) {
+	return React.createClass( {
+		displayName,
+		render: () => { return <div/> }
+	} );
+};
 
 describe( 'ThemesList', function() {
 	before( function() {
-		mockery.registerMock( './more-button', MockMoreButton);
+		mockery.registerMock( './more-button', mockComponent() );
+		mockery.registerMock( 'components/infinite-list', mockComponent( 'InfiniteList' ) );
 
 		mockery.enable( {
 			warnOnReplace: false,

--- a/shared/lib/formatting/Makefile
+++ b/shared/lib/formatting/Makefile
@@ -1,8 +1,11 @@
 REPORTER ?= spec
-MOCHA ?= ../../../node_modules/.bin/mocha
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
 
 # In order to simply stub modules, add test to the NODE_PATH
 test:
-	@NODE_ENV=test NODE_PATH=test:../../../client $(MOCHA) --compilers js:babel/register --reporter $(REPORTER)
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers js:babel/register --reporter $(REPORTER)
 
 .PHONY: test


### PR DESCRIPTION
Tests in /shared were not being run by the test runner. Some makefiles also needed tweaking. The /shared folder will be removed soon but the tests should be run in the meantime.

Let's wait until after #840 has been merged to fix the two failing _Themes_ test sets