### PR TITLE
Framework: Use context.query for getting querystring

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -40,7 +40,7 @@ var devdocs = {
 	 */
 	devdocs: function( context ) {
 		function onSearchChange( searchTerm ) {
-			var query = qs.parse( context.querystring );
+			var query = context.query;
 			if ( searchTerm ) {
 				query.term = searchTerm;
 			} else {

--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -3,8 +3,7 @@
  */
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
-	ReduxProvider = require( 'react-redux' ).Provider,
-	Qs = require( 'qs' );
+	ReduxProvider = require( 'react-redux' ).Provider;
 
 /**
  * Internal Dependencies
@@ -32,7 +31,7 @@ module.exports = {
 					domain: context.params.domain || '',
 					sites: sites,
 					prevPath: context.prevPath || '',
-					query: Qs.parse( context.querystring )
+					query: context.query
 				} )
 			),
 			document.getElementById( 'primary' )

--- a/client/my-sites/media/controller.js
+++ b/client/my-sites/media/controller.js
@@ -2,8 +2,7 @@
  * External Dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	qs = require( 'querystring' );
+	React = require( 'react' );
 
 /**
  * Internal Dependencies
@@ -19,7 +18,7 @@ module.exports = {
 	media: function( context ) {
 		var MediaComponent = require( 'my-sites/media/main' ),
 			filter = context.params.filter,
-			search = qs.parse( context.querystring ).s,
+			search = context.query.s,
 			baseAnalyticsPath = route.sectionify( context.path );
 
 		// Analytics

--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -2,8 +2,7 @@
  * External Dependencies
  */
 var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	qs = require( 'querystring' );
+	React = require( 'react' );
 
 /**
  * Internal Dependencies
@@ -22,7 +21,7 @@ var controller = {
 		var Pages = require( 'my-sites/pages/main' ),
 			siteID = route.getSiteFragment( context.path ),
 			status = context.params.status,
-			search = qs.parse( context.querystring ).s,
+			search = context.query.s,
 			basePath = route.sectionify( context.path ),
 			analyticsPageTitle = 'Pages',
 			baseAnalyticsPath;

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -13,7 +13,6 @@ import i18n from 'lib/mixins/i18n';
 import sitesList from 'lib/sites-list';
 import PeopleList from './main';
 import EditTeamMember from './edit-team-member-form';
-import qs from 'querystring';
 import layoutFocus from 'lib/layout-focus';
 import analytics from 'analytics';
 import titlecase from 'to-title-case';
@@ -61,7 +60,7 @@ function renderPeopleList( filter, context ) {
 			sites: sites,
 			peopleLog: PeopleLogStore,
 			filter: filter,
-			search: qs.parse( context.querystring ).s
+			search: context.query.s
 		} ),
 		document.getElementById( 'primary' )
 	);

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -4,7 +4,6 @@
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	page = require( 'page' ),
-	qs = require( 'querystring' ),
 	some = require( 'lodash/collection/some' ),
 	capitalize = require( 'lodash/string/capitalize' );
 
@@ -88,7 +87,7 @@ function getPathWithoutSiteSlug( context, site ) {
 }
 
 function renderPluginList( context, basePath, siteUrl ) {
-	var search = qs.parse( context.querystring ).s,
+	var search = context.query.s,
 		site = sites.getSelectedSite(),
 		analyticsPageTitle;
 
@@ -120,7 +119,7 @@ function renderPluginList( context, basePath, siteUrl ) {
 function renderPluginsBrowser( context, siteUrl ) {
 	var site = sites.getSelectedSite(),
 		category = context.params.category,
-		searchTerm = qs.parse( context.querystring ).s,
+		searchTerm = context.query.s,
 		analyticsPageTitle;
 
 	lastPluginsListVisited = getPathWithoutSiteSlug( context, site );

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -27,7 +27,7 @@ module.exports = {
 			siteID = route.getSiteFragment( context.path ),
 			author = ( context.params.author === 'my' ) ? user.get().ID : null,
 			statusSlug = ( author ) ? context.params.status : context.params.author,
-			search = qs.parse( context.querystring ).s,
+			search = context.query.s,
 			basePath = route.sectionify( context.path ),
 			analyticsPageTitle = 'Blog Posts',
 			baseAnalyticsPath;

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -4,8 +4,7 @@
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	store = require( 'store' ),
-	page = require( 'page' ),
-	querystring = require( 'querystring' );
+	page = require( 'page' );
 
 /**
  * Internal Dependencies
@@ -231,7 +230,7 @@ module.exports = {
 				];
 			},
 			activeFilter = false,
-			queryOptions = querystring.parse( context.querystring ),
+			queryOptions = context.query,
 			basePath = route.sectionify( context.path ),
 			statSummaryList,
 			summarySites;
@@ -293,7 +292,7 @@ module.exports = {
 		var currentSite,
 			siteId = context.params.site_id,
 			siteFragment = route.getSiteFragment( context.path ),
-			queryOptions = querystring.parse( context.querystring ),
+			queryOptions = context.query,
 			FollowList = require( 'lib/follow-list' ),
 			SiteStatsComponent = require( 'my-sites/stats/site' ),
 			NuxSite = require( 'my-sites/stats/nux/site' ),
@@ -523,7 +522,7 @@ module.exports = {
 		var site,
 			siteId = context.params.site_id,
 			siteFragment = route.getSiteFragment( context.path ),
-			queryOptions = querystring.parse( context.querystring ),
+			queryOptions = context.query,
 			StatsList = require( 'lib/stats/stats-list' ),
 			FollowList = require( 'lib/follow-list' ),
 			StatsSummaryComponent = require( 'my-sites/stats/summary' ),

--- a/client/vip/controller.js
+++ b/client/vip/controller.js
@@ -3,8 +3,7 @@
  */
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
-	page = require( 'page' ),
-	qs = require( 'querystring' );
+	page = require( 'page' );
 
 /**
  * Internal Dependencies
@@ -111,7 +110,7 @@ module.exports = {
 	},
 
 	logs: function( context ) {
-		var search = qs.parse( context.querystring ).s,
+		var search = context.query.s,
 			siteUrl = route.getSiteFragment( context.path ),
 			site = sites.getSelectedSite(),
 			status = context.params.status,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/1070

Until now, when we wanted to get a param from querystring, we were using the module `querystring` to parse the content of `context.querystring`. This was throwing exceptions in some of the cases (for example, if the querystring value contained a `%`). 

This PR changes the way we get that querystring values to use directly `context.query`, avoiding the exceptions for the unparseable cases.

How to test
=========
1. Go to http://calypso.dev:3000/posts (or any page that have a search component).
2. Search for "test %"
3. You shouldn't get any exception in the console.