### PR TITLE
Settings: Align "+ Add a Custom Address" button to display properly on small screens

### DIFF
--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -91,10 +91,13 @@
 
 		.button {
 			width: 100%;
-			margin-left: 16px;
+			margin-left: 0;
+			margin-top: 5px;
 
 			@include breakpoint( ">660px" ) {
 				width: 45%;
+				margin-left: 16px;
+				margin-top: 0;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes [#2550](https://github.com/Automattic/wp-calypso/issues/2550)

Steps to test:

1. Go to https://wordpress.com/ on a small screen
1. Click My Sites (the "W" icon)
1. Select a site
1. Click Settings
1. Scroll to the "Site Address" section

**Result:** the "+ Add a Custom Address" button should no longer be
shifted too far to the right.

**Before:**
![screen shot 2016-01-27 at 11 23 50 am](https://cloud.githubusercontent.com/assets/4932671/12620388/1d11e35c-c4ea-11e5-8fc0-770dba0cfd00.png)

**After:**
![screen shot 2016-01-27 at 11 23 06 am](https://cloud.githubusercontent.com/assets/4932671/12620402/28c5d410-c4ea-11e5-8f40-2e37016c3ebb.png)
