### PR TITLE
Jetpack-plans: Plugins install scaffolding

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -15,6 +15,7 @@ var route = require( 'lib/route' ),
 	notices = require( 'notices' ),
 	sites = require( 'lib/sites-list' )(),
 	analytics = require( 'analytics' ),
+	PlanSetup = require( './plan-setup' ),
 	PluginListComponent = require( './main' ),
 	PluginComponent = require( './plugin' ),
 	PluginBrowser = require( './plugins-browser' ),
@@ -156,6 +157,16 @@ function renderPluginsBrowser( context, siteUrl ) {
 	);
 }
 
+function renderProvisionPlugins() {
+	let site = sites.getSelectedSite();
+	ReactDom.render(
+		React.createElement( PlanSetup, {
+			selectedSite: site,
+		} ),
+		document.getElementById( 'primary' )
+	);
+}
+
 controller = {
 
 	plugins: function( filter, context ) {
@@ -206,6 +217,9 @@ controller = {
 			}
 		}
 		next();
+	},
+	setupPlugins: function() {
+		renderProvisionPlugins();
 	}
 
 };

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -16,6 +16,11 @@ module.exports = function() {
 		page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 	}
 
+	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
+		page( '/plugins/setup', controller.siteSelection, controller.navigation, pluginsController.setupPlugins );
+		page( '/plugins/setup/:site', controller.siteSelection, controller.navigation, pluginsController.setupPlugins );
+	}
+
 	if ( config.isEnabled( 'manage/plugins' ) ) {
 		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
 		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {

--- a/client/my-sites/plugins/plan-setup/index.jsx
+++ b/client/my-sites/plugins/plan-setup/index.jsx
@@ -1,0 +1,58 @@
+/**
+* External dependencies
+*/
+import React from 'react'
+
+/**
+* Internal dependencies
+*/
+import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+
+module.exports = React.createClass( {
+
+	displayName: 'PlanSetup',
+
+	getInitialState: function() {
+		return {
+			keys: {},
+			status: 'not-started', // installing $plugin, configuring $plugin, finished, error
+		};
+	},
+
+	renderNoManageWarning() {
+		return (
+			<JetpackManageErrorPage
+				site={ this.props.selectedSite }
+				template={ 'optInManage' }
+				title={ this.translate( 'Oh no! We can\'t automatically install your new plugins.' ) }
+			section={ 'plugins' }
+				illustration={ '/calypso/images/jetpack/jetpack-manage.svg' } />
+		);
+	},
+
+	renderNoJetpackSiteSelected() {
+		return (
+			<JetpackManageErrorPage
+				site={ this.props.selectedSite }
+				title={ this.translate( 'Oh no! You need to select a jetpack site to be able to setup your plan' ) }
+				illustration={ '/calypso/images/jetpack/jetpack-manage.svg' } />
+		);
+	},
+
+	render() {
+		if ( ! this.props.selectedSite || ! this.props.selectedSite.jetpack ) {
+			return this.renderNoJetpackSiteSelected();
+		}
+		if ( ! this.props.selectedSite.canManage() ) {
+			return this.renderNoManageWarning();
+		}
+		return (
+			<div>
+				<h1>Setting up your plan…</h1>
+				<p>Most of this will happen automatically, in steps, so we can notify the user what&apos;s happening</p>
+				<p>Currently… { this.state.status }</p>
+			</div>
+		)
+	}
+
+} );

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -41,6 +41,7 @@
 		"manage/plugins": false,
 		"manage/plugins/browser": false,
 		"manage/plugins/cache": false,
+		"manage/plugins/setup": false,
 		"manage/customize": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -39,6 +39,7 @@
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
+		"manage/plugins/setup": false,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/sharing": true,

--- a/config/development.json
+++ b/config/development.json
@@ -57,6 +57,7 @@
 		"manage/plugins/browser": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/plugins/cache": false,
+		"manage/plugins/setup": true,
 
 		"manage/export": true,
 		"manage/security": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,6 +35,7 @@
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/browser": true,
+		"manage/plugins/setup": false,
 		"manage/customize": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,

--- a/config/production.json
+++ b/config/production.json
@@ -32,6 +32,7 @@
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
+		"manage/plugins/setup": false,
 		"manage/posts": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,6 +38,7 @@
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
+		"manage/plugins/setup": false,
 		"manage/security": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/posts": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -36,6 +36,7 @@
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
+		"manage/plugins/setup": false,
 		"manage/customize": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,


### PR DESCRIPTION
This PR is an attemp to make https://github.com/Automattic/wp-calypso/pull/2244 a little lighter. It doesn't add anything that can be seen by any user yet. It just creates all the routes, controllers & paths needed for starting to work on jetpack plans plugin automattic configuration.

The only things you can test is:
· http://calypso.dev:3000/plugins/setup works and takes you to a jetpack error page
· http://calypso.dev:3000/plugins/setup/some-not-jetpack-site works and takes you to a jetpack error page
· http://calypso.dev:3000/plugins/setup/jetpack-site-without-manage-on works and takes you to a jetpack 'enable manage' error page
· http://calypso.dev:3000/plugins/setup/jetpack-site-with-manage-on works and shows some (not yet real) message about installing plugins

/cc @ryelle @roccotripaldi @oskosk 