### PR TITLE
Global Notices: new design and cleanup

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -36,6 +36,7 @@
 @import 'components/foldable-card/style';
 @import 'components/follow-button/style';
 @import 'components/gauge/style';
+@import 'components/global-notices/style';
 @import 'components/gravatar/style';
 @import 'components/gridicon/style';
 @import 'components/social-logo/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -91,6 +91,7 @@ $z-layers: (
 		'.accessible-focus .select-dropdown.is-open .select-dropdown__container': 170,
 		'.popover.editor-visibility__popover': 179,
 		'.feature-example__gradient': 179,
+		'.global-notices': 179,
 		'.notices-list.is-pinned': 180,
 		'.notices-list.is-pinned .notice': 180,
 		'.masterbar': 180,

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
 import debugModule from 'debug';
 
 /**
@@ -30,48 +29,18 @@ const NoticesList = React.createClass( {
 		notices: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.array
-		] ),
-		forcePinned: React.PropTypes.bool
-	},
-
-	getInitialState() {
-		return { pinned: this.props.forcePinned };
+		] )
 	},
 
 	getDefaultProps() {
 		return {
 			id: 'overlay-notices',
-			notices: Object.freeze( [] ),
-			forcePinned: false
+			notices: Object.freeze( [] )
 		};
 	},
 
 	componentWillMount() {
-		debug( 'Mounting Notices React component.' );
-	},
-
-	componentDidMount() {
-		if ( ! this.props.forcePinned ) {
-			window.addEventListener( 'scroll', this.updatePinnedState );
-		}
-	},
-
-	componentDidUpdate( prevProps ) {
-		if ( this.props.forcePinned && ! prevProps.forcePinned ) {
-			window.removeEventListener( 'scroll', this.updatePinnedState );
-			this.setState( { pinned: true } );
-		} else if ( ! this.props.forcePinned && prevProps.forcePinned ) {
-			window.addEventListener( 'scroll', this.updatePinnedState );
-			this.updatePinnedState();
-		}
-	},
-
-	componentWillUnmount() {
-		window.removeEventListener( 'scroll', this.updatePinnedState );
-	},
-
-	updatePinnedState() {
-		this.setState( { pinned: window.scrollY > 0 } );
+		debug( 'Mounting Global Notices React component.' );
 	},
 
 	removeNotice( notice ) {
@@ -123,14 +92,9 @@ const NoticesList = React.createClass( {
 			return null;
 		}
 		return (
-			<div>
-				<div id={ this.props.id } className={ classNames( 'notices-list', { 'is-pinned': this.state.pinned } ) }>
-					<DeleteSiteNotices />
-					{ noticesList }
-				</div>
-				{ this.state.pinned && ! this.props.forcePinned
-					? <div className="notices-list__whitespace" />
-					: null }
+			<div id={ this.props.id } className="global-notices">
+				<DeleteSiteNotices />
+				{ noticesList }
 			</div>
 		);
 	}

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -1,7 +1,7 @@
 .global-notices {
 	overflow: hidden;
 
-	z-index: 180;
+	z-index: z-index( 'root', '.global-notices' );
 	position: fixed;
 		top: auto;
 		right: 0;
@@ -9,19 +9,21 @@
 		left: 0;
 
 	@include breakpoint( ">660px" ) {
-		top: 47px + 16px;
-		right: 16px;
-		bottom: auto;
-		left: auto;
+			top: 47px + 16px;
+			right: 16px;
+			bottom: auto;
+			left: auto;
+		max-width: calc( 100% - 32px );
 	}
 
 	@include breakpoint( ">960px" ) {
-		top: 47px + 24px;
-		right: 24px;
+			top: 47px + 24px;
+			right: 24px;
+		max-width: calc( 100% - 48px );
 	}
 
 	@include breakpoint( ">1040" ) {
-		right: 48px;
+			right: 48px;
 	}
 }
 
@@ -30,9 +32,9 @@
 	margin-bottom: 0;
 
 	@include breakpoint( ">660px" ) {
+		float: right;
 		border-radius: 20px;
 		display: inline-flex;
-		z-index: 180;
 		margin-bottom: 24px;
 	}
 }
@@ -49,6 +51,9 @@
 
 	@include breakpoint( ">660px" ) {
 		padding: 9px 13px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 }
 

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -8,13 +8,17 @@
 		left: 0;
 
 	@include breakpoint( ">660px" ) {
-		top: 47px + 24px;
-		right: 24px;
+		top: 47px + 16px;
+		right: 16px;
 		left: auto;
 	}
 
 	@include breakpoint( ">960px" ) {
-		top: 47px + 32px;
+		top: 47px + 24px;
+		right: 24px;
+	}
+
+	@include breakpoint( ">1040" ) {
 		right: 48px;
 	}
 }
@@ -30,21 +34,17 @@
 }
 
 .global-notices .notice__icon {
-	padding: 8px 0 8px 8px;
-
-	@include breakpoint( ">660px" ) {
-		padding: 8px 0 8px 16px;
-	}
+	padding: 8px 0 8px 16px;
 }
 
 .global-notices .notice__text {
-	padding: 9px 13px;
+	padding: 9px 16px;
+
+	@include breakpoint( ">660px" ) {
+		padding: 9px 13px;
+	}
 }
 
 .global-notices .notice__dismiss {
-	padding: 8px 8px 8px 16px;
-
-	@include breakpoint( ">660px" ) {
-		padding: 8px 16px;
-	}
+	padding: 8px 16px;
 }

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -3,13 +3,15 @@
 
 	z-index: 180;
 	position: fixed;
-		top: 47px;
+		top: auto;
 		right: 0;
+		bottom: 0;
 		left: 0;
 
 	@include breakpoint( ">660px" ) {
 		top: 47px + 16px;
 		right: 16px;
+		bottom: auto;
 		left: auto;
 	}
 
@@ -25,20 +27,25 @@
 
 .global-notices .notice {
 	display: flex;
+	margin-bottom: 0;
 
 	@include breakpoint( ">660px" ) {
 		border-radius: 20px;
 		display: inline-flex;
 		z-index: 180;
+		margin-bottom: 24px;
 	}
 }
 
 .global-notices .notice__icon {
-	padding: 8px 0 8px 16px;
+
+	@include breakpoint( ">660px" ) {
+		padding: 8px 0 8px 16px;
+	}
 }
 
 .global-notices .notice__text {
-	padding: 9px 16px;
+	padding-left: 16px;
 
 	@include breakpoint( ">660px" ) {
 		padding: 9px 13px;
@@ -46,5 +53,8 @@
 }
 
 .global-notices .notice__dismiss {
-	padding: 8px 16px;
+
+	@include breakpoint( ">660px" ) {
+		padding: 8px 16px;
+	}
 }

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -3,19 +3,48 @@
 
 	z-index: 180;
 	position: fixed;
-		top: 47px + 32px;
-		right: 48px;
+		top: 47px;
+		right: 0;
+		left: 0;
 
-	@include breakpoint( "<960px" ) {
+	@include breakpoint( ">660px" ) {
+		top: 47px + 24px;
+		right: 24px;
+		left: auto;
 	}
 
-	@include breakpoint( "<660px" ) {
-		top: 16px;
+	@include breakpoint( ">960px" ) {
+		top: 47px + 32px;
+		right: 48px;
 	}
 }
 
 .global-notices .notice {
-	border-radius: 50px;
-	display: inline-flex;
-	z-index: 180;
+	display: flex;
+
+	@include breakpoint( ">660px" ) {
+		border-radius: 20px;
+		display: inline-flex;
+		z-index: 180;
+	}
+}
+
+.global-notices .notice__icon {
+	padding: 8px 0 8px 8px;
+
+	@include breakpoint( ">660px" ) {
+		padding: 8px 0 8px 16px;
+	}
+}
+
+.global-notices .notice__text {
+	padding: 9px 13px;
+}
+
+.global-notices .notice__dismiss {
+	padding: 8px 8px 8px 16px;
+
+	@include breakpoint( ">660px" ) {
+		padding: 8px 16px;
+	}
 }

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -1,0 +1,21 @@
+.global-notices {
+	overflow: hidden;
+
+	z-index: 180;
+	position: fixed;
+		top: 47px + 32px;
+		right: 48px;
+
+	@include breakpoint( "<960px" ) {
+	}
+
+	@include breakpoint( "<660px" ) {
+		top: 16px;
+	}
+}
+
+.global-notices .notice {
+	border-radius: 50px;
+	display: inline-flex;
+	z-index: 180;
+}

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -127,7 +127,7 @@
 // "X" for dismissing a notice
 .notice__dismiss {
 	display: flex;
-	padding: 9px 16px;
+	padding: 11px 16px;
 	cursor: pointer;
 	color: $gray;
 

--- a/client/my-sites/site-settings/form-base.js
+++ b/client/my-sites/site-settings/form-base.js
@@ -158,7 +158,7 @@ module.exports = {
 				}
 				this.setState( { submittingForm: false } );
 			} else {
-				notices.success( this.translate( 'Settings saved successfully!' ) );
+				notices.success( this.translate( 'Settings saved!' ) );
 				this.markSaved();
 				//for dirtyFields, see lib/mixins/dirty-linked-state
 				this.setState( { submittingForm: false, dirtyFields: [] } );


### PR DESCRIPTION
Picking up the work for better global notices.

Reference:
<img width="929" alt="screen shot 2016-01-28 at 3 47 15 pm" src="https://cloud.githubusercontent.com/assets/437258/12658340/766dab60-c5d6-11e5-9c09-6c147719d230.png">

<img width="376" alt="screen shot 2016-01-28 at 3 48 13 pm" src="https://cloud.githubusercontent.com/assets/437258/12658359/9b3dfa08-c5d6-11e5-962a-30a37d2cb6f2.png">


cc @rickybanister feel free to pick it up from here and tweak the styles until we are comfortable.