### PR TITLE
Update Gridicons, add nuance to offset-fix

### DIFF
--- a/shared/components/gridicon/index.jsx
+++ b/shared/components/gridicon/index.jsx
@@ -85,8 +85,8 @@ var Gridicon = React.createClass( {
 			'gridicons-user-circle'
 		];
 
-		if( iconNeedsOffset.indexOf( icon ) >= 0 ){
-			return( size % 18 === 0 );
+		if ( iconNeedsOffset.indexOf( icon ) >= 0 ) {
+			return ( size % 18 === 0 );
 		} else {
 			return false;
 		}
@@ -104,8 +104,8 @@ var Gridicon = React.createClass( {
 			'gridicons-strikethrough'
 		];
 
-		if( iconNeedsOffsetX.indexOf( icon ) >= 0 ){
-			return( size % 18 === 0 );
+		if ( iconNeedsOffsetX.indexOf( icon ) >= 0 ) {
+			return ( size % 18 === 0 );
 		} else {
 			return false;
 		}
@@ -131,8 +131,8 @@ var Gridicon = React.createClass( {
 			'gridicons-video-camera'
 		];
 
-		if( iconNeedsOffsetY.indexOf( icon ) >= 0 ){
-			return( size % 18 === 0 );
+		if ( iconNeedsOffsetY.indexOf( icon ) >= 0 ) {
+			return ( size % 18 === 0 );
 		} else {
 			return false;
 		}
@@ -140,21 +140,16 @@ var Gridicon = React.createClass( {
 
 	render: function() {
 		var icon = 'gridicons-' + this.props.icon,
-				svg,
-				needsOffset = this.needsOffset( icon, this.props.size ),
-				needsOffsetX = this.needsOffsetX( icon, this.props.size ),
-				needsOffsetY = this.needsOffsetY( icon, this.props.size );
+			needsOffset = this.needsOffset( icon, this.props.size ),
+			needsOffsetX = this.needsOffsetX( icon, this.props.size ),
+			needsOffsetY = this.needsOffsetY( icon, this.props.size ),
+			svg, iconClass;
 
-				var iconClass = classNames(
-					this.props.className,
-					icon,
-					'gridicon',
-					{
-						'needs-offset': needsOffset,
-						'needs-offset-x': needsOffsetX,
-						'needs-offset-y': needsOffsetY,
-					}
-				);
+		iconClass = classNames( 'gridicon', icon, this.props.className, {
+			'needs-offset': needsOffset,
+			'needs-offset-x': needsOffsetX,
+			'needs-offset-y': needsOffsetY,
+		} );
 
 		switch ( icon ) {
 			default:
@@ -598,10 +593,10 @@ var Gridicon = React.createClass( {
 			case 'gridicons-visible':
 				svg = <svg className={ iconClass } height={ this.props.size } width={ this.props.size } onClick={ this.props.onClick } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M12 6C5.188 6 1 12 1 12s4.188 6 11 6 11-6 11-6-4.188-6-11-6zm0 10c-3.943 0-6.926-2.484-8.38-4 1.04-1.085 2.863-2.657 5.255-3.47C8.335 9.214 8 10.064 8 11c0 2.21 1.79 4 4 4s4-1.79 4-4c0-.937-.335-1.787-.875-2.47 2.393.813 4.216 2.386 5.254 3.47-1.456 1.518-4.438 4-8.38 4z"/></g></svg>;
 				break;
-        }
+		}
 
-        return ( svg );
-  }
+		return ( svg );
+	}
 } );
 
 module.exports = Gridicon;

--- a/shared/components/gridicon/index.jsx
+++ b/shared/components/gridicon/index.jsx
@@ -9,12 +9,13 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 /**
  * External dependencies
  */
-var React = require( 'react/addons' ),
-		classNames = require( 'classnames' );
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
+	classNames = require( 'classnames' );
 
 var Gridicon = React.createClass( {
 
-	mixins: [ React.addons.PureRenderMixin ],
+	mixins: [ PureRenderMixin ],
 
 	getDefaultProps: function() {
 		return {

--- a/shared/components/gridicon/index.jsx
+++ b/shared/components/gridicon/index.jsx
@@ -9,13 +9,12 @@ OR if you're looking to change now SVGs get output, you'll need to edit strings 
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
+var React = require( 'react/addons' ),
 		classNames = require( 'classnames' );
 
 var Gridicon = React.createClass( {
 
-	mixins: [ PureRenderMixin ],
+	mixins: [ React.addons.PureRenderMixin ],
 
 	getDefaultProps: function() {
 		return {
@@ -35,31 +34,27 @@ var Gridicon = React.createClass( {
 		var iconNeedsOffset = [
 			'gridicons-add-outline',
 			'gridicons-add',
-			'gridicons-align-center',
 			'gridicons-align-image-center',
 			'gridicons-align-image-left',
 			'gridicons-align-image-none',
 			'gridicons-align-image-right',
-			'gridicons-align-justify',
-			'gridicons-align-left',
-			'gridicons-align-right',
-			'gridicons-arrow-down',
-			'gridicons-arrow-left',
-			'gridicons-arrow-right',
-			'gridicons-arrow-up',
 			'gridicons-attachment',
 			'gridicons-backspace',
 			'gridicons-bold',
 			'gridicons-bookmark-outline',
 			'gridicons-bookmark',
 			'gridicons-calendar',
-			'gridicons-clear-formatting',
+			'gridicons-cart',
 			'gridicons-create',
 			'gridicons-custom-post-type',
-			'gridicons-flag',
+			'gridicons-external',
 			'gridicons-folder',
 			'gridicons-heading',
-			'gridicons-house',
+			'gridicons-help-outline',
+			'gridicons-help',
+			'gridicons-history',
+			'gridicons-info-outline',
+			'gridicons-info',
 			'gridicons-italic',
 			'gridicons-layout-blocks',
 			'gridicons-link-break',
@@ -68,27 +63,75 @@ var Gridicon = React.createClass( {
 			'gridicons-list-ordered',
 			'gridicons-list-unordered',
 			'gridicons-menus',
-			'gridicons-minus-small',
 			'gridicons-minus',
+			'gridicons-my-sites',
+			'gridicons-notice-outline',
+			'gridicons-notice',
 			'gridicons-plus-small',
 			'gridicons-plus',
+			'gridicons-popout',
 			'gridicons-posts',
-			'gridicons-reader',
 			'gridicons-scheduled',
 			'gridicons-share-ios',
-			'gridicons-sign-out',
 			'gridicons-star-outline',
 			'gridicons-star',
-			'gridicons-stats-alt',
 			'gridicons-stats',
+			'gridicons-status',
+			'gridicons-thumbs-up',
 			'gridicons-textcolor',
+			'gridicons-time',
 			'gridicons-trophy',
-			'gridicons-underline',
-			'gridicons-video-camera'
-		 ];
+			'gridicons-user-circle'
+		];
 
 		if( iconNeedsOffset.indexOf( icon ) >= 0 ){
-			return( size % 18 === 0);
+			return( size % 18 === 0 );
+		} else {
+			return false;
+		}
+	},
+
+	needsOffsetX: function( icon, size ) {
+		var iconNeedsOffsetX = [
+			'gridicons-arrow-down',
+			'gridicons-arrow-up',
+			'gridicons-comment',
+			'gridicons-clear-formatting',
+			'gridicons-flag',
+			'gridicons-menu',
+			'gridicons-reader',
+			'gridicons-strikethrough'
+		];
+
+		if( iconNeedsOffsetX.indexOf( icon ) >= 0 ){
+			return( size % 18 === 0 );
+		} else {
+			return false;
+		}
+	},
+
+	needsOffsetY: function( icon, size ) {
+		var iconNeedsOffsetY = [
+			'gridicons-align-center',
+			'gridicons-align-justify',
+			'gridicons-align-left',
+			'gridicons-align-right',
+			'gridicons-arrow-left',
+			'gridicons-arrow-right',
+			'gridicons-house',
+			'gridicons-indent-left',
+			'gridicons-indent-right',
+			'gridicons-minus-small',
+			'gridicons-print',
+			'gridicons-sign-out',
+			'gridicons-stats-alt',
+			'gridicons-trash',
+			'gridicons-underline',
+			'gridicons-video-camera'
+		];
+
+		if( iconNeedsOffsetY.indexOf( icon ) >= 0 ){
+			return( size % 18 === 0 );
 		} else {
 			return false;
 		}
@@ -97,13 +140,19 @@ var Gridicon = React.createClass( {
 	render: function() {
 		var icon = 'gridicons-' + this.props.icon,
 				svg,
-				needsOffset = this.needsOffset( icon, this.props.size );
+				needsOffset = this.needsOffset( icon, this.props.size ),
+				needsOffsetX = this.needsOffsetX( icon, this.props.size ),
+				needsOffsetY = this.needsOffsetY( icon, this.props.size );
 
 				var iconClass = classNames(
 					this.props.className,
 					icon,
 					'gridicon',
-					{ 'needs-offset': needsOffset }
+					{
+						'needs-offset': needsOffset,
+						'needs-offset-x': needsOffsetX,
+						'needs-offset-y': needsOffsetY,
+					}
 				);
 
 		switch ( icon ) {

--- a/shared/components/gridicon/style.scss
+++ b/shared/components/gridicon/style.scss
@@ -4,4 +4,12 @@
 	&.needs-offset g {
 		transform: translate( 1px, 1px );	/* translates to .5px because it's in a child element */
 	}
+
+	&.needs-offset-x g {
+		transform: translate( 1px, 0 );		/* only nudges horizontally */
+	}
+
+	&.needs-offset-y g {
+		transform: translate( 0, 1px );		/* only nudges vertically */
+	}
 }


### PR DESCRIPTION
The offset-fix nudges vectors inside the gridicon icons by subpixels in order to enhance crispness when used at 18 or 36px sizes.

This PR further enhances that by ambiguating whether an icon needs nudging only horizontally, vertically, or both. It also includes an updated list of which icons need either.

This has been tested in Calypso and works as intended.

Screenshots of 18px icons with the new offset-fixes applied:

![18px](https://cloud.githubusercontent.com/assets/1204802/12087015/85cd0002-b2cf-11e5-8d74-3b54561eca20.png)

Screenshots of 36px icons with the new offset-fixes applied:

![36px](https://cloud.githubusercontent.com/assets/1204802/12087017/8ea22676-b2cf-11e5-8233-d4fa4c2d1459.png)

Reminder: 18px icons should still only be used for ephemeral icons that aren't permanently visible.