### PR TITLE
Adding full-post styles for Discover's intro class

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -327,17 +327,16 @@
 
 		&:first-child:first-letter {
 			float: left;
-			font-size: 60px;
-			font-weight: 400;
-			line-height: 0.5em;
-			margin-top: 0.4em;
-			margin-right: 0.15em;
+			margin: 21px 12px 0 0;
+			font-size: 66px;
+		    font-weight: 400;
+		    line-height: 0.5;
 		}
 
 		// Firefox-only position fix
 		@-moz-document url-prefix() {
 			&:first-child:first-letter {
-				margin-top: 0.25em;
+				margin-top: 8px;
 			}
 		}
 	}

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -324,5 +324,21 @@
 		font-size: 20px;
 	    font-weight: 700;
 	    margin: 0 0 24px 0;
+
+		&:first-child:first-letter {
+			float: left;
+			font-size: 60px;
+			font-weight: 400;
+			line-height: 0.5em;
+			margin-top: 0.4em;
+			margin-right: 0.15em;
+		}
+
+		// Firefox-only position fix
+		@-moz-document url-prefix() {
+			&:first-child:first-letter {
+				margin-top: 0.25em;
+			}
+		}
 	}
 }

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -316,3 +316,13 @@
 .is-next-post-teaser {
 	display: none;
 }
+
+// Discover-Specific Full Post View Styles
+.blog-53424024 .reader__full-post-content {
+
+	.intro {
+		font-size: 20px;
+	    font-weight: 700;
+	    margin: 0 0 24px 0;
+	}
+}


### PR DESCRIPTION
Adding an “intro” style to Discover’s full post views in the Reader.
This is meant to mimic intro text hierarchy styles used on discover.wordpress.com. Only applies to the full post view for Discover (blog id 53424024). This class visually matches the current .reader__full-post-content h3 style.

We'd previously been using h tags to emulate this style in the Reader, but that's not a semantic approach. 

You can test this branch by viewing the full post view for two recent Discover features. Both these posts use <p class="intro"> tags for their first paragraph.

Example Post: https://discover.wordpress.com/2016/01/21/fennabee/
Full Post View: http://calypso.localhost:3000/read/post/id/53424024/9037

Example Post 2: https://discover.wordpress.com/2016/01/19/can-comedy-be-comfortable/
Full Post View 2: http://calypso.localhost:3000/read/post/id/53424024/8589

cc @shaunandrews