### PR TITLE
Reader: Fix how CommentButton cancels events, update Reader to use it

### DIFF
--- a/client/components/comment-button/index.jsx
+++ b/client/components/comment-button/index.jsx
@@ -26,6 +26,9 @@ var CommentButton = React.createClass( {
 
 	onClick: function( event ) {
 		event.preventDefault();
+	},
+
+	onTap: function() {
 		this.props.onClick();
 	},
 
@@ -37,7 +40,8 @@ var CommentButton = React.createClass( {
 		return React.createElement(
 			containerTag, {
 				className: 'comment-button',
-				onTouchTap: this.onClick
+				onTouchTap: this.onTap,
+				onClick: this.onClick
 			},
 			<Gridicon icon="comment" size={ this.props.size } className="comment-button__icon" />, labelElement
 		);

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -223,11 +223,18 @@ var Post = React.createClass( {
 		classes( headerNode ).toggle( 'is-long', this.shouldApplyIsLong() );
 	},
 
+	propogateCardClick: function( options = {} ) {
+		let postToOpen = this.props.post;
+		// For Discover posts (but not site picks), open the original post in full post view
+		if ( this.state.originalPost ) {
+			postToOpen = this.state.originalPost;
+		}
+
+		this.props.handleClick( postToOpen, options );
+	},
+
 	handleCardClick: function( event ) {
-		var rootNode = ReactDom.findDOMNode( this ),
-			post = this.props.post,
-			postToOpen = post,
-			postOptions = {};
+		var rootNode = ReactDom.findDOMNode( this );
 
 		// if the click has modifier or was not primary, ignore it
 		if ( event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey ) {
@@ -254,26 +261,17 @@ var Post = React.createClass( {
 			return;
 		}
 
-		// For Discover posts (but not site picks), open the original post in full post view
-		if ( this.state.originalPost ) {
-			postToOpen = this.state.originalPost;
-		}
-
-		// if the user clicked the comments button.
-		if ( closest( event.target, '.comment-button', true, rootNode ) ) {
-			postOptions.comments = true;
-		}
-
 		// programattic ignore
 		if ( ! event.defaultPrevented ) { // some child handled it
 			event.preventDefault();
-			this.props.handleClick( postToOpen, postOptions );
+			this.propogateCardClick();
 		}
 	},
 
-	recordCommentButtonClick: function() {
+	handleCommentButtonClick: function() {
 		stats.recordAction( 'click_comments' );
 		stats.recordGaEvent( 'Clicked Post Comment Button' );
+		this.propogateCardClick( { comments: true } );
 	},
 
 	recordTagClick: function() {
@@ -421,7 +419,7 @@ var Post = React.createClass( {
 				<ul className="reader__post-footer">
 					<PostPermalink siteName={ siteName } postUrl={ post.URL } />
 					<Share post={ post } />
-					{ ( shouldShowComments ) ? <CommentButton onClick={ this.recordCommentButtonClick } commentCount={ commentCount } /> : null }
+					{ ( shouldShowComments ) ? <CommentButton onClick={ this.handleCommentButtonClick } commentCount={ commentCount } /> : null }
 					{ ( shouldShowLikes ) ? <LikeButton siteId={ likeSiteId } postId={ likePostId } /> : null }
 					<li className="reader__post-options"><PostOptions post={ post } site={ this.state.site } /></li>
 				</ul>

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -223,7 +223,7 @@ var Post = React.createClass( {
 		classes( headerNode ).toggle( 'is-long', this.shouldApplyIsLong() );
 	},
 
-	propogateCardClick: function( options = {} ) {
+	propagateCardClick: function( options = {} ) {
 		let postToOpen = this.props.post;
 		// For Discover posts (but not site picks), open the original post in full post view
 		if ( this.state.originalPost ) {
@@ -264,14 +264,14 @@ var Post = React.createClass( {
 		// programattic ignore
 		if ( ! event.defaultPrevented ) { // some child handled it
 			event.preventDefault();
-			this.propogateCardClick();
+			this.propagateCardClick();
 		}
 	},
 
 	handleCommentButtonClick: function() {
 		stats.recordAction( 'click_comments' );
 		stats.recordGaEvent( 'Clicked Post Comment Button' );
-		this.propogateCardClick( { comments: true } );
+		this.propagateCardClick( { comments: true } );
 	},
 
 	recordTagClick: function() {


### PR DESCRIPTION
The CommentButton `comment-button` component was only using onTapTouch to handle events. This meant that the prevent didn't actually work, unless you were on a system with touch events, when it did. This patch changes it to be consistent and always prevent the click.

It also updates the Reader to handle clicks on the comment button, as we can no longer rely on it falling through. This also cleans up the click handler a bit which is a bonus.

Fixes #535 