### PR TITLE
Reader: Fix tag streams and like streams.

### DIFF
--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -438,7 +438,7 @@ assign( FeedStream.prototype, {
 			postKeys = this.filterNewPosts( data.posts );
 			if ( postKeys.length > 0 ) {
 				this.pendingPostKeys = postKeys;
-				this.pendingDateAfter = moment( FeedPostStore.get( this.keyMaker( data.posts[ data.posts.length - 1 ] ) ).date );
+				this.pendingDateAfter = moment( FeedPostStore.get( this.keyMaker( data.posts[ data.posts.length - 1 ] ) )[ this.dateProperty ] );
 				this.emit( 'change' );
 			}
 		}

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -70,7 +70,8 @@ function getStoreForTag( storeId ) {
 		fetcher: fetcher,
 		keyMaker: siteKeyMaker,
 		onGapFetch: limitSiteParams,
-		onUpdateFetch: limitSiteParams
+		onUpdateFetch: limitSiteParams,
+		dateProperty: 'tagged_on'
 	} );
 }
 


### PR DESCRIPTION
Tag streams by paging based on tagged_on date, like streams by using the date property when picking the last date on a page.

cc @bluefuton 