### PR TITLE
Invites: delete 'invite_accepted' flag upon redirect

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import Debug from 'debug';
 import classNames from 'classnames';
 import page from 'page';
+import store from 'store';
 
 /**
  * Internal Dependencies
@@ -16,7 +17,6 @@ import user from 'lib/user';
 import { fetchInvite, displayInviteDeclined } from 'lib/invites/actions';
 import InvitesStore from 'lib/invites/stores/invites-validation';
 import EmptyContent from 'components/empty-content';
-import store from 'store';
 import { displayInviteAccepted } from 'lib/invites/actions';
 
 /**
@@ -40,6 +40,7 @@ export default React.createClass( {
 	componentWillMount() {
 		const acceptedInvite = store.get( 'invite_accepted' );
 		if ( acceptedInvite && acceptedInvite.inviteKey === this.props.inviteKey ) {
+			store.remove( 'invite_accepted' );
 			page( this.getRedirectAfterAccept( acceptedInvite ) );
 			displayInviteAccepted( acceptedInvite );
 			return;


### PR DESCRIPTION
__How to Test__

* checkout `fix/invites-accept-twice`
* invite new user as admin
* copy the invitation link from the email
* replace wpcalypso.wordpress.com with calypso.dev:3000
* accept the invite
* remove that new user from site
* generate a new invite for the same user
* copy the invitation link from the email
* replace wpcalypso.wordpress.com with calypso.dev:3000
* while logged in accept the invite
* __assert__ the user gets added again!

Closes #2174