### PR TITLE
Plugins: Fixes type which causes a js error

### DIFF
--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -138,7 +138,7 @@ export default React.createClass( {
 		}
 		if ( limits.minVersion && limits.maxVersion && limits.minVersion === limits.maxVersion ) {
 			versionView = <div className="plugin-information__version-limit">
-				{ this.translate( '{{icon/}} Compatible with %(maxVersion)s',
+				{ this.translate( '{{wpIcon/}} Compatible with %(maxVersion)s',
 					{
 						args: { maxVersion: limits.maxVersion },
 						components: { wpIcon: this.props.siteVersion ? null : <Gridicon icon="my-sites" size={ 18 } /> }


### PR DESCRIPTION
There is a js error that prevents the loading http://calypso.localhost:3000/plugins/online-booking only on development. 

Before:
![screen shot 2016-01-04 at 17 46 16](https://cloud.githubusercontent.com/assets/115071/12105607/2b1e8e6e-b30b-11e5-8c29-b22402c14c3c.png)

After:
![screen shot 2016-01-04 at 17 46 41](https://cloud.githubusercontent.com/assets/115071/12105605/26e6b1fa-b30b-11e5-9e91-143673f2158e.png)

**To test**
Visit http://calypso.localhost:3000/plugins/online-booking
The page is able to load as expected. 