### PR TITLE
Invites: Fix email only subscription link

### DIFF
--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -31,6 +31,7 @@
 	font-size: 14px;
 	line-height: 21px;
 	padding: 16px 0 16px 16px;
+	cursor: pointer;
 
 	@include breakpoint( ">480px" ) {
 		padding-left: 24px;

--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -91,8 +91,9 @@ export function acceptInvite( invite, callback ) {
 			} else {
 				analytics.tracks.recordEvent( 'calypso_invite_accepted' );
 			}
-
-			callback( error, data );
+			if ( typeof callback === 'function' ) {
+				callback( error, data );
+			}
 		}
 	);
 }

--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -70,7 +70,7 @@ export function createAccount( userData, callback ) {
 	);
 }
 
-export function acceptInvite( invite ) {
+export function acceptInvite( invite, callback ) {
 	Dispatcher.handleViewAction( {
 		type: ActionTypes.INVITE_ACCEPTED,
 		invite,
@@ -91,6 +91,8 @@ export function acceptInvite( invite ) {
 			} else {
 				analytics.tracks.recordEvent( 'calypso_invite_accepted' );
 			}
+
+			callback( error, data );
 		}
 	);
 }

--- a/client/lib/sites-list/index.js
+++ b/client/lib/sites-list/index.js
@@ -22,7 +22,7 @@ module.exports = function() {
 					_sites.removeSite( action.site );
 					break;
 				case InvitesActionTypes.INVITE_ACCEPTED:
-					if ( action.invite.role !== 'follower' ) {
+					if ( [ 'follower', 'viewer' ].indexOf( action.invite.role ) === -1 ) {
 						let sites = clone( _sites.get() );
 						if ( sites.length === 0 ) {
 							action.invite.site.primary = true;

--- a/client/lib/sites-list/index.js
+++ b/client/lib/sites-list/index.js
@@ -4,7 +4,6 @@
 import { action as InvitesActionTypes } from 'lib/invites/constants';
 import clone from 'lodash/lang/clone';
 
-
 var SitesList = require( './list' ),
 	PollerPool = require( 'lib/data-poller' ),
 	Dispatcher = require( 'dispatcher' ),
@@ -23,12 +22,14 @@ module.exports = function() {
 					_sites.removeSite( action.site );
 					break;
 				case InvitesActionTypes.INVITE_ACCEPTED:
-					let sites = clone( _sites.get() );
-					if ( sites.length === 0 ) {
-						action.invite.site.primary = true;
+					if ( action.invite.role !== 'follower' ) {
+						let sites = clone( _sites.get() );
+						if ( sites.length === 0 ) {
+							action.invite.site.primary = true;
+						}
+						sites.push( action.invite.site );
+						_sites.update( sites );
 					}
-					sites.push( action.invite.site );
-					_sites.update( sites );
 					break;
 				case InvitesActionTypes.INVITE_ACCEPTED_SUCCESS:
 				case 'RECEIVE_DISCONNECTED_SITE':

--- a/client/lib/user/index.js
+++ b/client/lib/user/index.js
@@ -27,7 +27,9 @@ User.dispatchToken = Dispatcher.register( function( payload ) {
 			_user.fetch();
 			break;
 		case InvitesActionTypes.INVITE_ACCEPTED:
-			incrementSiteCount();
+			if ( action.invite.role !== 'follower' ) {
+				incrementSiteCount();
+			}
 			break;
 	}
 } );

--- a/client/lib/user/index.js
+++ b/client/lib/user/index.js
@@ -27,7 +27,7 @@ User.dispatchToken = Dispatcher.register( function( payload ) {
 			_user.fetch();
 			break;
 		case InvitesActionTypes.INVITE_ACCEPTED:
-			if ( action.invite.role !== 'follower' ) {
+			if ( [ 'follower', 'viewer' ].indexOf( action.invite.role ) === -1 ) {
 				incrementSiteCount();
 			}
 			break;

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -42,6 +42,20 @@ export default {
 					}
 				];
 				break;
+			case 'viewer':
+				return [
+					i18n.translate(
+						'You are now a viewer of: {{site/}}', {
+							components: { site }
+						}
+					),
+					{
+						button: i18n.translate( 'Visit Site' ),
+						href: get( invite, 'site.URL' ),
+						displayOnNextPage
+					}
+				];
+				break;
 			case 'administrator':
 				return [
 					<div>


### PR DESCRIPTION
__How to test__

To test:

* Checkout fix/invites-accept-follower-error branch
* Go to $site/wp-admin/users.php?page=wpcom-invite-users where $site is a public WP.com site
Invite a user as a follower
* Click the link in the invitation email, and then replace wpcalypso.wordpress.com with calypso.localhost:3000
* Click on "Follow by email subscription only."
* Assert that everything flows :)
