### PR TITLE
Site: add home-link support.

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -10,6 +10,7 @@ var React = require( 'react/addons' ),
  * Internal dependencies
  */
 var AllSites = require( 'my-sites/all-sites' ),
+	analytics = require( 'analytics' ),
 	AddNewButton = require( 'components/add-new-button' ),
 	Card = require( 'components/card' ),
 	Notice = require( 'components/notice' ),
@@ -149,6 +150,10 @@ module.exports = React.createClass( {
 		);
 	},
 
+	trackHomepageClick: function() {
+		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
+	},
+
 	render: function() {
 		var site,
 			hasOneSite = this.props.siteCount === 1;
@@ -189,14 +194,13 @@ module.exports = React.createClass( {
 							{ this.translate( 'Switch Site' ) }
 						</span>
 				}
-				{ this.props.sites.selected ?
-					<Site
+				{ this.props.sites.selected
+					? <Site
 						site={ site }
 						homeLink={ true }
 						externalLink={ true }
-					/>
-				:
-					<AllSites sites={ this.props.sites }/>
+						onSelect={ this.trackHomepageClick } />
+					: <AllSites sites={ this.props.sites } />
 				}
 				{ this.getSiteNotices( site ) }
 			</Card>

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -189,7 +189,15 @@ module.exports = React.createClass( {
 							{ this.translate( 'Switch Site' ) }
 						</span>
 				}
-				{ this.props.sites.selected ? <Site site={ site }/> : <AllSites sites={ this.props.sites }/> }
+				{ this.props.sites.selected ?
+					<Site
+						site={ site }
+						homeLink={ true }
+						externalLink={ true }
+					/>
+				:
+					<AllSites sites={ this.props.sites }/>
+				}
 				{ this.getSiteNotices( site ) }
 			</Card>
 		);

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -8,6 +8,8 @@
 	padding: 0;
 	box-shadow: none;
 	border-bottom: 1px solid lighten( $gray, 25% );
+	// Needed to avoid Safari rendering bugs during transitions
+	-webkit-font-smoothing: subpixel-antialiased;
 
 	&.is-loading {
 		.site-icon {

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -8,8 +8,6 @@
 	padding: 0;
 	box-shadow: none;
 	border-bottom: 1px solid lighten( $gray, 25% );
-	// Needed to avoid Safari rendering bugs during transitions
-	-webkit-font-smoothing: subpixel-antialiased;
 
 	&.is-loading {
 		.site-icon {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -439,27 +439,6 @@ module.exports = React.createClass( {
 		);
 	},
 
-	homepage: function() {
-		var site = this.getSelectedSite();
-
-		if ( ! this.isSingle() ) {
-			return null;
-		}
-
-		return (
-			<li className={ this.itemLinkClass( '/homepage', 'homepage' ) }>
-				<a onClick={ this.trackHomepageClick } href={ site.URL }>
-					<Gridicon icon="house" size={ 24 } />
-					<span className="menu-link-text">{ this.translate( 'View Site' ) }</span>
-				</a>
-			</li>
-		);
-	},
-
-	trackHomepageClick: function() {
-		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
-	},
-
 	wpAdmin: function() {
 		var site = this.getSelectedSite(),
 			currentUser = this.props.user.get();
@@ -634,7 +613,6 @@ module.exports = React.createClass( {
 
 				<li className="sidebar-menu">
 					<ul>
-						{ this.homepage() }
 						{ this.stats() }
 						{ this.ads() }
 						{ this.plan() }

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -87,7 +87,7 @@ module.exports = React.createClass( {
 					</div>
 					{ this.props.homeLink &&
 						<span className="site__home">
-							<Gridicon icon="house" size={ 18 } />
+							<Gridicon icon="house" size={ 12 } />
 						</span>
 					}
 				</a>

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -10,6 +10,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var SiteIcon = require( 'components/site-icon' ),
+	Gridicon = require( 'components/gridicon' ),
 	SiteIndicator = require( 'my-sites/site-indicator' );
 
 module.exports = React.createClass( {
@@ -34,7 +35,9 @@ module.exports = React.createClass( {
 			indicator: true,
 
 			// Mark as selected or not
-			isSelected: false
+			isSelected: false,
+
+			homeLink: false
 		};
 	},
 
@@ -70,7 +73,7 @@ module.exports = React.createClass( {
 		return (
 			<div className={ siteClass }>
 				<a className="site__content"
-					href={ this.props.href }
+					href={ this.props.homeLink ? site.URL : this.props.href }
 					target={ this.props.externalLink && '_blank' }
 					onTouchTap={ this.onSelect }
 					onMouseEnter={ this.props.onMouseEnter }
@@ -82,6 +85,11 @@ module.exports = React.createClass( {
 						<div className="site__title">{ site.title }</div>
 						<div className="site__domain">{ site.domain }</div>
 					</div>
+					{ this.props.homeLink &&
+						<span className="site__home">
+							<Gridicon icon="house" size={ 18 } />
+						</span>
+					}
 				</a>
 				{ this.props.indicator ? <SiteIndicator site={ site } /> : null }
 			</div>

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -60,6 +60,10 @@
 	padding: 16px;
 	position: relative;
 	width: 100%;
+
+	&:focus {
+		outline: none;
+	}
 }
 
 // Adjusts the SiteIcon component for use
@@ -123,6 +127,7 @@
 	overflow: initial;
 	opacity: 0;
 	transition: opacity 0.2s;
+	transform: translate3d(0, 0, 0);
 
 	.gridicon {
 		line-height: 28px;

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -109,3 +109,32 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+
+.site__home {
+	align-self: center;
+	background: $blue-medium;
+	border-radius: 50%;
+	color: $white;
+	display: block;
+	width: 28px;
+	height: 28px;
+	text-align: center;
+	text-transform: none;
+	overflow: initial;
+	opacity: 0;
+	transition: opacity 0.2s;
+
+	.gridicon {
+		line-height: 28px;
+		margin: 1px 0 0 -1px;
+		vertical-align: middle;
+	}
+
+	&:hover {
+		color: $white;
+	}
+}
+
+.site:hover .site__home {
+	opacity: 1;
+}

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -135,6 +135,6 @@
 	}
 }
 
-.site:hover .site__home {
+.site__content:hover .site__home {
 	opacity: 1;
 }

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -133,6 +133,21 @@
 	&:hover {
 		color: $white;
 	}
+
+	@include breakpoint( "<660px" ) {
+		background: $white;
+		color: $blue-medium;
+		opacity: 1;
+
+		.gridicon {
+			width: 24px;
+			height: 24px;
+		}
+
+		&:hover {
+			color: $blue-medium;
+		}
+	}
 }
 
 .site__content:hover .site__home {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -69,7 +69,6 @@ module.exports = React.createClass( {
 			showSchedulePopover: false,
 			showAdvanceStatus: false,
 			showDateTooltip: false,
-			siteTooltip: false,
 			firstDayOfTheMonth: this.getFirstDayOfTheMonth(),
 			lastDayOfTheMonth: this.getLastDayOfTheMonth()
 		};
@@ -258,14 +257,6 @@ module.exports = React.createClass( {
 		this.setState( { showAdvanceStatus: ! this.state.showAdvanceStatus } );
 	},
 
-	showSiteTooltip: function() {
-		this.setState( { siteTooltip: true } );
-	},
-
-	hideSiteTooltip: function() {
-		this.setState( { siteTooltip: false } );
-	},
-
 	onPrimaryButtonClick: function() {
 		this.trackPrimaryButton();
 
@@ -329,17 +320,9 @@ module.exports = React.createClass( {
 					<Site
 						site={ this.props.site }
 						indicator={ false }
-						href={ this.props.site.URL }
+						homeLink={ true }
 						externalLink={ true }
-						ref="site"
-						onMouseEnter={ this.showSiteTooltip }
-						onMouseLeave={ this.hideSiteTooltip }
 					/>
-					<Tooltip context={ this.refs && this.refs.site } isVisible={ this.state.siteTooltip } position="right">
-						<span className="editor-ground-control__view-site-tooltip">
-							{ this.translate( 'View site' ) }
-						</span>
-					</Tooltip>
 					<hr className="editor-ground-control__separator" />
 					<div className="editor-ground-control__status">
 						<StatusLabel


### PR DESCRIPTION
Collaborating with @rickybanister on supporting a home link within `<Site>`. It adds a `homeLink` prop you can set to true when using Site component, which renders a home icon when hovering and sets up the href value.

-----

![image](https://cloud.githubusercontent.com/assets/548849/11820371/783aee56-a364-11e5-8f69-02515973be24.png)

![image](https://cloud.githubusercontent.com/assets/548849/11840874/8832daa4-a3f9-11e5-9971-d81536eb03f9.png)

![image](https://cloud.githubusercontent.com/assets/548849/11840878/9752c026-a3f9-11e5-9011-9b746596cc59.png)
