### PR TITLE
Site Picker: Scroll to selected site when opening picker

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -73,36 +73,6 @@ module.exports = React.createClass( {
 		this.refs.siteSearch.blur();
 	},
 
-	visibleCount: function() {
-		return this.props.sites.selected ? 1 : this.getCount();
-	},
-
-	// more complex translation logic here
-	getTranslations: function() {
-		var output = {},
-			visibleCount = this.visibleCount();
-
-		if ( ! this.props.sites.selected ) {
-			output.selectedSites = this.translate( 'All sites' );
-		} else {
-			output.selectedSites = this.translate( '%(numberSelected)s site selected', '%(numberSelected)s sites selected', {
-				count: visibleCount,
-				args: {
-					numberSelected: visibleCount
-				}
-			} );
-		}
-
-		output.totalSites = this.translate( '%(numberTotal)s site', 'All %(numberTotal)s Sites', {
-			count: this.getCount(),
-			args: {
-				numberTotal: this.getCount()
-			}
-		} );
-
-		return output;
-	},
-
 	addNewSite: function() {
 		return (
 			<AddNewButton

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -134,7 +134,8 @@ module.exports = React.createClass( {
 	},
 
 	isSelected: function( site ) {
-		return this.props.sites.selected === site.domain || this.props.selected === site.slug;
+		var selectedSite = this.props.selected || this.props.sites.selected;
+		return selectedSite === site.domain || selectedSite === site.slug;
 	},
 
 	renderSiteElements: function() {

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -21,6 +21,7 @@ module.exports = React.createClass( {
 	displayName: 'SiteSelector',
 
 	propTypes: {
+		sites: React.PropTypes.object,
 		showAddNewSite: React.PropTypes.bool,
 		showAllSites: React.PropTypes.bool,
 		indicator: React.PropTypes.bool,
@@ -33,6 +34,7 @@ module.exports = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
+			sites: {},
 			showAddNewSite: false,
 			showAllSites: false,
 			siteBasePath: false,

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -109,6 +109,7 @@
 .site-selector__sites {
 	max-height: calc( 100% - 89px );
 	overflow-y: auto;
+	position: relative; // for calculation of offsetTop in <Site>
 }
 
 .site-selector__no-results {

--- a/client/components/sites-popover/index.jsx
+++ b/client/components/sites-popover/index.jsx
@@ -8,7 +8,6 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var Popover = require( 'components/popover' ),
-	sitesList = require( 'lib/sites-list' )(),
 	hasTouch = require( 'lib/touch-detect' ).hasTouch,
 	SiteSelector = require( 'components/site-selector' );
 
@@ -16,6 +15,7 @@ module.exports = React.createClass( {
 	displayName: 'SitesPopover',
 
 	propTypes: {
+		sites: React.PropTypes.object,
 		context: React.PropTypes.object,
 		visible: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
@@ -62,7 +62,7 @@ module.exports = React.createClass( {
 				className="popover sites-popover">
 				{ this.state.popoverVisible ?
 					<SiteSelector
-						sites={ sitesList }
+						sites={ this.props.sites }
 						siteBasePath="/post"
 						showAddNewSite={ false }
 						indicator={ false }

--- a/client/components/sites-popover/style.scss
+++ b/client/components/sites-popover/style.scss
@@ -11,6 +11,7 @@ $sites-popover-width: 300px;
 .sites-popover .tip-inner {
 	position: relative;
 	text-align: left;
+	overflow: hidden;
 }
 
 .sites-popover .site-selector {
@@ -64,11 +65,6 @@ $sites-popover-width: 300px;
 			.site__title:before {
 				color: white;
 			}
-		}
-
-		&:last-child {
-			border-bottom-right-radius: 2px;
-			border-bottom-left-radius: 2px;
 		}
 	}
 }

--- a/client/components/sites-popover/style.scss
+++ b/client/components/sites-popover/style.scss
@@ -14,7 +14,6 @@ $sites-popover-width: 300px;
 }
 
 .sites-popover .site-selector {
-
 	&.is-large {
 		padding-top: 50px;
 	}
@@ -38,18 +37,18 @@ $sites-popover-width: 300px;
 
 .sites-popover .site-selector .site {
 	&.is-selected {
-		background: $white;
+		background-color: $gray;
 
 		.site__title {
-			color: $gray-dark;
+			color: $white;
 
 			&::before {
-				color: $gray;
+				color: $white;
 			}
 		}
 
 		.site__domain {
-			color: $gray;
+			color: $white;
 		}
 	}
 

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -95,6 +95,7 @@ export default React.createClass( {
 			>
 				{ this.props.children }
 				<SitesPopover
+					sites={ this.props.sites }
 					visible={ this.state.isShowingPopover }
 					context={ this.state.postButtonContext }
 					onClose={ this.toggleSitesPopover.bind( this, false ) }

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	ReactDom = require( 'react-dom' ),
 	classNames = require( 'classnames' ),
 	noop = require( 'lodash/utility/noop' );
 
@@ -29,7 +28,7 @@ module.exports = React.createClass( {
 	},
 
 	scrollIntoView: function() {
-		var node = ReactDom.findDOMNode( this ),
+		var node = this.refs.site,
 			parentScrollTop = node.offsetTop;
 		if ( node.previousSibling ) {
 			parentScrollTop -= node.previousSibling.offsetHeight / 2;
@@ -97,7 +96,7 @@ module.exports = React.createClass( {
 		} );
 
 		return (
-			<div className={ siteClass }>
+			<div className={ siteClass } ref="site">
 				<a className="site__content"
 					href={ this.props.homeLink ? site.URL : this.props.href }
 					target={ this.props.externalLink && '_blank' }

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -29,8 +29,12 @@ module.exports = React.createClass( {
 	},
 
 	scrollIntoView: function() {
-		var node = ReactDom.findDOMNode( this );
-		node.parentNode.scrollTop = node.offsetTop;
+		var node = ReactDom.findDOMNode( this ),
+			parentScrollTop = node.offsetTop;
+		if ( node.previousSibling ) {
+			parentScrollTop -= node.previousSibling.offsetHeight / 2;
+		}
+		node.parentNode.scrollTop = parentScrollTop;
 	},
 
 	getDefaultProps: function() {

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:my-sites:site' ),
+	ReactDom = require( 'react-dom' ),
 	classNames = require( 'classnames' ),
 	noop = require( 'lodash/utility/noop' );
 
@@ -17,7 +17,20 @@ module.exports = React.createClass( {
 	displayName: 'Site',
 
 	componentDidMount: function() {
-		debug( 'The Site component is mounted.' );
+		if ( this.props.isSelected ) {
+			this.scrollIntoView();
+		}
+	},
+
+	componentDidUpdate: function( prevProps, prevState ) {
+		if ( this.props.isSelected && ! prevProps.isSelected ) {
+			this.scrollIntoView();
+		}
+	},
+
+	scrollIntoView: function() {
+		var node = ReactDom.findDOMNode( this );
+		node.parentNode.scrollTop = node.offsetTop;
 	},
 
 	getDefaultProps: function() {

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -53,7 +53,6 @@
 
 // Wraps the anchor element
 .site__content {
-	border-radius: 2px;
 	display: flex;
 	justify-content: space-between;
 	overflow: hidden;


### PR DESCRIPTION
This PR seeks to accomplish the same goal as https://github.com/Automattic/wp-calypso/pull/1507: making it easier to select the current site in the site picker.

Here we do that by scrolling to the selected site when the sites picker is loaded or updated:

| Sidebar | Masterbar |
| --- | --- |
| ![image](https://cloud.githubusercontent.com/assets/227022/11825252/9bd44982-a343-11e5-9666-08f6b8307e0c.png) | ![image](https://cloud.githubusercontent.com/assets/227022/11825262/b0130b36-a343-11e5-94d6-270123f106dd.png) |

We intentionally show half of the previous site (if any) to make it visually obvious that there are more sites available if you scroll up.

I've also added a highlight to the selected site in the sites picker that appears when you click the "New Post" icon in the masterbar.  I used the same selected colors as the sidebar.  Marking as Needs Design Review because of that, and because the hover effects in particular need some love:

![site-picker-scroll-and-hover](https://cloud.githubusercontent.com/assets/227022/11825461/ba20441c-a344-11e5-836d-676052ec5a8b.gif)

Plus a bit of trash pickup along the way:

- Fix the site highlight for sites like `nylen.io/blog` by matching against site slug correctly.  Currently we have both `this.props.sites.selected` and `this.props.selected`, we should probably get rid of one of these for clarity.  cc @mtias - looks like you're working on changes in this area of the code.
- Correctly clip sites in the masterbar picker to the `border-radius` of the popover.  This is done by setting the scrollable parent to `overflow: hidden` ([reference](http://stackoverflow.com/questions/3714862/forcing-child-to-obey-parents-curved-borders-in-css)).