### PR TITLE
Signup: Prevent the site step in signup from being submitted twice

### DIFF
--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -14,7 +14,6 @@ var debug = require( 'debug' )( 'calypso:signup-progress-store' ), // eslint-dis
  * Internal dependencies
  */
 var Dispatcher = require( 'dispatcher' ),
-	config = require( 'config' ),
 	emitter = require( 'lib/mixins/emitter' ),
 	SignupDependencyStore = require( './dependency-store' ),
 	steps = require( 'signup/config/steps' );

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -132,14 +132,8 @@ module.exports = React.createClass( {
 
 		this.setState( { submitting: true } );
 
-		if ( this.props.step && 'completed' === this.props.step.status ) {
+		if ( this.props.step && 'in-progress' !== this.props.step.status ) {
 			this.resetAnalyticsData();
-
-			SignupActions.submitSignupStep( {
-				processingMessage: this.translate( 'Setting up your site' ),
-				stepName: this.props.stepName,
-				form: this.state.form
-			} );
 
 			this.props.goToNextStep();
 			return;
@@ -226,7 +220,7 @@ module.exports = React.createClass( {
 	},
 
 	formFields: function() {
-		var fieldDisabled = this.props.step && 'completed' === this.props.step.status;
+		var fieldDisabled = this.props.step && 'in-progress' !== this.props.step.status;
 
 		return <ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }>
 			<FormLabel htmlFor="site">
@@ -249,12 +243,12 @@ module.exports = React.createClass( {
 	},
 
 	buttonText: function() {
-		if ( this.state.submitting ) {
-			return this.translate( 'Creating your site…' );
-		}
-
 		if ( this.props.step && 'completed' === this.props.step.status ) {
 			return this.translate( 'Site created - Go to next step' );
+		}
+
+		if ( this.state.submitting || ( this.props.step && 'in-progress' !== this.props.step.status ) ) {
+			return this.translate( 'Creating your site…' );
 		}
 
 		return this.translate( 'Create My Site' );


### PR DESCRIPTION
This pull request prevents the site step in the signup flow from submitting to the API twice. We were seeing some instances of this form being submitted twice which was causing some strange behaviour through the API. This PR seeks to address that by making it impossible to submit this step more than once.
 
#### Testing instructions

This is hard to test.

1. Run `git checkout fix/double-submit-site-step` and start your server
2. Open the [`Free trials signup` page](http://calypso.dev:3000/start/free-trials) as a logged in user
3. Go to the site step
4. Try to submit the site step twice. You have to be a logged in user so the request is made right away.

You can see the requests in the network tab to /sites/new - there are two different requests - one with a `validate` property `true` - these won't create a site, only validate it. We can make as many of these as we want. However when the `validate` property is `false` we will create the site. There should only be one request of this type.

Some things I tried to replicate the problem, or cause other problems are:
- Going back to the step after submitting it and seeing if I could submit it again
- Hit the enter button a lot of times to do lots of submits

#### Reviews

- [x] Code
- [x] Product