### PR TITLE
FoldableCard: Allow custom action button icon

### DIFF
--- a/client/components/foldable-card/README.md
+++ b/client/components/foldable-card/README.md
@@ -31,6 +31,7 @@ render: function() {
 ##### Optional props
 * `actionButton`: a component to substitute the regular expand button
 * `actionButtonExpanded`: a component to substitute the regular expand button when the card is expanded. If not provided, we use `actionButton`
+* `actionButtonIcon`: a string to set the Gridicon slug for the regular expand button. Defaults to `chevron-down`. Only applies when the `actionButton` or `actionButtonExpanded` props are not set.
 * `cardKey`: a unique identifier for the card that can be used to help track its state outside the component (for example, to record which cards are open).
 * `compact`: a boolean indicating if the foldable card is compact
 * `disabled`: boolean indicating if the component it's not interactive

--- a/client/components/foldable-card/README.md
+++ b/client/components/foldable-card/README.md
@@ -31,7 +31,7 @@ render: function() {
 ##### Optional props
 * `actionButton`: a component to substitute the regular expand button
 * `actionButtonExpanded`: a component to substitute the regular expand button when the card is expanded. If not provided, we use `actionButton`
-* `actionButtonIcon`: a string to set the Gridicon slug for the regular expand button. Defaults to `chevron-down`. Only applies when the `actionButton` or `actionButtonExpanded` props are not set.
+* `icon`: a string to set the Gridicon slug for the regular expand button. Defaults to `chevron-down`. Only applies when the `actionButton` or `actionButtonExpanded` props are not set.
 * `cardKey`: a unique identifier for the card that can be used to help track its state outside the component (for example, to record which cards are open).
 * `compact`: a boolean indicating if the foldable card is compact
 * `disabled`: boolean indicating if the component it's not interactive

--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -38,7 +38,7 @@ module.exports = React.createClass( {
 				<p>
 					<FoldableCard
 						header="This is a foldable card with a custom action icon"
-						actionButtonIcon="arrow-down"
+						icon="arrow-down"
 						>
 						These are its contents
 					</FoldableCard>

--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -37,6 +37,14 @@ module.exports = React.createClass( {
 				</p>
 				<p>
 					<FoldableCard
+						header="This is a foldable card with a custom action icon"
+						actionButtonIcon="arrow-down"
+						>
+						These are its contents
+					</FoldableCard>
+				</p>
+				<p>
+					<FoldableCard
 						header="This is a compact box with summary"
 						summary="Unexpanded Summary"
 						expandedSummary="Expanded Summary"

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -17,6 +17,7 @@ var FoldableCard = React.createClass( {
 	propTypes: {
 		actionButton: React.PropTypes.element,
 		actionButtonExpanded: React.PropTypes.element,
+		actionButtonIcon: React.PropTypes.string,
 		cardKey: React.PropTypes.string,
 		compact: React.PropTypes.bool,
 		disabled: React.PropTypes.bool,
@@ -36,6 +37,7 @@ var FoldableCard = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
+			actionButtonIcon: 'chevron-down',
 			onOpen: noop,
 			onClose: noop,
 			cardKey: '',
@@ -87,7 +89,7 @@ var FoldableCard = React.createClass( {
 			return (
 				<button disabled={ this.props.disabled } className="foldable-card__action foldable-card__expand" onClick={ clickAction }>
 					<span className="screen-reader-text">{ this.translate( 'More' ) }</span>
-					<Gridicon icon="chevron-down" size={ iconSize } />
+					<Gridicon icon={ this.props.actionButtonIcon } size={ iconSize } />
 				</button>
 			);
 		}

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -17,12 +17,12 @@ var FoldableCard = React.createClass( {
 	propTypes: {
 		actionButton: React.PropTypes.element,
 		actionButtonExpanded: React.PropTypes.element,
-		actionButtonIcon: React.PropTypes.string,
 		cardKey: React.PropTypes.string,
 		compact: React.PropTypes.bool,
 		disabled: React.PropTypes.bool,
 		expandedSummary: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] ),
 		expanded: React.PropTypes.bool,
+		icon: React.PropTypes.string,
 		onClick: React.PropTypes.func,
 		onClose: React.PropTypes.func,
 		onOpen: React.PropTypes.func,
@@ -37,10 +37,10 @@ var FoldableCard = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
-			actionButtonIcon: 'chevron-down',
 			onOpen: noop,
 			onClose: noop,
 			cardKey: '',
+			icon: 'chevron-down',
 			isExpanded: false
 		};
 	},
@@ -89,7 +89,7 @@ var FoldableCard = React.createClass( {
 			return (
 				<button disabled={ this.props.disabled } className="foldable-card__action foldable-card__expand" onClick={ clickAction }>
 					<span className="screen-reader-text">{ this.translate( 'More' ) }</span>
-					<Gridicon icon={ this.props.actionButtonIcon } size={ iconSize } />
+					<Gridicon icon={ this.props.icon } size={ iconSize } />
 				</button>
 			);
 		}


### PR DESCRIPTION
This PR adds an `icon` prop which allows the `FoldableCard` action button icon to be changed. This will be used for a cog icon in #1126.

### Examples
#### `icon="arrow-down"`
<img width="680" alt="wordpress_com" src="https://cloud.githubusercontent.com/assets/416133/11843692/3514eb02-a40b-11e5-91d4-de43b341b22a.png">

#### `icon="cog"`
<img width="660" alt="wordpress_com" src="https://cloud.githubusercontent.com/assets/416133/11843727/6dbb68d2-a40b-11e5-845e-8fb6dac7fcfc.png">

### Why not use `actionButton` and `actionButtonExpanded` props?
Although the action button can already be overridden using the `actionButton` and `actionButtonExpanded` props, overriding those require that the user also recreates the `button` and `Gridicon` and apply appropriate classes. Overriding the default `actionButton` also removes the screen reader `span` element.

To get the same functionality, you'd need to do something like:

```js
import Gridicon from 'components/gridicon';
   ...
<FoldableCard
  actionButton={
    <button disabled={ this.props.disabled } className="foldable-card__action foldable-card__expand" onClick={ clickAction }>
      <span className="screen-reader-text">{ this.translate( 'More' ) }</span>
      <Gridicon icon="arrow-down" size={ 24 } />
    </button>
  }
  actionButtonExpanded={
    <button disabled={ this.props.disabled } className="foldable-card__action foldable-card__expand" onClick={ clickAction }>
      <span className="screen-reader-text">{ this.translate( 'More' ) }</span>
      <Gridicon icon="arrow-up" size={ 24 } />
    </button>
  }
>
   ...
</FoldableCard>
```

With this change, the above can be achieved with:
```js
<FoldableCard icon="arrow-down"> ... </FoldableCard>
```
This still applies the current CSS animation/transformation, so the icon will appear upside-down when the card is expanded.