### PR TITLE
SectionHeader: remove redundant styles for <Count>.

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -23,8 +23,6 @@
 
 	.count {
 		margin-left: 8px;
-		opacity: 0.5;
-		font-size: 11px;
 	}
 }
 


### PR DESCRIPTION
Gets rid of the opacity value and the font-size, which is already set:

![image](https://cloud.githubusercontent.com/assets/548849/11873064/fcf7d760-a4d8-11e5-8f09-52be439a2e6f.png)
