### PR TITLE
SSR: Mark masterbar and layout files as `@ssr-ready`

### DIFF
--- a/server/pragma-checker/index.js
+++ b/server/pragma-checker/index.js
@@ -10,6 +10,7 @@ var includes = require( 'lodash/collection/includes' );
 
 var PLUGIN_TITLE = 'PragmaChecker';
 var SSR_READY = '/** @ssr-ready **/';
+var IGNORED_MODULES = [ 'config' ];
 
 function PragmaCheckPlugin( options ) {
 	this.options = options || {};
@@ -28,6 +29,7 @@ function scanDependencies( module, compilation ) {
 		// If the module is compiled through babel, we can be pretty sure it's our own module, not from npm.
 		if ( includes( dep.module.request, 'babel-loader' ) &&
 				dep.module._source &&
+				! includes( IGNORED_MODULES, dep.module.rawRequest ) &&
 				! includes( dep.module._source._value, SSR_READY ) ) {
 			compilation.errors.push( PLUGIN_TITLE + ': ' + module.rawRequest + ', dependency ' + dep.module.rawRequest + ' is not ' + SSR_READY );
 		}

--- a/shared/components/gridicon/index.jsx
+++ b/shared/components/gridicon/index.jsx
@@ -1,3 +1,4 @@
+/** @ssr-ready **/
 
 /* !!!
 IF YOU ARE EDITING gridicon/index.jsx

--- a/shared/layout/logged-out-design.jsx
+++ b/shared/layout/logged-out-design.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/shared/layout/masterbar/item.jsx
+++ b/shared/layout/masterbar/item.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/shared/layout/masterbar/logged-out.jsx
+++ b/shared/layout/masterbar/logged-out.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/shared/layout/masterbar/masterbar.jsx
+++ b/shared/layout/masterbar/masterbar.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */


### PR DESCRIPTION
Part of #1551

Mark everything necessary to render the MasterBar on logged-out `/design` as `@ssr-ready`. Gridicons manually updated for now.

TODO:
- [x] Look at the rest of the components in `shared/`, see what we can mark as ready
- [x] Figure out what to do for `config`

To test:
- Restart `make run`
- Make sure pragma checker isn't complaining