### PR TITLE
Editor: Enable keyboard shortcut for media library

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -458,6 +458,10 @@ function mediaButton( editor ) {
 		}
 	} );
 
+	editor.addCommand( 'WP_Medialib', () => {
+		renderModal( { visible: true } );
+	} );
+
 	editor.addCommand( 'wpcomEditGallery', function( content ) {
 		const site = sites.getSelectedSite();
 		if ( ! site ) {

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -257,7 +257,7 @@ function mediaButton( editor ) {
 		onPostRender: function() {
 			this.innerHtml( ReactDomServer.renderToStaticMarkup(
 				<button type="button" role="presentation" tabIndex="-1">
-					<Gridicon icon="image-multiple" size={ 20 } />
+					<Gridicon icon="image-multiple" size={ 20 } nonStandardSize />
 				</button>
 			) );
 		},


### PR DESCRIPTION
Fixes #1749

This pull request seeks to enable an already-existing keyboard shortcut for opening the media library while the TinyMCE post editor is focused using "Access+M" (Ctrl+Option+M on OSX).

__Implementation notes:__

Shortcut is declared here: https://github.com/Automattic/wp-calypso/blob/349d6481089db7603982383e626d8021606b34e6/client/components/tinymce/plugins/wpcom/plugin.js#L315

__Testing instructions:__

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Focus the post editor
4. Press "Access+M" on your keyboard (Ctrl+Option+M on OSX)
5. Note that the media library is shown

/cc @lancewillett 