### PR TITLE
Reader: Click on Featured posts should show original

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -112,7 +112,7 @@ function getStoreForSite( storeId ) {
 function getStoreForFeatured( storeId ) {
 	var siteId = storeId.split( ':' )[ 1 ],
 		fetcher = function( query, callback ) {
-			wpcomUndoc.readSiteFeatured( siteId, callback );
+			wpcomUndoc.readSiteFeatured( siteId, query, callback );
 		};
 
 	return new FeedStream( {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1174,8 +1174,9 @@ Undocumented.prototype.readSite = function( query, fn ) {
 };
 
 Undocumented.prototype.readSiteFeatured = function( siteId, query, fn ) {
+	var params = omit( query, [ 'before', 'after' ] );
 	debug( '/read/sites/:site/featured' );
-	this.wpcom.req.get( '/read/sites/' + siteId + '/featured', query, fn );
+	this.wpcom.req.get( '/read/sites/' + siteId + '/featured', params, fn );
 };
 
 Undocumented.prototype.readSitePosts = function( query, fn ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1173,9 +1173,9 @@ Undocumented.prototype.readSite = function( query, fn ) {
 	this.wpcom.req.get( '/read/sites/' + query.site, params, fn );
 };
 
-Undocumented.prototype.readSiteFeatured = function( siteId, fn ) {
+Undocumented.prototype.readSiteFeatured = function( siteId, query, fn ) {
 	debug( '/read/sites/:site/featured' );
-	this.wpcom.req.get( '/read/sites/' + siteId + '/featured', null, fn );
+	this.wpcom.req.get( '/read/sites/' + siteId + '/featured', query, fn );
 };
 
 Undocumented.prototype.readSitePosts = function( query, fn ) {

--- a/client/reader/discover/helper.jsx
+++ b/client/reader/discover/helper.jsx
@@ -45,6 +45,27 @@ module.exports = {
 		return post.discover_metadata.permalink;
 	},
 
+	hasSource( post ) {
+		return post && this.isDiscoverPost( post ) && !this.isDiscoverSitePick( post );
+	},
+
+	getSourceData: function( post ) {
+		if ( !this.hasSource( post ) ) {
+			return null;
+		}
+
+		const data = get( post, 'discover_metadata.featured_post_wpcom_data' );
+
+		if ( !data ) {
+			return null;
+		}
+
+		return {
+			blogId: data.blog_id,
+			postId: data.post_id
+		};
+	},
+
 	// Given an external or internal URL, return the relevant link props for an <a> tag
 	getLinkProps: function( linkUrl ) {
 		let parsedUrl = url.parse( linkUrl );

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -29,21 +29,23 @@ export default React.createClass( {
 
 		let postKeys = store.get();
 		let posts = postKeys.map( postKey => {
-			let post = FeedPostStore.get( postKey );
+			let post = FeedPostStore.get( postKey ),
+				originalPost,
+				isDiscoverPost;
+
 			if ( ! post || post._state === 'minimal' ) {
 				FeedPostStoreActions.fetchPost( postKey );
-				post._state = 'pending';
-			}
+			} else {
+				isDiscoverPost = post && DiscoverHelper.isDiscoverPost( post );
 
-			let isDiscoverPost = post && DiscoverHelper.isDiscoverPost( post ),
-				isDiscoverSitePick = post && isDiscoverPost && DiscoverHelper.isDiscoverSitePick( post ),
-				originalPost;
+				let isDiscoverSitePick = post && isDiscoverPost && DiscoverHelper.isDiscoverSitePick( post );
 
-			if ( isDiscoverPost && ! isDiscoverSitePick && get( post, 'discover_metadata.featured_post_wpcom_data.blog_id' ) ) {
-				originalPost = FeedPostStore.get( {
-					blogId: post.discover_metadata.featured_post_wpcom_data.blog_id,
-					postId: post.discover_metadata.featured_post_wpcom_data.post_id
-				} );
+				if ( isDiscoverPost && ! isDiscoverSitePick && get( post, 'discover_metadata.featured_post_wpcom_data.blog_id' ) ) {
+					originalPost = FeedPostStore.get( {
+						blogId: post.discover_metadata.featured_post_wpcom_data.blog_id,
+						postId: post.discover_metadata.featured_post_wpcom_data.post_id
+					} );
+				}
 			}
 
 			return {
@@ -54,7 +56,7 @@ export default React.createClass( {
 		} );
 
 		return {
-			posts: posts
+			posts
 		};
 	},
 
@@ -100,6 +102,7 @@ export default React.createClass( {
 				postState = post._state;
 
 			switch ( postState ) {
+				case 'minimal':
 				case 'pending':
 				case 'error':
 					break;

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -34,17 +34,18 @@ export default React.createClass( {
 
 			if ( ! post || post._state === 'minimal' ) {
 				FeedPostStoreActions.fetchPost( postKey );
-			} else {
-				isDiscoverPost = post && DiscoverHelper.isDiscoverPost( post );
+				return { post };
+			}
 
-				let isDiscoverSitePick = post && isDiscoverPost && DiscoverHelper.isDiscoverSitePick( post );
+			isDiscoverPost = post && DiscoverHelper.isDiscoverPost( post );
 
-				if ( isDiscoverPost && ! isDiscoverSitePick && get( post, 'discover_metadata.featured_post_wpcom_data.blog_id' ) ) {
-					originalPost = FeedPostStore.get( {
-						blogId: post.discover_metadata.featured_post_wpcom_data.blog_id,
-						postId: post.discover_metadata.featured_post_wpcom_data.post_id
-					} );
-				}
+			let isDiscoverSitePick = post && isDiscoverPost && DiscoverHelper.isDiscoverSitePick( post );
+
+			if ( isDiscoverPost && ! isDiscoverSitePick && get( post, 'discover_metadata.featured_post_wpcom_data.blog_id' ) ) {
+				originalPost = FeedPostStore.get( {
+					blogId: post.discover_metadata.featured_post_wpcom_data.blog_id,
+					postId: post.discover_metadata.featured_post_wpcom_data.post_id
+				} );
 			}
 
 			return {

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -27,8 +27,7 @@ export default React.createClass( {
 	getStateFromStores( store ) {
 		store = store || this.props.store;
 
-		let postKeys = store.get();
-		let posts = postKeys.map( postKey => {
+		let posts = store.get().map( postKey => {
 			let post = FeedPostStore.get( postKey ),
 				originalPost,
 				isDiscoverPost;


### PR DESCRIPTION
In the normal post stream, Editors’ Picks pop open the original post. But in the featured area, they currently open up our Discover post instead. This changes things to properly open up the original post instead to mirror the stream behaviour.

This borrows some code from the `following-stream`'s `post` component and I'm open to suggestions on how to consolidate some of it.

## Before

https://cloudup.com/iO5Afo4RXAZ

## After

https://cloudup.com/cfMTbmvMmm2