### PR TITLE
Me: Fixes logout button in Me sidebar

### DIFF
--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -29,7 +29,7 @@ var userUtils = {
 			url = userData.logout_URL;
 		}
 
-		if ( redirect ) {
+		if ( 'string' === typeof redirect ) {
 			redirect = '&redirect_to=' + encodeURIComponent( redirect );
 			url += redirect;
 		}


### PR DESCRIPTION
Fixes a regression of the logout functionality in `/me` after merging #2647.

In #2647, we added the ability to pass a redirect while logging out a user. The issue that we didn't anticipate is that in some places we already pass an object to `userUtils.logout()`. Specifically, in [/me/sidebar/index.jsx](https://github.com/Automattic/wp-calypso/blob/master/client/me/sidebar/index.jsx#L66) with how we track analytics.

This PR fixes the issue by ensuring that the redirect is a string before appending it to the logout URL.

To test:
- Checkout `fix/me-logout-button` branch
- Go to `/me`
- Click "Sign Out" button
- Ensure that you land on `wordpress.com` and not `wordpress.com/{Object object]`.