### PR TITLE
Docs: use better pre-filled GitHub issues link for new issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ There are many ways to contribute – reporting bugs, feature suggestions, fixin
 
 ## Reporting Bugs, Asking Questions, Sending Suggestions
 
-Just [file a GitHub issue](https://github.com/Automattic/wp-calypso/issues/new), that’s all. If you want to prefix the title with a “Question:”, “Bug:”, or the general area of the application, that would be helpful, but by no means mandatory. If you have write access, add the appropriate labels.
+Just [file a GitHub issue](https://github.com/Automattic/wp-calypso/issues/), that’s all. If you want to prefix the title with a “Question:”, “Bug:”, or the general area of the application, that would be helpful, but by no means mandatory. If you have write access, add the appropriate labels.
 
 If you’re filing a bug, specific steps to reproduce are helpful. Please include the URL of the page that has the bug, along with what you expected to see and what happened instead.
 
-Here is a [handy link for submitting a new bug](https://github.com/Automattic/wp-calypso/issues/new?body=URL%3A%0A%0AWhat+I+expected%3A%0A%0ASteps+to+reproduce%3A%0A%0AWhat+happened+instead%3A&title=Description%20of%20the%20problem).
+Here is a [handy link for submitting a new bug](https://github.com/Automattic/wp-calypso/issues/new?body=URL%3A%0A%0AWhat+I+expected%3A%0A%0AWhat+happened+instead%3A%0A%0ASteps+to+reproduce%3A%0A%0ABrowser%20OS%20version%3A%0A%0AScreenshots/Video%3A&title=Feature:%20description%20of%20the%20problem&labels%5B%5D=%5BType%5D%20Bug).
 
 ## Installing Calypso Locally
 

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -146,7 +146,7 @@ function getDefaultContext( request ) {
 	if ( CALYPSO_ENV === 'wpcalypso' ) {
 		context.badge = CALYPSO_ENV;
 		context.devDocs = true;
-		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/new';
+		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
 		context.faviconURL = '/calypso/images/favicons/favicon-wpcalypso.ico';
 	}
 
@@ -158,14 +158,14 @@ function getDefaultContext( request ) {
 
 	if ( CALYPSO_ENV === 'stage' ) {
 		context.badge = 'staging';
-		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/new';
+		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
 		context.faviconURL = '/calypso/images/favicons/favicon-staging.ico';
 	}
 
 	if ( CALYPSO_ENV === 'development' ) {
 		context.badge = 'dev';
 		context.devDocs = true;
-		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/new';
+		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
 		context.faviconURL = '/calypso/images/favicons/favicon-development.ico';
 		context.branchName = getCurrentBranchName();
 	}


### PR DESCRIPTION
When making a new issue, pre-fill more information we'd like from bug reports.

Change the bug report link in bottom left-corner badge to view All Issues and not New Issue so that people can look at existing before reporting a new bug.

To test:

1. Switch to the branch.
2. Click the Bug link in bottom left corner, in the badge.
3. Make sure it works. :)

It should look like this:
<img width="1181" alt="screen shot 2015-12-21 at 14 55 59" src="https://cloud.githubusercontent.com/assets/66797/11942325/fefa8e1e-a7f2-11e5-834f-a099493ff8c5.png">
