### PR TITLE
Desktop: Change Calypso script name

### DIFF
--- a/server/pages/desktop.jade
+++ b/server/pages/desktop.jade
@@ -23,7 +23,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class='is-desktop' + ( isFluidWidth ?
 				link(rel='stylesheet', href=urls['style.css'])
 
 		link(rel='stylesheet', href='/desktop/wordpress-desktop.css')
-		script(src='/calypso/build-desktop.js')
+		script(src='/calypso/build.js')
 		script(src='/desktop/desktop-app.js')
 
 	body(class=isRTL ? 'rtl' : '')


### PR DESCRIPTION
Part of Automattic/wp-desktop/pull/54.

This is very simple change to use different script name for Calypso build.

### Testing
It should be tested together with desktop app using `fix/run-mac-app-store` branch.