### PR TITLE
Checkout: Add new TOS copy for subscription purchases

### DIFF
--- a/assets/stylesheets/sections/_checkout.scss
+++ b/assets/stylesheets/sections/_checkout.scss
@@ -222,16 +222,31 @@
 
 	.checkout-terms {
 		color: darken( $gray, 10% );
-		font-size: 12px;
-		font-weight: 100;
-		margin: 10px 0;
-		padding: 0 30px;
+		margin: 16px 0;
+		padding: 0;
 		text-align: center;
 
 		@include breakpoint( ">660px" ) {
-			margin-bottom: 20px;
 			padding: 0;
 			text-align: left;
+		}
+
+		p {
+			font-size: 12px;
+			font-weight: 100;
+			margin: 0;
+
+			@include breakpoint( ">660px" ) {
+				margin-left: 24px;
+			}
+		}
+
+		.gridicon {
+			float: left;
+
+			@include breakpoint( "<660px" ) {
+				display: none;
+			}
 		}
 	}
 

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -290,10 +290,10 @@ function hasOnlyRenewalItems( cart ) {
  * Will return false if the cart is empty.
  *
  * @param {Object} cart - cart as `CartValue` object
- * @returns {boolean} true if all the products in the cart are of the productSlug type
+ * @returns {boolean} true if any product in the cart renews
  */
 function hasRenewableSubscription( cart ) {
-	return cart.products && some( getAll( cart ), function (cartItem){ return cartItem.bill_period > 0 } );
+	return cart.products && some( getAll( cart ), cartItem => cartItem.bill_period > 0 );
 }
 
 /**
@@ -698,9 +698,9 @@ module.exports = {
 	hasOnlyFreeTrial,
 	hasOnlyProductsOf,
 	hasOnlyRenewalItems,
-	hasRenewableSubscription,
 	hasPlan,
 	hasProduct,
+	hasRenewableSubscription,
 	hasRenewalItem,
 	noAdsItem,
 	planItem,

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -286,6 +286,17 @@ function hasOnlyRenewalItems( cart ) {
 }
 
 /**
+ * Determines whether any product in the specified shopping cart is a renewable subscription.
+ * Will return false if the cart is empty.
+ *
+ * @param {Object} cart - cart as `CartValue` object
+ * @returns {boolean} true if all the products in the cart are of the productSlug type
+ */
+function hasRenewableSubscription( cart ) {
+	return cart.products && some( getAll( cart ), function (cartItem){ return cartItem.bill_period > 0 } );
+}
+
+/**
  * Creates a new shopping cart item for a plan.
  *
  * @param {Object} productSlug - the unique string that identifies the product
@@ -687,6 +698,7 @@ module.exports = {
 	hasOnlyFreeTrial,
 	hasOnlyProductsOf,
 	hasOnlyRenewalItems,
+	hasRenewableSubscription,
 	hasPlan,
 	hasProduct,
 	hasRenewalItem,

--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -39,8 +39,8 @@ var CreditCardPaymentBox = React.createClass( {
 					transaction={ this.props.transaction } />
 
 				<TermsOfService
-					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
-					/>
+					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) } />
+
 				<div className="payment-box-actions">
 					<PayButton
 						cart={ this.props.cart }

--- a/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/credit-card-payment-box.jsx
@@ -38,7 +38,9 @@ var CreditCardPaymentBox = React.createClass( {
 					initialCard={ this.props.initialCard }
 					transaction={ this.props.transaction } />
 
-				<TermsOfService />
+				<TermsOfService
+					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( cart ) }
+					/>
 				<div className="payment-box-actions">
 					<PayButton
 						cart={ this.props.cart }

--- a/client/my-sites/upgrades/checkout/terms-of-service.jsx
+++ b/client/my-sites/upgrades/checkout/terms-of-service.jsx
@@ -30,8 +30,8 @@ module.exports = React.createClass( {
 				'By checking out, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{purchasesLink}}how your subscription works{{/purchasesLink}} and {{cancelLink}}how to cancel{{/cancelLink}}.', {
 				components: {
 					tosLink: <a href="//wordpress.com/tos/" target="_blank" />,
-					cancelLink: <a href="//en.support.wordpress.com/auto-renewal/" target="_blank" />,
-					purchasesLink: <a href="//en.support.wordpress.com/manage-purchases/" target="_blank" />
+					cancelLink: <a href="//support.wordpress.com/auto-renewal/" target="_blank" />,
+					purchasesLink: <a href="//support.wordpress.com/manage-purchases/" target="_blank" />
 				}
 			} );
 		}

--- a/client/my-sites/upgrades/checkout/terms-of-service.jsx
+++ b/client/my-sites/upgrades/checkout/terms-of-service.jsx
@@ -6,7 +6,8 @@ var React = require( 'react' );
 /**
  * Internal dependencies
  */
-var analytics = require( 'analytics' );
+var analytics = require( 'analytics' ),
+	Gridicon = require( 'components/gridicon' );
 
 module.exports = React.createClass( {
 	displayName: 'TermsOfService',
@@ -15,17 +16,35 @@ module.exports = React.createClass( {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Terms and Conditions Link' );
 	},
 
+	termsCopy: function() {
+		var message = this.translate(
+			'By checking out, you agree to our {{link}}fascinating terms and conditions{{/link}}.', {
+			components: {
+				link: <a href="//wordpress.com/tos/" target="_blank" />
+			}
+		} );
+
+		// Need to add check for subscription products in the cart so we don't show this for one-off purchases like themes
+		if ( true ) {
+			message =  this.translate(
+				'By checking out, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{purchasesLink}}how your subscription works{{/purchasesLink}} and {{cancelLink}}how to cancel{{/cancelLink}}.', {
+				components: {
+					tosLink: <a href="//wordpress.com/tos/" target="_blank" />,
+					cancelLink: <a href="//en.support.wordpress.com/auto-renewal/" target="_blank" />,
+					purchasesLink: <a href="//en.support.wordpress.com/manage-purchases/" target="_blank" />
+				}
+			} );
+		}
+
+		return message;
+	},
+
 	render: function() {
 		return (
-			<p className="checkout-terms" onClick={ this.recordTermsAndConditionsClick }>
-				{
-					this.translate( 'By checking out, you agree to our {{link}}fascinating terms and conditions{{/link}}.', {
-						components: {
-							link: <a href="//wordpress.com/tos/" target="_blank" />
-						}
-					} )
-				}
-			</p>
+			<div className="checkout-terms" onClick={ this.recordTermsAndConditionsClick }>
+				<Gridicon icon="info-outline" size={ 18 } />
+				<p>{ this.termsCopy() }</p>
+			</div>
 		);
 	}
 } );

--- a/client/my-sites/upgrades/checkout/terms-of-service.jsx
+++ b/client/my-sites/upgrades/checkout/terms-of-service.jsx
@@ -16,7 +16,7 @@ module.exports = React.createClass( {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Terms and Conditions Link' );
 	},
 
-	termsCopy: function() {
+	renderTerms: function() {
 		var message = this.translate(
 			'By checking out, you agree to our {{link}}fascinating terms and conditions{{/link}}.', {
 			components: {
@@ -43,7 +43,7 @@ module.exports = React.createClass( {
 		return (
 			<div className="checkout-terms" onClick={ this.recordTermsAndConditionsClick }>
 				<Gridicon icon="info-outline" size={ 18 } />
-				<p>{ this.termsCopy() }</p>
+				<p>{ this.renderTerms() }</p>
 			</div>
 		);
 	}

--- a/client/my-sites/upgrades/checkout/terms-of-service.jsx
+++ b/client/my-sites/upgrades/checkout/terms-of-service.jsx
@@ -25,7 +25,7 @@ module.exports = React.createClass( {
 		} );
 
 		// Need to add check for subscription products in the cart so we don't show this for one-off purchases like themes
-		if ( true ) {
+		if ( this.props.hasRenewableSubscription ) {
 			message =  this.translate(
 				'By checking out, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{purchasesLink}}how your subscription works{{/purchasesLink}} and {{cancelLink}}how to cancel{{/cancelLink}}.', {
 				components: {


### PR DESCRIPTION
This PR aims to provide users with more info about recurring payment in our checkout TOS statement. 

cc: @peterbutler for adding the logic so we only show this copy when there is a subscription purchase in the cart (i.e. don't show for one-off purchases like themes).