### PR TITLE
Domain Management: Add onclick back for the privacy protection compact notice

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import page from 'page';
 import React from 'react';
 
 /**
@@ -61,8 +60,13 @@ const RegisteredDomain = React.createClass( {
 			);
 		}
 
+		const path = paths.domainManagementPrivacyProtection(
+			this.props.selectedSite.domain,
+			this.props.domain.name
+		);
+
 		return (
-			<a href="#" onClick={ this.goToPrivacyProtection }>
+			<a href={ path } onClick={ this.recordEvent( 'noneClick', this.props.domain ) }>
 				<Notice
 					isCompact
 					status="is-warning"
@@ -197,12 +201,6 @@ const RegisteredDomain = React.createClass( {
 				{ this.getVerticalNav() }
 			</div>
 		);
-	},
-
-	goToPrivacyProtection() {
-		this.recordEvent( 'noneClick', this.props.domain );
-
-		page( paths.domainManagementPrivacyProtection( this.props.selectedSite.domain, this.props.domain.name ) );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -42,8 +42,13 @@ const RegisteredDomain = React.createClass( {
 
 	getPrivacyProtection() {
 		if ( this.props.domain.hasPrivacyProtection ) {
+			const path = paths.domainManagementContactsPrivacy(
+				this.props.selectedSite.domain,
+				this.props.domain.name
+			);
+
 			return (
-				<a href="#" onClick={ this.goToPrivacyProtection }>
+				<a href={ path }>
 					<Notice
 						isCompact
 						status="is-success"

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -43,27 +43,30 @@ const RegisteredDomain = React.createClass( {
 	getPrivacyProtection() {
 		if ( this.props.domain.hasPrivacyProtection ) {
 			return (
-				<Notice
-					isCompact
-					status="is-success"
-					icon="lock">
-					{ this.translate( 'On', {
-						context: 'An icon label when Privacy Protection is enabled.'
-					} ) }
-				</Notice>
+				<a href="#" onClick={ this.goToPrivacyProtection }>
+					<Notice
+						isCompact
+						status="is-success"
+						icon="lock">
+						{ this.translate( 'On', {
+							context: 'An icon label when Privacy Protection is enabled.'
+						} ) }
+					</Notice>
+				</a>
 			);
 		}
 
 		return (
-			<Notice
-				isCompact
-				status="is-warning"
-				icon="notice"
-				onClick={ this.goToPrivacyProtection }>
-				{ this.translate( 'None', {
-					context: 'An icon label when Privacy Protection is disabled.'
-				} ) }
-			</Notice>
+			<a href="#" onClick={ this.goToPrivacyProtection }>
+				<Notice
+					isCompact
+					status="is-warning"
+					icon="notice">
+					{ this.translate( 'None', {
+						context: 'An icon label when Privacy Protection is disabled.'
+					} ) }
+				</Notice>
+			</a>
 		);
 	},
 


### PR DESCRIPTION
Updates the Privacy Protection on/off compact notices (shown below) so they correctly click through to the privacy settings page.

<img width="368" alt="screen shot 2015-12-17 at 8 40 56 am" src="https://cloud.githubusercontent.com/assets/3011211/11875526/ea82537e-a499-11e5-99f2-be114c1846ab.png">

cc: @gziolo who raised this issue in https://github.com/Automattic/wp-calypso/pull/1676#issuecomment-165378325.