### PR TITLE
Signup: Fix invalid gridicon prop in Plans step

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -93,7 +93,7 @@ module.exports = React.createClass( {
 					href={ this.comparePlansUrl() }
 					className='plans-step__compare-plans-link'
 					onClick={ this.handleComparePlansLinkClick.bind( null, 'footer' ) }>
-						<Gridicon icon="clipboard" size="18" />
+						<Gridicon icon="clipboard" size={ 18 } />
 						{ this.translate( 'Compare Plans' ) }
 				</a>
 			</div>


### PR DESCRIPTION
This pull request fixes a warning raised in the `Plans` step during signup:

![screenshot](https://cloud.githubusercontent.com/assets/594356/11918911/3cb429d8-a742-11e5-9667-ca847889e108.png)

The actual Javascript warning displayed in the console is:

```
Warning: Failed propType: Invalid prop `size` of type `string` supplied to `Gridicon`, expected `number`. Check the render method of `PlansStep`.
```

#### Testing instructions

1. Run `git checkout fix/gridicon-plans-step` and start your server
2. Open the [`Signup` page](http://calypso.localhost:3000/start/plans)
3. Process until the `Plans` step
4. Check that no warning is displayed in your browser console

#### Reviews
 
- [x] Code
- [x] Product