### PR TITLE
Fix line-height on mobile view.

### DIFF
--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -113,8 +113,8 @@
 	color: $gray-dark;
 	display: block;
 	font-size: 14px;
+	line-height: 21px;
 	font-weight: 600;
-	line-height: 30px;
 	overflow: hidden;
 	text-align: left;
 	text-overflow: ellipsis;
@@ -122,6 +122,7 @@
 
 	@include breakpoint( '>480px' ) {
 		font-size: 24px;
+		line-height: 32px;
 		font-weight: 700;
 		font-family: $serif;
 	}


### PR DESCRIPTION
Fixes the spacing in the plugin list.

Before:

![screen shot 2016-01-25 at 11 14 48](https://cloud.githubusercontent.com/assets/115071/12561765/a05d7e0a-c356-11e5-9fac-84d18560d5d7.png)


After:
![screen shot 2016-01-25 at 11 17 32](https://cloud.githubusercontent.com/assets/115071/12561769/a564d556-c356-11e5-8c82-de7a44663c6b.png)

To test visit the 
http://calypso.localhost:3000/plugins

and resize the browser to see the fixes and make sure that it doesn't break the desktop view. 