### PR TITLE
Invites: Launch accept invites to horizon and staging

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -85,7 +85,8 @@
 		"settings/security/monitor": true,
 		"settings/security/scan": false,
 		"ad-tracking": false,
-		"perfmon": true
+		"perfmon": true,
+		"accept-invite": true
 	},
 	"siftscience_key": "a4f69f6759",
 	"wpcom_signup_id": "39911",

--- a/config/production.json
+++ b/config/production.json
@@ -79,7 +79,8 @@
 		"reader/recommendations": true,
 		"ad-tracking": true,
 		"perfmon": false,
-		"mailing-lists/unsubscribe": true
+		"mailing-lists/unsubscribe": true,
+		"accept-invite": false
 	},
 	"rtl": false,
 	"jetpack_min_version": "3.3",

--- a/config/stage.json
+++ b/config/stage.json
@@ -83,7 +83,8 @@
 		"reader/recommendations": true,
 		"ad-tracking": false,
 		"perfmon": true,
-		"mailing-lists/unsubscribe": true
+		"mailing-lists/unsubscribe": true,
+		"accept-invite": true
 	},
 	"siftscience_key": "e00e878351",
 	"wpcom_signup_id": "39911",


### PR DESCRIPTION
As we gear up to launch the new accept invite functionality, we are going to do another round of testing.

This PR launches the accept invite functionality in staging and in horizon.

To test:
- Checkout `update/invites-config-to-stage` branch
- In `horizon.json`, `stage.json`, `production.json`... make sure that `wpcom_user_bootstrap` is `false`
- In terminal, `CALYPSO_ENV={environment} make run`

cc @lezama 
