### PR TITLE
Free Trials: Fix wrapping issues in free trial hub feature section

### DIFF
--- a/client/my-sites/plans/plan-overview/style.scss
+++ b/client/my-sites/plans/plan-overview/style.scss
@@ -34,8 +34,10 @@
 	}
 	
 	.plan-feature {
-		flex-direction: row;
-		flex-wrap: wrap;
+		@include breakpoint( "<480px" ) {
+			flex-direction: row;
+			flex-wrap: wrap;
+		}
 
 		.plan-feature__heading {
 			margin-right: 10px;


### PR DESCRIPTION
In #2433 I introduced a bug by not limiting `flex-direction: row;` and `flex-wrap: wrap;` to `<480px`.

This caused this issue in the features section when the longer descriptions were displayed:

![image](https://cloud.githubusercontent.com/assets/12596797/12344245/4e4e0c88-bb09-11e5-9123-352f371761c3.png)
