### PR TITLE
Update Emojify to use twemoji

### DIFF
--- a/client/components/emojify/README.md
+++ b/client/components/emojify/README.md
@@ -5,34 +5,46 @@ This module includes functionality for converting strings that could possibly co
 
 This is desirable since implementations are inconsistent or non-existant.
 
-# Usage
+## Usage
 ```js
 // require the module
 var Emojify = require( 'components/emojify' ),
 	textToEmojify = 'This will be converted 🙈🙉🙊';
 
-ReactDom.render( <div><p>This text will be unaffected</p><Emojify size="72">{ textToEmojify }</Emojify></div> );
+	// more component stuff
+	// ...
+	render( <div><p>This text will be unaffected</p><Emojify size="72">{ textToEmojify }</Emojify></div> );
 
 ```
 
-CSS
-```css
-// Emoji!!
-.emojified__emoji {
-	height: 18px;
-	width: 18px;
-	vertical-align: middle;
-}
+## Props
 
-```
+### `children`
 
-* The `<Emojify>` component requires exactly one child and it must be a text node.
-* The `size` property is optional:
-	* It defaults to `'36x36'`
-	* Available options are determined by your CDN
+<table>
+	<tr><th>Type</th><td>Text|Components</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+	<tr><th>Default</th><td><code>none</code></td></tr>
+</table>
 
-# Requires
-### [punycode](https://github.com/bestiejs/punycode.js/) -- built into node since v0.6.2
+Typically a string that you want to search for UTF emoji
 
-# Attributions
-The parsing code was adapted from [this gist](https://gist.github.com/thomasboyt/b5ef9ed8606ce6d93982)
+### `size`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td><code>32x32</code></td></tr>
+</table>
+
+The size of emoji image to use - determined by CDN support
+
+### `className`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td><code>emojify__emoji</code></td></tr>
+</table>
+
+classname applied to the image

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -1,84 +1,53 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	punycode = require( 'punycode' );
+import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+import twemoji from 'twemoji';
 
-/**
- * Internal dependencies
- */
-var baseCDNUrl = '//s0.wp.com/wp-content/mu-plugins/emoji/twemoji/';
+const baseCDNUrl = '//s0.wp.com/wp-content/mu-plugins/emoji/twemoji/';
 
-module.exports = React.createClass( {
+export default React.createClass( {
+	displayName: 'Emojify',
+
 	mixins: [ PureRenderMixin ],
-	propTypes: {
-		children: React.PropTypes.string.isRequired,
 
-		 // Optional. These are dependent on your CDN.
-		size: React.PropTypes.oneOf( [
+	propTypes: {
+		children: PropTypes.string.isRequired,
+		size: PropTypes.oneOf( [
 			'16x16', '36x36', '72x72'
-		] )
+		] ),
+		className: PropTypes.string
+	},
+
+	componentDidMount: function() {
+		this._parseEmoji();
+	},
+
+	componentDidUpdate: function() {
+		this._parseEmoji();
 	},
 
 	getDefaultProps: function() {
 		return {
-			size: '36x36'
+			size: '36x36',
+			className: 'emojify__emoji'
 		};
 	},
 
-	isEmojiCode: function( charCode ) {
-		return (
-			( charCode >= 0x1F300 && charCode <= 0x1F5FF ) ||
-			( charCode >= 0x1F600 && charCode <= 0x1F64F ) ||
-			( charCode >= 0x1F680 && charCode <= 0x1F6FF ) ||
-			( charCode >= 0x2600 && charCode <= 0x26FF )
-		);
-	},
+	_parseEmoji: function() {
+		const { size, className } = this.props;
 
-	emojiTransform: function( text ) {
-		var decoded,
-			entries = [];
-
-		if ( null === text ) {
-			return null;
-		}
-
-		decoded = punycode.ucs2.decode( text );
-
-		decoded.forEach( function( charCode, idx ) {
-			var hexCode,
-				lastIdx,
-				src,
-				char;
-
-			if ( this.isEmojiCode( charCode ) ) {
-
-				// emoji char encountered, insert img tag
-				hexCode = charCode.toString( 16 );
-				src = encodeURI( baseCDNUrl + this.props.size + '/' + hexCode + '.png' );
-
-				entries.push(
-					<img className="emojified__emoji" src={ src } key={ idx } alt={ 'U+' + hexCode } />
-				);
-			} else {
-				char = punycode.ucs2.encode( [ charCode ] );
-				lastIdx = entries.length - 1;
-
-				if ( typeof entries[ lastIdx ] === 'string' ) {
-					entries[ lastIdx ] += char;
-				} else {
-					entries.push( char );
-				}
-			}
-		}, this );
-
-		return entries;
+		twemoji.parse( this.refs.emojified, {
+			base: baseCDNUrl,
+			size: size,
+			className: className
+		} );
 	},
 
 	render: function() {
 		return (
-			<span>{ this.emojiTransform( this.props.children ) }</span>
+			<span ref="emojified">{ this.props.children }</span>
 		);
 	}
 } );

--- a/client/components/emojify/style.scss
+++ b/client/components/emojify/style.scss
@@ -3,7 +3,7 @@
  */
 
 // Emoji!!
-.emojified__emoji {
+.emojify__emoji {
 	height: 18px;
 	width: 18px;
 	vertical-align: middle;


### PR DESCRIPTION
Since we have `twemoji` available and currently in use by the Reader, this branch updates the `<Emojify />` component to utilize this module.

__To Test__
- Create a post with an emoji in the title ( so fun :tada: )
- View the site's stats insights page, and verify the emoji is show in the "Latest Post Summary" card

![stats_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/12285806/cbeaf072-b972-11e5-8005-192bcdd71783.png)

/cc @jblz