### PR TITLE
Framework: Bundler loader: Refactor

### DIFF
--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -13,16 +13,19 @@ function getSectionsModule( sections ) {
 			"\tReact = require( 'react' ),",
 			"\tLoadingError = require( 'layout/error' ),",
 			"\tclasses = require( 'component-classes' );",
-			'\n',
+			'',
 			'var _loadedSections = {};'
 		].join( '\n' );
 
-		sections.forEach( function( section ) {
-			loadSection += ensureTemplate( section.name );
-			section.paths.forEach( function( path ) {
-				sectionLoaders += splitTemplate( path, section.module, section.name );
-			} );
-		} );
+		loadSection = sections.map( function( section ) {
+			return ensureTemplate( section.name );
+		} ).join( ' ' );
+
+		sectionLoaders = sections.map( function( section ) {
+			return section.paths.map( function( path ) {
+				return splitTemplate( path, section.module, section.name );
+			} )
+		} ).reduce( function( acc, section ) { return acc.concat( section ); }, [] );
 	} else {
 		sectionLoaders = getRequires( sections );
 	}

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -63,8 +63,8 @@ function getRouteHandlers( sections ) {
 	return sections.map( function( section ) {
 		return section.paths.map( function( path ) {
 			return pageTemplate( path, section.module, section.name );
-		} )
-	} ).reduce( function( acc, section ) { return acc.concat( section ); }, [] );
+		} ).join( '\n' );
+	} ).join( '\n' );
 }
 
 function pageTemplate( path, module, chunkName ) {

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -46,13 +46,9 @@ function getSectionsModule( sections ) {
 }
 
 function getRequires( sections ) {
-	var content = '';
-
-	sections.forEach( function( section ) {
-		content += requireTemplate( section.module );
-	} );
-
-	return content;
+	return sections.map( function( section ) {
+		return requireTemplate( section.module );
+	} ).join( '' );
 }
 
 function splitTemplate( path, module, chunkName ) {

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -18,7 +18,7 @@ function getSectionsModule( sections ) {
 		].join( '\n' );
 
 		sections.forEach( function( section ) {
-			loadSection += singleEnsure( section.name );
+			loadSection += ensureTemplate( section.name );
 			section.paths.forEach( function( path ) {
 				sectionLoaders += splitTemplate( path, section.module, section.name );
 			} );
@@ -100,14 +100,12 @@ function requireTemplate( module ) {
 	return 'require( ' + JSON.stringify( module ) + ' )();\n';
 }
 
-function singleEnsure( chunkName ) {
-	var result = [
+function ensureTemplate( chunkName ) {
+	return [
 		'case ' + JSON.stringify( chunkName ) + ':',
 		'	return require.ensure([], function() {}, ' + JSON.stringify( chunkName ) + ' );',
-		'	break;\n'
-	];
-
-	return result.join( '\n' );
+		'	break;'
+	].join( '\n' );
 }
 
 module.exports = function( content ) {


### PR DESCRIPTION
Depends on #1561

This PR aims to improve readability of `server/bundler/loader.js`, via clearer naming, new functions, and preferring map/reduce-chaining over stateful `forEach` iterations. Note that, for now, any changes in other files are imported from the parent PR mentioned above.

As code clarity is, to some extent, subjective, I welcome feedback on whether this is helpful.