### PR TITLE
Plugins: Add a intermediate updating state when bulk-updating plugins

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -466,6 +466,14 @@ PluginsActions = {
 		}
 	},
 
+	removePluginUpdateInfo: function( site, plugin ) {
+		Dispatcher.handleViewAction( {
+			type: 'REMOVE_PLUGINS_UPDATE_INFO',
+			site: site,
+			plugin: plugin
+		} );
+	},
+
 	resetQueue: function() {
 		_actionsQueueBySite = {};
 	}

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -27,7 +27,9 @@ var Dispatcher = require( 'dispatcher' ),
  * Constants
  */
 var _CACHE_TIME_TO_LIVE = 10 * 1000, // 10 sec
+	_UPDATED_PLUGIN_INFO_TIME_TO_LIVE = 10 * 1000,
 	_STORAGE_LIST_NAME = 'CachedPluginsBySite';
+
 // Stores the plugins of each site.
 var _fetching = {},
 	_pluginsBySite = {},
@@ -353,6 +355,10 @@ PluginsStore.dispatchToken = Dispatcher.register( function( payload ) {
 
 		case 'AUTOUPDATE_PLUGIN':
 		case 'UPDATE_PLUGIN':
+			PluginsStore.emitChange();
+			break;
+
+		case 'REMOVE_PLUGINS_UPDATE_INFO':
 			update( action.site, action.plugin.slug, { update: null } );
 			PluginsStore.emitChange();
 			break;
@@ -365,8 +371,12 @@ PluginsStore.dispatchToken = Dispatcher.register( function( payload ) {
 				// still needs to be updated
 				update( action.site, action.plugin.slug, { update: action.plugin.update } );
 			} else {
-				update( action.site, action.plugin.slug, action.data );
+				update( action.site,
+					action.plugin.slug,
+					Object.assign( { update: { recentlyUpdated: true } }, action.data )
+				);
 				sitesList.onUpdatedPlugin( action.site );
+				setTimeout( PluginsActions.removePluginUpdateInfo.bind( PluginsActions, action.site, action.plugin ), _UPDATED_PLUGIN_INFO_TIME_TO_LIVE );
 			}
 			PluginsStore.emitChange();
 			break;

--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -27,6 +27,7 @@ var Dispatcher = require( 'dispatcher' ),
  * Constants
  */
 var _CACHE_TIME_TO_LIVE = 10 * 1000, // 10 sec
+	// time to wait until a plugin recentlyUpdate flag is cleared once it's updated
 	_UPDATED_PLUGIN_INFO_TIME_TO_LIVE = 10 * 1000,
 	_STORAGE_LIST_NAME = 'CachedPluginsBySite';
 

--- a/client/lib/plugins/test/lib/mock-actions.js
+++ b/client/lib/plugins/test/lib/mock-actions.js
@@ -62,6 +62,13 @@ module.exports = {
 		error: null
 	},
 
+	clearPluginUpdate: {
+		type: 'REMOVE_PLUGINS_UPDATE_INFO',
+		action: 'REMOVE_PLUGINS_UPDATE_INFO',
+		site: site,
+		plugin: plugins[ 2 ]
+	},
+
 	updatedPluginError: {
 		type: 'RECEIVE_UPDATED_PLUGIN',
 		action: 'UPDATE_PLUGIN',

--- a/client/lib/plugins/test/test-store.js
+++ b/client/lib/plugins/test/test-store.js
@@ -367,14 +367,14 @@ describe( 'Plugins Store', function() {
 	describe( 'Update Plugin', function() {
 		var HelloDolly = {};
 
-		describe( 'Updateing Plugin', function() {
+		describe( 'Updating Plugin', function() {
 			beforeEach( function() {
 				Dispatcher.handleViewAction( actions.updatePlugin );
 				HelloDolly = PluginsStore.getSitePlugin( site, 'hello-dolly' );
 			} );
 
-			it( 'update = null', function() {
-				assert.isNull( HelloDolly.update );
+			it( 'doesn\'t remove update when lauched', function() {
+				assert.isNotNull( HelloDolly.update );
 			} );
 		} );
 
@@ -384,8 +384,8 @@ describe( 'Plugins Store', function() {
 				HelloDolly = PluginsStore.getSitePlugin( site, 'hello-dolly' );
 			} );
 
-			it( 'should set update = null', function() {
-				assert.isNull( HelloDolly.update );
+			it( 'should set lastUpdated', function() {
+				assert.isNotNull( HelloDolly.update.lastUpdated );
 			} );
 
 			it( 'should update the plugin data', function() {
@@ -394,6 +394,17 @@ describe( 'Plugins Store', function() {
 				assert.equal( HelloDolly.description, updatePluginData.description );
 				assert.equal( HelloDolly.author_url, updatePluginData.author_url );
 				assert.equal( HelloDolly.name, updatePluginData.name );
+			} );
+		} );
+
+		describe( 'Remove Plugin Update Info', function() {
+			beforeEach( function() {
+				Dispatcher.handleViewAction( actions.clearPluginUpdate );
+				HelloDolly = PluginsStore.getSitePlugin( site, 'hello-dolly' );
+			} );
+
+			it( 'should remove lastUpdated', function() {
+				assert.isNull( HelloDolly.update );
 			} );
 		} );
 

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -93,6 +93,31 @@ module.exports = React.createClass( {
 		return message;
 	},
 
+	renderUpdateFlag: function() {
+		const recentlyUpdated = this.props.sites.some( function( site ) {
+			return site.plugin &&
+				site.plugin.update &&
+				site.plugin.update.recentlyUpdated
+		} );
+
+		if ( recentlyUpdated ) {
+			return (
+				<Notice isCompact
+					icon="checkmark"
+					status="is-success"
+					inline={ true }
+					text={ this.translate( 'Updated' ) } />
+			);
+		}
+		return (
+			<Notice isCompact
+				icon="sync"
+				status="is-warning"
+				inline={ true }
+				text={ this.translate( 'A newer version is available' ) } />
+		);
+	},
+
 	pluginMeta: function( pluginData ) {
 		if ( this.props.progress.length ) {
 			return (
@@ -100,13 +125,7 @@ module.exports = React.createClass( {
 			);
 		}
 		if ( this.hasUpdate() ) {
-			return (
-				<Notice isCompact
-					icon="sync"
-					status="is-warning"
-					inline={ true }
-					text={ this.translate( 'A newer version is available' ) } />
-			);
+			return this.renderUpdateFlag();
 		}
 
 		if ( pluginData.wpcom ) {


### PR DESCRIPTION
fix https://github.com/Automattic/wp-calypso/issues/1211

Until now, when users clicked on the 'update all' button on their plugin list, every plugin to be updated was immediatly marked as updated as soon as we sent the update request to the server. That would make it dissapear from the "update needed" tab as soon as the user clicks the button, even if the operation is still going on... so if there's an error, the plugin appears again and the overall feeling can be described as WTF-esque.

With this PR, now the plugins are not marked as updated as soon as the update action is dispatched, but when the request' success notification is received. Also, the plugin is marked as "recently updated" for 10 seconds, so we render a "updated" success notice in the list:

Video (don't mind that jetpack instance failing to update): https://cloudup.com/cVxC6GQ01cJ

![image](https://cloud.githubusercontent.com/assets/1554855/11974675/9c939804-a966-11e5-9662-91f90e46e3c5.png)

![image](https://cloud.githubusercontent.com/assets/1554855/11974678/a0c6ca54-a966-11e5-809d-d4fde1c3bdd3.png)

ping @enejb & @rickybanister 