### PR TITLE
Free trials: Add a border around the plan icon in the free trial hub

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-status/style.scss
+++ b/client/my-sites/plans/plan-overview/plan-status/style.scss
@@ -22,6 +22,8 @@
 .plan-status__icon {
 	background-position: center;
 	background-repeat: no-repeat;
+	border-radius: 50%;
+	border: 3px solid lighten( $gray, 30% );
 	height: 50px;
 	min-width: 50px;
 	position: relative;


### PR DESCRIPTION
This pull request fixes #2239 by adding a CSS border around the plan icon so it matches the icon on /plans

Before:
<img width="660" alt="screen shot 2016-01-12 at 15 41 59" src="https://cloud.githubusercontent.com/assets/275961/12268056/1007393a-b943-11e5-8990-d411a17b5295.png">

After:
<img width="657" alt="screen shot 2016-01-12 at 15 41 04" src="https://cloud.githubusercontent.com/assets/275961/12268057/104d3ba6-b943-11e5-9e44-1273604a6634.png">

 
#### Testing instructions

1. Run `git checkout fix/2239-plan-icon-border` and start your server
2. Open http://calypso.dev:3000/plans/:site for a site that has a free trial
3. Check that the icon has a border.

#### Additional notes

You can also check the expired state.

#### Reviews

- [x] Code
- [x] Product