### PR TITLE
Stats: Do not show weeks before post_date on Post Details

### DIFF
--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -70,7 +70,7 @@ export default React.createClass( {
 						<th>{ this.translate( 'Change', { context: 'Stats: noun - change over a period in weekly numbers' } ) }</th>
 					</tr>
 				</thead>
-				);
+			);
 
 			tableRows = data.weeks.map( function( week, index ) {
 				let cells = [];
@@ -79,7 +79,7 @@ export default React.createClass( {
 				let lastDayOfWeek = lastDay.day ? this.moment( lastDay.day, 'YYYY-MM-DD' ) : null;
 
 				// If the end of this week is before post_date, return
-				if ( publishDate && lastDayOfWeek && lastDayOfWeek.isBefore( publishDate ) ) {
+				if ( 7 === week.days.length && publishDate && lastDayOfWeek && lastDayOfWeek.isBefore( publishDate ) ) {
 					return null;
 				}
 

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -38,6 +38,7 @@ export default React.createClass( {
 
 	render() {
 		const data = this.props.postViewsList.response;
+		const post = data.post;
 		const { showInfo, noData } = this.state;
 		const infoIcon = this.state.showInfo ? 'info' : 'info-outline';
 		let tableHeader,
@@ -52,6 +53,7 @@ export default React.createClass( {
 		};
 
 		if ( data && data.weeks ) {
+			const publishDate = post.post_date ? this.moment( post.post_date ) : null;
 			highest = data.highest_week_average;
 			tableHeader = (
 				<thead>
@@ -71,8 +73,15 @@ export default React.createClass( {
 				);
 
 			tableRows = data.weeks.map( function( week, index ) {
-				let cells = [],
-					iconType;
+				let cells = [];
+				let iconType;
+				let lastDay = week.days[ week.days.length - 1 ];
+				let lastDayOfWeek = lastDay.day ? this.moment( lastDay.day, 'YYYY-MM-DD' ) : null;
+
+				// If the end of this week is before post_date, return
+				if ( publishDate && lastDayOfWeek && lastDayOfWeek.isBefore( publishDate ) ) {
+					return null;
+				}
 
 				// If there are fewer than 7 days in the first week, prepend blank days
 				if ( week.days.length < 7 && 0 === index ) {


### PR DESCRIPTION
When viewing a post detail page in stats, the "Recent Weeks" component currently shows data for weeks before the post was published.  This branch fixes #196 by not showing these empty weeks.

__Before__

![wordpress_com](https://cloud.githubusercontent.com/assets/22080/12397614/2af7175e-bdc3-11e5-95f6-d39d1024c6d5.png)

__After__

![wordpress_com 2](https://cloud.githubusercontent.com/assets/22080/12397624/3dbd955c-bdc3-11e5-91f6-197e979e0fd8.png)

__To Test__
- Open a site stats page
- Click on a newer post in the "Post & Pages" module
- On the subsequent post detail page, verify no empty weeks are shown