### PR TITLE
Plans: Add a/b test with 'upgrade' button in the sidebar

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -61,4 +61,12 @@ module.exports = {
 		},
 		defaultVariation: 'yearly'
 	},
+	plansUpgradeButton: {
+		datestamp: '20160118',
+		variations: {
+			original: 50,
+			button: 50
+		},
+		defaultVariation: 'original'
+	}
 };

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -326,10 +326,18 @@ module.exports = React.createClass( {
 			linkClass += ' is-paid-plan';
 		}
 
-		let planName = site.plan.product_name_short;
+		let planName = site.plan.product_name_short,
+			labelClass = 'plan-name';
+
+		if ( abtest( 'plansUpgradeButton' ) === 'button' && productsValues.isFreePlan( site.plan ) ) {
+			labelClass = 'add-new';
+			planName = 'Upgrade'; // TODO: translate this string if the test is removed
+		}
 
 		if ( productsValues.isFreeTrial( site.plan ) ) {
-			planName = this.translate( 'Trial' );
+			planName = this.translate( 'Trial', {
+				context: 'Label in the sidebar indicating that the user is on the free trial for a plan.'
+			} );
 		}
 
 		return (
@@ -338,7 +346,7 @@ module.exports = React.createClass( {
 					<Gridicon icon="clipboard" size={ 24 } />
 					<span className="menu-link-text">{ this.translate( 'Plan', { context: 'noun' } ) }</span>
 				</a>
-				<a href={ planLink } className="plan-name" onClick={ this.trackUpgradeClick }>{ planName }</a>
+				<a href={ planLink } className={ labelClass } onClick={ this.trackUpgradeClick }>{ planName }</a>
 			</li>
 		);
 	},


### PR DESCRIPTION
Fixes #2382.

This adds an a/b test to change the label in the sidebar next to 'Plans' from 'Free' to a button with the label 'Upgrade'.

`original` variation:
<img width="253" alt="screen shot 2016-01-14 at 3 44 25 pm" src="https://cloud.githubusercontent.com/assets/1130674/12341411/55ce22d2-bad6-11e5-996e-fb4f06d41759.png">

`button` variation:
<img width="259" alt="screen shot 2016-01-14 at 3 43 49 pm" src="https://cloud.githubusercontent.com/assets/1130674/12341414/5db49094-bad6-11e5-9013-d26ad32c2bfb.png">

I'll update the datestamp for this test before merging to the current day.

**Testing**
`original`:
- Run `localStorage.setItem( 'ABTests', '{"plansUpgradeButton_20040114":"original"}' );` in the console.
- Visit `/stats/year/:site` (or any 'My Sites' route) for a site with the free plan.
- Assert that you see the 'Free' label next to 'Plans' in the sidebar.

`original`:
- Run `localStorage.setItem( 'ABTests', '{"plansUpgradeButton_20040114":"button"}' );` in the console.
- Visit `/stats/year/:site` (or any 'My Sites' route) for a site with the free plan.
- Assert that you see the 'Upgrade' button next to 'Plans' in the sidebar.

- [x] Product review
- [ ] Code review

cc @breezyskies 