### PR TITLE
Plugins: tracks event rejection fix

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -68,7 +68,7 @@ function recordEvent( eventType, plugin, site, error ) {
 	if ( error ) {
 		analytics.tracks.recordEvent( eventType + '_error', {
 			site: site.ID,
-			pluginSlug: plugin.slug,
+			plugin: plugin.slug,
 			error: error.error
 		} );
 		analytics.mc.bumpStat( eventType, 'failed' );
@@ -76,7 +76,7 @@ function recordEvent( eventType, plugin, site, error ) {
 	}
 	analytics.tracks.recordEvent( eventType + '_success', {
 		site: site.ID,
-		pluginSlug: plugin.slug
+		plugin: plugin.slug
 	} );
 	analytics.mc.bumpStat( eventType, 'succeeded' );
 }
@@ -103,7 +103,7 @@ function autoupdatePlugin( site, plugin ) {
 
 	analytics.tracks.recordEvent( 'calypso_plugin_update_automatic', {
 		site: site.ID,
-		pluginSlug: plugin.slug
+		plugin: plugin.slug
 	} );
 	analytics.mc.bumpStat( 'calypso_plugin_update_automatic' );
 
@@ -335,7 +335,7 @@ PluginsActions = {
 				analytics.tracks.recordEvent( 'calypso_plugin_activated_error', {
 					error: error && error.error ? error.error : 'Undefined activation error',
 					site: site.ID,
-					pluginSlug: plugin.slug
+					plugin: plugin.slug
 				} );
 
 				return;
@@ -343,7 +343,7 @@ PluginsActions = {
 			analytics.mc.bumpStat( 'calypso_plugin_activated', 'succeeded' );
 			analytics.tracks.recordEvent( 'calypso_plugin_activated_success', {
 				site: site.ID,
-				pluginSlug: plugin.slug
+				plugin: plugin.slug
 			} );
 		} );
 	},
@@ -376,7 +376,7 @@ PluginsActions = {
 				analytics.tracks.recordEvent( 'calypso_plugin_deactivated_error', {
 					error: error.error ? error.error : 'Undefined deactivation error',
 					site: site.ID,
-					pluginSlug: plugin.slug
+					plugin: plugin.slug
 				} );
 
 				return;
@@ -384,7 +384,7 @@ PluginsActions = {
 			analytics.mc.bumpStat( 'calypso_plugin_deactivated', 'succeeded' );
 			analytics.tracks.recordEvent( 'calypso_plugin_deactivated_success', {
 				site: site.ID,
-				pluginSlug: plugin.slug
+				plugin: plugin.slug
 			} );
 		} );
 	},


### PR DESCRIPTION
closes https://github.com/Automattic/wp-calypso/issues/2315

Tracks was rejecting some of our events because one of the parameters we sent was named using camelcase ( `pluginSlug` ) instead of snake case, as tracks expects.

This PR corrects this so the events aren't rejected anymore (and use the same naming that we have in other plugins' tracks events, just `plugin` instead of `plugin_slug` )

I don't really know how to test this without deploying it to production so we really log the events :/

piiiiiiiiiiiiing @enejb & @lezama 
