### PR TITLE
disabling perfmon in response to fatal errors in safari/ie

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,7 @@
 		"reader/discover": true,
 		"reader/recommendations": true,
 		"ad-tracking": true,
-		"perfmon": true,
+		"perfmon": false,
 		"mailing-lists/unsubscribe": true
 	},
 	"rtl": false,


### PR DESCRIPTION
This came in via p2 post
> While troubleshooting this earlier in Slack, I saw this browser console error (in Safari 7.1, and I just saw a similar console error in IE 11): TypeError: undefined is not a function (evaluating 'featureSlug.startsWith("read_list")')

@goldsounds — That looks like it could be related to the changes you recently made to this file: https://github.com/Automattic/wp-calypso/blob/55131e07c1dc4f31fe610a7ff08e1295c02056c1/client/analytics/index.js#L163

Could you take a look and see if that looks familiar?