### PR TITLE
Chart: Remove animations on bars.

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -169,7 +169,6 @@
 		bottom: 0; // 1
 		left: 16%; // 1
 	z-index: z-index( 'root', '.chart__bar-section' );
-	transition: top .3s ease-out; // 2
 
 	.chart__bar:hover &.is-bar {
 		background-color: $blue-medium;


### PR DESCRIPTION
Fixes #2485 - This branch removes the animation that happens in the chart bars on stats pages.

__To Test__
- Open a site stats page
- interact with the chart tabs, note the bars no longer animate on change

/cc @alternatekev & @jancavan I believe this is what we discussed doing, but hoping you both could weigh-in on this change.