### PR TITLE
Themes: Fix multiple initial data fetches

### DIFF
--- a/shared/components/data/themes-list-fetcher/index.jsx
+++ b/shared/components/data/themes-list-fetcher/index.jsx
@@ -96,9 +96,8 @@ const ThemesListFetcher = React.createClass( {
 
 		if ( options.triggeredByScroll ) {
 			onRealScroll();
+			this.props.fetchNextPage( site );
 		}
-
-		this.props.fetchNextPage( site );
 	},
 
 	render: function() {


### PR DESCRIPTION
The infinite-scroll mixin makes an initial call to `fetchNextPage`,
so moving away from inifinite-list has introduced a bug whereby
we make multiple initital data requests.

Fix by only requesting data when the request was triggered by
a scroll.

**To Test**
* Set `localStorage.setItem( 'debug', 'calypso:themes:actions' );` in browser js console
* Check that there is only one initial data fetch when http://calypso.localhost:3000/design loads, then subsequent requests on scroll
