### PR TITLE
Editor: Always focus title field on new draft

### DIFF
--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 import classNames from 'classnames';
 import omit from 'lodash/object/omit';
-import ReactDom from 'react-dom';
 
 export default React.createClass( {
 
@@ -20,7 +19,7 @@ export default React.createClass( {
 	},
 
 	focus() {
-		ReactDom.findDOMNode( this.refs.textField ).focus();
+		this.refs.textField.focus();
 	},
 
 	render() {

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' ),
-	omit = require( 'lodash/object/omit' ),
-	classNames = require( 'classnames' );
+import React from 'react/addons';
+import classNames from 'classnames';
+import omit from 'lodash/object/omit';
+import ReactDom from 'react-dom';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'FormTextInput',
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			isError: false,
 			isValid: false,
@@ -19,25 +19,31 @@ module.exports = React.createClass( {
 		};
 	},
 
-	render: function() {
-		var otherProps = omit( this.props, [ 'className', 'type' ] ),
-			classes = classNames( {
-				'form-text-input': true,
-				'is-error': this.props.isError,
-				'is-valid': this.props.isValid
-			} );
+	focus() {
+		ReactDom.findDOMNode( this.refs.textField ).focus();
+	},
+
+	render() {
+		const otherProps = omit( this.props, [ 'className', 'type', 'ref' ] );
+		const { className, type, selectOnFocus } = this.props;
+		const classes = classNames( {
+			'form-text-input': true,
+			'is-error': this.props.isError,
+			'is-valid': this.props.isValid
+		} );
 
 		return (
 			<input
 				{ ...otherProps }
-				type={ this.props.type }
-				className={ classnames( this.props.className, classes ) }
-				onClick={ this.props.selectOnFocus ? this.selectOnFocus : null }
-				/>
+				ref="textField"
+				type={ type }
+				className={ classNames( className, classes ) }
+				onClick={ selectOnFocus ? this.selectOnFocus : null }
+			/>
 		);
 	},
 
-	selectOnFocus: function( event ) {
+	selectOnFocus( event ) {
 		event.target.select();
 	}
 

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -22,7 +22,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { className, type, selectOnFocus } = this.props;
+		const { className, selectOnFocus } = this.props;
 		const classes = classNames( className, {
 			'form-text-input': true,
 			'is-error': this.props.isError,
@@ -33,7 +33,6 @@ export default React.createClass( {
 			<input
 				{ ...this.props }
 				ref="textField"
-				type={ type }
 				className={ classes }
 				onClick={ selectOnFocus ? this.selectOnFocus : null } />
 		);

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -23,9 +23,8 @@ export default React.createClass( {
 	},
 
 	render() {
-		const otherProps = omit( this.props, [ 'className', 'type', 'ref' ] );
 		const { className, type, selectOnFocus } = this.props;
-		const classes = classNames( {
+		const classes = classNames( className, {
 			'form-text-input': true,
 			'is-error': this.props.isError,
 			'is-valid': this.props.isValid
@@ -33,10 +32,10 @@ export default React.createClass( {
 
 		return (
 			<input
-				{ ...otherProps }
+				{ ...this.props }
 				ref="textField"
 				type={ type }
-				className={ classNames( className, classes ) }
+				className={ classes }
 				onClick={ selectOnFocus ? this.selectOnFocus : null }
 			/>
 		);

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import omit from 'lodash/object/omit';
 
 export default React.createClass( {
 
@@ -36,8 +35,7 @@ export default React.createClass( {
 				ref="textField"
 				type={ type }
 				className={ classes }
-				onClick={ selectOnFocus ? this.selectOnFocus : null }
-			/>
+				onClick={ selectOnFocus ? this.selectOnFocus : null } />
 		);
 	},
 

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -40,6 +40,23 @@ export default React.createClass( {
 		};
 	},
 
+	componentWillReceiveProps( nextProps ) {
+		if ( isMobile() ) {
+			return;
+		}
+
+		// If next post is new, or the next site is different, focus title
+		if ( nextProps.isNew && ! this.props.isNew ||
+			( nextProps.isNew && ( this.props.site && nextProps.site ) && ( this.props.site.ID !== nextProps.site.ID ) )
+		) {
+			this.setState( {
+				isFocused: true
+			}, () => {
+				React.findDOMNode( this.refs.titleInput ).focus();
+			} )
+		}
+	},
+
 	onChange( event ) {
 		const { post, onChange } = this.props;
 
@@ -104,6 +121,7 @@ export default React.createClass( {
 						autoFocus={ isNew && ! isMobile() }
 						value={ post ? post.title : '' }
 						aria-label={ this.translate( 'Edit title' ) }
+						ref="titleInput"
 					/>
 				</TrackInputChanges>
 			</div>

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import omit from 'lodash/object/omit';
+import ReactDOM from 'react-dom';
 
 /**
  * Internal dependencies
@@ -52,7 +53,7 @@ export default React.createClass( {
 			this.setState( {
 				isFocused: true
 			}, () => {
-				React.findDOMNode( this.refs.titleInput ).focus();
+				ReactDOM.findDOMNode( this.refs.titleInput ).focus();
 			} )
 		}
 	},

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -4,7 +4,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import omit from 'lodash/object/omit';
-import ReactDOM from 'react-dom';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -53,7 +53,7 @@ export default React.createClass( {
 			this.setState( {
 				isFocused: true
 			}, () => {
-				ReactDOM.findDOMNode( this.refs.titleInput ).focus();
+				this.refs.titleInput.focus();
 			} )
 		}
 	},

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -108,8 +108,8 @@ export default React.createClass( {
 					<EditorPermalink
 						slug={ post.slug }
 						path={ isPermalinkEditable ? PostUtils.getPermalinkBasePath( post ) : post.URL }
-						isEditable={ isPermalinkEditable }
-					/> }
+						isEditable={ isPermalinkEditable } />
+				}
 				<TrackInputChanges onNewValue={ this.recordChangeStats }>
 					<FormTextInput
 						{ ...omit( this.props, Object.keys( this.constructor.propTypes ) ) }
@@ -121,8 +121,7 @@ export default React.createClass( {
 						autoFocus={ isNew && ! isMobile() }
 						value={ post ? post.title : '' }
 						aria-label={ this.translate( 'Edit title' ) }
-						ref="titleInput"
-					/>
+						ref="titleInput" />
 				</TrackInputChanges>
 			</div>
 		);

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -53,7 +53,7 @@ export default React.createClass( {
 				isFocused: true
 			}, () => {
 				this.refs.titleInput.focus();
-			} )
+			} );
 		}
 	},
 


### PR DESCRIPTION
Fixes #1622 

When you first open the editor via the pencil or add in a site sidebar, the title field is focused and ready to receive a witty post title.  Once within the editor though, any action that results in another new post - the title field is not auto focused.  This branch aims to focus the title field on all new drafts - regardless of how one arrives at that new draft ( only on non-mobile viewports ).

__To Test__
- Open up the editor via the pencil in the masterbar 
- Note the title field will be focused on a desktop viewport sized browser
- Expand your draft drawer, load in a draft post - or load an existing published post
- Note the title field does not focus
- Now click the pencil again, select a site if applicable
- Once the new post loads, note that the title field is again focused