### PR TITLE
Importer/wpcom.js: Update API call to make changes on sever

### DIFF
--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -1680,14 +1680,14 @@ Undocumented.prototype.fetchImporterState = function( siteId ) {
 
 Undocumented.prototype.updateImporter = function( siteId, importerStatus ) {
 	debug( `/sites/${ siteId }/imports/${ importerStatus.importId }` );
+	const formData = Object
+		.keys( importerStatus )
+		.map( key => [ key, JSON.stringify( importerStatus[ key ] ) ] );
 
-	// Don't actually send the request until fully coordinated
-	// with the API to make sure all the ducks line up :)
-	// also to make sure we are polling the API for updates before starting one
-	//this.wpcom.req.post( Object.assign( {},
-	//	{ path: `/sites/${ siteId }/imports/${ importerStatus.importId }` },
-	//	{ importerStatus }
-	//) );
+	return this.wpcom.req.post( {
+		path: `/sites/${ siteId }/imports/${ importerStatus.importerId }`,
+		formData
+	} );
 };
 
 Undocumented.prototype.uploadExportFile = function( siteId, params ) {


### PR DESCRIPTION
Previously the `updateImporter` function in `wpcom.js` didn't actually
do anything. Now, it has been updated to actually send the information
to the server and it has been modified to translate the input data into
the appropriate format needed for the API. Namely, we need to pass
key/value pairs as `formData` vs the previoulsy assumed behavior or
sending a single JavaScript object marshalled as JSON.

cc: @fredrocious @roundhill 