### PR TITLE
Editor: Fix resizing of embeds where viewports units are used

### DIFF
--- a/client/components/resizable-iframe/index.jsx
+++ b/client/components/resizable-iframe/index.jsx
@@ -97,6 +97,22 @@ export default React.createClass( {
 					subtree: true
 				} );
 
+				// Hack: Remove viewport unit styles, as these are relative
+				// the iframe root and interfere with our mechanism for
+				// determining the unconstrained page bounds.
+				function removeViewportStyles( ruleOrNode ) {
+					[ 'width', 'height', 'minHeight', 'maxHeight' ].forEach( function( style ) {
+						if ( /^\\d+(vmin|vmax|vh|vw)$/.test( ruleOrNode.style[ style ] ) ) {
+							ruleOrNode.style[ style ] = '';
+						}
+					} );
+				}
+
+				Array.prototype.forEach.call( document.querySelectorAll( '[style]' ), removeViewportStyles );
+				Array.prototype.forEach.call( document.styleSheets, function( stylesheet ) {
+					Array.prototype.forEach.call( stylesheet.cssRules || stylesheet.rules, removeViewportStyles );
+				} );
+
 				document.body.style.position = 'absolute';
 				document.body.setAttribute( 'data-resizable-iframe-connected', '' );
 


### PR DESCRIPTION
This pull request seeks to resolve an issue with at least one embed where the resizing behavior of the [`<ResizableIframe />` component](https://github.com/Automattic/wp-calypso/tree/master/client/components/resizable-iframe) is unable to properly calculate the unconstrained bounds of the frame body when a viewport unit is used in the frame contents. [Per specification](https://www.w3.org/TR/css3-values/#viewport-relative-lengths), these units are relative the initial containing block which, in this case, is the `<iframe>` wrapper rendered by `<ResizableIframe />`. Because this component is rendered in the editor without a predefined height, the calculated dimensions of the frame will always be `0`, so the embed will not display correctly.

__Implementation notes:__

The changes here attempt to find all styles, inline or through style tags, that would apply a width or height using a viewport unit, and reset the style to an empty value.

A few alternative solutions explored include:
- Providing a default height to rendered embeds
 - It's ideal to allow the embeds to dictate their own size, hence the usage of `<ResizableIframe />`
- Not rendering the embed in an `iframe`, matching wp-admin behavior
 - It's ideal that the embeds be sandboxed; less from a security standpoint, but rather from markup, scripts, and styles interfering with editor contents

__Testing instructions:__

Currently, the only known embed which this affects is embeds from Sway.com. Verify that Sway embeds are displayed correctly with the changes, and that other usages are not impacted (e.g. editor gallery previews, [sharing buttons official preview](https://calypso.localhost:3000/sharing)).

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Enter an embed URL
 - Example Sway embed: https://sway.com/nLa7rrYhdCmzRyQd
 - Should also test other embeds (e.g. https://www.youtube.com/watch?v=84j61_aI0q8 )
4. Note that the embed displays correctly in the editor