### PR TITLE
Signup: Change the start date of `autoFillUsernameSignup`

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -82,7 +82,7 @@ module.exports = {
 		defaultVariation: 'main'
 	},
 	autoFillUsernameSignup: {
-		datestamp: '20151201',
+		datestamp: '20151216',
 		variations: {
 			autoFill: 50,
 			dontAutoFill: 50


### PR DESCRIPTION
This was previously stale. The test starts today, 2015/12/16.

cc @scruffian 