### PR TITLE
Components: Add tests to bulk select component

### DIFF
--- a/client/components/bulk-select/Makefile
+++ b/client/components/bulk-select/Makefile
@@ -1,0 +1,10 @@
+REPORTER ?= spec
+NODE_BIN := $(shell npm bin)
+MOCHA ?= ../../../node_modules/.bin/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := test:$(BASE_DIR)/client:$(BASE_DIR)/shared
+
+test:
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers jsx:babel/register --reporter $(REPORTER)
+
+.PHONY: test

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -39,10 +40,14 @@ export default React.createClass( {
 	},
 
 	render() {
+		const isChecked = this.hasAllElementsSelected();
+		const inputClasses = classNames( 'bulk-select__box', {
+			'is-checked': isChecked // we need to add this css class to be able to test if the input if checked, since enzyme still doesn't support :checked pseudoselector
+		} );
 		return (
 			<span className="bulk-select" onClick={ this.handleToggleAll }>
 				<span className="bulk-select__container">
-					<input type="checkbox" className="bulk-select__box" checked={ this.hasAllElementsSelected() } readOnly />
+					<input type="checkbox" className={ inputClasses } checked={ isChecked } readOnly />
 					<Count count={ this.props.selectedElements } />
 					{ this.getStateIcon() }
 				</span>

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -1,0 +1,79 @@
+
+require( 'lib/react-test-env-setup' )();
+
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
+import React from 'react';
+import { shallow } from 'enzyme';
+import noop from 'lodash/utility/noop';
+
+/**
+ * Internal dependencies
+ */
+import BulkSelect from '../index';
+
+describe( 'BulkSelect', function() {
+	it( 'should have BulkSelect class', function() {
+		const bulkSelect = shallow( <BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ noop } /> );
+		assert.equal( 1, bulkSelect.find( '.bulk-select' ).length );
+	} );
+
+	it( 'should not be checked when initialized without selectedElements', function() {
+		const bulkSelect = shallow( <BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ noop } /> );
+		assert.equal( 0, bulkSelect.find( '.is-checked' ).length );
+	} );
+
+	it( 'should be checked when initialized with all elements selected', function() {
+		const bulkSelect = shallow( <BulkSelect selectedElements={ 3 } totalElements={ 3 } onToggle={ noop } /> );
+		assert.equal( 1, bulkSelect.find( '.is-checked' ).length );
+	} );
+
+	it( 'should not be checked when initialized with some elements selected', function() {
+		const bulkSelect = shallow( <BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } /> );
+		assert.equal( 0, bulkSelect.find( '.is-checked' ).length );
+	} );
+
+	it( 'should render line gridicon when initialized with some elements selected', function() {
+		const bulkSelect = shallow( <BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } /> );
+		assert.equal( 1, bulkSelect.find( '.bulk-select__some-checked-icon' ).length );
+	} );
+
+	it( 'should be call onToggle when clicked', function() {
+		let hasBeenCalled = false;
+		const callback = function() {
+			hasBeenCalled = true;
+		};
+		const bulkSelect = shallow( <BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ callback } /> );
+		bulkSelect.simulate( 'click' );
+		assert.equal( hasBeenCalled, true );
+	} );
+
+	it( 'should be call onToggle with the new state when there are no selected elements', function( done ) {
+		const callback = function( newState ) {
+			assert.equal( newState, true );
+			done();
+		};
+		const bulkSelect = shallow( <BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ callback } /> );
+		bulkSelect.simulate( 'click' );
+	} );
+
+	it( 'should be call onToggle with the new state when there are some selected elements', function( done ) {
+		const callback = function( newState ) {
+			assert.equal( newState, false );
+			done();
+		};
+		const bulkSelect = shallow( <BulkSelect selectedElements={ 1 } totalElements={ 3 } onToggle={ callback } /> );
+		bulkSelect.simulate( 'click' );
+	} );
+
+	it( 'should be call onToggle with the new state when there all elements are selected', function( done ) {
+		const callback = function( newState ) {
+			assert.equal( newState, false );
+			done();
+		};
+		const bulkSelect = shallow( <BulkSelect selectedElements={ 3 } totalElements={ 3 } onToggle={ callback } /> );
+		bulkSelect.simulate( 'click' );
+	} );
+} );


### PR DESCRIPTION
Bulk select component was missing tests. This PR adds them:

![image](https://cloud.githubusercontent.com/assets/1554855/12232660/bfbdf488-b860-11e5-8738-50729975191e.png)

How to test
=========
1. In a CLI, go to /client/components/bulk-select and run `make test`