### PR TITLE
Desktop App: command line actions

### DIFF
--- a/client/lib/route/page-notifier.js
+++ b/client/lib/route/page-notifier.js
@@ -1,22 +1,33 @@
 /*eslint no-multi-spaces: 0*/
 // node dependency
 var EventEmitter   = require( 'events' ).EventEmitter;
+var ipc = require( 'electron' ).ipcRenderer;
+var includes = require( 'lodash' ).includes;
 
 // internal dependency
-var page           = require( 'page' );
-var Route          = page.Route;
+var page		   = require( 'page' );
+var Route		  = page.Route;
 
 // routing state and middleware
-var location       = new EventEmitter();
+var location	   = new EventEmitter();
 var currentContext = null;
-var route          = new Route( '*' );
+var commandLine	= {};
+var route		  = new Route( '*' );
 
 // Inject our route at the front so we are always called
 page.callbacks.unshift( route.middleware( function( context, next ) {
+	context.commandLine = commandLine;
 	next();
 	location.emit( 'change', context, currentContext );
 	currentContext = context;
 } ) );
+
+ipc.on( 'args', function( sender, args ) {
+	commandLine = args;
+	if ( includes( args._, 'post' ) ) {
+		page.redirect( '/post/' + args.site );
+	}
+} );
 
 // Export a function that attaches a listener to the location change event
 // If a page has already been rendered the listener will be called with

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -140,6 +140,16 @@ module.exports = {
 					} );
 				}
 
+				// handle command line arguments if applicable
+				if ( context.commandLine && context.commandLine.title && context.commandLine.content ) {
+					Object.assign( postOptions, {
+						title: context.commandLine.title,
+						content: context.commandLine.content
+					} );
+					context.commandLine.title = undefined;
+					context.commandLine.content = undefined;
+				}
+
 				actions.startEditingNew( site, postOptions );
 				titleActions.setTitle( titleStrings.new, { siteID: site.ID } );
 				analytics.pageView.record( '/' + postType, titleStrings.ga + ' > New' );


### PR DESCRIPTION
# Motivation
During Core Calypso Miami meetup we were discussing what would entice users more to install desktop app.
It can have some far ranging OS integrations. For me, in particular it would be awesome to:
- Integrate it with OSX 'services' (  they work a bit like 'send to app' on iphone and intents on android : http://www.macworld.com/article/1163996/software-utilities/how-to-use-services-in-mac-os-x.html )
- Launch image editing in the seperate app directly from our app
- Generally tying it all together

# This PR
This PR introduces rudimentary command line parameters handling for launching post editor and populating it.
This also basically can replace 'post template' functionality.
It is only a first step, but I would argue - very necessary.
In future, we need mime type detection and image upload, maybe detecting title from the first line of file, etc.
Also, We need to somehow handle passing arguments when the app is open.

There is a second PR in desktop repository which compliments this one.

# How to test?
- Check out the complimentary branch of wp-desktop
- Check out working branch of calypso (master is broken on desktop)
- Cherry-pick this commit on top of working branch
- `Make run` to compile
- Kill the app
- Launch it with parameters: 
```
./node-modules/.bin/electron . post --site=YOUR_SITE(ex: .artpitesting116.wordpress.com) --title="I love WordPress" --file="./LICENSE.md
```


