### PR TITLE
Components: Render Dialog as RootChild

### DIFF
--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -32,17 +32,17 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		const { isVisible, baseClassName } = this.props;
+		const { isVisible, baseClassName, transitionLeave, enterTimeout, leaveTimeout } = this.props;
 
 		return (
 			<RootChild>
 				<SingleChildCSSTransitionGroup
 					transitionName={ baseClassName || 'dialog' }
 					component="div"
-					transitionLeave={ this.props.transitionLeave }
+					transitionLeave={ transitionLeave }
 					onChildDidLeave={ this.onDialogDidLeave }
-					enterTimeout={ this.props.enterTimeout }
-					leaveTimeout={ this.props.leaveTimeout }>
+					enterTimeout={ enterTimeout }
+					leaveTimeout={ leaveTimeout }>
 					{ isVisible && (
 						<DialogBase { ...this.props } key="dialog" onDialogClose={ this.onDialogClose } />
 					) }

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -1,21 +1,15 @@
 /**
  * External dependencies
  */
-import ReactDom from 'react-dom';
 import React from 'react';
 import noop from 'lodash/utility/noop';
-import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
 import SingleChildCSSTransitionGroup from 'components/single-child-css-transition-group';
+import RootChild from 'components/root-child';
 import DialogBase from './dialog-base';
-
-/**
- * Module variables
- */
-const debug = debugModule( 'calypso:dialog' );
 
 export default React.createClass( {
 	propTypes: {
@@ -37,48 +31,24 @@ export default React.createClass( {
 		};
 	},
 
-	componentDidMount: function() {
-		debug( 'mounting' );
-		this._container = document.createElement( 'div' );
-		document.body.appendChild( this._container );
-
-		this._renderDialogBase();
-	},
-
-	componentDidUpdate: function() {
-		debug( 'updating' );
-		this._renderDialogBase();
-	},
-
-	componentWillUnmount: function() {
-		debug( 'unmounting' );
-		if ( this._container ) {
-			ReactDom.unmountComponentAtNode( this._container );
-			this._container.parentNode.removeChild( this._container );
-			this._container = null;
-		}
-	},
-
-	_renderDialogBase: function() {
-		var dialogComponent = this.props.isVisible ? <DialogBase { ...this.props } key="dialog" onDialogClose={ this.onDialogClose } /> : null,
-			transitionName = this.props.baseClassName || 'dialog';
-
-		ReactDom.render(
-			<SingleChildCSSTransitionGroup
-				transitionName={ transitionName }
-				component="div"
-				transitionLeave={ this.props.transitionLeave }
-				onChildDidLeave={ this.onDialogDidLeave }
-				enterTimeout={ this.props.enterTimeout }
-				leaveTimeout={ this.props.leaveTimeout }>
-				{ dialogComponent }
-			</SingleChildCSSTransitionGroup>,
-			this._container
-		);
-	},
-
 	render: function() {
-		return null;
+		const { isVisible, baseClassName } = this.props;
+
+		return (
+			<RootChild>
+				<SingleChildCSSTransitionGroup
+					transitionName={ baseClassName || 'dialog' }
+					component="div"
+					transitionLeave={ this.props.transitionLeave }
+					onChildDidLeave={ this.onDialogDidLeave }
+					enterTimeout={ this.props.enterTimeout }
+					leaveTimeout={ this.props.leaveTimeout }>
+					{ isVisible && (
+						<DialogBase { ...this.props } key="dialog" onDialogClose={ this.onDialogClose } />
+					) }
+				</SingleChildCSSTransitionGroup>
+			</RootChild>
+		);
 	},
 
 	onDialogDidLeave: function() {

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -1,18 +1,23 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	noop = require( 'lodash/utility/noop' ),
-	debug = require( 'debug' )( 'calypso:dialog' );
+import ReactDom from 'react-dom';
+import React from 'react';
+import noop from 'lodash/utility/noop';
+import debugModule from 'debug';
 
 /**
  * Internal dependencies
  */
-var SingleChildCSSTransitionGroup = require( 'components/single-child-css-transition-group' ),
-	DialogBase = require( './dialog-base' );
+import SingleChildCSSTransitionGroup from 'components/single-child-css-transition-group';
+import DialogBase from './dialog-base';
 
-var Dialog = React.createClass( {
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:dialog' );
+
+export default React.createClass( {
 	propTypes: {
 		isVisible: React.PropTypes.bool,
 		baseClassName: React.PropTypes.string,
@@ -88,5 +93,3 @@ var Dialog = React.createClass( {
 		}
 	}
 } );
-
-module.exports = Dialog;


### PR DESCRIPTION
This pull request seeks to reimplement the `<Dialog />` component using [`<RootChild />`](https://github.com/Automattic/wp-calypso/tree/master/client/components/root-child). The `<RootChild />` component was heavily influenced by the behavior of `<Dialog />`, but was abstracted for more generalized usage (e.g. used for the [`<DropZone />` component](https://github.com/Automattic/wp-calypso/tree/master/client/components/drop-zone)). The changes here aim to reduce code duplication by consolidating the root DOM management in `<RootChild />`.

__Testing instructions:__

Verify that there are no regressions in Dialog usage. Here are a few examples:

- [Reader](http://calypso.localhost:3000) post detail view
- [Post editor](http://calypso.localhost:3000/post) media modal
- [Sharing](http://calypso.localhost:3000/sharing) connection confirmation screen