### PR TITLE
Checkout: Make sure it is not possible to purchase any plan when checkout flag disabled

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -213,15 +213,15 @@ module.exports = React.createClass( {
 				</button>
 
 				<small className="plan-actions__trial-period">
-					{ config.isEnabled( 'upgrades/checkout' ) ?
-						this.translate( 'Try it free for 14 days, no credit card needed, or {{a}}upgrade now{{/a}}.', {
+					{ config.isEnabled( 'upgrades/checkout' )
+						? this.translate( 'Try it free for 14 days, no credit card needed, or {{a}}upgrade now{{/a}}.', {
 							context: 'Store action',
 							components: {
 								a: <a href="#"
 									onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'link' ) } />
 							}
-						} ) :
-						this.translate( 'Try it free for 14 days, no credit card needed.' )
+						} )
+						: this.translate( 'Try it free for 14 days, no credit card needed.' )
 					}
 				</small>
 			</div>
@@ -289,7 +289,7 @@ module.exports = React.createClass( {
 				'Like what you see? {{link}}Upgrade Now{{/link}}',
 				{
 					components: {
-						link: <a href='#'
+						link: <a href="#"
 							className="plan-actions__trial-upgrade-now"
 							onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'link' ) } />
 					}

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -8,6 +8,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
+	config = require( 'config' ),
 	productsValues = require( 'lib/products-values' ),
 	isFreePlan = productsValues.isFreePlan,
 	isBusiness = productsValues.isBusiness,
@@ -76,6 +77,10 @@ module.exports = React.createClass( {
 			return this.freePlanButton();
 		}
 
+		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
+			return null;
+		}
+
 		if ( this.props.sitePlan && this.props.sitePlan.freeTrial ) {
 			label = this.translate( 'Purchase Now' );
 		} else {
@@ -140,6 +145,10 @@ module.exports = React.createClass( {
 	},
 
 	canSelectPlan: function() {
+		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
+			return false;
+		}
+
 		if ( this.props.site ) {
 			if ( this.siteHasThisPlan() ) {
 				return false;
@@ -204,12 +213,16 @@ module.exports = React.createClass( {
 				</button>
 
 				<small className="plan-actions__trial-period">
-					{ this.translate( 'Try it free for 14 days, no credit card needed, or {{a}}upgrade now{{/a}}.', {
-						context: 'Store action',
-						components: {
-							a: <a href="#"
-								onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'link' ) } />
-						} } ) }
+					{ config.isEnabled( 'upgrades/checkout' ) ?
+						this.translate( 'Try it free for 14 days, no credit card needed, or {{a}}upgrade now{{/a}}.', {
+							context: 'Store action',
+							components: {
+								a: <a href="#"
+									onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'link' ) } />
+							}
+						} ) :
+						this.translate( 'Try it free for 14 days, no credit card needed.' )
+					}
 				</small>
 			</div>
 		);
@@ -251,37 +264,44 @@ module.exports = React.createClass( {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Current Plan' );
 	},
 
-	getTrialPlanHint: function() {
-		var remainingDays = this.moment(
+	getTrialPlanHint() {
+		const remainingDays = this.moment(
 				this.props.sitePlan.expiry
-			).diff( this.moment(), 'days' ),
-			translationComponents = {
-				strong: <strong />,
-				link: <a href='#'
-					className="plan-actions__trial-upgrade-now"
-					onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'link' ) } />
-			},
-			hint;
+			).diff( this.moment(), 'days' );
+		let hint, upgradePrompt;
 
 		if ( remainingDays === 0 ) {
-			hint = this.translate(
-				'{{strong}}Your trial ends today.{{/strong}} Like what you see? {{link}}Upgrade Now{{/link}}',
-				{ components: translationComponents }
-			);
+			hint = this.translate( 'Your trial ends today.' );
 		} else {
 			hint = this.translate(
-				'{{strong}}Your trial ends in %(days)d day.{{/strong}} Like what you see? {{link}}Upgrade Now{{/link}}',
-				'{{strong}}Your trial ends in %(days)d days.{{/strong}} Like what you see? {{link}}Upgrade Now{{/link}}',
+				'Your trial ends in %(days)d day.',
+				'Your trial ends in %(days)d days.',
 				{
 					args: { days: remainingDays },
-					count: remainingDays,
-					components: translationComponents
+					count: remainingDays
+				}
+			);
+		}
+
+		if ( config.isEnabled( 'upgrades/checkout' ) ) {
+			hint += ' ';
+			upgradePrompt = this.translate(
+				'Like what you see? {{link}}Upgrade Now{{/link}}',
+				{
+					components: {
+						link: <a href='#'
+							className="plan-actions__trial-upgrade-now"
+							onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'link' ) } />
+					}
 				}
 			);
 		}
 
 		return (
-			<div className="plan-actions__trial-hint">{ hint }</div>
+			<div className="plan-actions__trial-hint">
+				<strong>{ hint }</strong>
+				{ upgradePrompt }
+			</div>
 		);
 	},
 

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -264,54 +264,9 @@ module.exports = React.createClass( {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Current Plan' );
 	},
 
-	getTrialPlanHint() {
-		const remainingDays = this.moment(
-				this.props.sitePlan.expiry
-			).diff( this.moment(), 'days' );
-		let hint, upgradePrompt;
-
-		if ( remainingDays === 0 ) {
-			hint = this.translate( 'Your trial ends today.' );
-		} else {
-			hint = this.translate(
-				'Your trial ends in %(days)d day.',
-				'Your trial ends in %(days)d days.',
-				{
-					args: { days: remainingDays },
-					count: remainingDays
-				}
-			);
-		}
-
-		if ( config.isEnabled( 'upgrades/checkout' ) ) {
-			hint += ' ';
-			upgradePrompt = this.translate(
-				'Like what you see? {{link}}Upgrade Now{{/link}}',
-				{
-					components: {
-						link: <a href="#"
-							className="plan-actions__trial-upgrade-now"
-							onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'link' ) } />
-					}
-				}
-			);
-		}
-
-		return (
-			<div className="plan-actions__trial-hint">
-				<strong>{ hint }</strong>
-				{ upgradePrompt }
-			</div>
-		);
-	},
-
 	getCurrentPlanHint: function() {
 		if ( ! this.props.sitePlan ) {
 			return;
-		}
-
-		if ( this.props.sitePlan.freeTrial ) {
-			return this.getTrialPlanHint();
 		}
 
 		return (

--- a/client/my-sites/plans/plan-overview/plan-status/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/index.jsx
@@ -11,6 +11,7 @@ import page from 'page';
 import Button from 'components/button';
 import { cartItems } from 'lib/cart-values';
 import CompactCard from 'components/card/compact';
+import config from 'config';
 import Gridicon from 'components/gridicon';
 import { getDaysUntilUserFacingExpiry, isInGracePeriod } from 'lib/plans';
 import Notice from 'components/notice';
@@ -60,6 +61,21 @@ const PlanStatus = React.createClass( {
 		}
 	},
 
+	renderPurchaseButton() {
+		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
+			return null;
+		}
+
+		return (
+			<Button
+				className="plan-status__button"
+				onClick={ this.purchasePlan }
+				primary>
+				{ this.translate( 'Purchase Now' ) }
+			</Button>
+		);
+	},
+
 	render() {
 		const { plan } = this.props,
 			iconClasses = classNames( 'plan-status__icon', {
@@ -90,12 +106,7 @@ const PlanStatus = React.createClass( {
 						{ this.renderNotice() }
 					</div>
 
-					<Button
-						className="plan-status__button"
-						onClick={ this.purchasePlan }
-						primary>
-						{ this.translate( 'Purchase Now' ) }
-					</Button>
+					{ this.renderPurchaseButton() }
 				</CompactCard>
 
 				{ ! isInGracePeriod( plan ) && <PlanProgress plan={ plan } /> }

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -47,8 +47,8 @@
 		"manage/themes": true,
 		"manage/themes-jetpack": true,
 		"manage/sharing": true,
-		"manage/plans": false,
-		"manage/jetpack-plans": false,
+		"manage/plans": true,
+		"manage/jetpack-plans": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,
 


### PR DESCRIPTION
Part of #291.

This PR makes sure it's possible to hide the following features (including buttons & links) behind flags:
* [x] Plans

The main goal of this task is to make sure we can proceed with Mac App Store app verification process, which requires that we don't use our current checkout flow at all. We can always improve UX when we are about to release app in the App Store. I'd like to focus on quick app approval first.

### Testing
Make sure you have plan trial activated for any of your sites.

1. Disable the following flags in the config file:
 * `upgrades/checkout`
2. Execute `make run` and go to http://calypso.localhost:3000/.
3. Go to My Sites.
4. Select a Site without any plan.
5. Go to Plans page.
6. You shouldn't see buttons that allow to purchase plan.
7. Go to Compare Plans page.
8. You shouldn't see buttons that allow to purchase plan.
9. Select a Site with premium or business plan.
10. Go to Plans page.
11. You shouldn't see buttons that allow to purchase plan.
12. Go to Compare Plans page.
13. You shouldn't see buttons that allow to purchase plan.
14. Select a Site with plan trial active.
15. You shouldn't see buttons that allow to purchase plan.

Now enable flags listed in (1) and repeat all other steps, you should see all action buttons and links :)

### Review
* [ ] product
* [x] code