### PR TITLE
Don't include build/* in JS_FILES.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ALL_DEVDOCS_JS ?= $(THIS_DIR)/server/devdocs/bin/generate-devdocs-index
 
 # files used as prereqs
 SASS_FILES := $(shell find client shared assets -type f -name '*.scss')
-JS_FILES := $(shell find . -type f \( -name '*.js' -or -name '*.jsx' \) -and -not \( -path './node_modules/*' -or  -path './public/*' \) )
+JS_FILES := $(shell find . -type f \( -name '*.js' -or -name '*.jsx' \) -and -not \( -path './node_modules/*' -or -path './public/*' -or -path './build/*' \) )
 MD_FILES := $(shell find . -name '*.md' -and -not -path '*node_modules*' -and -not -path '*.git*' | sed 's/ /\\ /g')
 CLIENT_CONFIG_FILE := client/config/index.js
 


### PR DESCRIPTION
This change keeps built code out of the JS_FILES make variable, which is used when linting. Currently, if you run a build and then lint, you'll see errors from the built, transpiled code. This is less than ideal, as it's a false warning and slightly increases linting time.

This patch removes the build/* path from consideration.

To test, run `make build; make lint;`. You shouldn't see any errors. On `master`, you will.

Noticed when testing #1779 