### PR TITLE
Plugins: clean up of the single plugin view padding

### DIFF
--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -52,10 +52,6 @@
 }
 
 .plugin-information__version-info.is-singlesite {
-	// display: table;
-
-	.plugin-information__version-shell {
-	}
 
 	.plugin-information__last-updated,
 	.plugin-information__versions,

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -117,11 +117,11 @@
 		text-align: right;
 
 		.plugin-action {
-			margin-top: 20px;
+			margin-top: 16px;
 		}
 
 		.plugin-action:first-child {
-			margin-top: 12px;
+			margin-top: 8px;
 		}
 	}
 

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -1,4 +1,3 @@
-
 .plugin-meta__banner {
 	position: relative;
 		top: 0;
@@ -36,15 +35,6 @@
 
 .plugin-meta__information {
 	position: relative;
-
-	&.has-button {
-		@include breakpoint( "<660px" ) {
-			padding-bottom: 0;
-		}
-		@include breakpoint( "<480px" ) {
-			padding-bottom: 10px;
-		}
-	}
 }
 
 .plugin-meta__name {
@@ -112,8 +102,8 @@
 .plugin-meta__actions {
 	border-top: 1px solid lighten( $gray, 30% );
 	flex-grow: 1;
-	margin-top: 1em;
-	padding-top: 1.5em;
+	margin-top: 16px;
+	padding-top: 16px;
 
 	.has-button & {
 		position: initial;
@@ -142,18 +132,6 @@
 		color: $gray-dark;
 		font-size: 11px;
 	}
-}
-
-.plugin-meta__actions .plugin-action {
-	@include breakpoint( '<480px' ) {
-		margin-bottom: 2em;
-
-		&:last-child {
-			margin-bottom: 0;
-		}
-	}
-
-
 }
 
 .plugin-meta__version-notice {


### PR DESCRIPTION
I remove old `em` values and make things more symmetrical between mobile and wider view. Everything is now spaced out in 8/16/24px increments to match our grid.

**Before:**
<img width="748" alt="screen shot 2015-12-21 at 1 30 55 pm" src="https://cloud.githubusercontent.com/assets/437258/11938319/227d07be-a7e8-11e5-852e-6dd4618a6e57.png">
<img width="394" alt="screen shot 2015-12-21 at 1 33 21 pm" src="https://cloud.githubusercontent.com/assets/437258/11938321/22813e1a-a7e8-11e5-9ba7-fb4498d5395b.png">
<img width="396" alt="screen shot 2015-12-21 at 1 33 33 pm" src="https://cloud.githubusercontent.com/assets/437258/11938320/227edf26-a7e8-11e5-8f18-2500079f5414.png">

**After:**
<img width="729" alt="screen shot 2015-12-21 at 1 35 20 pm" src="https://cloud.githubusercontent.com/assets/437258/11938330/2d752c6e-a7e8-11e5-9ec1-16f42f954757.png">
<img width="389" alt="screen shot 2015-12-21 at 1 36 00 pm" src="https://cloud.githubusercontent.com/assets/437258/11938331/2d7a028e-a7e8-11e5-9225-d59d71cdb418.png">
<img width="394" alt="screen shot 2015-12-21 at 1 36 13 pm" src="https://cloud.githubusercontent.com/assets/437258/11938332/2d7b36cc-a7e8-11e5-816e-612eb517e1a9.png">

cc @enejb 