### PR TITLE
Framework: Update React addons dependency if addons are unused

### DIFF
--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	noop = require( 'lodash/utility/noop' ),
 	classNames = require( 'classnames' );
 

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 
 export default React.createClass( {

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
 	noop = require( 'lodash/utility/noop' ),
 	debug = require( 'debug' )( 'calypso:dialog' );
 

--- a/client/components/forms/form-buttons-bar/index.jsx
+++ b/client/components/forms/form-buttons-bar/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 

--- a/client/components/forms/form-checkbox/index.jsx
+++ b/client/components/forms/form-checkbox/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 

--- a/client/components/forms/form-country-select/index.jsx
+++ b/client/components/forms/form-country-select/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	isEmpty = require( 'lodash/lang/isEmpty' ),
 	classnames = require( 'classnames' ),
 	observe = require( 'lib/mixins/data-observe' ),

--- a/client/components/forms/form-fieldset/index.jsx
+++ b/client/components/forms/form-fieldset/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 

--- a/client/components/forms/form-input-validation/index.jsx
+++ b/client/components/forms/form-input-validation/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 import classNames from 'classnames';
 
 /**

--- a/client/components/forms/form-label/index.jsx
+++ b/client/components/forms/form-label/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 

--- a/client/components/forms/form-legend/index.jsx
+++ b/client/components/forms/form-legend/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 

--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	Gridicon = require( 'components/gridicon' ),
 	classNames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );

--- a/client/components/forms/form-radio/index.jsx
+++ b/client/components/forms/form-radio/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 

--- a/client/components/forms/form-select/index.jsx
+++ b/client/components/forms/form-select/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 

--- a/client/components/forms/form-setting-explanation/index.jsx
+++ b/client/components/forms/form-setting-explanation/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 

--- a/client/components/forms/form-tel-input/index.jsx
+++ b/client/components/forms/form-tel-input/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' ),
 	classNames = require( 'classnames' );

--- a/client/components/forms/form-text-input-with-affixes/index.jsx
+++ b/client/components/forms/form-text-input-with-affixes/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 import classNames from  'classnames';
 import omit from 'lodash/object/omit';
 

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' ),
 	classNames = require( 'classnames' );

--- a/client/components/forms/form-textarea/index.jsx
+++ b/client/components/forms/form-textarea/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' );
 

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' );
 
 var idNum = 0;

--- a/client/components/gravatar/test/index.jsx
+++ b/client/components/gravatar/test/index.jsx
@@ -11,7 +11,7 @@ function stripReactAttributes( string ) {
  */
 var assert = require( 'assert' ),
 	ReactDomServer = require( 'react-dom/server' ),
-	React = require( 'react/addons' );
+	React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 import classnames from 'classnames';
 import noop from 'lodash/utility/noop';
 

--- a/client/components/overlay/overlay.jsx
+++ b/client/components/overlay/overlay.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:overlay' ),
 	classes = require( 'component-classes' );
 

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	times = require( 'lodash/utility/times' );
 
 /**

--- a/client/components/search-card/index.jsx
+++ b/client/components/search-card/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/components/section-nav/test/index.jsx
+++ b/client/components/section-nav/test/index.jsx
@@ -16,7 +16,7 @@ require( 'lib/react-test-env-setup' )( '<html><body><script></script><div id="co
 require( 'react-tap-event-plugin' )();
 
 function createComponent( component, props, children ) {
-	var shallowRenderer = React.addons.TestUtils.createRenderer();
+	var shallowRenderer = TestUtils.createRenderer();
 	shallowRenderer.render(
 		React.createElement( component, props, children )
 	);

--- a/client/components/select-dropdown/separator.jsx
+++ b/client/components/select-dropdown/separator.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 var SelectDropdownSeparator = React.createClass( {
 

--- a/client/components/site-selector-modal/index.jsx
+++ b/client/components/site-selector-modal/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	includes = require( 'lodash/collection/includes' );
 

--- a/client/components/upgrades/google-apps/dialog/index.jsx
+++ b/client/components/upgrades/google-apps/dialog/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var React = require( 'react/addons' ),
 	ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 
 /**

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/lib/accept/test/index.js
+++ b/client/lib/accept/test/index.js
@@ -5,7 +5,7 @@ require( 'lib/react-test-env-setup' )();
  * External dependencies
  */
 var expect = require( 'chai' ).expect,
-	TestUtils = require( 'react/addons' ).addons.TestUtils,
+	TestUtils = require( 'react' ).addons.TestUtils,
 	mockery = require( 'mockery' ),
 	sinon = require( 'sinon' );
 

--- a/client/lib/accept/test/index.js
+++ b/client/lib/accept/test/index.js
@@ -5,7 +5,8 @@ require( 'lib/react-test-env-setup' )();
  * External dependencies
  */
 var expect = require( 'chai' ).expect,
-	TestUtils = require( 'react' ).addons.TestUtils,
+	React = require( 'react/addons' ),
+	TestUtils = React.addons.TestUtils,
 	mockery = require( 'mockery' ),
 	sinon = require( 'sinon' );
 

--- a/client/lib/ads/README.md
+++ b/client/lib/ads/README.md
@@ -140,7 +140,7 @@ Actions get triggered by views and stores.
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/lib/email-followers/README.md
+++ b/client/lib/email-followers/README.md
@@ -30,7 +30,7 @@ Fetches followers in batches of 100 starting from the given page, which defaults
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/lib/followers/README.md
+++ b/client/lib/followers/README.md
@@ -30,7 +30,7 @@ Fetches followers in batches of 100 starting from the given page, which defaults
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/lib/mixins/update-post-status/index.jsx
+++ b/client/lib/mixins/update-post-status/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -81,7 +81,7 @@ Returns an array of sites that have a particular plugin.
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/lib/plugins/wporg-data/README.md
+++ b/client/lib/plugins/wporg-data/README.md
@@ -50,7 +50,7 @@ Returns a plugin object or null
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/lib/users/README.md
+++ b/client/lib/users/README.md
@@ -42,7 +42,7 @@ Actions get triggered by views and stores.
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/me/action-remove/index.jsx
+++ b/client/me/action-remove/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	omit = require( 'lodash/object/omit' ),
 	classNames = require( 'classnames' );

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	uniq = require( 'lodash/array/uniq' ),
 	pluck = require( 'lodash/collection/pluck' ),
 	range = require( 'lodash/utility/range' ),

--- a/client/me/connected-application-icon/index.jsx
+++ b/client/me/connected-application-icon/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/me/credit-cards/credit-card-delete.jsx
+++ b/client/me/credit-cards/credit-card-delete.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:me:credit-card-delete' );
 
 /**

--- a/client/me/credit-cards/index.jsx
+++ b/client/me/credit-cards/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:me:credit-cards' );
 
 /**

--- a/client/me/notification-settings/navigation.jsx
+++ b/client/me/notification-settings/navigation.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/my-sites/all-sites-icon/index.jsx
+++ b/client/my-sites/all-sites-icon/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	union = require( 'lodash/array/union' );
 
 /**

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:my-sites:current-site' ),
 	analytics = require( 'analytics' ),
 	url = require( 'url' );

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' ),
 	noop = require( 'lodash/utility/noop' ),
 	url = require( 'url' );

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react/addons'
+import React from 'react'
 import merge from 'lodash/object/merge'
 
 /**

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 import noop from 'lodash/utility/noop';
 import classNames from 'classnames';
 

--- a/client/my-sites/menus/item-options/category-options.jsx
+++ b/client/my-sites/menus/item-options/category-options.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	isEqual = require( 'lodash/lang/isEqual' ),
 	debug = require( 'debug' )( 'calypso:menus:categories-options' );
 

--- a/client/my-sites/menus/item-options/posts.jsx
+++ b/client/my-sites/menus/item-options/posts.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependenices
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	find = require( 'lodash/collection/find' );
 /**
  * Internal Dependencies

--- a/client/my-sites/menus/item-options/taxonomy-list.jsx
+++ b/client/my-sites/menus/item-options/taxonomy-list.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:menus:taxonomy-list' );
 
 /**

--- a/client/my-sites/menus/location-picker.jsx
+++ b/client/my-sites/menus/location-picker.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:menus:location-picker' ); // eslint-disable-line no-unused-vars
 
 /**

--- a/client/my-sites/menus/main.jsx
+++ b/client/my-sites/menus/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	find = require( 'lodash/collection/find' ),
 	debug = require( 'debug' )( 'calypso:menus:index' ); // eslint-disable-line no-unused-vars
 

--- a/client/my-sites/menus/menu-delete-button.jsx
+++ b/client/my-sites/menus/menu-delete-button.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:menus:delete-button' ); // eslint-disable-line no-unused-vars
 
 /**

--- a/client/my-sites/menus/menu-item-drop-target.jsx
+++ b/client/my-sites/menus/menu-item-drop-target.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/menus/menu-name.jsx
+++ b/client/my-sites/menus/menu-name.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:menus:menu' ); // eslint-disable-line no-unused-vars
 
 /**

--- a/client/my-sites/menus/menu-panel-back-button.jsx
+++ b/client/my-sites/menus/menu-panel-back-button.jsx
@@ -11,7 +11,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/menus/menu-picker.jsx
+++ b/client/my-sites/menus/menu-picker.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:menus:menu-picker' ); // eslint-disable-line no-unused-vars
 
 /**

--- a/client/my-sites/menus/menu.jsx
+++ b/client/my-sites/menus/menu.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:menus:menu' ); // eslint-disable-line no-unused-vars
 
 /**

--- a/client/my-sites/menus/menus-save-button.jsx
+++ b/client/my-sites/menus/menus-save-button.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	debug = require( 'debug' )( 'calypso:menus:save-button' ); // eslint-disable-line no-unused-vars
 

--- a/client/my-sites/navigation/navigation.jsx
+++ b/client/my-sites/navigation/navigation.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:my-sites:pages:pages' );
 
 /**

--- a/client/my-sites/pages/placeholder.jsx
+++ b/client/my-sites/pages/placeholder.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	omit = require( 'lodash/object/omit' ),
 	debug = require( 'debug' )( 'calypso:my-sites:people:main' );
 

--- a/client/my-sites/people/people-notices/index.jsx
+++ b/client/my-sites/people/people-notices/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	config = require( 'config' ),
 	findWhere = require( 'lodash/collection/findWhere' ),
 	includes = require( 'lodash/collection/includes' );

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debugFactory = require( 'debug' ),
 	omit = require( 'lodash/object/omit' ),
 	titleCase = require( 'to-title-case' );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	connect = require( 'react-redux' ).connect;
 
 /**

--- a/client/my-sites/plugins/plugin-action/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-action/plugin-action.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' );
 
 /**

--- a/client/my-sites/plugins/plugin-activate-toggle/test/mocks/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/test/mocks/plugin-action.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 module.exports = React.createClass( {
 	render: function() {

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/test/mocks/plugin-action.jsx
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/test/mocks/plugin-action.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 module.exports = React.createClass( {
 	render: function() {

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	titleCase = require( 'to-title-case' ),
 	find = require( 'lodash/collection/find' ),
 	filter = require( 'lodash/collection/filter' ),

--- a/client/my-sites/plugins/plugin-site-list/index.jsx
+++ b/client/my-sites/plugins/plugin-site-list/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	compact = require( 'lodash/array/compact' );
 

--- a/client/my-sites/plugins/plugin-version/index.jsx
+++ b/client/my-sites/plugins/plugin-version/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' );
 
 /**

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react/addons'
+import React from 'react'
 import debugModule from 'debug';
 import page from 'page';
 import classNames from 'classnames';

--- a/client/my-sites/post-trends/day.jsx
+++ b/client/my-sites/post-trends/day.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	noop = require( 'lodash/utility/noop' ),
 	classNames = require( 'classnames' );
 

--- a/client/my-sites/post-trends/index.jsx
+++ b/client/my-sites/post-trends/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	throttle = require( 'lodash/function/throttle' );
 

--- a/client/my-sites/post-trends/month.jsx
+++ b/client/my-sites/post-trends/month.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/post-trends/week.jsx
+++ b/client/my-sites/post-trends/week.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/posts/post-placeholder.jsx
+++ b/client/my-sites/posts/post-placeholder.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import React from 'react/addons';
+import React from 'react';
 import Debug from 'debug';
 
 /**

--- a/client/my-sites/site-settings/action-panel/body.jsx
+++ b/client/my-sites/site-settings/action-panel/body.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Main

--- a/client/my-sites/site-settings/action-panel/figure.jsx
+++ b/client/my-sites/site-settings/action-panel/figure.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' );
 
 /**

--- a/client/my-sites/site-settings/action-panel/footer.jsx
+++ b/client/my-sites/site-settings/action-panel/footer.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Main

--- a/client/my-sites/site-settings/action-panel/index.jsx
+++ b/client/my-sites/site-settings/action-panel/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/site-settings/action-panel/title.jsx
+++ b/client/my-sites/site-settings/action-panel/title.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Main

--- a/client/my-sites/site-settings/start-over/index.jsx
+++ b/client/my-sites/site-settings/start-over/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:my-sites:site-settings' ),
 	page = require( 'page' );
 

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	throttle = require( 'lodash/function/throttle' ),
 	debug = require( 'debug' )( 'calypso:stats:geochart' );
 

--- a/client/my-sites/stats/insights.jsx
+++ b/client/my-sites/stats/insights.jsx
@@ -1,7 +1,7 @@
 /**
 * External dependencies
 */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	store = require( 'store' );
 
 /**

--- a/client/my-sites/stats/module-date-picker.jsx
+++ b/client/my-sites/stats/module-date-picker.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:stats:module-date-picker' );
 
 /**

--- a/client/my-sites/stats/module-site-overview-placeholder.jsx
+++ b/client/my-sites/stats/module-site-overview-placeholder.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/most-popular/index.jsx
+++ b/client/my-sites/stats/most-popular/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' );
 
 /**

--- a/client/my-sites/stats/overview/index.jsx
+++ b/client/my-sites/stats/overview/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	debug = require( 'debug' )( 'calypso:stats:module-site-overview' );
 

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:stats:postPerformance' ),
 	classNames = require( 'classnames' );
 

--- a/client/my-sites/stats/stats-list/action-follow.jsx
+++ b/client/my-sites/stats/stats-list/action-follow.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	debug = require( 'debug' )( 'calypso:stats:action-follow' );
 

--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/stats-list/action-page.jsx
+++ b/client/my-sites/stats/stats-list/action-page.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	page = require( 'page' ),
 	debug = require( 'debug' )( 'calypso:stats:action-page' );
 

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	debug = require( 'debug' )( 'calypso:stats:action-spam' );
 

--- a/client/my-sites/stats/stats-navigation.jsx
+++ b/client/my-sites/stats/stats-navigation.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/upgrades/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/free-cart-payment-box.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' );
 
 /**

--- a/client/my-sites/upgrades/checkout/new-card-form.jsx
+++ b/client/my-sites/upgrades/checkout/new-card-form.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	isEmpty = require( 'lodash/lang/isEmpty' ),
 	classNames = require( 'classnames' );
 

--- a/client/my-sites/upgrades/checkout/payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/payment-box.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	Card = require( 'components/card' ),
 	classNames = require( 'classnames' );
 

--- a/client/my-sites/upgrades/checkout/privacy-protection-dialog.jsx
+++ b/client/my-sites/upgrades/checkout/privacy-protection-dialog.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/upgrades/checkout/privacy-protection-example.jsx
+++ b/client/my-sites/upgrades/checkout/privacy-protection-example.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	find = require( 'lodash/collection/find' );
 
 module.exports = React.createClass( {

--- a/client/my-sites/upgrades/checkout/privacy-protection.jsx
+++ b/client/my-sites/upgrades/checkout/privacy-protection.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/upgrades/checkout/secure-payment-form.jsx
+++ b/client/my-sites/upgrades/checkout/secure-payment-form.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/upgrades/checkout/stored-card.jsx
+++ b/client/my-sites/upgrades/checkout/stored-card.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 module.exports = React.createClass( {
 	displayName: 'StoredCard',

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	store = require( 'store' );
 
 /**

--- a/client/my-sites/upgrades/components/form/country-select.jsx
+++ b/client/my-sites/upgrades/components/form/country-select.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	isEmpty = require( 'lodash/lang/isEmpty' ),
 	observe = require( 'lib/mixins/data-observe' );

--- a/client/my-sites/upgrades/components/form/hidden-input.jsx
+++ b/client/my-sites/upgrades/components/form/hidden-input.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	isEmpty = require( 'lodash/lang/isEmpty' );
 
 /**

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
 	classNames = require( 'classnames' );
 
 /**

--- a/client/my-sites/upgrades/domain-management/add-google-apps/domains-select.jsx
+++ b/client/my-sites/upgrades/domain-management/add-google-apps/domains-select.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const React = require( 'react/addons' );
+const React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	startsWith = require( 'lodash/string/startsWith' ),
 	Dispatcher = require( 'dispatcher' ),
 	find = require( 'lodash/collection/find' ),

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -7,7 +7,7 @@ require( 'lib/react-test-env-setup' )();
 var chai = require( 'chai' ),
 	moment = require( 'moment' ),
 	ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
 	sinon = require( 'sinon' ),
 	sinonChai = require( 'sinon-chai' ),
 	mockery = require( 'mockery' );

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const React = require( 'react/addons' ),
+const React = require( 'react' ),
 	url = require( 'url' );
 
 /**

--- a/client/post-editor/editor-sharing/test/specs/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/test/specs/publicize-connection.jsx
@@ -5,7 +5,7 @@ require( 'lib/react-test-env-setup' )();
  * External dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
 	expect = require( 'chai' ).expect;
 
 /**

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:post-editor' ),
 	page = require( 'page' ),
 	classnames = require( 'classnames' ),

--- a/client/reader/discover/post-attribution.jsx
+++ b/client/reader/discover/post-attribution.jsx
@@ -1,8 +1,12 @@
-// External dependencies
-var React = require( 'react/addons' ),
+/**
+ * External dependencies
+ */
+var React = require( 'react' ),
 	classNames = require( 'classnames' );
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 var DiscoverHelper = require( './helper' );
 
 var arrowGridicon = ( <svg className="gridicon gridicon-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 11H6.414l6.293-6.293-1.414-1.414L2.586 12l8.707 8.707 1.414-1.414L6.414 13H20"/></svg> );

--- a/client/reader/discover/site-attribution.jsx
+++ b/client/reader/discover/site-attribution.jsx
@@ -1,8 +1,12 @@
-// External dependencies
-var React = require( 'react/addons' ),
+/**
+ * External dependencies
+ */
+var React = require( 'react' ),
 	classNames = require( 'classnames' );
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 var DiscoverHelper = require( './helper' );
 
 var DiscoverSiteAttribution = React.createClass( {

--- a/client/reader/following-edit/placeholder.jsx
+++ b/client/reader/following-edit/placeholder.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 var Card = require( 'components/card' );
 var SiteIcon = require( 'components/site-icon' );

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' ),
+	React = require( 'react' ),
 	noop = require( 'lodash/utility/noop' ),
 	times = require( 'lodash/utility/times' );
 

--- a/client/reader/list-gap/index.jsx
+++ b/client/reader/list-gap/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	classnames = require( 'classnames' );
 
 /**

--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -1,9 +1,13 @@
-/** External dependencies */
-var React = require( 'react/addons' ),
+/**
+ * External dependencies
+ */
+var React = require( 'react' ),
 	noop = require( 'lodash/utility/noop' ),
 	page = require( 'page' );
 
-/** Internal dependencies */
+/**
+ * Internal dependencies
+ */
 var PopoverMenu = require( 'components/popover/menu' ),
 	PopoverMenuItem = require( 'components/popover/menu-item' ),
 	FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions/index' ),

--- a/server/i18nlint/test/testfiles/concatenation-and-quotes.js
+++ b/server/i18nlint/test/testfiles/concatenation-and-quotes.js
@@ -1,4 +1,4 @@
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 module.exports = React.createClass( {
 	render: function() {

--- a/server/i18nlint/test/testfiles/duplicate-placeholders.js
+++ b/server/i18nlint/test/testfiles/duplicate-placeholders.js
@@ -1,5 +1,5 @@
 
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:test:i18nlint' );
 
 module.exports = React.createClass( {

--- a/server/i18nlint/test/testfiles/fine.js
+++ b/server/i18nlint/test/testfiles/fine.js
@@ -1,5 +1,5 @@
 
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:test:i18nlint' );
 
 module.exports = React.createClass( {

--- a/server/i18nlint/test/testfiles/hashbang.js
+++ b/server/i18nlint/test/testfiles/hashbang.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:test:i18nlint' );
 
 module.exports = React.createClass( {

--- a/server/i18nlint/test/testfiles/missing-singular-placeholder.js
+++ b/server/i18nlint/test/testfiles/missing-singular-placeholder.js
@@ -1,5 +1,5 @@
 
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:test:i18nlint' );
 
 module.exports = React.createClass( {

--- a/server/i18nlint/test/testfiles/testfile.jsx
+++ b/server/i18nlint/test/testfiles/testfile.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:test:i18nlint' );
 
 /**

--- a/shared/components/card/compact.jsx
+++ b/shared/components/card/compact.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	assign = require( 'lodash/object/assign' ),
 	classnames = require( 'classnames' );
 

--- a/shared/components/card/index.jsx
+++ b/shared/components/card/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	assign = require( 'lodash/object/assign' ),
 	classnames = require( 'classnames' );
 

--- a/shared/components/theme/docs/example.jsx
+++ b/shared/components/theme/docs/example.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/shared/components/theme/more-button.jsx
+++ b/shared/components/theme/more-button.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:components:themes:more-button' ), // eslint-disable-line no-unused-vars
 	classNames = require( 'classnames' ),
 	isFunction = require( 'lodash/lang/isFunction' );

--- a/shared/components/themes-list/index.jsx
+++ b/shared/components/themes-list/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	times = require( 'lodash/utility/times' );
 
 /**

--- a/shared/my-sites/themes/main.jsx
+++ b/shared/my-sites/themes/main.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	bindActionCreators = require( 'redux' ).bindActionCreators,
 	partialRight = require( 'lodash/function/partialRight' ),
 	connect = require( 'react-redux' ).connect;

--- a/shared/my-sites/themes/thanks-modal.jsx
+++ b/shared/my-sites/themes/thanks-modal.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' );
+var React = require( 'react' );
 
 /**
  * Internal dependencies

--- a/shared/my-sites/themes/themes-search-card/index.jsx
+++ b/shared/my-sites/themes/themes-search-card/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
+var React = require( 'react' ),
 	find = require( 'lodash/collection/find' ),
 	debounce = require( 'lodash/function/debounce' );
 

--- a/shared/my-sites/themes/themes-search-card/select-dropdown.jsx
+++ b/shared/my-sites/themes/themes-search-card/select-dropdown.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react/addons' );
+	React = require( 'react' );
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Related: #1498, #1878, #1901

This pull request seeks to change the declared dependency of React from `react/addons` to `react` if the file does not use any methods from `React.addons`. React addons were moved to separate packages in [React 0.14](https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html) and currently cause warnings to appear in development environments.

__Implementation notes:__

These replacements were made programmatically using the following script: https://gist.github.com/aduth/8fee70ba5719d48d6b7f

__Testing instructions:__

Assuming the replacements are valid, there should be no effective change in the application.