### PR TITLE
Formatting: Use a working tag stripper

### DIFF
--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -2,7 +2,8 @@
  * External Dependencies
  */
 var trim = require( 'lodash/string/trim' ),
-	warn = require( 'lib/warn' );
+	warn = require( 'lib/warn' ),
+	stripTags = require( 'striptags' );
 
 /**
  * Internal Dependencies
@@ -43,7 +44,7 @@ function interpose( separator, list ) {
  * @return {string}        The stripped string
  */
 function stripHTML( string ) {
-	return string.replace( /<\/?[^<>]*>/gi, '' );
+	return stripTags( string );
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "source-map-support": "0.3.2",
     "srcset": "1.0.0",
     "store": "1.3.16",
+    "striptags": "2.1.1",
     "superagent": "1.2.0",
     "tinymce": "4.2.8",
     "to-title-case": "0.1.5",


### PR DESCRIPTION
Our old tag stripper was just a plain regex that could be fooled by < and > characters inside an attribute string. This led to html tags slipping through the stripper and into at least some reader streams.

Switch to a parser-based stripper, which isn't as easily fooled.

Fixes #2744