### PR TITLE
Me: Fixes issue where receipts were not able to be viewed

### DIFF
--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -73,11 +73,13 @@ module.exports = React.createClass( {
 	},
 
 	renderTransaction: function( transaction ) {
-		<div className="transaction-links">
-			<a className="view-receipt" href={ '/me/billing/' + transaction.id } onClick={ this.recordClickEvent( 'View Receipt in Billing History' ) } >
-				{ this.translate( 'View Receipt' ) }
-			</a>
-			{ this.renderEmailAction( transaction.id ) }
-		</div>
+		return (
+			<div className="transaction-links">
+				<a className="view-receipt" href={ '/me/billing/' + transaction.id } onClick={ this.recordClickEvent( 'View Receipt in Billing History' ) } >
+					{ this.translate( 'View Receipt' ) }
+				</a>
+				{ this.renderEmailAction( transaction.id ) }
+			</div>
+		);
 	}
 } );


### PR DESCRIPTION
Earlier today, @vparkhere reported via Slack that users were not able to view receipts. After looking into the issue, I noticed the that "View receipt" was no longer displayed for purchases. I then tracked the regression to being introduced in #1929.

In that PR, we created a method that never returned anything. This PR fixes that.

To test:
- Checkout `fix/me-billing-receipts`
- Go to `/me/billing` for an account that has purchases
- Verify that you can view and email a receipt

cc @roccotripaldi 