### PR TITLE
Reader: Tweaking afk-tagged post styles

### DIFF
--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -127,16 +127,48 @@
 		background: transparent;
 		box-shadow: none;
 
+		&:hover {
+			cursor: pointer;
+		}
+
 		.reader__full-post-content,
 		.reader-post-byline__tag,
-		.reader__post-footer {
+		.reader-post-byline__date,
+		.reader__post-footer,
+		.site__info {
 			display: none;
 		}
 
-		.reader__post-title,
+		.site {
+			pointer-events: none;
+		}
+
+		.reader__post-header {
+			margin-bottom: 0;
+		}
+
+		.reader__post-title {
+			font-size: 14px;
+			margin: 0;
+			position: absolute;
+				top: 17px;
+				left: 66px;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
 		.reader-post-byline {
-			font-size: 12px;
-			line-height: normal;
+			margin: 0;
+			font-size: 13px;
+			position: absolute;
+				top: 30px;
+				left: 44px;
+		}
+
+		.reader-post-byline {
+			//font-size: 12px;
+			//line-height: normal;
 		}
 	}
 }

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -148,10 +148,10 @@
 		}
 
 		.reader__post-title {
-			font-size: 14px;
+			font-size: 16px;
 			margin: 0;
 			position: absolute;
-				top: 17px;
+				top: 14px;
 				left: 66px;
 			white-space: nowrap;
 			overflow: hidden;

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -10,7 +10,9 @@
 		&.is-selected,
 		&:hover,
 		&.is-x-post.is-selected,
-		&.is-x-post:hover {
+		&.is-x-post:hover,
+		&.tag-afk.is-selected,
+		&.tag-afk:hover {
 			box-shadow: 0 0 0 1px $gray,
 						0 2px 4px lighten( $gray, 20 );
 		}
@@ -126,6 +128,7 @@
 	&.tag-afk {
 		background: transparent;
 		box-shadow: none;
+		padding: 16px 24px;
 
 		&:hover {
 			cursor: pointer;

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -156,6 +156,7 @@
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
+			max-width: calc( 100% - 90px );
 		}
 
 		.reader-post-byline {

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -165,11 +165,6 @@
 				top: 30px;
 				left: 44px;
 		}
-
-		.reader-post-byline {
-			//font-size: 12px;
-			//line-height: normal;
-		}
 	}
 }
 


### PR DESCRIPTION
Tweaking the display of afk tagged posts to match x-posts.

Here's a before (top) and after (bottom):
![screen shot 2016-01-27 at 1 00 44 pm](https://cloud.githubusercontent.com/assets/191598/12622992/094c5724-c4f6-11e5-99cc-edc9d0fd8f61.png)


(Sorry for the redacted screenshot, it contains what could be considered private info.)