### PR TITLE
Upgrades: Domains: Show correct state for punycode domains.

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -41,6 +41,13 @@ function canRegister( domain, onComplete ) {
 		return;
 	}
 
+	// Punycode version of IDN starts with this ACE prefix: xn--,
+	// we cannot register those domains on WordPress.com
+	if ( domain.startsWith( 'xn--' ) ) {
+		onComplete( new ValidationError( 'not_registrable' ) );
+		return;
+	}
+
 	wpcom.undocumented().isDomainAvailable( domain, function( serverError, data ) {
 		var errorCode;
 		if ( serverError ) {


### PR DESCRIPTION
Fixes #380

This fixes an issue where a user tries to register an IDN (International Domain Name) via its punycode (The ASCII version). They are not supported on WordPress.com and will fail at checkout so it makes sense to prevent them from being added to cart.

`xn--` is the ACE prefix, the identifier of the punycode. We look for it in the domain name and fail fast.

Testing
-
1. Go to Domain Search
2. Type xn--trkiye-3ya.com or try this guy: http://mct.verisign-grs.com/convertServlet (at your own discretion)
3. Confirm you see the message that this domain cannot be registered on WordPress.com

/cc: @SiobhyB @aidvu