### PR TITLE
Masterbar: Ensure visited new post is rendered as blue

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -86,18 +86,22 @@ $autobar-height: 20px;
 	height: 36px;
 	margin: 5px 8px;
 
-	&.is-active {
-		color: $white;
+	&:visited {
+		color: $blue-wordpress;
 	}
 
-	.masterbar__item-content {
-		display: none;
+	&.is-active {
+		color: $white;
 	}
 
 	&:hover,
 	&:focus {
 		background: $gray-light;
 		color: $blue-wordpress;
+	}
+
+	.masterbar__item-content {
+		display: none;
 	}
 
 	@include breakpoint( ">480px" ) {


### PR DESCRIPTION
This pull request seeks to resolve an issue where the Masterbar New Post icon appears as white in Firefox if the editor page had been visited.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/12172216/8d7878d6-b51d-11e5-922a-cb829d73c22b.png)|![After](https://cloud.githubusercontent.com/assets/1779930/12172213/86ce7df0-b51d-11e5-8fae-c9abb238c02b.png)

__Testing instructions:__

The following testing instructions should be confirmed in Firefox and in your preferred browser:

1. Ensure that you have already visited the [Calypso post editor](http://calypso.localhost:3000/post)
2. Navigate to any other Calypso page (e.g. Reader)
3. Note that the New Post icon in the Masterbar should be shown as blue when not active, with a subtle gray background when hovered/focussed, and white with blue background when active (i.e. on the editor page)