### PR TITLE
Checkout: Fix disappearing Privacy Protection issue

### DIFF
--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -3,7 +3,8 @@
  */
 var extend = require( 'lodash/object/assign' ),
 	partialRight = require( 'lodash/function/partialRight' ),
-	compose = require( 'lodash/function/compose' );
+	compose = require( 'lodash/function/compose' ),
+	flow = require( 'lodash/function/flow' );
 
 /**
  * Internal dependencies
@@ -98,16 +99,8 @@ function update( changeFunction ) {
 	cartAnalytics.recordEvents( previousCart, nextCart );
 }
 
-CartStore.dispatchToken = Dispatcher.register( function( payload ) {
-	var action = payload.action,
-		cartItem;
-
-	if ( action.cartItem ) {
-		cartItem = cartValues.fillInSingleCartItemAttributes(
-			action.cartItem,
-			productsList.get()
-		);
-	}
+CartStore.dispatchToken = Dispatcher.register( ( payload ) => {
+	const { action } = payload;
 
 	switch ( action.type ) {
 		case UpgradesActionTypes.CART_PRIVACY_PROTECTION_ADD:
@@ -118,8 +111,8 @@ CartStore.dispatchToken = Dispatcher.register( function( payload ) {
 			update( cartItems.removePrivacyFromAllDomains( CartStore.get() ) );
 			break;
 
-		case UpgradesActionTypes.CART_ITEM_ADD:
-			update( cartItems.add( cartItem ) );
+		case UpgradesActionTypes.CART_ITEMS_ADD:
+			update( flow( ...action.cartItems.map( cartItem => cartItems.add( cartItem ) ) ) );
 			break;
 
 		case UpgradesActionTypes.CART_COUPON_APPLY:
@@ -127,7 +120,7 @@ CartStore.dispatchToken = Dispatcher.register( function( payload ) {
 			break;
 
 		case UpgradesActionTypes.CART_ITEM_REMOVE:
-			update( cartItems.removeItemAndDependencies( cartItem, CartStore.get() ) );
+			update( cartItems.removeItemAndDependencies( action.cartItem, CartStore.get() ) );
 			break;
 	}
 } );

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -40,24 +40,31 @@ function removePrivacyFromAllDomains() {
 	} );
 }
 
-function addItem( cartItem ) {
-	const extra = assign( {}, cartItem.extra, {
-			context: 'calypstore'
-		} ),
-		newCartItem = assign( {}, cartItem, { extra } );
+function addItem( item ) {
+	addItems( [ item ] );
+}
 
-	recordAddToCart( cartItem );
+function addItems( items ) {
+	const extendedItems = items.map( ( item ) => {
+		const extra = assign( {}, item.extra, {
+			context: 'calypstore'
+		} );
+
+		return assign( {}, item, { extra } );
+	} );
+
+	extendedItems.forEach( item => recordAddToCart( item ) );
 
 	Dispatcher.handleViewAction( {
-		type: ActionTypes.CART_ITEM_ADD,
-		cartItem: newCartItem
+		type: ActionTypes.CART_ITEMS_ADD,
+		cartItems: extendedItems
 	} );
 }
 
-function removeItem( cartItem ) {
+function removeItem( item ) {
 	Dispatcher.handleViewAction( {
 		type: ActionTypes.CART_ITEM_REMOVE,
-		cartItem
+		item
 	} );
 }
 
@@ -85,6 +92,7 @@ function applyCoupon( coupon ) {
 export {
 	addDomainToCart,
 	addItem,
+	addItems,
 	addPrivacyToAllDomains,
 	applyCoupon,
 	closeCartPopup,

--- a/client/lib/upgrades/constants.js
+++ b/client/lib/upgrades/constants.js
@@ -2,7 +2,7 @@ const keyMirror = require( 'key-mirror' );
 
 module.exports.action = keyMirror( {
 	CART_COUPON_APPLY: null,
-	CART_ITEM_ADD: null,
+	CART_ITEMS_ADD: null,
 	CART_ITEM_REMOVE: null,
 	CART_POPUP_CLOSE: null,
 	CART_POPUP_OPEN: null,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -217,17 +217,16 @@ const ManagePurchase = React.createClass( {
 
 	handleRenew() {
 		const purchase = getPurchase( this.props ),
-			cartItem = cartItems.getRenewalItemFromProduct( purchase, {
+			renewItem = cartItems.getRenewalItemFromProduct( purchase, {
 				domain: purchase.meta
-			} );
+			} ),
+			renewItems = [ renewItem ];
 
 		// Track the renew now submit
 		analytics.tracks.recordEvent(
 			'calypso_purchases_renew_now_click',
 			{ product_slug: purchase.productSlug }
 		);
-
-		upgradesActions.addItem( cartItem );
 
 		if ( hasPrivateRegistration( purchase ) ) {
 			const privacyItem = cartItems.getRenewalItemFromCartItem( cartItems.domainPrivacyProtection( {
@@ -237,7 +236,7 @@ const ManagePurchase = React.createClass( {
 				domain: purchase.domain
 			} );
 
-			upgradesActions.addItem( privacyItem );
+			renewItems.push( privacyItem );
 		}
 
 		if ( isRedeemable( purchase ) ) {
@@ -248,8 +247,10 @@ const ManagePurchase = React.createClass( {
 				domain: purchase.domain
 			} );
 
-			upgradesActions.addItem( redemptionItem );
+			renewItems.push( redemptionItem );
 		}
+
+		upgradesActions.addItems( renewItems );
 
 		page( '/checkout/' + this.props.selectedSite.slug );
 	},


### PR DESCRIPTION
From @peterbutler:
> It seems that sometimes a user adds a domain renewal to their cart, then the privacy disappears from it, and the user renews. As a result, the user doesnt pay for privacy

This fix allows multiple products to be added to the cart at once. This should fix also **issue with missing redemption item**.

### Testing
1. Go to Purchases (http://calypso.localhost:3000/purchases).
2. Select expiring domain with privacy protection enabled.
3. Click Renew button, you should see domain and privacy protection in the cart.