### PR TITLE
Fix: long tags cutoff in Editor

### DIFF
--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -26,6 +26,7 @@
 .token-field__input-container {
 	display: flex;
 	flex-wrap: wrap;
+	align-items: flex-start;
 	padding: 7px 14px 0 0;
 }
 

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -51,13 +51,11 @@ input[type="text"].token-field__input {
 // Tokens
 .token-field__token {
 	font-size: 14px;
-	display: inline-block;
+	display: flex;
 	margin: 2px 0 2px 8px;
 	padding: 0;
 	color: $white;
 	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 .token-field__token-text, .token-field__remove-token {
@@ -69,6 +67,9 @@ input[type="text"].token-field__input {
 .token-field__token-text {
 	border-radius: 4px 0 0 4px;
 	padding: 0 4px 0 6px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .token-field__remove-token {


### PR DESCRIPTION
Fixes long tags being cutoff without ellipsis and pushing delete "X" mark out off the box in the Editor (https://github.com/Automattic/wp-calypso/issues/1004) / cc @designsimply / READY FOR REVIEW

BEFORE:

![wp-long-tags-before](https://cloud.githubusercontent.com/assets/241243/11843638/f3602a64-a40a-11e5-86c3-53b051627ce4.jpg)

AFTER:

![wp-long-tags-after](https://cloud.githubusercontent.com/assets/241243/11843534/65db568c-a40a-11e5-8b56-3c9e9dd0ad2f.jpg)