### PR TITLE
Invites: Signup: Fixes JS error for logged out invites

### DIFF
--- a/client/components/signup-form/README.md
+++ b/client/components/signup-form/README.md
@@ -31,7 +31,7 @@ render: function() {
 
 * `submitForm` function - Called when the form is submitted. It will receive the following parameters: `form`, `userData` and `analyticsData`
 * `submitButtonText` string: The text displayed inside the submit button
-* `getRedirectToAfterLoginUrl` function: Where the user should be redirected after being logged in
+* `getRedirectToAfterLoginUrl` string: Where the user should be redirected after being logged in
 * (optional) `save` function: Called `onBlur` of each field with `form` as parameter
 * (optional) `disabled` boolean: Sets the form as disabled
 * (optional) `submitting` boolean: Sets the state of the form as being submitted

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -279,7 +279,8 @@ export default React.createClass( {
 		if ( ! messages ) {
 			return;
 		}
-		let link = config( 'login_url' ) + '?redirect_to=' + this.props.getRedirectToAfterLoginUrl();
+
+		let link = config( 'login_url' ) + '?redirect_to=' + this.props.getRedirectToAfterLoginUrl;
 		return map( messages, ( message, error_code ) => {
 			if ( error_code === 'taken' ) {
 				link += '&email_address=' + encodeURIComponent( formState.getFieldValue( this.state.form, fieldName ) );

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -373,7 +373,7 @@ export default React.createClass( {
 
 	termsOfServiceLink() {
 		return (
-			<p className='signup-form__terms-of-service-link'>{
+			<p className="signup-form__terms-of-service-link">{
 				this.translate(
 					'By creating an account you agree to our {{a}}fascinating Terms of Service{{/a}}.',
 					{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -97,7 +97,7 @@ export default React.createClass( {
 		return (
 			<SignupForm
 				{ ...this.props }
-				getRedirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl }
+				getRedirectToAfterLoginUrl={ this.getRedirectToAfterLoginUrl() }
 				disabled={ this.userCreationStarted() }
 				submitting={ this.userCreationStarted() }
 				save={ this.save }


### PR DESCRIPTION
Earlier, I noticed that there was a JS error when attempting to accept an invite while logged out.

![screen shot](https://cloud.githubusercontent.com/assets/1126811/12406710/2fd9a1c2-be15-11e5-8999-d23d58fc5720.png)

This was occurring because the `signup-form` component expects `getRedirectToAfterLoginUrl` to be a function, but we were now passing a string.

This PR updates the signup form component to expect a string.

To test:
- Checkout `fix/invites-redirect` branch
- Go to `/start`
  - Create a user
  - Ensure you are redirected to `/me/next`
- Go to `$site/wp-admin/users.php?page=wpcom-invite-users` where `$site` is a public WP.com site
  - Create a follower invite
  - Click activation link in your email and replace `wpcalypso.wordpress.com` with `calypso.localhost:3000`
  - Create a user and follow
  - Ensure there are no errors and you land on `/`


cc @lezama 