### PR TITLE
Themes: Add LayoutLoggedOutDesign

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -175,6 +175,8 @@ function boot() {
 
 		if ( config.isEnabled( 'oauth' ) ) {
 			LoggedOutLayout = require( 'layout/logged-out-oauth' );
+		} else if ( startsWith( window.location.pathname, '/design' ) ) {
+			LoggedOutLayout = require( 'layout/logged-out-design' );
 		} else {
 			LoggedOutLayout = require( 'layout/logged-out' );
 		}

--- a/client/layout/logged-out-design.jsx
+++ b/client/layout/logged-out-design.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import MasterbarLoggedOut from 'layout/masterbar/logged-out';
+
+const LayoutLoggedOutDesign = () => (
+	<div className="wp is-section-design has-no-sidebar">
+		<MasterbarLoggedOut />
+		<div id="content" className="wp-content">
+			<div id="primary" className="wp-primary wp-section" />
+			<div id="secondary" className="wp-secondary" />
+		</div>
+		<div id="tertiary" className="wp-overlay fade-background" />
+	</div>
+)
+
+LayoutLoggedOutDesign.displayName = 'LayoutLoggedOutDesign';
+
+export default LayoutLoggedOutDesign;

--- a/client/layout/logged-out-oauth.jsx
+++ b/client/layout/logged-out-oauth.jsx
@@ -3,17 +3,15 @@
  */
 import React from 'react';
 
-module.exports = React.createClass( {
-	displayName: 'LayoutLoggedOutAuth',
-
-	render: function() {
-		return (
-			<div className="wp logged-out-auth">
-				<div id="content" className="wp-content">
-					<div id="primary" className="wp-primary wp-section">
-					</div>
-				</div>
+const LayoutLoggedOutAuth = () => (
+	<div className="wp logged-out-auth">
+		<div id="content" className="wp-content">
+			<div id="primary" className="wp-primary wp-section">
 			</div>
-		);
-	}
-} );
+		</div>
+	</div>
+);
+
+LayoutLoggedOutAuth.displayName = 'LayoutLoggedOutAuth';
+
+export default LayoutLoggedOutAuth;

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,42 +1,37 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	connect = require( 'react-redux' ).connect;
+import React from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import MasterbarLoggedOut from 'layout/masterbar/logged-out';
+import GlobalNotices from 'components/global-notices';
+import notices from 'notices';
 
-var MasterbarLoggedOut = require( 'layout/masterbar/logged-out' ),
-	GlobalNotices = require( 'components/global-notices' ),
-	notices = require( 'notices' ),
-	LoggedOutLayout;
+const LoggedOutLayout = ( { section, hasSidebar } ) => {
+	const sectionClass = section ? ' is-section-' + section : '';
+	const classes = classNames( 'wp', sectionClass, {
+		'has-no-sidebar': ! hasSidebar
+	} );
 
-LoggedOutLayout = React.createClass( {
-	displayName: 'LayoutLoggedOut',
-
-	render: function() {
-		var sectionClass = this.props.section ? ' is-section-' + this.props.section : '',
-			classes = classNames( 'wp', sectionClass, {
-				'has-no-sidebar': ! this.props.hasSidebar
-			} );
-
-		return (
-			<div className={ classes }>
-				<MasterbarLoggedOut />
-				<div id="content" className="wp-content">
-					<GlobalNotices id="notices" notices={ notices.list } />
-					<div id="primary" className="wp-primary wp-section" />
-					<div id="secondary" className="wp-secondary" />
-				</div>
-				<div id="tertiary" className="wp-overlay fade-background" />
+	return (
+		<div className={ classes }>
+			<MasterbarLoggedOut />
+			<div id="content" className="wp-content">
+				<GlobalNotices id="notices" notices={ notices.list } />
+				<div id="primary" className="wp-primary wp-section" />
+				<div id="secondary" className="wp-secondary" />
 			</div>
-		);
-	}
+			<div id="tertiary" className="wp-overlay fade-background" />
+		</div>
+	);
+}
 
-} );
+LoggedOutLayout.displayName = 'LoggedOutLayout';
 
 export default connect(
 	( state ) => {


### PR DESCRIPTION
This PR adds a separate `client/layout/logged-out-design` which is invoked for, well, the `/design` route for logged-out users :-) It also ES6ifies the other logged-out layouts, from which it is copied (and slightly modified). This is meant to fix #1325.

Visually, this means mainly that logged-out `/design` (still only available in the `dev` environment) looks better now, since it now has a class indicating that it doesn't need a sidebar.

Before:

![bildschirmfoto am 2016-01-04 um 15 24 42](https://cloud.githubusercontent.com/assets/96308/12091451/80b3fa3a-b2f7-11e5-995e-27ffd79efc55.png)

After:

![bildschirmfoto am 2016-01-04 um 15 27 14](https://cloud.githubusercontent.com/assets/96308/12091470/a8b017ee-b2f7-11e5-9b29-cf9926f1aee7.png)

To test:
* Use an incognito window, and open calypso.localhost:3000/design
* Inspect the `div` inside `body` > `div#wpcom`: it should have `wp is-section-design has-no-sidebar`. (Compare this to the `master` branch, which only has `wp`.)
* Verify that other logged-out layouts also still work:
 * `/` (log-in with WP.com)
 * `/start` (beginning of the signup flow)