### PR TITLE
Stats: Use Emojify on the individual post stats page

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -8,6 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import observe from 'lib/mixins/data-observe';
+import Emojify from 'components/emojify';
 import SummaryChart from '../stats-summary-chart';
 import PostMonths from '../stats-detail-months';
 import PostWeeks from '../stats-detail-weeks';
@@ -37,16 +38,14 @@ export default React.createClass( {
 	render() {
 		let title;
 
-		if ( this.props.postViewsList.response.post && this.props.postViewsList.response.post.post_title ) {
-			title = this.translate( 'Stats for %(posttitle)s', {
-				comment: 'Title of the individual post stats page.',
-				args: {
-					posttitle: this.props.postViewsList.response.post.post_title
-				}
-			} );
-		}
+		const post = this.props.postViewsList.response.post;
+		const postOnRecord = post && post.post_title !== null;
 
-		if ( this.props.postViewsList.isError() ) {
+		if ( postOnRecord ) {
+			if ( typeof post.post_title === 'string' && post.post_title.length ) {
+				title = <Emojify>{ post.post_title }</Emojify>;
+			}
+		} else {
 			title = this.translate( 'We don\'t have that post on record yet.' );
 		}
 


### PR DESCRIPTION
The [`Emojfiy` component](https://github.com/Automattic/wp-calypso/tree/f38bc98ab8539548cbf4431204159c3aae947fde/client/components/emojify) was removed from the post title on the post stats page in b464be8 because it wasn't working properly.

This correctly applies it to the post title only -- not the localized string `Stats for <PostTitle>`. It removes the translate call altogether since doing this sort of replacement (text to text nodes & maybe some `img` nodes) on a translated string is non-insignificant with regard to multibyte strings & RTL languages.

Translated labels should be separate from any string that needs Emojification. If we decide the `HeaderCake` needs some label aside from the post title, it should be in a separately-styled `span` or other inline containing component.

To test:
* Create (or find) a post with emoji in the title (🤘) & make note of its `post_id`
* Ensure it has some traffic (visit it while logged-out if it doesn't & wait a couple of minutes)
* Visit http://calypso.localhost:3000/stats/post/post_id_here/site_slug_here
* Make sure the the title is rendered correctly:
  * emoji are converted to twemoji `img`s on our CDN
  * re-renders are kept to a minimum, etc.
* Do the same for a post without emoji in the tile & make sure it renders correctly