### PR TITLE
Reader List stream: fix header for list names in non-Latin character sets

### DIFF
--- a/client/lib/reader-lists/lists.js
+++ b/client/lib/reader-lists/lists.js
@@ -11,7 +11,7 @@ import { action as actionTypes } from './constants';
 var lists = {}, errors = [], updatedLists = {}, isFetching = false, ListStore;
 
 function keyForList( owner, slug ) {
-	return owner + '-' + slug;
+	return decodeURIComponent( owner ) + '-' + decodeURIComponent( slug );
 }
 
 function getListURL( list ) {


### PR DESCRIPTION
This PR makes list keys more reliable in the Reader ListStore. This should mean that list information can be reliably fetched for the list stream header when using non-Latin list names. Fixes #920.

Test list: http://calypso.localhost:3000/read/list/bluefuton/%E6%9C%AA%E5%88%86%E9%A1%9E

Before:

<img width="754" alt="screen shot 2016-01-21 at 17 23 05" src="https://cloud.githubusercontent.com/assets/17325/12471574/b9bae400-c063-11e5-9f3b-656bdf06eea6.png">

After:

<img width="754" alt="screen shot 2016-01-21 at 17 23 15" src="https://cloud.githubusercontent.com/assets/17325/12471577/bd48d76c-c063-11e5-94cd-36aee6a1d258.png">

