### PR TITLE
Posts: fix posts warnings

### DIFF
--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -239,7 +239,7 @@ module.exports = React.createClass({
 		if ( showComments ) {
 			commentHref = post.URL + '#comments';
 			if ( post.discussion && post.discussion.comment_count > 0 ) {
-				commentTitle = this.translate( '1 Comment', '%(count)s Comments', {
+				commentTitle = this.translate( '%(count)s Comment', '%(count)s Comments', {
 					count: post.discussion.comment_count,
 					args: {
 						count: post.discussion.comment_count
@@ -278,7 +278,7 @@ module.exports = React.createClass({
 
 		if ( showLikes ) {
 			if ( post.like_count > 0 ) {
-				likeTitle = this.translate( '1 Like', '%(count)s Likes', {
+				likeTitle = this.translate( '%(count)s Like', '%(count)s Likes', {
 					count: post.like_count,
 					args: {
 						count: post.like_count
@@ -393,7 +393,10 @@ module.exports = React.createClass({
 					onDelete={ this.deletePost }
 					onRestore={ this.restorePost }
 				/>
-				<ReactCSSTransitionGroup transitionName="updated-trans">
+				<ReactCSSTransitionGroup
+					transitionName="updated-trans"
+					transitionEnterTimeout={ 300 }
+					transitionLeaveTimeout={ 300 }>
 					{ this.buildUpdateTemplate() }
 				</ReactCSSTransitionGroup>
 			</Card>

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -177,7 +177,7 @@ export default React.createClass( {
 					key={ 'statusTabs' + path }
 					path={ path }
 					count={ null === this.props.sites.selected || isJetpackSite ?
-						false :
+						null :
 						count
 					}
 					value={ textItem }
@@ -368,14 +368,10 @@ export default React.createClass( {
 	 * Return count of the given status
 	 *
 	 * @param {String} status - status type
-	 * @return {String|Boolean} return count of the given status
+	 * @return {Number|Null} return count of the given status
 	 */
 	getCountByStatus( status ) {
-		var count = false;
-		if ( false !== this.state.counts[ status ] ) {
-			count = this.numberFormat( this.state.counts[ status ] );
-		}
-
-		return count;
+		let count = this.state.counts[ status ];
+		return ( count !== false ) ? count : null;
 	}
 } );


### PR DESCRIPTION
While checking out an unrelated issue, I noticed quite a few warnings in the console when visiting the posts page for all-sites, jetpack sites, and wpcom sites.

![posts warnings](https://cloudup.com/i6oHO9MjDSC+)

## testing
Just go to http://calypso.localhost:3000/posts with your console open and make sure you're not seeing any of the warnings from the screenshot above.