### PR TITLE
Domains: fix domain search

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -177,6 +177,7 @@ var RegisterDomainStep = React.createClass( {
 					placeholder={ this.translate( 'Enter a domain or keyword', { textOnly: true } ) }
 					autoFocus={ true }
 					delaySearch={ true }
+					delayTimeout="2000"
 				/>
 			</div>
 		);

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -220,7 +220,7 @@ var RegisterDomainStep = React.createClass( {
 		async.parallel(
 			[
 				callback => {
-					if ( domain.indexOf( '.' ) < 0 ) {
+					if ( ! domain.match( /.{3,}\..{2,}/ ) ) {
 						return callback();
 					}
 


### PR DESCRIPTION
2 problems:
1. No need to send availability checks if the domain is obviously not written yet (ends with a dot). This is very common when I search, about half of the times I see the availability search error.
2. No need to send 10 suggestions requests to the server while typing. 

To test:
1. go to /domains/add/, select a site
2. start searching and watch for the api calls to suggestions. There shouldn't be thousands of them
3. type something. (ending with a dot). You should not see the availability error.