### PR TITLE
Purchases: Add nav when user has no sites

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -23,6 +23,7 @@ import ManagePurchase from './manage-purchase';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
 import paths from './paths';
 import PurchasesData from 'components/data/purchases';
+import PurchasesHeader from './list/header';
 import PurchasesList from './list';
 import sitesFactory from 'lib/sites-list';
 import titleActions from 'lib/screen-title/actions';
@@ -214,6 +215,7 @@ export default {
 
 		renderPage(
 			<Main>
+				<PurchasesHeader section={ 'purchases' } />
 				<NoSitesMessage />
 			</Main>
 		);


### PR DESCRIPTION
Currently, when a user has no sites on their account, they're unable to view the section nav for /purchases, which means they can't view their past Billing History. Here's what that currently looks like:

<img width="1280" alt="screen shot 2016-01-17 at 1 03 59 pm" src="https://cloud.githubusercontent.com/assets/7240478/12379592/d0e00742-bd1a-11e5-8b62-b8948d0f90a5.png">

This PR imports `PurchasesHeader` and uses it in the render for `noSitesMessage()`. Here's the result for the same account:

<img width="1280" alt="screen shot 2016-01-17 at 1 05 33 pm" src="https://cloud.githubusercontent.com/assets/7240478/12379600/0509affa-bd1b-11e5-8dee-48a61c2aa305.png">

Shot at fixing #2415