### PR TITLE
Editor: Support VideoPress post-editor preview

### DIFF
--- a/client/components/shortcode/frame.jsx
+++ b/client/components/shortcode/frame.jsx
@@ -13,6 +13,7 @@ import mapValues from 'lodash/object/mapValues';
  * Internal dependencies
  */
 import ResizableIframe from 'components/resizable-iframe'
+import shortcodeUtils from 'lib/shortcode';
 
 /**
  * Module variables
@@ -122,6 +123,19 @@ export default React.createClass( {
 		this.props.onLoad( event );
 	},
 
+	getSandboxAttribute() {
+		// Tags of shortcodes that do not work if rendered in a sandboxed iframe.
+		const iframeNoSandbox = [
+			'wpvideo'
+		]
+		const shortcodeTag = shortcodeUtils.parse( this.props.shortcode ).tag;
+		const trustedHost = iframeNoSandbox.some( function ( trustedShortcodeTag ) {
+			return shortcodeTag === trustedShortcodeTag;
+		});
+
+		return trustedHost ? null : 'allow-scripts';
+	},
+
 	render() {
 		const classes = classNames( 'shortcode-frame', this.props.className );
 
@@ -134,6 +148,11 @@ export default React.createClass( {
 		// `shouldComponentUpdate`
 		const key = Math.random();
 
+		const extraProps = {};
+		if ( this.getSandboxAttribute() ) {
+			extraProps.sandbox = this.getSandboxAttribute();
+		}
+
 		return (
 			<ResizableIframe
 				key={ key }
@@ -141,8 +160,8 @@ export default React.createClass( {
 				src="https://wpcomwidgets.com/render/"
 				onLoad={ this.onFrameLoad }
 				frameBorder="0"
-				sandbox="allow-scripts"
-				className={ classes } />
+				className={ classes }
+				{ ...extraProps } />
 		);
 	}
 } );

--- a/client/components/tinymce/plugins/wpcom-view/views.js
+++ b/client/components/tinymce/plugins/wpcom-view/views.js
@@ -14,6 +14,7 @@ import config from 'config';
 import GalleryView from './gallery-view';
 import EmbedViewManager from './views/embed';
 import ContactFormView from './contact-form-view';
+import WpVideoView from './wpvideo-view';
 
 /**
  * Module variables
@@ -25,6 +26,10 @@ let views = {
 
 if ( config.isEnabled( 'post-editor/contact-form' ) ) {
 	views.contact = ContactFormView;
+}
+
+if ( config.isEnabled( 'post-editor/wpvideo-view' ) ) {
+	views.wpvideo = WpVideoView;
 }
 
 const components = mapValues( views, ( view ) => {

--- a/client/components/tinymce/plugins/wpcom-view/wpvideo-view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/wpvideo-view.jsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import shortcodeUtils from 'lib/shortcode';
+import Shortcode from 'components/shortcode';
+
+var WpVideoView = React.createClass( {
+
+	statics: {
+		match( content ) {
+			const match = shortcodeUtils.next( 'wpvideo', content );
+
+			if ( match ) {
+				return {
+					index: match.index,
+					content: match.content,
+					options: {
+						shortcode: match.shortcode
+					}
+				};
+			}
+		},
+
+		serialize( content ) {
+			return encodeURIComponent( content );
+		}
+	},
+
+	render() {
+		return (
+			<div className="wpview-content wpview-type-wpvideo">
+				<Shortcode siteId={ this.props.siteId }>
+					{ this.props.content }
+				</Shortcode>
+			</div>
+		);
+	}
+
+} );
+
+export default WpVideoView;

--- a/client/components/tinymce/plugins/wpcom-view/wpvideo-view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/wpvideo-view.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import shortcodeUtils from 'lib/shortcode';
 import Shortcode from 'components/shortcode';
 
-var WpVideoView = React.createClass( {
+const WpVideoView = React.createClass( {
 
 	statics: {
 		match( content ) {

--- a/config/development.json
+++ b/config/development.json
@@ -44,6 +44,7 @@
 		"post-editor-github-link": false,
 		"post-editor/post-type-switch": false,
 		"post-editor/contact-form": true,
+		"post-editor/wpvideo-view": true,
 
 		"manage/media": true,
 		"manage/posts": true,


### PR DESCRIPTION
Closes: #1730

There is currently no VideoPress preview offered in the post editor on WordPress.com. When adding a VideoPress video to a post, only the shortcode text is shown in the editor post content. Only after saving and previewing the post can a user see how the post will look like.

This PR enables previewing of VideoPress videos in the wpcom-view TinyMCE plugin.