### PR TITLE
Plugin Notices: Fix/buisness plugin setup link in notice

### DIFF
--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	groupBy = require( 'lodash/collection/groupBy' );
+var groupBy = require( 'lodash/collection/groupBy' );
 
 /**
  * Internal dependencies
@@ -80,9 +79,9 @@ module.exports = {
 				onRemoveCallback: PluginsActions.removePluginsNotices.bind( this, logNotices.errors )
 			} );
 		} else if ( logNotices.completed.length > 0 ) {
-			const sampleLog = logNotices.completed[ 0 ].status === 'inProgress' ?
-				logNotices.completed[ 0 ] :
-				logNotices.completed[ logNotices.completed.length - 1 ],
+			const sampleLog = logNotices.completed[ 0 ].status === 'inProgress'
+				? logNotices.completed[ 0 ]
+				: logNotices.completed[ logNotices.completed.length - 1 ],
 				// the dismiss button would overlap the link to the settings page when activating
 				showDismiss = ! ( sampleLog.plugin.wp_admin_settings_page_url && 'ACTIVATE_PLUGIN' === sampleLog.action );
 

--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -8,7 +8,6 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var notices = require( 'notices' ),
-	NoticeAction = require( 'components/notice/notice-action' ),
 	PluginsLog = require( 'lib/plugins/log-store' ),
 	PluginsActions = require( 'lib/plugins/actions' ),
 	PluginsUtil = require( 'lib/plugins/utils' ),
@@ -88,6 +87,8 @@ module.exports = {
 				showDismiss = ! ( sampleLog.plugin.wp_admin_settings_page_url && 'ACTIVATE_PLUGIN' === sampleLog.action );
 
 			notices.success( this.getMessage( logNotices.completed, this.successMessage ), {
+				button: this.getSuccessButton( logNotices.completed ),
+				href: this.getSuccessHref( logNotices.completed ),
 				onRemoveCallback: PluginsActions.removePluginsNotices.bind( this, logNotices.completed ),
 				showDismiss
 			} );
@@ -182,18 +183,6 @@ module.exports = {
 			case 'ACTIVATE_PLUGIN':
 				switch ( combination ) {
 					case '1 site 1 plugin':
-						if ( translateArg.wp_admin_settings_page_url ) {
-							return i18n.translate( 'Successfully activated %(plugin)s on %(site)s. ' +
-									'{{action}}Setup{{/action}}', {
-										args: translateArg,
-										components: {
-											action: <NoticeAction
-												href={ translateArg.wp_admin_settings_page_url }
-												external={ true } />
-										},
-										context: 'Success message when activating a plugin with a link to the plugin settings.'
-									} );
-						}
 						return i18n.translate( 'Successfully activated %(plugin)s on %(site)s.', { args: translateArg } );
 					case '1 site n plugins':
 						return i18n.translate( 'Successfully activated %(numberOfPlugins)d plugins on %(site)s.', {
@@ -670,5 +659,32 @@ module.exports = {
 			remoteManagementUrl = log.site.options.admin_url + 'admin.php?page=jetpack&configure=manage';
 		}
 		return remoteManagementUrl;
+	},
+
+	getSuccessButton: function( log ) {
+		if ( log.length > 1 ) {
+			return null;
+		}
+		log = log.length ? log[ 0 ] : log;
+
+		if ( log.action !== 'ACTIVATE_PLUGIN' ||
+			! log.plugin.wp_admin_settings_page_url ) {
+			return null;
+		}
+
+		return i18n.translate( 'Setup' );
+	},
+
+	getSuccessHref: function( log ) {
+		if ( log.length > 1 ) {
+			return null;
+		}
+		log = log.length ? log[ 0 ] : log;
+
+		if ( log.action !== 'ACTIVATE_PLUGIN' &&
+			! log.plugin.wp_admin_settings_page_url ) {
+			return null;
+		}
+		return log.plugin.wp_admin_settings_page_url;
 	}
 };


### PR DESCRIPTION
Currently the successful plugin notice looks something like this:
<img width="527" alt="screen shot 2015-12-21 at 21 22 03" src="https://cloud.githubusercontent.com/assets/115071/11948452/e77c4bfc-a828-11e5-8e9c-7278c79b32c4.png">

This PR fixes to look like the following:
<img width="527" alt="screen shot 2015-12-21 at 21 19 46" src="https://cloud.githubusercontent.com/assets/115071/11948456/f78790ba-a828-11e5-9b96-e35704c9cd2e.png">


**To test**
On the single plugin view activate a com plugin from a business plan site. Notice the fixed setup link. 

cc: @drewblaisdell and @johnHackworth 