### PR TITLE
Stats: remove No Views Yet message in Summary info panel

### DIFF
--- a/client/my-sites/stats/stats-detail-months/index.jsx
+++ b/client/my-sites/stats/stats-detail-months/index.jsx
@@ -12,6 +12,7 @@ import observe from 'lib/mixins/data-observe';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import StatsModulePlaceholder from '../stats-module/placeholder';
+import StatsModuleContent from '../stats-module/content-text';
 
 export default React.createClass( {
 	displayName: 'StatsPostDetailMonths',
@@ -130,29 +131,27 @@ export default React.createClass( {
 						</li>
 					</ul>
 				</div>
-				<div className="module-content">
-					<div className="module-content-text module-content-text-info">
-						<p>
-							{ this.translate( 'This panel gives you an overview of how many views your website gets on average.', { context: 'Info box description for post stats page in Stats' } ) }
-						</p>
-						<span className="legend achievement">{
-							this.translate(
-								'%(value)s = The all-time highest value.',
-								{ args:
-									{ value: ( this.numberFormat( highest ) ) },
-									context: 'Legend for post stats page in Stats'
-								}
-							)
-						}</span>
-					</div>
-					<StatsModulePlaceholder isLoading={ isLoading } />
-					<div className="module-content-table">
-						<div className="module-content-table-scroll">
-							<table cellPadding="0" cellSpacing="0">
-								{ tableHeader }
-								{ tableBody }
-							</table>
-						</div>
+				<StatsModuleContent className="module-content-text-info">
+					<p>
+						{ this.translate( 'This panel gives you an overview of how many views your website gets on average.', { context: 'Info box description for post stats page in Stats' } ) }
+					</p>
+					<span className="legend achievement">{
+						this.translate(
+							'%(value)s = The all-time highest value.',
+							{ args:
+								{ value: ( this.numberFormat( highest ) ) },
+								context: 'Legend for post stats page in Stats'
+							}
+						)
+					}</span>
+				</StatsModuleContent>
+				<StatsModulePlaceholder isLoading={ isLoading } />
+				<div className="module-content-table">
+					<div className="module-content-table-scroll">
+						<table cellPadding="0" cellSpacing="0">
+							{ tableHeader }
+							{ tableBody }
+						</table>
 					</div>
 				</div>
 			</Card>

--- a/client/my-sites/stats/stats-detail-months/index.jsx
+++ b/client/my-sites/stats/stats-detail-months/index.jsx
@@ -132,13 +132,10 @@ export default React.createClass( {
 				</div>
 				<div className="module-content">
 					<div className="module-content-text module-content-text-info">
-						<p className="message">
-							{ this.translate( 'No views yet', { context: 'Empty info box title for post stats page in Stats' } ) }
-						</p>
 						<p>
 							{ this.translate( 'This panel gives you an overview of how many views your website gets on average.', { context: 'Info box description for post stats page in Stats' } ) }
 						</p>
-						<p className="legend achievement">{
+						<span className="legend achievement">{
 							this.translate(
 								'%(value)s = The all-time highest value.',
 								{ args:
@@ -146,7 +143,7 @@ export default React.createClass( {
 									context: 'Legend for post stats page in Stats'
 								}
 							)
-						}</p>
+						}</span>
 					</div>
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<div className="module-content-table">

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -12,6 +12,7 @@ import toggle from '../mixin-toggle';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import StatsModulePlaceholder from '../stats-module/placeholder';
+import StatsModuleContent from '../stats-module/content-text';
 
 export default React.createClass( {
 	displayName: 'StatsPostDetailWeeks',
@@ -169,25 +170,23 @@ export default React.createClass( {
 						</li>
 					</ul>
 				</div>
-				<div className="module-content">
-					<div className="module-content-text module-content-text-info">
-						<p>{ this.translate( 'This panel gives you an overview of how many views your website is getting recently.' ) }</p>
-						<span className="legend achievement">{
-							this.translate(
-								'%(value)s = The highest recent value.',
-								{ args: { value: ( this.numberFormat( highest ) ) },
-								context: 'Legend for post stats page in Stats' }
-							)
-						}</span>
-					</div>
-					<StatsModulePlaceholder isLoading={ isLoading } />
-					<div className="module-content-table">
-						<div className="module-content-table-scroll">
-							<table cellPadding="0" cellSpacing="0">
-								{ tableHeader }
-								{ tableBody }
-							</table>
-						</div>
+				<StatsModuleContent className="module-content-text-info">
+					<p>{ this.translate( 'This panel gives you an overview of how many views your website is getting recently.' ) }</p>
+					<span className="legend achievement">{
+						this.translate(
+							'%(value)s = The highest recent value.',
+							{ args: { value: ( this.numberFormat( highest ) ) },
+							context: 'Legend for post stats page in Stats' }
+						)
+					}</span>
+				</StatsModuleContent>
+				<StatsModulePlaceholder isLoading={ isLoading } />
+				<div className="module-content-table">
+					<div className="module-content-table-scroll">
+						<table cellPadding="0" cellSpacing="0">
+							{ tableHeader }
+							{ tableBody }
+						</table>
 					</div>
 				</div>
 			</Card>

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -171,15 +171,14 @@ export default React.createClass( {
 				</div>
 				<div className="module-content">
 					<div className="module-content-text module-content-text-info">
-						<p className="message">{ this.translate( 'No views yet' ) }</p>
 						<p>{ this.translate( 'This panel gives you an overview of how many views your website is getting recently.' ) }</p>
-						<p className="legend achievement">{
+						<span className="legend achievement">{
 							this.translate(
 								'%(value)s = The highest recent value.',
 								{ args: { value: ( this.numberFormat( highest ) ) },
 								context: 'Legend for post stats page in Stats' }
 							)
-						}</p>
+						}</span>
 					</div>
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<div className="module-content-table">


### PR DESCRIPTION
This PR removes the "No views yet" message that's on the Post Summary info panel.

![screenshot_2015-11-18_11 48 00](https://cloud.githubusercontent.com/assets/4924246/12458572/4f80e652-bf5f-11e5-81ff-4c4a84ca22c0.png)

Any error message or warning should be placed on the content area of the module itself and not on the info panels.

/cc @timmyc 