### PR TITLE
Free trials: Show a purchase now button on /plans/compare

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -282,7 +282,7 @@ module.exports = React.createClass( {
 			return;
 		}
 
-		if ( this.isPlanOnTrial() ) {
+		if ( this.props.sitePlan.freeTrial ) {
 			return this.getTrialPlanHint();
 		}
 
@@ -297,10 +297,6 @@ module.exports = React.createClass( {
 
 	planHasCost: function() {
 		return this.props.plan.cost > 0;
-	},
-
-	isPlanOnTrial: function() {
-		return this.props.sitePlan.freeTrial;
 	},
 
 	placeholder: function() {
@@ -332,5 +328,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-
 } );

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -70,16 +70,24 @@ module.exports = React.createClass( {
 	},
 
 	upgradeActions: function() {
+		var label;
+
 		if ( isFreePlan( this.props.plan ) ) {
 			return this.freePlanButton();
 		}
 
+		if ( this.props.sitePlan && this.props.sitePlan.freeTrial ) {
+			label = this.translate( 'Purchase Now' );
+		} else {
+			label = this.translate( 'Upgrade Now' );
+		}
+
 		return (
 			<div>
-				<button className="button is-primary plan-actions__upgrade-button"
+				<button
+					className="button is-primary plan-actions__upgrade-button"
 					onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'button' ) }>
-
-					{ this.props.sitePlan.freeTrial ? this.translate( 'Purchase Now' ) : this.translate( 'Upgrade Now' ) }
+					{ label }
 				</button>
 			</div>
 		);

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -31,6 +31,10 @@ module.exports = React.createClass( {
 		}
 
 		if ( this.siteHasThisPlan() ) {
+			if ( this.props.sitePlan.freeTrial ) {
+				return this.upgradeActions();
+			}
+
 			return (
 				<div className="plan-actions__action-details">
 					<div className="plan-actions__current">
@@ -74,7 +78,8 @@ module.exports = React.createClass( {
 			<div>
 				<button className="button is-primary plan-actions__upgrade-button"
 					onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'button' ) }>
-					{ this.translate( 'Upgrade Now' ) }
+
+					{ this.props.sitePlan.freeTrial ? this.translate( 'Purchase Now' ) : this.translate( 'Upgrade Now' ) }
 				</button>
 			</div>
 		);


### PR DESCRIPTION
This pull request fixes #2112 by showing a "Purchase now" button on the /plans/compare page when a site is currently in a free trial for this plan:

Before:
<img width="1236" alt="screen shot 2016-01-05 at 17 08 53" src="https://cloud.githubusercontent.com/assets/275961/12150542/3c22bd28-b4a2-11e5-9850-90486828d5be.png">

After:
<img width="663" alt="screen shot 2016-01-06 at 18 19 33" src="https://cloud.githubusercontent.com/assets/275961/12150515/0e902706-b4a2-11e5-8fc4-860959393b39.png">

#### Testing instructions

1. Run `git checkout fix/2112-expired-plan-actions` and start your server
2. Open the [`Compare Plans` page](http://calypso.dev:3000/plans/compare/:site) for a site that is currently in a free trial
3. Assert that the "Manage plan" button now says "Purchase now"


#### Reviews

- [x] Code
- [x] Product