### PR TITLE
Editor: fix help shortcut again, standardize on `WP_Help`

### DIFF
--- a/client/components/tinymce/plugins/wpcom-help/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-help/plugin.js
@@ -25,7 +25,7 @@ function wpcomHelpPlugin( editor ) {
 		node = null;
 	} );
 
-	editor.addCommand( 'Wpcom_Help', function() {
+	editor.addCommand( 'WP_Help', function() {
 		function onClose() {
 			editor.focus();
 			render( 'hide' );

--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -149,7 +149,7 @@ function wpcomPlugin( editor ) {
 
 	editor.addButton( 'wp_help', {
 		tooltip: 'Keyboard Shortcuts',
-		cmd: 'Wpcom_Help'
+		cmd: 'WP_Help'
 	} );
 
 	editor.addButton( 'wp_charmap', {
@@ -315,7 +315,7 @@ function wpcomPlugin( editor ) {
 			m: 'WP_Medialib',
 			t: 'WP_More',
 			d: 'Strikethrough',
-			h: 'Wpcom_Help',
+			h: 'WP_Help',
 			p: 'WP_Page',
 			x: 'WP_Code'
 		}, function( command, key ) {


### PR DESCRIPTION
See #1457, first try was in #1746 but this standardizes on `WP_Help` everywhere.

To test:

- Open up a post or page in Calypso editor
- Use your keyboard to open the Help shortcuts menu with `Control-Option-h` on Mac OS X You should see this:
<img width="712" alt="screen shot 2015-12-17 at 11 17 17" src="https://cloud.githubusercontent.com/assets/66797/11879386/3c284eb8-a4b8-11e5-8787-86668c0f6a27.png">
- And using `Esc` key or hitting `Close` button at bottom right of the window should close it.