### PR TITLE
Site Settings: fix security settings redirect glitch

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -170,7 +170,6 @@ module.exports = {
 		redirectMap = {
 			account: '/me/account',
 			password: '/me/security',
-			security: '/me/security',
 			'public-profile': '/me/public-profile',
 			notifications: '/me/notifications',
 			disbursements: '/me/public-profile',


### PR DESCRIPTION
This fixes #48, where an unexpected redirect occurs in site settings from `/settings/security/blogname` to `/me/security` when switching to `All My Sites'. 

## Testing Instructions
1. Navigate to calypso.localhost:3000/settings
2. Select a site if prompted (a jetpack site is preferrable)
3. Click on the security tab, or navigate to /settings/security/blogname
4. Click on 'Switch Site'
5. Select 'All My Sites'
Expected: Page redirects to '/settings/security'

Navigating directly to `/settings/security` should no longer redirect to `/me/security`

cc @hoverduck @rralian