### PR TITLE
Reader List Management: add missing stats include

### DIFF
--- a/client/reader/list-management/tags/index.jsx
+++ b/client/reader/list-management/tags/index.jsx
@@ -23,6 +23,7 @@ import ListManagementError from '../error';
 import EmptyContent from 'components/empty-content';
 
 const debug = debugModule( 'calypso:reader:list-management' ); // eslint-disable-line
+const stats = require( 'reader/stats' );
 
 const ListManagementTags = React.createClass( {
 	propTypes: {


### PR DESCRIPTION
A missing include of `reader/stats` in Reader List Management > Tags is causing the tests to fail on master, due to the recent addition of a `no-undef` rule:

https://circleci.com/gh/Automattic/wp-calypso/3236

Merging this PR immediately because the affected feature is not enabled on any environment except dev, and it's breaking Circle CI tests for all of `master`.