### PR TITLE
Fixes editor-title overlapping on editor__header

### DIFF
--- a/client/post-editor/editor-title/style.scss
+++ b/client/post-editor/editor-title/style.scss
@@ -1,5 +1,6 @@
 .editor-title {
 	position: relative;
+	top: 2px;
 
 	&:not( .is-focused ):not( .is-loading )::after {
 		@include long-content-fade( $color: $white );


### PR DESCRIPTION
Fixes [#1681](https://github.com/Automattic/wp-calypso/issues/1681)

cc @apeatling 

This PR adds a slight modification to `.editor-title` to fix the overlapping defect found on Safari. A quick run through on the Responsive Design Mode available in Safari shows fixes on mobile devices. Actually testing on mobile devices did not occur. 

There might be a larger issue at hand though, as the padding between `editor-title` and `editor__header` vary greatly between Chrome and Safari. Thoughts?

**Before**

<img width="713" alt="screen shot 2015-12-16 at 4 00 00 pm" src="https://cloud.githubusercontent.com/assets/4613917/11857364/c95c5eb8-a414-11e5-95ca-9bc86d668227.png">


**After**

<img width="734" alt="screen shot 2015-12-16 at 3 59 22 pm" src="https://cloud.githubusercontent.com/assets/4613917/11857371/d69a5562-a414-11e5-9033-69d93002f5ba.png">


**For reference, here's what Chrome looks like**

<img width="711" alt="screen shot 2015-12-16 at 4 49 16 pm" src="https://cloud.githubusercontent.com/assets/4613917/11857389/08b01d02-a415-11e5-8e51-4f04c534b900.png">

