### PR TITLE
Free Trials: Added promotional copy to /plans and /start/plans for no-cc trials

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -71,7 +71,10 @@ var Plans = React.createClass( {
 		if ( ! this.props.sitePlans.hasLoadedFromServer || ! config.isEnabled( 'upgrades/free-trials' ) ) {
 			return null;
 		}
-		return <div className="plans__trial-copy">{ this.translate( 'Try WordPress.com Premium or Business free for 14 days, no credit card required' ) }</div>;
+
+		return <div className="plans__trial-copy"><span className="plans__trial-copy-text">{ this.translate( 'Try WordPress.com Premium or Business free for 14 days, no credit card{{nbsp/}}required', {
+				components: { nbsp: <span>&nbsp;</span> }
+		} ) }</span></div>;
 	},
 
 	render: function() {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -67,6 +67,13 @@ var Plans = React.createClass( {
 		);
 	},
 
+	renderTrialCopy: function() {
+		if ( ! this.props.sitePlans.hasLoadedFromServer || ! config.isEnabled( 'upgrades/free-trials' ) ) {
+			return null;
+		}
+		return <div className="plans__trial-copy">{ this.translate( 'Try WordPress.com Premium or Business free for 14 days, no credit card required' ) }</div>;
+	},
+
 	render: function() {
 		var classNames = 'main main-column ',
 			hasJpphpBundle,
@@ -98,6 +105,8 @@ var Plans = React.createClass( {
 						path={ this.props.context.path }
 						cart={ this.props.cart }
 						selectedSite={ this.props.selectedSite } />
+
+					{ this.renderTrialCopy() }
 
 					<PlanList
 						sites={ this.props.sites }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	connect = require( 'react-redux' ).connect;
+	connect = require( 'react-redux' ).connect,
+	find = require( 'lodash/collection/find' );
 
 /**
  * Internal dependencies
@@ -18,6 +19,8 @@ var analytics = require( 'analytics' ),
 	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
 	getPlansBySiteId = require( 'state/sites/plans/selectors' ).getPlansBySiteId,
 	getCurrentPlan = require( 'lib/plans' ).getCurrentPlan,
+	isBusiness = require( 'lib/products-values' ).isBusiness,
+	isPremium = require( 'lib/products-values' ).isPremium,
 	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle;
 
 var Plans = React.createClass( {
@@ -68,13 +71,46 @@ var Plans = React.createClass( {
 	},
 
 	renderTrialCopy: function() {
+		var message,
+			businessPlan,
+			premiumPlan;
+
 		if ( ! this.props.sitePlans.hasLoadedFromServer || ! config.isEnabled( 'upgrades/free-trials' ) ) {
 			return null;
 		}
 
-		return <div className="plans__trial-copy"><span className="plans__trial-copy-text">{ this.translate( 'Try WordPress.com Premium or Business free for 14 days, no credit card{{nbsp/}}required', {
+		businessPlan = find( this.props.sitePlans.data, isBusiness );
+		premiumPlan = find( this.props.sitePlans.data, isPremium );
+
+		if ( businessPlan.canStartTrial && premiumPlan.canStartTrial ) {
+			message = this.translate( 'Try WordPress.com Premium or Business free for 14 days, no credit card{{nbsp/}}required', {
 				components: { nbsp: <span>&nbsp;</span> }
-		} ) }</span></div>;
+			} );
+		}
+
+		if ( businessPlan.canStartTrial && ! premiumPlan.canStartTrial ) {
+			message = this.translate( 'Try WordPress.com Business free for 14 days, no credit card{{nbsp/}}required', {
+				components: { nbsp: <span>&nbsp;</span> }
+			} );
+		}
+
+		if ( ! businessPlan.canStartTrial && premiumPlan.canStartTrial ) {
+			message = this.translate( 'Try WordPress.com Premium free for 14 days, no credit card{{nbsp/}}required', {
+				components: { nbsp: <span>&nbsp;</span> }
+			} );
+		}
+
+		if ( ! businessPlan.canStartTrial && ! premiumPlan.canStartTrial ) {
+			return null;
+		}
+
+		return (
+			<div className="plans__trial-copy">
+				<span className="plans__trial-copy-text">
+					{ message }
+				</span>
+			</div>
+		);
 	},
 
 	render: function() {

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -16,15 +16,29 @@
 .plans__trial-copy{
 	position: relative;
 	text-align: center;
+	color: $gray;
+	margin-bottom: 12px;
 
 	&:after,
 	&:before{
 		content: '';
 	    position: absolute;
-	    top: 50%;
-	    left: 0;
-	    right: 0;
-	    z-index: -1;
+	    	top: 50%;
+	    	left: 0;
+	    	right: 0;
+	    	z-index: -1;
 	    border-bottom: solid 1px #d9e3ea;
 	}
 }
+
+.plans__trial-copy-text{
+	background-color: $gray-light;
+	margin: 0 8%;
+	padding: 0 6px;
+	display: inline-block;
+	font-style:italic;
+
+
+}
+
+	

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -12,3 +12,19 @@
 		}
 	}
 }
+
+.plans__trial-copy{
+	position: relative;
+	text-align: center;
+
+	&:after,
+	&:before{
+		content: '';
+	    position: absolute;
+	    top: 50%;
+	    left: 0;
+	    right: 0;
+	    z-index: -1;
+	    border-bottom: solid 1px #d9e3ea;
+	}
+}

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -13,32 +13,28 @@
 	}
 }
 
-.plans__trial-copy{
+.plans__trial-copy {
+	color: $gray;
 	position: relative;
 	text-align: center;
-	color: $gray;
 	margin-bottom: 12px;
 
 	&:after,
-	&:before{
+	&:before {
+	    border-bottom: solid 1px #d9e3ea;
 		content: '';
 	    position: absolute;
 	    	top: 50%;
 	    	left: 0;
 	    	right: 0;
-	    	z-index: -1;
-	    border-bottom: solid 1px #d9e3ea;
+	    z-index: -1;
 	}
 }
 
-.plans__trial-copy-text{
+.plans__trial-copy-text {
 	background-color: $gray-light;
-	margin: 0 8%;
-	padding: 0 6px;
 	display: inline-block;
 	font-style:italic;
-
-
+	margin: 0 8%;
+	padding: 0 6px;
 }
-
-	

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -115,15 +115,14 @@ module.exports = React.createClass( {
 			);
 		} else {
 			subHeaderText = this.translate(
-				'Not sure which plan to choose? Take a look at our {{a}}plan comparison chart{{/a}}.',
-				{ 
+				'Not sure which plan to choose? Take a look at our {{a}}plan comparison chart{{/a}}.', {
 					components: { a: <a
 						href={ this.comparePlansUrl() }
 						onClick={ this.handleComparePlansLinkClick.bind( null, 'header' ) } /> }
 				}
 			);
-
 		}
+
 		return (
 			<StepWrapper
 				flowName={ this.props.flowName }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -10,6 +10,7 @@ var React = require( 'react' ),
  */
 var productsList = require( 'lib/products-list' )(),
 	analytics = require( 'analytics' ),
+	config = require( 'config' ),
 	featuresList = require( 'lib/features-list' )(),
 	plansList = require( 'lib/plans-list' )(),
 	PlanList = require( 'components/plans/plan-list' ),
@@ -106,13 +107,23 @@ module.exports = React.createClass( {
 
 	plansSelection: function() {
 		let headerText = this.translate( 'Pick a plan that\'s right for you.' ),
+			subHeaderText;
+
+		if ( config.isEnabled( 'upgrades/free-trials' ) ) {
+			subHeaderText = this.translate(
+				'Try WordPress.com Premium or Business free for 14 days, no credit card required.'
+			);
+		} else {
 			subHeaderText = this.translate(
 				'Not sure which plan to choose? Take a look at our {{a}}plan comparison chart{{/a}}.',
-				{ components: { a: <a
-					href={ this.comparePlansUrl() }
-					onClick={ this.handleComparePlansLinkClick.bind( null, 'header' ) } /> } }
+				{ 
+					components: { a: <a
+						href={ this.comparePlansUrl() }
+						onClick={ this.handleComparePlansLinkClick.bind( null, 'header' ) } /> }
+				}
 			);
 
+		}
 		return (
 			<StepWrapper
 				flowName={ this.props.flowName }


### PR DESCRIPTION
Fixes #1155

Added preliminary text to start/plans which looks pretty clean.
Text in /plans requires further styling and if statements to work for all conditions.

Waiting for #1649 to merge before adding conditions to the plans page.

Testing instructions:
1. run `git checkout update/no-credit-card-required-text` and start your server
2. Make a new site - assert there is promotional copy in the signup flow
3. Choose the free plan anyway (your marketing doesn't work on me)
4. Navigate to `/plans` and assert there is copy there, listing both Premium and Business as options
5. Start a free trial of Premium
6. Remove the free trial from the site
7. Check `/plans` again, it should have promotional copy for only Business
8. Repeat 2-6, but start a Business trial instead on step 5
9. Assert that the promotional copy has only business
10.  Finally, add and remove the Premium Trial from the same site
11. Assert the promotional copy isn't shown at all.

- [x] code review
- [x] product review