### PR TITLE
Stats: fix posting activity tooltip hover

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -494,6 +494,7 @@
 		.tip-arrow {
 			&::before {
 				left: 87px;
+				top: -7px;
 			}
 		}
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -491,10 +491,15 @@
 	}
 
 	&.is-streak {
+
+		margin-top: -5px;
+		height: 35px;
+
 		.tip-arrow {
-			&::before {
-				left: 87px;
-				top: -7px;
+
+	    	&::before {
+				left: 85px;
+				top: 30px;
 			}
 		}
 
@@ -539,7 +544,8 @@
 	}
 
 	&.is-published-item {
-			height: 19px;
+
+		height: 19px;
 
 		.label {
 			text-transform: none;

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -491,16 +491,12 @@
 	}
 
 	&.is-streak {
-
 		margin-top: -5px;
 		height: 35px;
 
-		.tip-arrow {
-
-	    	&::before {
-				left: 85px;
-				top: 30px;
-			}
+		.tip-arrow::before {
+			left: 85px;
+			top: 30px;
 		}
 
 		.tip-inner {

--- a/client/my-sites/post-trends/day.jsx
+++ b/client/my-sites/post-trends/day.jsx
@@ -100,7 +100,7 @@ module.exports = React.createClass( {
 					isVisible={ this.state.showPopover }
 					position="top"
 					onClose={ noop }
-					className="chart__tooltip is-streak trends__tooltip"
+					className="chart__tooltip is-streak"
 					>
 					<Tooltip data={ this.buildTooltipData( date, data ) } />
 				</Popover>
@@ -116,5 +116,4 @@ module.exports = React.createClass( {
 			</div>
 		);
 	}
-
 } );

--- a/client/my-sites/post-trends/day.jsx
+++ b/client/my-sites/post-trends/day.jsx
@@ -100,7 +100,7 @@ module.exports = React.createClass( {
 					isVisible={ this.state.showPopover }
 					position="top"
 					onClose={ noop }
-					className="chart__tooltip is-streak"
+					className="chart__tooltip is-streak trends__tooltip"
 					>
 					<Tooltip data={ this.buildTooltipData( date, data ) } />
 				</Popover>

--- a/client/my-sites/post-trends/style.scss
+++ b/client/my-sites/post-trends/style.scss
@@ -117,8 +117,9 @@
 	display: inline-block;
 	width: 7px;
 	height: 7px;
+	border: 1px solid $gray-light;
 	background-color: lighten( $gray, 20% );
-	margin: 1px;
+	margin: 0;
 }
 
 .post-trends__day,
@@ -212,5 +213,22 @@
 		height: 10px;
 		float: left;
 		margin-left: 3px;
+	}
+}
+
+// A customization of chart__tooltip
+
+.trends__tooltip {
+	border: 1px solid red;
+	height: 0;
+	margin-top: -5px;
+
+	&.tip-top {
+
+		.tip-arrow {
+		    height: 10px;
+		    margin-top: -48px;
+		    position: static;
+		}
 	}
 }

--- a/client/my-sites/post-trends/style.scss
+++ b/client/my-sites/post-trends/style.scss
@@ -215,20 +215,3 @@
 		margin-left: 3px;
 	}
 }
-
-// A customization of chart__tooltip
-
-.trends__tooltip {
-	border: 1px solid red;
-	height: 0;
-	margin-top: -5px;
-
-	&.tip-top {
-
-		.tip-arrow {
-		    height: 10px;
-		    margin-top: -48px;
-		    position: static;
-		}
-	}
-}


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/213

Eventually, we may want to explore different ways of presenting the number of posts in the Posting Activity section, but this solves the issue for now.

/cc @timmyc @designsimply 