### PR TITLE
Upgrades: Replace the noticon used for the Google Apps add user button

### DIFF
--- a/assets/stylesheets/sections/_domain-search.scss
+++ b/assets/stylesheets/sections/_domain-search.scss
@@ -218,9 +218,9 @@ form.google-apps-dialog {
 
 		&:before {
 			position: absolute;
-				left: 15px;
-				top: 6px;
-			@include noticon( '\f8b3', 60px );
+				left: 10px;
+				top: 7px;
+			@include noticon( '\f510', 30px );
 		}
 	}
 }


### PR DESCRIPTION
`noticon-add` is small and has bottom and right margin which doesn't work well in LTR mode. `noticon-plus` is better and easier to use. Fixes #2226 

Before 
![ar_desktop_2a_domain_new_screenshot1449462392402](https://cloud.githubusercontent.com/assets/7637835/12196408/95ff6cd0-b5fe-11e5-832b-099c92489e17.jpg)

After
![after](https://cldup.com/jLGn2cTcBc.png)
