### PR TITLE
Reader: Add a link to comment author usernames

### DIFF
--- a/client/reader/comments/index.jsx
+++ b/client/reader/comments/index.jsx
@@ -13,7 +13,8 @@ var Gravatar = require( 'components/gravatar' ),
 	PostCommentForm = require( './form' ),
 	CommentLikeButtonContainer = require( './comment-likes' ),
 	stats = require( 'reader/stats' ),
-	PostCommentContent = require( './post-comment-content' );
+	PostCommentContent = require( './post-comment-content' ),
+	Gridicon = require( 'components/gridicon' );
 
 var PostComment = React.createClass( {
 
@@ -139,7 +140,10 @@ var PostComment = React.createClass( {
 			<li className={ 'comment depth-' + this.props.depth }>
 				<div className="comment__author">
 					<Gravatar user={ comment.author } />
-					<strong className="comment__username">{ comment.author.name }</strong>
+
+					{ comment.author.URL
+						? <a href={ comment.author.URL } target="_blank" className="comment__username">{ comment.author.name }<Gridicon icon="external" /></a>
+						: <strong className="comment__username">{ comment.author.name }</strong> }
 					<small className="comment__timestamp">
 						<a href={ comment.URL }>
 							<PostTime date={ comment.date } />

--- a/client/reader/comments/style.scss
+++ b/client/reader/comments/style.scss
@@ -139,6 +139,7 @@
 }
 
 .comment__author {
+	font-weight: bold;
 	color: darken( $gray, 30 );
 
 	.gravatar {
@@ -147,6 +148,18 @@
 			left: -41px;
 		border-radius: 48px;
 	}
+
+	.gridicon {
+		height: 16px;
+		fill: lighten( $gray, 10 );
+		margin-left: 2px;
+		position: relative;
+			top: 2px;
+	}
+
+	&:hover .gridicon {
+		fill: $link-highlight;
+	}
 }
 
 .comment__username {
@@ -154,10 +167,15 @@
 }
 
 .comment__timestamp a {
+	font-weight: normal;
 	font-size: 13px;
 	color: lighten( $gray, 10 );
 	margin-left: 8px;
 	text-decoration: none;
+
+	&:hover {
+		color: $link-highlight;
+	}
 }
 
 .comment__moderation {


### PR DESCRIPTION
![screen shot 2016-01-21 at 12 33 58 pm](https://cloud.githubusercontent.com/assets/191598/12488832/8385b1ee-c03b-11e5-94b2-c68a73c4974f.png)

Adding a link to the comment author’s site if it exists, along with an external icon. Also added a hover color to the comment timestamp link.

This aims to fix #981 