### PR TITLE
Plugins: Show update notification even when there's no selected site

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -245,15 +245,15 @@ export default React.createClass( {
 			if ( site.canUpdateFiles && plugin.update && 'error' !== plugin.update && plugin.update.new_version ) {
 				PluginsActions.updatePlugin( site, plugin );
 				PluginsActions.removePluginsNotices( this.props.notices.completed.concat( this.props.notices.errors ) );
+
+				analytics.tracks.recordEvent( 'calypso_plugins_actions_update_plugin_all_sites', {
+					site: site,
+					plugin: plugin.slug
+				} );
 			}
 		} );
 
 		analytics.ga.recordEvent( 'Plugins', 'Clicked Update All Sites Plugin', 'Plugin Name', this.props.pluginSlug );
-		analytics.tracks.recordEvent( 'calypso_plugins_actions_update_plugin_all_sites', {
-			site: this.props.sites[ 0 ].ID,
-			plugin: this.props.sites[ 0 ].plugin.slug,
-			selected_site: this.props.sites[ 0 ].ID
-		} );
 	},
 
 	render() {

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import classNames from 'classnames';
 import i18n from 'lib/mixins/i18n';
 import some from 'lodash/collection/some';
-import uniq from 'lodash/array/uniq';
 
 /**
  * Internal dependencies
@@ -162,10 +161,12 @@ export default React.createClass( {
 					</Notice>
 				);
 			}
-
 			const noticeMessage = newVersions.length > 1
-				? i18n.translate( 'A new version is available for %(numberOfSites)s sites', { args: { numberOfSites: newVersions.length } } )
-				: i18n.translate( 'A new version is available for %(siteName)s', { args: { siteName: newVersions[0].title } } );
+				? i18n.translate( 'Version %(newPluginVersion)s is available for %(numberOfSites)s sites', { args: { numberOfSites: newVersions.length, newPluginVersion: this.props.plugin.version } } )
+				: i18n.translate( 'Version %(newPluginVersion)s is available for %(siteName)s', { args: { siteName: newVersions[0].title, newPluginVersion: this.props.plugin.version } } );
+			const noticeActionMessage = newVersions.length > 1
+				? i18n.translate( 'Update all' )
+				: i18n.translate( 'Update' )
 			return (
 				<Notice
 					status="is-warning"
@@ -174,7 +175,7 @@ export default React.createClass( {
 					icon="sync"
 					text={ noticeMessage }>
 					<NoticeAction onClick={ this.handlePluginUpdatesMultiSite }>
-						{ i18n.translate( 'Update to %(newPluginVersion)s', { args: { newPluginVersion: uniq( newVersions ).join( ', ' ) } } ) }
+						{ noticeActionMessage }
 					</NoticeAction>
 				</Notice>
 			);

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -4,7 +4,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import i18n from 'lib/mixins/i18n';
-import _some from 'lodash/collection/some';
+import some from 'lodash/collection/some';
+import uniq from 'lodash/array/uniq';
 
 /**
  * Internal dependencies
@@ -169,7 +170,7 @@ export default React.createClass( {
 					icon="sync"
 					text={ i18n.translate( 'A new version is available in some of your sites' ) }>
 					<NoticeAction onClick={ this.handlePluginUpdatesMultiSite }>
-						{ i18n.translate( 'Update to %(newPluginVersion)s', { args: { newPluginVersion: newVersions.join( ', ' ) } } ) }
+						{ i18n.translate( 'Update to %(newPluginVersion)s', { args: { newPluginVersion: uniq( newVersions ).join( ', ' ) } } ) }
 					</NoticeAction>
 				</Notice>
 			);
@@ -191,7 +192,7 @@ export default React.createClass( {
 		}
 
 		const siteVersion = this.props.selectedSite.options.software_version.split( '-' )[ 0 ];
-		return _some( this.props.plugin.compatibility, compatibleVersion => {
+		return some( this.props.plugin.compatibility, compatibleVersion => {
 			return compatibleVersion.indexOf( siteVersion ) === 0;
 		} );
 	},

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -241,8 +241,9 @@ export default React.createClass( {
 	handlePluginUpdatesMultiSite( event ) {
 		event.preventDefault();
 		this.props.sites.forEach( ( site ) => {
-			if ( site.canUpdateFiles && site.plugin && site.plugin.update && 'error' !== site.plugin.update ) {
-				PluginsActions.updatePlugin( site, site.plugin );
+			const { plugin } = site;
+			if ( site.canUpdateFiles && plugin.update && 'error' !== plugin.update && plugin.update.new_version ) {
+				PluginsActions.updatePlugin( site, plugin );
 				PluginsActions.removePluginsNotices( this.props.notices.completed.concat( this.props.notices.errors ) );
 			}
 		} );

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -240,9 +240,10 @@ export default React.createClass( {
 
 	handlePluginUpdatesMultiSite( event ) {
 		event.preventDefault();
-		this.props.sites.forEach( function( site ) {
+		this.props.sites.forEach( ( site ) => {
 			if ( site.canUpdateFiles && site.plugin && site.plugin.update && 'error' !== site.plugin.update ) {
 				PluginsActions.updatePlugin( site, site.plugin );
+				PluginsActions.removePluginsNotices( this.props.notices.completed.concat( this.props.notices.errors ) );
 			}
 		} );
 

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -76,9 +76,9 @@ module.exports = React.createClass( {
 			return;
 		}
 		if ( this.props.site.canUpdateFiles &&
-				( this.props.site.plugin.update || this.isUpdating() ) ) {
+				( ( this.props.site.plugin.update && ! this.props.site.plugin.update.recentlyUpdated ) || this.isUpdating() ) ) {
 			if ( ! this.props.expanded ) {
-				return <span className="plugin-site-update-indicator"><Gridicon icon="sync" size={ 20 } /></span>;
+				return <span className="plugin-site-update-indicator"><Gridicon icon="sync" size={ 20 } nonStandardSize /></span>;
 			}
 
 			return this.renderUpdate();


### PR DESCRIPTION
closes https://github.com/Automattic/wp-calypso/issues/910

When you are in a single plugin page without any site selected, you don't see any warning if some of your sites have an outdated version of the plugin. This PR adds a notice in those cases.

Before:
![image](https://cloud.githubusercontent.com/assets/1554855/12396722/3887cd5a-be09-11e5-9ab4-9e377e1acb0c.png)

After:
![image](https://cloud.githubusercontent.com/assets/1554855/12396730/421f994c-be09-11e5-9069-f7dc9f9a3a21.png)

