### PR TITLE
Build: Improve efficiency of `find` commands in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,30 @@ LIST_ASSETS ?= $(BIN)/list-assets
 ALL_DEVDOCS_JS ?= $(THIS_DIR)/server/devdocs/bin/generate-devdocs-index
 
 # files used as prereqs
-SASS_FILES := $(shell find client shared assets -type f -name '*.scss')
-JS_FILES := $(shell find . -type f \( -name '*.js' -or -name '*.jsx' \) -and -not \( -path './node_modules/*' -or -path './public/*' -or -path './build/*' \) )
-MD_FILES := $(shell find . -name '*.md' -and -not -path '*node_modules*' -and -not -path '*.git*' | sed 's/ /\\ /g')
+SASS_FILES := $(shell \
+	find client shared assets \
+		-type f \
+		-name '*.scss' \
+)
+JS_FILES := $(shell \
+	find . \
+		-not \( -path './.git' -prune \) \
+		-not \( -path './build' -prune \) \
+		-not \( -path './node_modules' -prune \) \
+		-not \( -path './public' -prune \) \
+		-type f \
+		\( -name '*.js' -or -name '*.jsx' \) \
+)
+MD_FILES := $(shell \
+	find . \
+		-not \( -path './.git' -prune \) \
+		-not \( -path './build' -prune \) \
+		-not \( -path './node_modules' -prune \) \
+		-not \( -path './public' -prune \) \
+		-type f \
+		-name '*.md' \
+	| sed 's/ /\\ /g' \
+)
 CLIENT_CONFIG_FILE := client/config/index.js
 
 # variables


### PR DESCRIPTION
Noticed while investigating #1807.  I originally just wanted to exclude `build/` from `make lint`, but @blowery beat me to that at #1781 :)

This PR includes some further refactoring of the `find` commands in our Makefile:

- Use `-prune` to skip entire directory trees ([reference](http://stackoverflow.com/a/16595367); `node_modules` is large)
- Standardize exclude paths and syntax between different commands
- Indentation for readability

### To test

Here's a handy shell snippet to grab the `find` output before and after this PR and compare the two.  Run it from the repo root:

```sh
find client shared assets -type f -name '*.scss' \
    > old-scss.txt
find . -type f \( -name '*.js' -or -name '*.jsx' \) -and -not \( -path './node_modules/*' -or -path './public/*' -or -path './build/*' \) \
    > old-js.txt
find . -name '*.md' -and -not -path '*node_modules*' -and -not -path '*.git*' | sed 's/ /\\ /g' \
    > old-md.txt

find client shared assets \
    -type f \
    -name '*.scss' \
    > new-scss.txt
find . \
    -not \( -path './.git' -prune \) \
    -not \( -path './build' -prune \) \
    -not \( -path './node_modules' -prune \) \
    -not \( -path './public' -prune \) \
    -type f \
    \( -name '*.js' -or -name '*.jsx' \) \
    > new-js.txt
find . \
    -not \( -path './.git' -prune \) \
    -not \( -path './build' -prune \) \
    -not \( -path './node_modules' -prune \) \
    -not \( -path './public' -prune \) \
    -type f \
    -name '*.md' \
    | sed 's/ /\\ /g' \
    > new-md.txt

diff -u old-scss.txt new-scss.txt
diff -u old-js.txt new-js.txt
diff -u old-md.txt new-md.txt
```