### PR TITLE
i18n: Memoize the translate call

### DIFF
--- a/client/lib/mixins/i18n/index.js
+++ b/client/lib/mixins/i18n/index.js
@@ -294,8 +294,6 @@ function reRenderTranslations() {
 	i18nState.emit( 'change' );
 }
 
-var cacheHits = 0, cacheMisses = 0;
-
 // The mixin object is injected during startup
 mixin = {
 	moment: moment,
@@ -350,17 +348,9 @@ mixin = {
 
 			translation = i18nState.translations.get( optionsString );
 			if ( translation ) {
-				cacheHits++;
-				if ( cacheHits % 100 === 0 ) {
-					console.log( 'translation cache hit rate: %f (%d / %d )', cacheHits / ( cacheHits + cacheMisses ), cacheHits, cacheMisses );
-				}
 				return translation;
 			}
 		}
-
-		cacheMisses++;
-
-		console.log( 'translation cache hit rate: %f (%d / %d )', cacheHits / ( cacheHits + cacheMisses ), cacheHits, cacheMisses );
 
 		translation = getTranslationFromJed( options );
 

--- a/client/lib/mixins/i18n/index.js
+++ b/client/lib/mixins/i18n/index.js
@@ -30,7 +30,8 @@ i18nState = {
 	numberFormatSettings: {},
 	jed: undefined,
 	locale: undefined,
-	localeSlug: undefined
+	localeSlug: undefined,
+	translations: undefined,
 };
 
 // add event emitter mixin
@@ -102,6 +103,7 @@ function setLocale( locale ) {
 	i18nState.locale = locale;
 	buildJedData( locale );
 	buildMomentAndNumber( locale );
+	i18nState.translations = new Map();
 	i18nState.emit( 'change' );
 }
 
@@ -334,9 +336,15 @@ mixin = {
 	 * @return {string|React-components} translated text or an object containing React children that can be inserted into a parent component
 	 */
 	translate: function() {
-		var options, translation, sprintfArgs, errorMethod;
+		var options, translation, sprintfArgs, errorMethod, optionsString;
 
 		options = normalizeTranslateArguments( arguments );
+		optionsString = JSON.stringify( options );
+
+		translation = i18nState.translations.get( optionsString );
+		if ( translation ) {
+			return translation;
+		}
 
 		translation = getTranslationFromJed( options );
 
@@ -373,6 +381,7 @@ mixin = {
 			translation = hook( translation, options );
 		} );
 
+		i18nState.translations.set( optionsString, translation );
 		return translation;
 	},
 };

--- a/client/lib/mixins/i18n/index.js
+++ b/client/lib/mixins/i18n/index.js
@@ -361,7 +361,7 @@ mixin = {
 			sprintfArgs.unshift( translation );
 			try {
 				translation = Jed.sprintf.apply( Jed, sprintfArgs );
-			} catch( error ) {
+			} catch ( error ) {
 				if ( ! window || ! window.console ) {
 					return;
 				}

--- a/client/lib/mixins/i18n/index.js
+++ b/client/lib/mixins/i18n/index.js
@@ -387,7 +387,7 @@ mixin = {
 			translation = hook( translation, options );
 		} );
 
-		if ( cacheable && optionsString ) {
+		if ( cacheable ) {
 			i18nState.translations.set( optionsString, translation );
 		}
 		return translation;

--- a/client/lib/mixins/i18n/index.js
+++ b/client/lib/mixins/i18n/index.js
@@ -338,29 +338,28 @@ mixin = {
 	 * @return {string|React-components} translated text or an object containing React children that can be inserted into a parent component
 	 */
 	translate: function() {
-		var options, translation, sprintfArgs, errorMethod, optionsString;
+		var options, translation, sprintfArgs, errorMethod, optionsString, cacheable;
 
 		options = normalizeTranslateArguments( arguments );
 
-		try {
+		cacheable = ! options.components;
+
+		if ( cacheable ) {
 			optionsString = JSON.stringify( options );
 
 			translation = i18nState.translations.get( optionsString );
 			if ( translation ) {
 				cacheHits++;
 				if ( cacheHits % 100 === 0 ) {
-					console.log( 'translation cache hit rate: %f', cacheHits / ( cacheHits + cacheMisses ) );
+					console.log( 'translation cache hit rate: %f (%d / %d )', cacheHits / ( cacheHits + cacheMisses ), cacheHits, cacheMisses );
 				}
 				return translation;
 			}
-		} catch ( e ) {
-			// some translations end up with options that are not serializable as json
-			// this catches those and lets them on through to the normal processing
 		}
 
 		cacheMisses++;
 
-		console.log( 'translation cache hit rate: %f', cacheHits / ( cacheHits + cacheMisses ) );
+		console.log( 'translation cache hit rate: %f (%d / %d )', cacheHits / ( cacheHits + cacheMisses ), cacheHits, cacheMisses );
 
 		translation = getTranslationFromJed( options );
 
@@ -397,7 +396,7 @@ mixin = {
 			translation = hook( translation, options );
 		} );
 
-		if ( optionsString ) {
+		if ( cacheable && optionsString ) {
 			i18nState.translations.set( optionsString, translation );
 			console.log( 'translation cache: %d', i18nState.translations.size );
 		}

--- a/client/lib/mixins/i18n/index.js
+++ b/client/lib/mixins/i18n/index.js
@@ -5,7 +5,8 @@ var debug = require( 'debug' )( 'calypso:i18n' ),
 	Jed = require( 'jed' ),
 	request = require( 'superagent' ),
 	tzDetect = require( './timezone' ).timezone,
-	moment = require( 'moment-timezone' );
+	moment = require( 'moment-timezone' ),
+	LRU = require( 'lru-cache' );
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ i18nState = {
 	jed: undefined,
 	locale: undefined,
 	localeSlug: undefined,
-	translations: undefined,
+	translations: LRU( { max: 100 } ),
 };
 
 // add event emitter mixin
@@ -103,7 +104,7 @@ function setLocale( locale ) {
 	i18nState.locale = locale;
 	buildJedData( locale );
 	buildMomentAndNumber( locale );
-	i18nState.translations = new Map();
+	i18nState.translations.reset();
 	i18nState.emit( 'change' );
 }
 
@@ -398,7 +399,6 @@ mixin = {
 
 		if ( cacheable && optionsString ) {
 			i18nState.translations.set( optionsString, translation );
-			console.log( 'translation cache: %d', i18nState.translations.size );
 		}
 		return translation;
 	},

--- a/client/lib/mixins/i18n/index.js
+++ b/client/lib/mixins/i18n/index.js
@@ -291,6 +291,7 @@ function registerTranslateHook( callback ) {
  */
 function reRenderTranslations() {
 	debug( 'Re-rendering all translations due to external request' );
+	i18nState.translations.reset();
 	i18nState.emit( 'change' );
 }
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "key-mirror": "1.0.1",
     "keymaster": "1.6.2",
     "lodash": "3.10.1",
+    "lru-cache": "4.0.0",
     "lunr": "0.5.7",
     "marked": "0.3.5",
     "moment": "2.10.6",


### PR DESCRIPTION
Inspired by [investigation](https://github.com/Automattic/wp-calypso/pull/2306#issuecomment-171256970) into Theme Showcase scroll performance 

Store translations in a ~~map~~ LRU cache referenced by the options. This prevents the overhead of using the Jed parser for every call, which can be expensive in tight render loops.

The `lru-cache` dependency adds 25k to build.production.min.js on disk (<2%).

Screenshots from Chrome timeline view showing a frame during which the themes are rendered:
**Before**
<img width="647" alt="screen shot 2016-01-13 at 21 16 29" src="https://cloud.githubusercontent.com/assets/7767559/12308192/b81ea998-ba3b-11e5-8d6d-008d4c802545.png">

**After**
<img width="627" alt="screen shot 2016-01-13 at 21 12 39" src="https://cloud.githubusercontent.com/assets/7767559/12308198/c112f734-ba3b-11e5-80ac-5de4f8eb44f7.png">

Don't read too much into the overall time, since the frame times vary, but in the second shot we can see that the costly `parse` and `Jed...` calls have been eliminated.

**Problems**
* We can see from the second shot that the `translate` call is still costly. Caching the translation returned from this call, somewhere in the theme showcase code, would give better performance still
* ~~Creating the hashmap key using `JSON.stringify()` on the normalized translate options cannot cope with circular references in some options.~~

update: regardless of this PR, `translate` is not optimized by v8 for various reasons (try/catch, apply()). Can look at this later.

**To Test**
* switch user interface lang in Calypso (causes a full re-render) and check that the language changes
