### PR TITLE
Sites: Allow normal touch link behavior on Site if home link

### DIFF
--- a/client/my-sites/site/README.md
+++ b/client/my-sites/site/README.md
@@ -22,3 +22,4 @@ render: function() {
 * `onSelect (func)` - A function to handle the event callback when clicking/tapping on the site.
 * `href (string)` - A URL to add to the anchor.
 * `isSelected (bool)` - Whether the site should be marked as selected.
+* `homeLink (bool)` - Whether the site should behave as a link to the site home URL

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -53,6 +53,10 @@ module.exports = React.createClass( {
 	},
 
 	onSelect: function( event ) {
+		if ( this.props.homeLink ) {
+			return;
+		}
+
 		this.props.onSelect( event );
 		event.preventDefault();
 	},


### PR DESCRIPTION
Fixes #1881

This pull request seeks to resolve an issue where on touch devices, the user cannot tap on the site shown in the my sites or post editor sidebars to navigate to the site home page.

__Implementation notes:__

The changes here assume that `homeLink` is used to indicate that the `<Site />` component usage is intended to be a link to the site itself, as opposed to being used in the context of selecting a site (e.g. sidebar site selector, New Post dropdown).

__Testing instructions:__

Verify that `<Site />` can be tapped or clicked regardless of device context when intended to be used as link for site, and that doing so navigates to the site home URL.

Confirm also that `<Site />` usage for selecting a site (sidebar site selector, New Post dropdown) __does not__ navigate to the site home URL and instead performs the intended selection behavior.

/cc @mtias , @rickybanister , @lancewillett 