### PR TITLE
Themes: fix problem where large viewport is not initially filled

### DIFF
--- a/client/components/data/themes-list-fetcher/index.jsx
+++ b/client/components/data/themes-list-fetcher/index.jsx
@@ -96,8 +96,9 @@ const ThemesListFetcher = React.createClass( {
 
 		if ( options.triggeredByScroll ) {
 			onRealScroll();
-			this.props.fetchNextPage( site );
 		}
+
+		this.props.fetchNextPage( site );
 	},
 
 	render: function() {


### PR DESCRIPTION
A previous fix, #2231, was preventing subsequent fetches necessary for filling large viewports with themes.

**To Test**
1) go to http://calypso.localhost:3000/design/
2) zoom out (cmd-minus) about 4 times to give a huge viewport
3) refresh the page and check that themes fill the page, and that it is possible to scroll down and fetch more themes

@ehg: although this is simply the reversion of #2231, I can no longer reproduce the multiple-fetch bug that prompted that change:
<img width="956" alt="screen shot 2016-01-13 at 19 57 35" src="https://cloud.githubusercontent.com/assets/7767559/12306206/7dba7008-ba30-11e5-95c2-3a7984787536.png">
