### PR TITLE
Jetpack Settings: Fixes entire card for syncing non-public post types by hiding it all behind a feature flag

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -311,15 +311,19 @@ module.exports = React.createClass( {
 			return null;
 		}
 		return (
-			<ul id="settings-jetpack" className="settings-jetpack">
-				<li>
-					<label>
-						<input name="jetpack_sync_non_public_post_stati" type="checkbox" checkedLink={ this.linkState( 'jetpack_sync_non_public_post_stati' ) }/>
-						<span>{ this.translate( 'Allow synchronization of Posts and Pages with non-public post statuses' ) }</span>
-						<p className="settings-explanation is-indented">{ this.translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }</p>
-					</label>
-				</li>
-			</ul>
+			<Card className="is-compact">
+				<form onChange={ this.markChanged }>
+					<ul id="settings-jetpack" className="settings-jetpack">
+						<li>
+							<label>
+								<input name="jetpack_sync_non_public_post_stati" type="checkbox" checkedLink={ this.linkState( 'jetpack_sync_non_public_post_stati' ) }/>
+								<span>{ this.translate( 'Allow synchronization of Posts and Pages with non-public post statuses' ) }</span>
+								<p className="settings-explanation is-indented">{ this.translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }</p>
+							</label>
+						</li>
+					</ul>
+				</form>
+			</Card>	
 		);
 	},
 
@@ -435,11 +439,9 @@ module.exports = React.createClass( {
 									}
 							</Button>
 						</SectionHeader>
-						<Card className="is-compact">
-							<form onChange={ this.markChanged }>
-								{ this.syncNonPublicPostTypes() }
-							</form>
-						</Card>
+
+						{ this.syncNonPublicPostTypes() }
+
 						<Card href={ '../security/' + site.slug } className="is-compact">
 							{ this.translate( 'View Jetpack Monitor Settings' ) }
 						</Card>


### PR DESCRIPTION
Currently, production looks like this:
<img width="814" alt="screen shot 2015-12-15 at 11 02 07 am" src="https://cloud.githubusercontent.com/assets/1084656/11819637/2718d204-a31e-11e5-80c7-52a39a78a2a3.png">

This PR fixes it so that it looks like this for now:
<img width="805" alt="screen shot 2015-12-15 at 11 12 27 am" src="https://cloud.githubusercontent.com/assets/1084656/11819641/2ea1bf04-a31e-11e5-967f-406721852591.png">

and like this when the feature launches:
<img width="806" alt="screen shot 2015-12-15 at 11 13 40 am" src="https://cloud.githubusercontent.com/assets/1084656/11819652/342cc266-a31e-11e5-9d56-e780dddc64a2.png">
