### PR TITLE
Add the Headstart signup flow back into production for temporary testing.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -71,6 +71,13 @@ const flows = {
 		lastModified: '2015-12-10'
 	},
 
+	headstart: {
+		steps: [ 'theme-headstart', 'domains-with-theme', 'plans', 'user' ],
+		destination: getCheckoutDestination,
+		description: 'Show users their site after signup, with prepopulated content',
+		lastModified: '2015-10-01'
+	},
+
 	'delta-discover': {
 		steps: [ 'user' ],
 		destination: '/',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -12,6 +12,7 @@ var UserSignupComponent = require( 'signup/steps/user' ),
 
 module.exports = {
 	themes: ThemeSelectionComponent,
+	'theme-headstart': ThemeSelectionComponent,
 	site: SiteComponent,
 	user: UserSignupComponent,
 	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
@@ -19,6 +20,7 @@ module.exports = {
 	domains: DomainsStepComponent,
 	survey: SurveyStepComponent,
 	'survey-user': UserSignupComponent,
+	'domains-with-theme': DomainsStepComponent,
 	'design-type': DesignTypeComponent,
 	'jetpack-user': UserSignupComponent
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -16,6 +16,15 @@ module.exports = {
 		dependencies: [ 'siteSlug' ]
 	},
 
+	'theme-headstart': {
+		stepName: 'theme-headstart',
+		props: {
+			useHeadstart: true
+		},
+		dependencies: [ 'siteSlug' ],
+		providesDependencies: [ 'theme', 'images' ]
+	},
+
 	'design-type': {
 		stepName: 'design-type',
 		providesDependencies: [ 'themes' ]
@@ -65,6 +74,14 @@ module.exports = {
 		stepName: 'domains',
 		apiRequestFunction: stepActions.addDomainItemsToCart,
 		providesDependencies: [ 'siteSlug', 'domainItem' ],
+		delayApiRequestUntilComplete: true
+	},
+
+	'domains-with-theme': {
+		stepName: 'domains-with-theme',
+		apiRequestFunction: stepActions.addDomainItemsToCart,
+		providesDependencies: [ 'siteSlug', 'domainItem' ],
+		dependencies: [ 'theme', 'images' ],
 		delayApiRequestUntilComplete: true
 	},
 

--- a/client/signup/steps/theme-selection/theme-thumbnail.jsx
+++ b/client/signup/steps/theme-selection/theme-thumbnail.jsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+var React = require( 'react' );
+
+/**
+ * Internal dependencies
+ */
+var analytics = require( 'analytics' ),
+	SignupActions = require( 'lib/signup/actions' );
+
+module.exports = React.createClass( {
+	displayName: 'ThemeThumbnail',
+
+	propTypes: {
+		themeName: React.PropTypes.string.isRequired,
+		themeSlug: React.PropTypes.string.isRequired,
+	},
+
+	handleSubmit: function() {
+		var themeSlug = this.props.themeSlug;
+
+		if ( true === this.props.useHeadstart && themeSlug ) {
+			analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: true } );
+
+			SignupActions.submitSignupStep( { stepName: this.props.stepName }, null, {
+				theme: 'pub/' + themeSlug,
+				images: undefined
+			} );
+		} else {
+			analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: false } );
+
+			SignupActions.submitSignupStep( {
+				stepName: this.props.stepName,
+				processingMessage: this.translate( 'Adding your theme' ),
+				themeSlug
+			} );
+		}
+
+		this.props.goToNextStep();
+	},
+
+	getThumbnailUrl: function() {
+		return 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + this.props.themeSlug + '/screenshot.png?w=660';
+	},
+
+	render: function() {
+		return (
+			<div onClick={ this.handleSubmit } className="theme-thumbnail__theme">
+				<img src={ this.getThumbnailUrl() } />
+				<span className="theme-thumbnail__name">{ this.props.themeName }</span>
+			</div>
+		);
+	}
+} );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#2194.

This PR adds Headstart back into the signup flow, so that we can test Automattic/headstart#41. It will be removed again after the test (maybe an hour later).