### PR TITLE
Add contact us link to the upgrades confirmation page

### DIFF
--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -258,25 +258,34 @@ var CheckoutThankYou = React.createClass( {
 		if ( this.cartHasJetpackPlan() ) {
 			return (
 				<p>
-					{ this.translate( 'Check out our {{supportDocsLink}}support docs{{/supportDocsLink}} or {{emailLink}}send an email{{/emailLink}} to our Happiness Engineers.', {
-						components: {
-							supportDocsLink: <a href={ 'http://jetpack.me/support/' } target="_blank" />,
-							emailLink: <a href="http://jetpack.me/contact-support/" target="_blank" />
+					{ this.translate(
+						'Check out our {{supportDocsLink}}support docs{{/supportDocsLink}} ' +
+						'or {{contactLink}}contact us{{/contactLink}}.',
+						{
+							components: {
+								supportDocsLink: <a href={ 'http://jetpack.me/support/' } target="_blank" />,
+								contactLink: <a href={ 'http://jetpack.me/contact-support/' } target="_blank" />
+							}
 						}
-					} ) }
+					) }
 				</p>
 			);
 		}
 
 		return (
 			<p>
-				{ this.translate( 'Check out our {{supportDocsLink}}support docs{{/supportDocsLink}}, search for tips and tricks in {{forumLink}}the forum{{/forumLink}}, or {{emailLink}}send an email{{/emailLink}} to our Happiness Engineers.', {
-					components: {
-						supportDocsLink: <a href={ 'http://' + localeSlug + '.support.wordpress.com' } target="_blank" />,
-						forumLink: <a href={ 'http://' + localeSlug + '.forums.wordpress.com' } target="_blank" />,
-						emailLink: <a href="http://support.wordpress.com/contact/" target="_blank" />
+				{ this.translate(
+					'Check out our {{supportDocsLink}}support docs{{/supportDocsLink}}, ' +
+					'search for tips and tricks in {{forumLink}}the forum{{/forumLink}}, ' +
+					'or {{contactLink}}contact us{{/contactLink}}.',
+					{
+						components: {
+							supportDocsLink: <a href={ 'http://' + localeSlug + '.support.wordpress.com' } target="_blank" />,
+							forumLink: <a href={ 'http://' + localeSlug + '.forums.wordpress.com' } target="_blank" />,
+							contactLink: <a href={ '/help/contact' } />
+						}
 					}
-				} ) }
+				) }
 			</p>
 		);
 	}


### PR DESCRIPTION
Replace "send an email" link with "contact us" link
======================================

This pull request replaces the "send an email" link with "contact us" which leads to the help section of calypso. This is driven by our recent release of help within calypso and is noted in #29.

# How to test
1. Navigate to http://calypso.localhost:3000/purchases
2. Click the "Upgrade now" button
3. Follow the upgrade flow until you get to the "Thank you for your purchase"
4. Notice that the bottom of the help links at the bottom now include "Contact us".

# What to expect
![screen shot 2016-01-11 at 8 29 53 pm](https://cloud.githubusercontent.com/assets/1854440/12252105/30937610-b8a2-11e5-8604-863a4012577f.png)


fixes #29