### PR TITLE
DNS: Domains: pass boolean instead of string to isError

### DIFF
--- a/client/my-sites/upgrades/domain-management/dns/a-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/a-record.jsx
@@ -40,7 +40,7 @@ const ARecord = React.createClass( {
 			<div className={ classes }>
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError="true" /> : null }
+					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="name"
 						onChange={ onChange( 'name' ) }
@@ -50,7 +50,7 @@ const ARecord = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Points To' ) }</FormLabel>
-					{ ! isValid( 'data' ) ? <FormInputValidation text={ this.translate( 'Invalid IP' ) } isError="true" /> : null }
+					{ ! isValid( 'data' ) ? <FormInputValidation text={ this.translate( 'Invalid IP' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="data"
 						onChange={ onChange( 'data' ) }

--- a/client/my-sites/upgrades/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/cname-record.jsx
@@ -35,7 +35,7 @@ const CnameRecord = React.createClass( {
 			<div className={ classes }>
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Host', { context: 'Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError="true" /> : null }
+					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="name"
 						onChange={ this.props.onChange( 'name' ) }
@@ -45,7 +45,7 @@ const CnameRecord = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Alias Of' ) }</FormLabel>
-					{ ! isValid( 'data' ) ? <FormInputValidation text={ this.translate( 'Invalid Target Host' ) } isError="true" /> : null }
+					{ ! isValid( 'data' ) ? <FormInputValidation text={ this.translate( 'Invalid Target Host' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="data"
 						onChange={ this.props.onChange( 'data' ) }

--- a/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
@@ -38,7 +38,7 @@ const MxRecord = React.createClass( {
 			<div className={ classes }>
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Host', { context: 'MX Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError="true" /> : null }
+					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="name"
 						onChange={ this.props.onChange( 'name' ) }
@@ -48,7 +48,7 @@ const MxRecord = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Handled by', { context: 'MX Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'data' ) ? <FormInputValidation text={ this.translate( 'Invalid Mail Server' ) } isError="true" /> : null }
+					{ ! isValid( 'data' ) ? <FormInputValidation text={ this.translate( 'Invalid Mail Server' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="data"
 						onChange={ this.props.onChange( 'data' ) }
@@ -58,7 +58,7 @@ const MxRecord = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Priority', { context: 'MX Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'aux' ) ? <FormInputValidation text={ this.translate( 'Invalid Priority' ) } isError="true" /> : null }
+					{ ! isValid( 'aux' ) ? <FormInputValidation text={ this.translate( 'Invalid Priority' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="aux"
 						onChange={ this.props.onChange( 'aux' ) }

--- a/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
@@ -45,7 +45,7 @@ const SrvRecord = React.createClass( {
 			<div className={ classes }>
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError="true" /> : null }
+					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="name"
 						onChange={ this.props.onChange( 'name' ) }
@@ -55,7 +55,7 @@ const SrvRecord = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Service', { context: 'Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'service' ) ? <FormInputValidation text={ this.translate( 'Invalid Service' ) } isError="true" /> : null }
+					{ ! isValid( 'service' ) ? <FormInputValidation text={ this.translate( 'Invalid Service' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="service"
 						onChange={ this.props.onChange( 'service' ) }
@@ -76,7 +76,7 @@ const SrvRecord = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Priority', { context: 'Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'aux' ) ? <FormInputValidation text={ this.translate( 'Invalid Priority' ) } isError="true" /> : null }
+					{ ! isValid( 'aux' ) ? <FormInputValidation text={ this.translate( 'Invalid Priority' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="aux"
 						onChange={ this.props.onChange( 'aux' ) }
@@ -86,7 +86,7 @@ const SrvRecord = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Weight', { context: 'Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'weight' ) ? <FormInputValidation text={ this.translate( 'Invalid Weight' ) } isError="true" /> : null }
+					{ ! isValid( 'weight' ) ? <FormInputValidation text={ this.translate( 'Invalid Weight' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="weight"
 						onChange={ this.props.onChange( 'weight' ) }
@@ -96,7 +96,7 @@ const SrvRecord = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Target Host', { context: 'Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'target' ) ? <FormInputValidation text={ this.translate( 'Invalid Target Host' ) } isError="true" /> : null }
+					{ ! isValid( 'target' ) ? <FormInputValidation text={ this.translate( 'Invalid Target Host' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="target"
 						onChange={ this.props.onChange( 'target' ) }
@@ -106,7 +106,7 @@ const SrvRecord = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Target Port', { context: 'Dns Record' } ) }</FormLabel>
-					{ ! isValid( 'port' ) ? <FormInputValidation text={ this.translate( 'Invalid Target Port' ) } isError="true" /> : null }
+					{ ! isValid( 'port' ) ? <FormInputValidation text={ this.translate( 'Invalid Target Port' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="port"
 						onChange={ this.props.onChange( 'port' ) }

--- a/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
@@ -38,7 +38,7 @@ const TxtRecord = React.createClass( {
 			<div className={ classes }>
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record TXT' } ) }</FormLabel>
-					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError="true" /> : null }
+					{ ! isValid( 'name' ) ? <FormInputValidation text={ this.translate( 'Invalid Name' ) } isError={ true } /> : null }
 					<FormTextInput
 						name="name"
 						onChange={ this.props.onChange( 'name' ) }
@@ -54,7 +54,7 @@ const TxtRecord = React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Text', { context: 'Dns Record TXT' } ) }</FormLabel>
-					{ ! isValid( 'data' ) ? <FormInputValidation text={ this.translate( 'Invalid TXT Record' ) } isError="true" /> : null }
+					{ ! isValid( 'data' ) ? <FormInputValidation text={ this.translate( 'Invalid TXT Record' ) } isError={ true } /> : null }
 					<FormTextarea
 						name="data"
 						onChange={ this.props.onChange( 'data' ) }


### PR DESCRIPTION
A boolean is expected, as per [`form-input-validation`'s `propTypes`](https://github.com/Automattic/wp-calypso/blob/master/client/components/forms/form-input-validation/index.jsx#L17), not a string. Otherwise, an error is displayed in the console.