### PR TITLE
Framework: Introduce new rules to warn about duplicate properties

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,6 +53,7 @@
 		"react/jsx-uses-react": 1,
 		"react/jsx-uses-vars": 1,
 		"react/jsx-no-undef": 2,
+		"react/jsx-no-duplicate-props": 1,
 		"react/react-in-jsx-scope": 2,
 		"react/no-did-mount-set-state": 1,
 		"react/no-did-update-set-state": 1,


### PR DESCRIPTION
In order to prevent double defined properties that cause `acorn` to complain (and thus lets `make translate` fail, see #1874 and #1950), let's introduce these rules that warn about it.

--
`"no-dupe-keys": 1` causes a
```
  45:3  warning  Duplicate key 'pluginUpdateCount'   no-dupe-keys
```
see http://eslint.org/docs/rules/no-dupe-keys

--

`"react/jsx-no-duplicate-props": 1` causes a
```
  97:7   warning  No duplicate props allowed               react/jsx-no-duplicate-props
```
see https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md
