### PR TITLE
Domain Management: Replace name server remove button with new pattern

### DIFF
--- a/client/my-sites/upgrades/domain-management/name-servers/custom-nameservers-row.jsx
+++ b/client/my-sites/upgrades/domain-management/name-servers/custom-nameservers-row.jsx
@@ -7,6 +7,8 @@ import React from 'react';
  * Internal dependencies
  */
 import analyticsMixin from 'lib/mixins/analytics';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 
 const CustomNameserversRow = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'nameServers' ) ],
@@ -28,7 +30,11 @@ const CustomNameserversRow = React.createClass( {
 		if ( ! this.props.nameserver ) {
 			return null;
 		}
-		return <label className="remove" onClick={ this.handleRemove }>{ this.translate( 'Remove' ) }</label>
+		return (
+			<Button borderless compact onClick={ this.handleRemove }>
+				<Gridicon icon="trash" />
+			</Button>
+		);
 	},
 
 	render() {

--- a/client/my-sites/upgrades/domain-management/name-servers/custom-nameservers-row.jsx
+++ b/client/my-sites/upgrades/domain-management/name-servers/custom-nameservers-row.jsx
@@ -22,14 +22,17 @@ const CustomNameserversRow = React.createClass( {
 
 	handleRemove( event ) {
 		event.preventDefault();
+
 		this.recordEvent( 'removeClick', this.props.selectedDomainName );
+
 		this.props.onRemove( this.props.index );
 	},
 
-	removeLabel() {
+	renderRemoveIcon() {
 		if ( ! this.props.nameserver ) {
 			return null;
 		}
+
 		return (
 			<Button borderless compact onClick={ this.handleRemove }>
 				<Gridicon icon="trash" />
@@ -40,14 +43,15 @@ const CustomNameserversRow = React.createClass( {
 	render() {
 		return (
 			<div className="custom-nameservers-row">
-					<fieldset>
-						{ this.removeLabel() }
-						<input type="text"
-							placeholder={ this.props.placeholder }
-							onChange={ this.handleChange }
-							onFocus={ this.handleFocus }
-							value={ this.props.nameserver } />
-					</fieldset>
+				<fieldset>
+					<input type="text"
+						placeholder={ this.props.placeholder }
+						onChange={ this.handleChange }
+						onFocus={ this.handleFocus }
+						value={ this.props.nameserver } />
+
+					{ this.renderRemoveIcon() }
+				</fieldset>
 			</div>
 		);
 	},

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -846,15 +846,23 @@ ul.email-forwarding__list {
 .name-servers {
 	.custom-nameservers-row {
 		margin-top: 10px;
+		position: relative;
+
+		input[type=text] {
+			padding-right: 38px;
+
+			@include breakpoint( '<480px' ) {
+				padding-right: 35px;
+			}
+		}
 
 		.button {
 			position: absolute;
-				right: 0;
-			margin-top: 8px;
-			margin-right: 32px;
+			right: 7px;
+			top: 8px;
 
 			@include breakpoint( '<480px' ) {
-				margin-right: 24px;
+				right: 4px;
 			}
 		}
 	}

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -846,28 +846,17 @@ ul.email-forwarding__list {
 .name-servers {
 	.custom-nameservers-row {
 		margin-top: 10px;
-	}
 
-	.remove,
-	.add {
-		border-radius: 2px;
-		color: #FFF;
-		cursor: pointer;
-		display: inline-block;
-		font-size: 9px;
-		padding: 3px 8px;
-		position: absolute;
-		margin-top: 11px;
-		margin-right: 34px;
-		text-transform: uppercase;
-		right: 0px;
-	}
+		.button {
+			position: absolute;
+				right: 0;
+			margin-top: 8px;
+			margin-right: 32px;
 
-	.add {
-		background: $alert-green;
-	}
-	.remove {
-		background: $alert-red;
+			@include breakpoint( '<480px' ) {
+				margin-right: 24px;
+			}
+		}
 	}
 
 	.notice {


### PR DESCRIPTION
Updates the non-standard "remove" buttons to use the new borderless trash icon pattern.

Before | After
------------ | -------------
<img width="655" alt="screen shot 2015-12-18 at 2 16 51 pm" src="https://cloud.githubusercontent.com/assets/3011211/11908572/17bbb878-a592-11e5-8c78-c23fe26081f5.png"> | <img width="653" alt="screen shot 2015-12-18 at 2 17 30 pm" src="https://cloud.githubusercontent.com/assets/3011211/11908571/17bb4136-a592-11e5-914d-01d51991d537.png">
