### PR TITLE
Reader: use tag.display_name to display tag names

### DIFF
--- a/client/reader/post-byline/index.jsx
+++ b/client/reader/post-byline/index.jsx
@@ -32,7 +32,7 @@ var PostByline = React.createClass( {
 
 	renderAuthorName: function() {
 		const post = this.props.post,
-			gravatar = ( <Gravatar user={post.author} size={ 24 } /> ),
+			gravatar = ( <Gravatar user={ post.author } size={ 24 } /> ),
 			authorName = ( <span className="byline__author-name">{ post.author.name }</span> );
 
 		if ( ! post.author.URL ) {
@@ -73,11 +73,11 @@ var PostByline = React.createClass( {
 					<a className="reader-post-byline__date-link"
 						onClick={ this.recordDateClick }
 						href={ post.URL }
-						target="_blank"><PostTime date={ post.date } />{ this.props.icon ? <Gridicon icon="external" size={ 14 } /> : null }</a>
+						target="_blank"><PostTime date={ post.date } />{ this.props.icon ? <Gridicon icon="external" nonStandardSize size={ 14 } /> : null }</a>
 				</li> : null }
 			{ primaryTag ?
 				<li className="reader-post-byline__tag">
-					<a href={ '/tag/' + primaryTag.slug } className="ignore-click" onClick={ this.recordTagClick }><Gridicon icon="tag" size={ 16 } /> { primaryTag.name }</a>
+					<a href={ '/tag/' + primaryTag.slug } className="ignore-click" onClick={ this.recordTagClick }><Gridicon icon="tag" nonStandardSize size={ 16 } /> { primaryTag.display_name }</a>
 				</li> : null }
 			</ul>
 		);

--- a/client/reader/sidebar/sidebar.jsx
+++ b/client/reader/sidebar/sidebar.jsx
@@ -233,7 +233,7 @@ module.exports = React.createClass( {
 			return (
 				<li className={ this.itemLinkClass( '/tag/' + tag.slug, { 'sidebar-dynamic-menu__tag': true } ) } key={ tag.ID } >
 					<a href={ tag.URL }>
-						{ tag.title || tag.slug }
+						{ tag.display_name || tag.slug }
 					</a>
 					{ tag.ID !== 'pending' ? <button className="sidebar-dynamic-menu__action" data-tag-slug={ tag.slug } onClick={ this.unfollowTag }>
 						<Gridicon icon="cross" size={ 24 } />

--- a/client/reader/tag-stream/index.jsx
+++ b/client/reader/tag-stream/index.jsx
@@ -50,7 +50,7 @@ var FeedStream = React.createClass( {
 			return this.translate( 'Loading Tag' );
 		}
 
-		return tag.title || tag.slug;
+		return tag.display_name || tag.slug;
 	},
 
 	isSubscribed: function() {


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/issues/2551#issuecomment-172667309 we decided to lowercase all tag names in the Reader.

This PR makes use of the newly-added tag `display_name` property (wpcom-130241) to do just that.

If a tag slug is alphanumeric (dashes are also permitted), it will be used as the display name. Otherwise, the title is used. For example, the tag 未分類 uses the title rather than the slug.

Before:
<img width="270" alt="screen shot 2016-01-26 at 17 48 19" src="https://cloud.githubusercontent.com/assets/17325/12572749/22018b3c-c455-11e5-81cb-d658fd1c09e0.png">

After:
<img width="260" alt="screen shot 2016-01-26 at 17 48 39" src="https://cloud.githubusercontent.com/assets/17325/12572750/22305eda-c455-11e5-88be-75c8292d987d.png">
