### PR TITLE
Posts: add placeholder for errored requests

### DIFF
--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -59,6 +59,7 @@ var Posts = React.createClass( {
 	propTypes: {
 		author: React.PropTypes.number,
 		context: React.PropTypes.object.isRequired,
+		hasRecentError: React.PropTypes.bool.isRequired,
 		lastPage: React.PropTypes.bool.isRequired,
 		loading: React.PropTypes.bool.isRequired,
 		page: React.PropTypes.number.isRequired,
@@ -73,6 +74,7 @@ var Posts = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
+			hasRecentError: false,
 			loading: false,
 			lastPage: false,
 			page: 0,
@@ -111,7 +113,7 @@ var Posts = React.createClass( {
 	},
 
 	fetchPosts: function( options ) {
-		if ( this.props.loading || this.props.lastPage ) {
+		if ( this.props.loading || this.props.lastPage || this.props.hasRecentError ) {
 			return;
 		}
 		if ( options.triggeredByScroll ) {
@@ -142,36 +144,43 @@ var Posts = React.createClass( {
 				newPostLink = selectedSite ? '//wordpress.com/post/' + selectedSite.ID + '/new' : '//wordpress.com/post';
 			}
 
-			switch( this.props.statusSlug ) {
-				case 'drafts':
-					attributes = {
-						title: this.translate( 'You don\'t have any drafts.' ),
-						line: this.translate( 'Would you like to create one?' ),
-						action: this.translate( 'Start a Post' ),
-						actionURL: newPostLink
-					};
-					break;
-				case 'scheduled':
-					attributes = {
-						title: this.translate( 'You don\'t have any scheduled posts.' ),
-						line: this.translate( 'Would you like to schedule a draft to publish?' ),
-						action: this.translate( 'Edit Drafts' ),
-						actionURL: ( this.props.siteID ) ? '/posts/drafts/' + this.props.siteID : '/posts/drafts'
-					};
-					break;
-				case 'trashed':
-					attributes = {
-						title: this.translate( 'You don\'t have any posts in your trash folder.' ),
-						line: this.translate( 'Everything you write is solid gold.' )
-					};
-					break;
-				default:
-					attributes = {
-						title: this.translate( 'You haven\'t published any posts yet.' ),
-						line: this.translate( 'Would you like to publish your first post?' ),
-						action: this.translate( 'Start a Post' ),
-						actionURL: newPostLink
-					};
+			if ( this.props.hasRecentError ) {
+				attributes = {
+					title: this.translate( 'Oh, no! We couldn\'t fetch your posts.' ),
+					line: this.translate( 'Please check your internet connection.' )
+				}
+			} else {
+				switch ( this.props.statusSlug ) {
+					case 'drafts':
+						attributes = {
+							title: this.translate( 'You don\'t have any drafts.' ),
+							line: this.translate( 'Would you like to create one?' ),
+							action: this.translate( 'Start a Post' ),
+							actionURL: newPostLink
+						};
+						break;
+					case 'scheduled':
+						attributes = {
+							title: this.translate( 'You don\'t have any scheduled posts.' ),
+							line: this.translate( 'Would you like to schedule a draft to publish?' ),
+							action: this.translate( 'Edit Drafts' ),
+							actionURL: ( this.props.siteID ) ? '/posts/drafts/' + this.props.siteID : '/posts/drafts'
+						};
+						break;
+					case 'trashed':
+						attributes = {
+							title: this.translate( 'You don\'t have any posts in your trash folder.' ),
+							line: this.translate( 'Everything you write is solid gold.' )
+						};
+						break;
+					default:
+						attributes = {
+							title: this.translate( 'You haven\'t published any posts yet.' ),
+							line: this.translate( 'Would you like to publish your first post?' ),
+							action: this.translate( 'Start a Post' ),
+							actionURL: newPostLink
+						};
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #1332 to add an error message instead of stating that the user has no posts.

Before:
![screen shot 2015-12-15 at 1 39 34 pm](https://cloud.githubusercontent.com/assets/1270189/11824936/4d613470-a331-11e5-92cb-18d05a395dae.png)

After:
![screen shot 2015-12-15 at 1 28 19 pm](https://cloud.githubusercontent.com/assets/1270189/11824913/26db8436-a331-11e5-82aa-8fca1ee1cea5.png)

### Testing Instructions:
1. Navigate to calypso.localhost:3000
2. Select a site with published posts
3. Click on `/pages`
4. Turn off internet connection
5. Click on `/posts`
![screen shot 2015-12-15 at 1 28 55 pm](https://cloud.githubusercontent.com/assets/1270189/11824984/860b46ee-a331-11e5-99f8-2e2002739d0a.png)
An error placeholder should display.
6. Turn on internet connection.
The posts page should recover and shows your published site posts.

cc @rickybanister @rralian 
