### PR TITLE
Themes: Do not render <SidebarNavigation /> when logged out

### DIFF
--- a/client/my-sites/themes/main.jsx
+++ b/client/my-sites/themes/main.jsx
@@ -133,7 +133,7 @@ var Themes = React.createClass( {
 
 		return (
 			<Main className="themes">
-				<SidebarNavigation />
+				{ this.isLoggedOut() ? null : <SidebarNavigation /> }
 				{ this.state.showPreview &&
 					<WebPreview showPreview={ this.state.showPreview }
 						onClose={ this.togglePreview }


### PR DESCRIPTION
Fixes #2516

**Before**
<img width="307" alt="screen shot 2016-01-18 at 10 56 25" src="https://cloud.githubusercontent.com/assets/7767559/12390427/d8123cfc-bdd7-11e5-84d8-20a7a37c7f55.png">

**After**
<img width="304" alt="screen shot 2016-01-18 at 11 37 42" src="https://cloud.githubusercontent.com/assets/7767559/12390438/f12c52f4-bdd7-11e5-9b50-db391812b672.png">


Since there is no sidebar when logged out, the sidebar navigation header—which gives access to the sidebar on mobile—is not necessary.