### PR TITLE
Editor: Add plugin for wrapping (source)code shortcodes

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -24,21 +24,39 @@ require( 'tinymce/plugins/textcolor/plugin.js' );
 require( './plugins/wptextpattern/plugin.js' );
 
 // TinyMCE plugins that we've forked or written ourselves
-require( './plugins/wpcom/plugin.js' )();
-require( './plugins/wpcom-autoresize/plugin.js' )();
-require( './plugins/wpcom-help/plugin.js' )();
-require( './plugins/wpcom-charmap/plugin.js' )();
-require( './plugins/wpcom-view/plugin.js' )();
-require( './plugins/wpcom-sourcecode/plugin' ).default();
-require( './plugins/wpeditimage/plugin.js' )();
-require( './plugins/wplink/plugin.js' )();
-require( './plugins/media/plugin' )();
-require( './plugins/advanced/plugin' )();
-require( './plugins/wpcom-tabindex/plugin' )();
-require( './plugins/touch-scroll-toolbar/plugin' )();
-require( './plugins/editor-button-analytics/plugin' )();
-require( './plugins/calypso-alert/plugin' )();
-require( './plugins/contact-form/plugin' )();
+import wpcomPlugin from './plugins/wpcom/plugin.js';
+import wpcomAutoresizePlugin from './plugins/wpcom-autoresize/plugin.js';
+import wpcomHelpPlugin from './plugins/wpcom-help/plugin.js';
+import wpcomCharmapPlugin from './plugins/wpcom-charmap/plugin.js';
+import wpcomViewPlugin from './plugins/wpcom-view/plugin.js';
+import wpcomSourcecode from './plugins/wpcom-sourcecode/plugin';
+import wpeditimagePlugin from './plugins/wpeditimage/plugin.js';
+import wplinkPlugin from './plugins/wplink/plugin.js';
+import mediaPlugin from './plugins/media/plugin';
+import advancedPlugin from './plugins/advanced/plugin';
+import wpcomTabindexPlugin from './plugins/wpcom-tabindex/plugin';
+import touchScrollToolbarPlugin from './plugins/touch-scroll-toolbar/plugin';
+import editorButtonAnalyticsPlugin from './plugins/editor-button-analytics/plugin';
+import calypsoAlertPlugin from './plugins/calypso-alert/plugin';
+import contactFormPlugin from './plugins/contact-form/plugin';
+
+[
+	wpcomPlugin,
+	wpcomAutoresizePlugin,
+	wpcomHelpPlugin,
+	wpcomCharmapPlugin,
+	wpcomViewPlugin,
+	wpcomSourcecode,
+	wpeditimagePlugin,
+	wplinkPlugin,
+	mediaPlugin,
+	advancedPlugin,
+	wpcomTabindexPlugin,
+	touchScrollToolbarPlugin,
+	editorButtonAnalyticsPlugin,
+	calypsoAlertPlugin,
+	contactFormPlugin
+].forEach( ( initializePlugin ) => initializePlugin() );
 
 /**
  * Internal Dependencies

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -29,6 +29,7 @@ require( './plugins/wpcom-autoresize/plugin.js' )();
 require( './plugins/wpcom-help/plugin.js' )();
 require( './plugins/wpcom-charmap/plugin.js' )();
 require( './plugins/wpcom-view/plugin.js' )();
+require( './plugins/wpcom-sourcecode/plugin' ).default();
 require( './plugins/wpeditimage/plugin.js' )();
 require( './plugins/wplink/plugin.js' )();
 require( './plugins/media/plugin' )();
@@ -97,7 +98,8 @@ const PLUGINS = [
 	'wpcom/editorbuttonanalytics',
 	'wpcom/calypsoalert',
 	'wpcom/tabindex',
-	'wpcom/contactform'
+	'wpcom/contactform',
+	'wpcom/sourcecode',
 ];
 
 const CONTENT_CSS = [

--- a/client/components/tinymce/plugins/wpcom-sourcecode/Makefile
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/Makefile
@@ -1,0 +1,10 @@
+REPORTER ?= spec
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
+
+test:
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers js:babel/register  --reporter $(REPORTER)
+
+.PHONY: test

--- a/client/components/tinymce/plugins/wpcom-sourcecode/README.md
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/README.md
@@ -1,0 +1,4 @@
+wpcom-sourcecode
+================
+
+Automatically wraps `[sourcecode]` and `[code]` shortcodes with a `<pre>` tag only when rendered in the TinyMCE visual editor for the purpose of preserving indentation and visually indicating code.

--- a/client/components/tinymce/plugins/wpcom-sourcecode/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/plugin.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce/tinymce';
+
+/**
+ * Module variables
+ */
+const REGEXP_CODE_SHORTCODE = new RegExp( '(?:<p>\\s*)?(?:<pre>\\s*)?(\\[(code|sourcecode)[^\\]]*\\][\\s\\S]*?\\[\\/\\2\\])(?:\\s*<\\/pre>)?(?:\\s*<\\/p>)?', 'gi' );
+
+export function wrapPre( content, initial ) {
+	return content = content.replace( REGEXP_CODE_SHORTCODE, function( match, shortcode ) {
+		shortcode = shortcode.replace( /\r/, '' );
+		shortcode = shortcode.replace( /<br ?\/?>\n?/g, '\n' ).replace( /<\/?p( [^>]*)?>\n?/g, '\n' );
+
+		if ( ! initial ) {
+			shortcode = shortcode.replace( /&/g, '&amp;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
+		}
+
+		return `<pre>${ shortcode }</pre>`;
+	} );
+}
+
+export function unwrapPre( content ) {
+	if ( ! content || content.indexOf( '[' ) === -1 ) {
+		return content;
+	}
+
+	return content.replace( REGEXP_CODE_SHORTCODE, function( match, shortcode ) {
+		shortcode = shortcode.replace( /&lt;/g, '<' ).replace( /&gt;/g, '>' ).replace( /&amp;/g, '&' );
+
+		return `<p>${ shortcode }</p>`;
+	} );
+}
+
+function sourcecode( editor ) {
+	editor.on( 'BeforeSetContent', ( event ) => {
+		if ( ! event.content || 'html' === event.mode ) {
+			return;
+		}
+
+		event.content = wrapPre( event.content, event.initial );
+	} );
+
+	editor.on( 'GetContent', ( event ) => {
+		if ( event.format !== 'raw' || ! event.content || event.selection ) {
+			return;
+		}
+
+		event.content = unwrapPre( event.content );
+	} );
+
+	editor.on( 'PostProcess', ( event ) => {
+		if ( ! event.content ) {
+			return;
+		}
+
+		event.content = unwrapPre( event.content );
+	} );
+}
+
+export default function() {
+	tinymce.PluginManager.add( 'wpcom/sourcecode', sourcecode );
+}

--- a/client/components/tinymce/plugins/wpcom-sourcecode/test/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/test/plugin.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import mockery from 'mockery';
+
+describe( 'wpcom-sourcecode', () => {
+	let wrapPre, unwrapPre;
+
+	before( () => {
+		mockery.enable( {
+			warnOnReplace: false,
+			warnOnUnregistered: false
+		} );
+		mockery.registerMock( 'tinymce/tinymce', {} );
+
+		const plugin = require( '../plugin' );
+		wrapPre = plugin.wrapPre;
+		unwrapPre = plugin.unwrapPre;
+	} );
+
+	after( () => {
+		mockery.deregisterAll();
+		mockery.disable();
+	} );
+
+	describe( '#wrapPre()', () => {
+		it( 'should wrap a code shortcode', () => {
+			const wrapped = wrapPre( '[code lang="javascript"]var foo;[/code]' );
+			expect( wrapped ).to.equal( '<pre>[code lang="javascript"]var foo;[/code]</pre>' );
+		} );
+
+		it( 'should wrap a sourcecode shortcode', () => {
+			const wrapped = wrapPre( '[sourcecode lang="javascript"]var foo;[/sourcecode]' );
+			expect( wrapped ).to.equal( '<pre>[sourcecode lang="javascript"]var foo;[/sourcecode]</pre>' );
+		} );
+	} );
+
+	describe( '#unwrapPre()', () => {
+		it( 'should unwrap a code shortcode', () => {
+			const unwrapped = unwrapPre( '<pre>[code lang="javascript"]var foo;[/code]</pre>' );
+			expect( unwrapped ).to.equal( '<p>[code lang="javascript"]var foo;[/code]</p>' );
+		} );
+
+		it( 'should unwrap a sourcecode shortcode', () => {
+			const unwrapped = unwrapPre( '<pre>[sourcecode lang="javascript"]var foo;[/sourcecode]</pre>' );
+			expect( unwrapped ).to.equal( '<p>[sourcecode lang="javascript"]var foo;[/sourcecode]</p>' );
+		} );
+
+		it( 'should gracefully handle surrounding content', () => {
+			const unwrapped = unwrapPre( '<p>foo</p><p><pre>[sourcecode lang="javascript"]var foo;[/sourcecode]</pre></p><p>bar</p>' );
+			expect( unwrapped ).to.equal( '<p>foo</p><p>[sourcecode lang="javascript"]var foo;[/sourcecode]</p><p>bar</p>' );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes #1023

This pull request seeks to preserve indentation in `[sourcecode]` and `[code]` shortcodes by wrapping them with a `<pre>` tag only when rendered in the TinyMCE visual editor.

__Testing instructions:__

1. Navigate to the [Calypso post editor](https://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Insert a code shortcode (in Visual or HTML) with some indentation
4. Switch between Visual and HTML modes
5. Note that...
 - Indentation is not lost when switching between modes
 - The wrapping `<pre>` is never shown in the HTML tab, nor saved with the post

/cc @alisterscott 