### PR TITLE
Free Trials: Improve responsive display of inline notices in free trial hub

### DIFF
--- a/client/my-sites/plans/plan-overview/style.scss
+++ b/client/my-sites/plans/plan-overview/style.scss
@@ -32,4 +32,12 @@
 			display: none;
 		}
 	}
+	.plan-feature {
+		flex-direction: row;
+		flex-wrap: wrap;
+
+		.plan-feature__heading {
+			margin-right: 10px;
+		}
+	}
 }

--- a/client/my-sites/plans/plan-overview/style.scss
+++ b/client/my-sites/plans/plan-overview/style.scss
@@ -32,6 +32,7 @@
 			display: none;
 		}
 	}
+	
 	.plan-feature {
 		flex-direction: row;
 		flex-wrap: wrap;


### PR DESCRIPTION
The inline notices that display in the features section of the free trial hub were displaying full width below 480px which was unnecessary and distracting to the rest of the page. To improve I changed them to always be auto width, letting flexbox handle the wrapping when/if necessary.

**Before**:
![image](https://cloud.githubusercontent.com/assets/12596797/12334316/6e0a6ffe-bac7-11e5-9c93-99b234d41e58.png)

**After**:
![image](https://cloud.githubusercontent.com/assets/12596797/12334262/1e1d0db2-bac7-11e5-8bbb-465102f48254.png)

cc @breezyskies 