### PR TITLE
Plugins: fixes #2285, my making sure that we display the right action even for hidden sites.

### DIFF
--- a/client/my-sites/plugins/plugin-meta/README.md
+++ b/client/my-sites/plugins/plugin-meta/README.md
@@ -26,4 +26,5 @@ render: function() {
 * `sites` : (array) An array of the sites that current plugin is installed on.
 * `isPlaceholder`: (boolean) Whether the component is being rendered in placeholder mode
 * `isMock`: a boolean indicating if the toggle should not launch any real action when interacted
+* `isInstalledOnSite`: a boolean indicating if the plugin is installed on the site or not.
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -35,7 +35,8 @@ export default React.createClass( {
 		sites: React.PropTypes.array,
 		notices: React.PropTypes.object,
 		plugin: React.PropTypes.object.isRequired,
-		isPlaceholder: React.PropTypes.bool
+		isInstalledOnSite: React.PropTypes.bool.isRequired,
+		isPlaceholder: React.PropTypes.bool,
 	},
 
 	displayBanner() {
@@ -55,7 +56,7 @@ export default React.createClass( {
 			return;
 		}
 
-		if ( ! this.isInstalledOnSite( this.props.selectedSite ) ) {
+		if ( ! this.props.isInstalledOnSite ) {
 			return ( <div className="plugin-meta__actions"> { this.getInstallButton() } </div> );
 		}
 
@@ -117,14 +118,6 @@ export default React.createClass( {
 				linkToAuthor
 			}
 		} );
-	},
-
-	isInstalledOnSite( site ) {
-		return ( this.props.sites &&
-			this.props.sites.some( iteratorSite => {
-				return site.slug === iteratorSite.slug;
-			} )
-		);
 	},
 
 	getInstallButton() {
@@ -198,7 +191,7 @@ export default React.createClass( {
 
 	hasInstallButton() {
 		if ( this.props.selectedSite ) {
-			return ! this.isInstalledOnSite( this.props.selectedSite ) &&
+			return ! this.props.isInstalledOnSite &&
 				this.props.selectedSite.user_can_manage &&
 				this.props.selectedSite.jetpack;
 		}

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -243,6 +243,7 @@ export default React.createClass( {
 	},
 
 	renderPluginPlaceholder( classes ) {
+		const selectedSite = this.props.sites.getSelectedSite();
 		return (
 			<MainComponent>
 				<SidebarNavigation />
@@ -252,10 +253,11 @@ export default React.createClass( {
 						isPlaceholder
 						isWpcomPlugin={ this.props.isWpcomPlugin }
 						notices={ this.state.notices }
+						isInstalledOnSite={ !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug ) }
 						plugin={ this.state.plugin }
 						siteUrl={ this.props.siteUrl }
 						sites={ this.state.sites }
-						selectedSite={ this.props.sites.getSelectedSite() } />
+						selectedSite={ selectedSite } />
 				</div>
 			</MainComponent>
 		);
@@ -277,6 +279,7 @@ export default React.createClass( {
 					<PluginMeta
 						notices={ {} }
 						isWpcomPlugin={ this.props.isWpcomPlugin }
+						isInstalledOnSite={ !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug ) }
 						plugin={ this.state.plugin }
 						siteUrl={ 'no-real-url' }
 						sites={ [ selectedSite ] }
@@ -349,6 +352,7 @@ export default React.createClass( {
 						siteUrl={ this.props.siteUrl }
 						sites={ this.state.sites }
 						selectedSite={ selectedSite }
+						isInstalledOnSite={ !! PluginsStore.getSitePlugin( selectedSite, this.state.plugin.slug ) }
 						isInstalling={ installInProgress } />
 					<PluginSections plugin={ this.state.plugin } />
 					{ this.renderSitesList() }


### PR DESCRIPTION
**To test**

Hide 2 sites one buisness and the other jetpack. 
make sure when you visit the single plugin page you see what you expect. 

On the business site you should see the activate toggle. 
On the jetpack site you should see other actions. Such as install or activate toggle, etc. 

 This fixes #2285 bug. 

Also navigate around make sure that the other sites on the single and multi plugin view display as intended. You will not be able to see the hidden site on the sites list. 

