### PR TITLE
Plugins: Fix jump in plugin-items when compact notices are rendered

### DIFF
--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -118,7 +118,7 @@
 	display: block;
 	font-size: 14px;
 	font-weight: 600;
-	line-height: 32px;
+	line-height: 30px;
 	overflow: hidden;
 	text-align: left;
 	text-overflow: ellipsis;


### PR DESCRIPTION
There's a small size jump when we show a compact notice inside one of the plugin-items in the main plugins page due to a too large line-height:

Before
[video] https://cloudup.com/cLO6sNRM78R

After:
[video] https://cloudup.com/cna0kf3N_6o

How to test:
=======
1. Go to http://calypso.dev:3000/plugins
2. click in "edit all"
3. Select one of the jetpack plugins which have no pending updates
4. Activate/Deactivate it
5. The height of the plugin item should not change when the deactivation/activation notices are shown inside it.