### PR TITLE
Invites: Do not show sign up for match email error to known user

### DIFF
--- a/client/components/forms/form-setting-explanation/index.jsx
+++ b/client/components/forms/form-setting-explanation/index.jsx
@@ -11,7 +11,8 @@ module.exports = React.createClass( {
 
 	render: function() {
 		return (
-			<p { ...omit( this.props, 'className' ) } className={ classnames( this.props.className, 'form-setting-explanation' ) } >
+			<p { ...omit( this.props, 'className' ) }
+				className={ classnames( this.props.className, 'form-setting-explanation', { 'no-validate': this.props.noValidate } ) } >
 				{ this.props.children }
 			</p>
 		);

--- a/client/components/signup-form/README.md
+++ b/client/components/signup-form/README.md
@@ -36,4 +36,5 @@ render: function() {
 * (optional) `disabled` boolean: Sets the form as disabled
 * (optional) `submitting` boolean: Sets the state of the form as being submitted
 * (optional) `email` string: Initial value for email input
-* (options) `disableEmailInput` boolean: Disables the email input. Useful if email must be a certain value and that value is passed in through the `email` prop
+* (optional) `disableEmailInput` boolean: Disables the email input. Useful if email must be a certain value and that value is passed in through the `email` prop
+* (optional) `disableEmailExplanation` string: Explanation text that appears beneath the email field when disabled.

--- a/client/components/signup-form/index.jsx
+++ b/client/components/signup-form/index.jsx
@@ -320,6 +320,7 @@ export default React.createClass( {
 						isValid={ ! this.props.disableEmailInput && this.state.validationInitialized && formState.isFieldValid( this.state.form, 'email' ) }
 						onBlur={ this.handleBlur }
 						onChange={ this.handleChangeEvent } />
+					{ this.emailDisableExplanation() }
 				</ValidationFieldset>
 
 				<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'username' ) }>
@@ -398,6 +399,14 @@ export default React.createClass( {
 			return this.globalNotice( this.state.notice );
 		}
 		return false;
+	},
+
+	emailDisableExplanation() {
+		if ( this.props.disableEmailInput && this.props.disableEmailExplanation ) {
+			return (
+				<FormSettingExplanation noValidate={ true }>{ this.props.disableEmailExplanation }</FormSettingExplanation>
+			);
+		}
 	},
 
 	formFooter() {

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -18,6 +18,8 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import analytics from 'analytics';
 import { errorNotice } from 'state/notices/actions';
+import Card from 'components/card';
+import FormButton from 'components/forms/form-button';
 
 let InviteAcceptLoggedOut = React.createClass( {
 
@@ -38,7 +40,9 @@ let InviteAcceptLoggedOut = React.createClass( {
 	},
 
 	clickSignInLink() {
+		let signInLink = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
 		analytics.tracks.recordEvent( 'calypso_invite_accept_logged_out_sign_in_link_click' );
+		window.location = signInLink;
 	},
 
 	submitForm( form, userData ) {
@@ -93,10 +97,9 @@ let InviteAcceptLoggedOut = React.createClass( {
 	},
 
 	renderFooterLink() {
-		let logInUrl = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
 		return (
 			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem onClick={ this.clickSignInLink } href={ logInUrl }>
+				<LoggedOutFormLinkItem onClick={ this.clickSignInLink }>
 					{ this.translate( 'Already have a WordPress.com account? Log in now.' ) }
 				</LoggedOutFormLinkItem>
 				{ this.renderEmailOnlySubscriptionLink() }
@@ -116,7 +119,26 @@ let InviteAcceptLoggedOut = React.createClass( {
 		);
 	},
 
+	renderSignInLinkOnly() {
+		return (
+			<div className="sign-up-form">
+				<Card className="logged-out-form">
+					{ this.renderFormHeader() }
+					<Card className="logged-out-form__footer">
+						<FormButton className="signup-form__submit" onClick={ this.clickSignInLink }>
+							{ this.translate( 'Sign In' ) }
+						</FormButton>
+					</Card>
+				</Card>
+			</div>
+		);
+	},
+
 	render() {
+		if ( this.props.forceMatchingEmail && this.props.invite.knownUser ) {
+			return this.renderSignInLinkOnly();
+		}
+
 		return (
 			<div>
 				<SignupForm
@@ -129,7 +151,8 @@ let InviteAcceptLoggedOut = React.createClass( {
 					submitButtonText={ this.submitButtonText() }
 					footerLink={ this.renderFooterLink() }
 					email={ this.props.invite.sentTo }
-					disableEmailInput={ this.props.forceMatchingEmail }/>
+					disableEmailInput={ this.props.forceMatchingEmail }
+					disableEmailExplanation={ this.translate( 'This invite is only valid for %(email)s.', { args: { email: this.props.invite.sentTo } } ) } />
 				{ this.state.userData && this.loginUser() }
 			</div>
 		)

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -37,8 +37,11 @@ export default React.createClass( {
 
 	getLoggedOutTitleForInvite() {
 		let title = '';
+		const { role, forceMatchingEmail, knownUser } = this.props;
 
-		const { role } = this.props;
+		if ( forceMatchingEmail && knownUser ) {
+			return this.translate( 'Sign in to continue:' );
+		}
 
 		switch ( role ) {
 			case 'administrator':

--- a/client/signup/validation-fieldset/style.scss
+++ b/client/signup/validation-fieldset/style.scss
@@ -6,6 +6,11 @@
 		max-height: 0;
 		overflow: hidden;
 		transition: all .3s ease-in-out;
+		
+		&.no-validate {
+			max-height: none;
+			overflow: auto;
+		}
 	}
 
 	input:focus + .form-setting-explanation {


### PR DESCRIPTION
If an invite was sent to a known user, and the site requires that all
invites be accepted with a matching email, there's no need to show a signup form.

Closes #2767 

Prior to this PR we'd present this for invites to known users:
![screen shot 2016-01-26 at 12 32 31 pm](https://cloud.githubusercontent.com/assets/2694219/12590919/61839bfa-c433-11e5-98e2-b1dde9961b2a.png)

But it doesn't make sense to ask a known user to sign up. So this PR will instead present this:
![screen shot 2016-01-26 at 1 36 09 pm](https://cloud.githubusercontent.com/assets/2694219/12590931/69312e80-c433-11e5-87ac-043ae0ad8e33.png)


To test:
- Invite a known user to a blog that requires matching email addresses
- As a logged out user, visit the accept invite page in calypso.localhost:3000
- Ensure that the flow makes sense, and there are no errors
- Repeat for an invite to an unknown user


