### PR TITLE
Revert "Revert "Signup: Use the `domains` step instead in the main signup flow""

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -48,7 +48,7 @@ const flows = {
 	},
 
 	main: {
-		steps: [ 'themes', 'site', 'plans', 'user' ],
+		steps: [ 'themes', 'domains', 'plans', 'user' ],
 		destination: getCheckoutDestination,
 		description: 'The current best performing flow in AB tests',
 		lastModified: '2015-09-03'


### PR DESCRIPTION
Reverts Automattic/wp-calypso#2627