### PR TITLE
Checkout: Reset transaction before setting payment

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -27,6 +27,10 @@ module.exports = React.createClass( {
 		return { previousCart: null };
 	},
 
+	componentWillMount: function() {
+		upgradesActions.resetTransaction();
+	},
+
 	componentDidMount: function() {
 		if ( this.redirectIfEmptyCart() ) {
 			return;
@@ -41,8 +45,6 @@ module.exports = React.createClass( {
 		}
 
 		window.scrollTo( 0, 0 );
-
-		upgradesActions.resetTransaction();
 	},
 
 	componentWillReceiveProps: function( nextProps ) {


### PR DESCRIPTION
Fixes #1923.

We have to call `upgradesActions.reset` earlier.

`upgradesActions.setPayment` is called from [`SecurePaymentForm.componentWillMount`](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/upgrades/checkout/secure-payment-form.jsx#L182). 

If stored cards and cart are already loaded when opening checkout, than the `setPayment` happens before `reset`, and that break things.