### PR TITLE
Desktop: Disable scroll bounce

### DIFF
--- a/server/pages/desktop.jade
+++ b/server/pages/desktop.jade
@@ -26,6 +26,23 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class='is-desktop' + ( isFluidWidth ?
 		script(src='/calypso/build-desktop.js')
 		script(src='/desktop/desktop-app.js')
 
+		script.
+			(function() {
+				if ( window.navigator.userAgent.indexOf( 'Macintosh' ) !== -1 ) {
+					//Disable rubber band scrolling edge for OSX
+					document.addEventListener( 'DOMContentLoaded', function() {
+						document.body.addEventListener( 'mousewheel', function( e ) {
+							if ( 
+								( e.deltaY < 0 && document.body.scrollTop === 0 ) ||
+								( e.deltaY > 0 && document.body.scrollTop === document.body.scrollHeight - window.innerHeight )
+							) {
+								e.preventDefault()
+							}
+						} );
+					} );
+				}
+			})();
+
 	body(class=isRTL ? 'rtl' : '')
 		#wpcom.wpcom-site
 			.wpcom-site__logo.noticon.noticon-wordpress


### PR DESCRIPTION
# What are you talking about?

OSX has natively this effect of 'bounce' when you are scrolling to the edge of current window.
I HATE THIS in the app.

![](https://cldup.com/LQ7VNvnEkJ-3000x3000.png)

# Y u no CSS?
It is possible to achieve the same effect in CSS:
```css
html.is-desktop {
overflow:hidden;
}
html.is-desktop body {
overflow: auto;
}
```

But this hides the scrollbar under masterbar and also messes with scrollbar visibility (the scrollbar disappers, but scrolling is still working)

# Better solution
We discussed it with @rralian and decided that even better solution would be to play this video when while scrolling, we
**[push it to the limit / past the point of no return](https://youtu.be/kZu5iDTtNg0?t=24s)**
Unfortunately, this clip is not GPL :/

# Testing
I branched from master, but master does not work on desktop.
You can cherry-pick this commit to working branch for testing.

@gwwar : Which branch is working on desktop?

CC @mtias @adambbecker 