### PR TITLE
Editor: Resize publicize info message to fit in sidebar

### DIFF
--- a/client/post-editor/editor-sharing/publicize-message.scss
+++ b/client/post-editor/editor-sharing/publicize-message.scss
@@ -21,7 +21,7 @@
 
 .info-popover__tooltip.publicize-message-counter-info {
 	.tip-inner {
-		max-width: 245px;
+		max-width: 210px;
 		text-align: left;
 	}
 }


### PR DESCRIPTION
Fixes [#2736](https://github.com/Automattic/wp-calypso/issues/2736)

Changed the max-width from 245px to 210px so that the publicize info
message is no longer cut off.

To test:
- Go to WordPress.com/post
- Start writing a new post on a site where Publicize is connected
- Open the Publicize box.
- Click on the "i" icon to view more info about Publicize.


**Screenshot before change:**

![screen shot 2016-01-26 at 6 07 40 pm](https://cloud.githubusercontent.com/assets/4932671/12614993/1160dd10-c4d1-11e5-8593-d851c249798c.png)


**Screenshot after change:**

![screen shot 2016-01-26 at 6 09 51 pm](https://cloud.githubusercontent.com/assets/4932671/12615001/1a921b4c-c4d1-11e5-8c86-ec3663379f88.png)