### PR TITLE
Invites: Do not force email for follower invites

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -80,7 +80,9 @@ let InviteAccept = React.createClass( {
 
 	refreshMatchEmailError() {
 		const { invite, user } = this.state;
-		this.setState( { matchEmailError: invite.forceMatchingEmail && user.email !== invite.sentTo } );
+		this.setState( {
+			matchEmailError: invite && invite.forceMatchingEmail && ( 'follower' !== invite.role ) && ( user.email !== invite.sentTo )
+		} );
 	},
 
 	isInvalidInvite() {


### PR DESCRIPTION
For follower invites, which don't require a matching email when accepting, our UI shouldn't require that the follower email matches the invite email.

To test:
- Checkout `fix/invite-match-email-follower` branch
- On a public WP.com site, create a follower invite and an invite for another role
- Sandbox API
- Implement filter associated with this documentation: https://vip.wordpress.com/functions/wpcom_invite_force_matching_email_address/
- When accepting the follow invite, you should not see an error. But, you should see some sort of error for any other role.

Logged in flow:

![logged-in-invite-follower-ok](https://cloud.githubusercontent.com/assets/1126811/12597803/544e2df6-c44c-11e5-8d3f-d3c18e1a1b17.png)
![logged-in-role-error](https://cloud.githubusercontent.com/assets/1126811/12597804/544f01b8-c44c-11e5-9e70-7328b1d3790d.png)

Logged out flow:

![logged-out-follow-ok](https://cloud.githubusercontent.com/assets/1126811/12597808/5962d8be-c44c-11e5-990b-b8656b24e5ad.png)

![logged-out-editor-error](https://cloud.githubusercontent.com/assets/1126811/12597810/5ddca6ae-c44c-11e5-9852-a962c9e88b03.png)
