### PR TITLE
Themes: Remove 'Support' link for free themes

### DIFF
--- a/client/components/data/current-theme/index.js
+++ b/client/components/data/current-theme/index.js
@@ -27,7 +27,12 @@ const CurrentThemeData = React.createClass( {
 		// Connected props
 		currentTheme: React.PropTypes.shape( {
 			name: React.PropTypes.string,
-			id: React.PropTypes.string
+			id: React.PropTypes.string,
+			cost: React.PropTypes.shape( {
+				currency: React.PropTypes.string.isRequired,
+				number: React.PropTypes.number.isRequired,
+				display: React.PropTypes.string
+			} )
 		} ),
 		fetchCurrentTheme: React.PropTypes.func.isRequired
 	},

--- a/client/lib/themes/actions.js
+++ b/client/lib/themes/actions.js
@@ -66,7 +66,8 @@ export function fetchCurrentTheme( site ) {
 					type: ThemeConstants.RECEIVE_CURRENT_THEME,
 					site: site,
 					themeId: data.id,
-					themeName: data.name
+					themeName: data.name,
+					themeCost: data.cost
 				} );
 			}
 		};

--- a/client/lib/themes/helpers.js
+++ b/client/lib/themes/helpers.js
@@ -73,7 +73,19 @@ var ThemesHelpers = {
 	},
 
 	isPremium: function( theme ) {
-		return startsWith( theme.stylesheet, 'premium/' );
+		if ( ! theme ) {
+			return false;
+		}
+
+		if ( theme.stylesheet && startsWith( theme.stylesheet, 'premium/' ) ) {
+			return true;
+		}
+		// The /v1.1/sites/:site_id/themes/mine endpoint (which is used by the
+		// current-theme reducer, selector, and component) does not return a
+		// `stylesheet` attribute. However, it does return a `cost` field (which
+		// contains the correct price even if the user has already purchased that
+		// theme, or if they have an upgrade that includes all premium themes).
+		return !! ( theme.cost && theme.cost.number );
 	},
 
 	trackClick: function( componentName, eventName, verb = 'click' ) {

--- a/client/lib/themes/reducers/current-theme.js
+++ b/client/lib/themes/reducers/current-theme.js
@@ -19,7 +19,8 @@ export default ( state = initialState, action ) => {
 		case ThemeConstants.RECEIVE_CURRENT_THEME:
 			return state.setIn( [ 'currentThemes', action.site.ID ], {
 				name: action.themeName,
-				id: action.themeId
+				id: action.themeId,
+				cost: action.themeCost
 			} );
 		case ThemeConstants.ACTIVATE_THEME:
 			return state.set( 'isActivating', true );

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -32,7 +32,8 @@ var CurrentTheme = React.createClass( {
 		var currentTheme = this.props.currentTheme,
 			placeholderText = <span className="current-theme__placeholder">loading...</span>,
 			text = currentTheme ? currentTheme.name : placeholderText,
-			site = this.props.site;
+			site = this.props.site,
+			displaySupportButton = Helpers.isPremium( currentTheme ) && ! site.jetpack;
 
 		return (
 			<Card className="current-theme">
@@ -46,7 +47,7 @@ var CurrentTheme = React.createClass( {
 				</div>
 				<div className={ classNames(
 					'current-theme__actions',
-					{ 'two-buttons': site.jetpack }
+					{ 'two-buttons': ! displaySupportButton }
 					) } >
 					<CurrentThemeButton name="customize"
 						label={ this.translate( 'Customize' ) }
@@ -58,7 +59,7 @@ var CurrentTheme = React.createClass( {
 						noticon="info"
 						href={ currentTheme ? Helpers.getDetailsUrl( currentTheme, site ) : null }
 						onClick={ this.trackClick } />
-					{ ! site.jetpack && <CurrentThemeButton name="support"
+					{ displaySupportButton && <CurrentThemeButton name="support"
 						label={ this.translate( 'Support' ) }
 						noticon="help"
 						href={ currentTheme ? Helpers.getSupportUrl( currentTheme, site ) : null }
@@ -70,4 +71,3 @@ var CurrentTheme = React.createClass( {
 } );
 
 module.exports = CurrentTheme;
-

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -42,7 +42,9 @@ const buttonOptions = {
 	},
 	support: {
 		hasUrl: true,
-		isHidden: site => site && site.jetpack // We don't know where support docs for a given theme on a self-hosted WP install are.
+		// We don't know where support docs for a given theme on a self-hosted WP install are,
+		// and free themes don't have support docs.
+		isHidden: ( site, theme ) => ( site && site.jetpack ) || ! Helper.isPremium( theme )
 	},
 };
 


### PR DESCRIPTION
Remove the 'Support' link from free themes' 'More' button menus, and the 'Support' button from the 'Current Theme' card in single site view, if the current theme is free.

Before:
<img width="1108" alt="bildschirmfoto 2016-01-19 um 23 18 04" src="https://cloud.githubusercontent.com/assets/96308/12433732/16a90b90-bf03-11e5-8376-6e9c40a26988.png">

After:
<img width="1110" alt="bildschirmfoto 2016-01-19 um 23 15 19" src="https://cloud.githubusercontent.com/assets/96308/12433769/5437b0c4-bf03-11e5-8a9b-647bc8aa9067.png">

To test:
* Verify that the 'More' Button menu has a 'Support' link _iff_ a theme is premium (that definition includes already purchased ones, and premium themes on sites with an all-premium-themes upgrade, e.g. the Business plan, even though those latter themes are shown without a price on such sites). 

Question:
Do we want to add `stylesheet` to the `/v1.1/sites/:site_id/themes/mine` endpoint so we can get rid of [that hack](https://github.com/Automattic/wp-calypso/pull/2591/files#diff-c26fd306fc7c451e17939f01fff10e88R83)? (IIRC it was acceptable to add a field to an existing endpoint.) _Update:_ API patch at `D891-code`

Fixes #2489