### PR TITLE
Importer: Ignore stopped imports from the API

### DIFF
--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -4,6 +4,7 @@ import { appStates } from './constants';
 
 // Left( UI ) - Right( API )
 const importerStateMap = [
+	[ appStates.DEFUNCT, 'importStopped' ],
 	[ appStates.DISABLED, 'disabled' ],
 	[ appStates.IMPORT_FAILURE, 'importer-import-failure' ],
 	[ appStates.IMPORT_SUCCESS, 'importer-import-success' ],
@@ -68,7 +69,7 @@ export function toApi( state ) {
 
 	return Object.assign( {},
 		{ importerId, progress },
-		{ importerState: appStateToApi( importerState ) },
+		{ importerStatus: appStateToApi( importerState ) },
 		site && site.ID ? { siteId: site.ID } : {},
 		{ type: type.replace( 'importer-type-', '' ) },
 		customData ? { customData: replaceUserInfoWithIds( customData ) } : {}

--- a/client/lib/importer/constants.js
+++ b/client/lib/importer/constants.js
@@ -1,4 +1,5 @@
 export const appStates = Object.freeze( {
+	DEFUNCT: 'importer-defunct',
 	DISABLED: 'importer-disabled',
 	IMPORT_FAILURE: 'importer-import-failure',
 	IMPORT_SUCCESS: 'importer-import-success',

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -92,8 +92,13 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 			break;
 
 		case actionTypes.RECEIVE_IMPORT_STATUS:
+			newState = state.setIn( [ 'api', 'isHydrated' ], true );
+
+			if ( action.importerStatus.importerState === appStates.DEFUNCT ) {
+				break;
+			}
+
 			newState = state
-				.setIn( [ 'api', 'isHydrated' ], true )
 				.setIn( [ 'importers', action.importerStatus.importerId ], Immutable.fromJS( action.importerStatus ) );
 			break;
 


### PR DESCRIPTION
Previously when calling the API for getting the list of current imports,
if one had been previously cancelled, it would still show up in the
results from the API call. This led to issues in the UI because it
thought that there were still imports in progress.

This patch changes the behavior so that previously cancelled or stopped
import sessions get ignored in the UI.

cc: @fredrocious @roundhill 