### PR TITLE
Stats: move stats-module

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -8,17 +8,17 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var toggle = require( './mixin-toggle' ),
-	skeleton = require( './mixin-skeleton' ),
+var toggle = require( '../mixin-toggle' ),
+	skeleton = require( '../mixin-skeleton' ),
 	observe = require( 'lib/mixins/data-observe' ),
-	ErrorPanel = require( './stats-error' ),
-	InfoPanel = require( './info-panel' ),
-	StatsList = require( './stats-list' ),
-	StatsListLegend = require( './stats-list/legend' ),
-	DownloadCsv = require( './stats-download-csv' ),
-	DatePicker = require( './stats-date-picker' ),
+	ErrorPanel = require( '../stats-error' ),
+	InfoPanel = require( '../info-panel' ),
+	StatsList = require( '../stats-list' ),
+	StatsListLegend = require( '../stats-list/legend' ),
+	DownloadCsv = require( '../stats-download-csv' ),
+	DatePicker = require( '../stats-date-picker' ),
 	Card = require( 'components/card' ),
-	StatsModulePlaceholder = require( './stats-module/placeholder' ),
+	StatsModulePlaceholder = require( './placeholder' ),
 	Gridicon = require( 'components/gridicon' );
 
 module.exports = React.createClass( {


### PR DESCRIPTION
Quick branch that moves `stats-module.jsx` into the `stats-module` directory.  A follow-up PR will include a full refactor of this component.

__To Test__
The stats-module powers most of the stats list-based components.  To test, open up a site stats page and verify all the components render properly.