### PR TITLE
Editor: Restore sidebar accordion hover effect

### DIFF
--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -15,8 +15,14 @@
 	}
 }
 
-.editor-drawer .accordion:not( .is-expanded ) .accordion__subtitle::after {
-	@include long-content-fade( $color: lighten( $gray, 30% ) );
+.editor-drawer .accordion:not( .is-expanded ) .accordion__toggle {
+	.accordion__subtitle::after {
+		@include long-content-fade( $color: lighten( $gray, 30% ) );
+	}
+
+	&:hover .accordion__subtitle::after {
+		@include long-content-fade( $color: $gray-light );
+	}
 }
 
 .editor-drawer__accordion.is-loading .accordion__subtitle {

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -9,13 +9,13 @@
 
 .editor-drawer .accordion__toggle {
 	background: lighten( $gray, 30% );
-
-	&:hover {
-		background: $gray-light;
-	}
 }
 
 .editor-drawer .accordion:not( .is-expanded ) .accordion__toggle {
+	&:hover {
+		background: $gray-light;
+	}
+
 	.accordion__subtitle::after {
 		@include long-content-fade( $color: lighten( $gray, 30% ) );
 	}

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -9,6 +9,10 @@
 
 .editor-drawer .accordion__toggle {
 	background: lighten( $gray, 30% );
+
+	&:hover {
+		background: $gray-light;
+	}
 }
 
 .editor-drawer .accordion:not( .is-expanded ) .accordion__subtitle::after {


### PR DESCRIPTION
In #2131 (specifically 782f700f2042ac1d20cbc255fe52c2bb1370e883), the background color of the accordions was changed to match the background color of the sidebar. However, because the default accordion hover background color is the same color as the sidebar background, this means that hovering over an accordion causes no distinguishable difference in color.

This pull request seeks to restore the hover effect by applying a slightly lighter gray color when hovering the editor sidebar accordion.

![Hover](https://cloud.githubusercontent.com/assets/1779930/12306224/a45eb3b0-ba06-11e5-8059-c7a93d935b42.png)

__Testing instructions:__

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Hover an accordion in the sidebar
4. Note the change in color while hovering