### PR TITLE
Checkout: Prevent cart sidebar from overlapping content

### DIFF
--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -176,6 +176,8 @@ module.exports = {
 			siteID: context.params.domain
 		} );
 
+		context.store.dispatch( setSection( null, { hasSidebar: true } ) );
+
 		ReactDom.render(
 			(
 				<CheckoutData>


### PR DESCRIPTION
Fixes #900 by ensuring that `has-no-sidebar` isn't set on the layout class in checkout, by dispatching one of the `state/ui` actions.

**Testing**
- Visit http://calypso.localhost:3000/start and sign up for a site with either a domain name or non-free plan.
- Assert that the cart doesn't overlap the primary content when you are redirected to `/checkout/:site` and your viewport is ~900px wide.

- [x] code review
- [x] product review