### PR TITLE
Update react-redux to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-addons-create-fragment": "0.14.3",
     "react-day-picker": "1.1.0",
     "react-dom": "0.14.3",
-    "react-redux": "3.1.0",
+    "react-redux": "4.0.1",
     "react-tap-event-plugin": "0.2.1",
     "redux": "3.0.4",
     "redux-analytics": "0.3.0",


### PR DESCRIPTION
This is possible now that we've upgraded to React 0.14.

Relevant breaking changes (from https://github.com/rackt/react-redux/releases/tag/v4.0.0):

`<Provider>` no longer accepts a function child

To test:
* Make sure `<Provider>` is only wrapped around another React child element (and not a `{ () => <Element />}` function child)
* Test sections that import `react-redux` still work (Themes, Editor, Export)