### PR TITLE
Reader: Fix update alert on mobile

### DIFF
--- a/client/reader/update-notice/_style.scss
+++ b/client/reader/update-notice/_style.scss
@@ -2,7 +2,7 @@
 // Slides in when there are new posts available
 .reader-update-notice {
 	position: fixed;
-		top: 16px;
+		top: ( 47px + 8px );
 		right: 16px;
 	background: rgba( $orange-jazzy, 0.96 );
 	padding: 6px 18px 6px 34px;
@@ -15,10 +15,6 @@
 	transform: translateY( -100px );
 	pointer-events: none;
 	transition: background 0.15s ease-in-out, transform 0.20s cubic-bezier( 0.175, 0.885, 0.320, 1.275 );
-
-	@include breakpoint( ">660px" ) {
-		top: ( 47px + 8px ); // Make way for the sticky Masterbar
-	}
 
 	&:hover {
 		background: $blue-medium;


### PR DESCRIPTION
Now that the Masterbar is fixed on mobile, Reader's update notice is a little out of whack:

![screen shot 2016-01-27 at 2 19 15 pm](https://cloud.githubusercontent.com/assets/191598/12625322/4700bdf2-c501-11e5-9d27-7557bc18c697.png)

#2798 is related as well.

This PR resolves the positioning issue:

![screen shot 2016-01-27 at 2 16 34 pm](https://cloud.githubusercontent.com/assets/191598/12625346/6d53ef88-c501-11e5-954d-febedc827a84.png)
