### PR TITLE
Plans: Remove `freeTrials` a/b test

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var config = require( 'config' ),
+	React = require( 'react' ),
 	classNames = require( 'classnames' );
 
 /**
@@ -12,7 +13,6 @@ var analytics = require( 'analytics' ),
 	isFreePlan = productsValues.isFreePlan,
 	isBusiness = productsValues.isBusiness,
 	isEnterprise = productsValues.isEnterprise,
-	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	cartItems = require( 'lib/cart-values' ).cartItems,
 	puchasesPaths = require( 'me/purchases/paths' );
 
@@ -154,11 +154,7 @@ module.exports = React.createClass( {
 	},
 
 	shouldOfferFreeTrial: function() {
-		if ( getABTestVariation( 'freeTrials' ) !== 'offered' ) {
-			return false;
-		}
-
-		if ( ! this.props.enableFreeTrials ) {
+		if ( ! config.isEnabled( 'upgrades/free-trials' ) || ! this.props.enableFreeTrials ) {
 			return false;
 		}
 

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	config = require( 'config' ),
 	connect = require( 'react-redux' ).connect,
 	page = require( 'page' ),
 	classNames = require( 'classnames' ),
@@ -12,7 +13,6 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var observe = require( 'lib/mixins/data-observe' ),
-	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	PlanFeatures = require( 'components/plans/plan-features' ),
 	PlanHeader = require( 'components/plans/plan-header' ),
@@ -108,7 +108,7 @@ var PlansCompare = React.createClass( {
 				? this.props.sitePlans.data.some( property( 'canStartTrial' ) )
 				: false;
 
-		if ( getABTestVariation( 'freeTrials' ) !== 'offered' ) {
+		if ( ! config.isEnabled( 'upgrades/free-trials' ) ) {
 			return false;
 		}
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -45,14 +45,6 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
-	freeTrials: {
-		datestamp: '20160112',
-		variations: {
-			notOffered: 90,
-			offered: 10
-		},
-		defaultVariation: 'notOffered'
-	},
 	monthlyPlanPricing: {
 		datestamp: '20160118',
 		variations: {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	config = require( 'config' ),
 	connect = require( 'react-redux' ).connect,
 	find = require( 'lodash/collection/find' );
 
@@ -9,7 +10,6 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
-	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	observe = require( 'lib/mixins/data-observe' ),
 	PlanList = require( 'components/plans/plan-list' ),
 	PlanOverview = require( './plan-overview' ),
@@ -76,7 +76,7 @@ var Plans = React.createClass( {
 			businessPlan,
 			premiumPlan;
 
-		if ( ! this.props.sitePlans.hasLoadedFromServer || getABTestVariation( 'freeTrials' ) !== 'offered' ) {
+		if ( ! this.props.sitePlans.hasLoadedFromServer || ! config.isEnabled( 'upgrades/free-trials' ) ) {
 			return null;
 		}
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -11,10 +11,8 @@ import isEmpty from 'lodash/lang/isEmpty';
 /**
  * Internal Dependencies
  */
-import { abtest } from 'lib/abtest';
 import i18n from 'lib/mixins/i18n';
 import config from 'config';
-import { defaultFlowName } from 'signup/config/flows';
 import route from 'lib/route';
 import analytics from 'analytics';
 import layoutFocus from 'lib/layout-focus';
@@ -71,10 +69,6 @@ export default {
 	},
 
 	redirectToFlow( context, next ) {
-		if ( utils.getFlowName( context.params ) === defaultFlowName && abtest( 'freeTrials' ) === 'offered' ) {
-			return page.redirect( utils.getValidPath( { flowName: 'free-trial' } ) );
-		}
-
 		if ( context.path !== utils.getValidPath( context.params ) ) {
 			return page.redirect( utils.getValidPath( context.params ) );
 		}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -9,7 +9,6 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var productsList = require( 'lib/products-list' )(),
-	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	analytics = require( 'analytics' ),
 	featuresList = require( 'lib/features-list' )(),
 	plansList = require( 'lib/plans-list' )(),
@@ -109,7 +108,7 @@ module.exports = React.createClass( {
 		let headerText = this.translate( 'Pick a plan that\'s right for you.' ),
 			subHeaderText;
 
-		if ( this.isFreeTrialFlow() && getABTestVariation( 'freeTrials' ) === 'offered' ) {
+		if ( this.isFreeTrialFlow() ) {
 			subHeaderText = this.translate(
 				'Try WordPress.com Premium or Business free for 14 days, no credit card required.'
 			);

--- a/config/development.json
+++ b/config/development.json
@@ -94,6 +94,7 @@
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": true,
 		"upgrades/domain-search": true,
+		"upgrades/free-trials": true,
 
 		"manage/customize": true,
 

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -69,6 +69,7 @@
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": true,
 		"upgrades/domain-search": true,
+		"upgrades/free-trials": true,
 
 		"notifications2beta": true,
 		"muse": true,


### PR DESCRIPTION
This PR replaces the `freeTrials` a/b test with a feature flag, `upgrades/free-trials`, and enables this feature in development/wpcalypso.

**Testing**
*With free trials enabled*
- Visit http://calypso.localhost:3000/start while logged out, complete the signup, and assert that you were not offered a free trial during signup, but are offered a free trial through `/plans`.
- Visit http://calypso.localhost:3000/start/free-trial and assert that you are offered a free trial during signup and on `/plans`.

*With free trials disabled*
You can disable free trials by setting `upgrades/free-trials` to false in `config/development.json` and restarting the Calypso server.
- Visit http://calypso.localhost:3000/plans/:site for a site that is already on the free trial and assert that you see the 'trial hub'.
- Visit http://calypso.localhost:3000/start/free-trial while logged out and assert that you are not offered free trials on the plans step. Sign up, and assert that you are not offered free trials on `/plans`.

- [x] Product review
- [x] Code review