### PR TITLE
Free trials: Add a new library to fix widows

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -13,6 +13,7 @@ var analytics = require( 'analytics' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	PlanList = require( 'components/plans/plan-list' ),
 	PlanOverview = require( './plan-overview' ),
+	preventWidows = require( 'lib/formatting' ).preventWidows,
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	UpgradesNavigation = require( 'my-sites/upgrades/navigation' ),
 	Gridicon = require( 'components/gridicon' ),
@@ -83,21 +84,15 @@ var Plans = React.createClass( {
 		premiumPlan = find( this.props.sitePlans.data, isPremium );
 
 		if ( businessPlan.canStartTrial && premiumPlan.canStartTrial ) {
-			message = this.translate( 'Try WordPress.com Premium or Business free for 14 days, no credit card{{nbsp/}}required', {
-				components: { nbsp: <span>&nbsp;</span> }
-			} );
+			message = this.translate( 'Try WordPress.com Premium or Business free for 14 days, no credit card required' );
 		}
 
 		if ( businessPlan.canStartTrial && ! premiumPlan.canStartTrial ) {
-			message = this.translate( 'Try WordPress.com Business free for 14 days, no credit card{{nbsp/}}required', {
-				components: { nbsp: <span>&nbsp;</span> }
-			} );
+			message = this.translate( 'Try WordPress.com Business free for 14 days, no credit card required' );
 		}
 
 		if ( ! businessPlan.canStartTrial && premiumPlan.canStartTrial ) {
-			message = this.translate( 'Try WordPress.com Premium free for 14 days, no credit card{{nbsp/}}required', {
-				components: { nbsp: <span>&nbsp;</span> }
-			} );
+			message = this.translate( 'Try WordPress.com Premium free for 14 days, no credit card required' );
 		}
 
 		if ( ! businessPlan.canStartTrial && ! premiumPlan.canStartTrial ) {
@@ -107,7 +102,7 @@ var Plans = React.createClass( {
 		return (
 			<div className="plans__trial-copy">
 				<span className="plans__trial-copy-text">
-					{ message }
+					{ preventWidows( message, 2 ) }
 				</span>
 			</div>
 		);

--- a/client/signup/step-header/index.jsx
+++ b/client/signup/step-header/index.jsx
@@ -3,14 +3,19 @@
  */
 var React = require( 'react' );
 
+/**
+ * Internal dependencies
+ */
+var preventWidows = require( 'lib/formatting' ).preventWidows;
+
 module.exports = React.createClass( {
 	displayName: 'StepHeader',
 
 	render: function() {
 		return (
 			<header className="step-header">
-				<h1 className="step-header__title">{ this.props.headerText }</h1>
-				<p className="step-header__subtitle">{ this.props.subHeaderText }</p>
+				<h1 className="step-header__title">{ preventWidows( this.props.headerText, 2 ) }</h1>
+				<p className="step-header__subtitle">{ preventWidows( this.props.subHeaderText, 2 ) }</p>
 			</header>
 		);
 	}

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -93,8 +93,8 @@ module.exports = React.createClass( {
 		return (
 			<StepWrapper
 				fallbackHeaderText={ this.translate( 'Choose a theme.' ) }
-				fallbackSubHeaderText={ this.translate( 'No need to overthink it. You can always switch to a different theme\u00a0later.' ) }
-				subHeaderText={ this.translate( 'Choose a theme. You can always switch to a different theme\u00a0later.' ) }
+				fallbackSubHeaderText={ this.translate( 'No need to overthink it. You can always switch to a different theme later.' ) }
+				subHeaderText={ this.translate( 'Choose a theme. You can always switch to a different theme later.' ) }
 				stepContent={ this.renderThemesList() }
 				defaultDependencies={ defaultDependencies }
 				{ ...this.props } />


### PR DESCRIPTION
Widows are words that live on a new line by themselves. We have two different approaches to fixing this problem, neither of which are compatible with our approach to `ii8n`. 

This pull request introduces a new library to insert these `&nbsp;` in JavaScript.

I looked into solving this with CSS, or using an existing node module but I didn't find a good solution with either approach, so I built this to work specifically with React.

This is what it should look like:
<img width="461" alt="screen shot 2016-01-14 at 16 35 33" src="https://cloud.githubusercontent.com/assets/275961/12330412/e51ad204-badc-11e5-9320-938fef8522e5.png">
<img width="428" alt="screen shot 2016-01-14 at 16 35 18" src="https://cloud.githubusercontent.com/assets/275961/12330413/e51dda30-badc-11e5-913f-9acd52a8bb3b.png">

Fixes #2304

#### Testing instructions

1. Run `git checkout fix/2304-fix-widows` and start your server
2. Open http://calypso.dev:3000/start/themes
3. Make the screen smaller and make sure that the header and subheader don`t have widows.
2. Open http://calypso.dev:3000/plans/:site for a site that is offered a free trial (but hasn't started one)
3. Make the screen smaller and make sure that the header text doesn't have widows.

#### Reviews

- [x] Code
- [x] Product