### PR TITLE
Themes: Refactor `themes-selection`

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -5,7 +5,6 @@ var React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' ),
 	noop = require( 'lodash/utility/noop' ),
-	pick = require( 'lodash/object/pick' ),
 	isEmpty = require( 'lodash/lang/isEmpty' );
 
 /**
@@ -22,18 +21,24 @@ var Theme = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	propTypes: {
-		// Theme ID (theme-slug)
-		id: React.PropTypes.string.isRequired,
-		// Theme name
-		name: React.PropTypes.string.isRequired,
-		// Theme screenshot URL
-		screenshot: React.PropTypes.string,
-		// Theme price (pre-formatted string) -- empty string indicates free theme
-		price: React.PropTypes.string,
-		// If true, the user has 'purchased' the theme
-		purchased: React.PropTypes.bool,
-		// If true, highlight this theme as active
-		active: React.PropTypes.bool,
+		theme: React.PropTypes.shape( {
+			// Theme ID (theme-slug)
+			id: React.PropTypes.string.isRequired,
+			// Theme name
+			name: React.PropTypes.string.isRequired,
+			// Theme screenshot URL
+			screenshot: React.PropTypes.string,
+			// Theme price (pre-formatted string) -- empty string indicates free theme
+			price: React.PropTypes.string,
+			// If true, the user has 'purchased' the theme
+			purchased: React.PropTypes.bool,
+			// If true, highlight this theme as active
+			active: React.PropTypes.bool,
+			author: React.PropTypes.string,
+			author_uri: React.PropTypes.string,
+			demo_uri: React.PropTypes.string,
+			stylesheet: React.PropTypes.string
+		} ),
 		// If true, render a placeholder
 		isPlaceholder: React.PropTypes.bool,
 		// URL the screenshot link points to
@@ -46,7 +51,9 @@ var Theme = React.createClass( {
 		buttonContents: React.PropTypes.objectOf(
 			React.PropTypes.shape( {
 				label: React.PropTypes.string,
+				header: React.PropTypes.string,
 				action: React.PropTypes.func,
+				getUrl: React.PropTypes.func
 			} )
 		),
 		// Index of theme in results list
@@ -65,8 +72,7 @@ var Theme = React.createClass( {
 	},
 
 	onScreenshotClick: function() {
-		const theme = [ 'author', 'author_uri', 'demo_uri', 'id', 'name', 'screenshot', 'stylesheet' ];
-		this.props.onScreenshotClick( pick( this.props, theme ), this.props.index );
+		this.props.onScreenshotClick( this.props.theme, this.props.index );
 	},
 
 	renderPlaceholder: function() {
@@ -78,24 +84,12 @@ var Theme = React.createClass( {
 	},
 
 	renderHover: function() {
-		var actionLabel = this.translate( 'Preview', {
-			comment: 'appears on hovering a single theme thumbnail, opens the theme demo site preview'
-		} );
-
-		if ( this.props.active ) {
-			actionLabel = this.translate( 'Customize', {
-				comment: 'appears on hovering the active single theme thumbnail, opens the customizer'
-			} );
-		} else {
-			actionLabel = this.props.actionLabel || actionLabel;
-		}
-
 		if ( this.props.screenshotClickUrl || this.props.onScreenshotClick ) {
 			return (
 				<a className="theme__active-focus"
 					onClick={ this.onScreenshotClick }>
 					<span>
-						{ actionLabel }
+						{ this.props.actionLabel }
 					</span>
 				</a>
 			);
@@ -103,8 +97,15 @@ var Theme = React.createClass( {
 	},
 
 	render: function() {
+		const {
+			name,
+			active,
+			price,
+			purchased,
+			screenshot
+		} = this.props.theme;
 		const themeClass = classNames( 'theme', {
-			'is-active': this.props.active,
+			'is-active': active,
 			'is-actionable': !! ( this.props.screenshotClickUrl || this.props.onScreenshotClick )
 		} );
 
@@ -121,9 +122,9 @@ var Theme = React.createClass( {
 				<div className="theme__content">
 					{ this.renderHover() }
 					<a href={ this.props.screenshotClickUrl }>
-						{ this.props.screenshot
+						{ screenshot
 							? <img className="theme__img"
-								src={ this.props.screenshot + '?w=' + screenshotWidth }
+								src={ screenshot + '?w=' + screenshotWidth }
 								onClick={ this.onScreenshotClick }
 								id={ screenshotID }/>
 							: <div className="theme__no-screenshot" >
@@ -132,25 +133,23 @@ var Theme = React.createClass( {
 						}
 					</a>
 					<div className="theme__info" >
-						<h2>{ this.props.name }</h2>
-						{ this.props.active &&
+						<h2>{ name }</h2>
+						{ active &&
 							<span className="theme__active-label">{ this.translate( 'Active', {
 								context: 'singular noun, the currently active theme'
 							} ) }</span>
 						}
-						{ this.props.price && ! this.props.purchased &&
-							<span className="price">{ this.props.price }</span>
+						{ price && ! purchased &&
+							<span className="price">{ price }</span>
 						}
-						{ this.props.purchased && ! this.props.active &&
+						{ purchased && ! active &&
 							<span className="price">{ this.translate( 'Purchased' ) }</span>
 						}
-						{ ! isEmpty( this.props.buttonContents ) ? <ThemeMoreButton id={ this.props.id }
+						{ ! isEmpty( this.props.buttonContents ) ? <ThemeMoreButton
 							index={ this.props.index }
+							theme={ this.props.theme }
 							onClick={ this.props.onMoreButtonClick }
-							price={ this.props.price }
-							purchased={ this.props.purchased }
-							options={ this.props.buttonContents }
-							active={ this.props.active } /> : null }
+							options={ this.props.buttonContents } /> : null }
 					</div>
 				</div>
 			</Card>

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -20,15 +20,17 @@ var PopoverMenu = require( 'components/popover/menu' ),
  */
 var ThemeMoreButton = React.createClass( {
 	propTypes: {
-		// Theme ID (theme-slug)
-		id: React.PropTypes.string.isRequired,
-		// Index of theme in results list, if any
+		// See Theme component propTypes
+		theme: React.PropTypes.object,
+		// Index of theme in results list
 		index: React.PropTypes.number,
 		// Options to populate the popover menu with
 		options: React.PropTypes.objectOf(
 			React.PropTypes.shape( {
 				label: React.PropTypes.string,
+				header: React.PropTypes.string,
 				action: React.PropTypes.func,
+				getUrl: React.PropTypes.func
 			} )
 		).isRequired,
 		active: React.PropTypes.bool
@@ -42,12 +44,12 @@ var ThemeMoreButton = React.createClass( {
 
 	togglePopover: function() {
 		this.setState( { showPopover: ! this.state.showPopover } );
-		! this.state.showPopover && this.props.onClick( this.props.id, this.props.index );
+		! this.state.showPopover && this.props.onClick( this.props.theme.id, this.props.index );
 	},
 
 	closePopover: function( action ) {
 		this.setState( { showPopover: false } );
-		isFunction( action ) && action();
+		isFunction( action ) && action( this.props.theme );
 	},
 
 	focus: function( event ) {
@@ -57,7 +59,7 @@ var ThemeMoreButton = React.createClass( {
 	render: function() {
 		var classes = classNames(
 			'theme__more-button',
-			{ 'is-active': this.props.active },
+			{ 'is-active': this.props.theme.active },
 			{ 'is-open': this.state.showPopover }
 		);
 
@@ -74,19 +76,20 @@ var ThemeMoreButton = React.createClass( {
 
 					{ map( this.props.options, function( option, key ) {
 						if ( option.separator ) {
-							return ( <hr key={ 'separator-' + key } className="popover__hr" /> );
+							return ( <hr key={ key } className="popover__hr" /> );
 						}
-						if ( option.url ) {
+						if ( option.getUrl ) {
+							const url = option.getUrl( this.props.theme );
 							return (
 								<a className="theme__more-button-menu-item popover__menu-item"
 									onMouseOver={ this.focus }
 									key={ option.label }
-									href={ option.url }
-									target={ ( isOutsideCalypso( option.url ) &&
+									href={ url }
+									target={ ( isOutsideCalypso( url ) &&
 										// We don't want to open a new tab for the signup flow
 										// TODO: Remove this hack once we can just hand over
 										// to Calypso's signup flow with a theme selected.
-										option.url !== getSignupUrl( { id: this.props.id } ) )
+										url !== getSignupUrl( this.props.theme ) )
 										? '_blank' : null }>
 									{ option.label }
 								</a>

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -41,10 +41,11 @@ describe( 'Theme', function() {
 
 	beforeEach( function() {
 		this.props = {
-			id: 'atheme',
-			name: 'Theme name',
-			screenshot: '/theme/screenshot.png',
-			isSelected: true,
+			theme: {
+				id: 'atheme',
+				name: 'Theme name',
+				screenshot: '/theme/screenshot.png',
+			},
 			buttonContents: { dummyAction: { label: 'Dummy action', action: sinon.spy() } } // TODO: test if called when clicked
 		};
 	} );
@@ -101,7 +102,7 @@ describe( 'Theme', function() {
 
 		context( 'with empty buttonContents', function() {
 			beforeEach( function() {
-				this.props.buttonContents = [];
+				this.props.buttonContents = {};
 
 				this.theme = ReactDom.render(
 					React.createElement( this.Theme, this.props ),
@@ -122,7 +123,7 @@ describe( 'Theme', function() {
 	context( 'when isPlaceholder is set to true', function() {
 		beforeEach( function() {
 			this.theme = ReactDom.render(
-				React.createElement( this.Theme, { id: 'placeholder-1', name: 'Loading', isPlaceholder: true } ),
+				React.createElement( this.Theme, { theme: { id: 'placeholder-1', name: 'Loading' }, isPlaceholder: true } ),
 				this.container
 			);
 
@@ -137,7 +138,7 @@ describe( 'Theme', function() {
 
 	context( 'when the theme has a price', function() {
 		beforeEach( function() {
-			this.props.price = '$50';
+			this.props.theme.price = '$50';
 			this.theme = ReactDom.render(
 				React.createElement( this.Theme, this.props ),
 				this.container

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -28,6 +28,7 @@ var ThemesList = React.createClass( {
 		getButtonOptions: React.PropTypes.func,
 		onScreenshotClick: React.PropTypes.func.isRequired,
 		onMoreButtonClick: React.PropTypes.func,
+		getActionLabel: React.PropTypes.func
 	},
 
 	fetchNextPage: function( options ) {
@@ -42,6 +43,9 @@ var ThemesList = React.createClass( {
 			optionsGenerator: function() {
 				return [];
 			},
+			getActionLabel: function() {
+				return '';
+			}
 		};
 	},
 
@@ -57,13 +61,14 @@ var ThemesList = React.createClass( {
 			screenshotClickUrl={ this.props.getScreenshotUrl && this.props.getScreenshotUrl( theme ) }
 			onScreenshotClick={ this.props.onScreenshotClick }
 			onMoreButtonClick={ this.props.onMoreButtonClick }
+			actionLabel={ this.props.getActionLabel( theme ) }
 			index={ index }
-			{ ...theme } />;
+			theme={ theme } />;
 	},
 
 	renderLoadingPlaceholders: function() {
 		return times( PER_PAGE, function( i ) {
-			return <Theme key={ 'placeholder-' + i } id={ 'placeholder-' + i } name="Loading…" isPlaceholder={ true } />;
+			return <Theme key={ 'placeholder-' + i } theme={ { id: 'placeholder-' + i, name: 'Loading…' } } isPlaceholder={ true } />;
 		} );
 	},
 

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -22,17 +22,17 @@ const ThemesSelection = React.createClass( {
 	mixins: [ urlSearch ],
 
 	propTypes: {
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
+		selectedSite: PropTypes.oneOfType( [
+			PropTypes.object,
+			PropTypes.bool
 		] ).isRequired,
 		siteId: PropTypes.string,
 		search: PropTypes.string,
-		togglePreview: PropTypes.func.isRequired,
-		getOptions: PropTypes.func.isRequired,
-		customize: PropTypes.func.isRequired,
+		onScreenshotClick: PropTypes.func.isRequired,
+		getOptions: React.PropTypes.func,
 		queryParams: PropTypes.object.isRequired,
-		themesList: PropTypes.array.isRequired
+		themesList: PropTypes.array.isRequired,
+		getActionLabel: React.PropTypes.func
 	},
 
 	getInitialState: function() {
@@ -75,15 +75,11 @@ const ThemesSelection = React.createClass( {
 	},
 
 	onScreenshotClick( theme, resultsRank ) {
-		const site = this.props.selectedSite;
-
 		Helper.trackClick( 'theme', 'screenshot' );
-		if ( theme.active && site ) {
-			this.props.customize( theme, site );
-		} else {
+		if ( ! theme.active ) {
 			this.recordSearchResultsClick( theme, resultsRank );
-			this.props.togglePreview( theme );
 		}
+		this.props.onScreenshotClick( theme );
 	},
 
 	render() {
@@ -106,10 +102,11 @@ const ThemesSelection = React.createClass( {
 						tier={ this.state.tier }
 						onRealScroll={ this.trackScrollPage }
 						onLastPage={ this.trackLastPage } >
-					<ThemesList getButtonOptions={ this.props.getOptions.bind( null, site ) }
+					<ThemesList getButtonOptions={ this.props.getOptions }
 						onMoreButtonClick={ this.onMoreButtonClick }
 						onScreenshotClick={ this.onScreenshotClick }
-						getScreenshotUrl={ site ? partialRight( Helper.getPreviewUrl, site ) : null } />
+						getScreenshotUrl={ site ? partialRight( Helper.getPreviewUrl, site ) : null }
+						getActionLabel={ this.props.getActionLabel } />
 				</ThemesData>
 			</div>
 		);

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -52,7 +52,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 				mainAction={ this.redirectAndCallAction }
 				mainActionLabel={ label }>
 
-				<Theme isActionable={ false } { ...theme } />
+				<Theme isActionable={ false } theme={ theme } />
 				<h1>{ header }</h1>
 			</SiteSelectorModal>
 		);

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -74,8 +74,7 @@ module.exports = React.createClass( {
 				return {
 					id: theme.slug,
 					name: theme.name,
-					screenshot: 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + theme.slug + '/screenshot.png?w=660',
-					actionLabel: actionLabel
+					screenshot: 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + theme.slug + '/screenshot.png?w=660'
 				}
 			} );
 		return (
@@ -83,6 +82,9 @@ module.exports = React.createClass( {
 				getButtonOptions= { noop }
 				onScreenshotClick= { this.handleScreenshotClick }
 				onMoreButtonClick= { noop }
+				getActionLabel={ function() {
+					return actionLabel;
+				} }
 				{ ...this.props }
 				themes= { themes } />
 		);


### PR DESCRIPTION
**tl;dr**: Instead of passing down a gradually more bound `getButtonOptions()` function, invoke it fully inside `main.jsx` already, and make its `getUrl` and `action` properties functions that accept `theme` as an argument. Then, invoke those functions inside the `Theme` and `MoreButton` components, i.e. only at the very bottom of the component hierarchy. Also, use the return value from `getButtonOptions()` to pass some other props more cleanly. **Why?** Been an illegible mess on the brink of unmaintenable.

---

Removes the `theme` argument from `getButtonOptions()`, as returned from `theme-options`. This way, `getButtonOptions()` returns an object that is much easier to work with than the bound functions it previously returned. Instead, that object's (nested)  `getUrl` and `action` properties are now bound functions that accept `theme` and are invoked at the very leaves of the component hierarchy -- in the 'More' button menu, when the latter's entries are rendered. (If this turns out to affect performance negatively, we might want to tackle #1599 as a follow-up to this PR.)

This means no more expensive JSX `.bind()`s along that chain. It also means we have to pass an entire theme object down to the 'More' button, instead of just select attributes, as `getUrl` and `action` functions rely on helpers that use all different theme object properties. Note that we also had a hack in place that re-created a `theme` object from individual properties, and that this PR now also gets rid of.

Furthermore, that bundled information on theme actions is used inside `main.jsx` to pass data more cleanly down to descendant components. For example, action and label for the theme screenshot are now set there (instead of passing down `customize` and `togglePreview` actions as props individually, and letting the `Theme` component itself decide on the labelling. Ugh.).

No visual changes. To test -- check that the theme showcase works as before. Also check the logged-out signup flow since it also uses `ThemesList`.

Some more possible refactoring items for future PRs:
* For components that are meant for use as elements in a list (such as `Theme` inside `ThemesList`), avoiding JSX `.bind()`s quite naturally leads to a pattern where the list (parent) component passes two different kind of data to the element (child) component: 1 -- the individual element data (the theme object in this case), and 2 -- a bunch of functions that accept the element data as an argument (e.g. `onScreenshotClick`), and are invoked by the element component. However, this is still a bit inconsistent as of this PR, as some of those functions are already invoked at `ThemesList`'s level.
* Instead of passing `actions` to `theme-options`, we might `import` the actions module there, and only pass `dispatch` from `main`.
* We might want to give `ThemesSiteSelectorModal` an `isVisible` prop (instead of conditionally rendering it via `{ this.isThemeOrActionSet() && <ThemesSiteSelectorModal ... /> }`). There used to be some issues with this approach in the past (as ThemesSiteSelectorModal renders `Theme`, so possibly due to missing props), but we might want to re-visit this.
* One neat way to assign screenshot action/label/URL at Theme component level would be by just picking the appropriate action object from `buttonOptions`, i.e. by passing the action name (e.g. 'preview') as a string for key lookup. This would somewhat minimize duplicated props. (For the special case of `Theme` components that don't need a more button menu (signup flow!), we could pass just one option in `buttonOptions`.) However, we can't currently do this due to different analytics events that we are recording.
* We are using names like `getButtonOptions`, `getOptions`, `buttonContents` etc for essentially the same thing, so we should probably settle on a unique name for these things.
* To get rid of some redundant logic, we might want to use `theme-options` for `CurrentThemeCard` (we can re-use `isHidden` in order to hide the 'Support' button on Jetpack sites, and for free themes).
* We might want a cleaner approach to tracking.
* `WebPreview` (and how its `Button` is wired to an action and given a label) could still use some more makeover.