### PR TITLE
Themes: Remove the `bind`s in `getButtonOptions`

### DIFF
--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -92,7 +92,7 @@ var ThemeMoreButton = React.createClass( {
 							);
 						}
 						return (
-							<PopoverMenuItem key={ option.label } action={ option.action }>
+							<PopoverMenuItem key={ option.label } action={ this.state.showPopover ? option.action() : null }>
 								{ option.label }
 							</PopoverMenuItem>
 						);

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -57,7 +57,6 @@ export default function getButtonOptions( site, theme, isLoggedOut, actions, set
 		}
 
 		let actionCreator = function createAction() {
-			console.log( 'calling createAction' );
 			return () => {
 				action.apply( params.this, params.args );
 				Helper.trackClick( 'more button', name );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -33,6 +33,7 @@ export default function getButtonOptions( site, theme, isLoggedOut, actions, set
 
 	function appendAction( option ) {
 		const { hasAction, name } = option;
+		let params = {};
 
 		if ( ! hasAction ) {
 			return option;
@@ -40,27 +41,32 @@ export default function getButtonOptions( site, theme, isLoggedOut, actions, set
 
 		let action;
 		if ( name === 'preview' ) {
-			action = togglePreview.bind( null, theme );
+			action = togglePreview;
+			params.args = [ theme ];
 		} else if ( site ) {
 			if ( name === 'customize' ) {
-				action = actions.customize.bind( actions, theme, site, 'showcase' );
+				action = actions.customize;
 			} else {
-				action = actions[ name ].bind( actions, theme, site, 'showcase' );
+				action = actions[ name ];
 			}
+			params.this = actions;
+			params.args = [ theme, site, 'showcase' ];
 		} else {
 			action = setSelectedTheme.bind( null, name, theme );
+			params.args = [ name, theme ];
 		}
 
-		return assign( {}, option, {
-			action: trackedAction( action, name )
-		} );
-	}
-
-	function trackedAction( action, name ) {
-		return () => {
-			action();
-			Helper.trackClick( 'more button', name );
+		let actionCreator = function createAction() {
+			console.log( 'calling createAction' );
+			return () => {
+				action.apply( params.this, params.args );
+				Helper.trackClick( 'more button', name );
+			};
 		};
+
+		return assign( {}, option, {
+			action: actionCreator
+		} );
 	}
 };
 


### PR DESCRIPTION
Using Chrome's Timeline View whilst scrolling through the themes at http://calypso.localhost:3000/design, we can see that the frame rate regularly drops to around 1 frame-per-second. The frame rate needs to stay at around 60fps for a smooth scroll.

<img width="798" alt="screen shot 2016-01-12 at 15 39 20" src="https://cloud.githubusercontent.com/assets/7767559/12268069/227a84c8-b943-11e5-992c-cf8df3377bdf.png">

* Taking measurements on the Master branch in dev mode, the longest frames are around 1373ms
* By removing the call to `getButtonOptions` in [`themes-list`](https://github.com/Automattic/wp-calypso/blob/928fd8c74058bafbf929c8fbed2b521409a813ca/client/components/themes-list/index.jsx#L56), the longest frames can be reduced to around 383ms, which whilst not perfect makes a large difference to perceived performance

This PR is an attempt to optimise whatever is happening in `getButtonOptions` that causes the janky scroll.

**To Do**
- [ ] Cache translations in `getButtonOptions`