### PR TITLE
Domain Management: Fix spacing issues in SectionHeader when setting the primary domain

### DIFF
--- a/client/my-sites/upgrades/domain-management/primary-domain/index.jsx
+++ b/client/my-sites/upgrades/domain-management/primary-domain/index.jsx
@@ -88,9 +88,8 @@ const PrimaryDomain = React.createClass( {
 				{ this.errors() }
 
 				<SectionHeader
-					label={ this.translate( 'Make {{em}}%(domainName)s{{/em}} the Primary Domain', {
-						args: { domainName: this.props.selectedDomainName },
-						components: { em: <em /> }
+					label={ this.translate( 'Make %(domainName)s the Primary Domain', {
+						args: { domainName: this.props.selectedDomainName }
 					} ) } />
 
 				<Card className="primary-domain-card">


### PR DESCRIPTION
The `<em>` tag applied to the domain name was getting caught up by `display: flex` on the parent div. 

I removed the italics, as it was pretty hard to read in all caps, which fixed the spacing issue.

Before:
<img width="718" alt="screen shot 2015-12-30 at 7 55 05 am" src="https://cloud.githubusercontent.com/assets/3011211/12053122/ae3e335c-aeca-11e5-91b8-e1fa8e568a73.png">

After:
<img width="723" alt="screen shot 2015-12-30 at 7 54 34 am" src="https://cloud.githubusercontent.com/assets/3011211/12053121/ae2a8780-aeca-11e5-89ea-1828fd189f8a.png">

Fixes https://github.com/Automattic/wp-calypso/issues/1930. cc: @scruffian 