### PR TITLE
Plugins: Add missing message when removing a plugin

### DIFF
--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -59,33 +59,37 @@ module.exports = React.createClass( {
 			case 'UPDATE_PLUGIN':
 				message = ( this.props.selectedSite
 					? i18n.translate( 'Updating', { context: 'plugin' } )
-					: i18n.translate( 'Updating on %(count)s site', 'updating on %(count)s sites', translationArgs ) );
+					: i18n.translate( 'Updating on %(count)s site', 'Updating on %(count)s sites', translationArgs ) );
 				break;
 
 			case 'ACTIVATE_PLUGIN':
 				message = ( this.props.selectedSite
 					? i18n.translate( 'Activating', { context: 'plugin' } )
-					: i18n.translate( 'Activating on %(count)s site', 'activating on %(count)s sites', translationArgs ) );
+					: i18n.translate( 'Activating on %(count)s site', 'Activating on %(count)s sites', translationArgs ) );
 				break;
 
 			case 'DEACTIVATE_PLUGIN':
 				message = ( this.props.selectedSite
 					? i18n.translate( 'Deactivating', { context: 'plugin' } )
-					: i18n.translate( 'Deactivating on %(count)s site', 'deactivating on %(count)s sites', translationArgs ) );
+					: i18n.translate( 'Deactivating on %(count)s site', 'Deactivating on %(count)s sites', translationArgs ) );
 				break;
 
 			case 'ENABLE_AUTOUPDATE_PLUGIN':
 				message = ( this.props.selectedSite
 					? i18n.translate( 'Enabling autoupdates' )
-					: i18n.translate( 'Enabling autoupdates on %(count)s site', 'enabling autoupdates on %(count)s sites', translationArgs ) );
+					: i18n.translate( 'Enabling autoupdates on %(count)s site', 'Enabling autoupdates on %(count)s sites', translationArgs ) );
 				break;
 
 			case 'DISABLE_AUTOUPDATE_PLUGIN':
 				message = ( this.props.selectedSite
 					? i18n.translate( 'Disabling autoupdates' )
-					: i18n.translate( 'Disabling autoupdates on %(count)s site', 'disabling autoupdates on %(count)s sites', translationArgs ) );
+					: i18n.translate( 'Disabling autoupdates on %(count)s site', 'Disabling autoupdates on %(count)s sites', translationArgs ) );
 
 				break;
+			case 'REMOVE_PLUGIN':
+				message = ( this.props.selectedSite
+					? i18n.translate( 'Removing plugin' )
+					: i18n.translate( 'Removing plugin on %(count)s site', 'Removing plugin on %(count)s sites', translationArgs ) );
 		}
 		return message;
 	},


### PR DESCRIPTION
We are missing a text in the notification a plugin-item shows when a plugin is being removed:

![image](https://cloud.githubusercontent.com/assets/1554855/11934556/51ab2d48-a803-11e5-86de-e4f5d96f9282.png)

This PR solves it:
![image](https://cloud.githubusercontent.com/assets/1554855/11934583/740f5882-a803-11e5-93cb-86894ec768ed.png)

How to test:
======
1. Go to http://calypso.localhost:3000/plugins
2. Click in "edit all"
3. Select a jetpack plugin
4. Click on "remove" 
5. You should see a compact notice with the 'removing... ' message inside the plugin item