### PR TITLE
Add visible indicator for tapping sidebar links

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -126,6 +126,8 @@
 			outline: none;
 		}
 
+		-webkit-tap-highlight-color: rgba( $gray-dark, .2 );
+
 		@include breakpoint( "<660px" ) {
 			padding: 18px 16px 18px 53px;
 		}


### PR DESCRIPTION
Per the request in #1131 I made the sidebar links more visible when tapping on them by adding `-webkit-tap-highlight-color`.

Adding a :focus, or rather removing `&:focus { outline: none; }`, also helps quite a bit when navigating with the tab button as it will highlight each menu item.
 
cc @hoverduck 