### PR TITLE
Media: Hide delete button if user cannot delete items

### DIFF
--- a/client/components/root-child/index.jsx
+++ b/client/components/root-child/index.jsx
@@ -1,11 +1,20 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' );
+import ReactDom from 'react-dom';
+import React, { PropTypes } from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'RootChild',
+
+	propTypes: {
+		children: PropTypes.node
+	},
+
+	contextTypes: {
+		store: PropTypes.object
+	},
 
 	componentDidMount: function() {
 		this.container = document.createElement( 'div' );
@@ -36,6 +45,16 @@ module.exports = React.createClass( {
 			content = <div { ...this.props }>{ this.props.children }</div>;
 		} else {
 			content = this.props.children;
+		}
+
+		// Context is lost when creating a new render hierarchy, so ensure that
+		// we preserve the context that we care about
+		if ( this.context.store ) {
+			content = (
+				<ReduxProvider store={ this.context.store }>
+					{ content }
+				</ReduxProvider>
+			);
 		}
 
 		ReactDom.render( content, this.container );

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -3,6 +3,7 @@
  */
 var ReactDom = require( 'react-dom' ),
 	ReactDomServer = require( 'react-dom/server' ),
+	ReduxProvider = require( 'react-redux' ).Provider,
 	React = require( 'react' ),
 	tinymce = require( 'tinymce/tinymce' ),
 	pick = require( 'lodash/object/pick' ),
@@ -71,16 +72,18 @@ function mediaButton( editor ) {
 		}
 
 		ReactDom.render(
-			<MediaLibrarySelectedData siteId={ selectedSite.ID }>
-				<EditorMediaModal
-					{ ...props }
-					onClose={ renderModal.bind( null, { visible: false } ) }
-					onInsertMedia={ ( markup ) => {
-						insertMedia( markup );
-						renderModal( { visible: false } );
-					} }
-					site={ selectedSite } />
-			</MediaLibrarySelectedData>,
+			<ReduxProvider store={ editor.getParam( 'redux_store' ) }>
+				<MediaLibrarySelectedData siteId={ selectedSite.ID }>
+					<EditorMediaModal
+						{ ...props }
+						onClose={ renderModal.bind( null, { visible: false } ) }
+						onInsertMedia={ ( markup ) => {
+							insertMedia( markup );
+							renderModal( { visible: false } );
+						} }
+						site={ selectedSite } />
+				</MediaLibrarySelectedData>
+			</ReduxProvider>,
 			nodes.modal
 		);
 	}

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -460,4 +460,52 @@ describe( 'MediaUtils', function() {
 			expect( value ).to.equal( '[gallery ids="100,200" type="rectangular"]' );
 		} );
 	} );
+
+	describe( '#canUserDeleteItem()', () => {
+		const item = { author_ID: 73705554 };
+
+		it( 'should return false if the user ID matches the item author but user cannot delete posts', () => {
+			const user = { ID: 73705554 };
+			const site = {
+				capabilities: {
+					delete_posts: false
+				}
+			};
+
+			expect( MediaUtils.canUserDeleteItem( item, user, site ) ).to.be.false;
+		} );
+
+		it( 'should return true if the user ID matches the item author and user can delete posts', () => {
+			const user = { ID: 73705554 };
+			const site = {
+				capabilities: {
+					delete_posts: true
+				}
+			};
+
+			expect( MediaUtils.canUserDeleteItem( item, user, site ) ).to.be.true;
+		} );
+
+		it( 'should return false if the user ID does not match the item author and user cannot delete others posts', () => {
+			const user = { ID: 73705672 };
+			const site = {
+				capabilities: {
+					delete_others_posts: false
+				}
+			};
+
+			expect( MediaUtils.canUserDeleteItem( item, user, site ) ).to.be.false;
+		} );
+
+		it( 'should return true if the user ID does not match the item author but user can delete others posts', () => {
+			const user = { ID: 73705672 };
+			const site = {
+				capabilities: {
+					delete_others_posts: true
+				}
+			};
+
+			expect( MediaUtils.canUserDeleteItem( item, user, site ) ).to.be.true;
+		} );
+	} );
 } );

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -364,6 +364,23 @@ var MediaUtils = {
 			type: 'single',
 			attrs: attrs
 		} );
+	},
+
+	/**
+	 * Returns true if the specified user is capable of deleting the media
+	 * item, or false otherwise.
+	 *
+	 * @param  {Object}  item Media item
+	 * @param  {Object}  user User object
+	 * @param  {Object}  site Site object
+	 * @return {Boolean}      Whether user can delete item
+	 */
+	canUserDeleteItem( item, user, site ) {
+		if ( user.ID === item.author_ID ) {
+			return site.capabilities.delete_posts;
+		}
+
+		return site.capabilities.delete_others_posts;
 	}
 };
 

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -2,10 +2,12 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import values from 'lodash/object/values';
 import noop from 'lodash/utility/noop';
 import some from 'lodash/collection/some';
+import every from 'lodash/collection/every';
 
 /**
  * Internal dependencies
@@ -15,12 +17,12 @@ import { Views as ModalViews } from './constants';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'components/gridicon';
-import { userCan } from 'lib/site/utils';
+import { canUserDeleteItem } from 'lib/media/utils';
+import { getCurrentUser } from 'state/current-user/selectors';
 
-export default React.createClass( {
-	displayName: 'MediaModalSecondaryActions',
-
+const MediaModalSecondaryActions = React.createClass( {
 	propTypes: {
+		user: PropTypes.object,
 		site: PropTypes.object,
 		selectedItems: PropTypes.array,
 		activeView: React.PropTypes.oneOf( values( ModalViews ) ),
@@ -62,6 +64,7 @@ export default React.createClass( {
 
 	getButtons() {
 		const {
+			user,
 			site,
 			selectedItems,
 			activeView,
@@ -80,7 +83,11 @@ export default React.createClass( {
 			} );
 		}
 
-		if ( ModalViews.GALLERY !== activeView && selectedItems.length && userCan( 'upload_files', site ) ) {
+		const canDeleteItems = selectedItems.length && every( selectedItems, ( item ) => {
+			return canUserDeleteItem( item, user, site );
+		} );
+
+		if ( ModalViews.GALLERY !== activeView && canDeleteItems ) {
 			buttons.push( {
 				key: 'delete',
 				value: this.translate( 'Delete' ),
@@ -164,3 +171,9 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	return {
+		user: getCurrentUser( state )
+	};
+} )( MediaModalSecondaryActions );


### PR DESCRIPTION
Closes #2416

This pull request seeks to remove the Delete button from the post editor media modal if the user cannot delete the items. In particular, a user can only delete an item if they have the [`delete_posts` capability](https://codex.wordpress.org/Roles_and_Capabilities#delete_posts) if the media was uploaded by them, or the [`delete_others_posts` capability](https://codex.wordpress.org/Roles_and_Capabilities#delete_others_posts) if the item was uploaded by another user.

__Testing instructions:__

Author is an example of a user role which has the `delete_posts` capability, but not the `delete_others_posts` capability. Confirm that as an administrator, you have the option to delete your own or others' media. Confirm that as an author, you only have the option to delete your own media, and that the delete option is hidden if the current media selection contains any media uploaded by another user.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click the media button in the editor toolbar
4. Click a media item to select it
5. Note in the action bar at the bottom of the modal, that the presence of the Delete action matches the expected behavior described above