### PR TITLE
Stats: update All-time module to use already existing module styles

### DIFF
--- a/assets/stylesheets/sections/_stats.scss
+++ b/assets/stylesheets/sections/_stats.scss
@@ -508,14 +508,17 @@ ul.module-tabs {
 			text-align: left;
 		}
 
+		a {
+			color: $gray-dark;
+		}
+
 		a,
 		.no-link {
-			@extend %mobile-interface-element;
+			@extend %mobile-link-element;
 			@include clear-fix;
 			padding: 5px 0 10px;
 			display: block;
 			background: $white;
-			color: $gray-dark;
 
 			@include breakpoint( "<480px" ) {
 				line-height: 24px;
@@ -615,6 +618,7 @@ ul.module-tabs {
 		}
 
 		// Low state ('disabled')
+		.is-low,
 		&.is-low a .value {
 			color: $gray;
 		}

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -36,7 +36,6 @@ module.exports = React.createClass( {
 
 	render: function() {
 		var bestDay = null,
-			classSets = {},
 			infoIcon = this.state.showInfo ? 'info' : 'info-outline',
 			valueClass,
 			bestViews,

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -19,7 +19,7 @@ module.exports = React.createClass( {
 	mixins: [ toggle( 'allTimeList' ), observe( 'allTimeList' ) ],
 
 	propTypes: {
-		allTimeList: React.PropTypes.object.isRequired,
+		allTimeList: React.PropTypes.object.isRequired
 	},
 
 	renderValue: function( value ) {

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -37,7 +37,6 @@ module.exports = React.createClass( {
 	render: function() {
 		var bestDay = null,
 			statTabs = [ 'posts', 'views', 'visitors', 'best' ],
-			data = this.props.allTimeList.data,
 			classSets = {},
 			infoIcon = this.state.showInfo ? 'info' : 'info-outline',
 			valueClass,

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -19,7 +19,7 @@ module.exports = React.createClass( {
 	mixins: [ toggle( 'allTimeList' ), observe( 'allTimeList' ) ],
 
 	propTypes: {
-		allTimeList: React.PropTypes.object.isRequired
+		allTimeList: React.PropTypes.object.isRequired,
 	},
 
 	ensureValue: function( value ) {
@@ -36,16 +36,26 @@ module.exports = React.createClass( {
 
 	render: function() {
 		var bestDay = null,
+			statTabs = [ 'posts', 'views', 'visitors', 'best' ],
+			data = this.props.allTimeList.data,
+			classSets = {},
 			infoIcon = this.state.showInfo ? 'info' : 'info-outline',
 			valueClass,
 			bestViews,
 			classes;
 
+		statTabs.forEach( function( tabName ) {
+			var tabClassOptions = {};
+			tabClassOptions[ 'module-tab' ] = true;
+			tabClassOptions[ 'is-' + tabName ] = true;
+			classSets[ tabName ] = classNames( tabClassOptions );
+		} );
+
 		if ( this.props.allTimeList.response['best-views'] && this.props.allTimeList.response['best-views'].day ) {
 			bestDay = this.moment( this.props.allTimeList.response['best-views'].day ).format( 'LL' );
 		}
 
-		valueClass = classNames( 'stats-all-time__value', {
+		valueClass = classNames( 'value', {
 			'is-loading': this.props.allTimeList.isLoading()
 		} );
 
@@ -97,27 +107,35 @@ module.exports = React.createClass( {
 						<p>{ this.translate( 'These are your site\'s overall total number of Posts, Views and Visitors as well as the day when you had the most number of Views.' ) }</p>
 					</div>
 
-				<ul className="stats-all-time__list">
-					<li className="stats-all-time__list-item stats-all-time__item-posts">
-						<Gridicon icon="posts" size={ 18 } />
-						<span className="stats-all-time__label">{ this.translate( 'Posts' ) }</span>
-						<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.posts ) } ) }>{ this.ensureValue( this.props.allTimeList.response.posts ) }</span>
+				<ul className="module-tabs">
+					<li className={ classSets.posts }>
+						<span className="no-link">
+							<Gridicon icon="posts" size={ 18 } />
+							<span className="label">{ this.translate( 'Posts' ) }</span>
+							<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.posts ) } ) }>{ this.ensureValue( this.props.allTimeList.response.posts ) }</span>
+						</span>
 					</li>
-					<li className="stats-all-time__list-item">
-						<Gridicon icon="visible" size={ 18 } />
-						<span className="stats-all-time__label">{ this.translate( 'Views' ) }</span>
-						<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.views ) } ) }>{ this.ensureValue( this.props.allTimeList.response.views ) }</span>
+					<li className={ classSets.views }>
+						<span className="no-link">
+							<Gridicon icon="visible" size={ 18 } />
+							<span className="label">{ this.translate( 'Views' ) }</span>
+							<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.views ) } ) }>{ this.ensureValue( this.props.allTimeList.response.views ) }</span>
+						</span>
 					</li>
-					<li className="stats-all-time__list-item">
-						<Gridicon icon="user" size={ 18 } />
-						<span className="stats-all-time__label">{ this.translate( 'Visitors' ) }</span>
-						<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.visitors ) } ) }>{ this.ensureValue( this.props.allTimeList.response.visitors ) }</span>
+					<li className={ classSets.visitors }>
+						<span className="no-link">
+							<Gridicon icon="user" size={ 18 } />
+							<span className="label">{ this.translate( 'Visitors' ) }</span>
+							<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.visitors ) } ) }>{ this.ensureValue( this.props.allTimeList.response.visitors ) }</span>
+						</span>
 					</li>
-					<li className="stats-all-time__list-item stats-all-time__best">
-						<Gridicon icon="trophy" size={ 18 } />
-						<span className="stats-all-time__label">{ this.translate( 'Best Views Ever' ) }</span>
-						<span className={ classNames( valueClass, { 'is-low': this.isLow( bestViews ) } ) }>{ this.ensureValue( bestViews ) }</span>
-						<span className="stats-all-time__best-day">{ bestDay }</span>
+					<li className={ classSets.best }>
+						<span className="no-link">
+							<Gridicon icon="trophy" size={ 18 } />
+							<span className="label">{ this.translate( 'Best Views Ever' ) }</span>
+							<span className={ classNames( valueClass, { 'is-low': this.isLow( bestViews ) } ) }>{ this.ensureValue( bestViews ) }</span>
+							<span className="stats-all-time__best-day">{ bestDay }</span>
+						</span>
 					</li>
 				</ul>
 			</div>

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -26,7 +26,7 @@ module.exports = React.createClass( {
 		if ( value || value === 0 ) {
 			return this.numberFormat( value );
 		}
-		// If no value present, return en-dash
+		// If no value return en-dash
 		return String.fromCharCode( 8211 );
 	},
 

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -36,19 +36,11 @@ module.exports = React.createClass( {
 
 	render: function() {
 		var bestDay = null,
-			statTabs = [ 'posts', 'views', 'visitors', 'best' ],
 			classSets = {},
 			infoIcon = this.state.showInfo ? 'info' : 'info-outline',
 			valueClass,
 			bestViews,
 			classes;
-
-		statTabs.forEach( function( tabName ) {
-			var tabClassOptions = {};
-			tabClassOptions[ 'module-tab' ] = true;
-			tabClassOptions[ 'is-' + tabName ] = true;
-			classSets[ tabName ] = classNames( tabClassOptions );
-		} );
 
 		if ( this.props.allTimeList.response['best-views'] && this.props.allTimeList.response['best-views'].day ) {
 			bestDay = this.moment( this.props.allTimeList.response['best-views'].day ).format( 'LL' );
@@ -107,28 +99,28 @@ module.exports = React.createClass( {
 					</div>
 
 				<ul className="module-tabs">
-					<li className={ classSets.posts }>
+					<li className="module-tab">
 						<span className="no-link">
 							<Gridicon icon="posts" size={ 18 } />
 							<span className="label">{ this.translate( 'Posts' ) }</span>
 							<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.posts ) } ) }>{ this.ensureValue( this.props.allTimeList.response.posts ) }</span>
 						</span>
 					</li>
-					<li className={ classSets.views }>
+					<li className="module-tab">
 						<span className="no-link">
 							<Gridicon icon="visible" size={ 18 } />
 							<span className="label">{ this.translate( 'Views' ) }</span>
 							<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.views ) } ) }>{ this.ensureValue( this.props.allTimeList.response.views ) }</span>
 						</span>
 					</li>
-					<li className={ classSets.visitors }>
+					<li className="module-tab">
 						<span className="no-link">
 							<Gridicon icon="user" size={ 18 } />
 							<span className="label">{ this.translate( 'Visitors' ) }</span>
 							<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.visitors ) } ) }>{ this.ensureValue( this.props.allTimeList.response.visitors ) }</span>
 						</span>
 					</li>
-					<li className={ classSets.best }>
+					<li className="module-tab is-best">
 						<span className="no-link">
 							<Gridicon icon="trophy" size={ 18 } />
 							<span className="label">{ this.translate( 'Best Views Ever' ) }</span>

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -22,48 +22,42 @@ module.exports = React.createClass( {
 		allTimeList: React.PropTypes.object.isRequired,
 	},
 
-	ensureValue: function( value ) {
-		if ( value || value === 0 ) {
-			return this.numberFormat( value );
-		}
-		// If no value return en-dash
-		return String.fromCharCode( 8211 );
-	},
+	renderValue: function( value ) {
+		var valueClass = classNames( 'value', {
+				'is-loading': this.props.allTimeList.isLoading(),
+				'is-low': ! value || 0 === value
+			} ),
+			displayValue = String.fromCharCode( 8211 );
 
-	isLow: function( value ) {
-		return ! value || 0 === value
+		if ( value || 0 === value ) {
+			displayValue = this.numberFormat( value );
+		}
+
+		return <span className={ valueClass }>{ displayValue }</span>;
 	},
 
 	render: function() {
-		var bestDay = null,
-			infoIcon = this.state.showInfo ? 'info' : 'info-outline',
-			valueClass,
+		var infoIcon = this.state.showInfo ? 'info' : 'info-outline',
+			allTimeList = this.props.allTimeList.response,
+			bestDay,
 			bestViews,
 			classes;
 
-		if ( this.props.allTimeList.response['best-views'] && this.props.allTimeList.response['best-views'].day ) {
-			bestDay = this.moment( this.props.allTimeList.response['best-views'].day ).format( 'LL' );
+		if ( allTimeList['best-views'] && allTimeList['best-views'].day ) {
+			bestDay = this.moment( allTimeList['best-views'].day ).format( 'LL' );
 		}
 
-		valueClass = classNames( 'value', {
-			'is-loading': this.props.allTimeList.isLoading()
-		} );
+		classes = {
+			'is-expanded': this.state.showModule,
+			'is-showing-info': this.state.showInfo,
+			'is-loading': this.props.allTimeList.isLoading(),
+			'is-non-en': user.data.localeSlug && ( user.data.localeSlug !== 'en' )
+		};
 
-		classes = [
-			'stats-module',
-			'stats-all-time',
-			{
-				'is-expanded': this.state.showModule,
-				'is-showing-info': this.state.showInfo,
-				'is-loading': this.props.allTimeList.isLoading(),
-				'is-non-en': user.data.localeSlug && ( user.data.localeSlug !== 'en' )
-			}
-		];
-
-		bestViews = this.props.allTimeList.response['best-views'] ? this.props.allTimeList.response['best-views'].count : null;
+		bestViews = allTimeList['best-views'] ? allTimeList['best-views'].count : null;
 
 		return (
-			<Card className={ classNames.apply( null, classes ) }>
+			<Card className={ classNames( 'stats-module', 'stats-all-time', classes ) }>
 				<div className="module-header">
 				<h1 className="module-header-title">{ this.translate( 'All-time posts, views, and visitors' ) }</h1>
 					<ul className="module-header-actions">
@@ -102,28 +96,28 @@ module.exports = React.createClass( {
 						<span className="no-link">
 							<Gridicon icon="posts" size={ 18 } />
 							<span className="label">{ this.translate( 'Posts' ) }</span>
-							<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.posts ) } ) }>{ this.ensureValue( this.props.allTimeList.response.posts ) }</span>
+							{ this.renderValue( allTimeList.posts ) }
 						</span>
 					</li>
 					<li className="module-tab">
 						<span className="no-link">
 							<Gridicon icon="visible" size={ 18 } />
 							<span className="label">{ this.translate( 'Views' ) }</span>
-							<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.views ) } ) }>{ this.ensureValue( this.props.allTimeList.response.views ) }</span>
+							{ this.renderValue( allTimeList.views ) }
 						</span>
 					</li>
 					<li className="module-tab">
 						<span className="no-link">
 							<Gridicon icon="user" size={ 18 } />
 							<span className="label">{ this.translate( 'Visitors' ) }</span>
-							<span className={ classNames( valueClass, { 'is-low': this.isLow( this.props.allTimeList.response.visitors ) } ) }>{ this.ensureValue( this.props.allTimeList.response.visitors ) }</span>
+							{ this.renderValue( allTimeList.visitors ) }
 						</span>
 					</li>
 					<li className="module-tab is-best">
 						<span className="no-link">
 							<Gridicon icon="trophy" size={ 18 } />
 							<span className="label">{ this.translate( 'Best Views Ever' ) }</span>
-							<span className={ classNames( valueClass, { 'is-low': this.isLow( bestViews ) } ) }>{ this.ensureValue( bestViews ) }</span>
+							{ this.renderValue( bestViews ) }
 							<span className="stats-all-time__best-day">{ bestDay }</span>
 						</span>
 					</li>

--- a/client/my-sites/stats/all-time/style.scss
+++ b/client/my-sites/stats/all-time/style.scss
@@ -1,140 +1,42 @@
 // Stats All-time module on Insights page
-.stats-all-time__list {
-	margin: 0;
-	padding: 0;
-}
 
-.stats-all-time__list-item {
-	list-style-type: none;
-	float: left;
-	text-align: center;
-	margin: 20px 0 14px;
-	border-right: 1px solid $gray-light;
-	width: 25%;
-	box-sizing: border-box;
-	box-sizing: content-box;
-	color: $gray-dark;
+.stats-all-time {
 
-	&:last-child {
-		border-right: 0;
-	}
+	.module-tab {
 
-	&.stats-all-time__best {
-		color: $alert-yellow;
-	}
+		padding-bottom: 0;
 
-	@include breakpoint ( ">960px" ) {
-		.is-non-en & {
-			width: 49%;
+		@include breakpoint( ">480px" ) {
+			padding-bottom: 24px;
+		}
 
-			&:nth-child(2) {
-				border-right: 0;
+		&.is-best {
+			color: $alert-yellow;
+		}
+
+		&:nth-child(4) {
+			padding-bottom: 0;
+		}
+
+		.value {
+			font-size: 20px;
+			padding: 10px 0 5px;
+		}
+
+		.stats-all-time__best-day {
+			color: $gray-dark;
+			font-size: 11px;
+			letter-spacing: 0.1em;
+			text-transform: uppercase;
+
+			@include breakpoint( "<480px" )  {
+				box-sizing: border-box;
+				display: block;
+				line-height: 1.7;
+				padding: 25px 0 0 56px;
+				text-align: left;
+				width: 100%;
 			}
 		}
-	}
-
-	@include breakpoint( "<960px" ) {
-		width: 49%;
-
-		&:nth-child(2) {
-			border-right: 0;
-		}
-	}
-
-	@include breakpoint( "<480px" ) {
-		width: 100%;
-		border: 0;
-		padding: 10px 0;
-	}
-
-	.gridicon {
-		margin-right: 4px;
-		vertical-align: middle;
-
-		@include breakpoint( "<480px" ) {
-			width: 24px;
-			height: 24px;
-			margin-left: 24px;
-			margin-right: 8px;
-			float: left;
-		}
-	}
-}
-
-.stats-all-time__item-posts {
-	width: 23%;
-
-	@include breakpoint( "<960px" ) {
-		width: 49%;
-	}
-}
-
-.stats-all-time__list-item,
-.stats-all-time__item-posts {
-	@include breakpoint( "<480px" ) {
-		width: auto;
-		float: none;
-		text-align: left;
-		margin: 0;
-		font-size: 16px;
-		clear: none;
-		border-top: 1px solid $gray-light;
-		box-sizing: border-box;
-	}
-}
-
-.stats-all-time__label {
-	font-size: 11px;
-	letter-spacing: 0.1em;
-	text-transform: uppercase;
-	line-height: 1.6;
-
-	@include breakpoint( "<480px" ) {
-		font-size: 14px;
-		line-height: 1.8;
-	}
-}
-
-.stats-all-time__value {
-	font-size: 20px;
-	color: $gray-dark;
-	width: 100%;
-	display: block;
-	padding: 16px 0;
-
-	&.is-loading {
-		animation: loading-fade 1.6s ease-in-out infinite;
-	}
-
-	&.is-low {
-		color: $gray;
-	}
-
-	@include breakpoint( "<480px" ) {
-		clear: none;
-		display: inline-table; // fixes "Best" section moving down the next line when resizing screen
-		float: right;
-		font-size: 16px;
-		margin-right: 24px;
-		padding: 0;
-		text-align: right;
-		width: auto;
-	}
-}
-
-.stats-all-time__best-day {
-	font-size: 11px;
-	letter-spacing: 0.1em;
-	text-transform: uppercase;
-	color: $gray-dark;
-	line-height: 1.8;
-	display: block;
-	width: 100%;
-
-	@include breakpoint( "<480px" )  {
-		box-sizing: border-box;
-		text-align: left;
-		line-height: 1.7;
-		padding-left: 56px;
 	}
 }


### PR DESCRIPTION
Currently, the All-time module on Insights is using lots of custom CSS. This PR updates it so it utilizes already existing classes just like the rest of the modules on Insights, thus, eliminating the need for lots of extra custom styles.

The design has also slightly been updated to match the rest of the tabbed modules:

**Before:**
![screenshot 2016-01-07 16 25 47](https://cloud.githubusercontent.com/assets/4924246/12186851/58b77cd0-b55b-11e5-97d6-6c979bf5bec9.png)

**After:**
![screenshot 2016-01-07 16 25 29](https://cloud.githubusercontent.com/assets/4924246/12186855/5f5e0dc4-b55b-11e5-9639-654e670b1f57.png)

/cc @timmyc @jonathansadowski 