### PR TITLE
Domain Management: add expired domain notice

### DIFF
--- a/client/my-sites/upgrades/domain-management/list/item.jsx
+++ b/client/my-sites/upgrades/domain-management/list/item.jsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
  */
 import CompactCard from 'components/card/compact';
 import DomainPrimaryFlag from 'my-sites/upgrades/domain-management/components/domain/primary-flag';
+import Notice from 'components/notice';
 import { type as domainTypes } from 'lib/domains/constants';
 import Spinner from 'components/spinner';
 import Gridicon from 'components/gridicon';
@@ -46,12 +47,11 @@ const ListItem = React.createClass( {
 				<div className="domain-management-list-item__title">
 					{ this.props.domain.name }
 				</div>
-
-					<span className="domain-management-list-item__meta">
-						<span className="domain-management-list-item__type">{ this.getDomainTypeText() }</span>
-
-						<DomainPrimaryFlag domain={ this.props.domain }/>
-					</span>
+				<span className="domain-management-list-item__meta">
+					<span className="domain-management-list-item__type">{ this.getDomainTypeText() }</span>
+					{ this.props.domain.type !== 'WPCOM' && this.showDomainExpirationWarning( this.props.domain ) }
+					<DomainPrimaryFlag domain={ this.props.domain }/>
+				</span>
 				{ this.busyMessage() }
 			</div>
 		);
@@ -100,6 +100,34 @@ const ListItem = React.createClass( {
 			type="radio"
 			checked={ this.props.isSelected }
 			onChange={ this.handleSelect }/>
+	},
+
+	showDomainExpirationWarning( domain ) {
+		if ( domain.expired ) {
+			return (
+				<Notice isCompact status="is-error" icon="spam">
+					{ this.translate( 'Expired %(timeSinceExpiry)s', {
+						args: {
+							timeSinceExpiry: domain.expirationMoment.fromNow()
+						},
+						context: 'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"'
+					} ) }
+				</Notice>
+			);
+		}
+
+		if ( domain.expirationMoment && domain.expirationMoment < this.moment().add( 30, 'days' ) ) {
+			return (
+				<Notice isCompact status="is-error" icon="spam">
+					{ this.translate( 'Expires %(timeUntilExpiry)s', {
+						args: {
+							timeUntilExpiry: domain.expirationMoment.fromNow()
+						},
+						context: 'timeUntilExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"'
+					} ) }
+				</Notice>
+			);
+		}
 	},
 
 	getDomainTypeText() {

--- a/client/my-sites/upgrades/domain-management/list/test/index.js
+++ b/client/my-sites/upgrades/domain-management/list/test/index.js
@@ -3,6 +3,7 @@
  */
 import deepFreeze from 'deep-freeze';
 import assert from 'assert';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -38,6 +39,7 @@ describe( 'upgrades/domain-management/list', function() {
 
 			ReactInjection = require( 'react/lib/ReactInjection' );
 			ReactInjection.Class.injectMixin( i18n );
+			ReactInjection.Class.injectMixin( { moment } );
 
 			const EMPTY_COMPONENT = React.createClass( {
 				render() {


### PR DESCRIPTION
Potential fix for #2422:

- Adds a check to see if the domain is expiring or expired (returns null if type is `WPCOM`)
- If the domain is expired, displays notice in the form of "Expired 3 days ago"
- If the domain is expiring in the next 30 days, displays notice in the form of "Expires in 2 days"

It's not quite ready to go just yet. I'm running into an issue when the domain is expiring in the near term (within a few hours). On the Purchases page, the `purchase.expiryMoment` comes in the form `"2016-01-27T00:00:00+00:00"`. On Domain Management, `domain.expirationMoment` doesn't have a time component (comes like `"January 25, 2016"`). I believe this is why the time is rendering differently. It's always a 7 hour time difference (I'm GMT-7 timezone). 

Here's the Purchases view of a domain set to expire today (Reads "Expired 4 hours ago"):

![screen shot 2016-01-24 at 9 09 33 pm](https://cloud.githubusercontent.com/assets/7240478/12542369/8db45b42-c2df-11e5-8213-b219dc9ac38d.png)

Here's that same domain from Domain Management. It recognizes as expired, but it reads "Expired in 3 hours":

![screen shot 2016-01-24 at 9 09 15 pm](https://cloud.githubusercontent.com/assets/7240478/12542377/a69e3c72-c2df-11e5-8544-0aeec8637e2e.png)

Is there a simple way around this?

Any and all feedback welcome. I borrowed the `domain.expirationMoment` logic from `purchases/list/item/index.jsx`.