### PR TITLE
Free trials: Show free trials copy when the user is in the test

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -12,7 +12,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var observe = require( 'lib/mixins/data-observe' ),
-	config = require( 'config' ),
+	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	PlanFeatures = require( 'components/plans/plan-features' ),
 	PlanHeader = require( 'components/plans/plan-header' ),
@@ -108,7 +108,7 @@ var PlansCompare = React.createClass( {
 				? this.props.sitePlans.data.some( property( 'canStartTrial' ) )
 				: false;
 
-		if ( ! config.isEnabled( 'upgrades/free-trials' ) ) {
+		if ( getABTestVariation( 'freeTrials' ) !== 'offered' ) {
 			return false;
 		}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -9,8 +9,8 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var productsList = require( 'lib/products-list' )(),
+	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	analytics = require( 'analytics' ),
-	config = require( 'config' ),
 	featuresList = require( 'lib/features-list' )(),
 	plansList = require( 'lib/plans-list' )(),
 	PlanList = require( 'components/plans/plan-list' ),
@@ -109,7 +109,7 @@ module.exports = React.createClass( {
 		let headerText = this.translate( 'Pick a plan that\'s right for you.' ),
 			subHeaderText;
 
-		if ( config.isEnabled( 'upgrades/free-trials' ) ) {
+		if ( this.isFreeTrialFlow() && getABTestVariation( 'freeTrials' ) === 'offered' ) {
 			subHeaderText = this.translate(
 				'Try WordPress.com Premium or Business free for 14 days, no credit card required.'
 			);


### PR DESCRIPTION
I missed some cases of using the config for free trials when implementing the test. This replaces those with the correct conditions under which to show special copy for free trials.

Before:
<img width="735" alt="screen shot 2016-01-12 at 16 55 21" src="https://cloud.githubusercontent.com/assets/275961/12270333/7b39e87e-b94d-11e5-8779-1b899b5c1097.png">
<img width="742" alt="screen shot 2016-01-12 at 16 54 44" src="https://cloud.githubusercontent.com/assets/275961/12270334/7b3b3ce2-b94d-11e5-89da-2de2500af5a4.png">

After:
<img width="761" alt="screen shot 2016-01-12 at 16 51 58" src="https://cloud.githubusercontent.com/assets/275961/12270248/0d62a3b8-b94d-11e5-9b28-7cd805cad111.png">
<img width="776" alt="screen shot 2016-01-12 at 16 52 06" src="https://cloud.githubusercontent.com/assets/275961/12270249/0d65deb6-b94d-11e5-80b3-0d4796753a3b.png">

 
#### Testing instructions

1. Run `git checkout `/fix/free-trials-copy` and start your server
2. Open http://calypso.localhost:3000/start/free-trial
3. Add yourself to the abtest: `localStorage.setItem('ABTests','{"freeTrials_20160112":"offered"}')`
3. Check that you see the mention of free trials in the header on the plans page
4. Check that you see the exception message for custom domains in the plan comparison screen
5. Create the site without a free trial
6. Go to http://calypso.localhost:3000/plans/compare/:site
7. Check that you see the exception message for custom domains

#### Additional notes
You can do the reverse checks for when you are not in a trial test

#### Reviews

- [ ] Code
- [x] Product