### PR TITLE
Themes: Add SEO-friendly meta tags to server output

### DIFF
--- a/client/layout/head/README.md
+++ b/client/layout/head/README.md
@@ -1,0 +1,38 @@
+Head
+====
+
+A generic component for layouts and Calypso sections, `Head` has
+isomorphism in mind. It allows a parent component to define the document
+title, as well as other data important for SEO — namely, a page's
+description and its canonical URL. It is, essentially, a wrapper for
+[`react-helmet`][helmet].
+
+It should work out of the box on both client- and server-side code,
+allowing e.g. a Calypso section to just declare its SEO-oriented meta.
+If SEO is not a concern for you, `Head` still has the benefit of
+providing a React-minded interface for setting document title.
+
+# Usage
+
+```js
+// In `my-sites/foo/controller.js`:
+<Head
+		title="Foo — WordPress.com"
+		description="Awesome foos for your WordPressen!"
+		canonicalUrl="https://wordpress.com/foo">
+	<FooMain />
+</Head>
+```
+
+# Next
+
+- This is a newborn component whose status is still uncertain. There
+  have been discussions about extending `Main` from `components/main` to
+  take the props shown in the example above, rendering `Head` obsolete.
+
+- Whether we keep `Head` or iterate on `Main`, if these components
+  prove themselves fit for `/design`'s isomorphic concerns, we could
+  start to phase out `lib/screen-title`'s `TitleStore` and actions in
+  favor of a Helmet-based approach.
+
+[helmet]: https://github.com/nfl/react-helmet

--- a/client/layout/head/index.jsx
+++ b/client/layout/head/index.jsx
@@ -1,0 +1,38 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Helmet from 'react-helmet';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:layout:head' );
+
+const Head = ( { title, description, canonicalUrl, children } ) => (
+	<div>
+		<Helmet
+			title={ title }
+			meta={ [
+				description ? { name: 'description', property: 'og:description', content: description } : {},
+				title ? { property: 'og:title', content: title } : {},
+				canonicalUrl ? { property: 'og:url', content: canonicalUrl } : {},
+			] }
+			link={ [
+				canonicalUrl ? { rel: 'canonical', href: canonicalUrl } : {}
+			] }
+			onChangeClientState={ debug }
+		/>
+		{ children }
+	</div>
+);
+
+Head.displayName = 'Head';
+Head.propTypes = {
+	title: React.PropTypes.string,
+	description: React.PropTypes.string,
+	canonicalUrl: React.PropTypes.string,
+	children: React.PropTypes.node,
+};
+
+export default Head;

--- a/client/layout/logged-out-design.jsx
+++ b/client/layout/logged-out-design.jsx
@@ -9,9 +9,11 @@ import React from 'react';
  * Internal dependencies
  */
 import MasterbarMinimal from 'layout/masterbar/minimal';
+import ThemesHead from 'my-sites/themes/head';
 
-const LayoutLoggedOutDesign = () => (
+const LayoutLoggedOutDesign = ( { tier = 'all' } ) => (
 	<div className="wp is-section-design has-no-sidebar">
+		<ThemesHead tier={ tier } />
 		<MasterbarMinimal url="/" />
 		<div id="content" className="wp-content">
 			<div id="primary" className="wp-primary wp-section" />
@@ -22,5 +24,8 @@ const LayoutLoggedOutDesign = () => (
 )
 
 LayoutLoggedOutDesign.displayName = 'LayoutLoggedOutDesign';
+LayoutLoggedOutDesign.propTypes = {
+	tier: React.PropTypes.string
+}
 
 export default LayoutLoggedOutDesign;

--- a/client/lib/screen-title/utils.js
+++ b/client/lib/screen-title/utils.js
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { fromJS } from 'immutable';
+
+/**
  * Internal dependencies
  */
-
 import { decodeEntities } from 'lib/formatting';
 import config from 'config';
 import sitesList from 'lib/sites-list';
@@ -10,6 +14,8 @@ const sites = sitesList();
 
 function buildTitle( title, options ) {
 	let pageTitle = '';
+
+	options = toImmutable( options );
 
 	if ( options.get( 'count' ) ) {
 		pageTitle += '(' + options.get( 'count' ) + ') ';
@@ -53,6 +59,12 @@ function appendSite( title, options ) {
 	}
 
 	return title + ' \u2039 ' + siteName;
+}
+
+function toImmutable( object = {} ) {
+	return object.toJS
+		? object
+		: fromJS( object );
 }
 
 export default buildTitle;

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -14,17 +14,20 @@ var ThemesComponent = require( 'my-sites/themes/main' ),
 	route = require( 'lib/route' ),
 	i18n = require( 'lib/mixins/i18n' ),
 	trackScrollPage = require( 'lib/track-scroll-page' ),
-	user = require( 'lib/user' )(),
+	getCurrentUser = require( 'state/current-user/selectors' ).getCurrentUser,
 	buildTitle = require( 'lib/screen-title/utils' );
 
 var controller = {
 
 	themes: function( context ) {
 		const { tier, site_id } = context.params;
+		const user = getCurrentUser( context.store.getState() );
 		const title = buildTitle(
 			i18n.translate( 'Themes', { textOnly: true } ),
-			{ siteID: context.params.site_id } );
-		const Head = user.get() ? require( 'layout/head' ) : require( 'my-sites/themes/head' );
+			{ siteID: site_id } );
+		const Head = user
+			? require( 'layout/head' )
+			: require( 'my-sites/themes/head' );
 
 		let basePath = route.sectionify( context.path );
 		let analyticsPageTitle = 'Themes';

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -14,19 +14,20 @@ var ThemesComponent = require( 'my-sites/themes/main' ),
 	route = require( 'lib/route' ),
 	i18n = require( 'lib/mixins/i18n' ),
 	trackScrollPage = require( 'lib/track-scroll-page' ),
-	titleActions = require( 'lib/screen-title/actions' );
+	user = require( 'lib/user' )(),
+	buildTitle = require( 'lib/screen-title/utils' );
 
 var controller = {
 
 	themes: function( context ) {
-		var basePath = route.sectionify( context.path ),
-			analyticsPageTitle = 'Themes',
-			{ tier, site_id } = context.params;
-
-		titleActions.setTitle(
+		const { tier, site_id } = context.params;
+		const title = buildTitle(
 			i18n.translate( 'Themes', { textOnly: true } ),
-			{ siteID: context.params.site_id }
-		);
+			{ siteID: context.params.site_id } );
+		const Head = user.get() ? require( 'layout/head' ) : require( 'my-sites/themes/head' );
+
+		let basePath = route.sectionify( context.path );
+		let analyticsPageTitle = 'Themes';
 
 		if ( site_id ) {
 			basePath = basePath + '/:site_id';
@@ -38,21 +39,22 @@ var controller = {
 		}
 
 		analytics.pageView.record( basePath, analyticsPageTitle );
-
 		ReactDom.render(
 			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( ThemesComponent, {
-					key: site_id,
-					siteId: site_id,
-					tier: tier,
-					search: context.query.s,
-					trackScrollPage: trackScrollPage.bind(
-						null,
-						basePath,
-						analyticsPageTitle,
-						'Themes'
-					)
-				} )
+				React.createElement( Head, { title, tier: tier || 'all' },
+					React.createElement( ThemesComponent, {
+						key: site_id,
+						siteId: site_id,
+						tier: tier,
+						search: context.query.s,
+						trackScrollPage: trackScrollPage.bind(
+							null,
+							basePath,
+							analyticsPageTitle,
+							'Themes'
+						)
+					} )
+				)
 			),
 			document.getElementById( 'primary' )
 		);

--- a/client/my-sites/themes/head.jsx
+++ b/client/my-sites/themes/head.jsx
@@ -1,0 +1,50 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Head from 'layout/head';
+
+const ThemesHead = ( { tier, children } ) => (
+	<Head
+		title={ get( 'title', tier ) }
+		description={ get( 'description', tier ) }
+		canonicalUrl={ get( 'canonicalUrl', tier ) } >
+		{ children }
+	</Head>
+)
+
+ThemesHead.propTypes = {
+	tier: React.PropTypes.string.isRequired
+};
+
+const themesMeta = {
+	all: {
+		title: 'WordPress Themes — WordPress.com',
+		description: 'Beautiful, responsive, free and premium WordPress themes for your photography site, portfolio, magazine, business website, or blog.',
+		canonicalUrl: 'https://wordpress.com/design',
+	},
+	free: {
+		title: 'Free WordPress Themes — WordPress.com',
+		description: 'Discover Free WordPress Themes on the WordPress.com Theme Showcase.',
+		canonicalUrl: 'https://wordpress.com/design/type/free',
+	},
+	premium: {
+		title: 'Premium WordPress Themes — WordPress.com',
+		description: 'Discover Premium WordPress Themes on the WordPress.com Theme Showcase.',
+		canonicalUrl: 'https://wordpress.com/design/type/premium',
+	}
+}
+
+function get( key, tier ) {
+	return tier in themesMeta && key in themesMeta[ tier ]
+	? themesMeta[ tier ][ key ]
+	: '';
+}
+
+export default ThemesHead;

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-addons-update": "0.14.3",
     "react-day-picker": "1.1.0",
     "react-dom": "0.14.3",
+    "react-helmet": "2.2.0",
     "react-pure-render": "1.0.2",
     "react-redux": "4.0.1",
     "react-tap-event-plugin": "0.2.1",

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -11,12 +11,22 @@ doctype html
 
 html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width' : '')
 	head
-		title WordPress.com
+		if helmetTitle
+			!= helmetTitle
+		else
+			title WordPress.com
 		meta(charset='utf-8')
 		meta(http-equiv='X-UA-Compatible' content='IE=Edge')
 		meta(name='viewport', content='width=device-width, initial-scale=1, maximum-scale=1')
 		meta(name='format-detection', content='telephone=no')
 		meta(name='mobile-web-app-capable', content='yes')
+
+		if helmetMeta
+			!= helmetMeta
+
+		if helmetLink
+			!= helmetLink
+
 		link(rel='shortcut icon', type='image/vnd.microsoft.icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='shortcut icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')
 		link(rel='icon', type='image/x-icon', href=faviconURL, sizes='16x16 32x32')

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -410,16 +410,16 @@ module.exports = function() {
 						throw ex;
 					}
 				}
+
+				const { layout, helmetData } = cachedDesignMarkup[ tier ];
+
+				Object.assign( context, {
+					layout,
+					helmetTitle: helmetData.title,
+					helmetMeta: helmetData.meta,
+					helmetLink: helmetData.link,
+				} );
 			}
-
-			const { layout, helmetData } = cachedDesignMarkup[ tier ];
-
-			Object.assign( context, {
-				layout,
-				helmetTitle: helmetData.title,
-				helmetMeta: helmetData.meta,
-				helmetLink: helmetData.link,
-			} );
 
 			res.render( 'index.jade', context );
 		}

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -408,20 +408,20 @@ module.exports = function() {
 						}
 						bumpStat( 'calypso-ssr', 'loggedout-design-cache-miss' );
 					}
+
+					const { layout, helmetData } = cachedDesignMarkup[ tier ];
+
+					Object.assign( context, {
+						layout,
+						helmetTitle: helmetData.title,
+						helmetMeta: helmetData.meta,
+						helmetLink: helmetData.link,
+					} );
 				} catch ( ex ) {
 					if ( config( 'env' ) === 'development' ) {
 						throw ex;
 					}
 				}
-
-				const { layout, helmetData } = cachedDesignMarkup[ tier ];
-
-				Object.assign( context, {
-					layout,
-					helmetTitle: helmetData.title,
-					helmetMeta: helmetData.meta,
-					helmetLink: helmetData.link,
-				} );
 			}
 
 			res.render( 'index.jade', context );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -7,6 +7,7 @@ var express = require( 'express' ),
 	i18nUtils = require( 'lib/i18n-utils' ),
 	debug = require( 'debug' )( 'calypso:pages' ),
 	superagent = require( 'superagent' ),
+	includes = require( 'lodash/collection/includes' ),
 	React = require( 'react' ),
 	ReactDomServer = require( 'react-dom/server' ),
 	Helmet = require( 'react-helmet' );
@@ -385,7 +386,9 @@ module.exports = function() {
 			renderLoggedInRoute( req, res );
 		} else {
 			const context = getDefaultContext( req );
-			const tier = req.params.themeTier || 'all';
+			const tier = includes( [ 'all', 'free', 'premium' ], req.params.themeTier )
+				? req.params.themeTier
+				: 'all';
 
 			if ( config.isEnabled( 'server-side-rendering' ) ) {
 				try {


### PR DESCRIPTION
Implements #1329.

~~Branch based on #2087.~~

### How to test
1. Open a private/incognito tab
2. Disable JS
3. Navigate to `/design` and `/design/type/<tier>` where `tier ∈ { all, free, premium }`
4. Make sure the page title, as well as other meta fields in the server-rendered document match the copy from #1329.
5. Enable JS. Make sure the post-render title is sane.
6. Log in, reload. Same as the above, though without the SEO-friendly tweaks, as the logged-in page title should be consistent with the rest of Calypso (_i.e._ "Themes — WordPress.com" instead of _e.g._ "Free WordPress Themes — WordPress.com").

### Caveats
- No i18n yet.