### PR TITLE
Help: Fix linter warnings and simplify logic around tracking the offline form event

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -135,7 +135,6 @@ module.exports = React.createClass( {
 			} );
 
 			analytics.tracks.recordEvent( 'calypso_help_contact_submit', { ticket_type: 'kayako' } );
-
 		} );
 	},
 
@@ -211,16 +210,14 @@ module.exports = React.createClass( {
 	},
 
 	onOperatorsAway: function() {
-		const { isOlarkReady, isUserEligible, details } = this.state.olark;
-		const showChatVariation = isUserEligible && details.isOperatorAvailable;
-		const showKayakoVariation = ! showChatVariation && ( details.isConversing || isUserEligible );
-		const showForumsVariation = ! ( showChatVariation || showKayakoVariation );
+		const { details } = this.state.olark;
 
 		if ( ! details.isConversing ) {
 			analytics.tracks.recordEvent( 'calypso_help_offline_form_display', {
-				form_type: showKayakoVariation ? 'kayako' : 'forum'
+				form_type: 'kayako'
 			} );
 		}
+
 		this.showOperatorAvailabilityNotice( false );
 	},
 


### PR DESCRIPTION
I saw some linter warnings after a rebase and then decided to fix them and try to simplify the logic here a bit.

**How to test**
*Target a group where there is only one operator and make sure the operator is available. Also enable `calyspo:analytics` debugging*
1. Navigate to http://calypso.localhost:3000/help/contact
2. Notice the "Chat with us" variation of the contact form.
3. Set the olark operator to away.
4. You should notice that the form has changed to the "Submit support ticket" variation.
5. Also notice in the javascript console that an event has been recorded for `calypso_help_offline_form_display` with a form_type of "kayako".

**What to expect**
![screen shot 2015-12-16 at 6 18 00 pm](https://cloud.githubusercontent.com/assets/1854440/11856813/62b74e68-a421-11e5-8610-880842a3a8bc.png)


