### PR TITLE
Plans: Layout and text changes for Jetpack sites

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -199,6 +199,8 @@
 @import 'my-sites/plans/plan-overview/plan-progress/style';
 @import 'my-sites/plans/plan-overview/plan-remove/style';
 @import 'my-sites/plans/plan-overview/plan-status/style';
+@import 'my-sites/plans/jetpack-plan-price/style';
+@import 'my-sites/plans/jetpack-plan-details/style';
 @import 'my-sites/post/post-image/style';
 @import 'my-sites/post-selector/style';
 @import 'my-sites/plugins/featured-plugins/style';

--- a/client/components/plans/plan-actions/style.scss
+++ b/client/components/plans/plan-actions/style.scss
@@ -171,3 +171,7 @@
 .jetpack_business.plan-actions__illustration {
 	background-image: url('/calypso/images/plans/plan-business.svg');
 }
+
+.jetpack_premium .is-image-button, .jetpack_business .is-image-button {
+	display: none;
+}

--- a/client/components/plans/plan-header/style.scss
+++ b/client/components/plans/plan-header/style.scss
@@ -90,7 +90,7 @@
 	.plan-header {
 		border-bottom: 2px solid lighten( $gray, 20% );
 		height: 3em;
-		padding: 0 15px 10px 15px;
+		padding: 0 15px 0 15px;
 
 		.plan-header__title {
 			text-align: center;
@@ -185,4 +185,8 @@
 	@include breakpoint( ">660px" ) {
 		@include plans-in-three-columns();
 	}
+}
+
+.plan-list .jetpack_premium .plan-header__title, .plan-list .jetpack_business .plan-header__title {
+	margin-top: 15px;
 }

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -75,6 +75,11 @@ module.exports = React.createClass( {
 				return ( showJetpackPlans === ( 'jetpack' === plan.product_type ) );
 			} );
 
+			// If showing Jetpack plans remove the first item (Free)
+			if ( site && site.jetpack ) {
+				plans.shift();
+			}
+
 			plansList = plans.map( function( plan ) {
 				return (
 					<Plan

--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -9,6 +9,9 @@ var React = require( 'react' ),
  */
 import { abtest } from 'lib/abtest';
 
+var JetpackPlanPrice = require( 'my-sites/plans/jetpack-plan-price' ),
+	WpcomPlanPrice = require( 'my-sites/plans/wpcom-plan-price' );
+
 module.exports = React.createClass( {
 	displayName: 'PlanPrice',
 
@@ -49,7 +52,7 @@ module.exports = React.createClass( {
 
 	render: function() {
 		let periodLabel;
-		const { plan, sitePlan: details } = this.props,
+		const { plan, site, sitePlan: details } = this.props,
 			hasDiscount = details && details.rawDiscount > 0;
 
 		if ( this.props.isPlaceholder ) {
@@ -62,13 +65,21 @@ module.exports = React.createClass( {
 			periodLabel = hasDiscount ? this.translate( 'due today when you upgrade' ) : plan.bill_period_label
 		}
 
+		if ( site && site.jetpack ) {
+			return (
+				<JetpackPlanPrice
+					getPrice={ this.getPrice }
+					hasDiscount={ hasDiscount }
+					plan={ plan } />
+			);
+		}
+
 		return (
-			<div className={ hasDiscount ? "plan-price plan-price__discount" : "plan-price" }>
-				<span>{ this.getPrice() }</span>
-				<small className="plan-price__billing-period">
-					{ periodLabel }
-				</small>
-			</div>
+			<WpcomPlanPrice
+				getPrice={ this.getPrice }
+				hasDiscount={ hasDiscount }
+				periodLabel={ periodLabel }
+				plan={ plan } />
 		);
 	}
 } );

--- a/client/components/plans/plan-price/style.scss
+++ b/client/components/plans/plan-price/style.scss
@@ -1,32 +1,46 @@
-.plan-header .plan-price {
+.plan-header .plan-price,
+.plan-header .jetpack-plan-price,
+.plan-header .wpcom-plan-price {
 	color: $gray-dark;
 	font-size: 14px;
 	font-weight: 400;
 	line-height: 20px;
 }
 
-.plan-price__billing-period {
+.plan-price__billing-period,
+.jetpack-plan-price__billing-period,
+.wpcom-plan-price__billing-period {
 	font-size: 12px;
 	font-style: italic;
 	color: darken( $gray, 10% );
 }
 
 .plan-header .plan-price__discount,
-.plan-price__discount .plan-price__billing-period {
+.plan-header .jetpack-plan-price__discount,
+.plan-header .wpcom-plan-price__discount,
+.plan-price__discount .plan-price__billing-period,
+.jetpack-plan-price__discount .jetpack-plan-price__billing-period,
+.wpcom-plan-price__discount .wpcom-plan-price__billing-period {
 	color: $alert-green;
 }
 
-.plan-price.is-placeholder {
+.plan-price.is-placeholder,
+.jetpack-plan-price.is-placeholder,
+.wpcom-plan-price.is-placeholder {
 	@include placeholder( 23% );
 }
 
-.plan-price__discounted {
+.plan-price__discounted,
+.jetpack-plan-price__discounted,
+.wpcom-plan-price__discounted {
 	color: $gray;
 	text-decoration: line-through;
 }
 
 .plans-compare {
-	.plan-price {
+	.plan-price,
+	.jetpack-plan-price,
+	.wpcom-plan-price {
 		font-size: 10px;
 		padding: 1em 0;
 
@@ -39,33 +53,45 @@
 		}
 	}
 
-	.plan-price__billing-period {
+	.plan-price__billing-period,
+	.jetpack-plan-price__billing-period,
+	.wpcom-plan-price__billing-period {
 		display: block;
 		opacity: .7;
 	}
 
-	.plan-price__discount {
+	.plan-price__discount,
+	.jetpack-plan-price__discount,
+	.wpcom-plan-price__discount {
 		color: $alert-green;
 	}
 }
 
 @mixin plans-collapsed() {
-	.plan-header .plan-price {
+	.plan-header .plan-price,
+	.plan-header .jetpack-plan-price,
+	.plan-header .wpcom-plan-price {
 		padding: 0 20px 0 40px;
 	}
 
-	.plan-price__billing-period {
+	.plan-price__billing-period,
+	.jetpack-plan-price__billing-period,
+	.wpcom-plan-price__billing-period {
 		margin-left: 3px;
 	}
 }
 
 @mixin plans-in-three-columns() {
-	.plan-header .plan-price {
+	.plan-header .plan-price,
+	.plan-header .jetpack-plan-price,
+	.plan-header .wpcom-plan-price {
 		text-align: center;
 		font-size: 18px;
 	}
 
-	.plan-price__billing-period {
+	.plan-price__billing-period,
+	.jetpack-plan-price__billing-period,
+	.wpcom-plan-price__billing-period {
 		display: block;
 	}
 }

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -10,11 +10,13 @@ var React = require( 'react' ),
  */
 var analytics = require( 'analytics' ),
 	Gridicon = require( 'components/gridicon' ),
+	JetpackPlanDetails = require( 'my-sites/plans/jetpack-plan-details' ),
 	PlanActions = require( 'components/plans/plan-actions' ),
 	PlanHeader = require( 'components/plans/plan-header' ),
 	PlanPrice = require( 'components/plans/plan-price' ),
 	PlanDiscountMessage = require( 'components/plans/plan-discount-message' ),
-	Card = require( 'components/card' );
+	Card = require( 'components/card' ),
+	WpcomPlanDetails = require( 'my-sites/plans/wpcom-plan-details' );
 
 module.exports = React.createClass( {
 	displayName: 'Plan',
@@ -37,6 +39,7 @@ module.exports = React.createClass( {
 
 	getDescription: function() {
 		var comparePlansUrl, siteSuffix;
+		const { plan, site } = this.props;
 
 		if ( this.isPlaceholder() ) {
 			return (
@@ -48,15 +51,20 @@ module.exports = React.createClass( {
 			);
 		}
 
-		siteSuffix = this.props.site ? this.props.site.slug : '';
+		siteSuffix = site ? site.slug : '';
 		comparePlansUrl = this.props.comparePlansUrl ? this.props.comparePlansUrl : '/plans/compare/' + siteSuffix;
 
+		if ( site && site.jetpack ) {
+			return (
+				<JetpackPlanDetails plan={ plan } />
+			);
+		}
+
 		return (
-			<div>
-				<p>{ this.props.plan.shortdesc }</p>
-				<a href={ comparePlansUrl } onClick={ this.handleLearnMoreClick }
-					className="plan__learn-more">{ this.translate( 'Learn more', { context: 'Find out more details about a plan' } ) }</a>
-			</div>
+			<WpcomPlanDetails
+				comparePlansUrl={ comparePlansUrl }
+				handleLearnMoreClick={ this.handleLearnMoreClick }
+				plan={ plan } />
 		);
 	},
 

--- a/client/components/plans/plan/style.scss
+++ b/client/components/plans/plan/style.scss
@@ -133,6 +133,10 @@
 	.plan__plan-details {
 		min-height: 155px;
 	}
+
+	.plan-list .jetpack_premium, .plan-list .jetpack_business {
+		width: 49%;
+	}
 }
 
 .plans.has-sidebar {

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -161,6 +161,11 @@ var PlansCompare = React.createClass( {
 			return ( showJetpackPlans === ( 'jetpack' === plan.product_type ) );
 		} );
 
+		// If showing Jetpack plans remove the first item (Free)
+		if ( site && site.jetpack ) {
+			plans.shift();
+		}
+
 		if ( this.props.features.hasLoadedFromServer() && (
 			this.props.isInSignup || ! this.props.selectedSite || ( this.props.sitePlans && this.props.sitePlans.hasLoadedFromServer ) )
 		) {

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -220,6 +220,12 @@ var PlansCompare = React.createClass( {
 	},
 
 	render: function() {
+		var compareString = this.translate( 'Compare Plans' );
+
+		if ( this.props.selectedSite && this.props.selectedSite.jetpack ) {
+			compareString = this.translate( 'Compare Options' );
+		}
+
 		return (
 			<div className={ this.props.className }>
 				{
@@ -228,7 +234,7 @@ var PlansCompare = React.createClass( {
 					: <SidebarNavigation />
 				}
 				<HeaderCake onClick={ this.goBack }>
-					{ this.translate( 'Compare Plans' ) }
+					{ compareString }
 				</HeaderCake>
 				<Card className="plans">
 					{ this.comparisonTable() }

--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -15,3 +15,7 @@
 	text-align: right;
 	margin-top: 15px;
 }
+
+.plans-compare .jetpack_premium, .plans-compare .jetpack_business {
+	width: 37%;
+}

--- a/client/my-sites/plans/jetpack-plan-details/index.jsx
+++ b/client/my-sites/plans/jetpack-plan-details/index.jsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+var React = require( 'react' );
+
+module.exports = React.createClass( {
+	displayName: 'JetpackPlanDetails',
+
+	render: function() {
+		return (
+			<div>
+				<p>{ this.props.plan.shortdesc }</p>
+				<ul>
+					<li>{ this.props.plan.feature_1 }</li>
+					<li>{ this.props.plan.feature_2 }</li>
+					<li>{ this.props.plan.feature_3 }</li>
+				</ul>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/plans/jetpack-plan-details/style.scss
+++ b/client/my-sites/plans/jetpack-plan-details/style.scss
@@ -1,0 +1,7 @@
+.jetpack_premium .plan__plan-details ul, .jetpack_business .plan__plan-details ul {
+	margin: 10px 0 10px 10px;
+}
+
+.jetpack_premium .plan__plan-details li, .jetpack_business .plan__plan-details li {
+	opacity: 1.0;
+}

--- a/client/my-sites/plans/jetpack-plan-price/index.jsx
+++ b/client/my-sites/plans/jetpack-plan-price/index.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+var React = require( 'react' );
+
+module.exports = React.createClass( {
+	displayName: 'JetpackPlanPrice',
+
+	render: function() {
+		return (
+			<div className="jetpack-plan-price">
+				<span className="jetpack-price">{ this.props.plan.formatted_original_price }</span>
+				<small className="jetpack-plan-price__billing-period">
+					{ this.translate( 'cost of individual plugins' ) }
+				</small>
+				<span className="jetpack-price">{ this.props.getPrice() }</span>
+				<small className="jetpack-plan-price__billing-period">
+					{ this.props.hasDiscount ? this.translate( 'for first year' ) : this.props.plan.bill_period_label } (
+					{ this.props.plan.saving }
+					{ this.translate( '% savings', { context: 'A percentage discount, eg: 20% savings' } ) })
+				</small>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/plans/jetpack-plan-price/style.scss
+++ b/client/my-sites/plans/jetpack-plan-price/style.scss
@@ -1,0 +1,22 @@
+
+.jetpack-price {
+	margin-top: 20px;
+	padding: 0 6px;
+	display: inline-block;
+	position: relative;
+}
+
+.jetpack-price:first-child {
+	opacity: 0.4;
+}
+
+.jetpack-price:first-child::before {
+	content: '';
+	border-bottom: 2px solid red;
+	width: 100%;
+	position: absolute;
+		right: 0;
+		top: 50%;
+	-webkit-transform: skewY(-10deg);
+	transform: skewY(-10deg);
+}

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -58,6 +58,12 @@ var Plans = React.createClass( {
 		var url = '/plans/compare',
 			selectedSite = this.props.sites.getSelectedSite();
 
+		var compareString = this.translate( 'Compare Plans' );
+
+		if ( selectedSite.jetpack ) {
+			compareString = this.translate( 'Compare Options' );
+		}
+
 		if ( this.props.plans.get().length <= 0 ) {
 			return '';
 		}
@@ -69,7 +75,7 @@ var Plans = React.createClass( {
 		return (
 			<a href={ url } className="compare-plans-link" onClick={ this.recordComparePlansClick }>
 				<Gridicon icon="clipboard" size={ 18 } />
-				{ this.translate( 'Compare Plans' ) }
+				{ compareString }
 			</a>
 		);
 	},

--- a/client/my-sites/plans/wpcom-plan-details/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-details/index.jsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+var React = require( 'react' );
+
+module.exports = React.createClass( {
+	displayName: 'WpcomPlanDetails',
+
+	render: function() {
+		return (
+			<div>
+				<p>{ this.props.plan.shortdesc }</p>
+				<a href={ this.props.comparePlansUrl } onClick={ this.props.handleLearnMoreClick }
+					className="plan__learn-more">{ this.translate( 'Learn more', { context: 'Find out more details about a plan' } ) }</a>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/plans/wpcom-plan-price/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-price/index.jsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+var React = require( 'react' );
+
+module.exports = React.createClass( {
+	displayName: 'WpcomPlanPrice',
+
+	render: function() {
+		return (
+			<div className={ this.props.hasDiscount ? "wpcom-plan-price wpcom-plan-price__discount" : "wpcom-plan-price" }>
+				<span>{ this.props.getPrice() }</span>
+				<small className="wpcom-plan-price__billing-period">
+					{ this.props.periodLabel }
+				</small>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -30,6 +30,12 @@ var config = require( 'config' ),
 // remaining paths will make the button highlighted on that page.
 
 var NAV_ITEMS = {
+	Addons: {
+		paths: [ '/plans' ],
+		label: i18n.translate( 'Add-ons for Jetpack sites' ),
+		allSitesPath: false
+	},
+
 	Plans: {
 		paths: [ '/plans' ],
 		label: i18n.translate( 'Plans' ),
@@ -111,7 +117,7 @@ var UpgradesNavigation = React.createClass( {
 		var items;
 
 		if ( this.props.selectedSite.jetpack ) {
-			items = [ 'Plans' ];
+			items = [ 'Addons' ];
 		} else {
 			items = [ 'Plans', 'Domains', 'Email' ];
 		}


### PR DESCRIPTION
We're trying a different approach with presenting plans for .org sites including: hiding the "Free" tier, showing the savings over buying individual plugins (VaultPress, Akismet, and PollDaddy), and updating the text descriptions of the plans themselves as well as the feature detail.

Screenshots of what the final result should look like:

**Plan selection page:**

![plans-3](https://cloud.githubusercontent.com/assets/2287740/12456609/80e49214-bf98-11e5-8f75-ec2fba2f29b9.png)


**Plan comparison page:**

![plans-2](https://cloud.githubusercontent.com/assets/2287740/12456190/9a2e01bc-bf96-11e5-8fe8-7d60b386dcf0.png)
