### PR TITLE
Fix/1275 disable disconnect link

### DIFF
--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -21,6 +21,7 @@ export default React.createClass( {
 		redirect: React.PropTypes.string.isRequired,
 		disabled: React.PropTypes.bool,
 		linkDisplay: React.PropTypes.bool,
+		isMock: React.PropTypes.bool,
 		text: React.PropTypes.string
 	},
 
@@ -48,6 +49,9 @@ export default React.createClass( {
 			scary: true,
 			onClick: ( event ) => {
 				event.preventDefault();
+				if ( this.props.isMock ) {
+					return;
+				}
 				this.refs.dialog.open();
 				analytics.ga.recordEvent( 'Jetpack', 'Clicked To Open Disconnect Jetpack Dialog' );
 			}

--- a/client/my-sites/plugins/plugin-activate-toggle/index.jsx
+++ b/client/my-sites/plugins/plugin-activate-toggle/index.jsx
@@ -67,6 +67,7 @@ module.exports = React.createClass( {
 						disabled={ this.props.disabled || ! this.props.plugin }
 						site={ this.props.site }
 						redirect="/plugins/jetpack"
+						isMock={ this.props.isMock }
 						/>
 				</PluginAction>
 			);

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -37,6 +37,7 @@ export default React.createClass( {
 		plugin: React.PropTypes.object.isRequired,
 		isInstalledOnSite: React.PropTypes.bool,
 		isPlaceholder: React.PropTypes.bool,
+		isMock: React.PropTypes.bool,
 	},
 
 	displayBanner() {
@@ -282,14 +283,14 @@ export default React.createClass( {
 						</div>
 						{ this.renderActions() }
 					</div>
-					<PluginInformation
+					{ ! this.props.isMock && <PluginInformation
 						isWpcomPlugin={ this.props.isWpcomPlugin }
 						plugin={ this.props.plugin }
 						isPlaceholder={ this.props.isPlaceholder }
 						site={ this.props.selectedSite }
 						pluginVersion={ plugin && plugin.version }
 						siteVersion={ this.props.selectedSite && this.props.selectedSite.options.software_version }
-						hasUpdate={ this.getAvailableNewVersions().length > 0 } />
+						hasUpdate={ this.getAvailableNewVersions().length > 0 } /> }
 
 				</Card>
 				{ this.getVersionWarning() }


### PR DESCRIPTION
Fixes #1275 

Remove the ability to navigate to the disconnect link. Also remove the plugin info component if the plugin is display the mock version. 
Prevents this from happening:
![screen shot 2016-01-21 at 14 21 09](https://cloud.githubusercontent.com/assets/115071/12496403/5cece728-c04a-11e5-9182-806defb1bda2.png)
After:
![screen shot 2016-01-21 at 14 21 22](https://cloud.githubusercontent.com/assets/115071/12496399/5991bbda-c04a-11e5-8e1b-e445c676cd59.png)

