### PR TITLE
Help: Implement a loading placeholder the contact form

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -257,7 +257,19 @@ module.exports = React.createClass( {
 		}
 
 		if ( ! ( olark.isOlarkReady && sitesInitialized ) ) {
-			return <div className="help-contact__placeholder" />;
+
+			return (
+				<div className="help-contact__placeholder">
+					<h4 className="help-contact__header">Loading contact form</h4>
+					<div className="help-contact__textarea" />
+
+					<h4 className="help-contact__header">Loading contact form</h4>
+					<div className="help-contact__textarea" />
+
+					<h4 className="help-contact__header">Loading contact form</h4>
+					<div className="help-contact__textarea" />
+				</div>
+			);
 		}
 
 		if ( olark.details.isConversing && olark.isOperatorAvailable ) {

--- a/client/me/help/help-contact/style.scss
+++ b/client/me/help/help-contact/style.scss
@@ -1,5 +1,17 @@
 .help-contact__placeholder {
-	@include placeholder();
-	height: 237px;
-	width: 100%;
+	color: transparent;
+
+	.help-contact__header {
+		@include placeholder();
+		background-color: lighten( $gray, 30% );
+		height: 18px;
+		margin-bottom: 2px;
+		width: 150px;
+	}
+	.help-contact__textarea {
+		@include placeholder();
+		background-color: lighten( $gray, 30% );
+		height: 50px;
+		margin-bottom: 32px;
+	}
 }


### PR DESCRIPTION
When loading the contact form, we have to fetch information about the availability of chat. The loading screen isn't very useful right now, as described in #515. Here's what it looks like:

![loading](https://cloud.githubusercontent.com/assets/8658164/11339823/3cdaf572-91f3-11e5-82b8-4847fe1568bc.png)

A user who sees this screen might reasonably think that something's broken. To repro:

1. Go to http://calypso.localhost:3000/help/contact
2. Observe the blinking placeholder

This PR attempts to improve the UX by adding some placeholder form controls and styles to more closely mirror similar loading experiences elsewhere in the product. Here it is in action:

![chat-loading](https://cloud.githubusercontent.com/assets/2738252/11854271/c60f488c-a410-11e5-9054-2322278263f2.gif)

Cc @folletto since you had kindly offered feedback on #515. Cc @omarjackman.