### PR TITLE
Sites: Make sure recent sites persist when clearing localStorage.

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -372,7 +372,11 @@ SitesList.prototype.isSelected = function( site ) {
  * @api private
  */
 SitesList.prototype.setRecentlySelectedSite = function( siteID ) {
-	if ( ! siteID ) {
+	if ( ! this.recentlySelected.length ) {
+		this.recentlySelected = PreferencesStore.get( 'recentSites' );
+	}
+
+	if ( ! siteID || ! this.initialized ) {
 		return;
 	}
 


### PR DESCRIPTION
Do not write to empty array before initialization.