### PR TITLE
People: use consistent html tag in people list item

### DIFF
--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -50,9 +50,9 @@ export default React.createClass( {
 			<CompactCard
 				{ ...omit( this.props, 'className' ) }
 				className={ classNames( 'people-list-item', this.props.className ) }
+				tagName="a"
 				href={ canLinkToProfile && '/people/edit/' + this.props.user.login + '/' + this.props.site.slug }
-				onClick={ canLinkToProfile && this.navigateToUser }
-			>
+				onClick={ canLinkToProfile && this.navigateToUser }>
 				<div className="people-list-item__profile-container">
 					<PeopleProfile user={ this.props.user } />
 				</div>


### PR DESCRIPTION
Previously, we would use either `<a>` or `<div>` as the main
container for the `<PeopleListItem>` component. This commit
will always use `<a>` so that `nth-of-type` and `last-of-type`
will style this component consistently.

Closes #1577 

To test: 
- Note the visual regression described in #1577
- checkout this branch and ensure the regression is resolved

cc: @lezama 