### PR TITLE
Fixes the title blur not covering the entire title

### DIFF
--- a/client/post-editor/editor-title/style.scss
+++ b/client/post-editor/editor-title/style.scss
@@ -33,6 +33,7 @@
 
 .editor-title__input[type="text"] {
 	margin-left: 16px;
+	padding-right: 16px;
 	border: none;
 	font-family: $serif;
 	font-size: 28px;


### PR DESCRIPTION
Fixes [#1680](https://github.com/Automattic/wp-calypso/issues/1680)

cc @apeatling 

The original issue noted this occurs on Safari, but I found it to exist on many breakpoints in the realm of mobile phone sizes. Adding more padding to `.editor-title_input[type="text"]` ultimately solved the defect. I tried looking around for more examples of title blur, but only found less than a handful. If this appears on more than just blog post titles and page titles that don't appear to be fixed, let me know. Ready for review!

**Before**
![_before](https://cloud.githubusercontent.com/assets/4613917/11858621/57f5e1ac-a420-11e5-9ed7-790994c8376d.jpg)

**After**
![_after](https://cloud.githubusercontent.com/assets/4613917/11858626/5e2c5e70-a420-11e5-99b9-9d716b89bef8.jpg)

