### PR TITLE
Framework: Jetpack Sites: Use updates info from `/me/sites` endpoint

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -27,7 +27,6 @@ var abtest = require( 'lib/abtest' ).abtest,
 	PulsingDot = require( 'components/pulsing-dot' ),
 	SitesListNotices = require( 'lib/sites-list/notices' ),
 	OfflineStatus = require( 'layout/offline-status' ),
-	PollerPool = require( 'lib/data-poller' ),
 	CartData = require( 'components/data/cart' ),
 	KeyboardShortcutsMenu,
 	Layout;
@@ -43,35 +42,6 @@ Layout = React.createClass( {
 
 	mixins: [ SitesListNotices, observe( 'user', 'focus', 'nuxWelcome', 'sites', 'translatorInvitation' ) ],
 
-	_sitesPoller: null,
-
-	componentWillUpdate: function( nextProps ) {
-		if ( this.props.section !== nextProps.section ) {
-			if ( nextProps.section === 'sites' ) {
-				setTimeout( function() {
-					if ( ! this.isMounted() || this._sitesPoller ) {
-						return;
-					}
-					this._sitesPoller = PollerPool.add( this.props.sites, 'fetchAvailableUpdates', { interval: 900000 } );
-				}.bind( this ), 0 );
-			} else {
-				this.removeSitesPoller();
-			}
-		}
-	},
-
-	componentWillUnmount: function() {
-		this.removeSitesPoller();
-	},
-
-	removeSitesPoller: function() {
-		if ( ! this._sitesPoller ) {
-			return;
-		}
-
-		PollerPool.remove( this._sitesPoller );
-		this._sitesPoller = null;
-	},
 	closeWelcome: function() {
 		this.props.nuxWelcome.closeWelcome();
 		analytics.ga.recordEvent( 'Welcome Box', 'Clicked Close Button' );
@@ -143,7 +113,7 @@ Layout = React.createClass( {
 export default connect(
 	( state ) => {
 		const { isLoading, section, hasSidebar, chunkName } = state.ui;
-		return { 
+		return {
 			isLoading,
 			section,
 			hasSidebar,

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -67,12 +67,12 @@ JetpackSite.prototype.fetchAvailableUpdates = function() {
 		if ( error ) {
 			debug( 'error fetching Updates data from api', error );
 			// 403 is returned when the user does not have manage capabilities.
-			if ( 403 !== error.statusCode && ! ( this.update instanceof Object ) ) {
-				this.set( { update: 'error', unreachable: true } );
+			if ( 403 !== error.statusCode && ! ( this.updates instanceof Object ) ) {
+				this.set( { updates: 'error', unreachable: true } );
 			}
 			return;
 		}
-		this.set( { update: data } );
+		this.set( { updates: data } );
 	}.bind( this ) );
 };
 
@@ -192,8 +192,8 @@ JetpackSite.prototype.updateWordPress = function( onError, onSuccess ) {
 		}
 
 		// Decrease count
-		this.update.wordpress--;
-		this.update.total--;
+		this.updates.wordpress--;
+		this.updates.total--;
 
 		this.emit( 'change' );
 	}.bind( this ) );

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -537,12 +537,6 @@ SitesList.prototype.hasSiteWithPlugins = function() {
 	} );
 };
 
-SitesList.prototype.fetchAvailableUpdates = function() {
-	this.getJetpack().forEach( function( site ) {
-		site.fetchAvailableUpdates();
-	}, this );
-};
-
 SitesList.prototype.removeSite = function( site ) {
 	var sites, changed;
 	if ( this.isSelected( site ) ) {
@@ -625,13 +619,13 @@ SitesList.prototype.onUpdatedPlugin = function( site ) {
 	}
 	site = this.getSite( site.slug );
 
-	if ( site.update && site.update.plugins ) {
-		let siteUpdateInfo = assign( {}, site.update );
+	if ( site.updates && site.updates.plugins ) {
+		let siteUpdateInfo = assign( {}, site.updates );
 		siteUpdateInfo.plugins--;
 		siteUpdateInfo.total--;
-		site.set( { update: siteUpdateInfo } );
+		site.set( { updates: siteUpdateInfo } );
 
-		if ( site.update.plugins <= 0 ) {
+		if ( site.updates.plugins <= 0 ) {
 			site.fetchAvailableUpdates();
 		}
 	}

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -21,7 +21,7 @@ export default React.createClass( {
 	},
 
 	hasUpdate() {
-		return this.props.site.update && ! this.hasError() && this.props.site.update.total > 0;
+		return this.props.site.updates && ! this.hasError() && this.props.site.updates.total > 0;
 	},
 
 	hasError() {
@@ -29,7 +29,7 @@ export default React.createClass( {
 		if ( site.unreachable ) {
 			return true;
 		}
-		if ( site.hasMinimumJetpackVersion && site.update === 'error' ) {
+		if ( site.hasMinimumJetpackVersion && site.updates === 'error' ) {
 			return true;
 		}
 		return false;
@@ -66,7 +66,7 @@ export default React.createClass( {
 	},
 
 	updatesAvailable() {
-		if ( config.isEnabled( 'jetpack_core_inline_update' ) && this.props.site.update.wordpress && this.props.site.update.wp_update_version ) {
+		if ( config.isEnabled( 'jetpack_core_inline_update' ) && this.props.site.updates.wordpress && this.props.site.updates.wp_update_version ) {
 			return (
 				<span>
 					{
@@ -75,7 +75,7 @@ export default React.createClass( {
 								link: <button className="button is-link" onClick={ this.handleUpdate } />
 							},
 							args: {
-								version: this.props.site.update.wp_update_version
+								version: this.props.site.updates.wp_update_version
 							}
 						} )
 					}
@@ -83,13 +83,13 @@ export default React.createClass( {
 			);
 		}
 
-		if ( this.props.site.update.plugins === this.props.site.update.total && this.props.site.canUpdateFiles ) {
+		if ( this.props.site.updates.plugins === this.props.site.updates.total && this.props.site.canUpdateFiles ) {
 			return (
 				<span>
 					<a
 						onClick={ this.handlePluginsUpdate }
 						href={ '/plugins/updates/' + this.props.site.slug } >
-						{ this.translate( 'There is a plugin update available.', 'There are plugin updates available.', { count: this.props.site.update.total } ) }
+						{ this.translate( 'There is a plugin update available.', 'There are plugin updates available.', { count: this.props.site.updates.total } ) }
 					</a>
 				</span>
 			);
@@ -97,9 +97,9 @@ export default React.createClass( {
 		return (
 			<span>
 				<a
-					onClick={ analytics.ga.recordEvent.bind( analytics, 'Site-Indicator', 'Clicked updates available link to wp-admin updates', 'Total Updates', this.props.site.update && this.props.site.update.total ) }
+					onClick={ analytics.ga.recordEvent.bind( analytics, 'Site-Indicator', 'Clicked updates available link to wp-admin updates', 'Total Updates', this.props.site.updates && this.props.site.updates.total ) }
 					href={ this.props.site.options.admin_url + 'update-core.php' } >
-					{ this.translate( 'There is an update available.', 'There are updates available.', { count: this.props.site.update.total } ) }
+					{ this.translate( 'There is an update available.', 'There are updates available.', { count: this.props.site.updates.total } ) }
 				</a>
 			</span>
 		);
@@ -126,7 +126,7 @@ export default React.createClass( {
 
 	handlePluginsUpdate() {
 		window.scrollTo( 0, 0 );
-		analytics.ga.recordEvent( 'Site-Indicator', 'Clicked updates available link to plugins updates', 'Total Updates', this.props.site.update && this.props.site.update.total );
+		analytics.ga.recordEvent( 'Site-Indicator', 'Clicked updates available link to plugins updates', 'Total Updates', this.props.site.updates && this.props.site.updates.total );
 	},
 
 	handleUpdate() {

--- a/client/my-sites/sites/site-card.jsx
+++ b/client/my-sites/sites/site-card.jsx
@@ -70,7 +70,7 @@ module.exports = React.createClass( {
 			return;
 		}
 
-		update = ( site.update && 'error' !== site.update && site.update.total > 0 ) ? <li><a href={ site.options.admin_url + 'update-core.php' } className="update-available">{ this.translate( 'Update Available' ) }</a></li> : null;
+		update = ( site.updates && 'error' !== site.updates && site.updates.total > 0 ) ? <li><a href={ site.options.admin_url + 'update-core.php' } className="update-available">{ this.translate( 'Update Available' ) }</a></li> : null;
 
 		if ( ! site.jetpack || config.isEnabled( 'manage/jetpack' ) ) {
 			settings = <a href={ '/settings/general/' + site.slug } className="site-settings">{ this.translate( 'Settings' ) }</a>;
@@ -143,7 +143,7 @@ module.exports = React.createClass( {
 			{
 				'is-jetpack': site.jetpack,
 				'is-private': site.is_private,
-				'has-update': site.update && ( 'error' !== site.update ) && ( site.update.total > 0 ),
+				'has-update': site.updates && ( 'error' !== site.updates ) && ( site.updates.total > 0 ),
 				'is-selected': this.props.selected
 			}
 		);


### PR DESCRIPTION
Instead of fetching updates data for every Jetpack site in different network calls, use the `updates` data included in `/me/sites`.

Improves the ux as we can render the sidebar with the updates data available in the first load.

__How to test__

* Assert that site indicators display accurate update data.

cc @enejb @johnHackworth 
