### PR TITLE
Invites: Adds send_verification_email property to createAccount activation

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -56,10 +56,12 @@ export function fetchInvite( siteId, inviteKey ) {
 	} );
 }
 
-export function createAccount( userData, callback ) {
+export function createAccount( userData, invite, callback ) {
+	const send_verification_email = ( userData.email !== invite.sentTo );
+
 	return dispatch => {
 		wpcom.undocumented().usersNew(
-			Object.assign( {}, userData, { validate: false } ),
+			Object.assign( {}, userData, { validate: false, send_verification_email } ),
 			( error, response ) => {
 				const bearerToken = response && response.bearer_token;
 				if ( error ) {

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -55,6 +55,7 @@ let InviteAcceptLoggedOut = React.createClass( {
 
 		this.props.createAccount(
 			userData,
+			this.props.invite,
 			createAccountCallback
 		);
 	},


### PR DESCRIPTION
Adding on to #2790, we also don't want to send a verification to new users if they create an account with the same email address that the invite was sent to.

This PR send the required property to the API so that we don't send the verification email.

To test:
- Checkout `fix/invite-send-verification-email` branch
- Go to `$site/wp-admin/users.php?page=wpcom-invite-users`
- Send an invite to 
- While logged out, click the accept link in email (make sure to swap wordpress.com for calypso.localhost:3000)
- Fill out the form and accept the invite
- You should not receive an activation email
- Repeat the process, and this time, change the email before accepting
  - You should receive an activation email.

cc @lezama 