### PR TITLE
Fix/focus plugin list update

### DIFF
--- a/client/my-sites/site-indicator/README.md
+++ b/client/my-sites/site-indicator/README.md
@@ -14,3 +14,21 @@ render: function() {
     );
 }
 ```
+
+## Props
+
+### `site`
+
+<table>
+	<tr><th>Type</th><td>Object</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site object. 
+
+### `onSelect`
+
+<table>
+	<tr><th>Type</th><td>Function</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import config from 'config';
 import classNames from 'classnames';
+import noop from 'lodash/utility/noop';
 
 /**
  * Internal dependencies
@@ -15,6 +16,17 @@ import analytics from 'analytics';
 
 export default React.createClass( {
 	displayName: 'SiteIndicator',
+
+	propTypes: {
+		site: React.PropTypes.object.isRequired,
+		onSelect: React.PropTypes.func
+	},
+
+	getDefaultProps() {
+		return {
+			onSelect: noop
+		};
+	},
 
 	getInitialState() {
 		return { expand: false };
@@ -94,10 +106,19 @@ export default React.createClass( {
 				</span>
 			);
 		}
+
+		const recordEvent = analytics.ga.recordEvent.bind(
+				analytics,
+				'Site-Indicator',
+				'Clicked updates available link to wp-admin updates',
+				'Total Updates',
+				this.props.site.update && this.props.site.update.total
+			);
+
 		return (
 			<span>
 				<a
-					onClick={ analytics.ga.recordEvent.bind( analytics, 'Site-Indicator', 'Clicked updates available link to wp-admin updates', 'Total Updates', this.props.site.update && this.props.site.update.total ) }
+					onClick={ recordEvent }
 					href={ this.props.site.options.admin_url + 'update-core.php' } >
 					{ this.translate( 'There is an update available.', 'There are updates available.', { count: this.props.site.update.total } ) }
 				</a>
@@ -124,8 +145,9 @@ export default React.createClass( {
 		}.bind( this ), 15000 );
 	},
 
-	handlePluginsUpdate() {
+	handlePluginsUpdate( event ) {
 		window.scrollTo( 0, 0 );
+		this.props.onSelect( event );
 		analytics.ga.recordEvent( 'Site-Indicator', 'Clicked updates available link to plugins updates', 'Total Updates', this.props.site.update && this.props.site.update.total );
 	},
 
@@ -255,9 +277,10 @@ export default React.createClass( {
 		return (
 			<div className={ indicatorClass }>
 				<button className="site-indicator__button" onClick={ this.toggleExpand }>
-					{ this.state.expand ?
-						<Gridicon icon="cross" size={ 18 } />
-					: <Gridicon icon={ this.getIcon() } size={ 16 } /> }
+					{ this.state.expand
+						? <Gridicon icon="cross" size={ 18 } />
+						: <Gridicon icon={ this.getIcon() } size={ 16 } nonStandardSize />
+					}
 				</button>
 				{ this.state.expand
 					? <div className="site-indicator__message">

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -68,7 +68,7 @@ module.exports = React.createClass( {
 		}
 
 		siteClass = classNames( {
-			'site': true,
+			site: true,
 			'is-jetpack': site.jetpack,
 			'is-primary': site.primary,
 			'is-private': site.is_private,
@@ -99,7 +99,7 @@ module.exports = React.createClass( {
 						</span>
 					}
 				</a>
-				{ this.props.indicator ? <SiteIndicator site={ site } /> : null }
+				{ this.props.indicator ? <SiteIndicator site={ site } onSelect={ this.props.onSelect } /> : null }
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes #2227

Currently site indicator when clicked on can't refocus the right side of the page. 
This PR fixes this by passing the onSelect function to the site indicator. 

To test:
1. Go to https://wordpress.com/plugins
2. In the sidebar, click on "Switch Site". The main content area gets hidden.
3. In the sidebar, click on the Orange update icon on a site where a plugin update is available.
4. In the sidebar, click on "There is a plugin update available"
5. The site's plugin update page loads, but the main content area is still now shown. 

cc @jeherve


