### PR TITLE
Framework: small tweak to clean up url-search

### DIFF
--- a/client/lib/mixins/url-search/index.js
+++ b/client/lib/mixins/url-search/index.js
@@ -26,21 +26,12 @@ module.exports = {
 	},
 
 	doSearch: function( keywords ) {
+		var searchURL;
+
 		this.setState( {
 			searchOpen: ( false !== keywords )
 		} );
 
-		// don't wait to clear out search
-		if ( false === keywords && this.props.search ) {
-			this.handleSearch( keywords );
-			return;
-		}
-
-		this.handleSearch( keywords );
-	},
-
-	handleSearch: function( keywords ) {
-		var searchURL;
 		if ( this.onSearch ) {
 			this.onSearch( keywords );
 			return;


### PR DESCRIPTION
I noticed while looking into another issue that this code is doing some unnecessary checks as a holdover from other refactored logic. `doSearch` _always_ calls `handleSearch` in the same way now, so there's really no reason for the methods to be separated. The logic was a carryover from when one of the branches had called handleSearch with a debounce.

## testing
Just load up http://calypso.localhost:3000/posts use the search field. You may see some unrelated warnings in the console (also in master, about to push a PR to address those), but it should otherwise work as expected.

@adambbecker do you mind giving this a look?