### PR TITLE
Checkboxes & Radio Buttons: Fix vertical alignment

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -106,7 +106,7 @@ input[type=radio] {
 	display: inline-block;
 	line-height: 0;
 	height: 16px;
-	margin: 4px 0 0;
+	margin: 2px 0 0;
 	float: left;
 	outline: 0;
 	padding: 0;


### PR DESCRIPTION
When rendered in Firefox, Chrome & Safari on desktop, there's a minor misalignment with the radio buttons and checkboxes:

<img width="1621" alt="screen shot 2015-12-21 at 5 40 05 pm" src="https://cloud.githubusercontent.com/assets/1084656/11945171/113286d8-a80a-11e5-9f8d-45282803d1a9.png">

It's sort of hard to tell, but I've reduced the top margin on these elements by 2px, resulting in this:

<img width="1646" alt="screen shot 2015-12-21 at 5 35 13 pm" src="https://cloud.githubusercontent.com/assets/1084656/11945177/27170938-a80a-11e5-92ef-48a8abd03915.png">
