### PR TITLE
Plugin Browser: Use the no result component to render no results in plugin browser search 

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -14,6 +14,7 @@ import SectionNav from 'components/section-nav'
 import MainComponent from 'components/main'
 import NavTabs from 'components/section-nav/tabs'
 import NavItem from 'components/section-nav/item'
+import NoResults from 'my-sites/no-results'
 import PluginsList from 'my-sites/plugins/plugins-browser-list'
 import PluginsListStore from 'lib/plugins/wporg-data/list-store'
 import PluginsActions from 'lib/plugins/wporg-data/actions'
@@ -128,10 +129,10 @@ module.exports = React.createClass( {
 		if ( this.getPluginsFullList( 'search' ).length > 0 || isFetching ) {
 			return <PluginsList plugins={ this.getPluginsFullList( 'search' ) } listName={ searchTerm } title={ searchTerm } site={ this.props.site } showPlaceholders={ isFetching } currentSites={ this.props.sites.getSelectedOrAllJetpackCanManage() } />;
 		}
-		return <EmptyContent
-			title={ this.translate( 'Nothing to see here!' ) }
-			line={ this.translate( 'We could\'t find any plugin with that text' ) }
-			illustration={ '/calypso/images/drake/drake-404.svg' } />;
+		return <NoResults text={ this.translate( 'No plugins match your search for {{searchTerm/}}.', {
+			textOnly: true,
+			components: { searchTerm: <em>{ searchTerm }</em> }
+		} ) } />
 	},
 
 	getPluginSingleListView( category ) {


### PR DESCRIPTION
Fixes #829.

Before:
![screen shot 2015-12-17 at 14 46 43](https://cloud.githubusercontent.com/assets/115071/11884411/8c25455e-a4ce-11e5-96dd-99746ee05bc7.png)


After:
![screen shot 2015-12-17 at 14 57 16](https://cloud.githubusercontent.com/assets/115071/11884403/7f775fea-a4ce-11e5-8fdd-da3399e0d676.png)

**To test**
visit http://calypso.localhost:3000/plugins/browse?s=automatticasdasd

Notice that we don't have a icon yet. This will be updated once we have one. 
cc @johnHackworth, @rickybanister

Related https://github.com/Automattic/wp-calypso/pull/1772
