### PR TITLE
Themes: Modify 'More' button items for logged-out view

### DIFF
--- a/shared/components/theme/index.jsx
+++ b/shared/components/theme/index.jsx
@@ -78,12 +78,12 @@ var Theme = React.createClass( {
 
 	renderHover: function() {
 		var actionLabel = this.translate( 'Preview', {
-			context: 'appears on hovering a single theme thumbnail, opens the theme demo site preview'
+			comment: 'appears on hovering a single theme thumbnail, opens the theme demo site preview'
 		} );
 
 		if ( this.props.active ) {
 			actionLabel = this.translate( 'Customize', {
-				context: 'appears on hovering the active single theme thumbnail, opens the customizer'
+				comment: 'appears on hovering the active single theme thumbnail, opens the customizer'
 			} );
 		} else {
 			actionLabel = this.props.actionLabel || actionLabel;

--- a/shared/components/theme/more-button.jsx
+++ b/shared/components/theme/more-button.jsx
@@ -11,7 +11,8 @@ var React = require( 'react' ),
  */
 var PopoverMenu = require( 'components/popover/menu' ),
 	PopoverMenuItem = require( 'components/popover/menu-item' ),
-	isOutsideCalypso = require( 'lib/url' ).isOutsideCalypso;
+	isOutsideCalypso = require( 'lib/url' ).isOutsideCalypso,
+	getSignupUrl = require( 'lib/themes/helpers' ).getSignupUrl;
 
 /**
  * Component
@@ -80,7 +81,12 @@ var ThemeMoreButton = React.createClass( {
 									onMouseOver={ this.focus }
 									key={ option.label }
 									href={ option.url }
-									target={ isOutsideCalypso( option.url ) ? '_blank' : null }>
+									target={ ( isOutsideCalypso( option.url ) &&
+										// We don't want to open a new tab for the signup flow
+										// TODO: Remove this hack once we can just hand over
+										// to Calypso's signup flow with a theme selected.
+										option.url !== getSignupUrl( { id: this.props.id } ) )
+										? '_blank' : null }>
 									{ option.label }
 								</a>
 							);

--- a/shared/lib/themes/actions.js
+++ b/shared/lib/themes/actions.js
@@ -168,6 +168,21 @@ export function clearActivated() {
 	};
 };
 
+export function signup( theme ) {
+	return dispatch => {
+		const signupUrl = ThemeHelpers.getSignupUrl( theme );
+
+		dispatch( {
+			type: ThemeConstants.SIGNUP_WITH_THEME,
+			theme
+		} );
+
+		// `ThemeHelpers.navigateTo` uses `page()` here, which messes with `pushState`,
+		// which we don't want here, since we're navigating away from Calypso.
+		window.location = signupUrl;
+	}
+}
+
 // Might be obsolete, since in theme-options.js, `hasUrl === true`
 export function details( theme, site ) {
 	return dispatch => {

--- a/shared/lib/themes/constants.js
+++ b/shared/lib/themes/constants.js
@@ -17,6 +17,7 @@ module.exports = assign( keyMirror( {
 	ACTIVATE_THEME: null,
 	ACTIVATED_THEME: null,
 	CLEAR_ACTIVATED_THEME: null,
+	SIGNUP_WITH_THEME: null,
 	THEME_DETAILS: null,
 	THEME_SUPPORT: null,
 	THEME_CUSTOMIZE: null

--- a/shared/lib/themes/helpers.js
+++ b/shared/lib/themes/helpers.js
@@ -9,6 +9,13 @@ var analytics = require( 'analytics' ),
 var ThemesHelpers = {
 	oldShowcaseUrl: '//wordpress.com/themes/',
 
+	getSignupUrl( theme ) {
+		// TODO:
+		// * Possibly add a `source` parameter
+		// * Can we point to Calypso NUX (/start) and pass it the theme id?
+		return '//signup.wordpress.com/signup/?source=calypso_showcase&theme=' + theme.id;
+	},
+
 	getPreviewUrl( theme, site ) {
 		if ( site && site.jetpack ) {
 			return site.options.admin_url + 'customize.php?theme=' + theme.id + '&return=' + encodeURIComponent( window.location );

--- a/shared/lib/themes/helpers.js
+++ b/shared/lib/themes/helpers.js
@@ -10,9 +10,7 @@ var ThemesHelpers = {
 	oldShowcaseUrl: '//wordpress.com/themes/',
 
 	getSignupUrl( theme ) {
-		// TODO:
-		// * Possibly add a `source` parameter
-		// * Can we point to Calypso NUX (/start) and pass it the theme id?
+		// TODO: Point to Calypso NUX (/start), passing it the theme id.
 		return '//signup.wordpress.com/signup/?source=calypso_showcase&theme=' + theme.id;
 	},
 

--- a/shared/my-sites/themes/main.jsx
+++ b/shared/my-sites/themes/main.jsx
@@ -79,6 +79,10 @@ var Themes = React.createClass( {
 		}
 	},
 
+	hideSiteSelectorModal: function() {
+		this.setSelectedTheme( null, null );
+	},
+
 	isThemeOrActionSet: function() {
 		return this.state.selectedTheme || this.state.selectedAction;
 	},
@@ -153,7 +157,7 @@ var Themes = React.createClass( {
 				}
 				{ this.isThemeOrActionSet() && <ThemesSiteSelectorModal selectedAction={ this.state.selectedAction }
 					selectedTheme={ this.state.selectedTheme }
-					onHide={ this.setSelectedTheme.bind( null, null, null ) }
+					onHide={ this.hideSiteSelectorModal }
 					actions={ bindActionCreators( Action, dispatch ) }
 					getOptions={ partialRight(
 						getButtonOptions,

--- a/shared/my-sites/themes/main.jsx
+++ b/shared/my-sites/themes/main.jsx
@@ -27,7 +27,8 @@ var Main = require( 'components/main' ),
 	ThemesSelection = require( './themes-selection' ),
 	ThemeHelpers = require( 'lib/themes/helpers' ),
 	getButtonOptions = require( './theme-options' ),
-	ThemesListSelectors = require( 'lib/themes/selectors/themes-list' );
+	ThemesListSelectors = require( 'lib/themes/selectors/themes-list' ),
+	user = require( 'lib/user' )();
 
 var Themes = React.createClass( {
 	mixins: [ observe( 'sites' ) ],
@@ -148,7 +149,7 @@ var Themes = React.createClass( {
 						sites={ this.props.sites }
 						setSelectedTheme={ this.setSelectedTheme }
 						togglePreview={ this.togglePreview }
-						getOptions={ partialRight( getButtonOptions, bindActionCreators( Action, dispatch ), this.setSelectedTheme, this.togglePreview, false ) }
+						getOptions={ partialRight( getButtonOptions, ! user.get(), bindActionCreators( Action, dispatch ), this.setSelectedTheme, this.togglePreview, false ) }
 						trackScrollPage={ this.props.trackScrollPage }
 						tier={ this.props.tier }
 						customize={ bindActionCreators( Action.customize, dispatch ) }
@@ -161,6 +162,7 @@ var Themes = React.createClass( {
 					actions={ bindActionCreators( Action, dispatch ) }
 					getOptions={ partialRight(
 						getButtonOptions,
+						! user.get(),
 						bindActionCreators( Action, dispatch ),
 						this.setSelectedTheme,
 						this.togglePreview,

--- a/shared/my-sites/themes/main.jsx
+++ b/shared/my-sites/themes/main.jsx
@@ -122,9 +122,13 @@ var Themes = React.createClass( {
 			return <JetpackManageDisabledMessage site={ site } />;
 		}
 
-		const webPreviewButtonText = this.translate( 'Try & Customize', {
-			context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
-		} );
+		const webPreviewButtonText = this.isLoggedOut()
+			? this.translate( 'Choose this design', {
+				comment: 'when signing up for a WordPress.com account with a selected theme'
+			} )
+			: this.translate( 'Try & Customize', {
+				context: 'when previewing a theme demo, this button opens the Customizer with the previewed theme'
+			} );
 
 		return (
 			<Main className="themes">
@@ -135,7 +139,9 @@ var Themes = React.createClass( {
 						previewUrl={ this.state.previewUrl } >
 						<Button primary onClick={ this.setState.bind( this, { showPreview: false },
 							() => {
-								if ( site ) {
+								if ( this.isLoggedOut() ) {
+									dispatch( Action.signup( this.state.previewingTheme ) );
+								} else if ( site ) {
 									dispatch( Action.customize( this.state.previewingTheme, site ) );
 								} else {
 									this.setSelectedTheme( 'customize', this.state.previewingTheme );

--- a/shared/my-sites/themes/main.jsx
+++ b/shared/my-sites/themes/main.jsx
@@ -92,6 +92,10 @@ var Themes = React.createClass( {
 		return ! this.props.siteId; // Not the same as `! site` !
 	},
 
+	isLoggedOut: function() {
+		return ! user.get();
+	},
+
 	renderJetpackMessage: function() {
 		var site = this.props.sites.getSelectedSite();
 		return (
@@ -149,7 +153,7 @@ var Themes = React.createClass( {
 						sites={ this.props.sites }
 						setSelectedTheme={ this.setSelectedTheme }
 						togglePreview={ this.togglePreview }
-						getOptions={ partialRight( getButtonOptions, ! user.get(), bindActionCreators( Action, dispatch ), this.setSelectedTheme, this.togglePreview, false ) }
+						getOptions={ partialRight( getButtonOptions, this.isLoggedOut(), bindActionCreators( Action, dispatch ), this.setSelectedTheme, this.togglePreview, false ) }
 						trackScrollPage={ this.props.trackScrollPage }
 						tier={ this.props.tier }
 						customize={ bindActionCreators( Action.customize, dispatch ) }
@@ -162,7 +166,7 @@ var Themes = React.createClass( {
 					actions={ bindActionCreators( Action, dispatch ) }
 					getOptions={ partialRight(
 						getButtonOptions,
-						! user.get(),
+						this.isLoggedOut(),
 						bindActionCreators( Action, dispatch ),
 						this.setSelectedTheme,
 						this.togglePreview,

--- a/shared/my-sites/themes/theme-options.js
+++ b/shared/my-sites/themes/theme-options.js
@@ -10,8 +10,8 @@ import assign from 'lodash/object/assign';
 import i18n from 'lib/mixins/i18n';
 import Helper from 'lib/themes/helpers';
 
-export default function getButtonOptions( site, theme, actions, setSelectedTheme, togglePreview, showAll = false ) {
-	return rawOptions( site, theme )
+export default function getButtonOptions( site, theme, isLoggedOut, actions, setSelectedTheme, togglePreview, showAll = false ) {
+	return rawOptions( site, theme, isLoggedOut )
 		.filter( option => showAll || ! option.isHidden )
 		.map( appendUrl )
 		.map( appendAction );
@@ -64,7 +64,7 @@ export default function getButtonOptions( site, theme, actions, setSelectedTheme
 	}
 };
 
-function rawOptions( site, theme ) {
+function rawOptions( site, theme, isLoggedOut ) {
 	return [
 		{
 			name: 'preview',
@@ -89,14 +89,14 @@ function rawOptions( site, theme ) {
 				comment: 'label for selecting a site for which to purchase a theme'
 			} ),
 			hasAction: true,
-			isHidden: theme.active || theme.purchased || ! theme.price
+			isHidden: isLoggedOut || theme.active || theme.purchased || ! theme.price
 		},
 		{
 			name: 'activate',
 			label: i18n.translate( 'Activate' ),
 			header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
 			hasAction: true,
-			isHidden: theme.active || ( theme.price && ! theme.purchased )
+			isHidden: isLoggedOut || theme.active || ( theme.price && ! theme.purchased )
 		},
 		{
 			name: 'customize',

--- a/shared/my-sites/themes/theme-options.js
+++ b/shared/my-sites/themes/theme-options.js
@@ -12,7 +12,7 @@ import Helper from 'lib/themes/helpers';
 
 export default function getButtonOptions( site, theme, actions, setSelectedTheme, togglePreview, showAll = false ) {
 	return rawOptions( site, theme )
-		.filter( option => showAll || ! option.hideIf )
+		.filter( option => showAll || ! option.isHidden )
 		.map( appendUrl )
 		.map( appendAction );
 
@@ -77,7 +77,7 @@ function rawOptions( site, theme ) {
 			} ),
 			hasAction: true,
 			hasUrl: false,
-			hideIf: theme.active
+			isHidden: theme.active
 		},
 		{
 			name: 'purchase',
@@ -89,21 +89,21 @@ function rawOptions( site, theme ) {
 				comment: 'label for selecting a site for which to purchase a theme'
 			} ),
 			hasAction: true,
-			hideIf: theme.active || theme.purchased || ! theme.price
+			isHidden: theme.active || theme.purchased || ! theme.price
 		},
 		{
 			name: 'activate',
 			label: i18n.translate( 'Activate' ),
 			header: i18n.translate( 'Activate on:', { comment: 'label for selecting a site on which to activate a theme' } ),
 			hasAction: true,
-			hideIf: theme.active || ( theme.price && ! theme.purchased )
+			isHidden: theme.active || ( theme.price && ! theme.purchased )
 		},
 		{
 			name: 'customize',
 			label: i18n.translate( 'Customize' ),
 			header: i18n.translate( 'Customize on:', { comment: 'label for selecting a site for which to customize a theme' } ),
 			hasAction: true,
-			hideIf: ! theme.active || ( site && ! site.isCustomizable() )
+			isHidden: ! theme.active || ( site && ! site.isCustomizable() )
 		},
 		{
 			separator: true
@@ -117,7 +117,7 @@ function rawOptions( site, theme ) {
 			name: 'support',
 			label: i18n.translate( 'Support' ),
 			hasUrl: true,
-			hideIf: site && site.jetpack // We don't know where support docs for a given theme on a self-hosted WP install are.
+			isHidden: site && site.jetpack // We don't know where support docs for a given theme on a self-hosted WP install are.
 		},
 	];
 }

--- a/shared/my-sites/themes/theme-options.js
+++ b/shared/my-sites/themes/theme-options.js
@@ -67,6 +67,12 @@ export default function getButtonOptions( site, theme, isLoggedOut, actions, set
 function rawOptions( site, theme, isLoggedOut ) {
 	return [
 		{
+			name: 'signup',
+			label: i18n.translate( 'Start a Blog' ),
+			hasUrl: true,
+			isHidden: ! isLoggedOut
+		},
+		{
 			name: 'preview',
 			label: i18n.translate( 'Preview', {
 				context: 'verb'

--- a/shared/my-sites/themes/theme-options.js
+++ b/shared/my-sites/themes/theme-options.js
@@ -68,7 +68,7 @@ function rawOptions( site, theme, isLoggedOut ) {
 	return [
 		{
 			name: 'signup',
-			label: i18n.translate( 'Start a Blog' ),
+			label: i18n.translate( 'Choose this design' ),
 			hasUrl: true,
 			isHidden: ! isLoggedOut
 		},

--- a/shared/my-sites/themes/theme-options.js
+++ b/shared/my-sites/themes/theme-options.js
@@ -68,7 +68,9 @@ function rawOptions( site, theme, isLoggedOut ) {
 	return [
 		{
 			name: 'signup',
-			label: i18n.translate( 'Choose this design' ),
+			label: i18n.translate( 'Choose this design', {
+				comment: 'when signing up for a WordPress.com account with a selected theme'
+			} ),
 			hasUrl: true,
 			isHidden: ! isLoggedOut
 		},

--- a/shared/my-sites/themes/themes-selection.jsx
+++ b/shared/my-sites/themes/themes-selection.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import partial from 'lodash/function/partial';
+import partialRight from 'lodash/function/partialRight';
 import page from 'page';
 
 /**
@@ -109,7 +109,7 @@ const ThemesSelection = React.createClass( {
 					<ThemesList getButtonOptions={ this.props.getOptions.bind( null, site ) }
 						onMoreButtonClick={ this.onMoreButtonClick }
 						onScreenshotClick={ this.onScreenshotClick }
-						getScreenshotUrl={ site ? partial( Helper.getPreviewUrl, partial.placeholder, site ) : null } />
+						getScreenshotUrl={ site ? partialRight( Helper.getPreviewUrl, site ) : null } />
 				</ThemesData>
 			</div>
 		);


### PR DESCRIPTION
Continued from 11387-gh-calypso-pre-oss. Fixes #2127

Remove 'Activate' and 'Purchase' from the logged-out Themes Showcase's 'More' button menu, and add a signup item.

Logged-out, client-side rendered `/design` has already worked quite well in `development`, except for the links in the 'More' button menu, and the screenshot link. This PR is meant to fix those links so that we have something we can possibly activate on `wpcalypso` and/or `horizon` soon.

Before:

![before](https://cloud.githubusercontent.com/assets/96308/12198322/2d3883ba-b60f-11e5-9c16-5bf595c42cc6.png)

After:

![after](https://cloud.githubusercontent.com/assets/96308/12198327/3b406a2c-b60f-11e5-8150-8e7b1fad47e2.png)

To test:
* Verify that the theme showcase works as before
 * for multisite, single WPCOM site, and single Jetpack site
 * with logged-out `/design` (use an incognito window) featuring only 'Choose this design', 'Preview', 'Details', and 'Support' links in the 'More' button menu
  * 'Choose this design' opens the (old) signup flow, with that theme pre-selected, in the same tab
 * Preview also has a 'Choose this design' button (instead of 'Try & Activate') that acts the same way

If the signup flow doesn't open, you probably don't have SSL enabled for your local Calypso (check your console for `SecurityError: The operation is insecure.`)