### PR TITLE
Billing History: Wrap `ViewReceiptModal` in `Provider`

### DIFF
--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -282,7 +282,9 @@ export default {
 			analytics.pageView.record( basePath + '/receipt', ANALYTICS_PAGE_TITLE + ' > Billing History > Receipt' );
 
 			ReactDom.render(
-				React.createElement( ViewReceiptModal, { transaction: billingData.getTransaction( transactionId ) } ),
+				React.createElement( Provider, { store: context.store },
+					React.createElement( ViewReceiptModal, { transaction: billingData.getTransaction( transactionId ) } )
+				),
 				document.getElementById( 'tertiary' )
 			);
 		} else {


### PR DESCRIPTION
Currently, visiting `/me/billing` and clicking to view a receipt currently causes an uncaught error and doesn't bring up the receipt. This is because `NoticesList` requires access to the global state, and is a grandchild of `ViewReceiptModal` (via `Overlay`).

Eventually, we should rewrite this page to avoid using an `Overlay` (`ViewReceiptModal` is the only component that still uses one), but in the mean time, this fixes the error.

Fixes #1943.

**Testing**
- Visit `/me/billing` and click 'View Receipt' by a receipt in the list of receipts.
- Assert that the receipt appears in an overlay.