### PR TITLE
ui/selectors: Return null if no/all sites are selected

### DIFF
--- a/client/my-sites/themes/main.jsx
+++ b/client/my-sites/themes/main.jsx
@@ -183,7 +183,7 @@ export default connect(
 		{
 			queryParams: ThemesListSelectors.getQueryParams( state ),
 			themesList: ThemesListSelectors.getThemesList( state ),
-			selectedSite: getSelectedSite( state ),
+			selectedSite: getSelectedSite( state ) || false,
 			isLoggedOut: ! getCurrentUser( state )
 		}
 	)

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -6,7 +6,7 @@
  */
 export function getSelectedSite( state ) {
 	if ( ! state.ui.selectedSiteId ) {
-		return false;
+		return null;
 	}
 
 	return state.sites.items[ state.ui.selectedSiteId ];

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -10,14 +10,14 @@ import { getSelectedSite } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#getSelectedSite()', () => {
-		it( 'should return false if no site is selected', () => {
+		it( 'should return null if no site is selected', () => {
 			const selected = getSelectedSite( {
 				ui: {
-					selectedSiteId: false
+					selectedSiteId: null
 				}
 			} );
 
-			expect( selected ).to.be.false;
+			expect( selected ).to.be.null;
 		} );
 
 		it( 'should return the object for the selected site', () => {


### PR DESCRIPTION
It's more semantically correct this way. This means we will no longer
able to rely on `getSelectedSite( state ).someAttribute` to return `undefined`
but need to guard manually against TypeErrors from happening.

No visual changes. To test -- verify that everything still works as expected, in particular the Theme Showcase (single-site, multi-site, and logged-out).

Pinging @aduth for review, per discussion at https://github.com/Automattic/wp-calypso/pull/2657#discussion_r50544162