### PR TITLE
Plugins: changed 'bulk edit' to 'edit all'

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -547,7 +547,7 @@ export default React.createClass( {
 			}
 
 			rightSideButtons.push(
-				<ButtonGroup key="plugins__buttons-bulk-management"><Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>{ this.translate( 'Bulk Edit', { context: 'button label' } ) }</Button></ButtonGroup>
+				<ButtonGroup key="plugins__buttons-bulk-management"><Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>{ this.translate( 'Edit All', { context: 'button label' } ) }</Button></ButtonGroup>
 			);
 		} else {
 			activateButtons.push( <Button key="plugins__buttons-activate" disabled={ ! this.areSelected( 'inactive' ) } compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )


### PR DESCRIPTION
The word 'bulk' is obscure. This will now create language parity with the `Update All` button as well. 

**Before:**
<img width="750" alt="screen shot 2015-12-16 at 2 10 47 pm" src="https://cloud.githubusercontent.com/assets/437258/11851148/19185724-a3ff-11e5-86af-373557b10ef1.png">

**After:**
<img width="751" alt="screen shot 2015-12-16 at 2 11 01 pm" src="https://cloud.githubusercontent.com/assets/437258/11851153/1ae6fb78-a3ff-11e5-9b17-c30937d40f92.png">

@alternatekev @johnHackworth @enejb 

