### PR TITLE
Reader: Auto-expand comment textarea

### DIFF
--- a/assets/stylesheets/layout/_detail-page.scss
+++ b/assets/stylesheets/layout/_detail-page.scss
@@ -34,10 +34,14 @@
 
 	.card {
 		margin: 0 auto;
-		min-height: 100vh;
 		background: transparent;
 		padding: 0;
 		box-shadow: none;
+		position: absolute;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
 	}
 }
 

--- a/client/reader/comments/form.jsx
+++ b/client/reader/comments/form.jsx
@@ -43,6 +43,14 @@ var PostCommentForm = React.createClass( {
 			event.preventDefault();
 			this.submit();
 		}
+
+		// Adjust the height of the textarea as needed.
+		var commentTextNode = this.refs.commentText;
+
+		setTimeout( function() {
+			commentTextNode.style.cssText = 'height: auto';
+			commentTextNode.style.cssText = 'height:' + commentTextNode.scrollHeight + 'px';
+		}, 0 );
 	},
 
 	handleKeyUp: function() {

--- a/client/reader/comments/form.jsx
+++ b/client/reader/comments/form.jsx
@@ -48,8 +48,8 @@ var PostCommentForm = React.createClass( {
 		var commentTextNode = this.refs.commentText;
 
 		setTimeout( function() {
-			commentTextNode.style.cssText = 'height: auto';
-			commentTextNode.style.cssText = 'height:' + commentTextNode.scrollHeight + 'px';
+			commentTextNode.style.height = 'auto';
+			commentTextNode.style.height = commentTextNode.scrollHeight + 'px';
 		}, 0 );
 	},
 

--- a/client/reader/comments/form.jsx
+++ b/client/reader/comments/form.jsx
@@ -32,6 +32,13 @@ var PostCommentForm = React.createClass( {
 		}
 	},
 
+	componentDidUpdate: function() {
+		const commentTextNode = this.refs.commentText,
+			commentText = this.getCommentText(),
+			currentHeight = parseInt( commentTextNode.style.height, 10 ) || 0;
+		commentTextNode.style.height = commentText.length ? Math.max( commentTextNode.scrollHeight, currentHeight ) + 'px' : null;
+	},
+
 	handleSubmit: function( event ) {
 		event.preventDefault();
 		this.submit();
@@ -43,14 +50,6 @@ var PostCommentForm = React.createClass( {
 			event.preventDefault();
 			this.submit();
 		}
-
-		// Adjust the height of the textarea as needed.
-		var commentTextNode = this.refs.commentText;
-
-		setTimeout( function() {
-			commentTextNode.style.height = 'auto';
-			commentTextNode.style.height = commentTextNode.scrollHeight + 'px';
-		}, 0 );
 	},
 
 	handleKeyUp: function() {

--- a/client/reader/comments/style.scss
+++ b/client/reader/comments/style.scss
@@ -34,7 +34,9 @@
 	}
 
 	textarea {
+		max-height: 400px;
 		min-height: 33px;
+		height: auto;
 		padding-right: 60px;
 		resize: vertical;
 		font-family: $serif;

--- a/client/reader/comments/style.scss
+++ b/client/reader/comments/style.scss
@@ -36,7 +36,7 @@
 	textarea {
 		max-height: 400px;
 		min-height: 33px;
-		height: auto;
+		height: 33px;
 		padding-right: 60px;
 		resize: vertical;
 		font-family: $serif;
@@ -46,7 +46,7 @@
 		opacity: 0;
 		position: absolute;
 		top: 4px;
-		right: 12px;
+		right: 16px;
 		padding: 4px;
 		font-size: 12px;
 		font-weight: 600;


### PR DESCRIPTION
![comment autoexpand](https://cloud.githubusercontent.com/assets/191598/12489517/b1436858-c03e-11e5-9717-47231cf34696.gif)

Adding a really basic way of expanding the comment textarea based on the scrollHeight. This makes it easier to write longer comments and aims to fix #695.