### PR TITLE
Plugins: Fixes overflow issue with the plugin name

### DIFF
--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -64,6 +64,7 @@
 
 .plugin-meta__detail {
 	position: relative;
+	width: 100%;
 	flex-grow: 1;
 
 	@include breakpoint( '>480px' ) {


### PR DESCRIPTION
Before:
![screen shot 2016-01-07 at 14 01 29](https://cloud.githubusercontent.com/assets/115071/12184141/535dc27a-b548-11e5-83b0-00e25ec86a7c.png)

After:
![screen shot 2016-01-07 at 14 01 50](https://cloud.githubusercontent.com/assets/115071/12184143/5897a026-b548-11e5-87a0-e05cd976eaa8.png)


**To test**:
Visit a plugins page that has a really long plugin name. 
For example http://calypso.localhost:3000/plugins/online-booking 

cc: @rickybanister, @johnHackworth, @lezama 