### PR TITLE
Picker: disable greyscale treatment of icons.

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -25,20 +25,6 @@
 .site-selector .all-sites {
 	font-size: 14px;
 
-	.site-icon__img {
-		// Renders a grayscale-filtered image at retina size
-		-webkit-transform: translateZ( 0 );
-	}
-
-	// Sites that are not selected display a dimmer icon
-	&:not( .is-selected ) {
-		.site-icon__img {
-			filter: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'grayscale\'><feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/></filter></svg>#grayscale"); /* Firefox 10+, Firefox on Android */
-			filter: grayscale( 100% );
-			opacity: 0.7;
-		}
-	}
-
 	// Highlight selected site
 	&.is-selected,
 	.notouch &.is-selected:hover {
@@ -63,11 +49,6 @@
 			.site__title,
 			.site__domain {
 				color: $blue-medium;
-			}
-
-			.site-icon__img {
-				filter: none;
-				opacity: 1;
 			}
 		}
 	}


### PR DESCRIPTION
This is a remnant of an old design predating the fixed sidebar. Given the current visual treatment, the dimming down of the main screen when opening the picker, we no longer need this effect for the purpose it had originally.

![image](https://cloud.githubusercontent.com/assets/548849/11840389/d7e49cf8-a3f5-11e5-9ea8-0bb27d471487.png)
