### PR TITLE
Editor: use correct command for help shortcut

### DIFF
--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -315,7 +315,7 @@ function wpcomPlugin( editor ) {
 			m: 'WP_Medialib',
 			t: 'WP_More',
 			d: 'Strikethrough',
-			h: 'WP_Help',
+			h: 'Wpcom_Help',
 			p: 'WP_Page',
 			x: 'WP_Code'
 		}, function( command, key ) {


### PR DESCRIPTION
Fixes #1457

To test:

- [ ] Open up a post or page in Calypso editor
- [ ] Use your keyboard to open the Help shortcuts menu with `Control-Option-h` on Mac OS X You should see this:
<img width="712" alt="screen shot 2015-12-17 at 11 17 17" src="https://cloud.githubusercontent.com/assets/66797/11879386/3c284eb8-a4b8-11e5-8787-86668c0f6a27.png">
- [ ] And using `Esc` key or hitting `Close` button at bottom right of the window should close it.