### PR TITLE
Plans: Use compact buttons for features in free trial hub

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-feature/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-feature/index.jsx
@@ -20,7 +20,7 @@ const PlanFeature = ( { button, description, heading } ) => {
 				<Button
 					className="plan-feature__button"
 					href={ button.href }
-					primary
+					secondary
 					compact>
 					{ button.label }
 				</Button>

--- a/client/my-sites/plans/plan-overview/plan-feature/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-feature/index.jsx
@@ -20,7 +20,8 @@ const PlanFeature = ( { button, description, heading } ) => {
 				<Button
 					className="plan-feature__button"
 					href={ button.href }
-					primary>
+					primary
+					compact>
 					{ button.label }
 				</Button>
 			}

--- a/client/my-sites/plans/plan-overview/plan-feature/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-feature/index.jsx
@@ -20,7 +20,6 @@ const PlanFeature = ( { button, description, heading } ) => {
 				<Button
 					className="plan-feature__button"
 					href={ button.href }
-					secondary
 					compact>
 					{ button.label }
 				</Button>

--- a/client/my-sites/plans/plan-overview/plan-status/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/index.jsx
@@ -60,7 +60,8 @@ const PlanStatus = React.createClass( {
 					<Button
 						primary={ getDaysUntilUserFacingExpiry( this.props.plan ) < 6 }
 						className="plan-status__button"
-						onClick={ this.purchasePlan }>
+						onClick={ this.purchasePlan }
+						primary>
 						{ this.translate( 'Purchase Now' ) }
 					</Button>
 				</CompactCard>

--- a/client/my-sites/plans/plan-overview/style.scss
+++ b/client/my-sites/plans/plan-overview/style.scss
@@ -2,7 +2,7 @@
 	.plan-feature__button,
 	.plan-status__button {
 		flex-shrink: 0;
-		min-width: 160px;
+		min-width: 125px;
 		text-align: center;
 
 		@include breakpoint( "<480px" ) {

--- a/client/my-sites/plans/plan-overview/style.scss
+++ b/client/my-sites/plans/plan-overview/style.scss
@@ -2,7 +2,6 @@
 	.plan-feature__button,
 	.plan-status__button {
 		flex-shrink: 0;
-		min-width: 125px;
 		text-align: center;
 
 		@include breakpoint( "<480px" ) {
@@ -11,7 +10,7 @@
 		}
 
 		@include breakpoint( ">480px" ) {
-			margin-left: 15px;
+			margin-left: 30px;
 		}
 	}
 }


### PR DESCRIPTION
Changes the feature buttons on the free trial hub to use the compact style, as suggested by @mtias in https://github.com/Automattic/wp-calypso/pull/1565/files#r48037498.

Before | After
------------ | ------------
<img width="721" alt="screen shot 2015-12-18 at 8 05 51 am" src="https://cloud.githubusercontent.com/assets/3011211/11901046/46d9db00-a55e-11e5-8ecc-3ce96cb204f5.png"> | <img width="726" alt="screen shot 2015-12-18 at 8 05 19 am" src="https://cloud.githubusercontent.com/assets/3011211/11901047/46da6a5c-a55e-11e5-9e66-6ffbdbbac6aa.png">

cc: @stephanethomas @mikeshelton1503 