### PR TITLE
Masterbar: Add login and signup links when logged-out

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -12,7 +12,7 @@ var React = require( 'react' ),
 var abtest = require( 'lib/abtest' ).abtest,
 	MasterbarCheckout = require( 'layout/masterbar/checkout' ),
 	MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
-	MasterbarMinimal = require( 'layout/masterbar/minimal' ),
+	MasterbarLoggedOut = require( 'layout/masterbar/logged-out' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	GlobalNotices = require( 'components/global-notices' ),
 	notices = require( 'notices' ),
@@ -97,7 +97,7 @@ Layout = React.createClass( {
 		}
 
 		if ( ! this.props.user ) {
-			return <MasterbarMinimal url="/" />;
+			return <MasterbarLoggedOut url="/" />;
 		}
 
 		if ( 'checkout' === this.props.section && abtest( 'checkoutMasterbar' ) === 'minimal' ) {

--- a/client/layout/logged-out-design.jsx
+++ b/client/layout/logged-out-design.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import MasterbarMinimal from 'layout/masterbar/minimal';
+import MasterbarLoggedOut from 'layout/masterbar/logged-out';
 import ThemesHead from 'my-sites/themes/head';
 
 const LayoutLoggedOutDesign = ( { section, hasSidebar, tier = 'all' } ) => {
@@ -22,7 +22,7 @@ const LayoutLoggedOutDesign = ( { section, hasSidebar, tier = 'all' } ) => {
 	return (
 		<div className={ classes }>
 			<ThemesHead tier={ tier } />
-			<MasterbarMinimal url="/" />
+			<MasterbarLoggedOut url="/" />
 			<div id="content" className="wp-content">
 				<div id="primary" className="wp-primary wp-section" />
 				<div id="secondary" className="wp-secondary" />

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -1,0 +1,37 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import React from 'react/addons';
+import MasterbarMinimal from './minimal';
+
+/**
+ * Internal dependencies
+ */
+import Item from './item';
+import config from 'config';
+
+export default React.createClass( {
+	propTypes: {
+		// Target for the logo link
+		url: React.PropTypes.string.isRequired
+	},
+
+	render() {
+		return(
+			<MasterbarMinimal
+				url={ this.props.url }
+				loggedOut={ true }>
+				<div className="masterbar__login-links">
+					<Item url={ config( 'signup_url' ) }>
+						{ this.translate( 'Sign up', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
+					</Item>
+					<Item url={ config( 'login_url' ) }>
+						{ this.translate( 'Log in', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
+					</Item>
+				</div>
+			</MasterbarMinimal>
+		);
+	},
+} );

--- a/client/layout/masterbar/minimal.jsx
+++ b/client/layout/masterbar/minimal.jsx
@@ -5,22 +5,34 @@
  */
 import React from 'react';
 import Masterbar from './masterbar';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import Item from './item';
 
-const MasterbarMinimal = ( { url } ) => (
+const MasterbarMinimal = ( { url, loggedOut, children } ) => (
 	<Masterbar>
-		<Item url={ url } icon="my-sites" className="masterbar__item-logo">
+		<Item url={ url }
+			icon="my-sites"
+			className={ classnames(
+				'masterbar__item-logo',
+				{ 'is-loggedout': loggedOut } ) }>
 			WordPress<span className="tld">.com</span>
 		</Item>
+		{ children }
 	</Masterbar>
 );
 
 MasterbarMinimal.propTypes = {
-	url: React.PropTypes.string.isRequired
+	url: React.PropTypes.string.isRequired,
+	loggedOut: React.PropTypes.bool,
+	children: React.PropTypes.node,
+};
+
+MasterbarMinimal.defaultProps = {
+	loggedOut: false,
 };
 
 export default MasterbarMinimal;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -86,6 +86,28 @@ $autobar-height: 20px;
 	.tld {
 		color: rgba(255, 255, 255, 0.6);
 	}
+
+	&.is-loggedout {
+		.gridicon {
+			margin: 0;
+		}
+	}
+}
+
+.masterbar__login-links {
+	display: flex;
+	margin-left: auto;
+	margin-right: 12px;
+}
+
+.masterbar__login-links .masterbar__item-content {
+	display: inline;
+	padding-right: 6px;
+}
+
+.masterbar__login-links .masterbar__item {
+	padding-left: 5px;
+	padding-right: 5px;
 }
 
 .masterbar__item-new {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -10,6 +10,7 @@ var express = require( 'express' ),
 	includes = require( 'lodash/collection/includes' ),
 	React = require( 'react' ),
 	ReactDomServer = require( 'react-dom/server' ),
+	ReactInjection = require( 'react/lib/ReactInjection' ),
 	Helmet = require( 'react-helmet' ),
 	pick = require( 'lodash/object/pick' );
 
@@ -17,11 +18,10 @@ var config = require( 'config' ),
 	sanitize = require( 'sanitize' ),
 	utils = require( 'bundler/utils' ),
 	sections = require( '../../client/sections' ),
-	LayoutLoggedOutDesign = require( 'layout/logged-out-design' ),
 	createReduxStore = require( 'state' ).createReduxStore,
-	setSection = require( 'state/ui/actions' ).setSection;
+	setSection = require( 'state/ui/actions' ).setSection,
+	i18n = require( 'lib/mixins/i18n');
 
-var LayoutLoggedOutDesignFactory = React.createFactory( LayoutLoggedOutDesign );
 var cachedDesignMarkup = {};
 
 var HASH_LENGTH = 10,
@@ -38,6 +38,11 @@ var staticFiles = [
 ];
 
 var chunksByPath = {};
+
+i18n.initialize();
+ReactInjection.Class.injectMixin( i18n.mixin );
+const LayoutLoggedOutDesign = require( 'layout/logged-out-design' );
+const LayoutLoggedOutDesignFactory = React.createFactory( LayoutLoggedOutDesign );
 
 sections.forEach( function( section ) {
 	section.paths.forEach( function( path ) {

--- a/server/pages/test/index.js
+++ b/server/pages/test/index.js
@@ -5,10 +5,14 @@ import { assert } from 'chai';
 import React from 'react';
 import ReactDomServer from 'react-dom/server';
 import { createReduxStore } from 'state';
+import ReactInjection from 'react/lib/ReactInjection';
+import i18n from 'lib/mixins/i18n';
 
 describe( 'Server pages:', function() {
 	context( 'when trying to renderToString() LayoutLoggedOutDesign ', function() {
 		before( function() {
+			i18n.initialize();
+			ReactInjection.Class.injectMixin( i18n.mixin );
 			const LayoutLoggedOutDesign = require( 'layout/logged-out-design' );
 			this.LayoutLoggedOutDesignFactory = React.createFactory( LayoutLoggedOutDesign );
 			this.props = {


### PR DESCRIPTION
Addresses #2568

**Before**
<img width="996" alt="screen shot 2016-01-29 at 12 50 01" src="https://cloud.githubusercontent.com/assets/7767559/12676092/6056b82e-c687-11e5-907c-43b6d0184c00.png">
<img width="302" alt="screen shot 2016-01-29 at 12 50 23" src="https://cloud.githubusercontent.com/assets/7767559/12676096/663ab92a-c687-11e5-9ea9-acdac9ea01f6.png">


**After**
<img width="998" alt="screen shot 2016-01-29 at 12 52 15" src="https://cloud.githubusercontent.com/assets/7767559/12676100/71b5d2e4-c687-11e5-9d58-f139dd4af068.png">
<img width="302" alt="screen shot 2016-01-29 at 12 52 50" src="https://cloud.githubusercontent.com/assets/7767559/12676103/74bd1b78-c687-11e5-9d33-5e8da0607daf.png">

From this design:
<img width="635" alt="screen shot 2016-01-19 at 12 04 26" src="https://cloud.githubusercontent.com/assets/7767559/12418102/e5c088fe-bea4-11e5-9d3a-f0cd41fb5450.png">

The logged-out masterbar is rendered on the server for the logged-out /design route, so at some stage will need i18n to be working on the server (exporing in #2656), but this is not necessary at present since we are not yet determining any locale for this logged-out route.
