### PR TITLE
Framework: Ensure all modules using React addons declare dependency

### DIFF
--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import ReactDom from 'react-dom';
-import React from 'react';
+import React from 'react/addons';
 
 /**
  * Internal dependencies

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	noop = require( 'lodash/utility/noop' ),
 	first = require( 'lodash/array/first' ),
 	where = require( 'lodash/collection/where' );

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -2,7 +2,7 @@
 * External dependencies
 */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react' );
+	React = require( 'react/addons' );
 
 /**
 * Internal dependencies

--- a/client/components/segmented-control/index.jsx
+++ b/client/components/segmented-control/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
+	React = require( 'react/addons' ),
 	filter = require( 'lodash/collection/filter' ),
 	map = require( 'lodash/collection/map' ),
 	classNames = require( 'classnames' );

--- a/client/lib/domains/nameservers/index.js
+++ b/client/lib/domains/nameservers/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React from 'react/addons';
 import reject from 'lodash/collection/reject';
 import constant from 'lodash/utility/constant';
 import every from 'lodash/collection/every';

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	debug = require( 'debug' )( 'calypso:me:account-password' ),
 	_debounce = require( 'lodash/function/debounce' ),
 	_first = require( 'lodash/array/first' ),

--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React from 'react/addons';
 import i18n from 'lib/mixins/i18n';
 import Debug from 'debug';
 import emailValidator from 'email-validator';

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	debug = require( 'debug' )( 'calypso:application-passwords' );
 
 /**

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React from 'react/addons';
 
 /**
  * Internal dependencies

--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react/addons' );
 
 /**
  * Internal dependencies

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	debug = require( 'debug' )( 'calypso:me:profile' );
 
 /**

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	debug = require( 'debug' )( 'calypso:me:reauth-required' );
 
 /**

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	debug = require( 'debug' )( 'calypso:me:security:2fa-backup-codes-prompt' );
 
 /**

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	debug = require( 'debug' )( 'calypso:me:security:2fa-code-prompt' );
 
 /**

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	debug = require( 'debug' )( 'calypso:me:security:2fa-enable' ),
 	QRCode = require( 'qrcode.react' ),
 	classNames = require( 'classnames' );

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	debug = require( 'debug' )( 'calypso:me:security:2fa-sms-settings' ),
 	observe = require( 'lib/mixins/data-observe' );
 

--- a/client/me/security-checkup/edit-email.jsx
+++ b/client/me/security-checkup/edit-email.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
+	React = require( 'react/addons' ),
 	emailValidator = require( 'email-validator' );
 
 /**

--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	notices = require( 'notices' ),
 	debug = require( 'debug' )( 'calypso:my-sites:ads-settings' );
 


### PR DESCRIPTION
This is a first step towards migrating away from `react/addons`. Before starting to replace addons with their module counterpart, we must first ensure that any module using `React.addons` declares its dependency, since these modules benefit from the existence of `React.addons` implicitly. As addons are replaced, bundles may be able to optimize to remove the addons code, so if modules assume the existence of them without declaring their dependency, they will break.

__Testing instructions:__

Since `react/addons` is a superset of `react`, there should be no effective difference. Confirm that the application continues to load without error.