### PR TITLE
Allow CNAME entries that are not full URLs

### DIFF
--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -61,8 +61,7 @@ function isValidName( name, type, selectedDomainName ) {
 	switch ( type ) {
 		case 'CNAME':
 			return (
-				isValidCname( name, selectedDomainName ) &&
-				isValidDomainName( name, type )
+				isValidDomainName( name + '.' + selectedDomainName, type )
 			);
 		case 'SRV':
 			return (
@@ -72,10 +71,6 @@ function isValidName( name, type, selectedDomainName ) {
 		default:
 			return isValidDomainName( name, type );
 	}
-}
-
-function isValidCname( name, selectedDomainName ) {
-	return endsWith( name, '.' + selectedDomainName );
 }
 
 function isValidData( data, type ) {


### PR DESCRIPTION
Fixes #2609 by removing the check for a complete URL.

We remove `isValidCname`, since we only call it from this code block we're modifying here, and instead use `isValidDomainName` to check that the CNAME the user enters can be used to create a valid subdomain.

With this fix, you can enter both "subdomain" and "subdomain.example.com" into the 'Host' field and the DNS editor will create a valid CNAME record.

Preliminary testing doesn't indicate anything breaking as a result of this change, but I will keep testing and post here if I find anything.
