### PR TITLE
Signup: Add verticals survey to default flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -68,6 +68,21 @@ const flows = {
 		lastModified: '2016-02-02'
 	},
 
+	/* WP.com homepage flows */
+	website: {
+		steps: [ 'survey', 'themes', 'domains', 'plans', 'user' ],
+		destination: getCheckoutDestination,
+		description: 'This flow is used for the users who clicked "Create Website" on the two-button homepage.',
+		lastModified: '2016-01-28'
+	},
+
+	blog: {
+		steps: [ 'survey', 'themes', 'domains', 'plans', 'user' ],
+		destination: getCheckoutDestination,
+		description: 'This flow is used for the users who clicked "Create Blog" on the two-button homepage.',
+		lastModified: '2016-01-28'
+	},
+
 	/* On deck flows*/
 
 	/* Testing flows */
@@ -76,13 +91,6 @@ const flows = {
 		destination: '/me/next/welcome',
 		description: 'This flow is used to test the site step.',
 		lastModified: '2015-09-22'
-	},
-
-	verticals: {
-		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
-		destination: getCheckoutDestination,
-		description: 'Categorizing blog signups for Verticals Survey',
-		lastModified: '2015-12-10'
 	},
 
 	'delta-discover': {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -20,7 +20,6 @@ module.exports = {
 	'select-plan': PaidPlansWithFreeTrials,
 	domains: DomainsStepComponent,
 	survey: SurveyStepComponent,
-	'survey-user': UserSignupComponent,
 	'design-type': DesignTypeComponent,
 	'themes-headstart': ThemeSelectionComponent,
 	'domains-with-theme': DomainsStepComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -47,18 +47,10 @@ module.exports = {
 		stepName: 'test',
 	},
 
-	'survey-user': {
-		stepName: 'survey-user',
-		apiRequestFunction: stepActions.createAccount,
-		dependencies: [ 'surveySiteType', 'surveyQuestion' ],
-		providesToken: true,
-		providesDependencies: [ 'bearer_token', 'username' ]
-	},
-
 	survey: {
 		stepName: 'survey',
 		props: {
-			surveySiteType: ( '/start/vert-blog' === current ) ? 'blog' : 'site'
+			surveySiteType: ( current && current.toString().match( /\/start\/blog/ ) ) ? 'blog' : 'site'
 		},
 		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
 	},


### PR DESCRIPTION
Recent A/B tests have shown no negative impact on conversions if the first step of the signup flow includes a three-step question asking the user to categorize their new site (e.g.: Site → Business and Services → Technology & Computing, or Blog → Health and Wellness → Mental Health).

The categories are a subset of the IAB taxonomy, customized for WordPress.com.

Currently these selections are only recorded as data for analysis; they have no effect on the signup process. However, they can be used to segment other parts of signup during future tests. For example, the list of nine themes shown during the signup flow is based on very old data about theme selection trends. Using the data from the verticals survey, it is possible to create tailored theme sets for different types of sites. 

This PR includes the survey step as the first step of the default signup flow.

The first question of the survey flow, "Blog" or "Website", is not part of this PR as it lives on the WordPress.com home page. The second two questions are handled by a component called `Survey` that varies slightly based on the first question. In order to pass the first choice to the `Survey` component, there must be two different URLs for each answer.

As part of this PR we will need to determine what those URLs should be (although one of them will be the default flow, so we really only need to decide one of the URLs).