### PR TITLE
Framework: enable devdocs in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -66,7 +66,7 @@
 		"olark": false,
 		"olark_use_wpcom_configuration": false,
 		"community-translator": true,
-		"devdocs": false,
+		"devdocs": true,
 		"keyboard-shortcuts": true,
 		"jetpack_core_inline_update": true,
 		"me/my-profile": true,

--- a/config/production.json
+++ b/config/production.json
@@ -66,6 +66,7 @@
 		"olark": true,
 		"olark_use_wpcom_configuration": false,
 		"community-translator": true,
+		"devdocs": true,
 		"reader": true,
 		"reader/teams": true,
 		"reader/lists": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -68,6 +68,7 @@
 		"olark": true,
 		"olark_use_wpcom_configuration": false,
 		"community-translator": true,
+		"devdocs": true,
 		"jetpack_core_inline_update": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,


### PR DESCRIPTION
This would make our devdocs section available at wordpress.com/devdocs instead of only making it available to locally running instances and wpcalypso.wordpress.com/devdocs.

There isn't much point in reserving this section to development and wpcalypso. wpcalypso is public anyway, so people can get to it... it's not like there's anything to hide. And enabling this in production isn't going to all of a sudden make it appear for regular users. It just gives us a less awkward place to point OSS developers/designers to see some of our documentation and to play with our available components.

/cc @mtias @nb 