### PR TITLE
Lint: Ignore tag closings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -60,7 +60,6 @@
 		"jsx-quotes": [ 1, "prefer-double" ],
 		"react/jsx-no-bind": 1,
 		"react/jsx-curly-spacing": [ 1, "always" ],
-		"react/jsx-closing-bracket-location": [ 1, "after-props" ],
 		// Allows function use before declaration
 		"no-use-before-define": [ 2, "nofunc" ],
 		// We split external, internal, module variables


### PR DESCRIPTION
[In #1807](https://github.com/Automattic/wp-calypso/pull/1807/files#diff-1dc6ee56b778cd91e0327b52aaeaa1b9R61) we added the `react/jsx-closing-bracket-location` rule to eslint.  Here is the current "valid" style (`after-props`):

```js
render() {
    return (
        <Component
            lotsOfProps
            lastProp />
    );
}
```

This style (`tag-aligned` or `line-aligned`) is now a warning:

```js
render() {
    return (
        <Component
            lotsOfProps
            lastProp
        />
    );
}
```

However, the second style makes a lot more sense to me:

- Like the `);` and `}` immediately below, the tag closing denotes the end of a block
- Easier to rearrange props this way, like trailing `,` in arrays

We use a mix of different styles ([about 1000 `after-props` and about 500 `line-aligned`](https://gist.github.com/nylen/29d9a0480e348d0f6c50)).  Let's just remove this rule as those 500 extra warnings aren't doing us any good.