### PR TITLE
Free Trials: Create a signup flow for free trials

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -146,6 +146,19 @@ module.exports = React.createClass( {
 		return true;
 	},
 
+	shouldOfferFreeTrial: function() {
+		if ( config.isEnabled( 'upgrades/free-trials' ) ) {
+			if ( this.props.isInSignup && this.props.flowName !== 'free-trial' ) {
+				return false;
+			}
+
+			if ( this.props.siteSpecificPlansDetails && this.props.siteSpecificPlansDetails.can_start_trial ) {
+				return true;
+			}
+		}
+		return false;
+	},
+
 	getImageButton: function() {
 		const classes = classNames( 'plan-actions__illustration', this.props.plan.product_slug );
 
@@ -162,7 +175,7 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<div onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'button' ) } className={ classes } />
+			<div onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: this.shouldOfferFreeTrial() } ), 'button' ) } className={ classes } />
 		);
 	},
 

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -141,18 +141,19 @@ module.exports = React.createClass( {
 	},
 
 	shouldOfferFreeTrial: function() {
-		if ( config.isEnabled( 'upgrades/free-trials' ) ) {
-			if ( this.props.isInSignup && this.props.flowName !== 'free-trial' ) {
-				return false;
-			}
-
-			if ( this.props.siteSpecificPlansDetails && ! this.props.siteSpecificPlansDetails.can_start_trial ) {
-				return false;
-			}
-
-			return true;
+		if ( ! config.isEnabled( 'upgrades/free-trials' ) ) {
+			return false;
 		}
-		return false;
+
+		if ( this.props.isInSignup && this.props.flowName !== 'free-trial' ) {
+			return false;
+		}
+
+		if ( this.props.siteSpecificPlansDetails && ! this.props.siteSpecificPlansDetails.can_start_trial ) {
+			return false;
+		}
+
+		return true;
 	},
 
 	getImageButton: function() {

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -27,11 +27,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( this.props.isInSignup ) {
-			if ( this.props.flowName === 'free-trial' && config.isEnabled( 'upgrades/free-trials' ) ) {
-				return this.freeTrialActions();
-			}
-
-			return this.upgradeActions();
+			return this.shouldOfferFreeTrial() ? this.freeTrialActions() : this.upgradeActions();
 		}
 
 		if ( this.siteHasThisPlan() ) {
@@ -55,9 +51,7 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		const canStartTrial = config.isEnabled( 'upgrades/free-trials' ) ? this.props.siteSpecificPlansDetails.can_start_trial : false;
-
-		return canStartTrial ? this.freeTrialActions() : this.upgradeActions();
+		return this.shouldOfferFreeTrial() ? this.freeTrialActions() : this.upgradeActions();
 	},
 
 	freePlanButton: function() {
@@ -152,9 +146,11 @@ module.exports = React.createClass( {
 				return false;
 			}
 
-			if ( this.props.siteSpecificPlansDetails && this.props.siteSpecificPlansDetails.can_start_trial ) {
-				return true;
+			if ( this.props.siteSpecificPlansDetails && ! this.props.siteSpecificPlansDetails.can_start_trial ) {
+				return false;
 			}
+
+			return true;
 		}
 		return false;
 	},

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -145,11 +145,13 @@ module.exports = React.createClass( {
 			return false;
 		}
 
-		if ( this.props.isInSignup && this.props.flowName !== 'free-trial' ) {
+		if ( ! this.props.enableFreeTrials ) {
 			return false;
 		}
 
-		if ( this.props.siteSpecificPlansDetails && ! this.props.siteSpecificPlansDetails.can_start_trial ) {
+		const siteCanOfferTrial = this.props.siteSpecificPlansDetails && this.props.siteSpecificPlansDetails.can_start_trial;
+
+		if ( ! this.props.isInSignup && ! siteCanOfferTrial ) {
 			return false;
 		}
 

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -27,7 +27,11 @@ module.exports = React.createClass( {
 		}
 
 		if ( this.props.isInSignup ) {
-			return config.isEnabled( 'upgrades/free-trials' ) ? this.freeTrialActions() : this.upgradeActions();
+			if ( this.props.flowName === 'free-trial' && config.isEnabled( 'upgrades/free-trials' ) ) {
+				return this.freeTrialActions();
+			}
+
+			return this.upgradeActions();
 		}
 
 		if ( this.siteHasThisPlan() ) {

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -67,6 +67,7 @@ module.exports = React.createClass( {
 						onOpen={ this.openPlan }
 						onSelectPlan={ this.props.onSelectPlan }
 						site={ site }
+						flowName={ this.props.flowName }
 						cart={ this.props.cart } />
 				);
 			}, this );

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -67,7 +67,7 @@ module.exports = React.createClass( {
 						onOpen={ this.openPlan }
 						onSelectPlan={ this.props.onSelectPlan }
 						site={ site }
-						flowName={ this.props.flowName }
+						enableFreeTrials={ this.props.enableFreeTrials }
 						cart={ this.props.cart } />
 				);
 			}, this );

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -169,7 +169,7 @@ module.exports = React.createClass( {
 				siteSpecificPlansDetails={ this.getSiteSpecificPlanDetails() }
 				site={ this.props.site }
 				cart={ this.props.cart }
-				flowName={ this.props.flowName }
+				enableFreeTrials={ this.props.enableFreeTrials }
 				isPlaceholder={ this.isPlaceholder() }/>
 		);
 	},
@@ -183,7 +183,7 @@ module.exports = React.createClass( {
 				siteSpecificPlansDetails={ this.getSiteSpecificPlanDetails() }
 				site={ this.props.site }
 				cart={ this.props.cart }
-				flowName={ this.props.flowName }
+				enableFreeTrials={ this.props.enableFreeTrials }
 				isPlaceholder={ this.isPlaceholder() }
 				isImageButton />
 		);

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -169,6 +169,7 @@ module.exports = React.createClass( {
 				siteSpecificPlansDetails={ this.getSiteSpecificPlanDetails() }
 				site={ this.props.site }
 				cart={ this.props.cart }
+				flowName={ this.props.flowName }
 				isPlaceholder={ this.isPlaceholder() }/>
 		);
 	},
@@ -182,6 +183,7 @@ module.exports = React.createClass( {
 				siteSpecificPlansDetails={ this.getSiteSpecificPlanDetails() }
 				site={ this.props.site }
 				cart={ this.props.cart }
+				flowName={ this.props.flowName }
 				isPlaceholder={ this.isPlaceholder() }
 				isImageButton />
 		);

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -89,6 +89,7 @@ module.exports = React.createClass( {
 						sites={ this.props.sites }
 						plans={ this.props.plans.get() }
 						siteSpecificPlansDetailsList={ this.props.siteSpecificPlansDetailsList }
+						enableFreeTrials={ true }
 						onOpen={ this.openPlan }
 						onSelectPlan={ this.props.onSelectPlan }
 						cart={ this.props.cart } />

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -135,7 +135,7 @@ const flows = {
 		lastModified: '2015-11-13'
 	},
 
-	'layout': {
+	layout: {
 		steps: [ 'design-type', 'themes', 'domains', 'plans', 'user' ],
 		destination: getCheckoutDestination,
 		description: 'Theme trifurcation flow',
@@ -149,7 +149,7 @@ const flows = {
 		lastModified: '2015-11-23'
 	},
 
-	'jetpack': {
+	jetpack: {
 		steps: [ 'jetpack-user' ],
 		destination: '/'
 	},

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -152,6 +152,13 @@ const flows = {
 	'jetpack': {
 		steps: [ 'jetpack-user' ],
 		destination: '/'
+	},
+
+	'free-trial': {
+		steps: [ 'themes', 'site', 'plans', 'user' ],
+		destination: getCheckoutDestination,
+		description: 'Signup flow for free trials',
+		lastModified: '2015-12-18'
 	}
 };
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -86,6 +86,7 @@ module.exports = React.createClass( {
 				<PlanList
 					plans={ this.state.plans }
 					comparePlansUrl={ this.comparePlansUrl() }
+					flowName={ this.props.flowName }
 					isInSignup={ true }
 					onSelectPlan={ this.onSelectPlan } />
 				<a

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -86,7 +86,7 @@ module.exports = React.createClass( {
 				<PlanList
 					plans={ this.state.plans }
 					comparePlansUrl={ this.comparePlansUrl() }
-					flowName={ this.props.flowName }
+					enableFreeTrials={ 'free-trial' === this.props.flowName }
 					isInSignup={ true }
 					onSelectPlan={ this.onSelectPlan } />
 				<a


### PR DESCRIPTION
This pull request fixes #1374 by creating a new signup flow that removes the domains step since we don't offer domains as part of free trials.
 
#### Testing instructions: Plans

1. Run `git checkout update/1374-create-free-trial-flow` and start your server
2. Open http://calypso.localhost:3000/plans
3. Check that you are offered to start a free trial on a site that has no plans
4. Start a free trial
5. Assert that a free trial is added to the cart
5. Assert that you are not offered a free trial on /plans
6. Purchase Premium
7. Assert that you are not offered a free trial on /plans

#### Testing instructions 2: Signup without a trial

1. Open http://calypso.localhost:3000/start
2. Move to the plans step
3. Assert that you are not offered a free trial
4. Select a plan
5. Assert that a paid plan is added to the cart

#### Testing instructions 3: Signup with a trial

1. Open http://calypso.localhost:3000/start/free-trial
2. Move to the plans step
3. Assert that you are offered a free trial
4. Select a plan
5. Assert that a free trial is added to the cart


#### Note

This PR also modifies the behaviour of the image button; it will have the same effect as the primary button on the corresponding plan. (If the button says Start Free Trial, the image button should start a free trial).

#### Reviews

- [x] Code
- [x] Product

cc @spncrb @drewblaisdell 