### PR TITLE
Build: fix the node-version rule.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ run: welcome githooks-commit install build
 	@$(NODE) build/bundle-$(CALYPSO_ENV).js
 
 node-version:
-	@NPM_GLOBAL_ROOT=
+	@NPM_GLOBAL_ROOT=$(shell $(NPM) -g root) $(BIN)/check-node-version
 
 # a helper rule to ensure that a specific module is installed,
 # without relying on a generic `npm install` command


### PR DESCRIPTION
Somehow I broke this with the last commit on #1204 and didn't notice.

This re-instates the call to `check-node-version` to inform folks on old nodes that they need to upgrade.

To test, downgrade to node v12.x.x and try to run `make install` or `make lint`.