### PR TITLE
Components: InfiniteList — fix type errors

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -271,7 +271,8 @@ module.exports = React.createClass( {
 
 	boundsForRef: function( ref ) {
 		if ( ref in this.refs ) {
-			return ReactDom.findDOMNode( this.refs[ ref ] ).getBoundingClientRect();
+			const node = this.refs[ ref ];
+			return node.getBoundingClientRect ? node.getBoundingClientRect() : ReactDom.findDOMNode( node ).getBoundingClientRect();
 		}
 		return null;
 	},


### PR DESCRIPTION
In React 0.14, refs to built in types such as `<div>`s are DOM nodes
already, but custom components are not.

findDOMNode doesn't seem to handle built in types well, so we can test
that the ref is probably a DOM node, and use it directly if it is,
otherwise use findDOMNode.

This purports to fix https://github.com/Automattic/wp-calypso/issues/1698

/cc @ockham @mcsf 