### PR TITLE
Checkout: Credit card payments can be disabled in case of outage

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -118,6 +118,10 @@ function getRefundPolicy( cart ) {
 	return 'genericRefund';
 }
 
+function isCreditCardPaymentsEnabled( cart ) {
+	return cart.allowed_payment_methods.indexOf( 'WPCOM_Billing_MoneyPress_Paygate' ) >= 0;
+}
+
 function isPayPalExpressEnabled( cart ) {
 	return cart.allowed_payment_methods.indexOf( 'WPCOM_Billing_PayPal_Express' ) >= 0;
 }
@@ -133,5 +137,6 @@ module.exports = {
 	getRefundPolicy,
 	isFree,
 	isPaidForFullyInCredits,
-	isPayPalExpressEnabled
+	isPayPalExpressEnabled,
+	isCreditCardPaymentsEnabled
 };

--- a/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
@@ -9,7 +9,7 @@ var assign = require( 'lodash/object/assign' ),
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
-	cartItems = require( 'lib/cart-values' ).cartItems,
+	cartValues = require( 'lib/cart-values' ),
 	CheckoutThankYou = require( './thank-you' ),
 	CountrySelect = require( 'my-sites/upgrades/components/form/country-select' ),
 	Input = require( 'my-sites/upgrades/components/form/input' ),
@@ -114,7 +114,7 @@ module.exports = React.createClass( {
 	},
 
 	renderButtonText: function() {
-		if ( cartItems.hasRenewalItem( this.props.cart ) ) {
+		if ( cartValues.cartItems.hasRenewalItem( this.props.cart ) ) {
 			return this.translate( 'Purchase %(price)s subscription with PayPal', {
 				args: { price: this.props.cart.total_cost_display },
 				context: 'Pay button on /checkout'
@@ -158,8 +158,14 @@ module.exports = React.createClass( {
 						</button>
 						<SubscriptionText cart={ this.props.cart } />
 					</div>
-					
-					<a href="" className="credit-card-payment-box__switch-link" onClick={ this.handleToggle }>{ this.translate( 'or use a credit card', { context: 'Upgrades: PayPal checkout screen', comment: '"Checkout with PayPal -- or use a credit card"' } ) }</a>
+
+					{ cartValues.isCreditCardPaymentsEnabled( this.props.cart ) &&
+						<a href="" className="credit-card-payment-box__switch-link" onClick={ this.handleToggle }>
+							{ this.translate( 'or use a credit card', {
+								context: 'Upgrades: PayPal checkout screen',
+								comment: 'Checkout with PayPal -- or use a credit card'
+							} ) }
+						</a> }
 				</div>
 			</form>
 		);

--- a/client/my-sites/upgrades/checkout/secure-payment-form.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form.jsx
@@ -7,6 +7,7 @@ var React = require( 'react/addons' );
  * Internal dependencies
  */
 var CreditCardPaymentBox = require( './credit-card-payment-box' ),
+	EmptyContent = require( 'components/empty-content' ),
 	FreeTrialConfirmationBox = require( './free-trial-confirmation-box' ),
 	PayPalPaymentBox = require( './paypal-payment-box' ),
 	CreditsPaymentBox = require( './credits-payment-box' ),
@@ -49,9 +50,12 @@ var SecurePaymentForm = React.createClass( {
 			return 'free-trial';
 		} else if ( this.state && this.state.userSelectedPaymentBox ) {
 			return this.state.userSelectedPaymentBox;
-		} else {
-			// Default state
+		} else if ( cartValues.isCreditCardPaymentsEnabled( cart ) ) {
 			return 'credit-card';
+		} else if ( cartValues.isPayPalExpressEnabled( cart ) ) {
+			return 'paypal';
+		} else {
+			return null;
 		}
 	},
 
@@ -74,6 +78,17 @@ var SecurePaymentForm = React.createClass( {
 	},
 
 	render: function() {
+		if ( this.state.visiblePaymentBox === null ) {
+			return (
+				<EmptyContent
+					illustration='/calypso/images/drake/drake-500.svg'
+					title={ this.translate( 'Checkout is not available' ) }
+					line={ this.translate( "We're hard at work on the issue. Please check back shortly." ) }
+					action={ this.translate( 'Back to Plans' ) }
+					actionURL={ '/plans/' + this.props.selectedSite.slug } />
+			);
+		}
+
 		return (
 			<div className="secure-payment-form">
 				<CreditsPaymentBox
@@ -161,12 +176,11 @@ var SecurePaymentForm = React.createClass( {
 				// We do nothing here because PayPal transactions don't go through the
 				// `store-transactions` module.
 				break;
-
-			default:
-				throw new Error( 'Not implemented' );
 		}
 
-		upgradesActions.setPayment( newPayment );
+		if ( newPayment ) {
+			upgradesActions.setPayment( newPayment );
+		}
 	},
 
 	selectPaymentBox: function( paymentBox ) {


### PR DESCRIPTION
Follow up of #635. 

If no payment method is available, checkout looks like this:

![image](https://cloud.githubusercontent.com/assets/203105/11872177/3cb08104-a4d4-11e5-9ea1-3b0028c91a9a.png)

This needs D742-code to be applied first. Testing instructions are in the backend diff.