### PR TITLE
Plans: Update support copy in Plan Overview page

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-features/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-features/index.jsx
@@ -81,7 +81,13 @@ const PlanFeatures = React.createClass( {
 					willBeRemoved={ willBeRemoved } />
 
 				<PlanFeature
-					description={ this.translate( 'You can live chat with our happiness engineers anytime you need.' ) }
+					description={
+						isBusiness( this.props.selectedSite.plan )
+						?
+							this.translate( 'You can live chat with our Happiness Engineers anytime you need.' )
+						:
+							this.translate( 'You can contact our Happiness Engineers anytime you need.' )
+					}
 					heading={ this.translate( 'Support' ) }
 					willBeRemoved={ willBeRemoved } />
 			</div>


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/1829 by tweaking the copy of the **Support** feature section in the `Plan Overview` page according to the type of plan on trial:

##### Premium

![screenshot](https://cloud.githubusercontent.com/assets/594356/12112990/421d3940-b3a0-11e5-8bad-34b53626ecc6.png)


##### Business

![screenshot](https://cloud.githubusercontent.com/assets/594356/12112953/0e78b29a-b3a0-11e5-93f5-91ddd33bd08b.png)

 
#### Testing instructions

1. Run `git checkout update/plan-features` and start your server
2. Get a new test account and blog
3. Enable your proxy
4. Select the Premium plan by clicking the `Start Free Trial` button on the [`Plans` page](http://calypso.localhost:3000/plans)
5. Click the `Start 14 Day Free Trial` button on the `Secure Payment` page
6. Check that the purchase was successful
7. Navigate back to the `Plans` page which should now display the `Plan Overview` variant
8. Check that the support section shows the right text
9. Repeat previous steps with a Business Plan

#### Reviews

- [x] Code
- [x] Product