### PR TITLE
Stats: Update Components to Use StatsTabs / StatsTab

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -247,6 +247,7 @@
 @import 'my-sites/stats/stats-module/style';
 @import 'my-sites/stats/stats-overview-placeholder/style';
 @import 'my-sites/stats/stats-site-overview/style';
+@import 'my-sites/stats/stats-tabs/style';
 @import 'my-sites/themes/current-theme/style';
 @import 'my-sites/themes/style';
 @import 'my-sites/themes/themes-search-card/style';

--- a/client/my-sites/stats/all-time/index.jsx
+++ b/client/my-sites/stats/all-time/index.jsx
@@ -1,60 +1,51 @@
 /**
 * External dependencies
 */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var observe = require( 'lib/mixins/data-observe' ),
-	Card = require( 'components/card' ),
-	user = require( 'lib/user' )(),
-	toggle = require( '../mixin-toggle' ),
-	Gridicon = require( 'components/gridicon' );
+import observe from 'lib/mixins/data-observe';
+import Card from 'components/card';
+import User from 'lib/user';
+import toggle from '../mixin-toggle';
+import Gridicon from 'components/gridicon';
+import StatsTabs from '../stats-tabs';
+import StatsTab from '../stats-tabs/tab';
 
-module.exports = React.createClass( {
+const user = User();
+
+export default React.createClass( {
 	displayName: 'StatsAllTime',
 
 	mixins: [ toggle( 'allTimeList' ), observe( 'allTimeList' ) ],
 
 	propTypes: {
-		allTimeList: React.PropTypes.object.isRequired
+		allTimeList: PropTypes.object.isRequired
 	},
 
-	renderValue: function( value ) {
-		var valueClass = classNames( 'value', {
-				'is-loading': this.props.allTimeList.isLoading(),
-				'is-low': ! value || 0 === value
-			} ),
-			displayValue = String.fromCharCode( 8211 );
+	render() {
+		const infoIcon = this.state.showInfo ? 'info' : 'info-outline';
+		const allTimeList = this.props.allTimeList.response;
+		const { showInfo, showModule } = this.state;
+		const isLoading = this.props.allTimeList.isLoading();
 
-		if ( value || 0 === value ) {
-			displayValue = this.numberFormat( value );
-		}
-
-		return <span className={ valueClass }>{ displayValue }</span>;
-	},
-
-	render: function() {
-		var infoIcon = this.state.showInfo ? 'info' : 'info-outline',
-			allTimeList = this.props.allTimeList.response,
-			bestDay,
-			bestViews,
-			classes;
+		let bestDay;
 
 		if ( allTimeList['best-views'] && allTimeList['best-views'].day ) {
 			bestDay = this.moment( allTimeList['best-views'].day ).format( 'LL' );
 		}
 
-		classes = {
-			'is-expanded': this.state.showModule,
-			'is-showing-info': this.state.showInfo,
+		const classes = {
+			'is-expanded': showModule,
+			'is-showing-info': showInfo,
 			'is-loading': this.props.allTimeList.isLoading(),
 			'is-non-en': user.data.localeSlug && ( user.data.localeSlug !== 'en' )
 		};
 
-		bestViews = allTimeList['best-views'] ? allTimeList['best-views'].count : null;
+		const bestViews = allTimeList['best-views'] ? allTimeList['best-views'].count : null;
 
 		return (
 			<Card className={ classNames( 'stats-module', 'stats-all-time', classes ) }>
@@ -91,39 +82,33 @@ module.exports = React.createClass( {
 						<p>{ this.translate( 'These are your site\'s overall total number of Posts, Views and Visitors as well as the day when you had the most number of Views.' ) }</p>
 					</div>
 
-				<ul className="module-tabs">
-					<li className="module-tab">
-						<span className="no-link">
-							<Gridicon icon="posts" size={ 18 } />
-							<span className="label">{ this.translate( 'Posts' ) }</span>
-							{ this.renderValue( allTimeList.posts ) }
-						</span>
-					</li>
-					<li className="module-tab">
-						<span className="no-link">
-							<Gridicon icon="visible" size={ 18 } />
-							<span className="label">{ this.translate( 'Views' ) }</span>
-							{ this.renderValue( allTimeList.views ) }
-						</span>
-					</li>
-					<li className="module-tab">
-						<span className="no-link">
-							<Gridicon icon="user" size={ 18 } />
-							<span className="label">{ this.translate( 'Visitors' ) }</span>
-							{ this.renderValue( allTimeList.visitors ) }
-						</span>
-					</li>
-					<li className="module-tab is-best">
-						<span className="no-link">
-							<Gridicon icon="trophy" size={ 18 } />
-							<span className="label">{ this.translate( 'Best Views Ever' ) }</span>
-							{ this.renderValue( bestViews ) }
+					<StatsTabs>
+						<StatsTab
+							gridicon="posts"
+							label={ this.translate( 'Posts' ) }
+							loading={ isLoading }
+							value={ allTimeList.posts } />
+						<StatsTab
+							gridicon="visible"
+							label={ this.translate( 'Views' ) }
+							loading={ isLoading }
+							value={ allTimeList.views } />
+						<StatsTab
+							gridicon="user"
+							label={ this.translate( 'Visitors' ) }
+							loading={ isLoading }
+							value={ allTimeList.visitors } />
+						<StatsTab
+							className="stats-all-time__is-best"
+							gridicon="trophy"
+							label={ this.translate( 'Best Views Ever' ) }
+							loading={ isLoading }
+							value={ bestViews }>
 							<span className="stats-all-time__best-day">{ bestDay }</span>
-						</span>
-					</li>
-				</ul>
-			</div>
-		</Card>
+						</StatsTab>
+					</StatsTabs>
+				</div>
+			</Card>
 		);
 	}
 } );

--- a/client/my-sites/stats/all-time/style.scss
+++ b/client/my-sites/stats/all-time/style.scss
@@ -2,16 +2,12 @@
 
 .stats-all-time {
 
-	.module-tab {
+	.stats-tab {
 
 		padding-bottom: 0;
 
 		@include breakpoint( ">480px" ) {
 			padding-bottom: 24px;
-		}
-
-		&.is-best {
-			color: $alert-yellow;
 		}
 
 		&:nth-child(4) {
@@ -38,5 +34,12 @@
 				width: 100%;
 			}
 		}
+	}
+}
+
+.stats-all-time__is-best {
+	.gridicon,
+	.label {
+		color: $alert-yellow;
 	}
 }

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -305,10 +305,10 @@ module.exports = {
 			date,
 			charts = function() {
 				return [
-					{ attr: 'views', legendOptions: [ 'visitors' ], className: 'visible', label: i18n.translate( 'Views', { context: 'noun' } ) },
-					{ attr: 'visitors', className: 'user', label: i18n.translate( 'Visitors', { context: 'noun' } ) },
-					{ attr: 'likes', className: 'star', label: i18n.translate( 'Likes', { context: 'noun' } ) },
-					{ attr: 'comments', className: 'comment', label: i18n.translate( 'Comments', { context: 'noun' } ) }
+					{ attr: 'views', legendOptions: [ 'visitors' ], gridicon: 'visible', label: i18n.translate( 'Views', { context: 'noun' } ) },
+					{ attr: 'visitors', gridicon: 'user', label: i18n.translate( 'Visitors', { context: 'noun' } ) },
+					{ attr: 'likes', gridicon: 'star', label: i18n.translate( 'Likes', { context: 'noun' } ) },
+					{ attr: 'comments', gridicon: 'comment', label: i18n.translate( 'Comments', { context: 'noun' } ) }
 				];
 			},
 			chartDate,

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -11,6 +11,7 @@ var React = require( 'react' ),
 var Card = require( 'components/card' ),
 	PostListStore = require( 'lib/posts/post-list-store-factory' )(),
 	PostStatsStore = require( 'lib/post-stats/store' ),
+	StatsTabs = require( '../stats-tabs' ),
 	Emojify = require( 'components/emojify' ),
 	actions = require( 'lib/posts/actions' ),
 	Gridicon = require( 'components/gridicon' );
@@ -129,7 +130,7 @@ module.exports = React.createClass( {
 		return tabs.map( function( tabOptions, index ) {
 			var valueClass = classNames( 'value', { 'is-low': tabOptions.value === 0 } ),
 				wrapperClass = classNames( {
-					'module-tab': true,
+					'stats-tab': true,
 					'is-post-summary': true,
 					'is-loading': isLoading
 				} ),
@@ -212,9 +213,9 @@ module.exports = React.createClass( {
 						) : null
 					}
 				</div>
-				<ul className="module-tabs">
+				<StatsTabs>
 					{ this.buildTabs( summaryUrl ) }
-				</ul>
+				</StatsTabs>
 			</Card>
 		);
 	}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -338,6 +338,13 @@ ul.module-header-actions {
 	display: none;
 }
 
+.tab-email-followers .tab-content.email-followers,
+.tab-wpcom-followers .tab-content.wpcom-followers,
+.tab-top-authors .tab-content.top-authors,
+.tab-top-content .tab-content.top-content {
+	display: block;
+}
+
 // Module Content
 .module-content {
 	display: none;

--- a/client/my-sites/stats/stats-overview-placeholder/index.jsx
+++ b/client/my-sites/stats/stats-overview-placeholder/index.jsx
@@ -8,6 +8,8 @@ import React, { PropTypes } from 'react';
  */
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
+import StatsTabs from '../stats-tabs';
+import StatsTab from '../stats-tabs/tab';
 
 export default React.createClass( {
 	displayName: 'StatsOverviewPlaceholder',
@@ -38,20 +40,28 @@ export default React.createClass( {
 					</h3>
 				</div>
 
-				<ul className="module-tabs">
-					<li className="module-tab is-views is-loading">
-						<a href="#"><Gridicon icon="visible" size={ 18 } /><span className="label">{ this.translate( 'Views' ) }</span> <span className="value">&ndash;</span></a>
-					</li>
-					<li className="module-tab is-visitors is-loading">
-						<a href="#"><Gridicon icon="user" size={ 18 } /><span className="label">{ this.translate( 'Visitors' ) }</span> <span className="value">&ndash;</span></a>
-					</li>
-					<li className="module-tab is-likes is-loading">
-						<a href="#"><Gridicon icon="star" size={ 18 } /><span className="label">{ this.translate( 'Likes' ) }</span> <span className="value">&ndash;</span></a>
-					</li>
-					<li className="module-tab is-comments is-loading">
-						<a href="#"><Gridicon icon="comment" size={ 18 } /><span className="label">{ this.translate( 'Comments' ) }</span> <span className="value">&ndash;</span></a>
-					</li>
-				</ul>
+				<StatsTabs>
+					<StatsTab
+						isLoading={ true }
+						gridicon="visible"
+						label={ this.translate( 'Views', { context: 'noun' } ) }
+						value={ null } />
+					<StatsTab
+						isLoading={ true }
+						gridicon="user"
+						label={ this.translate( 'Visitors', { context: 'noun' } ) }
+						value={ null } />
+					<StatsTab
+						isLoading={ true }
+						gridicon="star"
+						label={ this.translate( 'Likes', { context: 'noun' } ) }
+						value={ null } />
+					<StatsTab
+						isLoading={ true }
+						gridicon="comment"
+						label={ this.translate( 'Comments', { context: 'noun' } ) }
+						value={ null } />
+				</StatsTabs>
 			</Card>
 		);
 	}

--- a/client/my-sites/stats/stats-site-overview/index.jsx
+++ b/client/my-sites/stats/stats-site-overview/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies

--- a/client/my-sites/stats/stats-site-overview/index.jsx
+++ b/client/my-sites/stats/stats-site-overview/index.jsx
@@ -12,6 +12,8 @@ import observe from 'lib/mixins/data-observe';
 import route from 'lib/route';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
+import StatsTabs from '../stats-tabs';
+import StatsTab from '../stats-tabs/tab';
 
 export default React.createClass( {
 	displayName: 'StatsSiteOverview',
@@ -23,15 +25,6 @@ export default React.createClass( {
 	},
 
 	mixins: [ observe( 'summaryData' ) ],
-
-	ensureValue( value ) {
-		if ( value || value === 0 ) {
-			return this.numberFormat( value );
-		}
-
-		// If no value present, return en-dash
-		return String.fromCharCode( 8211 );
-	},
 
 	isValueLow( value ) {
 		return ! value || 0 === value;
@@ -71,36 +64,32 @@ export default React.createClass( {
 						</a>
 					</h3>
 				</div>
-				<ul className="module-tabs">
-					<li className={ classNames( 'module-tab', { 'is-low': this.isValueLow( views ) } ) }>
-						<a href={ siteStatsPath }>
-							<Gridicon icon="visible" size={ 18 } />
-							<span className="label">{ this.translate( 'Views', { context: 'noun' } ) }</span>
-							<span className="value">{ this.ensureValue( views ) }</span>
-						</a>
-					</li>
-					<li className={ classNames( 'module-tab', { 'is-low': this.isValueLow( visitors ) } ) } >
-						<a href={ siteStatsPath + '?tab=visitors' }>
-							<Gridicon icon="user" size={ 18 } />
-							<span className="label">{ this.translate( 'Visitors', { context: 'noun' } ) }</span>
-							<span className="value">{ this.ensureValue( visitors ) }</span>
-						</a>
-					</li>
-					<li className={ classNames( 'module-tab', { 'is-low': this.isValueLow( likes ) } ) } >
-						<a href={ siteStatsPath + '?tab=likes' }>
-							<Gridicon icon="star" size={ 18 } />
-							<span className="label">{ this.translate( 'Likes', { context: 'noun' } ) }</span>
-							<span className="value">{ this.ensureValue( likes ) }</span>
-						</a>
-					</li>
-					<li className={ classNames( 'module-tab', { 'is-low': this.isValueLow( comments ) } ) } >
-						<a href={ siteStatsPath + '?tab=comments' }>
-							<Gridicon icon="comment" size={ 18 } />
-							<span className="label">{ this.translate( 'Comments', { context: 'noun' } ) }</span>
-							<span className="value">{ this.ensureValue( comments ) }</span>
-						</a>
-					</li>
-				</ul>
+				<StatsTabs>
+					<StatsTab
+						className={ this.isValueLow( views ) ? 'is-low' : null }
+						href={ siteStatsPath }
+						gridicon="visible"
+						label={ this.translate( 'Views', { context: 'noun' } ) }
+						value={ views } />
+					<StatsTab
+						className={ this.isValueLow( visitors ) ? 'is-low' : null }
+						href={ siteStatsPath + '?tab=visitors' }
+						gridicon="user"
+						label={ this.translate( 'Visitors', { context: 'noun' } ) }
+						value={ visitors } />
+					<StatsTab
+						className={ this.isValueLow( likes ) ? 'is-low' : null }
+						href={ siteStatsPath + '?tab=likes' }
+						gridicon="star"
+						label={ this.translate( 'Likes', { context: 'noun' } ) }
+						value={ likes } />
+					<StatsTab
+						className={ this.isValueLow( comments ) ? 'is-low' : null }
+						href={ siteStatsPath + '?tab=comments' }
+						gridicon="comment"
+						label={ this.translate( 'Comments', { context: 'noun' } ) }
+						value={ comments } />
+				</StatsTabs>
 			</Card>
 		);
 	}

--- a/client/my-sites/stats/stats-summary-chart/index.jsx
+++ b/client/my-sites/stats/stats-summary-chart/index.jsx
@@ -128,7 +128,7 @@ module.exports = React.createClass( {
 			attr: this.props.labelKey,
 			value: selectedBar ? this.state.selectedBar[ this.props.dataKey ] : null,
 			selected: true,
-			className: this.props.labelClass,
+			gridicon: this.props.labelClass,
 			label: this.props.tabLabel + label
 		};
 

--- a/client/my-sites/stats/stats-summary-chart/index.jsx
+++ b/client/my-sites/stats/stats-summary-chart/index.jsx
@@ -11,7 +11,8 @@ var React = require( 'react' ),
  */
 var observe = require( 'lib/mixins/data-observe' ),
 	ElementChart = require( 'components/chart' ),
-	StatTab = require( '../stats-tabs/tab' ),
+	StatsTabs = require( '../stats-tabs' ),
+	StatsTab = require( '../stats-tabs/tab' ),
 	analytics = require( 'analytics' ),
 	Card = require( 'components/card' );
 
@@ -132,9 +133,9 @@ module.exports = React.createClass( {
 			label: this.props.tabLabel + label
 		};
 
-		tabs = <StatTab key="chart-tab" { ...tabOptions } />;
+		tabs = <StatsTab key="chart-tab" { ...tabOptions } />;
 
-		return ( <ul className="module-tabs is-expanded">{ tabs }</ul> );
+		return ( <StatsTabs>{ tabs }</StatsTabs> );
 	},
 
 	render: function() {

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -14,7 +14,9 @@ export default React.createClass( {
 
 	propTypes: {
 		activeKey: PropTypes.string,
+		activeIndex: PropTypes.number,
 		dataList: PropTypes.object,
+		selectedTab: PropTypes.string,
 		switchTab: PropTypes.func,
 		tabs: PropTypes.array
 	},

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -14,7 +14,7 @@ export default React.createClass( {
 
 	propTypes: {
 		activeKey: PropTypes.string,
-		activeIndex: PropTypes.number,
+		activeIndex: PropTypes.string,
 		dataList: PropTypes.object,
 		selectedTab: PropTypes.string,
 		switchTab: PropTypes.func,

--- a/client/my-sites/stats/stats-tabs/index.jsx
+++ b/client/my-sites/stats/stats-tabs/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -19,35 +20,39 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { dataList, activeIndex, activeKey, tabs, switchTab, selectedTab } = this.props;
+		const { children, dataList, activeIndex, activeKey, tabs, switchTab, selectedTab } = this.props;
+		let statsTabs;
 
-		let data = dataList.response.data.filter( function( item ) {
-			return item[ activeKey ] === activeIndex;
-		} );
+		if ( dataList ) {
+			let data = dataList.response.data.filter( function( item ) {
+				return item[ activeKey ] === activeIndex;
+			} );
 
-		if ( data.length ) {
-			data = data.pop();
+			if ( data.length ) {
+				data = data.pop();
+			}
+
+			statsTabs = tabs.map( function( tab ) {
+				const hasData = data && ( data[ tab.attr ] >= 0 ) && ( data[ tab.attr ] !== null );
+
+				const tabOptions = {
+					attr: tab.attr,
+					gridicon: tab.gridicon,
+					className: tab.className,
+					label: tab.label,
+					loading: ! hasData,
+					selected: selectedTab === tab.attr,
+					tabClick: switchTab,
+					value: hasData ? data[ tab.attr ] : null
+				};
+
+				return <StatTab key={ tabOptions.attr } { ...tabOptions } />;
+			} );
 		}
 
-		const statsTabs = tabs.map( function( tab ) {
-			const hasData = data && ( data[ tab.attr ] >= 0 ) && ( data[ tab.attr ] !== null );
-
-			const tabOptions = {
-				attr: tab.attr,
-				className: tab.className,
-				label: tab.label,
-				loading: ! hasData,
-				selected: selectedTab === tab.attr,
-				tabClick: switchTab,
-				value: hasData ? data[ tab.attr ] : null
-			};
-
-			return <StatTab key={ tabOptions.attr } { ...tabOptions } />;
-		} );
-
 		return (
-			<ul className="module-tabs is-enabled">
-				{ statsTabs }
+			<ul className={ classNames( 'stats-tabs', { 'is-enabled': !! dataList } ) }>
+				{ statsTabs || children }
 			</ul>
 		);
 	}

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -1,0 +1,231 @@
+// Module Tabs
+// (currently only used for the bar chart module at the top)
+
+.stats-tabs {
+	@include clear-fix;
+	border-top: 1px solid $gray-light;
+	list-style: none;
+	background: $white;
+	margin: 0;
+
+	.stats-tab {
+		margin: 0;
+		font-size: 16px;
+		clear: none;
+		border-top: 1px solid $gray-light;
+		box-sizing: border-box;
+
+		&:first-child {
+			border-top: none;
+		}
+
+		@include breakpoint( ">480px" ) {
+			border-top: none;
+			border-left: 1px solid $gray-light;
+			float: left;
+			width: 25%;
+			text-align: center;
+
+			&.is-post-summary {
+				width: 33%;
+			}
+
+			&:first-child {
+				border-left: none;
+			}
+		}
+
+		@include breakpoint( "<480px" ) {
+			width: auto;
+			float: none;
+			text-align: left;
+		}
+
+		a {
+			color: $gray-dark;
+		}
+
+		a,
+		.no-link {
+			@extend %mobile-link-element;
+			@include clear-fix;
+			padding: 5px 0 10px;
+			display: block;
+			background: $white;
+
+			@include breakpoint( "<480px" ) {
+				line-height: 24px;
+				padding-top: 10px;
+				-webkit-touch-callout: none;
+			}
+		}
+
+		.label {
+			font-size: 11px;
+			letter-spacing: 0.1em;
+			line-height: inherit;
+			text-transform: uppercase;
+
+			@include breakpoint( "<480px" ) {
+				font-size: 14px;
+				line-height: 24px;
+				float: left;
+			}
+		}
+
+		.gridicon {
+			vertical-align: middle;
+			margin-right: 4px;
+			margin-top: -2px;
+
+			@include breakpoint( "<480px" ) {
+				width: 24px;
+				height: 24px;
+				margin-left: 24px;
+				margin-right: 8px;
+				float: left;
+			}
+		}
+
+		.value {
+			clear: both;
+			display: block;
+			line-height: 24px;
+			color: $blue-wordpress;
+			transition: font-size .3s 0 ease-out;
+
+			@include breakpoint( "<480px" ) {
+				clear: none;
+				float: right;
+				font-size: 16px;
+				margin-right: 24px;
+				padding: 0;
+			}
+		}
+
+		@include breakpoint( ">480px" ) {
+			// Hover state
+			a:hover,
+			a:hover .value,
+			&.is-low a:hover,
+			&.is-low a:hover .value {
+				color: $link-highlight;
+			}
+
+			a:hover {
+				background: rgba(255,255,255,.5);
+			}
+		}
+
+		// Focus state
+		a:focus,
+		a:focus .value,
+		.stats-module &.is-selected a:focus,
+		.stats-module &.is-selected a:focus .value,
+		&.is-low a:focus,
+		&.is-low a:focus .value {
+			color: $link-highlight;
+		}
+
+		a:focus {
+			background: rgba(255,255,255,.5);
+		}
+
+		// Selected state
+		.stats-module &.is-selected a {
+			background: $white;
+			border-top: 1px solid $white;
+			margin-top: -1px;
+			cursor: default;
+		}
+
+		&.is-selected a,
+		&.is-selected.is-low a {
+			color: $gray-dark;
+		}
+
+		&.is-selected a .value,
+		&.is-selected.is-low a .value,
+		&.is-selected a:hover .value {
+			color: $orange-jazzy;
+		}
+
+		// Low state ('disabled')
+		.is-low,
+		&.is-low a .value {
+			color: $gray;
+		}
+
+		// Individual tab loading state
+		&.is-loading a,
+		&.is-loading a:hover {
+			cursor: default;
+		}
+
+		.no-link .value {
+			color: $gray-dark;
+
+			&.is-low {
+				color: $gray;
+			}
+		}
+
+		&.is-loading a .value,
+		&.is-loading a:hover .value,
+		&.is-loading .no-link .value {
+			animation: loading-fade 1.6s ease-in-out infinite;
+			cursor: default;
+			font-size: 110%;
+			color: $gray;
+		}
+
+		&.is-loading.is-selected a .value,
+		&.is-loading.is-selected a:hover .value {
+			color: $gray;
+		}
+	}
+
+	// If there's only one tab (used on the Post/Video Details page)
+	li:only-child {
+		width: auto;
+		float: none;
+		text-align: left;
+
+		a {
+			line-height: 24px;
+			padding-top: 10px;
+		}
+
+		.label {
+			font-size: 14px;
+			line-height: 24px;
+			float: left;
+		}
+
+		.gridicon {
+			width: 24px;
+			height: 24px;
+			margin: 0 8px 0 24px;
+			float: left;
+		}
+
+		.value {
+			clear: none;
+			float: right;
+			margin-right: 24px;
+		}
+	}
+
+	&.is-enabled {
+		background: $gray-light;
+
+		&,
+		li {
+			border-color: $gray-light;
+		}
+
+		a {
+			background: $gray-light;
+		}
+	}
+}

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -24,8 +24,7 @@ export default React.createClass( {
 
 	getDefaultProps() {
 		return {
-			tabClick: () => {},
-			href: '#'
+			tabClick: () => {}
 		}
 	},
 
@@ -60,7 +59,7 @@ export default React.createClass( {
 				'is-low': ! value
 			} );
 
-		const linkClass = '#' === href ? 'no-link' : null;
+		const linkClass = ! href ? 'no-link' : null;
 
 		return (
 			<li className={ tabClass } onClick={ this.clickHandler } >

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -15,6 +15,7 @@ export default React.createClass( {
 	propTypes: {
 		className: PropTypes.string,
 		gridicon: PropTypes.string,
+		href: PropTypes.string,
 		label: PropTypes.string,
 		loading: PropTypes.bool,
 		selected: PropTypes.bool,

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -23,15 +23,11 @@ export default React.createClass( {
 		value: PropTypes.number
 	},
 
-	getDefaultProps() {
-		return {
-			tabClick: () => {}
-		}
-	},
-
 	clickHandler( event ) {
-		event.preventDefault();
-		this.props.tabClick( this.props );
+		if ( this.props.tabClick ) {
+			event.preventDefault();
+			this.props.tabClick( this.props );
+		}
 	},
 
 	ensureValue( value ) {
@@ -42,14 +38,8 @@ export default React.createClass( {
 		return String.fromCharCode( 8211 );
 	},
 
-	handleLinkClick( event ) {
-		if ( ! this.props.href ) {
-			event.preventDefault();
-		}
-	},
-
 	render() {
-		const { className, children, gridicon, href, label, loading, selected, value } = this.props;
+		const { className, children, gridicon, href, label, loading, selected, tabClick, value } = this.props;
 
 		const tabClass = classNames(
 			'stats-tab',
@@ -60,16 +50,22 @@ export default React.createClass( {
 				'is-low': ! value
 			} );
 
-		const linkClass = ! href ? 'no-link' : null;
+		const tabIcon = gridicon ? <Gridicon icon={ gridicon } size={ 18 } /> : null;
+		const tabLabel = <span className="label">{ label }</span>;
+		const tabValue = <span className="value">{ this.ensureValue( value ) }</span>;
+		const hasClickAction = href || tabClick;
 
 		return (
 			<li className={ tabClass } onClick={ this.clickHandler } >
-				<a href={ href } className={ linkClass } onClick={ this.handleLinkClick }>
-					{ gridicon ? <Gridicon icon={ gridicon } size={ 18 } /> : null }
-					<span className="label">{ label }</span>
-					<span className="value">{ this.ensureValue( value ) }</span>
-					{ children }
-				</a>
+				{
+					hasClickAction
+					?	<a href={ href }>
+							{ tabIcon }{ tabLabel }{ tabValue }{ children }
+						</a>
+					: 	<span className="no-link">
+							{ tabIcon }{ tabLabel }{ tabValue }{ children }
+						</span>
+				}
 			</li>
 		);
 	}

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -13,8 +13,8 @@ export default React.createClass( {
 	displayName: 'StatsTabsTab',
 
 	propTypes: {
-		attr: PropTypes.string,
 		className: PropTypes.string,
+		gridicon: PropTypes.string,
 		label: PropTypes.string,
 		loading: PropTypes.bool,
 		selected: PropTypes.bool,
@@ -49,22 +49,26 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { attr, className, href, label, loading, selected, value } = this.props;
+		const { className, children, gridicon, href, label, loading, selected, value } = this.props;
 
-		const tabClassOptions = {
-			'is-selected': selected,
-			'is-loading': loading,
-			'is-low': ! value
-		};
+		const tabClass = classNames(
+			'stats-tab',
+			className,
+			{
+				'is-selected': selected,
+				'is-loading': loading,
+				'is-low': ! value
+			} );
 
-		tabClassOptions[ 'is-' + attr ] = true;
+		const linkClass = '#' === href ? 'no-link' : null;
 
 		return (
-			<li className={ classNames( 'module-tab', tabClassOptions ) } onClick={ this.clickHandler } >
-				<a href={ href } onClick={ this.handleLinkClick }>
-					<Gridicon icon={ className } size={ 18 } />
+			<li className={ tabClass } onClick={ this.clickHandler } >
+				<a href={ href } className={ linkClass } onClick={ this.handleLinkClick }>
+					{ gridicon ? <Gridicon icon={ gridicon } size={ 18 } /> : null }
 					<span className="label">{ label }</span>
 					<span className="value">{ this.ensureValue( value ) }</span>
+					{ children }
 				</a>
 			</li>
 		);


### PR DESCRIPTION
Part of the great stats cleanup in the sky project - this branch aims to standardize all the "tabs" used throughout stats to utilize the `<StatsTabs>` and `<StatsTab>` components.

### To Test
Thanks in advance for testing this branch out as it does cover quite a few parts of stats.  For your valiant efforts, I will thank you with [this](https://www.youtube.com/watch?v=sIlNIVXpIns).

Each of the following components use either `<StatsTabs>` and/or `<StatsTab>` and will need to be verified they still function as they do in production, and visually look the same:

#### Chart Tabs
<img width="748" alt="stats_ _testingtimmy2_wordpress_com_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12312197/50385618-ba12-11e5-8274-6c52bcd04a16.png">

Viewed on a site stats page for anytime period.  Click on each tab, verify they all function as expected

#### Summary Chart Tabs
<img width="722" alt="stats_ _wordpress_com_news_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12312230/8c1b5e82-ba12-11e5-989c-69d60ddb413b.png">

These charts are shown on summary pages for Post Details and Video views, and can be accessed by clicking on an entry in the Post & Pages component.  Test that no hover state is shown for this tab, and the cursor does not change on hover.

#### Latest Post Summary
<img width="729" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12312257/e1d5ef22-ba12-11e5-928f-ad6a4bf9e8ad.png">

Accessed via the Insights page, verify the tabs visually look the same, and the Views tab clicks through to the post detail page.

#### Today's Stats
<img width="730" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12312295/2e75a110-ba13-11e5-98ff-177dd0197b47.png">

Also on the Insights Page.  Verify it looks the same, and that you can click on each tab, and that when you do so, the corresponding chart is loaded ( tab is active ) on the site stats page

#### All Time
<img width="730" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12312330/6db27a10-ba13-11e5-9f2a-d6d459ba37a9.png">

The last on the insights page, again validate it all looks the same and that there is not any hover state properties on the tabs.

#### Overview
<img width="725" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12312347/8ecf46b0-ba13-11e5-9b76-f240f2016bbb.png">

Accessed from `/stats` - pretty much identical to "Today's Stats" above as far as testing goes.