### PR TITLE
Site Selector: enter key select

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -62,6 +62,20 @@ export default React.createClass( {
 		this.setState( { search: terms } );
 	},
 
+	onKeyDown( event ) {
+		var filteredSites;
+
+		if ( event.keyCode === 13 ) {
+			// enter key
+			filteredSites = this.getFilteredSites();
+
+			if ( filteredSites.length === 1 && this.props.siteBasePath ) {
+				this.onSiteSelect( filteredSites[ 0 ].slug, event );
+				page( this.getSiteBasePath( filteredSites[ 0 ] ) + '/' + filteredSites[ 0 ].slug );
+			}
+		}
+	},
+
 	onSiteSelect( siteSlug, event ) {
 		this.closeSelector();
 		this.props.onSiteSelect( siteSlug );
@@ -75,6 +89,7 @@ export default React.createClass( {
 	},
 
 	closeSelector() {
+		this.refs.siteSearch.clear();
 		this.refs.siteSearch.blur();
 	},
 
@@ -107,6 +122,22 @@ export default React.createClass( {
 		return siteBasePath;
 	},
 
+	getFilteredSites() {
+		var sites;
+
+		if ( this.state.search ) {
+			sites = this.props.sites.search( this.state.search );
+		} else {
+			sites = this.shouldShowGroups() ? this.props.sites.getVisibleAndNotRecent() : this.props.sites.getVisible();
+		}
+
+		if ( this.props.filter ) {
+			sites = sites.filter( this.props.filter );
+		}
+
+		return sites;
+	},
+
 	isSelected( site ) {
 		var selectedSite = this.props.selected || this.props.sites.selected;
 		return selectedSite === site.domain || selectedSite === site.slug;
@@ -121,20 +152,11 @@ export default React.createClass( {
 	},
 
 	renderSites() {
-		var sites, siteElements;
+		var sites = this.getFilteredSites(),
+			siteElements;
 
 		if ( ! this.props.sites.initialized ) {
 			return <SitePlaceholder key="site-placeholder" />;
-		}
-
-		if ( this.state.search ) {
-			sites = this.props.sites.search( this.state.search );
-		} else {
-			sites = this.shouldShowGroups() ? this.props.sites.getVisibleAndNotRecent() : this.props.sites.getVisible();
-		}
-
-		if ( this.props.filter ) {
-			sites = sites.filter( this.props.filter );
 		}
 
 		// Render sites
@@ -251,6 +273,7 @@ export default React.createClass( {
 				<Search
 					ref="siteSearch"
 					onSearch={ this.onSearch }
+					onKeyDown={ this.onKeyDown }
 					autoFocus={ this.props.autoFocus }
 					disabled={ ! this.props.sites.initialized }
 				/>


### PR DESCRIPTION
On the site selector, if search is utilized to filter the sites list and only one result is visible, the enter key will now select that site. Think of it like a quick switcher.

In the future, I'd like to expand this to account for other keyboard events like arrow keys, etc. but in order to keep this PR as focused as possible, it's **only focused** on the specific case of hitting the enter key when filtered to one site.

##### Example screencast

![enterkey](https://cloud.githubusercontent.com/assets/1427136/12467461/8bbd3b30-bfa9-11e5-95ef-558ee83c4927.gif)

## Testing

1. Open site picker
2. Enter search term (only visible if account has many sites)
3. When only one site is visible, hit **enter**
4. You should navigate to the appropriate url for that filtered site

---

/cc @mtias 