### PR TITLE
Themes: Fix Support link to point to site-specific URL

### DIFF
--- a/client/lib/themes/helpers.js
+++ b/client/lib/themes/helpers.js
@@ -48,7 +48,7 @@ var ThemesHelpers = {
 
 	getSupportUrl: function( theme, site ) {
 		if ( ! site ) {
-			return ThemesHelpers.oldShowcaseUrl + theme.id;
+			return ThemesHelpers.oldShowcaseUrl + theme.id + '/support';
 		}
 
 		if ( site.jetpack ) {

--- a/client/lib/themes/helpers.js
+++ b/client/lib/themes/helpers.js
@@ -47,11 +47,15 @@ var ThemesHelpers = {
 	},
 
 	getSupportUrl: function( theme, site ) {
-		if ( site && site.jetpack ) {
+		if ( ! site ) {
+			return ThemesHelpers.oldShowcaseUrl + theme.id;
+		}
+
+		if ( site.jetpack ) {
 			return '//wordpress.org/support/theme/' + theme.id;
 		}
 
-		return ThemesHelpers.oldShowcaseUrl + theme.id + '/support';
+		return ThemesHelpers.oldShowcaseUrl + site.slug + '/' + theme.id + '/support';
 	},
 
 	getForumUrl: function( theme ) {


### PR DESCRIPTION
In single-site mode, point to
https://wordpress.com/themes/[SITE ADDRESS]/[THEME SLUG]/support instead of just
https://wordpress.com/themes/[THEME SLUG]/support

Fixes #2425

To test: see #2425 :-)

cc @rachelmcr 