### PR TITLE
Site Selector: use <Button> for add-new-site.

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -63,6 +63,8 @@ button {
 		box-shadow: 0 0 0 2px $blue-light;
 	}
 	&.is-compact {
+		background: transparent;
+		border-radius: 0;
 		padding: 7px;
 		color: darken( $gray, 10% );
 		font-size: 11px;

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -10,7 +10,8 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var AllSites = require( 'my-sites/all-sites' ),
-	AddNewButton = require( 'components/add-new-button' ),
+	Button = require( 'components/button' ),
+	Gridicon = require( 'components/gridicon' ),
 	Site = require( 'my-sites/site' ),
 	SitePlaceholder = require( 'my-sites/site/placeholder' ),
 	Search = require( 'components/search' ),
@@ -77,12 +78,11 @@ module.exports = React.createClass( {
 
 	addNewSite: function() {
 		return (
-			<AddNewButton
-				isCompact={ true }
-				href={ config( 'signup_url' ) + '?ref=calypso-selector' }
-			>
-				{ this.translate( 'Add New WordPress' ) }
-			</AddNewButton>
+			<span className="site-selector__add-new-site">
+				<Button compact borderless href={ config( 'signup_url' ) + '?ref=calypso-selector' }>
+					<Gridicon icon="add-outline" /> { this.translate( 'Add New WordPress' ) }
+				</Button>
+			</span>
 		);
 	},
 

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -119,7 +119,7 @@
 }
 
 .site-selector__add-new-site {
-	padding: 8px 16px;
+	padding: 8px 9px;
 	display: block;
 	border-top: 1px solid lighten( $gray, 20% );
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -118,12 +118,10 @@
 	padding: 10px 20px;
 }
 
-.site-selector .add-new-button {
+.site-selector__add-new-site {
 	padding: 8px 16px;
-
-	.gridicon {
-		margin-top: 2px;
-	}
+	display: block;
+	border-top: 1px solid lighten( $gray, 20% );
 }
 
 // Containers in the list of sites are larger

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -3,7 +3,6 @@
  */
 var React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:my-sites:current-site' ),
-	analytics = require( 'analytics' ),
 	url = require( 'url' );
 
 /**
@@ -11,7 +10,7 @@ var React = require( 'react' ),
  */
 var AllSites = require( 'my-sites/all-sites' ),
 	analytics = require( 'analytics' ),
-	AddNewButton = require( 'components/add-new-button' ),
+	Button = require( 'components/button' ),
 	Card = require( 'components/card' ),
 	Notice = require( 'components/notice' ),
 	NoticeAction = require( 'components/notice/notice-action' ),
@@ -119,7 +118,7 @@ module.exports = React.createClass( {
 			domains = domainStore && domainStore.list || [];
 		return (
 			<DomainWarnings
-				selectedSite={this.getSelectedSite()}
+				selectedSite={ this.getSelectedSite() }
 				domains={ domains }
 				ruleWhiteList={ [ 'expiredDomains', 'expiringDomains' ] } />
 		);
@@ -140,13 +139,14 @@ module.exports = React.createClass( {
 
 	addNewWordPressButton: function() {
 		return (
-			<AddNewButton
-				isCompact={ true }
-				href={ config( 'signup_url' ) + '?ref=calypso-selector' }
-				onClick={ this.focusContent }
-			>
-				{ this.translate( 'Add New WordPress' ) }
-			</AddNewButton>
+			<span className="current-site__add-new-site">
+				<Button compact borderless
+					href={ config( 'signup_url' ) + '?ref=calypso-selector' }
+					onClick={ this.focusContent }
+				>
+					<Gridicon icon="add-outline" /> { this.translate( 'Add New WordPress' ) }
+				</Button>
+			</span>
 		);
 	},
 

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -38,16 +38,13 @@
 	}
 }
 
-.current-site .add-new-button {
+.current-site__add-new-site {
 	background: $gray-light;
 	border-bottom: 1px solid lighten( $gray, 25% );
-	font-size: 13px;
 	display: block;
-	padding: 8px 8px 8px 52px;
+	padding: 4px 8px;
 	margin: 0;
-	color: $gray-dark;
 	box-sizing: border-box;
-	cursor: pointer;
 	position: relative;
 
 	@include breakpoint( "<660px" ) {
@@ -58,32 +55,6 @@
 	&:hover {
 		background-color: $gray-light;
 		color: $blue-medium;
-	}
-
-	.gridicon {
-		height: 16px;
-		width: 16px;
-		margin: 0;
-		float: none;
-		position: absolute;
-			top: 9px;
-			left: 24px;
-		fill: darken( $gray, 20% );
-		transition: all 0.2s cubic-bezier(0.680, -0.550, 0.265, 1.550);
-
-		@include breakpoint( "<660px" ) {
-				top: 15px;
-				left: 16px;
-			height: 24px;
-			width: 24px;
-		}
-	}
-
-	.add-new-button__text {
-		padding: 0;
-		font-size: 13px;
-		line-height: 1;
-		text-transform: none;
 	}
 }
 


### PR DESCRIPTION
Uses compact borderless button and adds a border to the fixed positioned area.
`AddNewButton` will be deprecated.

Before:
![image](https://cloud.githubusercontent.com/assets/548849/12235012/158d6d5c-b871-11e5-82a0-a67a31e13eb6.png)

After:
![image](https://cloud.githubusercontent.com/assets/548849/12235149/26d55af6-b872-11e5-855e-734b8e2291a7.png)

------

![image](https://cloud.githubusercontent.com/assets/548849/12235299/2c722646-b873-11e5-90b4-4e870e4982db.png)
