### PR TITLE
Notifications: new setting for Promotions

### DIFF
--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -30,7 +30,8 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 const options = {
 	marketing: 'marketing',
 	research: 'research',
-	community: 'community'
+	community: 'community',
+	promotion: 'promotion'
 };
 
 const WPCOMNotifications = React.createClass( {
@@ -94,6 +95,14 @@ const WPCOMNotifications = React.createClass( {
 					<FormLegend>{ this.translate( 'Community' ) }</FormLegend>
 					<FormLabel>
 						<FormCheckbox checked={ this.state.settings.get( options.community ) } onChange={ this.toggleSetting.bind( this, options.community ) }/>
+						<span>{ this.translate( 'Information on WordPress.com courses and events (online & in-person).' ) }</span>
+					</FormLabel>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLegend>{ this.translate( 'Promotion' ) }</FormLegend>
+					<FormLabel>
+						<FormCheckbox checked={ this.state.settings.get( options.promotion ) } onChange={ this.toggleSetting.bind( this, options.promotion ) }/>
 						<span>{ this.translate( 'Information on WordPress.com courses and events (online & in-person).' ) }</span>
 					</FormLabel>
 				</FormFieldset>

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -31,7 +31,8 @@ const options = {
 	marketing: 'marketing',
 	research: 'research',
 	community: 'community',
-	promotion: 'promotion'
+	promotion: 'promotion',
+	news: 'news'
 };
 
 const WPCOMNotifications = React.createClass( {
@@ -100,10 +101,18 @@ const WPCOMNotifications = React.createClass( {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLegend>{ this.translate( 'Promotion' ) }</FormLegend>
+					<FormLegend>{ this.translate( 'Promotions' ) }</FormLegend>
 					<FormLabel>
 						<FormCheckbox checked={ this.state.settings.get( options.promotion ) } onChange={ this.toggleSetting.bind( this, options.promotion ) }/>
-						<span>{ this.translate( 'Information on WordPress.com courses and events (online & in-person).' ) }</span>
+						<span>{ this.translate( 'Promotions and deals on upgrades.' ) }</span>
+					</FormLabel>
+				</FormFieldset>
+
+				<FormFieldset>
+					<FormLegend>{ this.translate( 'News' ) }</FormLegend>
+					<FormLabel>
+						<FormCheckbox checked={ this.state.settings.get( options.news ) } onChange={ this.toggleSetting.bind( this, options.news ) }/>
+						<span>{ this.translate( 'WordPress.com news and announcements.' ) }</span>
 					</FormLabel>
 				</FormFieldset>
 


### PR DESCRIPTION
Added new setting for _promotions_ on _email from WordPress.com_ section.

Backend changes for settings endpoint already implemented.

Test live: https://calypso.live/?branch=add/notification-settings-promotions

This closes #2184 .