### PR TITLE
Free trials: Update copy

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-features/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-features/index.jsx
@@ -71,7 +71,11 @@ const PlanFeatures = React.createClass( {
 					willBeRemoved={ willBeRemoved } />
 
 				<PlanFeature
-					description={ this.translate( 'You can upload unlimited photos, videos, or music.' ) }
+					description={
+						isBusiness( this.props.selectedSite.plan )
+						? this.translate( 'You can upload unlimited photos, videos, or music.' )
+						: this.translate( 'You can upload up to 10GB of photos, videos, or music.' )
+					}
 					heading={ this.translate( 'Storage Space' ) }
 					willBeRemoved={ willBeRemoved } />
 

--- a/client/my-sites/plans/plan-overview/plan-features/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-features/index.jsx
@@ -87,10 +87,8 @@ const PlanFeatures = React.createClass( {
 				<PlanFeature
 					description={
 						isBusiness( this.props.selectedSite.plan )
-						?
-							this.translate( 'You can live chat with our Happiness Engineers anytime you need.' )
-						:
-							this.translate( 'You can contact our Happiness Engineers anytime you need.' )
+						? this.translate( 'You can live chat with our Happiness Engineers anytime you need.' )
+						: this.translate( 'You can contact our Happiness Engineers anytime you need.' )
 					}
 					heading={ this.translate( 'Support' ) }
 					willBeRemoved={ willBeRemoved } />

--- a/client/my-sites/plans/plan-overview/plan-features/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-features/index.jsx
@@ -76,7 +76,7 @@ const PlanFeatures = React.createClass( {
 					willBeRemoved={ willBeRemoved } />
 
 				<PlanFeature
-					description={ this.translate( 'You can upload and hosts videos on your site without advertising.' ) }
+					description={ this.translate( 'You can upload and host videos on your site without advertising.' ) }
 					heading={ this.translate( 'VideoPress' ) }
 					willBeRemoved={ willBeRemoved } />
 


### PR DESCRIPTION
This pull request fixes #2202 by updating the copy for the storage space feature when a user has a premium trial, and fixing a typo in the videopress feature.

Before
<img width="774" alt="screen shot 2016-01-08 at 11 43 03" src="https://cloud.githubusercontent.com/assets/275961/12197314/cc4a1ade-b5fd-11e5-969c-445bf682c917.png">

After
<img width="770" alt="screen shot 2016-01-08 at 11 42 54" src="https://cloud.githubusercontent.com/assets/275961/12197315/cca8a7fc-b5fd-11e5-875b-a59380c3a672.png">
 
#### Testing instructions

1. Run `git checkout fix/2202-free-trial-copy` and start your server
2. Open http://calypso.localhost:3000/plans/:site for a site on a Premium trial
3. Check that the copy for Storage Space mentions that 10GB limit
2. Open http://calypso.localhost:3000/plans/:site for a site on a Business trial
3. Check that the copy for Storage Space mentions that it is unlimited still
7. Assert that the typo in the videopress section is fixed.

#### Reviews

- [x] Code
- [x] Product