### PR TITLE
Domain Management: Fix compact notice margins in domains list

### DIFF
--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -111,9 +111,8 @@
 		text-transform: uppercase;
 	}
 
-	.flag {
-		cursor: pointer;
-		margin: 0 0 0 5px;
+	.notice {
+		margin: 0 0 0 8px;
 	}
 }
 


### PR DESCRIPTION
Fixes the missing margin from the new compact notices in the domains list.

Before | After
------------ | -------------
<img width="304" alt="screen_shot_2015-12-16_at_1_39_48_pm" src="https://cloud.githubusercontent.com/assets/3011211/11854724/b02b0454-a3fa-11e5-81a8-c36796e2b758.png"> | <img width="310" alt="screen_shot_2015-12-16_at_1_38_18_pm" src="https://cloud.githubusercontent.com/assets/3011211/11854723/b00fa8bc-a3fa-11e5-8017-0d78a32cf739.png">

cc: @aidvu 