### PR TITLE
Ads: Display AdControl sidebar item in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -12,6 +12,7 @@
 	"features": {
 		"code-splitting": true,
 		"manage/ads": true,
+		"manage/ads/jetpack": true,
 		"manage/customize": true,
 		"manage/jetpack": true,
 		"manage/menus": true,


### PR DESCRIPTION
Flipping the switch for JWAC now that the AdControl plugin is live in the .org plugin repo.

Requires no routing updates or any other configuration.