### PR TITLE
Free Trials: Show upgrade notice on domain search and in cart during trial

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -2,7 +2,22 @@
  * External dependencies
  */
 import find from 'lodash/collection/find';
+import page from 'page';
 import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { addItem } from 'lib/upgrades/actions';
+import { cartItems } from 'lib/cart-values';
+
+export function addCurrentPlanToCartAndRedirect( sitePlans, selectedSite, event ) {
+	event.preventDefault();
+
+	addItem( cartItems.planItem( getCurrentPlan( sitePlans.data ).productSlug ) );
+
+	page( `/checkout/${ selectedSite.slug }` );
+}
 
 export function getCurrentPlan( plans ) {
 	return find( plans, { currentPlan: true } );

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -18,6 +18,12 @@ export function getCurrentTrialPeriodInDays( plan ) {
 	return userFacingExpiryMoment.diff( subscribedDayMoment, 'days' );
 };
 
+export function getDaysSinceTrialStarted( plan ) {
+	const { subscribedDayMoment } = plan;
+
+	return moment().startOf( 'day' ).diff( subscribedDayMoment, 'days' );
+};
+
 export function getDaysUntilUserFacingExpiry( plan ) {
 	const { userFacingExpiryMoment } = plan;
 

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -11,9 +11,7 @@ import moment from 'moment';
 import { addItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
 
-export function addCurrentPlanToCartAndRedirect( sitePlans, selectedSite, event ) {
-	event.preventDefault();
-
+export function addCurrentPlanToCartAndRedirect( sitePlans, selectedSite ) {
 	addItem( cartItems.planItem( getCurrentPlan( sitePlans.data ).productSlug ) );
 
 	page( `/checkout/${ selectedSite.slug }` );

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -33,10 +33,11 @@ export function getCurrentTrialPeriodInDays( plan ) {
 	return userFacingExpiryMoment.diff( subscribedDayMoment, 'days' );
 };
 
-export function getDaysSinceTrialStarted( plan ) {
+export function getDayOfTrial( plan ) {
 	const { subscribedDayMoment } = plan;
 
-	return moment().startOf( 'day' ).diff( subscribedDayMoment, 'days' );
+	// we return the difference plus one day so that the first day is day 1 instead of day 0
+	return moment().startOf( 'day' ).diff( subscribedDayMoment, 'days' ) + 1;
 };
 
 export function getDaysUntilUserFacingExpiry( plan ) {

--- a/client/my-sites/upgrades/cart/cart-trial-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-trial-ad.jsx
@@ -10,42 +10,58 @@ import { cartItems } from 'lib/cart-values';
 import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDayOfTrial } from 'lib/plans';
 import i18n from 'lib/mixins/i18n';
 
-const CartTrialAd = ( { cart, sitePlans, selectedSite } ) => {
-	const isDataLoading = ! sitePlans.hasLoadedFromServer || ! cart.hasLoadedFromServer,
-		currentPlan = getCurrentPlan( sitePlans.data );
+const CartTrialAd = React.createClass( {
+	propTypes: {
+		cart: React.PropTypes.object.isRequired,
+		sitePlans: React.PropTypes.object.isRequired,
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.object,
+			React.PropTypes.bool
+		] ).isRequired
+	},
 
-	if ( isDataLoading ||
-		! currentPlan.freeTrial ||
-		cartItems.getDomainRegistrations( cart ).length !== 1 ||
-		cartItems.hasPlan( cart ) ) {
-		// we return `<noscript />` here because we can't return null in a stateless component
-		// see https://github.com/facebook/react/issues/5355#issuecomment-152949327
-		return <noscript />;
+	addPlanAndRedirect( event ) {
+		event.preventDefault();
+
+		addCurrentPlanToCartAndRedirect( this.props.sitePlans, this.props.selectedSite );
+	},
+
+	render() {
+		const { cart, sitePlans } = this.props,
+			isDataLoading = ! sitePlans.hasLoadedFromServer || ! cart.hasLoadedFromServer,
+			currentPlan = getCurrentPlan( sitePlans.data );
+
+		if ( isDataLoading ||
+			! currentPlan.freeTrial ||
+			cartItems.getDomainRegistrations( cart ).length !== 1 ||
+			cartItems.hasPlan( cart ) ) {
+			return null;
+		}
+
+		return (
+			<div className="popover-cart__cart-trial-ad">
+				{
+					i18n.translate( 'You are currently on day %(days)d of your {{strong}}%(planName)s trial{{/strong}}.', {
+						components: { strong: <strong /> },
+						args: {
+							days: getDayOfTrial( currentPlan ),
+							planName: currentPlan.productName
+						}
+					} )
+				}
+				{ ' ' }
+				{
+					i18n.translate( 'Get this domain for free when you upgrade.' )
+				}
+				{ ' ' }
+				<a
+					href="#"
+					onClick={ this.addPlanAndRedirect }>
+						{ i18n.translate( 'Upgrade Now' ) }
+				</a>
+			</div>
+		);
 	}
-
-	return (
-		<div className="popover-cart__cart-trial-ad">
-			{
-				i18n.translate( 'You are currently on day %(days)d of your {{strong}}%(planName)s trial{{/strong}}.', {
-					components: { strong: <strong /> },
-					args: {
-						days: getDayOfTrial( currentPlan ),
-						planName: currentPlan.productName
-					}
-				} )
-			}
-			{ ' ' }
-			{
-				i18n.translate( 'Get this domain for free when you upgrade.' )
-			}
-			{ ' ' }
-			<a
-				href="#"
-				onClick={ addCurrentPlanToCartAndRedirect.bind( null, sitePlans, selectedSite ) }>
-					{ i18n.translate( 'Upgrade Now' ) }
-			</a>
-		</div>
-	);
-};
+} );
 
 export default CartTrialAd;

--- a/client/my-sites/upgrades/cart/cart-trial-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-trial-ad.jsx
@@ -7,7 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { cartItems } from 'lib/cart-values';
-import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDaysSinceTrialStarted } from 'lib/plans';
+import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDayOfTrial } from 'lib/plans';
 import i18n from 'lib/mixins/i18n';
 
 const CartTrialAd = ( { cart, sitePlans, selectedSite } ) => {
@@ -28,7 +28,7 @@ const CartTrialAd = ( { cart, sitePlans, selectedSite } ) => {
 				i18n.translate( 'You are currently on day %(days)d of your {{strong}}%(planName)s trial{{/strong}}.', {
 					components: { strong: <strong /> },
 					args: {
-						days: getDaysSinceTrialStarted( currentPlan ),
+						days: getDayOfTrial( currentPlan ),
 						planName: currentPlan.productName
 					}
 				} )

--- a/client/my-sites/upgrades/cart/cart-trial-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-trial-ad.jsx
@@ -1,26 +1,16 @@
 /**
  * External dependencies
  */
-import page from 'page';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
 import { cartItems } from 'lib/cart-values';
-import { getCurrentPlan, getDaysSinceTrialStarted } from 'lib/plans';
+import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDaysSinceTrialStarted } from 'lib/plans';
 import i18n from 'lib/mixins/i18n';
-import { addItem } from 'lib/upgrades/actions';
 
 const CartTrialAd = ( { cart, sitePlans, selectedSite } ) => {
-	function addToCartAndRedirect( event ) {
-		event.preventDefault();
-
-		addItem( cartItems.planItem( getCurrentPlan( sitePlans.data ).productSlug ) );
-
-		page( `/checkout/${ selectedSite.slug }` );
-	}
-
 	const isDataLoading = ! sitePlans.hasLoadedFromServer || ! cart.hasLoadedFromServer,
 		currentPlan = getCurrentPlan( sitePlans.data );
 
@@ -48,7 +38,11 @@ const CartTrialAd = ( { cart, sitePlans, selectedSite } ) => {
 				i18n.translate( 'Get this domain for free when you upgrade.' )
 			}
 			{ ' ' }
-			<a href="#" onClick={ addToCartAndRedirect }>{ i18n.translate( 'Upgrade Now' ) }</a>
+			<a
+				href="#"
+				onClick={ addCurrentPlanToCartAndRedirect.bind( null, sitePlans, selectedSite ) }>
+					{ i18n.translate( 'Upgrade Now' ) }
+			</a>
 		</div>
 	);
 };

--- a/client/my-sites/upgrades/cart/cart-trial-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-trial-ad.jsx
@@ -16,7 +16,8 @@ const CartTrialAd = ( { cart, sitePlans, selectedSite } ) => {
 
 	if ( isDataLoading ||
 		! currentPlan.freeTrial ||
-		cartItems.getDomainRegistrations( cart ).length !== 1 ) {
+		cartItems.getDomainRegistrations( cart ).length !== 1 ||
+		cartItems.hasPlan( cart ) ) {
 		// we return `<noscript />` here because we can't return null in a stateless component
 		// see https://github.com/facebook/react/issues/5355#issuecomment-152949327
 		return <noscript />;

--- a/client/my-sites/upgrades/cart/cart-trial-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-trial-ad.jsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { cartItems } from 'lib/cart-values';
+import { getCurrentPlan, getDaysSinceTrialStarted } from 'lib/plans';
+import i18n from 'lib/mixins/i18n';
+import { addItem } from 'lib/upgrades/actions';
+
+const CartTrialAd = ( { cart, sitePlans, selectedSite } ) => {
+	function addToCartAndRedirect( event ) {
+		event.preventDefault();
+
+		addItem( cartItems.planItem( getCurrentPlan( sitePlans.data ).productSlug ) );
+
+		page( `/checkout/${ selectedSite.slug }` );
+	}
+
+	const isDataLoading = ! sitePlans.hasLoadedFromServer || ! cart.hasLoadedFromServer,
+		currentPlan = getCurrentPlan( sitePlans.data );
+
+	if ( isDataLoading ||
+		! currentPlan.freeTrial ||
+		cartItems.getDomainRegistrations( cart ).length !== 1 ) {
+		// we return `<noscript />` here because we can't return null in a stateless component
+		// see https://github.com/facebook/react/issues/5355#issuecomment-152949327
+		return <noscript />;
+	}
+
+	return (
+		<div className="popover-cart__cart-trial-ad">
+			{
+				i18n.translate( 'You are currently on day %(days)d of your {{strong}}%(planName)s trial{{/strong}}.', {
+					components: { strong: <strong /> },
+					args: {
+						days: getDaysSinceTrialStarted( currentPlan ),
+						planName: currentPlan.productName
+					}
+				} )
+			}
+			{ ' ' }
+			{
+				i18n.translate( 'Get this domain for free when you upgrade.' )
+			}
+			{ ' ' }
+			<a href="#" onClick={ addToCartAndRedirect }>{ i18n.translate( 'Upgrade Now' ) }</a>
+		</div>
+	);
+};
+
+export default CartTrialAd;

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	connect = require( 'react-redux' ).connect,
 	reject = require( 'lodash/collection/reject' ),
 	classNames = require( 'classnames' );
 
@@ -14,8 +15,10 @@ var CartBody = require( './cart-body' ),
 	Popover = require( 'components/popover' ),
 	CartEmpty = require( './cart-empty' ),
 	CartPlanAd = require( './cart-plan-ad' ),
+	CartTrialAd = require( './cart-trial-ad' ),
 	isCredits = require( 'lib/products-values' ).isCredits,
-	Gridicon = require( 'components/gridicon' );
+	Gridicon = require( 'components/gridicon' ),
+	getPlansBySiteId = require( 'state/sites/plans/selectors' ).getPlansBySiteId;
 
 var PopoverCart = React.createClass( {
 	propTypes: {
@@ -108,6 +111,7 @@ var PopoverCart = React.createClass( {
 
 		return (
 			<div>
+				<CartTrialAd cart={ this.props.cart } sitePlans={ this.props.sitePlans } selectedSite={ this.props.selectedSite } />
 				<CartPlanAd cart={ this.props.cart } selectedSite={ this.props.selectedSite } />
 
 				<CartBody
@@ -140,4 +144,10 @@ var PopoverCart = React.createClass( {
 	}
 } );
 
-module.exports = PopoverCart;
+module.exports = connect(
+	( state, props ) => {
+		return {
+			sitePlans: getPlansBySiteId( state, props.selectedSite.ID )
+		};
+	}
+)( PopoverCart );

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -18,6 +18,7 @@ var CartBody = require( './cart-body' ),
 	CartTrialAd = require( './cart-trial-ad' ),
 	isCredits = require( 'lib/products-values' ).isCredits,
 	Gridicon = require( 'components/gridicon' ),
+	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
 	getPlansBySiteId = require( 'state/sites/plans/selectors' ).getPlansBySiteId;
 
 var PopoverCart = React.createClass( {
@@ -33,6 +34,10 @@ var PopoverCart = React.createClass( {
 		pinned: React.PropTypes.bool.isRequired,
 		showKeepSearching: React.PropTypes.bool.isRequired,
 		onKeepSearchingClick: React.PropTypes.func.isRequired
+	},
+
+	componentDidMount: function() {
+		this.props.fetchSitePlans( this.props.selectedSite.ID );
 	},
 
 	itemCount: function() {
@@ -151,9 +156,14 @@ var PopoverCart = React.createClass( {
 } );
 
 module.exports = connect(
-	( state, props ) => {
+	function( state, props ) {
+		return { sitePlans: getPlansBySiteId( state, props.selectedSite.ID ) };
+	},
+	function( dispatch ) {
 		return {
-			sitePlans: getPlansBySiteId( state, props.selectedSite.ID )
+			fetchSitePlans( siteId ) {
+				dispatch( fetchSitePlans( siteId ) );
+			}
 		};
 	}
 )( PopoverCart );

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -111,8 +111,14 @@ var PopoverCart = React.createClass( {
 
 		return (
 			<div>
-				<CartTrialAd cart={ this.props.cart } sitePlans={ this.props.sitePlans } selectedSite={ this.props.selectedSite } />
-				<CartPlanAd cart={ this.props.cart } selectedSite={ this.props.selectedSite } />
+				<CartTrialAd
+					cart={ this.props.cart }
+					selectedSite={ this.props.selectedSite }
+					sitePlans={ this.props.sitePlans } />
+
+				<CartPlanAd
+					cart={ this.props.cart }
+					selectedSite={ this.props.selectedSite } />
 
 				<CartBody
 					collapse={ true }

--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -139,7 +139,8 @@
 	font-size: 14px;
 }
 
-.cart-plan-ad {
+.cart-plan-ad,
+.popover-cart__cart-trial-ad {
 	background: lighten( $gray, 34% );
 	border: 1px solid lighten( $gray, 30% );
 	border-radius: 4px;

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -54,7 +54,7 @@ module.exports = {
 
 		analytics.pageView.record( basePath, 'Domain Search > Domain Registration' );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			(
 				<CartData>
 					<DomainSearch
@@ -64,7 +64,8 @@ module.exports = {
 						productsList={ productsList } />
 				</CartData>
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -19,6 +19,7 @@ import NameserversData from 'components/data/domain-management/nameservers';
 import paths from 'my-sites/upgrades/paths';
 import PrimaryDomainData from 'components/data/domain-management/primary-domain';
 import ProductsList from 'lib/products-list';
+import { renderWithReduxStore } from 'lib/react-helpers';
 import SiteRedirectData from 'components/data/domain-management/site-redirect';
 import SitesList from 'lib/sites-list';
 import TransferData from 'components/data/domain-management/transfer';
@@ -54,12 +55,14 @@ module.exports = {
 			'Domain Management'
 		);
 
-		renderPage(
+		renderWithReduxStore(
 			<DomainManagementData
 				component={ DomainManagement.List }
 				context={ context }
 				productsList={ productsList }
-				sites={ sites } />
+				sites={ sites } />,
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -157,13 +160,15 @@ module.exports = {
 			'Domain Management › Email'
 		);
 
-		renderPage(
+		renderWithReduxStore(
 			<EmailData
 				component={ DomainManagement.Email }
 				productsList={ productsList }
 				selectedDomainName={ context.params.domain }
 				context={ context }
-				sites={ sites } />
+				sites={ sites } />,
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var page = require( 'page' ),
+var connect = require( 'react-redux' ).connect,
+	page = require( 'page' ),
 	React = require( 'react' ),
 	classnames = require( 'classnames' );
 
@@ -10,14 +11,15 @@ var page = require( 'page' ),
  */
 var observe = require( 'lib/mixins/data-observe' ),
 	EmptyContent = require( 'components/empty-content' ),
+	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
+	FreeTrialNotice = require( './free-trial-notice' ),
+	getPlansBySiteId = require( 'state/sites/plans/selectors' ).getPlansBySiteId,
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	RegisterDomainStep = require( 'components/domains/register-domain-step' ),
 	UpgradesNavigation = require( 'my-sites/upgrades/navigation' ),
 	Main = require( 'components/main' );
 
-module.exports = React.createClass( {
-	displayName: 'DomainSearch',
-
+var DomainSearch = React.createClass( {
 	mixins: [ observe( 'productsList', 'sites' ) ],
 
 	propTypes: {
@@ -37,6 +39,7 @@ module.exports = React.createClass( {
 
 	componentDidMount: function() {
 		this.props.sites.on( 'change', this.checkSiteIsUpgradeable );
+		this.props.fetchSitePlans( this.props.sites.getSelectedSite().ID );
 	},
 
 	componentWillUnmount: function() {
@@ -73,22 +76,29 @@ module.exports = React.createClass( {
 			);
 		} else {
 			content = (
-				<div className="domain-search__content">
-					<UpgradesNavigation
-						path={ this.props.context.path }
+				<span>
+					<FreeTrialNotice
 						cart={ this.props.cart }
+						sitePlans={ this.props.sitePlans }
 						selectedSite={ selectedSite } />
 
-					<RegisterDomainStep
-						path={ this.props.context.path }
-						suggestion={ this.props.context.params.suggestion }
-						onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
-						cart={ this.props.cart }
-						selectedSite={ selectedSite }
-						offerMappingOption
-						basePath={ this.props.basePath }
-						products={ this.props.productsList.get() } />
-				</div>
+					<div className="domain-search__content">
+						<UpgradesNavigation
+							path={ this.props.context.path }
+							cart={ this.props.cart }
+							selectedSite={ selectedSite } />
+
+						<RegisterDomainStep
+							path={ this.props.context.path }
+							suggestion={ this.props.context.params.suggestion }
+							onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
+							cart={ this.props.cart }
+							selectedSite={ selectedSite }
+							offerMappingOption
+							basePath={ this.props.basePath }
+							products={ this.props.productsList.get() } />
+					</div>
+				</span>
 			);
 		}
 
@@ -100,3 +110,16 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+module.exports = connect(
+	function( state, props ) {
+		return { sitePlans: getPlansBySiteId( state, props.sites.getSelectedSite().ID ) };
+	},
+	function( dispatch ) {
+		return {
+			fetchSitePlans( siteId ) {
+				dispatch( fetchSitePlans( siteId ) );
+			}
+		};
+	}
+)( DomainSearch );

--- a/client/my-sites/upgrades/domain-search/free-trial-notice.jsx
+++ b/client/my-sites/upgrades/domain-search/free-trial-notice.jsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDaysSinceTrialStarted } from 'lib/plans';
+import i18n from 'lib/mixins/i18n';
+import Notice from 'components/notice';
+
+const FreeTrialNotice = ( { cart, selectedSite, sitePlans } ) => {
+	const isDataLoading = ! cart.hasLoadedFromServer || ! sitePlans.hasLoadedFromServer,
+		currentPlan = getCurrentPlan( sitePlans.data );
+
+	if ( isDataLoading || ! currentPlan.freeTrial ) {
+		return <noscript />;
+	}
+
+	return (
+		<Notice
+			status="is-info"
+			showDismiss={ false }>
+			{
+				i18n.translate( 'You are currently on day %(day)d of your %(planName)s trial.', {
+					args: {
+						day: getDaysSinceTrialStarted( currentPlan ),
+						planName: currentPlan.productName
+					}
+				} )
+			}
+			{ ' ' }
+			{
+				i18n.translate( 'Get a free domain when you {{a}}upgrade{{/a}}.', {
+					components: {
+						a: <a
+							href="#"
+							onClick={ addCurrentPlanToCartAndRedirect.bind( null, sitePlans, selectedSite ) } />
+					}
+				} )
+			}
+		</Notice>
+	);
+};
+
+export default FreeTrialNotice;

--- a/client/my-sites/upgrades/domain-search/free-trial-notice.jsx
+++ b/client/my-sites/upgrades/domain-search/free-trial-notice.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDaysSinceTrialStarted } from 'lib/plans';
+import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDayOfTrial } from 'lib/plans';
 import i18n from 'lib/mixins/i18n';
 import Notice from 'components/notice';
 
@@ -25,7 +25,7 @@ const FreeTrialNotice = ( { cart, selectedSite, sitePlans } ) => {
 			{
 				i18n.translate( 'You are currently on day %(day)d of your %(planName)s trial.', {
 					args: {
-						day: getDaysSinceTrialStarted( currentPlan ),
+						day: getDayOfTrial( currentPlan ),
 						planName: currentPlan.productName
 					}
 				} )

--- a/client/my-sites/upgrades/domain-search/free-trial-notice.jsx
+++ b/client/my-sites/upgrades/domain-search/free-trial-notice.jsx
@@ -10,38 +10,56 @@ import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDayOfTrial } from '
 import i18n from 'lib/mixins/i18n';
 import Notice from 'components/notice';
 
-const FreeTrialNotice = ( { cart, selectedSite, sitePlans } ) => {
-	const isDataLoading = ! cart.hasLoadedFromServer || ! sitePlans.hasLoadedFromServer,
-		currentPlan = getCurrentPlan( sitePlans.data );
+const FreeTrialNotice = React.createClass( {
+	propTypes: {
+		cart: React.PropTypes.object.isRequired,
+		sitePlans: React.PropTypes.object.isRequired,
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.object,
+			React.PropTypes.bool
+		] ).isRequired
+	},
 
-	if ( isDataLoading || ! currentPlan.freeTrial ) {
-		return <noscript />;
+	addPlanAndRedirect( event ) {
+		event.preventDefault();
+
+		addCurrentPlanToCartAndRedirect( this.props.sitePlans, this.props.selectedSite );
+	},
+
+	render() {
+		const { cart, sitePlans } = this.props,
+			isDataLoading = ! cart.hasLoadedFromServer || ! sitePlans.hasLoadedFromServer,
+			currentPlan = getCurrentPlan( sitePlans.data );
+
+		if ( isDataLoading || ! currentPlan.freeTrial ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				status="is-info"
+				showDismiss={ false }>
+				{
+					i18n.translate( 'You are currently on day %(day)d of your %(planName)s trial.', {
+						args: {
+							day: getDayOfTrial( currentPlan ),
+							planName: currentPlan.productName
+						}
+					} )
+				}
+				{ ' ' }
+				{
+					i18n.translate( 'Get a free domain when you {{a}}upgrade{{/a}}.', {
+						components: {
+							a: <a
+								href="#"
+								onClick={ this.addPlanAndRedirect } />
+						}
+					} )
+				}
+			</Notice>
+		);
 	}
-
-	return (
-		<Notice
-			status="is-info"
-			showDismiss={ false }>
-			{
-				i18n.translate( 'You are currently on day %(day)d of your %(planName)s trial.', {
-					args: {
-						day: getDayOfTrial( currentPlan ),
-						planName: currentPlan.productName
-					}
-				} )
-			}
-			{ ' ' }
-			{
-				i18n.translate( 'Get a free domain when you {{a}}upgrade{{/a}}.', {
-					components: {
-						a: <a
-							href="#"
-							onClick={ addCurrentPlanToCartAndRedirect.bind( null, sitePlans, selectedSite ) } />
-					}
-				} )
-			}
-		</Notice>
-	);
-};
+} );
 
 export default FreeTrialNotice;


### PR DESCRIPTION
Fixes #1119.

![screen shot 2015-12-30 at 5 11 57 pm](https://cloud.githubusercontent.com/assets/1130674/12059902/5ee268ba-af19-11e5-913e-98d451161b37.png)

This PR:
- Adds a notice above `DomainSearch` when the user has a free trial.
- Adds a message in `PopoverCart` when the user has a free trial and a domain in their cart.

**Testing**
- Assert that the top notice in the screenshot is displayed to sites with a free trial on `DomainSearch`.
- Assert that the message in the cart in the screenshot is displayed in `PopoverCart` to sites with a free trial that have a single domain in their cart.

- [x] Product review
- [x] Code review