### PR TITLE
Desktop App: Add feature flag for In-App Purchase

### DIFF
--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -85,6 +85,7 @@
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": false,
 		"upgrades/domain-search": false,
+		"upgrades/in-app-purchase": true,
 		"upgrades/premium-themes": false
 	},
 	"rtl": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -85,6 +85,7 @@
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": false,
 		"upgrades/domain-search": true,
+		"upgrades/in-app-purchase": false,
 		"upgrades/premium-themes": true
 	},
 	"rtl": false,

--- a/config/development.json
+++ b/config/development.json
@@ -94,6 +94,7 @@
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": true,
 		"upgrades/domain-search": true,
+		"upgrades/in-app-purchase": false,
 		"upgrades/premium-themes": true,
 
 		"manage/customize": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -61,6 +61,7 @@
 
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
+		"upgrades/in-app-purchase": false,
 		"upgrades/premium-themes": true,
 
 		"show-site-groups": true,

--- a/config/production.json
+++ b/config/production.json
@@ -64,6 +64,7 @@
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": false,
 		"upgrades/domain-search": true,
+		"upgrades/in-app-purchase": false,
 		"upgrades/premium-themes": true,
 		"muse": true,
 		"olark": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -64,6 +64,7 @@
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": false,
 		"upgrades/domain-search": true,
+		"upgrades/in-app-purchase": false,
 		"upgrades/premium-themes": true,
 		"notifications2beta": true,
 		"muse": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -69,6 +69,7 @@
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": true,
 		"upgrades/domain-search": true,
+		"upgrades/in-app-purchase": false,
 		"upgrades/premium-themes": true,
 
 		"show-site-groups": true,


### PR DESCRIPTION
New feature flag `upgrades/in-app-purchase` added. Active only for desktop Mac App Store env.

It's going to be used in https://github.com/Automattic/wp-desktop/pull/17.