### PR TITLE
Invites: Handle improper accept invite routes

### DIFF
--- a/client/my-sites/invites/index.js
+++ b/client/my-sites/invites/index.js
@@ -15,12 +15,7 @@ export default () => {
 	);
 
 	page(
-		'/accept-invite/:site_id/:invitation_key',
-		acceptInvite
-	);
-
-	page(
-		'/accept-invite/:site_id/:invitation_key/:activation_key/:auth_key',
+		'/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?',
 		acceptInvite
 	);
 };

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -39,7 +39,11 @@ let InviteAccept = React.createClass( {
 	},
 
 	componentWillMount() {
-		fetchInvite( this.props.siteId, this.props.inviteKey );
+		// The site ID and invite key are required, so only fetch if set
+		if ( this.props.siteId && this.props.inviteKey ) {
+			fetchInvite( this.props.siteId, this.props.inviteKey );
+		}
+
 		userModule.on( 'change', this.refreshUser );
 		InvitesStore.on( 'change', this.refreshInvite );
 	},
@@ -65,6 +69,10 @@ let InviteAccept = React.createClass( {
 			} );
 		}
 		this.setState( { invite, error } );
+	},
+
+	isErrorState() {
+		return this.state.error || ! this.props.siteId || ! this.props.inviteKey;
 	},
 
 	getErrorTitle() {
@@ -112,11 +120,11 @@ let InviteAccept = React.createClass( {
 	},
 
 	render() {
-		const classes = classNames( 'invite-accept', { 'is-error': !! this.state.error } );
+		const classes = classNames( 'invite-accept', { 'is-error': !! this.isErrorState() } );
 		return (
 			<div className={ classes }>
-				{ ! this.state.error && <InviteHeader { ...this.state.invite } /> }
-				{ this.state.error ? this.renderError() : this.renderForm() }
+				{ ! this.isErrorState() && <InviteHeader { ...this.state.invite } /> }
+				{ this.isErrorState() ? this.renderError() : this.renderForm() }
 			</div>
 		);
 	}

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -389,7 +389,7 @@ module.exports = function() {
 		}
 	} );
 
-	app.get( '/accept-invite/:site_id/:invitation_key?/:activation_key?/:auth_key?', function( req, res ) {
+	app.get( '/accept-invite/?.*', function( req, res ) {
 		if ( req.cookies.wordpress_logged_in ) {
 			// the user is probably logged in
 			renderLoggedInRoute( req, res );


### PR DESCRIPTION
Fixes #2543

Previously, we were only handling the expected routes for invites, which is to say that we didn't handle cases such as `/accept-invite` or `/accept-invite/`.

This PR updates that.

To test:
- Checkout `update/invites-routing` branch
- Bounce the server: `ctrl + c` and `make run`
- Create invites at `$site/wp-admin/users.php?page=wpcom-invite-users` where `$site` is a WordPress.com site
- In the invite email, swap `wpcalypso.wordpress.com` for `calypso.localhost:3000`.

Be sure to test:
- Logged in and logged out flows
- Follower invites
- Viewer invites (private WP.com site)
- Other various roles

Testing instructions assume that you're on our testing whitelist. If you are not, and would like to be, please ping me.