### PR TITLE
Help: adjust chatbox height and width when on contact form

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -275,12 +275,18 @@ module.exports = React.createClass( {
 		}
 	},
 
+	canShowChatbox: function() {
+		const { olark, isChatEnded } = this.state;
+
+		return isChatEnded || ( olark.details.isConversing && olark.isOperatorAvailable );
+	},
+
 	/**
 	 * Get the view for the contact page. This could either be the olark chat widget if a chat is in progress or a contact form.
 	 * @return {object} A JSX object that should be rendered
 	 */
 	getView: function() {
-		const { olark, confirmation, sitesInitialized, isSubmitting, isChatEnded } = this.state;
+		const { olark, confirmation, sitesInitialized, isSubmitting } = this.state;
 		const showChatVariation = olark.isUserEligible && olark.isOperatorAvailable;
 		const showKayakoVariation = ! showChatVariation && ( olark.details.isConversing || olark.isUserEligible );
 		const showForumsVariation = ! ( showChatVariation || showKayakoVariation );
@@ -304,7 +310,7 @@ module.exports = React.createClass( {
 			);
 		}
 
-		if ( isChatEnded || ( olark.details.isConversing && olark.isOperatorAvailable ) ) {
+		if ( this.canShowChatbox() ) {
 			return <OlarkChatbox />;
 		}
 
@@ -352,7 +358,7 @@ module.exports = React.createClass( {
 		return (
 			<Main className="help-contact">
 				<HeaderCake onClick={ this.backToHelp } isCompact={ true }>{ this.translate( 'Contact Us' ) }</HeaderCake>
-				<Card>
+				<Card className={ this.canShowChatbox() ? 'help-contact__chat-form' : 'help-contact__form' }>
 					{ this.getView() }
 				</Card>
 			</Main>

--- a/client/me/help/help-contact/style.scss
+++ b/client/me/help/help-contact/style.scss
@@ -15,3 +15,43 @@
 		margin-bottom: 32px;
 	}
 }
+
+.help-contact__chat-form {
+	padding: 0px;
+
+	#habla_conversation_div {
+		// Use !important here because olark sets the height in the style attribute for this element
+		height: calc( 100vh - 220px ) !important;
+		min-height: 167px;
+
+		@include breakpoint( ">660px" ) {
+			max-height: 625px;
+		}
+	}
+
+	#habla_window_div {
+		#habla_expanded_div {
+			border: none;
+		}
+
+		#habla_chatform_form {
+			margin-top: 0px;
+		}
+
+		#habla_input_div {
+			/* Stretch the text area to the sides of the contact form */
+			margin-right: -8px;
+			margin-left: -8px;
+			margin-bottom: -6px;
+		}
+
+		#habla_wcsend_input {
+			border: none;
+			resize: none;
+		}
+
+		#habla_middle_div {
+			padding-bottom: 0px;
+		}
+	}
+}


### PR DESCRIPTION
This pull request does a portion of the work outlined to restyle the olark chat. It simply makes the inlined chat widget full height/width with the contact form. 

#### Before:
![screen shot 2016-01-21 at 10 56 03 pm](https://cloud.githubusercontent.com/assets/1854440/12502023/4573ca60-c092-11e5-8f4c-5f09fb4b87b1.png)

#### After:
![screen shot 2016-01-21 at 10 53 34 pm](https://cloud.githubusercontent.com/assets/1854440/12501997/f07b77b0-c091-11e5-9d72-4f40e996befc.png)

#### Original design:
![chat-full1](https://cloud.githubusercontent.com/assets/1854440/12501942/48c6f56c-c091-11e5-9efd-58212a1c7d7a.png)