### PR TITLE
Add tracking ref to Linux Debian download link.

### DIFF
--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -50,7 +50,7 @@ module.exports = React.createClass( {
 						</div>
 						<p><strong>{ this.translate( 'Linux' ) }</strong><br />
 						{ this.translate( 'Choose your distribution' ) }</p>
-						<Button href="https://desktop.wordpress.com/d/linux?ref=getapps">{ this.translate( '.TAR.GZ' ) }</Button> <Button href="https://desktop.wordpress.com/d/linux-deb">{ this.translate( '.DEB' ) }</Button>
+						<Button href="https://desktop.wordpress.com/d/linux?ref=getapps">{ this.translate( '.TAR.GZ' ) }</Button> <Button href="https://desktop.wordpress.com/d/linux-deb?ref=getapps">{ this.translate( '.DEB' ) }</Button>
 					</section>
 
 				</Card>


### PR DESCRIPTION
This is a bugfix. I forgot to add this reference initially.