### PR TITLE
Remove double defined property

### DIFF
--- a/client/my-sites/menus/menu-editable-item.jsx
+++ b/client/my-sites/menus/menu-editable-item.jsx
@@ -323,11 +323,10 @@ var MenuEditableItem = React.createClass( {
 			},
 			{
 				key: 'ok',
-				className: 'button is-primary',
+				className: 'is-primary',
 				label: this.isNew() ?
 					this.translate( 'Add Item', { textOnly: true } ) :
 					this.translate( 'OK', { textOnly: true } ),
-				className: 'is-primary',
 				showIfNew: true,
 				onClick: this.save
 			}


### PR DESCRIPTION
The double definition of `className` lets `make translate` (hence the i18n label) fail with the cryptic error message:

```
SyntaxError: Redefinition of property (360079:4)
    at raise (/Users/alex/Sites/Automattic/wp-calypso/node_modules/xgettext-js/node_modules/acorn/acorn.js:239:15)
    at parseObj (/Users/alex/Sites/Automattic/wp-calypso/node_modules/xgettext-js/node_modules/acorn/acorn.js:1741:27)
    at parseExprAtom (/Users/alex/Sites/Automattic/wp-calypso/node_modules/xgettext-js/node_modules/acorn/acorn.js:1677:14)
    at parseExprSubscripts (/Users/alex/Sites/Automattic/wp-calypso/node_modules/xgettext-js/node_modules/acorn/acorn.js:1603:28)
    at parseMaybeUnary (/Users/alex/Sites/Automattic/wp-calypso/node_modules/xgettext-js/node_modules/acorn/acorn.js:1587:16)
    at parseExprOps (/Users/alex/Sites/Automattic/wp-calypso/node_modules/xgettext-js/node_modules/acorn/acorn.js:1545:24)
    at parseMaybeConditional (/Users/alex/Sites/Automattic/wp-calypso/node_modules/xgettext-js/node_modules/acorn/acorn.js:1530:16)
    at parseMaybeAssign (/Users/alex/Sites/Automattic/wp-calypso/node_modules/xgettext-js/node_modules/acorn/acorn.js:1514:16)
    at parseExpression (/Users/alex/Sites/Automattic/wp-calypso/node_modules/xgettext-js/node_modules/acorn/acorn.js:1500:16)
    at parseExprList (/Users/alex/Sites/Automattic/wp-calypso/node_modules/xgettext-js/node_modules/acorn/acorn.js:1828:22)
```