### PR TITLE
Signup: Domains: don't run availability checks on .wordpress.com domains

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -221,7 +221,7 @@ var RegisterDomainStep = React.createClass( {
 		async.parallel(
 			[
 				callback => {
-					if ( ! domain.match( /.{3,}\..{2,}/ ) ) {
+					if ( ! domain.match( /.{3,}\..{2,}/ ) || domain.match( /\.wordpress\.com/i ) ) {
 						return callback();
 					}
 


### PR DESCRIPTION
To test:
1. Go to domains/add or /start, register domain step
2. Search for something01934.wordpress.com
3. It should not trigger an availability check and errors (something01934.wordpress.com is not a valid domain)