### PR TITLE
NOTICES Move timeouts from actions to lifecycle methods

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -111,6 +111,7 @@ const NoticesList = React.createClass( {
 				<Notice
 					key={ 'notice-' + index }
 					status={ notice.status }
+					duration = { notice.duration || null }
 					showDismiss={ notice.showDismiss }
 					onDismissClick={ this.props.removeNotice.bind( this, notice.noticeId ) }
 					text={ notice.text }>

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -12,9 +12,11 @@ import Gridicon from 'components/gridicon';
 
 export default React.createClass( {
 	displayName: 'Notice',
+	dismissTimeout: null,
 
 	getDefaultProps() {
 		return {
+			duration: null,
 			status: 'is-info',
 			showDismiss: true,
 			className: '',
@@ -33,6 +35,18 @@ export default React.createClass( {
 		] ),
 		icon: PropTypes.string,
 		className: PropTypes.string
+	},
+
+	componentDidMount() {
+		if ( this.props.duration > 0 ) {
+			this.dismissTimeout = setTimeout( this.props.onDismissClick, this.props.duration );
+		}
+	},
+
+	componentWillMount() {
+		if ( this.dismissTimeout ) {
+			clearTimeout( this.dismissTimeout );
+		}
 	},
 
 	renderChildren() {

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -16,7 +16,7 @@ export default React.createClass( {
 
 	getDefaultProps() {
 		return {
-			duration: null,
+			duration: 0,
 			status: 'is-info',
 			showDismiss: true,
 			className: '',
@@ -29,6 +29,7 @@ export default React.createClass( {
 		status: PropTypes.string,
 		showDismiss: PropTypes.bool,
 		isCompact: PropTypes.bool,
+		duration: React.PropTypes.number,
 		text: PropTypes.oneOfType( [
 			PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 			PropTypes.arrayOf( PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ) )
@@ -43,7 +44,7 @@ export default React.createClass( {
 		}
 	},
 
-	componentWillMount() {
+	componentWillUnmount() {
 		if ( this.dismissTimeout ) {
 			clearTimeout( this.dismissTimeout );
 		}

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -17,28 +17,20 @@ export function removeNotice( noticeId ) {
 }
 
 function createNotice( status, text, options = {} ) {
-	return ( dispatch ) => {
-		const notice = {
-			noticeId: uniqueId(),
-			duration: options.duration,
-			showDismiss: ( typeof options.showDismiss === 'boolean' ? options.showDismiss : true ),
-			isPersistent: options.isPersistent || false,
-			displayOnNextPage: options.displayOnNextPage || false,
-			status: status,
-			text: text
-		};
+	const notice = {
+		noticeId: options.id || uniqueId(),
+		duration: options.duration,
+		showDismiss: ( typeof options.showDismiss === 'boolean' ? options.showDismiss : true ),
+		isPersistent: options.isPersistent || false,
+		displayOnNextPage: options.displayOnNextPage || false,
+		status: status,
+		text: text
+	};
 
-		if ( notice.duration > 0 ) {
-			setTimeout( () => {
-				dispatch( removeNotice( notice.noticeId ) );
-			}, notice.duration );
-		}
-
-		dispatch( {
-			type: NEW_NOTICE,
-			notice: notice
-		} );
-	}
+	return {
+		type: NEW_NOTICE,
+		notice: notice
+	};
 }
 
 export function setRoute( path ) {

--- a/client/state/notices/test/actions.js
+++ b/client/state/notices/test/actions.js
@@ -23,67 +23,37 @@ describe( 'actions', function() {
 	} );
 
 	describe( 'successNotice()', function() {
-		it( 'should call dispatch with proper text and is-success status', function() {
+		it( 'should return action object with a proper text', function() {
 			const text = 'potato',
-				dispatch = spy();
+				action = successNotice( text );
 
-			//successNotice is a thunk - returns a function:
-			successNotice( text )( dispatch );
-
-			expect( dispatch.calledWithMatch( {
-				type: NEW_NOTICE,
-				notice: {
-					text,
-					status: 'is-success'
-				}
-			} ) ).to.be.ok;
+			expect( action.type ).to.eql( NEW_NOTICE );
+			expect( action.notice ).to.include( {
+				text,
+				status: 'is-success'
+			} );
 		} );
 
-		it( 'should call dispatch with proper default options when none provided', function() {
-			const dispatch = spy();
+		it( 'should use default options when none provided', function() {
+			const action = successNotice( '' );
 
-			//successNotice is a thunk - returns a function:
-			successNotice( '' )( dispatch );
-
-			expect( dispatch.calledWithMatch( {
-				notice: {
-					showDismiss: true
-				}
-			} ) ).to.be.ok;
+			expect( action.notice ).to.include( {
+				showDismiss: true
+			} );
 		} );
 
-		it( 'should call dispatch with type REMOVE_NOTICE and proper noticeId when duration is provided', function( done ) {
-			const dispatch = spy();
-
-			//successNotice is a thunk - returns a function:
-			successNotice( '', { duration: 2 } )( dispatch );
-			let noticeId = dispatch.firstCall.args[0].notice.noticeId;
-
-			setTimeout( function() {
-				expect( dispatch.calledWithMatch( {
-					type: REMOVE_NOTICE,
-					noticeId: noticeId
-				} ) ).to.be.ok;
-				done();
-			}, 3 );
-		} );
 	} );
 
 	describe( 'errorNotice()', function() {
-		it( 'should call dispatch proper text and is-error status', function() {
+		it( 'should return action object with a proper text', function() {
 			const text = 'potato',
-				dispatch = spy();
+				action = errorNotice( text );
 
-			//errorNotice is a thunk - returns a function:
-			errorNotice( text )( dispatch );
-
-			expect( dispatch.calledWithMatch( {
-				type: NEW_NOTICE,
-				notice: {
-					text,
-					status: 'is-error'
-				}
-			} ) ).to.be.ok;
+			expect( action.type ).to.eql( NEW_NOTICE );
+			expect( action.notice ).to.include( {
+				text,
+				status: 'is-error'
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Timeout for notice duration is now moved from redux actions to component lifecycle methods.

Plays much better while dehydrating store.
CC @gwwar 