### PR TITLE
Formatting: Don't try to prevent widows on objects

### DIFF
--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -68,6 +68,10 @@ function unicodeToString( character ) {
 function preventWidows( text, wordsToKeep ) {
 	var words, endWords;
 
+	if ( typeof text !== 'string' ) {
+		return text;
+	}
+
 	text = text && trim( text );
 	if ( ! text ) {
 		return text;


### PR DESCRIPTION
We shouldn't try to prevent widows on objects. This checks that the `text` passed to `preventWidows` is a string before processing it.

Before:
<img width="787" alt="screen shot 2016-01-19 at 11 17 04" src="https://cloud.githubusercontent.com/assets/275961/12417250/94897ea6-be9e-11e5-92a4-9911e25f6cba.png">

After:
<img width="763" alt="screen shot 2016-01-19 at 11 17 09" src="https://cloud.githubusercontent.com/assets/275961/12417246/92fb32b4-be9e-11e5-9b8e-fb19afe6d4ce.png">

#### Testing instructions

1. Go to http://calypso.localhost:3000/start/plans
2. Assert that you don't see [object] in the header.

#### Reviews

- [x] Code
- [x] Product