### PR TITLE
Try: Full Width

### DIFF
--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -2,7 +2,7 @@
 	margin: auto;
 	max-width: 100%;
 	z-index: z-index( 'root', '.main' );
-	padding-top: 56px;
+	padding-top: 51px;
 
 	// Themes is a great example of using all this new space ;)
 	&.themes,

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -12,10 +12,16 @@
 	&.account,
 	&.next-steps,
 	&.help,
-	&.following,
 	&.customize {
 		max-width: 100%;
 		padding-top: 0px;
+	}
+
+	&.following{
+		max-width: 720px;
+		padding-top: 0;
+		margin-left: 0;
+		margin-right: auto;
 	}
 
 	@include breakpoint( "<960px" ) {

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -1,7 +1,8 @@
 .main {
 	margin: auto;
-	max-width: 720px;
+	max-width: 100%;
 	z-index: z-index( 'root', '.main' );
+	padding-top: 48px;
 
 	// Themes is a great example of using all this new space ;)
 	&.themes,

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -2,22 +2,30 @@
 	margin: auto;
 	max-width: 100%;
 	z-index: z-index( 'root', '.main' );
-	padding-top: 48px;
+	padding-top: 56px;
 
 	// Themes is a great example of using all this new space ;)
 	&.themes,
-	&.sites {
-		max-width: 100%;
-	}
-
-	// The customizer is full-width
+	&.sites,
+	&.manage-menus,
+	&.profile,
+	&.account,
+	&.next-steps,
+	&.help,
+	&.following,
 	&.customize {
 		max-width: 100%;
+		padding-top: 0px;
+	}
+
+	@include breakpoint( "<960px" ) {
+		padding-top: 52px;
 	}
 
 	@include breakpoint( "<660px" ) {
 		backface-visibility: hidden;
 		perspective: 1000;
+		padding-top: 0px;
 	}
 }
 

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -2,7 +2,8 @@
 	display: flex;
 		flex-wrap: wrap;
 	position: relative;
-	margin-bottom: 24px;
+	margin-top: 48px;
+	margin-bottom: 0px;
 	border-radius: 1px;
 	background: $gray-light;
 	box-sizing: border-box;

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -4,7 +4,9 @@
 
 // -------- Main Component --------
 .section-nav {
-	position: relative;
+	position: fixed;
+	top: 48px;
+	z-index: 100000;
 	width: 100%;
 	padding: 0;
 	margin: 0 0 17px 0;

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -39,7 +39,10 @@
 	}
 
 	@include breakpoint( "<660px" ) {
-		margin-bottom: 9px;
+		position: relative;
+		width: auto;
+		top: 4px;
+
 	}
 }
 

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -496,6 +496,8 @@ div.mce-inline-toolbar-grp.mce-arrow-full > div {
 
 .mce-tinymce .mce-edit-area.mce-stack-layout-item.mce-last {
 	border-top: 0;
+	max-width: 720px;
+	margin: 0 auto;
 }
 
 .mce-toolbar-grp .mce-stack-layout-item {

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -92,7 +92,7 @@
 	border-bottom: 1px solid lighten( $gray, 25% );
 	font-size: 13px;
 	display: block;
-	padding: 8px 8px 8px 40px;
+	padding: 16px 8px 16px 40px;
 	color: darken( $gray, 20% );
 	box-sizing: border-box;
 	cursor: pointer;
@@ -115,7 +115,7 @@
 
 	.gridicon {
 		position: absolute;
-			top: 9px;
+			top: 18px;
 			left: 16px;
 		transition: all 0.2s cubic-bezier(0.680, -0.550, 0.265, 1.550);
 

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -57,7 +57,7 @@
 .post-editor__inner {
 	padding: 0 24px;
 	position: relative;
-	width: 1040px;
+	width: 100%;
 
 	display: flex;
 	flex: 1;


### PR DESCRIPTION
With the advent of the sticky sidebar, the T-shaped layout we've got going on now feels a little odd to me, especially on wide computer screens:

![screen shot 2015-12-16 at 1 10 57 pm](https://cloud.githubusercontent.com/assets/1084656/11852668/8090bce2-a3f6-11e5-86df-296259cd8107.png)

This PR is more or less a place for me to sketch some ideas on how we can start to use the space a little more effectively, which I've done with some hacky SCSS changes. This branch looks like this:

![screen shot 2015-12-16 at 1 12 27 pm](https://cloud.githubusercontent.com/assets/1084656/11852705/c2edfa78-a3f6-11e5-9161-1400002eac2e.png)
![screen shot 2015-12-16 at 1 12 41 pm](https://cloud.githubusercontent.com/assets/1084656/11852701/c2e88386-a3f6-11e5-90c4-71e5d549213f.png)
![screen shot 2015-12-16 at 1 12 47 pm](https://cloud.githubusercontent.com/assets/1084656/11852703/c2eb53c2-a3f6-11e5-8083-5dc8d6bd5667.png)
![screen shot 2015-12-16 at 1 13 00 pm](https://cloud.githubusercontent.com/assets/1084656/11852702/c2ea932e-a3f6-11e5-93ea-c35c6f36b3f7.png)
![screen shot 2015-12-16 at 1 13 06 pm](https://cloud.githubusercontent.com/assets/1084656/11852704/c2eddde0-a3f6-11e5-980c-4d301f01662e.png)
![screen shot 2015-12-16 at 1 13 13 pm](https://cloud.githubusercontent.com/assets/1084656/11852706/c2f1a178-a3f6-11e5-987d-bf078dc030a4.png)
![screen shot 2015-12-16 at 1 17 39 pm](https://cloud.githubusercontent.com/assets/1084656/11852815/604a1cca-a3f7-11e5-9005-e3bba9682685.png)


It doesn't fix all of each page's problems but I honestly don't see anything show-stopping here in that regard. I'm probably disagreed-with.

What I mostly affected:
- SectionNav: This is fixed to right beneath the MasterBar, and goes all the way to the right edge of the screen, mirroring the MasterBar, since it also sticks in place on top of content now.
- Needed some exemptions made for non-SectionNav sections which should be distributed to components instead of being baked into the Main component like how I did here.
- It was hard to figure out which margins to use in some places. I'm sure there are some adjustments to make there.
- Certain page, like Insights and Blog Posts look super weird now. We'd have to pretty quickly update those layouts to make better use of the stretchy space, including some of their responsive strategies (particularly the "more" swap-a-roo that happens for Blog Posts).

Paging @rickybanister @MichaelArestad @justinkropp @jeffgolenski @mtias @folletto @shaunandrews @kellychoffman 