### PR TITLE
User: Fix bug where fetch error prevents any further attempts

### DIFF
--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -107,6 +107,9 @@ User.prototype.fetch = function() {
 	debug( 'Getting user from api' );
 
 	me.get( { meta: 'flags' }, function( error, data ) {
+		// Release lock from subsequent fetches
+		this.fetching = false;
+
 		if ( error ) {
 			if ( ! config( 'wpcom_user_bootstrap' ) && error.error === 'authorization_required' ) {
 				/**
@@ -124,9 +127,6 @@ User.prototype.fetch = function() {
 		}
 
 		var userData = userUtils.filterUserObject( data );
-
-		// Release lock from subsequent fetches
-		this.fetching = false;
 
 		this.clearStoreIfChanged( userData.ID );
 


### PR DESCRIPTION
The `User` object has a `fetching` property used to avoid doubling up on fetch requests. If `user.fetching` is `true`, any attempts to call `user.fetch()` will be ignored. This PR fixes a bug where `this.fetching` was not being reset after a failed fetch.

**Before this change**
1. `user.fetch()` is called
2. An error occurs during fetch
3. `user.fetch()` is called again, but the attempt is ignored

**After this change**
1. `user.fetch()` is called
2. An error occurs during fetch
3. `user.fetch()` is called again, the request is made as expected