### PR TITLE
Framework: Fixes logged out invite acceptance path

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -363,7 +363,7 @@ module.exports = function() {
 		}
 	} );
 
-	app.get( '/accept-invite/:site_id/:invitation_key', function( req, res ) {
+	app.get( '/accept-invite/:site_id/:invitation_key?/:activation_key?/:auth_key?', function( req, res ) {
 		if ( req.cookies.wordpress_logged_in ) {
 			// the user is probably logged in
 			renderLoggedInRoute( req, res );


### PR DESCRIPTION
Fixes an issue where follow invitations could not be accepted on `wpcalypso`.

Currently, you can go to `/accept-invite/$site/$invite_key` on `wpcalypso` to accept an invite for a role. But, for a follower invite, which looks like `/accept-invite/$site/$invite_key/$activation_key/$auth_key`, a user is redirected to WP.com to login.