### PR TITLE
AB Test: Limit ab tests to users who signed up after the test began

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -125,6 +125,12 @@ ABTest.prototype.isEligibleForAbTest = function() {
 		return false;
 	}
 
+	//limit the test to new users
+	if ( this.hasRegisteredBeforeTestBegan() ) {
+		debug( '%s: User was registered before the test began', this.experimentId );
+		return false;
+	}
+
 	return true;
 };
 
@@ -155,6 +161,10 @@ ABTest.prototype.hasBeenInPreviousSeriesTest = function() {
 		return ( previousExperimentId !== this.experimentId ) && ( previousName === this.name );
 	}, this );
 };
+
+ABTest.prototype.hasRegisteredBeforeTestBegan = function() {
+	return user.get() && i18n.moment( user.get().date ).isBefore( this.startDate );
+}
 
 ABTest.prototype.getSavedVariation = function() {
 	return getSavedVariations()[ this.experimentId ] || null;


### PR DESCRIPTION
This pull request fixes #2181 by restricting AB tests to users who registered after the test started.
 
#### Testing instructions (old account)

1. Run `git checkout update/limit-abtests-to-new-users` and start your server
3. Enable debugging for `calypso:abtests`.
2. Log in with an account that was registered before 19th November 2015
2. Open the http://calypso.localhost:3000/plugins/:domain
4. Assert that you see the following message in your console:

`calypso:abtests businessPluginsNudge_20151119: User was registered before the test began`

#### Testing instructions (new account)

1. Run `git checkout update/limit-abtests-to-new-users` and start your server
2. Open the http://calypso.localhost:3000/start
3. Go through the flow to the Create Account step
4. Run this in your console: localStorage.getItem('ABTests');
5. Assert that you see a value for `autoFillUsernameSignup` in the output
(This shows that new users are still being put into tests)

#### Reviews

- [ ] Code
- [ ] Product