### PR TITLE
Editor: Fix bug adding tags on Hebrew keyboards

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -77,6 +77,7 @@ var TokenField = React.createClass( {
 				className={ classes }
 				tabIndex="-1"
 				onKeyDown={ this._onKeyDown }
+				onKeyPress={ this._onKeyPress }
 				onBlur={ this._onBlur }
 				onFocus={ this._onFocus }
 			>
@@ -261,10 +262,21 @@ var TokenField = React.createClass( {
 			case 46: // delete (to right)
 				preventDefault = this._handleDeleteKey( this._deleteTokenAfterInput );
 				break;
-			case 188: // comma
-				if ( ! event.shiftKey ) { // ignore <
-					preventDefault = this._handleCommaKey();
-				}
+			default:
+				break;
+		}
+
+		if ( preventDefault ) {
+			event.preventDefault();
+		}
+	},
+
+	_onKeyPress: function( event ) {
+		var preventDefault = false;
+
+		switch ( event.charCode ) {
+			case 44: // comma
+				preventDefault = this._handleCommaKey();
 				break;
 			default:
 				break;
@@ -382,7 +394,6 @@ var TokenField = React.createClass( {
 
 		if ( ! this._isInputEmpty() ) {
 			this._addNewToken( this.state.incompleteTokenValue );
-			preventDefault = true;
 		}
 
 		return preventDefault;

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -175,11 +175,11 @@ var TokenField = React.createClass( {
 				// there is a suggested token selected.  In that case, we don't
 				// want to add it, because it's easy to inadvertently hover
 				// over a suggestion.
-				if ( this._isInputEmptyOrWhitespace() ) {
-					debug( '_onBlur after timeout not adding current token' );
-				} else {
+				if ( this._inputHasValidValue() ) {
 					debug( '_onBlur after timeout adding current token' );
 					this._addCurrentToken();
+				} else {
+					debug( '_onBlur after timeout not adding current token' );
 				}
 				debug( '_onBlur resetting component state' );
 				this.setState( this.getInitialState() );
@@ -332,13 +332,12 @@ var TokenField = React.createClass( {
 
 	_addCurrentToken: function() {
 		var preventDefault = false,
-			isInputEmpty = this._isInputEmptyOrWhitespace(),
 			selectedSuggestion = this._getSelectedSuggestion();
 
 		if ( selectedSuggestion ) {
 			this._addNewToken( selectedSuggestion );
 			preventDefault = true;
-		} else if ( ! isInputEmpty ) {
+		} else if ( this._inputHasValidValue() ) {
 			this._addNewToken( this.state.incompleteTokenValue );
 			preventDefault = true;
 		}
@@ -392,7 +391,7 @@ var TokenField = React.createClass( {
 	_handleCommaKey: function() {
 		var preventDefault = true;
 
-		if ( ! this._isInputEmpty() ) {
+		if ( this._inputHasValidValue() ) {
 			this._addNewToken( this.state.incompleteTokenValue );
 		}
 
@@ -403,8 +402,8 @@ var TokenField = React.createClass( {
 		return this.state.incompleteTokenValue.length === 0;
 	},
 
-	_isInputEmptyOrWhitespace: function() {
-		return /^\s*$/.test( this.state.incompleteTokenValue );
+	_inputHasValidValue: function() {
+		return this.props.saveTransform( this.state.incompleteTokenValue ).length > 0;
 	},
 
 	_deleteTokenBeforeInput: function() {

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -29,6 +29,10 @@ var keyCodes = {
 	comma: 188
 };
 
+var charCodes = {
+	comma: 44
+};
+
 describe( 'TokenField', function() {
 	var reactContainer, wrapper, tokenFieldNode, textInputNode;
 
@@ -36,10 +40,16 @@ describe( 'TokenField', function() {
 		TestUtils.Simulate.change( textInputNode, { target: { value: text } } );
 	}
 
-	function sendKey( keyCode, shiftKey ) {
+	function sendKeyDown( keyCode, shiftKey ) {
 		TestUtils.Simulate.keyDown( textInputNode, {
 			keyCode: keyCode,
 			shiftKey: !! shiftKey
+		} );
+	}
+
+	function sendKeyPress( charCode ) {
+		TestUtils.Simulate.keyPress( textInputNode, {
+			charCode: charCode
 		} );
 	}
 
@@ -185,9 +195,9 @@ describe( 'TokenField', function() {
 			setText( 't' );
 			expect( getSuggestionsHTML() ).to.deep.equal( fixtures.matchingSuggestions.t );
 			expect( getSelectedSuggestion() ).to.equal( null );
-			sendKey( keyCodes.downArrow ); // 'the'
+			sendKeyDown( keyCodes.downArrow ); // 'the'
 			expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'he' ] );
-			sendKey( keyCodes.downArrow ); // 'to'
+			sendKeyDown( keyCodes.downArrow ); // 'to'
 			expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'o' ] );
 			hoverSuggestion = tokenFieldNode.querySelectorAll( '.token-field__suggestion' )[5]; // 'it'
 			expect( getSuggestionNodeHTML( hoverSuggestion ) ).to.deep.equal( [ 'i', 't', '' ] );
@@ -200,9 +210,9 @@ describe( 'TokenField', function() {
 				// this would happen in a real browser but doesn't seem to be needed here
 				// TestUtils.SimulateNative.mouseOver( hoverSuggestion, { relatedTarget: textInputNode } );
 				expect( getSelectedSuggestion() ).to.deep.equal( [ 'i', 't', '' ] );
-				sendKey( keyCodes.upArrow );
+				sendKeyDown( keyCodes.upArrow );
 				expect( getSelectedSuggestion() ).to.deep.equal( [ 'wi', 't', 'h' ] );
-				sendKey( keyCodes.upArrow );
+				sendKeyDown( keyCodes.upArrow );
 				expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'his' ] );
 				TestUtils.Simulate.click( hoverSuggestion );
 				expect( getSelectedSuggestion() ).to.equal( null );
@@ -217,49 +227,49 @@ describe( 'TokenField', function() {
 
 		it( 'should add a token when Tab pressed', function() {
 			setText( 'baz' );
-			sendKey( keyCodes.tab );
+			sendKeyDown( keyCodes.tab );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
 			expect( textInputNode.value ).to.equal( '' );
 		} );
 
 		it( 'should not allow adding blank tokens with Tab', function() {
-			sendKey( keyCodes.tab );
+			sendKeyDown( keyCodes.tab );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should not allow adding whitespace tokens with Tab', function() {
 			setText( '   ' );
-			sendKey( keyCodes.tab );
+			sendKeyDown( keyCodes.tab );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should add a token when Enter pressed', function() {
 			setText( 'baz' );
-			sendKey( keyCodes.enter );
+			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
 			expect( textInputNode.value ).to.equal( '' );
 		} );
 
 		it( 'should not allow adding blank tokens with Enter', function() {
-			sendKey( keyCodes.enter );
+			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should not allow adding whitespace tokens with Enter', function() {
 			setText( '   ' );
-			sendKey( keyCodes.enter );
+			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should add a token when comma pressed', function() {
 			setText( 'baz' );
-			sendKey( keyCodes.comma );
+			sendKeyPress( charCodes.comma );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
 		} );
 
 		it( 'should not add a token when < pressed', function() {
 			setText( 'baz' );
-			sendKey( keyCodes.comma, true );
+			sendKeyDown( keyCodes.comma, true );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
 			// The text input does not register the < keypress when it is sent this way.
 			expect( textInputNode.value ).to.equal( 'baz' );
@@ -267,15 +277,15 @@ describe( 'TokenField', function() {
 
 		it( 'should trim token values when adding', function() {
 			setText( '  baz  ' );
-			sendKey( keyCodes.enter );
+			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
 		} );
 
 		function testOnBlur( initialText, selectSuggestion, expectedSuggestion, expectedTokens, done ) {
 			setText( initialText );
 			if ( selectSuggestion ) {
-				sendKey( keyCodes.downArrow ); // 'the'
-				sendKey( keyCodes.downArrow ); // 'to'
+				sendKeyDown( keyCodes.downArrow ); // 'the'
+				sendKeyDown( keyCodes.downArrow ); // 'to'
 			}
 			expect( getSelectedSuggestion() ).to.deep.equal( expectedSuggestion );
 
@@ -365,22 +375,22 @@ describe( 'TokenField', function() {
 		} );
 
 		it( 'should add tokens in the middle of the current tokens', function() {
-			sendKey( keyCodes.leftArrow );
+			sendKeyDown( keyCodes.leftArrow );
 			setText( 'baz' );
-			sendKey( keyCodes.tab );
+			sendKeyDown( keyCodes.tab );
 			setText( 'quux' );
-			sendKey( keyCodes.tab );
+			sendKeyDown( keyCodes.tab );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'baz', 'quux', 'bar' ] );
 		} );
 
 		it( 'should add tokens from the selected matching suggestion using Tab', function() {
 			setText( 't' );
 			expect( getSelectedSuggestion() ).to.equal( null );
-			sendKey( keyCodes.downArrow ); // 'the'
+			sendKeyDown( keyCodes.downArrow ); // 'the'
 			expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'he' ] );
-			sendKey( keyCodes.downArrow ); // 'to'
+			sendKeyDown( keyCodes.downArrow ); // 'to'
 			expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'o' ] );
-			sendKey( keyCodes.tab );
+			sendKeyDown( keyCodes.tab );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'to' ] );
 			expect( getSelectedSuggestion() ).to.equal( null );
 		} );
@@ -388,33 +398,33 @@ describe( 'TokenField', function() {
 		it( 'should add tokens from the selected matching suggestion using Enter', function() {
 			setText( 't' );
 			expect( getSelectedSuggestion() ).to.equal( null );
-			sendKey( keyCodes.downArrow ); // 'the'
+			sendKeyDown( keyCodes.downArrow ); // 'the'
 			expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'he' ] );
-			sendKey( keyCodes.downArrow ); // 'to'
+			sendKeyDown( keyCodes.downArrow ); // 'to'
 			expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'o' ] );
-			sendKey( keyCodes.enter );
+			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'to' ] );
 			expect( getSelectedSuggestion() ).to.equal( null );
 		} );
 
 		it( 'should add tokens from the selected suggestion using Tab', function() {
 			expect( getSelectedSuggestion() ).to.equal( null );
-			sendKey( keyCodes.downArrow ); // 'the'
+			sendKeyDown( keyCodes.downArrow ); // 'the'
 			expect( getSelectedSuggestion() ).to.equal( 'the' );
-			sendKey( keyCodes.downArrow ); // 'of'
+			sendKeyDown( keyCodes.downArrow ); // 'of'
 			expect( getSelectedSuggestion() ).to.equal( 'of' );
-			sendKey( keyCodes.tab );
+			sendKeyDown( keyCodes.tab );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'of' ] );
 			expect( getSelectedSuggestion() ).to.equal( null );
 		} );
 
 		it( 'should add tokens from the selected suggestion using Enter', function() {
 			expect( getSelectedSuggestion() ).to.equal( null );
-			sendKey( keyCodes.downArrow ); // 'the'
+			sendKeyDown( keyCodes.downArrow ); // 'the'
 			expect( getSelectedSuggestion() ).to.equal( 'the' );
-			sendKey( keyCodes.downArrow ); // 'of'
+			sendKeyDown( keyCodes.downArrow ); // 'of'
 			expect( getSelectedSuggestion() ).to.equal( 'of' );
-			sendKey( keyCodes.enter );
+			sendKeyDown( keyCodes.enter );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'of' ] );
 			expect( getSelectedSuggestion() ).to.equal( null );
 		} );
@@ -429,14 +439,14 @@ describe( 'TokenField', function() {
 		} );
 
 		it( 'should remove the token to the left when backspace pressed', function() {
-			sendKey( keyCodes.backspace );
+			sendKeyDown( keyCodes.backspace );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo' ] );
 		} );
 
 		it( 'should remove the token to the right when delete pressed', function() {
-			sendKey( keyCodes.leftArrow );
-			sendKey( keyCodes.leftArrow );
-			sendKey( keyCodes.delete );
+			sendKeyDown( keyCodes.leftArrow );
+			sendKeyDown( keyCodes.leftArrow );
+			sendKeyDown( keyCodes.delete );
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'bar' ] );
 		} );
 

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -261,6 +261,12 @@ describe( 'TokenField', function() {
 			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
+		it( 'should not allow adding whitespace tokens with comma', function() {
+			setText( '   ' );
+			sendKeyPress( charCodes.comma );
+			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
+		} );
+
 		it( 'should add a token when comma pressed', function() {
 			setText( 'baz' );
 			sendKeyPress( charCodes.comma );


### PR DESCRIPTION
Fixes #740.  The Hebrew letter "ת" is in the position of the comma key on US keyboards.  As a result, pressing this letter in the editor tags control will add the currently typed tag instead of adding the letter.

Handling special keys like arrows and Enter in `onKeyDown` based on their `keyCode` works well, but for comma and other keys that result in typed characters, we should use `onKeyPress` and `charCode` to correctly determine the character that was typed.

This PR also fixes a bonus related bug: currently it is possible to add tags consisting of only whitespace by pressing the comma key.

### To test

Switch your keyboard layout to Hebrew.  For those unfamiliar with this process, like I was, here's a poor-quality GIF demonstrating how to do it on OS X:

![keyboard-hebrew-cropped](https://cloud.githubusercontent.com/assets/227022/12382741/0c7e761a-bd63-11e5-9877-5e15968235b7.gif)

Navigate to the post editor and activate the tags control.  Type a few letters and then press the comma key to send "ת".  Verify that the letter is typed instead of adding the currently typed tag.

Also, type a tag consisting of only one or more spaces, then press the comma key and verify that this does nothing instead of adding an empty tag.