### PR TITLE
Translator Jumpstart: Add back textOnly support

### DIFF
--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -2,8 +2,7 @@
  * External dependencies
  */
 var debug = require( 'debug' )( 'calypso:community-translator' ),
-	React = require( 'react' ),
-	ReactElement = require( 'react/lib/ReactElement' );
+	React = require( 'react' );
 
 /**
  * Internal dependencies
@@ -42,32 +41,6 @@ var communityTranslatorToString = function() {
 	}
 	return Object.prototype.toString.call( this );
 };
-
-/**
- * When a translation is used in an html attribute, the ReactElement-wrapped translation
- * is treated as a string and .toString() is called implicitly on it. To avoid undesired
- * [object Object] display, we return the plain text translation from the ReactElement by
- * overriding ReactElement.prototype's .toString() method.
- *
- * We bail out of the override for safety if ReactElement.prototype.toString() isn't
- * initially what we expect.
- */
-function overrideReactElementToString() {
-	if ( ReactElement.prototype.toString !== Object.prototype.toString ) {
-		debug( 'Aborted ReactElement.prototype.toString override: unexpected value!' );
-		return;
-	}
-	ReactElement.prototype.toString = communityTranslatorToString;
-}
-
-// We restore the original ReactElement.prototype.toString behaviour when CT is disabled.
-function restoreReactElementToString() {
-	if ( ReactElement.prototype.toString !== communityTranslatorToString ) {
-		debug( 'Aborted ReactElement.prototype.toString restore: unexpected value!' );
-		return;
-	}
-	ReactElement.prototype.toString = Object.prototype.toString;
-}
 
 /* "Enabled" means that the user has opted in on the settings page
  *     ( but it's false until userSettings has loaded)
@@ -228,7 +201,6 @@ communityTranslatorJumpstart = {
 		function activate() {
 			// Wrap DOM elements and then activate the translator
 			_shouldWrapTranslations = true;
-			overrideReactElementToString();
 			i18n.reRenderTranslations();
 			window.communityTranslator.load();
 			debug( 'Translator activated' );
@@ -239,7 +211,6 @@ communityTranslatorJumpstart = {
 			window.communityTranslator.unload();
 			// Remove all the data tags from the DOM
 			_shouldWrapTranslations = false;
-			restoreReactElementToString();
 			i18n.reRenderTranslations();
 			debug( 'Translator deactivated' );
 			return false;

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -35,13 +35,6 @@ var communityTranslatorBaseUrl = 'https://widgets.wp.com/community-translator/',
 	previousEnabledSetting,
 	_shouldWrapTranslations = false;
 
-var communityTranslatorToString = function() {
-	if ( typeof this.props.children === 'string' ) {
-		return this.props.children;
-	}
-	return Object.prototype.toString.call( this );
-};
-
 /* "Enabled" means that the user has opted in on the settings page
  *     ( but it's false until userSettings has loaded)
  * "Activated" means that the translator is toggled on, and wrapTranslate()

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -118,6 +118,12 @@ communityTranslatorJumpstart = {
 			optionsFromPage = {};
 		}
 
+		// text will be used in a text-only context, such as HTML attribute
+		if ( 'undefined' !== typeof optionsFromPage.textOnly && optionsFromPage.textOnly ) {
+			// for the moment we will just not make it translatable
+			return displayedTranslationFromPage;
+		}
+
 		props = { className: 'translatable' };
 
 		if ( 'string' === typeof originalFromPage ) {


### PR DESCRIPTION
This PR is intended as a temporary partial fix for Issue #2455 while we figure out how we'd like to handle it.

It turns out that we've still got a whole lot of textOnly arguments, so if we turn on support for it in the jumpstart, we fix a lot of it.

In order to reproduce the problem and then verify the fix you'll need to:
 1. Set your interface language to something other than english: http://calypso.localhost:3000/me/account
 2. Tick the "Enable the translator" box
 3. Save your changes
 4. Wait a moment, then enable the translator (to make everything glow)
 5. Change tabs
 6. Check that the page title is not [object Object]

![parametres_du_compte_ _wordpress_com](https://cloud.githubusercontent.com/assets/5952255/12343877/651bcd36-bb83-11e5-8151-f02f6e17ccdc.jpg)

Out of scope for this PR, but It's very hard to know how many we don't fix.  There are a lot of type warnings that may or may not be a problem:

![stats_ _i18n__ glob l__ _wordpress_com](https://cloud.githubusercontent.com/assets/5952255/12343659/8f8f9298-bb81-11e5-821d-8bd334fcd789.jpg)