### PR TITLE
i18n: switches back to using 'echo' instead of 'printf'

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -2,7 +2,7 @@
 
 PATH="$PATH:/usr/local/bin"
 
-printf "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see CONTRIBUTING.md for details.\n\n"
+echo "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see CONTRIBUTING.md for details.\n\n"
 
 files=$(git diff --cached --name-only --diff-filter=ACM | grep ".jsx*$")
 if [ "$files" = "" ]; then
@@ -12,43 +12,43 @@ fi
 pass=true
 
 # i18nlinting.  Just have i18nlint issue warnings for now without failing
-printf "\nValidating translatable strings:\n"
+echo "\nValidating translatable strings:\n"
 for file in ${files}; do
     result=$(./bin/i18nlint --color ${file})
     if [ $? -ne 0 ]; then
-        printf "\033[31mi18nlint Failed: \033[0m$result\n"
-        printf "\n -----\n"
+        echo "\033[31mi18nlint Failed: \033[0m$result\n"
+        echo "\n -----\n"
         pass=false
     else
-        printf "\033[32mi18nlint Passed: ${file}\033[0m\n"
+        echo "\033[32mi18nlint Passed: ${file}\033[0m\n"
     fi
 done
 
-printf "\nValidating .jsx and .js:\n"
+echo "\nValidating .jsx and .js:\n"
 
 for file in ${files}; do
     ./node_modules/.bin/eslint ${file}
     if [ $? -ne 0 ]; then
-        printf "\033[31meslint Failed: ${file}\033[0m\n"
+        echo "\033[31meslint Failed: ${file}\033[0m\n"
         pass=false
     else
-        printf "\033[32meslint Passed: ${file}\033[0m\n"
+        echo "\033[32meslint Passed: ${file}\033[0m\n"
     fi
 done
 
-printf "\neslint validation complete\n"
+echo "\neslint validation complete\n"
 
 for file in ${files}; do
     ./bin/gridiconFormatChecker ${file}
         if [ $? -ne 0 ]; then
-        printf "\033[31mGridicon Format Check Failed: \033[0m${file}\n"
+        echo "\033[31mGridicon Format Check Failed: \033[0m${file}\n"
         pass=false
     fi
 done
 
 if ! $pass; then
-    printf "\n\033[41mCOMMIT FAILED:\033[0m Your commit contains files that should pass validation tests but do not. Please fix the errors and try again.\n\n"
+    echo "\n\033[41mCOMMIT FAILED:\033[0m Your commit contains files that should pass validation tests but do not. Please fix the errors and try again.\n\n"
     exit 1
 else
-    printf "\n\033[42mCOMMIT SUCCEEDED\033[0m\n\n"
+    echo "\n\033[42mCOMMIT SUCCEEDED\033[0m\n\n"
 fi


### PR DESCRIPTION
The printf was not working correctly for me when I had an eslint warning. I don't know if it makes a difference, but I use zsh. It seem to choke on [line 19 of the pre-commit hook](https://github.com/Automattic/wp-calypso/blob/master/bin/pre-commit#L19), specifically... 

```bsh
printf "\033[31mi18nlint Failed: \033[0m$result\n"
```

I'm not exactly sure what the problem is. This is what I saw with the printf statements.

![printf](https://cloudup.com/ipt3pPZvwKA+)

and this is what I saw when I switched them back to echo statements.

![echo](https://cloudup.com/c5QesLzwxY0+)

So the upshot is that it made it difficult to debug the problem with the i18n request, since the reason didn't print out until I switched to using echo statements. This was originally written with echo statements, but switched to printf statements here https://github.com/Automattic/wp-calypso/commit/f45632efda1a4ed7e29208843681ec744eef2b00. I think we should switch it back.

/cc @klimeryk @blowery 