### PR TITLE
client/state/ui/actions: Add setAllSitesSelected()

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -127,6 +127,7 @@ module.exports = {
 		// If the path fragment does not resemble a site, set all sites to visible
 		if ( ! siteID ) {
 			sites.selectAll();
+			context.store.dispatch( uiActions.setAllSitesSelected() );
 			return next();
 		}
 

--- a/client/state/ui/actions.js
+++ b/client/state/ui/actions.js
@@ -20,6 +20,19 @@ export function setSelectedSiteId( siteId ) {
 	};
 }
 
+/**
+ * Returns an action object to be used in signalling that all sites have been
+ * set as selected.
+ *
+ * @return {Object}        Action object
+ */
+export function setAllSitesSelected() {
+	return {
+		type: SELECTED_SITE_SET,
+		siteId: null
+	};
+}
+
 export function setSection( section, options = {} ) {
 	options.type = SET_SECTION;
 	if ( section ) {

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -6,7 +6,7 @@
  */
 export function getSelectedSite( state ) {
 	if ( ! state.ui.selectedSiteId ) {
-		return null;
+		return false;
 	}
 
 	return state.sites.items[ state.ui.selectedSiteId ];

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -10,14 +10,14 @@ import { getSelectedSite } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#getSelectedSite()', () => {
-		it( 'should return null if no site is selected', () => {
+		it( 'should return false if no site is selected', () => {
 			const selected = getSelectedSite( {
 				ui: {
-					selectedSiteId: null
+					selectedSiteId: false
 				}
 			} );
 
-			expect( selected ).to.be.null;
+			expect( selected ).to.be.false;
 		} );
 
 		it( 'should return the object for the selected site', () => {


### PR DESCRIPTION
Call that function inside my-sites/controller if no site has been
selected for functionial parity with sites-list's selectAll()
(which is called in the same place).

Also, have the corresponding selectors' getSelectedSite() return
false instead of null, so that trying to obtain any object attributes
will yield undefined instead of a TypeError (again for parity).

Required for #2657. Read testing instructions there and test that branch without this commit applied to see what fails.

No visual changes. To test: Verifiy that switching sites via the site selector still works as expected, in particular for those sections that use the `client/state/ui` Redux store/actions/selectors already.

Pinging @aduth for review :-)