### PR TITLE
Domain Management: make chevrons consistent with Purchases

### DIFF
--- a/client/my-sites/upgrades/domain-management/list/item.jsx
+++ b/client/my-sites/upgrades/domain-management/list/item.jsx
@@ -10,11 +10,14 @@ import CompactCard from 'components/card/compact';
 import DomainPrimaryFlag from 'my-sites/upgrades/domain-management/components/domain/primary-flag';
 import { type as domainTypes } from 'lib/domains/constants';
 
+var Gridicon = require( 'components/gridicon' );
+
 const ListItem = React.createClass( {
 	render() {
 		return (
 			<CompactCard className="domain-management-list-item">
 				<div className="domain-management-list-item__link" onClick={ this.props.onClick }>
+					<Gridicon className='card__link-indicator' icon='chevron-right' />
 					<div className="domain-management-list-item__title">
 						{ this.props.domain.name }
 					</div>

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -53,22 +53,6 @@
 	cursor: pointer;
 	display: block;
 	overflow: hidden;
-
-	&:after {
-		@include noticon( '\f431', 25px );
-		color: $gray;
-		display: block;
-		height: auto;
-		line-height: 72px;
-		position: absolute;
-			right: 16px;
-			top: 0;
-		transform: rotate( -90deg );
-
-		@include breakpoint( ">660px" ) {
-			line-height: 83px;
-		}
-	}
 }
 
 .domain-management-list-item__title {


### PR DESCRIPTION
This pull request fixes #2078 by using the `chevron-right` Gridicon on the Domain Management list item, instead of the old, darker Noticon.

Before | After
------------ | -------------
<img width="736" alt="screen shot 2016-01-05 at 12 25 44 pm" src="https://cloud.githubusercontent.com/assets/448298/12122290/070dd104-b3a8-11e5-85f9-dd70a0d01656.png"> | <img width="734" alt="screen shot 2016-01-05 at 12 24 41 pm" src="https://cloud.githubusercontent.com/assets/448298/12122295/0a7fe30e-b3a8-11e5-8f5b-ed822852217d.png">

cc @breezyskies 