### PR TITLE
Invites: Handle forceMatchingEmail invite attribute.

### DIFF
--- a/client/components/signup-form/README.md
+++ b/client/components/signup-form/README.md
@@ -35,3 +35,5 @@ render: function() {
 * (optional) `save` function: Called `onBlur` of each field with `form` as parameter
 * (optional) `disabled` boolean: Sets the form as disabled
 * (optional) `submitting` boolean: Sets the state of the form as being submitted
+* (optional) `email` string: Initial value for email input
+* (options) `disableEmailInput` boolean: Disables the email input. Useful if email must be a certain value and that value is passed in through the `email` prop

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -311,13 +311,13 @@ export default React.createClass( {
 						autoCapitalize="off"
 						autoCorrect="off"
 						className="signup-form__input"
-						disabled={ this.state.submitting || this.props.disabled }
+						disabled={ this.state.submitting || this.props.disabled || ! this.props.allowEmailChange }
 						id="email"
 						name="email"
 						type="email"
 						value={ formState.getFieldValue( this.state.form, 'email' ) }
 						isError={ formState.isFieldInvalid( this.state.form, 'email' ) }
-						isValid={ this.state.validationInitialized && formState.isFieldValid( this.state.form, 'email' ) }
+						isValid={ this.props.allowEmailChange && this.state.validationInitialized && formState.isFieldValid( this.state.form, 'email' ) }
 						onBlur={ this.handleBlur }
 						onChange={ this.handleChangeEvent } />
 				</ValidationFieldset>

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -311,13 +311,13 @@ export default React.createClass( {
 						autoCapitalize="off"
 						autoCorrect="off"
 						className="signup-form__input"
-						disabled={ this.state.submitting || this.props.disabled || ! this.props.allowEmailChange }
+						disabled={ this.state.submitting || !! this.props.disabled || !! this.props.disableEmailInput }
 						id="email"
 						name="email"
 						type="email"
 						value={ formState.getFieldValue( this.state.form, 'email' ) }
 						isError={ formState.isFieldInvalid( this.state.form, 'email' ) }
-						isValid={ this.props.allowEmailChange && this.state.validationInitialized && formState.isFieldValid( this.state.form, 'email' ) }
+						isValid={ ! this.props.disableEmailInput && this.state.validationInitialized && formState.isFieldValid( this.state.form, 'email' ) }
 						onBlur={ this.handleBlur }
 						onChange={ this.handleChangeEvent } />
 				</ValidationFieldset>

--- a/client/lib/invites/reducers/invites-validation.js
+++ b/client/lib/invites/reducers/invites-validation.js
@@ -33,7 +33,8 @@ function normalizeInvite( data ) {
 		sentTo: decodeEntities( data.invite.meta.sent_to ),
 		forceMatchingEmail: data.invite.meta.force_matching_email,
 		site: Object.assign( filterObjectProperties( data.blog_details ), { ID: parseInt( data.invite.blog_id, 10 ) } ),
-		inviter: filterObjectProperties( data.inviter )
+		inviter: filterObjectProperties( data.inviter ),
+		knownUser: data.invite.meta.known
 	}
 }
 

--- a/client/lib/invites/reducers/invites-validation.js
+++ b/client/lib/invites/reducers/invites-validation.js
@@ -31,6 +31,7 @@ function normalizeInvite( data ) {
 		date: data.invite.invite_date,
 		role: decodeEntities( data.invite.meta.role ),
 		sentTo: decodeEntities( data.invite.meta.sent_to ),
+		forceMatchingEmail: data.invite.meta.force_matching_email,
 		site: Object.assign( filterObjectProperties( data.blog_details ), { ID: parseInt( data.invite.blog_id, 10 ) } ),
 		inviter: filterObjectProperties( data.inviter )
 	}

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -10,7 +10,7 @@ var debug = require( 'debug' )( 'calypso:user:utilities' ),
 var user = require( 'lib/user' )();
 
 var userUtils = {
-	getLogoutUrl: function() {
+	getLogoutUrl: function( redirect ) {
 		var url = '/logout',
 			userData = user.get(),
 			subdomain = '';
@@ -29,13 +29,18 @@ var userUtils = {
 			url = userData.logout_URL;
 		}
 
+		if ( redirect ) {
+			redirect = '&redirect_to=' + encodeURIComponent( redirect );
+			url += redirect;
+		}
+
 		debug( 'Logout Url: ' + url );
 
 		return url;
 	},
 
-	logout: function() {
-		var logoutUrl = userUtils.getLogoutUrl();
+	logout: function( redirect ) {
+		var logoutUrl = userUtils.getLogoutUrl( redirect );
 
 		// Clear any data stored locally within the user data module or localStorage
 		user.clear();

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -90,13 +90,32 @@ let InviteAcceptLoggedIn = React.createClass( {
 		return text;
 	},
 
-	render() {
-		const { invite, user, signInLink, matchEmailError } = this.props;
+	renderMatchEmailError() {
 		return (
-			<div className={ classNames( 'invite-accept-logged-in', this.props.className ) }>
+			<Card>
+				<InviteFormHeader { ... this.props.invite } user={ this.props.user } matchEmailError />
+				<div className="invite-accept-logged-in__button-bar">
+					<Button onClick={ this.signInLink } href={ this.props.signInLink }>
+						{
+							this.props.invite.knownUser
+							? this.translate( 'Sign In as %(email)s', { context: 'button', args: { email: this.props.invite.sentTo } } )
+							: this.translate( 'Register as %(email)s', { context: 'button', args: { email: this.props.invite.sentTo } } )
+						}
+					</Button>
+				</div>
+			</Card>
+		);
+	},
+
+	renderAccept() {
+		return (
+			<div>
 				<Card>
-					<InviteFormHeader { ... invite } user matchEmailError />
-					{ ! matchEmailError &&
+					<InviteFormHeader { ... this.props.invite } user={ this.props.user } />
+					<div className="invite-accept-logged-in__join-as">
+						<Gravatar user={ this.props.user } size={ 72 } />
+						{ this.getJoinAsText() }
+					</div>
 					<div className="invite-accept-logged-in__button-bar">
 						<Button onClick={ this.decline } disabled={ this.state.submitting }>
 							{ this.translate( 'Decline', { context: 'button' } ) }
@@ -105,23 +124,21 @@ let InviteAcceptLoggedIn = React.createClass( {
 							{ this.getButtonText() }
 						</Button>
 					</div>
-					}
-					{ matchEmailError &&
-					<div className="invite-accept-logged-in__button-bar">
-						<Button onClick={ this.signInLink } href={ signInLink }>
-							{ this.translate( 'Sign In as %(email)s', { context: 'button', args: { email: invite.sentTo } } ) }
-						</Button>
-					</div>
-					}
 				</Card>
 
-				{ ! invite.forceMatchingEmail &&
-					<LoggedOutFormLinks>
-						<LoggedOutFormLinkItem onClick={ this.signInLink } href={ signInLink }>
-							{ this.translate( 'Sign in as a different user' ) }
-						</LoggedOutFormLinkItem>
-					</LoggedOutFormLinks>
-				}
+				<LoggedOutFormLinks>
+					<LoggedOutFormLinkItem onClick={ this.signInLink } href={ this.props.signInLink }>
+						{ this.translate( 'Sign in as a different user' ) }
+					</LoggedOutFormLinkItem>
+				</LoggedOutFormLinks>
+			</div>
+		);
+	},
+
+	render() {
+		return (
+			<div className={ classNames( 'invite-accept-logged-in', this.props.className ) }>
+				{ this.props.forceMatchingEmail ? this.renderMatchEmailError() : this.renderAccept() }
 			</div>
 		);
 	}

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -13,7 +13,6 @@ import { bindActionCreators } from 'redux';
 import Card from 'components/card';
 import Gravatar from 'components/gravatar';
 import Button from 'components/button';
-import config from 'config';
 import InviteFormHeader from 'my-sites/invites/invite-form-header';
 import { acceptInvite } from 'lib/invites/actions';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
@@ -92,17 +91,12 @@ let InviteAcceptLoggedIn = React.createClass( {
 	},
 
 	render() {
-		const { user } = this.props,
-			signInLink = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
-
+		const { invite, user, signInLink, matchEmailError } = this.props;
 		return (
 			<div className={ classNames( 'invite-accept-logged-in', this.props.className ) }>
 				<Card>
-					<InviteFormHeader { ... this.props.invite } />
-					<div className="invite-accept-logged-in__join-as">
-						<Gravatar user={ user } size={ 72 } />
-						{ this.getJoinAsText() }
-					</div>
+					<InviteFormHeader { ... invite } user matchEmailError />
+					{ ! matchEmailError &&
 					<div className="invite-accept-logged-in__button-bar">
 						<Button onClick={ this.decline } disabled={ this.state.submitting }>
 							{ this.translate( 'Decline', { context: 'button' } ) }
@@ -111,13 +105,23 @@ let InviteAcceptLoggedIn = React.createClass( {
 							{ this.getButtonText() }
 						</Button>
 					</div>
+					}
+					{ matchEmailError &&
+					<div className="invite-accept-logged-in__button-bar">
+						<Button onClick={ this.signInLink } href={ signInLink }>
+							{ this.translate( 'Sign In as %(email)s', { context: 'button', args: { email: invite.sentTo } } ) }
+						</Button>
+					</div>
+					}
 				</Card>
 
-				<LoggedOutFormLinks>
-					<LoggedOutFormLinkItem onClick={ this.signInLink } href={ signInLink }>
-						{ this.translate( 'Sign in as a different user' ) }
-					</LoggedOutFormLinkItem>
-				</LoggedOutFormLinks>
+				{ ! invite.forceMatchingEmail &&
+					<LoggedOutFormLinks>
+						<LoggedOutFormLinkItem onClick={ this.signInLink } href={ signInLink }>
+							{ this.translate( 'Sign in as a different user' ) }
+						</LoggedOutFormLinkItem>
+					</LoggedOutFormLinks>
+				}
 			</div>
 		);
 	}

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -128,7 +128,7 @@ let InviteAcceptLoggedOut = React.createClass( {
 					submitButtonText={ this.submitButtonText() }
 					footerLink={ this.renderFooterLink() }
 					email={ this.props.invite.sentTo }
-					allowEmailChange={ ! this.props.forceMatchingEmail }/>
+					disableEmailInput={ this.props.forceMatchingEmail }/>
 				{ this.state.userData && this.loginUser() }
 			</div>
 		)

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -127,7 +127,8 @@ let InviteAcceptLoggedOut = React.createClass( {
 					submitForm={ this.submitForm }
 					submitButtonText={ this.submitButtonText() }
 					footerLink={ this.renderFooterLink() }
-					email={ this.props.invite.sentTo } />
+					email={ this.props.invite.sentTo }
+					allowEmailChange={ ! this.props.forceMatchingEmail }/>
 				{ this.state.userData && this.loginUser() }
 			</div>
 		)

--- a/client/my-sites/invites/invite-accept/style.scss
+++ b/client/my-sites/invites/invite-accept/style.scss
@@ -6,3 +6,7 @@
 		max-width: none;
 	}
 }
+
+.invite-accept .notice__text {
+	word-wrap: break-word;
+}


### PR DESCRIPTION
__Context__
The get invite endpoint could return `force_matching_email` true in some particular cases.
This PR intends to force the user to accept an invite with the user/email it was sent to.

__How To Test__
- Checkout `update/invites-force-matching-email` branch
- Change `forceMatchingEmail: data.invite.meta.force_matching_email,` to `forceMatchingEmail: ! data.invite.meta.force_matching_email,` in https://github.com/Automattic/wp-calypso/pull/2647/files#diff-8c2746c50a020ab9f59fc38f264fa2bbR34
- Create invites at `$site/wp-admin/users.php?page=wpcom-invite-users` where `$site` is a WordPress.com site
- In the invite email, swap `wpcalypso.wordpress.com` for `calypso.localhost:3000`.
- Test logged in as a different user than the one the invite was sent to
- Test logged out and try to change the email the invite was sent to


 
