### PR TITLE
SelectedSite: Fix redux error

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -139,7 +139,9 @@ module.exports = {
 
 		// If there's a valid site from the url path
 		// set site visibility to just that site on the picker
-		if ( ! sites.select( siteID ) ) {
+		if ( sites.select( siteID ) ) {
+			onSelectedSiteAvailable();
+		} else {
 			// if sites has fresh data and siteID is invalid
 			// redirect to allSitesPath
 			if ( sites.fetched || ! sites.fetching ) {
@@ -148,14 +150,12 @@ module.exports = {
 			// Otherwise, check when sites has loaded
 			sites.once( 'change', function() {
 				// if sites have loaded, but siteID is invalid, redirect to allSitesPath
-				if ( ! sites.select( siteID ) ) {
+				if ( sites.select( siteID ) ) {
+					onSelectedSiteAvailable();
+				} else {
 					page.redirect( allSitesPath );
 				}
-
-				onSelectedSiteAvailable();
 			} );
-		} else {
-			onSelectedSiteAvailable();
 		}
 
 		next();

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -18,7 +18,7 @@ import { SET_SELECTED_SITE, SET_SECTION } from 'state/action-types';
 export function selectedSite( state = null, action ) {
 	switch ( action.type ) {
 		case SET_SELECTED_SITE:
-			state = action.siteId;
+			state = action.siteId || null;
 			break;
 	}
 

--- a/client/state/ui/test/reducer.js
+++ b/client/state/ui/test/reducer.js
@@ -25,5 +25,14 @@ describe( 'reducer', () => {
 
 			expect( state ).to.equal( 2916284 );
 		} );
+
+		it( 'should set to null if siteId is undefined', () => {
+			const state = selectedSite( null, {
+				type: SET_SELECTED_SITE,
+				siteId: undefined
+			} );
+
+			expect( state ).to.be.null;
+		} );
 	} );
 } );


### PR DESCRIPTION
Currently if you attempt to load a site that a user does not have access to, a redux error is shown in the console:

`Uncaught Error: Reducer "selectedSite" returned undefined handling "SET_SELECTED_SITE". To ignore an action, you must explicitly return the previous state.`

To re-create the error, attempt to load the editor for a site that does not exist in your sitesList ( i.e. https://wordpress.com/post/somerandom.wordpress.com )

This branch tests to see if the `siteId` supplied to the `SET_SELECTED_SITE` is undefined, and sets the state to `null` instead.

/cc @aduth 