### PR TITLE
Signup: replace `welcome/next/` with NUX Trampoline

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -16,7 +16,7 @@ function getCheckoutDestination( dependencies ) {
 		return '/checkout/' + dependencies.siteSlug;
 	}
 
-	return '/me/next?welcome';
+	return 'https://' + dependencies.siteSlug;
 }
 
 const flows = {


### PR DESCRIPTION
In #1446, we tested the NUX Trampoline for non-purchasing new signups against the `welcome/next/` screen. After taking a look at internal metrics, we found the following:

- **Retention**: 1- and 2-week user retention increased 35.5% and 17% respectively with the NUX Trampoline.
- **Purchasing Conversions**: remained relatively unchanged.
- **Site Customization**: dropped 14.5% with the NUX Trampoline. Given the de-emphasis of site customization between the designs, this was expected.
- **Post/Page Publishing**: increased 3.3% with the NUX Trampoline.
- **Theme Switching**: remained relatively unchanged.

With those results, we'd like to replace the `welcome/next/` checkout destination in Signup with an experience that takes the non-purchasing new user to the front end of their website with the Trampoline active. The Trampoline only runs once per each new user and has already been activated for new users on dotcom.