### PR TITLE
Typo when removing listener for the CommentEmailSubscriptionStore

### DIFF
--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -57,7 +57,7 @@ var FollowingEditNotificationSettings = React.createClass( {
 
 	componentWillUnmount: function() {
 		PostEmailSubscriptionStore.off( 'change', this.handleChange );
-		CommentEmailSubscriptionStore.on( 'change', this.handleChange );
+		CommentEmailSubscriptionStore.off( 'change', this.handleChange );
 	},
 
 	componentWillReceiveProps: function( nextProps ) {


### PR DESCRIPTION
Just going to merge this one because it's simple and causing issues with following management.