### PR TITLE
Domains: don't display Domains Unavailable for a single empty search result

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -419,6 +419,12 @@ var RegisterDomainStep = React.createClass( {
 				message = this.translate( 'Please enter a domain name or keyword.' );
 				break;
 
+			case 'empty_results':
+				message = this.translate( "We couldn't find any available domains for: %(domain)s", {
+					args: { domain }
+				} );
+				break;
+
 			case 'invalid_query':
 				message = this.translate( 'Sorry but %(domain)s does not appear to be a valid domain name.', {
 					args: { domain: domain }


### PR DESCRIPTION
Displaying Domain Registration Unavailable each time we can't find any domains to suggest is very bad.

To test:
0. Apply the patch 10eb7-pb
1. Go to domain search
2. Search for ji

You shouldn't see that domain registration is unavailable