### PR TITLE
Domain Search: Improve notice copy when a domain is taken

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -65,7 +65,7 @@ var DomainSearchResults = React.createClass( {
 				} );
 			}
 
-			const domainUnavailableMessage = this.translate( ' %(domain)s is taken.', {
+			const domainUnavailableMessage = this.translate( '%(domain)s is taken.', {
 				args: { domain: lastDomainSearched }
 			} );
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -59,13 +59,13 @@ var DomainSearchResults = React.createClass( {
 				);
 		} else if ( this.props.suggestions && this.props.suggestions.length !== 0 && this.isDomainUnavailable() ) {
 			if ( this.props.products.domain_map && this.props.lastDomainError.code === 'not_available_but_mappable' ) {
-				mappingOffer = this.translate( 'Is it yours? {{a}}Map it{{/a}} for %(cost)s.', {
-					args: { cost: this.props.products.domain_map.cost_display },
-					components: { a: <a href="#" onClick={ this.addMappingAndRedirect } /> }
+				mappingOffer = this.translate( '{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}', {
+					args: { domain: lastDomainSearched, cost: this.props.products.domain_map.cost_display },
+					components: { a: <a href="#" onClick={ this.addMappingAndRedirect } />, small: <small /> }
 				} );
 			}
 
-			const domainUnavailableMessage = this.translate( 'Aww \u2014 %(domain)s is not available.', {
+			const domainUnavailableMessage = this.translate( ' %(domain)s is taken.', {
 				args: { domain: lastDomainSearched }
 			} );
 

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -15,6 +15,13 @@
 			margin-bottom: 30px;
 		}
 	}
+
+	.notice {
+		small {
+			display: block;
+			font-size: 12px;
+		}
+	}
 }
 
 .map-domain-step {


### PR DESCRIPTION
As reported by @hafizrahman in https://github.com/Automattic/wp-calypso/issues/1956, some users were getting confused by the "map it" option in the domain taken notice. I updated the copy and also deemphasized this option (since it's much more likely the domain just simply registered by someone else than actually one they own).

Before:
![screen shot 2016-01-06 at 7 02 52 am](https://cloud.githubusercontent.com/assets/3011211/12145528/86a295f8-b443-11e5-82cc-3c82c0249f4c.png)

After:
![screen shot 2016-01-06 at 7 00 38 am](https://cloud.githubusercontent.com/assets/3011211/12145505/6a3077b4-b443-11e5-8126-984889584b30.png)