### PR TITLE
Try/redux flux sync miami

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -43,6 +43,7 @@ var config = require( 'config' ),
 	TitleStore = require( 'lib/screen-title/store' ),
 	createReduxStore = require( 'state' ).createReduxStore,
 	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
+	reduxFluxSync = require( 'lib/redux-flux-sync' ),
 	// The following mixins require i18n content, so must be required after i18n is initialized
 	Layout,
 	LoggedOutLayout;

--- a/client/lib/redux-flux-sync/Makefile
+++ b/client/lib/redux-flux-sync/Makefile
@@ -1,0 +1,10 @@
+REPORTER ?= spec
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+NODE_PATH := $(BASE_DIR)/client:$(BASE_DIR)/shared
+
+test:
+	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers jsx:babel/register,js:babel/register --reporter $(REPORTER)
+
+.PHONY: test

--- a/client/lib/redux-flux-sync/index.js
+++ b/client/lib/redux-flux-sync/index.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import Dispatcher from 'dispatcher';
+import { receivePost } from 'state/posts/actions';
+
+/**
+ * Object mapping Flux action type to a function which, when called with the
+ * Flux action object, returns a Redux action object to be dispatched to the
+ * Redux store.
+ */
+const SYNC_ACTIONS = {
+	RECEIVE_POST_TO_EDIT: ( action ) => receivePost( action.post )
+};
+
+/**
+ * Subscribes to the global Flux dispatcher and dispatches to the provided
+ * Redux store instance if an action mapping can be determined when a Flux
+ * action is dispatched.
+ *
+ * @param  {Object} store Redux store instance
+ * @return {String}       Dispatcher subscription ID
+ */
+export default function( store ) {
+	return Dispatcher.register( ( payload ) => {
+		const handler = SYNC_ACTIONS[ payload.action.type ];
+		if ( handler ) {
+			store.dispatch( handler( payload.action ) );
+		}
+	} );
+}

--- a/client/lib/redux-flux-sync/test/index.js
+++ b/client/lib/redux-flux-sync/test/index.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import Chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+/**
+ * Internal dependencies
+ */
+import Dispatcher from 'dispatcher';
+import reduxFluxSync from '../';
+import { receivePost } from 'state/posts/actions';
+
+describe( 'reduxFluxSync', () => {
+	let sandbox, store, dispatch, subscriberId;
+
+	before( () => {
+		Chai.use( sinonChai );
+
+		sandbox = sinon.sandbox.create();
+		sandbox.spy( Dispatcher, 'register' );
+		dispatch = sandbox.spy();
+		store = { dispatch };
+	} );
+
+	beforeEach( () => {
+		sandbox.reset();
+		subscriberId = reduxFluxSync( store );
+	} );
+
+	afterEach( () => {
+		Dispatcher.unregister( subscriberId );
+	} );
+
+	after( () => {
+		sandbox.restore();
+	} );
+
+	it( 'should register to the dispatcher', () => {
+		expect( Dispatcher.register ).to.have.been.calledOnce;
+	} );
+
+	it( 'should return a dispatcher subscription ID', () => {
+		expect( subscriberId ).to.be.a( 'string' );
+	} );
+
+	it( 'should dispatch when having received a mapped action', () => {
+		const post = { ID: 1 };
+
+		Dispatcher.handleServerAction( {
+			type: 'RECEIVE_POST_TO_EDIT',
+			post
+		} );
+
+		expect( dispatch ).to.have.been.calledWith( receivePost( post ) );
+	} );
+} );


### PR DESCRIPTION
In order to avoid clearing out the posts-list cache when you hit the editor, I'd like to try clearing the posts-list upon the initiator actions, like creating/editing/deleting a post, rather than upon navigating to the editor in https://github.com/Automattic/wp-calypso/pull/2350#issuecomment-172646109.

This is a cloned branch from @aduth's `add/redux-flux-sync`, rebased onto our meetup feature branch.