### PR TITLE
Framework: Send a boot "signal" when server has started

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,12 @@ console.info( chalk.cyan( '\nGetting bundles ready, hold on...' ) );
 server = http.createServer( app );
 server.listen( port );
 
+// The desktop app runs Calypso in a fork.
+// This tells the parent process that Calypso has booted.
+if ( process.env.CALYPSO_IS_FORK ) {
+	process.send( { boot: 'ready' } );
+}
+
 // Enable hot reloader in development
 if ( config( 'env' ) === 'development' ) {
 	hotReloader = require( 'bundler/hot-reloader' );


### PR DESCRIPTION
This is for the desktop app, which runs Calypso in a forked child
process. This boot signal will let the desktop node process know that
the Calypso server is ready and that we can now load it.

See https://github.com/Automattic/wp-desktop/pull/45#discussion_r50259865