### PR TITLE
Reader: Update comment anchor

### DIFF
--- a/client/reader/comments/index.jsx
+++ b/client/reader/comments/index.jsx
@@ -222,6 +222,10 @@ var PostCommentList = React.createClass( {
 		CommentStore.on( 'add', this._onAdd );
 	},
 
+	componentDidUpdate: function() {
+		this.props.onCommentsUpdate();
+	},
+
 	// Remove change listers from stores
 	componentWillUnmount: function() {
 		CommentStore.off( 'change', this._onChange );

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -322,11 +322,16 @@ module.exports = React.createClass( {
 	},
 
 	showFullPost: function( post, options ) {
+		options = options || {};
+		var hashtag = '';
+		if ( options[ 'comments' ] ) {
+			hashtag += '#comments';
+		}
 		var method = options && options.replaceHistory ? 'replace' : 'show';
 		if ( post.feed_ID && post.feed_item_ID ) {
-			page[ method ]( '/read/post/feed/' + post.feed_ID + '/' + post.feed_item_ID );
+			page[ method ]( '/read/post/feed/' + post.feed_ID + '/' + post.feed_item_ID + hashtag );
 		} else {
-			page[ method ]( '/read/post/id/' + post.site_ID + '/' + post.ID );
+			page[ method ]( '/read/post/id/' + post.site_ID + '/' + post.ID + hashtag );
 		}
 	},
 

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -223,7 +223,8 @@ var Post = React.createClass( {
 			post = this.props.post,
 			isDiscoverPost = this.state.isDiscoverPost,
 			postUrl = isDiscoverPost ? post.discover_metadata.permalink : post.URL,
-			postToOpen = post;
+			postToOpen = post,
+			postOptions = {};
 
 		// if the click has modifier or was not primary, ignore it
 		if ( event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey ) {
@@ -255,10 +256,15 @@ var Post = React.createClass( {
 			postToOpen = this.state.originalPost;
 		}
 
+		// if the user clicked the comments button.
+		if ( closest( event.target, '.comment-button', true, rootNode ) ) {
+			postOptions[ 'comments' ] = true;
+		}
+
 		// programattic ignore
 		if ( ! event.defaultPrevented ) { // some child handled it
 			event.preventDefault();
-			this.props.handleClick( postToOpen );
+			this.props.handleClick( postToOpen, postOptions );
 		}
 	},
 

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -86,12 +86,24 @@ FullPostView = React.createClass( {
 
 	mixins: [ React.addons.PureRenderMixin ],
 
+	hasScrolledToAnchor: false,
+
 	componentDidMount: function() {
 		this._parseEmoji();
+		this.checkForCommentAnchor();
 	},
 
 	componentDidUpdate: function() {
 		this._parseEmoji();
+		this.checkForCommentAnchor();
+	},
+
+	// if comments updated and we have not scrolled to the anchor yet, then scroll
+	checkForCommentAnchor: function() {
+		const hash = window.location.hash.substr(1);
+		if ( this.refs.commentList && hash.indexOf( 'comments' ) > -1 && ! this.hasScrolledToAnchor ) {
+			this.scrollToComments();
+		}
 	},
 
 	scrollToComments: function() {
@@ -100,6 +112,7 @@ FullPostView = React.createClass( {
 		}
 		let commentListNode = React.findDOMNode( this.refs.commentList );
 		if ( commentListNode ) {
+			this.hasScrolledToAnchor = true;
 			commentListNode.scrollIntoView( { behavior: 'smooth' } );
 		}
 	},
@@ -170,7 +183,7 @@ FullPostView = React.createClass( {
 
 					{ shouldShowExcerptOnly && ! isDiscoverPost ? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> : null }
 					{ isDiscoverPost ? <DiscoverVisitLink siteName={ discoverSiteName } siteUrl={ discoverSiteUrl } /> : null }
-					{ this.props.shouldShowComments ? <PostCommentList ref="commentList" post={ post } /> : null }
+					{ this.props.shouldShowComments ? <PostCommentList ref="commentList" post={ post } onCommentsUpdate={ this.checkForCommentAnchor } /> : null }
 				</article>
 			</div>
 		);


### PR DESCRIPTION
When the comment button is clicked on infinite scroll, pass in the url
an anchor indicating that the comments were clicked. Then on the post,
wait for the comments to fully load, and then scroll to them. Update
for #683. Had issues with my original pull request, so canceled it and added this one. 