### PR TITLE
Invites: Fix site URL in invite form header and success notices

### DIFF
--- a/client/lib/invites/reducers/invites-validation.js
+++ b/client/lib/invites/reducers/invites-validation.js
@@ -31,7 +31,7 @@ function normalizeInvite( data ) {
 		date: data.invite.invite_date,
 		role: decodeEntities( data.invite.meta.role ),
 		sentTo: decodeEntities( data.invite.meta.sent_to ),
-		site: Object.assign( filterObjectProperties( data.blog_details ), { ID: parseInt( data.invite.blog_id, 10 ), URL: data.blog_details.domain } ),
+		site: Object.assign( filterObjectProperties( data.blog_details ), { ID: parseInt( data.invite.blog_id, 10 ) } ),
 		inviter: filterObjectProperties( data.inviter )
 	}
 }

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -14,7 +14,7 @@ export default React.createClass( {
 		}
 
 		return (
-			<a href={ site.domain } className="invite-header__site-link">
+			<a href={ site.URL } className="invite-header__site-link">
 				{ site.title }
 			</a>
 		);


### PR DESCRIPTION
As I mentioned in [this comment](https://github.com/Automattic/wp-calypso/pull/1849#issuecomment-165952320), we were improperly using the protocol-less `domain` property in place of a proper URL with a scheme. This caused links in the `InviteFormHeader` and the success notices to not work.

This PR fixes that.

To test:
- Checkout `fix/people-invites-domain-to-url` branch
- Go to `$site/wp-admin/users.php?page=wpcom-invite-users` where `$site` is a private site
- Invite a `viewer`
- In the invite email, make not of the invitation key in the activation link
- Go to `/accept-invite/$site/$invite_key`
- Test that links to the site actually take you to the site
- Accept the invite
- In the notice, does the view site link work correctly?