### PR TITLE
Desktop: fix i18n startup error

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -4,7 +4,6 @@ var express = require( 'express' ),
 	qs = require( 'qs' ),
 	execSync = require( 'child_process' ).execSync,
 	cookieParser = require( 'cookie-parser' ),
-	i18nUtils = require( 'lib/i18n-utils' ),
 	debug = require( 'debug' )( 'calypso:pages' ),
 	React = require( 'react' ),
 	ReactDomServer = require( 'react-dom/server' );
@@ -197,6 +196,7 @@ function getDefaultContext( request ) {
 
 function renderLoggedOutRoute( req, res ) {
 	var context = getDefaultContext( req ),
+		i18nUtils = require( 'lib/i18n-utils' ),
 		language;
 
 	res.set( {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -11,10 +11,7 @@ var express = require( 'express' ),
 var config = require( 'config' ),
 	sanitize = require( 'sanitize' ),
 	utils = require( 'bundler/utils' ),
-	sections = require( '../../client/sections' ),
-	LayoutLoggedOutDesign = require( 'layout/logged-out-design' );
-
-var LayoutLoggedOutDesignFactory = React.createFactory( LayoutLoggedOutDesign );
+	sections = require( '../../client/sections' );
 
 var HASH_LENGTH = 10,
 	URL_BASE_PATH = '/calypso',
@@ -374,6 +371,8 @@ module.exports = function() {
 			renderLoggedInRoute( req, res );
 		} else {
 			const context = getDefaultContext( req );
+			const LayoutLoggedOutDesign = require( 'layout/logged-out-design' )
+			const LayoutLoggedOutDesignFactory = React.createFactory( LayoutLoggedOutDesign );
 
 			try {
 				context.layout = ReactDomServer.renderToString( LayoutLoggedOutDesignFactory() );


### PR DESCRIPTION
The i18nutils are used in the Calypso server and make use of some ES6 functionality that isn't supported in Electron (imports, in this case).

The desktop app doesn't make use of this (it doesn't use the `renderLoggedOutRoute` at all) so moving the require to inside the `renderLoggedOutRoute` removes the problem.

I suspect we'll need a better way of handling these kinds of problems in the future, but for now this allows us to get the desktop app working again.