### PR TITLE
Fix typo in notifications area

### DIFF
--- a/client/notices/index.js
+++ b/client/notices/index.js
@@ -154,7 +154,7 @@ module.exports = {
 		}
 
 		if ( changed ) {
-			list.emit( 'changed' );
+			list.emit( 'change' );
 		}
 		next();
 	},


### PR DESCRIPTION
This pull request fixes a typo in the event name that is emitted when a notification is automatically removed because the user has navigated away from the page where it was shown.

The symptoms of this were:
1. User performs an action that shows a notice.
2. User navigates to a new page.
3. The notice is still showing and the "X" button does not clear it.

This bad behavior was exhibited while testing #2081 and noted [here](https://github.com/Automattic/wp-calypso/pull/2081#issuecomment-168994135)

An easy way to reproduce this issue is to:
1. Navigate to http://calypso.localhost:3000/me
2. Make a change in one of the fields.
3. Click the "Save Profile Details" button.
4. Notice that a notice now appears stating "Settings saved successfully!".
5. Click on any link to navigate away from the current page.
6. Notice that the notice is still there and you are unable to dismiss it.

Running the test noted above after this fix is applied will make the notice disappear as originally intended.