### PR TITLE
Reader: Adjust line-heights

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -155,40 +155,37 @@
 	position: relative;
 
 	font-size: 16px;
-	line-height: 1.8;
+	line-height: 1.7;
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 
 	h1 {
 		font-size: 28px;
-		line-height: 1.4;
 		font-weight: 700;
 		margin: 0 0 16px 0;
 	}
 
 	h2 {
 		font-size: 24px;
-		line-height: 1.2;
 		font-weight: 700;
 		margin: 0 0 8px 0;
 	}
 
 	h3 {
 		font-size: 20px;
-		line-height: 1.2;
 		font-weight: 700;
 		margin: 0 0 8px 0;
 	}
 
 	h4 {
 		font-size: 18px;
-		line-height: 1.2;
 		font-weight: 700;
 		margin: 0 0 8px 0;
 	}
 
 	p {
 		margin: 0 0 24px 0;
+
 		&:last-child {
 			margin-bottom: 0;
 		}


### PR DESCRIPTION
This PR removes the line-heights from individual elements in the full post view, and moves it to the containing div. This helps with longer headings. Here's a quick before/after:

![screen shot 2016-01-19 at 3 32 53 pm](https://cloud.githubusercontent.com/assets/191598/12431173/ea683ace-bec1-11e5-94d5-404f88789384.png)

![screen shot 2016-01-19 at 3 32 43 pm](https://cloud.githubusercontent.com/assets/191598/12431176/eeb1ae12-bec1-11e5-9aa1-acb2041cb5db.png)
