### PR TITLE
Reader: Fix polling for updates on Discover, blog streams.

### DIFF
--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -22,7 +22,7 @@ function getNextPageParams( store ) {
 	} else {
 		// only fetch four items for the initial page
 		// speeds up the initial fetch a fair bit
-		params.number = 4;
+		params.before = '2015-12-01T00:00:00Z';
 	}
 
 	return params;
@@ -58,6 +58,8 @@ FeedStreamActions = {
 		//
 		// This also lets other stores that are interested in posts pick them up. Handling it internally to the post store
 		// would rob them of that chance.
+		//
+		// TODO add a new action that receives an array of posts, so we can batch up this change and only emit once
 		if ( ! error && data && data.posts ) {
 			forEach( data.posts, function( post ) {
 				if ( post && get( post, 'meta.data.discover_original_post' ) ) {
@@ -66,7 +68,9 @@ FeedStreamActions = {
 						blogId: post.meta.data.discover_original_post.site_ID,
 						postId: post.meta.data.discover_original_post.ID
 					} );
-				} else if ( post && get( post, 'meta.data.post' ) ) {
+				}
+
+				if ( post && get( post, 'meta.data.post' ) ) {
 					FeedPostStoreActions.receivePost( null, post.meta.data.post, {
 						feedId: post.feed_ID,
 						postId: post.ID

--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -22,7 +22,7 @@ function getNextPageParams( store ) {
 	} else {
 		// only fetch four items for the initial page
 		// speeds up the initial fetch a fair bit
-		params.before = '2015-12-01T00:00:00Z';
+		params.number = 4;
 	}
 
 	return params;

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -441,7 +441,7 @@ assign( FeedStream.prototype, {
 			postKeys = this.filterNewPosts( data.posts );
 			if ( postKeys.length > 0 ) {
 				this.pendingPostKeys = postKeys;
-				this.pendingDateAfter = moment( data.date_range.after );
+				this.pendingDateAfter = moment( FeedPostStore.get( postKeys[ postKeys.length - 1 ] ).date );
 				this.emit( 'change' );
 			}
 		}

--- a/client/lib/feed-stream-store/test/post-list-store-tests.js
+++ b/client/lib/feed-stream-store/test/post-list-store-tests.js
@@ -29,7 +29,6 @@ describe( 'FeedPostList', function() {
 	} );
 
 
-
 	it( 'should require an id, a fetcher, a keyMaker', function() {
 		expect( function() {
 			return new PostListStore();
@@ -80,6 +79,8 @@ describe( 'FeedPostList', function() {
 		} );
 
 		it( 'should receive updates', function() {
+			let feedPostStoreStub = sinon.stub( FeedPostStore, 'get' );
+			feedPostStoreStub.returns( { date: '1999-12-31T23:58:00' } );
 			store.receiveUpdates( 'test', null, {
 				date_range: {
 					before: '1999-12-31T23:59:59',
@@ -88,6 +89,7 @@ describe( 'FeedPostList', function() {
 				posts: [ { feed_ID: 1, ID: 1 }, { feed_ID: 2, ID: 2 } ]
 			} );
 			expect( store.getUpdateCount() ).to.equal( 2 );
+			FeedPostStore.get.restore();
 		} );
 
 		it( 'should treat each set of updates as definitive', function() {
@@ -142,6 +144,8 @@ describe( 'FeedPostList', function() {
 					}
 				]
 			};
+			let feedPostStoreStub = sinon.stub( FeedPostStore, 'get' );
+			feedPostStoreStub.returns( { date: '1999-12-31T23:58:00' } );
 			store.receiveUpdates( 'test', null, firstSet );
 			expect( store.getUpdateCount() ).to.equal( 3 );
 
@@ -152,6 +156,7 @@ describe( 'FeedPostList', function() {
 			// new updates, overlapping
 			store.receiveUpdates( 'test', null, secondSet );
 			expect( store.getUpdateCount() ).to.equal( 4 );
+			FeedPostStore.get.restore();
 		} );
 	} );
 


### PR DESCRIPTION
Some streams don't hand back a date_range, so the code to set the pendingDateAfter was breaking. This changes it to pull the date off of the post in the post store instead.

To test, change `getNextPageParams` in `lib/feed-stream-store/actions.js` to look like this:

```js
function getNextPageParams( store ) {
	var params = {
			orderBy: store.orderBy,
			number: store.perPage,
			meta: 'post,discover_original_post'
		},
		lastDate = store.getLastItemWithDate();

	if ( lastDate ) {
		params.before = lastDate;
	} else {
		// only fetch four items for the initial page
		// speeds up the initial fetch a fair bit
		params.number = 4;
		params.before = '2015-12-01T00:00:00Z'; // important part
	}

	return params;
}
```

and then pull up a site stream, like http://calypso.localhost:3000/read/blog/id/64089429 (Fortune). In prod, this throws an error on the second poll that finds new posts. In dev it just works.
