### PR TITLE
Stats: Move summary.jsx

### DIFF
--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -10,11 +10,11 @@ var React = require( 'react' ),
  */
 var observe = require( 'lib/mixins/data-observe' ),
 	HeaderCake = require( 'components/header-cake' ),
-	StatsModule = require( './stats-module' ),
-	StatsStrings = require( './stats-strings' )(),
-	Countries = require( './stats-countries' ),
-	SummaryChart = require( './stats-summary-chart' ),
-	VideoPlayDetails = require( './stats-video-details' );
+	StatsModule = require( '../stats-module' ),
+	StatsStrings = require( '../stats-strings' )(),
+	Countries = require( '../stats-countries' ),
+	SummaryChart = require( '../stats-summary-chart' ),
+	VideoPlayDetails = require( '../stats-video-details' );
 
 module.exports = React.createClass( {
 	displayName: 'StatsSummary',


### PR DESCRIPTION
This branch moves `summary.jsx` into its own directory as part of the stats maintenance iteration.

__To Test__
- Open a site stats page
- Click a 'View All' link at the bottom of a stats component like Posts & Pages
- Verify the summary page is shown correctly