### PR TITLE
Free Trials: Empty the cart when a free trial item is added to it

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -62,9 +62,10 @@ function add( newCartItem ) {
 }
 
 /**
- * Determines if the given cart item should replace the cart. Currently, only if
- * the given item will result in mixed renewals/non-renewals or multiple renewals
- * (excluding private registration).
+ * Determines if the given cart item should replace the cart.
+ * This can happen if the given item:
+ * - will result in mixed renewals/non-renewals or multiple renewals (excluding private registration).
+ * - is a free trial plan
  *
  * @param {Object} cartItem - `CartItemValue` object
  * @param {Object} cart - the existing shopping cart
@@ -78,6 +79,12 @@ function cartItemShouldReplaceCart( cartItem, cart ) {
 
 	if ( ! isRenewal( cartItem ) && hasRenewalItem( cart ) ) {
 		// all items should replace the cart if the cart contains a renewal
+		return true;
+	}
+
+	if ( productsValues.isFreeTrial( cartItem ) || hasFreeTrial( cart ) ) {
+		// adding a free trial plan to your cart replaces the cart
+		// adding another product to a cart containing a free trial removes the free trial
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #1922 

#### Testing instructions
1. Checkout this branch `git checkout fix/1922-empty-cart-free-trial`.
2. Start from an empty cart and add a product different from a free trial to your cart.
3. Go back to the "Plans" page and click on one of the "Start Free Trial" button.
4. Check that your previous item has disappeared and that the Free Trial plan is the only item in your cart.

#### Reviews

- [x] Product Review
- [x] Code Review