### PR TITLE
General: Updated Jade dependency to 1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "immutable": "3.7.5",
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",
-    "jade": "jadejs/jade#29784fd",
+    "jade": "1.11.0",
     "jed": "1.0.2",
     "json-loader": "0.5.4",
     "jstimezonedetect": "1.0.5",


### PR DESCRIPTION
Hi!

Early today I noticed some warnings about deprecated dependencies when installing the project for the first time. I asked https://github.com/Automattic/wp-calypso/issues/123#issuecomment-175253636 if there is any plan to upgrade them. @ockham told me to go ahead and do it, so here is.

Basically I updated `jade` dependency to the latest stable version, it removed the deprecated warnings, I manually tested that all four Jade files loaded correctly.

Thanks