### PR TITLE
Checkout: A/B test a minimal version of the masterbar in checkout

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -25,6 +25,7 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	PulsingDot = require( 'components/pulsing-dot' ),
 	SitesListNotices = require( 'lib/sites-list/notices' ),
 	PollerPool = require( 'lib/data-poller' ),
+	CartData = require( 'components/data/cart' ),
 	KeyboardShortcutsMenu,
 	Layout;
 
@@ -95,7 +96,9 @@ Layout = React.createClass( {
 		return (
 			<div className={ sectionClass }>
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
-				<MasterbarLoggedIn user={ this.props.user } section={ this.props.section } sites={ this.props.sites } />
+				<CartData>
+					<MasterbarLoggedIn user={ this.props.user } section={ this.props.section } sites={ this.props.sites } />
+				</CartData>
 				<div className={ loadingClass } ><PulsingDot active={ this.props.isLoading } /></div>
 				<div id="content" className="wp-content">
 					<Welcome isVisible={ showWelcome } closeAction={ this.closeWelcome } additionalClassName="NuxWelcome">

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import Masterbar from './masterbar';
 import Item from './item';
 import Stats from './stats';
@@ -14,6 +15,7 @@ import Notifications from './notifications';
 import Gravatar from 'components/gravatar';
 import layoutFocus from 'lib/layout-focus';
 import config from 'config';
+import { getExitCheckoutUrl } from 'lib/checkout';
 
 export default React.createClass( {
 	displayName: 'Masterbar',
@@ -58,7 +60,33 @@ export default React.createClass( {
 		return 'my-sites';
 	},
 
+	getMinimalLogoUrl() {
+		if ( ! this.props.cart.hasLoadedFromServer || ! this.props.sites.getSelectedSite() ) {
+			return '/';
+		}
+
+		return getExitCheckoutUrl( this.props.cart, this.props.sites.getSelectedSite().slug );
+	},
+
+	renderMinimal() {
+		return (
+			<Masterbar>
+				<Item
+					url={ this.getMinimalLogoUrl() }
+					icon="my-sites"
+					className="masterbar__item-logo"
+				>
+					WordPress<span className="tld">.com</span>
+				</Item>
+			</Masterbar>
+		);
+	},
+
 	render() {
+		if ( 'checkout' === this.props.section && abtest( 'checkoutMasterbar' ) === 'minimal' ) {
+			return this.renderMinimal();
+		}
+
 		return (
 			<Masterbar>
 				<Stats

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -68,5 +68,13 @@ module.exports = {
 			button: 50
 		},
 		defaultVariation: 'original'
+	},
+	checkoutMasterbar: {
+		datestamp: '20160119',
+		variations: {
+			original: 50,
+			minimal: 50
+		},
+		defaultVariation: 'original'
 	}
 };

--- a/client/lib/checkout/index.js
+++ b/client/lib/checkout/index.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { cartItems } from 'lib/cart-values';
+import { managePurchase } from 'me/purchases/paths';
+
+export function getExitCheckoutUrl( cart, siteSlug ) {
+	let url = '/plans/';
+
+	if ( cartItems.hasDomainRegistration( cart ) ) {
+		url = '/domains/add/';
+	} else if ( cartItems.hasDomainMapping( cart ) ) {
+		url = '/domains/add/mapping/';
+	} else if ( cartItems.hasProduct( cart, 'offsite_redirect' ) ) {
+		url = '/domains/add/site-redirect/';
+	} else if ( cartItems.hasProduct( cart, 'premium_theme' ) ) {
+		url = '/design/';
+	}
+
+	url = url + siteSlug;
+
+	if ( cartItems.hasRenewalItem( cart ) ) {
+		let renewalItem = cartItems.getRenewalItems( cart )[ 0 ];
+
+		url = managePurchase( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId );
+	}
+
+	return url;
+}

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -18,6 +18,7 @@ var analytics = require( 'analytics' ),
 	planActions = require( 'state/sites/plans/actions' ),
 	purchasePaths = require( 'me/purchases/paths' ),
 	SecurePaymentForm = require( './secure-payment-form' ),
+	getExitCheckoutUrl = require( 'lib/checkout' ).getExitCheckoutUrl,
 	upgradesActions = require( 'lib/upgrades/actions' );
 
 module.exports = React.createClass( {
@@ -109,22 +110,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( this.state.previousCart ) {
-			if ( cartItems.hasDomainRegistration( this.state.previousCart ) ) {
-				redirectTo = '/domains/add/';
-			} else if ( cartItems.hasDomainMapping( this.state.previousCart ) ) {
-				redirectTo = '/domains/add/mapping/';
-			} else if ( cartItems.hasProduct( this.state.previousCart, 'offsite_redirect' ) ) {
-				redirectTo = '/domains/add/site-redirect/';
-			} else if ( cartItems.hasProduct( this.state.previousCart, 'premium_theme' ) ) {
-				redirectTo = '/design/';
-			}
-			redirectTo = redirectTo + this.props.sites.getSelectedSite().slug;
-
-			if ( cartItems.hasRenewalItem( this.state.previousCart ) ) {
-				renewalItem = cartItems.getRenewalItems( this.state.previousCart )[ 0 ];
-
-				redirectTo = purchasePaths.managePurchase( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId );
-			}
+			redirectTo = getExitCheckoutUrl( this.state.previousCart, this.props.sites.getSelectedSite().slug );
 		}
 
 		page.redirect( redirectTo );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -172,6 +172,8 @@ module.exports = {
 
 		analytics.pageView.record( basePath, 'Checkout' );
 
+		context.store.dispatch( setSection( 'checkout' ) );
+
 		titleActions.setTitle( i18n.translate( 'Checkout' ), {
 			siteID: context.params.domain
 		} );


### PR DESCRIPTION
Fixes #2383.

This PR tests displaying a minimal version of the masterbar in checkout:

![screen shot 2016-01-18 at 3 41 51 pm](https://cloud.githubusercontent.com/assets/1130674/12405561/2ec5515c-bdfa-11e5-8f1c-e86e4dfa6d96.png)

**Testing**
- Run `localStorage.setItem( 'ABTests', '{"checkoutMasterbar_20040119":"original"}' );` in your console.
- Add an item to the cart and proceed to checkout.
- Assert that the masterbar in checkout links to 'My Sites', the Reader, etc. (i.e. remains unchanged).
- Exit checkout by removing all items from your cart.
- Run `localStorage.setItem( 'ABTests', '{"checkoutMasterbar_20040119":"minimal"}' );` in your console.
- Add an item to the cart and proceed to checkout.
- Assert that the a minimal version of the masterbar appears.
- Assert that the page that the WordPress.com logo in the masterbar links to changes based on the content of your cart. For instance, if your cart contains a domain, it should link to `/domains/add/:site`. The link should be the same as the page that you are redirected to if you remove all items from the cart.

- [x] Product review
- [x] Code review

cc @breezyskies 