### PR TITLE
Notices redux: Test and README

### DIFF
--- a/client/state/notices/Makefile
+++ b/client/state/notices/Makefile
@@ -1,0 +1,10 @@
+REPORTER ?= spec
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := $(BASE_DIR)/client:$(BASE_DIR)/shared
+
+test:
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers jsx:babel/register,js:babel/register --reporter $(REPORTER)
+
+.PHONY: test

--- a/client/state/notices/README.md
+++ b/client/state/notices/README.md
@@ -1,0 +1,50 @@
+Notices
+===========
+
+A subtree of state that manages global notices.
+Suported types of notices are `error`, `success`.
+
+## How to use?
+
+### Connect to Redux
+First, the component that wants to send notices must be connected to Redux.
+
+```javascript
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { successNotice, errorNotice } from 'state/notices/actions';
+
+...
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( { successNotice, errorNotice }, dispatch )
+)( Component );
+```
+
+### Uses
+
+Now you can use notices like so:
+
+```javascript
+
+this.props.successNotice(
+    'Settings saved successfully!', {
+    	duration: 4000
+} );
+
+```
+
+
+### The available methods are:
+
+* `successNotice()`
+* `errorNotice()`
+
+## Options
+
+The first argument is the text to be displayed on the notice. The second argument is an optional object and accepts some properties:
+
+* `duration: 5000`: (optional) Duration in milliseconds to display the notice before dismissing.
+* `showDismiss: false`: (optional) To indicate if dismiss button should be rendered within the overlay.
+

--- a/client/state/notices/test/actions.js
+++ b/client/state/notices/test/actions.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import { NEW_NOTICE, REMOVE_NOTICE } from 'state/action-types';
+import { removeNotice, successNotice, errorNotice } from '../actions';
+
+describe( 'actions', function() {
+	describe( 'removeNotice()', function() {
+		it( 'should return an action object', function() {
+			const action = removeNotice( 123 );
+
+			expect( action ).to.eql( {
+				type: REMOVE_NOTICE,
+				noticeId: 123
+			} );
+		} );
+	} );
+
+	describe( 'successNotice()', function() {
+		it( 'should call dispatch with proper text and is-success status', function() {
+			const text = 'potato',
+				dispatch = spy();
+
+			//successNotice is a thunk - returns a function:
+			successNotice( text )( dispatch );
+
+			expect( dispatch.calledWithMatch( {
+				type: NEW_NOTICE,
+				notice: {
+					text,
+					status: 'is-success'
+				}
+			} ) ).to.be.ok;
+		} );
+
+		it( 'should call dispatch with proper default options when none provided', function() {
+			const dispatch = spy();
+
+			//successNotice is a thunk - returns a function:
+			successNotice( '' )( dispatch );
+
+			expect( dispatch.calledWithMatch( {
+				notice: {
+					showDismiss: true
+				}
+			} ) ).to.be.ok;
+		} );
+
+		it( 'should call dispatch with type REMOVE_NOTICE and proper noticeId when duration is provided', function( done ) {
+			const dispatch = spy();
+
+			//successNotice is a thunk - returns a function:
+			successNotice( '', { duration: 2 } )( dispatch );
+			let noticeId = dispatch.firstCall.args[0].notice.noticeId;
+
+			setTimeout( function() {
+				expect( dispatch.calledWithMatch( {
+					type: REMOVE_NOTICE,
+					noticeId: noticeId
+				} ) ).to.be.ok;
+				done();
+			}, 3 );
+		} );
+	} );
+
+	describe( 'errorNotice()', function() {
+		it( 'should call dispatch proper text and is-error status', function() {
+			const text = 'potato',
+				dispatch = spy();
+
+			//errorNotice is a thunk - returns a function:
+			errorNotice( text )( dispatch );
+
+			expect( dispatch.calledWithMatch( {
+				type: NEW_NOTICE,
+				notice: {
+					text,
+					status: 'is-error'
+				}
+			} ) ).to.be.ok;
+		} );
+	} );
+} );

--- a/client/state/notices/test/reducer.js
+++ b/client/state/notices/test/reducer.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { NEW_NOTICE, REMOVE_NOTICE } from 'state/action-types';
+import { items } from '../reducer';
+
+describe( 'reducer', () => {
+	describe( '#items()', () => {
+		it( 'should default to an empty array', () => {
+			const state = items( undefined, [] );
+			expect( state ).to.eql( [] );
+		} );
+
+		it( 'should properly add new notice', () => {
+			const notice = { text: 'Example Notice Text' },
+				state = items( undefined, {
+					type: NEW_NOTICE,
+					notice: notice
+				} );
+
+			expect( state ).to.eql( [ notice ] );
+		} );
+
+		it( 'should properly remove selected notice', () => {
+			const notices = [
+					{ noticeId: 1 },
+					{ noticeId: 2 },
+					{ noticeId: 3 }
+				],
+				state = items( notices, {
+					type: REMOVE_NOTICE,
+					noticeId: 2
+				} );
+
+			expect( state ).to.eql( [
+				{ noticeId: 1 },
+				{ noticeId: 3 }
+			] );
+		} );
+	} );
+} );


### PR DESCRIPTION
This is again part of effort to reduxify all notices.
Continues work from #1496 

This PR adds Tests and readme

# Testing
`cd client/state/notices && make test`