### PR TITLE
Notices: Fix links opening in new window despite external prop being false

### DIFF
--- a/client/components/notice/notice-action.jsx
+++ b/client/components/notice/notice-action.jsx
@@ -24,13 +24,18 @@ export default React.createClass( {
 	},
 
 	render() {
+		const attributes = {
+			className: 'notice__action',
+			href: this.props.href,
+			onClick: this.props.onClick
+		};
+
+		if ( this.props.external ) {
+			attributes.target = '_blank';
+		}
+
 		return (
-			<a
-				className="notice__action"
-				href={ this.props.href }
-				onClick={ this.props.onClick }
-				target={ this.props.external && '_blank' }
-			>
+			<a {...attributes} >
 				<span>{ this.props.children }</span>
 				{ this.props.external && <Gridicon icon="external" size={ 24 } /> }
 			</a>


### PR DESCRIPTION
This pull request makes sure the optional anchor of `<NoticeAction />` doesn't end up with `target="false"` when the `external` prop is false, which has the exact opposite effect of opening the link in another window:

![screenshot](https://cloud.githubusercontent.com/assets/594356/11919987/8de03404-a761-11e5-828a-0dcb0b4e8901.png)

#### Testing instructions

1. Run `git checkout fix/notice-action-external` and start your server
2. Open the [`UI Components` page](http://calypso.localhost:3000/devdocs/design)
3. Check that clicking the `Update` link on the second to last notice doesn't open a new window
3. Check that clicking the`Preview` link on the last notice does open a new window
