### PR TITLE
Add 'no-danger' rule to .eslintrc to warn against use of dangerouslySetInnerHTML

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,6 +56,7 @@
 		"react/jsx-no-undef": 2,
 		"react/jsx-no-duplicate-props": 1,
 		"react/react-in-jsx-scope": 2,
+		"react/no-danger": 1,
 		"react/no-did-mount-set-state": 1,
 		"react/no-did-update-set-state": 1,
 		"jsx-quotes": [ 1, "prefer-double" ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -56,7 +56,7 @@
 		"react/jsx-no-undef": 2,
 		"react/jsx-no-duplicate-props": 1,
 		"react/react-in-jsx-scope": 2,
-		"react/no-danger": 1,
+		"react/no-danger": 2,
 		"react/no-did-mount-set-state": 1,
 		"react/no-did-update-set-state": 1,
 		"jsx-quotes": [ 1, "prefer-double" ],

--- a/client/components/shortcode/frame.jsx
+++ b/client/components/shortcode/frame.jsx
@@ -33,11 +33,13 @@ function buildFrameBody( { body, scripts, styles } = { body: '', scripts: {}, st
 	fragment.scripts = mapValues( scripts, ( script ) => {
 		let extra;
 		if ( script.extra ) {
+			/*eslint-disable react/no-danger*/
 			extra = (
 				<script dangerouslySetInnerHTML={ {
 					__html: script.extra
 				} } />
 			);
+			/*eslint-enable react/no-danger*/
 		}
 
 		return createFragment( {
@@ -46,6 +48,7 @@ function buildFrameBody( { body, scripts, styles } = { body: '', scripts: {}, st
 		} );
 	} );
 
+	/*eslint-disable react/no-danger*/
 	return ReactDomServer.renderToStaticMarkup(
 		<html>
 			<head>
@@ -68,6 +71,7 @@ function buildFrameBody( { body, scripts, styles } = { body: '', scripts: {}, st
 			</body>
 		</html>
 	);
+	/*eslint-enable react/no-danger*/
 }
 
 export default React.createClass( {

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -77,6 +77,7 @@ Spinner = React.createClass( {
 		// SVG's `mask` attribute, see https://github.com/facebook/react/issues/1657#issuecomment-63209488
 		// The only variable we're using inside is `instanceId`, which is an (integer) counter
 		// we generate ourselves, so we're fine.
+		/*eslint-disable react/no-danger*/
 		return (
 			<div className={ this.getClassName() }>
 				<svg className="spinner__image"
@@ -113,6 +114,7 @@ Spinner = React.createClass( {
 				` } } />
 			</div>
 		);
+		/*eslint-enable react/no-danger*/
 	}
 } );
 

--- a/client/devdocs/doc.jsx
+++ b/client/devdocs/doc.jsx
@@ -98,7 +98,7 @@ module.exports = React.createClass( {
 				<div
 					className="devdocs__doc-content"
 					ref="body"
-					dangerouslySetInnerHTML={{ __html: highlight( this.props.term, this.state.body ) }}
+					dangerouslySetInnerHTML={{ __html: highlight( this.props.term, this.state.body ) }} //eslint-disable-line react/no-danger
 				/>
 			</div>
 		);

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -152,6 +152,7 @@ module.exports = React.createClass( {
 			return null;
 		}
 
+		/*eslint-disable react/no-danger*/
 		return (
 			<div className="plugin-sections">
 				<PluginCardHeader>
@@ -182,5 +183,6 @@ module.exports = React.createClass( {
 				</Card>
 			</div>
 		);
+		/*eslint-enable react/no-danger*/
 	}
 } );

--- a/client/post-editor/media-modal/gallery/preview-individual.jsx
+++ b/client/post-editor/media-modal/gallery/preview-individual.jsx
@@ -20,7 +20,7 @@ export default React.createClass( {
 			const caption = markup.caption( item );
 
 			if ( null === caption ) {
-				return <div key={ item.ID } dangerouslySetInnerHTML={ { __html: markup.get( item ) } } />;
+				return <div key={ item.ID } dangerouslySetInnerHTML={ { __html: markup.get( item ) } } />; //eslint-disable-line react/no-danger
 			}
 
 			return React.cloneElement( caption, { key: item.ID } );

--- a/client/post-editor/media-modal/markup.js
+++ b/client/post-editor/media-modal/markup.js
@@ -98,12 +98,14 @@ Markup = {
 			width = MediaSerialization.deserialize( img ).width;
 		}
 
+		/*eslint-disable react/no-danger*/
 		return (
 			<dl className={ classNames( 'wp-caption', parsed.attrs.named.align, parsed.attrs.named.classes ) } style={ { width: width } }>
 				<dt className="wp-caption-dt" dangerouslySetInnerHTML={ { __html: img } } />
 				<dd className="wp-caption-dd">{ caption }</dd>
 			</dl>
 		);
+		/*eslint-enable react/no-danger*/
 	},
 
 	mimeTypes: {

--- a/client/reader/comments/post-comment-content.jsx
+++ b/client/reader/comments/post-comment-content.jsx
@@ -24,10 +24,12 @@ const PostCommentContent = React.createClass( {
 			return <div className="comment__content">{ this.props.content }</div>;
 		}
 
+		/*eslint-disable react/no-danger*/
 		return (
 			<div className="comment__content" dangerouslySetInnerHTML={{ __html: this.props.content }}>
 			</div>
 		);
+		/*eslint-enable react/no-danger*/
 	}
 } );
 

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -187,7 +187,7 @@ var Post = React.createClass( {
 		}
 
 		return useFeaturedEmbed ?
-			<div ref="featuredEmbed" className="reader__post-featured-video" key="featuredVideo" dangerouslySetInnerHTML={ { __html: featuredEmbed.iframe } } /> :
+			<div ref="featuredEmbed" className="reader__post-featured-video" key="featuredVideo" dangerouslySetInnerHTML={ { __html: featuredEmbed.iframe } } /> : //eslint-disable-line react/no-danger
 			<div className="reader__post-featured-image" onClick={ this.handlePermalinkClick }>
 				{ featuredSize ?
 					<img className="reader__post-featured-image-image"
@@ -394,7 +394,7 @@ var Post = React.createClass( {
 				<PostByline post={ post } site={ this.props.site } />
 
 				{ shouldUseFullExcerpt ?
-					<div key="full-post-inline" className="reader__full-post-content" dangerouslySetInnerHTML={{ __html: post.content }} ></div> :
+					<div key="full-post-inline" className="reader__full-post-content" dangerouslySetInnerHTML={{ __html: post.content }} ></div> : //eslint-disable-line react/no-danger
 					<PostExcerpt text={ post.excerpt } />
 				}
 

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -166,6 +166,7 @@ FullPostView = React.createClass( {
 			postContent = post.content;
 		}
 
+		/*eslint-disable react/no-danger*/
 		return (
 			<div>
 				<article className={ articleClasses } id="modal-full-post" ref="article">
@@ -190,6 +191,7 @@ FullPostView = React.createClass( {
 				</article>
 			</div>
 		);
+		/*eslint-enable react/no-danger*/
 	},
 
 	_generateButtonClickHandler: function( clickHandler ) {


### PR DESCRIPTION
The eslint-plugin-react package provides a `no-danger` rule to warn against use of dangerouslySetInnerHTML:

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md

Fixes #2546.