### PR TITLE
Plugins: Fix regression in terms of file mod permission.

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -130,28 +130,28 @@ PluginsActions = {
 
 	fetchSitePlugins: function( site ) {
 		if ( ! site.user_can_manage || ( ! site.jetpack && ! isBusiness( site.plan ) ) ) {
-			defer( ( ) => {
-			Dispatcher.handleViewAction( {
-				type: 'NOT_ALLOWED_TO_RECEIVE_PLUGINS',
-				action: 'RECEIVE_PLUGINS',
-				site: site
-			} );
+			defer( () => {
+				Dispatcher.handleViewAction( {
+					type: 'NOT_ALLOWED_TO_RECEIVE_PLUGINS',
+					action: 'RECEIVE_PLUGINS',
+					site: site
+				} );
 			} );
 			return;
 		}
 		const endpoint = site.jetpack ? wpcom.plugins : wpcom.wpcomPlugins;
 
 		endpoint.call( wpcom, site.ID, ( error, data ) => {
-		Dispatcher.handleServerAction( {
-			type: 'RECEIVE_PLUGINS',
-			action: 'RECEIVE_PLUGINS',
-			site: site,
-			data: data,
-			error: error
-		} );
-		if ( ! error ) {
-			processAutoupdates( site, data.plugins );
-		}
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_PLUGINS',
+				action: 'RECEIVE_PLUGINS',
+				site: site,
+				data: data,
+				error: error
+			} );
+			if ( ! error ) {
+				processAutoupdates( site, data.plugins );
+			}
 		} );
 	},
 

--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -403,6 +403,9 @@ PluginsActions = {
 	},
 
 	enableAutoUpdatesPlugin: function( site, plugin ) {
+		if ( ! site.user_can_manage || ! site.canAutoupdateFiles ) {
+			return;
+		}
 		Dispatcher.handleViewAction( {
 			type: 'ENABLE_AUTOUPDATE_PLUGIN',
 			action: 'ENABLE_AUTOUPDATE_PLUGIN',
@@ -428,6 +431,9 @@ PluginsActions = {
 	},
 
 	disableAutoUpdatesPlugin: function( site, plugin ) {
+		if ( ! site.user_can_manage || ! site.canAutoupdateFiles ) {
+			return;
+		}
 		Dispatcher.handleViewAction( {
 			type: 'DISABLE_AUTOUPDATE_PLUGIN',
 			action: 'DISABLE_AUTOUPDATE_PLUGIN',

--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -390,7 +390,7 @@ PluginsActions = {
 	},
 
 	togglePluginActivation: function( site, plugin ) {
-		if ( ! site.canAutoupdateFiles || ! site.user_can_manage ) {
+		if ( ! site.user_can_manage ) {
 			return;
 		}
 
@@ -450,6 +450,9 @@ PluginsActions = {
 	},
 
 	togglePluginAutoUpdate: function( site, plugin ) {
+		if ( ! site.user_can_manage || ! site.canAutoupdateFiles ) {
+			return;
+		}
 		if ( ! plugin.autoupdate ) {
 			PluginsActions.enableAutoUpdatesPlugin( site, plugin );
 		} else {

--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -82,7 +82,7 @@ function recordEvent( eventType, plugin, site, error ) {
 }
 
 function processAutoupdates( site, plugins ) {
-	if ( site.canUpdateFiles && site.jetpack && site.canManage() && site.user_can_manage ) {
+	if ( site.canAutoupdateFiles && site.jetpack && site.canManage() && site.user_can_manage ) {
 		plugins.forEach( function( plugin ) {
 			if ( plugin.update && plugin.autoupdate ) {
 				autoupdatePlugin( site, plugin );
@@ -130,28 +130,28 @@ PluginsActions = {
 
 	fetchSitePlugins: function( site ) {
 		if ( ! site.user_can_manage || ( ! site.jetpack && ! isBusiness( site.plan ) ) ) {
-			defer( () => {
-				Dispatcher.handleViewAction( {
-					type: 'NOT_ALLOWED_TO_RECEIVE_PLUGINS',
-					action: 'RECEIVE_PLUGINS',
-					site: site
-				} );
+			defer( ( ) => {
+			Dispatcher.handleViewAction( {
+				type: 'NOT_ALLOWED_TO_RECEIVE_PLUGINS',
+				action: 'RECEIVE_PLUGINS',
+				site: site
+			} );
 			} );
 			return;
 		}
 		const endpoint = site.jetpack ? wpcom.plugins : wpcom.wpcomPlugins;
 
 		endpoint.call( wpcom, site.ID, ( error, data ) => {
-			Dispatcher.handleServerAction( {
-				type: 'RECEIVE_PLUGINS',
-				action: 'RECEIVE_PLUGINS',
-				site: site,
-				data: data,
-				error: error
-			} );
-			if ( ! error ) {
-				processAutoupdates( site, data.plugins );
-			}
+		Dispatcher.handleServerAction( {
+			type: 'RECEIVE_PLUGINS',
+			action: 'RECEIVE_PLUGINS',
+			site: site,
+			data: data,
+			error: error
+		} );
+		if ( ! error ) {
+			processAutoupdates( site, data.plugins );
+		}
 		} );
 	},
 
@@ -390,6 +390,10 @@ PluginsActions = {
 	},
 
 	togglePluginActivation: function( site, plugin ) {
+		if ( ! site.canAutoupdateFiles || ! site.user_can_manage ) {
+			return;
+		}
+
 		debug( 'togglePluginActivation', site, plugin );
 		if ( ! plugin.active ) {
 			PluginsActions.activatePlugin( site, plugin );

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -36,6 +36,7 @@ JetpackSite.prototype.updateComputedAttributes = function() {
 	// is_multi_network checks to see that a site is not part of a multi network
 	// Since there is no primary network we disable updates for that case
 	this.canUpdateFiles = SiteUtils.canUpdateFiles( this );
+	this.canAutoupdateFiles = SiteUtils.canAutoupdateFiles( this );
 	this.hasJetpackMenus = versionCompare( this.options.jetpack_version, '3.5-alpha' ) >= 0;
 	this.hasJetpackThemes = versionCompare( this.options.jetpack_version, '3.7-beta' ) >= 0;
 };

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -68,47 +68,28 @@ export default {
 		if ( ! site || ! site.options || ! site.options.file_mod_disabled ) {
 			return;
 		}
-		let reasons = [];
-		for ( let clue of site.options.file_mod_disabled ) {
-			if ( action === 'modifyFiles'
-				|| action === 'autoupdateFiles'
-				|| action === 'autoupdateCore' ) {
-				switch ( clue ) {
-					case 'has_no_file_system_write_access':
-						reasons.push(
-							i18n.translate( 'The file permissions on this host prevent editing files.' )
-						);
-						break;
-					case 'disallow_file_mods':
-						reasons.push(
-							i18n.translate( 'File modifications are explicitly disabled by a site administrator.' )
-						);
-						break;
+
+		return site.options.file_mod_disabled.map( ( clue ) => {
+			if ( action === 'modifyFiles' || action === 'autoupdateFiles' || action === 'autoupdateCore' ) {
+				if ( clue === 'has_no_file_system_write_access' ) {
+					return i18n.translate( 'The file permissions on this host prevent editing files.' );
+				}
+				if ( clue === 'disallow_file_mods' ) {
+					return i18n.translate( 'File modifications are explicitly disabled by a site administrator.' );
 				}
 			}
 
-			if ( action === 'autoupdateFiles'
-				|| action === 'autoupdateCore' ) {
-				switch ( clue ) {
-					case 'automatic_updater_disabled':
-						reasons.push(
-							i18n.translate( 'Any autoupdates are explicitly disabled by a site administrator.' )
-						);
-						break;
-				}
+			if ( ( action === 'autoupdateFiles' || action === 'autoupdateCore' ) &&
+				clue === 'automatic_updater_disabled' ) {
+				return i18n.translate( 'Any autoupdates are explicitly disabled by a site administrator.' );
 			}
 
-			if ( action === 'autoupdateCore' ) {
-				switch ( clue ) {
-					case 'wp_auto_update_core_disabled':
-						reasons.push(
-							i18n.translate( 'Core autoupdates are explicitly disabled by a site administrator.' )
-						);
-						break;
-				}
+			if ( action === 'autoupdateCore' &&
+				clue === 'wp_auto_update_core_disabled' ) {
+				return i18n.translate( 'Core autoupdates are explicitly disabled by a site administrator.' );
 			}
-		}
-		return reasons;
+			return null;
+		} ).filter( reason => reason );
 	},
 
 	canUpdateFiles( site ) {
@@ -129,10 +110,9 @@ export default {
 			return false;
 		}
 
-		if ( options.file_mod_disabled
-			&& ( -1 < options.file_mod_disabled.indexOf( 'disallow_file_mods' )
-				|| -1 < options.file_mod_disabled.indexOf( 'has_no_file_system_write_access' ) )
-		) {
+		if ( options.file_mod_disabled &&
+			( -1 < options.file_mod_disabled.indexOf( 'disallow_file_mods' ) ||
+			-1 < options.file_mod_disabled.indexOf( 'has_no_file_system_write_access' ) ) ) {
 			return false;
 		}
 
@@ -144,8 +124,8 @@ export default {
 			return false;
 		}
 
-		if ( site.options.file_mod_disabled
-			&& -1 < site.options.file_mod_disabled.indexOf( 'automatic_updater_disabled' ) ) {
+		if ( site.options.file_mod_disabled &&
+			-1 < site.options.file_mod_disabled.indexOf( 'automatic_updater_disabled' ) ) {
 			return false;
 		}
 		return true;
@@ -156,8 +136,8 @@ export default {
 			return false;
 		}
 
-		if ( site.options.file_mod_disabled
-			&& -1 < site.options.file_mod_disabled.indexOf( 'automatic_updater_disabled' ) ) {
+		if ( site.options.file_mod_disabled &&
+			-1 < site.options.file_mod_disabled.indexOf( 'automatic_updater_disabled' ) ) {
 			return false;
 		}
 		return true;

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -130,8 +130,8 @@ export default {
 		}
 
 		if ( options.file_mod_disabled
-			&& ( options.file_mod_disabled.includes( 'disallow_file_mods' )
-				|| options.file_mod_disabled.includes( 'has_no_file_system_write_access' ) )
+			&& ( -1 < options.file_mod_disabled.indexOf( 'disallow_file_mods' )
+				|| -1 < options.file_mod_disabled.indexOf( 'has_no_file_system_write_access' ) )
 		) {
 			return false;
 		}
@@ -145,7 +145,7 @@ export default {
 		}
 
 		if ( site.options.file_mod_disabled
-			&& site.options.file_mod_disabled.includes( 'automatic_updater_disabled' ) ) {
+			&& -1 < site.options.file_mod_disabled.indexOf( 'automatic_updater_disabled' ) ) {
 			return false;
 		}
 		return true;
@@ -157,7 +157,7 @@ export default {
 		}
 
 		if ( site.options.file_mod_disabled
-			&& site.options.file_mod_disabled.includes( 'automatic_updater_disabled' ) ) {
+			&& -1 < site.options.file_mod_disabled.indexOf( 'automatic_updater_disabled' ) ) {
 			return false;
 		}
 		return true;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -541,6 +541,12 @@ export default React.createClass( {
 			.some( plugin => plugin.sites.some( site => site.canUpdateFiles ) );
 	},
 
+	canAutoupdatePlugins() {
+		return this.state.plugins
+			.filter( plugin => plugin.selected )
+			.some( plugin => plugin.sites.some( site => site.canAutoupdateFiles ) );
+	},
+
 	hasJetpackSelectedSites() {
 		const selectedSite = this.props.sites.getSelectedSite();
 		if ( selectedSite ) {
@@ -589,8 +595,8 @@ export default React.createClass( {
 			leftSideButtons.push( <ButtonGroup key="plugins__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
 
 			if ( this.hasJetpackSelectedSites() && ! isWpCom ) {
-				updateButtons.push( <Button key="plugins__buttons-autoupdate-on" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
-				updateButtons.push( <Button key="plugins__buttons-autoupdate-off" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
+				updateButtons.push( <Button key="plugins__buttons-autoupdate-on" disabled={ hasWpcomPlugins || ! this.canAutoupdatePlugins() } compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
+				updateButtons.push( <Button key="plugins__buttons-autoupdate-off" disabled={ hasWpcomPlugins || ! this.canAutoupdatePlugins() } compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
 
 				leftSideButtons.push( <ButtonGroup key="plugins__buttons-update-buttons">{ updateButtons }</ButtonGroup> );
 				leftSideButtons.push( <ButtonGroup key="plugins__buttons-remove-button"><Button disabled={ ! needsRemoveButton } compact scary onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/index.jsx
@@ -74,8 +74,8 @@ module.exports = React.createClass( {
 			} );
 		}
 
-		if ( ! this.props.site.canUpdateFiles && this.props.site.options.file_mod_disabled ) {
-			let reasons = utils.getSiteFileModDisableReason( this.props.site );
+		if ( ! this.props.site.canAutoupdateFiles && this.props.site.options.file_mod_disabled ) {
+			let reasons = utils.getSiteFileModDisableReason( this.props.site, 'autoupdateFiles' );
 			let html = [];
 
 			if ( reasons.length > 1 ) {

--- a/client/my-sites/plugins/plugin-install-button/index.jsx
+++ b/client/my-sites/plugins/plugin-install-button/index.jsx
@@ -67,7 +67,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( ! this.props.selectedSite.canUpdateFiles && this.props.selectedSite.options.file_mod_disabled ) {
-			let reasons = utils.getSiteFileModDisableReason( this.props.selectedSite );
+			let reasons = utils.getSiteFileModDisableReason( this.props.selectedSite, 'modifyFiles' );
 			let html = [];
 
 			if ( reasons.length > 1 ) {

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -85,7 +85,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( ! this.props.site.canUpdateFiles && this.props.site.options.file_mod_disabled ) {
-			const reasons = utils.getSiteFileModDisableReason( this.props.site );
+			const reasons = utils.getSiteFileModDisableReason( this.props.site, 'modifyFiles' );
 			let html = [];
 
 			if ( reasons.length > 1 ) {


### PR DESCRIPTION
Currently a user is not able to install, remove and update plugins
if a site has certain constants set and version control set. 

This PR fixes this by removing some of these restrictions since they are currently not in core as well. 

This PR will enable autoupdates to work as previously and will allow autoupdates to happen unless the user has the constant AUTOMATIC_UPDATER_DISABLED set. 

**To test**:

Update your sandbox with the following constants. 
define( 'FS_METHOD', 'ssh2' );
define( 'DISALLOW_FILE_MODS',true );
define( 'AUTOMATIC_UPDATER_DISABLED', true );

if the FS_METHOD is set you will not be able to install, update, remove and autoupdate plugins
if the DISALLOW_FILE_MODS is set you will not be able to install, update, remove and autoupdate plugins
if AUTOMATIC_UPDATER_DISABLED  is set you will not be able to autoupdate plugins.
