### PR TITLE
Invites: Link site title to site in accepted notice

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -21,6 +21,7 @@ import { fetchInvite } from 'lib/invites/actions';
 import InvitesStore from 'lib/invites/stores/invites-validation';
 import EmptyContent from 'components/empty-content';
 import { successNotice, infoNotice } from 'state/notices/actions';
+import analytics from 'analytics';
 
 /**
  * Module variables
@@ -88,6 +89,10 @@ let InviteAccept = React.createClass( {
 		);
 	},
 
+	clickedNoticeSiteLink() {
+		analytics.tracks.recordEvent( 'calypso_invite_accept_notice_site_link_click' );
+	},
+
 	acceptedNotice( invite ) {
 		invite = invite || this.state.invite;
 		let displayOnNextPage = true;
@@ -101,13 +106,18 @@ let InviteAccept = React.createClass( {
 				}
 			</p>
 		);
+		let site = (
+			<a href={ get( invite, 'site.URL' ) } className="invite-accept__notice-site-link">
+				{ get( invite, 'site.title' ) }
+			</a>
+		);
 
 		switch ( get( invite, 'role' ) ) {
 			case 'follower':
 				this.props.successNotice(
 					this.translate(
-						'You are now following %(site)s', {
-							args: { site: get( invite, 'site.title' ) }
+						'You are now following {{site/}}', {
+							components: { site }
 						}
 					),
 					{
@@ -121,8 +131,8 @@ let InviteAccept = React.createClass( {
 				this.props.successNotice(
 					<div>
 						<h3 className="invite-message__title">
-							{ this.translate( 'You\'re now an Administrator of: %(site)s', {
-								args: { site: get( invite, 'site.title' ) }
+							{ this.translate( 'You\'re now an Administrator of: {{site/}}', {
+								components: { site }
 							} ) }
 						</h3>
 						<p className="invite-message__intro">
@@ -139,8 +149,8 @@ let InviteAccept = React.createClass( {
 				this.props.successNotice(
 					<div>
 						<h3 className="invite-message__title">
-							{ this.translate( 'You\'re now an Editor of: %(site)s', {
-								args: { site: get( invite, 'site.title' ) }
+							{ this.translate( 'You\'re now an Editor of: {{site/}}', {
+								components: { site }
 							} ) }
 						</h3>
 						<p className="invite-message__intro">
@@ -155,8 +165,8 @@ let InviteAccept = React.createClass( {
 				this.props.successNotice(
 					<div>
 						<h3 className="invite-message__title">
-							{ this.translate( 'You\'re now an Author of: %(site)s', {
-								args: { site: get( invite, 'site.title' ) }
+							{ this.translate( 'You\'re now an Author of: {{site/}}', {
+								components: { site }
 							} ) }
 						</h3>
 						<p className="invite-message__intro">
@@ -171,8 +181,8 @@ let InviteAccept = React.createClass( {
 				this.props.successNotice(
 					<div>
 						<h3 className="invite-message__title">
-							{ this.translate( 'You\'re now a Contributor of: %(site)s', {
-								args: { site: get( invite, 'site.title' ) }
+							{ this.translate( 'You\'re now a Contributor of: {{site/}}', {
+								components: { site }
 							} ) }
 						</h3>
 						<p className="invite-message__intro">
@@ -185,8 +195,8 @@ let InviteAccept = React.createClass( {
 				break;
 			case 'subscriber':
 				this.props.successNotice(
-					this.translate( 'You\'re now a Subscriber of: %(site)s', {
-						args: { site: get( invite, 'site.title' ) }
+					this.translate( 'You\'re now a Subscriber of: {{site/}}', {
+						components: { site }
 					} ),
 					{ displayOnNextPage }
 				);

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -91,6 +91,17 @@ let InviteAccept = React.createClass( {
 	acceptedNotice( invite ) {
 		invite = invite || this.state.invite;
 		let displayOnNextPage = true;
+		let takeATour = (
+			<p className="invite-message__intro">
+				{
+					this.translate(
+						'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
+						{ components: { docsLink: <a href="https://learn.wordpress.com/" target="_blank" /> } }
+					)
+				}
+			</p>
+		);
+
 		switch ( get( invite, 'role' ) ) {
 			case 'follower':
 				this.props.successNotice(
@@ -119,14 +130,7 @@ let InviteAccept = React.createClass( {
 								args: { site: get( invite, 'site.title' ) }
 							} ) }
 						</p>
-						<p className="invite-message__intro">
-							{
-								this.translate(
-									'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-									{ components: { docsLink: <a href="https://learn.wordpress.com/" target="_blank" /> } }
-								)
-							}
-						</p>
+						{ takeATour }
 					</div>,
 					{ displayOnNextPage }
 				);
@@ -142,14 +146,7 @@ let InviteAccept = React.createClass( {
 						<p className="invite-message__intro">
 							{ this.translate( 'This is your site dashboard where you can publish and manage your own posts and the posts of others, as well as upload media.' ) }
 						</p>
-						<p className="invite-message__intro">
-							{
-								this.translate(
-									'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-									{ components: { docsLink: <a href="https://learn.wordpress.com/" target="_blank" /> } }
-								)
-							}
-						</p>
+						{ takeATour }
 					</div>,
 					{ displayOnNextPage }
 				);
@@ -165,14 +162,7 @@ let InviteAccept = React.createClass( {
 						<p className="invite-message__intro">
 							{ this.translate( 'This is your site dashboard where you can publish and edit your own posts as well as upload media.' ) }
 						</p>
-						<p className="invite-message__intro">
-							{
-								this.translate(
-									'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-									{ components: { docsLink: <a href="https://learn.wordpress.com/" target="_blank" /> } }
-								)
-							}
-						</p>
+						{ takeATour }
 					</div>,
 					{ displayOnNextPage }
 				);
@@ -188,14 +178,7 @@ let InviteAccept = React.createClass( {
 						<p className="invite-message__intro">
 							{ this.translate( 'This is your site dashboard where you can write and manage your own posts.' ) }
 						</p>
-						<p className="invite-message__intro">
-							{
-								this.translate(
-									'Since you\'re new, you might like to {{docsLink}}take a tour{{/docsLink}}.',
-									{ components: { docsLink: <a href="https://learn.wordpress.com/" target="_blank" /> } }
-								)
-							}
-						</p>
+						{ takeATour }
 					</div>,
 					{ displayOnNextPage }
 				);


### PR DESCRIPTION
Closes #2337

Previously, the site title was not linked, which may have made it difficult for users to see which site they were added to. This PR links the site title that in the invite accepted notice.

![screen shot 5](https://cloud.githubusercontent.com/assets/1126811/12278056/7a47abe4-b944-11e5-9beb-6ef68d950a08.png)

cc @lezama 