### PR TITLE
Help: Only show notifications while on the contact form

### DIFF
--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -171,9 +171,6 @@ const olark = {
 			}
 		} );
 
-		olarkEvents.on( 'api.chat.onOperatorsAway', this.showAvailabilityNotice );
-		olarkEvents.on( 'api.chat.onOperatorsAvailable', this.showAvailabilityNotice );
-
 		this.setOlarkOptions( userData, wpcomOlarkConfig );
 		this.updateLivechatActiveCookie();
 		this.bindBeginConversationEvent( userData, siteUrl );
@@ -197,23 +194,6 @@ const olark = {
 
 	hookExpansionEventToStoreSync( eventName ) {
 		olarkEvents.on( eventName, this.syncStoreWithExpandedState );
-	},
-
-	showAvailabilityNotice() {
-		const noticeOptions = { showDismiss: true };
-		const { isOperatorAvailable, isUserEligible, isOlarkExpanded, isOlarkReady } = olarkStore.get();
-		const onEligibleContactForm = isUserEligible && window.location.pathname === '/help/contact';
-		const showNotice = isOlarkReady && ( isOlarkExpanded || onEligibleContactForm );
-
-		if ( ! showNotice ) {
-			return;
-		}
-
-		if ( isOperatorAvailable ) {
-			notices.success( i18n.translate( 'Our Happiness Engineers have returned, chat with us.' ), noticeOptions );
-		} else {
-			notices.warning( i18n.translate( 'Sorry! We just missed you as our Happiness Engineers stepped away.' ), noticeOptions );
-		}
 	},
 
 	setOlarkOptions( userData, wpcomOlarkConfig = {} ) {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -34,6 +34,7 @@ module.exports = React.createClass( {
 	componentDidMount: function() {
 		olarkStore.on( 'change', this.updateOlarkState );
 		olarkEvents.on( 'api.chat.onOperatorsAway', this.onOperatorsAway );
+		olarkEvents.on( 'api.chat.onOperatorsAvailable', this.onOperatorsAvailable );
 		olarkEvents.on( 'api.chat.onCommandFromOperator', this.onCommandFromOperator );
 
 		sites.on( 'change', this.onSitesChanged );
@@ -52,6 +53,7 @@ module.exports = React.createClass( {
 
 		olarkStore.removeListener( 'change', this.updateOlarkState );
 		olarkEvents.off( 'api.chat.onOperatorsAway', this.onOperatorsAway );
+		olarkEvents.off( 'api.chat.onOperatorsAvailable', this.onOperatorsAvailable );
 		olarkEvents.off( 'api.chat.onCommandFromOperator', this.onCommandFromOperator );
 
 		if ( details.isConversing && ! isOperatorAvailable ) {
@@ -217,6 +219,7 @@ module.exports = React.createClass( {
 	},
 
 	onOperatorsAway: function() {
+		const IS_UNAVAILABLE = false;
 		const { details } = this.state.olark;
 
 		if ( ! details.isConversing ) {
@@ -227,6 +230,28 @@ module.exports = React.createClass( {
 
 		//Autofill the subject field since we will be showing it now that operators have went away.
 		this.autofillSubject();
+
+		this.showAvailabilityNotice( IS_UNAVAILABLE );
+	},
+
+	onOperatorsAvailable: function() {
+		const IS_AVAILABLE = true;
+
+		this.showAvailabilityNotice( IS_AVAILABLE );
+	},
+
+	showAvailabilityNotice( isAvailable ) {
+		const { isUserEligible, isOlarkReady } = this.state.olark;
+
+		if ( ! isOlarkReady || ! isUserEligible ) {
+			return;
+		}
+
+		if ( isAvailable ) {
+			notices.success( this.translate( 'Our Happiness Engineers have returned, chat with us.' ) );
+		} else {
+			notices.warning( this.translate( 'Sorry! We just missed you as our Happiness Engineers stepped away.' ) );
+		}
 	},
 
 	/**
@@ -265,7 +290,6 @@ module.exports = React.createClass( {
 		}
 
 		if ( ! ( olark.isOlarkReady && sitesInitialized ) ) {
-
 			return (
 				<div className="help-contact__placeholder">
 					<h4 className="help-contact__header">Loading contact form</h4>


### PR DESCRIPTION
This pull request fixes an issue reported in #1912 and #2076. We will now only show the operator availability notifications while viewing the help contact form.

#### How to test
*Note: You should be in a test group where there is only one operator.*
1. Navigate to http://calypso.localhost:3000/help/contact
2. From the olark console set your self as "Away".
3. Shortly after setting your self away you should see a warning in calypso. See the image below.
4. From the olark console set your self as "Available".
5. Shortly after setting your self available you should see a success message in calypso. See the image below.
6. Click to navigate away from the contact form.
7. From the olark console set your self as "Away".
8. Notice that no notification is displayed.

#### What to expect

![screen shot 2016-01-04 at 3 47 26 pm](https://cloud.githubusercontent.com/assets/1854440/12100084/bc579738-b2fa-11e5-9a1e-b77fa6ff503d.png)
![screen shot 2016-01-04 at 3 46 58 pm](https://cloud.githubusercontent.com/assets/1854440/12100088/c16e8c4a-b2fa-11e5-8696-96d6e0568acf.png)


fixes #1912