### PR TITLE
Start: Add theme selection to business/premium flows.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -35,7 +35,7 @@ const flows = {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
 		description: 'Create an account and a blog and then add the business plan to the users cart.',
-		lastModified: null
+		lastModified: '2016-01-21'
 	},
 
 	premium: {
@@ -44,7 +44,7 @@ const flows = {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
 		description: 'Create an account and a blog and then add the business plan to the users cart.',
-		lastModified: null
+		lastModified: '2016-01-21'
 	},
 
 	main: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -30,7 +30,7 @@ const flows = {
 	},
 
 	business: {
-		steps: [ 'domains', 'user' ],
+		steps: [ 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
@@ -39,7 +39,7 @@ const flows = {
 	},
 
 	premium: {
-		steps: [ 'domains', 'user' ],
+		steps: [ 'themes', 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},


### PR DESCRIPTION
The Marketing folks are working on a new landing page that focuses on how easy WordPress.com is and want to reference theme selection.

It’s weird that if the user chooses to go with a paid plan that step is not seen when there was a reference to it on the landing page.