### PR TITLE
Stats: remove extra boxes in Posting Activity

### DIFF
--- a/client/my-sites/post-trends/style.scss
+++ b/client/my-sites/post-trends/style.scss
@@ -117,12 +117,12 @@
 	display: inline-block;
 	width: 7px;
 	height: 7px;
-	border: 1px solid lighten( $gray, 30% );
 	background-color: lighten( $gray, 20% );
+	margin: 1px;
 }
 
 .post-trends__day,
-.post-trends__key-day{
+.post-trends__key-day {
 	&.is-outside-month {
 		background-color: $transparent;
 	}
@@ -161,6 +161,7 @@
 }
 
 @include breakpoint( ">960px" ) {
+
 	.post-trends__scroll-left,
 	.post-trends__scroll-right {
 		display: none;
@@ -168,6 +169,7 @@
 }
 
 @include breakpoint( "<960px" ) {
+
 	.post-trends__year {
 		margin: 0 40px 0;
 	}


### PR DESCRIPTION
This is a tiny fix that removes the extra empty squares on Posting Activity. They originally weren't there, but got added in for some reason. Removing them because they only add clutter.

**Before:**
![screenshot 2016-01-11 12 15 13](https://cloud.githubusercontent.com/assets/4924246/12246210/0b3ec3dc-b862-11e5-9ca5-b32040ca2f1f.png)

**Before:**
![screenshot 2016-01-11 12 26 20](https://cloud.githubusercontent.com/assets/4924246/12246211/0fe4b4a0-b862-11e5-80ab-27feebb495a2.png)
