### PR TITLE
Reader: Strip autoplay attributes from audio and video elements

### DIFF
--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -29,6 +29,7 @@ var fastPostNormalizationRules = [
 			postNormalizer.content.safeContentImages( READER_CONTENT_WIDTH ),
 			postNormalizer.content.makeEmbedsSecure,
 			postNormalizer.content.disableAutoPlayOnEmbeds,
+			postNormalizer.content.disableAutoPlayOnMedia,
 			postNormalizer.content.detectEmbeds,
 			postNormalizer.content.wordCountAndReadingTime
 		] ),

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -676,6 +676,19 @@ normalizePost.content = {
 		callback();
 	},
 
+	disableAutoPlayOnMedia: function disableAutoPlayOnMedia( post, callback ) {
+		if ( ! post.__contentDOM ) {
+			throw new Error( 'this transform must be used as part of withContentDOM' );
+		}
+
+		let mediaElements = toArray( post.__contentDOM.querySelectorAll( 'audio, video' ) );
+		mediaElements.forEach( function( mediaElement ) {
+			mediaElement.autoplay = false;
+		} );
+
+		callback();
+	},
+
 	disableAutoPlayOnEmbeds: function disableAutoPlayOnEmbeds( post, callback ) {
 		if ( ! post.__contentDOM ) {
 			throw new Error( 'this transform must be used as part of withContentDOM' );

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -280,6 +280,34 @@ describe( 'post-normalizer', function() {
 		} );
 	} );
 
+	describe( 'content.disableAutoPlayOnMediaShortcodes', function() {
+		it( 'should strip autoplay attributes from video', function( done ) {
+			normalizer(
+				{
+					content: '<video autoplay="1"></video>'
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.disableAutoPlayOnMedia ] ) ],
+				function( err, normalized ) {
+					assert.deepEqual( normalized, { content: '<video></video>' } );
+					done( err );
+				}
+			)
+		} );
+
+		it( 'should strip autoplay attributes from audio', function( done ) {
+			normalizer(
+				{
+					content: '<audio autoplay="1"></audio>'
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.disableAutoPlayOnMedia ] ) ],
+				function( err, normalized ) {
+					assert.deepEqual( normalized, { content: '<audio></audio>' } );
+					done( err );
+				}
+			)
+		} );
+	} );
+
 	describe( 'the content normalizer (withContentDOM)', function() {
 		it( 'should not call nested transforms if content is blank', function( done ) {
 			var post = {


### PR DESCRIPTION
This PR aims to fix #980

During post normalization strip autoplay attributes from
both audio and video elements to prevent them from
autoplaying.

I'm seeking feedback on my potential solution of adding another
content normalizer function that explicitly sets the `autoplay` of
all `video` and `audio` elements to `false`.

I opted not to try to repurpose the `stripAutoPlays` function in use
for stripping autoplay from embedded iframes as that is particularly
targeted at stripping autoplay from the query params of the iframe
url.

Is this the desired way to approach this issue? Also, should I add this
content normalizer to the `fastPostNormalizationRules`?

Thanks for the feedback.