### PR TITLE
Reader: Fix wrong breakpoint value in SCSS file

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -59,7 +59,7 @@
 			top: 0;
 			right: 0;
 
-		@include breakpoint( "<440px" ) {
+		@include breakpoint( "<480px" ) {
 			.follow-button__label {
 				display: none;
 			}


### PR DESCRIPTION
It produced warning when running Calypso in development mode.