### PR TITLE
Framework: Fixes clipping of focus styles on section header buttons

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -30,6 +30,8 @@
 
 .section-header__actions {
 	flex-grow: 0;
+	position: relative;
+
 	@include clear-fix;
 }
 


### PR DESCRIPTION
Fixes an issue that @rickybanister reported in Slack where the focus styles of a `button` within `SectionHeader` get clipped on the left side.

cc @rickybanister for design review

__After__

![screen shot 2](https://cloud.githubusercontent.com/assets/1126811/11828366/b6c1a7f6-a359-11e5-93ff-d15e4c75999b.png)

__Before__

<img width="796" alt="slack-imgs com" src="https://cloud.githubusercontent.com/assets/1126811/11828367/bd107b5a-a359-11e5-8aa4-51c1920ed40f.png">
