### PR TITLE
Analytics: Bust cache for `w.js`  to match version on WordPress.com

### DIFF
--- a/client/analytics/index.js
+++ b/client/analytics/index.js
@@ -22,7 +22,7 @@ window.ga = window.ga || function() {
 };
 window.ga.l = +new Date();
 
-loadScript( '//stats.wp.com/w.js?50' );
+loadScript( '//stats.wp.com/w.js?51' );
 loadScript( '//www.google-analytics.com/analytics.js' );
 
 function buildQuerystring( group, name ) {


### PR DESCRIPTION
This change updates the cache bust for `w.js` to match the rest of WordPress.com

Functionally there isn't anything to test, aside from ensuring that `w.js` is loaded with the proper cache bust.