### PR TITLE
Plugin List: Set the title corretly on mobile

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -93,7 +93,6 @@ function renderPluginList( context, basePath, siteUrl ) {
 
 	lastPluginsListVisited = getPathWithoutSiteSlug( context, site );
 	lastPluginsQuerystring = context.querystring;
-
 	titleActions.setTitle( i18n.translate( 'Plugins', { textOnly: true } ), { siteID: siteUrl } );
 
 	// Render multiple plugins component


### PR DESCRIPTION
Fixes #441 See https://cloudup.com/cOuGNFudhPW

This fix works because on the single plugin view we update the page title after a page finished loading. 
This just makes sure that the page title gets overwritten when the user is on the plugin list page. On a tick after the plugin list gets shown. Which then in turn overwrites the page title correctly again. 

To test make sure that the page title displays correctly when navigatin in mobile view between a single plugin view and the list plugin view. 
cc: @johnHackworth 