### PR TITLE
Invite: Update wording for follower and viewer invites

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -45,6 +45,48 @@ export default React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_invite_accept_logged_in_sign_in_link_click' );
 	},
 
+	getButtonText() {
+		let text = '';
+		if ( 'follower' === this.props.role ) {
+			text = this.state.submitting
+				? this.translate( 'Following…', { context: 'button' } )
+				: this.translate( 'Follow', { context: 'button' } );
+		} else {
+			text = this.state.submitting
+				? this.translate( 'Joining…', { context: 'button' } )
+				: this.translate( 'Join', { context: 'button' } );
+		}
+
+		return text;
+	},
+
+	getJoinAsText() {
+		const { user } = this.props;
+		let text = '';
+
+		if ( 'follower' === this.props.role ) {
+			text = this.translate( 'Follow as {{usernameWrap}}%(username)s{{/usernameWrap}}', {
+				components: {
+					usernameWrap: <span className="invite-accept-logged-in__join-as-username" />
+				},
+				args: {
+					username: user && user.display_name
+				}
+			} );
+		} else {
+			text = this.translate( 'Join as {{usernameWrap}}%(username)s{{/usernameWrap}}', {
+				components: {
+					usernameWrap: <span className="invite-accept-logged-in__join-as-username" />
+				},
+				args: {
+					username: user && user.display_name
+				}
+			} );
+		}
+
+		return text;
+	},
+
 	render() {
 		const { user } = this.props,
 			signInLink = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
@@ -55,26 +97,14 @@ export default React.createClass( {
 					<InviteFormHeader { ...this.props } />
 					<div className="invite-accept-logged-in__join-as">
 						<Gravatar user={ user } size={ 72 } />
-						{
-							this.translate( 'Join as {{usernameWrap}}%(username)s{{/usernameWrap}}', {
-								components: {
-									usernameWrap: <span className="invite-accept-logged-in__join-as-username" />
-								},
-								args: {
-									username: user && user.display_name
-								}
-							} )
-						}
+						{ this.getJoinAsText() }
 					</div>
 					<div className="invite-accept-logged-in__button-bar">
 						<Button onClick={ this.decline } disabled={ this.state.submitting }>
 							{ this.translate( 'Decline', { context: 'button' } ) }
 						</Button>
 						<Button primary onClick={ this.accept } disabled={ this.state.submitting }>
-							{ this.state.submitting
-								? this.translate( 'Joining…', { context: 'button' } )
-								: this.translate( 'Join', { context: 'button' } )
-							}
+							{ this.getButtonText() }
 						</Button>
 					</div>
 				</Card>

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -30,7 +30,15 @@ export default React.createClass( {
 	},
 
 	submitButtonText() {
-		return this.translate( 'Sign Up & Join' );
+		let text = '';
+		if ( 'follower' === this.props.role ) {
+			text = this.translate( 'Sign Up & Follow' );
+		} else if ( 'viewer' === this.props.role ) {
+			text = this.translate( 'Sign Up & View' );
+		} else {
+			text = this.translate( 'Sign Up & Join' );
+		}
+		return text;
 	},
 
 	clickSignInLink() {

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -86,6 +86,15 @@ export default React.createClass( {
 					}
 				);
 				break;
+			case 'viewer':
+				title = this.translate(
+					'Sign up to begin viewing {{siteLink/}}.', {
+						components: {
+							siteLink: this.getSiteLink()
+						}
+					}
+				);
+				break;
 			case 'follower':
 				title = this.translate(
 					'Sign up to start following {{siteLink/}} in the WordPress.com Reader.', {
@@ -163,6 +172,15 @@ export default React.createClass( {
 					}
 				);
 				break;
+			case 'viewer':
+				title = this.translate(
+					'Would you like to be able to view {{siteLink/}}?', {
+						components: {
+							siteLink: this.getSiteLink()
+						}
+					}
+				);
+				break;
 			case 'follower':
 				title = this.translate(
 					'Would you like to become a follower of {{siteLink/}}?', {
@@ -219,7 +237,16 @@ export default React.createClass( {
 				break;
 			case 'subscriber':
 				explanation = this.translate(
-					'As a subscriber, you will be able to manage your profile on %(siteName)s', {
+					'As a subscriber, you will be able to manage your profile on %(siteName)s.', {
+						args: {
+							siteName: this.getSiteName()
+						}
+					}
+				);
+				break;
+			case 'viewer':
+				explanation = this.translate(
+					'As a viewer, you will be able to view the private site %(siteName)s.', {
 						args: {
 							siteName: this.getSiteName()
 						}
@@ -228,7 +255,7 @@ export default React.createClass( {
 				break;
 			case 'follower':
 				explanation = this.translate(
-					'As a follower, you will receive updates every time there is a new post on %(siteName)s', {
+					'As a follower, you will receive updates every time there is a new post on %(siteName)s.', {
 						args: {
 							siteName: this.getSiteName()
 						}

--- a/client/my-sites/invites/invite-header/index.jsx
+++ b/client/my-sites/invites/invite-header/index.jsx
@@ -81,6 +81,15 @@ export default React.createClass( {
 					}
 				);
 				break;
+			case 'viewer':
+				text = this.translate(
+					'{{inviterName/}} invited you to view:', {
+						components: {
+							inviterName: inviterName
+						}
+					}
+				);
+				break;
 			case 'follower':
 				text = this.translate(
 					'{{inviterName/}} invited you to follow:', {
@@ -92,7 +101,7 @@ export default React.createClass( {
 				break
 			default:
 				text = this.translate(
-					'{{inviterName/}} invited you to be: %(invitedRole)s on:', {
+					'{{inviterName/}} invited you to be %(invitedRole)s on:', {
 						args: {
 							invitedRole: role
 						},


### PR DESCRIPTION
@lezama pointed out to me that we should consider updating the "Join as..." text to something like "Follow as...".

As part of this PR, I also went ahead and updated the wording for viewer roles. Previously, viewers were returned from the API as followers. After an update in the API, we are not able to distinguish between the two.

To test:
- Checkout `update/invite-viewer-follower-wording` branch
- Go to `$site/wp-admin/users.php?page=wpcom-invite-users` where `$site` is a public WP.com site
- Invite a user as a follower
- Click the link in the invitation email, and then replace `wpcalypso.wordpress.com` with `calypso.localhost:3000`
- If wording is for a follower, and seems correct, then :+1: 

- Go to `$site/wp-admin/users.php?page=wpcom-invite-users` where `$site` is a private WP.com site
- Invite a user as a viewer
- Click the link in the invitation email, and then replace `wpcalypso.wordpress.com` with `calypso.localhost:3000`
- If wording is for a viewer and uses the action word "Join" then :+1: 

__Note:__ For the instructions to work, you must be a whitelisted tester. If you'd like to test, please ping me.