### PR TITLE
Purchases: Add site slug to SectionHeaders

### DIFF
--- a/client/me/purchases/list/site/index.jsx
+++ b/client/me/purchases/list/site/index.jsx
@@ -29,7 +29,9 @@ const PurchasesSite = React.createClass( {
 
 		return (
 			<div className={ classes }>
-				<SectionHeader label={ isPlaceholder ? this.translate( 'Loading…' ) : this.props.name } />
+				<SectionHeader label={ isPlaceholder ? this.translate( 'Loading…' ) : this.props.name }>
+					<span className="purchases-site__slug">{ this.props.slug }</span>
+				</SectionHeader>
 				{
 					isPlaceholder ?
 					this.placeholders() :

--- a/client/me/purchases/list/site/style.scss
+++ b/client/me/purchases/list/site/style.scss
@@ -1,9 +1,22 @@
 .purchases-site {
 	margin-bottom: 15px;
 
-	.purchases-site__slug {
-		color: $gray;
-		font-size: 12px;
-		line-height: 28px;
+	.section-header {
+		@include breakpoint( "<660px" ) {
+			display: block;
+		}
+	}
+}
+
+.purchases-site__slug {
+	color: darken( $gray, 15% );
+	font-size: 12px;
+	line-height: 28px;
+}
+
+.section-header__label,
+.purchases-site__slug {
+	@include breakpoint( "<660px" ) {
+		line-height: 140%;
 	}
 }

--- a/client/me/purchases/list/site/style.scss
+++ b/client/me/purchases/list/site/style.scss
@@ -1,3 +1,9 @@
 .purchases-site {
 	margin-bottom: 15px;
+
+	.purchases-site__slug {
+		color: $gray;
+		font-size: 12px;
+		line-height: 28px;
+	}
 }

--- a/client/me/purchases/list/site/style.scss
+++ b/client/me/purchases/list/site/style.scss
@@ -5,18 +5,23 @@
 		@include breakpoint( "<660px" ) {
 			display: block;
 		}
+
+		&.card {
+			align-items: baseline;
+		}
 	}
 }
 
 .purchases-site__slug {
 	color: darken( $gray, 15% );
 	font-size: 12px;
-	line-height: 28px;
 }
 
 .section-header__label,
 .purchases-site__slug {
+	white-space: nowrap;
+
 	@include breakpoint( "<660px" ) {
-		line-height: 140%;
+		line-height: 15px;
 	}
 }


### PR DESCRIPTION
This adds the site slug (primary domain) to the SectionHeaders for each site in `/purchases`, as suggested by @mikeshelton1503 in https://github.com/Automattic/wp-calypso/issues/170#issuecomment-160983578, to help make it easier to identify each site in the list. 

Before | After
------------ | -------------
<img width="740" alt="screen shot 2016-01-12 at 3 20 55 pm" src="https://cloud.githubusercontent.com/assets/3011211/12280057/193d2cd8-b940-11e5-944f-22116b2a2d4b.png"> | <img width="741" alt="screen shot 2016-01-12 at 3 31 21 pm" src="https://cloud.githubusercontent.com/assets/3011211/12280276/8e348ddc-b941-11e5-9baf-747fecda5054.png">

@mikeshelton1503 Note that in your original mockup, the SectionHeader label and slug were different colors, creating more hierarchy in the information presented here. I updated the color on the slug to add some contrast.