### PR TITLE
Plugins: Allow siteID in plugins-list view

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -185,7 +185,7 @@ controller = {
 		var isWpcomPlugin = 'business' === context.params.business_plugin,
 			siteUrl = route.getSiteFragment( context.path );
 
-		if ( context.params.plugin && context.params.plugin === siteUrl ) {
+		if ( context.params.plugin && context.params.plugin === siteUrl.toString() ) {
 			controller.plugins( 'all', context );
 			return;
 		}


### PR DESCRIPTION
Currently a user is not able to go to the plugin list if she enters the siteID instead of the site slug. 

This is because we do a strict comparison. Since the siteUrl should be a number instead of a string. The comparison fails and we trying to see if a plugin exists with the siteID as a slug. 

Which most likely it does not. 

To test:
Make sure that you are able to navigate to different sections of the plugin. 
On a single and multi site plugins list view. 

So visit
http://calypso.localhost:3000/plugins
http://calypso.localhost:3000/plugins/example.com
http://calypso.localhost:3000/plugins/123
http://calypso.localhost:3000/plugins/active/example.com
http://calypso.localhost:3000/plugins/active/123
etc. 

Fixes #415