### PR TITLE
Importer: Start listening to store at `didMount` vs `willMount`

### DIFF
--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -34,7 +34,7 @@ export default React.createClass( {
 		} )
 	},
 
-	componentWillMount: function() {
+	componentDidMount: function() {
 		ImporterStore.on( 'change', this.updateState );
 	},
 


### PR DESCRIPTION
Small change to start listening to the store for the importer on `componentDidMount` instead of `componentWillMount` - hopefully to make it easier for things like SSR

@omarjackman would you mind looking this over?