### PR TITLE
Reader: Fix how we record follows

### DIFF
--- a/client/reader/feed-header/index.jsx
+++ b/client/reader/feed-header/index.jsx
@@ -63,7 +63,7 @@ var FeedHeader = React.createClass( {
 					{ siteish ? <Site site={ siteish } href={ siteish.URL } indicator={ false } /> : null }
 
 					{ siteish ? <div className="feed-header__follow">
-						<ReaderFollowButton siteUrl={ siteish.URL } iconSize={ 24 } location="blog_page" />
+						<ReaderFollowButton siteUrl={ siteish.URL } iconSize={ 24 } />
 					</div> : null }
 				</Card>
 

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -16,9 +16,6 @@ var ReaderFollowButton = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	recordFollowToggle: function( isFollowing ) {
-		stats.recordAction( isFollowing ? 'followed_blog' : 'unfollowed_blog' );
-		stats.recordGaEvent( isFollowing ? 'Clicked Follow Blog' : 'Clicked Unfollow Blog', this.props.location );
-
 		stats[ isFollowing ? 'recordFollow' : 'recordUnfollow' ]( this.props.siteUrl );
 
 		if ( this.props.onFollowToggle ) {

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -257,9 +257,10 @@ const FollowingEdit = React.createClass( {
 		}
 	},
 
-	handleFollow: function() {
+	handleFollow: function( newUrl ) {
 		this.toggleAddSite();
 		this.setState( { isAttemptingFollow: true } );
+		stats.recordFollow( newUrl );
 	},
 
 	renderUnfollowError: function() {

--- a/client/reader/following-edit/list-item.jsx
+++ b/client/reader/following-edit/list-item.jsx
@@ -103,7 +103,7 @@ var SubscriptionListItem = React.createClass( {
 				</Title>
 				<Description><a href={ subscription.get( 'URL' ) }>{ displayUrl }</a></Description>
 				<Actions>
-					<ReaderFollowButton following={ isFollowing } onFollowToggle={ this.handleFollowToggle } location="following_edit" isButtonOnly={ true } siteUrl={ subscription.get( 'URL' ) } />
+					<ReaderFollowButton following={ isFollowing } onFollowToggle={ this.handleFollowToggle } isButtonOnly={ true } siteUrl={ subscription.get( 'URL' ) } />
 				</Actions>
 			</div>
 		);

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -9,7 +9,8 @@ const React = require( 'react' ),
 const Search = require( 'components/search' ),
 	FollowingEditSubscribeFormResult = require( './subscribe-form-result' ),
 	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' ),
-	Gridicon = require( 'components/gridicon' );
+	Gridicon = require( 'components/gridicon' ),
+	stats = require( 'reader/stats' );
 
 const minSearchLength = 8; // includes protocol
 
@@ -51,7 +52,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 		this.refs.followingEditSubscriptionSearch.clear();
 
 		// Call onFollow method on the parent
-		this.props.onFollow();
+		this.props.onFollow( this.state.searchString );
 	},
 
 	handleFollowIconClick: function() {

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -19,7 +19,6 @@ import SiteStore from 'lib/reader-site-store';
 import { recordFollow, recordUnfollow, recordAction, recordGaEvent } from 'reader/stats';
 import { getSiteUrl } from 'reader/route';
 
-
 const RecommendedForYou = React.createClass( {
 
 	getInitialState() {
@@ -81,8 +80,8 @@ const RecommendedForYou = React.createClass( {
 
 		times( number, ( i ) => {
 			placeholders.push(
-				<ListItem className="is-placeholder" key={'recommendation-placeholder-' + i}>
-					<Icon><SiteIcon size={48} /></Icon>
+				<ListItem className="is-placeholder" key={ 'recommendation-placeholder-' + i }>
+					<Icon><SiteIcon size={ 48 } /></Icon>
 					<Title>Loading</Title>
 					<Description>Loading the results...</Description>
 				</ListItem>
@@ -94,14 +93,6 @@ const RecommendedForYou = React.createClass( {
 
 	getItemRef( rec ) {
 		return 'recommendation-' + rec.blog_id;
-	},
-
-	trackFollowToggle( following ) {
-		if ( following ) {
-			recordFollow();
-		} else {
-			recordUnfollow();
-		}
 	},
 
 	trackSiteClick() {
@@ -123,7 +114,7 @@ const RecommendedForYou = React.createClass( {
 				</Title>
 				<Description>{ rec.reason }</Description>
 				<Actions>
-					<FollowButton siteUrl={ site.URL } onFollowToggle={ this.trackFollowToggle } />
+					<FollowButton siteUrl={ site.URL } />
 				</Actions>
 			</ListItem>
 			);

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -12,7 +12,7 @@ import Description from 'reader/list-item/description';
 import Actions from 'reader/list-item/actions';
 
 import SiteIcon from 'components/site-icon';
-import FollowButton from 'components/follow-button';
+import FollowButton from 'reader/follow-button';
 import RecommendedSites from 'lib/recommended-sites-store/store';
 import { fetchMore } from 'lib/recommended-sites-store/actions';
 import SiteStore from 'lib/reader-site-store';

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -16,7 +16,7 @@ import FollowButton from 'components/follow-button';
 import RecommendedSites from 'lib/recommended-sites-store/store';
 import { fetchMore } from 'lib/recommended-sites-store/actions';
 import SiteStore from 'lib/reader-site-store';
-import { recordFollow, recordUnfollow, recordAction, recordGaEvent } from 'reader/stats';
+import { recordAction, recordGaEvent } from 'reader/stats';
 import { getSiteUrl } from 'reader/route';
 
 const RecommendedForYou = React.createClass( {
@@ -127,7 +127,7 @@ const RecommendedForYou = React.createClass( {
 					<h1>{ this.translate( 'Recommendations' ) }</h1>
 				</MobileBackToSidebar>
 
-				<h2 className="reader-recommended__heading">{ this.translate( 'We think you\'ll like' )}</h2>
+				<h2 className="reader-recommended__heading">{ this.translate( 'We think you\'ll like' ) }</h2>
 				<InfiniteList
 					items={ this.state.recommendations }
 					fetchingNextPage={ this.state.fetching }

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -48,6 +48,9 @@ function getLocation() {
 	if ( path.indexOf( '/following/edit' ) === 0 ) {
 		return 'following_edit';
 	}
+	if ( path.indexOf( '/discover' ) === 0 ) {
+		return 'discover';
+	}
 	return 'unknown';
 }
 

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -54,6 +54,8 @@ function getLocation() {
 export function recordFollow( url ) {
 	const source = getLocation();
 	mc.bumpStat( 'reader_follows', source );
+	recordAction( 'followed_blog' );
+	recordGaEvent( 'Clicked Follow Blog', source )
 	tracks.recordEvent( 'calypso_reader_site_followed', {
 		url,
 		source
@@ -63,6 +65,8 @@ export function recordFollow( url ) {
 export function recordUnfollow( url ) {
 	const source = getLocation();
 	mc.bumpStat( 'reader_unfollows', source );
+	recordAction( 'unfollowed_blog' );
+	recordGaEvent( 'Clicked Unfollow Blog', source )
 	tracks.recordEvent( 'calypso_reader_site_unfollowed', {
 		url,
 		source


### PR DESCRIPTION
I noticed that recommendations were not firing all of the relevant mc stats when a user followed or unfollowed a site from there. reader_follows was bumped, but not reader_actions::followed_blog. This patch corrects that by refactoring how we use the follow button across the reader. Hopefully this will be more consistent and easier to use.

I avoided moving the stat bumps up to the action creators in flux because these are reader stats and if stats were to use the same stores and actions, I'm not sure I'd want to bump the same set of stats. /cc @timmyc 

It also teaches the reader stats about the Discover stream and adds a new action source so we can track follows from the discover stream.

To test, enable analytics debugging in the console with `localStorage.debug = 'calypso:analytics'` and then follow sites from various places in the app, including:

- [x] Following Stream at `/`
- [x] Discover stream at `/discover`
- [x] My Likes stream at `/activities/likes`
- [x] Recommendations at `/recommendations`
- [x] A list stream
- [x] A tag stream
- [x] The full post view

You should see two mc stats bumped for each follow or unfollow. `reader_actions:[un]followed_blog` and `reader_[un]follows:$location`.