### PR TITLE
Plans: Add expired state to `PlanStatus`

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -26,5 +26,5 @@ export function getDaysUntilExpiry( plan ) {
 };
 
 export function isInGracePeriod( plan ) {
-	return getDaysUntilUserFacingExpiry( plan ) <= 0 && getDaysUntilExpiry( plan ) > 0;
+	return getDaysUntilUserFacingExpiry( plan ) <= 0;
 };

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -6,13 +6,13 @@ import moment from 'moment';
 export function getDaysUntilUserFacingExpiry( plan ) {
 	const { userFacingExpiryMoment } = plan;
 
-	return userFacingExpiryMoment.diff( moment(), 'days' );
+	return userFacingExpiryMoment.diff( moment().startOf( 'day' ), 'days' );
 };
 
 export function getDaysUntilExpiry( plan ) {
 	const { expiryMoment } = plan;
 
-	return expiryMoment.diff( moment(), 'days' );
+	return expiryMoment.diff( moment().startOf( 'day' ), 'days' );
 };
 
 export function isInGracePeriod( plan ) {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -3,6 +3,16 @@
  */
 import moment from 'moment';
 
+export function getCurrentTrialPeriodInDays( plan ) {
+	const { expiryMoment, subscribedMoment, userFacingExpiryMoment } = plan;
+
+	if ( isInGracePeriod( plan ) ) {
+		return expiryMoment.diff( userFacingExpiryMoment, 'days' );
+	}
+
+	return userFacingExpiryMoment.diff( subscribedMoment, 'days' );
+}
+
 export function getDaysUntilUserFacingExpiry( plan ) {
 	const { userFacingExpiryMoment } = plan;
 

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -8,3 +8,13 @@ export function getDaysUntilUserFacingExpiry( plan ) {
 
 	return userFacingExpiryMoment.diff( moment(), 'days' );
 };
+
+export function getDaysUntilExpiry( plan ) {
+	const { expiryMoment } = plan;
+
+	return expiryMoment.diff( moment(), 'days' );
+};
+
+export function isInGracePeriod( plan ) {
+	return getDaysUntilUserFacingExpiry( plan ) <= 0 && getDaysUntilExpiry( plan ) > 0;
+};

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -11,7 +11,7 @@ export function getCurrentTrialPeriodInDays( plan ) {
 	}
 
 	return userFacingExpiryMoment.diff( subscribedMoment, 'days' );
-}
+};
 
 export function getDaysUntilUserFacingExpiry( plan ) {
 	const { userFacingExpiryMoment } = plan;

--- a/client/lib/site-specific-plans-details-list/assembler.js
+++ b/client/lib/site-specific-plans-details-list/assembler.js
@@ -7,7 +7,7 @@ function createSiteSpecificPlanObject( plan ) {
 	return {
 		currentPlan: Boolean( plan.current_plan ),
 		expiry: plan.expiry,
-		expiryMoment: moment( plan.expiry ),
+		expiryMoment: moment( plan.expiry ).startOf( 'day' ),
 		formattedDiscount: plan.formatted_discount,
 		formattedPrice: plan.formatted_price,
 		freeTrial: Boolean( plan.free_trial ),
@@ -17,10 +17,9 @@ function createSiteSpecificPlanObject( plan ) {
 		rawDiscount: plan.raw_discount,
 		rawPrice: plan.raw_price,
 		subscribedDate: plan.subscribed_date,
-		subscribedMoment: moment( plan.subscribed_date ),
+		subscribedMoment: moment( plan.subscribed_date ).startOf( 'day' ),
 		userFacingExpiry: plan.user_facing_expiry,
-		// we add a day to the user facing expiry so that it isn't expired on the last day
-		userFacingExpiryMoment: moment( plan.user_facing_expiry ).add( { day: 1 } )
+		userFacingExpiryMoment: moment( plan.user_facing_expiry ).startOf( 'day' )
 	}
 }
 

--- a/client/my-sites/plans/plan-overview/plan-status/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/index.jsx
@@ -61,7 +61,8 @@ const PlanStatus = React.createClass( {
 						primary={ getDaysUntilUserFacingExpiry( this.props.plan ) < 6 }
 						className="plan-status__button"
 						onClick={ this.purchasePlan }
-						primary>
+						primary
+					>
 						{ this.translate( 'Purchase Now' ) }
 					</Button>
 				</CompactCard>

--- a/client/my-sites/plans/plan-overview/plan-status/progress.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/progress.jsx
@@ -16,13 +16,29 @@ const PlanStatusProgress = React.createClass( {
 		plan: React.PropTypes.object.isRequired
 	},
 
+	/*
+	 *          |------------------------trialPeriodInDays (17 days)-------------------|
+	 *     plan.subscribedDate (datetime)       plan.userFacingExpiry (day)       plan.expiry (day)
+	 *          |-----------------------------------------|----gracePeriod (3 days)----|
+	 *          |                                         |                            |
+	 * -> Today before user facing expiry:
+	 *                  today
+	 *          |         |-----timeUntilExpiryInDays-----|                            |
+	 * -> Today is in grace period:
+	 *                                                       today
+	 *          |                                         |    |-timeUntilExpiryInDays-|
+	 * -> Today is after trial period in days:
+	 *                                                                                     today
+	 *          |                                         |                            |
+	 *     timeUntilExpiryInDays = 0
+	 */
 	renderProgressBar() {
 		const { plan } = this.props,
-			// we strip the hour/minute/second/millisecond data here from `subscribed_date` to match `expiry`
 			trialPeriodInDays = getCurrentTrialPeriodInDays( plan ),
 			timeUntilExpiryInDays = isInGracePeriod( plan )
 				? Math.max( getDaysUntilExpiry( plan ), 0 )
 				: getDaysUntilUserFacingExpiry( plan ),
+			// set minimum progress to 0.5 to show that the trial started immediately
 			progress = Math.max( 0.5, trialPeriodInDays - timeUntilExpiryInDays );
 
 		return (

--- a/client/my-sites/plans/plan-overview/plan-status/progress.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/progress.jsx
@@ -8,7 +8,7 @@ import React from 'react';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import { getDaysUntilExpiry, getDaysUntilUserFacingExpiry, isInGracePeriod } from 'lib/plans';
+import { getCurrentTrialPeriodInDays, getDaysUntilExpiry, getDaysUntilUserFacingExpiry, isInGracePeriod } from 'lib/plans';
 import ProgressBar from 'components/progress-bar';
 
 const PlanStatusProgress = React.createClass( {
@@ -17,10 +17,12 @@ const PlanStatusProgress = React.createClass( {
 	},
 
 	renderProgressBar() {
-		const { plan, plan: { subscribedMoment, userFacingExpiryMoment } } = this.props,
+		const { plan } = this.props,
 			// we strip the hour/minute/second/millisecond data here from `subscribed_date` to match `expiry`
-			trialPeriodInDays = userFacingExpiryMoment.diff( subscribedMoment, 'days' ),
-			timeUntilExpiryInDays = getDaysUntilUserFacingExpiry( plan ),
+			trialPeriodInDays = getCurrentTrialPeriodInDays( plan ),
+			timeUntilExpiryInDays = isInGracePeriod( plan )
+				? getDaysUntilExpiry( plan )
+				: getDaysUntilUserFacingExpiry( plan ),
 			progress = Math.max( 0.5, trialPeriodInDays - timeUntilExpiryInDays );
 
 		return (

--- a/client/my-sites/plans/plan-overview/plan-status/progress.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/progress.jsx
@@ -21,15 +21,14 @@ const PlanStatusProgress = React.createClass( {
 			// we strip the hour/minute/second/millisecond data here from `subscribed_date` to match `expiry`
 			trialPeriodInDays = getCurrentTrialPeriodInDays( plan ),
 			timeUntilExpiryInDays = isInGracePeriod( plan )
-				? getDaysUntilExpiry( plan )
+				? Math.max( getDaysUntilExpiry( plan ), 0 )
 				: getDaysUntilUserFacingExpiry( plan ),
 			progress = Math.max( 0.5, trialPeriodInDays - timeUntilExpiryInDays );
 
 		return (
 			<ProgressBar
 				value={ progress }
-				total={ trialPeriodInDays }
-			/>
+				total={ trialPeriodInDays } />
 		);
 	},
 
@@ -37,6 +36,10 @@ const PlanStatusProgress = React.createClass( {
 		const { plan } = this.props;
 
 		if ( isInGracePeriod( plan ) ) {
+			if ( getDaysUntilExpiry( plan ) <= 0 ) {
+				return this.translate( 'Plan features will be removed momentarily' );
+			}
+
 			return this.translate(
 				'Plan features will be removed in %(daysUntilExpiry)s day',
 				'Plan features will be removed in %(daysUntilExpiry)s days',

--- a/client/my-sites/plans/plan-overview/plan-status/progress.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/progress.jsx
@@ -8,7 +8,7 @@ import React from 'react';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import { getDaysUntilUserFacingExpiry } from 'lib/plans';
+import { getDaysUntilExpiry, getDaysUntilUserFacingExpiry, isInGracePeriod } from 'lib/plans';
 import ProgressBar from 'components/progress-bar';
 
 const PlanStatusProgress = React.createClass( {
@@ -26,12 +26,25 @@ const PlanStatusProgress = React.createClass( {
 		return (
 			<ProgressBar
 				value={ progress }
-				total={ trialPeriodInDays } />
+				total={ trialPeriodInDays }
+			/>
 		);
 	},
 
 	renderDaysRemaining() {
 		const { plan } = this.props;
+
+		if ( isInGracePeriod( plan ) ) {
+			return this.translate(
+				'Plan features will be removed in %(daysUntilExpiry)s day',
+				'Plan features will be removed in %(daysUntilExpiry)s days',
+				{
+					args: { daysUntilExpiry: getDaysUntilExpiry( plan ) },
+					count: getDaysUntilExpiry( plan ),
+					context: "The amount of time until the trial plan is removed from the user's account."
+				}
+			);
+		}
 
 		return this.translate(
 			'%(daysUntilExpiry)d day remaining',
@@ -45,9 +58,11 @@ const PlanStatusProgress = React.createClass( {
 	},
 
 	render() {
-		const classes = classNames( 'plan-status__progress', {
-			'is-expiring': getDaysUntilUserFacingExpiry( this.props.plan ) < 6
-		} );
+		const { plan } = this.props,
+			classes = classNames( 'plan-status__progress', {
+				'is-expiring': getDaysUntilUserFacingExpiry( plan ) < 6 && ! isInGracePeriod( plan ),
+				'is-in-grace-period': isInGracePeriod( plan )
+			} );
 
 		return (
 			<CompactCard>

--- a/client/my-sites/plans/plan-overview/plan-status/style.scss
+++ b/client/my-sites/plans/plan-overview/plan-status/style.scss
@@ -59,7 +59,7 @@
 	font-weight: 700;
 
 	@include breakpoint( ">960px" ) {
-		font-size: 24px;
+		font-size: 21px;
 	}
 }
 

--- a/client/my-sites/plans/plan-overview/plan-status/style.scss
+++ b/client/my-sites/plans/plan-overview/plan-status/style.scss
@@ -24,6 +24,7 @@
 	background-repeat: no-repeat;
 	height: 50px;
 	min-width: 50px;
+	position: relative;
 
 	&.is-premium {
 		background-image: url( '/calypso/images/plans/plan-trial-premium.svg' );
@@ -35,6 +36,13 @@
 
 	@include breakpoint( "<480px" ) {
 		display: none;
+	}
+
+	.gridicon {
+		fill: $alert-red;
+		position: absolute;
+			bottom: -7px;
+			right: -7px;
 	}
 }
 

--- a/client/my-sites/plans/plan-overview/plan-status/style.scss
+++ b/client/my-sites/plans/plan-overview/plan-status/style.scss
@@ -69,6 +69,12 @@
 			background-color: $alert-red;
 		}
 	}
+
+	&.is-in-grace-period {
+		.progress-bar__progress {
+			background-color: $alert-yellow;
+		}
+	}
 }
 
 .plan-status__progress-bar,


### PR DESCRIPTION
Addresses part of #1471.

![screen shot 2015-12-17 at 5 23 38 pm](https://cloud.githubusercontent.com/assets/1130674/11886861/919fec54-a4e3-11e5-9873-460a1fab7a17.png)

**Testing**
- Visit http://calypso.localhost:3000/plans/:site for a site with a trial that is in the grace period (within three days of expiring).
- If there are three days left, assert that the notice reads 'EXPIRED TODAY', and that the remaining time text reads 'Plan features will be removed in 3 days'.
- If there are two days left, assert that the notice reads 'EXPIRED 1 DAY AGO', and that the remaining time text reads 'Plan features will be removed in 2 days'.
- If there is one day left, assert that the notice reads 'EXPIRED 2 DAYS AGO', and that the remaining time text reads 'Plan features will be removed in 1 day'.
- If it is the day of the expiry, assert that the notice reads 'EXPIRED 3 DAYS AGO', and that the remaining time text reads 'Plan features will be removed momentarily'.

**Reviews**
- [x] Code
- [x] Product