### PR TITLE
Domain Management: Update domain list item styles to be consistent with Purchases

### DIFF
--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -49,20 +49,10 @@
 	white-space: nowrap;
 }
 
-.domain-management-list-item.card {
-	padding: 0;
-	@include clear-fix;
-}
-
 .domain-management-list-item__link {
 	cursor: pointer;
 	display: block;
-	padding: 16px;
 	overflow: hidden;
-
-	@include breakpoint( ">660px" ) {
-		padding: 24px;
-	}
 
 	&:after {
 		@include noticon( '\f431', 25px );
@@ -76,7 +66,7 @@
 		transform: rotate( -90deg );
 
 		@include breakpoint( ">660px" ) {
-			line-height: 103px;
+			line-height: 83px;
 		}
 	}
 }
@@ -92,7 +82,7 @@
 	max-width: 70%;
 
 	@include breakpoint( ">480px" ) {
-		font-size: 24px;
+		font-size: 18px;
 		font-weight: 700;
 		font-family: $serif;
 		max-width: none;


### PR DESCRIPTION
Makes the following changes to the domains list to be more consistent with the styles on `/purchases`:
- Removes the compact card padding override on each of the domain items in the list
- Reduces the font size of the domain name

Before | After
------------ | -------------
<img width="726" alt="screen shot 2015-12-30 at 2 45 25 pm" src="https://cloud.githubusercontent.com/assets/3011211/12058745/0198d9d8-af04-11e5-8cf4-45775df72362.png"> | <img width="725" alt="screen shot 2015-12-30 at 2 43 57 pm" src="https://cloud.githubusercontent.com/assets/3011211/12058746/019b2d3c-af04-11e5-803c-b8335b0bf1e2.png">

cc: @mikeshelton1503 