### PR TITLE
Plans: Allow users to cancel free trials on Plans Overview page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -193,6 +193,7 @@
 @import 'my-sites/plans/plan-overview/style';
 @import 'my-sites/plans/plan-overview/plan-feature/style';
 @import 'my-sites/plans/plan-overview/plan-progress/style';
+@import 'my-sites/plans/plan-overview/plan-remove/style';
 @import 'my-sites/plans/plan-overview/plan-status/style';
 @import 'my-sites/post/post-image/style';
 @import 'my-sites/post-selector/style';

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1784,6 +1784,14 @@ Undocumented.prototype.cancelPrivateRegistration = function( purchaseId, fn ) {
 	}, fn );
 };
 
+Undocumented.prototype.cancelPlanTrial = function( planId, fn ) {
+	debug( '/upgrades/{planId}/cancel-plan-trial' );
+
+	this.wpcom.req.post( {
+		path: `/upgrades/${planId}/cancel-plan-trial`
+	}, fn );
+};
+
 Undocumented.prototype.submitKayakoTicket = function( subject, message, locale, fn ) {
 	debug( 'submitKayakoTicket' );
 

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -84,7 +84,8 @@ module.exports = {
 						selectedSite={ site }
 						onSelectPlan={ onSelectPlan }
 						plans={ plans }
-						context={ context } />
+						context={ context }
+						destinationType={ context.params.destinationType }/>
 				</CartData>
 			</ReduxProvider>,
 			document.getElementById( 'primary' )

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -6,14 +6,15 @@ var page = require( 'page' );
 /**
  * Internal dependencies
  */
-var controller = require( 'my-sites/controller' ),
-	plansController = require( './controller' ),
-	adTracking = require( 'analytics/ad-tracking' ),
-	config = require( 'config' );
+var adTracking = require( 'analytics/ad-tracking' ),
+	config = require( 'config' ),
+	controller = require( 'my-sites/controller' ),
+	plansController = require( './controller' );
 
 module.exports = function() {
 	if ( config.isEnabled( 'manage/plans' ) ) {
-		page( '/plans',
+		page(
+			'/plans',
 			adTracking.retarget,
 			controller.siteSelection,
 			controller.sites

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -9,6 +9,7 @@ var page = require( 'page' );
 var adTracking = require( 'analytics/ad-tracking' ),
 	config = require( 'config' ),
 	controller = require( 'my-sites/controller' ),
+	paths = require( './paths' ),
 	plansController = require( './controller' );
 
 module.exports = function() {
@@ -44,7 +45,7 @@ module.exports = function() {
 		);
 
 		page(
-			'/plans/:domain/:destinationType?',
+			paths.plansDestination(),
 			adTracking.retarget,
 			controller.siteSelection,
 			controller.navigation,

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -3,6 +3,7 @@
  */
 var connect = require( 'react-redux' ).connect,
 	find = require( 'lodash/collection/find' ),
+	page = require( 'page' ),
 	React = require( 'react' );
 
 /**
@@ -18,7 +19,9 @@ var analytics = require( 'analytics' ),
 	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle,
 	isPremium = require( 'lib/products-values' ).isPremium,
 	Main = require( 'components/main' ),
+	Notice = require( 'components/notice' ),
 	observe = require( 'lib/mixins/data-observe' ),
+	paths = require( './paths' ),
 	PlanList = require( 'components/plans/plan-list' ),
 	PlanOverview = require( './plan-overview' ),
 	preventWidows = require( 'lib/formatting' ).preventWidows,
@@ -70,6 +73,20 @@ var Plans = React.createClass( {
 				{ this.translate( 'Compare Plans' ) }
 			</a>
 		);
+	},
+
+	redirectToDefault() {
+		page.redirect( paths.plans( this.props.selectedSite.slug ) );
+	},
+
+	renderNotice() {
+		if ( 'free-trial-canceled' === this.props.destinationType ) {
+			return (
+				<Notice onDismissClick={ this.redirectToDefault } status="is-success">
+					{ this.translate( 'Your trial has been removed. Thanks for giving it a try!' ) }
+				</Notice>
+			);
+		}
 	},
 
 	renderTrialCopy: function() {
@@ -125,33 +142,38 @@ var Plans = React.createClass( {
 					cart={ this.props.cart }
 					destinationType={ this.props.context.params.destinationType }
 					plan={ currentPlan }
-					selectedSite={ this.props.selectedSite } />
+					selectedSite={ this.props.selectedSite }
+					store={ this.props.context.store } />
 			);
 		}
 
 		return (
-			<Main>
-				<SidebarNavigation />
+			<div>
+				{ this.renderNotice() }
 
-				<div id="plans" className="plans has-sidebar">
-					<UpgradesNavigation
-						path={ this.props.context.path }
-						cart={ this.props.cart }
-						selectedSite={ this.props.selectedSite } />
+				<Main>
+					<SidebarNavigation />
 
-					{ this.renderTrialCopy() }
+					<div id="plans" className="plans has-sidebar">
+						<UpgradesNavigation
+							path={ this.props.context.path }
+							cart={ this.props.cart }
+							selectedSite={ this.props.selectedSite } />
 
-					<PlanList
-						sites={ this.props.sites }
-						plans={ this.props.plans.get() }
-						enableFreeTrials={ true }
-						sitePlans={ this.props.sitePlans }
-						onOpen={ this.openPlan }
-						onSelectPlan={ this.props.onSelectPlan }
-						cart={ this.props.cart } />
-					{ ! hasJpphpBundle && this.comparePlansLink() }
-				</div>
-			</Main>
+						{ this.renderTrialCopy() }
+
+						<PlanList
+							sites={ this.props.sites }
+							plans={ this.props.plans.get() }
+							enableFreeTrials={ true }
+							sitePlans={ this.props.sitePlans }
+							onOpen={ this.openPlan }
+							onSelectPlan={ this.props.onSelectPlan }
+							cart={ this.props.cart } />
+						{ ! hasJpphpBundle && this.comparePlansLink() }
+					</div>
+				</Main>
+			</div>
 		);
 	}
 } );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -1,28 +1,28 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	connect = require( 'react-redux' ).connect,
-	find = require( 'lodash/collection/find' );
+var connect = require( 'react-redux' ).connect,
+	find = require( 'lodash/collection/find' ),
+	React = require( 'react' );
 
 /**
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
+	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
 	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
+	getCurrentPlan = require( 'lib/plans' ).getCurrentPlan,
+	getPlansBySiteId = require( 'state/sites/plans/selectors' ).getPlansBySiteId,
+	Gridicon = require( 'components/gridicon' ),
+	isBusiness = require( 'lib/products-values' ).isBusiness,
+	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle,
+	isPremium = require( 'lib/products-values' ).isPremium,
 	observe = require( 'lib/mixins/data-observe' ),
 	PlanList = require( 'components/plans/plan-list' ),
 	PlanOverview = require( './plan-overview' ),
 	preventWidows = require( 'lib/formatting' ).preventWidows,
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	UpgradesNavigation = require( 'my-sites/upgrades/navigation' ),
-	Gridicon = require( 'components/gridicon' ),
-	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
-	getPlansBySiteId = require( 'state/sites/plans/selectors' ).getPlansBySiteId,
-	getCurrentPlan = require( 'lib/plans' ).getCurrentPlan,
-	isBusiness = require( 'lib/products-values' ).isBusiness,
-	isPremium = require( 'lib/products-values' ).isPremium,
-	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle;
+	UpgradesNavigation = require( 'my-sites/upgrades/navigation' );
 
 var Plans = React.createClass( {
 	displayName: 'Plans',

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -17,6 +17,7 @@ var analytics = require( 'analytics' ),
 	isBusiness = require( 'lib/products-values' ).isBusiness,
 	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle,
 	isPremium = require( 'lib/products-values' ).isPremium,
+	Main = require( 'components/main' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	PlanList = require( 'components/plans/plan-list' ),
 	PlanOverview = require( './plan-overview' ),
@@ -109,8 +110,7 @@ var Plans = React.createClass( {
 	},
 
 	render: function() {
-		var classNames = 'main main-column ',
-			hasJpphpBundle,
+		var hasJpphpBundle,
 			currentPlan;
 
 		if ( this.props.sitePlans.hasLoadedFromServer ) {
@@ -130,7 +130,7 @@ var Plans = React.createClass( {
 		}
 
 		return (
-			<div className={ classNames } role="main">
+			<Main>
 				<SidebarNavigation />
 
 				<div id="plans" className="plans has-sidebar">
@@ -151,7 +151,7 @@ var Plans = React.createClass( {
 						cart={ this.props.cart } />
 					{ ! hasJpphpBundle && this.comparePlansLink() }
 				</div>
-			</div>
+			</Main>
 		);
 	}
 } );

--- a/client/my-sites/plans/paths.js
+++ b/client/my-sites/plans/paths.js
@@ -1,0 +1,16 @@
+function root() {
+	return '/plans';
+}
+
+function plans( siteName = ':site' ) {
+	return root() + `/${ siteName }`;
+}
+
+function plansDestination( siteName = ':site', destinationType = ':destinationType?' ) {
+	return plans( siteName ) + `/${ destinationType }`;
+}
+
+export default {
+	plans,
+	plansDestination
+};

--- a/client/my-sites/plans/plan-overview/index.jsx
+++ b/client/my-sites/plans/plan-overview/index.jsx
@@ -8,8 +8,9 @@ import page from 'page';
  * Internal dependencies
  */
 import Main from 'components/main';
-import PlanFeatures from 'my-sites/plans/plan-overview/plan-features';
-import PlanStatus from 'my-sites/plans/plan-overview/plan-status';
+import paths from '../paths';
+import PlanFeatures from './plan-features';
+import PlanStatus from './plan-status';
 import Notice from 'components/notice';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
@@ -27,7 +28,7 @@ const PlanOverview = React.createClass( {
 	},
 
 	redirectToDefault() {
-		page.redirect( `/plans/${ this.props.selectedSite.slug }` );
+		page.redirect( paths.plans( this.props.selectedSite.slug ) );
 	},
 
 	renderNotice() {

--- a/client/my-sites/plans/plan-overview/index.jsx
+++ b/client/my-sites/plans/plan-overview/index.jsx
@@ -10,6 +10,7 @@ import page from 'page';
 import Main from 'components/main';
 import paths from '../paths';
 import PlanFeatures from './plan-features';
+import PlanRemove from './plan-remove';
 import PlanStatus from './plan-status';
 import Notice from 'components/notice';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -24,7 +25,8 @@ const PlanOverview = React.createClass( {
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.bool
-		] ).isRequired
+		] ).isRequired,
+		store: React.PropTypes.object.isRequired
 	},
 
 	redirectToDefault() {
@@ -48,7 +50,6 @@ const PlanOverview = React.createClass( {
 	render() {
 		return (
 			<div>
-
 				{ this.renderNotice() }
 
 				<Main className="plan-overview">
@@ -66,6 +67,11 @@ const PlanOverview = React.createClass( {
 					<PlanFeatures
 						plan={ this.props.plan }
 						selectedSite={ this.props.selectedSite } />
+
+					<PlanRemove
+						plan={ this.props.plan }
+						selectedSite={ this.props.selectedSite }
+						store={ this.props.store } />
 				</Main>
 			</div>
 		);

--- a/client/my-sites/plans/plan-overview/plan-feature/style.scss
+++ b/client/my-sites/plans/plan-overview/plan-feature/style.scss
@@ -1,5 +1,11 @@
+.plan-feature {
+	font-size: 14px;
+}
+
+
 .plan-feature__heading {
 	display: block;
+	font-size: 16px;
 
 	&.will-be-removed {
 		font-weight: normal;

--- a/client/my-sites/plans/plan-overview/plan-remove/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-remove/index.jsx
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import Dispatcher from 'dispatcher';
+import page from 'page';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import Dialog from 'components/dialog';
+import { isInGracePeriod } from 'lib/plans';
+import notices from 'notices';
+import paths from '../../paths';
+import { fetchSitePlansCompleted } from 'state/sites/plans/actions';
+import wpcom from 'lib/wp';
+
+const PlanRemove = React.createClass( {
+	propTypes: {
+		plan: React.PropTypes.object.isRequired,
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.object,
+			React.PropTypes.bool
+		] ).isRequired,
+		store: React.PropTypes.object.isRequired
+	},
+
+	getInitialState() {
+		return {
+			showDialog: false
+		};
+	},
+
+	removePlan( closeDialog ) {
+		wpcom.undocumented().cancelPlanTrial( this.props.plan.id, ( error, data ) => {
+			closeDialog();
+
+			if ( data && data.success ) {
+				this.props.store.dispatch( fetchSitePlansCompleted( this.props.selectedSite.ID, data.plans ) );
+
+				Dispatcher.handleViewAction( {
+					type: 'FETCH_SITES'
+				} );
+
+				page( paths.plansDestination( this.props.selectedSite.slug, 'free-trial-canceled' ) );
+			} else {
+				notices.error( error.message || this.translate( 'There was a problem removing the plan. Please try again later or contact support.' ) );
+			}
+		} );
+	},
+
+	closeDialog() {
+		this.setState( { showDialog: false } );
+	},
+
+	showDialog( event ) {
+		event.preventDefault();
+
+		this.setState( { showDialog: true } );
+	},
+
+	renderCard() {
+		return (
+			<CompactCard className="plan-remove">
+				{ this.translate( '{{strong}}Not looking to purchase?{{/strong}} No problem, you can remove the plan and all its features from your site.', {
+					components: {
+						strong: <strong />
+					}
+				} ) }
+				{ ' ' }
+				<a href="#" onClick={ this.showDialog }>{ this.translate( 'Remove now' ) }</a>.
+			</CompactCard>
+		);
+	},
+
+	renderDialog() {
+		const buttons = [
+			{ action: 'cancel', label: this.translate( 'Cancel' ) },
+			{ action: 'remove', label: this.translate( 'Remove Now' ), onClick: this.removePlan, isPrimary: true }
+		];
+
+		return (
+			<Dialog
+				buttons={ buttons }
+				isVisible={ this.state.showDialog }
+				onClose={ this.closeDialog }>
+				<h1>{ this.translate( 'Remove Free Trial' ) }</h1>
+
+				<p>
+					{ this.translate( 'Are you sure you want to end your {{strong}}%(planName)s{{/strong}} free trial and remove it from {{em}}%(siteName)s{{/em}}?', {
+						args: {
+							planName: this.props.plan.productName,
+							siteName: this.props.selectedSite.name || this.props.selectedSite.title
+						},
+						components: {
+							em: <em />,
+							strong: <strong />
+						}
+					} ) }
+					{ ' ' }
+					{ this.translate( 'You will lose any custom changes you have made.' ) }
+				</p>
+			</Dialog>
+		);
+	},
+
+	render() {
+		if ( isInGracePeriod( this.props.plan ) ) {
+			return (
+				<div>
+					{ this.renderCard() }
+					{ this.renderDialog() }
+				</div>
+			);
+		}
+
+		return null;
+	}
+} );
+
+export default PlanRemove;

--- a/client/my-sites/plans/plan-overview/plan-remove/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-remove/index.jsx
@@ -28,11 +28,14 @@ const PlanRemove = React.createClass( {
 
 	getInitialState() {
 		return {
+			isCanceling: false,
 			showDialog: false
 		};
 	},
 
 	removePlan( closeDialog ) {
+		this.setState( { isCanceling: true } );
+
 		wpcom.undocumented().cancelPlanTrial( this.props.plan.id, ( error, data ) => {
 			closeDialog();
 
@@ -51,7 +54,10 @@ const PlanRemove = React.createClass( {
 	},
 
 	closeDialog() {
-		this.setState( { showDialog: false } );
+		this.setState(  {
+			isCanceling: false,
+			showDialog: false
+		} );
 	},
 
 	showDialog( event ) {
@@ -76,8 +82,18 @@ const PlanRemove = React.createClass( {
 
 	renderDialog() {
 		const buttons = [
-			{ action: 'cancel', label: this.translate( 'Cancel' ) },
-			{ action: 'remove', label: this.translate( 'Remove Now' ), onClick: this.removePlan, isPrimary: true }
+			{
+				action: 'cancel',
+				disabled: this.state.isCanceling,
+				label: this.translate( 'Cancel' )
+			},
+			{
+				action: 'remove',
+				disabled: this.state.isCanceling,
+				isPrimary: true,
+				label: this.translate( 'Remove Now' ),
+				onClick: this.removePlan
+			}
 		];
 
 		return (

--- a/client/my-sites/plans/plan-overview/plan-remove/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-remove/index.jsx
@@ -37,8 +37,6 @@ const PlanRemove = React.createClass( {
 		this.setState( { isCanceling: true } );
 
 		wpcom.undocumented().cancelPlanTrial( this.props.plan.id, ( error, data ) => {
-			closeDialog();
-
 			if ( data && data.success ) {
 				this.props.store.dispatch( fetchSitePlansCompleted( this.props.selectedSite.ID, data.plans ) );
 
@@ -48,6 +46,8 @@ const PlanRemove = React.createClass( {
 
 				page( paths.plansDestination( this.props.selectedSite.slug, 'free-trial-canceled' ) );
 			} else {
+				closeDialog();
+
 				notices.error( error.message || this.translate( 'There was a problem removing the plan. Please try again later or contact support.' ) );
 			}
 		} );

--- a/client/my-sites/plans/plan-overview/plan-remove/style.scss
+++ b/client/my-sites/plans/plan-overview/plan-remove/style.scss
@@ -1,0 +1,3 @@
+.plan-remove {
+	font-size: 14px;
+}

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -126,9 +126,9 @@ module.exports = React.createClass( {
 
 			return purchasePaths.managePurchaseDestination( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId, 'thank-you' );
 		} else if ( cartItems.hasFreeTrial( this.props.cart ) ) {
-			planActions.clearSitePlans();
+			planActions.clearSitePlans( this.props.sites.getSelectedSite().ID );
 
-			Dispatcher.handleServerAction( {
+			Dispatcher.handleViewAction( {
 				type: 'FETCH_SITES'
 			} );
 


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/1380 by adding a new section with a link at the bottom of the `Plans Overview` page during the grace period:

![screenshot](https://cloud.githubusercontent.com/assets/594356/12267140/f6d1c21a-b946-11e5-8bd1-d7d7014246cd.png)

This link displays a modal that allows users to cancel a free trial:

![screenshot](https://cloud.githubusercontent.com/assets/594356/12267216/59f2eb44-b947-11e5-97aa-b37656bb8f23.png)

Users are redirected on the `Plans` page with a message if the cancelation is successful:

![screenshot](https://cloud.githubusercontent.com/assets/594356/12388305/551ae4f2-bdd2-11e5-9d3f-ed76c36467a2.png)

#### Testing instructions

1. Run `git checkout add/trial-cancelation` and start your server
2. Apply server-side patch `D875-code`
3. Open the [`Plans` page](http://calypso.dev:3000/plans) with a free trial in grace period
4. Check that the new section is displayed on the `Plan Overview` page
5. Click the `Remove now` link and then click the `Remove Now` button in the modal
6. Check that the free trial was canceled successfully

#### Reviews
 
- [x] Code
- [x] Product