### PR TITLE
Olark: Ensure error message is set before showing notice

### DIFF
--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -69,7 +69,7 @@ const olark = {
 	handleError: function( error ) {
 		// error.error === 'authorization_required' when the user is logged out
 		// when https://github.com/Automattic/wp-calypso/issues/289 is fixed then we can remove this condition
-		if ( error.error !== 'authorization_required' ) {
+		if ( error && error.message && error.error !== 'authorization_required' ) {
 			notices.error( error.message );
 		}
 	},


### PR DESCRIPTION
Earlier today I noticed a blank error notice show while on the reader:

![olark-notice](https://cloud.githubusercontent.com/assets/1126811/12361151/170714b2-bb82-11e5-86f3-289ffa74f385.png)

Based on the error message in the console above, I tracked the API call to:

https://github.com/Automattic/wp-calypso/blob/d24e6402682bc5d5eb5296f2053e8a8e054ed76f/client/lib/wpcom-undocumented/lib/undocumented.js#L1795-L1800

That method is called in [client/lib/olark/index.js](https://github.com/Automattic/wp-calypso/blob/master/client/lib/olark/index.js#L84), and when it errors, the `handleError` method in the same file is called.

While I have not been able to reproduce the notice showing without a message, I believe we could be a bit more defensive to prevent this in the future.

The suggested fix here is to check that `error.message` is set before showing the notice.

cc @omarjackman @dllh 