### PR TITLE
Free Trials: Add min-width to free trial hub progress bar

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-progress/style.scss
+++ b/client/my-sites/plans/plan-overview/plan-progress/style.scss
@@ -27,6 +27,7 @@
 
 .plan-progress__bar {
 	flex: 1 0 6em;
+	min-width: 250px;
 }
 
 .plan-progress__time-until-expiry {


### PR DESCRIPTION
To prevent the progress bar from displaying too narrow, I added a min-width of `250px`.

**Before:**
![image](https://cloud.githubusercontent.com/assets/12596797/12328833/3fd49914-baab-11e5-9ba0-af076dc92a6b.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/12596797/12328846/50fb9044-baab-11e5-8733-4bd6111c062f.png)

cc @breezyskies 