### PR TITLE
Signup: Use `ReactCSSTransitionGroup` instead of `TimeoutTransitionGroup`

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -4,7 +4,7 @@
 import debugModule from 'debug';
 const debug = debugModule( 'calypso:signup' );
 import React from 'react';
-import TimeoutTransitionGroup from 'timeout-transition-group';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import page from 'page';
 import startsWith from 'lodash/string/startsWith';
 import sortBy from 'lodash/collection/sortBy';
@@ -328,13 +328,13 @@ const Signup = React.createClass( {
 						positionInFlow={ this.positionInFlow() }
 						flowName={ this.props.flowName } />
 				}
-				<TimeoutTransitionGroup
+				<ReactCSSTransitionGroup
 					className="signup__steps"
 					transitionName="signup__step"
-					enterTimeout={ 500 }
-					leaveTimeout={ 300 }>
+					transitionEnterTimeout={ 500 }
+					transitionLeaveTimeout={ 300 }>
 					{ this.currentStep() }
-				</TimeoutTransitionGroup>
+				</ReactCSSTransitionGroup>
 				{ this.loginForm() }
 			</span>
 		);


### PR DESCRIPTION
The latter seems to have broken signup, possibly due to an unchecked dependency downstream. We can switch back to `ReactCSSTransitionGroup` now because it allows us to use explicit timeouts, and doing so fixes the issue.

We also use `TimeoutTransitionGroup` in `PostImages`, so it can't be removed as a dependency yet.

**Testing**
- `make distclean`
- `npm cache clean`
- `make run`
- Assert that you can sign up successfully through `/start`