### PR TITLE
Signup: Design Layout: Stop the last option from expanding to full-width w…

### DIFF
--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -38,6 +38,7 @@ export default React.createClass( {
 		return (
 			<div className="design-type__list">
 				{ this.getChoices().map( this.renderChoice ) }
+				<div className="design-type__choice is-spacergif" />
 			</div>
 		);
 	},

--- a/client/signup/steps/design-type/style.scss
+++ b/client/signup/steps/design-type/style.scss
@@ -25,4 +25,11 @@
 	&:hover {
 		box-shadow: 0 0 0 1px $gray, 0 2px 4px lighten( $gray, 20 );
 	}
+
+	&.is-spacergif {
+		height: 0;
+		width: 230px;
+		margin: 0 10px;
+		padding: 0;
+	}
 }


### PR DESCRIPTION
…hen in two columns.

Because of flexbox, the third layout option will currently expand to full-width when the screen is at a width forcing a two-column layout.

![screen shot 2015-12-15 at 4 20 18 pm](https://cloud.githubusercontent.com/assets/349751/11828239/d2c17bd2-a347-11e5-9321-2b6f62eab1b4.png)

I hoped to just override this with `max-width: calc(50% - 20px);`, but there isn't an acceptable Calypso breakpoint at which that will fix the problem for all screen widths.

Inserting dummy markup, however, will work at all widths:

![screen shot 2015-12-15 at 4 13 43 pm](https://cloud.githubusercontent.com/assets/349751/11828214/a71dd00c-a347-11e5-94f5-df2b82c587bc.png)

I named the class `spacergif` because it seemed horribly appropriate :) Any better suggestions for a more elegant fix?..