### PR TITLE
Importer: Fix an issue starting a new import (missing site ID)

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -10,10 +10,11 @@ const wpcom = require( 'lib/wp' ).undocumented();
 import { actionTypes } from './constants';
 import { fromApi, toApi } from './common';
 
-export function cancelImport( importerId ) {
+export function cancelImport( siteId, importerId ) {
 	Dispatcher.handleViewAction( {
 		type: actionTypes.CANCEL_IMPORT,
-		importerId
+		importerId,
+		siteId
 	} );
 }
 
@@ -95,7 +96,7 @@ export function setUploadProgress( importerId, data ) {
 }
 
 export function startImport( siteId, importerType ) {
-	// Dev-only: this will come from an API call
+	// Use a fake ID until the server returns the real one
 	let importerId = `${ Math.round( Math.random() * 10000 ) }`;
 
 	Dispatcher.handleViewAction( {

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -94,14 +94,15 @@ export function setUploadProgress( importerId, data ) {
 	} );
 }
 
-export function startImport( importerType ) {
+export function startImport( siteId, importerType ) {
 	// Dev-only: this will come from an API call
 	let importerId = `${ Math.round( Math.random() * 10000 ) }`;
 
 	Dispatcher.handleViewAction( {
 		type: actionTypes.START_IMPORT,
 		importerId,
-		importerType
+		importerType,
+		siteId
 	} );
 }
 

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -109,15 +109,16 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 			break;
 
 		case actionTypes.START_IMPORT:
-			let newImporter = Immutable.fromJS( {
+			const newImporter = Immutable.fromJS( {
 				id: action.importerId,
 				type: action.importerType,
-				importerState: appStates.READY_FOR_UPLOAD
+				importerState: appStates.READY_FOR_UPLOAD,
+				site: { ID: action.siteId }
 			} );
 
 			newState = state
 				.update( 'count', count => count + 1 )
-				.setIn( [ 'importers', action.importerId ], Immutable.fromJS( newImporter ) );
+				.setIn( [ 'importers', action.importerId ], newImporter );
 			break;
 
 		case actionTypes.START_IMPORTING:

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -98,7 +98,7 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 				break;
 			}
 
-			newState = state
+			newState = newState
 				.setIn( [ 'importers', action.importerStatus.importerId ], Immutable.fromJS( action.importerStatus ) );
 			break;
 

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -63,6 +63,7 @@ export default React.createClass( {
 
 	render: function() {
 		const { title, icon, description, uploadDescription } = this.props.importerData;
+		const site = this.props.site;
 		const state = this.props.importerStatus,
 			isEnabled = ( appStates.DISABLED !== state.importerState ),
 			cardClasses = classNames( 'importer__shell', {
@@ -72,7 +73,7 @@ export default React.createClass( {
 
 		return (
 			<Card className={ cardClasses }>
-				<ImporterHeader importerStatus={ state } icon={ icon } title={ title } description={ description } isEnabled={ isEnabled } />
+				<ImporterHeader importerStatus={ state } {...{ icon, title, description, isEnabled, site } } />
 				{ state.errorData &&
 					<ErrorPane type={ state.errorData.type } description={ state.errorData.description } />
 				}

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -44,8 +44,7 @@ export default React.createClass( {
 	},
 
 	controlButtonClicked: function() {
-		const { id: importerId, importerState, type } = this.props.importerStatus;
-		const { ID: siteId } = this.props.site;
+		const { importerStatus: { importerId, importerState, type }, site: { ID: siteId } } = this.props;
 
 		if ( includes( [ ...cancelStates, ...stopStates ], importerState ) ) {
 			cancelImport( importerId );

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -45,11 +45,12 @@ export default React.createClass( {
 
 	controlButtonClicked: function() {
 		const { id: importerId, importerState, type } = this.props.importerStatus;
+		const { ID: siteId } = this.props.site;
 
 		if ( includes( [ ...cancelStates, ...stopStates ], importerState ) ) {
 			cancelImport( importerId );
 		} else if ( includes( startStates, importerState ) ) {
-			startImport( type );
+			startImport( siteId, type );
 		} else if ( includes( doneStates, importerState ) ) {
 			resetImport( importerId );
 		}


### PR DESCRIPTION
As soon as the API integration began, small consistency issues between
the UI and the API started creeping in.  In this case, it was impossible
to start a new import session because that session depends on both the
type of the importer (already handled) and the site id for which it
belongs.

Previously that site id was missing but this PR adds it back in.

cc: @roundhill @rodrigoi @rralian 