### PR TITLE
External js error logging service

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -31,6 +31,7 @@ var config = require( 'config' ),
 	layoutFocus = require( 'lib/layout-focus' ),
 	nuxWelcome = require( 'nux-welcome' ),
 	emailVerification = require( 'components/email-verification' ),
+	errorReporting = require( 'lib/error-reporting' ),
 	viewport = require( 'lib/viewport' ),
 	detectHistoryNavigation = require( 'lib/detect-history-navigation' ),
 	sections = require( 'sections' ),
@@ -160,6 +161,7 @@ function boot() {
 		// When logged in the analytics module requires user and superProps objects
 		// Inject these here
 		analytics.initialize( user, superProps );
+		errorReporting.setUser( user );
 
 		// Create layout instance with current user prop
 		Layout = require( 'layout' );

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -93,7 +93,9 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 					window.location = 'https://wordpress.com/browsehappy?url=' + encodeURIComponent( window.location );
 				}
 			})();
-
+		if errorReporter && errorReporter.scriptUrl && errorReporter.installCode
+			script(src=errorReporter.scriptUrl)
+			script(type='text/javascript')!=errorReporter.installCode
 		if user
 			script(type='text/javascript')!='var currentUser = ' + sanitize.jsonStringifyForHtml( user )
 		if app

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -10,6 +10,7 @@ var express = require( 'express' ),
 var config = require( 'config' ),
 	sanitize = require( 'sanitize' ),
 	utils = require( 'bundler/utils' ),
+	errorReporter = require( '../../shared/lib/error-reporting/' ),
 	sections = require( '../../client/sections' );
 
 var HASH_LENGTH = 10,
@@ -124,6 +125,7 @@ function getDefaultContext( request ) {
 		urls: generateStaticUrls( request ),
 		user: false,
 		env: CALYPSO_ENV,
+		errorReporter: errorReporter.installErrorReporter( CALYPSO_ENV ),
 		sanitize: sanitize,
 		isRTL: config( 'rtl' ),
 		isDebug: request.query.debug !== undefined ? true : false,

--- a/shared/lib/error-reporting/index.js
+++ b/shared/lib/error-reporting/index.js
@@ -1,0 +1,25 @@
+export function setUser() {};
+
+if ( typeof window === 'object' && window.Raven ) {
+	setUser = user => {
+		window.Raven.setUserContext( {
+			id: user.data.ID
+		} );
+	}
+}
+
+export function installErrorReporter( env ) {
+	return {
+		scriptUrl: 'https://cdn.ravenjs.com/2.0.1/raven.min.js',
+		installCode: `
+			if ( Raven ) {
+				Raven.config( 'https://5bae20cfadc949b48ffd4f96c1900b6c@app.getsentry.com/62683', {
+				  whitelistUrls: [/calypso\.localhost/, /wordpress\.com/],
+				  tags: {
+				  	env: '` + env + `'
+				  }
+				} ).install();
+			}
+		`
+	}
+}


### PR DESCRIPTION
### TLDR
This PR connects Calypso to the error-logging service 'Sentry': https://getsentry.com/welcome/
We have 14 days to test it for free.
This is more of a proof-of-concept, but I would love to see some kind of solution for this.

## Why?
Recently, `plans/compare` was broken for more than 2 weeks. This is kinda embarassing and we shouldn't have let this happen.
We have a lot of users that click through Calypso and test stuff for us. Even we do the same on Staging. Lets make use of it!

## Why service?
There are similar PRs that aim to do the same on our infrastructure- #1949 

### Pros of using a service
- Someone will be actually improving the UI for tracking errors
- This one has nice integrations (Slack, Github...)
- Having error handling outside the application is in my opinion safer, because it is less likely to fail at the same time as app

## I wanna see errors!
Please ping me, I will add you to the project.

CC
@drewblaisdell @scruffian @dmsnell @blowery 
