### PR TITLE
Posts: status noticon replacement

### DIFF
--- a/assets/stylesheets/sections/_post-relative-time-status.scss
+++ b/assets/stylesheets/sections/_post-relative-time-status.scss
@@ -16,10 +16,10 @@
 		text-transform: capitalize;
 	}
 
-	.noticon {
+	.gridicon {
 		display: inline-block;
-		font-size: (13 / 12) * 1em;
-		margin-right: (3 / 13) * 1em;
+		margin: -4px 8px 0 0;
+		vertical-align: middle;
 	}
 
 	// Apply colors on /posts/* cards

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -4,6 +4,11 @@
 var React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' );
 
+/**
+ * Internal dependencies
+ */
+var Gridicon = require( 'components/gridicon' );
+
 module.exports = React.createClass( {
 
 	displayName: 'PostRelativeTime',
@@ -41,26 +46,30 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		return ( <span className="time"><span className="noticon noticon-time"></span><span className="time-text">{ this.moment( time ).fromNow() }</span>{ timeReference }</span> );
+		return ( <span className="time"><Gridicon icon="time" size={ 18 } /><span className="time-text">{ this.moment( time ).fromNow() }</span>{ timeReference }</span> );
 	},
 
 	getStatusText: function() {
 		var status = this.props.post.status,
 			statusClassName = 'status',
+			statusIcon = 'aside',
 			statusText;
 
 		if ( this.props.post.sticky ) {
 			statusText = this.translate( 'sticky' );
 			statusClassName += ' is-sticky';
+			statusIcon = 'bookmark-outline';
 		} else if ( status === 'pending' ) {
 			statusText = this.translate( 'pending review' );
 			statusClassName += ' is-pending';
 		} else if ( status === 'future' ) {
 			statusText = this.translate( 'scheduled' );
 			statusClassName += ' is-scheduled';
+			statusIcon = 'calendar';
 		} else if ( status === 'trash' ) {
 			statusText = this.translate( 'trashed' );
 			statusClassName += ' is-trash';
+			statusIcon = 'trash';
 		} else if ( this.props.includeBasicStatus ) {
 			if ( status === 'draft' ) {
 				statusText = this.translate( 'draft' );
@@ -72,7 +81,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( statusText ) {
-			return ( <span className={ statusClassName }><span className="noticon noticon-document"></span><span className="status-text">{ statusText }</span></span> );
+			return ( <span className={ statusClassName }><Gridicon icon={ statusIcon } size={ 18 } /><span className="status-text">{ statusText }</span></span> );
 		}
 	},
 


### PR DESCRIPTION
On post cards displayed in `/posts/*`, changed the status icons from noticons to gridicon components. Updated the size to the standard `18px` as well as switching a few specific status to more appropriate icon types.

Before | After
------------ | -------------
![before](https://cloud.githubusercontent.com/assets/1427136/12274401/bd68bb22-b938-11e5-9d44-e2201e1ed80e.png) | ![after](https://cloud.githubusercontent.com/assets/1427136/12274419/dbe95e58-b938-11e5-814c-97b679ede779.png)

## Testing

1. Visit `/posts` or any subsequent subpage that contains posts like scheduled, trashed, etc.
2. Check that the icons in the lower left of the card (time icon, status icon, etc.) are visible and `18px` size.
3. Some specific status will now utilize more appropriate icons rather than just the "page" noticon:
  * **General/Default**: `aside`
  * Sticky: `bookmark-outline`
  * Scheduled: `calendar`
  * Trashed: `trash`

---

/cc @mattmiklic, @rickybanister 