### PR TITLE
Help: Track page views while users are chatting with olark operators.

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -320,7 +320,7 @@ function boot() {
 	page( '*', require( 'notices' ).clearNoticesOnNavigation );
 
 	if ( config.isEnabled( 'olark' ) ) {
-		require( 'lib/olark' );
+		page( '*', require( 'lib/olark' ).notifyLocation );
 	}
 
 	if ( config.isEnabled( 'keyboard-shortcuts' ) ) {

--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -21,6 +21,7 @@ import olarkEvents from 'lib/olark-events';
 import olarkStore from 'lib/olark-store';
 import olarkActions from 'lib/olark-store/actions';
 import i18n from 'lib/mixins/i18n';
+import url from 'url';
 
 /**
  * Module variables
@@ -209,6 +210,9 @@ const olark = {
 		debug( 'Nickname: ' + visitorNickname );
 		debug( 'Group: ' + group );
 
+		// system.give_location_to_operator doesn't work well with our app so we do
+		// it our selves using page context in the notifyLocation function
+		olarkApi.configure( 'system.give_location_to_operator', false );
 		olarkApi.configure( 'system.chat_does_not_follow_external_links', true );
 		olarkApi.configure( 'system.mask_credit_cards', true );
 
@@ -392,8 +396,28 @@ const olark = {
 			this.userType = userType;
 			return true;
 		} );
+	},
+
+	notifyLocation( location ) {
+		const { details: { isConversing = false } } = olarkStore.get();
+
+		if ( isConversing ) {
+			return;
+		}
+
+		olarkActions.sendNotificationToOperator( 'looking at ' + location );
 	}
 };
 
 emitter( olark );
 olark.initialize();
+
+export function notifyLocation( context, next ) {
+	// Use context.path here because window.location.href has the previous location and not what the new location will be.
+	const location = url.resolve( url.parse( window.location.href ), context.canonicalPath );
+
+	// queue up the notification for when olark is ready. If its ready this will execute right away.
+	olarkEvents.once( 'api.chat.onReady', () => olark.notifyLocation( location ) );
+
+	next();
+};


### PR DESCRIPTION
This pull request allows Happiness Engineers to see the URL of the page being viewed by the user they are chatting with.

Olark operators will now see something similar to this:

![screen shot 2015-12-17 at 5 56 51 am](https://cloud.githubusercontent.com/assets/1854440/11868046/148b9ea8-a483-11e5-822e-fd98b5f63f15.png)

Fixes #1506