### PR TITLE
Framework: fix AllSites selection flow via site-selector.

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -185,7 +185,7 @@ module.exports = React.createClass( {
 					key="selector-all-sites"
 					sites={ this.props.sites }
 					href={ allSitesPath }
-					onSelect={ this.closeSelector }
+					onSelect={ this.onSiteSelect.bind( this, null ) }
 					isSelected={ ! this.props.sites.selected }
 				/>
 			);


### PR DESCRIPTION
We weren't triggering the whole function, which means `<Picker>` wasn't properly changing the `layout-focus` and you could end up stuck with the picker open when trying to switch to all-sites.

cc @rralian @aduth 

By the way, I think there may be some optimizations to be done here in the order and computations done. Switching a site seems a bit slower than what it should be for me.