### PR TITLE
Foldable Card: Add border between summary and expand button if summary is included

### DIFF
--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -55,15 +55,6 @@ module.exports = React.createClass( {
 				</p>
 				<p>
 					<FoldableCard
-						header="This is a FoldableCard with iconBorder"
-						iconBorder={ true }
-						summary={ <button className="button">Update</button> }
-						expandedSummary={ <button className="button">Update</button> }>
-						Nothing to see here. Keep walking!
-					</FoldableCard>
-				</p>
-				<p>
-					<FoldableCard
 						header={ <div><div>This is a multiline foldable card</div><div><small> with a summary component & a expanded summary component</small></div></div> }
 						summary={ <button className="button">Update</button> }
 						expandedSummary={ <button className="button">Update</button> }>

--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -55,6 +55,15 @@ module.exports = React.createClass( {
 				</p>
 				<p>
 					<FoldableCard
+						header="This is a FoldableCard with iconBorder"
+						iconBorder={ true }
+						summary={ <button className="button">Update</button> }
+						expandedSummary={ <button className="button">Update</button> }>
+						Nothing to see here. Keep walking!
+					</FoldableCard>
+				</p>
+				<p>
+					<FoldableCard
 						header={ <div><div>This is a multiline foldable card</div><div><small> with a summary component & a expanded summary component</small></div></div> }
 						summary={ <button className="button">Update</button> }
 						expandedSummary={ <button className="button">Update</button> }>

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -41,7 +41,7 @@ var FoldableCard = React.createClass( {
 			onClose: noop,
 			cardKey: '',
 			icon: 'chevron-down',
-			isExpanded: false,
+			isExpanded: false
 		};
 	},
 

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -23,7 +23,6 @@ var FoldableCard = React.createClass( {
 		expandedSummary: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] ),
 		expanded: React.PropTypes.bool,
 		icon: React.PropTypes.string,
-		iconBorder: React.PropTypes.bool,
 		onClick: React.PropTypes.func,
 		onClose: React.PropTypes.func,
 		onOpen: React.PropTypes.func,
@@ -43,7 +42,6 @@ var FoldableCard = React.createClass( {
 			cardKey: '',
 			icon: 'chevron-down',
 			isExpanded: false,
-			iconBorder: false
 		};
 	},
 
@@ -111,7 +109,7 @@ var FoldableCard = React.createClass( {
 			headerClickAction = this.props.clickableHeader ? this.getClickAction() : null,
 			headerClasses = classNames( 'foldable-card__header', {
 				'is-clickable': !! this.props.clickableHeader,
-				'has-border': !! this.props.iconBorder
+				'has-border': !! this.props.summary
 			} );
 		return (
 			<div className={ headerClasses } onClick={ headerClickAction }>

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -23,6 +23,7 @@ var FoldableCard = React.createClass( {
 		expandedSummary: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.element ] ),
 		expanded: React.PropTypes.bool,
 		icon: React.PropTypes.string,
+		iconBorder: React.PropTypes.bool,
 		onClick: React.PropTypes.func,
 		onClose: React.PropTypes.func,
 		onOpen: React.PropTypes.func,
@@ -41,7 +42,8 @@ var FoldableCard = React.createClass( {
 			onClose: noop,
 			cardKey: '',
 			icon: 'chevron-down',
-			isExpanded: false
+			isExpanded: false,
+			iconBorder: false
 		};
 	},
 
@@ -86,8 +88,13 @@ var FoldableCard = React.createClass( {
 		}
 		if ( this.props.children ) {
 			let iconSize = 24;
+			const classes = classNames( {
+				'foldable-card__action': true,
+				'foldable-card__expand': true,
+				'has-border': !! this.props.iconBorder
+			} );
 			return (
-				<button disabled={ this.props.disabled } className="foldable-card__action foldable-card__expand" onClick={ clickAction }>
+				<button disabled={ this.props.disabled } className={ classes } onClick={ clickAction }>
 					<span className="screen-reader-text">{ this.translate( 'More' ) }</span>
 					<Gridicon icon={ this.props.icon } size={ iconSize } />
 				</button>
@@ -108,7 +115,8 @@ var FoldableCard = React.createClass( {
 			expandedSummary = this.props.expandedSummary ? <span className="foldable-card__summary_expanded">{ this.props.expandedSummary } </span> : null,
 			headerClickAction = this.props.clickableHeader ? this.getClickAction() : null,
 			headerClasses = classNames( 'foldable-card__header', {
-				'is-clickable': !! this.props.clickableHeader
+				'is-clickable': !! this.props.clickableHeader,
+				'has-border': !! this.props.iconBorder
 			} );
 		return (
 			<div className={ headerClasses } onClick={ headerClickAction }>

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -88,13 +88,8 @@ var FoldableCard = React.createClass( {
 		}
 		if ( this.props.children ) {
 			let iconSize = 24;
-			const classes = classNames( {
-				'foldable-card__action': true,
-				'foldable-card__expand': true,
-				'has-border': !! this.props.iconBorder
-			} );
 			return (
-				<button disabled={ this.props.disabled } className={ classes } onClick={ clickAction }>
+				<button disabled={ this.props.disabled } className="foldable-card__action foldable-card__expand" onClick={ clickAction }>
 					<span className="screen-reader-text">{ this.translate( 'More' ) }</span>
 					<Gridicon icon={ this.props.icon } size={ iconSize } />
 				</button>

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -25,6 +25,13 @@
 		cursor: pointer;
 	}
 
+	&.has-border{
+		.foldable-card__summary,
+		.foldable-card__summary_expanded{
+			margin-right: 48px;
+		}
+	}
+
 	.foldable-card.is-compact & {
 		padding: 8px 16px;
 		min-height: 40px;
@@ -98,6 +105,10 @@ button.foldable-card__action {
 		.foldable-card.is-expanded & {
 			transform: rotate( 180deg );
 		}
+	}
+
+	&.has-border{
+		border-left: 1px $gray-light solid;
 	}
 
 	.gridicon:hover {

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -27,8 +27,12 @@
 
 	&.has-border{
 		.foldable-card__summary,
-		.foldable-card__summary_expanded{
+		.foldable-card__summary_expanded {
 			margin-right: 48px;
+		}
+
+		.foldable-card__expand {
+			border-left: 1px $gray-light solid;
 		}
 	}
 
@@ -105,10 +109,6 @@ button.foldable-card__action {
 		.foldable-card.is-expanded & {
 			transform: rotate( 180deg );
 		}
-	}
-
-	&.has-border{
-		border-left: 1px $gray-light solid;
 	}
 
 	.gridicon:hover {


### PR DESCRIPTION
During the discussions of #1477 and #1898, it's become clear that we could use a divider between the expand/collapse icon and the action button (if present) on a FoldableCard. This icon helps divide the disclosure icon from a potentially destructive action, like accidentally disabling your Twitter connection.

Instead of forcing every single instance of FoldableCard that has an action button to inherit this style, I'm adding an `iconBorder` prop to the component, the rendering of which looks like this:

<img width="723" alt="screen shot 2016-01-13 at 1 07 40 pm" src="https://cloud.githubusercontent.com/assets/1084656/12306382/ae23f06e-b9f6-11e5-9f38-7a30582c4f76.png">
<img width="720" alt="screen shot 2016-01-13 at 1 07 47 pm" src="https://cloud.githubusercontent.com/assets/1084656/12306383/ae3c7418-b9f6-11e5-8710-b12bd73ae4f3.png">

cc @mtias @kellychoffman @folletto 