### PR TITLE
Help: Begin recording a few stats pertaining to the help section.

### DIFF
--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -7,14 +7,19 @@ var ReactDom = require( 'react-dom' ),
 /**
  * Internal dependencies
  */
-var i18n = require( 'lib/mixins/i18n' ),
+var analytics = require( 'analytics' ),
+	i18n = require( 'lib/mixins/i18n' ),
+	route = require( 'lib/route' ),
 	titleActions = require( 'lib/screen-title/actions' );
 
 module.exports = {
-	help: function() {
-		var Help = require( './main' );
+	help: function( context ) {
+		var Help = require( './main' ),
+			basePath = route.sectionify( context.path );
 
 		titleActions.setTitle( i18n.translate( 'Help', { textOnly: true } ) );
+
+		analytics.pageView.record( basePath, 'Help' );
 
 		ReactDom.render(
 			React.createElement( Help ),
@@ -22,8 +27,11 @@ module.exports = {
 		);
 	},
 
-	contact: function() {
-		var ContactComponent = require( './help-contact' );
+	contact: function( context ) {
+		var ContactComponent = require( './help-contact' ),
+			basePath = route.sectionify( context.path );
+
+		analytics.pageView.record( basePath, 'Help > Contact' );
 
 		ReactDom.render(
 			<ContactComponent />,

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -19,6 +19,7 @@ import HeaderCake from 'components/header-cake';
 import wpcomLib from 'lib/wp';
 import notices from 'notices';
 import siteList from 'lib/sites-list';
+import analytics from 'analytics';
 
 /**
  * Module variables
@@ -96,6 +97,8 @@ module.exports = React.createClass( {
 
 		notifications.forEach( olarkActions.sendNotificationToOperator );
 
+		analytics.tracks.recordEvent( 'calypso_help_live_chat_begin' );
+
 		this.sendMessageToOperator( message );
 	},
 
@@ -130,6 +133,9 @@ module.exports = React.createClass( {
 						'one of our Happiness Engineers shortly.' )
 				}
 			} );
+
+			analytics.tracks.recordEvent( 'calypso_help_contact_submit', { ticket_type: 'kayako' } );
+
 		} );
 	},
 
@@ -162,6 +168,8 @@ module.exports = React.createClass( {
 					)
 				}
 			} );
+
+			analytics.tracks.recordEvent( 'calypso_help_contact_submit', { ticket_type: 'forum' } );
 		} );
 	},
 
@@ -203,6 +211,16 @@ module.exports = React.createClass( {
 	},
 
 	onOperatorsAway: function() {
+		const { isOlarkReady, isUserEligible, details } = this.state.olark;
+		const showChatVariation = isUserEligible && details.isOperatorAvailable;
+		const showKayakoVariation = ! showChatVariation && ( details.isConversing || isUserEligible );
+		const showForumsVariation = ! ( showChatVariation || showKayakoVariation );
+
+		if ( ! details.isConversing ) {
+			analytics.tracks.recordEvent( 'calypso_help_offline_form_display', {
+				form_type: showKayakoVariation ? 'kayako' : 'forum'
+			} );
+		}
 		this.showOperatorAvailabilityNotice( false );
 	},
 

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -13,6 +13,7 @@ import HelpResults from 'me/help/help-results';
 import NoResults from 'my-sites/no-results';
 import SearchCard from 'components/search-card';
 import CompactCard from 'components/card/compact';
+import analytics from 'analytics';
 
 module.exports = React.createClass( {
 	displayName: 'HelpSearch',
@@ -40,6 +41,7 @@ module.exports = React.createClass( {
 
 	onSearch: function( searchQuery ) {
 		this.setState( { helpLinks: [], searchQuery: searchQuery } );
+		analytics.tracks.recordEvent( 'calypso_help_search', { query: searchQuery } );
 		HelpSearchActions.fetch( searchQuery );
 	},
 
@@ -78,19 +80,19 @@ module.exports = React.createClass( {
 				<HelpResults
 					header={ this.translate( 'WordPress.com Documentation' ) }
 					helpLinks={ this.state.helpLinks.wordpress_support_links }
-					footer={ this.translate( 'See more from WordPress.com Documentation...' ) }
+					footer={ this.translate( 'See more from WordPress.com Documentation…' ) }
 					iconPathDescription="M18.75 16.5h.75V3h-12c-1.656 0-3 1.344-3 3v12c0 1.656 1.344 3 3 3h12v-1.5h-.75c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5zm-11.25 3c-.828 0-1.5-.67-1.5-1.5s.672-1.5 1.5-1.5h9.585c-.36.4-.585.92-.585 1.5s.225 1.1.585 1.5H7.5z"
 					searchLink={ 'https://en.support.wordpress.com?s=' + this.state.searchQuery } />
 				<HelpResults
 					header={ this.translate( 'Community Answers' ) }
 					helpLinks={ this.state.helpLinks.wordpress_forum_links }
-					footer={ this.translate( 'See more from Community Forum...' ) }
+					footer={ this.translate( 'See more from Community Forum…' ) }
 					iconPathDescription="M16.5 3h-12c-1.656 0-3 1.344-3 3v4.5c0 1.656 1.344 3 3 3H6v5.25l5.25-5.25h5.25c1.656 0 3-1.344 3-3V6c0-1.656-1.344-3-3-3zM21 6v4.5c0 2.48-2.02 4.5-4.5 4.5h-4.63l-1.5 1.5h3.88l5.25 5.25V16.5H21c1.656 0 3-1.344 3-3V9c0-1.656-1.344-3-3-3z"
 					searchLink={ 'https://en.forums.wordpress.com/search.php?search=' + this.state.searchQuery } />
 				<HelpResults
 					header={ this.translate( 'Jetpack Documentation' ) }
 					helpLinks={ this.state.helpLinks.jetpack_support_links }
-					footer={ this.translate( 'See more from Jetpack Documentation...' ) }
+					footer={ this.translate( 'See more from Jetpack Documentation…' ) }
 					iconPathDescription="M12 1.5C6.15 1.5 1.5 6.15 1.5 12S6.15 22.5 12 22.5 22.5 17.85 22.5 12 17.85 1.5 12 1.5zM10.5 15l-3.45-.9c-.9-.15-1.35-1.2-.9-2.1l4.35-7.5V15zm7.35-3l-4.35 7.5V9l3.45.9c.9.15 1.35 1.2.9 2.1z"
 					searchLink="https://jetpack.me/support/" />
 			</div>


### PR DESCRIPTION
At present we're recording no stats for actions taken in the help section. This PR begins recording the basic things we'd like to record. Specifically it records events for views of `/help` and `/help/contact`, chat initiation, contact form submits, display of contact form views when chat is unavailable, and search queries. I think we should also look into adding some event properties congruent with what we're logging elsewhere, but this gives us a baseline to build on.

To test:

* Load /help
* Do a search
* Load /help/contact
* Start a chat or submit a contact form

Check the tracks live view for your user in our internal tool after a few minutes to see if your stats come through.

I note that we seem to fire some of these multiple times. For example, when I load the contact form view because no chat operators are available, I see that the stat fires a couple of times at least in some cases. I'm not sure why this is happening and would be grateful for any insight. <strong>Update:</strong> I've fixed this (and leave this statement in the description because it comes up in the comments below and it'd be weird to delete it and lose context).

A note on naming. Arguably, it's a little weird that the chat stat is named `calypso_help_live_chat_begin` while the non-chat contact form stats are named `calypso_help_contact_submit`. A case could be made for using the latter name in all cases and merely passing `chat` as the type in the event property. My choice to separate the naming is based on the fact that we have similarly named stats for chat initiation in other code, and we do not at present have an event for submit of other contact forms. So I'm standardizing the chat naming scheme to match prior naming conventions while introducing a new name for non-chat ticket creation. I'm surely open to feedback re naming but wanted to explain the rationale behind the original decision.

This commit also incidentally fixes up some ellipses that didn't pass linter tests.

This PR addresses issue #1348.