### PR TITLE
Support User: Add Support User libraries (fix)

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -154,6 +154,11 @@ function boot() {
 		i18n.setLocaleSlug( user.get().localeSlug );
 	} );
 
+	// Temporary support for development of the Support User feature
+	if ( config.isEnabled( 'support-user' ) ) {
+		require( 'lib/user/dev-support-user' )( user );
+	}
+
 	translatorJumpstart.init();
 
 	reduxStore = createReduxStore();

--- a/client/lib/user/dev-support-user.js
+++ b/client/lib/user/dev-support-user.js
@@ -1,0 +1,22 @@
+/**
+ * This is a temporary file to assist development of the support user feature.
+ */
+
+import config from 'config';
+
+export default function( user ) {
+	if ( config.isEnabled( 'support-user' ) ) {
+		const callback = ( error ) => {
+			if ( error ) {
+				console.error( error );
+			} else {
+				console.log( 'success' );
+			}
+		};
+
+		window.supportUser = {
+			login: ( username, password ) => user.changeUser( username, password, callback ),
+			logout: () => user.restoreUser()
+		};
+	}
+}

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -238,6 +238,25 @@ User.prototype.set = function( attributes ) {
 	return changed;
 };
 
+User.prototype.changeUser = function( username, password, callback ) {
+	if ( config.isEnabled( 'support-user' ) ) {
+		wpcom.changeUser( username, password, function( error ) {
+			if ( ! error ) {
+				this.fetch();
+			}
+			callback( error );
+		}.bind( this ) );
+	}
+};
+
+User.prototype.restoreUser = function() {
+	if ( config.isEnabled( 'support-user' ) ) {
+		wpcom.restoreUser();
+
+		this.fetch();
+	}
+};
+
 /**
  * Expose `User`
  */

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -9,6 +9,7 @@ const debug = debugFactory( 'calypso:wp' );
  */
 import wpcomUndocumented from 'lib/wpcom-undocumented';
 import config from 'config';
+import wpcomSupport from 'lib/wp/support';
 
 let wpcom;
 
@@ -36,4 +37,8 @@ if ( config.isEnabled( 'oauth' ) ) {
 /**
  * Expose `wpcom`
  */
-module.exports = wpcom;
+if ( config.isEnabled( 'support-user' ) ) {
+	module.exports = wpcomSupport( wpcom );
+} else {
+	module.exports = wpcom;
+}

--- a/client/lib/wp/support.js
+++ b/client/lib/wp/support.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import qs from 'qs';
+
+export default function wpcomSupport( wpcom ) {
+	let supportUser = '';
+	let supportToken = '';
+
+	/**
+	 * Add the supportUser and supportToken to the query.
+	 * @param {Object}  params The original request params object
+	 * @return {Object}        The new query object with support data injected
+	 */
+	const addSupportData = function( params ) {
+		// Unwind the query string
+		let query = qs.parse( params.query );
+
+		// Inject the credentials
+		query.support_user = supportUser;
+		query._support_token = supportToken
+
+		return Object.assign( {}, params, {
+			query: qs.stringify( query )
+		} );
+	};
+
+	const request = wpcom.request.bind( wpcom );
+
+	return Object.assign( wpcom, {
+		changeUser: function( username, password, fn ) {
+			return wpcom.req.post(
+				{
+					apiVersion: '1.1',
+					path: `/internal/support/${ username }/grant`
+				},
+				{
+					password: password
+				},
+				( error, response ) => {
+					if ( ! error ) {
+						supportUser = response.username;
+						supportToken = response.token;
+					}
+
+					fn( error, response );
+				}
+			);
+		},
+		restoreUser: function() {
+			supportUser = '';
+			supportToken = '';
+		},
+		request: ( params, callback ) => {
+			if ( supportUser && supportToken ) {
+				return request( addSupportData( params ), callback );
+			}
+
+			return request( params, callback );
+		}
+	} );
+};

--- a/config/client.json
+++ b/config/client.json
@@ -25,5 +25,6 @@
   "logout_url",
   "siftscience_key",
   "facebook_api_key",
-  "discover_blog_id"
+  "discover_blog_id",
+  "support-user"
 ]

--- a/config/development.json
+++ b/config/development.json
@@ -122,6 +122,7 @@
 		"me/trophies": false,
 
 		"help": true,
+		"support-user": true,
 
 		"notifications2beta": true,
 		"muse": true,


### PR DESCRIPTION
This PR is a retry of #2368. The original PR broke staging by causing a 'module not found' error and was subsequently reverted in #2509. This was due to the `shared` directory being removed in #2309.
<img width="1249" alt="screen shot 2016-01-18 at 9 03 39 am" src="https://cloud.githubusercontent.com/assets/416133/12381326/72a9e17a-bdd3-11e5-8712-c2cb5c0952e5.png">

The only change in this PR is the [3rd commit moving `/shared/lib/wp/support.js` to `client/lib/wp/support.js`](https://github.com/Automattic/wp-calypso/commit/a858bb3c1613c7a699632c39088438545e363be4); otherwise it's the same as #2368.

Lesson learned: Always rebase from master and test before merging, even if GitHub says the merge can be done cleanly.

### Original PR (#2368)
-------

This PR adds libraries that will be used in the support user functionality (ref p195om-2GO-p2)

An access token is granted when a support user and password are provided; the token can be revoked during a restore operation, or will expire after a set period of time. Once granted, the support username and token are passed along all queries to the API.

This is a subset of the original PR #1202 (props to @jmdodd), separated out for easier progressive review.