### PR TITLE
Plugin List: Bulk edit only .com and jetpack plugins.

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -5,7 +5,8 @@ var debug = require( 'debug' )( 'calypso:sites-list' ),
 	store = require( 'store' ),
 	assign = require( 'lodash/object/assign' ),
 	find = require( 'lodash/collection/find' ),
-	some = require( 'lodash/collection/some' );
+	some = require( 'lodash/collection/some' ),
+	unique = require( 'lodash/array/uniq' );
 
 /**
  * Internal dependencies
@@ -464,11 +465,16 @@ SitesList.prototype.getSelectedOrAllJetpackCanManage = function() {
 };
 
 SitesList.prototype.getSelectedOrAllWithPlugins = function() {
-	return this.getSelectedOrAll().concat(
+	return unique( this.getSelectedOrAll().concat(
 		this.getSelectedOrAll().filter( function( site ) {
 			return isBusiness( site.plan );
-		} )
-	);
+		} ) ), 'ID' );
+};
+
+SitesList.prototype.getSelectedOrWPComBusiness = function() {
+	return this.getSelectedOrAll().filter( function( site ) {
+		return isBusiness( site.plan );
+	} );
 };
 
 SitesList.prototype.hasSiteWithPlugins = function() {

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -41,8 +41,7 @@ export default React.createClass( {
 		sites: React.PropTypes.object.isRequired,
 		plugins: React.PropTypes.array.isRequired,
 		selected: React.PropTypes.array.isRequired,
-		isWpCom: React.PropTypes.bool,
-		pluginUpdateCount: React.PropTypes.number
+		isWpCom: React.PropTypes.bool
 	},
 
 	onBrowserLinkClick() {
@@ -63,6 +62,9 @@ export default React.createClass( {
 	},
 
 	hasJetpackSelectedSites() {
+		if ( this.props.isWpCom ) {
+			return;
+		}
 		const selectedSite = this.props.sites.getSelectedSite();
 		if ( selectedSite ) {
 			return !! selectedSite.jetpack;
@@ -71,16 +73,20 @@ export default React.createClass( {
 	},
 
 	unselectOrSelectAll() {
+		const sites = this.props.isWpCom
+			? this.props.sites.getSelectedOrWPComBusiness()
+			: this.props.sites.getSelectedOrAllJetpackCanManage();
+
 		if ( this.props.selected.length > 0 ) {
-			PluginsActions.selectPlugins( this.props.sites.getSelectedOrAllWithPlugins(), 'none' );
+			PluginsActions.selectPlugins( sites, 'none' );
 			analytics.ga.recordEvent( 'Plugins', 'Clicked to Uncheck All Plugins' );
 			return;
 		}
-		PluginsActions.selectPlugins( this.props.sites.getSelectedOrAllWithPlugins(), 'all' );
+		PluginsActions.selectPlugins( sites, 'all' );
 		analytics.ga.recordEvent( 'Plugins', 'Clicked to Check All Plugins' );
 	},
 
-	renderCurrentActionButtons( isWpCom ) {
+	renderCurrentActionButtons() {
 		let buttons = [];
 		let rightSideButtons = [];
 		let leftSideButtons = [];
@@ -88,10 +94,10 @@ export default React.createClass( {
 		let activateButtons = [];
 
 		const hasWpcomPlugins = this.props.selected.some( property( 'wpcom' ) );
-		const isJetpackSelected = this.props.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
+		const isJetpackSelected = this.props.isWpCom ? false : this.props.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
 		const needsRemoveButton = this.props.selected.length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
 		if ( ! this.props.isBulkManagementActive ) {
-			if ( ! isWpCom && 0 < this.props.pluginUpdateCount ) {
+			if ( ! this.props.isWpCom && 0 < this.props.pluginUpdateCount ) {
 				rightSideButtons.push(
 					<ButtonGroup key="plugin-list-header__buttons-update-all">
 						<Button compact primary onClick={ this.props.updateAllPlugins } >
@@ -107,7 +113,7 @@ export default React.createClass( {
 					</Button>
 				</ButtonGroup>
 			);
-			if ( ! isWpCom && this.canAddNewPlugins() ) {
+			if ( ! this.props.isWpCom && this.canAddNewPlugins() ) {
 				const selectedSite = this.props.sites.getSelectedSite();
 				const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
 
@@ -145,7 +151,7 @@ export default React.createClass( {
 			activateButtons.push( deactivateButton )
 			leftSideButtons.push( <ButtonGroup key="plugin-list-header__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
 
-			if ( this.hasJetpackSelectedSites() && ! isWpCom ) {
+			if ( this.hasJetpackSelectedSites() ) {
 				updateButtons.push(
 					<Button key="plugin-list-header__buttons-autoupdate-on"
 						disabled={ hasWpcomPlugins || ! this.canUpdatePlugins() }
@@ -196,7 +202,7 @@ export default React.createClass( {
 		let actions = [];
 
 		const hasWpcomPlugins = this.props.selected.some( property( 'wpcom' ) );
-		const isJetpackSelected = this.props.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
+		const isJetpackSelected = this.props.isWpCom ? false : this.props.plugins.some( plugin => plugin.selected && 'jetpack' === plugin.slug );
 		const needsRemoveButton = !! this.props.selected.length && ! hasWpcomPlugins && this.canUpdatePlugins() && ! isJetpackSelected;
 
 		if ( this.props.isBulkManagementActive ) {


### PR DESCRIPTION
Before: When clicking Edit All it would open up both sections.
![screen shot 2015-12-18 at 16 54 49](https://cloud.githubusercontent.com/assets/115071/11910266/2a97f9be-a5a8-11e5-90c0-7d1f9d4fb05f.png)

After: Only the section that you clicked Edit All on would opens.
![screen shot 2015-12-18 at 16 54 38](https://cloud.githubusercontent.com/assets/115071/11910271/3a23c6d8-a5a8-11e5-917a-9dc3dc334336.png)

**To Test:**
Visit http://calypso.localhost:3000/plugins
And click on Edit All. 

Notice that it only opens up one section . 
Try to perform the actions Activate, deactivate etc. make sure that it works as expected. 

cc: @johnHackworth and @rickybanister 

Note this doesn't fix the spectection of both .com and jetpack version of the plugin Gumroad. 
I think some more work will need to happen in order for this to hold true. 

Also this would be easier to work with if we have more specific components for each of the different sections in main.js plugins file. 
