### PR TITLE
Plugins List: Only select each section to go into bulk edit mode

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -61,7 +61,7 @@ export default React.createClass( {
 	mixins: [ URLSearch, PluginNotices ],
 
 	getInitialState() {
-		return this.getPluginsState( this.props );
+		return Object.assign( {}, this.getPluginsState( this.props ), { bulkManagement: [] } );
 	},
 
 	filterSelection: {
@@ -148,7 +148,7 @@ export default React.createClass( {
 	},
 
 	getPluginsState( nextProps ) {
-		const sites = this.state && this.state.bulkManagement ? this.props.sites.getSelectedOrAllWithPlugins() : this.props.sites.getSelectedOrAll(),
+		const sites = this.state && this.state.bulkManagement.length ? this.props.sites.getSelectedOrAllWithPlugins() : this.props.sites.getSelectedOrAll(),
 			pluginUpdate = PluginsStore.getPlugins( sites, 'updates' );
 
 		return {
@@ -207,17 +207,25 @@ export default React.createClass( {
 		);
 	},
 
-	toggleBulkManagement() {
-		const bulkManagement = ! this.state.bulkManagement,
-			sites = bulkManagement ? this.props.sites.getSelectedOrAllWithPlugins() : this.props.sites.getSelectedOrAll();
+	toggleBulkManagement( section ) {
+		let bulkManagement = this.state.bulkManagement;
+		const foundIndex = bulkManagement.indexOf( section );
 
+		if ( foundIndex === -1 ) {
+			bulkManagement.push( section );
+		} else {
+			bulkManagement.splice( foundIndex, 1 );
+		}
+
+		const sites = bulkManagement ? this.props.sites.getSelectedOrAllWithPlugins() : this.props.sites.getSelectedOrAll();
+		console.log( bulkManagement );
 		this.setState( {
 			plugins: this.getPluginsFromStore( this.props, sites ),
 			bulkManagement: bulkManagement,
 			filter: 'all'
 		} );
 
-		if ( bulkManagement ) {
+		if ( bulkManagement.length ) {
 			this.recordEvent( 'Clicked Manage' );
 		} else {
 			PluginsActions.selectPlugins( this.props.sites.getSelectedOrAll(), 'none' );
@@ -236,12 +244,23 @@ export default React.createClass( {
 	},
 
 	unselectOrSelectAll() {
+		const sites = this.props.sites.getSelectedOrAllWithPlugins().filter( site => this.state.bulkManagement.some( section => {
+			if ( section === 'jetpack' ) {
+				return site[ section ];
+			}
+
+			if ( section === 'wpcom' ) {
+				return ! site.jetpack;
+			}
+			return false;
+		} ) );
+
 		if ( this.areSelected() ) {
-			PluginsActions.selectPlugins( this.props.sites.getSelectedOrAllWithPlugins(), 'none' );
+			PluginsActions.selectPlugins( sites, 'none' );
 			this.recordEvent( 'Clicked to Uncheck All Plugins' );
 			return;
 		}
-		PluginsActions.selectPlugins( this.props.sites.getSelectedOrAllWithPlugins(), 'all' );
+		PluginsActions.selectPlugins( sites, 'all' );
 		this.recordEvent( 'Clicked to Check All Plugins' );
 	},
 
@@ -416,11 +435,11 @@ export default React.createClass( {
 		];
 	},
 
-	formatPlugins( plugins ) {
+	formatPlugins( plugins, isSelectable ) {
 		const manageableSites = this.props.sites.getSelectedOrAllJetpackCanManage();
-
 		return plugins.map( plugin => {
 			const hasAllNoManageSites = ! plugin.wpcom && plugin.sites.every( pluginSite => manageableSites.every( site => site.slug !== pluginSite.slug ) );
+			const togglePluginSelection = this.togglePluginSelection.bind( this, plugin );
 			return (
 				<PluginItem
 					key={ plugin.slug }
@@ -428,8 +447,8 @@ export default React.createClass( {
 					plugin={ plugin }
 					sites={ plugin.sites }
 					isSelected={ plugin.selected }
-					isSelectable={ this.state.bulkManagement }
-					onClick={ this.togglePluginSelection.bind( this, plugin ) }
+					isSelectable={ isSelectable }
+					onClick={ togglePluginSelection }
 					pluginLink={ this.props.path + '/' + encodeURIComponent( plugin.slug ) + ( plugin.wpcom ? '/business' : '' ) + this.siteSuffix() }
 					progress={ this.state.notices.inProgress.filter( log => log.plugin.slug === plugin.slug ) }
 					errors={
@@ -444,27 +463,33 @@ export default React.createClass( {
 	renderPluginList( plugins, header, isWpCom ) {
 		let headerMarkup;
 		const slug = header.replace( / /g, '' );
+		const inBulkEditMode = this.state.bulkManagement.indexOf( isWpCom ? 'wpcom' : 'jetpack' ) !== -1 ? true : false;
 
 		if ( isEmpty( plugins ) ) {
 			return;
 		}
 
 		const itemListClasses = classNames( 'list-cards-compact', 'plugins__list', {
-			'is-bulk-editing': this.state.bulkManagement
+			'is-bulk-editing': inBulkEditMode
 		} );
 
 		const headerClasses = classNames( 'plugins__section-actions', {
-			'is-bulk-editing': this.state.bulkManagement
+			'is-bulk-editing': inBulkEditMode
 		} );
 
-		if ( this.state.bulkManagement ) {
+		if ( inBulkEditMode ) {
 			header = null;
 		}
 
 		headerMarkup = (
 			<SectionHeader label={ header } className={ headerClasses } key={ 'plugins__section-header-' + slug } >
-				{ ! this.state.bulkManagement ? null : <BulkSelect key="plugins__bulk-select" totalElements={ this.state.plugins.length } selectedElements={ this.getSelected().length } onToggle={ this.unselectOrSelectAll } /> }
-				{ this.getCurrentActionDropdown() }
+				{ inBulkEditMode && <BulkSelect
+						key="plugins__bulk-select"
+						totalElements={ this.state.plugins.length }
+						selectedElements={ this.getSelected().length }
+						onToggle={ this.unselectOrSelectAll } />
+				}
+				{ this.getCurrentActionDropdown( isWpCom ) }
 				{ this.getCurrentActionButtons( isWpCom ) }
 			</SectionHeader>
 		);
@@ -472,7 +497,7 @@ export default React.createClass( {
 		return (
 			<span key={ 'plugins__header-' + slug }>
 				{ headerMarkup }
-				<div className={ itemListClasses }>{ this.formatPlugins( plugins ) }</div>
+				<div className={ itemListClasses }>{ this.formatPlugins( plugins, inBulkEditMode ) }</div>
 			</span>
 		);
 	},
@@ -562,10 +587,12 @@ export default React.createClass( {
 		let updateButtons = [];
 		let activateButtons = [];
 
+		const inBulkEditMode = this.state.bulkManagement.indexOf( isWpCom ? 'wpcom' : 'jetpack' ) !== -1 ? true : false;
 		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
 		const isJetpackSelected = this.state.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
 		const needsRemoveButton = this.getSelected().length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
-		if ( ! this.state.bulkManagement ) {
+		const toggleBulkManagement = this.toggleBulkManagement.bind( this, isWpCom ? 'wpcom' : 'jetpack' );
+		if ( ! inBulkEditMode ) {
 			if ( ! isWpCom && 0 < this.state.pluginUpdateCount ) {
 				rightSideButtons.push(
 					<ButtonGroup key="plugins__buttons-update-all">
@@ -575,8 +602,9 @@ export default React.createClass( {
 					</ButtonGroup>
 				);
 			}
+
 			rightSideButtons.push(
-				<ButtonGroup key="plugins__buttons-bulk-management"><Button compact onClick={ this.toggleBulkManagement } selected={ this.state.bulkManagement }>{ this.translate( 'Edit All', { context: 'button label' } ) }</Button></ButtonGroup>
+				<ButtonGroup key="plugins__buttons-bulk-management"><Button compact onClick={ toggleBulkManagement } selected={ inBulkEditMode }>{ this.translate( 'Edit All', { context: 'button label' } ) }</Button></ButtonGroup>
 			);
 			if ( ! isWpCom && this.canAddNewPlugins() ) {
 				const selectedSite = this.props.sites.getSelectedSite();
@@ -603,7 +631,7 @@ export default React.createClass( {
 			}
 
 			rightSideButtons.push(
-				<button key="plugins__buttons-close-button" className="plugins__section-actions-close" onClick={ this.toggleBulkManagement }>
+				<button key="plugins__buttons-close-button" className="plugins__section-actions-close" onClick={ toggleBulkManagement }>
 					<span className="screen-reader-text">{ this.translate( 'Close' ) }</span>
 					<Gridicon icon="cross" />
 				</button>
@@ -616,15 +644,16 @@ export default React.createClass( {
 		return buttons;
 	},
 
-	getCurrentActionDropdown() {
+	getCurrentActionDropdown( isWpCom ) {
 		let options = [];
 		let actions = [];
 
 		const hasWpcomPlugins = this.getSelected().some( property( 'wpcom' ) );
 		const isJetpackSelected = this.state.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
 		const needsRemoveButton = !! this.getSelected().length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
+		const inBulkEditMode = this.state.bulkManagement.indexOf( isWpCom ? 'wpcom' : 'jetpack' ) !== -1 ? true : false;
 
-		if ( this.state.bulkManagement ) {
+		if ( inBulkEditMode ) {
 			options.push( <DropdownItem key="plugin__actions_title" selected={ true } v1alue="Actions">{ this.translate( 'Actions' ) }</DropdownItem> );
 			options.push( <DropdownSeparator key="plugin__actions_separator_1" /> );
 
@@ -782,13 +811,15 @@ export default React.createClass( {
 		}
 
 		return plugins.map( plugin => {
-			return <PluginItem
-				key={ 'plugin-item-mock-' + plugin.slug }
-				plugin={ plugin }
-				sites={ [] }
-				selectedSite={ selectedSite }
-				progress={ [] }
-				isMock={ true } />
+			return (
+				<PluginItem
+					key={ 'plugin-item-mock-' + plugin.slug }
+					plugin={ plugin }
+					sites={ [] }
+					selectedSite={ selectedSite }
+					progress={ [] }
+					isMock={ true } />
+			);
 		} );
 	},
 
@@ -856,15 +887,13 @@ export default React.createClass( {
 							);
 						} ) }
 					</NavTabs>
-
 					<Search
 						pinned
 						onSearch={ this.doSearch }
 						initialValue={ this.props.search }
 						ref="url-search"
 						analyticsGroup="Plugins"
-						placeholder={ this.getSearchPlaceholder() }
-					/>
+						placeholder={ this.getSearchPlaceholder() } />
 				</SectionNav>
 				{ this.renderPluginsContent() }
 				<DisconnectJetpackDialog ref="dialog" site={ this.props.site } sites={ this.props.sites } redirect="/plugins" />


### PR DESCRIPTION
Before: When clicking Edit All it would open up both sections.
![screen shot 2015-12-18 at 16 54 49](https://cloud.githubusercontent.com/assets/115071/11910266/2a97f9be-a5a8-11e5-90c0-7d1f9d4fb05f.png)

After: Only the section that you clicked Edit All on would opens.
![screen shot 2015-12-18 at 16 54 38](https://cloud.githubusercontent.com/assets/115071/11910271/3a23c6d8-a5a8-11e5-917a-9dc3dc334336.png)

**To Test:**
Visit http://calypso.localhost:3000/plugins
And click on Edit All. 

Notice that it only opens up one section . 
Try to perform the actions Activate, deactivate etc. make sure that it works as expected. 

cc: @johnHackworth and @rickybanister 

Note this doesn't fix the spectection of both .com and jetpack version of the plugin Gumroad. 
I think some more work will need to happen in order for this to hold true. 

Also this would be easier to work with if we have more specific components for each of the different sections in main.js plugins file. 
