### PR TITLE
Plans: Render plans table if no site selected

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -108,8 +108,8 @@ var PlansCompare = React.createClass( {
 		} );
 
 		if ( this.props.features.hasLoadedFromServer() && (
-			this.props.isInSignup || this.props.sitePlans.hasLoadedFromServer )
-			) {
+			this.props.isInSignup || ! this.props.selectedSite || ( this.props.sitePlans && this.props.sitePlans.hasLoadedFromServer ) )
+		) {
 			// Remove features not supported by any plan
 			featuresList = featuresList.filter( function( feature ) {
 				var keepFeature = false;


### PR DESCRIPTION
This pull request seeks to resolve an issue where the plans compare page will not load if no site is selected, or if loaded for a specific site when localStorage is fresh, i.e. before sites have been initially populated.

__Implementation notes:__

This resolves the loading issues, though there is still some undesirable behavior when loading the site-specific plans compare page with a fresh localStorage. More changes are likely needed to better handle this scenario, particularly around dispatching fetch for site plans dependent upon selected site whether selected site has been loaded yet or not.

__Testing instructions:__

Navigate to the plans compare page and confirm that the comparison table is rendered, regardless of whether a site is currently selected, or whether the page is loaded with a fresh localStorage.

All sites plan comparison page: http://calypso.localhost:3000/plans/compare

Clear localStorage by typing `localStorage.clear()` in your browser developer tools console, then reloading the page.

cc @stephanethomas @artpi 