### PR TITLE
Editor: Mirror behavior of new terms to REST API

### DIFF
--- a/client/my-sites/category-selector/index.jsx
+++ b/client/my-sites/category-selector/index.jsx
@@ -4,6 +4,7 @@
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	classNames = require( 'classnames' ),
+	unescapeString = require( 'lodash/string/unescape' ),
 	isEqual = require( 'lodash/lang/isEqual' ),
 	debounce = require( 'lodash/function/debounce' ),
 	throttle = require( 'lodash/function/throttle' ),
@@ -14,8 +15,7 @@ var ReactDom = require( 'react-dom' ),
 /**
  * Internal dependencies
  */
-var decodeEntities = require( 'lib/formatting' ).decodeEntities,
-	NoResults = require( './no-results' ),
+var NoResults = require( './no-results' ),
 	analytics = require( 'analytics' ),
 	Search = require( './search' );
 
@@ -123,7 +123,7 @@ module.exports = React.createClass( {
 
 	renderItem: function( item ) {
 		var itemId = item.ID,
-			name = decodeEntities( item.name ) || this.translate( 'Untitled' ),
+			name = unescapeString( item.name ) || this.translate( 'Untitled' ),
 			checked = ( -1 !== this.state.selectedIds.indexOf( item.ID ) ),
 			inputType = this.props.multiple ? 'checkbox' : 'radio',
 			domId = camelCase( this.props.analyticsPrefix ) + '-option-' + itemId,

--- a/client/post-editor/editor-tags/index.jsx
+++ b/client/post-editor/editor-tags/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { unescapeAndFormatSpaces } from 'lib/formatting';
+import unescapeString from 'lodash/string/unescape';
 import _debug from 'debug';
 
 /**
@@ -78,7 +78,7 @@ module.exports = React.createClass( {
 				</span>
 				<TokenField
 					value={ this.getPostTags() }
-					displayTransform={ unescapeAndFormatSpaces }
+					displayTransform={ unescapeString }
 					suggestions={ tagNames }
 					onChange={ this.onTagsChange }
 					maxSuggestions={ TermsConstants.MAX_TAGS_SUGGESTIONS }

--- a/client/post-editor/editor-taxonomies/accordion.jsx
+++ b/client/post-editor/editor-taxonomies/accordion.jsx
@@ -17,7 +17,7 @@ import TermStore from 'lib/terms/store';
 import siteUtils from 'lib/site/utils';
 import InfoPopover from 'components/info-popover';
 import { isPage } from 'lib/posts/utils';
-import { decodeEntities } from 'lib/formatting';
+import unescapeString from 'lodash/string/unescape';
 
 module.exports = React.createClass( {
 	displayName: 'EditorTaxonomiesAccordion',
@@ -103,7 +103,7 @@ module.exports = React.createClass( {
 		// either, so we need to get them from the site categories data
 		const categories = this.getCategories().map( ( categoryId ) => {
 			const category = TermStore.get( siteId, categoryId );
-			return category ? decodeEntities( category.name ) : null;
+			return category ? unescapeString( category.name ) : null;
 		} ).filter( categoryName => categoryName );
 
 		switch ( categories.length ) {
@@ -127,7 +127,7 @@ module.exports = React.createClass( {
 	getTagsSubtitle() {
 		let tags = this.props.post.tags || [];
 		tags = Array.isArray( tags ) ? tags : Object.keys( tags );
-		tags = tags.map( decodeEntities );
+		tags = tags.map( unescapeString );
 
 		switch ( tags.length ) {
 			case 0:


### PR DESCRIPTION
This pull request seeks to align the behavior of adding new terms locally to the behavior of the REST API, specifically in encoding the terms before adding them to the local Flux store. This should help reduce inconsistencies in the display of terms regardless of whether they are known locally or have been returned as part of a REST API response.

__Testing instructions:__

Ensure that no regressions occur when adding a new tag, specifically that terms are displayed with decoded entities, and that double-decoding does not occur when persisting terms to the REST API.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Toggle the Categories & Tags accordion
4. Add a category and tag, optionally including a character that would be encoded (e.g. ampersand)
5. Note that in either case, the term is shown decoded as originally entered
6. Save the post
7. Refresh the page
8. Toggle the Categories & Tags accordion
9. Note that the term is still shown as decoded as originally entered