### PR TITLE
Plugins: Return a rejected promise when install can't be performed

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -34,6 +34,10 @@ function getSolvedPromise( dataToPass ) {
 	return new Promise( resolve => resolve( dataToPass ) );
 }
 
+function getRejectedPromise( errorToPass ) {
+	return new Promise( ( resolve, reject ) => reject( errorToPass ) );
+}
+
 function queueSitePluginAction( action, siteId, pluginId, callback ) {
 	let next = function( nextCallback, error, data ) {
 		let nextAction;
@@ -191,8 +195,12 @@ PluginsActions = {
 	installPlugin: function( site, plugin ) {
 		var install, activate, autoupdate, dispatchMessage;
 
-		if ( ! site.canUpdateFiles || ! site.user_can_manage ) {
-			return;
+		if ( ! site.canUpdateFiles ) {
+			return getRejectedPromise( 'Error: Can\'t update files on the site' )
+		}
+
+		if ( ! site.user_can_manage ) {
+			return getRejectedPromise( 'Error: User can\'t manage the site' )
 		}
 
 		install = function() {

--- a/client/lib/plugins/test/test-actions.js
+++ b/client/lib/plugins/test/test-actions.js
@@ -58,6 +58,19 @@ describe( 'WPcom Data Actions', function() {
 		assert.equal( mockedWpcom.getActivity().pluginsInstallCalls, 0 );
 	} );
 
+
+	it( 'when installing a plugin, it should return a rejected promise if the site files can\'t be updated', function( done ) {
+		actions.installPlugin( { canUpdateFiles: false, user_can_manage: true }, 'test', function() {} )
+			.then( function() { done( 'Promise should be rejected' ) } )
+			.catch( function() { done() } );
+	} );
+
+	it( 'when installing a plugin, it should return a rejected promise if user can\'t manage the site', function( done ) {
+		actions.installPlugin( { canUpdateFiles: true, user_can_manage: false }, 'test', function() {} )
+			.then( function() { done( 'Promise should be rejected' ) } )
+			.catch( function() { done() } );
+	});
+
 	it( 'Actions should have method removePlugin', function() {
 		assert.isFunction( actions.removePlugin );
 	} );


### PR DESCRIPTION
While reviewing jetpack plans PR (https://github.com/Automattic/wp-calypso/pull/2244/files#diff-4f4696e3ecff8d16d9efac83d54602b6R86) I've found a condition where an exception was being thrown due `PluginsAction.installPlugin` not returning a promise when the install conditions wasn't being met. For consistency, installPlugin should return a promise always.

How to test
========

Nothing to test from the UI. I've included a couple of test to make sure this works as expected in each case

/cc @enejb @lezama @ryelle 