### PR TITLE
Editor: Display placeholder on empty content

### DIFF
--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -1,3 +1,5 @@
+@import 'plugins/placeholder/style';
+
 body {
 	@extend %content-font;
 	font-family: $serif;

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -39,6 +39,7 @@ import touchScrollToolbarPlugin from './plugins/touch-scroll-toolbar/plugin';
 import editorButtonAnalyticsPlugin from './plugins/editor-button-analytics/plugin';
 import calypsoAlertPlugin from './plugins/calypso-alert/plugin';
 import contactFormPlugin from './plugins/contact-form/plugin';
+import placeholderPlugin from './plugins/placeholder/plugin';
 
 [
 	wpcomPlugin,
@@ -55,7 +56,8 @@ import contactFormPlugin from './plugins/contact-form/plugin';
 	touchScrollToolbarPlugin,
 	editorButtonAnalyticsPlugin,
 	calypsoAlertPlugin,
-	contactFormPlugin
+	contactFormPlugin,
+	placeholderPlugin,
 ].forEach( ( initializePlugin ) => initializePlugin() );
 
 /**
@@ -99,6 +101,7 @@ const PLUGINS = [
 	'lists',
 	'media',
 	'paste',
+	'placeholder',
 	'tabfocus',
 	'textcolor',
 	'wptextpattern',
@@ -132,6 +135,7 @@ module.exports = React.createClass( {
 
 	propTypes: {
 		mode: React.PropTypes.string,
+		placeholder: React.PropTypes.string,
 		onActivate: React.PropTypes.func,
 		onBlur: React.PropTypes.func,
 		onChange: React.PropTypes.func,
@@ -460,6 +464,7 @@ module.exports = React.createClass( {
 				id={ this._id }
 				onChange={ this.onTextAreaChange }
 				tabIndex={ this.props.tabIndex }
+				placeholder={ this.props.placeholder }
 				value={ this.state.content }
 			/>
 		);

--- a/client/components/tinymce/plugins/placeholder/plugin.js
+++ b/client/components/tinymce/plugins/placeholder/plugin.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+
+import tinymce from 'tinymce/tinymce';
+
+/**
+ * Module variables
+ */
+
+const REGEXP_EMPTY_CONTENT = /^<p>(<br[^>]*>|&nbsp;|\s)*<\/p>$/;
+
+function hasContent( content ) {
+	return content.length && ! REGEXP_EMPTY_CONTENT.test( content );
+}
+
+function placeholder( editor ) {
+	const element = editor.getElement();
+	if ( ! element.hasAttribute( 'placeholder' ) ) {
+		return;
+	}
+
+	let isShowingPlaceholder = false;
+	function toggleShowingPlaceholder( state ) {
+		if ( state === isShowingPlaceholder ) {
+			return;
+		}
+
+		isShowingPlaceholder = state;
+		editor.dom.toggleClass( editor.getBody(), 'is-showing-placeholder', isShowingPlaceholder );
+	}
+
+	function getRawContent() {
+		return editor.getContent( { format: 'raw' } ).trim();
+	}
+
+	function maybeRemovePlaceholder() {
+		if ( hasContent( getRawContent() ) || editor.isHidden() ) {
+			toggleShowingPlaceholder( false );
+		}
+	}
+
+	function maybeAddPlaceholder() {
+		if ( ! hasContent( getRawContent() ) && ! editor.isHidden() ) {
+			toggleShowingPlaceholder( true );
+		}
+	}
+
+	editor.on( 'init', () => {
+		editor.dom.addStyle( `
+			body.is-showing-placeholder:not( :focus )::before {
+				content: '${ element.getAttribute( 'placeholder' ) }';
+			}
+		` );
+
+		editor.on( 'show', maybeAddPlaceholder );
+		editor.on( 'hide', maybeRemovePlaceholder );
+		editor.dom.bind( editor.getBody(), 'focus', maybeRemovePlaceholder );
+		editor.dom.bind( editor.getBody(), 'blur', maybeAddPlaceholder );
+
+		if ( ! editor.isHidden() ) {
+			maybeAddPlaceholder();
+		}
+	} );
+
+	editor.on( 'SetContent', ( event ) => {
+		toggleShowingPlaceholder( ! hasContent( event.content ) );
+	} );
+}
+
+export default function() {
+	tinymce.PluginManager.add( 'placeholder', placeholder );
+}

--- a/client/components/tinymce/plugins/placeholder/style.scss
+++ b/client/components/tinymce/plugins/placeholder/style.scss
@@ -1,0 +1,4 @@
+body.is-showing-placeholder:not( :focus )::before {
+	font-style: italic;
+	opacity: 0.7;
+}

--- a/client/components/tinymce/plugins/placeholder/style.scss
+++ b/client/components/tinymce/plugins/placeholder/style.scss
@@ -1,4 +1,3 @@
 body.is-showing-placeholder:not( :focus )::before {
-	font-style: italic;
-	opacity: 0.7;
+	opacity: 0.5;
 }

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -327,6 +327,7 @@ var PostEditor = React.createClass( {
 							<TinyMCE
 								ref="editor"
 								mode={ mode }
+								placeholder={ this.translate( 'Tell me your story…', { comment: 'Editor placeholder' } ) }
 								tabIndex={ 2 }
 								isNew={ this.state.isNew }
 								onSetContent={ this.debouncedSaveRawContent }


### PR DESCRIPTION
This pull request seeks to add a placeholder label to the editor content area when the post has no contents.

Before|After
---|---
![After](https://cloud.githubusercontent.com/assets/1779930/12248886/58cedeac-b88a-11e5-97e3-d12f65cc5243.png)|![Before](https://cloud.githubusercontent.com/assets/1779930/12248872/43f85c1a-b88a-11e5-9975-43b9286a3c39.png)

__Testing instructions:__

Confirm that in Visual mode the placeholder label is only shown when the post editor has no content and when it is not focused. In Edit mode, the placeholder should be shown until some characters are entered.

Particularly, try a variety of situations such as loading a draft while another is opened, or starting a new draft while a post is currently visible.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Assuming the default tab is Visual, note that a placeholder label is shown
4. Focus the editor area
5. Note that the placeholder disappears
6. (Optional) Enter some post content
7. Click elsewhere on the page to unfocus the editor
8. Note that the placeholder label is only shown if no content was added in Step 6