### PR TITLE
Settings: Disabling security scan settings in the Horizon enviornment

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,7 @@
 		"login": false,
 		"network-connection": true,
 		"settings/security/monitor": true,
-		"settings/security/scan": true,
+		"settings/security/scan": false,
 		"ad-tracking": false,
 		"perfmon": true
 	},


### PR DESCRIPTION
Horizon testing for security scan settings are no longer needed. We will disable it there for now while we iterate in development environments.