### PR TITLE
Checkout / Invites: Access `dispatch` through correct property

### DIFF
--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -16,7 +16,7 @@ export function acceptInvite( context ) {
 	titleActions.setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) );
 
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-	context.layout.dispatch( setSection( null, { hasSidebar: false } ) );
+	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 
 	ReactDom.render(
 		React.createElement(

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -201,7 +201,7 @@ module.exports = {
 			basePath = route.sectionify( context.path );
 
 		analytics.pageView.record( basePath, 'Checkout Thank You' );
-		context.layout.dispatch( setSection( null, { hasSidebar: false } ) );
+		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 
 		if ( ! lastTransaction ) {
 			page.redirect( '/plans' );


### PR DESCRIPTION
Currently, the checkout thank you and accept-invite pages are broken because of an uncaught error caused by calling `context.layout.dispatch`. `dispatch` lives in `context.store`, not `context.layout`.

**Testing**
- Purchase a plan from `/plans` and assert that you see the thank you page after checkout.
- Visit `/accept-invite/foo/bar` and assert that you see "Oops, your invite is not valid" instead of an error in the console.