### PR TITLE
Plugins: update notices to the new format

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -15,7 +15,7 @@ var CompactCard = require( 'components/card/compact' ),
 	PluginActivateToggle = require( 'my-sites/plugins/plugin-activate-toggle' ),
 	PluginAutoupdateToggle = require( 'my-sites/plugins/plugin-autoupdate-toggle' ),
 	Count = require( 'components/count' ),
-	Notice = require( 'notices/notice' ),
+	Notice = require( 'components/notice' ),
 	PluginNotices = require( 'lib/plugins/notices' ),
 	analytics = require( 'analytics' );
 
@@ -57,70 +57,71 @@ module.exports = React.createClass( {
 
 			case 'UPDATE_PLUGIN':
 				message = ( this.props.selectedSite
-					? i18n.translate( 'updating', { context: 'plugin' } )
-					: i18n.translate( 'updating on %(count)s site', 'updating on %(count)s sites', translationArgs ) );
+					? i18n.translate( 'Updating', { context: 'plugin' } )
+					: i18n.translate( 'Updating on %(count)s site', 'updating on %(count)s sites', translationArgs ) );
 				break;
 
 			case 'ACTIVATE_PLUGIN':
 				message = ( this.props.selectedSite
-					? i18n.translate( 'activating', { context: 'plugin' } )
-					: i18n.translate( 'activating on %(count)s site', 'activating on %(count)s sites', translationArgs ) );
+					? i18n.translate( 'Activating', { context: 'plugin' } )
+					: i18n.translate( 'Activating on %(count)s site', 'activating on %(count)s sites', translationArgs ) );
 				break;
 
 			case 'DEACTIVATE_PLUGIN':
 				message = ( this.props.selectedSite
-					? i18n.translate( 'deactivating', { context: 'plugin' } )
-					: i18n.translate( 'deactivating on %(count)s site', 'deactivating on %(count)s sites', translationArgs ) );
+					? i18n.translate( 'Deactivating', { context: 'plugin' } )
+					: i18n.translate( 'Deactivating on %(count)s site', 'deactivating on %(count)s sites', translationArgs ) );
 				break;
 
 			case 'ENABLE_AUTOUPDATE_PLUGIN':
 				message = ( this.props.selectedSite
-					? i18n.translate( 'enabling autoupdates' )
-					: i18n.translate( 'enabling autoupdates on %(count)s site', 'enabling autoupdates on %(count)s sites', translationArgs ) );
+					? i18n.translate( 'Enabling autoupdates' )
+					: i18n.translate( 'Enabling autoupdates on %(count)s site', 'enabling autoupdates on %(count)s sites', translationArgs ) );
 				break;
 
 			case 'DISABLE_AUTOUPDATE_PLUGIN':
 				message = ( this.props.selectedSite
-					? i18n.translate( 'disabling autoupdates' )
-					: i18n.translate( 'disabling autoupdates on %(count)s site', 'disabling autoupdates on %(count)s sites', translationArgs ) );
+					? i18n.translate( 'Disabling autoupdates' )
+					: i18n.translate( 'Disabling autoupdates on %(count)s site', 'disabling autoupdates on %(count)s sites', translationArgs ) );
+
 				break;
 		}
 		return message;
 	},
 
 	pluginMeta: function( pluginData ) {
-		var metaText,
-			meta;
 		if ( this.props.progress.length ) {
-			meta = (
-				<div className="plugin-item__meta doing">
-						{ this.doing() }
-				</div>
-				);
-		} else if ( this.hasUpdate() ) {
-			meta = (
-				<div className="plugin-item__meta has-update">
-					<span className="noticon noticon-refresh"></span>
-					<span className="plugin-item__meta-text ">
-						{ this.translate( 'A newer version is available' ) }
-					</span>
-				</div>
-				);
-		} else {
-			if ( pluginData.wpcom ) {
-				metaText = this.translate( 'Updated Automatically' );
-			} else if ( pluginData.last_updated ) {
-				metaText = this.translate( 'Last updated %(ago)s', {
-					args: { ago: this.ago( pluginData.last_updated ) }
-				} );
-			} else {
-				metaText = '';
-			}
-
-			meta = <div className="plugin-item__meta">{ metaText }</div>;
+			return (
+				<Notice isCompact status="is-info" text={ this.doing() } inline={ true }/>
+			);
+		}
+		if ( this.hasUpdate() ) {
+			return (
+				<Notice isCompact
+					icon="sync"
+					status="is-warning"
+					inline={ true }
+					text={ this.translate( 'A newer version is available' ) } />
+			);
 		}
 
-		return meta;
+		if ( pluginData.wpcom ) {
+			return (
+				<div className="plugin-item__last_updated">
+					{ this.translate( 'Updated Automatically' ) }
+				</div>
+			);
+		}
+
+		if ( pluginData.last_updated ) {
+			return (
+				<div className="plugin-item__last_updated">
+					{ this.translate( 'Last updated %(ago)s', { args: { ago: this.ago( pluginData.last_updated ) } } ) }
+				</div>
+			);
+		}
+
+		return null;
 	},
 
 	clickNoManageItem: function() {
@@ -179,8 +180,8 @@ module.exports = React.createClass( {
 			errors = this.props.errors ? this.props.errors : [],
 			numberOfWarningIcons = 0,
 			errorNotices = [],
-			errorCounter = 0,
-			pluginItemClasses = classNames( 'plugin-item', { disabled: this.props.hasAllNoManageSites } );
+			errorCounter = 0;
+		const pluginItemClasses = classNames( 'plugin-item', { disabled: this.props.hasAllNoManageSites } );
 
 		if ( ! this.props.plugin ) {
 			return this.renderPlaceholder();
@@ -189,9 +190,11 @@ module.exports = React.createClass( {
 		if ( this.props.hasNoManageSite ) {
 			numberOfWarningIcons++;
 		}
+
 		if ( this.hasUpdate() ) {
 			numberOfWarningIcons++;
 		}
+
 		pluginTitle = (
 			<div className="plugin-item__title" data-warnings={ numberOfWarningIcons }>
 				{ plugin.name }
@@ -204,8 +207,8 @@ module.exports = React.createClass( {
 					<Notice
 						type='message'
 						status='is-error'
+						showDismiss={ false }
 						text={ PluginNotices.getMessage( [ error ], PluginNotices.errorMessage.bind( PluginNotices ) ) }
-						isCompact={ true }
 						button={ PluginNotices.getErrorButton( error ) }
 						href={ PluginNotices.getErrorHref( error ) }
 						raw={ { onRemoveCallback: PluginsActions.removePluginsNotices.bind( this, [ error ] ) } }
@@ -235,8 +238,8 @@ module.exports = React.createClass( {
 							{ this.pluginMeta( plugin ) }
 						</div>
 					</CompactCard>
-					<div>
-					{ errorNotices }
+					<div className="plugin-item__error-notices">
+						{ errorNotices }
 					</div>
 				</div>
 			);

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -8,8 +8,17 @@
 	.plugins-list &.is-compact:last-child {
 		margin-bottom: 0;
 	}
-}
 
+	.notice.is-info {
+		.notice__text {
+			text-transform: capitalize;
+		}
+
+		.notice__icon {
+			display: none;
+		}
+	}
+}
 
 .plugin-item {
 	position: relative;
@@ -83,15 +92,15 @@
 
 // Plugin title
 .plugin-item__title {
-	display: block;
-	margin-top: 2px;
 	color: $gray-dark;
+	display: block;
 	font-size: 14px;
 	font-weight: 600;
-	white-space: pre;
+	line-height: 32px;
+	overflow: hidden;
 	text-align: left;
 	text-overflow: ellipsis;
-	overflow: hidden;
+	white-space: pre;
 
 	@include breakpoint( '>480px' ) {
 		font-size: 24px;
@@ -123,71 +132,6 @@
 			margin-top: -6px;
 		}
 	}
-}
-
-// Last updated, version, whatever
-.plugin-item__meta {
-	display: block;
-	font-size: 11px;
-	color: $gray;
-	white-space: pre;
-	text-align: left;
-	text-overflow: ellipsis;
-	overflow: hidden;
-
-	@include breakpoint( '>480px' ) {
-		text-transform: uppercase;
-	}
-	&.has-update {
-		display: inline-block;
-
-		@include breakpoint( '>480px' ) {
-			padding: 2px 6px 2px 2px;
-			border-radius: 2px;
-			background: $alert-yellow;
-			color: $white;
-		}
-	}
-	&.is-warning {
-		@include breakpoint( '>480px' ) {
-			display: inline-block;
-			margin-top: -3px;
-			padding: 2px 6px 2px 2px;
-			border-radius: 2px;
-			background: $alert-red;
-			color: $white;
-		}
-	}
-	&.is-placeholder {
-		margin-top: 4px;
-		width: 40%;
-		background-color: lighten( $gray, 30% );
-		animation: loading-fade 1.6s ease-in-out infinite;
-
-		@include breakpoint( '>480px' ) {
-			margin-top: 5px;
-		}
-		&:before {
-			content: ' ';
-		}
-	}
-
-	.plugin-item__meta ~ & {
-		margin-left: 8px;
-	}
-}
-
-.plugin-item__meta-text {
-	vertical-align: middle;
-
-	 @include breakpoint( "<480px" ) {
-		display: none;
-	}
-}
-
-.plugin-item__meta_manage {
-	left: 5px;
-	top: 60px;
 }
 
 .plugin-item__meta.has-update {
@@ -236,4 +180,11 @@
 	@include breakpoint( '>480px' ) {
 		display: block;
 	}
+}
+
+.plugin-item__last_updated {
+	color: $gray;
+	font-size: 12px;
+	line-height: 1;
+	padding: 6px 0;
 }


### PR DESCRIPTION
This PR updates notices in /plugins/ to the new format introduced in https://github.com/Automattic/wp-calypso/pull/1603/files

It both updates the 'update' flags inside of each plugin item

Before:
![image](https://cloud.githubusercontent.com/assets/1554855/11845782/b7982044-a415-11e5-903b-8e405918ab69.png)

After:
![image](https://cloud.githubusercontent.com/assets/1554855/11845731/8478740c-a415-11e5-92e9-e938a54156a0.png)


And the full-width notice error messages:
Before:
![image](https://cloud.githubusercontent.com/assets/1554855/11845792/c69fecac-a415-11e5-907d-3bb3599beeb0.png)

After:
![image](https://cloud.githubusercontent.com/assets/1554855/11845765/a69cd0fa-a415-11e5-88d4-c261adf8d5c1.png)


How to test
========
1. Go to http://calypso.dev:3000/plugins/
2. Check that any update flag you have in the plugin list is rendered with the new notice-compact format
3. Click on "bulk edit"
4. Select a plugin and do any action that would result in a error (you probably have to have a failing jetpack site for this);
5. Check the error notice is shown full-width