### PR TITLE
Invites: fix wrong default value in `getRedirectAfterAccept`

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -83,7 +83,7 @@ export default React.createClass( {
 		);
 	},
 
-	getRedirectAfterAccept( invite = this.state ) {
+	getRedirectAfterAccept( invite = this.state.invite ) {
 		switch ( invite.role ) {
 			case 'viewer':
 			case 'follower':


### PR DESCRIPTION
Fix followers, and viewers, being redirected to the sites posts list instead of being redirected to the reader.

cc @ebinnion @roccotripaldi 