### PR TITLE
Fix how we set the after date on a gap.

### DIFF
--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -379,9 +379,6 @@ assign( FeedStream.prototype, {
 		return map( posts, this.keyMaker );
 	},
 
-	/**
-	 * Process a new page of data and concatenate to the end of the list
-	 **/
 	receivePage: function( id, error, data ) {
 		var posts, postKeys;
 
@@ -441,7 +438,7 @@ assign( FeedStream.prototype, {
 			postKeys = this.filterNewPosts( data.posts );
 			if ( postKeys.length > 0 ) {
 				this.pendingPostKeys = postKeys;
-				this.pendingDateAfter = moment( FeedPostStore.get( postKeys[ postKeys.length - 1 ] ).date );
+				this.pendingDateAfter = moment( FeedPostStore.get( this.keyMaker( data.posts[ data.posts.length - 1 ] ) ).date );
 				this.emit( 'change' );
 			}
 		}

--- a/client/lib/feed-stream-store/test/post-list-store-tests.js
+++ b/client/lib/feed-stream-store/test/post-list-store-tests.js
@@ -28,7 +28,6 @@ describe( 'FeedPostList', function() {
 		mockery.disable();
 	} );
 
-
 	it( 'should require an id, a fetcher, a keyMaker', function() {
 		expect( function() {
 			return new PostListStore();
@@ -78,85 +77,61 @@ describe( 'FeedPostList', function() {
 			expect( store.get() ).to.have.lengthOf( 2 );
 		} );
 
-		it( 'should receive updates', function() {
-			let feedPostStoreStub = sinon.stub( FeedPostStore, 'get' );
-			feedPostStoreStub.returns( { date: '1999-12-31T23:58:00' } );
-			store.receiveUpdates( 'test', null, {
-				date_range: {
-					before: '1999-12-31T23:59:59',
-					after: '1999-12-31T23:58:00'
-				},
-				posts: [ { feed_ID: 1, ID: 1 }, { feed_ID: 2, ID: 2 } ]
+		describe( 'updates', function() {
+			beforeEach( function() {
+				let feedPostStoreStub = sinon.stub( FeedPostStore, 'get' );
+				feedPostStoreStub.returns( { date: '1999-12-31T23:58:00' } );
+				store.receiveUpdates( 'test', null, {
+					date_range: {
+						before: '1999-12-31T23:59:59',
+						after: '1999-12-31T23:58:00'
+					},
+					posts: [ { feed_ID: 1, ID: 1 }, { feed_ID: 2, ID: 2 } ]
+				} );
 			} );
-			expect( store.getUpdateCount() ).to.equal( 2 );
-			FeedPostStore.get.restore();
-		} );
 
-		it( 'should treat each set of updates as definitive', function() {
-			var firstSet = {
-				date_range: {
-					before: '1999-12-31T23:59:59',
-					after: '1999-12-31T23:58:00'
-				},
-				posts: [
-					{
-						feed_ID: 1,
-						ID: 3,
-						date: '1976-09-15T00:00:03+00:00'
-					},
-					{
-						feed_ID: 1,
-						ID: 2,
-						date: '1976-09-15T00:00:02+00:00'
-					},
-					{
-						feed_ID: 1,
-						ID: 1,
-						date: '1976-09-15T00:00:01+00:00'
-					}
-				]
-			},
-			secondSet = {
-				date_range: {
-					before: '1999-12-31T23:59:59',
-					after: '1999-12-31T23:58:00'
-				},
-				posts: [
-					{
-						feed_ID: 1,
-						ID: 6,
-						date: '1976-09-15T00:00:06+00:00'
-					},
-					{
-						feed_ID: 1,
-						ID: 5,
-						date: '1976-09-15T00:00:05+00:00'
-					},
-					{
-						feed_ID: 1,
-						ID: 4,
-						date: '1976-09-15T00:00:04+00:00'
-					},
-					{
-						feed_ID: 1,
-						ID: 3,
-						date: '1976-09-15T00:00:03+00:00'
-					}
-				]
-			};
-			let feedPostStoreStub = sinon.stub( FeedPostStore, 'get' );
-			feedPostStoreStub.returns( { date: '1999-12-31T23:58:00' } );
-			store.receiveUpdates( 'test', null, firstSet );
-			expect( store.getUpdateCount() ).to.equal( 3 );
+			afterEach( function() {
+				FeedPostStore.get.restore();
+			} );
 
-			// same updates again
-			store.receiveUpdates( 'test', null, firstSet );
-			expect( store.getUpdateCount() ).to.equal( 3 );
+			it( 'should receive updates', function() {
+				expect( store.getUpdateCount() ).to.equal( 2 );
+			} );
 
-			// new updates, overlapping
-			store.receiveUpdates( 'test', null, secondSet );
-			expect( store.getUpdateCount() ).to.equal( 4 );
-			FeedPostStore.get.restore();
+			it( 'should treat each set of updates as definitive', function() {
+				var secondSet = {
+					date_range: {
+						before: '1999-12-31T23:59:59',
+						after: '1999-12-31T23:58:00'
+					},
+					posts: [
+						{
+							feed_ID: 1,
+							ID: 6,
+							date: '1976-09-15T00:00:06+00:00'
+						},
+						{
+							feed_ID: 1,
+							ID: 5,
+							date: '1976-09-15T00:00:05+00:00'
+						},
+						{
+							feed_ID: 1,
+							ID: 4,
+							date: '1976-09-15T00:00:04+00:00'
+						},
+						{
+							feed_ID: 1,
+							ID: 3,
+							date: '1976-09-15T00:00:03+00:00'
+						}
+					]
+				};
+
+				// new updates, overlapping
+				store.receiveUpdates( 'test', null, secondSet );
+				expect( store.getUpdateCount() ).to.equal( 4 );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes #2198 

To test, pull up a stream and wait a bit for updates to become available. When you click the update pill, the posts should load with no Load More Posts indicator after the last new post.