### PR TITLE
Editor: use correct command for link shortcut

### DIFF
--- a/client/components/tinymce/plugins/wplink/plugin.js
+++ b/client/components/tinymce/plugins/wplink/plugin.js
@@ -43,10 +43,9 @@ function wpLink( editor ) {
 	} );
 
 	// WP default shortcut
-	editor.addShortcut( 'Alt+Shift+A', '', 'WP_Link' );
-
+	editor.addShortcut( 'access+a', '', 'WP_Link' );
 	// The "de-facto standard" shortcut, see #27305
-	editor.addShortcut( 'Meta+K', '', 'WP_Link' );
+	editor.addShortcut( 'meta+k', '', 'WP_Link' );
 
 	editor.addButton( 'link', {
 		icon: 'link',


### PR DESCRIPTION
See #1457

To test:

- Open up a post or page in Calypso editor
- Highlight some text, then use your keyboard to open the Link editing shortcut menu with `Control-Option-a` on Mac OS X You should see this:
<img width="420" alt="screen shot 2015-12-17 at 12 34 22" src="https://cloud.githubusercontent.com/assets/66797/11879772/95b657ca-a4ba-11e5-99e9-5d7c49f0fc2a.png">
- Same thing should work with `Command-a` and `Alt-Shift-a` as well
- And using `Esc` key or hitting `Cancel` or `Add Link` at bottom right of the window should close it.