### PR TITLE
Plugins List: Use the no result component to render no results in plugin search

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -28,6 +28,7 @@ import PluginItem from './plugin-item/plugin-item';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
+import NoResults from 'my-sites/no-results';
 import Search from 'components/search';
 import URLSearch from 'lib/mixins/url-search';
 import EmptyContent from 'components/empty-content';
@@ -697,24 +698,16 @@ export default React.createClass( {
 	getEmptyContentData() {
 		let emptyContentData = { illustration: '/calypso/images/drake/drake-empty-results.svg', };
 
-		if ( this.props.search ) {
-			emptyContentData.title = this.translate( 'No plugins match your search for {{searchTerm/}}.', {
-				textOnly: true,
-				components: { searchTerm: <em>{ this.props.search }</em> }
-			} );
-		} else {
-			switch ( this.props.filter ) {
-				case 'inactive':
-					emptyContentData.title = this.translate( 'No plugins are inactive.', { textOnly: true } );
-					break;
-				case 'updates':
-					emptyContentData = this.getEmptyContentUpdateData();
-					break;
-				default:
-					emptyContentData.title = this.translate( 'No plugins match that filter.', { textOnly: true } );
-			}
+		switch ( this.props.filter ) {
+			case 'inactive':
+				emptyContentData.title = this.translate( 'No plugins are inactive.', { textOnly: true } );
+				break;
+			case 'updates':
+				emptyContentData = this.getEmptyContentUpdateData();
+				break;
+			default:
+				emptyContentData.title = this.translate( 'No plugins match that filter.', { textOnly: true } );
 		}
-
 		return emptyContentData;
 	},
 
@@ -739,15 +732,23 @@ export default React.createClass( {
 	renderPluginsContent() {
 		const plugins = this.state.plugins || [];
 
-		if ( isEmpty( plugins ) && ( this.props.search || 'inactive' === this.props.filter || 'updates' === this.props.filter ) ) {
-			let emptyContentData = this.getEmptyContentData();
-			return (
-				<EmptyContent
+		if ( isEmpty( plugins ) ) {
+			if ( this.props.search ) {
+				return <NoResults text={ this.translate( 'No plugins match your search for {{searchTerm/}}.', {
+					textOnly: true,
+					components: { searchTerm: <em>{ this.props.search }</em> }
+				} ) } />
+			}
+
+			if ( 'inactive' === this.props.filter || 'updates' === this.props.filter ) {
+				let emptyContentData = this.getEmptyContentData();
+				return ( <EmptyContent
 					title={ emptyContentData.title }
 					illustration={ emptyContentData.illustration }
 					actionURL={ emptyContentData.actionURL }
 					action={ emptyContentData.action } />
-			);
+				);
+			}
 		}
 		return (
 			<div className="plugins__lists">


### PR DESCRIPTION
Fixes #829. 

Before:
![screen shot 2015-12-17 at 14 46 34](https://cloud.githubusercontent.com/assets/115071/11884223/159b2e9a-a4cd-11e5-8546-37734137a72c.png)


After:
![screen shot 2015-12-17 at 14 43 15](https://cloud.githubusercontent.com/assets/115071/11884197/de870c30-a4cc-11e5-9d74-c4981c94aacf.png)

**To Test**
Visit http://calypso.localhost:3000/plugins?s=automatticasdasd

Notice that we don't have a icon yet. This will be updated once we have one. 
cc @johnHackworth, @rickybanister 

Related https://github.com/Automattic/wp-calypso/pull/1773
