### PR TITLE
masterbar/stats-item: ES6ify some more, rename to stats

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -8,7 +8,7 @@ import React from 'react';
  */
 import Masterbar from './masterbar';
 import Item from './item';
-import StatsItem from './stats-item';
+import Stats from './stats';
 import Publish from './publish';
 import Notifications from './notifications';
 import Gravatar from 'components/gravatar';
@@ -61,7 +61,7 @@ export default React.createClass( {
 	render() {
 		return (
 			<Masterbar>
-				<StatsItem
+				<Stats
 					icon={ this.wordpressIcon() }
 					onClick={ this.clickMySites }
 					isActive={ this.isActive( 'sites' ) }
@@ -71,7 +71,7 @@ export default React.createClass( {
 						? this.translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 						: this.translate( 'My Site', { comment: 'Toolbar, must be shorter than ~12 chars' } )
 					}
-				</StatsItem>
+				</Stats>
 				<Item
 					url="/"
 					icon="reader"

--- a/client/layout/masterbar/stats-item.jsx
+++ b/client/layout/masterbar/stats-item.jsx
@@ -16,21 +16,21 @@ export default React.createClass( {
 		children: PropTypes.node
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			url: siteStatsStickyTabStore.getUrl()
 		};
 	},
 
-	componentDidMount: function() {
+	componentDidMount() {
 		siteStatsStickyTabStore.on( 'change', this.handleStatsStickyTabChange );
 	},
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		siteStatsStickyTabStore.off( 'change', this.handleStatsStickyTabChange );
 	},
 
-	handleStatsStickyTabChange: function() {
+	handleStatsStickyTabChange() {
 		var url = siteStatsStickyTabStore.getUrl();
 
 		if ( url !== this.state.url ) {
@@ -40,7 +40,7 @@ export default React.createClass( {
 		}
 	},
 
-	render: function() {
+	render() {
 		return (
 			<Item { ...this.props } url={ this.state.url }>
 				{ this.props.children }

--- a/client/layout/masterbar/stats.jsx
+++ b/client/layout/masterbar/stats.jsx
@@ -10,7 +10,7 @@ import Item from './item';
 import siteStatsStickyTabStore from 'lib/site-stats-sticky-tab/store';
 
 export default React.createClass( {
-	displayName: 'MasterbarStatsItem',
+	displayName: 'MasterbarStats',
 
 	propTypes: {
 		children: PropTypes.node


### PR DESCRIPTION
No visual changes.

To test:

Check that the masterbar works as before (both logged in and out -- i.e. incognito browser window, calypso.localhost:3000/start)

Meant to finish off #1326

cc @ehg