### PR TITLE
Invites: Change invite accepted notice link

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -123,7 +123,7 @@ let InviteAccept = React.createClass( {
 							{
 								this.translate(
 									'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-									{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
+									{ components: { docsLink: <a href="https://learn.wordpress.com/" target="_blank" /> } }
 								)
 							}
 						</p>
@@ -146,7 +146,7 @@ let InviteAccept = React.createClass( {
 							{
 								this.translate(
 									'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-									{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
+									{ components: { docsLink: <a href="https://learn.wordpress.com/" target="_blank" /> } }
 								)
 							}
 						</p>
@@ -169,7 +169,7 @@ let InviteAccept = React.createClass( {
 							{
 								this.translate(
 									'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-									{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
+									{ components: { docsLink: <a href="https://learn.wordpress.com/" target="_blank" /> } }
 								)
 							}
 						</p>
@@ -192,7 +192,7 @@ let InviteAccept = React.createClass( {
 							{
 								this.translate(
 									'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-									{ components: { docsLink: <a href="http://en.support.wordpress.com/" target="_blank" /> } }
+									{ components: { docsLink: <a href="https://learn.wordpress.com/" target="_blank" /> } }
 								)
 							}
 						</p>


### PR DESCRIPTION
__How to test__

* checkout `fix/invites-notices-link`
* on a WP.com site, go to $site/wp-admin/users.php?page=wpcom-invite-users and invite a test user
* in the invitation email, make note of the invitation key
* go to /accept-invite/$site/$invitation_key* check that the invite accepted notice link points to https://learn.wordpress.com/

Closes #2246