### PR TITLE
Domains: Edit site address skeleton page

### DIFF
--- a/client/components/data/domain-management/edit-site-address/index.jsx
+++ b/client/components/data/domain-management/edit-site-address/index.jsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import StoreConnection from 'components/data/store-connection';
+import observe from 'lib/mixins/data-observe';
+import DomainsStore from 'lib/domains/store';
+import { fetchDomains } from 'lib/upgrades/actions/domain-management';
+
+var stores = [
+	DomainsStore
+];
+
+function getStateFromStores( props ) {
+	let domains;
+
+	if ( props.selectedSite ) {
+		domains = DomainsStore.getBySite( props.selectedSite.ID );
+	}
+
+	return {
+		domains,
+		context: props.context,
+		selectedDomainName: props.selectedDomainName,
+		selectedSite: props.selectedSite
+	};
+}
+
+module.exports = React.createClass( {
+	displayName: 'EditSiteAddressData',
+
+	propTypes: {
+		component: React.PropTypes.func.isRequired,
+		context: React.PropTypes.object.isRequired,
+		selectedDomainName: React.PropTypes.string,
+		sites: React.PropTypes.object.isRequired
+	},
+
+	mixins: [ observe( 'productsList' ) ],
+
+	componentWillMount() {
+		this.loadDomains();
+	},
+
+	componentWillUpdate() {
+		this.loadDomains();
+	},
+
+	loadDomains() {
+		const selectedSite = this.props.sites.getSelectedSite();
+
+		if ( this.prevSelectedSite !== selectedSite ) {
+			fetchDomains( selectedSite.ID );
+
+			this.prevSelectedSite = selectedSite;
+		}
+	},
+
+	render() {
+		return (
+			<StoreConnection
+				component={ this.props.component }
+				stores={ stores }
+				getStateFromStores={ getStateFromStores }
+				selectedDomainName={ this.props.selectedDomainName }
+				selectedSite={ this.props.sites.getSelectedSite() }
+				context={ this.props.context } />
+		);
+	}
+} );

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -25,6 +25,7 @@ import SitesList from 'lib/sites-list';
 import TransferData from 'components/data/domain-management/transfer';
 import WhoisData from 'components/data/domain-management/whois';
 import titleActions from 'lib/screen-title/actions';
+import EditSiteAddressData from 'components/data/domain-management/edit-site-address';
 
 const productsList = new ProductsList(),
 	sites = new SitesList();
@@ -303,7 +304,23 @@ module.exports = {
 			<TransferData
 				component={ DomainManagement.Transfer }
 				selectedDomainName={ context.params.domain }
-				sites={ sites } />
+				sites={ sites }/>
+		);
+	},
+
+	domainManagementEditSiteAddress( context ) {
+		setTitle(
+			i18n.translate( 'Domain Management' ) + ' › ' + i18n.translate( 'Edit Site Address' ),
+			context
+		);
+
+		renderPage(
+			<EditSiteAddressData
+				component={ DomainManagement.EditSiteAddress }
+				selectedDomainName={ context.params.domain }
+				sites={ sites }
+				context={ context }
+				/>
 		);
 	}
 };

--- a/client/my-sites/upgrades/domain-management/domain-management.jsx
+++ b/client/my-sites/upgrades/domain-management/domain-management.jsx
@@ -11,5 +11,6 @@ module.exports = {
 	PrimaryDomain: require( './primary-domain' ),
 	PrivacyProtection: require( './privacy-protection' ),
 	SiteRedirect: require( './site-redirect' ),
-	Transfer: require( './transfer' )
+	Transfer: require( './transfer' ),
+	EditSiteAddress: require( './edit-site-address' )
 };

--- a/client/my-sites/upgrades/domain-management/edit-site-address/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-site-address/index.jsx
@@ -13,19 +13,44 @@ import Main from 'components/main';
 import { getSelectedDomain } from 'lib/domains';
 import paths from 'my-sites/upgrades/paths';
 
+import FormFieldset from 'components/forms/form-fieldset';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+
+import Card from 'components/card/compact';
+import SectionHeader from 'components/section-header';
+
 const EditSiteAddress = React.createClass( {
+	onFieldChange( event ) {
+
+	},
+
 	render() {
 		const domain = getSelectedDomain( this.props );
 
 		if ( ! domain ) {
-			return <DomainMainPlaceholder goBack={ this.goToDomainManagement } />;
+			return <DomainMainPlaceholder goBack={ this.goToDomainManagement }/>;
 		}
 
 		return (
 			<Main>
 				<Header onClick={ this.goToDomainManagement } selectedDomainName={ this.props.selectedDomainName }>
-					{ this.translate( 'Domain Settings' ) }
+					{ this.translate( 'Edit Site Address' ) }
 				</Header>
+				<SectionHeader label={ this.translate( 'Edit Site Address' ) }/>
+				<Card>
+					<FormFieldset>
+						<FormLabel htmlFor="new-address">{ this.translate( 'New Address' ) }</FormLabel>
+						<FormTextInputWithAffixes suffix="wordpress.com" id="new-address" name="new-address" type="text" onChange={ this.onFieldChange }/>
+					</FormFieldset>
+
+					<FormFieldset>
+						<FormLabel htmlFor="new-address-repeat">{ this.translate( 'New Address Again' ) }</FormLabel>
+						<FormTextInputWithAffixes suffix="wordpress.com" id="new-address-repeat" name="new-address-repeat" type="text" onChange={ this.onFieldChange }/>
+					</FormFieldset>
+				</Card>
 			</Main>
 		);
 	},

--- a/client/my-sites/upgrades/domain-management/edit-site-address/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-site-address/index.jsx
@@ -14,17 +14,25 @@ import { getSelectedDomain } from 'lib/domains';
 import paths from 'my-sites/upgrades/paths';
 
 import FormFieldset from 'components/forms/form-fieldset';
-import FormInputValidation from 'components/forms/form-input-validation';
+import FormButton from 'components/forms/form-button';
 import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 
 import Card from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 
 const EditSiteAddress = React.createClass( {
-	onFieldChange( event ) {
+	getInitialState() {
+		return {
+			newAddress: '',
+			newAddressRepeat: ''
+		};
+	},
 
+	onFieldChange( event ) {
+		event.preventDefault();
+		let name = event.target.getAttribute( 'name' );
+		this.setState( { [ name ]: event.target.value } );
 	},
 
 	render() {
@@ -43,13 +51,27 @@ const EditSiteAddress = React.createClass( {
 				<Card>
 					<FormFieldset>
 						<FormLabel htmlFor="new-address">{ this.translate( 'New Address' ) }</FormLabel>
-						<FormTextInputWithAffixes suffix="wordpress.com" id="new-address" name="new-address" type="text" onChange={ this.onFieldChange }/>
+						<FormTextInputWithAffixes
+							suffix="wordpress.com"
+							id="new-address"
+							name="newAddress"
+							type="text"
+							onChange={ this.onFieldChange }/>
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel htmlFor="new-address-repeat">{ this.translate( 'New Address Again' ) }</FormLabel>
-						<FormTextInputWithAffixes suffix="wordpress.com" id="new-address-repeat" name="new-address-repeat" type="text" onChange={ this.onFieldChange }/>
+						<FormLabel htmlFor="new-address-repeat">{ this.translate( 'Confirm New Address' ) }</FormLabel>
+						<FormTextInputWithAffixes
+							suffix="wordpress.com"
+							id="new-address-repeat"
+							name="newAddressRepeat"
+							type="text"
+							onChange={ this.onFieldChange }
+							disabled={ ! this.state.newAddress } />
 					</FormFieldset>
+
+					<FormButton
+						disabled={ ! this.state.newAddress || this.state.newAddress !== this.state.newAddressRepeat } />
 				</Card>
 			</Main>
 		);

--- a/client/my-sites/upgrades/domain-management/edit-site-address/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-site-address/index.jsx
@@ -1,0 +1,38 @@
+/**
+ * External Dependencies
+ **/
+import React from 'react';
+import page from 'page';
+
+/**
+ * Internal Dependencies
+ **/
+import DomainMainPlaceholder from 'my-sites/upgrades/domain-management/components/domain/main-placeholder';
+import Header from 'my-sites/upgrades/domain-management/components/header';
+import Main from 'components/main';
+import { getSelectedDomain } from 'lib/domains';
+import paths from 'my-sites/upgrades/paths';
+
+const EditSiteAddress = React.createClass( {
+	render() {
+		const domain = getSelectedDomain( this.props );
+
+		if ( ! domain ) {
+			return <DomainMainPlaceholder goBack={ this.goToDomainManagement } />;
+		}
+
+		return (
+			<Main>
+				<Header onClick={ this.goToDomainManagement } selectedDomainName={ this.props.selectedDomainName }>
+					{ this.translate( 'Domain Settings' ) }
+				</Header>
+			</Main>
+		);
+	},
+
+	goToDomainManagement() {
+		page( paths.domainManagementList( this.props.selectedSite.domain ) );
+	}
+} );
+
+export default EditSiteAddress;

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -290,4 +290,15 @@ module.exports = function() {
 			upgradesController.checkout
 		);
 	}
+
+	if ( config.isEnabled( 'upgrades/domain-management/edit-site-address' ) ) {
+		page(
+			paths.domainManagementEditSiteAddress( ':site', ':domain' ),
+			controller.siteSelection,
+			controller.navigation,
+			upgradesController.redirectIfNoSite( '/domains' ),
+			controller.jetPackWarning,
+			domainManagementController.domainManagementEditSiteAddress
+		);
+	}
 };

--- a/client/my-sites/upgrades/paths.js
+++ b/client/my-sites/upgrades/paths.js
@@ -86,6 +86,10 @@ function domainManagementTransfer( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'transfer' );
 }
 
+function domainManagementEditSiteAddress( siteName, domainName ) {
+	return domainManagementEdit( siteName, domainName, 'edit-site-address' );
+}
+
 function getSectionName( pathname ) {
 	const regExp = new RegExp( '^' + domainManagementRoot() + '/[^/]+/([^/]+)', 'g' ),
 		matches = regExp.exec( pathname );
@@ -108,5 +112,6 @@ module.exports = {
 	domainManagementRedirectSettings,
 	domainManagementPrimaryDomain,
 	domainManagementTransfer,
+	domainManagementEditSiteAddress,
 	getSectionName
 };

--- a/config/development.json
+++ b/config/development.json
@@ -92,6 +92,7 @@
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": true,
+		"upgrades/domain-management/edit-site-address": true,
 		"upgrades/domain-search": true,
 		"upgrades/premium-themes": true,
 


### PR DESCRIPTION
This is the skeleton page for the editing site address described in #2473.

The URL is disabled on production.

Testing:
1. Go to http://calypso.dev:3000/domains/manage/:domain/edit-site-address/:site (where :domain is YOURSITE.wordpress.com)
2. Type something on the first field, confirm the second field gets enabled 
3. Type the same thing on the second field, confirm the button gets enabled.


![image](https://cloud.githubusercontent.com/assets/991022/12598055/e35bb32a-c43c-11e5-8d06-c4d8f9aa4c6a.png)