### PR TITLE
Plugins: Add Plugin Settings Link Component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -212,6 +212,7 @@
 @import 'my-sites/plugins/plugin-site-update-indicator/style';
 @import 'my-sites/plugins/plugin-site-business/style';
 @import 'my-sites/plugins/plugin-install-button/style';
+@import 'my-sites/plugins/plugin-settings-link/style';
 @import 'my-sites/plugins/plugin-remove-button/style';
 @import 'my-sites/plugins/plugins-browser-item/style';
 @import 'my-sites/plugins/plugins-browser-list/style';

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -11,7 +11,6 @@ import _some from 'lodash/collection/some';
  */
 import analytics from 'analytics';
 import Card from 'components/card';
-import Gridicon from 'components/gridicon';
 import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
@@ -23,6 +22,7 @@ import safeProtocolUrl from 'lib/safe-protocol-url';
 import config from 'config';
 import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
+import PluginSettingsLink from 'my-sites/plugins/plugin-settings-link';
 import PluginInformation from 'my-sites/plugins/plugin-information';
 
 export default React.createClass( {
@@ -87,14 +87,7 @@ export default React.createClass( {
 			return;
 		}
 
-		return (
-			<a className="plugin-meta__settings-link"
-				href={ this.props.plugin.wp_admin_settings_page_url }
-				target="_blank">
-				{ this.translate( 'Setup' ) }
-				<Gridicon size={ 18 } icon="external" />
-			</a>
-		);
+		return <PluginSettingsLink linkUrl={ this.props.plugin.wp_admin_settings_page_url } />;
 	},
 
 	renderName() {

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -142,23 +142,3 @@
 		margin-top: -15px;
 	}
 }
-
-a.plugin-meta__settings-link {
-	color: $gray;
-	display: block;
-	font-size: 11px;
-	line-height: 16px;
-	margin: 16px 9px 0 0;
-	text-transform: uppercase;
-
-	@include breakpoint( '>480px' ) {
-		display: inline-block;
-	}
-
-	.gridicon {
-		float: right;
-		position: relative;
-			left: 7px;
-			top: -3px;
-	}
-}

--- a/client/my-sites/plugins/plugin-settings-link/README.md
+++ b/client/my-sites/plugins/plugin-settings-link/README.md
@@ -1,0 +1,18 @@
+Plugin Settings Link
+=====================
+
+This component is used to display a link that take the user to the plugins settings section, where they can set up the plugin.
+
+#### How to use:
+
+```js
+var PluginSettingsLink = require( 'my-sites/plugins/plugin-settings-link' );
+
+render: function() {
+    return <PluginSettingsLink linkUrl={ plugin.wp_admin_settings_page_url }  />;
+}
+```
+
+#### Props
+
+* `linkUrl`: URL string to the site's plugin setting screen.

--- a/client/my-sites/plugins/plugin-settings-link/index.jsx
+++ b/client/my-sites/plugins/plugin-settings-link/index.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
+export default React.createClass( {
+	displayName: 'PluginSettingsLink',
+
+	propTypes: {
+		linkUrl: PropTypes.string.isRequired,
+	},
+
+	render() {
+		if ( ! this.props.linkUrl ) {
+			return;
+		}
+
+		return (
+			<a className="plugin-settings-link"
+				href={ this.props.linkUrl }
+				target="_blank">
+				{ this.translate( 'Setup' ) }
+				<Gridicon size={ 18 } icon="external" />
+			</a>
+		);
+	}
+} );

--- a/client/my-sites/plugins/plugin-settings-link/style.scss
+++ b/client/my-sites/plugins/plugin-settings-link/style.scss
@@ -1,0 +1,19 @@
+a.plugin-settings-link {
+	color: $gray;
+	display: block;
+	font-size: 11px;
+	line-height: 16px;
+	margin: 16px 9px 0 0;
+	text-transform: uppercase;
+
+	@include breakpoint( '>480px' ) {
+		display: inline-block;
+	}
+
+	.gridicon {
+		float: right;
+		position: relative;
+			left: 7px;
+			top: -3px;
+	}
+}


### PR DESCRIPTION
Separates out the Plugins Settings Link component so that it could be used in more placed. 
Fixes #447.

No visual changes. 

To test:
Visit http://calypso.localhost:3000/plugins/ecwid/business/example.wordpress.com site. Make sure that you see the settings link when the plugin is enabled. 
