### PR TITLE
Plans: A/B test for monthly pricing

### DIFF
--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -38,20 +38,20 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-	    const { plan, sitePlan: details } = this.props;
-	    const hasDiscount = details && details.rawDiscount > 0;
+		const { plan, sitePlan: details } = this.props;
+		const hasDiscount = details && details.rawDiscount > 0;
 
-	    if ( this.props.isPlaceholder ) {
+		if ( this.props.isPlaceholder ) {
 			return <div className="plan-price is-placeholder" />;
 		}
 
-	    return (
-	        <div className="plan-price">
-	            <span>{ this.getPrice() }</span>
-	            <small className="plan-price__billing-period">
-	                { hasDiscount ? this.translate( 'for first year' ) : plan.bill_period_label }
-	            </small>
-	        </div>
-	    );
+		return (
+			<div className="plan-price">
+				<span>{ this.getPrice() }</span>
+				<small className="plan-price__billing-period">
+					{ hasDiscount ? this.translate( 'for first year' ) : plan.bill_period_label }
+				</small>
+			</div>
+		);
 	}
 } );

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -156,6 +156,7 @@ module.exports = React.createClass( {
 			<PlanPrice
 				plan={ this.props.plan }
 				isPlaceholder={ this.isPlaceholder() }
+				isInSignup={ this.props.isInSignup }
 				sitePlan={ this.getSitePlan() }
 				site={ this.props.site } />
 		);

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -61,4 +61,12 @@ module.exports = {
 		},
 		defaultVariation: 'notOffered'
 	},
+	monthlyPlanPricing: {
+		datestamp: '20160118',
+		variations: {
+			yearly: 50,
+			monthly: 50
+		},
+		defaultVariation: 'yearly'
+	},
 };

--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -63,6 +63,13 @@
 			display: block;
 			font-size: 13px;
 		}
+		 
+		.product-monthly-price {
+			color: $gray;
+			display: block;
+			font-size: 11px;
+			font-style: italic;
+		}
 
 		.remove-item {
 			box-shadow: none;


### PR DESCRIPTION
This is the implementation of monthly pricing during the signup (and the monthly pricing should _only_ be shown during the signup).
Designs:
<img width="720" alt="cloudup-0a076588-eed3-440f-8fdd-02c3d5313984" src="https://cloud.githubusercontent.com/assets/3392497/12342730/9f429af4-bb2d-11e5-91ac-e7d13aa4d157.png">
![paste-1452703686188](https://cloud.githubusercontent.com/assets/3392497/12342735/ac3f7ccc-bb2d-11e5-8eec-b30b26fb7320.png)

I've made a slight last-minute adjustment to the cart view - I've added the currency in the monthly price calculations, to make it easier to understand what's going on:
![2016-01-15-020804_460x353_scrot](https://cloud.githubusercontent.com/assets/3392497/12342933/8b11823c-bb2f-11e5-82d3-cbec25043486.png)
I hope the designers will approve this change and won't yell at me :sob: 

/cc @lucasartoni @breezyskies @danhauk