### PR TITLE
Support User: Add Support User libraries

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -154,6 +154,11 @@ function boot() {
 		i18n.setLocaleSlug( user.get().localeSlug );
 	} );
 
+	// Temporary support for development of the Support User feature
+	if ( config.isEnabled( 'support-user' ) ) {
+		require( 'lib/user/dev-support-user' )( user );
+	}
+
 	translatorJumpstart.init();
 
 	reduxStore = createReduxStore();

--- a/client/lib/user/dev-support-user.js
+++ b/client/lib/user/dev-support-user.js
@@ -1,0 +1,22 @@
+/**
+ * This is a temporary file to assist development of the support user feature.
+ */
+
+import config from 'config';
+
+export default function( user ) {
+	if ( config.isEnabled( 'support-user' ) ) {
+		const callback = ( error ) => {
+			if ( error ) {
+				console.error( error );
+			} else {
+				console.log( 'success' );
+			}
+		};
+
+		window.supportUser = {
+			login: ( username, password ) => user.changeUser( username, password, callback ),
+			logout: () => user.restoreUser()
+		};
+	}
+}

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -238,6 +238,16 @@ User.prototype.set = function( attributes ) {
 	return changed;
 };
 
+User.prototype.changeUser = function( username, password ) {
+	if ( config.isEnabled( 'support-user' ) ) {
+		wpcom.changeUser( username, password, function( error ) {
+			if ( ! error ) {
+				this.fetch();
+			}
+		}.bind( this ) );
+	}
+};
+
 /**
  * Expose `User`
  */

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -238,13 +238,22 @@ User.prototype.set = function( attributes ) {
 	return changed;
 };
 
-User.prototype.changeUser = function( username, password ) {
+User.prototype.changeUser = function( username, password, callback ) {
 	if ( config.isEnabled( 'support-user' ) ) {
 		wpcom.changeUser( username, password, function( error ) {
 			if ( ! error ) {
 				this.fetch();
 			}
+			callback( error );
 		}.bind( this ) );
+	}
+};
+
+User.prototype.restoreUser = function() {
+	if ( config.isEnabled( 'support-user' ) ) {
+		wpcom.restoreUser();
+
+		this.fetch();
 	}
 };
 

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -9,6 +9,7 @@ const debug = debugFactory( 'calypso:wp' );
  */
 import wpcomUndocumented from 'lib/wpcom-undocumented';
 import config from 'config';
+import wpcomSupport from 'lib/wp/support';
 
 let wpcom;
 
@@ -36,4 +37,8 @@ if ( config.isEnabled( 'oauth' ) ) {
 /**
  * Expose `wpcom`
  */
-module.exports = wpcom;
+if ( config.isEnabled( 'support-user' ) ) {
+	module.exports = wpcomSupport( wpcom );
+} else {
+	module.exports = wpcom;
+}

--- a/config/client.json
+++ b/config/client.json
@@ -25,5 +25,6 @@
   "logout_url",
   "siftscience_key",
   "facebook_api_key",
-  "discover_blog_id"
+  "discover_blog_id",
+  "support-user"
 ]

--- a/config/development.json
+++ b/config/development.json
@@ -121,6 +121,7 @@
 		"me/trophies": false,
 
 		"help": true,
+		"support-user": true,
 
 		"notifications2beta": true,
 		"muse": true,

--- a/shared/lib/wp/support.js
+++ b/shared/lib/wp/support.js
@@ -1,102 +1,62 @@
+/**
+ * External dependencies
+ */
+import qs from 'qs';
+
 export default function wpcomSupport( wpcom ) {
 	let supportUser = '';
 	let supportToken = '';
 
 	/**
-	 * Request parameters are as follows:
-	 * - param (required) A string or object that contains the path
-	 * - query (optional) An object that expands the response object
-	 * - body (required*) Required by POST and PUT, but not by GET and DEL
-	 * - fn (required) A callback function to handle the returned result
-	 * - ...rest (optional) Some queries have additional parameters after
-	 *   callback function
-	 *
-	 * Return the index of the query parameter, or if one does not exist,
-	 * return false.
-	 */
-	const getQueryIndex = function( req, args ) {
-		let fnIndex, queryIndex;
-
-		// Find the index of the callback in the arguments
-		fnIndex = args.findIndex( function( e ) {
-			return 'function' === typeof e;
-		} );
-
-		// Set queryIndex based on the request type and fnIndex
-		if ( req === 'post' || req === 'put' ) {
-			queryIndex = ( 3 === fnIndex ) ? 1 : false;
-		} else {
-			queryIndex = ( 2 === fnIndex ) ? 1 : false;
-		}
-		return queryIndex;
-	}
-
-	/**
 	 * Add the supportUser and supportToken to the query.
+	 * @param {Object}  params The original request params object
+	 * @return {Object}        The new query object with support data injected
 	 */
-	const addSupportData = function( query ) {
-		return Object.assign( {}, query, {
-			support_user: supportUser,
-			_support_token: supportToken
+	const addSupportData = function( params ) {
+		// Unwind the query string
+		let query = qs.parse( params.query );
+
+		// Inject the credentials
+		query.support_user = supportUser;
+		query._support_token = supportToken
+
+		return Object.assign( {}, params, {
+			query: qs.stringify( query )
 		} );
-	}
+	};
 
-	/**
-	 * Mutate the query parameter of the request by adding values for
-	 * support_user and _support_token to the query parameter.
-	 */
-	const extendRequest = function( req, args ) {
-		if ( ! supportUser || ! supportToken ) {
-			return args;
-		}
-
-		let queryIndex = getQueryIndex( req, args );
-		if ( queryIndex ) {
-			args[ queryIndex ] = addSupportData( args[ queryIndex ] );
-		} else {
-			args.splice( 1, 0, addSupportData( {} ) );
-		}
-		return args;
-	}
-
-	const del = wpcom.req.del.bind( wpcom.req );
-	const get = wpcom.req.get.bind( wpcom.req );
-	const post = wpcom.req.post.bind( wpcom.req );
-	const put = wpcom.req.put.bind( wpcom.req );
+	const request = wpcom.request.bind( wpcom );
 
 	return Object.assign( wpcom, {
 		changeUser: function( username, password, fn ) {
-			var args = {
-				apiVersion: '1.1',
-				path: '/internal/support/' + username + '/grant'
-			};
+			return wpcom.req.post(
+				{
+					apiVersion: '1.1',
+					path: `/internal/support/${ username }/grant`
+				},
+				{
+					password: password
+				},
+				( error, response ) => {
+					if ( ! error ) {
+						supportUser = response.username;
+						supportToken = response.token;
+					}
 
-			return wpcom.req.post( args, { password: password }, function( error, response ) {
-				if ( ! error ) {
-					supportUser = response.username;
-					supportToken = response.token;
+					fn( error, response );
 				}
-
-				fn( error, response );
-			} );
+			);
 		},
 		restoreUser: function() {
 			supportUser = '';
 			supportToken = '';
 		},
-		req: {
-			del: function( ...args ) {
-				return del( ...extendRequest( 'del', args ) );
-			},
-			get: function( ...args ) {
-				return get( ...extendRequest( 'get', args ) );
-			},
-			post: function( ...args ) {
-				return post( ...extendRequest( 'post', args ) );
-			},
-			put: function( ...args ) {
-				return put( ...extendRequest( 'put', args ) );
+		request: ( params, callback ) => {
+			if ( supportUser && supportToken ) {
+				return request( addSupportData( params ), callback );
 			}
+
+			return request( params, callback );
 		}
 	} );
 };

--- a/shared/lib/wp/support.js
+++ b/shared/lib/wp/support.js
@@ -1,0 +1,102 @@
+export default function wpcomSupport( wpcom ) {
+	let supportUser = '';
+	let supportToken = '';
+
+	/**
+	 * Request parameters are as follows:
+	 * - param (required) A string or object that contains the path
+	 * - query (optional) An object that expands the response object
+	 * - body (required*) Required by POST and PUT, but not by GET and DEL
+	 * - fn (required) A callback function to handle the returned result
+	 * - ...rest (optional) Some queries have additional parameters after
+	 *   callback function
+	 *
+	 * Return the index of the query parameter, or if one does not exist,
+	 * return false.
+	 */
+	const getQueryIndex = function( req, args ) {
+		let fnIndex, queryIndex;
+
+		// Find the index of the callback in the arguments
+		fnIndex = args.findIndex( function( e ) {
+			return 'function' === typeof e;
+		} );
+
+		// Set queryIndex based on the request type and fnIndex
+		if ( req === 'post' || req === 'put' ) {
+			queryIndex = ( 3 === fnIndex ) ? 1 : false;
+		} else {
+			queryIndex = ( 2 === fnIndex ) ? 1 : false;
+		}
+		return queryIndex;
+	}
+
+	/**
+	 * Add the supportUser and supportToken to the query.
+	 */
+	const addSupportData = function( query ) {
+		return Object.assign( {}, query, {
+			support_user: supportUser,
+			_support_token: supportToken
+		} );
+	}
+
+	/**
+	 * Mutate the query parameter of the request by adding values for
+	 * support_user and _support_token to the query parameter.
+	 */
+	const extendRequest = function( req, args ) {
+		if ( ! supportUser || ! supportToken ) {
+			return args;
+		}
+
+		let queryIndex = getQueryIndex( req, args );
+		if ( queryIndex ) {
+			args[ queryIndex ] = addSupportData( args[ queryIndex ] );
+		} else {
+			args.splice( 1, 0, addSupportData( {} ) );
+		}
+		return args;
+	}
+
+	const del = wpcom.req.del.bind( wpcom.req );
+	const get = wpcom.req.get.bind( wpcom.req );
+	const post = wpcom.req.post.bind( wpcom.req );
+	const put = wpcom.req.put.bind( wpcom.req );
+
+	return Object.assign( wpcom, {
+		changeUser: function( username, password, fn ) {
+			var args = {
+				apiVersion: '1.1',
+				path: '/internal/support/' + username + '/grant'
+			};
+
+			return wpcom.req.post( args, { password: password }, function( error, response ) {
+				if ( ! error ) {
+					supportUser = response.username;
+					supportToken = response.token;
+				}
+
+				fn( error, response );
+			} );
+		},
+		restoreUser: function() {
+			supportUser = '';
+			supportToken = '';
+		},
+		req: {
+			del: function( ...args ) {
+				return del( ...extendRequest( 'del', args ) );
+			},
+			get: function( ...args ) {
+				return get( ...extendRequest( 'get', args ) );
+			},
+			post: function( ...args ) {
+				return post( ...extendRequest( 'post', args ) );
+			},
+			put: function( ...args ) {
+				return put( ...extendRequest( 'put', args ) );
+			}
+		}
+	} );
+};


### PR DESCRIPTION
This PR adds libraries that will be used in the support user functionality (ref p195om-2GO-p2)

An access token is granted when a support user and password are provided; the token can be revoked during a restore operation, or will expire after a set period of time. Once granted, the support username and token are passed along all queries to the API.

This is a subset of the original PR #1202 (props to @jmdodd), separated out for easier progressive review.