### PR TITLE
Signup: Fix variable not expanded in email verification notice

### DIFF
--- a/client/components/email-verification/email-verification-notice.jsx
+++ b/client/components/email-verification/email-verification-notice.jsx
@@ -83,8 +83,8 @@ module.exports = React.createClass( {
 		if ( this.state.emailSent ) {
 			user = this.props.user.get();
 			noticeText = this.translate(
-				'We sent another confirmation email to {{email /}}',
-				{ components: { email: user.email } }
+				'We sent another confirmation email to %(email)s',
+				{ args: { email: user.email } }
 			);
 			notices.success( noticeText );
 		}


### PR DESCRIPTION
This pull request addresses https://github.com/Automattic/wp-calypso/issues/1914 by fixing the success notice - and more specifically the email address inside it - displayed when users opt to resend an email to confirm their account:

![screenshot](https://cloud.githubusercontent.com/assets/594356/11957508/652ae4c0-a8c2-11e5-8459-e4a525f6b2ce.png)
 
#### Testing instructions

1. Run `git checkout fix/resend-email-verification-notice` and start your server
2. Open the [`Signup` page](http://calypso.dev:3000/start/) and create a new test account
3. Check that an email verification notice is displayed at the top of the page
4. Click the `Re-send your activation email` link in this notice
5. Make sure the success notice displays correctly

#### Reviews
 
- [x] Code
- [ ] Product