### PR TITLE
Signup: Add theme preselection flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -12,7 +12,7 @@ var config = require( 'config' ),
 	user = require( 'lib/user' )();
 
 function getCheckoutDestination( dependencies ) {
-	if ( dependencies.cartItem || dependencies.domainItem ) {
+	if ( dependencies.cartItem || dependencies.domainItem || dependencies.themeItem ) {
 		return '/checkout/' + dependencies.siteSlug;
 	}
 
@@ -45,6 +45,13 @@ const flows = {
 		},
 		description: 'Create an account and a blog and then add the business plan to the users cart.',
 		lastModified: '2016-01-21'
+	},
+
+	'with-theme': {
+		steps: [ 'domains', 'plans', 'user' ],
+		destination: getCheckoutDestination,
+		description: 'Preselect a theme to activate/buy from an external source',
+		lastModified: '2016-01-27'
 	},
 
 	main: {

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -74,7 +74,7 @@ module.exports = {
 	domains: {
 		stepName: 'domains',
 		apiRequestFunction: stepActions.addDomainItemsToCart,
-		providesDependencies: [ 'siteSlug', 'domainItem' ],
+		providesDependencies: [ 'siteSlug', 'domainItem', 'themeItem' ],
 		delayApiRequestUntilComplete: true
 	},
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -75,6 +75,16 @@ module.exports = React.createClass( {
 		} );
 	},
 
+	getThemeArgs: function() {
+		const isPurchasingTheme = this.props.queryObject && this.props.queryObject.premium;
+		const themeSlug = this.props.queryObject ? this.props.queryObject.theme : undefined;
+		const themeItem = isPurchasingTheme
+			? cartItems.themeItem( themeSlug, 'signup-with-theme' )
+			: undefined;
+
+		return { themeSlug, themeItem };
+	},
+
 	submitWithDomain: function( googleAppsCartItem ) {
 		const suggestion = this.props.step.suggestion,
 			isPurchasingItem = Boolean( suggestion.product_slug ),
@@ -88,7 +98,7 @@ module.exports = React.createClass( {
 				} ) :
 				undefined;
 
-		SignupActions.submitSignupStep( {
+		SignupActions.submitSignupStep( Object.assign( {
 			processingMessage: this.translate( 'Adding your domain' ),
 			stepName: this.props.stepName,
 			domainItem,
@@ -96,7 +106,7 @@ module.exports = React.createClass( {
 			isPurchasingItem,
 			siteUrl,
 			stepSectionName: this.props.stepSectionName
-		}, [], { domainItem } );
+		}, this.getThemeArgs() ), [], { domainItem } );
 
 		this.props.goToNextStep();
 	},
@@ -104,7 +114,7 @@ module.exports = React.createClass( {
 	handleAddMapping: function( sectionName, domain, state ) {
 		const domainItem = cartItems.domainMapping( { domain } );
 
-		SignupActions.submitSignupStep( {
+		SignupActions.submitSignupStep( Object.assign( {
 			processingMessage: this.translate( 'Adding your domain mapping' ),
 			stepName: this.props.stepName,
 			[ sectionName ]: state,
@@ -112,7 +122,7 @@ module.exports = React.createClass( {
 			isPurchasingItem: true,
 			siteUrl: domain,
 			stepSectionName: this.props.stepSectionName
-		} );
+		}, this.getThemeArgs() ) );
 
 		this.props.goToNextStep();
 	},


### PR DESCRIPTION
We want people to be able to sign up with a theme already chosen from an external source, such as the Theme Showcase(s).

We'll want to specify the theme to preselect using an URL, e.g. `/start/with-theme?theme=twentyten`. The selected theme should then be set as the selected theme, with no additional visual feedback or interaction necessary.

Questions:
- Since the preselection of a theme is done externally, how to we fit this into the flow? Do we have a dummy step, that selects the specified theme, and goes directly to the next step?
  * **A.** We embed the logic inside the domains step
- How do we handle premium themes? Can we just add them to the cart?
  * **A.** Yes, and redirect to the checkout if we have a theme in the cart.

To test:
- Log out/open an incognito window
- Go to http://calypso.localhost:3000/start/with-theme?theme=twentyten
- Sign up with a free plan, and a free subdomain
- On successful sign up, you should be redirect to your new site, with Twenty Ten activated
- Log out
- Go to http://calypso.localhost:3000/start/with-theme?theme=mood&premium=true
- Sign up with a free/premium plan/free subdomain/paid domain/mapping
- On successful sign up, you should be redirected to the cart, where the theme 'Mood' and all the other items you selected should be shown
- If you have the store sandboxed, try purchasing whatever is in your cart. The 'Mood' theme should be activated on purchase.
- Logged in, go to http://calypso.localhost:3000/start/with-theme?theme=twentyten
- Sign up, 'Twenty Ten' should be activated for a new site