### PR TITLE
Checkout: use new TOS with paypal, too

### DIFF
--- a/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
@@ -149,7 +149,8 @@ module.exports = React.createClass( {
 						eventFormName="Checkout Form" />
 				</div>
 
-				<TermsOfService />
+				<TermsOfService
+					hasRenewableSubscription={ cartValues.cartItems.hasRenewableSubscription( this.props.cart ) } />
 
 				<div className="payment-box-actions">
 					<div className="pay-button">


### PR DESCRIPTION
Addition to https://github.com/Automattic/wp-calypso/pull/2293, without this only when paying with CC the new TOS was shown.