### PR TITLE
Invites: Fixes wording for logged in follower invite accept

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -48,7 +48,7 @@ export default React.createClass( {
 
 	getButtonText() {
 		let text = '';
-		if ( 'follower' === this.props.role ) {
+		if ( 'follower' === this.props.invite.role ) {
 			text = this.state.submitting
 				? this.translate( 'Following…', { context: 'button' } )
 				: this.translate( 'Follow', { context: 'button' } );
@@ -65,7 +65,7 @@ export default React.createClass( {
 		const { user } = this.props;
 		let text = '';
 
-		if ( 'follower' === this.props.role ) {
+		if ( 'follower' === this.props.invite.role ) {
 			text = this.translate( 'Follow as {{usernameWrap}}%(username)s{{/usernameWrap}}', {
 				components: {
 					usernameWrap: <span className="invite-accept-logged-in__join-as-username" />


### PR DESCRIPTION
Since #2483, we now send an invite object from `invite-accept` to `invite-accept-logged-in` instead of spreading the invite object.

Making this update was mostly error free, except that over the weekend, we forgot that we were also working on #2499, which relied on the invite being passed down in the old way. Since the invite and role was not where expected, the updated wording for followers didn't get displayed.

This PR fixes that.

To test:
- Checkout `fix/invites-logged-in-invite-prop` branch
- Go to `$site/wp-admin/users.php?page=wpcom-invite-users` where `$site` is a public WP.com site.
- Send at least one `follower` and an invite for any other role
- In incognito tab, login with test account that was invited (or any test account)
- Copy the invitation link that you receive, replace wpcalypso.wordpress.com with calypso.localhost:3000

For a follower invite, you should see:

![screen shot 3](https://cloud.githubusercontent.com/assets/1126811/12406075/7c1c0ff8-be0f-11e5-82c1-3221bb93efed.png)

For the other invite:

![screen shot 4](https://cloud.githubusercontent.com/assets/1126811/12406078/810f444e-be0f-11e5-8743-11469aa62906.png)
