### PR TITLE
Code of Conduct: link to a contact form instead of using an email.

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -19,7 +19,7 @@ By adopting this Code of Conduct, project maintainers commit themselves to fairl
 
 This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing a project maintainer at developers@wordpress.com with a subject that includes `Code of Conduct`. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by emailing a project maintainer via [this contact form](https://developer.wordpress.com/contact/?g21-subject=Code%20of%20Conduct), with a subject that includes `Code of Conduct`. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.3.0, available at [http://contributor-covenant.org/version/1/3/0/][version]


### PR DESCRIPTION
Related: #1406, #2675

Using a contact form instead of an email address has a few advantages:
- It makes it easier for anyone who would want to contact us. No need to open an email client anymore.
- It allows us to automatically pre-fill the subject line with `Code of Conduct`
- It's a bit harder for spammers to harvest that email address.