### PR TITLE
Framework: remove unnecessary global constant for webpack-dev-server config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,6 @@ var config = require( './server/config' ),
  * Internal variables
  */
 var CALYPSO_ENV = process.env.CALYPSO_ENV || 'development',
-	PORT = process.env.PORT || 3000,
 	jsLoader,
 	webpackConfig;
 
@@ -99,7 +98,7 @@ jsLoader = {
 if ( CALYPSO_ENV === 'development' ) {
 	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
 	webpackConfig.entry[ 'build-' + CALYPSO_ENV ] = [
-		'webpack-dev-server/client?http://calypso.localhost:' + PORT,
+		'webpack-dev-server/client?/',
 		'webpack/hot/only-dev-server',
 		path.join( __dirname, 'client', 'boot' )
 	];


### PR DESCRIPTION
The path to the socket.io endpoint does not need to contain the host information so the relative path `/` can be used in place of `http://calypso.localhost:3000` with the same effect.

The advantage of this change is the ability to run calypso in development mode using any **hostname and port**\* we want.

#### Testing instructions
- `git checkout fix/webpack-dev-server-url`
- `make run`
- Ensure that the websocket connection is still established to `ws://calypso.localhost:3000/socket.io` and that the hot module reloader still works. (can be tested in all recent browsers)

#### Context
This is useful for a multi branch version of the application (See: https://github.com/Automattic/calypso-live-branches). This way we can run the hot reloader and avoid restarting the server for each commit.

**\* Limited to the whitelisted origins (at `https://public-api.wordpress.com/wp-admin/rest-proxy/`) when using `wpcom-proxy-request` or to authorized origins when using OAuth.**
