### PR TITLE
Free trials: Add free trial exception message

### DIFF
--- a/client/components/plans/plan-features/index.jsx
+++ b/client/components/plans/plan-features/index.jsx
@@ -57,6 +57,7 @@ module.exports = React.createClass( {
 					sitePlan={ sitePlan }
 					site={ this.props.site } />
 				<PlanActions
+					enableFreeTrials={ this.props.enableFreeTrials }
 					onSelectPlan={ this.props.onSelectPlan }
 					isInSignup={ this.props.isInSignup }
 					plan={ this.props.plan }

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -86,6 +86,7 @@ var PlansCompare = React.createClass( {
 		return plans.map( function( plan ) {
 			return (
 				<PlanFeatures
+					enableFreeTrials={ this.props.enableFreeTrials }
 					onSelectPlan={ this.props.onSelectPlan }
 					isInSignup={ this.props.isInSignup }
 					key={ plan.product_id }

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -19,7 +19,8 @@ var observe = require( 'lib/mixins/data-observe' ),
 	HeaderCake = require( 'components/header-cake' ),
 	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
 	getPlansBySiteId = require( 'state/sites/plans/selectors' ).getPlansBySiteId,
-	Card = require( 'components/card' );
+	Card = require( 'components/card' ),
+	featuresListUtils = require( 'lib/features-list/utils' );
 
 var PlansCompare = React.createClass( {
 	displayName: 'PlansCompare',
@@ -74,7 +75,7 @@ var PlansCompare = React.createClass( {
 		return featuresList.map( function( feature ) {
 			return (
 				<PlanFeatureCell key={ feature.product_slug } title={ feature.description }>
-					{ feature.title }
+					{ feature.title } { featuresListUtils.featureNotPartOfTrial( feature ) ? '*' : '' }
 				</PlanFeatureCell>
 			);
 		} );
@@ -94,6 +95,14 @@ var PlansCompare = React.createClass( {
 					sitePlans={ this.props.sitePlans } />
 			);
 		}, this );
+	},
+
+	freeTrialExceptionMessage: function( featuresList ) {
+		if ( featuresListUtils.featureListHasAFreeTrialException( featuresList ) ) {
+			return <div className="plans-compare__free-trial-exception-message">{ this.translate( '* Not included during the free trial period' ) }</div>;
+		}
+
+		return null;
 	},
 
 	comparisonTable: function() {
@@ -128,6 +137,7 @@ var PlansCompare = React.createClass( {
 						{ this.featureNames( featuresList ) }
 					</div>
 					{ this.featureColumns( site, plans, featuresList ) }
+					{ this.freeTrialExceptionMessage( featuresList ) }
 				</div>
 			);
 		}

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -168,9 +168,9 @@ var PlansCompare = React.createClass( {
 		return (
 			<div className={ this.props.className }>
 				{
-					this.props.isInSignup ?
-					null :
-					<SidebarNavigation />
+					this.props.isInSignup
+					? null
+					: <SidebarNavigation />
 				}
 				<HeaderCake onClick={ this.goBack }>
 					{ this.translate( 'Compare Plans' ) }

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -108,7 +108,7 @@ var PlansCompare = React.createClass( {
 			return false;
 		}
 
-		if ( canStartTrial || hasTrial ) {
+		if ( canStartTrial || hasTrial || this.props.enableFreeTrials ) {
 			return true;
 		}
 

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -5,7 +5,8 @@ var React = require( 'react' ),
 	connect = require( 'react-redux' ).connect,
 	page = require( 'page' ),
 	classNames = require( 'classnames' ),
-	times = require( 'lodash/utility/times' );
+	times = require( 'lodash/utility/times' ),
+	property = require( 'lodash/utility/property' );
 
 /**
  * Internal dependencies
@@ -100,16 +101,15 @@ var PlansCompare = React.createClass( {
 	},
 
 	showFreeTrialException: function() {
-		const hasTrial = this.props.sites ? this.props.sites.getSelectedSite().plan.free_trial : false,
-			canStartTrial = this.props.sitePlans ? this.props.sitePlans.data.some( function( plan ) {
-				return plan.canStartTrial;
-			} ) : false;
+		const canStartTrial = this.props.sitePlans && this.props.sitePlans.hasLoadedFromServer
+				? this.props.sitePlans.data.some( property( 'canStartTrial' ) )
+				: false;
 
 		if ( ! config.isEnabled( 'upgrades/free-trials' ) ) {
 			return false;
 		}
 
-		if ( canStartTrial || hasTrial || this.props.enableFreeTrials ) {
+		if ( canStartTrial || this.props.enableFreeTrials ) {
 			return true;
 		}
 
@@ -125,7 +125,7 @@ var PlansCompare = React.createClass( {
 	},
 
 	freeTrialExceptionMessage: function( featuresList ) {
-		if ( this.showFreeTrialException() && featuresListUtils.featureListHasAFreeTrialException( featuresList ) ) {
+		if ( this.showFreeTrialException() && featuresList.some( featuresListUtils.featureNotPartOfTrial ) ) {
 			return <div className="plans-compare__free-trial-exception-message">{ this.translate( '* Not included during the free trial period' ) }</div>;
 		}
 

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -141,7 +141,11 @@ var PlansCompare = React.createClass( {
 
 	freeTrialExceptionMessage: function( featuresList ) {
 		if ( this.showFreeTrialException() && featuresList.some( featuresListUtils.featureNotPartOfTrial ) ) {
-			return <div className="plans-compare__free-trial-exception-message">{ this.translate( '* Not included during the free trial period' ) }</div>;
+			return (
+				<div className="plans-compare__free-trial-exception-message">
+					{ this.translate( '* Not included during the free trial period' ) }
+				</div>
+			);
 		}
 
 		return null;

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -101,7 +101,10 @@ var PlansCompare = React.createClass( {
 	},
 
 	showFreeTrialException: function() {
-		const canStartTrial = this.props.sitePlans && this.props.sitePlans.hasLoadedFromServer
+		const hasTrial = this.props.sites
+				? this.props.sites.getSelectedSite().plan.free_trial
+				: false,
+			canStartTrial = this.props.sitePlans && this.props.sitePlans.hasLoadedFromServer
 				? this.props.sitePlans.data.some( property( 'canStartTrial' ) )
 				: false;
 
@@ -109,7 +112,19 @@ var PlansCompare = React.createClass( {
 			return false;
 		}
 
-		if ( canStartTrial || this.props.enableFreeTrials ) {
+		// always show if the user is currently in trial
+		if ( hasTrial ) {
+			return true;
+		}
+
+		// show if the site is eligible for a trial (it never had a free trial before)
+		// and free trial is enabled for this component
+		if ( canStartTrial && this.props.enableFreeTrials ) {
+			return true;
+		}
+
+		// show if we are in signup and free trial is enabled for this component
+		if ( this.props.isInSignup && this.props.enableFreeTrials ) {
 			return true;
 		}
 

--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -8,3 +8,8 @@
 		text-align: left;
 	}
 }
+
+.plans-compare__free-trial-exception-message {
+	font-size: .9em;
+	text-align: right;
+}

--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -10,6 +10,8 @@
 }
 
 .plans-compare__free-trial-exception-message {
-	font-size: .9em;
+	font-size: .8em;
+	font-style: italic;
 	text-align: right;
+	margin-top: 15px;
 }

--- a/client/lib/features-list/utils.js
+++ b/client/lib/features-list/utils.js
@@ -1,0 +1,14 @@
+function featureNotPartOfTrial( feature ) {
+	return feature.not_part_of_free_trial;
+}
+
+function featureListHasAFreeTrialException( featuresList ) {
+	return featuresList.some( function( feature ) {
+		return featureNotPartOfTrial( feature );
+	} );
+}
+
+export default {
+	featureNotPartOfTrial,
+	featureListHasAFreeTrialException
+};

--- a/client/lib/features-list/utils.js
+++ b/client/lib/features-list/utils.js
@@ -2,13 +2,6 @@ function featureNotPartOfTrial( feature ) {
 	return feature.not_part_of_free_trial;
 }
 
-function featureListHasAFreeTrialException( featuresList ) {
-	return featuresList.some( function( feature ) {
-		return featureNotPartOfTrial( feature );
-	} );
-}
-
 export default {
-	featureNotPartOfTrial,
-	featureListHasAFreeTrialException
+	featureNotPartOfTrial
 };

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -19,7 +19,7 @@ var sites = require( 'lib/sites-list' )(),
 	upgradesActions = require( 'lib/upgrades/actions' ),
 	titleActions = require( 'lib/screen-title/actions' );
 
-function handlePlanSelect( cartItem, siteSlug ) {
+function handlePlanSelect( cartItem ) {
 	upgradesActions.addItem( cartItem );
 
 	// FIXME: @rads: The `defer` is necessary here to prevent an error with

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -123,6 +123,7 @@ module.exports = {
 				<ReduxProvider store={ context.store }>
 					<CartData>
 						<PlansCompare sites={ sites }
+							enableFreeTrials={ true }
 							selectedSite={ site }
 							onSelectPlan={ onSelectPlan }
 							plans={ plans }

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -123,7 +123,7 @@ module.exports = {
 				<ReduxProvider store={ context.store }>
 					<CartData>
 						<PlansCompare sites={ sites }
-							enableFreeTrials={ true }
+							enableFreeTrials
 							selectedSite={ site }
 							onSelectPlan={ onSelectPlan }
 							plans={ plans }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -80,13 +80,17 @@ module.exports = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_signup_compare_plans_click', { location: linkLocation } );
 	},
 
+	isFreeTrialFlow: function() {
+		return 'free-trial' === this.props.flowName;
+	},
+
 	plansList: function() {
 		return (
 			<div>
 				<PlanList
 					plans={ this.state.plans }
 					comparePlansUrl={ this.comparePlansUrl() }
-					enableFreeTrials={ 'free-trial' === this.props.flowName }
+					enableFreeTrials={ this.isFreeTrialFlow() }
 					isInSignup={ true }
 					onSelectPlan={ this.onSelectPlan } />
 				<a
@@ -126,6 +130,7 @@ module.exports = React.createClass( {
 	plansCompare: function() {
 		return <PlansCompare
 			className="plans-step__compare"
+			enableFreeTrials={ this.isFreeTrialFlow() }
 			onSelectPlan={ this.onSelectPlan }
 			isInSignup={ true }
 			backUrl={ this.props.path.replace( '/compare', '' ) }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -91,7 +91,7 @@ module.exports = React.createClass( {
 					onSelectPlan={ this.onSelectPlan } />
 				<a
 					href={ this.comparePlansUrl() }
-					className='plans-step__compare-plans-link'
+					className="plans-step__compare-plans-link"
 					onClick={ this.handleComparePlansLinkClick.bind( null, 'footer' ) }>
 						<Gridicon icon="clipboard" size={ 18 } />
 						{ this.translate( 'Compare Plans' ) }
@@ -137,9 +137,9 @@ module.exports = React.createClass( {
 	render: function() {
 		return <div className="plans plans-step has-no-sidebar">
 			{
-				'compare' === this.props.stepSectionName ?
-				this.plansCompare() :
-				this.plansSelection()
+				'compare' === this.props.stepSectionName
+				? this.plansCompare()
+				: this.plansSelection()
 			}
 		</div>;
 	}


### PR DESCRIPTION
This PR adds an exception message to the /plans/compare screen like this:

![screen shot 2015-12-17 at 8 01 15 am](https://cloud.githubusercontent.com/assets/3011211/11874437/89e70faa-a494-11e5-8099-b1d9a21f2bb6.png)

The message will only show in cases where the user is being offered a free trial. There are five cases to consider.
Show the message when:
- 1. A new signup is offered a free trial
- 2. An existing site is offered a free trial
- 3. A site which is in a trial already, on /plans/compare/:domain

Don't show the message when
- 4. A new signup which is not offered a free trial
- 5. An existing site is not eligible for any free trials

Fixes #1482.

This also fixes #2149 - making it possible to start a trial from /plans/compare

#### Testing instructions 1

1. Open http://calypso.localhost:3000/start/free-trial
2. Go through the flow to the plans step, and view the plans comparison screen
3. Assert that you are shown the exception message for custom domains
4. Assert that you are given the option to start a free trial

#### Testing instructions 2

1. Open http://calypso.localhost:3000/plans
2. Select a site which has never had a trial before
3. Open the plans compare screen
4. Assert that you are shown the exception message for custom domains
5. Assert that you are given the option to start a free trial

#### Testing instructions 3

1. Open http://calypso.localhost:3000/plans
2. Select any site
3. Open the plans compare screen
2. Use the site selector to select a site which is currently on a free trial
4. Assert that you are shown the exception message for custom domains

#### Testing instructions 4

1. Open http://calypso.localhost:3000/start
2. Go through the flow to the plans step, and view the plans comparison screen
3. Assert that you are not shown the exception message for custom domains
4. Assert that you are not given the option to start a free trial

#### Testing instructions 5

1. Open http://calypso.localhost:3000/plans
2. Select a site which never had a trial before
3. Open the plans compare screen
4. Assert that you are not shown the exception message for custom domains
5. Assert that you are not given the option to start a free trial

#### Reviews

- [x] Code
- [x] Product
