### PR TITLE
i18n: Allow translations on the server

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -10,11 +10,22 @@ import Masterbar from './masterbar';
  * Internal dependencies
  */
 import Item from './item';
+import config from 'config';
 
-export default () => (
-	<Masterbar>
-		<Item url="/" icon="my-sites" className="masterbar__item-logo">
-			WordPress<span className="tld">.com</span>
-		</Item>
-	</Masterbar>
-);
+export default React.createClass( {
+
+	render() {
+		return(
+			<Masterbar>
+				<Item url="/" icon="my-sites" className="masterbar__item-logo">
+					WordPress<span className="tld">.com</span>
+				</Item>
+				<Item url={ config( 'login_url' ) } className="masterbar_item-login">
+					{ this.translate( 'Log in', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
+				</Item>
+			</Masterbar>
+		);
+	},
+
+} );
+

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React from 'react/addons';
 import Masterbar from './masterbar';
 
 /**

--- a/config/development.json
+++ b/config/development.json
@@ -27,7 +27,7 @@
 	"discover_blog_id": 53424024,
 	"features": {
 		"code-splitting": true,
-		"server-side-rendering": true,
+		"server-side-rendering": false,
 
 		"reader": true,
 		"reader/teams": true,

--- a/config/development.json
+++ b/config/development.json
@@ -27,7 +27,7 @@
 	"discover_blog_id": 53424024,
 	"features": {
 		"code-splitting": true,
-		"server-side-rendering": false,
+		"server-side-rendering": true,
 
 		"reader": true,
 		"reader/teams": true,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -8,15 +8,15 @@ var express = require( 'express' ),
 	debug = require( 'debug' )( 'calypso:pages' ),
 	superagent = require( 'superagent' ),
 	React = require( 'react' ),
-	ReactDomServer = require( 'react-dom/server' );
+	ReactDomServer = require( 'react-dom/server' ),
+	ReactInjection = require( 'react/lib/ReactInjection' );
 
 var config = require( 'config' ),
 	sanitize = require( 'sanitize' ),
 	utils = require( 'bundler/utils' ),
 	sections = require( '../../client/sections' ),
-	LayoutLoggedOutDesign = require( 'layout/logged-out-design' );
+	i18n = require( 'lib/mixins/i18n');
 
-var LayoutLoggedOutDesignElement = React.createFactory( LayoutLoggedOutDesign )();
 var cachedDesignMarkup;
 
 var HASH_LENGTH = 10,
@@ -383,6 +383,13 @@ module.exports = function() {
 			// the user is probably logged in
 			renderLoggedInRoute( req, res );
 		} else {
+			i18n.initialize();
+			console.log( ReactInjection.Class.injectMixin( i18n.mixin ) );
+			console.log( 'i18n init done' );
+
+			const LayoutLoggedOutDesign = require( 'layout/logged-out-design' );
+			const LayoutLoggedOutDesignElement = React.createFactory( LayoutLoggedOutDesign )();
+
 			const context = getDefaultContext( req );
 
 			if ( config.isEnabled( 'server-side-rendering' ) ) {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -40,6 +40,25 @@ sections.forEach( function( section ) {
 	} );
 } );
 
+let languages = initLanguages();
+
+/**
+ * Build a map of language files.
+ */
+function initLanguages() {
+	let langMap = new Map();
+	config( 'languages' ).forEach( ( lang ) => {
+		const path = process.cwd() + `/server/lang/${ lang.langSlug }.json`;
+		try {
+			const langFile = fs.readFileSync( path );
+			langMap.set( lang.langSlug, JSON.parse( langFile.toString() ) );
+		} catch ( e ) {
+			debug( 'Could not read language file: ', path );
+		}
+	} );
+	return langMap;
+}
+
 /**
  * Generates a hash of a files contents to be used as a version parameter on asset requests.
  * @param {String} path Path to file we want to hash
@@ -384,8 +403,7 @@ module.exports = function() {
 			renderLoggedInRoute( req, res );
 		} else {
 			i18n.initialize();
-			console.log( ReactInjection.Class.injectMixin( i18n.mixin ) );
-			console.log( 'i18n init done' );
+			ReactInjection.Class.injectMixin( i18n.mixin );
 
 			const LayoutLoggedOutDesign = require( 'layout/logged-out-design' );
 			const LayoutLoggedOutDesignElement = React.createFactory( LayoutLoggedOutDesign )();


### PR DESCRIPTION
Addresses #186

Experimental for now. Excuse the branch name.

Components rendered on the server will need the [i18n mixin](https://github.com/Automattic/wp-calypso/tree/master/client/lib/mixins/i18n) to be initialized and injected.

This PR is exploring the approach of having the language files checked out to the container. Testing requires an SVN checkout of https://wpcom-i18n.svn.automattic.com/calypso/ to `server/lang`

Next steps:
- [ ] Determine the locale to use for the logged-out /design route from the `accept-language` request header
- [ ] do the `i18n.setLocale()` accordingly
- [ ] Add the SVN checkout to the Dockerfile