### PR TITLE
Editor: adjust visual design of inline featured image.

### DIFF
--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -325,7 +325,7 @@
 
 // featured image
 .editor .editor-featured-image {
-	background: $gray-light;
+	box-shadow: 0 -1px 0 lighten( $gray, 20% ), 0 1px 0 lighten( $gray, 20% );
 	margin: -26px -48px 24px;
 	overflow: hidden;
 


### PR DESCRIPTION
The layout redesign that changed the background color of the page made the inline feature image box appear as a cutout. This updates the styles to white with a border.

Before:
![image](https://cloud.githubusercontent.com/assets/548849/11839989/89fb4904-a3f2-11e5-8089-42a941015e60.png)

After:
![image](https://cloud.githubusercontent.com/assets/548849/11839981/7fa05b48-a3f2-11e5-9a20-75207d589ea9.png)

cc @folletto @nylen 