### PR TITLE
Checkout: Update TOS link variable names to be less confusing

### DIFF
--- a/client/my-sites/upgrades/checkout/terms-of-service.jsx
+++ b/client/my-sites/upgrades/checkout/terms-of-service.jsx
@@ -27,11 +27,11 @@ module.exports = React.createClass( {
 		// Need to add check for subscription products in the cart so we don't show this for one-off purchases like themes
 		if ( this.props.hasRenewableSubscription ) {
 			message =  this.translate(
-				'By checking out, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{purchasesLink}}how your subscription works{{/purchasesLink}} and {{cancelLink}}how to cancel{{/cancelLink}}.', {
+				'By checking out, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and authorize your payment method to be charged on a recurring basis until you cancel, which you can do at any time. You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} and {{managePurchasesSupportPage}}how to cancel{{/managePurchasesSupportPage}}.', {
 				components: {
 					tosLink: <a href="//wordpress.com/tos/" target="_blank" />,
-					cancelLink: <a href="//support.wordpress.com/manage-purchases/" target="_blank" />,
-					purchasesLink: <a href="//support.wordpress.com/auto-renewal/" target="_blank" />
+					autoRenewalSupportPage: <a href="//support.wordpress.com/auto-renewal/" target="_blank" />,
+					managePurchasesSupportPage: <a href="//support.wordpress.com/manage-purchases/" target="_blank" />
 				}
 			} );
 		}


### PR DESCRIPTION
Changes variable names to be more consistent with the pages they link to:

- `cancelLink` -> `managePurchasesSupportPage`
- `purchasesLink` -> `autoRenewalSupportPage`

cc: @drewblaisdell 