### PR TITLE
My Sites: fix clicking on all my sites on /posts and /pages

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -95,11 +95,7 @@ module.exports = React.createClass( {
 			this.focus();
 		}
 
-		if (
-			this.state.keyword === prevState.keyword &&
-			this.props.initialValue === prevProps.initialValue &&
-			this.props.siteID === prevProps.siteID
-		) {
+		if ( this.state.keyword === prevState.keyword ) {
 			return;
 		}
 		// if there's a keyword change: trigger search
@@ -122,9 +118,6 @@ module.exports = React.createClass( {
 	componentDidMount: function() {
 		if ( this.props.autoFocus ) {
 			this.focus();
-		}
-		if ( this.props.initialValue ) {
-			this.onSearch( this.props.initialValue );
 		}
 	},
 

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -73,7 +73,6 @@ module.exports = React.createClass( {
 					</NavTabs>
 					<Search
 						pinned={ true }
-						siteID={ this.props.siteID }
 						onSearch={ this.doSearch }
 						initialValue={ this.props.search }
 						placeholder={ searchStrings[ status ] }

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -5,7 +5,6 @@ var page = require( 'page' ),
 	ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	qs = require( 'querystring' ),
-	url = require( 'url' ),
 	debug = require( 'debug' )( 'calypso:my-sites:posts' );
 
 /**
@@ -31,11 +30,6 @@ module.exports = {
 			basePath = route.sectionify( context.path ),
 			analyticsPageTitle = 'Blog Posts',
 			baseAnalyticsPath;
-
-		if ( !search && context.prevPath ) {
-			//Guessing search parameters from previous url
-			search = qs.parse( url.parse( context.prevPath ).query ).s;
-		}
 
 		function shouldRedirectMyPosts( author, sites ) {
 			var selectedSite = sites.getSelectedSite() || {};

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -134,7 +134,6 @@ export default React.createClass( {
 				}
 				<Search
 					pinned={ true }
-					siteID={ this.props.siteID }
 					onSearch={ this.doSearch }
 					initialValue={ this.props.search }
 					placeholder={ 'Search ' + statusTabs.selectedText + '...' }


### PR DESCRIPTION
Fixes regression in #2340, and reopens #453 and #1062. Related PR was: #1091

## Testing Instructions
- Make sure you have more than one site
- Navigate to calypso.localhost:3000/posts or http://calypso.localhost:3000/pages
- Select a site
- Click on switch site
- Select 'All My Sites'
Expected: You should see posts or pages from all of your sites
Actual: Your initial site is still selected.
See issue for video.

cc @blowery @rralian @artpi 