### PR TITLE
Bust cache for `w.js` so that version matches rest of WordPress.com

### DIFF
--- a/client/analytics/index.js
+++ b/client/analytics/index.js
@@ -22,7 +22,7 @@ window.ga = window.ga || function() {
 };
 window.ga.l = +new Date();
 
-loadScript( '//stats.wp.com/w.js?49' );
+loadScript( '//stats.wp.com/w.js?50' );
 loadScript( '//www.google-analytics.com/analytics.js' );
 
 function buildQuerystring( group, name ) {


### PR DESCRIPTION
Same drill as a few days ago...

I recently made some changes to `w.js` in the WordPress.com codebase and need to update the version number in Calypso in order to bust the cache so that the same version as used by the rest of WordPress.com will be loaded.

The changes made to `w.js` don't affect its use in Calypso, so there is nothing specific to test other than that the most recent version of `w.js` is loaded.

/cc @jonathansadowski 