### PR TITLE
Documentation: Clarify that Calypso does not run on Windows

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -12,9 +12,10 @@
 
 To be able to clone the repo and run the application you need:
 
--	[Node.js](http://nodejs.org/) and [NPM](https://www.npmjs.com/) installed. Here's a [handy installer](https://nodejs.org/dist/latest/) for Windows, Mac, and Linux. On Mac OSX using [brew]() is the easiest way to install `node` and `npm`.
+- Mac OS X or Linux. At this time Calypso does not run on Windows in development mode (but the [WordPress.com desktop app](https://desktop.wordpress.com/) supports Windows).
+-	[Node.js](http://nodejs.org/) and [NPM](https://www.npmjs.com/) installed. On Mac OS X using [brew](http://brew.sh/) is the easiest way to install `node` and `npm`.
 -	[Git](http://git-scm.com/). Try the `git` command from your terminal, if it's not found then use this [installer](http://git-scm.com/download/).
--	The repository also uses `make` to orchestrate compiling the JavaScript, running the server, and several other tasks. On Mac OSX, the easiest way to install `make` is through Apple's [Command Line Tools for Xcode](https://developer.apple.com/downloads/) (requires free registration).
+-	The repository also uses `make` to orchestrate compiling the JavaScript, running the server, and several other tasks. On Mac OS X, the easiest way to install `make` is through Apple's [Command Line Tools for Xcode](https://developer.apple.com/downloads/) (requires free registration).
 
 ## Installing and Running
 


### PR DESCRIPTION
Suggested by @hughc in https://github.com/Automattic/wp-calypso/issues/2029#issuecomment-168543119.

Also cleaned up a couple of other things here:

- Add link to `brew` for OS X
- Remove misleading link pointing to Node.js binaries (it's very easy to get to a better download page from the Node.js homepage)