### PR TITLE
Framework: Add the commit sha1 information in the environment badge (on hover)

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -56,7 +56,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				a(class='bug-report', href=feedbackURL, title='Report an issue', target='_blank')
 				span(class=['environment', 'is-' + badge])=badge
 				if branchName && branchName !== 'master'
-					span(class=['environment', 'branch-name'])=branchName
+					span(class=['environment', 'branch-name'], title='Commit ' + commitChecksum)=branchName
 				if devDocs
 					span(class=['environment', 'is-docs'])
 						a(href=devDocsURL title='DevDocs') docs

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -115,7 +115,15 @@ function getChunk( path ) {
 
 function getCurrentBranchName() {
 	try {
-		return execSync( 'git rev-parse --abbrev-ref HEAD' );
+		return execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().replace( /\s/gm, '' );
+	} catch ( err ) {
+		return undefined;
+	}
+}
+
+function getCurrentCommitShortChecksum() {
+	try {
+		return execSync( 'git rev-parse --short HEAD' ).toString().replace( /\s/gm, '' );
 	} catch ( err ) {
 		return undefined;
 	}
@@ -173,6 +181,7 @@ function getDefaultContext( request ) {
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
 		context.faviconURL = '/calypso/images/favicons/favicon-development.ico';
 		context.branchName = getCurrentBranchName();
+		context.commitChecksum = getCurrentCommitShortChecksum();
 	}
 
 	if ( config.isEnabled( 'code-splitting' ) ) {


### PR DESCRIPTION
This PR fixes a few thing from https://github.com/Automattic/wp-calypso/pull/1531 : 
- Fixes some code formatting issues
- Removes a line break at the end of the branch name
- `getCurrentBranchName()` now returns a `String` instead of a `Buffer`

And adds a new information: the last commit id (or sha1 checksum) available when hovering the branch name in the environment badge

![badge-with-hover](https://cloud.githubusercontent.com/assets/230230/12104818/5214b7e8-b34f-11e5-9d4f-cfb49c7bc691.png)


#### Context
This is useful for a multi branch version of the application (See: https://github.com/Automattic/calypso-live-branches). This way we can ensure the server has updated our changes.