### PR TITLE
Framework: Replace React.addons.cloneWithProps() usage with React.cloneElement()

### DIFF
--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -2,7 +2,7 @@
 * External dependencies
 */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' );
+	React = require( 'react' );
 
 /**
 * Internal dependencies
@@ -58,7 +58,7 @@ var PopoverMenu = React.createClass( {
 			onClick = child.props.onClick.bind( null, boundOnClose );
 		}
 
-		return React.addons.cloneWithProps( child, {
+		return React.cloneElement( child, {
 			onClick: onClick
 		} );
 	},

--- a/client/components/segmented-control/index.jsx
+++ b/client/components/segmented-control/index.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
 	filter = require( 'lodash/collection/filter' ),
 	map = require( 'lodash/collection/map' ),
 	classNames = require( 'classnames' );
@@ -95,7 +95,7 @@ var SegmentedControl = React.createClass( {
 		if ( this.props.children ) {
 			// add keys and refs to children
 			return React.Children.map( this.props.children, function( child, index ) {
-				var newChild = React.addons.cloneWithProps( child, {
+				var newChild = React.cloneElement( child, {
 					ref: ( child.type === ControlItem ) ? 'item-' + refIndex : null,
 					key: 'item-' + index,
 					onClick: function( event ) {


### PR DESCRIPTION
The former is deprecated in React 0.14.

To test:
* Verifiy that the `PopoverMenu` and `SegmentedControl` components still works.
 * Both are found at calypso.localhost:3000/devdocs/design (Popover: there's a button titled 'Show Poppver Menu')
 * Enable your browser's console and click on individual items of the `PopoverMenu` and on individual action areas of the `SegmentedControl`, respectively, and watch them being reported correctly in the console.

CC @aduth 