### PR TITLE
Reader: make the unauthorized error message appear below the "Oops!" heading

### DIFF
--- a/client/reader/following-stream/post-unavailable.jsx
+++ b/client/reader/following-stream/post-unavailable.jsx
@@ -16,13 +16,13 @@ var PostUnavailable = React.createClass( {
 
 	componentWillMount: function() {
 		this.errors = {
-			403: this.translate( 'This is a private site. You’re following the site, but not currently a member. Please request membership to display these posts in Reader.' ),
-			default: this.translate( 'An error occurred loading this post' )
+			unauthorized: this.translate( 'This is a post on a private site that you’re following, but not currently a member of. Please request membership to display these posts in Reader.' ),
+			default: this.translate( 'An error occurred loading this post.' )
 		};
 	},
 
 	render: function() {
-		var errorMessage = this.errors[ this.props.post.statusCode || 'default' ];
+		var errorMessage = this.errors[ this.props.post.errorCode || 'default' ] || this.errors.default;
 
 		if ( this.props.post.statusCode === 404 ) {
 			// don't render a card for 404s. These are posts that we once had but were deleted.


### PR DESCRIPTION
This pull request seeks to make the unauthorized error message appear below the "Oops!" heading as it should when someone tries to view a post in the Reader for a private site they are not authorized to see.

See 8753-gh-calypso-pre-oss for testing steps.

Before:

![screen shot 2016-01-21 at thu jan 21 7 19 53 pm](https://cloud.githubusercontent.com/assets/1119271/12499278/23b9f3a6-c077-11e5-8a5d-121daf28ab91.png)

After:

![screen shot 2016-01-21 at thu jan 21 7 41 31 pm](https://cloud.githubusercontent.com/assets/1119271/12499282/29d5d944-c077-11e5-82ef-5f21927cd604.png)

or with `"reader/full-errors": true` (i.e. local Calypso install)

![screen shot 2016-01-21 at thu jan 21 7 44 55 pm](https://cloud.githubusercontent.com/assets/1119271/12499329/9552574c-c077-11e5-83d0-348789a078b6.png)