### PR TITLE
Importer: Add locking mechanism to freeze updates from the API

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -26,6 +26,7 @@ const apiFailure = data => {
 
 	return data;
 };
+
 const asArray = a => [].concat( a );
 
 function receiveImporterStatus( importerStatus ) {

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -26,6 +26,7 @@ const apiFailure = data => {
 
 	return data;
 };
+const lockImport = importerId => Dispatcher.handleViewAction( { type: actionTypes.LOCK_IMPORT, importerId } );
 
 const asArray = a => [].concat( a );
 
@@ -110,6 +111,8 @@ export function setState( newState ) {
 }
 
 export function startMappingAuthors( importerId ) {
+	lockImport( importerId );
+
 	Dispatcher.handleViewAction( {
 		type: actionTypes.START_MAPPING_AUTHORS,
 		importerId

--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -9,7 +9,7 @@ const importerStateMap = [
 	[ appStates.DISABLED, 'disabled' ],
 	[ appStates.IMPORT_FAILURE, 'importer-import-failure' ],
 	[ appStates.IMPORT_SUCCESS, 'importer-import-success' ],
-	[ appStates.IMPORTING, 'importer-importing' ],
+	[ appStates.IMPORTING, 'importing' ],
 	[ appStates.INACTIVE, 'importer-inactive' ],
 	[ appStates.MAP_AUTHORS, 'importer-map-authors' ],
 	[ appStates.READY_FOR_UPLOAD, 'importer-ready-for-upload' ],

--- a/client/lib/importer/constants.js
+++ b/client/lib/importer/constants.js
@@ -25,6 +25,9 @@ export const actionTypes = Object.freeze( {
 	API_FAILURE: 'importer-api-failure',
 	API_SUCCESS: 'importer-api-success',
 
+	LOCK_IMPORT: 'importer-lock-import',
+	UNLOCK_IMPORT: 'importer-unlock-import',
+
 	RECEIVE_IMPORT_STATUS: 'importer-receive-import-status',
 
 	CANCEL_IMPORT: 'importer-cancel',

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -114,9 +114,13 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 			break;
 
 		case actionTypes.SET_UPLOAD_PROGRESS:
-			newState = state.setIn( [ 'importers', action.importerId, 'percentComplete' ],
-				action.uploadLoaded / ( action.uploadTotal + Number.EPSILON ) * 100
-			);
+			newState = state.update( 'importers', importers => importers.map( importer => {
+				if ( action.importerId !== importer.get( 'importerId' ) ) {
+					return importer;
+				}
+
+				return importer.set( 'percentComplete', action.uploadLoaded / ( action.uploadTotal + Number.EPSILON ) * 100 );
+			} ) );
 			break;
 
 		case actionTypes.START_IMPORT:
@@ -140,7 +144,8 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 		case actionTypes.START_UPLOAD:
 			newState = state
 				.setIn( [ 'importers', action.importerId, 'importerState' ], appStates.UPLOADING )
-				.setIn( [ 'importers', action.importerId, 'filename' ], action.filename );
+				.setIn( [ 'importers', action.importerId, 'filename' ], action.filename )
+				.setIn( [ 'importers', action.importerId, 'uploadAborter' ], action.uploadAborter );
 			break;
 
 		default:

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -33,11 +33,9 @@ const shouldRemove = importer => removableStates.some( partial( equals, importer
 const adjustImporterLock = ( state, { action } ) => {
 	switch ( action.type ) {
 		case actionTypes.LOCK_IMPORT:
-			console.log( `Freezing importer ${ action.importerId }` );
 			return state.setIn( [ 'importerLocks', action.importerId ], true );
 
 		case actionTypes.UNLOCK_IMPORT:
-			console.log( `Unfreezing importer ${ action.importerId }` );
 			return state.setIn( [ 'importerLocks', action.importerId ], false );
 
 		default:

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -7,7 +7,6 @@ import partial from 'lodash/function/partial';
 /**
  * Internal dependencies
  */
-import { fromApi } from './common';
 import { actionTypes, appStates } from './constants';
 import { createReducerStore } from 'lib/store';
 
@@ -17,6 +16,7 @@ import { createReducerStore } from 'lib/store';
 const initialState = Immutable.fromJS( {
 	count: 0,
 	importers: {},
+	importerLocks: {},
 	api: {
 		isHydrated: false,
 		isFetching: false,
@@ -29,6 +29,21 @@ const increment = a => a + 1;
 
 const removableStates = [ appStates.CANCEL_PENDING, appStates.DEFUNCT ];
 const shouldRemove = importer => removableStates.some( partial( equals, importer.get( 'importerState' ) ) );
+
+const adjustImporterLock = ( state, { action } ) => {
+	switch ( action.type ) {
+		case actionTypes.LOCK_IMPORT:
+			console.log( `Freezing importer ${ action.importerId }` );
+			return state.setIn( [ 'importerLocks', action.importerId ], true );
+
+		case actionTypes.UNLOCK_IMPORT:
+			console.log( `Unfreezing importer ${ action.importerId }` );
+			return state.setIn( [ 'importerLocks', action.importerId ], false );
+
+		default:
+			return state;
+	}
+}
 
 const ImporterStore = createReducerStore( function( state, payload ) {
 	let { action } = payload,
@@ -101,8 +116,11 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 			break;
 
 		case actionTypes.RECEIVE_IMPORT_STATUS:
-			newState = state
-				.setIn( [ 'api', 'isHydrated' ], true );
+			newState = state.setIn( [ 'api', 'isHydrated' ], true );
+
+			if ( newState.getIn( [ 'importerLocks', action.importerStatus.importerId ], false ) ) {
+				break;
+			}
 
 			if ( action.importerStatus.importerState === appStates.DEFUNCT ) {
 				break;
@@ -114,13 +132,9 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 			break;
 
 		case actionTypes.SET_UPLOAD_PROGRESS:
-			newState = state.update( 'importers', importers => importers.map( importer => {
-				if ( action.importerId !== importer.get( 'importerId' ) ) {
-					return importer;
-				}
-
-				return importer.set( 'percentComplete', action.uploadLoaded / ( action.uploadTotal + Number.EPSILON ) * 100 );
-			} ) );
+			newState = state.setIn( [ 'importers', action.importerId, 'percentComplete' ],
+				action.uploadLoaded / ( action.uploadTotal + Number.EPSILON ) * 100
+			);
 			break;
 
 		case actionTypes.START_IMPORT:
@@ -144,14 +158,15 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 		case actionTypes.START_UPLOAD:
 			newState = state
 				.setIn( [ 'importers', action.importerId, 'importerState' ], appStates.UPLOADING )
-				.setIn( [ 'importers', action.importerId, 'filename' ], action.filename )
-				.setIn( [ 'importers', action.importerId, 'uploadAborter' ], action.uploadAborter );
+				.setIn( [ 'importers', action.importerId, 'filename' ], action.filename );
 			break;
 
 		default:
 			newState = state;
 			break;
 	}
+
+	newState = adjustImporterLock( newState, payload );
 
 	return newState;
 }, initialState );

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -44,10 +44,10 @@ export default React.createClass( {
 	},
 
 	controlButtonClicked: function() {
-		const { importerStatus: { importerId, importerState, type, uploadAborter }, site: { ID: siteId } } = this.props;
+		const { importerStatus: { importerId, importerState, type }, site: { ID: siteId } } = this.props;
 
 		if ( includes( [ ...cancelStates, ...stopStates ], importerState ) ) {
-			cancelImport( siteId, importerId, uploadAborter );
+			cancelImport( siteId, importerId );
 		} else if ( includes( startStates, importerState ) ) {
 			startImport( siteId, type );
 		} else if ( includes( doneStates, importerState ) ) {

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -44,10 +44,10 @@ export default React.createClass( {
 	},
 
 	controlButtonClicked: function() {
-		const { importerStatus: { importerId, importerState, type }, site: { ID: siteId } } = this.props;
+		const { importerStatus: { importerId, importerState, type, uploadAborter }, site: { ID: siteId } } = this.props;
 
 		if ( includes( [ ...cancelStates, ...stopStates ], importerState ) ) {
-			cancelImport( siteId, importerId );
+			cancelImport( siteId, importerId, uploadAborter );
 		} else if ( includes( startStates, importerState ) ) {
 			startImport( siteId, type );
 		} else if ( includes( doneStates, importerState ) ) {


### PR DESCRIPTION
> This PR depends on #1932 and should not be merged until after that one has been merged.

Previously, there have been cases where changes to the UI get overwritten by changes coming from the API. For example, after uploading an import file, if the user starts to map the authors, then a successive update from the API (which contains no state transitions) would reset the UI to the previous state.

This patch adds a locking system that the actions can use to freeze things while the user makes UI updates. This locking system freezes updates to the store until the lock is lifted. No updates are merged or held in queue, rather they are simply dropped.

While dropping the updates could result in conflicts, it is unlikely to be a real problem in actuality since this would require multiple people trying to work on the same importer from different computers at the same time.

**Testing**

If working on **master**, start an import by uploading a file. When the upload is successful, start mapping the authors. Within a few seconds, the importer state should return to the previous screen because the API polling reset the state.

Checkout this branch and repeat the sequence. It should no longer reset the state.

cc: @roundhill @rralian @designsimply 