### PR TITLE
Stats: add numberFormat to post performance.

### DIFF
--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -108,9 +108,22 @@ module.exports = React.createClass( {
 				comments: post ? post.discussion.comment_count : emptyString
 			},
 			tabs = [
-				{ label: this.translate( 'Views' ), labelIcon: 'visible', value: values.views, link: summaryUrl },
-				{ label: this.translate( 'Likes' ), labelIcon: 'star', value: values.likes },
-				{ label: this.translate( 'Comments' ), labelIcon: 'comment', value: values.comments }
+				{
+					label: this.translate( 'Views' ),
+					labelIcon: 'visible',
+					value: this.numberFormat( values.views ),
+					link: summaryUrl
+				},
+				{
+					label: this.translate( 'Likes' ),
+					labelIcon: 'star',
+					value: this.numberFormat( values.likes )
+				},
+				{
+					label: this.translate( 'Comments' ),
+					labelIcon: 'comment',
+					value: this.numberFormat( values.comments )
+				}
 			];
 
 		return tabs.map( function( tabOptions, index ) {
@@ -179,8 +192,8 @@ module.exports = React.createClass( {
 					</h3>
 				</div>
 				<div className="module-content-text">
-					{ post ?
-						(
+					{ post
+						? (
 							<p>
 								{ this.translate(
 									'It\'s been %(timeLapsed)s since {{href}}{{postTitle/}}{{/href}} was published. Here\'s how the post has performed so far\u2026',


### PR DESCRIPTION
Though this file needs a good refactor to ES6 and tabs, that should all wait until #2384 lands.  This however just fixes #2534 by adding `numberFormat` to the values shown in Post Performance on the Insights page.

![stats_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/12396981/2d81bad2-bdbf-11e5-865e-7c13bd178a20.png)

__To Test__
- View the site insights page for a high-traffic site
- Verify that the large numbers have commas in the thousand place ( or whatever proper i18n formatting you would expect to see )