### PR TITLE
Stats: Fixes and improvements to loading behavior with empty localStorage

### DIFF
--- a/client/lib/stats/stats-list/index.js
+++ b/client/lib/stats/stats-list/index.js
@@ -171,11 +171,17 @@ StatsList.prototype.fetch = function() {
 	var wpcomSite,
 		options = this.options,
 		postIdEndpoints = [ 'statsVideo', 'statsPostViews' ];
+	const siteIdOrDomain = this.siteID || options.domain;
+
+	if ( ! siteIdOrDomain ) {
+		// Never try to fetch stats for a site without a site or domain
+		return;
+	}
 
 	if ( this.isDocumentedEndpoint ) {
-		wpcomSite = wpcom.site( this.siteID );
+		wpcomSite = wpcom.site( siteIdOrDomain );
 	} else {
-		wpcomSite = wpcom.undocumented().site( this.siteID );
+		wpcomSite = wpcom.undocumented().site( siteIdOrDomain );
 	}
 
 	// statsPostViews && statsVideo expect just the post.ID as a param

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -159,10 +159,10 @@ module.exports = {
 				sites.once( 'change', function() {
 					page( context.path );
 				} );
-			} else {
-				// site is not in the user's site list
-				next();
+				return;
 			}
+			// site is not in the user's site list
+			next();
 		}
 
 		if ( site && site.options && typeof site.options.gmt_offset !== 'undefined' ) {
@@ -171,19 +171,21 @@ module.exports = {
 			summarySites.push( { ID: siteId, date: summaryDate } );
 		}
 
-		allTimeList = new StatsList( { siteID: siteId, statType: 'stats' } );
-		streakList = new StatsList( { siteID: siteId, statType: 'statsStreak', startDate: startDate, endDate: endDate, max: 3000 } );
-		statSummaryList = new StatsSummaryList( { period: 'day', sites: summarySites } );
-		insightsList = new StatsList( { siteID: siteId, statType: 'statsInsights' } );
-		commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: site.slug } );
-		tagsList = new StatsList( { siteID: siteId, statType: 'statsTags', domain: site.slug } );
-		publicizeList = new StatsList( { siteID: siteId, statType: 'statsPublicize', domain: site.slug } );
-		wpcomFollowersList = new StatsList( { siteID: siteId, statType: 'statsFollowers', type: 'wpcom', domain: site.slug, max: 7 } );
-		emailFollowersList = new StatsList( { siteID: siteId, statType: 'statsFollowers', type: 'email', domain: site.slug, max: 7 } );
-		commentFollowersList = new StatsList( { siteID: siteId, statType: 'statsCommentFollowers', domain: site.slug, max: 7 } );
+		const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
+			? site.slug : route.getSiteFragment( context.path );
+
+		allTimeList = new StatsList( { siteID: siteId, statType: 'stats', domain: siteDomain } );
+		streakList = new StatsList( { siteID: siteId, statType: 'statsStreak', startDate: startDate, endDate: endDate, max: 3000, domain: siteDomain } );
+		statSummaryList = new StatsSummaryList( { period: 'day', sites: summarySites, domain: siteDomain } );
+		insightsList = new StatsList( { siteID: siteId, statType: 'statsInsights', domain: siteDomain } );
+		commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: siteDomain } );
+		tagsList = new StatsList( { siteID: siteId, statType: 'statsTags', domain: siteDomain } );
+		publicizeList = new StatsList( { siteID: siteId, statType: 'statsPublicize', domain: siteDomain } );
+		wpcomFollowersList = new StatsList( { siteID: siteId, statType: 'statsFollowers', type: 'wpcom', domain: siteDomain, max: 7 } );
+		emailFollowersList = new StatsList( { siteID: siteId, statType: 'statsFollowers', type: 'email', domain: siteDomain, max: 7 } );
+		commentFollowersList = new StatsList( { siteID: siteId, statType: 'statsCommentFollowers', domain: siteDomain, max: 7 } );
 
 		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
-
 
 		ReactDom.render(
 			React.createElement( StatsComponent, {
@@ -346,16 +348,16 @@ module.exports = {
 					sites.once( 'change', function() {
 						page( context.path );
 					} );
-				} else {
-					next();
+					return;
 				}
+				next();
 			}
 
 			if ( currentSite && currentSite.domain ) {
 				titleActions.setTitle( i18n.translate( 'Stats', { textOnly: true } ), { siteID: currentSite.domain } );
 			}
 
-			if ( 'object' === typeof( currentSite.options ) && 'undefined' !== typeof( currentSite.options.gmt_offset ) ) {
+			if ( currentSite && 'object' === typeof currentSite.options && 'undefined' !== typeof currentSite.options.gmt_offset ) {
 				siteOffset = currentSite.options.gmt_offset;
 			}
 			momentSiteZone = i18n.moment().utcOffset( siteOffset );
@@ -433,22 +435,25 @@ module.exports = {
 					break;
 			}
 
+			const siteDomain = ( currentSite && ( typeof currentSite.slug !== 'undefined' ) )
+					? currentSite.slug : siteFragment;
+
 			followList = new FollowList();
-			activeTabVisitsList = new StatsList( { siteID: siteId, statType: 'statsVisits', unit: activeFilter.period, quantity: chartQuantity, date: chartEndDate, stat_fields: visitsListFields } );
-			visitsList = new StatsList( { siteID: siteId, statType: 'statsVisits', unit: activeFilter.period, quantity: chartQuantity, date: chartEndDate, stat_fields: 'views,visitors,likes,comments,post_titles' } );
-			postsPagesList = new StatsList( { siteID: siteId, statType: 'statsTopPosts', period: activeFilter.period, date: endDate, domain: currentSite.slug } );
-			referrersList = new StatsList( { siteID: siteId, statType: 'statsReferrers', period: activeFilter.period, date: endDate, domain: currentSite.slug } );
-			clicksList = new StatsList( { siteID: siteId, statType: 'statsClicks', period: activeFilter.period, date: endDate, domain: currentSite.slug } );
-			authorsList = new StatsList( { siteID: siteId, statType: 'statsTopAuthors', period: activeFilter.period, date: endDate, domain: currentSite.slug } );
-			countriesList = new StatsList( { siteID: siteId, statType: 'statsCountryViews', period: activeFilter.period, date: endDate, domain: currentSite.slug } );
-			videoPlaysList = new StatsList( { siteID: siteId, statType: 'statsVideoPlays', period: activeFilter.period, date: endDate, domain: currentSite.slug } );
-			searchTermsList = new StatsList( { siteID: siteId, statType: 'statsSearchTerms', period: activeFilter.period, date: endDate, domain: currentSite.slug } );
-			tagsList = new StatsList( { siteID: siteId, statType: 'statsTags', domain: currentSite.slug } );
-			commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: currentSite.slug } );
-			wpcomFollowersList = new StatsList( { siteID: siteId, statType: 'statsFollowers', type: 'wpcom', domain: currentSite.slug, max: 7 } );
-			emailFollowersList = new StatsList( { siteID: siteId, statType: 'statsFollowers', type: 'email', domain: currentSite.slug, max: 7 } );
-			commentFollowersList = new StatsList( { siteID: siteId, statType: 'statsCommentFollowers', domain: currentSite.slug, max: 7 } );
-			publicizeList = new StatsList( { siteID: siteId, statType: 'statsPublicize', domain: currentSite.slug } );
+			activeTabVisitsList = new StatsList( { siteID: siteId, statType: 'statsVisits', unit: activeFilter.period, quantity: chartQuantity, date: chartEndDate, stat_fields: visitsListFields, domain: siteDomain } );
+			visitsList = new StatsList( { siteID: siteId, statType: 'statsVisits', unit: activeFilter.period, quantity: chartQuantity, date: chartEndDate, stat_fields: 'views,visitors,likes,comments,post_titles', domain: siteDomain } );
+			postsPagesList = new StatsList( { siteID: siteId, statType: 'statsTopPosts', period: activeFilter.period, date: endDate, domain: siteDomain } );
+			referrersList = new StatsList( { siteID: siteId, statType: 'statsReferrers', period: activeFilter.period, date: endDate, domain: siteDomain } );
+			clicksList = new StatsList( { siteID: siteId, statType: 'statsClicks', period: activeFilter.period, date: endDate, domain: siteDomain } );
+			authorsList = new StatsList( { siteID: siteId, statType: 'statsTopAuthors', period: activeFilter.period, date: endDate, domain: siteDomain } );
+			countriesList = new StatsList( { siteID: siteId, statType: 'statsCountryViews', period: activeFilter.period, date: endDate, domain: siteDomain } );
+			videoPlaysList = new StatsList( { siteID: siteId, statType: 'statsVideoPlays', period: activeFilter.period, date: endDate, domain: siteDomain } );
+			searchTermsList = new StatsList( { siteID: siteId, statType: 'statsSearchTerms', period: activeFilter.period, date: endDate, domain: siteDomain } );
+			tagsList = new StatsList( { siteID: siteId, statType: 'statsTags', domain: siteDomain } );
+			commentsList = new StatsList( { siteID: siteId, statType: 'statsComments', domain: siteDomain } );
+			wpcomFollowersList = new StatsList( { siteID: siteId, statType: 'statsFollowers', type: 'wpcom', domain: siteDomain, max: 7 } );
+			emailFollowersList = new StatsList( { siteID: siteId, statType: 'statsFollowers', type: 'email', domain: siteDomain, max: 7 } );
+			commentFollowersList = new StatsList( { siteID: siteId, statType: 'statsCommentFollowers', domain: siteDomain, max: 7 } );
+			publicizeList = new StatsList( { siteID: siteId, statType: 'statsPublicize', domain: siteDomain } );
 
 			siteComponent = SiteStatsComponent;
 
@@ -480,7 +485,7 @@ module.exports = {
 					publicizeList: publicizeList,
 					followList: followList,
 					searchTermsList: searchTermsList,
-					slug: currentSite.slug
+					slug: siteDomain
 				} ),
 				document.getElementById( 'primary' )
 			);
@@ -530,10 +535,10 @@ module.exports = {
 				sites.once( 'change', function() {
 					page( context.path );
 				} );
-			} else {
-				// site is not in the user's site list
-				window.location = '/stats';
+				return;
 			}
+			// site is not in the user's site list
+			window.location = '/stats';
 		} else if ( 0 === activeFilter.length || -1 === validModules.indexOf( context.params.module ) ) {
 			next();
 		} else {
@@ -549,39 +554,42 @@ module.exports = {
 			period = rangeOfPeriod( activeFilter.period, date );
 			endDate = period.endOf.format( 'YYYY-MM-DD' );
 
+			const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
+				? site.slug : siteFragment;
+
 			switch ( context.params.module ) {
 
 				case 'posts':
-					visitsList = new StatsList( { statType: 'statsVisits', unit: activeFilter.period, siteID: siteId, quantity: 10, date: endDate } );
-					summaryList = new StatsList( { statType: 'statsTopPosts', siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: site.slug } );
+					visitsList = new StatsList( { statType: 'statsVisits', unit: activeFilter.period, siteID: siteId, quantity: 10, date: endDate, domain: siteDomain } );
+					summaryList = new StatsList( { statType: 'statsTopPosts', siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
 					break;
 
 				case 'referrers':
-					summaryList = new StatsList( { siteID: siteId, statType: 'statsReferrers', period: activeFilter.period, date: endDate, max: 0, domain: site.slug } );
+					summaryList = new StatsList( { siteID: siteId, statType: 'statsReferrers', period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
 					break;
 
 				case 'clicks':
-					summaryList = new StatsList( { statType: 'statsClicks', siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: site.slug } );
+					summaryList = new StatsList( { statType: 'statsClicks', siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
 					break;
 
 				case 'countryviews':
-					summaryList = new StatsList( { siteID: siteId, statType: 'statsCountryViews', period: activeFilter.period, date: endDate, max: 0, domain: site.slug } );
+					summaryList = new StatsList( { siteID: siteId, statType: 'statsCountryViews', period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
 					break;
 
 				case 'authors':
-					summaryList = new StatsList( { statType: 'statsTopAuthors', siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: site.slug } );
+					summaryList = new StatsList( { statType: 'statsTopAuthors', siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
 					break;
 
 				case 'videoplays':
-					summaryList = new StatsList( { statType: 'statsVideoPlays', siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: site.slug } );
+					summaryList = new StatsList( { statType: 'statsVideoPlays', siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
 					break;
 
 				case 'videodetails':
-					summaryList = new StatsList( { statType: 'statsVideo', post: queryOptions.post, siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: site.slug } );
+					summaryList = new StatsList( { statType: 'statsVideo', post: queryOptions.post, siteID: siteId, period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
 					break;
 
 				case 'searchterms':
-					summaryList = new StatsList( { siteID: siteId, statType: 'statsSearchTerms', period: activeFilter.period, date: endDate, max: 0, domain: site.slug } );
+					summaryList = new StatsList( { siteID: siteId, statType: 'statsSearchTerms', period: activeFilter.period, date: endDate, max: 0, domain: siteDomain } );
 					break;
 
 			}
@@ -630,12 +638,15 @@ module.exports = {
 				sites.once( 'change', function() {
 					page( context.path );
 				} );
-			} else {
-				// site is not in the user's site list
-				window.location = '/stats';
+				return;
 			}
+			// site is not in the user's site list
+			window.location = '/stats';
 		} else {
-			postViewsList = new StatsList( { statType: 'statsPostViews', siteID: siteId, post: postId, domain: site.slug } );
+			const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
+				? site.slug : route.getSiteFragment( context.path );
+
+			postViewsList = new StatsList( { statType: 'statsPostViews', siteID: siteId, post: postId, domain: siteDomain } );
 
 			analytics.pageView.record( '/stats/' + postOrPage + '/:post_id/:site', analyticsPageTitle + ' > Single ' + titlecase( postOrPage ) );
 
@@ -672,6 +683,9 @@ module.exports = {
 		}
 		siteId = site ? ( site.ID || 0 ) : 0;
 
+		const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
+			? site.slug : route.getSiteFragment( context.path );
+
 		if ( -1 === validFollowTypes.indexOf( followType ) ) {
 			next();
 		} else if ( 0 === siteId ) {
@@ -679,10 +693,10 @@ module.exports = {
 				sites.once( 'change', function() {
 					page( context.path );
 				} );
-			} else {
-				// site is not in the user's site list
-				window.location = '/stats';
+				return;
 			}
+			// site is not in the user's site list
+			window.location = '/stats';
 		} else {
 			pageNum = parseInt( pageNum, 10 );
 
@@ -692,12 +706,12 @@ module.exports = {
 
 			switch ( followType ) {
 				case 'comment':
-					followersList = new StatsList( { siteID: siteId, statType: 'statsCommentFollowers', domain: site.slug, max: 20, page: pageNum } );
+					followersList = new StatsList( { siteID: siteId, statType: 'statsCommentFollowers', domain: siteDomain, max: 20, page: pageNum } );
 					break;
 
 				case 'email':
 				case 'wpcom':
-					followersList = new StatsList( { siteID: siteId, statType: 'statsFollowers', domain: site.slug, max: 20, page: pageNum, type: followType } );
+					followersList = new StatsList( { siteID: siteId, statType: 'statsFollowers', domain: siteDomain, max: 20, page: pageNum, type: followType } );
 					break;
 			}
 
@@ -717,7 +731,7 @@ module.exports = {
 					followersList: followersList,
 					followType: followType,
 					followList: followList,
-					domain: site.slug
+					domain: siteDomain
 				} ),
 				document.getElementById( 'primary' )
 			);

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -159,10 +159,10 @@ module.exports = {
 				sites.once( 'change', function() {
 					page( context.path );
 				} );
-				return;
+			} else {
+				// site is not in the user's site list
+				next();
 			}
-			// site is not in the user's site list
-			next();
 		}
 
 		if ( site && site.options && typeof site.options.gmt_offset !== 'undefined' ) {
@@ -348,9 +348,9 @@ module.exports = {
 					sites.once( 'change', function() {
 						page( context.path );
 					} );
-					return;
+				} else {
+					next();
 				}
-				next();
 			}
 
 			if ( currentSite && currentSite.domain ) {
@@ -535,10 +535,10 @@ module.exports = {
 				sites.once( 'change', function() {
 					page( context.path );
 				} );
-				return;
+			} else {
+				// site is not in the user's site list
+				window.location = '/stats';
 			}
-			// site is not in the user's site list
-			window.location = '/stats';
 		} else if ( 0 === activeFilter.length || -1 === validModules.indexOf( context.params.module ) ) {
 			next();
 		} else {
@@ -638,10 +638,10 @@ module.exports = {
 				sites.once( 'change', function() {
 					page( context.path );
 				} );
-				return;
+			} else {
+				// site is not in the user's site list
+				window.location = '/stats';
 			}
-			// site is not in the user's site list
-			window.location = '/stats';
 		} else {
 			const siteDomain = ( site && ( typeof site.slug !== 'undefined' ) )
 				? site.slug : route.getSiteFragment( context.path );
@@ -693,10 +693,10 @@ module.exports = {
 				sites.once( 'change', function() {
 					page( context.path );
 				} );
-				return;
+			} else {
+				// site is not in the user's site list
+				window.location = '/stats';
 			}
-			// site is not in the user's site list
-			window.location = '/stats';
 		} else {
 			pageNum = parseInt( pageNum, 10 );
 

--- a/client/my-sites/stats/insights/index.jsx
+++ b/client/my-sites/stats/insights/index.jsx
@@ -31,7 +31,10 @@ export default React.createClass( {
 		followList: PropTypes.object.isRequired,
 		insightsList: PropTypes.object.isRequired,
 		publicizeList: PropTypes.object.isRequired,
-		site: PropTypes.object,
+		site: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.object
+		] ),
 		statSummaryList: PropTypes.object.isRequired,
 		streakList: PropTypes.object.isRequired,
 		summaryDate: PropTypes.string,

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -54,7 +54,10 @@ export default React.createClass( {
 
 	componentWillMount() {
 		PostListStore.on( 'change', this.onPostsChange );
-		queryPosts( this.props.site.ID );
+		const site = this.props.site;
+		if ( site && site.ID ) {
+			queryPosts( site.ID );
+		}
 		PostStatsStore.on( 'change', this.onViewsChange );
 	},
 

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -129,10 +129,11 @@ module.exports = React.createClass( {
 			}
 		];
 
+		const summaryPageSlug = this.props.site ? this.props.site.slug : '';
 		if ( 'email-followers' === activeFilter ) {
-			summaryPageLink = '/stats/follows/email/' + this.props.site.slug;
+			summaryPageLink = '/stats/follows/email/' + summaryPageSlug;
 		} else {
-			summaryPageLink = '/stats/follows/wpcom/' + this.props.site.slug;
+			summaryPageLink = '/stats/follows/wpcom/' + summaryPageSlug;
 		}
 
 		if ( wpcomData && wpcomData.subscribers ) {

--- a/client/my-sites/stats/stats-navigation/index.jsx
+++ b/client/my-sites/stats/stats-navigation/index.jsx
@@ -14,7 +14,10 @@ var SectionNav = require( 'components/section-nav' ),
 module.exports = React.createClass( {
 	propTypes: {
 		section: React.PropTypes.string.isRequired,
-		site: React.PropTypes.object
+		site: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.object
+		] )
 	},
 
 	componentDidMount: function() {


### PR DESCRIPTION
Currently, loading stats pages with a cleared-out localStorage involves making an extra round of API calls for an invalid site ID (`0`) and a few errors in the console:

<img width="445" alt="screen shot 2016-01-14 at 10 54 39 pm" src="https://cloud.githubusercontent.com/assets/1587282/12345157/2cbd6e4c-bb13-11e5-9f2c-979ade6fb260.png">
<img width="451" alt="screen shot 2016-01-14 at 10 54 55 pm" src="https://cloud.githubusercontent.com/assets/1587282/12345158/31ac3abe-bb13-11e5-8df4-45d189b220fc.png">

"Streak" requests on the insights page before:
<img width="612" alt="screen shot 2016-01-14 at 10 58 28 pm" src="https://cloud.githubusercontent.com/assets/1587282/12345161/359f8e8c-bb13-11e5-9bed-1b582eb6fd06.png">
Those first two requests are for site ID `0`.

With this change:
<img width="683" alt="screen shot 2016-01-14 at 11 00 22 pm" src="https://cloud.githubusercontent.com/assets/1587282/12345167/45278bde-bb13-11e5-902e-491b36406513.png">

Changes:
* Fall back to querying the API by domain when the site ID is not yet known
* Include the `domain` prop in the few `StatsList` component calls that don't already have it (to support the above fallback)
* Never try to fetch stats for a site without a site or domain
* Add `bool` to allowable `PropTypes` for `site` as its value is `FALSE` when unresolved
* Guard against fatal errors when the `site` & `currentSite` variables & component props are null
* Return when forcing a site change to prevent double API calls

To test:
* Visit various pages inside and outside stats with and without clearing localStorage
* Ensure features work as they did before
* Verify in the network console that no site ID `0` requests are issued
* Verify that extraneous network requests are not made
* Verify that the stats cards pulse appropriately while things are loading

fixes #2400