### PR TITLE
Signup: Use the `domains` step instead in the main signup flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -48,7 +48,7 @@ const flows = {
 	},
 
 	main: {
-		steps: [ 'themes', 'site', 'plans', 'user' ],
+		steps: [ 'themes', 'domains', 'plans', 'user' ],
 		destination: getCheckoutDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2015-09-03'


### PR DESCRIPTION
We switched to the `site` step while the WWD API was down, in https://github.com/Automattic/wp-calypso/pull/2584. It is back up now, so we need to switch back to the `domains` step.

**Testing**
- Visit http://calypso.localhost:3000/start and assert that the domain search on the second step returns search results.