### PR TITLE
Framework: Me: Fixes mobile layout of buttons in FormButtonsBar

### DIFF
--- a/client/components/forms/form-buttons-bar/style.scss
+++ b/client/components/forms/form-buttons-bar/style.scss
@@ -1,3 +1,18 @@
 .form-buttons-bar {
 	@include clear-fix;
+
+	@include breakpoint( '<480px' ) {
+		display: flex;
+		flex-direction: column-reverse;
+
+		.button {
+			display: block;
+			margin-top: 8px;
+		}
+
+		.form-button {
+			float: none;
+			margin-left: 0;
+		}
+	}
 }

--- a/client/components/forms/form-buttons-bar/style.scss
+++ b/client/components/forms/form-buttons-bar/style.scss
@@ -2,6 +2,7 @@
 	@include clear-fix;
 
 	@include breakpoint( '<480px' ) {
+		align-items: flex-end;
 		display: flex;
 		flex-direction: column-reverse;
 

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -17,7 +17,8 @@ var FormButton = require( 'components/forms/form-button' ),
 	Security2faProgress = require( 'me/security-2fa-progress' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	analytics = require( 'analytics' ),
-	constants = require( 'me/constants' );
+	constants = require( 'me/constants' ),
+	FormButtonsBar = require( 'components/forms/form-buttons-bar' );
 
 module.exports = React.createClass( {
 
@@ -366,7 +367,7 @@ module.exports = React.createClass( {
 
 	renderButtons: function() {
 		return (
-			<div className="security-2fa-enable__buttons-bar">
+			<FormButtonsBar className="security-2fa-enable__buttons-bar">
 				<FormButton
 					className="security-2fa-enable__verify"
 					disabled={ this.getFormDisabled() }
@@ -415,7 +416,7 @@ module.exports = React.createClass( {
 					)
 
 				}
-			</div>
+			</FormButtonsBar>
 		);
 	},
 

--- a/client/me/security-2fa-enable/style.scss
+++ b/client/me/security-2fa-enable/style.scss
@@ -39,6 +39,5 @@
 }
 
 .security-2fa-enable__buttons-bar {
-	@include clear-fix;
 	margin-top: 16px;
 }


### PR DESCRIPTION
Fixes #230

Previously, mobile buttons had layout issues on mobile phones. This PR should fix that wherever buttons are used within `FormButtonsBar`.

My first pass at this was to have the buttons be on the same row, but when on smaller iPhones, the buttons ended up looking cramped (even unreadable).

![screen shot 1](https://cloud.githubusercontent.com/assets/1126811/11825986/2584f074-a348-11e5-8203-b12ca1cd24e4.png)

My next pass was to have the buttons be full-width, which is the first commit here:

![screen shot](https://cloud.githubusercontent.com/assets/1126811/11825992/2e8cc002-a348-11e5-8362-b4769e4f96f1.png)

My final pass was to have the buttons right aligned, which is the second commit:

![screen shot 2](https://cloud.githubusercontent.com/assets/1126811/11826007/428cedc0-a348-11e5-8f46-c1fc624d5720.png)

The third commit simply makes use of the `FormButtonsBar` component within `Security2faEnable`.

cc @rickybanister @MichaelArestad for design and code review.

To test
- Checkout `fix/me-2fa-buttons-mobile` branch
- Go to `/me/security/two-step` with a test account, and enable/disable 2fa.
- On screens where 3 buttons appear, does the button layout seem OK?