### PR TITLE
Signup: Fix widows on plans compare

### DIFF
--- a/client/components/plans/plan-features/index.jsx
+++ b/client/components/plans/plan-features/index.jsx
@@ -12,7 +12,8 @@ var PlanHeader = require( 'components/plans/plan-header' ),
 	PlanFeatureCell = require( 'components/plans/plan-feature-cell' ),
 	PlanActions = require( 'components/plans/plan-actions' ),
 	PlanPrice = require( 'components/plans/plan-price' ),
-	PlanDiscountMessage = require( 'components/plans/plan-discount-message' );
+	PlanDiscountMessage = require( 'components/plans/plan-discount-message' ),
+	preventWidows = require( 'lib/formatting' ).preventWidows;
 
 module.exports = React.createClass( {
 	displayName: 'PlanFeatures',
@@ -29,7 +30,7 @@ module.exports = React.createClass( {
 	},
 
 	headerText: function() {
-		return <span className="header-text">{ this.props.plan.product_name }</span>;
+		return <span className="header-text">{ preventWidows( this.props.plan.product_name, 2, 3 ) }</span>;
 	},
 
 	render: function() {

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -63,9 +63,10 @@ function unicodeToString( character ) {
  * Prevent widows by replacing spaces between the last `wordsToKeep` words in the text with non-breaking spaces
  * @param  {string} text        the text to work on
  * @param  {number} wordsToKeep the number of words to keep together
+ * @param  {number} minimun     the minimum number of words to apply this to
  * @return {string}             the widow-prevented string
  */
-function preventWidows( text, wordsToKeep ) {
+function preventWidows( text, wordsToKeep, minimun ) {
 	var words, endWords;
 
 	text = text && trim( text );
@@ -77,6 +78,10 @@ function preventWidows( text, wordsToKeep ) {
 
 	if ( ! words ) { // all whitespace
 		return text;
+	}
+
+	if ( words.length < minimun ) {
+		return words.join( ' ' );
 	}
 
 	if ( words.length <= wordsToKeep ) {


### PR DESCRIPTION
This pull request fixes #2434 by preventing widowed words in the header on /plans/compare
Before:
![zh-tw_desktop_3a_plan_comparison_screenshot1449463283949](https://cloud.githubusercontent.com/assets/7637835/12335287/b6663a6c-bafe-11e5-8b04-8e274a5ae6c2.png)

After:
<img width="695" alt="screen shot 2016-01-18 at 10 41 43" src="https://cloud.githubusercontent.com/assets/275961/12389371/1d67ce96-bdd0-11e5-954e-1739560d8753.png">
 
#### Testing instructions

1. Run `git checkout fix/2434-fix-widows-on-plans-compare` and start your server
2. Open http://calypso.localhost:3000/start/themes/zh-cn
3. Go to the /plans step and open the compare screen
4. Assert that the title doesn't have widows.

#### Additional notes

@akirk suggested that we insert a <br> after `WordPress.com` which might still be a more elegant solution than this.

#### Reviews

- [ ] Code
- [ ] Product