### PR TITLE
Sidebar: Restart plans 'upgrade' button a/b test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -54,7 +54,7 @@ module.exports = {
 		defaultVariation: 'yearly'
 	},
 	plansUpgradeButton: {
-		datestamp: '20160118',
+		datestamp: '20160129',
 		variations: {
 			original: 50,
 			button: 50

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -336,7 +336,7 @@ module.exports = React.createClass( {
 
 		if ( abtest( 'plansUpgradeButton' ) === 'button' && productsValues.isFreePlan( site.plan ) ) {
 			labelClass = 'add-new';
-			planName = 'Upgrade'; // TODO: translate this string if the test is removed
+			planName = 'More'; // TODO: translate this string if the test is removed
 		}
 
 		if ( productsValues.isFreeTrial( site.plan ) ) {


### PR DESCRIPTION
@scruffian wants to restart this test with a new date.

**Testing**
With a newly created account, you can test both variations with the following instructions:

`original`:
- Run `localStorage.setItem( 'ABTests', '{"plansUpgradeButton_20160128":"original"}' );` in the console.
- Visit `/stats/year/:site` (or any 'My Sites' route) for a site with the free plan.
- Assert that you see the 'Free' label next to 'Plans' in the sidebar.

`original`:
- Run `localStorage.setItem( 'ABTests', '{"plansUpgradeButton_20160128":"button"}' );` in the console.
- Visit `/stats/year/:site` (or any 'My Sites' route) for a site with the free plan.
- Assert that you see the 'Upgrade' button next to 'Plans' in the sidebar.
