### PR TITLE
Themes: calc num columns for a smooth scroll

### DIFF
--- a/shared/components/themes-list/index.jsx
+++ b/shared/components/themes-list/index.jsx
@@ -134,7 +134,7 @@ var ThemesList = React.createClass( {
 	render: function() {
 		const empty = ! this.props.loading && this.props.themes.length === 0;
 		return (
-			<div ref='themesList'>
+			<div ref="themesList">
 				{ empty ? this.renderEmpty() : this.renderList() }
 			</div>
 		);

--- a/shared/components/themes-list/index.jsx
+++ b/shared/components/themes-list/index.jsx
@@ -12,7 +12,7 @@ import Theme from 'components/theme';
 import EmptyContent from 'components/empty-content';
 import InfiniteList from 'components/infinite-list';
 import { THEME_COMPONENT_HEIGHT as ITEM_HEIGHT } from 'lib/themes/constants';
-import PER_PAGE from 'lib/themes/constants';
+import { PER_PAGE } from 'lib/themes/constants';
 import Debug from 'debug';
 
 const debug = new Debug( 'calypso:themes:themes-list' );

--- a/shared/components/themes-list/index.jsx
+++ b/shared/components/themes-list/index.jsx
@@ -1,17 +1,21 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	times = require( 'lodash/utility/times' );
+import React from 'react';
+import times from 'lodash/utility/times';
 
 /**
  * Internal dependencies
  */
-var Theme = require( 'components/theme' ),
-	EmptyContent = require( 'components/empty-content' ),
-	InfiniteList = require( 'components/infinite-list' ),
-	ITEM_HEIGHT = require( 'lib/themes/constants' ).THEME_COMPONENT_HEIGHT,
-	PER_PAGE = require( 'lib/themes/constants' ).PER_PAGE;
+import Theme from 'components/theme';
+import EmptyContent from 'components/empty-content';
+import InfiniteList from 'components/infinite-list';
+import { THEME_COMPONENT_HEIGHT as ITEM_HEIGHT } from 'lib/themes/constants';
+import PER_PAGE from 'lib/themes/constants';
+import { isDesktop, isWithinBreakpoint } from 'lib/viewport';
+import Debug from 'debug';
+
+const debug = new Debug( 'Calypso:themes:themes-list' );
 
 /**
  * Component
@@ -44,6 +48,25 @@ var ThemesList = React.createClass( {
 		return 'theme-' + theme.id;
 	},
 
+	getNumColumns: function() {
+		const ThemeListWidth = window.innerWidth - this.getSidebarWidth();
+		const themeWidth = 250;
+
+		const numColumns = Math.floor( ThemeListWidth / themeWidth ) || 1;
+		debug( 'numColumns: ', numColumns );
+		return numColumns;
+	},
+
+	getSidebarWidth: function() {
+		if ( isWithinBreakpoint( '<660px' ) ) {
+			return 0;
+		}
+		if ( isDesktop() ) {
+			return 300;
+		}
+		return 250;
+	},
+
 	renderTheme: function( theme, index ) {
 		var key = this.getThemeRef( theme );
 		return <Theme ref={ key }
@@ -64,8 +87,7 @@ var ThemesList = React.createClass( {
 
 	// Invisible trailing items keep all elements same width in flexbox grid.
 	renderTrailingItems: function() {
-		const NUM_SPACERS = 8; // gives enough spacers for a theoretical 9 column layout
-		return times( NUM_SPACERS, function( i ) {
+		return times( this.getNumColumns(), function( i ) {
 			return <div className="themes-list--spacer" key={ 'themes-list--spacer-' + i } />;
 		} );
 	},
@@ -96,7 +118,7 @@ var ThemesList = React.createClass( {
 				renderItem={ this.renderTheme }
 				renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
 				renderTrailingItems={ this.renderTrailingItems }
-				itemsPerRow={ 2 }
+				itemsPerRow={ this.getNumColumns() }
 			/>
 		);
 	}

--- a/shared/components/themes-list/index.jsx
+++ b/shared/components/themes-list/index.jsx
@@ -13,7 +13,6 @@ import EmptyContent from 'components/empty-content';
 import InfiniteList from 'components/infinite-list';
 import { THEME_COMPONENT_HEIGHT as ITEM_HEIGHT } from 'lib/themes/constants';
 import PER_PAGE from 'lib/themes/constants';
-import { isDesktop, isWithinBreakpoint } from 'lib/viewport';
 import Debug from 'debug';
 
 const debug = new Debug( 'calypso:themes:themes-list' );


### PR DESCRIPTION
**Before**
![scroll-before](https://cloud.githubusercontent.com/assets/7767559/12114085/1701dc8a-b39f-11e5-8fe5-5fba268b2aa7.gif)

**After**
![scroll-after](https://cloud.githubusercontent.com/assets/7767559/12114089/1b98a562-b39f-11e5-9b96-0f32ea593f37.gif)

The number of theme screenshots per row in the Showcase is dynamic and depends on the viewport size, yet the `<InfiniteList />` `itemsPerRow` prop is currently hardcoded to `2`. `<InfiniteList />` uses this prop to calculate spacer heights, so when it does not match with the actual number of items per row, the scroll is glitchy.

This change adds a pragmatic calculation for that prop.

**To Test**
1) Go to http://calypso.localhost:3000/design
2) In the console, type `localStorage.setItem( 'debug', 'calypso:themes:themes-list' );`
3) Check scroll is smooth at all viewport widths
4) Check that `numColumns` in the debug output matches visible number of columns

Update: a different solution to some of the scroll problems would be to replace infinite-list with infinite-scroll, which is tried in #2151
