### PR TITLE
Plans: Display properly formatted discount in `PlanPrice`

### DIFF
--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -1,19 +1,28 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+var React = require( 'react' ),
+	isUndefined = require( 'lodash/lang/isUndefined' );
 
 module.exports = React.createClass( {
 	displayName: 'PlanPrice',
 
-	getFormattedPrice: function( planDetails ) {
-		if ( planDetails ) {
-			if ( planDetails.raw_price === 0 ) {
+	getFormattedPrice: function( plan ) {
+		var rawPrice, formattedPrice;
+
+		if ( plan ) {
+			// the properties of a plan object from sites-list is snake_case
+			// the properties of a plan object from the global state are camelCase
+			rawPrice = isUndefined( plan.rawPrice ) ? plan.raw_price : plan.rawPrice;
+			formattedPrice = isUndefined( plan.formattedPrice ) ? plan.formatted_price : plan.formattedPrice;
+
+			if ( rawPrice === 0 ) {
 				return this.translate( 'Free', { context: 'Zero cost product price' } );
 			}
 
-			return planDetails.formatted_price;
+			return formattedPrice;
 		}
+
 		return this.translate( 'Loading' );
 	},
 


### PR DESCRIPTION
Fixes #2141.

As @apeatling pointed out in this issue, `getFormattedPrice` expects snake_case properties, but the plan objects from `plan` and `sitePlan` use different camel/snake variable names, as the plan object (which I believe is part of the site object) hasn't been rewritten to use the site-plans assembler yet.

This PR updates `getFormattedPrice` to check for the presence of either property name. We should eventually update the `plan` object from `SitesList` to follow our naming guidelines, but that will require a larger PR.

Before:
![image](https://cloud.githubusercontent.com/assets/1130674/12131838/0e711bf4-b3cb-11e5-9e3e-71d0c9b411cc.png)

After:
<img width="745" alt="screen shot 2016-01-05 at 4 38 15 pm" src="https://cloud.githubusercontent.com/assets/1130674/12131834/fbbd29d0-b3ca-11e5-9b9b-d49d5937893b.png">

**Testing**
- Visit `/plans/:site` for a site that has the premium plan.
- Assert that you see a full and discounted price like in the second screenshot above 'for the first year'.

cc @breezyskies 