### PR TITLE
Signup: Remove domains from the signup flow while the WWD API is down

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -48,7 +48,7 @@ const flows = {
 	},
 
 	main: {
-		steps: [ 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'themes', 'site', 'plans', 'user' ],
 		destination: getCheckoutDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2015-09-03'


### PR DESCRIPTION
Signup doesn't work when the API is down