### PR TITLE
Invites: Removes unused notices declaration in controller

### DIFF
--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -11,7 +11,6 @@ import i18n from 'lib/mixins/i18n';
 import titleActions from 'lib/screen-title/actions';
 import InviteAccept from 'my-sites/invites/invite-accept';
 import { setSection } from 'state/ui/actions';
-import notices from 'lib/invites/notices';
 
 export function acceptInvite( context ) {
 	titleActions.setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) );


### PR DESCRIPTION
In testing today, I noticed that we had an unused declaration in the `notices` controller. This PR removes it.