### PR TITLE
Stats: Move summary-chart

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import observe from 'lib/mixins/data-observe';
-import SummaryChart from '../module-summary-chart';
+import SummaryChart from '../stats-summary-chart';
 import PostMonths from '../stats-detail-months';
 import PostWeeks from '../stats-detail-weeks';
 import HeaderCake from 'components/header-cake';

--- a/client/my-sites/stats/stats-summary-chart/index.jsx
+++ b/client/my-sites/stats/stats-summary-chart/index.jsx
@@ -11,7 +11,7 @@ var React = require( 'react' ),
  */
 var observe = require( 'lib/mixins/data-observe' ),
 	ElementChart = require( 'components/chart' ),
-	StatTab = require( './stats-tabs/tab' ),
+	StatTab = require( '../stats-tabs/tab' ),
 	analytics = require( 'analytics' ),
 	Card = require( 'components/card' );
 

--- a/client/my-sites/stats/summary.jsx
+++ b/client/my-sites/stats/summary.jsx
@@ -13,7 +13,7 @@ var observe = require( 'lib/mixins/data-observe' ),
 	StatsModule = require( './stats-module' ),
 	StatsStrings = require( './stats-strings' )(),
 	Countries = require( './stats-countries' ),
-	SummaryChart = require( './module-summary-chart' ),
+	SummaryChart = require( './stats-summary-chart' ),
 	VideoPlayDetails = require( './stats-video-details' );
 
 module.exports = React.createClass( {


### PR DESCRIPTION
As part of the stats maintenance iteration, the `module-summary-chart` component is being moved here into its own component directory.  When it grows up, this component will have its very own `styles.scss` file and fancy ES6 syntax.  Like a toddler learning to walk, this component is taking baby steps to get there...

__To Test__
- Open a site stats page
- Click on a post in the Post & Pages list
- Verify that the Post Summary page is shown, and the chart is displayed
- Back on the site insights page, click on a video, and validate the chart is displayed on the videodetails page