### PR TITLE
Signup: Fix `calypso_plans_compare` analytic event in plans compare

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -45,7 +45,7 @@ var PlansCompare = React.createClass( {
 
 	componentDidMount: function() {
 		analytics.tracks.recordEvent( 'calypso_plans_compare', {
-			isInSignup: this.props.isInSignup
+			is_in_signup: this.props.isInSignup
 		} );
 
 		if ( ! this.props.isInSignup ) {


### PR DESCRIPTION
Fixes: #2313 

> The calypso_plans_compare event has an isInSignup prop. Props need to be in snake case (is_in_signup) otherwise they’re rejected.

This PR fixes this bug which impacts calypso's analytics.

#### Testing Instructions:
- `git fetch origin && git checkout fix/2313-plans-compare-analytics`
- Go to the plans compare page at http://calypso.localhost:3000/plans/compare and check that the events was accepted with the correct value for `is_in_signup` in tracks (our internal analytics dashboard).

#### Reviews
- [x] Code Review
- [x] Product Review