### PR TITLE
Manage Followed Sites: don't use compact notices

### DIFF
--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -271,7 +271,6 @@ const FollowingEdit = React.createClass( {
 
 		return ( <Notice
 					status="is-error"
-					isCompact={ true }
 					showDismiss={ true }
 					onDismissClick={ this.dismissError }>
 					{ this.translate( 'Sorry - there was a problem unfollowing {{strong}}%(url)s{{/strong}}.', {
@@ -299,7 +298,6 @@ const FollowingEdit = React.createClass( {
 
 		return ( <Notice
 					status="is-error"
-					isCompact={ true }
 					showDismiss={ true }
 					onDismissClick={ this.dismissError }>
 					{ errorMessage }


### PR DESCRIPTION
Due to recent changes in the `Notice` component, notices no longer display as intended on Manage Followed Sites.

This PR removes the `isCompact` prop to restore the dismiss button.

Before:

<img width="770" alt="screen shot 2015-12-19 at 07 37 55" src="https://cloud.githubusercontent.com/assets/17325/11909711/a3cf05e8-a625-11e5-8b7c-67f881e230c8.png">

After:

<img width="863" alt="screen shot 2015-12-19 at 07 53 36" src="https://cloud.githubusercontent.com/assets/17325/11909713/a876d8be-a625-11e5-985b-8794d363bda3.png">

