### PR TITLE
Stats: Remove Other Recent Stats link from Period pages

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,12 +1,4 @@
 module.exports = {
-	statsDefaultFilter: {
-		datestamp: '20150601',
-		variations: {
-			day: 90,
-			insights: 10
-		},
-		defaultVariation: 'day'
-	},
 	multiDomainRegistrationV1: {
 		datestamp: '20200721',
 		variations: {

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -66,13 +66,7 @@ function sectionify( path ) {
 }
 
 function getStatsDefaultSitePage( slug ) {
-	var path;
-
-	if ( config.isEnabled( 'manage/stats/insights' ) && 'insights' === abtest( 'statsDefaultFilter' ) ) {
-		path = '/stats/insights/';
-	} else {
-		path = '/stats/day/';
-	}
+	var path = '/stats/insights/';
 
 	if ( slug ) {
 		return path + slug;

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -2,9 +2,7 @@
  * Internal Dependencies
  */
 var trailingslashit = require( './trailingslashit' ),
-	untrailingslashit = require( './untrailingslashit' ),
-	abtest = require( 'lib/abtest' ).abtest,
-	config = require( 'config' );
+	untrailingslashit = require( './untrailingslashit' );
 
 /**
  * Module variables

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -94,12 +94,6 @@ module.exports = React.createClass( {
 		analytics.ga.recordEvent( 'Stats', 'Clicked Visit Old Stats Page Button', oldStatsLocation );
 	},
 
-	trackOtherStats: function() {
-		analytics.mc.bumpStat( 'calypso_stats_other_recent', 'click' );
-		analytics.ga.recordEvent( 'Stats', 'Clicked Other Recent Stats Link' );
-		analytics.tracks.recordEvent( 'calypso_stats_other_recent_click' );
-	},
-
 	barClick: function( bar ) {
 		analytics.ga.recordEvent( 'Stats', 'Clicked Chart Bar' );
 		page.redirect( this.props.path + '?startDate=' + bar.data.period );
@@ -175,70 +169,6 @@ module.exports = React.createClass( {
 					date={ queryDate }
 					beforeNavigate={ this.updateScrollPosition } />;
 			}
-		}
-
-		if ( config.isEnabled( 'manage/stats/insights' ) ) {
-			nonPeriodicModules = (
-				<div className="stats-nonperiodic has-no-recent">
-					<h3 className="stats-section-title">
-						{ this.translate( 'Other Recent Stats', {
-							context: 'Header on the Stats page',
-							comment: 'This header is important as stats below it do not conform to the time period selection that affects all panels above it.'
-						} ) }
-					</h3>
-					<p>
-						{ this.translate( 'Looking for your {{recent}}Other Recent Stats{{/recent}}? We\'ve moved them to the {{insights}}Insights{{/insights}} page. ', {
-							components: {
-								recent: <a href={ '/stats/insights/' + site.slug } onClick={ this.trackOtherStats } />,
-								insights: <a href={ '/stats/insights/' + site.slug } onClick={ this.trackOtherStats } />
-							},
-							context: 'Stats: Text at the bottom of the period pages pointing toward the insights page'
-						} ) }
-					</p>
-				</div>
-			);
-		} else {
-			nonPeriodicModules = (
-				<div className="stats-nonperiodic has-recent">
-					<h3 className="stats-section-title">
-						{ this.translate( 'Other Recent Stats', {
-							context: 'Header on the Stats page',
-							comment: 'This header is important as stats below it do not conform to the time period selection that affects all panels above it.'
-						} ) }
-					</h3>
-					<div className="module-list">
-						<div className="module-column">
-							<Comments
-								path={ 'comments' }
-								site={ site }
-								commentsList={ this.props.commentsList }
-								period={ this.props.period }
-								date={ queryDate }
-								followList={ this.props.followList }
-								commentFollowersList={ this.props.commentFollowersList } />
-							{ tagsList }
-						</div>
-						<div className="module-column">
-							<Followers
-								path={ 'followers' }
-								site={ site }
-								wpcomFollowersList={ this.props.wpcomFollowersList }
-								emailFollowersList={ this.props.emailFollowersList }
-								period={ this.props.period }
-								date={ queryDate }
-								followList={ this.props.followList } />
-							<StatsModule
-								path={ 'publicize' }
-								moduleStrings={ moduleStrings.publicize }
-								site={ site }
-								dataList={ this.props.publicizeList }
-								period={ this.props.period }
-								date={ queryDate } />
-						</div>
-					</div>
-					<div className="old-stats-link">{ oldStatsMessage }</div>
-				</div>
-			);
 		}
 
 		return (

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -44,7 +44,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,
 		"manage/stats": true,
-		"manage/stats/insights": true,
 		"manage/themes-jetpack": true,
 		"manage/themes": true,
 		"me/account": true,

--- a/config/development.json
+++ b/config/development.json
@@ -61,7 +61,6 @@
 		"manage/option_sync_non_public_post_stati": true,
 
 		"manage/stats": true,
-		"manage/stats/insights": true,
 
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -22,7 +22,6 @@
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/stats": true,
-		"manage/stats/insights": true,
 		"manage/jetpack": true,
 		"manage/security": true,
 		"manage/import": false,

--- a/config/production.json
+++ b/config/production.json
@@ -38,7 +38,6 @@
 		"settings/security/monitor": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/stats": true,
-		"manage/stats/insights": true,
 		"me/billing-history": true,
 		"me/credit-cards": true,
 		"me/find-friends": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,7 +41,6 @@
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/posts": true,
 		"manage/stats": true,
-		"manage/stats/insights": true,
 		"manage/site-settings/analytics" : true,
 		"manage/site-settings/delete-site": true,
 		"me/billing-history": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -22,7 +22,6 @@
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/stats": true,
-		"manage/stats/insights": true,
 		"manage/jetpack": true,
 		"manage/security": true,
 		"manage/option_sync_non_public_post_stati": true,


### PR DESCRIPTION
This PR removes the "Other Recent Stats" link from the time-based pages (Days/Months/Weeks/Years) on Stats.

![screenshot 2016-01-14 12 05 26](https://cloud.githubusercontent.com/assets/4924246/12336078/510a2788-bab7-11e5-96aa-48981327e969.png)

We moved non time-based modules (Comments, Tags & Categories, Followers and Publicize) to Insights when we launched it. Since these modules were originally on the time-based pages, we added links to them from these pages to direct users. Since this was supposed to be temporary and we've launched Insights a while back, it's about time to remove this link.

Hat tip @alternatekev 

/cc @timmyc 