### PR TITLE
Reader: Add styles for Discover's sidenotes

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -306,4 +306,53 @@
 			}
 		}
 	}
+
+	blockquote.sidenote {
+		margin: 0;
+		padding: 0;
+		border: none;
+		background: none;
+		font-size: 13px;
+		width: 175px;
+
+		@include breakpoint( ">1040px" ) {
+			position: absolute;
+
+			&.right {
+				right: -( 175px + 32px );
+			}
+
+			&.left {
+				left: -( 175px + 32px );
+			}
+		}
+
+		@include breakpoint( "<1040px" ) {
+			&.right {
+				float: right;
+				margin: 0 0 24px 24px;
+			}
+
+			&.left {
+				float: left;
+				margin: 0 24px 24px 0;
+			}
+		}
+
+		@include breakpoint( "<480px" ) {
+			&.right,
+			&.left {
+				width: auto;
+				float: none;
+				margin: 0 0 24px 0;
+				background: lighten( $gray, 30 );
+				padding: 16px;
+
+				img {
+					display: block;
+					margin-bottom: 8px;
+				}
+			}
+		}
+	}
 }

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -158,11 +158,12 @@
 	}
 
 	blockquote {
-		padding: 16px;
-		margin: 8px 0 24px 0;
-		border-left: 2px solid $gray;
+		padding: 16px 24px;
+		margin: 16px 0 32px 0;
 		color: darken( $gray, 20 );
-		background: lighten( $gray, 30 );
+		font-weight: normal;
+		font-size: 20px;
+		background: transparent;
 	}
 
 	img {
@@ -315,19 +316,33 @@
 		font-size: 13px;
 		width: 175px;
 
-		@include breakpoint( ">1040px" ) {
+		@media ( min-width: 1132px ) {
 			position: absolute;
 
 			&.right {
 				right: -( 175px + 32px );
+				margin-right: 0;
 			}
 
 			&.left {
 				left: -( 175px + 32px );
+				margin-left: 0;
 			}
 		}
 
-		@include breakpoint( "<1040px" ) {
+		@media ( max-width: 1132px ) {
+			&.right {
+				float: right;
+				margin: 0 -120px 24px 24px;
+			}
+
+			&.left {
+				float: left;
+				margin: 0 24px 24px -120px;
+			}
+		}
+
+		@include breakpoint( "<960px" ) {
 			&.right {
 				float: right;
 				margin: 0 0 24px 24px;

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -166,6 +166,11 @@
 		background: transparent;
 	}
 
+	hr {
+		background: lighten( $gray, 30 );
+		margin: 24px -32px;
+	}
+
 	img {
 		max-width: 100%;
 		height: auto;
@@ -203,32 +208,22 @@
 		.alignleft,
 		.alignright {
 			clear: both;
-			padding-top: 12px;
-			margin-top: 12px;
+			margin-top: 24px;
 			margin-bottom: 24px;
-			border-top: 1px solid lighten( $gray, 30% );
-			border-bottom: 1px solid lighten( $gray, 30% );
 		}
 	}
 
 	.aligncenter {
 		clear: both;
-		padding-top: 12px;
-		margin-top: 12px;
+		margin-top: 24px;
 		margin-bottom: 24px;
-		border-top: 1px solid lighten( $gray, 30% );
-		border-bottom: 1px solid lighten( $gray, 30% );
 	}
 
 	.alignnone {
 		clear: both;
 		display: block;
-		padding-top: 12px;
-		padding-bottom: 12px;
-		margin-top: 12px;
+		margin-top: 24px;
 		margin-bottom: 24px;
-		border-top: 1px solid lighten( $gray, 30% );
-		border-bottom: 1px solid lighten( $gray, 30% );
 	}
 
 	.wp-caption {


### PR DESCRIPTION
Moving Discover’s `.sidenote` elements into the margins on screens that have room:

Before:
![screen shot 2016-01-24 at 11 30 36 pm](https://cloud.githubusercontent.com/assets/191598/12542533/845a2096-c2f2-11e5-87ba-90e000ae757d.png)

After:
![screen shot 2016-01-24 at 11 30 48 pm](https://cloud.githubusercontent.com/assets/191598/12542536/8c76ac68-c2f2-11e5-9e2f-848267a5b6a4.png)

On smaller screens (but not mobile) the sidenotes "float" and cause the text to wrap:
![screen shot 2016-01-24 at 11 31 49 pm](https://cloud.githubusercontent.com/assets/191598/12542539/a4f31da8-c2f2-11e5-9308-1225ee848075.png)

On mobile screens, the sidenote shows inline, but with a background color to help separate it from the rest of the content:

![screen shot 2016-01-24 at 11 32 13 pm](https://cloud.githubusercontent.com/assets/191598/12542546/c04459dc-c2f2-11e5-80cb-2739dd85b828.png)

/cc @kjellr 