### PR TITLE
Jetpack: Add functions to get & set options for a site

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -369,11 +369,9 @@ JetpackSite.prototype.getOption = function( query, callback ) {
 
 		if ( error ) {
 			debug( 'error getting option', error );
-			callback && callback( error );
-			return;
 		}
 
-		callback && callback( null, data );
+		callback && callback( error, data );
 	}.bind( this ) );
 
 	this.emit( 'change' );
@@ -387,11 +385,9 @@ JetpackSite.prototype.setOption = function( query, callback ) {
 
 		if ( error ) {
 			debug( 'error getting option', error );
-			callback && callback( error );
-			return;
 		}
 
-		callback && callback( null, data );
+		callback && callback( error, data );
 	}.bind( this ) );
 
 	this.emit( 'change' );

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -363,4 +363,38 @@ JetpackSite.prototype.updateSshCredentials = function( query, callback ) {
 	this.emit( 'change' );
 };
 
+JetpackSite.prototype.getOption = function( query, callback ) {
+	wpcom.undocumented().site( this.ID ).getOption( query, function( error, data ) {
+		this.emit( 'change' );
+
+		if ( error ) {
+			debug( 'error getting option', error );
+			callback && callback( error );
+			return;
+		}
+
+		callback && callback( null, data );
+	}.bind( this ) );
+
+	this.emit( 'change' );
+};
+
+JetpackSite.prototype.setOption = function( query, callback ) {
+	query.site_option = query.site_option || false;
+	query.is_array = query.is_array || false;
+	wpcom.undocumented().site( this.ID ).setOption( query, function( error, data ) {
+		this.emit( 'change' );
+
+		if ( error ) {
+			debug( 'error getting option', error );
+			callback && callback( error );
+			return;
+		}
+
+		callback && callback( null, data );
+	}.bind( this ) );
+
+	this.emit( 'change' );
+};
+
 module.exports = JetpackSite;

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -20,7 +20,8 @@ var resources = [
 	[ 'sshCredentialsNew', 'ssh-credentials/new', '1.1', 'post' ],
 	[ 'sshCredentialsMine', 'ssh-credentials/mine', '1.1' ],
 	[ 'sshCredentialsMineDelete', 'ssh-credentials/mine/delete', '1.1', 'post' ],
-	[ 'sshScanToggle', 'ssh-credentials/mine', '1.1', 'post' ]
+	[ 'sshScanToggle', 'ssh-credentials/mine', '1.1', 'post' ],
+	[ 'getOption', 'option/' ]
 ];
 
 var list = function( resourceOptions ) {
@@ -167,6 +168,19 @@ UndocumentedSite.prototype.removeEmailFollower = function( followerId, callback 
 
 UndocumentedSite.prototype.getMuseCustomizations = function( callback ) {
 	this.wpcom.req.get( '/sites/' + this._id + '/customizations', callback );
+}
+
+UndocumentedSite.prototype.setOption = function( query, callback ) {
+	this.wpcom.req.post(
+		'/sites/' + this._id + '/option',
+		{
+			option_name: query.option_name,
+			is_array: query.is_array,
+			site_option: query.site_option
+		},
+		{ option_value: query.option_value },
+		callback
+	);
 }
 
 /**


### PR DESCRIPTION
Jetpack 3.9 enables a new endpoint which can be used to get & set an option on the site. This adds the corresponding functions to the JetpackSite object.

More context in #2244 – this PR is part of breaking that into smaller chunks.