### PR TITLE
Editor: Fix tinymce float toolbar not hide (fixes #1486)

### DIFF
--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -630,9 +630,9 @@ function wpcomPlugin( editor ) {
 			if ( activeToolbar ) {
 				activeToolbar.hide();
 
-				if ( event.type === 'hide' ) {
+				if ( event.type === 'hide' || event.type === 'blur' ) {
 					activeToolbar = false;
-				} else if ( event.type === 'resize' || event.type === 'scroll' ) {
+				} else if ( event.type === 'resizewindow' || event.type === 'scroll' ) {
 					clearTimeout( timeout );
 
 					timeout = setTimeout( function() {


### PR DESCRIPTION
Reason of this issue was that on blur event `activeToolbar` was hidden but after if window is got scroll event it was shown again.

Changed 'resize' to 'resizewindow' because it's right for window target (tested in ie11 on win10; ff, chrome, safari on mac os)

PS:
- This PR not fixed #331 (there are errors with firing blur in tinymce codebase for ios)
- This PR may be fixed #1815 (it's hard to reproduce)