### PR TITLE
Framework: Fix wrong interpolation error message displayed in console when running in strict mode

### DIFF
--- a/client/lib/interpolate-components/index.js
+++ b/client/lib/interpolate-components/index.js
@@ -114,17 +114,13 @@ function interpolate( options ) {
 
 	try {
 		return buildChildren( tokens, components );
-	} catch( error ) {
-		// don't mess around in production, just return what we can
+	} catch ( error ) {
+		// Returns what we can in environments that shouldn't throw errors
 		if ( ! throwErrors ) {
 			return mixedString;
 		}
-		// in pre-production environments we should make errors very visible
-		if ( window && window.console && window.console.error ) {
-			window.console.error( '\nInterpolation Error: ', interpolate.caller.caller, '\n> ' + mixedString );
-		}
 
-		throw error;
+		throw new Error( `Interpolation Error: unable to process \`${ mixedString }\` because of error \`${ error.message }\`` );
 	}
 };
 

--- a/client/lib/interpolate-components/index.js
+++ b/client/lib/interpolate-components/index.js
@@ -105,8 +105,9 @@ function interpolate( options ) {
 
 	if ( typeof components !== 'object' ) {
 		if ( throwErrors ) {
-			throw new Error( 'Interpolation Error: components argument must be an object', mixedString, components );
+			throw new Error( `Interpolation Error: unable to process \`${ mixedString }\` because components is not an object` );
 		}
+
 		return mixedString;
 	}
 

--- a/client/lib/interpolate-components/index.js
+++ b/client/lib/interpolate-components/index.js
@@ -116,12 +116,11 @@ function interpolate( options ) {
 	try {
 		return buildChildren( tokens, components );
 	} catch ( error ) {
-		// Returns what we can in environments that shouldn't throw errors
-		if ( ! throwErrors ) {
-			return mixedString;
+		if ( throwErrors ) {
+			throw new Error( `Interpolation Error: unable to process \`${ mixedString }\` because of error \`${ error.message }\`` );
 		}
 
-		throw new Error( `Interpolation Error: unable to process \`${ mixedString }\` because of error \`${ error.message }\`` );
+		return mixedString;
 	}
 };
 


### PR DESCRIPTION
This pull request fixes the `Interpolate Components` module which swallows [any error raised during interpolation](https://github.com/Automattic/wp-calypso/blob/1fd0426adae6498eaf557b836ee038b75612cbab/client/lib/interpolate-components/index.js#L117) for any environment configured to throw errors. To be more specific, the following error:

```javascript
Uncaught TypeError: 'caller' and 'arguments' are restricted function properties and cannot be accessed in this context.
```

Is displayed in lieu of the actual interpolation error:

```javascript
Error: Invalid interpolation, component node must be a ReactElement or null: `email`
```

[As explained here](http://stackoverflow.com/questions/31921189/caller-and-arguments-are-restricted-function-properties-and-cannot-be-access), the `interpolate.caller` indeed doesn't work any more in strict mode (Babel running with ES6 apparently injects `use script` at the top of every module):

> Second, in strict mode it's no longer possible to "walk" the JavaScript stack via commonly-implemented extensions to ECMAScript. In normal code with these extensions, when a function fun is in the middle of being called, fun.caller is the function that most recently called fun, and fun.arguments is the arguments for that invocation of fun. Both extensions are problematic for "secure" JavaScript, because they allow "secured" code to access "privileged" functions and their (potentially unsecured) arguments. If fun is in strict mode, both fun.caller and fun.arguments are non-deletable properties which throw when set or retrieved

##### Before

![screenshot 21](https://cloud.githubusercontent.com/assets/594356/11954368/3b311bd6-a8a8-11e5-8b67-266be8b0d4f0.png)

##### After

![screenshot 23](https://cloud.githubusercontent.com/assets/594356/11954847/428b37fa-a8ac-11e5-831a-de184f643120.png)

#### Testing instructions

1. Run `git checkout fix/interpolate-components` and start your server
2. Open the [`Signup` page](http://calypso.dev:3000/start/) and create a new test account
3. Check that an email verification notice is displayed at the top of the page
4. Click the `Re-send your activation email` link in this notice
5. Make sure the root error is displayed in the browser console

#### Additional notes

@rralian I guess you want to have a look at this.

I will fix the actual issue with the email verification notice (https://github.com/Automattic/wp-calypso/issues/1914) in another pull request.