### PR TITLE
Editor: Move initial connection fetching to didMount

### DIFF
--- a/client/post-editor/editor-sharing/container.jsx
+++ b/client/post-editor/editor-sharing/container.jsx
@@ -20,12 +20,13 @@ class EditorSharingContainer extends Component {
 		// Set state
 		this.state = this.getState();
 
-		// Trigger connection fetch
-		this.ensureHasConnections();
-
 		// Bind legacy store update handler
 		this.boundUpdateState = this.updateState.bind( this );
 		PostEditStore.on( 'change', this.boundUpdateState );
+	}
+
+	componentDidMount() {
+		this.ensureHasConnections();
 	}
 
 	componentDidUpdate() {


### PR DESCRIPTION
This pull request seeks to resolve an issue where a `setState` error is invoked after attempting to make an initial request for connections in the post editor.

![image](https://cloud.githubusercontent.com/assets/1779930/12097933/ad71f9a6-b2ec-11e5-9b94-7c65440f6baf.png)

The initial fetch should occur after the component has mounted, not in the constructor. The class constructor's relation to lifecycle methods [is a bit confusing](https://twitter.com/dan_abramov/status/576453138598723585), though notably calls to `setState` cannot occur in the constructor.

__Testing instructions:__

Verify that the error is not presented, and that connections continue to load as expected.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Note that no `setState` errors are shown in the developer tools console
4. Note that sharing connections are accurately reflected after load in the Sharing accordion

__Future tasks:__

`EditorSharingContainer` is relatively new, though I already want to refactor it to move connections fetching further up the render chain (see ["Fetching Components"](https://github.com/Automattic/wp-calypso/blob/add/docs-data-approach/docs/our-approach-to-data.md#fetching-components) distinction).

/cc @timmyc 