### PR TITLE
Plugins: Fix/plugins warning in console

### DIFF
--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -216,12 +216,13 @@ export default React.createClass( {
 			'plugin-information__version-info': true,
 			'is-singlesite': !! this.props.siteVersion
 		} );
+
 		return (
 			<div className="plugin-information">
 					<div className="plugin-information__wrapper">
 						<div className={ classes }>
 							<div className="plugin-information__version-shell">
-								<Version version={ this.props.pluginVersion } icon="plugins" className="plugin-information__version" />
+								{ this.props.pluginVersion && <Version version={ this.props.pluginVersion } icon="plugins" className="plugin-information__version" /> }
 								{ this.renderLastUpdated() }
 							</div>
 							<div className="plugin-information__version-shell">

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -258,7 +258,6 @@ export default React.createClass( {
 		}
 		return (
 			<MainComponent>
-				<SidebarNavigation />
 				<div className="plugin__page">
 					{ this.displayHeader() }
 					<PluginMeta

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -253,7 +253,7 @@ export default React.createClass( {
 			canUpdateFiles: true,
 			name: 'Not a real site',
 			options: {
-				software_version: 1
+				software_version: '1'
 			}
 		}
 		return (


### PR DESCRIPTION
When loading the single plugin view for a site that doesn't have jetpack manage
you get a set of a bunch of not very nice js warning. 

This PR fixes this be making sure that we only render info when we have all the available info.
Also we remove the double navigation found in the same view. 

Before:
![screen shot 2015-12-23 at 10 48 57](https://cloud.githubusercontent.com/assets/115071/11982832/8a5da876-a963-11e5-9ee3-84125eba6f4e.png)

After:
![screen shot 2015-12-23 at 10 49 18](https://cloud.githubusercontent.com/assets/115071/11982836/8f8412cc-a963-11e5-8af5-0bd716fdc9fc.png)
