### PR TITLE
Me: Removes isCompact prop from several notices

### DIFF
--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -272,7 +272,6 @@ module.exports = React.createClass( {
 
 		return (
 			<Notice
-				isCompact={ true }
 				showDismiss={ false }
 				status="is-info"
 				text={
@@ -297,7 +296,6 @@ module.exports = React.createClass( {
 		if ( this.props.username.isUsernameValid() ) {
 			return (
 				<Notice
-					isCompact={ true }
 					showDismiss={ false }
 					status="is-success"
 					text={ this.translate( '%(username)s is a valid username.', {
@@ -309,7 +307,6 @@ module.exports = React.createClass( {
 		} else if ( null !== this.props.username.getValidationFailureMessage() ) {
 			return (
 				<Notice
-					isCompact={ true }
 					showDismiss={ false }
 					status="is-error"
 					text={ this.props.username.getValidationFailureMessage() } />
@@ -330,7 +327,6 @@ module.exports = React.createClass( {
 
 		return (
 			<Notice
-				isCompact={ true }
 				showDismiss={ false }
 				status={ status }
 				text={ text } />

--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -117,7 +117,6 @@ module.exports = React.createClass( {
 		return (
 			<Notice
 				className="profile-links-add-other__error"
-				isCompact
 				status="is-error"
 				onDismissClick={ this.clearLastError }
 				text={ this.state.lastError }

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -117,7 +117,6 @@ module.exports = React.createClass( {
 		return (
 			<Notice
 				className="profile-links-add-wordpress__error"
-				isCompact={ true }
 				status="is-error"
 				onDismissClick={ this.clearLastError }>
 				{ this.state.lastError }

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -97,7 +97,6 @@ module.exports = React.createClass( {
 
 		return (
 				<Notice className="profile-links__error"
-					isCompact={ true }
 					status="is-error"
 					onDismissClick={ this.clearLastError }>
 					{ this.translate( 'An error occurred while attempting to remove the link. Please try again later.' ) }

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -144,7 +144,6 @@ module.exports = React.createClass( {
 		return (
 			<div className="reauth-required__send-sms-throttled">
 				<Notice
-					isCompact={ true }
 					showDismiss={ false }
 					text={ this.translate(
 						'SMS codes are limited to once per minute. Please wait and try again.'

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -241,7 +241,6 @@ module.exports = React.createClass( {
 
 		return (
 			<Notice
-				isCompact
 				status="is-error"
 				onDismissClick={ this.clearLastError }
 				text={ this.state.lastError }

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -114,7 +114,6 @@ module.exports = React.createClass( {
 
 		return (
 			<Notice
-				isCompact
 				status="is-error"
 				onDismissClick={ this.clearLastError }
 				text={ this.state.lastError }

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -187,7 +187,6 @@ module.exports = React.createClass( {
 
 		return (
 			<Notice
-				isCompact
 				status={ this.state.lastErrorType }
 				onDismissClick={ this.clearLastError }
 				text={ this.state.lastError }

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -323,7 +323,6 @@ module.exports = React.createClass( {
 
 		return (
 			<Notice
-				isCompact
 				status={ this.state.lastErrorType }
 				onDismissClick={ this.clearLastError }
 				text={ this.state.lastError }

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -78,7 +78,6 @@ module.exports = React.createClass( {
 
 		return (
 			<Notice
-				isCompact
 				showDismiss={ false }
 				status="is-error"
 				text={ errorMessage }

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -159,7 +159,6 @@ module.exports = React.createClass( {
 
 		return (
 			<Notice
-				isCompact
 				status="is-error"
 				onDismissClick={ this.clearLastError }
 				text={ errorMessage }

--- a/client/me/security-checkup/manage-contact.jsx
+++ b/client/me/security-checkup/manage-contact.jsx
@@ -90,7 +90,7 @@ module.exports = React.createClass( {
 			onClick,
 			isError;
 
-		if ( lastNotice ) {
+		if ( lastNotice && lastNotice.message ) {
 			isError = lastNotice.type === 'error';
 			showDismiss = lastNotice.showDismiss !== false;
 			onClick = showDismiss ? this.dismissNotice : null;
@@ -98,7 +98,6 @@ module.exports = React.createClass( {
 			notice = (
 				<Notice
 					status={ isError ? 'is-error' : 'is-success' }
-					isCompact={ true }
 					onDismissClick={ onClick }
 					showDismiss={ showDismiss }
 					>


### PR DESCRIPTION
@rickybanister mentioned to me today that after some styling updates to compact notices, we should probably not be using compact notices throughout `/me`. 

To test:
- Checkout `fix/me-email-change-notice` branch
- Go to `/me`
- Attempt to trigger notices
  - I often do this by using Chrome's emulator, and after loading a page, go offline before clicking buttons. You're sure to get errors this way :smile: 

__Note:__ This PR does not address instances of compact notices in the following components:
- /client/me/purchases/list/item/index.jsx cc @scruffian 
- <strike>/client/me/security-checkup/manage-contact.jsx</strike>

*Before:*

![screen_shot_6_720](https://cloud.githubusercontent.com/assets/1126811/12339995/db5cc528-badd-11e5-8775-37b4c490e2b8.png)

*After examples:*
![screen shot 3](https://cloud.githubusercontent.com/assets/1126811/12340001/e2afd6b2-badd-11e5-96b0-e6596f4a390c.png)
![screen shot 2](https://cloud.githubusercontent.com/assets/1126811/12340002/e2b3ef36-badd-11e5-8c31-0284d4d672ec.png)

