### PR TITLE
Editor: Add a pin to the location map.

### DIFF
--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -100,7 +100,7 @@ module.exports = React.createClass( {
 		}
 
 		src = GOOGLE_MAPS_BASE_URL + qs.stringify( {
-			center: this.props.coordinates.join( ',' ),
+			markers: this.props.coordinates.join( ',' ),
 			zoom: 8,
 			size: '400x300'
 		} );


### PR DESCRIPTION
Closes: #1671

This pull request is an enhancement to the existing Post Location editor. Location Editor accepts free-form user input for searching locations. It presents a search field which, when a search is entered, uses the Google Maps Geocoding API to find matching locations. The Geocoding API returns a list of possible matches, and upon selecting one of them, a map is displayed with the location in center.

In order to make the selected location more obvious on the map, and to bring Calypso functionality more in-line with that of WP Admin, this pull request adds a marker to the displayed location.

##### Before:
<img width="250" alt="screen shot 2015-12-21 at 2 43 19 pm" src="https://cloud.githubusercontent.com/assets/1017839/11931863/3acb5498-a7f1-11e5-976c-dbd050bc3748.png">

##### After:
<img width="250" alt="screen shot 2015-12-21 at 2 42 25 pm" src="https://cloud.githubusercontent.com/assets/1017839/11931853/15a9f7e6-a7f1-11e5-9718-9805f153311c.png">


##### Testing instructions:

1. Navigate to the Calypso post editor.
2. Select a site, if prompted.
3. Expand the More Options sidebar accordion.
4. Enter a query in the location search field.
5. After the search has completed the results are shown below the search input. Click on one of them.
6. Note that a map is displayed for the selected location, and it contains a pin.