### PR TITLE
Post Controls: updated delete permanently

### DIFF
--- a/assets/stylesheets/sections/_posts-controls.scss
+++ b/assets/stylesheets/sections/_posts-controls.scss
@@ -57,8 +57,6 @@
 	}
 }
 
-
-
 .post-controls__more-options {
 	transform: scale(0);
 	opacity: 0;
@@ -80,4 +78,8 @@
 			pointer-events: auto;
 		}
 	}
+}
+
+.post-controls__trash.is-scary {
+	color: $alert-red;
 }

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -152,8 +152,8 @@ module.exports = React.createClass( {
 		if ( utils.userCan( 'delete_post', post ) ) {
 			if ( post.status === 'trash') {
 				availableControls.push( {
-					text: this.translate( 'Delete' ),
-					className: 'post-controls__trash',
+					text: this.translate( 'Delete Permanently' ),
+					className: 'post-controls__trash is-scary',
 					onClick: this.props.onDelete,
 					icon: 'trash'
 				} );


### PR DESCRIPTION
For the post cards controls on `/posts/trashed/*`, updated the text/color to be more explicit on the `Delete` button.

Before | After
------------ | -------------
![delete_before](https://cloud.githubusercontent.com/assets/1427136/12275600/f6f74768-b93e-11e5-9075-32d67b00cf04.png) | ![delete_after](https://cloud.githubusercontent.com/assets/1427136/12275605/fb682970-b93e-11e5-9860-e47224e9a31b.png)


## Testing

1. Visit `/posts/trashed/*`.
2. Check that the text on the "delete" button now reads `Delete Permanently` and is colored red.

---

/cc @rickybanister 