### PR TITLE
Invites: Fixes routing for logged out invites

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -389,7 +389,7 @@ module.exports = function() {
 		}
 	} );
 
-	app.get( '/accept-invite/?.*', function( req, res ) {
+	app.get( '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?', function( req, res ) {
 		if ( req.cookies.wordpress_logged_in ) {
 			// the user is probably logged in
 			renderLoggedInRoute( req, res );


### PR DESCRIPTION
I noticed that logged out invite are no longer working for `wpcalypso` and `staging`. Based on #2155, I believe the issue is with our routing in `server/pages/index.js`.

Unfortunately, we didn't catch this in development because the logged out routes seem to be handled differently.
https://github.com/Automattic/wp-calypso/compare/fix/invites-logged-out-route?expand=1#