### PR TITLE
Reader: Add a back button to tag streams and improve how we show it.

### DIFF
--- a/client/lib/reader-lists/lists.js
+++ b/client/lib/reader-lists/lists.js
@@ -15,7 +15,7 @@ function keyForList( owner, slug ) {
 }
 
 function getListURL( list ) {
-	return '/read/list/' + encodeURIComponent( list.owner ) + '/' + encodeURIComponent( list.slug ) + '/';
+	return '/read/list/' + encodeURIComponent( list.owner ) + '/' + encodeURIComponent( list.slug );
 }
 
 ListStore = {

--- a/client/lib/reader-tags/tags.js
+++ b/client/lib/reader-tags/tags.js
@@ -16,7 +16,7 @@ emitter( TagStore );
 
 function receiveTags( newTags ) {
 	forOwn( newTags, ( sub ) => {
-		sub.URL = '/tag/' + sub.slug + '/';
+		sub.URL = '/tag/' + sub.slug;
 		sub.title = decodeEntities( sub.title );
 		sub.slug = sub.slug.toLowerCase();
 		tags[ sub.slug ] = sub;

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -58,7 +58,7 @@ function trackScrollPage( path, title, category, readerView, pageNum ) {
 }
 
 // Listen for route changes and remove the full post dialog when we navigate away from it
-pageNotifier( ( newContext, oldContext ) => {
+pageNotifier( function removeFullPostOnLeave( newContext, oldContext ) {
 	if ( ! oldContext ) {
 		return;
 	}
@@ -76,6 +76,10 @@ pageNotifier( ( newContext, oldContext ) => {
 function removeFullPostDialog() {
 	ReactDom.unmountComponentAtNode( document.getElementById( 'tertiary' ) );
 	__fullPostInstance = null;
+}
+
+function userHasHistory( context ) {
+	return !! context.lastRoute;
 }
 
 function ensureStoreLoading( store, context ) {
@@ -192,7 +196,8 @@ module.exports = {
 					mcKey
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
-				suppressSiteNameLink: true
+				suppressSiteNameLink: true,
+				showBack: userHasHistory( context )
 			} ),
 			document.getElementById( 'primary' )
 		);
@@ -226,7 +231,8 @@ module.exports = {
 					mcKey
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
-				suppressSiteNameLink: true
+				suppressSiteNameLink: true,
+				showBack: userHasHistory( context )
 			} ),
 			document.getElementById( 'primary' )
 		);
@@ -338,7 +344,8 @@ module.exports = {
 					analyticsPageTitle,
 					mcKey
 				),
-				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey )
+				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+				showBack: userHasHistory( context )
 			} ),
 			document.getElementById( 'primary' )
 		);

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -8,7 +8,7 @@ var EmptyContent = require( './empty' ),
 	FeedStoreActions = require( 'lib/feed-store/actions' ),
 	FeedStoreState = require( 'lib/feed-store/constants' ).state,
 	FeedError = require( 'reader/feed-error' ),
-	HeaderCake = require( 'components/header-cake' ),
+	HeaderBack = require( 'reader/header-back' ),
 	SiteStore = require( 'lib/reader-site-store' ),
 	SiteState = require( 'lib/reader-site-store/constants' ).state;
 
@@ -131,12 +131,6 @@ var FeedStream = React.createClass( {
 		}
 	},
 
-	goBack: function() {
-		if ( typeof window !== 'undefined' ) {
-			window.history.back();
-		}
-	},
-
 	render: function() {
 		var feed = FeedStore.get( this.props.feedId ),
 			emptyContent = ( <EmptyContent /> );
@@ -151,7 +145,7 @@ var FeedStream = React.createClass( {
 
 		return (
 			<FollowingStream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } >
-				{ this.props.showBack ? <HeaderCake isCompact={ false } onClick={ this.goBack } /> : null }
+				{ this.props.showBack && <HeaderBack /> }
 				<FeedHeader feed={ feed } site={ this.state.site } />
 			</FollowingStream>
 		);

--- a/client/reader/header-back/index.jsx
+++ b/client/reader/header-back/index.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import HeaderCake from 'components/header-cake';
+
+function goBack() {
+	if ( typeof window !== 'undefined' ) {
+		window.history.back();
+	}
+}
+
+export default function HeaderBack() {
+	return <HeaderCake isCompact={ false } onClick={ goBack } />
+}

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -11,15 +11,11 @@ var controller = require( './controller' ),
 
 var lastRoute = null;
 
-function saveLastRoute( context, next ) {
-	lastRoute = context.path;
-	next();
-}
-
-function setLastRoute( context, next ) {
+function updateLastRoute( context, next ) {
 	if ( lastRoute ) {
 		context.lastRoute = lastRoute;
 	}
+	lastRoute = context.path;
 	next();
 }
 
@@ -33,50 +29,50 @@ module.exports = function() {
 		page( '/', controller.loadSubscriptions );
 		page( '/read/*', controller.loadSubscriptions );
 
-		page( '/', saveLastRoute, controller.removePost, controller.sidebar, controller.following );
+		page( '/', updateLastRoute, controller.removePost, controller.sidebar, controller.following );
 
-		page( '/read/blog/feed/:feed_id', saveLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.feedListing );
+		page( '/read/blog/feed/:feed_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.feedListing );
 		page.exit( '/read/blog/feed/:feed_id', controller.resetTitle );
 
-		page( '/read/post/feed/:feed/:post', setLastRoute, controller.feedPost );
+		page( '/read/post/feed/:feed/:post', updateLastRoute, controller.feedPost );
 		page.exit( '/read/post/feed/:feed/:post', controller.resetTitle );
 
-		page( '/read/blog/id/:blog_id', saveLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.blogListing );
-		page( '/read/post/id/:blog/:post', setLastRoute, controller.blogPost );
+		page( '/read/blog/id/:blog_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.blogListing );
+		page( '/read/post/id/:blog/:post', updateLastRoute, controller.blogPost );
 		page.exit( '/read/post/id/:blog/:post', controller.resetTitle );
 
-		page( '/tag/:tag', saveLastRoute, controller.removePost, controller.sidebar, controller.tagListing );
+		page( '/tag/:tag', updateLastRoute, controller.removePost, controller.sidebar, controller.tagListing );
 	}
 
 	if ( config.isEnabled( 'reader/teams' ) ) {
-		page( '/read/a8c', saveLastRoute, controller.removePost, controller.sidebar, forceTeamA8C, controller.readA8C );
+		page( '/read/a8c', updateLastRoute, controller.removePost, controller.sidebar, forceTeamA8C, controller.readA8C );
 	}
 
 	if ( config.isEnabled( 'reader/lists' ) ) {
-		page( '/read/list/:user/:list', saveLastRoute, controller.removePost, controller.sidebar, controller.listListing );
+		page( '/read/list/:user/:list', updateLastRoute, controller.removePost, controller.sidebar, controller.listListing );
 	}
 
 	if ( config.isEnabled( 'reader/list-management' ) ) {
-		page( '/read/list/:user/:list/sites', saveLastRoute, controller.removePost, controller.sidebar, controller.listManagementSites );
-		page( '/read/list/:user/:list/tags', saveLastRoute, controller.removePost, controller.sidebar, controller.listManagementTags );
-		page( '/read/list/:user/:list/edit', saveLastRoute, controller.removePost, controller.sidebar, controller.listManagementDescriptionEdit );
-		page( '/read/list/:user/:list/followers', saveLastRoute, controller.removePost, controller.sidebar, controller.listManagementFollowers );
+		page( '/read/list/:user/:list/sites', updateLastRoute, controller.removePost, controller.sidebar, controller.listManagementSites );
+		page( '/read/list/:user/:list/tags', updateLastRoute, controller.removePost, controller.sidebar, controller.listManagementTags );
+		page( '/read/list/:user/:list/edit', updateLastRoute, controller.removePost, controller.sidebar, controller.listManagementDescriptionEdit );
+		page( '/read/list/:user/:list/followers', updateLastRoute, controller.removePost, controller.sidebar, controller.listManagementFollowers );
 	}
 
 	if ( config.isEnabled( 'reader/activities' ) ) {
-		page( '/activities/likes', controller.loadSubscriptions, saveLastRoute, controller.removePost, controller.sidebar, controller.likes );
+		page( '/activities/likes', controller.loadSubscriptions, updateLastRoute, controller.removePost, controller.sidebar, controller.likes );
 	}
 
 	if ( config.isEnabled( 'reader/following-edit' ) ) {
-		page( '/following/edit', controller.loadSubscriptions, saveLastRoute, controller.removePost, controller.sidebar, controller.followingEdit );
+		page( '/following/edit', controller.loadSubscriptions, updateLastRoute, controller.removePost, controller.sidebar, controller.followingEdit );
 	}
 
 	if ( config.isEnabled( 'reader/recommendations' ) ) {
-		page( '/recommendations', controller.loadSubscriptions, saveLastRoute, controller.removePost, controller.sidebar, controller.recommendedForYou );
-		page( '/tags', controller.loadSubscriptions, saveLastRoute, controller.removePost, controller.sidebar, controller.recommendedTags );
+		page( '/recommendations', controller.loadSubscriptions, updateLastRoute, controller.removePost, controller.sidebar, controller.recommendedForYou );
+		page( '/tags', controller.loadSubscriptions, updateLastRoute, controller.removePost, controller.sidebar, controller.recommendedTags );
 	}
 
 	if ( config.isEnabled( 'reader/discover' ) ) {
-		page( '/discover', setLastRoute, controller.removePost, controller.sidebar, controller.discover );
+		page( '/discover', updateLastRoute, controller.removePost, controller.sidebar, controller.discover );
 	}
 };

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -4,7 +4,7 @@ var FeedHeader = require( 'reader/feed-header' ),
 	FeedFeatured = require( './featured' ),
 	EmptyContent = require( './empty' ),
 	FollowingStream = require( 'reader/following-stream' ),
-	HeaderCake = require( 'components/header-cake' ),
+	HeaderBack = require( 'reader/header-back' ),
 	SiteStore = require( 'lib/reader-site-store' ),
 	SiteStoreActions = require( 'lib/reader-site-store/actions' ),
 	SiteState = require( 'lib/reader-site-store/constants' ).state,
@@ -109,7 +109,7 @@ var SiteStream = React.createClass( {
 
 		return (
 			<FollowingStream { ...this.props } listName={ title } emptyContent={ emptyContent }>
-				{ this.props.showBack ? <HeaderCake isCompact={ false } onClick={ this.goBack } /> : null }
+				{ this.props.showBack && <HeaderBack /> }
 				<FeedHeader site={ this.state.site } />
 				{ featuredContent }
 			</FollowingStream>

--- a/client/reader/tag-stream/index.jsx
+++ b/client/reader/tag-stream/index.jsx
@@ -6,7 +6,8 @@ var FollowingStream = require( 'reader/following-stream' ),
 	ReaderTagActions = require( 'lib/reader-tags/actions' ),
 	TagSubscriptions = require( 'lib/reader-tags/subscriptions' ),
 	StreamHeader = require( 'reader/stream-header' ),
-	stats = require( 'reader/stats' );
+	stats = require( 'reader/stats' ),
+	HeaderBack = require( 'reader/header-back' );
 
 var FeedStream = React.createClass( {
 
@@ -80,6 +81,7 @@ var FeedStream = React.createClass( {
 		}
 		return (
 			<FollowingStream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showFollowInHeader={ true } >
+				{ this.props.showBack && <HeaderBack /> }
 				<StreamHeader
 					isPlaceholder={ ! tag }
 					icon={ <svg className="gridicon gridicon__tag" height="32" width="32" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M16 7H5c-1.105 0-2 .896-2 2v6c0 1.104.895 2 2 2h11l5-5-5-5z"/></g></svg> }


### PR DESCRIPTION
Tag streams can be entered by clicking on a tag in a stream or a full post, so we should really show a back button at the top.

Also, hide the back button when we know that the current route is the first route we've seen.

Fixes #2622 