### PR TITLE
Reader: Replace `pageTitleSetter( context )` with `setPageTitle( title)`

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -66,10 +66,8 @@ function ensureStoreLoading( store ) {
 	return store;
 }
 
-function pageTitleSetter() {
-	return function( title ) {
-		titleActions.setTitle( i18n.translate( '%s ‹ Reader', { args: title } ) );
-	};
+function setPageTitle( title ) {
+	titleActions.setTitle( i18n.translate( '%s ‹ Reader', { args: title } ) );
 }
 
 module.exports = {
@@ -121,7 +119,7 @@ module.exports = {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		pageTitleSetter()( i18n.translate( 'Following' ) );
+		setPageTitle( i18n.translate( 'Following' ) );
 
 		ReactDom.render(
 			React.createElement( FollowingComponent, {
@@ -146,7 +144,6 @@ module.exports = {
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Feed > ' + context.params.feed_id,
 			feedStore = feedStreamFactory( 'feed:' + context.params.feed_id ),
-			setPageTitle = pageTitleSetter( context ),
 			mcKey = 'blog';
 
 		ensureStoreLoading( feedStore );
@@ -181,7 +178,6 @@ module.exports = {
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Site > ' + context.params.blog_id,
 			feedStore = feedStreamFactory( 'site:' + context.params.blog_id ),
-			setPageTitle = pageTitleSetter( context ),
 			mcKey = 'blog';
 
 		ensureStoreLoading( feedStore );
@@ -216,8 +212,7 @@ module.exports = {
 			feedId = context.params.feed,
 			postId = context.params.post,
 			basePath = route.sectionify( context.path ),
-			fullPageTitle = analyticsPageTitle + ' > Feed Post > ' + feedId + ' > ' + postId,
-			setPageTitle = pageTitleSetter( context );
+			fullPageTitle = analyticsPageTitle + ' > Feed Post > ' + feedId + ' > ' + postId;
 
 		__lastTitle = TitleStore.getState().title;
 
@@ -253,8 +248,7 @@ module.exports = {
 			blogId = context.params.blog,
 			postId = context.params.post,
 			basePath = route.sectionify( context.path ),
-			fullPageTitle = analyticsPageTitle + ' > Blog Post > ' + blogId + ' > ' + postId,
-			setPageTitle = pageTitleSetter( context );
+			fullPageTitle = analyticsPageTitle + ' > Blog Post > ' + blogId + ' > ' + postId;
 
 		__lastTitle = TitleStore.getState().title;
 
@@ -297,7 +291,6 @@ module.exports = {
 				.replace( /-{2,}/g, '-' ),
 			encodedTag = encodeURIComponent( tagSlug ).toLowerCase(),
 			tagStore = feedStreamFactory( 'tag:' + tagSlug ),
-			setPageTitle = pageTitleSetter( context ),
 			mcKey = 'topic';
 
 		ensureStoreLoading( tagStore );
@@ -331,7 +324,6 @@ module.exports = {
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > List > ' + context.params.user + ' - ' + context.params.list,
 			listStore = feedStreamFactory( 'list:' + context.params.user + '-' + context.params.list ),
-			setPageTitle = pageTitleSetter( context ),
 			mcKey = 'list';
 
 		ensureStoreLoading( listStore );
@@ -375,7 +367,7 @@ module.exports = {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-		pageTitleSetter( context )( 'Automattic' );
+		setPageTitle( 'Automattic' );
 
 		ReactDom.render(
 			React.createElement( FollowingComponent, {
@@ -400,7 +392,6 @@ module.exports = {
 			basePath = route.sectionify( context.path ),
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > My Likes',
 			likedPostsStore = feedStreamFactory( 'likes' ),
-			setPageTitle = pageTitleSetter( context ),
 			mcKey = 'postlike';
 
 		ensureStoreLoading( likedPostsStore );
@@ -432,7 +423,7 @@ module.exports = {
 			mcKey = 'following_edit',
 			search = context.query.s;
 
-		pageTitleSetter( context )( i18n.translate( 'Manage Followed Sites' ) );
+		setPageTitle( i18n.translate( 'Manage Followed Sites' ) );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
@@ -447,7 +438,7 @@ module.exports = {
 		);
 	},
 
-	recommendedForYou: function( context ) {
+	recommendedForYou: function() {
 		const RecommendedForYou = require( 'reader/recommendations/for-you' ),
 			basePath = '/recommendations',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Recommended Sites For You',
@@ -467,7 +458,7 @@ module.exports = {
 		);
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-		pageTitleSetter( context )( i18n.translate( 'Recommended Sites For You' ) );
+		setPageTitle( i18n.translate( 'Recommended Sites For You' ) );
 	},
 
 	listManagementSites: function( context ) {
@@ -476,7 +467,7 @@ module.exports = {
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage List',
 			mcKey = 'list_sites';
 
-		pageTitleSetter( context )( i18n.translate( 'Manage List' ) );
+		setPageTitle( i18n.translate( 'Manage List' ) );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
@@ -506,7 +497,7 @@ module.exports = {
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage List',
 			mcKey = 'list_tags';
 
-		pageTitleSetter( context )( i18n.translate( 'Manage List' ) );
+		setPageTitle( i18n.translate( 'Manage List' ) );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
@@ -536,7 +527,7 @@ module.exports = {
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Manage List Description',
 			mcKey = 'list_edit';
 
-		pageTitleSetter( context )( i18n.translate( 'Manage List Description' ) );
+		setPageTitle( i18n.translate( 'Manage List Description' ) );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 


### PR DESCRIPTION
In #10032-gh-calypso-pre-oss, `pageTitleSetter()` was changed to set the title
via `titleActions.setTitle()` instead of `context.layout.title.set()`, and such
the `context` parameter became obsolete. However, I seem to have missed to remove
the corresponding arguments from function calls.

This PR simplifies things even further, as we don't need to `pageTitleSetter()`
to return a function anymore but can directly define that function.

No visual changes. To test -- verify that page titles still work as before in the Reader.

CC @dmsnell who pointed me to the obsolete `context` parameters :-)