### PR TITLE
Export: Handle Jetpack sites with a message and link to the site's wp-admin

### DIFF
--- a/client/my-sites/site-settings/section-export.jsx
+++ b/client/my-sites/site-settings/section-export.jsx
@@ -7,10 +7,25 @@ import { Provider } from 'react-redux';
 /**
  * Internal dependencies
  */
+import EmptyContent from 'components/empty-content';
 import ExporterContainer from 'my-sites/exporter';
+import i18n from 'lib/mixins/i18n';
 
 export default class SiteSettingsExport extends Component {
 	render() {
+		if ( this.props.site.jetpack ) {
+			return (
+				<EmptyContent
+					illustration="/calypso/images/drake/drake-jetpack.svg"
+					title={ i18n.translate( 'Want to export your site?' ) }
+					line={ i18n.translate( `Visit your site's wp-admin for all your import and export needs.` ) }
+					action={ i18n.translate( 'Export %(siteTitle)s', { args: { siteTitle: this.props.site.title } } ) }
+					actionURL={ this.props.site.options.admin_url + 'export.php' }
+					actionTarget="_blank"
+				/>
+			);
+		}
+
 		return (
 			<Provider store={ this.props.store }>
 				<ExporterContainer site={ this.props.site } />

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -204,7 +204,7 @@ export default React.createClass( {
 				<EmptyContent
 					illustration="/calypso/images/drake/drake-jetpack.svg"
 					title={ this.translate( 'Want to import into your site?' ) }
-					line={ this.translate( 'Visit your site\'s wp-admin for all your import and export needs.' ) }
+					line={ this.translate( `Visit your site's wp-admin for all your import and export needs.` ) }
 					action={ this.translate( 'Import into %(siteTitle)s', { args: { siteTitle: this.props.site.title } } ) }
 					actionURL={ this.props.site.options.admin_url + 'import.php' }
 					actionTarget="_blank"


### PR DESCRIPTION
Jetpack sites currently cannot be exported via Calypso. Normally, clicking the **Export** tab while navigating a Jetpack site in Calypso takes the user to the Jetpack site's wp-admin export page.

However, if the user is already on the export tab and switches to a Jetpack site, the exporter is still displayed. This PR instead displays a message with a link to the Jetpack site's wp-admin export page.

Fixes #77

![screen shot 2016-01-14 at 1 47 28 pm](https://cloud.githubusercontent.com/assets/416133/12315363/ce22ceec-bac5-11e5-9c16-88b7c9db3241.png)

#### How to test
1. Switch to a wordpress.com site
2. Go to http://calypso.localhost:3000/settings/export
3. Switch to a Jetpack site
4. The message shown in the screenshot above should be displayed