### PR TITLE
Free Trials: Add expiring state to `PlanStatus`

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+export function getDaysUntilUserFacingExpiry( plan ) {
+	const { userFacingExpiryMoment } = plan;
+
+	return userFacingExpiryMoment.diff( moment(), 'days' );
+};

--- a/client/my-sites/plans/plan-overview/plan-status/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/index.jsx
@@ -12,7 +12,6 @@ import Button from 'components/button';
 import { cartItems } from 'lib/cart-values';
 import CompactCard from 'components/card/compact';
 import PlanStatusProgress from './progress';
-import ProgressBar from 'components/progress-bar';
 import { isPremium, isBusiness } from 'lib/products-values';
 import * as upgradesActions from 'lib/upgrades/actions';
 

--- a/client/my-sites/plans/plan-overview/plan-status/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/index.jsx
@@ -11,6 +11,7 @@ import page from 'page';
 import Button from 'components/button';
 import { cartItems } from 'lib/cart-values';
 import CompactCard from 'components/card/compact';
+import { getDaysUntilUserFacingExpiry } from 'lib/plans';
 import PlanStatusProgress from './progress';
 import { isPremium, isBusiness } from 'lib/products-values';
 import * as upgradesActions from 'lib/upgrades/actions';
@@ -57,6 +58,7 @@ const PlanStatus = React.createClass( {
 					</div>
 
 					<Button
+						primary={ getDaysUntilUserFacingExpiry( this.props.plan ) < 6 }
 						className="plan-status__button"
 						onClick={ this.purchasePlan }>
 						{ this.translate( 'Purchase Now' ) }

--- a/client/my-sites/plans/plan-overview/plan-status/progress.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/progress.jsx
@@ -1,15 +1,14 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import classNames from 'classnames';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
 import ProgressBar from 'components/progress-bar';
-import { isPremium, isBusiness } from 'lib/products-values';
 
 const PlanStatusProgress = React.createClass( {
 	propTypes: {
@@ -49,10 +48,14 @@ const PlanStatusProgress = React.createClass( {
 	},
 
 	render() {
+		const classes = classNames( 'plan-status__progress', {
+			'is-expiring': this.getDaysUntilExpiry() < 6
+		} );
+
 		return (
 			<CompactCard>
-				<div className="plan-status__progress">
-					<div className="plan-status__time-until-expiry">
+				<div className={ classes }>
+					<div className="plan-status__progress-time-until-expiry">
 						{ this.renderDaysRemaining() }
 					</div>
 

--- a/client/my-sites/plans/plan-overview/plan-status/progress.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/progress.jsx
@@ -8,6 +8,7 @@ import React from 'react';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
+import { getDaysUntilUserFacingExpiry } from 'lib/plans';
 import ProgressBar from 'components/progress-bar';
 
 const PlanStatusProgress = React.createClass( {
@@ -15,17 +16,11 @@ const PlanStatusProgress = React.createClass( {
 		plan: React.PropTypes.object.isRequired
 	},
 
-	getDaysUntilExpiry() {
-		const { userFacingExpiryMoment } = this.props.plan;
-
-		return userFacingExpiryMoment.diff( this.moment(), 'days' );
-	},
-
 	renderProgressBar() {
-		const { subscribedMoment, userFacingExpiryMoment } = this.props.plan,
+		const { plan, plan: { subscribedMoment, userFacingExpiryMoment } } = this.props,
 			// we strip the hour/minute/second/millisecond data here from `subscribed_date` to match `expiry`
 			trialPeriodInDays = userFacingExpiryMoment.diff( subscribedMoment, 'days' ),
-			timeUntilExpiryInDays = this.getDaysUntilExpiry(),
+			timeUntilExpiryInDays = getDaysUntilUserFacingExpiry( plan ),
 			progress = Math.max( 0.5, trialPeriodInDays - timeUntilExpiryInDays );
 
 		return (
@@ -36,12 +31,14 @@ const PlanStatusProgress = React.createClass( {
 	},
 
 	renderDaysRemaining() {
+		const { plan } = this.props;
+
 		return this.translate(
-			'%(daysUntilExpiry)s day remaining',
-			'%(daysUntilExpiry)s days remaining',
+			'%(daysUntilExpiry)d day remaining',
+			'%(daysUntilExpiry)d days remaining',
 			{
-				args: { daysUntilExpiry: this.getDaysUntilExpiry() },
-				count: this.getDaysUntilExpiry(),
+				args: { daysUntilExpiry: getDaysUntilUserFacingExpiry( plan ) },
+				count: getDaysUntilUserFacingExpiry( plan ),
 				context: 'The amount of time until the trial plan expires, e.g. "5 days remaining"'
 			}
 		);
@@ -49,7 +46,7 @@ const PlanStatusProgress = React.createClass( {
 
 	render() {
 		const classes = classNames( 'plan-status__progress', {
-			'is-expiring': this.getDaysUntilExpiry() < 6
+			'is-expiring': getDaysUntilUserFacingExpiry( this.props.plan ) < 6
 		} );
 
 		return (

--- a/client/my-sites/plans/plan-overview/plan-status/style.scss
+++ b/client/my-sites/plans/plan-overview/plan-status/style.scss
@@ -59,10 +59,20 @@
 	display: flex;
 	flex-wrap: wrap;
 	margin-left: -24px;
+
+	&.is-expiring {
+		.plan-status__progress-time-until-expiry {
+			color: $alert-red;
+		}
+
+		.progress-bar__progress {
+			background-color: $alert-red;
+		}
+	}
 }
 
 .plan-status__progress-bar,
-.plan-status__time-until-expiry {
+.plan-status__progress-time-until-expiry {
 	margin-left: 24px;
 }
 
@@ -70,7 +80,7 @@
 	flex: 1 0 6em;
 }
 
-.plan-status__time-until-expiry {
+.plan-status__progress-time-until-expiry {
 	font-weight: 700;
 
 	@include breakpoint( "<480px" ) {


### PR DESCRIPTION
Fixes part of #1151.

This PR updates the render() of `PlanStatus` and its child, `PlanStatusProgress`, to display a red progress bar/'days remaining' text and a primary 'Purchase Now' button if the trial expires within five days.

![screen shot 2015-12-16 at 3 03 54 pm](https://cloud.githubusercontent.com/assets/1130674/11856547/7be15322-a406-11e5-875c-8653a09fdee1.png)

**Testing**
- Visit http://calypso.localhost:3000/plans/:site and add a premium or business trial to a site.
- Update the expiry of the free trial subscription to less than eight days in the future.
- Visit http://calypso.localhost:3000/plans/:site and assert that you see the expiring state like in the screenshot above.

**Review**
- [x] Code
- [x] Product
