### PR TITLE
Plugins: Divide plugins main into smaller components

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -201,6 +201,7 @@
 @import 'my-sites/plugins/plugin-icon/style';
 @import 'my-sites/plugins/plugin-information/style';
 @import 'my-sites/plugins/plugin-item/style';
+@import 'my-sites/plugins/plugin-list-header/style';
 @import 'my-sites/plugins/plugin-meta/style';
 @import 'my-sites/plugins/plugin-ratings/style';
 @import 'my-sites/plugins/plugin-sections/style';

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -12,7 +12,6 @@ import reject from 'lodash/collection/reject';
 import assign from 'lodash/object/assign';
 import property from 'lodash/utility/property';
 import isEmpty from 'lodash/lang/isEmpty';
-import config from 'config';
 
 /**
  * Internal dependencies
@@ -42,13 +41,7 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PlanNudge from 'components/plans/plan-nudge';
 import FeatureExample from 'components/feature-example';
 import SectionHeader from 'components/section-header';
-import ButtonGroup from 'components/button-group';
-import Button from 'components/button';
-import Gridicon from 'components/gridicon';
-import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
-import DropdownSeparator from 'components/select-dropdown/separator';
-import BulkSelect from 'components/bulk-select';
+import PluginsListHeader from './plugin-list-header';
 
 /**
  * Module variables
@@ -225,10 +218,6 @@ export default React.createClass( {
 			PluginsActions.removePluginsNotices( this.state.notices.completed.concat( this.state.notices.errors ) );
 			this.recordEvent( 'Clicked Manage Done' );
 		}
-	},
-
-	onBrowserLinkClick() {
-		this.recordEvent( 'Clicked Add New Plugins' );
 	},
 
 	togglePluginSelection( plugin ) {
@@ -443,7 +432,6 @@ export default React.createClass( {
 	},
 
 	renderPluginList( plugins, header, isWpCom ) {
-		let headerMarkup;
 		const slug = header.replace( / /g, '' );
 
 		if ( isEmpty( plugins ) ) {
@@ -454,25 +442,26 @@ export default React.createClass( {
 			'is-bulk-editing': this.state.bulkManagement
 		} );
 
-		const headerClasses = classNames( 'plugins__section-actions', {
-			'is-bulk-editing': this.state.bulkManagement
-		} );
-
-		if ( this.state.bulkManagement ) {
-			header = null;
-		}
-
-		headerMarkup = (
-			<SectionHeader label={ header } className={ headerClasses } key={ 'plugins__section-header-' + slug } >
-				{ ! this.state.bulkManagement ? null : <BulkSelect key="plugins__bulk-select" totalElements={ this.state.plugins.length } selectedElements={ this.getSelected().length } onToggle={ this.unselectOrSelectAll } /> }
-				{ this.getCurrentActionDropdown() }
-				{ this.getCurrentActionButtons( isWpCom ) }
-			</SectionHeader>
-		);
-
 		return (
 			<span key={ 'plugins__header-' + slug }>
-				{ headerMarkup }
+				<PluginsListHeader label={ header }
+					isWpCom={ isWpCom }
+					bulkManagement={ this.state.bulkManagement }
+					sites={ this.props.sites }
+					plugins={ this.state.plugins }
+					selected={ this.getSelected() }
+					onToggle={ this.unselectOrSelectAll }
+					areSelected={ this.areSelected }
+					toggleBulkManagement={ this.toggleBulkManagement }
+					updateAllPlugins={ this.updateAllPlugins }
+					pluginUpdateCount={ this.state.pluginUpdateCount }
+					activateSelected={ this.activateSelected }
+					deactiveAndDisconnectSelected={ this.deactiveAndDisconnectSelected }
+					deactivateSelected={ this.deactivateSelected }
+					setAutoupdateSelected={ this.setAutoupdateSelected }
+					unsetAutoupdateSelected={ this.unsetAutoupdateSelected }
+					removePluginNotice={ this.removePluginNotice }
+					/>
 				<div className={ itemListClasses }>{ this.formatPlugins( plugins ) }</div>
 			</span>
 		);
@@ -527,127 +516,6 @@ export default React.createClass( {
 			case 'all':
 				return this.translate( 'Search All…', { textOnly: true } );
 		}
-	},
-
-	canAddNewPlugins() {
-		if ( config.isEnabled( 'manage/plugins/browser' ) ) {
-			return this.hasJetpackSelectedSites();
-		}
-		return false;
-	},
-
-	canUpdatePlugins() {
-		return this.state.plugins
-			.filter( plugin => plugin.selected )
-			.some( plugin => plugin.sites.some( site => site.canUpdateFiles ) );
-	},
-
-	canAutoupdatePlugins() {
-		return this.state.plugins
-			.filter( plugin => plugin.selected )
-			.some( plugin => plugin.sites.some( site => site.canAutoupdateFiles ) );
-	},
-
-	hasJetpackSelectedSites() {
-		const selectedSite = this.props.sites.getSelectedSite();
-		if ( selectedSite ) {
-			return !! selectedSite.jetpack;
-		}
-		return this.props.sites.getJetpack().length > 0;
-	},
-
-	getCurrentActionButtons( isWpCom ) {
-		let buttons = [];
-		let rightSideButtons = [];
-		let leftSideButtons = [];
-		let updateButtons = [];
-		let activateButtons = [];
-
-		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
-		const isJetpackSelected = this.state.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
-		const needsRemoveButton = this.getSelected().length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
-		if ( ! this.state.bulkManagement ) {
-			if ( ! isWpCom && 0 < this.state.pluginUpdateCount ) {
-				rightSideButtons.push(
-					<ButtonGroup key="plugins__buttons-update-all">
-						<Button compact primary onClick={ this.updateAllPlugins } >
-							{ this.translate( 'Update All', { context: 'button label' } ) }
-						</Button>
-					</ButtonGroup>
-				);
-			}
-			rightSideButtons.push(
-				<ButtonGroup key="plugins__buttons-bulk-management"><Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>{ this.translate( 'Edit All', { context: 'button label' } ) }</Button></ButtonGroup>
-			);
-			if ( ! isWpCom && this.canAddNewPlugins() ) {
-				const selectedSite = this.props.sites.getSelectedSite();
-				const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
-
-				rightSideButtons.push(
-					<ButtonGroup key="plugins__buttons-browser"><Button compact href={ browserUrl } onClick={ this.onBrowserLinkClick } className="plugins__browser-button"><Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } /></Button></ButtonGroup>
-				);
-			}
-		} else {
-			activateButtons.push( <Button key="plugins__buttons-activate" disabled={ ! this.areSelected( 'inactive' ) } compact onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
-			let deactivateButton = isJetpackSelected
-				? <Button key="plugins__buttons-deactivate" disabled={ ! this.areSelected( 'active' ) } compact onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</Button>
-				: <Button key="plugins__buttons-disable" disabled={ ! this.areSelected( 'active' ) } compact onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</Button>;
-			activateButtons.push( deactivateButton )
-			leftSideButtons.push( <ButtonGroup key="plugins__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
-
-			if ( this.hasJetpackSelectedSites() && ! isWpCom ) {
-				updateButtons.push( <Button key="plugins__buttons-autoupdate-on" disabled={ hasWpcomPlugins || ! this.canAutoupdatePlugins() } compact onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
-				updateButtons.push( <Button key="plugins__buttons-autoupdate-off" disabled={ hasWpcomPlugins || ! this.canAutoupdatePlugins() } compact onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
-
-				leftSideButtons.push( <ButtonGroup key="plugins__buttons-update-buttons">{ updateButtons }</ButtonGroup> );
-				leftSideButtons.push( <ButtonGroup key="plugins__buttons-remove-button"><Button disabled={ ! needsRemoveButton } compact scary onClick={ this.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
-			}
-
-			rightSideButtons.push(
-				<button key="plugins__buttons-close-button" className="plugins__section-actions-close" onClick={ this.toggleBulkManagement }>
-					<span className="screen-reader-text">{ this.translate( 'Close' ) }</span>
-					<Gridicon icon="cross" />
-				</button>
-			);
-		}
-
-		buttons.push( <span key="plugins__buttons-action-buttons" className="plugins__action-buttons">{ leftSideButtons }</span> );
-		buttons.push( <span key="plugins__buttons-global-buttons" className="plugins__mode-buttons">{ rightSideButtons }</span> );
-
-		return buttons;
-	},
-
-	getCurrentActionDropdown() {
-		let options = [];
-		let actions = [];
-
-		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
-		const isJetpackSelected = this.state.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
-		const needsRemoveButton = !! this.getSelected().length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
-
-		if ( this.state.bulkManagement ) {
-			options.push( <DropdownItem key="plugin__actions_title" selected={ true } v1alue="Actions">{ this.translate( 'Actions' ) }</DropdownItem> );
-			options.push( <DropdownSeparator key="plugin__actions_separator_1" /> );
-
-			options.push( <DropdownItem key="plugin__actions_activate" disabled={ ! this.areSelected( 'inactive' ) } onClick={ this.activateSelected }>{ this.translate( 'Activate' ) }</DropdownItem> );
-
-			let deactivateAction = isJetpackSelected
-				? <DropdownItem key="plugin__actions_disconnect" disabled={ ! this.areSelected( 'active' ) } onClick={ this.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</DropdownItem>
-				: <DropdownItem key="plugin__actions_deactivate" disabled={ ! this.areSelected( 'active' ) } onClick={ this.deactivateSelected }>{ this.translate( 'Deactivate' ) }</DropdownItem>;
-			options.push( deactivateAction );
-
-			if ( this.hasJetpackSelectedSites() ) {
-				options.push( <DropdownSeparator key="plugin__actions_separator_2" /> );
-				options.push( <DropdownItem key="plugin__actions_autoupdate" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } onClick={ this.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</DropdownItem> );
-				options.push( <DropdownItem key="plugin__actions_disable_autoupdate" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } onClick={ this.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</DropdownItem> );
-
-				options.push( <DropdownSeparator key="plugin__actions_separator_3" /> );
-				options.push( <DropdownItem key="plugin__actions_remove" className="plugins__actions_remove_item" disabled={ ! needsRemoveButton } onClick={ this.removePluginNotice } >{ this.translate( 'Remove' ) }</DropdownItem> );
-			}
-
-			actions.push( <SelectDropdown compact className="plugins__actions_dropdown" key="plugins__actions_dropdown" selectedText="Actions">{ options }</SelectDropdown> );
-		}
-		return actions;
 	},
 
 	getEmptyContentUpdateData() {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -171,14 +171,6 @@ export default React.createClass( {
 		return this.state.plugins.filter( this.filterSelection.selected );
 	},
 
-	areSelected( filterSelection ) {
-		const selectedFilter = filterSelection ? filterSelection : 'selected';
-		if ( ! this.state.plugins ) {
-			return false;
-		}
-		return this.state.plugins.some( this.filterSelection[ selectedFilter ] );
-	},
-
 	recordEvent( eventAction, includeSelectedPlugins ) {
 		eventAction += ( this.props.site ? '' : ' on Multisite' );
 
@@ -188,10 +180,6 @@ export default React.createClass( {
 		} else {
 			analytics.ga.recordEvent( 'Plugins', eventAction );
 		}
-	},
-
-	changeSelectionOptionsState() {
-		this.setState( { selectionOptionsOpen: ! this.state.selectionOptionsOpen } );
 	},
 
 	matchSearchTerms( search, plugin ) {
@@ -223,16 +211,6 @@ export default React.createClass( {
 	togglePluginSelection( plugin ) {
 		PluginsActions.togglePluginSelection( plugin );
 		analytics.ga.recordEvent( 'Plugins', 'Clicked to ' + plugin.selected ? 'Deselect' : 'Select' + 'Single Plugin', 'Plugin Name', plugin.slug );
-	},
-
-	unselectOrSelectAll() {
-		if ( this.areSelected() ) {
-			PluginsActions.selectPlugins( this.props.sites.getSelectedOrAllWithPlugins(), 'none' );
-			this.recordEvent( 'Clicked to Uncheck All Plugins' );
-			return;
-		}
-		PluginsActions.selectPlugins( this.props.sites.getSelectedOrAllWithPlugins(), 'all' );
-		this.recordEvent( 'Clicked to Check All Plugins' );
 	},
 
 	doActionOverSelected( actionName, action ) {
@@ -446,12 +424,10 @@ export default React.createClass( {
 			<span key={ 'plugins__header-' + slug }>
 				<PluginsListHeader label={ header }
 					isWpCom={ isWpCom }
-					bulkManagement={ this.state.bulkManagement }
+					isBulkManagementActive={ this.state.bulkManagement }
 					sites={ this.props.sites }
 					plugins={ this.state.plugins }
 					selected={ this.getSelected() }
-					onToggle={ this.unselectOrSelectAll }
-					areSelected={ this.areSelected }
 					toggleBulkManagement={ this.toggleBulkManagement }
 					updateAllPlugins={ this.updateAllPlugins }
 					pluginUpdateCount={ this.state.pluginUpdateCount }
@@ -461,7 +437,10 @@ export default React.createClass( {
 					setAutoupdateSelected={ this.setAutoupdateSelected }
 					unsetAutoupdateSelected={ this.unsetAutoupdateSelected }
 					removePluginNotice={ this.removePluginNotice }
-					/>
+					haveActiveSelected={ this.state.plugins.some( this.filterSelection.active ) }
+					haveInactiveSelected={ this.state.plugins.some( this.filterSelection.inactive ) }
+					haveUpdatesSelected={ this.state.plugins.some( this.filterSelection.updates ) }
+					haveSelected={ this.state.plugins.some( this.filterSelection.selected ) } />
 				<div className={ itemListClasses }>{ this.formatPlugins( plugins ) }</div>
 			</span>
 		);

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -389,6 +389,7 @@ export default React.createClass( {
 
 		return plugins.map( plugin => {
 			const hasAllNoManageSites = ! plugin.wpcom && plugin.sites.every( pluginSite => manageableSites.every( site => site.slug !== pluginSite.slug ) );
+			const selectThisPlugin = this.togglePluginSelection.bind( this, plugin );
 			return (
 				<PluginItem
 					key={ plugin.slug }
@@ -397,7 +398,7 @@ export default React.createClass( {
 					sites={ plugin.sites }
 					isSelected={ plugin.selected }
 					isSelectable={ this.state.bulkManagement }
-					onClick={ this.togglePluginSelection.bind( this, plugin ) }
+					onClick={ selectThisPlugin }
 					pluginLink={ this.props.path + '/' + encodeURIComponent( plugin.slug ) + ( plugin.wpcom ? '/business' : '' ) + this.siteSuffix() }
 					progress={ this.state.notices.inProgress.filter( log => log.plugin.slug === plugin.slug ) }
 					errors={
@@ -424,7 +425,7 @@ export default React.createClass( {
 			<span key={ 'plugins__header-' + slug }>
 				<PluginsListHeader label={ header }
 					isWpCom={ isWpCom }
-					isBulkManagementActive={ this.state.bulkManagement }
+					isBulkManagementActive={ !! this.state.bulkManagement }
 					sites={ this.props.sites }
 					plugins={ this.state.plugins }
 					selected={ this.getSelected() }
@@ -438,9 +439,7 @@ export default React.createClass( {
 					unsetAutoupdateSelected={ this.unsetAutoupdateSelected }
 					removePluginNotice={ this.removePluginNotice }
 					haveActiveSelected={ this.state.plugins.some( this.filterSelection.active ) }
-					haveInactiveSelected={ this.state.plugins.some( this.filterSelection.inactive ) }
-					haveUpdatesSelected={ this.state.plugins.some( this.filterSelection.updates ) }
-					haveSelected={ this.state.plugins.some( this.filterSelection.selected ) } />
+					haveInactiveSelected={ this.state.plugins.some( this.filterSelection.inactive ) } />
 				<div className={ itemListClasses }>{ this.formatPlugins( plugins ) }</div>
 			</span>
 		);
@@ -711,8 +710,7 @@ export default React.createClass( {
 						initialValue={ this.props.search }
 						ref="url-search"
 						analyticsGroup="Plugins"
-						placeholder={ this.getSearchPlaceholder() }
-					/>
+						placeholder={ this.getSearchPlaceholder() } />
 				</SectionNav>
 				{ this.renderPluginsContent() }
 				<DisconnectJetpackDialog ref="dialog" site={ this.props.site } sites={ this.props.sites } redirect="/plugins" />

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -24,6 +24,19 @@ export default React.createClass( {
 	displayName: 'Plugins-list-header',
 
 	propTypes: {
+		label: React.PropTypes.string,
+		isBulkManagementActive: React.PropTypes.bool,
+		toggleBulkManagement: React.PropTypes.func.isRequired,
+		updateAllPlugins: React.PropTypes.func.isRequired,
+		pluginUpdateCount: React.PropTypes.number.isRequired,
+		activateSelected: React.PropTypes.func.isRequired,
+		deactiveAndDisconnectSelected: React.PropTypes.func.isRequired,
+		deactivateSelected: React.PropTypes.func.isRequired,
+		setAutoupdateSelected: React.PropTypes.func.isRequired,
+		unsetAutoupdateSelected: React.PropTypes.func.isRequired,
+		removePluginNotice: React.PropTypes.func.isRequired,
+		haveActiveSelected: React.PropTypes.bool,
+		haveInactiveSelected: React.PropTypes.bool,
 		bulkManagement: React.PropTypes.bool,
 		sites: React.PropTypes.object.isRequired,
 		plugins: React.PropTypes.array.isRequired,
@@ -58,7 +71,7 @@ export default React.createClass( {
 	},
 
 	unselectOrSelectAll() {
-		if ( this.props.haveSelected ) {
+		if ( this.props.selected.length > 0 ) {
 			PluginsActions.selectPlugins( this.props.sites.getSelectedOrAllWithPlugins(), 'none' );
 			analytics.ga.recordEvent( 'Plugins', 'Clicked to Uncheck All Plugins' );
 			return;
@@ -88,34 +101,84 @@ export default React.createClass( {
 				);
 			}
 			rightSideButtons.push(
-				<ButtonGroup key="plugin-list-header__buttons-bulk-management"><Button compact onClick={ this.props.toggleBulkManagement }>{ this.translate( 'Edit All', { context: 'button label' } ) }</Button></ButtonGroup>
+				<ButtonGroup key="plugin-list-header__buttons-bulk-management">
+					<Button compact onClick={ this.props.toggleBulkManagement }>
+						{ this.translate( 'Edit All', { context: 'button label' } ) }
+					</Button>
+				</ButtonGroup>
 			);
 			if ( ! isWpCom && this.canAddNewPlugins() ) {
 				const selectedSite = this.props.sites.getSelectedSite();
 				const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
 
 				rightSideButtons.push(
-					<ButtonGroup key="plugin-list-header__buttons-browser"><Button compact href={ browserUrl } onClick={ this.onBrowserLinkClick } className="plugin-list-header__browser-button"><Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } /></Button></ButtonGroup>
+					<ButtonGroup key="plugin-list-header__buttons-browser">
+						<Button compact href={ browserUrl } onClick={ this.onBrowserLinkClick } className="plugin-list-header__browser-button">
+							<Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } />
+						</Button>
+					</ButtonGroup>
 				);
 			}
 		} else {
-			activateButtons.push( <Button key="plugin-list-header__buttons-activate" disabled={ ! this.props.haveInactiveSelected } compact onClick={ this.props.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
+			activateButtons.push(
+				<Button key="plugin-list-header__buttons-activate" disabled={ ! this.props.haveInactiveSelected } compact onClick={ this.props.activateSelected }>
+					{ this.translate( 'Activate' ) }
+				</Button>
+			);
 			let deactivateButton = isJetpackSelected
-				? <Button key="plugin-list-header__buttons-deactivate" disabled={ ! this.props.haveActiveSelected } compact onClick={ this.props.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</Button>
-				: <Button key="plugin-list-header__buttons-disable" disabled={ ! this.props.haveActiveSelected } compact onClick={ this.props.deactivateSelected }>{ this.translate( 'Deactivate' ) }</Button>;
+				? (
+					<Button compact
+						key="plugin-list-header__buttons-deactivate"
+						disabled={ ! this.props.haveActiveSelected }
+						onClick={ this.props.deactiveAndDisconnectSelected }>
+						{ this.translate( 'Disconnect' ) }
+					</Button>
+				)
+				: (
+					<Button compact
+						key="plugin-list-header__buttons-disable"
+						disabled={ ! this.props.haveActiveSelected }
+						onClick={ this.props.deactivateSelected }>
+						{ this.translate( 'Deactivate' ) }
+					</Button>
+				);
 			activateButtons.push( deactivateButton )
 			leftSideButtons.push( <ButtonGroup key="plugin-list-header__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
 
 			if ( this.hasJetpackSelectedSites() && ! isWpCom ) {
-				updateButtons.push( <Button key="plugin-list-header__buttons-autoupdate-on" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.props.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
-				updateButtons.push( <Button key="plugin-list-header__buttons-autoupdate-off" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.props.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
+				updateButtons.push(
+					<Button key="plugin-list-header__buttons-autoupdate-on"
+						disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() }
+						compact
+						onClick={ this.props.setAutoupdateSelected }>
+						{ this.translate( 'Autoupdate' ) }
+					</Button>
+				);
+				updateButtons.push(
+					<Button key="plugin-list-header__buttons-autoupdate-off"
+						disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() }
+						compact
+						onClick={ this.props.unsetAutoupdateSelected }>
+						{ this.translate( 'Disable Autoupdates' ) }
+					</Button>
+				);
 
 				leftSideButtons.push( <ButtonGroup key="plugin-list-header__buttons-update-buttons">{ updateButtons }</ButtonGroup> );
-				leftSideButtons.push( <ButtonGroup key="plugin-list-header__buttons-remove-button"><Button disabled={ ! needsRemoveButton } compact scary onClick={ this.props.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
+				leftSideButtons.push(
+					<ButtonGroup key="plugin-list-header__buttons-remove-button">
+						<Button compact scary
+							disabled={ ! needsRemoveButton }
+							onClick={ this.props.removePluginNotice }>
+							{ this.translate( 'Remove' ) }
+						</Button>
+					</ButtonGroup>
+				);
 			}
 
 			rightSideButtons.push(
-				<button key="plugin-list-header__buttons-close-button" className="plugin-list-header__section-actions-close" onClick={ this.props.toggleBulkManagement }>
+				<button key="plugin-list-header__buttons-close-button"
+					className="plugin-list-header__section-actions-close"
+					onClick={ this.props.toggleBulkManagement }>
 					<span className="screen-reader-text">{ this.translate( 'Close' ) }</span>
 					<Gridicon icon="cross" />
 				</button>
@@ -140,23 +203,63 @@ export default React.createClass( {
 			options.push( <DropdownItem key="plugin__actions_title" selected={ true } value="Actions">{ this.translate( 'Actions' ) }</DropdownItem> );
 			options.push( <DropdownSeparator key="plugin__actions_separator_1" /> );
 
-			options.push( <DropdownItem key="plugin__actions_activate" disabled={ ! this.props.haveInactiveSelected } onClick={ this.props.activateSelected }>{ this.translate( 'Activate' ) }</DropdownItem> );
+			options.push(
+				<DropdownItem key="plugin__actions_activate"
+					disabled={ ! this.props.haveInactiveSelected }
+					onClick={ this.props.activateSelected }>
+					{ this.translate( 'Activate' ) }
+				</DropdownItem>
+			);
 
 			let deactivateAction = isJetpackSelected
-				? <DropdownItem key="plugin__actions_disconnect" disabled={ ! this.props.haveActiveSelected } onClick={ this.props.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</DropdownItem>
-				: <DropdownItem key="plugin__actions_deactivate" disabled={ ! this.props.haveActiveSelected } onClick={ this.props.deactivateSelected }>{ this.translate( 'Deactivate' ) }</DropdownItem>;
+				? <DropdownItem key="plugin__actions_disconnect"
+					disabled={ ! this.props.haveActiveSelected }
+					onClick={ this.props.deactiveAndDisconnectSelected }>
+						{ this.translate( 'Disconnect' ) }
+					</DropdownItem>
+				: <DropdownItem key="plugin__actions_deactivate"
+					disabled={ ! this.props.haveActiveSelected }
+					onClick={ this.props.deactivateSelected }>
+						{ this.translate( 'Deactivate' ) }
+					</DropdownItem>;
 			options.push( deactivateAction );
 
 			if ( this.hasJetpackSelectedSites() ) {
 				options.push( <DropdownSeparator key="plugin__actions_separator_2" /> );
-				options.push( <DropdownItem key="plugin__actions_autoupdate" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } onClick={ this.props.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</DropdownItem> );
-				options.push( <DropdownItem key="plugin__actions_disable_autoupdate" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } onClick={ this.props.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</DropdownItem> );
+				options.push(
+					<DropdownItem key="plugin__actions_autoupdate"
+						disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() }
+						onClick={ this.props.setAutoupdateSelected }>
+						{ this.translate( 'Autoupdate' ) }
+					</DropdownItem>
+				);
+				options.push(
+					<DropdownItem key="plugin__actions_disable_autoupdate"
+						disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() }
+						onClick={ this.props.unsetAutoupdateSelected }>
+						{ this.translate( 'Disable Autoupdates' ) }
+					</DropdownItem>
+				);
 
 				options.push( <DropdownSeparator key="plugin__actions_separator_3" /> );
-				options.push( <DropdownItem key="plugin__actions_remove" className="plugin-list-header__actions_remove_item" disabled={ ! needsRemoveButton } onClick={ this.props.removePluginNotice } >{ this.translate( 'Remove' ) }</DropdownItem> );
+				options.push(
+					<DropdownItem key="plugin__actions_remove"
+						className="plugin-list-header__actions_remove_item"
+						disabled={ ! needsRemoveButton }
+						onClick={ this.props.removePluginNotice } >
+						{ this.translate( 'Remove' ) }
+					</DropdownItem>
+				);
 			}
 
-			actions.push( <SelectDropdown compact className="plugin-list-header__actions_dropdown" key="plugin-list-header__actions_dropdown" selectedText="Actions">{ options }</SelectDropdown> );
+			actions.push(
+				<SelectDropdown compact
+					className="plugin-list-header__actions_dropdown"
+					key="plugin-list-header__actions_dropdown"
+					selectedText="Actions">
+					{ options }
+				</SelectDropdown>
+			);
 		}
 		return actions;
 	},
@@ -166,9 +269,8 @@ export default React.createClass( {
 		return (
 			<SectionHeader label={ this.props.label } className={ sectionClasses }>
 				{
-					! this.props.isBulkManagementActive
-						? null
-						: <BulkSelect key="plugin-list-header__bulk-select"
+					this.props.isBulkManagementActive &&
+						<BulkSelect key="plugin-list-header__bulk-select"
 							totalElements={ this.props.plugins.length }
 							selectedElements={ this.props.selected.length }
 							onToggle={ this.unselectOrSelectAll } />

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -1,0 +1,171 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import property from 'lodash/utility/property';
+import config from 'config';
+import classNames from 'classnames';
+import analytics from 'analytics';
+
+/**
+ * Internal dependencies
+ */
+import SectionHeader from 'components/section-header';
+import ButtonGroup from 'components/button-group';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import SelectDropdown from 'components/select-dropdown';
+import DropdownItem from 'components/select-dropdown/item';
+import DropdownSeparator from 'components/select-dropdown/separator';
+import BulkSelect from 'components/bulk-select';
+
+export default React.createClass( {
+
+	displayName: 'Plugins-list-header',
+
+	propTypes: {
+		bulkManagement: React.PropTypes.bool,
+		sites: React.PropTypes.object.isRequired,
+		plugins: React.PropTypes.array.isRequired,
+		selected: React.PropTypes.array.isRequired,
+		isWpCom: React.PropTypes.bool,
+		pluginUpdateCount: React.PropTypes.number
+	},
+
+	onBrowserLinkClick() {
+		analytics.ga.recordEvent( 'Plugins', 'Clicked Add New Plugins' );
+	},
+
+	canAddNewPlugins() {
+		if ( config.isEnabled( 'manage/plugins/browser' ) ) {
+			return this.hasJetpackSelectedSites();
+		}
+		return false;
+	},
+
+	canUpdatePlugins() {
+		return this.props.plugins
+			.filter( plugin => plugin.selected )
+			.some( plugin => plugin.sites.some( site => site.canUpdateFiles ) );
+	},
+
+	hasJetpackSelectedSites() {
+		const selectedSite = this.props.sites.getSelectedSite();
+		if ( selectedSite ) {
+			return !! selectedSite.jetpack;
+		}
+		return this.props.sites.getJetpack().length > 0;
+	},
+
+	renderCurrentActionButtons( isWpCom ) {
+		let buttons = [];
+		let rightSideButtons = [];
+		let leftSideButtons = [];
+		let updateButtons = [];
+		let activateButtons = [];
+
+		const hasWpcomPlugins = this.props.selected.some( property( 'wpcom' ) );
+		const isJetpackSelected = this.props.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
+		const needsRemoveButton = this.props.selected.length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
+		if ( ! this.props.bulkManagement ) {
+			if ( ! isWpCom && 0 < this.props.pluginUpdateCount ) {
+				rightSideButtons.push(
+					<ButtonGroup key="plugin-list-header__buttons-update-all">
+						<Button compact primary onClick={ this.props.updateAllPlugins } >
+							{ this.translate( 'Update All', { context: 'button label' } ) }
+						</Button>
+					</ButtonGroup>
+				);
+			}
+			rightSideButtons.push(
+				<ButtonGroup key="plugin-list-header__buttons-bulk-management"><Button compact onClick={ this.props.toggleBulkManagement }>{ this.translate( 'Edit All', { context: 'button label' } ) }</Button></ButtonGroup>
+			);
+			if ( ! isWpCom && this.canAddNewPlugins() ) {
+				const selectedSite = this.props.sites.getSelectedSite();
+				const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
+
+				rightSideButtons.push(
+					<ButtonGroup key="plugin-list-header__buttons-browser"><Button compact href={ browserUrl } onClick={ this.onBrowserLinkClick } className="plugin-list-header__browser-button"><Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } /></Button></ButtonGroup>
+				);
+			}
+		} else {
+			activateButtons.push( <Button key="plugin-list-header__buttons-activate" disabled={ ! this.props.areSelected( 'inactive' ) } compact onClick={ this.props.activateSelected }>{ this.translate( 'Activate' ) }</Button> )
+			let deactivateButton = isJetpackSelected
+				? <Button key="plugin-list-header__buttons-deactivate" disabled={ ! this.props.areSelected( 'active' ) } compact onClick={ this.props.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</Button>
+				: <Button key="plugin-list-header__buttons-disable" disabled={ ! this.props.areSelected( 'active' ) } compact onClick={ this.props.deactivateSelected }>{ this.translate( 'Deactivate' ) }</Button>;
+			activateButtons.push( deactivateButton )
+			leftSideButtons.push( <ButtonGroup key="plugin-list-header__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
+
+			if ( this.hasJetpackSelectedSites() && ! isWpCom ) {
+				updateButtons.push( <Button key="plugin-list-header__buttons-autoupdate-on" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.props.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</Button> );
+				updateButtons.push( <Button key="plugin-list-header__buttons-autoupdate-off" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } compact onClick={ this.props.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</Button> );
+
+				leftSideButtons.push( <ButtonGroup key="plugin-list-header__buttons-update-buttons">{ updateButtons }</ButtonGroup> );
+				leftSideButtons.push( <ButtonGroup key="plugin-list-header__buttons-remove-button"><Button disabled={ ! needsRemoveButton } compact scary onClick={ this.props.removePluginNotice }>{ this.translate( 'Remove' ) }</Button></ButtonGroup> );
+			}
+
+			rightSideButtons.push(
+				<button key="plugin-list-header__buttons-close-button" className="plugin-list-header__section-actions-close" onClick={ this.props.toggleBulkManagement }>
+					<span className="screen-reader-text">{ this.translate( 'Close' ) }</span>
+					<Gridicon icon="cross" />
+				</button>
+			);
+		}
+
+		buttons.push( <span key="plugin-list-header__buttons-action-buttons" className="plugin-list-header__action-buttons">{ leftSideButtons }</span> );
+		buttons.push( <span key="plugin-list-header__buttons-global-buttons" className="plugin-list-header__mode-buttons">{ rightSideButtons }</span> );
+
+		return buttons;
+	},
+
+	renderCurrentActionDropdown() {
+		let options = [];
+		let actions = [];
+
+		const hasWpcomPlugins = this.props.selected.some( property( 'wpcom' ) );
+		const isJetpackSelected = this.props.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
+		const needsRemoveButton = !! this.props.selected.length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
+
+		if ( this.props.bulkManagement ) {
+			options.push( <DropdownItem key="plugin__actions_title" selected={ true } value="Actions">{ this.translate( 'Actions' ) }</DropdownItem> );
+			options.push( <DropdownSeparator key="plugin__actions_separator_1" /> );
+
+			options.push( <DropdownItem key="plugin__actions_activate" disabled={ ! this.props.areSelected( 'inactive' ) } onClick={ this.props.activateSelected }>{ this.translate( 'Activate' ) }</DropdownItem> );
+
+			let deactivateAction = isJetpackSelected
+				? <DropdownItem key="plugin__actions_disconnect" disabled={ ! this.props.areSelected( 'active' ) } onClick={ this.props.deactiveAndDisconnectSelected }>{ this.translate( 'Disconnect' ) }</DropdownItem>
+				: <DropdownItem key="plugin__actions_deactivate" disabled={ ! this.props.areSelected( 'active' ) } onClick={ this.props.deactivateSelected }>{ this.translate( 'Deactivate' ) }</DropdownItem>;
+			options.push( deactivateAction );
+
+			if ( this.hasJetpackSelectedSites() ) {
+				options.push( <DropdownSeparator key="plugin__actions_separator_2" /> );
+				options.push( <DropdownItem key="plugin__actions_autoupdate" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } onClick={ this.props.setAutoupdateSelected }>{ this.translate( 'Autoupdate' ) }</DropdownItem> );
+				options.push( <DropdownItem key="plugin__actions_disable_autoupdate" disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() } onClick={ this.props.unsetAutoupdateSelected }>{ this.translate( 'Disable Autoupdates' ) }</DropdownItem> );
+
+				options.push( <DropdownSeparator key="plugin__actions_separator_3" /> );
+				options.push( <DropdownItem key="plugin__actions_remove" className="plugin-list-header__actions_remove_item" disabled={ ! needsRemoveButton } onClick={ this.props.removePluginNotice } >{ this.translate( 'Remove' ) }</DropdownItem> );
+			}
+
+			actions.push( <SelectDropdown compact className="plugin-list-header__actions_dropdown" key="plugin-list-header__actions_dropdown" selectedText="Actions">{ options }</SelectDropdown> );
+		}
+		return actions;
+	},
+
+	render() {
+		const sectionClasses = classNames( 'plugin-list-header', { 'is-bulk-editing': this.props.bulkManagement } );
+		return (
+			<SectionHeader label={ this.props.label } className={ sectionClasses }>
+				{
+					! this.props.bulkManagement
+						? null
+						: <BulkSelect key="plugin-list-header__bulk-select"
+							totalElements={ this.props.plugins.length }
+							selectedElements={ this.props.selected.length }
+							onToggle={ this.props.onToggle } />
+				}
+				{ this.renderCurrentActionDropdown() }
+				{ this.renderCurrentActionButtons( this.props.isWpCom ) }
+			</SectionHeader>
+		);
+	}
+} );

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -1,0 +1,94 @@
+.plugin-list-header.section-header.card {
+	padding-right: 8px;
+
+	.section-header__actions {
+		flex-grow: 1;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.bulk-select {
+		margin-right: 16px;
+	}
+
+	.button {
+		position: relative;
+	}
+
+	.button-group {
+		margin-left: 8px;
+	}
+
+	.gridicons-plus-small {
+		height: 12px;
+		left: 4px;
+		margin-left: 0;
+		position: absolute;
+		top: 8px;
+		width: 12px;
+	}
+
+	&.is-placeholder {
+		.section-header__label span {
+			@include placeholder(23%);
+		}
+	}
+
+	&.is-bulk-editing .section-header__label {
+		display: none;
+	}
+
+	.button-group {
+		margin-left: 8px;
+	}
+
+	@include breakpoint( '>660px' ) {
+		padding-right: 16px;
+	}
+}
+
+.plugin-list-header__section-actions-close {
+	color: darken( $gray, 30% );
+	cursor: pointer;
+	display: flex;
+		align-items: center;
+
+	&:focus {
+		border-color: $blue-medium;
+		box-shadow: 0 0 0 2px $blue-light;
+	}
+}
+
+.plugin-list-header__actions_dropdown {
+	display: none;
+
+	@include breakpoint( "<960px" ) {
+		display: inline-block;
+	}
+}
+
+.plugin-list-header__actions_remove_item {
+	color: $alert-red;
+
+	&.is-disabled {
+		color: lighten( $alert-red, 30% );
+	}
+}
+
+.plugin-list-header__mode-buttons {
+	display: flex;
+		justify-content: flex-end;
+	flex-grow: 1;
+	text-align: right;
+}
+
+.plugin-list-header__action-buttons {
+	align-items: center;
+	display: flex;
+	flex-grow: 1;
+
+	@include breakpoint( "<960px" ) {
+		display: none;
+	}
+}

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -92,3 +92,7 @@
 		display: none;
 	}
 }
+
+.plugin-list-header__browser-button.button.is-compact {
+	padding-left: 12px;
+}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -2,105 +2,10 @@
 	margin-bottom: 16px;
 }
 
-.plugins__section-actions.section-header.card {
-	padding-right: 8px;
-
-	.section-header__actions {
-		flex-grow: 1;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-	}
-
-	.bulk-select {
-		margin-right: 16px;
-	}
-
-	.button {
-		position: relative;
-	}
-
-	.button-group {
-		margin-left: 8px;
-	}
-
-	.gridicons-plus-small {
-		height: 12px;
-		left: 4px;
-		margin-left: 0;
-		position: absolute;
-		top: 8px;
-		width: 12px;
-	}
-
-	&.is-placeholder {
-		.section-header__label span {
-			@include placeholder(23%);
-		}
-	}
-
-	&.is-bulk-editing .section-header__label {
-		display: none;
-	}
-
-	.button-group {
-		margin-left: 8px;
-	}
-
-	@include breakpoint( '>660px' ) {
-		padding-right: 16px;
-	}
-}
-
-.plugins__action-buttons {
-	align-items: center;
-	display: flex;
-	flex-grow: 1;
-
-	@include breakpoint( "<960px" ) {
-		display: none;
-	}
-}
-
-.plugins__mode-buttons {
-	display: flex;
-		justify-content: flex-end;
-	flex-grow: 1;
-	text-align: right;
-}
-
-
-.plugins__section-actions-close {
-	color: darken( $gray, 30% );
-	cursor: pointer;
-	display: flex;
-		align-items: center;
-
-	&:focus {
-		border-color: $blue-medium;
-		box-shadow: 0 0 0 2px $blue-light;
-	}
-}
-
-.plugins__actions_dropdown {
-	display: none;
-
-	@include breakpoint( "<960px" ) {
-		display: inline-block;
-	}
-}
-
-.plugins__actions_remove_item {
-	color: $alert-red;
-
-	&.is-disabled {
-		color: lighten( $alert-red, 30% );
-	}
-}
-
 .plugins__browser-button.button.is-compact {
 	padding-left: 12px;
 }
+
 .plugins__plugin-list-state {
 	white-space: nowrap;
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -2,10 +2,6 @@
 	margin-bottom: 16px;
 }
 
-.plugins__browser-button.button.is-compact {
-	padding-left: 12px;
-}
-
 .plugins__plugin-list-state {
 	white-space: nowrap;
 }


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/941

/plugins/ main fine `/plugins/main.jsx` have grow too large (almost 900 LoC). This PR starts trimming the code in that component to extract some components from it.

Here, we create a new component `plugin-list-header` to contain the header and the buttons in the top of each plugin list and all the logic associated with it:

![image](https://cloud.githubusercontent.com/assets/1554855/11933499/82e39492-a7fc-11e5-8481-22251ed40da0.png)

![image](https://cloud.githubusercontent.com/assets/1554855/11933505/8dc90d2e-a7fc-11e5-82dd-9bb09b63f994.png)


How to test
========
1. go to http://calypso.localhost:3000/plugins
2. Make sure that the header bar & the buttons get rendered and works in the same way than in https://wpcalypso.wordpress.com/plugins
