### PR TITLE
People: update the remove follower warning message

### DIFF
--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -69,7 +69,7 @@ let Followers = React.createClass( {
 				<p>
 				{
 					this.translate(
-						'If you remove this follower, he or she will not receive notifications about this site.'
+						'If you remove this follower, he or she will no longer receive notifications about this site unless they re-follow.'
 					)
 				}
 				</p>


### PR DESCRIPTION
Closes #2672

This pull request seeks to clarify the warning notice that appears after you remove a follower more clear so that it doesn't give site owners a false sense of privacy.

To test: 

1. Go to https://wordpress.com/people/followers and select a blog if prompted
1. Click "Remove" next to one of the followers
1. Check that the wording in the message has been updated to say:

```
If you remove this follower, he or she will no longer receive notifications about this site unless they re-follow.
```

![screen shot 2016-01-21 at thu jan 21 3 14 53 pm](https://cloud.githubusercontent.com/assets/1119271/12493179/e08ecfcc-c051-11e5-85b1-b47dfcb04ba8.png)