### PR TITLE
Framework: Add a react render helper aware of the redux store

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -5,7 +5,6 @@ var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	store = require( 'store' ),
 	ReactInjection = require( 'react/lib/ReactInjection' ),
-	ReduxProvider = require( 'react-redux' ).Provider,
 	some = require( 'lodash/collection/some' ),
 	startsWith = require( 'lodash/string/startsWith' ),
 	classes = require( 'component-classes' ),
@@ -40,6 +39,7 @@ var config = require( 'config' ),
 	accessibleFocus = require( 'lib/accessible-focus' ),
 	TitleStore = require( 'lib/screen-title/store' ),
 	createReduxStore = require( 'state' ).createReduxStore,
+	ReactHelpers = require('lib/react-helpers'),
 	// The following mixins require i18n content, so must be required after i18n is initialized
 	Layout,
 	LoggedOutLayout;
@@ -183,9 +183,10 @@ function boot() {
 		layoutElement = React.createElement( LoggedOutLayout );
 	}
 
-	layout = ReactDom.render(
-		React.createElement( ReduxProvider, { store: reduxStore }, layoutElement ),
-		document.getElementById( 'wpcom' )
+	layout = ReactHelpers.renderWithReduxStore(
+		layoutElement,
+		document.getElementById( 'wpcom' ),
+		reduxStore
 	);
 
 	debug( 'Main layout rendered.' );

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
+var React = require( 'react' ),
 	store = require( 'store' ),
 	ReactInjection = require( 'react/lib/ReactInjection' ),
 	some = require( 'lodash/collection/some' ),
@@ -39,7 +38,7 @@ var config = require( 'config' ),
 	accessibleFocus = require( 'lib/accessible-focus' ),
 	TitleStore = require( 'lib/screen-title/store' ),
 	createReduxStore = require( 'state' ).createReduxStore,
-	ReactHelpers = require('lib/react-helpers'),
+	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
 	// The following mixins require i18n content, so must be required after i18n is initialized
 	Layout,
 	LoggedOutLayout;
@@ -183,7 +182,7 @@ function boot() {
 		layoutElement = React.createElement( LoggedOutLayout );
 	}
 
-	layout = ReactHelpers.renderWithReduxStore(
+	layout = renderWithReduxStore(
 		layoutElement,
 		document.getElementById( 'wpcom' ),
 		reduxStore

--- a/client/lib/react-helpers/index.js
+++ b/client/lib/react-helpers/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import ReactDom from 'react-dom';
+import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+
+export default {
+	renderWithReduxStore( reactElement, domContainer, reduxStore ) {
+		const domContainerNode = ( 'string' === typeof domContainer )
+				? document.getElementById( domContainer )
+				: domContainer;
+
+		return ReactDom.render(
+			React.createElement( ReduxProvider, { store: reduxStore }, reactElement ),
+			domContainerNode
+		);
+	}
+};

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -19,7 +19,7 @@ import purchasesController from './purchases/controller';
 import userFactory from 'lib/user';
 import userSettings from 'lib/user-settings';
 import titleActions from 'lib/screen-title/actions';
-import { Provider } from 'react-redux';
+import ReactHelpers from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
 
 const ANALYTICS_PAGE_TITLE = 'Me',
@@ -31,12 +31,13 @@ export default {
 	sidebar( context, next ) {
 		const SidebarComponent = require( 'me/sidebar' );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( SidebarComponent, {
 				user,
 				context: context
 			} ),
-			document.getElementById( 'secondary' )
+			document.getElementById( 'secondary' ),
+			context.store
 		);
 
 		context.store.dispatch( setSection( 'me' ) );
@@ -52,14 +53,15 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > My Profile' );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( ProfileComponent,
 				{
 					userSettings: userSettings,
 					path: context.path
 				}
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -82,7 +84,7 @@ export default {
 			analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Account Settings' );
 		}
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( AccountComponent,
 				{
 					userSettings: userSettings,
@@ -91,7 +93,8 @@ export default {
 					showNoticeInitially: showNoticeInitially
 				}
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -110,7 +113,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Password' );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( PasswordComponent,
 				{
 					userSettings: userSettings,
@@ -118,7 +121,8 @@ export default {
 					accountPasswordData: accountPasswordData
 				}
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -131,7 +135,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Two-Step Authentication' );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( TwoStepComponent,
 				{
 					userSettings: userSettings,
@@ -139,7 +143,8 @@ export default {
 					appPasswordsData: appPasswordsData
 				}
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -152,7 +157,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Connected Applications' );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( ConnectedAppsComponent,
 				{
 					userSettings: userSettings,
@@ -160,7 +165,8 @@ export default {
 					connectedAppsData: connectedAppsData
 				}
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -172,14 +178,15 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Security Checkup' );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( CheckupComponent,
 				{
 					userSettings: userSettings,
 					path: context.path
 				}
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -191,17 +198,16 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications' );
 
-		ReactDom.render(
-			React.createElement( Provider, { store: context.store },
-				React.createElement( NotificationsComponent, {
-					user: user,
-					userSettings: userSettings,
-					blogs: sites,
-					devices: devices,
-					path: context.path
-				} )
-			),
-			document.getElementById( 'primary' )
+		ReactHelpers.renderWithReduxStore(
+			React.createElement( NotificationsComponent, {
+				user: user,
+				userSettings: userSettings,
+				blogs: sites,
+				devices: devices,
+				path: context.path
+			} ),
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -213,7 +219,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Comments on other sites' );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( CommentSettingsComponent,
 				{
 					user: user,
@@ -221,7 +227,8 @@ export default {
 					path: context.path
 				}
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -233,7 +240,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Updates from WordPress.com' );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( WPcomSettingsComponent,
 				{
 					user: user,
@@ -241,7 +248,8 @@ export default {
 					path: context.path
 				}
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -253,14 +261,15 @@ export default {
 
 		analytics.ga.recordPageView( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Comments on other sites' );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( NotificationSubscriptions,
 				{
 					userSettings: userSettings,
 					path: context.path
 				}
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -273,19 +282,19 @@ export default {
 
 		titleActions.setTitle( i18n.translate( 'Billing History', { textOnly: true } ) );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( BillingHistoryComponent, { billingData: billingData, sites: sites } ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 
 		if ( transactionId ) {
 			analytics.pageView.record( basePath + '/receipt', ANALYTICS_PAGE_TITLE + ' > Billing History > Receipt' );
 
-			ReactDom.render(
-				React.createElement( Provider, { store: context.store },
-					React.createElement( ViewReceiptModal, { transaction: billingData.getTransaction( transactionId ) } )
-				),
-				document.getElementById( 'tertiary' )
+			ReactHelpers.renderWithReduxStore(
+				React.createElement( ViewReceiptModal, { transaction: billingData.getTransaction( transactionId ) } ),
+				document.getElementById( 'tertiary' ),
+				context.store
 			);
 		} else {
 			analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Billing History' );
@@ -310,13 +319,14 @@ export default {
 		analytics.tracks.recordEvent( 'calypso_me_next_view', { is_welcome: isWelcome } );
 		analytics.pageView.record( analyticsBasePath, ANALYTICS_PAGE_TITLE + ' > Next' );
 
-		ReactDom.render(
+		ReactHelpers.renderWithReduxStore(
 			React.createElement( NextSteps, {
 				path: context.path,
 				isWelcome: isWelcome,
 				trophiesData: trophiesData
 			} ),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -19,7 +19,7 @@ import purchasesController from './purchases/controller';
 import userFactory from 'lib/user';
 import userSettings from 'lib/user-settings';
 import titleActions from 'lib/screen-title/actions';
-import ReactHelpers from 'lib/react-helpers';
+import { renderWithReduxStore } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
 
 const ANALYTICS_PAGE_TITLE = 'Me',
@@ -31,7 +31,7 @@ export default {
 	sidebar( context, next ) {
 		const SidebarComponent = require( 'me/sidebar' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( SidebarComponent, {
 				user,
 				context: context
@@ -53,7 +53,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > My Profile' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( ProfileComponent,
 				{
 					userSettings: userSettings,
@@ -84,7 +84,7 @@ export default {
 			analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Account Settings' );
 		}
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( AccountComponent,
 				{
 					userSettings: userSettings,
@@ -113,7 +113,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Password' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( PasswordComponent,
 				{
 					userSettings: userSettings,
@@ -135,7 +135,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Two-Step Authentication' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( TwoStepComponent,
 				{
 					userSettings: userSettings,
@@ -157,7 +157,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Connected Applications' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( ConnectedAppsComponent,
 				{
 					userSettings: userSettings,
@@ -178,7 +178,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Security Checkup' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( CheckupComponent,
 				{
 					userSettings: userSettings,
@@ -198,7 +198,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( NotificationsComponent, {
 				user: user,
 				userSettings: userSettings,
@@ -219,7 +219,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Comments on other sites' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( CommentSettingsComponent,
 				{
 					user: user,
@@ -240,7 +240,7 @@ export default {
 
 		analytics.pageView.record( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Updates from WordPress.com' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( WPcomSettingsComponent,
 				{
 					user: user,
@@ -261,7 +261,7 @@ export default {
 
 		analytics.ga.recordPageView( basePath, ANALYTICS_PAGE_TITLE + ' > Notifications > Comments on other sites' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( NotificationSubscriptions,
 				{
 					userSettings: userSettings,
@@ -282,7 +282,7 @@ export default {
 
 		titleActions.setTitle( i18n.translate( 'Billing History', { textOnly: true } ) );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( BillingHistoryComponent, { billingData: billingData, sites: sites } ),
 			document.getElementById( 'primary' ),
 			context.store
@@ -291,7 +291,7 @@ export default {
 		if ( transactionId ) {
 			analytics.pageView.record( basePath + '/receipt', ANALYTICS_PAGE_TITLE + ' > Billing History > Receipt' );
 
-			ReactHelpers.renderWithReduxStore(
+			renderWithReduxStore(
 				React.createElement( ViewReceiptModal, { transaction: billingData.getTransaction( transactionId ) } ),
 				document.getElementById( 'tertiary' ),
 				context.store
@@ -319,7 +319,7 @@ export default {
 		analytics.tracks.recordEvent( 'calypso_me_next_view', { is_welcome: isWelcome } );
 		analytics.pageView.record( analyticsBasePath, ANALYTICS_PAGE_TITLE + ' > Next' );
 
-		ReactHelpers.renderWithReduxStore(
+		renderWithReduxStore(
 			React.createElement( NextSteps, {
 				path: context.path,
 				isWelcome: isWelcome,


### PR DESCRIPTION
This is another version for a helper renderer after https://github.com/Automattic/wp-calypso/pull/1946

The `renderWithReduxStore` helper function in `lib/react-helpers` should help us remove boilerplate code. This is useful since we have multiple root elements and thus multiple calls to `ReactDom.render` and each would benefits from having the store injected using `react-redux`'s provider.

Moreover, it should avoid us repeating easy mistakes related to accessing the store from a component which is used in multiple context (some of them are not using the ReduxProvider yet).

Product Review:

- `git checkout try/redux-renderer-helper`
- Go to `http://calypso.localhost:3000/me`, visit each page and check that there are no errors in the console
- Go to the `/me/billing` page and click on "View Receipt". Check that there is no error in the console such as https://github.com/Automattic/wp-calypso/issues/1943


- [x] Product Review.
- [x] Code Review.
