### PR TITLE
Sharing: prevent notice for non-admins

### DIFF
--- a/client/my-sites/sharing/connections/service-example.jsx
+++ b/client/my-sites/sharing/connections/service-example.jsx
@@ -12,7 +12,7 @@ module.exports = React.createClass( {
 			src: React.PropTypes.string,
 			alt: React.PropTypes.string
 		} ),
-		label: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element, React.PropTypes.object ] ),
+		label: React.PropTypes.node,
 		single: React.PropTypes.bool
 	},
 

--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -43,18 +43,31 @@ module.exports = React.createClass( {
 	},
 
 	getEligibleServices: function() {
-		// Currently, we only filter services by Jetpack support. If the site
-		// isn't a Jetpack site, we can be assured all services are supported.
-		if ( ! this.props.site || ! this.props.site.jetpack ) {
-			return this.props.services;
+		const { site, services } = this.props;
+
+		if ( ! site ) {
+			return services;
 		}
 
-		return this.props.services.filter( function( service ) {
-			// Omit the service if it doesn't support Jetpack or if the
-			// required Jetpack module is not currently active
-			return service.jetpack_support && ( ! service.jetpack_module_required ||
-				this.props.site.isModuleActive( service.jetpack_module_required ) );
-		}, this );
+		return services.filter( function( service ) {
+			// Omit if the site is Jetpack and service doesn't support Jetpack
+			if ( site.jetpack && ! service.jetpack_support ) {
+				return false;
+			}
+
+			// Omit if Jetpack module not activated
+			if ( site.jetpack && service.jetpack_module_required &&
+					! site.isModuleActive( service.jetpack_module_required ) ) {
+				return false;
+			}
+
+			// Omit if service is settings-oriented and user cannot manage
+			if ( 'eventbrite' === service.name && ! site.user_can_manage ) {
+				return false;
+			}
+
+			return true;
+		} );
 	},
 
 	renderService: function( service ) {

--- a/client/my-sites/sharing/connections/services-group.jsx
+++ b/client/my-sites/sharing/connections/services-group.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	get = require( 'lodash/object/get' ),
 	classNames = require( 'classnames' );
 
 /**
@@ -63,6 +64,11 @@ module.exports = React.createClass( {
 
 			// Omit if service is settings-oriented and user cannot manage
 			if ( 'eventbrite' === service.name && ! site.user_can_manage ) {
+				return false;
+			}
+
+			// Omit if Publicize service and user cannot publish
+			if ( 'publicize' === service.type && ! get( site, 'capabilities.publish_posts' ) ) {
 				return false;
 			}
 

--- a/client/my-sites/sharing/controller.js
+++ b/client/my-sites/sharing/controller.js
@@ -25,7 +25,7 @@ module.exports = {
 
 		titleActions.setTitle( i18n.translate( 'Sharing', { textOnly: true } ), { siteID: siteUrl } );
 
-		if ( site && ! site.settings ) {
+		if ( site && ! site.settings && site.user_can_manage ) {
 			site.fetchSettings();
 		}
 


### PR DESCRIPTION
Currently non-admins (specifically authors and editors) receive the following notice when visiting `/sharing`:

![screenshot from 2015-12-15 16-11-53](https://cloud.githubusercontent.com/assets/260253/11828161/d24704e8-a346-11e5-9e99-94fc3bbdd139.png)

We only need site settings for buttons, not for connections. So this PR seeks to move the call to fetch the site settings to the buttons controller. This prevents the unnecessary notice for non-admins.

cc @aduth for review