### PR TITLE
Invites: Add event tracking

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -8,6 +8,7 @@ import Debug from 'debug';
 import Dispatcher from 'dispatcher';
 import wpcom from 'lib/wp';
 import { action as ActionTypes } from 'lib/invites/constants';
+import analytics from 'analytics';
 
 /**
  * Module variables
@@ -45,6 +46,10 @@ export function fetchInvite( siteId, inviteKey ) {
 			type: error ? ActionTypes.RECEIVE_INVITE_ERROR : ActionTypes.RECEIVE_INVITE,
 			siteId, inviteKey, data, error
 		} );
+
+		if ( error ) {
+			analytics.tracks.recordEvent( 'calypso_invite_validation_failure' );
+		}
 	} );
 }
 
@@ -54,6 +59,12 @@ export function createAccount( userData, callback ) {
 		( error, response ) => {
 			const bearerToken = response && response.bearer_token;
 			callback( error, bearerToken );
+
+			if ( error ) {
+				analytics.tracks.recordEvent( 'calypso_invite_account_creation_failed' );
+			} else {
+				analytics.tracks.recordEvent( 'calypso_invite_account_created' );
+			}
 		}
 	);
 }
@@ -73,6 +84,12 @@ export function acceptInvite( invite ) {
 				invite,
 				data
 			} );
+
+			if ( error ) {
+				analytics.tracks.recordEvent( 'calypso_invite_accept_failed' );
+			} else {
+				analytics.tracks.recordEvent( 'calypso_invite_accepted' );
+			}
 		}
 	);
 }

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -16,6 +16,7 @@ import InviteFormHeader from 'my-sites/invites/invite-form-header';
 import { acceptInvite } from 'lib/invites/actions';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import analytics from 'analytics';
 
 export default React.createClass( {
 
@@ -28,7 +29,19 @@ export default React.createClass( {
 	accept() {
 		this.setState( { submitting: true } );
 		acceptInvite( this.props );
+		analytics.tracks.recordEvent( 'calypso_invite_accept_logged_in_join_button_click' );
 		page( this.props.redirectTo );
+	},
+
+	decline() {
+		if ( this.props.decline && 'function' === typeof this.props.decline ) {
+			this.props.decline();
+			analytics.tracks.recordEvent( 'calypso_invite_accept_logged_in_decline_button_click' );
+		}
+	},
+
+	signInLink() {
+		analytics.tracks.recordEvent( 'calypso_invite_accept_logged_in_sign_in_link_click' );
 	},
 
 	render() {
@@ -53,7 +66,7 @@ export default React.createClass( {
 						}
 					</div>
 					<div className="invite-accept-logged-in__button-bar">
-						<Button onClick={ this.props.decline } disabled={ this.state.submitting }>
+						<Button onClick={ this.decline } disabled={ this.state.submitting }>
 							{ this.translate( 'Decline', { context: 'button' } ) }
 						</Button>
 						<Button primary onClick={ this.accept } disabled={ this.state.submitting }>
@@ -66,7 +79,7 @@ export default React.createClass( {
 				</Card>
 
 				<LoggedOutFormLinks>
-					<LoggedOutFormLinkItem href={ signInLink }>
+					<LoggedOutFormLinkItem onClick={ this.signInLink } href={ signInLink }>
 						{ this.translate( 'Sign in as a different user' ) }
 					</LoggedOutFormLinkItem>
 				</LoggedOutFormLinks>

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -15,6 +15,7 @@ import wpcom from 'lib/wp'
 import store from 'store'
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import analytics from 'analytics';
 
 export default React.createClass( {
 
@@ -30,6 +31,10 @@ export default React.createClass( {
 
 	submitButtonText() {
 		return this.translate( 'Sign Up & Join' );
+	},
+
+	clickSignInLink() {
+		analytics.tracks.recordEvent( 'calypso_invite_accept_logged_out_sign_in_link_click' );
 	},
 
 	submitForm( form, userData ) {
@@ -65,8 +70,7 @@ export default React.createClass( {
 			<WpcomLoginForm
 				log={ userData.username }
 				authorization={ 'Bearer ' + bearerToken }
-				redirectTo={ window.location.href }
-			/>
+				redirectTo={ window.location.href } />
 		)
 	},
 
@@ -82,13 +86,14 @@ export default React.createClass( {
 				}
 			}
 		);
+		analytics.tracks.recordEvent( 'calypso_invite_accept_logged_out_follow_by_email_click' );
 	},
 
 	renderFooterLink() {
 		let logInUrl = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
 		return (
 			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href={ logInUrl }>
+				<LoggedOutFormLinkItem onClick={ this.clickSignInLink } href={ logInUrl }>
 					{ this.translate( 'Already have a WordPress.com account? Log in now.' ) }
 				</LoggedOutFormLinkItem>
 				{ this.renderEmailOnlySubscriptionLink() }
@@ -120,8 +125,7 @@ export default React.createClass( {
 					submitForm={ this.submitForm }
 					submitButtonText={ this.submitButtonText() }
 					footerLink={ this.renderFooterLink() }
-					email={ this.props.sentTo }
-				/>
+					email={ this.props.sentTo } />
 				{ this.state.userData && this.loginUser() }
 			</div>
 		)

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -3,8 +3,17 @@
  */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
+import analytics from 'analytics';
+
 export default React.createClass( {
 	displayName: 'InviteFormHeader',
+
+	clickedSiteLink() {
+		analytics.tracks.recordEvent( 'calypso_invite_accept_form_header_site_link_click' );
+	},
 
 	getSiteLink() {
 		const { site } = this.props;
@@ -14,7 +23,7 @@ export default React.createClass( {
 		}
 
 		return (
-			<a href={ site.URL } className="invite-header__site-link">
+			<a href={ site.URL } onClick={ this.clickedSiteLink } className="invite-header__site-link">
 				{ site.title }
 			</a>
 		);


### PR DESCRIPTION
Closes #1174

Adds event tracking to the invite accept flow.

To test:
- Checkout `add/people-invite-analytics` branch
- For a WP.com site, go to `$site/wp-admin/users.php?page=wpcom-invite-users` and invite a test user
- In the invitation email, make note of the invitation key
- Go to `/accept-invite/$site/$invitation_key`
- In the Chrome console (or similar), enter `localStorage.setItem( 'debug', 'calypso:analytics' );`
- Now, test all of the things. Do analytics fire when UI elements are clicked? 