### PR TITLE
Editor: Update sharing container to use Redux user state

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -33,7 +33,6 @@ var Accordion = require( 'components/accordion' ),
 	stats = require( 'lib/posts/stats' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	siteUtils = require( 'lib/site/utils' ),
-	user = require( 'lib/user' )(),
 	userSettings = require( 'lib/user-settings' ),
 	AppPromo = require( 'components/app-promo' );
 
@@ -121,14 +120,7 @@ var EditorDrawer = React.createClass( {
 	},
 
 	renderSharing: function() {
-		const currentUser = user.get();
-		if ( ! currentUser ) {
-			return null;
-		}
-
-		return (
-			<EditorSharingContainer currentUserID={ currentUser.ID } />
-		);
+		return <EditorSharingContainer />;
 	},
 
 	renderFeaturedImage: function() {

--- a/client/post-editor/editor-sharing/container.jsx
+++ b/client/post-editor/editor-sharing/container.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  */
 import PostEditStore from 'lib/posts/post-edit-store';
 import { fetchConnections } from 'state/sharing/publicize/actions';
-import { getConnectionsBySiteIdAvailableToCurrentUser, hasFetchedConnections } from 'state/sharing/publicize/selectors';
+import { getConnectionsBySiteIdUserId, hasFetchedConnections } from 'state/sharing/publicize/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import EditorSharingAccordion from './accordion';
 
@@ -94,7 +94,7 @@ export default connect(
 		const site = getSelectedSite( state );
 		return {
 			hasFetchedConnections: site && hasFetchedConnections( state, site.ID ),
-			connections: site ? getConnectionsBySiteIdAvailableToCurrentUser( state, site.ID, ownProps.currentUserID ) : null,
+			connections: site ? getConnectionsBySiteIdUserId( state, site.ID, ownProps.currentUserID ) : null,
 			site
 		};
 	}

--- a/client/post-editor/editor-sharing/container.jsx
+++ b/client/post-editor/editor-sharing/container.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  */
 import PostEditStore from 'lib/posts/post-edit-store';
 import { fetchConnections } from 'state/sharing/publicize/actions';
-import { getConnectionsBySiteIdUserId, hasFetchedConnections } from 'state/sharing/publicize/selectors';
+import { getSiteUserConnections, hasFetchedConnections } from 'state/sharing/publicize/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import EditorSharingAccordion from './accordion';
@@ -95,7 +95,7 @@ export default connect( ( state ) => {
 
 	return {
 		hasFetchedConnections: site && hasFetchedConnections( state, site.ID ),
-		connections: site && user ? getConnectionsBySiteIdUserId( state, site.ID, user.ID ) : null,
+		connections: site && user ? getSiteUserConnections( state, site.ID, user.ID ) : null,
 		site
 	};
 } )( EditorSharingContainer );

--- a/client/post-editor/editor-sharing/container.jsx
+++ b/client/post-editor/editor-sharing/container.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import PostEditStore from 'lib/posts/post-edit-store';
 import { fetchConnections } from 'state/sharing/publicize/actions';
 import { getConnectionsBySiteIdUserId, hasFetchedConnections } from 'state/sharing/publicize/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import EditorSharingAccordion from './accordion';
 
@@ -83,19 +84,18 @@ class EditorSharingContainer extends Component {
 
 EditorSharingContainer.propTypes = {
 	site: PropTypes.object,
-	currentUserID: PropTypes.number.isRequired,
 	dispatch: PropTypes.func.isRequired,
 	hasFetchedConnections: PropTypes.bool,
 	connections: PropTypes.array
 };
 
-export default connect(
-	( state, ownProps ) => {
-		const site = getSelectedSite( state );
-		return {
-			hasFetchedConnections: site && hasFetchedConnections( state, site.ID ),
-			connections: site ? getConnectionsBySiteIdUserId( state, site.ID, ownProps.currentUserID ) : null,
-			site
-		};
-	}
-)( EditorSharingContainer );
+export default connect( ( state ) => {
+	const site = getSelectedSite( state );
+	const user = getCurrentUser( state );
+
+	return {
+		hasFetchedConnections: site && hasFetchedConnections( state, site.ID ),
+		connections: site && user ? getConnectionsBySiteIdUserId( state, site.ID, user.ID ) : null,
+		site
+	};
+} )( EditorSharingContainer );

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -19,18 +19,18 @@ export function getConnectionsBySiteId( state, siteId ) {
 
 /**
  * Returns an array of known connections for the given site ID
- * that are available to the current user
+ * that are available to the specified user ID.
  *
- * @param  {Object} state         Global state tree
- * @param  {Number} siteId        Site ID
- * @param  {Number} currentUserID ID of the current user
- * @return {Array}                Site connections
+ * @param  {Object} state  Global state tree
+ * @param  {Number} siteId Site ID
+ * @param  {Number} userId User ID to filter
+ * @return {Array}         User connections
  */
-export function getConnectionsBySiteIdAvailableToCurrentUser( state, siteId, currentUserID ) {
+export function getConnectionsBySiteIdUserId( state, siteId, userId ) {
 	const connectionsBySiteId = getConnectionsBySiteId( state, siteId );
 
-	return connectionsBySiteId.filter( connection => {
-		return connection.shared || connection.keyring_connection_user_ID === currentUserID;
+	return connectionsBySiteId.filter( ( connection ) => {
+		return connection.shared || connection.keyring_connection_user_ID === userId;
 	} );
 }
 

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -26,7 +26,7 @@ export function getConnectionsBySiteId( state, siteId ) {
  * @param  {Number} userId User ID to filter
  * @return {Array}         User connections
  */
-export function getConnectionsBySiteIdUserId( state, siteId, userId ) {
+export function getSiteUserConnections( state, siteId, userId ) {
 	const connectionsBySiteId = getConnectionsBySiteId( state, siteId );
 
 	return connectionsBySiteId.filter( ( connection ) => {

--- a/client/state/sharing/publicize/test/selectors.js
+++ b/client/state/sharing/publicize/test/selectors.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getConnectionsBySiteId,
-	getConnectionsBySiteIdAvailableToCurrentUser,
+	getConnectionsBySiteIdUserId,
 	hasFetchedConnections,
 	isFetchingConnections
 } from '../selectors';
@@ -49,9 +49,9 @@ describe( '#getConnectionsBySiteId()', () => {
 	} );
 } );
 
-describe( '#getConnectionsBySiteIdAvailableToCurrentUser()', () => {
+describe( '#getConnectionsBySiteIdUserId()', () => {
 	it( 'should return an empty array for a site which has not yet been fetched', () => {
-		const connections = getConnectionsBySiteIdAvailableToCurrentUser( {
+		const connections = getConnectionsBySiteIdUserId( {
 			sharing: {
 				publicize: {
 					connectionsBySiteId: {},
@@ -64,7 +64,7 @@ describe( '#getConnectionsBySiteIdAvailableToCurrentUser()', () => {
 	} );
 
 	it( 'should return an array of connection objects received for the site that are available to the current user', () => {
-		const connections = getConnectionsBySiteIdAvailableToCurrentUser( {
+		const connections = getConnectionsBySiteIdUserId( {
 			sharing: {
 				publicize: {
 					connectionsBySiteId: {

--- a/client/state/sharing/publicize/test/selectors.js
+++ b/client/state/sharing/publicize/test/selectors.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getConnectionsBySiteId,
-	getConnectionsBySiteIdUserId,
+	getSiteUserConnections,
 	hasFetchedConnections,
 	isFetchingConnections
 } from '../selectors';
@@ -49,9 +49,9 @@ describe( '#getConnectionsBySiteId()', () => {
 	} );
 } );
 
-describe( '#getConnectionsBySiteIdUserId()', () => {
+describe( '#getSiteUserConnections()', () => {
 	it( 'should return an empty array for a site which has not yet been fetched', () => {
-		const connections = getConnectionsBySiteIdUserId( {
+		const connections = getSiteUserConnections( {
 			sharing: {
 				publicize: {
 					connectionsBySiteId: {},
@@ -64,7 +64,7 @@ describe( '#getConnectionsBySiteIdUserId()', () => {
 	} );
 
 	it( 'should return an array of connection objects received for the site that are available to the current user', () => {
-		const connections = getConnectionsBySiteIdUserId( {
+		const connections = getSiteUserConnections( {
 			sharing: {
 				publicize: {
 					connectionsBySiteId: {


### PR DESCRIPTION
Related: #2080, #869

This pull request seeks to take advantage of the current user handlers added to Redux state in #2080 as an alternative solution to the issue resolved by #869 (filtering connections to those available for current user). It also refactors the Publicize selectors to generally accept any user ID for filtering connections.

__Testing instructions:__

Verify that the testing instructions still apply from #869.

Confirm that Mocha tests pass by running `make test` from the project root directory or directly from `client/state/sharing/publicize`.

__Future tasks:__

`<EditorSharingContainer />` is pretty broad in scope, and we should apply `react-redux` `connect` logic to the individual descendent components making use of the global Redux state.