### PR TITLE
Editor: Fix tags bug by using correct container for blur event

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -69,8 +69,18 @@ var TokenField = React.createClass( {
 		} );
 
 		return (
-			<div className={ classes } tabIndex="-1" onKeyDown={ this._onKeyDown } onBlur={ this._onBlur } onFocus={ this._onFocus }>
-				<div ref="tokensAndInput" className="token-field__input-container" onClick={ this._onClick } tabIndex="-1">
+			<div ref="main"
+				className={ classes }
+				tabIndex="-1"
+				onKeyDown={ this._onKeyDown }
+				onBlur={ this._onBlur }
+				onFocus={ this._onFocus }
+			>
+				<div ref="tokensAndInput"
+					className="token-field__input-container"
+					onClick={ this._onClick }
+					tabIndex="-1"
+				>
 					{ this._renderTokensAndInput() }
 				</div>
 				<SuggestionsList
@@ -81,7 +91,8 @@ var TokenField = React.createClass( {
 					scrollIntoView={ this.state.selectedSuggestionScroll }
 					isExpanded={ this.state.isActive }
 					onHover={ this._onSuggestionHovered }
-					onSelect={ this._onSuggestionSelected } />
+					onSelect={ this._onSuggestionSelected }
+				/>
 			</div>
 		);
 	},
@@ -127,7 +138,7 @@ var TokenField = React.createClass( {
 	},
 
 	_onBlur: function( event ) {
-		var stillActive = event.target.contains( event.relatedTarget );
+		var stillActive = this.refs.main.contains( event.relatedTarget );
 
 		if ( stillActive ) {
 			debug( '_onBlur but component still active; not doing anything' );

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -138,7 +138,11 @@ var TokenField = React.createClass( {
 	},
 
 	_onBlur: function( event ) {
-		var stillActive = this.refs.main.contains( event.relatedTarget );
+		var blurSource = event.relatedTarget ||
+			event.nativeEvent.explicitOriginalTarget || // FF
+			document.activeElement; // IE11
+
+		var stillActive = this.refs.main.contains( blurSource );
 
 		if ( stillActive ) {
 			debug( '_onBlur but component still active; not doing anything' );

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -270,6 +270,7 @@ describe( 'TokenField', function() {
 				expect( wrapper.refs.tokenField.state.isActive ).to.equal( isActive );
 			}
 
+			document.activeElement = document.body;
 			TestUtils.Simulate.blur( textInputNode );
 			setTimeout( function() {
 				// After blur, need to wait for TokenField#_blurTimeoutID


### PR DESCRIPTION
Fixes #1884, and other strange behavior, which I suspect is also related to the following forum threads:

- https://en.forums.wordpress.com/topic/problem-with-adding-new-tags#post-2517598 (partly)
- https://en.forums.wordpress.com/topic/i-am-not-able-to-add-tags-anymore-what-is-going-on

| Chrome | Safari |
|---|---|
| The tag suggestion list flickers when you select a tag, and sometimes the tag you select doesn't get added. <br /> <img width="250" src="https://cloud.githubusercontent.com/assets/227022/12069446/e6fcd078-aff5-11e5-9445-4d53a911036d.gif"> | The tag suggestion list disappears when you select a tag, and sometimes the tag you select doesn't get added. <br /> <img width="250" src="https://cloud.githubusercontent.com/assets/227022/12069448/ec0cbf92-aff5-11e5-86e6-113bc5435fb8.gif"> |

The reason this code change fixes these issues is that the `blur` event target is usually the text input, but we need to check the entire TokenField container for the `relatedTarget` instead.  Looks like this was changed [here](https://github.com/Automattic/wp-calypso/commit/e511e6fad78e4e0acb489535edcac7ad479f6e15#diff-ace89b667e7bd9a57e091cdd09278e63L129) - cc @aduth.

### To test

- Go to the editor and add tags to posts.
- See if you can reproduce #1884 (failure to add tags via the mouse) or either of the strange behaviors in the recordings above.
- Apply this patch and verify that all your problems go away.