### PR TITLE
Editor: Prefix non-standalone URLs with "http"

### DIFF
--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -23,7 +23,8 @@ var MediaSerialization = require( 'lib/media-serialization' ),
  * Module variables
  */
 var REGEXP_EMAIL = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i,
-	REGEXP_URL = /^(https?|ftp):\/\/[A-Z0-9.-]+\.[A-Z]{2,4}[^ "]*$/i;
+	REGEXP_URL = /^(https?|ftp):\/\/[A-Z0-9.-]+\.[A-Z]{2,4}[^ "]*$/i,
+	REGEXP_STANDALONE_URL = /^(?:[a-z]+:|#|\?|\.|\/)/;
 
 var LinkDialog = React.createClass( {
 
@@ -35,6 +36,16 @@ var LinkDialog = React.createClass( {
 		var editor = this.props.editor;
 
 		return editor.dom.getParent( editor.selection.getNode(), 'a' );
+	},
+
+	getCorrectedUrl() {
+		const url = this.state.url.trim();
+
+		if ( ! REGEXP_STANDALONE_URL.test( url ) ) {
+			return 'http://' + url;
+		}
+
+		return url;
 	},
 
 	updateEditor: function() {
@@ -55,7 +66,7 @@ var LinkDialog = React.createClass( {
 		link = this.getLink();
 		linkText = this.state.linkText;
 		attrs = {
-			href: this.state.url,
+			href: this.getCorrectedUrl(),
 			target: this.state.newWindow ? '_blank' : ''
 		};
 


### PR DESCRIPTION
Fixes #1846 

This pull request seeks to add an "http" prefix to links that cannot be used standalone (i.e. those with schemas, or hashbang/query/slash prefixed URLs).

__Implementation notes:__

The `wplink` plugin closely mirrors the behavior of the core equivalent plugin, which is why it is implemented the way it is. See original reference implementation:

https://github.com/WordPress/WordPress/blob/e844695e121c1a01f43f312ecd539affb004f0eb/wp-includes/js/wplink.js#L87-L95

__Testing instructions:__

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Add some text to the editor content
4. Highlight the text
5. Click the Insert Link button in the editor toolbar
6. Add URL text and click Add Link
7. Note that...
 - If the URL in step 6 includes a schema, that schema is used
 - If the URL in step 6 starts with a hashbang, query parameter, or slash, it is not modified
 - Otherwise, an HTTP schema is prefixed