### PR TITLE
Fix bug in importer - blank list after upload finishes

### DIFF
--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -81,7 +81,7 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 		case actionTypes.FINISH_UPLOAD:
 			newState = state
 				.deleteIn( [ 'importers' ], action.importerId )
-				.setIn( [ 'importers', fromApi( action.importerStatus ).importerId ], Immutable.fromJS( fromApi( action.importerStatus ) ) );
+				.setIn( [ 'importers', action.importerStatus.importerId ], Immutable.fromJS( action.importerStatus ) );
 			break;
 
 		case actionTypes.START_MAPPING_AUTHORS:

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1715,16 +1715,22 @@ Undocumented.prototype.updateImporter = function( siteId, importerStatus ) {
 };
 
 Undocumented.prototype.uploadExportFile = function( siteId, params ) {
-	var req = this.wpcom.req.post( {
-		path: `/sites/${ siteId }/imports/new`,
-		formData: [
-			[ 'importStatus', JSON.stringify( params.importStatus ) ],
-			[ 'import', params.file ]
-		]
-	}, params.onload );
+	return new Promise( ( resolve, reject ) => {
+		const resolver = ( error, data ) => {
+			error ? reject( error ) : resolve( data );
+		};
 
-	req.upload.onprogress = params.onprogress;
-	req.onabort = params.onabort;
+		const req = this.wpcom.req.post( {
+			path: `/sites/${ siteId }/imports/new`,
+			formData: [
+				[ 'importStatus', JSON.stringify( params.importStatus ) ],
+				[ 'import', params.file ]
+			]
+		}, resolver );
+
+		req.upload.onprogress = params.onprogress;
+		req.onabort = params.onabort;
+	} );
 };
 
 /**


### PR DESCRIPTION
Previously the importer would flash a blank list right after the
uploaded file finished. This would disappear after a moment when the
polling system got an update back form the API.

The cause for this bug was the fact that the site id wasn't being set
for the response - or that this site id was missing from the API
response. Therefore, when it came back from the upload request, the
importer was effectively removed since it wouldn't have been available
in any site slot.

Now, the site id is being added back into the response so that it files
appropriately in the store. To accomplish this, a few changes and/or
improvements have been made:

 - The uploading function in `wpcom-undocumented` now returns a promise
   so that the code can be a little clearer in `actions.js`
 - The response is transformed in the upload file instead of the store
   for `finishUpload`

**Testing**

Start in **master** and upload an export file in **My Sites** > **Settings** > **Import**. After the import finishes, and after the server processes the file, the importer in Calypso should disappear for a second or two until the normal polling brings it back into the "successfully uploaded" state.

Switch to this branch and then repeat the process. The blank screen should no longer appear and the process should be smooth after an upload.

This also impacted the error resolution, so if you would like to make sure that it handles errors appropriately, then you can open two windows and get to the point of uploading the file in each. Don't start the upload until both windows are ready. The window in which the second upload started should return and display a notice indicating that you can't start simultaneous uploads.

cc: @rralian @rodrigoi @designsimply 