### PR TITLE
Posts: controls color update

### DIFF
--- a/assets/stylesheets/sections/_posts-controls.scss
+++ b/assets/stylesheets/sections/_posts-controls.scss
@@ -3,11 +3,13 @@
  */
 .post-controls {
 	box-sizing: border-box;
-	background-color: $gray-light;
+	background-color: $white;
+	border-top: solid 1px transparentize( lighten( $gray, 20% ), .5 );
+	// border color matches shadow on components/card
 	overflow: hidden;
 	position: relative;
 	width: 100%;
-	height: (43 / 15) * 1em;
+	height: (45 / 15) * 1em;
 }
 
 .post-controls__pane {
@@ -36,16 +38,19 @@
 		// Normal
 		box-sizing: border-box;
 		text-align: center;
-		border-left: solid 1px lighten( $gray, 30% );
+		border-left: solid 1px transparentize( lighten( $gray, 20% ), .5 );
+		// border color matches shadow on components/card
 		&:first-child {
 			border-left: none;
 		}
 		a {
 			display: block;
+			color: darken( $gray, 10% );
 			box-sizing: border-box;
 			font-size: inherit;
 			padding: (11 / 14) * 1em 0;
 			&:hover {
+				color: darken( $gray, 20% );
 				cursor: pointer;
 			}
 			.gridicon{


### PR DESCRIPTION
I've noticed on the post cards (cards on `/posts/*`) that the bottom controls have become diverged quite a bit from some established styles found throughout Calypso.

This PR aligns those controls with other cards & buttons found throughout Calypso by replacing the gray/blue colors with regular button styles of white/gray.

Before | After
------------ | -------------
<img width="743" alt="screen shot 2016-01-20 at 9 41 30 am" src="https://cloud.githubusercontent.com/assets/1427136/12452060/8bc75eac-bf5a-11e5-8e12-104a047dff0a.png"> | <img width="748" alt="screen shot 2016-01-19 at 7 47 02 pm" src="https://cloud.githubusercontent.com/assets/1427136/12452073/9667001a-bf5a-11e5-8ead-79d2e64cb505.png">

## Testing

1. Visit any screen that shows the post cards `/posts/*`.
2. Confirm that the colors on the colors have the white/gray color scheme.
3. Visually scan the page in this branch vs. production and compare.
4. Particularly keep an eye out for how your eye scans the page when looking through multiple posts. Hopefully, the white/gray color scheme is a bit less distracting and will keep your eye focused on images & titles rather than controls.

---

/cc @mtias, @mattmiklic (potentially could influence the mobile apps)