### PR TITLE
Invites: Display different notices depending on the user role

### DIFF
--- a/client/lib/invites/notices.js
+++ b/client/lib/invites/notices.js
@@ -43,7 +43,7 @@ function displayNotice( invite, displayOnNextPage ) {
 						}
 					</p>
 				</div>,
-				{ displayOnNextPage	}
+				{ displayOnNextPage }
 			);
 			break;
 		case 'editor':
@@ -66,7 +66,7 @@ function displayNotice( invite, displayOnNextPage ) {
 						}
 					</p>
 				</div>,
-				{ displayOnNextPage	}
+				{ displayOnNextPage }
 			);
 			break;
 		case 'author':
@@ -89,7 +89,7 @@ function displayNotice( invite, displayOnNextPage ) {
 						}
 					</p>
 				</div>,
-				{ displayOnNextPage	}
+				{ displayOnNextPage }
 			);
 			break;
 		case 'contributor':
@@ -112,7 +112,7 @@ function displayNotice( invite, displayOnNextPage ) {
 						}
 					</p>
 				</div>,
-				{ displayOnNextPage	}
+				{ displayOnNextPage }
 			);
 			break;
 		case 'subscriber':
@@ -120,7 +120,7 @@ function displayNotice( invite, displayOnNextPage ) {
 				i18n.translate( 'You\'re now a Subscriber of: %(site)s', {
 					args: { site: get( invite, 'site.title' ) }
 				} ),
-				{ displayOnNextPage	}
+				{ displayOnNextPage }
 			);
 			break;
 	}

--- a/client/lib/invites/notices.js
+++ b/client/lib/invites/notices.js
@@ -32,7 +32,9 @@ function displayNotice( invite, displayOnNextPage ) {
 						} ) }
 					</h3>
 					<p className="invite-message__intro">
-						{ i18n.translate( 'This is your site dashboard where you can write posts and control your site. ' ) }
+						{ i18n.translate( 'This is your site dashboard where you will be able to manage all aspects of %(site)s', {
+							args: { site: get( invite, 'site.title' ) }
+						} ) }
 					</p>
 					<p className="invite-message__intro">
 						{
@@ -55,7 +57,7 @@ function displayNotice( invite, displayOnNextPage ) {
 						} ) }
 					</h3>
 					<p className="invite-message__intro">
-						{ i18n.translate( 'This is your site dashboard where you can write posts and control your site. ' ) }
+						{ i18n.translate( 'This is your site dashboard where you can publish and manage your own posts and the posts of others, as well as upload media.' ) }
 					</p>
 					<p className="invite-message__intro">
 						{
@@ -78,7 +80,7 @@ function displayNotice( invite, displayOnNextPage ) {
 						} ) }
 					</h3>
 					<p className="invite-message__intro">
-						{ i18n.translate( 'This is your site dashboard where you can write posts. ' ) }
+						{ i18n.translate( 'This is your site dashboard where you can publish and edit your own posts as well as upload media.' ) }
 					</p>
 					<p className="invite-message__intro">
 						{
@@ -101,7 +103,7 @@ function displayNotice( invite, displayOnNextPage ) {
 						} ) }
 					</h3>
 					<p className="invite-message__intro">
-						{ i18n.translate( 'This is your site dashboard where you can write posts. ' ) }
+						{ i18n.translate( 'This is your site dashboard where you can write and manage your own posts.' ) }
 					</p>
 					<p className="invite-message__intro">
 						{

--- a/client/lib/invites/notices.js
+++ b/client/lib/invites/notices.js
@@ -7,51 +7,131 @@ import get from 'lodash/object/get'
 
 const InviteNotices = {};
 
+function displayNotice( invite, displayOnNextPage ) {
+	switch ( get( invite, 'role' ) ) {
+		case 'follower':
+			notices.success(
+				i18n.translate(
+					'You are now following %(site)s', {
+						args: { site: get( invite, 'site.title' ) }
+					}
+				),
+				{
+					button: i18n.translate( 'Visit Site' ),
+					href: get( invite, 'site.URL' ),
+					displayOnNextPage
+				}
+			);
+			break;
+		case 'administrator':
+			notices.success(
+				<div>
+					<h3 className="invite-message__title">
+						{ i18n.translate( 'You\'re now an Administrator of: %(site)s', {
+							args: { site: get( invite, 'site.title' ) }
+						} ) }
+					</h3>
+					<p className="invite-message__intro">
+						{ i18n.translate( 'This is your site dashboard where you can write posts and control your site. ' ) }
+					</p>
+					<p className="invite-message__intro">
+						{
+							i18n.translate(
+								'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
+								{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
+							)
+						}
+					</p>
+				</div>,
+				{ displayOnNextPage	}
+			);
+			break;
+		case 'editor':
+			notices.success(
+				<div>
+					<h3 className="invite-message__title">
+						{ i18n.translate( 'You\'re now an Editor of: %(site)s', {
+							args: { site: get( invite, 'site.title' ) }
+						} ) }
+					</h3>
+					<p className="invite-message__intro">
+						{ i18n.translate( 'This is your site dashboard where you can write posts and control your site. ' ) }
+					</p>
+					<p className="invite-message__intro">
+						{
+							i18n.translate(
+								'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
+								{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
+							)
+						}
+					</p>
+				</div>,
+				{ displayOnNextPage	}
+			);
+			break;
+		case 'author':
+			notices.success(
+				<div>
+					<h3 className="invite-message__title">
+						{ i18n.translate( 'You\'re now an Author of: %(site)s', {
+							args: { site: get( invite, 'site.title' ) }
+						} ) }
+					</h3>
+					<p className="invite-message__intro">
+						{ i18n.translate( 'This is your site dashboard where you can write posts. ' ) }
+					</p>
+					<p className="invite-message__intro">
+						{
+							i18n.translate(
+								'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
+								{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
+							)
+						}
+					</p>
+				</div>,
+				{ displayOnNextPage	}
+			);
+			break;
+		case 'contributor':
+			notices.success(
+				<div>
+					<h3 className="invite-message__title">
+						{ i18n.translate( 'You\'re now a Contributor of: %(site)s', {
+							args: { site: get( invite, 'site.title' ) }
+						} ) }
+					</h3>
+					<p className="invite-message__intro">
+						{ i18n.translate( 'This is your site dashboard where you can write posts. ' ) }
+					</p>
+					<p className="invite-message__intro">
+						{
+							i18n.translate(
+								'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
+								{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
+							)
+						}
+					</p>
+				</div>,
+				{ displayOnNextPage	}
+			);
+			break;
+		case 'subscriber':
+			notices.success(
+				i18n.translate( 'You\'re now a Subscriber of: %(site)s', {
+					args: { site: get( invite, 'site.title' ) }
+				} ),
+				{ displayOnNextPage	}
+			);
+			break;
+	}
+}
+
 InviteNotices.dispatchToken = Dispatcher.register( ( payload ) => {
 	const { type, invite, displayOnNextPage } = payload.action;
 	switch ( type ) {
 		case ActionTypes.INVITE_ACCEPTED:
 		case ActionTypes.DISPLAY_INVITE_ACCEPTED_NOTICE:
-			if ( 'follower' === get( invite, 'role' ) ) {
-				notices.success(
-					i18n.translate(
-						'You are now following %(site)s', {
-							args: { site: get( invite, 'site.title' ) }
-						}
-					),
-					{
-						button: i18n.translate( 'Visit Site' ),
-						href: get( invite, 'site.URL' ),
-						displayOnNextPage
-					}
-				);
-			} else {
-				notices.success(
-					(
-						<div>
-							<h3 className="invite-message__title">
-								{ i18n.translate( 'You\'re now a user of: %(site)s', {
-									args: { site: get( invite, 'site.title' ) }
-								} ) }
-							</h3>
-							<p className="invite-message__intro">
-								{ i18n.translate( 'This is your site dashboard where you can write posts and control your site. ' ) }
-							</p>
-							<p className="invite-message__intro">
-								{
-									i18n.translate(
-										'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-										{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
-									)
-								}
-							</p>
-						</div>
-					),
-					{
-						displayOnNextPage
-					}
-				)
-			}
+			displayNotice( invite, displayOnNextPage );
 			break;
 		case ActionTypes.DISPLAY_INVITE_DECLINED_NOTICE:
 			notices.info( i18n.translate( 'You declined to join.' ) );


### PR DESCRIPTION
__How to test__

* checkout
* invite users with different user roles
* copy the invite email link and change wpcalypso.wordpress.com with calypso.dev:3000
* accept the invites
* __assert__ that different roles have different "invitation accepted" notices

Closes #2176

cc:
@rickybanister for improving wording
@ebinnion and @roccotripaldi for code review and testing :)