### PR TITLE
Plugins: Fix/plugins not available on any site

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -5,6 +5,7 @@ var debug = require( 'debug' )( 'calypso:sites-list' ),
 	store = require( 'store' ),
 	assign = require( 'lodash/object/assign' ),
 	find = require( 'lodash/collection/find' ),
+	isEmpty = require( 'lodash/lang/isEmpty' ),
 	some = require( 'lodash/collection/some' );
 
 /**
@@ -532,9 +533,7 @@ SitesList.prototype.getSelectedOrAllWithPlugins = function() {
 };
 
 SitesList.prototype.hasSiteWithPlugins = function() {
-	return some( this.get(), function( site ) {
-		return isBusiness( site.plan ) || site.jetpack;
-	} );
+	return ! isEmpty( this.getSelectedOrAllWithPlugins() );
 };
 
 SitesList.prototype.fetchAvailableUpdates = function() {

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -529,7 +529,12 @@ SitesList.prototype.getSelectedOrAllJetpackCanManage = function() {
 };
 
 SitesList.prototype.getSelectedOrAllWithPlugins = function() {
-	return this.getSelectedOrAll().filter( site => ( isBusiness( site.plan ) || site.jetpack ) && ( site.visible || this.selected ) );
+	return this.getSelectedOrAll().filter( site => {
+		return site.capabilities &&
+			site.capabilities.manage_options &&
+			( isBusiness( site.plan ) || site.jetpack ) &&
+			( site.visible || this.selected )
+	} );
 };
 
 SitesList.prototype.hasSiteWithPlugins = function() {

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -66,6 +66,18 @@ const hasRestrictedAccess = ( site ) => {
 
 	site = site || sites.getSelectedSite();
 
+	const WpCompluginPageError = {
+		title: i18n.translate( 'Want to add a store to your site?' ),
+		line: i18n.translate( 'Support for Shopify, Ecwid, and Gumroad is now available for WordPress.com Business.' ),
+		action: i18n.translate( 'Upgrade Now' ),
+		actionURL: '/plans/' + site.slug,
+		illustration: '/calypso/images/drake/drake-whoops.svg',
+		actionCallback: () => {
+			analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'business_plugins' } );
+		},
+		featureExample: getMockBusinessPluginItems()
+	};
+
 	// Display a 404 to users that don't have the rights to manage plugins
 	if ( hasErrorCondition( site, 'notRightsToManagePlugins' ) ) {
 		pluginPageError = {
@@ -91,31 +103,12 @@ const hasRestrictedAccess = ( site ) => {
 	}
 
 	if ( abtest( 'businessPluginsNudge' ) === 'drake' && hasErrorCondition( site, 'noBusinessPlan' ) ) {
-		pluginPageError = {
-			title: i18n.translate( 'Want to add a store to your site?' ),
-			line: i18n.translate( 'Support for Shopify, Ecwid, and Gumroad is now available for WordPress.com Business.' ),
-			action: i18n.translate( 'Upgrade Now' ),
-			actionURL: '/plans/' + site.slug,
-			illustration: '/calypso/images/drake/drake-whoops.svg',
-			actionCallback: () => {
-				analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'business_plugins' } );
-			},
-			featureExample: getMockBusinessPluginItems()
-		};
+		pluginPageError = WpCompluginPageError;
 	}
 
-	if ( ! sites.hasSiteWithPlugins() ) {
-		pluginPageError = {
-			title: i18n.translate( 'Want to add a store to your site?' ),
-			line: i18n.translate( 'Support for Shopify, Ecwid, and Gumroad is now available for WordPress.com Business.' ),
-			action: i18n.translate( 'Upgrade Now' ),
-			actionURL: '/plans/',
-			illustration: '/calypso/images/drake/drake-whoops.svg',
-			actionCallback: () => {
-				analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'business_plugins' } );
-			},
-			featureExample: getMockBusinessPluginItems()
-		};
+	if ( ! sites.hasSiteWithPlugins() && ! site ) {
+		pluginPageError = WpCompluginPageError;
+		pluginPageError.actionUrl = '/plans/';
 	}
 
 	return pluginPageError;

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -66,11 +66,11 @@ const hasRestrictedAccess = ( site ) => {
 
 	site = site || sites.getSelectedSite();
 
-	const WpCompluginPageError = {
+	const wpcomPluginPageError = {
 		title: i18n.translate( 'Want to add a store to your site?' ),
 		line: i18n.translate( 'Support for Shopify, Ecwid, and Gumroad is now available for WordPress.com Business.' ),
 		action: i18n.translate( 'Upgrade Now' ),
-		actionURL: '/plans/' + site.slug,
+		actionURL: '/plans/',
 		illustration: '/calypso/images/drake/drake-whoops.svg',
 		actionCallback: () => {
 			analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'business_plugins' } );
@@ -103,12 +103,12 @@ const hasRestrictedAccess = ( site ) => {
 	}
 
 	if ( abtest( 'businessPluginsNudge' ) === 'drake' && hasErrorCondition( site, 'noBusinessPlan' ) ) {
-		pluginPageError = WpCompluginPageError;
+		pluginPageError = wpcomPluginPageError;
+		pluginPageError.actionUrl = '/plans/' + site.slug;
 	}
 
 	if ( ! sites.hasSiteWithPlugins() && ! site ) {
-		pluginPageError = WpCompluginPageError;
-		pluginPageError.actionUrl = '/plans/';
+		pluginPageError = wpcomPluginPageError;
 	}
 
 	return pluginPageError;

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -104,6 +104,20 @@ const hasRestrictedAccess = ( site ) => {
 		};
 	}
 
+	if ( ! sites.hasSiteWithPlugins() ) {
+		pluginPageError = {
+			title: i18n.translate( 'Want to add a store to your site?' ),
+			line: i18n.translate( 'Support for Shopify, Ecwid, and Gumroad is now available for WordPress.com Business.' ),
+			action: i18n.translate( 'Upgrade Now' ),
+			actionURL: '/plans/',
+			illustration: '/calypso/images/drake/drake-whoops.svg',
+			actionCallback: () => {
+				analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'business_plugins' } );
+			},
+			featureExample: getMockBusinessPluginItems()
+		};
+	}
+
 	return pluginPageError;
 }
 

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -61,22 +61,24 @@ const getMockBusinessPluginItems = () => {
 	} );
 }
 
-const hasRestrictedAccess = ( site ) => {
-	let pluginPageError;
-
-	site = site || sites.getSelectedSite();
-
-	const wpcomPluginPageError = {
+const getWpcomPluginPageError = ( siteSlug = '' ) => {
+	return {
 		title: i18n.translate( 'Want to add a store to your site?' ),
 		line: i18n.translate( 'Support for Shopify, Ecwid, and Gumroad is now available for WordPress.com Business.' ),
 		action: i18n.translate( 'Upgrade Now' ),
-		actionURL: '/plans/',
+		actionURL: '/plans/' + siteSlug,
 		illustration: '/calypso/images/drake/drake-whoops.svg',
 		actionCallback: () => {
 			analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'business_plugins' } );
 		},
 		featureExample: getMockBusinessPluginItems()
 	};
+}
+
+const hasRestrictedAccess = ( site ) => {
+	let pluginPageError;
+
+	site = site || sites.getSelectedSite();
 
 	// Display a 404 to users that don't have the rights to manage plugins
 	if ( hasErrorCondition( site, 'notRightsToManagePlugins' ) ) {
@@ -102,13 +104,23 @@ const hasRestrictedAccess = ( site ) => {
 		);
 	}
 
-	if ( abtest( 'businessPluginsNudge' ) === 'drake' && hasErrorCondition( site, 'noBusinessPlan' ) ) {
-		pluginPageError = wpcomPluginPageError;
-		pluginPageError.actionUrl = '/plans/' + site.slug;
+	if ( hasErrorCondition( site, 'noBusinessPlan' ) ) {
+		switch ( abtest( 'businessPluginsNudge' ) ) {
+			case 'nudge':
+				pluginPageError = {
+					abtest: 'nudge'
+				};
+				break;
+
+			case 'drake':
+			default:
+				pluginPageError = getWpcomPluginPageError( site.slug );
+				break;
+		}
 	}
 
 	if ( ! sites.hasSiteWithPlugins() && ! site ) {
-		pluginPageError = wpcomPluginPageError;
+		pluginPageError = getWpcomPluginPageError();
 	}
 
 	return pluginPageError;

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -119,7 +119,7 @@ const hasRestrictedAccess = ( site ) => {
 		}
 	}
 
-	if ( ! sites.hasSiteWithPlugins() && ! site ) {
+	if ( ! sites.hasSiteWithPlugins() ) {
 		pluginPageError = getWpcomPluginPageError();
 	}
 

--- a/client/my-sites/plugins/access-control.js
+++ b/client/my-sites/plugins/access-control.js
@@ -82,7 +82,7 @@ const hasRestrictedAccess = ( site ) => {
 
 	// Display a 404 to users that don't have the rights to manage plugins
 	if ( hasErrorCondition( site, 'notRightsToManagePlugins' ) ) {
-		pluginPageError = {
+		return {
 			title: i18n.translate( 'Not Available' ),
 			line: i18n.translate( 'The page you requested could not be found' ),
 			illustration: '/calypso/images/drake/drake-404.svg',

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -18,11 +18,9 @@ import get from 'lodash/object/get';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import pluginsAccessControl from 'my-sites/plugins/access-control';
-import { isBusiness } from 'lib/products-values';
 import PluginItem from './plugin-item/plugin-item';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
@@ -353,22 +351,22 @@ const PluginsMain = React.createClass( {
 	},
 
 	render() {
+		const selectedSite = this.props.sites.getSelectedSite();
+
 		if ( this.state.accessError ) {
+			if ( this.state.accessError.abtest === 'nudge' ) {
+				return (
+					<Main>
+						<SidebarNavigation />
+						<PlanNudge currentProductId={ selectedSite.plan.product_id } selectedSiteSlug={ selectedSite.slug } />
+					</Main>
+				);
+			}
 			return (
 				<Main>
 					<SidebarNavigation />
 					<EmptyContent { ...this.state.accessError } />
 					{ this.state.accessError.featureExample ? <FeatureExample>{ this.state.accessError.featureExample }</FeatureExample> : null }
-				</Main>
-			);
-		}
-
-		const selectedSite = this.props.sites.getSelectedSite();
-		if ( abtest( 'businessPluginsNudge' ) === 'nudge' && selectedSite && ! selectedSite.jetpack && ! isBusiness( selectedSite.plan ) ) {
-			return (
-				<Main>
-					<SidebarNavigation />
-					<PlanNudge currentProductId={ selectedSite.plan.product_id } selectedSiteSlug={ selectedSite.slug } />
 				</Main>
 			);
 		}
@@ -379,7 +377,7 @@ const PluginsMain = React.createClass( {
 					<SidebarNavigation />
 					<JetpackManageErrorPage
 						template="optInManage"
-						site={ this.props.sites.getSelectedSite() }
+						site={ selectedSite }
 						title={ this.translate( 'Looking to manage this site\'s plugins?' ) }
 						section="plugins"
 						featureExample={ this.getMockPluginItems() } />

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -228,11 +228,11 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		if ( ! this.props.sites.canManageSelectedOrAll() ) {
+		if ( ! this.props.sites.canManageSelectedOrAll()  ) {
 			return null;
 		}
 
-		if ( ! this.props.sites.hasSiteWithPlugins() ) {
+		if ( ! this.props.sites.hasSiteWithPlugins() && ! this.isSingle() ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -232,6 +232,10 @@ module.exports = React.createClass( {
 			return null;
 		}
 
+		if ( ! this.props.sites.hasSiteWithPlugins() ) {
+			return null;
+		}
+
 		if ( ! config.isEnabled( 'manage/plugins' ) && site.options ) {
 			pluginsLink = site.options.admin_url + 'plugins.php';
 		}


### PR DESCRIPTION
Currently if you have no business plan sites and visit /plugins you end up on this page . 
![screen shot 2016-01-18 at 17 01 42](https://cloud.githubusercontent.com/assets/115071/12406785/300e03d2-be05-11e5-96db-ea9644428aee.png)

This PR fixes this by 
1. Removing the Plugins link in the sidebar if you don't have any sites that can manage plugins. 
2. Add a placeholder on the plugins page. 
![screen shot 2016-01-18 at 17 04 55](https://cloud.githubusercontent.com/assets/115071/12406831/ae1ddd88-be05-11e5-9b9f-c0e5c85060d8.png)

cc: @drewblaisdell, @johnHackworth, @rickybanister 


