### PR TITLE
PostNorm: Parse srcsets and make them safe.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1252,3 +1252,29 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
+
+
+### https://github.com/sindresorhus/srcset
+```text
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -440,6 +440,18 @@ describe( 'post-normalizer', function() {
 				}
 			);
 		} );
+
+		it( 'fixes up srcsets', function( done ) {
+			normalizer(
+				{
+					content: '<img src="http://example.com/example.jpg" srcset="http://example.com/example-100.jpg 100w, http://example.com/example-600.jpg 600w">'
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages() ] ) ], function( err, normalized ) {
+					assert.equal( normalized.content, '<img src="http://example.com/example.jpg-SAFE" srcset="http://example.com/example-100.jpg-SAFE 100w, http://example.com/example-600.jpg-SAFE 600w">' );
+					done( err );
+				}
+			);
+		} );
 	} );
 
 	describe( 'content.wordCountAndReadingTime', function() {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "sanitize-html": "1.11.1",
     "source-map": "0.1.39",
     "source-map-support": "0.3.2",
+    "srcset": "1.0.0",
     "store": "1.3.16",
     "superagent": "1.2.0",
     "tinymce": "4.2.8",


### PR DESCRIPTION
Fixes #2163 

To test, pull up http://calypso.localhost:3000/read/post/feed/41826258/898319035, inspect the images in the body of the post and notice that both the `src` and `srcset` elements have been rewritten to use photon.