### PR TITLE
Fix perfmon metric explosion

### DIFF
--- a/client/analytics/index.js
+++ b/client/analytics/index.js
@@ -158,10 +158,14 @@ var analytics = {
 				var featureSlug = pageUrl === '/' ? 'homepage' : pageUrl.replace(/^\//, '').replace(/\.|\/|:/g, '_');
 
 				// prevent explosion of read list metrics
-				if ( featureSlug.startsWith('read_list') ) {
+				// this is a hack - ultimately we want to report this URLs in a more generic way to 
+				// google analytics
+				if ( featureSlug.startsWith( 'read_list' ) ) {
 					featureSlug = 'read_list';
-				} else if ( featureSlug.startsWith('tag_') ) {
+				} else if ( featureSlug.startsWith( 'tag_' ) ) {
 					featureSlug = 'tag__id';
+				} else if ( document.location.pathname.startsWith( '/plugins/browse' ) ) {
+					featureSlug = 'plugins_browse__site';
 				}
 
 				var json = JSON.stringify({

--- a/client/analytics/index.js
+++ b/client/analytics/index.js
@@ -156,7 +156,7 @@ var analytics = {
 			// ignore triggerName for now, it has no obvious place in statsd
 			if ( config( 'boom_analytics_enabled' ) ) {
 				var featureSlug = pageUrl === '/' ? 'homepage' : pageUrl.replace(/^\//, '').replace(/\.|\/|:/g, '_');
-
+				var matched;
 				// prevent explosion of read list metrics
 				// this is a hack - ultimately we want to report this URLs in a more generic way to 
 				// google analytics
@@ -168,6 +168,12 @@ var analytics = {
 					featureSlug = 'domains_add_suggestion__suggestion__domain';
 				} else if ( document.location.pathname.startsWith( '/plugins/browse' ) ) {
 					featureSlug = 'plugins_browse__site';
+				} else if ( featureSlug.startsWith( 'read_post_feed_' ) ) {
+					featureSlug = 'read_post_feed__id';
+				} else if ( featureSlug.startsWith( 'read_post_id_' ) ) {
+					featureSlug = 'read_post_id__id';
+				} else if ( ( matched = featureSlug.match( /^start_(.*)_(..)$/ ) ) != null ) {
+					featureSlug = `start_${matched[1]}`;
 				}
 
 				var json = JSON.stringify({

--- a/client/analytics/index.js
+++ b/client/analytics/index.js
@@ -166,7 +166,7 @@ var analytics = {
 					featureSlug = 'tag__id';
 				} else if ( featureSlug.startsWith( 'domains_add_suggestion_' ) ) {
 					featureSlug = 'domains_add_suggestion__suggestion__domain';
-				} else if ( document.location.pathname.startsWith( '/plugins/browse' ) ) {
+				} else if ( document.location.pathname.startsWith( '/plugins/browse/' ) ) {
 					featureSlug = 'plugins_browse__site';
 				} else if ( featureSlug.startsWith( 'read_post_feed_' ) ) {
 					featureSlug = 'read_post_feed__id';

--- a/client/analytics/index.js
+++ b/client/analytics/index.js
@@ -164,6 +164,8 @@ var analytics = {
 					featureSlug = 'read_list';
 				} else if ( featureSlug.startsWith( 'tag_' ) ) {
 					featureSlug = 'tag__id';
+				} else if ( featureSlug.startsWith( 'domains_add_suggestion_' ) ) {
+					featureSlug = 'domains_add_suggestion__suggestion__domain';
 				} else if ( document.location.pathname.startsWith( '/plugins/browse' ) ) {
 					featureSlug = 'plugins_browse__site';
 				}

--- a/client/lib/perfmon/index.js
+++ b/client/lib/perfmon/index.js
@@ -16,7 +16,8 @@ var debug = require( 'debug' )( 'calypso:perfmon' );
 const PLACEHOLDER_CLASSES = [
 	'placeholder',
 	'pulsing-dot is-active',
-	'is-loading'
+	'is-loading',
+	'is-processing'
 ];
 
 const EXCLUDE_PLACEHOLDER_CLASSES = [


### PR DESCRIPTION
A few URLs are being reported to analytics with user-specific information (e.g. /tag/foobar, /read/list/mylist, etc) and this is resulting in grafana generating many many metrics when it comes to tracking placeholder timings.

This patch fixes the biggest few. Ultimately we should fix these at the source, as it will help with reporting across all the systems where we gather this data - tracks, GA, mc, etc.

It also adds monitoring for the "pulsing bullet point" that appears during site creation.