### PR TITLE
Framework: Replace LinkedStateMixin addon with standalone package

### DIFF
--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import ReactDom from 'react-dom';
-import React from 'react/addons';
+import React from 'react';
+import LinkedStateMixin from 'react-addons-linked-state-mixin';
 
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ const LostPassword = React.createClass( {
 module.exports = React.createClass( {
 	displayName: 'Auth',
 
-	mixins: [ React.addons.LinkedStateMixin, eventRecorder ],
+	mixins: [ LinkedStateMixin, eventRecorder ],
 
 	componentDidMount: function() {
 		AuthStore.on( 'change', this.refreshData );

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	noop = require( 'lodash/utility/noop' ),
 	first = require( 'lodash/array/first' ),
 	where = require( 'lodash/collection/where' );
@@ -21,7 +22,7 @@ var CLEAN_REGEX = /^0|[\s.\-()]+/g;
 module.exports = React.createClass( {
 	displayName: 'FormPhoneInput',
 
-	mixins: [ React.addons.LinkedStateMixin ],
+	mixins: [ LinkedStateMixin ],
 
 	propTypes: {
 		initialCountryCode: React.PropTypes.string,

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:me:account-password' ),
 	_debounce = require( 'lodash/function/debounce' ),
 	_first = require( 'lodash/array/first' ),
@@ -28,7 +29,7 @@ module.exports = React.createClass( {
 
 	displayName: 'AccountPassword',
 
-	mixins: [ React.addons.LinkedStateMixin, protectForm.mixin, observe( 'accountPasswordData' ), eventRecorder ],
+	mixins: [ LinkedStateMixin, protectForm.mixin, observe( 'accountPasswordData' ), eventRecorder ],
 
 	componentDidMount: function() {
 		this.debouncedPasswordValidate = _debounce( this.validatePassword, 300 );

--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react/addons';
+import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import i18n from 'lib/mixins/i18n';
 import Debug from 'debug';
 import emailValidator from 'email-validator';
@@ -58,7 +59,7 @@ module.exports = React.createClass( {
 
 	mixins: [
 		formBase,
-		React.addons.LinkedStateMixin,
+		LinkedStateMixin,
 		protectForm.mixin,
 		observe( 'userSettings', 'username' ),
 		eventRecorder

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:application-passwords' );
 
 /**
@@ -27,7 +28,7 @@ module.exports = React.createClass( {
 
 	displayName: 'ApplicationPasswords',
 
-	mixins: [ observe( 'appPasswordsData' ), React.addons.LinkedStateMixin, eventRecorder ],
+	mixins: [ observe( 'appPasswordsData' ), LinkedStateMixin, eventRecorder ],
 
 	componentDidMount: function() {
 		debug( this.displayName + ' React component is mounted.' );
@@ -177,7 +178,7 @@ module.exports = React.createClass( {
 			<div>
 				<SectionHeader label={ this.translate( 'Application Passwords' ) }>
 					<Button compact onClick={ this.recordClickEvent( 'Create Application Password Button', this.toggleNewPassword ) }>
-						<Gridicon icon="plus-small" size={ 16 } />
+						<Gridicon icon="plus-small" size={ 16 } nonStandardSize />
 						{ this.translate( 'Add New Application Password' ) }
 					</Button>
 				</SectionHeader>

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import PureRenderMixin from 'react-pure-render/mixin';
 import isEqual from 'lodash/lang/isEqual';
 
@@ -27,7 +28,7 @@ const sites = siteList();
 module.exports = React.createClass( {
 	displayName: 'HelpContactForm',
 
-	mixins: [ React.addons.LinkedStateMixin, PureRenderMixin ],
+	mixins: [ LinkedStateMixin, PureRenderMixin ],
 
 	propTypes: {
 		formDescription: React.PropTypes.node,

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
+import LinkedStateMixin from 'react-addons-linked-state-mixin';
 
 /**
  * Internal dependencies
@@ -28,7 +29,7 @@ import Main from 'components/main';
 module.exports = React.createClass( {
 	displayName: 'NotificationSubscriptions',
 
-	mixins: [ formBase, React.addons.LinkedStateMixin, protectForm.mixin, observe( 'userSettings' ), eventRecorder ],
+	mixins: [ formBase, LinkedStateMixin, protectForm.mixin, observe( 'userSettings' ), eventRecorder ],
 
 	getDeliveryHourLabel( hour ) {
 		return this.translate(

--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' );
 
 /**
  * Internal dependencies
@@ -16,7 +17,7 @@ module.exports = React.createClass( {
 
 	displayName: 'ProfileLinksAddOther',
 
-	mixins: [ React.addons.LinkedStateMixin, eventRecorder ],
+	mixins: [ LinkedStateMixin, eventRecorder ],
 
 	getInitialState: function() {
 		return {

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:me:profile' );
 
 /**
@@ -28,7 +29,7 @@ module.exports = React.createClass( {
 
 	displayName: 'Profile',
 
-	mixins: [ formBase, React.addons.LinkedStateMixin, protectForm.mixin, observe( 'userSettings' ), eventRecorder ],
+	mixins: [ formBase, LinkedStateMixin, protectForm.mixin, observe( 'userSettings' ), eventRecorder ],
 
 	componentDidMount: function() {
 		debug( this.constructor.displayName + ' component is mounted.' );

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:me:reauth-required' );
 
 /**
@@ -25,7 +26,7 @@ module.exports = React.createClass( {
 
 	displayName: 'ReauthRequired',
 
-	mixins: [ React.addons.LinkedStateMixin, observe( 'twoStepAuthorization' ), eventRecorder ],
+	mixins: [ LinkedStateMixin, observe( 'twoStepAuthorization' ), eventRecorder ],
 
 	getInitialState: function() {
 		return {

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:me:security:2fa-backup-codes-prompt' );
 
 /**
@@ -20,7 +21,7 @@ module.exports = React.createClass( {
 
 	displayName: 'Security2faBackupCodesPrompt',
 
-	mixins: [ React.addons.LinkedStateMixin ],
+	mixins: [ LinkedStateMixin ],
 
 	propTypes: {
 		onPrintAgain: React.PropTypes.func,

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:me:security:2fa-code-prompt' );
 
 /**
@@ -22,7 +23,7 @@ module.exports = React.createClass( {
 
 	displayName: 'Security2faCodePrompt',
 
-	mixins: [ React.addons.LinkedStateMixin ],
+	mixins: [ LinkedStateMixin ],
 
 	codeRequestTimer: false,
 

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:me:security:2fa-enable' ),
 	QRCode = require( 'qrcode.react' ),
 	classNames = require( 'classnames' );
@@ -24,7 +25,7 @@ module.exports = React.createClass( {
 
 	displayName: 'Security2faEnable',
 
-	mixins: [ React.addons.LinkedStateMixin ],
+	mixins: [ LinkedStateMixin ],
 
 	codeRequestTimer: false,
 

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:me:security:2fa-sms-settings' ),
 	observe = require( 'lib/mixins/data-observe' );
 
@@ -31,7 +32,7 @@ module.exports = React.createClass( {
 		debug( this.constructor.displayName + ' React component will unmount.' );
 	},
 
-	mixins: [ formBase, React.addons.LinkedStateMixin, protectForm.mixin, observe( 'userSettings' ) ],
+	mixins: [ formBase, LinkedStateMixin, protectForm.mixin, observe( 'userSettings' ) ],
 
 	propTypes: {
 		onCancel: React.PropTypes.func.isRequired,

--- a/client/me/security-checkup/edit-email.jsx
+++ b/client/me/security-checkup/edit-email.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	emailValidator = require( 'email-validator' );
 
 /**
@@ -17,7 +18,7 @@ var FormFieldset = require( 'components/forms/form-fieldset' ),
 module.exports = React.createClass( {
 	displayName: 'SecurityCheckupRecoveryEmailEdit',
 
-	mixins: [ React.addons.LinkedStateMixin ],
+	mixins: [ LinkedStateMixin ],
 
 	propTypes: {
 		storedEmail: React.PropTypes.string,

--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	notices = require( 'notices' ),
 	debug = require( 'debug' )( 'calypso:my-sites:ads-settings' );
 
@@ -29,7 +30,7 @@ module.exports = React.createClass( {
 
 	displayName: 'AdsFormSettings',
 
-	mixins: [ React.addons.LinkedStateMixin, protectForm.mixin ],
+	mixins: [ LinkedStateMixin, protectForm.mixin ],
 
 	propTypes: {
 		site: React.PropTypes.object.isRequired,

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	debug = require( 'debug' )( 'calypso:my-sites:people:edit-team-member-form' ),
 	omit = require( 'lodash/object/omit' ),
@@ -38,7 +39,7 @@ var Main = require( 'components/main' ),
 var EditUserForm = React.createClass( {
 	displayName: 'EditUserForm',
 
-	mixins: [ React.addons.LinkedStateMixin, PureRenderMixin ],
+	mixins: [ LinkedStateMixin, PureRenderMixin ],
 
 	getInitialState: function() {
 		return this.getStateObject( this.props );

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
+	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	debug = require( 'debug' )( 'calypso:my-sites:site-settings' ),
 	page = require( 'page' );
 
@@ -25,7 +26,7 @@ module.exports = React.createClass( {
 
 	displayName: 'DeleteSite',
 
-	mixins: [ React.addons.LinkedStateMixin ],
+	mixins: [ LinkedStateMixin ],
 
 	getInitialState: function() {
 		return {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "raf": "2.0.4",
     "react": "0.14.3",
     "react-addons-create-fragment": "0.14.3",
+    "react-addons-linked-state-mixin": "0.14.3",
     "react-day-picker": "1.1.0",
     "react-dom": "0.14.3",
     "react-pure-render": "1.0.2",


### PR DESCRIPTION
Related: #1498, #1878

This pull request seeks to replace all instances of `React.addons.LinkedStateMixin` with the standalone package `react-addons-linked-state-mixin`. React addons were moved to separate packages in [React 0.14](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html) and currently cause warnings to appear in development environments.

__Testing instructions:__

Verify that existing usage of `LinkedStateMixin` remain unaffected.