### PR TITLE
Plugins List: Add navigation on mobile when errored

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -643,6 +643,7 @@ export default React.createClass( {
 		if ( this.state.accessError ) {
 			return (
 				<Main>
+					<SidebarNavigation />
 					<EmptyContent { ...this.state.accessError } />
 					{ this.state.accessError.featureExample ? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample> : null }
 				</Main>
@@ -653,6 +654,7 @@ export default React.createClass( {
 		if ( abtest( 'businessPluginsNudge' ) === 'nudge' && selectedSite && ! selectedSite.jetpack && ! isBusiness( selectedSite.plan ) ) {
 			return (
 				<Main>
+					<SidebarNavigation />
 					<PlanNudge currentProductId={ selectedSite.plan.product_id } selectedSiteSlug={ selectedSite.slug } />
 				</Main>
 			);
@@ -661,6 +663,7 @@ export default React.createClass( {
 		if ( selectedSite && selectedSite.jetpack && ! selectedSite.canManage() ) {
 			return (
 				<Main>
+					<SidebarNavigation />
 					<JetpackManageErrorPage
 						template="optInManage"
 						site={ this.props.sites.getSelectedSite() }

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -24,6 +24,7 @@ import PluginsDataStore from 'lib/plugins/wporg-data/store';
 import PluginsActions from 'lib/plugins/actions';
 import PluginNotices from 'lib/plugins/notices';
 import MainComponent from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginSections from 'my-sites/plugins/plugin-sections';
 import pluginsAccessControl from 'my-sites/plugins/access-control';
@@ -146,11 +147,12 @@ export default React.createClass( {
 	},
 
 	displayHeader() {
+		const recordEvent = this.recordEvent.bind( this, 'Clicked Header Plugin Back Arrow' );
 		return (
 			<HeaderCake
 				isCompact={ true }
 				onClick={ this.goBack }
-				onBackArrowClick={ this.recordEvent.bind( this, 'Clicked Header Plugin Back Arrow' ) } />
+				onBackArrowClick={ recordEvent } />
 		);
 	},
 
@@ -229,6 +231,7 @@ export default React.createClass( {
 	renderPluginPlaceholder( classes ) {
 		return (
 			<MainComponent>
+				<SidebarNavigation />
 				<div className={ classes }>
 					{ this.displayHeader() }
 					<PluginMeta
@@ -254,6 +257,7 @@ export default React.createClass( {
 		}
 		return (
 			<MainComponent>
+				<SidebarNavigation />
 				<div className="plugin__page">
 					{ this.displayHeader() }
 					<PluginMeta
@@ -275,11 +279,11 @@ export default React.createClass( {
 		if ( ! this.props.isWpcomPlugin && selectedSite && ! selectedSite.jetpack ) {
 			return (
 				<MainComponent>
+					<SidebarNavigation />
 					<EmptyContent
 						title={ this.translate( 'Oops! Not supported' ) }
 						line={ this.translate( 'This site doesn\'t support installing plugins. Switch to a self-hosted site to install and manage plugins' ) }
-						illustration={ '/calypso/images/drake/drake-whoops.svg' }
-						fullWidth={ true } />
+						illustration={ '/calypso/images/drake/drake-whoops.svg' } />
 				</MainComponent>
 			);
 		}
@@ -287,6 +291,7 @@ export default React.createClass( {
 		if ( this.state.accessError ) {
 			return (
 				<MainComponent>
+					<SidebarNavigation />
 					<EmptyContent { ...this.state.accessError } />
 					{ this.state.accessError.featureExample ? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample> : null }
 				</MainComponent>
@@ -304,6 +309,7 @@ export default React.createClass( {
 		if ( selectedSite && selectedSite.jetpack && ! selectedSite.canManage() ) {
 			return (
 				<MainComponent>
+					<SidebarNavigation />
 					<JetpackManageErrorPage
 						template="optInManage"
 						title={ this.translate( 'Looking to manage this site\'s plugins?' ) }
@@ -318,6 +324,7 @@ export default React.createClass( {
 
 		return (
 			<MainComponent>
+				<SidebarNavigation />
 				<div className={ classes }>
 					{ this.displayHeader() }
 					<PluginMeta


### PR DESCRIPTION
Show the navigation on mobile so that the user can navigate back to other sections of the site. 
Before:
Plugin List:
<img width="427" alt="screen shot 2015-12-21 at 19 34 10" src="https://cloud.githubusercontent.com/assets/115071/11947384/db746118-a81a-11e5-9298-5c8478d1dca9.png">

Single Plugin View
<img width="571" alt="screen shot 2015-12-21 at 19 51 36" src="https://cloud.githubusercontent.com/assets/115071/11947485/59f7c902-a81c-11e5-84ae-04e00a7b44eb.png">

After:
Plugin List:
<img width="412" alt="screen shot 2015-12-21 at 19 33 43" src="https://cloud.githubusercontent.com/assets/115071/11947387/df6d9a82-a81a-11e5-89b7-90b1e25db2d0.png">

Single Plugin View:
<img width="557" alt="screen shot 2015-12-21 at 19 51 05" src="https://cloud.githubusercontent.com/assets/115071/11947489/6e9ad23c-a81c-11e5-8b2d-7444392a3aaa.png">

Fixes #443

**To test**:
Visit a site that has the error message that show the jetpack manage disabled. 
and visit the plugin list page and the single plugin list page. 
The same for a .com site that doesn't have a business upgrade.

cc: @johnHackworth and @rickybanister  for a review. 