### PR TITLE
Invites: Adds notice when accepting logged out viewer invite

### DIFF
--- a/client/lib/invites/stores/invite-accepted.js
+++ b/client/lib/invites/stores/invite-accepted.js
@@ -12,6 +12,7 @@ const InviteMessageStore = createReducerStore( ( state, payload ) => {
 		case ActionTypes.DISPLAY_INVITE_ACCEPTED_NOTICE:
 			newState.accepted = true;
 			newState.siteId = parseInt( action.invite.site.ID, 10 );
+			newState.invite = action.invite;
 			return newState;
 		case ActionTypes.DISPLAY_INVITE_DECLINED_NOTICE:
 			newState.declined = true;
@@ -25,6 +26,6 @@ const InviteMessageStore = createReducerStore( ( state, payload ) => {
 			return newState;
 	}
 	return state;
-}, { accepted: false, declined: false, siteId: false } );
+}, { accepted: false, declined: false, siteId: false, invite: false } );
 
 export default InviteMessageStore;

--- a/client/my-sites/invites/invite-message/index.jsx
+++ b/client/my-sites/invites/invite-message/index.jsx
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import React from 'react'
+import get from 'lodash/object/get';
 
 /**
  * Internal dependencies
  */
 import Notice from 'components/notice'
+import NoticeAction from 'components/notice/notice-action';
 import { dismissInviteAccepted, dismissInviteDeclined } from 'lib/invites/actions'
 import store from 'lib/invites/stores/invite-accepted'
 
@@ -28,31 +30,49 @@ export default React.createClass( {
 		if ( ! this.props.sites ) {
 			return null;
 		}
-		const { accepted, declined, siteId } = this.state;
+
+		let inviteNotice = null;
+
+		const { accepted, declined, invite } = this.state;
 		if ( accepted ) {
-			const site = this.props.sites.getSite( parseInt( siteId, 10 ) );
-			if ( ! site ) {
-				return null;
+			if ( 'follower' === get( invite, 'role' ) ) {
+				inviteNotice = (
+					<Notice
+
+						status="is-success"
+						onDismissClick={ dismissInviteAccepted }
+						text={ this.translate( 'You are now following %(site)s', {
+							args: { site: get( invite, 'site.title' ) }
+						} ) } >
+						<NoticeAction external href={ get( invite, 'site.URL' ) } >
+							{ this.translate( 'Visit Site' ) }
+						</NoticeAction>
+					</Notice>
+				);
+			} else {
+				inviteNotice = (
+					<Notice status="is-success" onDismissClick={ dismissInviteAccepted }>
+						<h3 className="invite-message__title">
+							{ this.translate( 'You\'re now a user of: %(site)s', {
+								args: { site: get( invite, 'site.title' ) }
+							} ) }
+						</h3>
+						<p className="invite-message__intro">
+							{ this.translate( 'This is your site dashboard where you can write posts and control your site. ' ) }
+						</p>
+						<p className="invite-message__intro">
+							{
+								this.translate(
+									'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
+									{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
+								)
+							}
+						</p>
+					</Notice>
+				);
 			}
-			return (
-				<Notice status="is-success" onDismissClick={ dismissInviteAccepted }>
-					<h3 className="invite-message__title">{ this.translate( 'You\'re now a user of: %(site)s', { args: { site: site.slug } } ) }</h3>
-					<p className="invite-message__intro">
-						{ this.translate( 'This is your site dashboard where you can write posts and control your site. ' ) }
-					</p>
-					<p className="invite-message__intro">
-						{
-							this.translate(
-								'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-								{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
-							)
-						}
-					</p>
-				</Notice>
-			);
-		}
-		if ( declined ) {
-			return (
+		} else if ( declined ) {
+			inviteNotice = (
 				<Notice status="is-info" onDismissClick={ dismissInviteDeclined }>
 					<h3>
 						{ this.translate( 'You declined to join.' ) }
@@ -60,6 +80,7 @@ export default React.createClass( {
 				</Notice>
 			);
 		}
-		return null;
+
+		return inviteNotice;
 	}
 } )


### PR DESCRIPTION
Fixes #1835

In #1835, @roccotripaldi reported that accepting a viewer invite while logged didn't show an notice to the user. This PR addresses that.

__Note:__ I made several changes to the logic for showing a notice, so we'll need to do some regression testing to make sure other parts aren't broken. Also, we now save the entire invite when storing the accepted invite in the store.

![accept viewer notice](https://cloud.githubusercontent.com/assets/1126811/11909700/2507e65a-a5b0-11e5-911f-71a8788dbf4e.png)

To test:
- Checkout `fix/invite-notice-viewer` branch
- Go to `$site/wp-admin/users.php?page=wpcom-invite-users` where `$site` is a WP.com site
- Invite users with various roles to site
- Do notices properly show?
- Now on a private `WP.com` site, invite a user as a `viewer`.