### PR TITLE
Reader: Add an icon to the Visit and Share links on cards.

### DIFF
--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -21,7 +21,14 @@ export default React.createClass( {
 		className: React.PropTypes.string,
 		href: React.PropTypes.string,
 		onClick: React.PropTypes.func,
-		icon: React.PropTypes.bool
+		icon: React.PropTypes.bool,
+		iconSize: React.PropTypes.number
+	},
+
+	getDefaultProps() {
+		return {
+			iconSize: 18
+		};
 	},
 
 	render() {
@@ -37,7 +44,7 @@ export default React.createClass( {
 		return (
 			<a { ...props }>
 				{ this.props.children }
-				{ this.props.icon ? <Gridicon icon="external" size={ 18 } /> : null }
+				{ this.props.icon ? <Gridicon icon="external" size={ this.props.iconSize } /> : null }
 			</a>
 		);
 	}

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -417,8 +417,8 @@ var Post = React.createClass( {
 				}
 
 				<ul className="reader__post-footer">
-					<Share post={ post } />
 					<PostPermalink siteName={ siteName } postUrl={ post.URL } />
+					<Share post={ post } />
 					{ ( shouldShowComments ) ? <CommentButton onClick={ this.recordCommentButtonClick } commentCount={ commentCount } /> : null }
 					{ ( shouldShowLikes ) ? <LikeButton siteId={ likeSiteId } postId={ likePostId } /> : null }
 					<li className="reader__post-options"><PostOptions post={ post } site={ this.state.site } /></li>

--- a/client/reader/post-permalink/index.jsx
+++ b/client/reader/post-permalink/index.jsx
@@ -26,7 +26,7 @@ var PostPermalink = React.createClass( {
 
 		return (
 			<li className="post-permalink" onClick={ this.recordClick }>
-				<ExternalLink href={ this.props.postUrl } rel="external" target="_blank">
+				<ExternalLink href={ this.props.postUrl } rel="external" target="_blank" icon={ true } iconSize={ 24 }>
 					{ this.translate( 'Visit', { comment: 'Visit the post on the original site' } ) }
 				</ExternalLink>
 			</li>

--- a/client/reader/post-permalink/index.jsx
+++ b/client/reader/post-permalink/index.jsx
@@ -26,7 +26,7 @@ var PostPermalink = React.createClass( {
 
 		return (
 			<li className="post-permalink" onClick={ this.recordClick }>
-				<ExternalLink href={ this.props.postUrl } rel="external" target="_blank" icon={ true } iconSize={ 24 }>
+				<ExternalLink href={ this.props.postUrl } rel="external" target="_blank" icon={ true } iconSize={ 16 }>
 					{ this.translate( 'Visit', { comment: 'Visit the post on the original site' } ) }
 				</ExternalLink>
 			</li>

--- a/client/reader/post-permalink/style.scss
+++ b/client/reader/post-permalink/style.scss
@@ -1,6 +1,6 @@
 .reader__post-footer li.post-permalink {
 	display: inline-block;
-	padding: 4px;
+	padding: 4px 4px 4px 27px;
 	color: lighten( $gray, 10 );
 	position: relative;
 	box-sizing: border-box;
@@ -13,5 +13,12 @@
 	&:hover {
 		cursor: pointer;
 		color: $blue-light;
+	}
+
+	.gridicons-external {
+		position: absolute;
+			top: 2px;
+			left: 0px;
+		margin-left: 0;
 	}
 }

--- a/client/reader/post-permalink/style.scss
+++ b/client/reader/post-permalink/style.scss
@@ -1,6 +1,6 @@
 .reader__post-footer li.post-permalink {
 	display: inline-block;
-	padding: 4px 4px 4px 27px;
+	padding: 4px;
 	color: lighten( $gray, 10 );
 	position: relative;
 	box-sizing: border-box;
@@ -13,12 +13,5 @@
 	&:hover {
 		cursor: pointer;
 		color: $blue-light;
-	}
-
-	.gridicons-external {
-		position: absolute;
-			top: 2px;
-			left: 0px;
-		margin-left: 0;
 	}
 }

--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -107,7 +107,8 @@ var ReaderShare = React.createClass( {
 		};
 	},
 
-	toggle() {
+	toggle( event ) {
+		event.preventDefault();
 		this.setState( { showingMenu: ! this.state.showingMenu } );
 	},
 
@@ -131,22 +132,28 @@ var ReaderShare = React.createClass( {
 		if ( ! config.isEnabled( 'reader/share' ) ) {
 			return null;
 		}
-		return React.createElement( this.props.tagName, { className: 'reader-share' }, [
-			( <span key="button" ref="shareButton" className={ buttonClasses } onTouchTap={ this.toggle }>
-				{ this.translate( 'Share', { comment: 'Share the post' } ) }
-			</span> ),
-			( <PopoverMenu key="menu" context={ this.refs && this.refs.shareButton }
-				isVisible={ this.state.showingMenu }
-				onClose={ this.closeMenu }
-				position={ this.props.position }>
-				{ canShareToWordpress ? <PopoverMenuItem action="pressThis" className="reader-share__popover-item">
-					<Gridicon icon='my-sites' size={ 24 } /> WordPress</PopoverMenuItem> : null }
-				<PopoverMenuItem action="twitter" className="reader-share__popover-item">
-					{ twitterIcon } Twitter</PopoverMenuItem>
-				<PopoverMenuItem action="facebook" className="reader-share__popover-item">
-					{ facebookIcon } Facebook</PopoverMenuItem>
-			</PopoverMenu> )
-		] );
+		return React.createElement( this.props.tagName, {
+			className: 'reader-share',
+			onClick: this.toggle,
+			ref: 'shareButton' },
+			[
+				( <span key="button" ref="shareButton" className={ buttonClasses }>
+					<Gridicon icon="share" size={ 24 } />
+					{ this.translate( 'Share', { comment: 'Share the post' } ) }
+				</span> ),
+				( <PopoverMenu key="menu" context={ this.refs && this.refs.shareButton }
+					isVisible={ this.state.showingMenu }
+					onClose={ this.closeMenu }
+					position={ this.props.position }>
+					{ canShareToWordpress ? <PopoverMenuItem action="pressThis" className="reader-share__popover-item">
+						<Gridicon icon="my-sites" size={ 24 } /> WordPress</PopoverMenuItem> : null }
+					<PopoverMenuItem action="twitter" className="reader-share__popover-item">
+						{ twitterIcon } Twitter</PopoverMenuItem>
+					<PopoverMenuItem action="facebook" className="reader-share__popover-item">
+						{ facebookIcon } Facebook</PopoverMenuItem>
+				</PopoverMenu> )
+			]
+		);
 	}
 
 } );

--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -7,7 +7,8 @@ var PopoverMenu = require( 'components/popover/menu' ),
 	PopoverMenuItem = require( 'components/popover/menu-item' ),
 	Gridicon = require( 'components/gridicon' ),
 	sitesList = require( 'lib/sites-list' )(),
-	stats = require( 'reader/stats' );
+	stats = require( 'reader/stats' ),
+	SocialLogo = require( 'components/social-logo' );
 
 var actionMap = {
 	twitter: function( post ) {
@@ -66,34 +67,6 @@ var actionMap = {
 	}
 };
 
-const twitterIcon = ( <svg
-	xmlns="http://www.w3.org/2000/svg"
-	width="171.5054"
-	height="139.37839"
-	viewBox="0 0 171.5054 139.37839"
-	version="1.1"
-	className="gridicon gridicons-twitter">
-	<g
-		transform="translate(-282.32053,-396.30734)">
-		<path
-			d="m 453.82593,412.80619 c -6.3097,2.79897 -13.09189,4.68982 -20.20852,5.54049 7.26413,-4.35454 12.84406,-11.24992 15.47067,-19.46675 -6.79934,4.03295 -14.3293,6.96055 -22.34461,8.53841 -6.41775,-6.83879 -15.56243,-11.111 -25.68298,-11.111 -19.43159,0 -35.18696,15.75365 -35.18696,35.18525 0,2.75781 0.31128,5.44359 0.91155,8.01875 -29.24344,-1.46723 -55.16995,-15.47582 -72.52461,-36.76396 -3.02879,5.19662 -4.76443,11.24048 -4.76443,17.6891 0,12.20777 6.21194,22.97747 15.65332,29.28716 -5.76773,-0.18265 -11.19331,-1.76565 -15.93716,-4.40083 -0.004,0.14663 -0.004,0.29412 -0.004,0.44248 0,17.04767 12.12889,31.26806 28.22555,34.50266 -2.95247,0.80436 -6.06101,1.23398 -9.26989,1.23398 -2.2673,0 -4.47114,-0.22124 -6.62011,-0.63114 4.47801,13.97857 17.47214,24.15143 32.86992,24.43441 -12.04227,9.43796 -27.21366,15.06335 -43.69965,15.06335 -2.84014,0 -5.64082,-0.16722 -8.39349,-0.49223 15.57186,9.98421 34.06703,15.8094 53.93768,15.8094 64.72024,0 100.11301,-53.61524 100.11301,-100.11387 0,-1.52554 -0.0343,-3.04251 -0.10204,-4.55261 6.87394,-4.95995 12.83891,-11.15646 17.55618,-18.21305 z" />
-	</g>
-</svg> ),
-	facebookIcon = ( <svg
-		version="1.1"
-		xmlns="http://www.w3.org/2000/svg"
-		x="0px" y="0px"
-		width="266.893px" height="266.895px" viewBox="0 0 266.893 266.895"
-		enable-background="new 0 0 266.893 266.895"
-		className="gridicon gridicons-facebook">
-		<path className="facebook-background" fill="#3C5A99" d="M248.082,262.307c7.854,0,14.223-6.369,14.223-14.225V18.812
-			c0-7.857-6.368-14.224-14.223-14.224H18.812c-7.857,0-14.224,6.367-14.224,14.224v229.27c0,7.855,6.366,14.225,14.224,14.225
-			H248.082z"/>
-		<path className="facebook-f" fill="#FFFFFF" d="M182.409,262.307v-99.803h33.499l5.016-38.895h-38.515V98.777c0-11.261,3.127-18.935,19.275-18.935
-			l20.596-0.009V45.045c-3.562-0.474-15.788-1.533-30.012-1.533c-29.695,0-50.025,18.126-50.025,51.413v28.684h-33.585v38.895h33.585
-			v99.803H182.409z"/>
-	</svg> );
-
 var ReaderShare = React.createClass( {
 
 	getInitialState() {
@@ -102,7 +75,7 @@ var ReaderShare = React.createClass( {
 
 	getDefaultProps() {
 		return {
-			position: 'top right',
+			position: 'top left',
 			tagName: 'li'
 		};
 	},
@@ -148,9 +121,9 @@ var ReaderShare = React.createClass( {
 					{ canShareToWordpress ? <PopoverMenuItem action="pressThis" className="reader-share__popover-item">
 						<Gridicon icon="my-sites" size={ 24 } /> WordPress</PopoverMenuItem> : null }
 					<PopoverMenuItem action="twitter" className="reader-share__popover-item">
-						{ twitterIcon } Twitter</PopoverMenuItem>
+						<SocialLogo icon="twitter" /> Twitter</PopoverMenuItem>
 					<PopoverMenuItem action="facebook" className="reader-share__popover-item">
-						{ facebookIcon } Facebook</PopoverMenuItem>
+						<SocialLogo icon="facebook" /> Facebook</PopoverMenuItem>
 				</PopoverMenu> )
 			]
 		);

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -1,6 +1,6 @@
 .reader-share {
 	display: inline-block;
-	padding: 4px;
+	padding: 4px 4px 4px 27px;
 	color: lighten( $gray, 10 );
 	position: relative;
 	box-sizing: border-box;
@@ -10,10 +10,12 @@
 	&:hover, &:focus, &:active, .is-active {
 		cursor: pointer;
 		color: $blue-light;
+	}
 
-		.gridicon {
-			color: $white;
-		}
+	.gridicons-share {
+		position: absolute;
+			top: 2px;
+			left: 0px;
 	}
 }
 

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -7,15 +7,24 @@
 	transition: color 0.15s linear;
 	cursor: pointer;
 
-	&:hover, &:focus, &:active, .is-active {
+	&:hover, &:focus, &:active {
 		cursor: pointer;
 		color: $blue-light;
 	}
 
-	.gridicons-share {
+	.gridicon {
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 		position: absolute;
-			top: 2px;
-			left: 0px;
+			top: 3px;
+			left: -3px;
+	}
+
+	.is-active {
+		color: $blue-dark;
+
+		.gridicon {
+			transform: rotate( 90deg );
+		}
 	}
 }
 
@@ -25,26 +34,33 @@
 		line-height: 24px;
 		margin-left: 32px;
 	}
-	.gridicon {
+	.gridicon,
+	.social-logo {
 		height: 24px;
 		width: 24px;
 		position: absolute;
-		top: 8px;
-		left: 16px;
+			top: 8px;
+			left: 16px;
 		padding: 0;
+		fill: $gray;
 	}
 
 	.gridicons-my-sites {
 		fill: $blue-wordpress;
 	}
 
-	.gridicons-twitter {
+	.social-logo.twitter {
 		fill: #2aa9e0;
+	}
+
+	.social-logo.facebook {
+		fill: #3B5998;
 	}
 
 	&:hover,
 	&:focus {
-		.gridicon {
+		.gridicon,
+		.social-logo {
 			fill: $white;
 		}
 	}


### PR DESCRIPTION
The Visit icon indicates that the click will take the user offsite.
The Share icon is because it looked lonely without it.

Also moved the click handler on the Share button up to the container, which matches where we apply the highlight and the pointer. No more just missing the click and moving to full post instead of the Sharing menu.

Last, stopped using onTouchTap, in favor of onClick, because onTouchTap doesn't seem capable of actually canceling an event properly, as least not in a manner that the card's click handler can understand and ignore.

Fixes #2623 

before
![screenshot](https://cldup.com/Gm2vtKlTij.png)

after
![screenshot](https://cldup.com/pRWOVm1CJA.png)