### PR TITLE
Editor: Fix error when navigating from page editor to Reader

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -312,7 +312,7 @@ var PostEditor = React.createClass( {
 								<EditorTitleContainer
 									onChange={ this.debouncedAutosave }
 									tabIndex={ 1 } />
-								{ this.state.post && isPage ?
+								{ this.state.post && isPage && site ?
 									<EditorPageSlug
 										slug={ this.state.post.slug }
 										path={ this.state.post.URL ? utils.getPagePath( this.state.post ) : site.URL + '/' }


### PR DESCRIPTION
This pull request seeks to resolve a JavaScript error which prevents a user from navigating from the Calypso page editor to any screen where a site is not assigned (Reader, Me, etc). The issue is that the selected site is unassigned, but one more render pass occurs before the actual navigation. The post editor attempts to render the page slug using the site URL, but no site object exists.

__Testing instructions:__

This issue only occurs for page editing, not post editing.

1. Navigate to the [Calypso page editor](http://calypso.localhost:3000/page)
2. Select a site, if prompted
3. Note that the page slug is correctly shown below the title field
4. Click Reader in the master bar
5. Confirm that no errors appear in your developer tools console, and that navigation occurs successfully