### PR TITLE
Masterbar: Fix `n` shortcut key to notifications panel

### DIFF
--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -37,7 +37,7 @@ export default React.createClass( {
 		const target = event ? event.target : false;
 		const notificationNode = this.getNotificationLinkDomNode();
 
-		if ( notificationNode.contains( target ) ) {
+		if ( target && notificationNode.contains( target ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #1907

We don't have a target node when the shortcut key is pressed, so don't
check it!

To test:
- Go to http://calypso.localhost:3000
- Press the `n` key
- Verify it toggles the notifications panel