### PR TITLE
Reader: Find featured images that are also in the content

### DIFF
--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -1,12 +1,14 @@
 /**
  * External Dependecies
  */
-var find = require( 'lodash/collection/find' );
+const find = require( 'lodash/collection/find' ),
+	url = require( 'url' ),
+	matches = require( 'lodash/utility/matches' );
 
 /**
  * Internal Dependencies
  */
-var postNormalizer = require( 'lib/post-normalizer' ),
+const postNormalizer = require( 'lib/post-normalizer' ),
 	DISPLAY_TYPES = require( './display-types' );
 
 /**
@@ -16,7 +18,7 @@ const READER_CONTENT_WIDTH = 720,
 	PHOTO_ONLY_MIN_WIDTH = READER_CONTENT_WIDTH * 0.8,
 	ONE_LINER_THRESHOLD = ( 20 * 10 ); // roughly 10 lines of words
 
-var fastPostNormalizationRules = [
+const fastPostNormalizationRules = [
 		postNormalizer.decodeEntities,
 		postNormalizer.stripHTML,
 		postNormalizer.preventWidows,
@@ -73,7 +75,16 @@ function classifyPost( post, callback ) {
 			}
 		}
 
-		if ( find( post.content_images, { src: canonicalImage.uri } ) ) {
+		const canonicalImageUrl = url.parse( canonicalImage.uri, true, true ),
+			canonicalImageUrlImportantParts = {
+				hostname: canonicalImageUrl.hostname,
+				pathname: canonicalImageUrl.pathname,
+				query: canonicalImageUrl.query
+			};
+		if ( find( post.content_images, ( img ) => {
+			const imgUrl = url.parse( img.src, true, true );
+			return matches( imgUrl, canonicalImageUrlImportantParts );
+		} ) ) {
 			displayType ^= DISPLAY_TYPES.CANONICAL_IN_CONTENT;
 		}
 	}


### PR DESCRIPTION
We already tried to do this, but this approaches it in a more robust manner.

Previously we were doing a straight string compare, which would let images that have the same path but query args in a different order pass. This new way parses out the URL and only compares the bits that matter, and compares the querystring in an order independant manner.

Fixes #2620

To test, pull up http://calypso.localhost:3000/read/blog/feed/4734485 and pull up some posts. Compare to https://wordpress.com/read/blog/feed/4734485