### PR TITLE
Catch JS errors and send them to the API

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -117,7 +117,7 @@ function setUpContext( layout, reduxStore ) {
 				context.hash = {};
 			}
 		} else {
-			context.hash = {};
+			contextz.hash = {};
 		}
 		next();
 	} );

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -13,6 +13,7 @@ var ReactDom = require( 'react-dom' ),
 	page = require( 'page' ),
 	url = require( 'url' ),
 	qs = require( 'querystring' ),
+	abtest = require( 'lib/abtest' ).abtest,
 	injectTapEventPlugin = require( 'react-tap-event-plugin' );
 
 /**
@@ -50,7 +51,9 @@ function init() {
 
 	debug( 'Starting Calypso. Let\'s do this.' );
 
-	window.onerror = catchJsErrors;
+	if ( abtest( 'catchJsErrors' ) === 'catchJsErrors' ) {
+		window.onerror = catchJsErrors;
+	}
 
 	// Initialize i18n
 	if ( window.i18nLocaleStrings ) {
@@ -117,7 +120,7 @@ function setUpContext( layout, reduxStore ) {
 				context.hash = {};
 			}
 		} else {
-			contextz.hash = {};
+			context.hash = {};
 		}
 		next();
 	} );

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -40,6 +40,7 @@ var config = require( 'config' ),
 	accessibleFocus = require( 'lib/accessible-focus' ),
 	TitleStore = require( 'lib/screen-title/store' ),
 	createReduxStore = require( 'state' ).createReduxStore,
+	catchJsErrors = require( 'lib/catch-js-errors' ),
 	// The following mixins require i18n content, so must be required after i18n is initialized
 	Layout,
 	LoggedOutLayout;
@@ -48,6 +49,8 @@ function init() {
 	var i18nLocaleStringsObject = null;
 
 	debug( 'Starting Calypso. Let\'s do this.' );
+
+	window.onerror = catchJsErrors;
 
 	// Initialize i18n
 	if ( window.i18nLocaleStrings ) {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -79,5 +79,13 @@ module.exports = {
 			dontAutoFill: 50
 		},
 		defaultVariation: 'dontAutoFill'
+	},
+	catchJsErrors: {
+		datestamp: '20151223',
+		variations: {
+			original: 99,
+			catchJsErrors: 1
+		},
+		defaultVariation: 'original'
 	}
 };

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import wpcomLib from 'lib/wp';
+
+/**
+ * Module variables
+ */
+const wpcom = wpcomLib.undocumented();
+
+export default ( error ) => {
+	// POST to the API
+	alert( error );
+	wpcom.jsError( error );
+};

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -8,7 +8,15 @@ import wpcomLib from 'lib/wp';
  */
 const wpcom = wpcomLib.undocumented();
 
-export default ( error ) => {
+export default ( message, scriptUrl, lineNumber, columnNumber, error ) => {
+	error = error || new Error( message );
+	const stringifiedError = JSON.stringify( {
+		message: error.message,
+		type: error.constructor && error.constructor.name,
+		userAgent: navigator.userAgent,
+		stack: error.stack
+	} );
+
 	// POST to the API
-	wpcom.jsError( error + ' ' + navigator.userAgent );
+	wpcom.jsError( stringifiedError );
 };

--- a/client/lib/catch-js-errors/index.js
+++ b/client/lib/catch-js-errors/index.js
@@ -10,6 +10,5 @@ const wpcom = wpcomLib.undocumented();
 
 export default ( error ) => {
 	// POST to the API
-	alert( error );
-	wpcom.jsError( error );
+	wpcom.jsError( error + ' ' + navigator.userAgent );
 };

--- a/shared/lib/wpcom-undocumented/lib/undocumented.js
+++ b/shared/lib/wpcom-undocumented/lib/undocumented.js
@@ -1796,6 +1796,13 @@ Undocumented.prototype.submitSupportForumsTopic = function( subject, message, fn
 	}, fn );
 };
 
+Undocumented.prototype.jsError = function( error, fn ) {
+	this.wpcom.req.post( {
+		path: '/js-error',
+		body: { error }
+	}, fn );
+};
+
 /**
  * Expose `Undocumented` module
  */


### PR DESCRIPTION
This is just a proof of concept for making an easy way to catch JS errors in production and send them to the API. It requires this patch to the API: D772-code.

There are some issues with this approach:
- We should disable it in the development environment
- Should we also restrict it only to a subset of users?

To test, apply the patch (D772-code) and then edit some code so it throws a JS error. You should see the API request happen in the Network tab.

You also need to add yourself to the AB test, like this:
`localStorage.setItem('ABTests','{"catchJsErrors_20151223":"catchJsErrors"}')`