### PR TITLE
Accessibility: Add title attribute to web-preview's iframe

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -37,7 +37,9 @@ const WebPreview = React.createClass( {
 		// Called when the preview is closed, either via the 'X' button or the escape key
 		onClose: React.PropTypes.func,
 		// Optional loading message to display during loading
-		loadingMessage: React.PropTypes.string
+		loadingMessage: React.PropTypes.string,
+		// The iframe's title element, used for accessibility purposes
+		iframeTitle: React.PropTypes.string
 	},
 
 	mixins: [ PureRenderMixin ],
@@ -174,6 +176,7 @@ const WebPreview = React.createClass( {
 								className="web-preview__frame"
 								src={ this.state.iframeUrl }
 								onLoad={ this.setLoaded }
+								title={ this.props.iframeTitle || this.translate( 'Preview' ) }
 							/>
 						}
 					</div>


### PR DESCRIPTION
This is to fix #1994. Props to @SiobhyB for the research and suggestion there.

How to test:
1. Start a new post: http://calypso.localhost:3000/post/
2. Write randomly on the post title box to make the Preview button clickable
3. Click the Preview button
4. Inspect element the iframe inside the preview popup, and it should now display a `title="Preview"` attribute, like so:

![screen shot 2015-12-30 at 5 14 30 pm](https://cloud.githubusercontent.com/assets/266376/12049777/a261655a-af1e-11e5-826a-b6eeaac1d865.png)

Question: Do we need to make the "Preview" text translatable as well?
