### PR TITLE
Framework: Add missing JSX rules for eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,6 +52,8 @@
 		// Teach eslint about React+JSX
 		"react/jsx-uses-react": 1,
 		"react/jsx-uses-vars": 1,
+		"react/jsx-no-undef": 1,
+		"react/react-in-jsx-scope": 1,
 		// Allows function use before declaration
 		"no-use-before-define": [ 2, "nofunc" ],
 		// We split external, internal, module variables


### PR DESCRIPTION
* react/jsx-no-undef: Disallow undeclared variables in JSX
* react/react-in-jsx-scope: Prevent missing React when using JSX

## Testing

Edit a JSX file that has no eslint errors and make some changes to see errors appear:

1. Remove the `import` (or `require`) line that imports a component.
2. If there is a file that doesn't use `React.createClass`, but does render JSX code, remove the `import` (or `require`) line that imports `React`.
