### PR TITLE
Remove the share option for private sites

### DIFF
--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -32,6 +32,7 @@ var Card = require( 'components/card' ),
 	SiteStore = require( 'lib/reader-site-store' ),
 	SiteStoreActions = require( 'lib/reader-site-store/actions' ),
 	Share = require( 'reader/share' ),
+	ShareHelper = require( 'reader/share/helper' ),
 	utils = require( 'reader/utils' ),
 	PostCommentHelper = require( 'reader/comments/helper' ),
 	LikeHelper = require( 'reader/like-helper' ),
@@ -305,6 +306,7 @@ var Post = React.createClass( {
 			featuredImage = this.featuredImageComponent( post ),
 			shouldShowComments = PostCommentHelper.shouldShowComments( post ),
 			shouldShowLikes = LikeHelper.shouldShowLikes( post ),
+			shouldShowShare = ShareHelper.shouldShowShare( post ),
 			hasFeaturedImage = featuredImage !== null,
 			articleClasses = assign( {
 				reader__card: true,
@@ -418,7 +420,7 @@ var Post = React.createClass( {
 
 				<ul className="reader__post-footer">
 					<PostPermalink siteName={ siteName } postUrl={ post.URL } />
-					<Share post={ post } />
+					{ ( shouldShowShare ) ? <Share post={ post } /> : null }
 					{ ( shouldShowComments ) ? <CommentButton onClick={ this.handleCommentButtonClick } commentCount={ commentCount } /> : null }
 					{ ( shouldShowLikes ) ? <LikeButton siteId={ likeSiteId } postId={ likePostId } /> : null }
 					<li className="reader__post-options"><PostOptions post={ post } site={ this.state.site } /></li>

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -38,6 +38,7 @@ var analytics = require( 'analytics' ),
 	stats = require( 'reader/stats' ),
 	PostExcerptLink = require( 'reader/post-excerpt-link' ),
 	ShareButton = require( 'reader/share' ),
+	ShareHelper = require( 'reader/share/helper' ),
 	DiscoverHelper = require( 'reader/discover/helper' ),
 	DiscoverVisitLink = require( 'reader/discover/visit-link' ),
 	readerRoute = require( 'reader/route' );
@@ -293,6 +294,7 @@ FullPostDialog = React.createClass( {
 			site = this.props.site,
 			shouldShowComments = false,
 			shouldShowLikes = false,
+			shouldShowShare = false,
 			buttons = [
 				{
 					label: this.translate( 'Back', { context: 'Go back in browser history' } ),
@@ -304,6 +306,7 @@ FullPostDialog = React.createClass( {
 		if ( post && ! post._state ) {
 			shouldShowComments = PostCommentHelper.shouldShowComments( post );
 			shouldShowLikes = LikeHelper.shouldShowLikes( post );
+			shouldShowShare = ShareHelper.shouldShowShare( post );
 
 			buttons.push( <PostOptions key="post-options" post={ post } site={ site } onBlock={ this.props.onClose } /> );
 
@@ -315,7 +318,9 @@ FullPostDialog = React.createClass( {
 				buttons.push( <CommentButton key="comment-button" commentCount={ this.props.commentCount } onClick={ this.handleCommentButtonClick } tagName="div" /> );
 			}
 
-			buttons.push( <ShareButton post={ post } position="bottom left" tagName="div" /> );
+			if ( shouldShowShare ) {
+				buttons.push( <ShareButton post={ post } position="bottom left" tagName="div" /> );
+			}
 		}
 
 		buttons = buttons.map( function( button ) {

--- a/client/reader/share/helper.jsx
+++ b/client/reader/share/helper.jsx
@@ -1,0 +1,7 @@
+
+module.exports = {
+	shouldShowShare: function( post ) {
+		return ! post.site_is_private;
+	}
+};
+


### PR DESCRIPTION
Fixes issue #2760,
Basically I've followed the same patter as per the comments and likes,
I created a helper, that has now very simple logic, share option should be shown if ``post.site_is_private`` is ``false``.

I've changed the post component of the following stream and the full post component to use that helper to decide whether to show the share option.

As I've mentioned before, I've followed the style of likes and comments, but maybe a better approach would be that the share component will decide whether to render itself or not.
Any thoughts on that?

Thanks!