### PR TITLE
Plugins: Fix IE error duplicate object property definition

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
 		"key-spacing": 1,
 		"new-cap": [ 1, { "capIsNew": false, "newIsCap": true } ],
 		"no-cond-assign": 2,
+		"no-dupe-keys": 2,
 		"no-else-return": 1,
 		"no-empty": 1,
 		// Flux stores use switch case fallthrough

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -41,8 +41,7 @@ export default React.createClass( {
 		sites: React.PropTypes.object.isRequired,
 		plugins: React.PropTypes.array.isRequired,
 		selected: React.PropTypes.array.isRequired,
-		isWpCom: React.PropTypes.bool,
-		pluginUpdateCount: React.PropTypes.number
+		isWpCom: React.PropTypes.bool
 	},
 
 	onBrowserLinkClick() {


### PR DESCRIPTION
Fix for #2025.

When in My Sites when attempting to purchase a domain/mapping they see the loading icon in the masterbar but are stuck in a perpetual state and the proper screen never loads. All these users were on Windows.

In https://github.com/Automattic/wp-calypso/commit/174279a1f3a245d5cf360cf02469266253a2225b#diff-4ecd5ad58f6397fea7d06d2b23322417R31 there was duplicated `propTypes` key added. Which causes errors under IE 11 browser.

As part of this change I also enabled ESLint rule `no-dupe-keys` which is going to prevent such issues in the future.

### Testing
On Windows and IE 11:
1. Go to My Sites.
2. Go to Plugins.
3. Go to Domains Management and try to purchase domain.
There should be no errors.