### PR TITLE
Masterbar: Reintroduce sticky site logic to stats item

### DIFF
--- a/client/layout/masterbar/index.jsx
+++ b/client/layout/masterbar/index.jsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Item from './item';
+import StatsItem from './stats-item';
 import Publish from './publish';
 import Notifications from './notifications';
 import Gravatar from 'components/gravatar';
@@ -65,8 +66,7 @@ export default React.createClass( {
 		if ( this.props.user ) { // Logged in
 			return (
 				<header id="header" className={ classes }>
-					<Item
-						url="/stats"
+					<StatsItem
 						icon={ this.wordpressIcon() }
 						onClick={ this.clickMySites }
 						isActive={ this.isActive( 'sites' ) }
@@ -76,7 +76,7 @@ export default React.createClass( {
 							? this.translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 							: this.translate( 'My Site', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 						}
-					</Item>
+					</StatsItem>
 					<Item
 						url="/"
 						icon="reader"

--- a/client/layout/masterbar/stats-item.jsx
+++ b/client/layout/masterbar/stats-item.jsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Item from './item';
+import siteStatsStickyTabStore from 'lib/site-stats-sticky-tab/store';
+
+export default React.createClass( {
+	displayName: 'MasterbarStatsItem',
+
+	propTypes: {
+		children: PropTypes.node
+	},
+
+	getInitialState: function() {
+		return {
+			url: siteStatsStickyTabStore.getUrl()
+		};
+	},
+
+	componentDidMount: function() {
+		siteStatsStickyTabStore.on( 'change', this.handleStatsStickyTabChange );
+	},
+
+	componentWillUnmount: function() {
+		siteStatsStickyTabStore.off( 'change', this.handleStatsStickyTabChange );
+	},
+
+	handleStatsStickyTabChange: function() {
+		var url = siteStatsStickyTabStore.getUrl();
+
+		if ( url !== this.state.url ) {
+			this.setState( {
+				url: url
+			} );
+		}
+	},
+
+	render: function() {
+		return (
+			<Item { ...this.props } url={ this.state.url }>
+				{ this.props.children }
+			</Item>
+		);
+	}
+} );


### PR DESCRIPTION
This pull request seeks to resolve a regression introduced in #631 where the selected site is no longer sticky when navigating to the My Sites section using the master bar link. Previously, we used the [`<SiteStatsStickyLink />` component](https://github.com/Automattic/wp-calypso/blob/master/client/components/site-stats-sticky-link/README.md) to preserve the selected site when navigating the application, but this was replaced with a simple link to the [base stats route](https://github.com/Automattic/wp-calypso/blob/d84201f/client/layout/masterbar/index.jsx#L69).

We may want to seek to eliminate or refactor `<SiteStatsStickyLink />` to reduce code duplication, but that is outside the scope of this pull request.

__Testing Instructions:__

Selecting site preserved:

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site
3. Click My Sites in the master bar
4. Note that the site selected in step 2 is still selected

/cc @mtias , @seear, @folletto 