### PR TITLE
Themes: Remove ThemesHelpers.getSlugFromName

### DIFF
--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -84,7 +84,6 @@ module.exports = {
 		stepName: 'theme-dss',
 		props: {
 			useHeadstart: true,
-			themes: [ 'Sela', 'Goran', 'Twenty Fifteen', 'Sequential', 'Colinear', 'Edin' ]
 		},
 		dependencies: [ 'siteSlug' ],
 		providesDependencies: [ 'theme', 'images' ]

--- a/client/signup/steps/dss/index.jsx
+++ b/client/signup/steps/dss/index.jsx
@@ -7,11 +7,10 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import ThemeThumbnail from './theme-thumbnail';
+import DssThemeThumbnail from './theme-thumbnail';
 import FormLabel from 'components/forms/form-label';
 import SearchCard from 'components/search-card';
 import StepWrapper from 'signup/step-wrapper';
-import ThemeHelper from 'lib/themes/helpers';
 import DynamicScreenshotsActions from 'lib/dss/actions';
 import DSSImageStore from 'lib/dss/image-store';
 import ThemePreviewStore from 'lib/dss/preview-store';
@@ -22,18 +21,20 @@ const debug = debugFactory( 'calypso:dss' );
 export default React.createClass( {
 	displayName: 'DssThemeSelection',
 
+	propTypes: {
+		themes: React.PropTypes.array,
+		useHeadstart: React.PropTypes.bool,
+	},
+
 	getDefaultProps() {
 		return {
 			themes: [
-				'Boardwalk',
-				'Cubic',
-				'Edin',
-				'Cols',
-				'Minnow',
-				'Sequential',
-				'Penscratch',
-				'Intergalactic',
-				'Eighties'
+				{ name: 'Sela', slug: 'sela' },
+				{ name: 'Goran', slug: 'goran' },
+				{ name: 'Twenty Fifteen', slug: 'twentyfifteen' },
+				{ name: 'Sequential', slug: 'sequential' },
+				{ name: 'Colinear', slug: 'colinear' },
+				{ name: 'Edin', slug: 'edin' },
 			],
 
 			useHeadstart: false
@@ -66,7 +67,7 @@ export default React.createClass( {
 
 	loadThemePreviews() {
 		debug( 'loading theme previews for these themes', this.props.themes );
-		this.props.themes.map( theme => DynamicScreenshotsActions.fetchThemePreview( 'pub/' + ThemeHelper.getSlugFromName( theme ) ) );
+		this.props.themes.map( theme => DynamicScreenshotsActions.fetchThemePreview( 'pub/' + theme.slug ) );
 	},
 
 	updateMarkup() {
@@ -136,14 +137,14 @@ export default React.createClass( {
 					<div className="dss-theme-selection__screenshots__pin">
 						<div className="dss-theme-selection__screenshots__themes">
 							{ this.props.themes.map( ( theme ) => {
-								return <ThemeThumbnail
-									key={ theme }
-									themeName={ theme }
-									themeSlug={ ThemeHelper.getSlugFromName( theme ) }
-									themeRepoSlug={ 'pub/' + ThemeHelper.getSlugFromName( theme ) }
+								return <DssThemeThumbnail
+									key={ theme.name }
+									themeName={ theme.name }
+									themeSlug={ theme.slug }
+									themeRepoSlug={ 'pub/' + theme.slug }
 									isLoading={ this.state.isLoading }
 									dssImage={ this.state.dssImage }
-									markupAndStyles={ this.state.markupAndStyles[ 'pub/' + ThemeHelper.getSlugFromName( theme ) ] }
+									markupAndStyles={ this.state.markupAndStyles[ 'pub/' + theme.slug ] }
 									renderComplete={ this.state.renderComplete }
 									{ ...this.props }/>;
 							} ) }

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -16,7 +16,10 @@ module.exports = React.createClass( {
 	displayName: 'ThemeSelection',
 
 	propTypes: {
-		themes: React.PropTypes.array,
+		themes: React.PropTypes.arrayOf( React.PropTypes.shape( {
+			name: React.PropTypes.string.isRequired,
+			slug: React.PropTypes.string.isRequired
+		} ) ),
 		useHeadstart: React.PropTypes.bool,
 	},
 

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -10,24 +10,28 @@ var React = require( 'react' ),
 var analytics = require( 'analytics' ),
 	SignupActions = require( 'lib/signup/actions' ),
 	ThemesList = require( 'components/themes-list' ),
-	ThemeHelper = require( 'lib/themes/helpers' ),
 	StepWrapper = require( 'signup/step-wrapper' );
 
 module.exports = React.createClass( {
 	displayName: 'ThemeSelection',
 
+	propTypes: {
+		themes: React.PropTypes.array,
+		useHeadstart: React.PropTypes.bool,
+	},
+
 	getDefaultProps: function() {
 		return {
 			themes: [
-				'Boardwalk',
-				'Cubic',
-				'Edin',
-				'Cols',
-				'Minnow',
-				'Sequential',
-				'Penscratch',
-				'Intergalactic',
-				'Eighties'
+				{ name: 'Boardwalk', slug: 'boardwalk' },
+				{ name: 'Cubic', slug: 'cubic' },
+				{ name: 'Edin', slug: 'edin' },
+				{ name: 'Cols', slug: 'cols' },
+				{ name: 'Minnow', slug: 'minnow' },
+				{ name: 'Sequential', slug: 'sequential' },
+				{ name: 'Penscratch', slug: 'penscratch' },
+				{ name: 'Intergalactic', slug: 'intergalactic' },
+				{ name: 'Eighties', slug: 'eighties' },
 			],
 
 			useHeadstart: false
@@ -61,9 +65,9 @@ module.exports = React.createClass( {
 		var actionLabel = this.translate( 'Pick' ),
 			themes = this.props.themes.map( function( theme ) {
 				return {
-					id: ThemeHelper.getSlugFromName( theme ),
-					name: theme,
-					screenshot: 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + ThemeHelper.getSlugFromName( theme ) + '/screenshot.png?w=660',
+					id: theme.slug,
+					name: theme.name,
+					screenshot: 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + theme.slug + '/screenshot.png?w=660',
 					actionLabel: actionLabel
 				}
 			} );

--- a/client/signup/steps/theme-selection/theme-thumbnail.jsx
+++ b/client/signup/steps/theme-selection/theme-thumbnail.jsx
@@ -7,14 +7,18 @@ var React = require( 'react' );
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
-	SignupActions = require( 'lib/signup/actions' ),
-	ThemeHelper = require( 'lib/themes/helpers' );
+	SignupActions = require( 'lib/signup/actions' );
 
 module.exports = React.createClass( {
 	displayName: 'ThemeThumbnail',
 
+	propTypes: {
+		themeName: React.PropTypes.string.isRequired,
+		themeSlug: React.PropTypes.string.isRequired,
+	},
+
 	handleSubmit: function() {
-		var themeSlug = ThemeHelper.getSlugFromName( this.props.theme );
+		var themeSlug = this.props.themeSlug;
 
 		if ( true === this.props.useHeadstart && themeSlug ) {
 			analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: true } );
@@ -37,14 +41,14 @@ module.exports = React.createClass( {
 	},
 
 	getThumbnailUrl: function() {
-		return 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + ThemeHelper.getSlugFromName( this.props.theme ) + '/screenshot.png?w=660';
+		return 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + this.props.themeSlug + '/screenshot.png?w=660';
 	},
 
 	render: function() {
 		return (
 			<div onClick={ this.handleSubmit } className="theme-thumbnail__theme">
 				<img src={ this.getThumbnailUrl() } />
-				<span className="theme-thumbnail__name">{ this.props.theme }</span>
+				<span className="theme-thumbnail__name">{ this.props.themeName }</span>
 			</div>
 		);
 	}

--- a/shared/lib/themes/helpers.js
+++ b/shared/lib/themes/helpers.js
@@ -67,11 +67,6 @@ var ThemesHelpers = {
 		return startsWith( theme.stylesheet, 'premium/' );
 	},
 
-	getSlugFromName: function( name ) {
-		var theme = name.replace( /\s+/g, '' );
-		return theme.toLowerCase();
-	},
-
 	trackClick: function( componentName, eventName, verb = 'click' ) {
 		const stat = `${componentName} ${eventName} ${verb}`;
 		analytics.ga.recordEvent( 'Themes', titlecase( stat ) );


### PR DESCRIPTION
It is not possible to reliably determine the theme slug from its name, particularly around the usage of spaces and hyphens (eg: `big-brother`, `twentythirteen`). It is much more reliable to include the theme slug with the data provided to theme selection components.

## Testing

Make sure the signup flows work: http://calypso.localhost:3000/start, http://calypso.localhost:3000/start/dss

That is, there are no JS errors, the site is correctly created, and the site has the chosen theme.