### PR TITLE
Free trials: Show a grey plan icon in the free trials overview, when the trial has expired

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-status/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/index.jsx
@@ -64,7 +64,8 @@ const PlanStatus = React.createClass( {
 		const { plan } = this.props,
 			iconClasses = classNames( 'plan-status__icon', {
 				'is-premium': isPremium( plan ),
-				'is-business': isBusiness( plan )
+				'is-business': isBusiness( plan ),
+				'is-expired': isInGracePeriod( plan )
 			} );
 
 		return (

--- a/client/my-sites/plans/plan-overview/plan-status/style.scss
+++ b/client/my-sites/plans/plan-overview/plan-status/style.scss
@@ -28,10 +28,18 @@
 
 	&.is-premium {
 		background-image: url( '/calypso/images/plans/plan-trial-premium.svg' );
+
+		&.is-expired {
+			background-image: url( '/calypso/images/plans/plan-premium.svg' );
+		}
 	}
 
 	&.is-business {
 		background-image: url( '/calypso/images/plans/plan-trial-business.svg' );
+
+		&.is-expired {
+			background-image: url( '/calypso/images/plans/plan-business.svg' );
+		}
 	}
 
 	@include breakpoint( "<480px" ) {


### PR DESCRIPTION
This pull request fixes #2203 by showing a grey plan icon instead of a blue one, when the plan has expired.

Before:
<img width="740" alt="screen shot 2016-01-08 at 11 18 44" src="https://cloud.githubusercontent.com/assets/275961/12196811/afe8e112-b5f9-11e5-923d-0b0d63f17ecb.png">

After:
<img width="660" alt="screen shot 2016-01-08 at 11 17 35" src="https://cloud.githubusercontent.com/assets/275961/12196813/b19a5f68-b5f9-11e5-96a6-3338b58db537.png">

@mikeshelton1503 I wasn't sure about adding the border - should I do it in CSS or in a different SVG, or do we want to be consistent, and not use the border here?
 
#### Testing instructions

1. Run `git checkout fix/2203-plan-icon` and start your server
2. Open the [`Plans` page](http://calypso.dev:3000/plans/:site) for a site that has an expired free trial
3. Assert that the plan icon is grey, not blue.

#### Reviews

- [x] Code
- [x] Product