### PR TITLE
Checkout: Change wording of text from "setup" to "set up"

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-features/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-features/index.jsx
@@ -22,12 +22,12 @@ const PlanFeatures = React.createClass( {
 		return (
 			<div>
 				<PlanFeature
-					button={ { label: this.translate( 'Setup eCommerce' ), href: `/plugins/${ this.props.selectedSite.slug }` } }
+					button={ { label: this.translate( 'Set up eCommerce' ), href: `/plugins/${ this.props.selectedSite.slug }` } }
 					description={ this.translate( 'Connect your Shopify, Ecwid, or Gumroad account to your WordPress.com site.' ) }
 					heading={ this.translate( 'eCommerce Integration' ) } />
 
 				<PlanFeature
-					button={ { label: this.translate( 'Setup Analytics' ), href: `/settings/analytics/${ this.props.selectedSite.slug }` } }
+					button={ { label: this.translate( 'Set up Analytics' ), href: `/settings/analytics/${ this.props.selectedSite.slug }` } }
 					description={ this.translate( 'Connect your Google Analytics account.' ) }
 					heading={ this.translate( 'Google Analytics Integration' ) } />
 

--- a/client/my-sites/upgrades/checkout/supporting-text.jsx
+++ b/client/my-sites/upgrades/checkout/supporting-text.jsx
@@ -50,11 +50,11 @@ var SupportingText = React.createClass( {
 	liveChatSupportingText: function() {
 		var cart = this.props.cart,
 			title = this.translate( 'Get Support' ),
-			content = this.translate( 'Need help? Our Happiness Engineers can help you setup your site & answer questions.' );
+			content = this.translate( 'Need help? Our Happiness Engineers can help you set up your site & answer questions.' );
 
 		if ( cartItems.hasProduct( cart, 'business-bundle' ) ) {
 			title = this.translate( 'Live Chat Support?' );
-			content = this.translate( 'Need help? Our Happiness Engineers can help you setup your site & answer questions.' );
+			content = this.translate( 'Need help? Our Happiness Engineers can help you set up your site & answer questions.' );
 		}
 
 		return this.supportingTextBox( 'live-chat-supporting-text', title, content );


### PR DESCRIPTION
Two instances of "setup" being used as a verb.