### PR TITLE
Post Checkout: Don't open internal links in a new window

### DIFF
--- a/client/my-sites/upgrades/checkout/purchase-detail.jsx
+++ b/client/my-sites/upgrades/checkout/purchase-detail.jsx
@@ -9,7 +9,15 @@ import React from 'react';
  */
 import Button from 'components/button';
 
-const PurchaseDetail = ( { additionalClass, buttonText, description, isPlaceholder, onButtonClick, title } ) => {
+const PurchaseDetail = ( {
+	additionalClass,
+	buttonText,
+	description,
+	href,
+	isPlaceholder,
+	target,
+	title
+} ) => {
 	const classes = classNames( 'checkout__purchase-detail', additionalClass, {
 		'is-placeholder': isPlaceholder
 	} );
@@ -20,7 +28,11 @@ const PurchaseDetail = ( { additionalClass, buttonText, description, isPlacehold
 				<h3 className="checkout__purchase-detail-title">{ title }</h3>
 				<p className="checkout__purchase-detail-description">{ description }</p>
 			</div>
-			<Button className="checkout__purchase-detail-button" onClick={ onButtonClick } primary>
+			<Button
+				className="checkout__purchase-detail-button"
+				href={ href }
+				target={ target }
+				primary>
 				{ buttonText }
 			</Button>
 		</li>
@@ -31,8 +43,9 @@ PurchaseDetail.propTypes = {
 	additionalClass: React.PropTypes.string,
 	buttonText: React.PropTypes.string,
 	description: React.PropTypes.string,
+	href: React.PropTypes.string,
 	isPlaceholder: React.PropTypes.bool,
-	onButtonClick: React.PropTypes.func,
+	target: React.PropTypes.string,
 	title: React.PropTypes.string
 };
 

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -359,7 +359,7 @@ PremiumPlanDetails = React.createClass( {
 						title={ this.translate( 'Get a free domain' ) }
 						description={ this.translate( 'WordPress.com Premium includes a free domain for your site.' ) }
 						buttonText={ this.translate( 'Add Free Domain' ) }
-						onButtonClick={ goToExternalPage( '/domains/add/' + this.props.selectedSite.slug ) } />
+						href={ '/domains/add/' + this.props.selectedSite.slug } />
 					: null
 				}
 
@@ -369,7 +369,8 @@ PremiumPlanDetails = React.createClass( {
 						title={ this.translate( 'Ads have been removed!' ) }
 						description={ this.translate( 'WordPress.com ads will not show up on your blog.' ) }
 						buttonText={ this.translate( 'View Your Site' ) }
-						onButtonClick={ goToExternalPage( this.props.selectedSite.URL ) } />
+						href={ this.props.selectedSite.URL }
+						target="_blank" />
 					: null
 				}
 
@@ -378,14 +379,16 @@ PremiumPlanDetails = React.createClass( {
 					title={ this.translate( 'Customize Fonts & Colors' ) }
 					description={ this.translate( 'You now have access to full font and CSS editing capabilites.' ) }
 					buttonText={ this.translate( 'Customize Your Site' ) }
-					onButtonClick={ goToExternalPage( customizeLink ) } />
+					href={ customizeLink }
+					target={ config.isEnabled( 'manage/customize' ) ? undefined : '_blank' } />
 
 				<PurchaseDetail
 					additionalClass="upload-to-videopress"
 					title={ this.translate( 'Upload to VideoPress' ) }
 					description={ this.translate( "Uploading videos to your blog couldn't be easier." ) }
 					buttonText={ this.translate( 'Start Using VideoPress' ) }
-					onButtonClick={ goToExternalPage( this.props.selectedSite.URL + '/wp-admin/media-new.php' ) } />
+					href={ this.props.selectedSite.URL + '/wp-admin/media-new.php' }
+					target="_blank" />
 			</ul>
 		);
 	}
@@ -400,14 +403,16 @@ JetpackPremiumPlanDetails = React.createClass( {
 					title={ this.translate( 'Akismet' ) }
 					description={ this.translate( 'Say goodbye to comment spam' ) }
 					buttonText={ this.translate( 'Start using Akismet' ) }
-					onButtonClick={ goToExternalPage( 'https://en.support.wordpress.com/setting-up-premium-services/' ) } />
+					href="https://en.support.wordpress.com/setting-up-premium-services/"
+					target="_blank" />
 
 				<PurchaseDetail
 					additionalClass="vaultpress"
 					title={ this.translate( 'VaultPress' ) }
 					description={ this.translate( 'Backup your site' ) }
 					buttonText={ this.translate( 'Start using VaultPress' ) }
-					onButtonClick={ goToExternalPage( 'https://en.support.wordpress.com/setting-up-premium-services/' ) } />
+					href="https://en.support.wordpress.com/setting-up-premium-services/"
+					target="_blank" />
 			</ul>
 		);
 	}
@@ -425,7 +430,7 @@ BusinessPlanDetails = React.createClass( {
 						title={ this.translate( 'Get a free domain' ) }
 						description={ this.translate( 'WordPress.com Business includes a free domain for your site.' ) }
 						buttonText={ this.translate( 'Add Free Domain' ) }
-						onButtonClick={ goToExternalPage( '/domains/add/' + this.props.selectedSite.slug ) } />
+						href={ '/domains/add/' + this.props.selectedSite.slug } />
 					: null }
 
 				<PurchaseDetail
@@ -433,7 +438,7 @@ BusinessPlanDetails = React.createClass( {
 					title={ this.translate( 'Add eCommerce' ) }
 					description={ this.translate( 'Connect your Ecwid or Shopify store with your WordPress.com site.' ) }
 					buttonText={ this.translate( 'Set Up eCommerce' ) }
-					onButtonClick={ goToExternalPage( '/plugins/' + this.props.selectedSite.slug ) } />
+					href={ '/plugins/' + this.props.selectedSite.slug } />
 
 				{ ! showGetFreeDomainTip
 				? <PurchaseDetail
@@ -441,7 +446,8 @@ BusinessPlanDetails = React.createClass( {
 						title={ this.translate( 'Start a Live Chat' ) }
 						description={ this.translate( 'Have a question? Chat live with WordPress.com Happiness Engineers.' ) }
 						buttonText={ this.translate( 'Talk to an Operator' ) }
-						onButtonClick={ goToExternalPage( '//support.wordpress.com/live-chat/' ) } />
+						href="//support.wordpress.com/live-chat/"
+						target="_blank" />
 					: null
 				}
 
@@ -450,7 +456,7 @@ BusinessPlanDetails = React.createClass( {
 					title={ this.translate( 'Browse Themes' ) }
 					description={ this.translate( 'Browse our collection of beautiful and amazing themes for your site.' ) }
 					buttonText={ this.translate( 'Find a New Theme' ) }
-					onButtonClick={ goToExternalPage( '/themes/' + this.props.selectedSite.slug ) } />
+					href={ '/themes/' + this.props.selectedSite.slug } />
 			</ul>
 		);
 	}
@@ -465,21 +471,24 @@ JetpackBusinessPlanDetails = React.createClass( {
 					title={ this.translate( 'Akismet' ) }
 					description={ this.translate( 'Say goodbye to comment spam' ) }
 					buttonText={ this.translate( 'Start using Akismet' ) }
-					onButtonClick={ goToExternalPage( 'https://en.support.wordpress.com/setting-up-premium-services/' ) } />
+					href="https://en.support.wordpress.com/setting-up-premium-services/"
+					target="_blank" />
 
 				<PurchaseDetail
 					additionalClass="vaultpress"
 					title={ this.translate( 'VaultPress' ) }
 					description={ this.translate( 'Backup your site' ) }
 					buttonText={ this.translate( 'Start using VaultPress' ) }
-					onButtonClick={ goToExternalPage( 'https://en.support.wordpress.com/setting-up-premium-services/' ) } />
+					href="https://en.support.wordpress.com/setting-up-premium-services/"
+					target="_blank" />
 
 				<PurchaseDetail
 					additionalClass="polldaddy"
 					title={ this.translate( 'PollDaddy' ) }
 					description={ this.translate( 'Create surveys and polls' ) }
 					buttonText={ this.translate( 'Start using PollDaddy' ) }
-					onButtonClick={ goToExternalPage( 'https://en.support.wordpress.com/setting-up-premium-services/' ) } />
+					href="https://en.support.wordpress.com/setting-up-premium-services/"
+					target="_blank" />
 			</ul>
 		);
 	}
@@ -523,21 +532,22 @@ DomainMappingDetails = React.createClass( {
 					title={ this.translate( 'Important!' ) }
 					description={ this.translate( "Your domain mapping won't work until you update the DNS settings." ) }
 					buttonText={ this.translate( 'Learn More' ) }
-					onButtonClick={ goToExternalPage( supportDoc ) } />
+					href={ supportDoc }
+					target="_blank" />
 
 				<PurchaseDetail
 					additionalClass="your-primary-domain"
 					title={ this.translate( 'Your Primary Domain' ) }
 					description={ primaryDomainDescription }
 					buttonText={ this.translate( 'Update Settings' ) }
-					onButtonClick={ goToDomainManagement( this.props.selectedSite, this.props.domain ) } />
+					href={ getDomainManagementUrl( this.props.selectedSite, this.props.domain ) } />
 
 				{ ! isPlan( this.props.selectedSite.plan ) ? <PurchaseDetail
 					additionalClass="upgrade-now"
 					title={ this.translate( 'Upgrade Now' ) }
 					description={ this.translate( 'Take your blog to the next level by upgrading to one of our plans.' ) }
 					buttonText={ this.translate( 'View Plans' ) }
-					onButtonClick={ goToExternalPage( '/plans/' + this.props.selectedSite.slug ) } /> : null }
+					href={ '/plans/' + this.props.selectedSite.slug } /> : null }
 			</ul>
 		);
 	}
@@ -552,21 +562,22 @@ DomainRegistrationDetails = React.createClass( {
 					title={ this.translate( 'Important!' ) }
 					description={ this.translate( 'It can take up to 72 hours for your domain setup to complete.' ) }
 					buttonText={ this.translate( 'Learn More' ) }
-					onButtonClick={ goToExternalPage( '//support.wordpress.com/domains/' ) } />
+					href="//support.wordpress.com/domains/"
+					target="_blank" />
 
 				<PurchaseDetail
 					additionalClass="your-primary-domain"
 					title={ this.translate( 'Your Primary Domain' ) }
 					description={ this.translate( 'Want this to be your primary domain for this site?' ) }
 					buttonText={ this.translate( 'Update Settings' ) }
-					onButtonClick={ goToDomainManagement( this.props.selectedSite, this.props.domain ) } />
+					href={ getDomainManagementUrl( this.props.selectedSite, this.props.domain ) } />
 
 				{ ! isPlan( this.props.selectedSite.plan ) ? <PurchaseDetail
 					additionalClass="upgrade-now"
 					title={ this.translate( 'Upgrade Now' ) }
 					description={ this.translate( 'Take your blog to the next level by upgrading to one of our plans.' ) }
 					buttonText={ this.translate( 'View Plans' ) }
-					onButtonClick={ goToExternalPage( '/plans/' + this.props.selectedSite.slug ) } /> : null }
+					href={ '/plans/' + this.props.selectedSite.slug } /> : null }
 			</ul>
 		);
 	}
@@ -581,21 +592,23 @@ GoogleAppsDetails = React.createClass( {
 					title={ this.translate( 'Google Apps Setup' ) }
 					description={ this.translate( 'You will receive an email shortly with your login information.' ) }
 					buttonText={ this.translate( 'More about Google Apps' ) }
-					onButtonClick={ goToExternalPage( 'https://en.support.wordpress.com/add-email/adding-google-apps-to-your-site/' ) } />
+					href="https://en.support.wordpress.com/add-email/adding-google-apps-to-your-site/"
+					target="_blank" />
 
 				<PurchaseDetail
 					additionalClass="important"
 					title={ this.translate( 'Important!' ) }
 					description={ this.translate( 'It can take up to 72 hours for your domain setup to complete.' ) }
 					buttonText={ this.translate( 'Learn More' ) }
-					onButtonClick={ goToExternalPage( '//support.wordpress.com/domains/' ) } />
+					href="//support.wordpress.com/domains/"
+					target="_blank" />
 
 				<PurchaseDetail
 					additionalClass="your-primary-domain"
 					title={ this.translate( 'Your Primary Domain' ) }
 					description={ this.translate( 'Want this to be your primary domain for this site?' ) }
 					buttonText={ this.translate( 'Update Settings' ) }
-					onButtonClick={ goToDomainManagement( this.props.selectedSite, this.props.domain ) } />
+					href={ getDomainManagementUrl( this.props.selectedSite, this.props.domain ) } />
 			</ul>
 		);
 	}
@@ -610,14 +623,15 @@ SiteRedirectDetails = React.createClass( {
 					title={ this.translate( 'Redirect now working' ) }
 					description={ this.translate( 'Visitors to your site will be redirected to your chosen target.' ) }
 					buttonText={ this.translate( 'Test Redirect' ) }
-					onButtonClick={ goToExternalPage( this.props.selectedSite.URL ) } />
+					href={ this.props.selectedSite.URL }
+					target="_blank" />
 
 				<PurchaseDetail
 					additionalClass="change-redirect-settings"
 					title={ this.translate( 'Change redirect settings' ) }
 					description={ this.translate( 'You can disable the redirect or change the target at any time.' ) }
 					buttonText={ this.translate( 'My Domains' ) }
-					onButtonClick={ goToDomainManagement( this.props.selectedSite ) } />
+					href={ getDomainManagementUrl( this.props.selectedSite ) } />
 			</ul>
 		);
 	}
@@ -632,14 +646,14 @@ ChargebackDetails = React.createClass( {
 					title={ this.translate( 'Important!' ) }
 					description={ this.translate( 'The chargeback fee has been paid and you can now use the full features of your site.' ) }
 					buttonText={ this.translate( 'Write a Post' ) }
-					onButtonClick={ goToExternalPage( '/post/' + this.props.selectedSite.slug ) } />
+					href={ '/post/' + this.props.selectedSite.slug } />
 
 				{ ! isPlan( this.props.selectedSite.plan ) ? <PurchaseDetail
 					additionalClass="upgrade-now"
 					title={ this.translate( 'Upgrade Now' ) }
 					description={ this.translate( 'Take your blog to the next level by upgrading to one of our plans.' ) }
 					buttonText={ this.translate( 'View Plans' ) }
-					onButtonClick={ goToExternalPage( '/plans/' + this.props.selectedSite.slug ) } /> : null }
+					href={ '/plans/' + this.props.selectedSite.slug } /> : null }
 			</ul>
 		);
 	}
@@ -657,15 +671,7 @@ GenericDetails = React.createClass( {
 	}
 } );
 
-function goToExternalPage( url ) {
-	return function( event ) {
-		event.preventDefault();
-
-		window.open( url );
-	};
-}
-
-function goToDomainManagement( selectedSite, domain ) {
+function getDomainManagementUrl( selectedSite, domain ) {
 	let url;
 
 	if ( config.isEnabled( 'upgrades/domain-management/list' ) ) {
@@ -678,7 +684,7 @@ function goToDomainManagement( selectedSite, domain ) {
 		url = '/my-domains/' + selectedSite.ID;
 	}
 
-	return goToExternalPage( url );
+	return url;
 }
 
 module.exports = connect(

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -195,49 +195,6 @@ var CheckoutThankYou = React.createClass( {
 		return getPurchases( this.props ).some( isJetpackPlan );
 	},
 
-	takeItForASpin: function() {
-		return (
-			<h3>
-				{ this.translate( 'Take it for a spin!', {
-					context: 'Upgrades: Header on thank you screen after successful upgrade trial activation.',
-					comment: 'It = Premium or Business plan'
-				} ) }
-			</h3>
-		);
-	},
-
-	premiumFreeTrialMessage: function() {
-		if ( this.freeTrialWasPurchased() ) {
-			return (
-				<div className="try-out-message">
-					<p>
-						{ this.translate( 'You have %(days)d days to try out all of the WordPress.com Premium features:', {
-							args: { days: 14 },
-							context: 'Upgrades: Description on thank you screen after successful upgrade trial activation',
-							comment: '"%(days)d" = 14'
-						} ) }
-					</p>
-				</div>
-			);
-		}
-	},
-
-	businessFreeTrialMessage: function() {
-		if ( this.freeTrialWasPurchased() ) {
-			return (
-				<div className="try-out-message">
-					<p>
-						{ this.translate( 'You have %(days)d days to try out all of the WordPress.com Business features:', {
-							args: { days: 14 },
-							context: 'Upgrades: Description on thank you screen after successful upgrade trial activation',
-							comment: '"%(days)d" = 14'
-						} ) }
-					</p>
-				</div>
-			);
-		}
-	},
-
 	productRelatedMessages: function() {
 		var selectedSite = this.props.selectedSite,
 			purchases,

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -471,9 +471,9 @@ DomainMappingDetails = React.createClass( {
 			supportDoc;
 
 		if ( isSubdomain( this.props.domain ) ) {
-			supportDoc = 'https://' + this.props.locale + '.support.wordpress.com/domains/map-subdomain/';
+			supportDoc = 'https://support.wordpress.com/domains/map-subdomain/';
 		} else {
-			supportDoc = 'https://' + this.props.locale + '.support.wordpress.com/domains/map-existing-domain/';
+			supportDoc = 'https://support.wordpress.com/domains/map-existing-domain/';
 		}
 
 		if ( this.state.primaryDomain === this.props.domain ) {

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -456,7 +456,7 @@ BusinessPlanDetails = React.createClass( {
 					title={ this.translate( 'Browse Themes' ) }
 					description={ this.translate( 'Browse our collection of beautiful and amazing themes for your site.' ) }
 					buttonText={ this.translate( 'Find a New Theme' ) }
-					href={ '/themes/' + this.props.selectedSite.slug } />
+					href={ '/design/' + this.props.selectedSite.slug } />
 			</ul>
 		);
 	}

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -262,7 +262,7 @@ var CheckoutThankYou = React.createClass( {
 	supportRelatedMessages: function() {
 		var localeSlug = i18n.getLocaleSlug();
 
-		if ( ! this.props.receipt.hasLoadedFromServer ) {
+		if ( ! this.isDataLoaded() ) {
 			return <p>{ this.translate( 'Loading…' ) }</p>;
 		}
 

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -403,7 +403,7 @@ JetpackPremiumPlanDetails = React.createClass( {
 					title={ this.translate( 'Akismet' ) }
 					description={ this.translate( 'Say goodbye to comment spam' ) }
 					buttonText={ this.translate( 'Start using Akismet' ) }
-					href="https://en.support.wordpress.com/setting-up-premium-services/"
+					href="https://support.wordpress.com/setting-up-premium-services/"
 					target="_blank" />
 
 				<PurchaseDetail
@@ -411,7 +411,7 @@ JetpackPremiumPlanDetails = React.createClass( {
 					title={ this.translate( 'VaultPress' ) }
 					description={ this.translate( 'Backup your site' ) }
 					buttonText={ this.translate( 'Start using VaultPress' ) }
-					href="https://en.support.wordpress.com/setting-up-premium-services/"
+					href="https://support.wordpress.com/setting-up-premium-services/"
 					target="_blank" />
 			</ul>
 		);
@@ -471,7 +471,7 @@ JetpackBusinessPlanDetails = React.createClass( {
 					title={ this.translate( 'Akismet' ) }
 					description={ this.translate( 'Say goodbye to comment spam' ) }
 					buttonText={ this.translate( 'Start using Akismet' ) }
-					href="https://en.support.wordpress.com/setting-up-premium-services/"
+					href="https://support.wordpress.com/setting-up-premium-services/"
 					target="_blank" />
 
 				<PurchaseDetail
@@ -479,7 +479,7 @@ JetpackBusinessPlanDetails = React.createClass( {
 					title={ this.translate( 'VaultPress' ) }
 					description={ this.translate( 'Backup your site' ) }
 					buttonText={ this.translate( 'Start using VaultPress' ) }
-					href="https://en.support.wordpress.com/setting-up-premium-services/"
+					href="https://support.wordpress.com/setting-up-premium-services/"
 					target="_blank" />
 
 				<PurchaseDetail
@@ -487,7 +487,7 @@ JetpackBusinessPlanDetails = React.createClass( {
 					title={ this.translate( 'PollDaddy' ) }
 					description={ this.translate( 'Create surveys and polls' ) }
 					buttonText={ this.translate( 'Start using PollDaddy' ) }
-					href="https://en.support.wordpress.com/setting-up-premium-services/"
+					href="https://support.wordpress.com/setting-up-premium-services/"
 					target="_blank" />
 			</ul>
 		);
@@ -592,7 +592,7 @@ GoogleAppsDetails = React.createClass( {
 					title={ this.translate( 'Google Apps Setup' ) }
 					description={ this.translate( 'You will receive an email shortly with your login information.' ) }
 					buttonText={ this.translate( 'More about Google Apps' ) }
-					href="https://en.support.wordpress.com/add-email/adding-google-apps-to-your-site/"
+					href="https://support.wordpress.com/add-email/adding-google-apps-to-your-site/"
 					target="_blank" />
 
 				<PurchaseDetail


### PR DESCRIPTION
Fixes #2810.

<img width="975" alt="screen shot 2016-01-26 at 2 50 41 pm" src="https://cloud.githubusercontent.com/assets/1130674/12600624/169adf96-c450-11e5-822d-3f1515cad80c.png">

This PR adds a commit to change the API of `PurchaseDetail` to accept props `href` and `target` instead of `onButtonClick`. This is an improvement over the previous method (using a single `onClick` prop) because:

- A new function isn't created during every render().
- It allows us to open links in the same window by omitting `target`.

All internal links should open in the same window now.

**Testing**
We should assert that the links highlighted above work on the thank you pages when checking out with the following products:

```
Business Plan
Chargeback
Domain Mapping
Domain Registration
Google Apps
Jetpack Business Plan
Jetpack Premium Plan
Premium Plan
Site Redirect 
```

A few of these might be difficult to test (I'm unsure about the chargeback and the Jetpack plans), but you can test the thank you for page for them by adding `componentClass = [thank you component]` on [this line](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/upgrades/checkout/thank-you.jsx#L242) where `[thank you component]` is one of the component names above, without spaces, followed by 'Details' (e.g. `JetpackBusinessPlanDetails`), then checking out with any product.

This builds on commits from #2713 which need to be removed when that is merged, so I'm labeling this as 'In Progress' until that is merged.

- [x] Product review
- [x] Code review