### PR TITLE
added X-Frame-Options header (#16)

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -14,6 +14,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		title WordPress.com
 		meta(charset='utf-8')
 		meta(http-equiv='X-UA-Compatible' content='IE=Edge')
+		meta(http-equiv='X-Frame-Options' content='DENY')
 		meta(name='viewport', content='width=device-width, initial-scale=1, maximum-scale=1')
 		meta(name='format-detection', content='telephone=no')
 		meta(name='mobile-web-app-capable', content='yes')


### PR DESCRIPTION
Added X-Frame-Options DENY to the index page (https://github.com/Automattic/wp-calypso/issues/16). 

Was considering SAMEORIGIN instead of DENY, but I think admin isn't displayed in an iframe anywhere (rather other content, like preview, can be displayed in an iframe IN the admin, but not the admin as a whole), so DENY shouldn't break any functionality - but I'm new to Calypso, so please verify.

Please review.

cc @hoverduck 

PS: also, there is another, separate index file for the desktop version - I don't know if it makes sense to add X-Frame-Options also to the desktop entry point? What do you think?