### PR TITLE
Measure how much time placeholders spend on screen

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -25,6 +25,7 @@ var config = require( 'config' ),
 	sites = require( 'lib/sites-list' )(),
 	superProps = require( 'analytics/super-props' ),
 	i18n = require( 'lib/mixins/i18n' ),
+	perfmon = require( 'lib/perfmon' ),
 	translatorJumpstart = require( 'lib/translator-jumpstart' ),
 	translatorInvitation = require( 'layout/community-translator/invitation-utils' ),
 	layoutFocus = require( 'lib/layout-focus' ),
@@ -182,6 +183,11 @@ function boot() {
 		}
 
 		layoutElement = React.createElement( LoggedOutLayout );
+	}
+
+	if ( config.isEnabled( 'perfmon' ) ) {
+		// Record time spent watching slowly-flashing divs
+		perfmon();
 	}
 
 	layout = renderWithReduxStore(

--- a/client/lib/perfmon/README.md
+++ b/client/lib/perfmon/README.md
@@ -1,0 +1,24 @@
+Performance Monitoring
+======
+
+`perfmon` records how much time one or more loading indicators spend on the screen (currently timings are only sent to Google Analytics, but the goal is to get them into statsd or Kibana pronto). This includes those flashing grey divs, and the "pulsing dot", but could be extended to any component.
+
+Rather than hooking into React, we monitor the DOM itself for anything that looks like a placeholder (being careful not to do anything that would noticeably hurt performance), figure out whether it's visible on the screen, and if so we record how long it was there for.
+
+How it works right now:
+
+- A MutationObserver is created which monitors DOM childList and class attribute changes within div#wpcom.
+- It matches classes on these altered nodes (and their children) against a very rudimentary list of strings (anything containing 'placeholder' or 'pulsing-dot is-active'). Any nodes that match are recorded as "activePlaceholders".
+- It checks to see if any activePlaceholders are in the viewport. The event timing is the duration between the first placeholder appearing in the viewport and the last one disappearing.
+- Placeholders can also be scrolled into view - it monitors for 'scroll' events with useCapture = true (debounced to 200ms) so that we can re-check if any known placeholders have now appeared.
+- It hooks into the `page()` system in order to clear pending events when the user navigates (or, at least, when that navigation is done via the `page` library rather than replaceState/pushState)
+
+You can enable this in development by running `ENABLE_FEATURES=perfmon make run`. You may also want to set `google_analytics_enabled` to `true` in your config file if you want to observe the events being sent to Google Analytics.
+
+You can see how many active placeholders (visible and non visible) there detected during each check by running this in your console:
+
+```
+localStorage.setItem('debug', 'calypso:perfmon')
+```
+
+and then reloading the browser.

--- a/client/lib/perfmon/index.js
+++ b/client/lib/perfmon/index.js
@@ -1,0 +1,173 @@
+/** 
+ * Internal dependencies
+ */
+import analytics from 'analytics';
+
+/**
+ * External dependencies
+ */
+import each from 'lodash/collection/each';
+import remove from 'lodash/array/remove';
+import debounce from 'lodash/function/debounce';
+import page from 'page';
+
+var debug = require( 'debug' )( 'calypso:perfmon' );
+
+const PLACEHOLDER_CLASSES = [
+	'placeholder',
+	'pulsing-dot is-active',
+	'is-loading'
+];
+
+const PLACEHOLDER_MATCHER = PLACEHOLDER_CLASSES.map(function(clazz) { return `[class*='${clazz}']`; }).join(', ');
+const OBSERVE_ROOT = document.getElementById('wpcom');
+
+let activePlaceholders = [];
+let placeholdersVisibleStart = null;
+let initialized = false;
+
+// add listeners for various DOM events - scrolling, mutation and navigation
+// and use these to trigger checks for visible placeholders (and, in the case of mutations,
+// to record new placeholders and remove nodes that are no longer placeholders)
+function observeDomChanges( MutationObserver ) {
+	// if anything scrolls, check if any of our placeholder elements are in view,
+	// but not more than a few times a second
+	window.addEventListener('scroll', debounce(checkForVisiblePlaceholders.bind(null, 'scroll'), 200), true);
+
+	// if the user navigates, stop the current event and proceed to the next one
+	page( function( context, next ) {
+		// send "placeholder-wait-navigated" event
+		checkForVisiblePlaceholders( 'navigate' );
+		next();
+	} );
+
+	// this is fired for matching mutations (childList and class attr changes)
+	var observer = new MutationObserver(function(mutations, observer) {
+		
+		// record all the nodes that match our placeholder classes in the "activePlaceholders" array
+		mutations.forEach( recordPlaceholders );
+
+		// remove any nodes from activePlaceholders that are no longer placeholders
+		// check each node for:
+		// a. whether it's still in the DOM at all, and if so:
+		// b. whether it still has a placeholder class
+		var removed = remove( activePlaceholders, function( node ) {
+			return !OBSERVE_ROOT.contains( node ) || !isPlaceholder( node );
+		} );
+
+		checkForVisiblePlaceholders( 'mutation' );
+
+	} );
+
+	observer.observe( OBSERVE_ROOT, {
+	  subtree: true,
+	  attributes: true,
+	  childList: true,
+	  attributeFilter: ['class']
+	} );
+}
+
+// check if there are any placeholders on the screen,
+// and trigger a timing event when all the placeholders are gone or the user
+// has navigated
+function checkForVisiblePlaceholders( trigger ) {
+	// determine how many placeholders are active in the viewport
+	const visibleCount = activePlaceholders.reduce( 
+		function( count, node ) { 
+			return count + ( isElementVisibleInViewport( node ) ? 1 : 0 ); 
+		}, 0 
+	);
+
+	// record event and reset timer if all placeholders are loaded OR user has just navigated
+	if ( placeholdersVisibleStart && ( visibleCount === 0 || trigger === 'navigate' ) ) {
+		// tell tracks to record duration
+		var duration = Date.now() - placeholdersVisibleStart;
+		debug(`Recording placeholder wait. Duration: ${duration}, Trigger: ${trigger}`);
+		analytics.timing.record( `placeholder-wait`, duration, trigger );
+		placeholdersVisibleStart = visibleCount === 0 ? null : Date.now();
+	}
+
+	// if we can see placeholders, placeholdersVisibleStart is falsy, start the clock
+	if ( visibleCount > 0 && !placeholdersVisibleStart ) {
+		placeholdersVisibleStart = Date.now(); // TODO: performance.now()?
+	}
+
+	// if there are placeholders hanging around, print some useful stats
+	if ( activePlaceholders.length > 0 ) {
+		debug("Active placeholders: "+activePlaceholders.length);
+		debug("Visible in viewport: "+visibleCount);
+	}
+}
+
+function isPlaceholder( node ) {
+	var className = node.className;
+	return className && className.indexOf && PLACEHOLDER_CLASSES.some( function( clazz ) { 
+		return (className.indexOf( clazz ) >= 0); 
+	} );
+}
+
+// adapted from http://stackoverflow.com/questions/123999/how-to-tell-if-a-dom-element-is-visible-in-the-current-viewport/7557433#7557433
+function isElementVisibleInViewport( node ) {
+	var rect = node.getBoundingClientRect();
+
+	// discard if width or height are zero
+	if ( (rect.top - rect.bottom) === 0 || (rect.right - rect.left) === 0) {
+		return false;
+	}
+
+	var windowHeight = (window.innerHeight || document.documentElement.clientHeight);
+	var windowWidth = (window.innerWidth || document.documentElement.clientWidth);
+
+	// if top or bottom are inside window, AND left or right edge are inside window, then
+	// the element is at least partially visible
+	return (
+		( ( rect.top >= 0 && rect.top <= windowHeight ) || ( rect.bottom >= 0 && rect.bottom <= windowHeight ) ) &&
+		( ( rect.left >= 0 && rect.left <= windowWidth ) || ( rect.right >= 0 && rect.right <= windowWidth  ) )
+	);
+}
+
+function recordPlaceholders( mutation ) { 
+	var nodes = [];
+
+	if ( mutation.attributeName === 'class' ) { // mutation.type === 'attributes' is redundant
+		nodes = [mutation.target];
+	} else if ( mutation.type === 'childList' && mutation.addedNodes.length > 0 ) {
+		nodes = mutation.addedNodes;
+	} else {
+		return;
+	}
+
+	each( nodes, function( node ) {
+
+		if ( isPlaceholder( node ) ) {
+			recordPlaceholderNode( node );
+		}
+
+		// we need to find matching children because the mutation observer
+		// only fires for the top element of an added subtree
+		if ( node.querySelectorAll ) {
+			// funky syntax because NodeList walks like an array but doesn't quack like one
+			each( node.querySelectorAll(PLACEHOLDER_MATCHER), recordPlaceholderNode );
+		}
+	} );
+}
+
+function recordPlaceholderNode( node ) {
+	if ( activePlaceholders.indexOf( node ) >= 0 ) {
+		// no-op
+	} else {
+		activePlaceholders.push(node);
+	}
+}
+
+module.exports = function() {
+	if ( !initialized ) {
+		var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+
+		if ( MutationObserver ) {
+			observeDomChanges( MutationObserver );
+		}
+
+		initialized = true;
+	}
+};

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -84,7 +84,8 @@
 		"network-connection": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
-		"ad-tracking": false
+		"ad-tracking": false,
+		"perfmon": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
TL/DR: monitor how much time Calypso users spend looking at spinners so that we can focus on performance.

----

With the advent of single page apps everything is "instant"... or is it?

Instead of one spinning indicator on page load we can have dozens, and while we avoid the trap of a frustrated user clicking the button over and over again because they're not sure if things are working, we're still not doing any better in raw performance (sometimes worse, due to the bottleneck of all the API calls we're doing to the same domain and the volume of data retrieved).

Furthermore, optimisation is hard because we don't currently know where users are waiting. Should we prefetch posts for the reader? Should we only fetch 5 posts instead of 10? Should we batch together certain API calls? How does that affect perceived load time?

In order to make this "waiting time" visible, this PR creates a library called `perfmon`, which records how much time one or more loading indicators spend on the screen (currently timings are only sent to Google Analytics, but the goal is to get them into statsd or Kibana pronto). This includes those flashing grey divs, stats boxes, and the "pulsing dot", but could be extended to any component.

A key thing to note about my approach is that I wanted to avoid directly coupling with any components - the last thing I wanted to add for an experiment is a helper class mixin over the place, and remembering to add it to any new placeholder-aware components in the future would be error prone.

Instead I monitor the DOM itself for anything that looks like a placeholder (being careful not to do anything that would noticeably hurt performance), figure out whether it's visible on the screen, and if so I can record how long it was there for.

Here's how it looks in Google Analytics, showing the cumulative time spent looking at placeholders in various sections of the product:

![timing-sample](https://cloud.githubusercontent.com/assets/51896/12129121/6f64e05e-b3b6-11e5-9482-6e95c8bcc5b1.png)

And here's how it looks in Graphite:

![graphite-placeholders](https://cloud.githubusercontent.com/assets/51896/12186412/4c9b7c66-b557-11e5-8559-49fdf11d4206.png)

How it works:

- A MutationObserver is created which monitors DOM childList and class attribute changes within `div#wpcom`.
- It matches classes on these altered nodes (and their children) against a very rudimentary list of strings (anything containing 'placeholder', 'is-loading' or 'pulsing-dot is-active'). Any nodes that match are recorded as "activePlaceholders".
- It checks to see if any activePlaceholders are in the viewport. The event timing is the duration between the first placeholder appearing in the viewport and the last one disappearing.
- Placeholders can also be scrolled into view - it monitors for 'scroll' events with useCapture = true (debounced to 200ms) so that we can re-check if any known placeholders have now appeared.
- If the user navigates to another URL, an event is fired for any active placeholders and a new countdown begins, so that wait time is correctly attributed to each URL.

I've done some performance testing and on Chrome on my Macbook Pro it adds about 10-20ms to first 15 seconds or so after the "reader" page loads (a very placeholder-heavy page), which works out to be < 1% performance degradation. 

You can see how many active placeholders (visible and non visible) there are by running this in your console:

```
localStorage.setItem('debug', 'calypso:perfmon')
```

This has been tested in the latest Chrome, Firefox and Safari on a Mac and Edge on Windows.

At this point I think this code is ready for review by others. It would be great to get this into Horizon and see what real world usage looks like.

Future work:
- ~~Hide behind a configuration variable!~~ DONE!
- ~~Log data in an internal API for filtering and aggregation - need to make a post somewhere to propose how such an API would look and how data should be stored.~~ DONE! (thanks @josephscott)
- Capture more information about which components are loading slowly (it's hard to go from DOM->React, even with a data-reactid)
- Figure out a better way to record the page URL than memoizing it when someone calls analytics.pageView.record :/
- ~~Perhaps distinguish between scroll-to events and those triggered by DOM changes~~
- Tests, ~~README~~, etc :)

cc @beaulebens @roccotripaldi @martinremy 