### PR TITLE
Editor: update visual design of TinyMCE toolbar.

### DIFF
--- a/client/components/tinymce/plugins/advanced/style.scss
+++ b/client/components/tinymce/plugins/advanced/style.scss
@@ -29,6 +29,7 @@
 .mce-toolbar .mce-btn-group .mce-advanced.mce-btn.mce-last {
 	position: absolute;
 		top: 3px;
+		right: 14px;
 }
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-active.mce-advanced {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -59,6 +59,12 @@
 		border-width: 1px 0;
 		padding: 0;
 		overflow-x: auto;
+		max-width: 700px;
+		margin: 0 auto;
+
+		@include breakpoint( ">1040px" ) {
+			border-width: 1px;
+		}
 	}
 
 	.mce-toolbar .mce-ico {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -62,7 +62,7 @@
 		max-width: 700px;
 		margin: 0 auto;
 
-		@include breakpoint( ">1040px" ) {
+		@include breakpoint( ">960px" ) {
 			border-width: 1px;
 		}
 	}

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -59,11 +59,11 @@
 		border-width: 1px 0;
 		padding: 0;
 		overflow-x: auto;
-		max-width: 700px;
 		margin: 0 auto;
 
 		@include breakpoint( ">960px" ) {
 			border-width: 1px;
+			max-width: 700px;
 		}
 	}
 

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -236,7 +236,7 @@
 	}
 
 	@include breakpoint( ">1040px" ) {
-		right: 0;
+		right: -1px;
 	}
 }
 


### PR DESCRIPTION
Constrain it to the column width for a more airy feeling.

![image](https://cloud.githubusercontent.com/assets/548849/12353975/efc72e58-bb92-11e5-9c98-0d2c6ad20e07.png)

cc @kellychoffman 

The breakpoint transition is not perfect, there's a gap where the toolbar shows without right-left borders but not full width.