### PR TITLE
Plugins: Show placeholder unless the site is loaded loading anymore.

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -464,11 +464,7 @@ SitesList.prototype.getSelectedOrAllJetpackCanManage = function() {
 };
 
 SitesList.prototype.getSelectedOrAllWithPlugins = function() {
-	return this.getSelectedOrAll().concat(
-		this.getSelectedOrAll().filter( function( site ) {
-			return isBusiness( site.plan );
-		} )
-	);
+	return this.getSelectedOrAll().filter( site => ( isBusiness( site.plan ) || site.jetpack ) && ( site.visible || this.selected ) );
 };
 
 SitesList.prototype.hasSiteWithPlugins = function() {

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -107,9 +107,8 @@ export default React.createClass( {
 	},
 
 	getPluginsState( nextProps ) {
-		const sites = this.state && this.state.bulkManagement ? this.props.sites.getSelectedOrAllWithPlugins() : this.props.sites.getSelectedOrAll(),
+		const sites = this.props.sites.getSelectedOrAllWithPlugins(),
 			pluginUpdate = PluginsStore.getPlugins( sites, 'updates' );
-
 		return {
 			accessError: pluginsAccessControl.hasRestrictedAccess(),
 			plugins: this.getPluginsFromStore( nextProps, sites ),
@@ -244,7 +243,7 @@ export default React.createClass( {
 				emptyContentData = this.getEmptyContentUpdateData();
 				break;
 			default:
-				emptyContentData.title = this.translate( 'No plugins match that filter.', { textOnly: true } );
+				return null;
 		}
 		return emptyContentData;
 	},
@@ -275,7 +274,7 @@ export default React.createClass( {
 		const plugins = this.state.plugins || [];
 		const selectedSite = this.props.sites.getSelectedSite();
 
-		if ( isEmpty( plugins ) ) {
+		if ( isEmpty( plugins ) && ! this.isFetchingPlugins() ) {
 			if ( this.props.search ) {
 				return <NoResults text={ this.translate( 'No plugins match your search for {{searchTerm/}}.', {
 					textOnly: true,
@@ -283,13 +282,14 @@ export default React.createClass( {
 				} ) } />
 			}
 
-			let emptyContentData = this.getEmptyContentData();
-			return ( <EmptyContent
-				title={ emptyContentData.title }
-				illustration={ emptyContentData.illustration }
-				actionURL={ emptyContentData.actionURL }
-				action={ emptyContentData.action } />
-			);
+			const emptyContentData = this.getEmptyContentData();
+			if ( emptyContentData ) {
+				return <EmptyContent
+					title={ emptyContentData.title }
+					illustration={ emptyContentData.illustration }
+					actionURL={ emptyContentData.actionURL }
+					action={ emptyContentData.action } />
+			}
 		}
 		return (
 			<div className="plugins__lists">


### PR DESCRIPTION
Currently when the plugins list loads you will notice that no plugin placeholders show up. 

Before:
![screen shot 2016-01-21 at 18 35 31](https://cloud.githubusercontent.com/assets/115071/12501049/cf42ca0e-c06d-11e5-9846-c2844e9d97da.png)

After:
![screen shot 2016-01-21 at 18 36 38](https://cloud.githubusercontent.com/assets/115071/12501062/f4535c6e-c06d-11e5-8fa1-7b8d668f7092.png)

To test visit 
http://calypso.localhost:3000/plugins and notice all the placeholders.
Try visiting different sites. both buisness, visible and jetpack sites. 
and the different tabs. 

The behaviour should be the same across. 

cc: @johnHackworth 

Also fixes #820 