### PR TITLE
Checkout: Fix swapped help links

### DIFF
--- a/client/my-sites/upgrades/checkout/terms-of-service.jsx
+++ b/client/my-sites/upgrades/checkout/terms-of-service.jsx
@@ -30,8 +30,8 @@ module.exports = React.createClass( {
 				'By checking out, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{purchasesLink}}how your subscription works{{/purchasesLink}} and {{cancelLink}}how to cancel{{/cancelLink}}.', {
 				components: {
 					tosLink: <a href="//wordpress.com/tos/" target="_blank" />,
-					cancelLink: <a href="//support.wordpress.com/auto-renewal/" target="_blank" />,
-					purchasesLink: <a href="//support.wordpress.com/manage-purchases/" target="_blank" />
+					cancelLink: <a href="//support.wordpress.com/manage-purchases/" target="_blank" />,
+					purchasesLink: <a href="//support.wordpress.com/auto-renewal/" target="_blank" />
 				}
 			} );
 		}


### PR DESCRIPTION
Fixes swapped links on the checkout page introduced in https://github.com/Automattic/wp-calypso/pull/2293. 