### PR TITLE
Themes: Get rid of some JSX prop `.bind()`s

### DIFF
--- a/shared/components/theme/index.jsx
+++ b/shared/components/theme/index.jsx
@@ -96,7 +96,7 @@ var Theme = React.createClass( {
 	},
 
 	render: function() {
-		var themeClass = classNames( 'theme', {
+		const themeClass = classNames( 'theme', {
 			'is-active': this.props.active,
 			'is-actionable': !! ( this.props.screenshotClickUrl || this.props.onScreenshotClick )
 		} );

--- a/shared/components/theme/index.jsx
+++ b/shared/components/theme/index.jsx
@@ -114,12 +114,12 @@ var Theme = React.createClass( {
 				<div className="theme__content">
 					{ this.renderHover() }
 					<a href={ this.props.screenshotClickUrl }>
-						{ this.props.screenshot ?
-							<img className="theme__img"
+						{ this.props.screenshot
+							? <img className="theme__img"
 								src={ this.props.screenshot + '?w=' + screenshotWidth }
 								onClick={ this.props.onScreenshotClick }
-								id={ screenshotID }/> :
-							<div className="theme__no-screenshot" >
+								id={ screenshotID }/>
+							: <div className="theme__no-screenshot" >
 								<Gridicon icon="themes" size={ 48 } />
 							</div>
 						}

--- a/shared/components/theme/index.jsx
+++ b/shared/components/theme/index.jsx
@@ -11,8 +11,7 @@ var React = require( 'react' ),
  */
 var Card = require( 'components/card' ),
 	ThemeMoreButton = require( './more-button' ),
-	Gridicon = require( 'components/gridicon' ),
-	isExternal = require( 'lib/url' ).isExternal;
+	Gridicon = require( 'components/gridicon' );
 
 /**
  * Component

--- a/shared/components/theme/index.jsx
+++ b/shared/components/theme/index.jsx
@@ -139,6 +139,7 @@ var Theme = React.createClass( {
 							<span className="price">{ this.translate( 'Purchased' ) }</span>
 						}
 						{ this.props.buttonContents.length ? <ThemeMoreButton id={ this.props.id }
+							index={ this.props.index }
 							onClick={ this.props.onMoreButtonClick }
 							price={ this.props.price }
 							purchased={ this.props.purchased }

--- a/shared/components/theme/index.jsx
+++ b/shared/components/theme/index.jsx
@@ -47,6 +47,7 @@ var Theme = React.createClass( {
 				action: React.PropTypes.func,
 			} )
 		),
+		// Index of theme in results list
 		index: React.PropTypes.number,
 		// Label to show on screenshot hover.
 		actionLabel: React.PropTypes.string

--- a/shared/components/theme/more-button.jsx
+++ b/shared/components/theme/more-button.jsx
@@ -18,6 +18,10 @@ var PopoverMenu = require( 'components/popover/menu' ),
  */
 var ThemeMoreButton = React.createClass( {
 	propTypes: {
+		// Theme ID (theme-slug)
+		id: React.PropTypes.string.isRequired,
+		// Index of theme in results list
+		index: React.PropTypes.number.isRequired,
 		// Options to populate the popover menu with
 		options: React.PropTypes.arrayOf(
 			React.PropTypes.shape( {
@@ -36,7 +40,7 @@ var ThemeMoreButton = React.createClass( {
 
 	togglePopover: function() {
 		this.setState( { showPopover: ! this.state.showPopover } );
-		! this.state.showPopover && this.props.onClick();
+		! this.state.showPopover && this.props.onClick( this.props.id, this.props.index );
 	},
 
 	closePopover: function( action ) {

--- a/shared/components/theme/more-button.jsx
+++ b/shared/components/theme/more-button.jsx
@@ -48,6 +48,10 @@ var ThemeMoreButton = React.createClass( {
 		isFunction( action ) && action();
 	},
 
+	focus: function( event ) {
+		event.target.focus();
+	},
+
 	render: function() {
 		var classes = classNames(
 			'theme__more-button',
@@ -73,9 +77,7 @@ var ThemeMoreButton = React.createClass( {
 						if ( option.url ) {
 							return (
 								<a className="theme__more-button-menu-item popover__menu-item"
-									onMouseOver={ event => {
-										event.target.focus();
-									} }
+									onMouseOver={ this.focus }
 									key={ option.label }
 									href={ option.url }
 									target={ isOutsideCalypso( option.url ) ? '_blank' : null }>
@@ -88,7 +90,7 @@ var ThemeMoreButton = React.createClass( {
 								{ option.label }
 							</PopoverMenuItem>
 						);
-					} ) }
+					}, this ) }
 
 				</PopoverMenu>
 			</span>

--- a/shared/components/themes-list/index.jsx
+++ b/shared/components/themes-list/index.jsx
@@ -51,7 +51,7 @@ var ThemesList = React.createClass( {
 			buttonContents={ this.props.getButtonOptions( theme ) }
 			screenshotClickUrl={ this.props.getScreenshotUrl && this.props.getScreenshotUrl( theme ) }
 			onScreenshotClick={ this.props.onScreenshotClick && this.props.onScreenshotClick.bind( null, theme, index ) }
-			onMoreButtonClick={ this.props.onMoreButtonClick.bind( null, theme, index ) }
+			onMoreButtonClick={ this.props.onMoreButtonClick }
 			index={ index }
 			{ ...theme } />;
 	},

--- a/shared/my-sites/themes/themes-selection.jsx
+++ b/shared/my-sites/themes/themes-selection.jsx
@@ -50,7 +50,7 @@ const ThemesSelection = React.createClass( {
 		const { queryParams, themesList } = this.props;
 		analytics.tracks.recordEvent( 'calypso_themeshowcase_theme_click', {
 			search_term: queryParams.search,
-			theme: theme.id,
+			theme: theme,
 			results_rank: resultsRank + 1,
 			results: themesList,
 			page_number: queryParams.page


### PR DESCRIPTION
Rationale: performance, see e.g. https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md

No visual changes.

To test:
* Navigate to calypso.localhost:3000/design
* Enter `localStorage.setItem( 'debug', 'calypso:analytics:*' )` in your browser console
* Verify that clicking on any theme screenshot triggers an event that looks like so in your console:

```
calypso:analytics Record event "calypso_themeshowcase_theme_click" called with props {"theme":"pique","results_rank":2,"results":["canape","pique","twentysixteen","goodz-magazine","adaline","dyad","janice","button","gather","twotone","venture","melody","jason","veggie","sapor","corporate","restaurant","anemone","qua","watermark"],"page_number":1} +9s
```

Verify in particular that the `theme` and `results_rank` fields are present.