### PR TITLE
Editor: Fix error message shown to non-admin users on Jetpack sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -205,7 +205,7 @@ module.exports = {
 			var site = sites.getSite( siteFragment );
 			if ( ! site ) {
 				sites.once( 'change', checkSiteShouldFetch );
-			} else if ( site.jetpack ) {
+			} else if ( site.jetpack && site.user_can_manage ) {
 				site.fetchSettings();
 			}
 		}


### PR DESCRIPTION
Fixes #1751

This pull request seeks to resolve an error which can occur when a non-administrator role user attempts to load the post editor for a Jetpack site.

![image](https://cloud.githubusercontent.com/assets/1779930/11898157/d334747a-a563-11e5-8254-cfed49b6864c.png)

__Implementation notes:__

Because of syncing issues with default post format and category availability from a Jetpack site, we attempt to fetch from the settings endpoint for a site, since this provides the same information but is always executed in the context of the Jetpack site environment, so the information is accurate. In the editor, we gracefully fall back to `options` if `settings` is not available. In Automattic/Jetpack#2999, more options were added to the sync, so the reliance on `settings` will not apply for newer versions of Jetpack.

See: https://github.com/Automattic/wp-calypso/blob/0b9cf4b/client/lib/site/utils.js#L39-L65

Ref: 11836-gh-calypso-pre-oss

__Testing instructions:__

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a Jetpack site for which you are not an administrator (e.g. Author)
3. Note that no error notice is shown

/cc @jkudish 