### PR TITLE
Free Trials: Update timestamp of free trials a/b test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -46,7 +46,7 @@ module.exports = {
 		defaultVariation: 'original'
 	},
 	freeTrials: {
-		datestamp: '20160112',
+		datestamp: '20160120',
 		variations: {
 			notOffered: 90,
 			offered: 10


### PR DESCRIPTION
This will create a new test group for the same test. There was some discussion about this decision here: p1453225934000283-slack-upgrades

**Testing**
We should test three cases here: users in the `offered` variation of the old test group, and users in either variation of the new test group.

*`offered` - previous test*
- Visit `/start`, run `localStorage.setItem( 'ABTests', '{"freeTrials_20160112":"offered"}' );` in your console, and refresh the page.
- Assert that you are not offered a free trial during signup, nor on the plans page after you complete signup.

*`offered` - new test*
- Visit `/start`, run `localStorage.setItem( 'ABTests', '{"freeTrials_20160119":"offered"}' );` in your console, and refresh the page.
- Assert that you offered a free trial during signup and on the plans page after you complete signup.

*`notOffered` - previous test*
- Visit `/start`, run `localStorage.setItem( 'ABTests', '{"freeTrials_20160119":"notOffered"}' );` in your console, and refresh the page.
- Assert that you are not offered a free trial during signup, nor on the plans page after you complete signup.

- [x] Product review
- [x] Code review