### PR TITLE
Site Picker: switch button active color removal

### DIFF
--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -117,22 +117,11 @@
 		position: absolute;
 			top: 9px;
 			left: 16px;
-		transition: all 0.2s cubic-bezier(0.680, -0.550, 0.265, 1.550);
 
 		@include breakpoint( "<660px" ) {
 				top: 15px;
 			height: 24px;
 			width: 24px;
-		}
-	}
-
-	.focus-sites & {
-		background-color: $gray;
-		color: $white;
-
-		.gridicon {
-			fill: $white;
-			transform: rotate( 180deg );
 		}
 	}
 }


### PR DESCRIPTION
When clicking the switch sites button, previously the button changed color because it was effectively a toggle button that stayed visible before & after the transition. Since that button now transitions along with the site sidebar, the "active" color change can be distracting during the transition and is not longer needed.

##### Before

![swtich_remove-before](https://cloud.githubusercontent.com/assets/1427136/11881943/cbed67bc-a4d7-11e5-87d7-13e42563f926.gif)

##### After

![swtich_remove](https://cloud.githubusercontent.com/assets/1427136/11881956/db1a1456-a4d7-11e5-8dca-0d3a091a2c3e.gif)

/cc @mtias, @shaunandrews 