### PR TITLE
Jetpack: Don't redirect to /sites if you are disconnecting a non-selected site

### DIFF
--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
@@ -39,14 +39,15 @@ module.exports = React.createClass( {
 	},
 
 	disconnectJetpack: function() {
-		var jetpackSites = sites.getJetpack();
+		var jetpackSites = sites.getJetpack(),
+			selectedSite = sites.getSelectedSite();
 
 		// remove any error and completed notices
 		SitesListActions.removeSitesNotices( [ { status: 'error' }, { status: 'completed' } ] );
 
 		if ( this.props.site ) {
 			SitesListActions.disconnect( this.props.site );
-			if ( this.props.redirect && jetpackSites.some( this.jetpackSiteRemain ) ) {
+			if ( selectedSite === this.props.site && this.props.redirect && jetpackSites.some( this.jetpackSiteRemain ) ) {
 				page.redirect( this.props.redirect );
 				return;
 			}
@@ -55,7 +56,9 @@ module.exports = React.createClass( {
 				SitesListActions.disconnect( site );
 			} );
 		}
-		page.redirect( '/sites' );
+		if ( selectedSite === this.props.site ) {
+			page.redirect( '/sites' );
+		}
 	},
 
 	render: function() {
@@ -90,8 +93,7 @@ module.exports = React.createClass( {
 				isVisible={ this.state.showJetpackDisconnectDialog }
 				buttons={ deactivationButtons }
 				onClose={ this.close }
-				transitionLeave={ false }
-			>
+				transitionLeave={ false }>
 				<h1>{ this.translate( 'Disconnect Jetpack' ) }</h1>
 				<p>{ moreInfo }</p>
 			</Dialog>

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-dialog.jsx
@@ -34,20 +34,15 @@ module.exports = React.createClass( {
 		}
 	},
 
-	jetpackSiteRemain: function( site ) {
-		return site.capabilities && site.capabilities.manage_options && site.ID !== this.props.site.ID;
-	},
-
 	disconnectJetpack: function() {
-		var jetpackSites = sites.getJetpack(),
-			selectedSite = sites.getSelectedSite();
+		var selectedSite = sites.getSelectedSite();
 
 		// remove any error and completed notices
 		SitesListActions.removeSitesNotices( [ { status: 'error' }, { status: 'completed' } ] );
 
 		if ( this.props.site ) {
 			SitesListActions.disconnect( this.props.site );
-			if ( selectedSite === this.props.site && this.props.redirect && jetpackSites.some( this.jetpackSiteRemain ) ) {
+			if ( selectedSite === this.props.site && this.props.redirect ) {
 				page.redirect( this.props.redirect );
 				return;
 			}


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/1755

When you are disconnecting a site from the site indicator on the sidebar, you always get redirected to /sites once it's done. If the current selected site is not the one being disconnected, this can be very confusing. 

This PR makes that you only get redirected if the disconnected site is the same one that is currently selected.

How to test
=========
1. You need a jetpack site which can't be accessed
2. Select any other site
3. Open the site selector, and click in the red round warning next to your unaccesible site name
4. Disconnect the site
5. You should not be redirected.

Repeat this proccess with the same site selected, and you should be redirected to /sites once you disconnect it.

@roccotripaldi @lezama 