### PR TITLE
Jetpack Sites: Use active modules list added to /me/sites endpoint

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -86,7 +86,7 @@ JetpackSite.prototype.isMainNetworkSite = function() {
 };
 
 JetpackSite.prototype.isModuleActive = function( moduleId ) {
-	return this.modules.includes( moduleId );
+	return this.modules && this.modules.includes( moduleId );
 };
 
 JetpackSite.prototype.verifyModulesActive = function( moduleIds, callback ) {

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -86,7 +86,7 @@ JetpackSite.prototype.isMainNetworkSite = function() {
 };
 
 JetpackSite.prototype.isModuleActive = function( moduleId ) {
-	return this.modules && this.modules.includes( moduleId );
+	return this.modules && this.modules.indexOf( moduleId ) > -1;
 };
 
 JetpackSite.prototype.verifyModulesActive = function( moduleIds, callback ) {

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:site:jetpack' ),
-	find = require( 'lodash/collection/find' );
+var debug = require( 'debug' )( 'calypso:site:jetpack' );
 
 /**
  * Internal dependencies
@@ -27,6 +26,10 @@ function JetpackSite( attributes ) {
 
 JetpackSite.prototype.updateComputedAttributes = function() {
 	JetpackSite.super_.prototype.updateComputedAttributes.apply( this );
+	if ( this.jetpack_modules ) {
+		this.modules = this.jetpack_modules;
+		delete this.jetpack_modules;
+	}
 	this.hasMinimumJetpackVersion = versionCompare( this.options.jetpack_version, config( 'jetpack_min_version' ) ) >= 0;
 	// Only sites that have the minimum Jetpack Version and siteurl matches the main_network_site can update plugins
 	// unmapped_url is more likely to equal main_network_site because they should both be set to siteurl option
@@ -46,7 +49,7 @@ JetpackSite.prototype.canManage = function() {
 	// for versions 3.4 and higher, canManage can be determined by the state of the Manage Module
 	if ( this.versionCompare( '3.4', '>=' ) ) {
 		// if we haven't fetched the modules yet, we default to true
-		if ( this.modulesFetched ) {
+		if ( this.modules ) {
 			return this.isModuleActive( 'manage' );
 		}
 		return true;
@@ -72,32 +75,6 @@ JetpackSite.prototype.fetchAvailableUpdates = function() {
 	}.bind( this ) );
 };
 
-JetpackSite.prototype.fetchModules = function() {
-	if ( ! this.hasMinimumJetpackVersion || this.fetchingModules ) {
-		return;
-	}
-
-	this.fetchingModules = true;
-	wpcom.undocumented().jetpackModules( this.ID, function( error, data ) {
-		if ( error || ! data.modules ) {
-			debug( 'error fetching Modules data from api', error );
-			return;
-		}
-
-		this.fetchingModules = false;
-		this.modulesFetched = true;
-		this.set( { modules: data.modules } );
-		this.emit( 'change' );
-	}.bind( this ) );
-};
-
-JetpackSite.prototype.getModule = function( moduleId ) {
-	if ( this.modulesFetched ) {
-		return find( this.modules, { id: moduleId } );
-	}
-	this.fetchModules();
-};
-
 JetpackSite.prototype.isSecondaryNetworkSite = function() {
 	return this.options.is_multi_site &&
 		this.options.unmapped_url !== this.options.main_network_site;
@@ -109,13 +86,7 @@ JetpackSite.prototype.isMainNetworkSite = function() {
 };
 
 JetpackSite.prototype.isModuleActive = function( moduleId ) {
-	var module = this.getModule( moduleId );
-
-	if ( module ) {
-		return module.active;
-	}
-
-	return false;
+	return this.modules.includes( moduleId );
 };
 
 JetpackSite.prototype.verifyModulesActive = function( moduleIds, callback ) {
@@ -123,12 +94,6 @@ JetpackSite.prototype.verifyModulesActive = function( moduleIds, callback ) {
 
 	if ( ! Array.isArray( moduleIds ) ) {
 		moduleIds = [ moduleIds ];
-	}
-
-	if ( ! this.modulesFetched ) {
-		this.fetchModules();
-		this.once( 'change', this.verifyModulesActive.bind( this, moduleIds, callback ) );
-		return;
 	}
 
 	modulesActive = moduleIds.every( function( moduleId ) {
@@ -152,8 +117,8 @@ JetpackSite.prototype.handleError = function( error, action, plugin, module ) {
 		return;
 	}
 
-	if ( module && module.name ) {
-		moduleTranslationArgs = { args: { module: module.name, site: this.domain } };
+	if ( module ) {
+		moduleTranslationArgs = { args: { module: module, site: this.domain } };
 	}
 
 	remoteManagementUrl = this.getRemoteManagementURL();
@@ -249,63 +214,53 @@ JetpackSite.prototype.callHome = function() {
 };
 
 JetpackSite.prototype.activateModule = function( moduleId, callback ) {
-	var module = this.getModule( moduleId );
 	debug( 'activate module', moduleId );
 
-	if ( ! module.id ) {
+	if ( ! moduleId ) {
 		callback && callback( new Error( 'No id' ) );
 		return;
 	}
 
-	if ( module.active ) {
+	if ( this.isModuleActive( moduleId ) ) {
 		// Nothing to do
 		callback();
 		return;
 	}
 
-	this.toggleModule( module, callback );
+	this.toggleModule( moduleId, callback );
 };
 
 JetpackSite.prototype.deactivateModule = function( moduleId, callback ) {
-	var module = this.getModule( moduleId );
 	debug( 'deactivate module', moduleId );
 
-	if ( ! module.id ) {
-		callback && callback( new Error( 'No id' ) );
-		return;
-	}
-
-	if ( ! module.active ) {
+	if ( ! this.isModuleActive( moduleId ) ) {
 		// Nothing to do
 		callback();
 		return;
 	}
 
-	this.toggleModule( module, callback );
+	this.toggleModule( moduleId, callback );
 };
 
-JetpackSite.prototype.toggleModule = function( module, callback ) {
-	var method;
+JetpackSite.prototype.toggleModule = function( moduleId, callback ) {
+	const isActive = this.isModuleActive( moduleId ),
+		method = isActive ? 'jetpackModulesDeactivate' : 'jetpackModulesActivate',
+		prevActiveModules = Object.assign( {}, this.modules );
 
-	if ( typeof module === 'string' ) {
-		module = this.getModule( module );
+	if ( isActive ) {
+		this.modules = this.modules.filter( module => module !== moduleId );
+	} else {
+		this.modules = [ ...this.modules, moduleId ];
 	}
-
-	method = module.active ? 'jetpackModulesDeactivate' : 'jetpackModulesActivate';
-
-	wpcom.undocumented()[ method ]( this.ID, module.id, function( error, data ) {
-		debug( 'module toggled', this.URL, module.id, data );
+	wpcom.undocumented()[ method ]( this.ID, moduleId, function( error, data ) {
+		debug( 'module toggled', this.URL, moduleId, data );
 
 		if ( error ) {
 			debug( 'error toggling module from api', error );
+			this.modules = prevActiveModules;
 			this.emit( 'change' );
-			callback && callback( error );
-			return;
 		}
-
-		module.active = ! module.active;
-		this.emit( 'change' );
-		callback && callback( null, data );
+		callback && callback( error, data );
 	}.bind( this ) );
 
 	this.emit( 'change' );

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -459,7 +459,7 @@ SitesList.prototype.getSelectedOrAllJetpackCanManage = function() {
 		return site.jetpack &&
 			site.capabilities &&
 			site.capabilities.manage_options &&
-			( ! site.modules || site.canManage() );
+			site.canManage();
 	} );
 };
 

--- a/client/my-sites/menus/main.jsx
+++ b/client/my-sites/menus/main.jsx
@@ -220,7 +220,7 @@ var Menus = React.createClass( {
 			site = this.props.site,
 			menu;
 
-		if ( site && site.jetpack && site.modulesFetched && ! site.canManage() ) {
+		if ( site && site.jetpack && ! site.canManage() ) {
 			return this.renderJetpackManageDisabledMessage( site );
 		}
 

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -182,15 +182,6 @@ controller = {
 		renderPluginsBrowser( context, siteUrl );
 	},
 
-	jetpackManageActive: function( context, next ) {
-		sites.getSelectedOrAll().forEach( function( site ) {
-			if ( site.jetpack ) {
-				site.fetchModules();
-			}
-		} );
-		next();
-	},
-
 	jetpackCanUpdate: function( filter, context, next ) {
 		let redirectToPlugins = false,
 			selectedSites = sites.getSelectedOrAllWithPlugins();

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -17,10 +17,10 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'manage/plugins' ) ) {
-		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.jetpackManageActive, pluginsController.plugins.bind( null, 'all' ) );
+		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
 		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {
-			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackManageActive, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
+			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
 		} );
-		page( '/plugins/:plugin/:business_plugin?/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackManageActive, pluginsController.plugin );
+		page( '/plugins/:plugin/:business_plugin?/:site_id?', controller.siteSelection, controller.navigation, pluginsController.plugin );
 	}
 };

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -775,9 +775,7 @@ export default React.createClass( {
 			);
 		}
 
-		if ( selectedSite &&
-				selectedSite.modulesFetched &&
-				! selectedSite.canManage() ) {
+		if ( selectedSite && ! selectedSite.canManage() ) {
 			return (
 				<Main>
 					<JetpackManageErrorPage

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -303,9 +303,7 @@ export default React.createClass( {
 			return this.getPluginDoesNotExistView( selectedSite );
 		}
 
-		if ( selectedSite &&
-				selectedSite.modulesFetched &&
-				! selectedSite.canManage() ) {
+		if ( selectedSite && ! selectedSite.canManage() ) {
 			return (
 				<MainComponent>
 					<JetpackManageErrorPage

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -238,7 +238,7 @@ module.exports = React.createClass( {
 	render() {
 		const selectedSite = this.props.sites.getSelectedSite();
 		if ( this.state.accessError ||
-				( selectedSite && selectedSite.modulesFetched && ! selectedSite.canManage() )
+				( selectedSite && ! selectedSite.canManage() )
 			) {
 			return this.renderAccessError( selectedSite );
 		}

--- a/client/my-sites/plugins/plugins-manage-mixin.js
+++ b/client/my-sites/plugins/plugins-manage-mixin.js
@@ -7,11 +7,7 @@ module.exports = {
 		if ( ! selectedSite ) {
 			return true;
 		}
-		if ( ! selectedSite || ! selectedSite.modulesFetched ) {
-			return true;
-		}
-		if ( ! selectedSite.getModule( 'manage' ) ||
-				! selectedSite.getModule( 'manage' ).active ) {
+		if ( ! selectedSite.isModuleActive( 'manage' ) ) {
 			return false;
 		}
 		return true;

--- a/client/my-sites/site-settings/form-base.js
+++ b/client/my-sites/site-settings/form-base.js
@@ -121,7 +121,7 @@ module.exports = {
 						error,
 						this.props.site.isModuleActive( module ) ? 'deactivateModule' : 'activateModule',
 						{},
-						this.props.site.getModule( module )
+						module
 					);
 				} else {
 					if( 'protect' === module ) {

--- a/client/my-sites/site-settings/section-security.jsx
+++ b/client/my-sites/site-settings/section-security.jsx
@@ -35,7 +35,7 @@ module.exports = React.createClass( {
 			);
 		}
 
-		if ( site.modulesFetched && ! site.canManage() ) {
+		if ( ! site.canManage() ) {
 			return (
 				<JetpackManageErrorPage
 					template="optInManage"

--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -97,8 +97,6 @@ module.exports = React.createClass( {
 			return;
 		}
 
-		this.props.site.fetchModules();
-
 		// Refresh the list of connections so that the user is given the latest
 		// possible state.  Also prevents a possible infinite loading state due
 		// to connections previously returning a 400 error

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -63,11 +63,6 @@ module.exports = React.createClass( {
 			MediaActions.setLibrarySelectedItems( nextProps.site.ID, [] );
 		}
 
-		if ( nextProps.site && nextProps.site.jetpack && ! nextProps.site.modulesFetched &&
-				( ! this.props.site || this.props.site.ID !== nextProps.site.ID ) ) {
-			nextProps.site.fetchModules();
-		}
-
 		if ( ! nextProps.visible || this.props.visible === nextProps.visible ) {
 			return;
 		}
@@ -76,11 +71,6 @@ module.exports = React.createClass( {
 	},
 
 	componentDidMount: function() {
-		var site = this.props.site;
-		if ( site && site.jetpack && ! site.modulesFetched ) {
-			site.fetchModules();
-		}
-
 		debug( '%s component mounted.', this.constructor.name );
 
 		this.statsTracking = {};
@@ -304,7 +294,7 @@ module.exports = React.createClass( {
 				action: 'confirm',
 				label: this.translate( 'Continue' ),
 				isPrimary: true,
-				disabled: isDisabled || ! this.props.site || ( this.props.site.jetpack && ! this.props.site.modulesFetched ),
+				disabled: isDisabled || ! this.props.site,
 				onClick: this.setView.bind( this, ModalViews.GALLERY )
 			} );
 		} else {

--- a/shared/my-sites/themes/main.jsx
+++ b/shared/my-sites/themes/main.jsx
@@ -109,7 +109,7 @@ var Themes = React.createClass( {
 			return <JetpackUpgradeMessage site={ site } />;
 		}
 
-		if ( isJetpack && jetpackEnabled && site.modulesFetched && ! site.canManage() ) {
+		if ( isJetpack && jetpackEnabled && ! site.canManage() ) {
 			return <JetpackManageDisabledMessage site={ site } />;
 		}
 


### PR DESCRIPTION
Use `jetpack_modules` list of active modules recently added to `/me/sites` endpoint, instead of fetching the list of modules on individual requests.

__How to test__

* Check this branch
* Test all the things!!!

cc @mtias @jkudish @aduth @enejb