### PR TITLE
Stats: Fix missing classnames on followers component.

### DIFF
--- a/client/my-sites/stats/stats-comments/style.scss
+++ b/client/my-sites/stats/stats-comments/style.scss
@@ -1,3 +1,4 @@
+.tab-content,
 .stats-comments__tab-content {
 	display: none;
 

--- a/client/my-sites/stats/stats-followers-page/index.jsx
+++ b/client/my-sites/stats/stats-followers-page/index.jsx
@@ -9,7 +9,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var StatsList = require( '../stats-list' ),
-	SelectDropdown = require( 'components/select-dropdown' ),
+	StatsModuleSelectDropdown = require( '../stats-module/select-dropdown' ),
 	toggle = require( '../mixin-toggle' ),
 	skeleton = require( '../mixin-skeleton' ),
 	ErrorPanel = require( '../stats-error' ),
@@ -55,11 +55,7 @@ module.exports = React.createClass( {
 			];
 
 		if ( 'comment' !== this.props.followType ) {
-			selectFilter = (
-				<div className="select-dropdown__wrapper">
-					<SelectDropdown options={ options } onSelect={ this.props.changeFilter } />
-				</div>
-			);
+			selectFilter = <StatsModuleSelectDropdown options={ options } onSelect={ this.props.changeFilter } />;
 		}
 
 		return selectFilter;

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -9,7 +9,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var toggle = require( '../mixin-toggle' ),
-	SelectDropdown = require( 'components/select-dropdown' ),
+	StatsModuleSelectDropdown = require( '../stats-module/select-dropdown' ),
 	StatsList = require( '../stats-list' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	ErrorPanel = require( '../stats-error' ),
@@ -80,11 +80,7 @@ module.exports = React.createClass( {
 			];
 
 		if ( ( ! this.props.wpcomFollowersList.isEmpty( 'subscribers' ) ) && ( ! this.props.emailFollowersList.isEmpty( 'subscribers' ) ) ) {
-			selectFilter = (
-				<div className="select-dropdown__wrapper">
-					<SelectDropdown options={ options } onSelect={ this.changeFilter } />
-				</div>
-			);
+			selectFilter = <StatsModuleSelectDropdown options={ options } onSelect={ this.changeFilter } />;
 		}
 
 		return selectFilter;


### PR DESCRIPTION
A regression was introduced in #2441 that is causing some display issues with the Followers components on the Insights page.  This branch fixes the missing classname, and utilizes the new `StatsModuleSelectDropdown` for the filters on the followers pages.

A follow-up PR will refactor the followers components to ES6.

__To Test__
- Open a site insights page
- Verify the followers component looks/behaves properly when interacting with the filter