### PR TITLE
Update/importer cancel import

### DIFF
--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -4,6 +4,7 @@ import { appStates } from './constants';
 
 // Left( UI ) - Right( API )
 const importerStateMap = [
+	[ appStates.CANCEL_PENDING, 'cancel' ],
 	[ appStates.DEFUNCT, 'importStopped' ],
 	[ appStates.DISABLED, 'disabled' ],
 	[ appStates.IMPORT_FAILURE, 'importer-import-failure' ],
@@ -69,9 +70,9 @@ export function toApi( state ) {
 
 	return Object.assign( {},
 		{ importerId, progress },
-		{ importerStatus: appStateToApi( importerState ) },
+		{ importStatus: appStateToApi( importerState ) },
 		site && site.ID ? { siteId: site.ID } : {},
-		{ type: type.replace( 'importer-type-', '' ) },
+		type && { type: type.replace( 'importer-type-', '' ) },
 		customData ? { customData: replaceUserInfoWithIds( customData ) } : {}
 	);
 }

--- a/client/lib/importer/constants.js
+++ b/client/lib/importer/constants.js
@@ -1,4 +1,5 @@
 export const appStates = Object.freeze( {
+	CANCEL_PENDING: 'importer-canceling',
 	DEFUNCT: 'importer-defunct',
 	DISABLED: 'importer-disabled',
 	IMPORT_FAILURE: 'importer-import-failure',

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import Immutable from 'immutable';
+import includes from 'lodash/collection/includes';
 
 /**
  * Internal dependencies
@@ -63,7 +64,7 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 		case actionTypes.RESET_IMPORT:
 			// Remove the specified importer from the list of current importers
 			newState = state.update( 'importers', importers => {
-				return importers.filterNot( importer => importer.get( 'id' ) === action.importerId );
+				return importers.filterNot( importer => importer.get( 'importerId' ) === action.importerId );
 			} );
 			break;
 
@@ -104,7 +105,12 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 			}
 
 			newState = newState
-				.setIn( [ 'importers', action.importerStatus.importerId ], Immutable.fromJS( action.importerStatus ) );
+				.setIn( [ 'importers', action.importerStatus.importerId ], Immutable.fromJS( action.importerStatus ) )
+				.update( 'importers', importers => {
+					const removableStates = [ appStates.CANCEL_PENDING, appStates.DEFUNCT ];
+
+					return importers.filterNot( importer => includes( removableStates, importer.get( 'importerState' ) ) )
+				} );
 			break;
 
 		case actionTypes.SET_UPLOAD_PROGRESS:
@@ -115,7 +121,7 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 
 		case actionTypes.START_IMPORT:
 			const newImporter = Immutable.fromJS( {
-				id: action.importerId,
+				importerId: action.importerId,
 				type: action.importerType,
 				importerState: appStates.READY_FOR_UPLOAD,
 				site: { ID: action.siteId }

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -114,9 +114,13 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 			break;
 
 		case actionTypes.SET_UPLOAD_PROGRESS:
-			newState = state.setIn( [ 'importers', action.importerId, 'percentComplete' ],
-				action.uploadLoaded / ( action.uploadTotal + Number.EPSILON ) * 100
-			);
+			newState = state.update( 'importers', importers => importers.map( importer => {
+				if ( action.importerId !== importer.get( 'importerId' ) ) {
+					return importer;
+				}
+
+				return importer.set( 'percentComplete', action.uploadLoaded / ( action.uploadTotal + Number.EPSILON ) * 100 );
+			} ) );
 			break;
 
 		case actionTypes.START_IMPORT:
@@ -140,7 +144,8 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 		case actionTypes.START_UPLOAD:
 			newState = state
 				.setIn( [ 'importers', action.importerId, 'importerState' ], appStates.UPLOADING )
-				.setIn( [ 'importers', action.importerId, 'filename' ], action.filename );
+				.setIn( [ 'importers', action.importerId, 'filename' ], action.filename )
+				.setIn( [ 'importers', action.importerId, 'uploadAborter' ], action.uploadAborter );
 			break;
 
 		default:

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1725,8 +1725,6 @@ Undocumented.prototype.uploadExportFile = function( siteId, params ) {
 
 	req.upload.onprogress = params.onprogress;
 	req.onabort = params.onabort;
-
-	return req;
 };
 
 /**

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1705,13 +1705,12 @@ Undocumented.prototype.fetchImporterState = function( siteId ) {
 
 Undocumented.prototype.updateImporter = function( siteId, importerStatus ) {
 	debug( `/sites/${ siteId }/imports/${ importerStatus.importId }` );
-	const formData = Object
-		.keys( importerStatus )
-		.map( key => [ key, JSON.stringify( importerStatus[ key ] ) ] );
 
 	return this.wpcom.req.post( {
 		path: `/sites/${ siteId }/imports/${ importerStatus.importerId }`,
-		formData
+		formData: [
+			[ 'importStatus', JSON.stringify( importerStatus ) ]
+		]
 	} );
 };
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1725,6 +1725,8 @@ Undocumented.prototype.uploadExportFile = function( siteId, params ) {
 
 	req.upload.onprogress = params.onprogress;
 	req.onabort = params.onabort;
+
+	return req;
 };
 
 /**

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -44,10 +44,10 @@ export default React.createClass( {
 	},
 
 	controlButtonClicked: function() {
-		const { importerStatus: { importerId, importerState, type, uploadAborter }, site: { ID: siteId } } = this.props;
+		const { importerStatus: { importerId, importerState, type }, site: { ID: siteId } } = this.props;
 
 		if ( includes( [ ...cancelStates, ...stopStates ], importerState ) ) {
-			cancelImport( siteId, importerId, uploadAborter );
+			cancelImport( siteId, importerId );
 		} else if ( includes( startStates, importerState ) ) {
 			startImport( siteId, type );
 		} else if ( includes( doneStates, importerState ) ) {

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -44,10 +44,10 @@ export default React.createClass( {
 	},
 
 	controlButtonClicked: function() {
-		const { importerStatus: { importerId, importerState, type }, site: { ID: siteId } } = this.props;
+		const { importerStatus: { importerId, importerState, type, uploadAborter }, site: { ID: siteId } } = this.props;
 
 		if ( includes( [ ...cancelStates, ...stopStates ], importerState ) ) {
-			cancelImport( siteId, importerId );
+			cancelImport( siteId, importerId, uploadAborter );
 		} else if ( includes( startStates, importerState ) ) {
 			startImport( siteId, type );
 		} else if ( includes( doneStates, importerState ) ) {

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -76,15 +76,16 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		const { importerStatus: { importerState }, icon, isEnabled, title, description } = this.props,
-			isPrimary = includes( [ ...cancelStates, ...stopStates ], importerState );
+		const { importerStatus: { importerState }, icon, isEnabled, title, description } = this.props;
+		const isPrimary = includes( [ ...cancelStates, ...stopStates ], importerState );
+		const canCancel = isEnabled && ! includes( [ appStates.UPLOADING ], importerState );
 
 		return (
 			<header className="importer-service">
 				<ImporterIcon {...{ icon } } />
 				<Button
 					className="importer__master-control"
-					disabled={ ! isEnabled }
+					disabled={ ! canCancel }
 					isPrimary={ isPrimary }
 					onClick={ this.controlButtonClicked }
 				>


### PR DESCRIPTION
Previously the cancel action didn't persist. Now the cancel action will
clear out any local importer status objects and it will also send an API
request to stop the import on the server as well.

There were a few additional changes that had to be made to allow this to
work properly

 - `id` turned into `importerId` in the importer status object in the
   datastore
 - a new `CANCEL_PENDING` state exists for sending the stop signal to
   the server
 - `siteId` gets passed where it previously didn't

<del>**Depends on a change to the import API** where quotes embedded in the `formData` for the `POST` to update the importer object on the server were coming through:

```php
// on the server - note the quotes around _cancel_
var_dump( $data[ 'importerState' ] ) // string(8) "'cancel'"
```
</del>

> Change on the server incorporated in r128717-wpcom

cc: @roundhill @rodrigoi @rralian 