### PR TITLE
Small spacing adjustment for Discover dropcaps

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -293,7 +293,7 @@
 
 		&:first-child:first-letter {
 			float: left;
-			margin: 21px 12px 0 0;
+			margin: 18px 12px 0 0;
 			font-size: 66px;
 		    font-weight: 400;
 		    line-height: 0.5;
@@ -302,7 +302,7 @@
 		// Firefox-only position fix
 		@-moz-document url-prefix() {
 			&:first-child:first-letter {
-				margin-top: 8px;
+				margin-top: 9px;
 			}
 		}
 	}


### PR DESCRIPTION
A small tweak related to PR #2703. This aligns the dropcap using the the proper version of Merriweather. The previous commit, 12703bd was configured using a local version of the font. 

Before:
![before_spacing](https://cloud.githubusercontent.com/assets/1202812/12551758/b4276a52-c33a-11e5-9a70-b6f740367791.png)

After: 
![after_spacing](https://cloud.githubusercontent.com/assets/1202812/12551773/d3d6eb8e-c33a-11e5-9729-36b0d6eb2ba0.png)

cc @blowery, who pointed out the inconsistency. @shaunandrews, would you mind testing too just to be sure?