### PR TITLE
FoldableCard: Added responsive flexbox rule to css to fix mobile layout

### DIFF
--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -1,15 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
-var FoldableCard = require( 'components/foldable-card' );
+import FoldableCard from 'components/foldable-card';
+import Button from 'components/button';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'FoldableCard',
 
 	mixins: [ PureRenderMixin ],
@@ -58,6 +59,14 @@ module.exports = React.createClass( {
 						header={ <div><div>This is a multiline foldable card</div><div><small> with a summary component & a expanded summary component</small></div></div> }
 						summary={ <button className="button">Update</button> }
 						expandedSummary={ <button className="button">Update</button> }>
+						Nothing to see here. Keep walking!
+					</FoldableCard>
+				</p>
+				<p>
+					<FoldableCard
+						header={ <div><div>This is a multiline foldable card</div><div><small> with a summary component & a expanded summary component</small></div></div> }
+						summary={ <Button compact scary>Update</Button> }
+						expandedSummary={ <Button compact scary>Update</Button> }>
 						Nothing to see here. Keep walking!
 					</FoldableCard>
 				</p>

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -85,6 +85,10 @@ button.foldable-card__action {
 	align-items: center;
 	flex: 2 1;
 	margin-right: 5px;
+
+	@include breakpoint( '<480px' ) {
+		flex: 1 1;
+	}
 }
 
 .foldable-card__secondary {


### PR DESCRIPTION
In issue #2832, I outlined how the FoldableCard component needs a responsive update in order to show buttons used in the `summary` prop better at small sizes.

Currently in the devdocs, FoldableCard behaves this way on an emulated iPhone 5s:

<img width="279" alt="screen shot 2016-01-27 at 8 44 40 am" src="https://cloud.githubusercontent.com/assets/1084656/12618778/a6d43382-c4d2-11e5-8fec-79275c3302ea.png">

This small tweak to the component's CSS updates it to render like this on smaller mobile sizes:

<img width="281" alt="screen shot 2016-01-27 at 8 44 53 am" src="https://cloud.githubusercontent.com/assets/1084656/12618796/b5f0cc54-c4d2-11e5-866b-85e35139b78e.png">

Pinging @enejb and @folletto for review.