### PR TITLE
Documentation: Clarify and simplify installation requirements

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -12,7 +12,7 @@
 
 To be able to clone the repo and run the application **on Mac OS X or Linux** you need:
 
--	[Node.js](http://nodejs.org/) and [NPM](https://www.npmjs.com/) installed. On Mac OS X using [brew](http://brew.sh/) is the easiest way to install `node` and `npm`.
+-	[Node.js](http://nodejs.org/) (at least version **4.3.0**) and [NPM](https://www.npmjs.com/) installed. On Mac OS X using [brew](http://brew.sh/) is the easiest way to install `node` and `npm`.
 -	[Git](http://git-scm.com/). Try the `git` command from your terminal, if it's not found then use this [installer](http://git-scm.com/download/).
 -	The repository also uses `make` to orchestrate compiling the JavaScript, running the server, and several other tasks. On Mac OS X, the easiest way to install `make` is through Apple's [Command Line Tools for Xcode](https://developer.apple.com/downloads/) (requires free registration).
 
@@ -23,7 +23,7 @@ To be able to clone the repo and run the application **on Mac OS X or Linux** yo
 Clone this git repo to your machine via the terminal using the `git clone` command and then run `make run` from the root Calypso directory:
 
 ```bash
-$ git clone git@github.com:Automattic/wp-calypso.git
+$ git clone https://github.com/Automattic/wp-calypso.git
 $ cd wp-calypso
 $ make run
 ```


### PR DESCRIPTION
- Add note about minimum Node.js version
- Direct users to clone the repository using HTTPS instead of SSH (doesn't require SSH key setup)