### PR TITLE
Me: Fix disabled verfication buttons on mobile

### DIFF
--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -15,7 +15,8 @@ var FormButton = require( 'components/forms/form-button' ),
 	Notice = require( 'components/notice' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
 	analytics = require( 'analytics' ),
-	constants = require( 'me/constants' );
+	constants = require( 'me/constants' ),
+	FormButtonsBar = require( 'components/forms/form-buttons-bar' );
 
 module.exports = React.createClass( {
 
@@ -230,51 +231,52 @@ module.exports = React.createClass( {
 					}
 					{ this.possiblyRenderError() }
 				</FormFieldset>
+				<FormButtonsBar className="security-2fa-code-prompt__buttons-bar">
+					<FormButton
+						className="security-2fa-code-prompt__verify-code"
+						disabled={ this.getFormDisabled() }
+						onClick={ function() {
+							analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Code Prompt Verify Button' );
+						} }
+					>
+						{ this.getSubmitButtonLabel() }
+					</FormButton>
 
-				<FormButton
-					className="security-2fa-code-prompt__verify-code"
-					disabled={ this.getFormDisabled() }
-					onClick={ function() {
-						analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Code Prompt Verify Button' );
-					} }
-				>
-					{ this.getSubmitButtonLabel() }
-				</FormButton>
+					{
+						this.props.showSMSButton
+						? (
+							<FormButton
+								className="security-2fa-code-prompt__send-code"
+								disabled={ ! this.state.codeRequestsAllowed }
+								isPrimary={ false }
+								onClick={ function( event ) {
+									analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Code Prompt Send Code Via SMS Button' );
+									this.onRequestCode( event );
+								}.bind( this ) }
+							>
+								{ this.state.codeRequestPerformed ? this.translate( 'Resend Code' ) : this.translate( 'Send Code via SMS' ) }
+							</FormButton>
+						)
+						: null
+					}
 
-				{
-					this.props.showSMSButton
-					? (
-						<FormButton
-							className="security-2fa-code-prompt__send-code"
-							disabled={ ! this.state.codeRequestsAllowed }
-							isPrimary={ false }
-							onClick={ function( event ) {
-								analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Code Prompt Send Code Via SMS Button' );
-								this.onRequestCode( event );
-							}.bind( this ) }
-						>
-							{ this.state.codeRequestPerformed ? this.translate( 'Resend Code' ) : this.translate( 'Send Code via SMS' ) }
-						</FormButton>
-					)
-					: null
-				}
-
-				{
-					this.props.showCancelButton
-					? (
-						<FormButton
-							className="security-2fa-code-prompt__cancel"
-							isPrimary={ false }
-							onClick={ function( event ) {
-								analytics.ga.recordEvent( 'Me', 'Clicked On Disable 2fa Cancel Button' );
-								this.onCancel( event );
-							}.bind( this ) }
-						>
-							{ this.translate( 'Cancel' ) }
-						</FormButton>
-					)
-					: null
-				}
+					{
+						this.props.showCancelButton
+						? (
+							<FormButton
+								className="security-2fa-code-prompt__cancel"
+								isPrimary={ false }
+								onClick={ function( event ) {
+									analytics.ga.recordEvent( 'Me', 'Clicked On Disable 2fa Cancel Button' );
+									this.onCancel( event );
+								}.bind( this ) }
+							>
+								{ this.translate( 'Cancel' ) }
+							</FormButton>
+						)
+						: null
+					}
+				</FormButtonsBar>
 			</form>
 		);
 	}

--- a/client/me/security-2fa-code-prompt/style.scss
+++ b/client/me/security-2fa-code-prompt/style.scss
@@ -1,5 +1,11 @@
 .security-2fa-code-prompt {
-	@include clear-fix;
+
+	.form-fieldset {
+		margin-bottom: 12px;
+	}
+	.button {
+		margin-top: 8px;
+	}
 }
 
 .security-2fa-code-prompt__verify-code {


### PR DESCRIPTION
Fixes some of the mobile button when canceling 2 Factor Authentication

Before:
![screen shot 2015-12-16 at 18 20 40](https://cloud.githubusercontent.com/assets/115071/11860057/8d43c82e-a425-11e5-8534-4e55bf85c5d7.png)

After:
On a screen that is slightly bigger then 480px
![screen shot 2015-12-16 at 18 42 06](https://cloud.githubusercontent.com/assets/115071/11860065/a99a19c4-a425-11e5-8432-691a1216cdae.png)

Smaller then 480px;
![screen shot 2015-12-16 at 18 42 12](https://cloud.githubusercontent.com/assets/115071/11860067/ad50a326-a425-11e5-805a-3fd95595151b.png)


**To test**
Visit http://calypso.localhost:3000/me/security/two-step

This PR implements the styles from decided on here https://github.com/Automattic/wp-calypso/pull/1642

cc: @ebinnion, @MichaelArestad, @rickybanister 
