### PR TITLE
Email Verification: Fix a broken placeholder

### DIFF
--- a/client/components/email-verification/email-verification-notice.jsx
+++ b/client/components/email-verification/email-verification-notice.jsx
@@ -83,8 +83,8 @@ module.exports = React.createClass( {
 		if ( this.state.emailSent ) {
 			user = this.props.user.get();
 			noticeText = this.translate(
-				'We sent another confirmation email to {{email /}}',
-				{ components: { email: user.email } }
+				'We sent another confirmation email to %(email)s.',
+				{ args: { email: user.email } }
 			);
 			notices.success( noticeText );
 		}


### PR DESCRIPTION
When a user signs up for a wordpress.com account but doesn't activate right away, a notice is displayed inviting the user to activate or have the activation email resent. At present, when the user clicks the link to resend the email, a template placeholder is displayed instead of the email address that's supposed to be displayed.

How to repro:

1. Sign up for a new wordpress.com account.
2. Visit http://calypso.localhost:3000/ and observe the big blue notice at the top of the screen.
3. Click the "Re-send your activation email" link.

It looks like this:

![activation-email-broken](https://cloud.githubusercontent.com/assets/2738252/12023350/9215aa1c-ad66-11e5-8365-e0354bf9b6e9.png)


With the fix supplied in this PR, the notice displayed after the link looks like this (address redacted):

![activation-fixed](https://cloud.githubusercontent.com/assets/2738252/12023359/aa0c0850-ad66-11e5-9886-cef6fb961c89.png)

I also incidentally here add a period to the end of the string since it's a sentence.