### PR TITLE
Themes: Fix always showing all themes regardless of route

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -37,7 +37,7 @@ const ThemesSelection = React.createClass( {
 
 	getInitialState: function() {
 		return {
-			tier: this.props.tier || config.isEnabled( 'upgrades/premium-themes' ) ? 'all' : 'free'
+			tier: this.props.tier || ( config.isEnabled( 'upgrades/premium-themes' ) ? 'all' : 'free' )
 		};
 	},
 


### PR DESCRIPTION
Infix sux.

### To reproduce bug
1. _Manually_ navigate to `/design/type/free`
2. Expect to only see free themes
3. Succumb to the disappointment of a lifetime