### PR TITLE
Framework: Replace shallowequal usage with react-pure-render/shallowEqual

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -600,7 +600,7 @@ such a program is covered only if its contents constitute a work based
 on the Library (independent of the use of the Library in a tool for
 writing it).  Whether that is true depends on what the Library does
 and what the program that uses the Library does.
-  
+
   1. You may copy and distribute verbatim copies of the Library's
 complete source code as you receive it, in any medium, provided that
 you conspicuously and appropriately publish on each copy an
@@ -986,7 +986,7 @@ THE SOFTWARE.
 #### client/lib/version-compare
 #### client/lib/mixins/i18n/number-format.js
 ```text
-Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) 
+Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io)
 and Contributors (http://phpjs.org/authors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -1227,30 +1227,6 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### https://github.com/dashed/shallowequal
-```text
-The MIT License (MIT)
-
-Copyright (c) 2015 Alberto Leal <mailforalberto@gmail.com> (github.com/dashed)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
 
 ### https://github.com/gaearon/react-pure-render
 ```text

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	shallowEqual = require( 'shallowequal' ),
+	shallowEqual = require( 'react-pure-render/shallowEqual' ),
 	config = require( 'config' );
 
 /**

--- a/client/reader/post-errors/index.jsx
+++ b/client/reader/post-errors/index.jsx
@@ -1,6 +1,6 @@
 // External dependencies
 var React = require( 'react' ),
-	shallowEqual = require( 'shallowequal' ),
+	shallowEqual = require( 'react-pure-render/shallowEqual' ),
 	debug = require( 'debug' )( 'calypso:reader:post-options-error' ); //eslint-disable-line no-unused-vars
 
 // Internal dependencies

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "redux-thunk": "1.0.0",
     "rtlcss": "1.6.1",
     "sanitize-html": "1.11.1",
-    "shallowequal": "0.2.2",
     "source-map": "0.1.39",
     "source-map-support": "0.3.2",
     "store": "1.3.16",


### PR DESCRIPTION
Follow-up to #1878.

To test:
* Check that affected parts of Calypso are still working (Reader).

Code verification:
* Check that no imports of `shallowequal` remain.

CC @aduth 