### PR TITLE
Plugin: fix buisness plugin redirect issue

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -50,11 +50,18 @@ function renderSinglePlugin( context, siteUrl, isWpcomPlugin ) {
 	}
 
 	if (
-		( ! site || ! site.jetpack ) &&
+		( site && ! site.jetpack ) &&
 		businessPlugins.indexOf( pluginSlug ) >= 0 &&
 		context.path.indexOf( '/business' ) < 0
 	) {
 		return page.redirect( '/plugins/' + pluginSlug + '/business' + ( site ? '/' + site.slug : '' ) );
+	}
+
+	if ( ! site &&
+		context.path.indexOf( '/business' ) >= 0 &&
+		-1 === businessPlugins.indexOf( pluginSlug )
+	) {
+		return page.redirect( '/plugins/' + pluginSlug );
 	}
 
 	analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle + ' > Plugin Details' );


### PR DESCRIPTION
Currently you are not able to go to 
https://wordpress.com/plugins/gumroad the user is redirected to https://wordpress.com/plugins/gumroad/business

This PR fixed this by making sure that the user is still able to visit any plugin slug. 
It also make sure that we redirect users if they for some reason try to visit a plugin url that is not a buisness plugin. for example /akismet/buiness that they get redirected to /akismet instead. 

**To test**
visit the following urls and make sure you end up the expected url.
http://calypso.localhost:3000/plugins/gumroad/business
http://calypso.localhost:3000/plugins/gumroad/
http://calypso.localhost:3000/plugins/jetpack/buisness

http://calypso.localhost:3000/plugins/gumroad/business/.comsite
http://calypso.localhost:3000/plugins/gumroad/.jetpack.site



