### PR TITLE
Purchases: Make it possible to edit payment details even if the user has no stored details

### DIFF
--- a/client/components/data/purchases/edit-card-details/index.jsx
+++ b/client/components/data/purchases/edit-card-details/index.jsx
@@ -40,7 +40,7 @@ function isDataLoading( state ) {
 
 const EditCardDetailsData = React.createClass( {
 	propTypes: {
-		cardId: React.PropTypes.string.isRequired,
+		cardId: React.PropTypes.string,
 		component: React.PropTypes.func.isRequired,
 		purchaseId: React.PropTypes.string.isRequired,
 		loadingPlaceholder: React.PropTypes.func.isRequired,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -213,7 +213,11 @@ function showCreditCardExpiringWarning( purchase ) {
 }
 
 function showEditPaymentDetails( purchase ) {
-	return ! isExpired( purchase ) && ! isOneTimePurchase( purchase ) && ! isIncludedWithPlan( purchase ) && isPaidWithCreditCard( purchase );
+	return showEditPaymentDetailsOption( purchase ) && isPaidWithCreditCard( purchase );
+}
+
+function showEditPaymentDetailsOption( purchase ) {
+	return ! isExpired( purchase ) && ! isOneTimePurchase( purchase ) && ! isIncludedWithPlan( purchase );
 }
 
 export {
@@ -238,5 +242,6 @@ export {
 	paymentLogoType,
 	purchaseType,
 	showCreditCardExpiringWarning,
-	showEditPaymentDetails
+	showEditPaymentDetails,
+	showEditPaymentDetailsOption,
 }

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -212,14 +212,6 @@ function showCreditCardExpiringWarning( purchase ) {
 		monthsUntilCardExpires( purchase ) < 3;
 }
 
-function showEditPaymentDetails( purchase ) {
-	return showEditPaymentDetailsOption( purchase ) && isPaidWithCreditCard( purchase );
-}
-
-function showEditPaymentDetailsOption( purchase ) {
-	return ! isExpired( purchase ) && ! isOneTimePurchase( purchase ) && ! isIncludedWithPlan( purchase );
-}
-
 export {
 	creditCardExpiresBeforeSubscription,
 	getName,
@@ -242,6 +234,4 @@ export {
 	paymentLogoType,
 	purchaseType,
 	showCreditCardExpiringWarning,
-	showEditPaymentDetails,
-	showEditPaymentDetailsOption,
 }

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -55,6 +55,13 @@ export default function() {
 	);
 
 	page(
+		paths.purchases.editCardDetailsWithCard(),
+		controller.sidebar,
+		controller.purchases.noSitesMessage,
+		controller.purchases.editCardDetails
+	);
+
+	page(
 		paths.purchases.list(),
 		controller.sidebar,
 		controller.purchases.noSitesMessage,

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -55,7 +55,7 @@ export default function() {
 	);
 
 	page(
-		paths.purchases.editCardDetailsWithCard(),
+		paths.purchases.editSpecificCardDetails(),
 		controller.sidebar,
 		controller.purchases.noSitesMessage,
 		controller.purchases.editCardDetails

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -491,7 +491,7 @@ const ManagePurchase = React.createClass( {
 			{ id, payment } = purchase;
 
 		let path = paths.editCardDetails( this.props.selectedSite.slug, id );
-		if ( payment.creditCard && payment.creditCard.id ) {
+		if ( isPaidWithCreditCard( purchase ) ) {
 			path = paths.editCardDetailsWithCard( this.props.selectedSite.slug, id, payment.creditCard.id );
 		}
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -43,11 +43,17 @@ import {
 	paymentLogoType,
 	purchaseType,
 	showCreditCardExpiringWarning,
-	showEditPaymentDetails,
-	showEditPaymentDetailsOption,
 } from 'lib/purchases';
 import { getPurchase, getSelectedSite, goToList, isDataLoading, recordPageView } from '../utils';
 import { isDomainProduct, isGoogleApps, isPlan, isSiteRedirect, isTheme } from 'lib/products-values';
+
+function showPaymentDetails( purchase ) {
+	return canEditPaymentDetails( purchase ) && isPaidWithCreditCard( purchase );
+}
+
+function canEditPaymentDetails( purchase ) {
+	return ! isExpired( purchase ) && ! isOneTimePurchase( purchase ) && ! isIncludedWithPlan( purchase );
+}
 
 const ManagePurchase = React.createClass( {
 	propTypes: {
@@ -354,7 +360,7 @@ const ManagePurchase = React.createClass( {
 			</span>
 		);
 
-		if ( isLoading || ! showEditPaymentDetails( purchase ) ) {
+		if ( isLoading || ! showPaymentDetails( purchase ) ) {
 			return (
 				<li>
 					{ paymentDetails }
@@ -489,7 +495,7 @@ const ManagePurchase = React.createClass( {
 			path = paths.editCardDetailsWithCard( this.props.selectedSite.slug, id, payment.creditCard.id );
 		}
 
-		if ( showEditPaymentDetailsOption( purchase ) ) {
+		if ( canEditPaymentDetails( purchase ) ) {
 			return (
 				<VerticalNavItem path={ path }>
 					{ this.translate( 'Edit Payment Method' ) }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -43,7 +43,8 @@ import {
 	paymentLogoType,
 	purchaseType,
 	showCreditCardExpiringWarning,
-	showEditPaymentDetails
+	showEditPaymentDetails,
+	showEditPaymentDetailsOption,
 } from 'lib/purchases';
 import { getPurchase, getSelectedSite, goToList, isDataLoading, recordPageView } from '../utils';
 import { isDomainProduct, isGoogleApps, isPlan, isSiteRedirect, isTheme } from 'lib/products-values';
@@ -483,9 +484,14 @@ const ManagePurchase = React.createClass( {
 		const purchase = getPurchase( this.props ),
 			{ id, payment } = purchase;
 
-		if ( showEditPaymentDetails( purchase ) ) {
+		let path = paths.editCardDetails( this.props.selectedSite.slug, id );
+		if ( payment.creditCard && payment.creditCard.id ) {
+			path = paths.editCardDetailsWithCard( this.props.selectedSite.slug, id, payment.creditCard.id );
+		}
+
+		if ( showEditPaymentDetailsOption( purchase ) ) {
 			return (
-				<VerticalNavItem path={ paths.editCardDetails( this.props.selectedSite.slug, id, payment.creditCard.id ) }>
+				<VerticalNavItem path={ path }>
 					{ this.translate( 'Edit Payment Method' ) }
 				</VerticalNavItem>
 			);

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -47,10 +47,6 @@ import {
 import { getPurchase, getSelectedSite, goToList, isDataLoading, recordPageView } from '../utils';
 import { isDomainProduct, isGoogleApps, isPlan, isSiteRedirect, isTheme } from 'lib/products-values';
 
-function showPaymentDetails( purchase ) {
-	return canEditPaymentDetails( purchase ) && isPaidWithCreditCard( purchase );
-}
-
 function canEditPaymentDetails( purchase ) {
 	return ! isExpired( purchase ) && ! isOneTimePurchase( purchase ) && ! isIncludedWithPlan( purchase );
 }
@@ -360,7 +356,7 @@ const ManagePurchase = React.createClass( {
 			</span>
 		);
 
-		if ( isLoading || ! showPaymentDetails( purchase ) ) {
+		if ( isLoading || ! canEditPaymentDetails( purchase ) || ! isPaidWithCreditCard( purchase ) ) {
 			return (
 				<li>
 					{ paymentDetails }
@@ -492,7 +488,7 @@ const ManagePurchase = React.createClass( {
 
 		let path = paths.editCardDetails( this.props.selectedSite.slug, id );
 		if ( isPaidWithCreditCard( purchase ) ) {
-			path = paths.editCardDetailsWithCard( this.props.selectedSite.slug, id, payment.creditCard.id );
+			path = paths.editSpecificCardDetails( this.props.selectedSite.slug, id, payment.creditCard.id );
 		}
 
 		if ( canEditPaymentDetails( purchase ) ) {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -85,7 +85,7 @@ const ManagePurchase = React.createClass( {
 	},
 
 	isDataFetchingAfterRenewal() {
-		return 'thank-you' === this.props.destinationType && this.props.selectedPurchase.isFetching;
+		return this.props.selectedPurchase.isFetching;
 	},
 
 	isDataValid( props = this.props ) {

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -26,7 +26,11 @@ function cancelPrivateRegistration( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/cancel-private-registration';
 }
 
-function editCardDetails( siteName, purchaseId, cardId = ':cardId' ) {
+function editCardDetails( siteName, purchaseId ) {
+	return editPaymentMethod( siteName, purchaseId ) + `/edit`;
+}
+
+function editCardDetailsWithCard( siteName, purchaseId, cardId = ':cardId' ) {
 	return editPaymentMethod( siteName, purchaseId ) + `/edit/${ cardId }`;
 }
 
@@ -39,6 +43,7 @@ export default {
 	confirmCancelPurchase,
 	cancelPrivateRegistration,
 	editCardDetails,
+	editCardDetailsWithCard,
 	editPaymentMethod,
 	list,
 	listNotice,

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -30,7 +30,7 @@ function editCardDetails( siteName, purchaseId ) {
 	return editPaymentMethod( siteName, purchaseId ) + `/edit`;
 }
 
-function editCardDetailsWithCard( siteName, purchaseId, cardId = ':cardId' ) {
+function editSpecificCardDetails( siteName, purchaseId, cardId = ':cardId' ) {
 	return editPaymentMethod( siteName, purchaseId ) + `/edit/${ cardId }`;
 }
 
@@ -43,7 +43,7 @@ export default {
 	confirmCancelPurchase,
 	cancelPrivateRegistration,
 	editCardDetails,
-	editCardDetailsWithCard,
+	editSpecificCardDetails,
 	editPaymentMethod,
 	list,
 	listNotice,

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -235,7 +235,7 @@ const EditCardDetails = React.createClass( {
 						<em>{ this.translate( 'All fields required' ) }</em>
 
 						<FormButton type="submit">
-							{ this.translate( 'Update Card', { context: 'Button label', comment: 'Credit card' } ) }
+							{ this.translate( 'Save Card', { context: 'Button label', comment: 'Credit card' } ) }
 						</FormButton>
 					</CompactCard>
 				</form>


### PR DESCRIPTION
Currently the option to edit payment details is only available to users who have a credit card saved for a purchase. This is an unnecessary restriction, since we can add new cards for any purchase.

This PR makes it possible users to update the CC data for any purchase that will renew and hasn't expired, and isn't included in another purchase.

I made a change to the conditions under which we display the placeholder state; now the placeholder state will show whenever we fetch new purchases data from the server, which means it will happen more often, but it means we are less likely to show incorrect data - for example when you update your credit card the placeholder state will show.

Pinging @peterbutler for a sanity check.
 
#### Testing instructions

There are several cases to test:
1. The purchase is a one time purchase (e.g. a theme) --> do not show a link to edit payment details
2. The purchase is has expired --> do not show a link to edit payment details
3. The purchase is included in another purchase (e.g. a domain in a plan) --> do not show a link to edit payment details
4. The purchase has a current valid credit card --> the link to edit payment details contains a card id and shows some information for the current card.
5. The purchase was made with PayPal or has no payment data --> there is still a link to edit payment details, but there is no card id and no card info. In this case it should be asserted that updating the information saves the changes.
6. The user has an expired credit card --> there is a link to edit payment details. It should be asserted that the form is empty, and that updating the information saves the changes.
7. The user has an upgrade within 30 days from expiration --> the link to edit payment details contains a card id and shows some information for the current card (similar to case 4).
8. The user has an upgrade within 30 days from expiration and a card that is expiring --> the link to edit payment details contains a card id and shows some information for the current card (similar to case 7). This case works, but it looks a little off:
<img width="557" alt="screen shot 2016-01-15 at 13 04 25" src="https://cloud.githubusercontent.com/assets/275961/12353658/924f9440-bb88-11e5-81f8-ad1b7ba87c28.png">

#### Reviews

- [x] Code
- [x] Product