### PR TITLE
Reader: Support an `at` param to set where a stream starts.

### DIFF
--- a/client/lib/feed-stream-store/actions.js
+++ b/client/lib/feed-stream-store/actions.js
@@ -23,6 +23,9 @@ function getNextPageParams( store ) {
 		// only fetch four items for the initial page
 		// speeds up the initial fetch a fair bit
 		params.number = 4;
+		if ( store.startDate ) {
+			params.before = store.startDate;
+		}
 	}
 
 	return params;

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -43,6 +43,7 @@ var FeedStream = function( spec ) {
 	this.id = spec.id;
 
 	assign( this, {
+		id: spec.id,
 		postKeys: [], // an array of keys, as determined by the key maker,
 		pendingPostKeys: [],
 		postById: {},
@@ -66,7 +67,8 @@ var FeedStream = function( spec ) {
 			interval: 60 * 1000,
 			leading: false,
 			pauseWhenHidden: false
-		} )
+		} ),
+		startDate: spec.startDate
 	} );
 };
 

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -5,7 +5,8 @@ var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	page = require( 'page' ),
 	debug = require( 'debug' )( 'calypso:reader:controller' ),
-	trim = require( 'lodash/string/trim' );
+	trim = require( 'lodash/string/trim' ),
+	moment = require( 'moment' );
 
 /**
  * Internal Dependencies
@@ -59,8 +60,14 @@ function removeFullPostDialog() {
 	__fullPostInstance = null;
 }
 
-function ensureStoreLoading( store ) {
+function ensureStoreLoading( store, context ) {
 	if ( store.getPage() === 1 ) {
+		if ( context.query.at ) {
+			const startDate = moment( context.query.at );
+			if ( startDate.isValid() ) {
+				store.startDate = startDate.format();
+			}
+		}
 		FeedStreamStoreActions.fetchNextPage( store.id );
 	}
 	return store;
@@ -117,7 +124,7 @@ module.exports = {
 			followingStore = feedStreamFactory( 'following' ),
 			mcKey = 'following';
 
-		ensureStoreLoading( followingStore );
+		ensureStoreLoading( followingStore, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
@@ -149,7 +156,7 @@ module.exports = {
 			setPageTitle = pageTitleSetter( context ),
 			mcKey = 'blog';
 
-		ensureStoreLoading( feedStore );
+		ensureStoreLoading( feedStore, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		analytics.tracks.recordEvent( 'calypso_reader_blog_preview', {
@@ -184,7 +191,7 @@ module.exports = {
 			setPageTitle = pageTitleSetter( context ),
 			mcKey = 'blog';
 
-		ensureStoreLoading( feedStore );
+		ensureStoreLoading( feedStore, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		analytics.tracks.recordEvent( 'calypso_reader_blog_preview', {
@@ -300,7 +307,7 @@ module.exports = {
 			setPageTitle = pageTitleSetter( context ),
 			mcKey = 'topic';
 
-		ensureStoreLoading( tagStore );
+		ensureStoreLoading( tagStore, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		analytics.tracks.recordEvent( 'calypso_reader_tag_loaded', {
@@ -334,7 +341,7 @@ module.exports = {
 			setPageTitle = pageTitleSetter( context ),
 			mcKey = 'list';
 
-		ensureStoreLoading( listStore );
+		ensureStoreLoading( listStore, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		analytics.tracks.recordEvent( 'calypso_reader_list_loaded', {
@@ -371,7 +378,7 @@ module.exports = {
 			feedStore = feedStreamFactory( 'a8c' ),
 			mcKey = 'a8c';
 
-		ensureStoreLoading( feedStore );
+		ensureStoreLoading( feedStore, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
@@ -403,7 +410,7 @@ module.exports = {
 			setPageTitle = pageTitleSetter( context ),
 			mcKey = 'postlike';
 
-		ensureStoreLoading( likedPostsStore );
+		ensureStoreLoading( likedPostsStore, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
@@ -549,7 +556,7 @@ module.exports = {
 
 		titleActions.setTitle( 'Discover' );
 
-		ensureStoreLoading( feedStore );
+		ensureStoreLoading( feedStore, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		analytics.tracks.recordEvent( 'calypso_reader_discover_viewed' );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -415,7 +415,7 @@ module.exports = function() {
 		} );
 	}
 
-	if ( config.isEnabled( 'reader/discover' ) ) {
+	if ( config.isEnabled( 'reader/discover' ) && config( 'env' ) !== 'development' ) {
 		app.get( '/discover', function( req, res ) {
 			if ( req.cookies.wordpress_logged_in ) {
 				renderLoggedInRoute( req, res );


### PR DESCRIPTION
This patch teaches all of the reader streams to start at a certain date. This helps when debugging streams that have a lot of volume, like tag streams, by allowing you to start at a particular date.

The at param will take any ISO-8601 compliant date, with timezone, and translate it to a UTC-based date before passing it down to the API.

Fixes #2574