### PR TITLE
Plugins: Fix business plugins placeholders

### DIFF
--- a/client/my-sites/plugins/plugin-information/README.md
+++ b/client/my-sites/plugins/plugin-information/README.md
@@ -6,4 +6,8 @@ This component is used to display a card including information about a plugin.
 #### Props
 
 * `plugin` : (object) A plugin object.
-* `isPlaceholder`: (boolean) Whether the component is being rendered in placeholder mode
+* `isPlaceholder`: (boolean) Whether the component is being rendered in placeholder mode.
+* `hasUpdate`: ( boolean ) If the plugin has an update. 
+* `pluginVersion`: ( string ) The plugin version to display to the user.
+* `siteVersion`: ( string or boolean ) string or false which hides the plugin version.
+* `isWpcomPlugin`: ( boolean ) if a plugin is a WordPress.com plugin. 

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -23,7 +23,11 @@ export default React.createClass( {
 
 	propTypes: {
 		plugin: React.PropTypes.object.isRequired,
-		isPlaceholder: React.PropTypes.bool
+		isPlaceholder: React.PropTypes.bool,
+		hasUpdate: React.PropTypes.bool,
+		pluginVersion: React.PropTypes.string,
+		siteVersion: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool] ),
+		isWpcomPlugin: React.PropTypes.bool,
 	},
 
 	getDefaultProps() {
@@ -161,8 +165,9 @@ export default React.createClass( {
 	},
 
 	renderPlaceholder() {
+		const classes = classNames( { 'plugin-information': true, 'is-placeholder': true, 'is-wpcom-plugin': this.props.isWpcomPlugin } );
 		return (
-			<div className="plugin-information is-placeholder">
+			<div className={ classes } >
 					<div className="plugin-information__wrapper">
 						<div className="plugin-information__version-info">
 							<div className="plugin-information__version-shell">
@@ -182,14 +187,14 @@ export default React.createClass( {
 							{ this.renderHomepageLink() }
 						</div>
 					</div>
+					{ ! this.props.isWpcomPlugin &&
 					<PluginRatings
 						rating={ this.props.plugin.rating }
 						ratings={ this.props.plugin.ratings }
 						downloaded={ this.props.plugin.downloaded }
 						numRatings={ this.props.plugin.num_ratings }
 						slug={ this.props.plugin.slug }
-						placeholder={ true }
-					/>
+						placeholder={ true } /> }
 			</div>
 		);
 	},
@@ -235,8 +240,7 @@ export default React.createClass( {
 						ratings={ this.props.plugin.ratings }
 						downloaded={ this.props.plugin.downloaded }
 						numRatings={ this.props.plugin.num_ratings }
-						slug={ this.props.plugin.slug }
-					/>
+						slug={ this.props.plugin.slug } />
 			</div>
 		);
 	},

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -47,14 +47,13 @@ export default React.createClass( {
 		if ( this.props.plugin.plugin_url.search( this._WPORG_PLUGINS_URL + this.props.plugin.slug ) !== -1 ) {
 			return;
 		}
-
+		const recordEvent = analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked Plugin Homepage Link', 'Plugin Name', this.props.plugin.slug );
 		return (
 			<ExternalLink
 				icon={ true }
 				href={ this.props.plugin.plugin_url }
-				onClick={ analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked Plugin Homepage Link', 'Plugin Name', this.props.plugin.slug ) }
-				className="plugin-information__external-link"
-			>
+				onClick={ recordEvent }
+				className="plugin-information__external-link" >
 				{ this.translate( 'Plugin homepage' ) }
 			</ExternalLink>
 		);
@@ -64,13 +63,13 @@ export default React.createClass( {
 		if ( ! this.props.plugin.slug ) {
 			return;
 		}
+		const recordEvent = analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked wp.org Plugin Link', 'Plugin Name', this.props.plugin.slug );
 		return (
 			<ExternalLink
 				icon={ true }
 				href={ 'https://' + this._WPORG_PLUGINS_URL + this.props.plugin.slug + '/' }
-				onClick={ analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked wp.org Plugin Link', 'Plugin Name', this.props.plugin.slug ) }
-				className="plugin-information__external-link"
-			>
+				onClick={ recordEvent }
+				className="plugin-information__external-link" >
 				{ this.translate( 'WordPress.org Plugin page' ) }
 			</ExternalLink>
 		);
@@ -80,14 +79,14 @@ export default React.createClass( {
 		if ( ! this.props.plugin || ! this.props.plugin.support_URL ) {
 			return;
 		}
+		const recordEvent = analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked Plugin Homepage Link', 'Plugin Name', this.props.plugin.slug );
 
 		return (
 			<ExternalLink
 				icon={ true }
 				href={ this.props.plugin.support_URL }
-				onClick={ analytics.ga.recordEvent.bind( analytics, 'Plugins', 'Clicked Plugin Homepage Link', 'Plugin Name', this.props.plugin.slug ) }
-				className="plugin-information__external-link"
-			>
+				onClick={ recordEvent }
+				className="plugin-information__external-link" >
 				{ this.translate( 'Learn More' ) }
 			</ExternalLink>
 		);

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -119,6 +119,10 @@
 			margin-right: 16px;
 		}
 	}
+	&.is-wpcom-plugin .plugin-information__wrapper {
+		margin-right: 0;
+	}
+
 	.plugin-information__external-link,
 	.version{
 		color: transparent;

--- a/client/my-sites/plugins/plugin-meta/README.md
+++ b/client/my-sites/plugins/plugin-meta/README.md
@@ -19,9 +19,11 @@ render: function() {
 
 #### Props
 
+* `isWpcomPlugin` : (boolean) If this plugin is a .com plugin or not.
 * `notices` : (object) Object of errored, inProgress, and completed actions.
 * `plugin` : (object) A plugin object.
 * `siteURL` : (string) The URL of the selected site. Used to determine if this is a single or all sites view.
 * `sites` : (array) An array of the sites that current plugin is installed on.
 * `isPlaceholder`: (boolean) Whether the component is being rendered in placeholder mode
 * `isMock`: a boolean indicating if the toggle should not launch any real action when interacted
+

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -254,6 +254,7 @@ export default React.createClass( {
 						{ this.renderActions() }
 					</div>
 					<PluginInformation
+						isWpcomPlugin={ this.props.isWpcomPlugin }
 						plugin={ this.props.plugin }
 						isPlaceholder={ this.props.isPlaceholder }
 						site={ this.props.selectedSite }

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -236,6 +236,7 @@ export default React.createClass( {
 					{ this.displayHeader() }
 					<PluginMeta
 						isPlaceholder
+						isWpcomPlugin={ this.props.isWpcomPlugin }
 						notices={ this.state.notices }
 						plugin={ this.state.plugin }
 						siteUrl={ this.props.siteUrl }
@@ -262,6 +263,7 @@ export default React.createClass( {
 					{ this.displayHeader() }
 					<PluginMeta
 						notices={ {} }
+						isWpcomPlugin={ this.props.isWpcomPlugin }
 						plugin={ this.state.plugin }
 						siteUrl={ 'no-real-url' }
 						sites={ [ selectedSite ] }
@@ -328,6 +330,7 @@ export default React.createClass( {
 				<div className={ classes }>
 					{ this.displayHeader() }
 					<PluginMeta
+						isWpcomPlugin={ this.props.isWpcomPlugin }
 						notices={ this.state.notices }
 						plugin={ this.state.plugin }
 						siteUrl={ this.props.siteUrl }


### PR DESCRIPTION
Currently the business plugins placeholders with the ratings stars.

This PR removed that info when you find out that we are dealing with a business plugin. 
before:
![screen shot 2015-12-21 at 11 36 01](https://cloud.githubusercontent.com/assets/115071/11939459/290ae6d4-a7d7-11e5-87fc-a339a40ae8d8.png)

after:
![screen shot 2015-12-21 at 11 36 09](https://cloud.githubusercontent.com/assets/115071/11939456/26d2005a-a7d7-11e5-935b-ab91e46433d6.png)

cc: @rickybanister and @johnHackworth 

