### PR TITLE
Unrevert perfmon and fix null error on Safari in production-like environments

### DIFF
--- a/client/analytics/index.js
+++ b/client/analytics/index.js
@@ -56,6 +56,16 @@ function buildQuerystringNoPrefix( group, name ) {
 	return uriComponent;
 }
 
+// we use this variable to track URL paths submitted to analytics.pageView.record
+// so that analytics.pageLoading.record can re-use the urlPath parameter.
+// this helps avoid some nasty coupling, but it's not the cleanest code - sorry.
+var mostRecentUrlPath = null;
+
+window.addEventListener('popstate', function() {
+	// throw away our URL value if the user used the back/forward buttons
+	mostRecentUrlPath = null;
+});
+
 var analytics = {
 
 	initialize: function( user, superProps ) {
@@ -92,8 +102,17 @@ var analytics = {
 	// pageView is a wrapper for pageview events across Tracks and GA
 	pageView: {
 		record: function( urlPath, pageTitle ) {
+			mostRecentUrlPath = urlPath;
 			analytics.tracks.recordPageView( urlPath );
 			analytics.ga.recordPageView( urlPath, pageTitle );
+		}
+	},
+
+	timing: {
+		record: function( eventType, duration, triggerName ) {
+			var urlPath = mostRecentUrlPath || document.location.pathname;
+			analytics.ga.recordTiming( urlPath, eventType, duration, triggerName );
+			analytics.statsd.recordTiming( urlPath, eventType, duration, triggerName );
 		}
 	},
 
@@ -129,6 +148,23 @@ var analytics = {
 			analytics.tracks.recordEvent( 'calypso_page_view', {
 				'path': urlPath
 			} );
+		}
+	},
+
+	statsd: {
+		recordTiming: function( pageUrl, eventType, duration, triggerName ) {
+			// ignore triggerName for now, it has no obvious place in statsd
+			if ( config( 'boom_analytics_enabled' ) ) {
+				var featureSlug = pageUrl === '/' ? 'homepage' : pageUrl.replace(/^\//, '').replace(/\.|\/|:/g, '_');
+
+				var json = JSON.stringify({
+					beacons:[
+						'calypso.' + config( 'boom_analytics_key' ) + '.' + featureSlug + '.' + eventType.replace('-', '_') + ':' + duration + '|ms'
+					]
+				});
+
+				new Image().src = 'https://pixel.wp.com/boom.gif?v=calypso&u=' + encodeURIComponent(pageUrl) + '&json=' + encodeURIComponent(json);
+			}
 		}
 	},
 
@@ -185,6 +221,16 @@ var analytics = {
 			if ( config( 'google_analytics_enabled' ) ) {
 				window.ga( 'send', 'event', category, action, label, value );
 			}
+		},
+
+		recordTiming: function( urlPath, eventType, duration, triggerName ) {
+			analytics.ga.initialize();
+		
+			debug( 'Recording Timing ~ [URL: ' + urlPath + '] [Duration: ' + duration + ']' );
+
+			if ( config( 'google_analytics_enabled' ) ) {
+				window.ga( 'send', 'timing', urlPath, eventType, duration, triggerName);
+			}	
 		}
 	},
 

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -25,6 +25,7 @@ var config = require( 'config' ),
 	sites = require( 'lib/sites-list' )(),
 	superProps = require( 'analytics/super-props' ),
 	i18n = require( 'lib/mixins/i18n' ),
+	perfmon = require( 'lib/perfmon' ),
 	translatorJumpstart = require( 'lib/translator-jumpstart' ),
 	translatorInvitation = require( 'layout/community-translator/invitation-utils' ),
 	layoutFocus = require( 'lib/layout-focus' ),
@@ -182,6 +183,11 @@ function boot() {
 		}
 
 		layoutElement = React.createElement( LoggedOutLayout );
+	}
+
+	if ( config.isEnabled( 'perfmon' ) ) {
+		// Record time spent watching slowly-flashing divs
+		perfmon();
 	}
 
 	layout = renderWithReduxStore(

--- a/client/lib/perfmon/README.md
+++ b/client/lib/perfmon/README.md
@@ -1,0 +1,24 @@
+Performance Monitoring
+======
+
+`perfmon` records how much time one or more loading indicators spend on the screen (currently timings are only sent to Google Analytics, but the goal is to get them into statsd or Kibana pronto). This includes those flashing grey divs, and the "pulsing dot", but could be extended to any component.
+
+Rather than hooking into React, we monitor the DOM itself for anything that looks like a placeholder (being careful not to do anything that would noticeably hurt performance), figure out whether it's visible on the screen, and if so we record how long it was there for.
+
+How it works right now:
+
+- A MutationObserver is created which monitors DOM childList and class attribute changes within div#wpcom.
+- It matches classes on these altered nodes (and their children) against a very rudimentary list of strings (anything containing 'placeholder' or 'pulsing-dot is-active'). Any nodes that match are recorded as "activePlaceholders".
+- It checks to see if any activePlaceholders are in the viewport. The event timing is the duration between the first placeholder appearing in the viewport and the last one disappearing.
+- Placeholders can also be scrolled into view - it monitors for 'scroll' events with useCapture = true (debounced to 200ms) so that we can re-check if any known placeholders have now appeared.
+- It hooks into the `page()` system in order to clear pending events when the user navigates (or, at least, when that navigation is done via the `page` library rather than replaceState/pushState)
+
+You can enable this in development by running `ENABLE_FEATURES=perfmon make run`. You may also want to set `google_analytics_enabled` to `true` in your config file if you want to observe the events being sent to Google Analytics.
+
+You can see how many active placeholders (visible and non visible) there detected during each check by running this in your console:
+
+```
+localStorage.setItem('debug', 'calypso:perfmon')
+```
+
+and then reloading the browser.

--- a/client/lib/perfmon/index.js
+++ b/client/lib/perfmon/index.js
@@ -1,0 +1,173 @@
+/** 
+ * Internal dependencies
+ */
+import analytics from 'analytics';
+
+/**
+ * External dependencies
+ */
+import each from 'lodash/collection/each';
+import remove from 'lodash/array/remove';
+import debounce from 'lodash/function/debounce';
+import page from 'page';
+
+var debug = require( 'debug' )( 'calypso:perfmon' );
+
+const PLACEHOLDER_CLASSES = [
+	'placeholder',
+	'pulsing-dot is-active',
+	'is-loading'
+];
+
+const PLACEHOLDER_MATCHER = PLACEHOLDER_CLASSES.map(function(clazz) { return `[class*='${clazz}']`; }).join(', ');
+const OBSERVE_ROOT = document.getElementById('wpcom');
+
+let activePlaceholders = [];
+let placeholdersVisibleStart = null;
+let initialized = false;
+
+// add listeners for various DOM events - scrolling, mutation and navigation
+// and use these to trigger checks for visible placeholders (and, in the case of mutations,
+// to record new placeholders and remove nodes that are no longer placeholders)
+function observeDomChanges( MutationObserver ) {
+	// if anything scrolls, check if any of our placeholder elements are in view,
+	// but not more than a few times a second
+	window.addEventListener('scroll', debounce(checkForVisiblePlaceholders.bind(null, 'scroll'), 200), true);
+
+	// if the user navigates, stop the current event and proceed to the next one
+	page( function( context, next ) {
+		// send "placeholder-wait-navigated" event
+		checkForVisiblePlaceholders( 'navigate' );
+		next();
+	} );
+
+	// this is fired for matching mutations (childList and class attr changes)
+	var observer = new MutationObserver(function(mutations, observer) {
+		
+		// record all the nodes that match our placeholder classes in the "activePlaceholders" array
+		mutations.forEach( recordPlaceholders );
+
+		// remove any nodes from activePlaceholders that are no longer placeholders
+		// check each node for:
+		// a. whether it's still in the DOM at all, and if so:
+		// b. whether it still has a placeholder class
+		var removed = remove( activePlaceholders, function( node ) {
+			return !OBSERVE_ROOT.contains( node ) || !isPlaceholder( node );
+		} );
+
+		checkForVisiblePlaceholders( 'mutation' );
+
+	} );
+
+	observer.observe( OBSERVE_ROOT, {
+	  subtree: true,
+	  attributes: true,
+	  childList: true,
+	  attributeFilter: ['class']
+	} );
+}
+
+// check if there are any placeholders on the screen,
+// and trigger a timing event when all the placeholders are gone or the user
+// has navigated
+function checkForVisiblePlaceholders( trigger ) {
+	// determine how many placeholders are active in the viewport
+	const visibleCount = activePlaceholders.reduce( 
+		function( count, node ) { 
+			return count + ( isElementVisibleInViewport( node ) ? 1 : 0 ); 
+		}, 0 
+	);
+
+	// record event and reset timer if all placeholders are loaded OR user has just navigated
+	if ( placeholdersVisibleStart && ( visibleCount === 0 || trigger === 'navigate' ) ) {
+		// tell tracks to record duration
+		var duration = Date.now() - placeholdersVisibleStart;
+		debug(`Recording placeholder wait. Duration: ${duration}, Trigger: ${trigger}`);
+		analytics.timing.record( `placeholder-wait`, duration, trigger );
+		placeholdersVisibleStart = visibleCount === 0 ? null : Date.now();
+	}
+
+	// if we can see placeholders, placeholdersVisibleStart is falsy, start the clock
+	if ( visibleCount > 0 && !placeholdersVisibleStart ) {
+		placeholdersVisibleStart = Date.now(); // TODO: performance.now()?
+	}
+
+	// if there are placeholders hanging around, print some useful stats
+	if ( activePlaceholders.length > 0 ) {
+		debug("Active placeholders: "+activePlaceholders.length);
+		debug("Visible in viewport: "+visibleCount);
+	}
+}
+
+function isPlaceholder( node ) {
+	var className = node.className;
+	return className && className.indexOf && PLACEHOLDER_CLASSES.some( function( clazz ) { 
+		return (className.indexOf( clazz ) >= 0); 
+	} );
+}
+
+// adapted from http://stackoverflow.com/questions/123999/how-to-tell-if-a-dom-element-is-visible-in-the-current-viewport/7557433#7557433
+function isElementVisibleInViewport( node ) {
+	var rect = node.getBoundingClientRect();
+
+	// discard if width or height are zero
+	if ( (rect.top - rect.bottom) === 0 || (rect.right - rect.left) === 0) {
+		return false;
+	}
+
+	var windowHeight = (window.innerHeight || document.documentElement.clientHeight);
+	var windowWidth = (window.innerWidth || document.documentElement.clientWidth);
+
+	// if top or bottom are inside window, AND left or right edge are inside window, then
+	// the element is at least partially visible
+	return (
+		( ( rect.top >= 0 && rect.top <= windowHeight ) || ( rect.bottom >= 0 && rect.bottom <= windowHeight ) ) &&
+		( ( rect.left >= 0 && rect.left <= windowWidth ) || ( rect.right >= 0 && rect.right <= windowWidth  ) )
+	);
+}
+
+function recordPlaceholders( mutation ) { 
+	var nodes = [];
+
+	if ( mutation.attributeName === 'class' ) { // mutation.type === 'attributes' is redundant
+		nodes = [mutation.target];
+	} else if ( mutation.type === 'childList' && mutation.addedNodes.length > 0 ) {
+		nodes = mutation.addedNodes;
+	} else {
+		return;
+	}
+
+	each( nodes, function( node ) {
+
+		if ( isPlaceholder( node ) ) {
+			recordPlaceholderNode( node );
+		}
+
+		// we need to find matching children because the mutation observer
+		// only fires for the top element of an added subtree
+		if ( node.querySelectorAll ) {
+			// funky syntax because NodeList walks like an array but doesn't quack like one
+			each( node.querySelectorAll(PLACEHOLDER_MATCHER), recordPlaceholderNode );
+		}
+	} );
+}
+
+function recordPlaceholderNode( node ) {
+	if ( activePlaceholders.indexOf( node ) >= 0 ) {
+		// no-op
+	} else {
+		activePlaceholders.push(node);
+	}
+}
+
+module.exports = function() {
+	if ( !initialized ) {
+		var MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+
+		if ( MutationObserver ) {
+			observeDomChanges( MutationObserver );
+		}
+
+		initialized = true;
+	}
+};

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -84,7 +84,8 @@
 		"network-connection": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
-		"ad-tracking": false
+		"ad-tracking": false,
+		"perfmon": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
Sometimes it seems like placeholders disappear before we recorded any pageviews in the analytics module, resulting in a null URL passed to the analytics.*.recordTiming methods.

This patch fixes that by falling back to the document pathname:

```
var urlPath = mostRecentUrlPath || document.location.pathname;
```

cc @dmsnell 