### PR TITLE
Checkout: Restart a/b test of a minimal version of the masterbar in checkout

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -9,7 +9,9 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
+var abtest = require( 'lib/abtest' ).abtest,
+	MasterbarCheckout = require( 'layout/masterbar/checkout' ),
+	MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	GlobalNotices = require( 'components/global-notices' ),
 	notices = require( 'notices' ),
@@ -25,6 +27,7 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	PulsingDot = require( 'components/pulsing-dot' ),
 	SitesListNotices = require( 'lib/sites-list/notices' ),
 	PollerPool = require( 'lib/data-poller' ),
+	CartData = require( 'components/data/cart' ),
 	KeyboardShortcutsMenu,
 	Layout;
 
@@ -75,6 +78,23 @@ Layout = React.createClass( {
 		return sortBy( this.props.sites.get(), property( 'ID' ) ).pop();
 	},
 
+	renderMasterbar() {
+		if ( 'checkout' === this.props.section && abtest( 'checkoutMasterbar' ) === 'minimal' ) {
+			return (
+				<CartData>
+					<MasterbarCheckout selectedSite={ this.props.sites.getSelectedSite() } />
+				</CartData>
+			);
+		}
+
+		return (
+			<MasterbarLoggedIn
+				user={ this.props.user }
+				section={ this.props.section }
+				sites={ this.props.sites } />
+		);
+	},
+
 	render: function() {
 		var sectionClass = 'wp layout is-section-' + this.props.section + ' focus-' + this.props.focus.getCurrent(),
 			showWelcome = this.props.nuxWelcome.getWelcome(),
@@ -95,7 +115,7 @@ Layout = React.createClass( {
 		return (
 			<div className={ sectionClass }>
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
-				<MasterbarLoggedIn user={ this.props.user } section={ this.props.section } sites={ this.props.sites } />
+				{ this.renderMasterbar() }
 				<div className={ loadingClass } ><PulsingDot active={ this.props.isLoading } chunkName={ this.props.chunkName } /></div>
 				<div id="content" className="wp-content">
 					<Welcome isVisible={ showWelcome } closeAction={ this.closeWelcome } additionalClassName="NuxWelcome">

--- a/client/layout/logged-out-design.jsx
+++ b/client/layout/logged-out-design.jsx
@@ -8,11 +8,11 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import MasterbarLoggedOut from 'layout/masterbar/logged-out';
+import MasterbarMinimal from 'layout/masterbar/minimal';
 
 const LayoutLoggedOutDesign = () => (
 	<div className="wp is-section-design has-no-sidebar">
-		<MasterbarLoggedOut />
+		<MasterbarMinimal url="/" />
 		<div id="content" className="wp-content">
 			<div id="primary" className="wp-primary wp-section" />
 			<div id="secondary" className="wp-secondary" />

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import MasterbarLoggedOut from 'layout/masterbar/logged-out';
+import MasterbarMinimal from 'layout/masterbar/minimal';
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
 
@@ -20,7 +20,7 @@ const LoggedOutLayout = ( { section, hasSidebar } ) => {
 
 	return (
 		<div className={ classes }>
-			<MasterbarLoggedOut />
+			<MasterbarMinimal url="/" />
 			<div id="content" className="wp-content">
 				<GlobalNotices id="notices" notices={ notices.list } />
 				<div id="primary" className="wp-primary wp-section" />

--- a/client/layout/masterbar/checkout.jsx
+++ b/client/layout/masterbar/checkout.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import Masterbar from './masterbar';
+
+/**
+ * Internal dependencies
+ */
+import Item from './item';
+import { getExitCheckoutUrl } from 'lib/checkout';
+
+function getMinimalLogoUrl( cart, selectedSite ) {
+	if ( ! cart.hasLoadedFromServer || ! selectedSite ) {
+		return '/';
+	}
+
+	return getExitCheckoutUrl( cart, selectedSite.slug );
+}
+
+const MasterbarCheckout = ( { cart, selectedSite } ) => (
+	<Masterbar>
+		<Item
+			url={ getMinimalLogoUrl( cart, selectedSite ) }
+			icon="my-sites"
+			className="masterbar__item-logo">
+			WordPress<span className="tld">.com</span>
+		</Item>
+	</Masterbar>
+);
+
+export default MasterbarCheckout;

--- a/client/layout/masterbar/checkout.jsx
+++ b/client/layout/masterbar/checkout.jsx
@@ -2,12 +2,11 @@
  * External dependencies
  */
 import React from 'react';
-import Masterbar from './masterbar';
 
 /**
  * Internal dependencies
  */
-import Item from './item';
+import MasterbarMinimal from './minimal';
 import { getExitCheckoutUrl } from 'lib/checkout';
 
 function getMinimalLogoUrl( cart, selectedSite ) {
@@ -19,14 +18,7 @@ function getMinimalLogoUrl( cart, selectedSite ) {
 }
 
 const MasterbarCheckout = ( { cart, selectedSite } ) => (
-	<Masterbar>
-		<Item
-			url={ getMinimalLogoUrl( cart, selectedSite ) }
-			icon="my-sites"
-			className="masterbar__item-logo">
-			WordPress<span className="tld">.com</span>
-		</Item>
-	</Masterbar>
+	<MasterbarMinimal url={ getMinimalLogoUrl( cart, selectedSite ) } />
 );
 
 export default MasterbarCheckout;

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import Masterbar from './masterbar';
 import Item from './item';
 import Stats from './stats';
@@ -15,6 +16,7 @@ import Gravatar from 'components/gravatar';
 import layoutFocus from 'lib/layout-focus';
 import config from 'config';
 import sections from 'sections';
+import { getExitCheckoutUrl } from 'lib/checkout';
 
 export default React.createClass( {
 	displayName: 'Masterbar',
@@ -59,7 +61,33 @@ export default React.createClass( {
 		return 'my-sites';
 	},
 
+	getMinimalLogoUrl() {
+		if ( ! this.props.cart.hasLoadedFromServer || ! this.props.sites.getSelectedSite() ) {
+			return '/';
+		}
+
+		return getExitCheckoutUrl( this.props.cart, this.props.sites.getSelectedSite().slug );
+	},
+
+	renderMinimal() {
+		return (
+			<Masterbar>
+				<Item
+					url={ this.getMinimalLogoUrl() }
+					icon="my-sites"
+					className="masterbar__item-logo"
+				>
+					WordPress<span className="tld">.com</span>
+				</Item>
+			</Masterbar>
+		);
+	},
+
 	render() {
+		if ( 'checkout' === this.props.section && abtest( 'checkoutMasterbar' ) === 'minimal' ) {
+			return this.renderMinimal();
+		}
+
 		return (
 			<Masterbar>
 				<Stats

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import Masterbar from './masterbar';
 import Item from './item';
 import Stats from './stats';
@@ -16,7 +15,6 @@ import Gravatar from 'components/gravatar';
 import layoutFocus from 'lib/layout-focus';
 import config from 'config';
 import sections from 'sections';
-import { getExitCheckoutUrl } from 'lib/checkout';
 
 export default React.createClass( {
 	displayName: 'Masterbar',
@@ -61,33 +59,7 @@ export default React.createClass( {
 		return 'my-sites';
 	},
 
-	getMinimalLogoUrl() {
-		if ( ! this.props.cart.hasLoadedFromServer || ! this.props.sites.getSelectedSite() ) {
-			return '/';
-		}
-
-		return getExitCheckoutUrl( this.props.cart, this.props.sites.getSelectedSite().slug );
-	},
-
-	renderMinimal() {
-		return (
-			<Masterbar>
-				<Item
-					url={ this.getMinimalLogoUrl() }
-					icon="my-sites"
-					className="masterbar__item-logo"
-				>
-					WordPress<span className="tld">.com</span>
-				</Item>
-			</Masterbar>
-		);
-	},
-
 	render() {
-		if ( 'checkout' === this.props.section && abtest( 'checkoutMasterbar' ) === 'minimal' ) {
-			return this.renderMinimal();
-		}
-
 		return (
 			<Masterbar>
 				<Stats

--- a/client/layout/masterbar/minimal.jsx
+++ b/client/layout/masterbar/minimal.jsx
@@ -11,10 +11,16 @@ import Masterbar from './masterbar';
  */
 import Item from './item';
 
-export default () => (
+const MasterbarMinimal = ( { url } ) => (
 	<Masterbar>
-		<Item url="/" icon="my-sites" className="masterbar__item-logo">
+		<Item url={ url } icon="my-sites" className="masterbar__item-logo">
 			WordPress<span className="tld">.com</span>
 		</Item>
 	</Masterbar>
 );
+
+MasterbarMinimal.propTypes = {
+	url: React.PropTypes.string.isRequired
+};
+
+export default MasterbarMinimal;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -68,5 +68,13 @@ module.exports = {
 			button: 50
 		},
 		defaultVariation: 'original'
+	},
+	checkoutMasterbar: {
+		datestamp: '20160125',
+		variations: {
+			original: 50,
+			minimal: 50
+		},
+		defaultVariation: 'original'
 	}
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -70,7 +70,7 @@ module.exports = {
 		defaultVariation: 'original'
 	},
 	checkoutMasterbar: {
-		datestamp: '20160125',
+		datestamp: '20160126',
 		variations: {
 			original: 50,
 			minimal: 50

--- a/client/lib/checkout/index.js
+++ b/client/lib/checkout/index.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { cartItems } from 'lib/cart-values';
+import { managePurchase } from 'me/purchases/paths';
+
+export function getExitCheckoutUrl( cart, siteSlug ) {
+	let url = '/plans/';
+
+	if ( cartItems.hasRenewalItem( cart ) ) {
+		let renewalItem = cartItems.getRenewalItems( cart )[ 0 ];
+
+		return managePurchase( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId );
+	}
+
+	if ( cartItems.hasDomainRegistration( cart ) ) {
+		url = '/domains/add/';
+	} else if ( cartItems.hasDomainMapping( cart ) ) {
+		url = '/domains/add/mapping/';
+	} else if ( cartItems.hasProduct( cart, 'offsite_redirect' ) ) {
+		url = '/domains/add/site-redirect/';
+	} else if ( cartItems.hasProduct( cart, 'premium_theme' ) ) {
+		url = '/design/';
+	}
+
+	return url + siteSlug;
+}

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -19,6 +19,7 @@ var analytics = require( 'analytics' ),
 	planActions = require( 'state/sites/plans/actions' ),
 	purchasePaths = require( 'me/purchases/paths' ),
 	SecurePaymentForm = require( './secure-payment-form' ),
+	getExitCheckoutUrl = require( 'lib/checkout' ).getExitCheckoutUrl,
 	upgradesActions = require( 'lib/upgrades/actions' );
 
 module.exports = React.createClass( {
@@ -110,22 +111,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( this.state.previousCart ) {
-			if ( cartItems.hasDomainRegistration( this.state.previousCart ) ) {
-				redirectTo = '/domains/add/';
-			} else if ( cartItems.hasDomainMapping( this.state.previousCart ) ) {
-				redirectTo = '/domains/add/mapping/';
-			} else if ( cartItems.hasProduct( this.state.previousCart, 'offsite_redirect' ) ) {
-				redirectTo = '/domains/add/site-redirect/';
-			} else if ( cartItems.hasProduct( this.state.previousCart, 'premium_theme' ) ) {
-				redirectTo = '/design/';
-			}
-			redirectTo = redirectTo + this.props.sites.getSelectedSite().slug;
-
-			if ( cartItems.hasRenewalItem( this.state.previousCart ) ) {
-				renewalItem = cartItems.getRenewalItems( this.state.previousCart )[ 0 ];
-
-				redirectTo = purchasePaths.managePurchase( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId );
-			}
+			redirectTo = getExitCheckoutUrl( this.state.previousCart, this.props.sites.getSelectedSite().slug );
 		}
 
 		page.redirect( redirectTo );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -172,6 +172,8 @@ module.exports = {
 
 		analytics.pageView.record( basePath, 'Checkout' );
 
+		context.store.dispatch( setSection( 'checkout' ) );
+
 		titleActions.setTitle( i18n.translate( 'Checkout' ), {
 			siteID: context.params.domain
 		} );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -210,7 +210,7 @@ module.exports = {
 			basePath = route.sectionify( context.path );
 
 		analytics.pageView.record( basePath, 'Checkout Thank You' );
-		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
+		context.store.dispatch( setSection( 'checkout-thank-you', { hasSidebar: false } ) );
 
 		if ( ! lastTransaction ) {
 			page.redirect( '/plans' );


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/2558 had to be reverted because it added `<CartData />` to the logged-in layout for all users, which caused every client to poll the shopping cart.

This PR starts the test again, and ensures that `<CartData />` is only mounted in `<Layout />` when the user is in checkout, to prevent excessive requests to the shopping cart endpoint.

![screen shot 2016-01-18 at 3 41 51 pm](https://cloud.githubusercontent.com/assets/1130674/12460260/c5c557d2-bf67-11e5-8c9a-80cd419d58d8.png)

**Testing**
- Sign up for a new user through http://calypso.localhost:3000/start
- Run `localStorage.setItem( 'ABTests', '{"checkoutMasterbar_20160125":"original"}' );` in your console.
- Visit http://calypso.localhost:3000/plans and add a plan to your cart.
- Assert that you are redirected to checkout with the full masterbar.
- Run `localStorage.setItem( 'ABTests', '{"checkoutMasterbar_20160125":"minimal"}' );` in your console.
- Refresh the page.
- Assert that you are in checkout with the 'minimal' masterbar.
- Navigate to a page where `<CartData />` isn't mounted, like http://calypso.localhost:3000/pages/:site
- Open the 'Network' pane of the developer tools.
- Assert that your browser is not making repeated requests to the shopping-cart endpoint ([screenshot](https://cloudup.com/cVS5VKl27xo)). You can filter out these requests by typing 'shopping-cart' into the filter input.

- [x] Product review
- [x] Code review