### PR TITLE
Stats: Update post-performance component

### DIFF
--- a/client/my-sites/stats/stats-module/header.jsx
+++ b/client/my-sites/stats/stats-module/header.jsx
@@ -17,17 +17,21 @@ export default React.createClass( {
 		siteId: PropTypes.number,
 		path: PropTypes.string,
 		title: PropTypes.string,
+		titleLink: PropTypes.string,
 		showInfo: PropTypes.bool,
 		showModule: PropTypes.bool,
 		isCollapsed: PropTypes.bool,
+		showActions: PropTypes.bool,
 		showCollapse: PropTypes.bool,
-		onActionClick: PropTypes.func.isRequired
+		onActionClick: PropTypes.func
 	},
 
 	getDefaultProps() {
 		return {
 			showCollapse: true,
-			showModule: true
+			showModule: true,
+			showActions: true,
+			onActionClick: () => {}
 		}
 	},
 
@@ -60,6 +64,31 @@ export default React.createClass( {
 		} );
 	},
 
+	renderActions() {
+		const { showCollapse, showInfo, showActions } = this.props;
+		const infoIcon = showInfo ? 'info' : 'info-outline';
+
+		if ( ! showActions ) {
+			return null;
+		}
+
+		return (
+			<ul className="module-header-actions">
+				<li className="module-header-action toggle-info">
+					<a href="#"
+						className="module-header-action-link"
+						aria-label={ this.translate( 'Show or hide panel information', { context: 'Stats panel action' } ) }
+						title={ this.translate( 'Show or hide panel information', { context: 'Stats panel action' } ) }
+						onClick={ this.toggleInfo }
+					>
+						<Gridicon icon={ infoIcon } />
+					</a>
+				</li>
+				{ showCollapse ? this.renderChevron() : null }
+			</ul>
+		);
+	},
+
 	renderChevron() {
 		return (
 			<li className="module-header-action toggle-services">
@@ -88,26 +117,30 @@ export default React.createClass( {
 		);
 	},
 
-	render() {
-		const { showCollapse, showInfo, title } = this.props;
-		const infoIcon = showInfo ? 'info' : 'info-outline';
+	renderTitle() {
+		const { title, titleLink } = this.props;
 
+		if ( titleLink ) {
+			return (
+				<h3 className="module-header-title">
+					<a href={ titleLink } className="module-header__link">
+						<span className="module-header__right-icon">
+							<Gridicon icon="stats" />
+						</span>
+						{ title }
+					</a>
+				</h3>
+			);
+		}
+
+		return <h3 className="module-header-title">{ title }</h3>;
+	},
+
+	render() {
 		return (
 			<div className="module-header">
-				<h4 className="module-header-title">{ title }</h4>
-				<ul className="module-header-actions">
-					<li className="module-header-action toggle-info">
-						<a href="#"
-							className="module-header-action-link"
-							aria-label={ this.translate( 'Show or hide panel information', { context: 'Stats panel action' } ) }
-							title={ this.translate( 'Show or hide panel information', { context: 'Stats panel action' } ) }
-							onClick={ this.toggleInfo }
-						>
-							<Gridicon icon={ infoIcon } />
-						</a>
-					</li>
-					{ showCollapse ? this.renderChevron() : null }
-				</ul>
+				{ this.renderTitle() }
+				{ this.renderActions() }
 			</div>
 		);
 	}

--- a/client/my-sites/stats/stats-tabs/tab.jsx
+++ b/client/my-sites/stats/stats-tabs/tab.jsx
@@ -20,7 +20,10 @@ export default React.createClass( {
 		loading: PropTypes.bool,
 		selected: PropTypes.bool,
 		tabClick: PropTypes.func,
-		value: PropTypes.number
+		value: PropTypes.oneOfType( [
+			PropTypes.number,
+			PropTypes.string
+		] )
 	},
 
 	clickHandler( event ) {


### PR DESCRIPTION
This branch does a refactor of the `PostPerformance` component that shows summary stats for the last post on the insights page.  I wanted to do a refactor of this component prior to adding some additional logic needed for #2487 

<img width="735" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/12469638/612dbe96-bfa2-11e5-9c0a-9352caee1ddf.png">

__Notes__
While attempting to use all the new "shared" `/stats-module` child components, I had to add in some more propTypes to `/stats-module/header.jsx` to accommodate headers that do not show the toggle or info actions.  This toggle-less / no-info icon pattern is used in PostPerformance and the StatsOverview components.

__To Test__
- Open a site stats insights page
- Verify the component looks/functions the same as it does in production
- Also verify that the comments module header looks the same and (i) and ^ toggle both operate as expected.