### PR TITLE
Invites: Adds error handling for accepting an invite

### DIFF
--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -242,18 +242,17 @@ export default React.createClass( {
 		}
 
 		this.formStateController.handleSubmit( hasErrors => {
-			if ( hasErrors ) {
-				this.setState( { submitting: false } );
-				return;
+			if ( ! hasErrors ) {
+				let analyticsData = {
+					unique_usernames_searched: usernamesSearched.length,
+					times_username_validation_failed: timesUsernameValidationFailed,
+					times_password_validation_failed: timesPasswordValidationFailed
+				};
+				this.props.submitForm( this.state.form, this.getUserData(), analyticsData );
+				resetAnalyticsData();
 			}
 
-			let analyticsData = {
-				unique_usernames_searched: usernamesSearched.length,
-				times_username_validation_failed: timesUsernameValidationFailed,
-				times_password_validation_failed: timesPasswordValidationFailed
-			};
-			this.props.submitForm( this.state.form, this.getUserData(), analyticsData );
-			resetAnalyticsData();
+			this.setState( { submitting: false } );
 		} );
 	},
 

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React from 'react'
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -16,8 +18,9 @@ import store from 'store'
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import analytics from 'analytics';
+import { errorNotice } from 'state/notices/actions';
 
-export default React.createClass( {
+let InviteAcceptLoggedOut = React.createClass( {
 
 	displayName: 'InviteAcceptLoggedOut',
 
@@ -51,7 +54,15 @@ export default React.createClass( {
 					wpcom.undocumented().acceptInvite(
 						this.props,
 						( acceptError ) => {
-							if ( ! acceptError ) {
+							if ( acceptError ) {
+								this.setState( { submitting: false } )
+								this.setState( { submitting: false } )
+								if ( acceptError.message ) {
+									this.props.errorNotice( acceptError.message );
+								} else {
+									this.props.errorNotice( this.translate( 'There was an error accepting your invitation. Please try again.' ) )
+								}
+							} else {
 								store.set( 'invite_accepted', this.props );
 								this.setState( { userData, bearerToken } );
 							}
@@ -84,7 +95,12 @@ export default React.createClass( {
 			this.props,
 			( error ) => {
 				if ( error ) {
-					this.setState( { error } );
+					this.setState( { submitting: false } );
+					if ( error.message ) {
+						this.props.errorNotice( error.message );
+					} else {
+						this.props.errorNotice( this.translate( 'There was an error accepting your invitation. Please try again.' ) )
+					}
 				} else {
 					window.location = 'https://subscribe.wordpress.com?update=activate&email=' + encodeURIComponent( this.props.sentTo ) + '&key=' + this.props.authKey;
 				}
@@ -134,5 +150,10 @@ export default React.createClass( {
 			</div>
 		)
 	}
-
 } );
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( { errorNotice }, dispatch )
+)( InviteAcceptLoggedOut );
+

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -18,7 +18,7 @@ import user from 'lib/user';
 import { fetchInvite } from 'lib/invites/actions';
 import InvitesStore from 'lib/invites/stores/invites-validation';
 import EmptyContent from 'components/empty-content';
-import { successNotice, infoNotice } from 'state/notices/actions';
+import { infoNotice, errorNotice } from 'state/notices/actions';
 import analytics from 'analytics';
 import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 
@@ -132,5 +132,5 @@ let InviteAccept = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { successNotice, infoNotice }, dispatch )
+	dispatch => bindActionCreators( { infoNotice, errorNotice }, dispatch )
 )( InviteAccept );


### PR DESCRIPTION
Previously, we didn't have error handling when actually accepting an invite. This was largely because we validate an invite before we ever allow a user to accept the invite. 

But, that doesn't account for network issues or any special filters that we are not aware of when validating that an invite exists.

This PR adds some basic error handling.

To test:
- Checkout `fix/invite-error-handling-on-accept`
- Create and accept invites while logged in and logged out
- Attempt to accept while disconnected or on a site that forces that a user's email address match the one where an invite was sent

cc @lezama 