### PR TITLE
Framework: Update node-phone version

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "morgan": "1.2.0",
     "node-sass": "3.4.2",
     "page": "1.6.1",
-    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-6",
+    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-8",
     "photon": "1.0.4",
     "q": "1.0.1",
     "qrcode.react": "0.5.2",


### PR DESCRIPTION
The latest version of node-phone fixes an issue where 7-digit mobile
Estonian phone numbers were rejected.

To test:
- Checkout `fix/estonia-7-digit-node-phone`
- Restart node server `make run` to pull down changes in modules
- Go to `/me/security/two-step`
- If 2fa is enabled, disable
- Click “Get Started” button
- Select “Estonia (+372)” for country and enter “5555555” for the number
- Click “Verify via App” button (don’t verify via SMS which will send a
verification SMS to that number)
- Ensure that no error is presented