### PR TITLE
JavaScript: Fix redefinitions of properties

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-status/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/index.jsx
@@ -90,7 +90,6 @@ const PlanStatus = React.createClass( {
 					</div>
 
 					<Button
-						primary={ getDaysUntilUserFacingExpiry( this.props.plan ) < 6 }
 						className="plan-status__button"
 						onClick={ this.purchasePlan }
 						primary>


### PR DESCRIPTION
`make translate` fails because of the redefinitions of properties (see  #1874).

I have fixed them in this PR, could you check if I correctly improved your changes?

@breezyskies you committed the introduction of the double defined property `primary` in `client/my-sites/plans/plan-overview/plan-status/index.jsx` here: https://github.com/Automattic/wp-calypso/commit/918f116cc1eefc8c52e86243673b4a6053d79336
The `primary` property should now always be true, correct?

@johnHackworth you introduced the double definition of `pluginUpdateCount` in `client/my-sites/plugins/plugin-list-header/index.jsx` here: https://github.com/Automattic/wp-calypso/commit/174279a1f3a245d5cf360cf02469266253a2225b
I assume the `pluginUpdateCount` is meant to be required, eventhough with the current code it is overwritten with a not required propType?

Thanks!