### PR TITLE
Me: Updates backup codes status to use compact notices

### DIFF
--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -127,7 +127,7 @@ module.exports = React.createClass( {
 		return (
 			<form className="security-2fa-backup-codes-prompt" onSubmit={ this.onVerify }>
 				<FormFieldset>
-					<FormLabel htmlFor="backup-code-entry">{ this.translate( 'Type a Backup Code' ) }</FormLabel>
+					<FormLabel htmlFor="backup-code-entry">{ this.translate( 'Type a Backup Code to Verify' ) }</FormLabel>
 					<FormTelInput
 						disabled={ this.state.submittingCode }
 						name="backup-code-entry"

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -86,6 +86,11 @@ module.exports = React.createClass( {
 		this.setState( { lastError: false } );
 	},
 
+	onClickPrintButton: function( event ) {
+		analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Print Backup Codes Again Button' );
+		this.onPrintAgain( event );
+	},
+
 	possiblyRenderPrintAgainButton: function() {
 		if ( ! this.props.onPrintAgain ) {
 			return null;
@@ -96,10 +101,7 @@ module.exports = React.createClass( {
 				className="security-2fa-backup-codes-prompt__print"
 				disabled={ this.state.submittingCode }
 				isPrimary={ false }
-				onClick={ function( event ) {
-					analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Print Backup Codes Again Button' );
-					this.onPrintAgain( event );
-				}.bind( this ) }
+				onClick={ this.onClickPrintButton }
 				type="button"
 			>
 				{ this.translate( "Didn't Print The Codes?" ) }

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -13,7 +13,8 @@ var Security2faBackupCodesPrompt = require( 'me/security-2fa-backup-codes-prompt
 	Card = require( 'components/card' ),
 	eventRecorder = require( 'me/event-recorder' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	Security2faBackupCodesList = require( 'me/security-2fa-backup-codes-list' );
+	Security2faBackupCodesList = require( 'me/security-2fa-backup-codes-list' ),
+	Notice = require( 'components/notice' );
 
 module.exports = React.createClass( {
 
@@ -83,42 +84,31 @@ module.exports = React.createClass( {
 	renderStatus: function() {
 		if ( ! this.state.printed ) {
 			return (
-				this.translate(
-					'{{status}}Status:{{/status}} Backup Codes have {{notVerified}}not been verified{{/notVerified}}.',
-					{
-						components: {
-							status: <span className="security-2fa-backup-codes__status-heading"/>,
-							notVerified: <span className="security-2fa-backup-codes__status-not-verified"/>
-						}
-					}
-				)
+				<Notice
+					isCompact
+					status="is-error"
+					text={ this.translate( 'Backup codes have not been verified.' ) }
+				/>
 			);
 		}
 
 		if ( ! this.state.verified ) {
 			return (
-				this.translate(
-					'{{verify}}New backup Codes have just been generated, but need to be verified. ' +
-					'Please enter one of them below for verification.{{/verify}}',
-					{
-						components: {
-							verify: <span className="security-2fa-backup-codes__status-need-verification"/>,
-						}
-					}
-				)
+				<Notice
+					isCompact
+					text={ this.translate(
+						'New backup codes have just been generated, but need to be verified.'
+					) }
+				/>
 			);
 		}
 
 		return (
-			this.translate(
-				'{{status}}Status:{{/status}} Backup Codes have been {{verified}}verified{{/verified}}.',
-				{
-					components: {
-						status: <span className="security-2fa-backup-codes__status-heading"/>,
-						verified: <span className="security-2fa-backup-codes__status-verified"/>
-					}
-				}
-			)
+			<Notice
+				isCompact
+				status="is-success"
+				text={ this.translate( 'Backup codes have been verified' ) }
+			/>
 		);
 	},
 
@@ -146,7 +136,7 @@ module.exports = React.createClass( {
 					}
 				</p>
 
-				<p className="security-2fa-backup-codes__status">{ this.renderStatus() }</p>
+				{ this.renderStatus() }
 
 				{ this.state.showPrompt &&
 					<Security2faBackupCodesPrompt onSuccess={ this.onVerified } />

--- a/client/me/security-2fa-backup-codes/style.scss
+++ b/client/me/security-2fa-backup-codes/style.scss
@@ -1,24 +1,3 @@
-.security-2fa-backup-codes__status {
-	margin-top: 20px;
-}
-
-.security-2fa-backup-codes__status-heading {
-	font-weight: bold;
-}
-
-.security-2fa-backup-codes__status-not-verified {
-	text-transform: uppercase;
-	color: $alert-red;
-	font-weight: bold;
-}
-
-.security-2fa-backup-codes__status-need-verification {
-	color: $blue-wordpress;
-	font-weight: bold;
-}
-
-.security-2fa-backup-codes__status-verified {
-	text-transform: uppercase;
-	color: $alert-green;
-	font-weight: bold;
+.security-2fa-backup-codes .security-2fa-backup-codes-prompt {
+	margin-top: 16px;
 }


### PR DESCRIPTION
Closes #2755 

Now that we have compact notices, let's use that instead of the previous custom status design.

I'm not sure that I like the wordy blue notice. cc @rickybanister for design thoughts.

To test:
- Checkout `update/me-backup-codes-notices`
- Login to test account
- Go to `/me/security/two-step`
- Enable 2fa
  - Right after enabling, you should see a red notice prompting you to enter a backup code
- Enter backup code
  - After entering backup code, you should see the green notice
- Hit "Generate new backup codes" button
  - There should be a blue notice prompting you to enter a backup code

Note: There is currently some jankiness with entering a backup code. It seems the code gets added as a URL param? I'll keep digging to find that.

![screen shot 2](https://cloud.githubusercontent.com/assets/1126811/12598441/f4c7852c-c44f-11e5-94d5-898c90f4c44c.png)
![screen shot 3](https://cloud.githubusercontent.com/assets/1126811/12598442/f4c7ca32-c44f-11e5-8478-238702c35fe5.png)
![screen shot 1](https://cloud.githubusercontent.com/assets/1126811/12598443/f4c95eec-c44f-11e5-8049-d12e63030fb1.png)
