### PR TITLE
Redux: devTools awesomeness

### DIFF
--- a/client/state/index.js
+++ b/client/state/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import thunkMiddleware from 'redux-thunk';
-import { createStore, applyMiddleware, combineReducers } from 'redux';
+import { createStore, applyMiddleware, combineReducers, compose } from 'redux';
 
 /**
  * Internal dependencies
@@ -27,9 +27,19 @@ const reducer = combineReducers( {
 	ui
 } );
 
+var createStoreWithMiddleware = applyMiddleware(
+	thunkMiddleware,
+	analyticsMiddleware
+);
+
 export function createReduxStore() {
-	return applyMiddleware(
-		thunkMiddleware,
-		analyticsMiddleware
-	)( createStore )( reducer );
+	if (
+		typeof window === 'object' &&
+		window.app &&
+		window.app.isDebug &&
+		window.devToolsExtension
+	) {
+		createStoreWithMiddleware = compose( createStoreWithMiddleware, window.devToolsExtension() );
+	}
+	return createStoreWithMiddleware( createStore )( reducer );
 };


### PR DESCRIPTION
# What?
This PR enables redux store devtools connnection using chrome plugin
With this merged, you will be able to see all the store mutations in chrome devTools!


This is what you can do with it:
![](https://raw.githubusercontent.com/zalmoxisus/redux-devtools-extension/master/demo/v0.1.0.gif)


## Pics or it didnt happen
![](https://cldup.com/0f9OB5l6xB-3000x3000.png)

## Testing

1. Install chrome plugin: https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd
2. Restart chrome
3. Load Calypso
4. Open devTools
5. Click "Redux"
6. See all the store mutations

CC @aduth, @gziolo, @Tug, @jordwest, - this may be useful for you