### PR TITLE
Framework: Replace React.addons.PureRenderMixin with react-pure-render

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1251,3 +1251,28 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
+
+### https://github.com/gaearon/react-pure-render
+```text
+The MIT License (MIT)
+
+Copyright (c) 2015 Dan Abramov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/client/components/accordion/docs/example.jsx
+++ b/client/components/accordion/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ var Accordion = require( 'components/accordion' ),
 module.exports = React.createClass( {
 	displayName: 'Accordions',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/add-new-button/docs/example.jsx
+++ b/client/components/add-new-button/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var AddNewButton = require( 'components/add-new-button' );
 var AddNewButtons = React.createClass( {
 	displayName: 'AddNewButton',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/button-group/docs/example.jsx
+++ b/client/components/button-group/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
 * External dependencies
 */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ var ButtonGroup = require( 'components/button-group' ),
 var Buttons = React.createClass( {
 	displayName: 'ButtonGroup',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
 * External dependencies
 */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -13,7 +14,7 @@ var Button = require( 'components/button' ),
 var Buttons = React.createClass( {
 	displayName: 'Buttons',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	PureRenderMixin = React.addons.PureRenderMixin,
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	debug = require( 'debug' )( 'calypso:module-chart:legend' );
 
 /**
@@ -63,14 +63,14 @@ var Legend = React.createClass( {
 			var colorClass = legendColors[ index ],
 				checked = ( -1 !== this.props.activeCharts.indexOf( legendItem ) ),
 				tab;
-				 
+
 			tab = this.props.tabs.filter( function( tab ) {
 				return tab.attr === legendItem;
 			} ).shift();
 
 			return <LegendItem key={ index } className={ colorClass } label={ tab.label } attr={ tab.attr } changeHandler={ this.onFilterChange } checked={ checked } />;
 		}, this );
-		
+
 
 		return (
 			<div className="chart__legend">

--- a/client/components/clipboard-button-input/docs/example.jsx
+++ b/client/components/clipboard-button-input/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import ClipboardButtonInput from '../';
 export default React.createClass( {
 	displayName: 'ClipboardButtonInput',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/count/docs/example.jsx
+++ b/client/components/count/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var Count = require( 'components/count' );
 module.exports = React.createClass( {
 	displayName: 'Count',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import React from 'react/addons';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 export default React.createClass( {
 
 	displayName: 'Count',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		count: React.PropTypes.number.isRequired,

--- a/client/components/date-picker/docs/example.jsx
+++ b/client/components/date-picker/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -13,7 +14,7 @@ var Card = require( 'components/card' ),
  * Date Picker Demo
  */
 var datePicker = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		var date = new Date();

--- a/client/components/drop-zone/docs/example.jsx
+++ b/client/components/drop-zone/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ var Card = require( 'components/card' ),
 module.exports = React.createClass( {
 	displayName: 'DropZones',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {};

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
-	PureRenderMixin = React.addons.PureRenderMixin,
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	punycode = require( 'punycode' );
 
 /**

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import classnames from 'classnames';
 import assign from 'lodash/object/assign';
 
@@ -14,7 +15,7 @@ export default React.createClass( {
 
 	displayName: 'ExternalLink',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		className: React.PropTypes.string,

--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var FoldableCard = require( 'components/foldable-card' );
 module.exports = React.createClass( {
 	displayName: 'FoldableCard',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/follow-button/docs/example.jsx
+++ b/client/components/follow-button/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
 * External dependencies
 */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ var FollowButton = require( 'components/follow-button/button' ),
 var FollowButtons = React.createClass( {
 	displayName: 'FollowButtons',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/forms/clipboard-button/docs/example.jsx
+++ b/client/components/forms/clipboard-button/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var ClipboardButton = require( '../' );
 module.exports = React.createClass( {
 	displayName: 'ClipboardButtons',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/forms/counted-textarea/docs/example.jsx
+++ b/client/components/forms/counted-textarea/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var CountedTextarea = require( 'components/forms/counted-textarea' );
 module.exports = React.createClass( {
 	displayName: 'CountedTextareas',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -33,7 +34,7 @@ var countriesList = require( 'lib/countries-list' ).forSms(),
 var FormFields = React.createClass( {
 	displayName: 'FormFields',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/forms/range/docs/example.jsx
+++ b/client/components/forms/range/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var FormRange = require( 'components/forms/range' );
 module.exports = React.createClass( {
 	displayName: 'Ranges',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/gauge/docs/example.jsx
+++ b/client/components/gauge/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var Gauge = require( 'components/gauge' );
 module.exports = React.createClass( {
 	displayName: 'Gauge',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/gauge/index.jsx
+++ b/client/components/gauge/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
-	PureRenderMixin = React.addons.PureRenderMixin;
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 module.exports = React.createClass( {
 	displayName: 'Gauge',

--- a/client/components/header-cake/docs/example.jsx
+++ b/client/components/header-cake/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ module.exports = React.createClass( {
 
 	displayName: 'Headers',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/info-popover/docs/example.jsx
+++ b/client/components/info-popover/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
 * External dependencies
 */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
 * Internal dependencies
@@ -11,7 +12,7 @@ var InfoPopover = require( 'components/info-popover' );
 var InfoPopoverExample = React.createClass( {
 	displayName: 'InfoPopover',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/input-chrono/docs/example.jsx
+++ b/client/components/input-chrono/docs/example.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ import Card from 'components/card';
 export default React.createClass( {
 	displayName: 'InputChrono',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState() {
 		return {

--- a/client/components/like-button/button.jsx
+++ b/client/components/like-button/button.jsx
@@ -1,7 +1,8 @@
 /**
  * Exeternal Dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classnames = require( 'classnames' );
 
 /**
@@ -11,7 +12,7 @@ var LikeIcons = require( './icons' );
 
 var LikeButton = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		liked: React.PropTypes.bool,

--- a/client/components/like-button/docs/example.jsx
+++ b/client/components/like-button/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
 * External dependencies
 */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var LikeButton = require( 'components/like-button/button' ),
 
 var SimpleLikeButtonContainer = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {
@@ -40,7 +41,7 @@ var SimpleLikeButtonContainer = React.createClass( {
 var LikeButtons = React.createClass( {
 	displayName: 'LikeButton',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/like-button/index.jsx
+++ b/client/components/like-button/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External Dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	omit = require( 'lodash/object/omit' ),
 	noop = require( 'lodash/utility/noop' );
 
@@ -21,7 +22,7 @@ var LikeButtonContainer = React.createClass( {
 		onLikeToggle: React.PropTypes.func
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps: function() {
 		return {

--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
 * External dependencies
 */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
 * Internal dependencies
@@ -10,7 +11,7 @@ var NoticeAction = require( 'components/notice/notice-action' ),
 	Notice = require( 'components/notice' );
 
 var Notices = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -9,7 +10,7 @@ import React from 'react';
 import PaymentLogo from '../index';
 
 const PaymentLogoExamples = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		return (

--- a/client/components/popover/docs/example.jsx
+++ b/client/components/popover/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
 * External dependencies
 */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
 * Internal dependencies
@@ -11,7 +12,7 @@ var Popover = require( 'components/popover' ),
 	PopoverMenuItem = require( 'components/popover/menu-item' );
 
 var Popovers = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/post-schedule/docs/example.jsx
+++ b/client/components/post-schedule/docs/example.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ import Card from 'components/card';
 export default React.createClass( {
 	displayName: 'PostSchedule',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState() {
 		var date = new Date(),

--- a/client/components/progress-bar/docs/example.jsx
+++ b/client/components/progress-bar/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var ProgressBar = require( 'components/progress-bar' );
 module.exports = React.createClass( {
 	displayName: 'ProgressBar',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/rating/docs/example.jsx
+++ b/client/components/rating/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var Rating = require( 'components/rating' );
 module.exports = React.createClass( {
 	displayName: 'Rating',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/search/docs/example.jsx
+++ b/client/components/search/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ var noop = () => {};
 var SearchDemo = React.createClass( {
 	displayName: 'Search',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
 * External dependencies
 */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ var SectionHeader = require( 'components/section-header' ),
 var Cards = React.createClass( {
 	displayName: 'SectionHeader',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/section-nav/docs/example.jsx
+++ b/client/components/section-nav/docs/example.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	forEach = require( 'lodash/collection/forEach' );
 
 /**
@@ -19,7 +20,7 @@ var SectionNav = require( 'components/section-nav' ),
 var SectionNavigation = React.createClass( {
 	displayName: 'SectionNav',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' );
 
 /**
@@ -14,7 +15,7 @@ var Count = require( 'components/count' );
  */
 var NavItem = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		itemType: React.PropTypes.string,

--- a/client/components/segmented-control/docs/example.jsx
+++ b/client/components/segmented-control/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ var SegmentedControl = require( 'components/segmented-control' ),
 var SegmentedControlDemo = React.createClass( {
 	displayName: 'SegmentedControl',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -13,7 +14,7 @@ var SelectDropdown = require( 'components/select-dropdown' ),
 var SelectDropdownDemo = React.createClass( {
 	displayName: 'SelectDropdown',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/select/docs/example.jsx
+++ b/client/components/select/docs/example.jsx
@@ -1,10 +1,11 @@
 /**
 * External dependencies
 */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 var Selects = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/sites-dropdown/index.jsx
+++ b/client/components/sites-dropdown/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
 import noop from 'lodash/utility/noop';
 
@@ -19,7 +20,7 @@ export default React.createClass( {
 
 	displayName: 'SitesDropdown',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		selected: React.PropTypes.oneOfType( [

--- a/client/components/spinner/docs/example.jsx
+++ b/client/components/spinner/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ var Spinner = require( 'components/spinner' );
 module.exports = React.createClass( {
 	displayName: 'Spinners',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/timezone-dropdown/docs/example.jsx
+++ b/client/components/timezone-dropdown/docs/example.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import Card from 'components/card';
 
 export default React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	displayName: 'TimezoneDropdown',
 

--- a/client/components/token-field/docs/example.jsx
+++ b/client/components/token-field/docs/example.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -21,7 +22,7 @@ var suggestions = [
 var TokenFields = React.createClass( {
 	displayName: 'TokenFields',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -5,7 +5,8 @@ var take = require( 'lodash/array/take' ),
 	clone = require( 'lodash/lang/clone' ),
 	contains = require( 'lodash/collection/contains' ),
 	map = require( 'lodash/collection/map' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	without = require( 'lodash/array/without' ),
 	each = require( 'lodash/collection/each' ),
 	identity = require( 'lodash/utility/identity' ),
@@ -38,7 +39,7 @@ var TokenField = React.createClass( {
 		};
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/components/token-field/suggestions-list.jsx
+++ b/client/components/token-field/suggestions-list.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var map = require( 'lodash/collection/map' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' ),
 	scrollIntoView = require( 'dom-scroll-into-view' );
 
@@ -26,7 +27,7 @@ var SuggestionsList = React.createClass( {
 		};
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	componentDidUpdate: function( prevProps ) {
 		var node;

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 var TokenInput = React.createClass( {
 	propTypes: {
@@ -18,7 +19,7 @@ var TokenInput = React.createClass( {
 		};
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	noop = require( 'lodash/utility/noop' );
 
 var Token = React.createClass( {
@@ -17,7 +18,7 @@ var Token = React.createClass( {
 		};
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/components/version/docs/example.jsx
+++ b/client/components/version/docs/example.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ export default React.createClass( {
 
 	displayName: 'Version',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		return (

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import classnames from 'classnames';
 import debugModule from 'debug';
 
@@ -39,7 +40,7 @@ const WebPreview = React.createClass( {
 		loadingMessage: React.PropTypes.string
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps() {
 		return {

--- a/client/components/wordpress-logo/index.jsx
+++ b/client/components/wordpress-logo/index.jsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 export default React.createClass( {
 
 	displayName: 'WordPressLogo',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps() {
 		return {

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import Main from 'components/main';
 export default React.createClass( {
 	displayName: 'Typography',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		const interfaceTitle = {

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ export default React.createClass( {
 
 	displayName: 'DevdocsSidebar',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		return (

--- a/client/devdocs/welcome.jsx
+++ b/client/devdocs/welcome.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ export default React.createClass( {
 
 	displayName: 'DevWelcome',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		return (

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
-	PureRenderMixin = React.addons.PureRenderMixin;
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies

--- a/client/me/help/help-contact-confirmation/index.jsx
+++ b/client/me/help/help-contact-confirmation/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import Gridicon from 'components/gridicon';
 import FormSectionHeading from 'components/forms/form-section-heading';
 
 module.exports = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		title: PropTypes.string.isRequired,

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React from 'react/addons';
+import PureRenderMixin from 'react-pure-render/mixin';
 import isEqual from 'lodash/lang/isEqual';
 
 /**
@@ -26,7 +27,7 @@ const sites = siteList();
 module.exports = React.createClass( {
 	displayName: 'HelpContactForm',
 
-	mixins: [ React.addons.LinkedStateMixin, React.addons.PureRenderMixin ],
+	mixins: [ React.addons.LinkedStateMixin, PureRenderMixin ],
 
 	propTypes: {
 		formDescription: React.PropTypes.node,

--- a/client/me/help/help-happiness-engineers/index.jsx
+++ b/client/me/help/help-happiness-engineers/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -14,7 +15,7 @@ var HappinessEngineersStore = require( 'lib/happiness-engineers/store' ),
 module.exports = React.createClass( {
 	displayName: 'HelpHappinessEngineers',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	componentDidMount: function() {
 		HappinessEngineersStore.on( 'change', this.refreshHappinessEngineers );

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import HelpResult from './item';
 module.exports = React.createClass( {
 	displayName: 'HelpResults',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		if ( ! this.props.helpLinks.length ) {

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import CompactCard from 'components/card/compact';
 module.exports = React.createClass( {
 	displayName: 'HelpResult',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	onClick: function( event ) {
 		if ( this.props.helpLink.disabled ) {

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import isEmpty from 'lodash/lang/isEmpty';
 
 /**
@@ -18,7 +19,7 @@ import analytics from 'analytics';
 module.exports = React.createClass( {
 	displayName: 'HelpSearch',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	componentDidMount: function() {
 		HelpSearchStore.on( 'change', this.refreshHelpLinks );

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ var Main = require( 'components/main' ),
 module.exports = React.createClass( {
 	displayName: 'Help',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getSupportLinks: function() {
 		return (

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import Immutable from 'immutable';
 import zip from 'lodash/array/zip';
 import includes from 'lodash/collection/includes';
@@ -15,7 +16,7 @@ import SiteInfo from 'my-sites/site';
 export default React.createClass( {
 	displayName: 'BlogSettingsHeader',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		blog: PropTypes.object.isRequired,

--- a/client/me/notification-settings/settings-form/actions.jsx
+++ b/client/me/notification-settings/settings-form/actions.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import FormButton from 'components/forms/form-button';
 export default React.createClass( {
 	displayName: 'NotificationSettingsFormActions',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		onSave: PropTypes.func.isRequired,

--- a/client/me/notification-settings/settings-form/device-selector.jsx
+++ b/client/me/notification-settings/settings-form/device-selector.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import FormSelect from 'components/forms/form-select';
 export default React.createClass( {
 	displayName: 'NotificationSettingsFormDeviceSelector',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		devices: PropTypes.object.isRequired,

--- a/client/me/notification-settings/settings-form/settings.jsx
+++ b/client/me/notification-settings/settings-form/settings.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import Immutable from 'immutable';
 
 /**
@@ -23,7 +24,7 @@ const streams = {
 export default React.createClass( {
 	displayName: 'NotificationSettingsForm',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		blogId: PropTypes.oneOfType( [

--- a/client/me/notification-settings/settings-form/stream-header.jsx
+++ b/client/me/notification-settings/settings-form/stream-header.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import { getLabelForStream } from './locales'
 export default React.createClass( {
 	displayName: 'NotificationSettingsFormHeader',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		stream: PropTypes.string,

--- a/client/me/notification-settings/settings-form/stream-options.jsx
+++ b/client/me/notification-settings/settings-form/stream-options.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import Immutable from 'immutable';
 
 /**
@@ -13,7 +14,7 @@ import FormCheckbox from 'components/forms/form-checkbox';
 export default React.createClass( {
 	displayName: 'NotificationSettingsFormStreamOptions',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		blogId: PropTypes.oneOfType( [

--- a/client/me/notification-settings/settings-form/stream-selector.jsx
+++ b/client/me/notification-settings/settings-form/stream-selector.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import Immutable from 'immutable';
 
 /**
@@ -13,7 +14,7 @@ import { getLabelForStream } from './locales'
 export default React.createClass( {
 	displayName: 'NotificationSettingsFormStreamSelector',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		devices: PropTypes.object,

--- a/client/me/notification-settings/settings-form/stream.jsx
+++ b/client/me/notification-settings/settings-form/stream.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import Immutable from 'immutable';
 import classNames from 'classnames';
 
@@ -15,7 +16,7 @@ import StreamOptions from './stream-options';
 export default React.createClass( {
 	displayName: 'NotificationSettingsFormStream',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		blogId: PropTypes.oneOfType( [

--- a/client/my-sites/drafts/draft-list.jsx
+++ b/client/my-sites/drafts/draft-list.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	omit = require( 'lodash/object/omit' );
 
 /**
@@ -17,7 +18,7 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 
 var DraftList = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		search: React.PropTypes.string,

--- a/client/my-sites/exporter/option-fieldset.jsx
+++ b/client/my-sites/exporter/option-fieldset.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -9,8 +10,6 @@ import React, { PropTypes } from 'react';
 import Checkbox from 'components/forms/form-checkbox';
 import Select from 'components/forms/form-select';
 import Label from 'components/forms/form-label';
-
-const PureRenderMixin = React.addons.PureRenderMixin;
 
 /**
  * Displays a list of select menus with a checkbox legend

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -13,7 +14,7 @@ import user from 'lib/user';
 export default React.createClass( {
 	displayName: 'ImporterAuthorMapping',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		hasSingleAuthor: PropTypes.bool.isRequired,

--- a/client/my-sites/importer/author-mapping-pane.jsx
+++ b/client/my-sites/importer/author-mapping-pane.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ import AuthorMapping from './author-mapping-item';
 export default React.createClass( {
 	displayName: 'ImporterMappingPane',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		hasSingleAuthor: PropTypes.bool.isRequired,

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import Notice from 'components/notice';
 export default React.createClass( {
 	displayName: 'SiteSettingsImporterError',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		description: PropTypes.string.isRequired,

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
 import includes from 'lodash/collection/includes';
 
@@ -35,7 +36,7 @@ const compactStates = [ appStates.DISABLED, appStates.INACTIVE ],
 export default React.createClass( {
 	displayName: 'FileImporter',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		importerData: PropTypes.shape( {

--- a/client/my-sites/importer/importer-ghost.jsx
+++ b/client/my-sites/importer/importer-ghost.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ const importerData = {
 export default React.createClass( {
 	displayName: 'ImporterGhost',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		importerData.description = this.translate( 'Import posts and tags from a Ghost export file.' );

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import includes from 'lodash/collection/includes';
 
 /**
@@ -29,7 +30,7 @@ const startStates = [ appStates.DISABLED, appStates.INACTIVE ],
 export default React.createClass( {
 	displayName: 'ImporterHeader',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		importerStatus: PropTypes.shape( {

--- a/client/my-sites/importer/importer-icons.jsx
+++ b/client/my-sites/importer/importer-icons.jsx
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
 
 export default React.createClass( {
 	displayName: 'ImporterIcon',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: { icon: PropTypes.oneOf( [ 'ghost', 'medium', 'squarespace', 'wordpress' ] ) },
 

--- a/client/my-sites/importer/importer-medium.jsx
+++ b/client/my-sites/importer/importer-medium.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ const importerData = {
 export default React.createClass( {
 	displayName: 'ImporterMedium',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		importerData.description = this.translate( 'Import posts from a Medium export file.' );

--- a/client/my-sites/importer/importer-squarespace.jsx
+++ b/client/my-sites/importer/importer-squarespace.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ const importerData = {
 export default React.createClass( {
 	displayName: 'ImporterSquarespace',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		importerData.description = this.translate(

--- a/client/my-sites/importer/importer-wordpress.jsx
+++ b/client/my-sites/importer/importer-wordpress.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ const importerData = {
 export default React.createClass( {
 	displayName: 'ImporterWordPress',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		importerStatus: PropTypes.shape( {

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
 
 /**
@@ -15,7 +16,7 @@ import MappingPane from './author-mapping-pane';
 export default React.createClass( {
 	displayName: 'SiteSettingsImportingPane',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		importerStatus: PropTypes.shape( {

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
 import noop from 'lodash/utility/noop';
 import includes from 'lodash/collection/includes';
@@ -18,7 +19,7 @@ import ProgressBar from 'components/progress-bar';
 export default React.createClass( {
 	displayName: 'SiteSettingsUploadingPane',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		description: PropTypes.oneOfType( [ PropTypes.node, PropTypes.string ] ),

--- a/client/my-sites/menus/item-options/post-list.jsx
+++ b/client/my-sites/menus/item-options/post-list.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	debug = require( 'debug' )( 'calypso:menus:post-list' ),
 	omit = require( 'lodash/object/omit' );
 
@@ -17,7 +18,7 @@ var	Posts = require( './posts' ),
  */
 var PostList = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return {

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	omit = require( 'lodash/object/omit' );
 
 /**
@@ -20,7 +21,7 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 
 var PageList = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		context: React.PropTypes.object,

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-const React = require( 'react/addons' );
+const React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -24,7 +25,7 @@ const Card = require( 'components/card' ),
 module.exports = React.createClass( {
 	displayName: 'DeleteUser',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		isMultisite: React.PropTypes.bool.isRequired,

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react/addons' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	debug = require( 'debug' )( 'calypso:my-sites:people:edit-team-member-form' ),
 	omit = require( 'lodash/object/omit' ),
 	assign = require( 'lodash/object/assign' ),
@@ -37,7 +38,7 @@ var Main = require( 'components/main' ),
 var EditUserForm = React.createClass( {
 	displayName: 'EditUserForm',
 
-	mixins: [ React.addons.LinkedStateMixin, React.addons.PureRenderMixin ],
+	mixins: [ React.addons.LinkedStateMixin, PureRenderMixin ],
 
 	getInitialState: function() {
 		return this.getStateObject( this.props );
@@ -227,7 +228,7 @@ var EditUserForm = React.createClass( {
 module.exports = React.createClass( {
 	displayName: 'EditTeamMemberForm',
 
-	mixins: [ React.addons.PureRenderMixin, protectForm.mixin ],
+	mixins: [ PureRenderMixin, protectForm.mixin ],
 
 	getInitialState: function() {
 		return ( {

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	omit = require( 'lodash/object/omit' ),
 	debug = require( 'debug' )( 'calypso:my-sites:people:followers-list' );
 
@@ -36,7 +37,7 @@ let Followers = React.createClass( {
 		};
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	renderPlaceholders() {
 		return <PeopleListItem key="people-list-item-placeholder"/>;
@@ -211,7 +212,7 @@ let Followers = React.createClass( {
 module.exports = React.createClass( {
 	displayName: 'FollowersList',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		let DataComponent;

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-const React = require( 'react/addons' ),
+const React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 
@@ -17,7 +18,7 @@ export default React.createClass( {
 
 	displayName: 'PeopleListItem',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	navigateToUser() {
 		window.scrollTo( 0, 0 );

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 
@@ -13,7 +14,7 @@ var Gravatar = require( 'components/gravatar' );
 module.exports = React.createClass( {
 	displayName: 'PeopleProfile',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getRole: function() {
 		var user = this.props.user;

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -27,7 +28,7 @@ let Viewers = React.createClass( {
 		};
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	renderPlaceholders() {
 		return <PeopleListItem key="people-list-item-placeholder"/>;
@@ -159,7 +160,7 @@ let Viewers = React.createClass( {
 module.exports = React.createClass( {
 	displayName: 'ViewersList',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		return (

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 module.exports = React.createClass( {
 
 	displayName: 'PostRelativeTime',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		post: React.PropTypes.object.isRequired,

--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import omit from 'lodash/object/omit';
 import noop from 'lodash/utility/noop';
 
@@ -14,7 +15,7 @@ import PostListFetcher from 'components/post-list-fetcher';
 export default React.createClass( {
 	displayName: 'PostSelector',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		type: PropTypes.string,

--- a/client/my-sites/post/post-image/index.jsx
+++ b/client/my-sites/post/post-image/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
-	PureRenderMixin = React.addons.PureRenderMixin,
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classnames = require( 'classnames' );
 
 /**

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	url = require( 'url' );
 
 /**
@@ -15,7 +16,7 @@ var config = require( 'config' ),
 module.exports = React.createClass( {
 	displayName: 'PostControls',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		post: React.PropTypes.object.isRequired,

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	debug = require( 'debug' )( 'calypso:my-sites:posts' ),
 	debounce = require( 'lodash/function/debounce' ),
 	omit = require( 'lodash/object/omit' );
@@ -25,7 +26,7 @@ var GUESSED_POST_HEIGHT = 250;
 
 var PostList = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		context: React.PropTypes.object,

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var noop = require( 'lodash/utility/noop' ),
-	React = require( 'react/addons' );
+	React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 /**
  * Internal dependencies
@@ -46,7 +47,7 @@ module.exports = React.createClass( {
 		type: React.PropTypes.string
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps: function() {
 		return {

--- a/client/post-editor/editor-more-options/slug.jsx
+++ b/client/post-editor/editor-more-options/slug.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react/addons';
+import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -13,7 +14,7 @@ import Slug from 'post-editor/editor-slug';
 export default React.createClass( {
 	displayName: 'EditorMoreOptionsSlug',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		slug: PropTypes.string,

--- a/client/post-editor/editor-page-order/index.jsx
+++ b/client/post-editor/editor-page-order/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import isNaN from 'lodash/lang/isNaN';
 
 /**
@@ -14,7 +15,7 @@ import { recordEvent, recordStat } from 'lib/posts/stats';
 export default React.createClass( {
 	displayName: 'EditorPageOrder',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		menuOrder: PropTypes.oneOfType( [

--- a/client/post-editor/editor-page-parent/index.jsx
+++ b/client/post-editor/editor-page-parent/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import AccordionSection from 'components/accordion/section';
 
 /**
@@ -15,7 +16,7 @@ import FormToggle from 'components/forms/form-toggle/compact';
 export default React.createClass( {
 	displayName: 'EditorPageParent',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		siteId: PropTypes.number,

--- a/client/post-editor/editor-page-slug/index.jsx
+++ b/client/post-editor/editor-page-slug/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react/addons';
+import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import pick from 'lodash/object/pick';
 
 /**
@@ -13,7 +14,7 @@ import Gridicon from 'components/gridicon';
 export default React.createClass( {
 	displayName: 'PostEditorPageSlug',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		path: PropTypes.string,

--- a/client/post-editor/editor-post-type/index.jsx
+++ b/client/post-editor/editor-post-type/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import page from 'page';
 import classNames from 'classnames';
 
@@ -22,7 +23,7 @@ export default React.createClass( {
 
 	displayName: 'EditorPostType',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps() {
 		return {

--- a/client/post-editor/editor-revisions/index.jsx
+++ b/client/post-editor/editor-revisions/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -12,7 +13,7 @@ export default React.createClass( {
 
 	displayName: 'EditorRevisions',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		adminUrl: React.PropTypes.string,

--- a/client/post-editor/editor-slug/index.jsx
+++ b/client/post-editor/editor-slug/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import ReactDom from 'react-dom';
-import React, { PropTypes } from 'react/addons';
+import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
 import noop from 'lodash/utility/noop';
 
@@ -17,7 +18,7 @@ import { recordStat, recordEvent } from 'lib/posts/stats';
 export default React.createClass( {
 	displayName: 'PostEditorSlug',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		path: PropTypes.string,

--- a/client/post-editor/editor-title/container.jsx
+++ b/client/post-editor/editor-title/container.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -18,7 +19,7 @@ const sites = sitesList();
 export default React.createClass( {
 	displayName: 'EditorTitleContainer',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState() {
 		return this.getState();

--- a/client/post-editor/editor-word-count/index.jsx
+++ b/client/post-editor/editor-word-count/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ const user = userModule();
 export default React.createClass( {
 	displayName: 'EditorWordCount',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState() {
 		return {

--- a/client/post-editor/media-modal/gallery-help.jsx
+++ b/client/post-editor/media-modal/gallery-help.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react/addons';
+import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ import Button from 'components/button';
 export default React.createClass( {
 	displayName: 'EditorMediaModalGalleryHelp',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		onDismiss: PropTypes.func

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react/addons';
+import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import reject from 'lodash/collection/reject';
 
 /**
@@ -14,7 +15,7 @@ import Gridicon from 'components/gridicon';
 export default React.createClass( {
 	displayName: 'EditorMediaModalGalleryRemoveButton',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		siteId: PropTypes.number,

--- a/client/post-editor/status-label.jsx
+++ b/client/post-editor/status-label.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var noop = require( 'lodash/utility/noop' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' );
 
 /**
@@ -18,7 +19,7 @@ var StatusLabel = React.createClass( {
 		type: React.PropTypes.string
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps: function() {
 		return {

--- a/client/reader/comments/post-comment-content.jsx
+++ b/client/reader/comments/post-comment-content.jsx
@@ -1,9 +1,17 @@
-import React, { PropTypes } from 'react/addons';
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+
+/**
+ * Internal dependencies
+ */
 import CommentConstants from 'lib/comment-store/constants';
 
 const PostCommentContent = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		content: PropTypes.string.isRequired,

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -1,12 +1,19 @@
-var React = require( 'react' );
+/**
+ * External dependencies
+ */
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+/**
+ * Internal dependencies
+ */
 var FollowButtonContainer = require( 'components/follow-button' ),
 	FollowButton = require( 'components/follow-button/button' ),
 	stats = require( 'reader/stats' );
 
 var ReaderFollowButton = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	recordFollowToggle: function( isFollowing ) {
 		stats.recordAction( isFollowing ? 'followed_blog' : 'unfollowed_blog' );

--- a/client/reader/following-edit/list-item.jsx
+++ b/client/reader/following-edit/list-item.jsx
@@ -1,8 +1,13 @@
-// External dependencies
-const React = require( 'react/addons' ),
+/**
+ * External dependencies
+ */
+const React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	noop = require( 'lodash/utility/noop' );
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 const Icon = require( 'reader/list-item/icon' ),
 	Title = require( 'reader/list-item/title' ),
 	Description = require( 'reader/list-item/description' ),
@@ -28,7 +33,7 @@ var SubscriptionListItem = React.createClass( {
 		openCards: React.PropTypes.object
 	},
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps() {
 		return {

--- a/client/reader/following-stream/post-blocked.jsx
+++ b/client/reader/following-stream/post-blocked.jsx
@@ -1,14 +1,19 @@
-// External dependencies
-var React = require( 'react/addons' );
+/**
+ * External dependencies
+ */
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 var analytics = require( 'analytics' ),
 	SiteBlockActions = require( 'lib/reader-site-blocks/actions' ),
 	Card = require( 'components/card' );
 
 var PostBlocked = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	unblock: function() {
 		analytics.mc.bumpStat( 'reader_actions', 'unblocked_blog' );

--- a/client/reader/following-stream/post-placeholder.jsx
+++ b/client/reader/following-stream/post-placeholder.jsx
@@ -1,10 +1,17 @@
-var React = require( 'react/addons' );
+/**
+ * External dependencies
+ */
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+/**
+ * Internal dependencies
+ */
 var Card = require( 'components/card' );
 
 var PostPlaceholder = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		return (

--- a/client/reader/following-stream/post-unavailable.jsx
+++ b/client/reader/following-stream/post-unavailable.jsx
@@ -1,11 +1,18 @@
-var React = require( 'react/addons' ),
+/**
+ * External dependencies
+ */
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	config = require( 'config' );
 
+/**
+ * Internal dependencies
+ */
 var Card = require( 'components/card' );
 
 var PostUnavailable = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	componentWillMount: function() {
 		this.errors = {

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -2,7 +2,8 @@
  * External Dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	assign = require( 'lodash/object/assign' ),
 	classnames = require( 'classnames' ),
 	closest = require( 'component-closest' ),
@@ -49,7 +50,7 @@ var Card = require( 'components/card' ),
 
 var Post = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin, ObserveWindowSizeMixin ],
+	mixins: [ PureRenderMixin, ObserveWindowSizeMixin ],
 
 	propTypes: {
 		post: React.PropTypes.object.isRequired,

--- a/client/reader/following-stream/x-post.jsx
+++ b/client/reader/following-stream/x-post.jsx
@@ -2,7 +2,8 @@
  * External Dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classnames = require( 'classnames' ),
 	closest = require( 'component-closest' ),
 	url = require( 'url' );
@@ -15,7 +16,7 @@ var Card = require( 'components/card' ),
 
 var CrossPost = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		post: React.PropTypes.object.isRequired,

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -2,7 +2,8 @@
  * External Dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	assign = require( 'lodash/object/assign' ),
 	classes = require( 'component-classes' ),
 	debug = require( 'debug' )( 'calypso:reader-full-post' ), //eslint-disable-line no-unused-vars
@@ -85,7 +86,7 @@ function readerPageView( blogId, blogUrl, postId, isPrivate ) {
  */
 FullPostView = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	componentDidMount: function() {
 		this._parseEmoji();
@@ -203,7 +204,7 @@ FullPostView = React.createClass( {
  */
 FullPostDialog = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	componentWillMount: function() {
 		classes( document.documentElement ).add( 'detail-page-active' );
@@ -331,7 +332,7 @@ function getSite( siteId ) {
 
 FullPostContainer = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState: function() {
 		return assign( { isVisible: false }, this.getStateFromStores() );

--- a/client/reader/list-item/actions.jsx
+++ b/client/reader/list-item/actions.jsx
@@ -1,7 +1,11 @@
-import React from 'react/addons';
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 const ListItemActions = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		return ( <div className="reader-list-item__actions">{ this.props.children }</div> );

--- a/client/reader/list-item/description.jsx
+++ b/client/reader/list-item/description.jsx
@@ -1,7 +1,11 @@
-import React from 'react/addons';
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 const ListItemDescription = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		// should this be a div instead of a p? p's have odd nesting rules that we can't enforce in code.

--- a/client/reader/list-item/icon.jsx
+++ b/client/reader/list-item/icon.jsx
@@ -1,12 +1,19 @@
-import React from 'react/addons';
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import noop from 'lodash/utility/noop';
 
+/**
+ * Internal dependencies
+ */
 import SiteIcon from 'components/site-icon';
 
 const genericFeedIcon = ( <SiteIcon size={ 48 } /> );
 
 const ListItemDescription = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps() {
 		return { onClick: noop };

--- a/client/reader/list-item/index.jsx
+++ b/client/reader/list-item/index.jsx
@@ -1,12 +1,17 @@
-// External dependencies
-import React from 'react/addons';
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import classnames from 'classnames';
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 import Card from 'components/card/compact';
 
 const ListItem = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		const classes = classnames( 'reader-list-item__card', this.props.className );

--- a/client/reader/list-item/title.jsx
+++ b/client/reader/list-item/title.jsx
@@ -1,8 +1,12 @@
-import React from 'react/addons';
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 import noop from 'lodash/utility/noop';
 
 const ListItemTitle = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps() {
 		return { onClick: noop };

--- a/client/reader/post-images/index.jsx
+++ b/client/reader/post-images/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	resizeImageUrl = require( 'lib/resize-image-url' ),
 	classes = require( 'component-classes' ),
 	domScrollIntoView = require( 'dom-scroll-into-view' ),
@@ -163,7 +164,7 @@ var PostImages = React.createClass( {
 
 var PostImageThumbList = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		var images = this.props.postImages,

--- a/client/reader/post-time/index.jsx
+++ b/client/reader/post-time/index.jsx
@@ -1,13 +1,20 @@
+/**
+ * External dependencies
+ */
 var debug = require( 'debug' )( 'calyso:reader:post-time' ),
-	React = require( 'react/addons' );
+	React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+/**
+ * Internal dependencies
+ */
 const smartSetState = require( 'lib/react-smart-set-state' ),
 	ticker = require( 'lib/ticker' ),
 	humanDate = require( 'lib/human-date' );
 
 var PostTime = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	componentWillMount: function() {
 		this._update();

--- a/client/reader/reading-time/index.jsx
+++ b/client/reader/reading-time/index.jsx
@@ -1,8 +1,12 @@
-var React = require( 'react/addons' );
+/**
+ * External dependencies
+ */
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
 
 var ReadingTime = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	render: function() {
 		var words = this.props.words || 0,

--- a/client/reader/site-and-author-icon/index.jsx
+++ b/client/reader/site-and-author-icon/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External Dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal Dependencies
@@ -13,7 +14,7 @@ import SiteStoreActions from 'lib/reader-site-store/actions';
 
 const SiteAndAuthorIcon = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		siteId: React.PropTypes.number.isRequired,

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal Dependencies
@@ -15,7 +16,7 @@ import * as stats from 'reader/stats';
 export default React.createClass( {
 	displayName: 'FeedFeatured',
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getInitialState() {
 		return this.getStateFromStores();

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -1,15 +1,19 @@
 /**
  * External Dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	noop = require( 'lodash/utility/noop' ),
 	classnames = require( 'classnames' );
 
+/**
+ * Internal dependencies
+ */
 var titleActions = require( 'lib/screen-title/actions' ),
 	Gridicon = require( 'components/gridicon' );
 
 var UpdateNotice = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		count: React.PropTypes.number.isRequired,

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "react-addons-create-fragment": "0.14.3",
     "react-day-picker": "1.1.0",
     "react-dom": "0.14.3",
+    "react-pure-render": "1.0.2",
     "react-redux": "4.0.1",
     "react-tap-event-plugin": "0.2.1",
     "redux": "3.0.4",

--- a/shared/components/gridicon/index.jsx
+++ b/shared/components/gridicon/index.jsx
@@ -9,12 +9,13 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 		classNames = require( 'classnames' );
 
 var Gridicon = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps: function() {
 		return {

--- a/shared/components/theme/index.jsx
+++ b/shared/components/theme/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' ),
 	noop = require( 'lodash/utility/noop' );
 
@@ -17,7 +18,7 @@ var Card = require( 'components/card' ),
  * Component
  */
 var Theme = React.createClass( {
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		// Theme ID (theme-slug)


### PR DESCRIPTION
This pull request seeks to replace `React.addons.PureRenderMixin` with the `react-pure-render` package. React addons were moved to separate packages in [React 0.14](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html) and currently cause warnings to appear in development environments. Facebook offers its own [`react-addons-pure-render-mixin` package](https://www.npmjs.com/package/react-addons-pure-render-mixin), but I suggest here that we use the [`react-pure-render` package](https://github.com/gaearon/react-pure-render) instead, as it includes a few useful variations for usage (i.e. function for use in React component classes).

__Testing instructions:__

- Verify that you can navigate the application without errors.

__Code verification:__

- Verify that `/addons` suffix in React import accurately reflects current existence of addon usage.
- Ensure that no usage of `React.addons.PureRenderMixin` remains

__Next steps:__

We should replace `shallowequal` usage with `react-pure-render`s own `react-pure-render/shallowEqual` module (see #1463, cc @ockham )