### PR TITLE
Signup: Fix margins on email verification notice on post editor.

### DIFF
--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -9,6 +9,18 @@
 	@include breakpoint( "<660px" ) {
 		padding: 0;
 	}
+
+	> .notice {
+		margin: 0 32px 64px;
+
+		@include breakpoint( "<1040px" ) {
+			margin: 0 24px 56px;
+		}
+
+		@include breakpoint( "<660px" ) {
+			margin: 8px 8px 0;
+		}
+	}
 }
 
 .post-editor {


### PR DESCRIPTION
Fixes a display issue with the email verification notice on the post editor (reported in https://github.com/Automattic/wp-calypso/issues/1519). 

Before | After
------------ | -------------
<img width="1440" alt="screen_shot_2015-12-17_at_11_32_51_am" src="https://cloud.githubusercontent.com/assets/3011211/11879744/13ece4fa-a4b2-11e5-9ce5-54131e65e7f0.png"> | <img width="1438" alt="screen_shot_2015-12-17_at_11_32_18_am" src="https://cloud.githubusercontent.com/assets/3011211/11879743/13cf7ba4-a4b2-11e5-99ca-37581f21d7e7.png">

This could probably use a copy edit, but we may need to test that separately since this is part of the NUX flow and there are various related tests in progress there.

cc: @mtias 