### PR TITLE
Themes: Add renderToString() test for LayoutLoggedOutDesign

### DIFF
--- a/server/pages/Makefile
+++ b/server/pages/Makefile
@@ -1,0 +1,12 @@
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := ../:$(BASE_DIR)/client:$(BASE_DIR)/shared
+COMPILERS ?= js:babel/register
+REPORTER ?= spec
+UI ?= bdd
+
+test:
+	@NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers $(COMPILERS) --reporter $(REPORTER) --ui $(UI)
+
+.PHONY: test

--- a/server/pages/test/index.js
+++ b/server/pages/test/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import React from 'react';
+import ReactDomServer from 'react-dom/server';
+
+describe( 'Server pages:', function() {
+	context( 'when trying to renderToString() LayoutLoggedOutDesign ', function() {
+		before( function() {
+			const LayoutLoggedOutDesign = require( 'layout/logged-out-design' );
+			this.LayoutLoggedOutDesignFactory = React.createFactory( LayoutLoggedOutDesign );
+		} );
+
+		it( "doesn't throw an exception", function() {
+			assert.doesNotThrow( ReactDomServer.renderToString.bind( ReactDomServer, this.LayoutLoggedOutDesignFactory() ) );
+		} );
+	} );
+} );


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/1327

Since components have a tendency to change, and SSR errors aren't likely to be noticed, let's write a test that makes sure `renderToString()` doesn't throw an exception when LayoutLoggedDesign is rendered.

We can't easily test the /design route handler, so our options are either to duplicate the `renderToString()` call, or to abstract it out somewhere.

I've opted for the former, we can either abstract later, or decide on a simple way now.

To test:
- `cd server/pages && make` to run the test
- Check it passes
- Edit `masterbar/item.jsx`, put something naughty like a `window` reference in `render()`
- Run the test again, it should fail
- Try more imaginative ways to make the test fail, with `componentWillMount` etc

Noting it would be super nice to be able to test client/server tree reconciliation, most likely in an e2e test?

/cc @mcsf @ockham @seear 