### PR TITLE
Framework: Proposed mechanism for replaying Flux actions to Redux

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -42,6 +42,7 @@ var config = require( 'config' ),
 	TitleStore = require( 'lib/screen-title/store' ),
 	createReduxStore = require( 'state' ).createReduxStore,
 	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
+	reduxFluxSync = require( 'lib/redux-flux-sync' ),
 	// The following mixins require i18n content, so must be required after i18n is initialized
 	Layout,
 	LoggedOutLayout;
@@ -157,6 +158,7 @@ function boot() {
 	translatorJumpstart.init();
 
 	reduxStore = createReduxStore();
+	reduxFluxSync( reduxStore );
 
 	if ( user.get() ) {
 		// When logged in the analytics module requires user and superProps objects

--- a/client/lib/redux-flux-sync/Makefile
+++ b/client/lib/redux-flux-sync/Makefile
@@ -1,0 +1,10 @@
+REPORTER ?= spec
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := $(BASE_DIR)/client:$(BASE_DIR)/shared
+
+test:
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers jsx:babel/register,js:babel/register --reporter $(REPORTER)
+
+.PHONY: test

--- a/client/lib/redux-flux-sync/index.js
+++ b/client/lib/redux-flux-sync/index.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import Dispatcher from 'dispatcher';
+import { receivePost } from 'state/posts/actions';
+
+/**
+ * Object mapping Flux action type to a function which, when called with the
+ * Flux action object, returns a Redux action object to be dispatched to the
+ * Redux store.
+ */
+const SYNC_ACTIONS = {
+	RECEIVE_POST_TO_EDIT: ( action ) => receivePost( action.post )
+};
+
+/**
+ * Subscribes to the global Flux dispatcher and dispatches to the provided
+ * Redux store instance if an action mapping can be determined when a Flux
+ * action is dispatched.
+ *
+ * @param  {Object} store Redux store instance
+ * @return {String}       Dispatcher subscription ID
+ */
+export default function( store ) {
+	return Dispatcher.register( ( payload ) => {
+		const handler = SYNC_ACTIONS[ payload.action.type ];
+		if ( handler ) {
+			store.dispatch( handler( payload.action ) );
+		}
+	} );
+}

--- a/client/lib/redux-flux-sync/test/index.js
+++ b/client/lib/redux-flux-sync/test/index.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import Chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+/**
+ * Internal dependencies
+ */
+import Dispatcher from 'dispatcher';
+import reduxFluxSync from '../';
+import { receivePost } from 'state/posts/actions';
+
+describe( 'reduxFluxSync', () => {
+	let sandbox, store, dispatch, subscriberId;
+
+	before( () => {
+		Chai.use( sinonChai );
+
+		sandbox = sinon.sandbox.create();
+		sandbox.spy( Dispatcher, 'register' );
+		dispatch = sandbox.spy();
+		store = { dispatch };
+	} );
+
+	beforeEach( () => {
+		sandbox.reset();
+		subscriberId = reduxFluxSync( store );
+	} );
+
+	afterEach( () => {
+		Dispatcher.unregister( subscriberId );
+	} );
+
+	after( () => {
+		sandbox.restore();
+	} );
+
+	it( 'should register to the dispatcher', () => {
+		expect( Dispatcher.register ).to.have.been.calledOnce;
+	} );
+
+	it( 'should return a dispatcher subscription ID', () => {
+		expect( subscriberId ).to.be.a( 'string' );
+	} );
+
+	it( 'should dispatch when having received a mapped action', () => {
+		const post = { ID: 1 };
+
+		Dispatcher.handleServerAction( {
+			type: 'RECEIVE_POST_TO_EDIT',
+			post
+		} );
+
+		expect( dispatch ).to.have.been.calledWith( receivePost( post ) );
+	} );
+} );


### PR DESCRIPTION
This pull request seeks to implement a new `lib/redux-flux-sync` module which bridges the divide between Flux and Redux actions by mapping Flux actions to an equivalent Redux action. This this will help ease the transition to Redux by enabling an incremental approach, rather than require the developer to migrate all actions at once.

Included is an example where a post receive action will be dispatched in Redux whenever the legacy `RECEIVE_POST_TO_EDIT` action is dispatched in the Flux dispatcher. Consequently, new post editor related Redux selectors and component bindings can be implemented without needing to transition all editor logic and components to Redux.

__Testing instructions:__

Verify that Mocha tests pass by running `make test` from the project root directory, or from `client/lib/redux-flux-sync` and `client/state/posts`.

Also confirm that a post object is added to the Redux global state when loading an existing post in the post editor. This is made easier by using the [Redux DevTools Chrome extension](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd/related).

1. Navigate to the [Calypso posts listing](http://calypso.localhost:3000/posts/my)
2. Edit an existing post
3. Click the Redux DevTools icon in the address bar
4. Note in the displayed overlay that a `POSTS_RECEIVE` action is fired, and that the subsequent state includes a post object under `state.posts.items`