### PR TITLE
Ad Tracking: Use standard events for ad-tracking

### DIFF
--- a/client/analytics/ad-tracking.js
+++ b/client/analytics/ad-tracking.js
@@ -1,19 +1,19 @@
 /**
  * External dependencies
  */
-const async = require( 'async' ),
-	noop = require( 'lodash/utility/noop' ),
-	map = require( 'lodash/collection/map' ),
-	some = require( 'lodash/collection/some' ),
-	debug = require( 'debug' )( 'calypso:ad-tracking' );
+import async from 'async';
+import noop from 'lodash/utility/noop';
+import map from 'lodash/collection/map';
+import some from 'lodash/collection/some';
+import debugFactory from 'debug';
+const debug = debugFactory( 'calypso:ad-tracking' );
 
 /**
  * Internal dependencies
  */
-const loadScript = require( 'lib/load-script' ),
-	config = require( 'config' ),
-	isPremium = require( 'lib/products-values' ).isPremium,
-	isBusiness = require( 'lib/products-values' ).isBusiness;
+import loadScript from 'lib/load-script';
+import config from 'config';
+import { isBusiness, isPremium } from 'lib/products-values';
 
 /**
  * Module variables

--- a/client/analytics/ad-tracking.js
+++ b/client/analytics/ad-tracking.js
@@ -24,34 +24,31 @@ let hasLoadedScripts = false,
 /**
  * Constants
  */
-const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbds.js',
+const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevents.js',
 	GOOGLE_TRACKING_SCRIPT_URL = 'https://www.googleadservices.com/pagead/conversion_async.js',
 	BING_TRACKING_SCRIPT_URL = 'https://bat.bing.com/bat.js',
 	GOOGLE_CONVERSION_ID = config( 'google_adwords_conversion_id' ),
 	TRACKING_IDS = {
+		facebookInit: '823166884443641',
+
 		freeSignup: {
-			facebook: '6024523283021',
 			google: 'd-fNCIe7m1wQ1uXz_AM'
 		},
 
 		premiumTrial: {
-			facebook: '6028365445821',
 			google: '_q3ECJ--m1wQ1uXz_AM'
 		},
 
 		premiumSignup: {
-			facebook: '6028365447021',
 			google: 'UMSeCIyYmFwQ1uXz_AM',
 			bing: '4074038'
 		},
 
 		businessTrial: {
-			facebook: '6028365448821',
 			google: 'm9zRCNO8m1wQ1uXz_AM'
 		},
 
 		businessSignup: {
-			facebook: '6028365461821',
 			google: 'JxKBCKK-m1wQ1uXz_AM',
 			bing: '4074039'
 		},
@@ -62,12 +59,35 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbds.js
 /**
  * Globals
  */
-if ( ! window._fbq ) {
-	window._fbq = []; // Facebook global
+if ( ! window.fbq ) {
+	setUpFacebookGlobal();
 }
 
 if ( ! window.uetq ) {
 	window.uetq = []; // Bing global
+}
+
+/**
+ * This sets up the globals that the Facebook event library expects.
+ * More info here: https://www.facebook.com/business/help/952192354843755
+ */
+function setUpFacebookGlobal() {
+	const facebookEvents = window.fbq = function() {
+		if ( facebookEvents.callMethod ) {
+			facebookEvents.callMethod.apply( facebookEvents, arguments );
+		} else {
+			facebookEvents.queue.push( arguments );
+		}
+	};
+
+	if ( ! window._fbq ) {
+		window._fbq = facebookEvents;
+	}
+
+	facebookEvents.push = facebookEvents;
+	facebookEvents.loaded = true;
+	facebookEvents.version = '2.0';
+	facebookEvents.queue = [];
 }
 
 function loadTrackingScripts( callback ) {
@@ -86,8 +106,7 @@ function loadTrackingScripts( callback ) {
 			hasLoadedScripts = true;
 
 			// update Facebook's tracking global
-			window._fbq.loaded = true;
-			window._fbq.push( [ 'addPixelId', TRACKING_IDS.retargeting ] );
+			window.fbq( 'init', TRACKING_IDS.facebookInit );
 
 			if ( typeof callback === 'function' ) {
 				callback();
@@ -106,7 +125,7 @@ function retarget() {
 	if ( ! retargetingInitialized ) {
 		debug( 'Retargeting initialized' );
 
-		window._fbq.push( [ 'track', 'PixelInitialized', {} ] );
+		window.fbq( 'track', 'PageView' );
 		retargetingInitialized = true;
 	}
 }
@@ -116,7 +135,7 @@ function recordPurchase( product ) {
 
 	if ( ! hasLoadedScripts ) {
 		return loadTrackingScripts( function() {
-			recordPurchase( type );
+			recordPurchase( product );
 		} );
 	}
 
@@ -136,31 +155,30 @@ function recordPurchase( product ) {
 		}
 	}
 
-	if ( ! type ) {
-		return;
-	}
-
 	debug( 'Recorded purchase', type );
 
 	// record the purchase w/ Facebook
-	window._fbq.push( [
+	window.fbq(
 		'track',
-		TRACKING_IDS[ type ].facebook,
+		'Purchase',
 		{
-			value: '0.00',
-			currency: 'USD'
+			currency: product.currency,
+			product_slug: product.product_slug,
+			value: product.cost
 		}
-	] );
+	);
 
-	// record the purchase w/ Google
-	window.google_trackConversion( {
-		google_conversion_id: GOOGLE_CONVERSION_ID,
-		google_conversion_label: TRACKING_IDS[ type ].google,
-		google_remarketing_only: false
-	} );
+	// record the purchase w/ Google if a tracking ID is present
+	if ( TRACKING_IDS[ type ] && TRACKING_IDS[ type ].google ) {
+		window.google_trackConversion( {
+			google_conversion_id: GOOGLE_CONVERSION_ID,
+			google_conversion_label: TRACKING_IDS[ type ].google,
+			google_remarketing_only: false
+		} );
+	}
 
 	// record the purchase w/ Bing if a tracking ID is present
-	if ( TRACKING_IDS[ type ].bing && typeof UET !== 'undefined' ) {
+	if ( TRACKING_IDS[ type ] && TRACKING_IDS[ type ].bing && typeof UET !== 'undefined' ) {
 		window.uetq = new UET( { // eslint-disable-line no-undef
 			ti: TRACKING_IDS[ type ].bing,
 			o: window.uetq

--- a/client/analytics/ad-tracking.js
+++ b/client/analytics/ad-tracking.js
@@ -130,13 +130,28 @@ function retarget() {
 	}
 }
 
+function recordAddToCart( cartItem ) {
+	if ( ! hasLoadedScripts ) {
+		return loadTrackingScripts( recordAddToCart.bind( null, cartItem ) );
+	}
+
+	debug( 'Recorded that this item was added to the cart', cartItem );
+
+	window.fbq(
+		'track',
+		'AddToCart',
+		{
+			product_slug: cartItem.product_slug,
+			free_trial: Boolean( cartItem.free_trial )
+		}
+	)
+}
+
 function recordPurchase( product ) {
 	let type;
 
 	if ( ! hasLoadedScripts ) {
-		return loadTrackingScripts( function() {
-			recordPurchase( product );
-		} );
+		return loadTrackingScripts( recordPurchase.bind( null, product ) );
 	}
 
 	if ( isPremium( product ) ) {
@@ -197,6 +212,12 @@ module.exports = {
 		}
 
 		nextFunction();
+	},
+
+	recordAddToCart: function( cartItem ) {
+		if ( config.isEnabled( 'ad-tracking' ) ) {
+			recordAddToCart( cartItem );
+		}
 	},
 
 	recordPurchases: function( products ) {

--- a/client/analytics/ad-tracking.js
+++ b/client/analytics/ad-tracking.js
@@ -3,7 +3,6 @@
  */
 import async from 'async';
 import noop from 'lodash/utility/noop';
-import map from 'lodash/collection/map';
 import some from 'lodash/collection/some';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:ad-tracking' );
@@ -131,6 +130,10 @@ function retarget() {
 }
 
 function recordAddToCart( cartItem ) {
+	if ( ! config.isEnabled( 'ad-tracking' ) ) {
+		return;
+	}
+
 	if ( ! hasStartedFetchingScripts ) {
 		return loadTrackingScripts( recordAddToCart.bind( null, cartItem ) );
 	}
@@ -149,6 +152,10 @@ function recordAddToCart( cartItem ) {
 
 function recordPurchase( product ) {
 	let type;
+
+	if ( ! config.isEnabled( 'ad-tracking' ) ) {
+		return;
+	}
 
 	if ( ! hasStartedFetchingScripts ) {
 		return loadTrackingScripts( recordPurchase.bind( null, product ) );
@@ -214,15 +221,6 @@ module.exports = {
 		nextFunction();
 	},
 
-	recordAddToCart: function( cartItem ) {
-		if ( config.isEnabled( 'ad-tracking' ) ) {
-			recordAddToCart( cartItem );
-		}
-	},
-
-	recordPurchases: function( products ) {
-		if ( config.isEnabled( 'ad-tracking' ) ) {
-			map( products, recordPurchase );
-		}
-	}
+	recordAddToCart,
+	recordPurchase
 };

--- a/client/analytics/ad-tracking.js
+++ b/client/analytics/ad-tracking.js
@@ -18,7 +18,7 @@ import { isBusiness, isPremium } from 'lib/products-values';
 /**
  * Module variables
  */
-let hasLoadedScripts = false,
+let hasStartedFetchingScripts = false,
 	retargetingInitialized = false;
 
 /**
@@ -91,6 +91,8 @@ function setUpFacebookGlobal() {
 }
 
 function loadTrackingScripts( callback ) {
+	hasStartedFetchingScripts = true;
+
 	async.parallel( [
 		function( onComplete ) {
 			loadScript.loadScript( FACEBOOK_TRACKING_SCRIPT_URL, onComplete );
@@ -103,8 +105,6 @@ function loadTrackingScripts( callback ) {
 		}
 	], function( errors ) {
 		if ( ! some( errors ) ) {
-			hasLoadedScripts = true;
-
 			// update Facebook's tracking global
 			window.fbq( 'init', TRACKING_IDS.facebookInit );
 
@@ -118,7 +118,7 @@ function loadTrackingScripts( callback ) {
 }
 
 function retarget() {
-	if ( ! hasLoadedScripts ) {
+	if ( ! hasStartedFetchingScripts ) {
 		return loadTrackingScripts( retarget );
 	}
 
@@ -131,7 +131,7 @@ function retarget() {
 }
 
 function recordAddToCart( cartItem ) {
-	if ( ! hasLoadedScripts ) {
+	if ( ! hasStartedFetchingScripts ) {
 		return loadTrackingScripts( recordAddToCart.bind( null, cartItem ) );
 	}
 
@@ -150,7 +150,7 @@ function recordAddToCart( cartItem ) {
 function recordPurchase( product ) {
 	let type;
 
-	if ( ! hasLoadedScripts ) {
+	if ( ! hasStartedFetchingScripts ) {
 		return loadTrackingScripts( recordPurchase.bind( null, product ) );
 	}
 

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -6,6 +6,7 @@ import assign from 'lodash/object/assign';
 /**
  * Internal dependencies
  */
+import { recordAddToCart } from 'analytics/ad-tracking';
 import { action as ActionTypes } from '../constants';
 import Dispatcher from 'dispatcher';
 import { cartItems } from 'lib/cart-values';
@@ -44,6 +45,8 @@ function addItem( cartItem ) {
 			context: 'calypstore'
 		} ),
 		newCartItem = assign( {}, cartItem, { extra } );
+
+	recordAddToCart( cartItem );
 
 	Dispatcher.handleViewAction( {
 		type: ActionTypes.CART_ITEM_ADD,

--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -122,7 +122,7 @@ var TransactionStepsMixin = {
 						success: false
 					} );
 				} else if ( step.data ) {
-					adTracking.recordPurchases( cartValue.products );
+					cartValue.products.map( adTracking.recordPurchase );
 
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_success', {
 						coupon_code: cartValue.coupon,


### PR DESCRIPTION
Fixes #2356.

This PR makes two significant changes to the `ad-tracking` module:

- Switches from using Facebook's 'Custom Audience' tracking pixel to use standard events.
- Updates the current events to use the new standard events syntax, adds an `AddToCart` event.

**Testing**
We need to assert that the three Facebook events are working properly here.

Before testing any of these events, enable the `ad-tracking` feature in `config/development.json` and restart the Calypso server.

*PageView*
This event is triggered when a user visits a store-related route (like `/plans/:site`), and is then triggered on each subsequent route change.
- Visit `/plans/:site`.
- Assert that you see a request for an image with the query string `&ev=PageView` in the network pane of the developer tools ([screenshot](https://cloudup.com/cwyK5kcOozb)).

*AddToCart*
- Add any item (a trial, plan, domain) to the cart.
- Assert that you see a request for an image with the query string `&ev=AddToCart` in the network pane of the developer tools, and that the query string contains parameters for `product_slug` and `free_trial` ([screenshot](https://cloudup.com/c4ECvuqACGX)).

*Purchase*
- Go through the checkout with any number of items.
- Assert that you see a request for an image with the query string `&ev=Purchase` in the network pane of the developer tools, and that the query string contains parameters for `product_slug`, `currency`, and `value` ([screenshot](https://cloudup.com/c1hiIWs-12L)).