### PR TITLE
Help: Fix chat ended experience

### DIFF
--- a/client/lib/olark-events/index.js
+++ b/client/lib/olark-events/index.js
@@ -69,16 +69,16 @@ var OlarkEventEmitter = {
 		boundEvents[ event ] = true;
 
 		// Listen to the olark api event
-		olarkApi( event, () => this.olarkEventListener( event ) );
+		olarkApi( event, ( ...args ) => this.olarkEventListener( event, ...args ) );
 	},
 
 	/**
 	 * Our generic callback that proxies the event fired by olark to our listeners. This method should not be called directly
 	 * @param  {string} event The olark api event
 	 */
-	olarkEventListener: function( event, ...eventArguments ) {
+	olarkEventListener: function( event, ...args ) {
 		debug( 'Olark event: %s', event );
-		this.emit( event, eventArguments );
+		this.emit( event, ...args );
 	}
 };
 

--- a/client/lib/olark-store/actions.js
+++ b/client/lib/olark-store/actions.js
@@ -45,6 +45,13 @@ const olarkActions = {
 		} );
 	},
 
+	setExpanded( isOlarkExpanded ) {
+		dispatcher.handleServerAction( {
+			isOlarkExpanded,
+			type: ActionTypes.OLARK_SET_EXPANDED
+		} );
+	},
+
 	updateDetails() {
 		olarkApi( 'api.visitor.getDetails', ( details ) => {
 			dispatcher.handleServerAction( {
@@ -52,6 +59,10 @@ const olarkActions = {
 				type: ActionTypes.OLARK_DETAILS,
 			} );
 		} );
+	},
+
+	sendNotificationToVisitor( body ) {
+		olarkApi( 'api.chat.sendNotificationToVisitor', { body } );
 	},
 
 	sendNotificationToOperator( body ) {

--- a/client/lib/olark-store/constants.js
+++ b/client/lib/olark-store/constants.js
@@ -13,4 +13,5 @@ export const action = keyMirror( {
 	OLARK_DETAILS: null,
 	OLARK_LOCALE: null,
 	OLARK_USER_ELIGIBILITY: null,
+	OLARK_SET_EXPANDED: null
 } );

--- a/client/lib/olark-store/index.js
+++ b/client/lib/olark-store/index.js
@@ -11,6 +11,7 @@ const initialState = {
 	isOperatorAvailable: false,
 	isOlarkReady: false,
 	isUserEligible: false,
+	isOlarkExpanded: false,
 	locale: 'en',
 	details: {}
 };
@@ -34,6 +35,9 @@ const olarkStore = createReducerStore( function( state, payload ) {
 			break;
 		case ActionTypes.OLARK_OPERATORS_AVAILABLE:
 			stateChanges = { isOperatorAvailable: true };
+			break;
+		case ActionTypes.OLARK_SET_EXPANDED:
+			stateChanges = { isOlarkExpanded: action.isOlarkExpanded };
 			break;
 		case ActionTypes.OLARK_DETAILS:
 			stateChanges = { details: action.details };


### PR DESCRIPTION
## Fix "chat has ended" experience.
This pull request aims to fix the jarring experience a user might have when a chat has ended and there are no operators available. 

#### Whats changed
* Removed the operator availability notifications that currently show up inside of the olark chat widget.
* Added calypso notifications to indicate olark operator availability when the chatbox is expanded or while viewing the contact form.
* Show a notification within the olark widget immediately after an operator sends the `!end` command.
* Allow the calypso notices to be dismissed.

#### How to test
*Note: You must be in a group that has one operator*
1. Navigate to http://calypso.localhost:3000/help/contact
2. Start a chat
3. Leave the contact form by clicking on any link in the sidebar.
4. Have the operator end the chat with the `!end` command.
5. Have the operator set them self as "Away" in olark.
6. Notice that the notification that operators went away now appears.
7. Have the operator set them self as "Available" in olark.
8. Notice that the notificaiton appears again saying that operators have returned.
9. Collapse the olark widget and repeat steps 5 and 7. Notice that no availability messages were displayed because the olark widget is collapsed.

**Before**
![screen shot 2015-12-17 at 4 50 46 am](https://cloud.githubusercontent.com/assets/1854440/11866535/ced23286-a479-11e5-97e2-02d896b3d7b1.png)

![screen shot 2015-12-17 at 2 43 58 am](https://cloud.githubusercontent.com/assets/1854440/11864148/25642f44-a468-11e5-813a-56064a24e73a.png)

![screen shot 2015-12-17 at 2 44 15 am](https://cloud.githubusercontent.com/assets/1854440/11864150/2a61469e-a468-11e5-8642-2f14ab6b7394.png)


**After**
![screen shot 2015-12-17 at 2 06 56 pm](https://cloud.githubusercontent.com/assets/1854440/11879290/73c36d48-a4c8-11e5-837d-60dc3981a8a7.png)

![screen shot 2015-12-17 at 4 28 45 am](https://cloud.githubusercontent.com/assets/1854440/11866199/79efdc70-a477-11e5-8356-880d2cfcf321.png)

![screen shot 2015-12-17 at 4 32 54 am](https://cloud.githubusercontent.com/assets/1854440/11866207/89013006-a477-11e5-8996-b4eb25db2221.png)

![screen shot 2015-12-17 at 2 40 10 am](https://cloud.githubusercontent.com/assets/1854440/11864061/ab4da2bc-a467-11e5-8694-13ec8995d1ff.png)

Fixes #1340
Fixes #1341
Fixes #1337