### PR TITLE
Ads: Turn on JP support for Desktop App

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -24,6 +24,7 @@
 		"help": false,
 		"mailing-lists/unsubscribe": true,
 		"manage/ads": true,
+		"manage/ads/jetpack": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/jetpack-plans": true,


### PR DESCRIPTION
`”manage/ads/jetpack": true` was omitted from the desktop config, turning the feature on for our Desktop users too :)