### PR TITLE
Help: Increase left padding on the help search results footers

### DIFF
--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -6,6 +6,12 @@
 .help-results__footer.card.is-compact {
 	padding: 8px 16px;
 }
+.help-results__footer.card.is-compact {
+	padding-left: 56px;
+	@include breakpoint( "<480px" ) {
+		padding-left: 48px;
+	}
+}
 
 .help-results__header {
 	font: 11px/16px $sans;
@@ -16,7 +22,6 @@
 }
 
 .help-results__footer {
-	padding-right: 56px;
 	font: 14px/24px $sans;
 	color: $gray;
 }


### PR DESCRIPTION
I've noticed that the search results footers on /help are aligned to the left instead of to the text above them:

![help-result-footer-padding-1](https://cloud.githubusercontent.com/assets/820374/12483426/458d45f4-c055-11e5-9857-0266c6b02db4.png)

Moving them a bit to the right makes them much easier to see and read (as it was proposed on the original design) so I've just added the left padding.

![help-result-footer-padding-2](https://cloud.githubusercontent.com/assets/820374/12483541/e7ff28fc-c055-11e5-90e6-3da97e996944.png)
