### PR TITLE
Reader: Use a friendlier full date in the title of our post dates

### DIFF
--- a/client/reader/post-time/index.jsx
+++ b/client/reader/post-time/index.jsx
@@ -43,7 +43,7 @@ var PostTime = React.createClass( {
 	render: function() {
 		var date = this.props.date;
 		return (
-			<time className={ this.props.className } dateTime={ date } title={ this.moment( date ).format( 'LLLL' ) } >
+			<time className={ this.props.className } dateTime={ date } title={ this.moment( date ).format( 'llll' ) } >
 				{ this.state.ago }
 			</time>
 		);

--- a/client/reader/post-time/index.jsx
+++ b/client/reader/post-time/index.jsx
@@ -43,7 +43,7 @@ var PostTime = React.createClass( {
 	render: function() {
 		var date = this.props.date;
 		return (
-			<time className={ this.props.className } dateTime={ date } title={ date } >
+			<time className={ this.props.className } dateTime={ date } title={ this.moment( date ).format( 'LLLL' ) } >
 				{ this.state.ago }
 			</time>
 		);


### PR DESCRIPTION
Fixes #2624 

Can't really show a screenshot of this one, as tooltips don't render in screenshots. 

Hover over the relative date in a card in the post stream and in the byline of a full post view. Before, we were showing an ISO 8601 date. Now we're showing a friendly localized full date. 