### PR TITLE
Stats: Updates to stats-comments component.

### DIFF
--- a/client/my-sites/stats/stats-comments/comment-tab.jsx
+++ b/client/my-sites/stats/stats-comments/comment-tab.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import observe from 'lib/mixins/data-observe';
+import StatsList from '../stats-list';
+import StatsListLegend from '../stats-list/legend';
+
+export default React.createClass( {
+	displayName: 'StatsCommentTab',
+
+	mixins: [ observe( 'dataList' ) ],
+
+	propTypes: {
+		dataList: PropTypes.object,
+		dataKey: PropTypes.string,
+		followList: PropTypes.object,
+		name: PropTypes.string,
+		value: PropTypes.string,
+		label: PropTypes.string,
+		isActive: PropTypes.bool
+	},
+
+	render() {
+		const { dataList, dataKey, followList, isActive, name, value, label } = this.props;
+		let statsList;
+
+		if ( dataList.response.data && dataList.response.data[ dataKey ] ) {
+			statsList = <StatsList
+								moduleName={ name }
+								data={ dataList.response.data[ dataKey ] }
+								followList={ followList } />;
+		}
+
+		const classes = classNames( 'stats-comments__tab-content', { 'is-active': isActive } );
+
+		return (
+			<div className={ classes }>
+				<StatsListLegend value={ value } label={ label } />
+				{ statsList }
+			</div>
+		);
+	}
+ } );

--- a/client/my-sites/stats/stats-comments/comment-tab.jsx
+++ b/client/my-sites/stats/stats-comments/comment-tab.jsx
@@ -32,9 +32,9 @@ export default React.createClass( {
 
 		if ( dataList.response.data && dataList.response.data[ dataKey ] ) {
 			statsList = <StatsList
-								moduleName={ name }
-								data={ dataList.response.data[ dataKey ] }
-								followList={ followList } />;
+							moduleName={ name }
+							data={ dataList.response.data[ dataKey ] }
+							followList={ followList } />;
 		}
 
 		const classes = classNames( 'stats-comments__tab-content', { 'is-active': isActive } );
@@ -46,4 +46,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
- } );
+} );

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -1,49 +1,58 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	debug = require( 'debug' )( 'calypso:stats:module-comments' );
+import React, { PropTypes } from 'react'
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var toggle = require( '../mixin-toggle' ),
-	SelectDropdown = require( 'components/select-dropdown' ),
-	StatsList = require( '../stats-list' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	ErrorPanel = require( '../stats-error' ),
-	skeleton = require( '../mixin-skeleton' ),
-	analytics = require( 'analytics' ),
-	Card = require( 'components/card' ),
-	Gridicon = require( 'components/gridicon' );
+import observe from 'lib/mixins/data-observe';
+import analytics from 'analytics';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+import CommentTab from './comment-tab';
+import StatsErrorPanel from '../stats-error';
+import StatsModuleHeader from '../stats-module/header';
+import StatsModuleContent from '../stats-module/content-text';
+import StatsModuleSelectDropdown from '../stats-module/select-dropdown';
 
-module.exports = React.createClass( {
-	displayName: 'StatModuleComments',
+export default React.createClass( {
+	displayName: 'StatsComments',
 
-	mixins: [ toggle('Comments'), skeleton('data'), observe( 'commentsList', 'commentFollowersList' ) ],
+	propTypes: {
+		site: PropTypes.object,
+		commentsList: PropTypes.object,
+		commentFollowersList: PropTypes.object
+	},
 
-	data: function( nextProps ) {
+	mixins: [ observe( 'commentsList', 'commentFollowersList' ) ],
+
+	data( nextProps ) {
 		var props = nextProps || this.props;
 		return props.commentsList.response.data.authors;
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			activeFilter: 'top-authors',
-			noData: this.props.commentsList.isEmpty( 'authors' )
+			noData: this.props.commentsList.isEmpty( 'authors' ),
+			showInfo: false,
+			showModule: true
 		};
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
-		this.setState( { noData: nextProps.commentsList.isEmpty( 'authors' ) } );
+	componentWillReceiveProps( nextProps ) {
+		this.setState( {
+			noData: nextProps.commentsList.isEmpty( 'authors' )
+		} );
 	},
 
-	changeFilter: function( selection ) {
-		var gaEvent,
-			filter = selection.value;
+	changeFilter( selection ) {
+		let gaEvent;
+		const filter = selection.value;
 
-		if( filter !== this.state.activeFilter ) {
+		if ( filter !== this.state.activeFilter ) {
 			switch ( filter ) {
 				case 'top-authors':
 					gaEvent = 'Clicked By Authors Comments Toggle';
@@ -63,175 +72,111 @@ module.exports = React.createClass( {
 		}
 	},
 
-	filterSelect: function() {
-		var selectFilter,
-			options= [
-				{ value: 'top-authors', label: this.translate( 'Comments By Authors' ) },
-				{ value: 'top-content', label: this.translate( 'Comments By Posts & Pages' ) }
-			];
-
-		selectFilter = (
-			<div className="select-dropdown__wrapper">
-				<SelectDropdown options={ options } onSelect={ this.changeFilter } />
-			</div>
-		);
-
-		return selectFilter;
+	updateHeaderState( options ) {
+		this.setState( options );
 	},
 
-	render: function() {
-		var data = this.data(),
-			commentsList = this.props.commentsList,
-			hasError = this.props.commentsList.isError(),
-			noData = this.props.commentsList.isEmpty( 'authors' ),
-			infoIcon = this.state.showInfo ? 'info' : 'info-outline',
-			classes,
-			topCommenters,
-			mostCommented,
-			summary,
-			moduleHeaderTitle,
-			moduleToggle,
-			commentFollowers,
-			commentFollowURL,
-			activeTab;
+	renderCommentFollowers() {
+		const { commentFollowersList, site } = this.props;
 
-			activeTab = 'tab-' + this.state.activeFilter;
+		if ( ! site || ! commentFollowersList.response.data || ! commentFollowersList.response.data.total ) {
+			return null;
+		}
 
-			classes = [
-				'stats-module',
-				activeTab,
-				{
-					'is-expanded': this.state.showModule,
-					'is-loading': ! data,
-					'is-showing-info': this.state.showInfo,
-					'has-no-data': noData,
-					'is-showing-error': hasError || noData
-				}
-			];
-
-			debug( 'Rendering comments with data', classes );
-			debug( 'data is', this.props.commentsList.data );
-
-			if ( commentsList.response.data && commentsList.response.data.authors ) {
-				topCommenters = <StatsList moduleName='Top Commenters' data={ commentsList.response.data.authors } followList={ this.props.followList } />;
-			}
-
-			if ( commentsList.response.data && commentsList.response.data.posts ) {
-				mostCommented = <StatsList moduleName='Most Commented' data={ commentsList.response.data.posts } />;
-			}
-
-			if ( data && data.monthly_comments ) {
-				summary = (
-					<div className="module-content-text">
-						<p>{ this.translate( 'Average comments per month:' ) } { this.numberFormat( data.monthly_comments ) }</p>
-					</div>
-				);
-			}
-
-			if ( !this.props.summary ) {
-				moduleToggle = (
-					<li className="module-header-action toggle-services">
-						<a
-							href="#"
-							className="module-header-action-link"
-							aria-label={
-								this.translate(
-									'Expand or collapse panel',
-									{ context: 'Stats panel action' }
-								)
-							}
-							title={
-								this.translate(
-									'Expand or collapse panel',
-									{ context: 'Stats panel action' }
-								)
-							}
-							onClick={
-								this.toggleModule
-							}
-						>
-							<Gridicon icon="chevron-down" />
-						</a>
-					</li>
-				);
-			}
-
-			if ( this.props.commentFollowersList.response.data && this.props.commentFollowersList.response.data.total ) {
-				commentFollowURL = '/stats/follows/comment/' + this.props.site.slug;
-				commentFollowers = (
-					<div className="module-content-text module-content-text-stat">
-						<p>
-							{ this.translate( 'Total posts with comment followers:' ) } <a href={ commentFollowURL }>{ this.numberFormat( this.props.commentFollowersList.response.data.total ) }</a>
-						</p>
-					</div>
-				);
-			}
-
-			moduleHeaderTitle = (
-				<h4 className="module-header-title">{ this.translate( 'Comments' ) }</h4>
-			);
+		const commentFollowURL = '/stats/follows/comment/' + site.slug;
 
 		return (
-			<Card className={ classNames.apply( null, classes ) }>
-				<div>
-					<div className="module-header">
-						{ moduleHeaderTitle }
-						<ul className="module-header-actions">
-							<li className="module-header-action toggle-info">
-								<a href="#" className="module-header-action-link" aria-label={ this.translate( 'Show or hide panel information', { context: 'Stats panel action' } ) } title={ this.translate( 'Show or hide panel information', { context: 'Stats panel action' } ) } onClick={ this.toggleInfo } >
-									<Gridicon icon={ infoIcon } />
-								</a>
-							</li>
-							{ moduleToggle }
+			<StatsModuleContent className="module-content-text-stat">
+				<p>{ this.translate( 'Total posts with comment followers:' ) } <a href={ commentFollowURL }>{ this.numberFormat( commentFollowersList.response.data.total ) }</a></p>
+			</StatsModuleContent>
+		);
+	},
+
+	renderSummary() {
+		const data = this.data();
+
+		if ( ! data || ! data.monthly_comments ) {
+			return null
+		}
+
+		return (
+			<StatsModuleContent>
+				<p>{ this.translate( 'Average comments per month:' ) } { this.numberFormat( data.monthly_comments ) }</p>
+			</StatsModuleContent>
+		);
+	},
+
+	render() {
+		const { activeFilter, showInfo, showModule } = this.state;
+		const { commentsList, followList, path, site } = this.props;
+		const hasError = commentsList.isError();
+		const noData = commentsList.isEmpty( 'authors' );
+		const data = this.data();
+		const selectOptions = [
+			{ value: 'top-authors', label: this.translate( 'Comments By Authors' ) },
+			{ value: 'top-content', label: this.translate( 'Comments By Posts & Pages' ) }
+		];
+
+		const classes = classNames(
+			'stats-module',
+			{
+				'is-expanded': this.state.showModule,
+				'is-loading': ! data,
+				'is-showing-info': this.state.showInfo,
+				'has-no-data': noData,
+				'is-showing-error': hasError || noData
+			}
+		);
+
+		return (
+			<Card className={ classes }>
+				<StatsModuleHeader
+					siteId={ site ? site.ID : null }
+					path={ path }
+					title={ this.translate( 'Comments' ) }
+					showInfo={ showInfo }
+					showModule={ showModule }
+					onActionClick={ this.updateHeaderState } />
+
+				<div className="module-content">
+					<StatsModuleContent className="module-content-text-info">
+						<p>{ this.translate( 'If you allow comments on your site, track your top commenters and discover what content sparks the liveliest conversations, based on the most recent 1,000 comments.' ) }</p>
+						<ul className="documentation">
+							<li><a href="http://en.support.wordpress.com/enable-disable-comments/" target="_blank"><Gridicon icon="help-outline" /> { this.translate( 'How do I turn on/off comments?' ) }</a></li>
+							<li><a href="http://en.support.wordpress.com/category/comments/" target="_blank"><Gridicon icon="folder" /> { this.translate( 'About Comments' ) }</a></li>
 						</ul>
-					</div>
+					</StatsModuleContent>
 
-					<div className="module-content">
-						<div className="module-content-text module-content-text-info">
-							<p>{ this.translate( 'If you allow comments on your site, track your top commenters and discover what content sparks the liveliest conversations, based on the most recent 1,000 comments.' ) }</p>
-							<ul className="documentation">
-								<li><a href="http://en.support.wordpress.com/enable-disable-comments/" target="_blank"><Gridicon icon="help-outline" /> { this.translate( 'How do I turn on/off comments?' ) }</a></li>
-								<li><a href="http://en.support.wordpress.com/category/comments/" target="_blank"><Gridicon icon="folder" /> { this.translate( 'About Comments' ) }</a></li>
-							</ul>
-						</div>
+					{ ( noData && ! hasError ) ? <StatsErrorPanel className="is-empty-message" message={ this.translate( 'No comments posted' ) } /> : null }
 
-						{ ( noData && ! hasError ) ? <ErrorPanel className='is-empty-message' message={ this.translate( 'No comments posted' ) } /> : null }
+					<StatsModuleSelectDropdown
+						options={ selectOptions }
+						onSelect={ this.changeFilter } />
 
-						{ this.filterSelect() }
+					{ this.renderCommentFollowers() }
 
-						{ commentFollowers }
+					{ hasError ? <StatsErrorPanel className="network-error" /> : null }
 
-						{ hasError ? <ErrorPanel className='network-error' /> : null }
+					<CommentTab
+						name="Top Commenters"
+						value={ this.translate( 'Comments' ) }
+						label={ this.translate( 'Author' ) }
+						dataList={ commentsList }
+						dataKey="authors"
+						followList={ followList }
+						isActive={ 'top-authors' === activeFilter } />
 
-						<div className="tab-content top-authors stats-async-metabox-wrapper">
-							<ul className="module-content-list module-content-list-legend">
-								<li className="module-content-list-item">
-									<span className="module-content-list-item-wrapper">
-										<span className="module-content-list-item-right">
-											<span className="module-content-list-item-value">{ this.translate( 'Comments' ) }</span>
-										</span>
-										<span className="module-content-list-item-label">{ this.translate( 'Author' ) }</span>
-									</span>
-								</li>
-							</ul>
-							{ topCommenters }
-						</div>
-						<div className="tab-content top-content stats-async-metabox-wrapper">
-							<ul className="module-content-list module-content-list-legend">
-								<li className="module-content-list-item">
-									<span className="module-content-list-item-wrapper">
-										<span className="module-content-list-item-right">
-											<span className="module-content-list-item-value">{ this.translate( 'Comments' ) }</span>
-										</span>
-										<span className="module-content-list-item-label">{ this.translate( 'Title' ) }</span>
-									</span>
-								</li>
-							</ul>
-							{ mostCommented }
-						</div>
-						{ summary }
-						<div className="module-placeholder is-void"></div>
-					</div>
+					<CommentTab
+						name="Most Commented"
+						value={ this.translate( 'Comments' ) }
+						label={ this.translate( 'Title' ) }
+						dataList={ commentsList }
+						dataKey="posts"
+						followList={ followList }
+						isActive={ 'top-content' === activeFilter } />
+
+					{ this.renderSummary }
+					<div className="module-placeholder is-void"></div>
 				</div>
 			</Card>
 		);

--- a/client/my-sites/stats/stats-comments/style.scss
+++ b/client/my-sites/stats/stats-comments/style.scss
@@ -1,7 +1,9 @@
-// Tab Content (for comments module)
-
-.tab-content {
+.stats-comments__tab-content {
 	display: none;
+
+	&.is-active {
+		display: block;
+	}
 }
 
 .tab-email-followers .tab-content.email-followers,

--- a/client/my-sites/stats/stats-list/legend.jsx
+++ b/client/my-sites/stats/stats-list/legend.jsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+
+/**
+ * Internal dependencies
+ */
+
+export default React.createClass( {
+	displayName: 'StatsListLegend',
+
+	mixins: [ PureRenderMixin ],
+
+	propTypes: {
+		value: PropTypes.string,
+		label: PropTypes.string
+	},
+
+	render() {
+		const { value, label } = this.props;
+		return (
+			<ul className="module-content-list module-content-list-legend">
+				<li className="module-content-list-item">
+					<span className="module-content-list-item-wrapper">
+						<span className="module-content-list-item-right">
+							<span className="module-content-list-item-value">{ value }</span>
+						</span>
+						<span className="module-content-list-item-label">{ label }</span>
+					</span>
+				</li>
+			</ul>
+		);
+	}
+ } );

--- a/client/my-sites/stats/stats-list/legend.jsx
+++ b/client/my-sites/stats/stats-list/legend.jsx
@@ -33,4 +33,4 @@ export default React.createClass( {
 			</ul>
 		);
 	}
- } );
+} );

--- a/client/my-sites/stats/stats-module/content-text.jsx
+++ b/client/my-sites/stats/stats-module/content-text.jsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+export default React.createClass( {
+	displayName: 'StatsModuleContentText',
+
+	propTypes: {
+		className: PropTypes.string
+	},
+	render() {
+		return (
+			<div className={ classNames( 'module-content-text', this.props.className ) }>
+				{ this.props.children }
+			</div>
+		);
+	}
+ } );

--- a/client/my-sites/stats/stats-module/content-text.jsx
+++ b/client/my-sites/stats/stats-module/content-text.jsx
@@ -17,4 +17,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
- } );
+} );

--- a/client/my-sites/stats/stats-module/header.jsx
+++ b/client/my-sites/stats/stats-module/header.jsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import analytics from 'analytics';
+import titlecase from 'to-title-case';
+
+export default React.createClass( {
+	displayName: 'StatsModuleHeader',
+
+	propTypes: {
+		siteId: PropTypes.number,
+		path: PropTypes.string,
+		title: PropTypes.string,
+		showInfo: PropTypes.bool,
+		showModule: PropTypes.bool,
+		isCollapsed: PropTypes.bool,
+		showCollapse: PropTypes.bool,
+		onActionClick: PropTypes.func.isRequired
+	},
+
+	getDefaultProps() {
+		return {
+			showCollapse: true,
+			showModule: true
+		}
+	},
+
+	toggleInfo: function( event ) {
+		event.stopPropagation();
+		event.preventDefault();
+		const { path, onActionClick, showInfo } = this.props;
+		const gaEvent = showInfo ? 'Closed' : 'Opened';
+
+		if ( path ) {
+			analytics.ga.recordEvent( 'Stats', gaEvent + ' More Information Panel', titlecase( path ) );
+		}
+
+		onActionClick( {
+			showInfo: ! showInfo
+		} );
+	},
+
+	toggleModule: function( event ) {
+		event.preventDefault();
+		const { path, onActionClick, showModule } = this.props;		
+		const gaEvent = showModule ? 'Collapsed' : 'Expanded';
+
+		if ( path ) {
+			analytics.ga.recordEvent( 'Stats', gaEvent + ' Module', titlecase( path ) );
+		}
+		
+		onActionClick( {
+			showModule: ! showModule
+		} );
+	},
+
+	renderChevron() {
+		return (
+			<li className="module-header-action toggle-services">
+				<a
+					href="#"
+					className="module-header-action-link"
+					aria-label={
+						this.translate(
+							'Expand or collapse panel',
+							{ context: 'Stats panel action' }
+						)
+					}
+					title={
+						this.translate(
+							'Expand or collapse panel',
+							{ context: 'Stats panel action' }
+						)
+					}
+					onClick={
+						this.toggleModule
+					}
+				>
+					<Gridicon icon="chevron-down" />
+				</a>
+			</li>
+		);
+	},
+
+	render() {
+		const { showCollapse, showInfo, title } = this.props;
+		const infoIcon = showInfo ? 'info' : 'info-outline';
+
+		return (
+			<div className="module-header">
+				<h4 className="module-header-title">{ title }</h4>
+				<ul className="module-header-actions">
+					<li className="module-header-action toggle-info">
+						<a href="#"
+							className="module-header-action-link"
+							aria-label={ this.translate( 'Show or hide panel information', { context: 'Stats panel action' } ) }
+							title={ this.translate( 'Show or hide panel information', { context: 'Stats panel action' } ) }
+							onClick={ this.toggleInfo }
+						>
+							<Gridicon icon={ infoIcon } />
+						</a>
+					</li>
+					{ showCollapse ? this.renderChevron() : null }
+				</ul>
+			</div>
+		);
+	}
+ } );

--- a/client/my-sites/stats/stats-module/header.jsx
+++ b/client/my-sites/stats/stats-module/header.jsx
@@ -112,4 +112,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
- } );
+} );

--- a/client/my-sites/stats/stats-module/header.jsx
+++ b/client/my-sites/stats/stats-module/header.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -49,13 +48,13 @@ export default React.createClass( {
 
 	toggleModule: function( event ) {
 		event.preventDefault();
-		const { path, onActionClick, showModule } = this.props;		
+		const { path, onActionClick, showModule } = this.props;
 		const gaEvent = showModule ? 'Collapsed' : 'Expanded';
 
 		if ( path ) {
 			analytics.ga.recordEvent( 'Stats', gaEvent + ' Module', titlecase( path ) );
 		}
-		
+
 		onActionClick( {
 			showModule: ! showModule
 		} );

--- a/client/my-sites/stats/stats-module/select-dropdown.jsx
+++ b/client/my-sites/stats/stats-module/select-dropdown.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SelectDropdown from 'components/select-dropdown';
+
+export default React.createClass( {
+	displayName: 'StatsModuleSelectDropdown',
+
+	propTypes: {
+		options: PropTypes.array,
+		onSelect: PropTypes.func
+	},
+
+	getDefaultProps() {
+		return {
+			onSelect: () => {}
+		}
+	},
+
+	render() {
+		const { onSelect, options } = this.props;
+
+		return (
+			<div className="stats-module__select-dropdown-wrapper">
+				<SelectDropdown options={ options } onSelect={ onSelect } />
+			</div>
+		);
+	}
+ } );

--- a/client/my-sites/stats/stats-module/select-dropdown.jsx
+++ b/client/my-sites/stats/stats-module/select-dropdown.jsx
@@ -31,4 +31,4 @@ export default React.createClass( {
 			</div>
 		);
 	}
- } );
+} );

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -1,3 +1,17 @@
+// Select Dropdown
+.stats-module__select-dropdown-wrapper {
+	margin: 1em 20px;
+
+	.select-dropdown__container {
+		position: relative;
+	}
+
+	.stats-module.is-loading &,
+	.stats-module.has-no-data & {
+		display: none;
+	}
+}
+
 .card.stats-module {
 	padding: 0;
 }

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -18,20 +18,6 @@
 	margin-left: 4px;
 }
 
-// Filter Select
-.select-dropdown__wrapper {
-	margin: 1em 20px;
-
-	.select-dropdown__container {
-		position: relative;
-	}
-
-	.stats-module.is-loading &,
-	.stats-module.has-no-data & {
-		display: none;
-	}
-}
-
 // Welcome Stats message
 // -- extends .welcome-message /assets/stylesheets/shared/welcome.scss
 


### PR DESCRIPTION
Another branch working on stats maintenance.  This branch primarily is a refactor of the `stats-comments` component which builds the comments module seen on the Insights page.  During the refactor I took the liberty to create some basic components out of markup that is repeated often throughout stats.

The goal here being to reduce code duplication, but it also adheres to current best practices, and makes it easier to apply styling updates.  Some information about each one is below.

### Discussion
Part of me feels I might have gotten too component happy in this branch, but I also believe the final refactor of the `stats-comment` component makes it much easier to read.  Also consolidating all of the duplicate markup throughout stats into simple/reusable components will make executing on-going maintenance and changes easier.

### To Test
- Open a site insights page
- Validate the comments module looks/functions the same
- Click on the info icon - ensure it still toggles the info panel
- Click on the chevron to test collapsing/expanding the module
- Switch between Comment Authors and Top Posts using the select dropdown

### stats-module/header.jsx
<img width="361" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12337965/0bb6f9bc-bac2-11e5-8bbe-1620ad97390f.png">

This component aims to consolidate all of the markup and logic used to build the header portion of a stats module.

Additionally this component incorporates the logic implemented in `mixin-toggle.jsx` that controls the collapsing of the component, and the info bubble status.  The big change here is the removal of persisting the module collapse state in `localStorage`.  In a future PR I would like to explore using the api-backed preferences module if this feature is still desired.

### stats/stats-module/content-text.jsx
<img width="355" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12338164/3490d0d2-bac3-11e5-91df-cfcfa9368cf1.png">

A very basic component that is used to display random chunks of text throughout stats.

### stats-module/select-dropdown.jsx
<img width="367" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12338243/993ecaac-bac3-11e5-9094-9875a68b0925.png">

The `<SelectDropdown>` component is used as a filter operator in three different stats components - in each case a div is wrapping the dropdown and applying some custom styling.  Again a simple component that consolidates this logic into one place.

### stats-list/legend.jsx
<img width="327" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12338095/b9be81e2-bac2-11e5-800a-d4a711c06cd9.png">

This component consolidates the markup that builds the first row - or legend - at the top of the stats list.