### PR TITLE
Signup: Remove autofill a/b test, keeping autofill behavior

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -30,7 +30,6 @@ import i18n from 'lib/mixins/i18n';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
-import { abtest } from 'lib/abtest';
 import { getValueFromProgressStore, mergeFormWithValue } from 'signup/utils';
 
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
@@ -40,7 +39,7 @@ let usernamesSearched = [],
 	timesUsernameValidationFailed = 0,
 	timesPasswordValidationFailed = 0;
 
-let resetAnalyticsData = () => {
+const resetAnalyticsData = () => {
 	usernamesSearched = [];
 	timesUsernameValidationFailed = 0;
 	timesPasswordValidationFailed = 0;
@@ -102,7 +101,7 @@ export default React.createClass( {
 			initialState: this.props.step ? this.props.step.form : undefined
 		} );
 		let initialState = this.formStateController.getInitialState();
-		if ( this.props.signupProgressStore && abtest( 'autoFillUsernameSignup' ) === 'autoFill' ) {
+		if ( this.props.signupProgressStore ) {
 			initialState = this.autoFillUsername( initialState );
 		}
 		this.setState( { form: initialState } );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -44,13 +44,5 @@ module.exports = {
 			nudge: 50
 		},
 		defaultVariation: 'drake'
-	},
-	autoFillUsernameSignup: {
-		datestamp: '20151216',
-		variations: {
-			autoFill: 50,
-			dontAutoFill: 50
-		},
-		defaultVariation: 'dontAutoFill'
 	}
 };


### PR DESCRIPTION
The `autoFill` variation of this test provides a better experience. Props to @SawyerHood for adding the test.

**Testing**
- Visit http://calypso.localhost:3000/start
- Proceed through the signup to the 'user' step.
- Assert that the 'username' field is populated with a value based on the domain or subdomain you chose in the domain step.

- [x] Product review
- [x] Code review