### PR TITLE
Reader: Limit the batching fetch to one inflight.

### DIFF
--- a/client/lib/reader-sidebar/actions.js
+++ b/client/lib/reader-sidebar/actions.js
@@ -18,8 +18,9 @@ module.exports = {
 		batch.add( '/read/lists' );
 		batch.add( '/read/teams' );
 
+		isFetching = true;
+
 		batch.run( { apiVersion: '1.2' }, function( error, data ) {
-			isFetching = false;
 			if ( error ) {
 				Dispatcher.handleServerAction( {
 					type: 'RECEIVE_READER_TAG_SUBSCRIPTIONS',
@@ -38,6 +39,7 @@ module.exports = {
 					data: null,
 					error: error
 				} );
+
 				return;
 			}
 
@@ -58,6 +60,9 @@ module.exports = {
 				data: data[ '/read/teams' ],
 				error: error
 			} );
+
+			// have to set this after we dispatch, otherwise we may try to fetch again as a result of the dispatch.
+			isFetching = false;
 		} );
 	}
 };


### PR DESCRIPTION
Somehow we were missing the set of inFlight to true...

Also, to avoid a second request, move the set back to false after the dispatches