### PR TITLE
Themes: Enable logged /design in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -19,6 +19,7 @@
 		"manage/menus-jetpack": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
+		"manage/themes/logged-out": true,
 		"premium-themes": true,
 		"press-this": true,
 		"manage/sharing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -24,6 +24,7 @@
 		"manage/menus-jetpack": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
+		"manage/themes/logged-out": true,
 		"premium-themes": true,
 		"press-this": true,
 		"manage/sharing": true,


### PR DESCRIPTION
Let's enable `/design` in production and staging, but only when https://github.com/Automattic/wp-calypso/pull/2464 is merged.