### PR TITLE
Themes: Add feature example in jetpack version error screen

### DIFF
--- a/shared/components/themes-list/style.scss
+++ b/shared/components/themes-list/style.scss
@@ -4,6 +4,11 @@
 	list-style: none;
 	padding: 0;
 	margin: 0 -10px; // items flush against list edge
+
+	.feature-example & {
+		max-width: 1000px;
+		margin: auto;
+	}
 }
 
 .themes-list--spacer {
@@ -12,3 +17,4 @@
 	margin: 0 10px;
 	flex-grow: 1;
 }
+

--- a/shared/my-sites/themes/jetpack-manage-disabled-message.jsx
+++ b/shared/my-sites/themes/jetpack-manage-disabled-message.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import noop from 'lodash/utility/noop';
 
 /**
  * Internal dependencies
@@ -10,6 +11,7 @@ import analytics from 'analytics';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import ThemesList from 'components/themes-list';
 
 export default React.createClass( {
 	displayName: 'JetpackManageDisabledMessage',
@@ -21,8 +23,35 @@ export default React.createClass( {
 		} ).isRequired
 	},
 
-	clickOnActivate: function() {
+	clickOnActivate() {
 		analytics.ga.recordEvent( 'Jetpack', 'Activate manage', 'Site', this.props.site ? this.props.site.ID : null );
+	},
+
+	renderMockThemes() {
+		const exampleThemesData = [
+			{ name: 'Boardwalk', slug: 'boardwalk' },
+			{ name: 'Cubic', slug: 'cubic' },
+			{ name: 'Edin', slug: 'edin' },
+			{ name: 'Cols', slug: 'cols' },
+			{ name: 'Minnow', slug: 'minnow' },
+			{ name: 'Sequential', slug: 'sequential' },
+			{ name: 'Penscratch', slug: 'penscratch' },
+			{ name: 'Intergalactic', slug: 'intergalactic' },
+			{ name: 'Eighties', slug: 'eighties' }
+		];
+		const themes = exampleThemesData.map( function( theme ) {
+			return {
+				id: theme.slug,
+				name: theme.name,
+				screenshot: 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + theme.slug + '/screenshot.png?w=660'
+			}
+		} );
+		return (
+			<ThemesList themes={ themes }
+				getButtonOptions={ noop }
+				onScreenshotClick= { noop }
+				onMoreButtonClick= { noop } />
+		);
 	},
 
 	render() {
@@ -38,7 +67,7 @@ export default React.createClass( {
 					secondaryActionURL={ this.props.site.options.admin_url + 'themes.php' }
 					secondaryActionTarget="_blank"
 					actionCallback={ this.clickOnActivate }
-				/>
+					featureExample={ this.renderMockThemes() } />
 			</Main>
 		);
 	}

--- a/shared/my-sites/themes/jetpack-manage-disabled-message.jsx
+++ b/shared/my-sites/themes/jetpack-manage-disabled-message.jsx
@@ -32,7 +32,6 @@ export default React.createClass( {
 			{ name: 'Boardwalk', slug: 'boardwalk' },
 			{ name: 'Cubic', slug: 'cubic' },
 			{ name: 'Edin', slug: 'edin' },
-			{ name: 'Cols', slug: 'cols' },
 			{ name: 'Minnow', slug: 'minnow' },
 			{ name: 'Sequential', slug: 'sequential' },
 			{ name: 'Penscratch', slug: 'penscratch' },


### PR DESCRIPTION
This PR adds a feature example showing the theme browser to the error screen showed to the jetpack sites which doesn't have a recent version of jetpack:

Before:
![image](https://cloud.githubusercontent.com/assets/1554855/12064158/3978aed8-afbc-11e5-9392-e6ed83409c44.png)

After:
![image](https://cloud.githubusercontent.com/assets/1554855/12064161/4130f950-afbc-11e5-95ff-e026cd639db7.png)
