### PR TITLE
Framework: Add a `context.render` wrapper for `ReactDom.render`

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -88,6 +88,12 @@ function setUpContext( layout, reduxStore ) {
 
 		context.layout = layout;
 		context.store = reduxStore;
+		context.render = ( reactElement, domContainerNode ) => {
+			return ReactDom.render(
+				React.createElement( ReduxProvider, { store: reduxStore }, reactElement ),
+				domContainerNode
+			);
+		};
 
 		// Break routing and do full page load for logout link in /me
 		if ( context.pathname === '/wp-login.php' ) {

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -281,7 +281,7 @@ export default {
 		if ( transactionId ) {
 			analytics.pageView.record( basePath + '/receipt', ANALYTICS_PAGE_TITLE + ' > Billing History > Receipt' );
 
-			ReactDom.render(
+			context.render(
 				React.createElement( ViewReceiptModal, { transaction: billingData.getTransaction( transactionId ) } ),
 				document.getElementById( 'tertiary' )
 			);


### PR DESCRIPTION
This PR adds a `context.render` function, a simple wrapper for `ReactDom.render` which injects the `ReduxStore` using `react-redux`'s `Provider`.

This could be another way of fixing issue https://github.com/Automattic/wp-calypso/issues/1943
So let's discuss it!