### PR TITLE
Framework: Remove `TimeoutTransitionGroup` in favor of `ReactCSSTransitionGroup`

### DIFF
--- a/client/reader/post-images/index.jsx
+++ b/client/reader/post-images/index.jsx
@@ -7,7 +7,7 @@ var ReactDom = require( 'react-dom' ),
 	resizeImageUrl = require( 'lib/resize-image-url' ),
 	classes = require( 'component-classes' ),
 	domScrollIntoView = require( 'dom-scroll-into-view' ),
-	TimeoutTransitionGroup = require( 'timeout-transition-group' );
+	ReactCSSTransitionGroup = require( 'react-addons-css-transition-group' );
 
 /**
  * Internal dependencies
@@ -145,16 +145,16 @@ var PostImages = React.createClass( {
 					className="reader-post-images__full-list"
 					ref={ ( c ) => this._fullListContainer = c } >
 					<span className="reader-post-images__close">{ this.translate( 'Close' ) }</span>
-					<TimeoutTransitionGroup
+					<ReactCSSTransitionGroup
 						ref={ ( c ) => this._fullList = c }
 						component="ol"
-						enterTimeout={ 200 }
-						leaveTimeout={ 200 }
+						transitionEnterTimeout={ 200 }
+						transitionLeaveTimeout={ 200 }
 						transitionName="gallery-image"
 						transitionEnter={ true }
 						transitionLeave={ true }>
 						{ fullList }
-					</TimeoutTransitionGroup>
+					</ReactCSSTransitionGroup>
 				</div>
 			</div>
 		);

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "source-map-support": "0.3.2",
     "store": "1.3.16",
     "superagent": "1.2.0",
-    "timeout-transition-group": "2.0.1",
     "tinymce": "4.2.8",
     "to-title-case": "0.1.5",
     "tween.js": "16.3.1",


### PR DESCRIPTION
Now that `ReactCSSTransitionGroup` accepts explicit timeout values, we have no use of the `TimeoutTransitionGroup`, which is causing errors, likely due to some downstream dependency update.

**Reproducing the bug**
On https://wordpress.com/
- Visit the reader through `/` or one of the streams.
- Scroll through your feed until you see a post containing images.
- Click on the 'View Gallery' link below the post:

![screen shot 2015-12-30 at 11 18 47 am](https://cloud.githubusercontent.com/assets/1130674/12056083/db3e2340-aee7-11e5-91d2-6b1f426b2aee.png)
- Assert that you see [errors](https://cloudup.com/cmH-20i78EE) in the console.

**Testing**
- Checkout this branch.
- Restart the Calypso server.
- Assert that you do not see errors in the console when following the previous instructions locally.

cc @blowery