### PR TITLE
@ssr-ready pragma check: fix module ignores

### DIFF
--- a/server/pragma-checker/index.js
+++ b/server/pragma-checker/index.js
@@ -29,7 +29,7 @@ function scanDependencies( module, compilation ) {
 		// If the module is compiled through babel, we can be pretty sure it's our own module, not from npm.
 		if ( includes( dep.module.request, 'babel-loader' ) &&
 				dep.module._source &&
-				! includes( IGNORED_MODULES, dep.module.rawRequest ) &&
+				! includes( IGNORED_MODULES, dep.request ) &&
 				! includes( dep.module._source._value, SSR_READY ) ) {
 			compilation.errors.push( PLUGIN_TITLE + ': ' + module.rawRequest + ', dependency ' + dep.module.rawRequest + ' is not ' + SSR_READY );
 		}


### PR DESCRIPTION
Previously, lines like

```js
import decodeEntities from 'lib/formatting/decode-entities';
```

would yield

```
PragmaChecker: layout/head, dependency ./decode-entities is not /** @ssr-ready **/
```

thus revealing that the plugin is not using the full module path of the dependency to match it against the ignored modules.

/cc @ehg 