### PR TITLE
Business Plugins: Only call `site#canManage` for Jetpack sites

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -805,7 +805,7 @@ export default React.createClass( {
 			);
 		}
 
-		if ( selectedSite && ! selectedSite.canManage() ) {
+		if ( selectedSite && selectedSite.jetpack && ! selectedSite.canManage() ) {
 			return (
 				<Main>
 					<JetpackManageErrorPage

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -303,7 +303,7 @@ export default React.createClass( {
 			return this.getPluginDoesNotExistView( selectedSite );
 		}
 
-		if ( selectedSite && ! selectedSite.canManage() ) {
+		if ( selectedSite && selectedSite.jetpack && ! selectedSite.canManage() ) {
 			return (
 				<MainComponent>
 					<JetpackManageErrorPage

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -238,7 +238,7 @@ module.exports = React.createClass( {
 	render() {
 		const selectedSite = this.props.sites.getSelectedSite();
 		if ( this.state.accessError ||
-				( selectedSite && ! selectedSite.canManage() )
+				( selectedSite && selectedSite.jetpack && selectedSite.canManage() )
 			) {
 			return this.renderAccessError( selectedSite );
 		}


### PR DESCRIPTION
This fixes an issue where `/plugins/:site` is inaccessible for business sites.

**Testing**
- Assert that you can load the list of plugins at `/plugins/:site` for a business site.
- Assert that you can visit a plugin page by clicking on a plugin from the list.
- Assert that you can activate and deactivate a plugin.

cc @enejb 