### PR TITLE
Plugins: Show empty content message in 'active' tab

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -234,6 +234,9 @@ export default React.createClass( {
 		let emptyContentData = { illustration: '/calypso/images/drake/drake-empty-results.svg', };
 
 		switch ( this.props.filter ) {
+			case 'active':
+				emptyContentData.title = this.translate( 'No plugins are active.', { textOnly: true } );
+				break;
 			case 'inactive':
 				emptyContentData.title = this.translate( 'No plugins are inactive.', { textOnly: true } );
 				break;
@@ -280,15 +283,13 @@ export default React.createClass( {
 				} ) } />
 			}
 
-			if ( 'inactive' === this.props.filter || 'updates' === this.props.filter ) {
-				let emptyContentData = this.getEmptyContentData();
-				return ( <EmptyContent
-					title={ emptyContentData.title }
-					illustration={ emptyContentData.illustration }
-					actionURL={ emptyContentData.actionURL }
-					action={ emptyContentData.action } />
-				);
-			}
+			let emptyContentData = this.getEmptyContentData();
+			return ( <EmptyContent
+				title={ emptyContentData.title }
+				illustration={ emptyContentData.illustration }
+				actionURL={ emptyContentData.actionURL }
+				action={ emptyContentData.action } />
+			);
 		}
 		return (
 			<div className="plugins__lists">


### PR DESCRIPTION
Currently we are not showing anything when you are in the 'active'  plugins tab and there isn't any active plugins for the selected site. This is probably due this case can only happens in business .com sites and we completely missed it out:
![image](https://cloud.githubusercontent.com/assets/1554855/12391758/4de1caa8-bdea-11e5-8cc9-aa5188d2c504.png)

This PR fixes this case:
![image](https://cloud.githubusercontent.com/assets/1554855/12391750/3df8332a-bdea-11e5-945d-ad254f4d8723.png)

How to test:
====
1. Select any business site and go to `/plugins`
2. Edit all plugins and mark them as inactive
3. Click on "active" tab. You should see Drake and a 'no content' message


pinging my pals' @enejb & @rickybanister 