### PR TITLE
Me: improving empty billing history tables with more helpful messages

### DIFF
--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -41,22 +41,19 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
+		const emptyTableText = this.translate(
+			'You do not currently have any upgrades. ' +
+			'To see what upgrades we offer visit our {{link}}Plans page{{/link}}.', {
+				components: { link: <a href="/plans" /> }
+			}
+		);
 		return (
 			<TransactionsTable
 				{ ...this.props }
 				initialFilter={ { date: { newest: 5 } } }
 				header
-				description={ function( transaction ) {
-					return (
-						<div className="transaction-links">
-							<a className="view-receipt" href={ '/me/billing/' + transaction.id } onClick={ this.recordClickEvent( 'View Receipt in Billing History' ) } >
-								{ this.translate( 'View Receipt' ) }
-							</a>
-							{ this.renderEmailAction( transaction.id ) }
-						</div>
-					);
-				}.bind( this ) }
-				/>
+				emptyTableText={ emptyTableText }
+				transactionRenderer={ this.renderTransaction } />
 		);
 	},
 
@@ -73,5 +70,14 @@ module.exports = React.createClass( {
 		}
 
 		return action;
+	},
+
+	renderTransaction: function( transaction ) {
+		<div className="transaction-links">
+			<a className="view-receipt" href={ '/me/billing/' + transaction.id } onClick={ this.recordClickEvent( 'View Receipt in Billing History' ) } >
+				{ this.translate( 'View Receipt' ) }
+			</a>
+			{ this.renderEmailAction( transaction.id ) }
+		</div>
 	}
 } );

--- a/client/me/billing-history/index.jsx
+++ b/client/me/billing-history/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	classes = require( 'component-classes' );
+	classes = require( 'component-classes' ),
+	isEmpty = require( 'lodash/lang/isEmpty' );
 
 /**
  * Internal dependencies
@@ -33,16 +34,9 @@ module.exports = React.createClass( {
 		classes( document.body ).remove( 'billing-history-page' );
 	},
 
-	renderManageCards: function() {
-		if ( config.isEnabled( 'me/credit-cards' ) ) {
-			return (
-				<CreditCards cards={ storedCards } />
-			);
-		}
-	},
-
 	render: function() {
 		var data = this.props.billingData.get();
+		const hasBillingHistory = ! isEmpty( data.billingHistory );
 
 		return (
 
@@ -69,12 +63,16 @@ module.exports = React.createClass( {
 					<BillingHistoryTable transactions={ data.billingHistory } />
 				</Card>
 
-				<SectionHeader label={ this.translate( 'Upcoming Charges' ) } />
-				<Card id="upcoming-charges">
-					<UpcomingChargesTable sites={ this.props.sites } transactions={ data.upcomingCharges } />
-				</Card>
+				{ hasBillingHistory &&
+					<div>
+						<SectionHeader label={ this.translate( 'Upcoming Charges' ) } />
+						<Card id="upcoming-charges">
+							<UpcomingChargesTable sites={ this.props.sites } transactions={ data.upcomingCharges } />
+						</Card>
+					</div> }
 
-				{ this.renderManageCards() }
+				{ config.isEnabled( 'me/credit-cards' ) &&
+					<CreditCards cards={ storedCards } /> }
 
 			</div>
 		);

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -131,10 +131,12 @@ var TransactionsTable = React.createClass( {
 					<td className="no-results-cell" colSpan="3">{ this.translate( 'Loading…' ) }</td>
 				</tr>
 			);
-		} else if ( isEmpty( this.state.transactions ) ) {
+		}
+
+		if ( isEmpty( this.state.transactions ) ) {
 			return (
 				<tr className="transactions__no-results">
-					<td className="no-results-cell" colSpan="3">{ this.translate( 'No matching receipts found' ) }</td>
+					<td className="no-results-cell" colSpan="3">{ this.props.emptyTableText }</td>
 				</tr>
 			);
 		}
@@ -149,7 +151,7 @@ var TransactionsTable = React.createClass( {
 						<div className="trans-wrap">
 							<div className="service-description">
 								<div className="service-name">{ this.serviceName( transaction ) }</div>
-								{ this.props.description.call( this, transaction ) }
+								{ this.props.transactionRenderer.call( this, transaction ) }
 							</div>
 						</div>
 					</td>

--- a/client/me/billing-history/upcoming-charges-table.jsx
+++ b/client/me/billing-history/upcoming-charges-table.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React, { PropTypes } from 'react';
 
 /**
  * Internal Dependencies
@@ -13,8 +13,20 @@ module.exports = React.createClass( {
 
 	displayName: 'UpcomingChargesTable',
 
+	propTypes: {
+		sites: PropTypes.shape( {
+			getSite: PropTypes.func.isRequired
+		} ).isRequired
+	},
+
 	render: function() {
 		var transactions = null;
+		const emptyTableText = this.translate(
+			'The upgrades on your account will not renew automatically. ' +
+			'To manage your upgrades or enable Auto Renew visit {{link}}My Upgrades{{/link}}.', {
+				components: { link: <a href="/purchases" /> }
+			}
+		);
 
 		if ( this.props.sites.initialized ) {
 			// `TransactionsTable` will render a loading state until the transactions are present
@@ -25,20 +37,24 @@ module.exports = React.createClass( {
 			<TransactionsTable
 				transactions={ transactions }
 				initialFilter={ { date: { newest: 20 } } }
-				description={ function( transaction ) {
-					var site = this.props.sites.getSite( Number( transaction.blog_id ) );
+				emptyTableText={ emptyTableText }
+				transactionRenderer={ this.renderTransaction } />
+		);
+	},
 
-					if ( site ) {
-						return (
-							<div className="transaction-links">
-								<a href={ purchasesPaths.managePurchase( site.slug, transaction.id ) }>
-									{ this.translate( 'Manage Purchase' ) }
-								</a>
-							</div>
-						);
-					}
-				}.bind( this ) }
-			/>
+	renderTransaction: function( transaction ) {
+		var site = this.props.sites.getSite( Number( transaction.blog_id ) );
+
+		if ( ! site ) {
+			return null;
+		}
+
+		return (
+			<div className="transaction-links">
+				<a href={ purchasesPaths.managePurchase( site.slug, transaction.id ) }>
+					{ this.translate( 'Manage Purchase' ) }
+				</a>
+			</div>
 		);
 	}
 } );


### PR DESCRIPTION
Closes #1012 

To test:

1) Checkout this branch

2) Visit /me/billing with a user who has no billing history and no upcoming charges
  - ensure that the 'Upcoming Charges' section is not shown
  - ensure that a message / link appears in the empty 'Receipts' table
  - "The upgrades on your account will not renew automatically. To manage your upgrades or enable Auto Renew visit My Upgrades (linked to http://wordpress.com/my-upgrades)"

3) Visit /me/billing with a user who has some receipts but no upcoming charges
  - ensure that a message / link appears in the empty 'Upcoming Charges' section
  - "You do not currently have any upgrades. To see what upgrades we offer visit our Plans page (linked to https://wordpress.com/plans)"

@v18 could you please test this and let me know what you think?
