### PR TITLE
Redux: Add utils actions and store-based uniqueId replacement

### DIFF
--- a/client/state/action-types.js
+++ b/client/state/action-types.js
@@ -27,4 +27,10 @@ export const SET_EXPORT_POST_TYPE = 'SET_EXPORT_POST_TYPE';
 export const SET_ROUTE = 'SET_ROUTE';
 export const SET_SECTION = 'SET_SECTION';
 export const SET_SELECTED_SITE = 'SET_SELECTED_SITE';
+<<<<<<< HEAD
 export const USER_RECEIVE = 'USER_RECEIVE';
+=======
+export const TOGGLE_EXPORTER_ADVANCED_SETTINGS = 'TOGGLE_EXPORTER_ADVANCED_SETTINGS';
+export const TOGGLE_EXPORTER_SECTION = 'TOGGLE_EXPORTER_SECTION';
+export const UTILS_UNIQUEID_INCREMENT = 'UTILS_UNIQUEID_INCREMENT';
+>>>>>>> Redux: Add utils actions and store-based uniqueId replacement

--- a/client/state/action-types.js
+++ b/client/state/action-types.js
@@ -27,10 +27,5 @@ export const SET_EXPORT_POST_TYPE = 'SET_EXPORT_POST_TYPE';
 export const SET_ROUTE = 'SET_ROUTE';
 export const SET_SECTION = 'SET_SECTION';
 export const SET_SELECTED_SITE = 'SET_SELECTED_SITE';
-<<<<<<< HEAD
 export const USER_RECEIVE = 'USER_RECEIVE';
-=======
-export const TOGGLE_EXPORTER_ADVANCED_SETTINGS = 'TOGGLE_EXPORTER_ADVANCED_SETTINGS';
-export const TOGGLE_EXPORTER_SECTION = 'TOGGLE_EXPORTER_SECTION';
 export const UTILS_UNIQUEID_INCREMENT = 'UTILS_UNIQUEID_INCREMENT';
->>>>>>> Redux: Add utils actions and store-based uniqueId replacement

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -16,6 +16,7 @@ import siteSettings from './site-settings/reducer'
 import themes from 'lib/themes/reducers';
 import users from './users/reducer';
 import ui from './ui/reducer';
+import utils from './utils/reducer';
 
 /**
  * Module variables
@@ -28,6 +29,7 @@ const reducer = combineReducers( {
 	siteSettings,
 	themes,
 	users,
+	utils,
 	ui
 } );
 

--- a/client/state/utils/Makefile
+++ b/client/state/utils/Makefile
@@ -1,0 +1,10 @@
+REPORTER ?= spec
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := $(BASE_DIR)/client:$(BASE_DIR)/shared
+
+test:
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers jsx:babel/register,js:babel/register --reporter $(REPORTER)
+
+.PHONY: test

--- a/client/state/utils/README.md
+++ b/client/state/utils/README.md
@@ -1,7 +1,7 @@
 Utils
 ========
 
-A module for those little helpers that need to interact woth the store.
+A module for those little helpers that need to interact with the store.
 
 # Actions
 Used in combination with the Redux store instance `dispatch` function, actions can be used in manipulating the current global state.

--- a/client/state/utils/README.md
+++ b/client/state/utils/README.md
@@ -1,0 +1,18 @@
+Utils
+========
+
+A module for those little helpers that need to interact woth the store.
+
+# Actions
+Used in combination with the Redux store instance `dispatch` function, actions can be used in manipulating the current global state.
+
+## uniqueId( prefix )
+Meant as a replacement for _ and lodash "uniqueId" function.
+Returns unique numeric prefixed by prefix and increments internal state, so the next uniqueId will be different.
+
+```js
+import { uniqueId } from 'state/utils/actions';
+
+const id = dispatch( uniqueId( 'myprefix_' ) );
+```
+

--- a/client/state/utils/actions.js
+++ b/client/state/utils/actions.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { UTILS_UNIQUEID_INCREMENT } from 'state/action-types';
+
+export function uniqueId( prefix ) {
+	return ( dispatch, getState ) => {
+		dispatch( { type: UTILS_UNIQUEID_INCREMENT } );
+		const id = getState().utils.uniqueId + '';
+		return prefix ? prefix + id : id;
+	};
+}

--- a/client/state/utils/actions.js
+++ b/client/state/utils/actions.js
@@ -3,9 +3,13 @@
  */
 import { UTILS_UNIQUEID_INCREMENT } from 'state/action-types';
 
+export function uniqueIdIncrement() {
+	return { type: UTILS_UNIQUEID_INCREMENT };
+}
+
 export function uniqueId( prefix ) {
 	return ( dispatch, getState ) => {
-		dispatch( { type: UTILS_UNIQUEID_INCREMENT } );
+		dispatch( uniqueIdIncrement() );
 		const id = getState().utils.uniqueId.toString();
 		return prefix ? prefix + id : id;
 	};

--- a/client/state/utils/actions.js
+++ b/client/state/utils/actions.js
@@ -6,7 +6,7 @@ import { UTILS_UNIQUEID_INCREMENT } from 'state/action-types';
 export function uniqueId( prefix ) {
 	return ( dispatch, getState ) => {
 		dispatch( { type: UTILS_UNIQUEID_INCREMENT } );
-		const id = getState().utils.uniqueId + '';
+		const id = getState().utils.uniqueId.toString();
 		return prefix ? prefix + id : id;
 	};
 }

--- a/client/state/utils/reducer.js
+++ b/client/state/utils/reducer.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { combineReducers } from 'redux';
+import { UTILS_UNIQUEID_INCREMENT } from 'state/action-types';
+
+export function uniqueId( state = 1, action ) {
+	switch ( action.type ) {
+		case UTILS_UNIQUEID_INCREMENT:
+			state = state + 1;
+			break;
+	}
+
+	return state;
+}
+
+export default combineReducers( {
+	uniqueId
+} );

--- a/client/state/utils/test/actions.js
+++ b/client/state/utils/test/actions.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+/**
+ * Internal dependencies
+ */
+import { UTILS_UNIQUEID_INCREMENT } from 'state/action-types';
+import { uniqueId, uniqueIdIncrement } from '../actions';
+
+describe( 'actions', () => {
+	describe( 'uniqueIdIncrement()', () => {
+		it( 'should return an action object with type UTILS_UNIQUEID_INCREMENT', () => {
+			const action = uniqueIdIncrement();
+			expect( action ).to.eql( {
+				type: UTILS_UNIQUEID_INCREMENT
+			} );
+		} );
+	} );
+
+	describe( 'uniqueId()', () => {
+		const getState = () => {
+			return {
+				utils: {
+					uniqueId: 3
+				}
+			}
+		};
+
+		it( 'should call dispatch to increment the counter', () => {
+			const dispatchSpy = spy(),
+				getStateSpy = spy( getState );
+
+			uniqueId()( dispatchSpy, getStateSpy );
+			expect( dispatchSpy.calledWithMatch( { type: UTILS_UNIQUEID_INCREMENT } ) ).to.be.ok;
+		} );
+
+		it( 'should return new counter value', () => {
+			const dispatchSpy = spy(),
+				getStateSpy = spy( getState ),
+				newValue = uniqueId()( dispatchSpy, getStateSpy );
+
+			expect( newValue ).to.eql( '3' );
+		} );
+
+		it( 'should return store value only after incrementing it', () => {
+			const dispatchSpy = spy(),
+				getStateSpy = spy( getState );
+
+			uniqueId()( dispatchSpy, getStateSpy )
+
+			expect( getStateSpy.calledAfter( dispatchSpy ) ).to.be.ok;
+		} );
+	} );
+} );

--- a/client/state/utils/test/integration.js
+++ b/client/state/utils/test/integration.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+/**
+ * Internal dependencies
+ */
+import { uniqueId as uniqueId } from '../actions';
+import { uniqueId as uniqueIdReducer } from '../reducer';
+
+describe( 'integrationTest', () => {
+	describe( 'uniqueId', () => {
+		let state = 0;
+		const getState = () => {
+			return {
+				utils: {
+					uniqueId: state
+				}
+			};
+		};
+		const dispatchSpy = spy( action => {
+			state = uniqueIdReducer( state, action );
+		} );
+		const getStateSpy = spy( getState );
+
+		it( 'should return incremented number', () => {
+			const initState = 1;
+			state = initState;
+
+			const returnValue = uniqueId()( dispatchSpy, getStateSpy );
+
+			expect( state ).to.eql( initState + 1 );
+			expect( returnValue ).to.eql( state.toString() );
+		} );
+	} );
+} );

--- a/client/state/utils/test/reducer.js
+++ b/client/state/utils/test/reducer.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { UTILS_UNIQUEID_INCREMENT } from 'state/action-types';
+import { uniqueId } from '../reducer';
+
+describe( 'reducer', () => {
+	describe( 'uniqueId', () => {
+		it( 'should default to a number', () => {
+			const state = uniqueId( undefined, {} );
+			expect( state ).to.be.a( 'number' );
+		} );
+
+		it( 'action UTILS_UNIQUEID_INCREMENT should increment previous state', () => {
+			const state = uniqueId( 1, { type: UTILS_UNIQUEID_INCREMENT } );
+			expect( state ).to.eql( 2 );
+		} );
+	} );
+} );


### PR DESCRIPTION
# Problem
In #1496 I needed to use lodash `uniqueId` but it keeps private increment value, so it would not survive dehydration of store. Also, it could create memory problems in SSR.
@rralian mentioned this in a comment:
https://github.com/Automattic/wp-calypso/pull/1496#discussion-diff-47968438

# Solution 
Store - based `uniqueId` and utils.
_, lodash is taken, so we can call them hyphen.js, but we dont need to.

# Testing
These are helpers, so no new functionality, but you can use code from README