### PR TITLE
Thank you page width

### DIFF
--- a/assets/stylesheets/sections/_checkout.scss
+++ b/assets/stylesheets/sections/_checkout.scss
@@ -762,6 +762,10 @@
 	text-align: center;
 	width: 100%;
 
+	&.main {
+		max-width: 960px;
+	}
+
 	.thank-you-message {
 		padding-bottom: 20px;
 


### PR DESCRIPTION
After the sidebar changes, the width of the thank you page got set to 720px instead of 960px causing the content to get too crowded on desktop. I set it back to 960px.

**Before:**

![image](https://cloud.githubusercontent.com/assets/12596797/12189379/01fbae90-b58b-11e5-8c98-49dddacb6a7a.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/12596797/12189405/427e798e-b58b-11e5-94a6-b014850c7879.png)
