### PR TITLE
Reader: Add a more obvious follow button to full post view

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -42,15 +42,8 @@
 		}
 	}
 
-	.reader__post-options {
-		float: none;
-		position: absolute;
-		top: 49px;
-		right: 4px;
-	}
-
-	.reader__post-header:after {
-		display: none;
+	.full-post__header {
+		position: relative;
 	}
 
 	.site {
@@ -58,6 +51,18 @@
 			padding: 0;
 			border-radius: 0;
 			text-decoration: none;
+		}
+	}
+
+	.follow-button {
+		position: absolute;
+			top: 0;
+			right: 0;
+
+		@include breakpoint( "<440px" ) {
+			.follow-button__label {
+				display: none;
+			}
 		}
 	}
 
@@ -79,17 +84,6 @@
 
 		a {
 			text-decoration: none;
-		}
-	}
-
-	.reader__post-footer {
-		margin: 8px 0 0 0;
-		padding: 0;
-		position: relative;
-
-		.reader__post-comments b,
-		.reader__post-likes b {
-			display: none;
 		}
 	}
 

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -33,6 +33,7 @@ var analytics = require( 'analytics' ),
 	SiteState = require( 'lib/reader-site-store/constants' ).state,
 	SiteStore = require( 'lib/reader-site-store' ),
 	SiteStoreActions = require( 'lib/reader-site-store/actions' ),
+	FollowButton = require( 'reader/follow-button' ),
 	utils = require( 'reader/utils' ),
 	LikeHelper = require( 'reader/like-helper' ),
 	stats = require( 'reader/stats' ),
@@ -196,13 +197,17 @@ FullPostView = React.createClass( {
 
 					<PostErrors post={ post } />
 
-					<Site site={ siteish }
-						href={ post.site_URL }
-						onSelect={ this.pickSite }
-						onClick={ this.handleSiteClick } />
+					<div className="full-post__header">
+						<Site site={ siteish }
+							href={ post.site_URL }
+							onSelect={ this.pickSite }
+							onClick={ this.handleSiteClick } />
+
+						<FollowButton siteUrl={ post.site_URL } />
+					</div>
 
 					{ hasFeaturedImage
-						? <div className="full-post__featured-image test">
+						? <div className="full-post__featured-image">
 								<img src={ this.props.post.canonical_image.uri } height={ this.props.post.canonical_image.height } width={ 	this.props.post.canonical_image.width } />
 							</div>
 						: null }


### PR DESCRIPTION
Adding the follow button to the full post view, next to the site component. This aims to fix #2750 and #2751 by making the follow button/status more obvious when reading a post. Here's how it looks with the new button:

![screen shot 2016-01-25 at 4 55 32 pm](https://cloud.githubusercontent.com/assets/191598/12565824/75ac27fa-c384-11e5-97b9-be625edb72b5.png)