### PR TITLE
Plugins: Update styling to be more consistent across sites lists.

### DIFF
--- a/client/my-sites/plugins/plugin-site-disabled-manage/style.scss
+++ b/client/my-sites/plugins/plugin-site-disabled-manage/style.scss
@@ -2,7 +2,7 @@
 	position: absolute;
 		top: 0;
 		right: 16px;
-	line-height: 52px;
+	line-height: 66px;
 	display: flex;
 	align-items: center;
 	text-transform: uppercase;

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -7,8 +7,8 @@
 		margin-right: 8px
 	}
 
-	.foldable-card__header {
-		padding: 8px 8px;
+	&.is-compact .foldable-card__header {
+		padding: 16px;
 	}
 
 	&.has-manage-error .foldable-card__action {

--- a/client/my-sites/plugins/plugin-site-network/style.scss
+++ b/client/my-sites/plugins/plugin-site-network/style.scss
@@ -2,12 +2,12 @@
 	padding: 8px;
 	margin: 0;
 
-	.foldable-card__header {
-		padding: 8px;
+	&.is-compact .foldable-card__header {
+		padding: 16px;
 	}
 
 	&.foldable-card.is-expanded .foldable-card__content {
-		padding: 16px 8px 0px 8px;
+		padding: 16px 16px 0px 16px;
 	}
 
 	&.has-manage-error .foldable-card__action {
@@ -53,9 +53,9 @@
 }
 
 .plugin-site-network__secondary-site.card.is-compact {
-	padding: 8px 0;
+	padding: 16px 0;
 	box-shadow: none;
-	border-top: 1px solid lighten( $gray, 20 );
+	border-top: 1px solid $gray-light;
 
 	.site__info {
 		width: auto;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -6,9 +6,6 @@
 	white-space: nowrap;
 }
 
-.disconnect-jetpack-button {
-	margin-right: 8px;
-}
 .card.is-compact.section-header.after-compact {
 	margin-top: 16px;
 }


### PR DESCRIPTION
Fixes #952 
- [x] Tight padding around the sub sites
- [x]  Left and right padding is non-standard
- [x]  Border between sub sites is too dark, it should match the folding card's header border color

Before:
![screen_shot_2016-01-12_at_11_59_48](https://cloud.githubusercontent.com/assets/115071/12275361/8d3e18b6-b924-11e5-93f3-eb8b138b76f2.png)

After:
![screen_shot_2016-01-13_at_13_28_03](https://cloud.githubusercontent.com/assets/115071/12308343/a2f3874c-b9f9-11e5-83c3-440caf759ee7.png)


To test: visit a single plugin page. And checkout the network list. Resize the window. 


cc @MichaelArestad and @rickybanister 
