### PR TITLE
Domain Management: Fix misaligned trash button and use borderless version for consistency

### DIFF
--- a/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-item.jsx
@@ -36,7 +36,7 @@ const EmailForwardingItem = React.createClass( {
 	render: function() {
 		return (
 			<li>
-				<Button disabled={ this.props.emailData.temporary } onClick={ this.deleteItem }>
+				<Button borderless disabled={ this.props.emailData.temporary } onClick={ this.deleteItem }>
 					<Gridicon icon="trash" />
 				</Button>
 				<span>{ this.translate( '{{strong1}}%(email)s{{/strong1}} {{em}}forwards to{{/em}} {{strong2}}%(forwardTo)s{{/strong2}}',

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -624,9 +624,9 @@ ul.email-forwarding__list {
 			}
 		}
 
-		.button-remove {
+		.button {
 			float: right;
-			margin-top: -2px;
+			margin-top: -3px;
 		}
 	}
 }


### PR DESCRIPTION
Fixes the misaligned trash button in the email forwarding section of domain management. I also changed the button to `borderless` to make it consistent with the ones we've started using throughout domain management.

Before | After
------------ | -------------
<img width="741" alt="screen_shot_2015-12-29_at_8_53_19_am" src="https://cloud.githubusercontent.com/assets/3011211/12038230/2736732a-ae0b-11e5-9bbb-87f306eddeeb.png"> | <img width="735" alt="screen_shot_2015-12-29_at_9_00_23_am" src="https://cloud.githubusercontent.com/assets/3011211/12038231/274a1678-ae0b-11e5-8f28-bdf00b266e21.png">
