### PR TITLE
Framework: Enable placeholder timing monitoring in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -77,6 +77,7 @@
 		"reader/discover": true,
 		"reader/recommendations": true,
 		"ad-tracking": true,
+		"perfmon": true,
 		"mailing-lists/unsubscribe": true
 	},
 	"rtl": false,
@@ -85,7 +86,7 @@
 	"wpcom_signup_id": "39911",
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": true,
-	"boom_analytics_enabled": false,
+	"boom_analytics_enabled": true,
 	"boom_analytics_key": "production",
 	"google_analytics_enabled": true,
 	"google_analytics_key": "UA-10673494-10",


### PR DESCRIPTION
This enables the "perfmon" feature in production, which collects information about how long placeholder elements spend visible on the screen in each section of Calypso.

This feature was enabled in all other environments over the weekend and I think any issues have been ironed out, but there's no great urgency to this so if folks have concerns I can wait to merge.

cc @josephscott @roccotripaldi @blowery 