### PR TITLE
Plans: Fix `PlansCompare` when no site is selected

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -28,7 +28,7 @@ var PlansCompare = React.createClass( {
 	displayName: 'PlansCompare',
 
 	mixins: [
-		observe( 'sites', 'features', 'plans' )
+		observe( 'features', 'plans' )
 	],
 
 	componentWillReceiveProps: function( nextProps ) {
@@ -58,7 +58,7 @@ var PlansCompare = React.createClass( {
 	},
 
 	goBack: function() {
-		var selectedSite = this.props.sites ? this.props.sites.getSelectedSite() : undefined,
+		var selectedSite = this.props.selectedSite,
 			plansLink = '/plans';
 
 		if ( this.props.backUrl ) {
@@ -101,8 +101,8 @@ var PlansCompare = React.createClass( {
 	},
 
 	showFreeTrialException: function() {
-		const hasTrial = this.props.sites
-				? this.props.sites.getSelectedSite().plan.free_trial
+		const hasTrial = this.props.selectedSite
+				? this.props.selectedSite.plan.free_trial
 				: false,
 			canStartTrial = this.props.sitePlans && this.props.sitePlans.hasLoadedFromServer
 				? this.props.sitePlans.data.some( property( 'canStartTrial' ) )
@@ -155,7 +155,7 @@ var PlansCompare = React.createClass( {
 		var plansColumns,
 			featuresList = this.props.features.get(),
 			plans = this.props.plans.get(),
-			site = this.props.sites ? this.props.sites.getSelectedSite() : undefined,
+			site = this.props.selectedSite,
 			showJetpackPlans = site ? site.jetpack : false;
 
 		plans = plans.filter( function( plan ) {

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -122,7 +122,7 @@ module.exports = {
 			<Main className="plans has-sidebar">
 				<ReduxProvider store={ context.store }>
 					<CartData>
-						<PlansCompare sites={ sites }
+						<PlansCompare
 							enableFreeTrials
 							selectedSite={ site }
 							onSelectPlan={ onSelectPlan }


### PR DESCRIPTION
#2113 added code to `PlansCompare` that checks the property of the selected site even if a site is not selected. The issue comes from the fact that were determining if a site was selected by checking for the presence of a `this.props.sites`, which is always present on `/plans/compare` even if a site isn't selected. Instead, we should check for the presence of `this.props.selectedSite`.

This PR includes a commit to remove `sites` as a prop of `PlansCompare`, which fixes this issue. We already pass `selectedSite` to this component and don't need information about any other site, so this simplifies the component as well.

**Testing**
- Visit `/plans/compare` and assert that the page loads properly without console errors.
- Visit `/plans/compare/:site` and assert that the page loads properly without console errors, and that you can click the button below each plan to go to checkout.
- Visit `/start`, continue to the plans step, click 'Compare Plans', and assert that `PlansCompare` loads properly and that you can continue to the next step after clicking one of 'Upgrade Now' buttons below a plan.

Props to @spncrb for pointing this out.

- [x] Product review
- [x] Code review