### PR TITLE
Reader: Replace reply Noticon with Gridicon

### DIFF
--- a/client/reader/comments/index.jsx
+++ b/client/reader/comments/index.jsx
@@ -124,7 +124,12 @@ var PostComment = React.createClass( {
 
 		return (
 			<div className="comment__actions">
-				{ showReplyButton ? <button className="comment__actions-reply" onClick={ this.handleReply }>Reply</button> : null }
+				{ showReplyButton ?
+					<button className="comment__actions-reply" onClick={ this.handleReply }>
+						<Gridicon icon="reply" size="18" />
+						<span className="comment__actions-reply-label">Reply</span>
+					</button>
+				: null }
 				{ showCancelReplyButton ? <button className="comment__actions-cancel-reply" onClick={ onReplyCancel }>Cancel reply</button> : null }
 				<CommentLikeButtonContainer className="comment__actions-like" tagName="button" siteId={ this.props.post.site_ID } commentId={ comment.ID } />
 				<span className="comment__actions-like-count">{ comment.like_count ? comment.like_count : null } likes</span>

--- a/client/reader/comments/style.scss
+++ b/client/reader/comments/style.scss
@@ -231,30 +231,24 @@
 			margin-right: 18px;
 		}
 
-		.gridicon {
-			top: 4px;
+		&.comment__actions-reply {
+			.gridicon {
+				position: relative;
+					top: 4px;
+				margin-right: 4px;
+				transform: rotate(180deg);
+			}
 		}
 
-		.gridicon__like-empty {
-			fill: $gray;
+		&.like-button {
+			.gridicon {
+				top: 4px;
+			}
 		}
 
 		&:hover {
 			color: $blue-medium;
-
-			.gridicon__like-empty {
-				fill: $blue-medium;
-			}
 		}
-	}
-}
-
-.comment__actions-reply {
-	&:before {
-		@include noticon( '\f412', 16px );
-		margin-right: 4px;
-		position: relative;
-		top: 2px;
 	}
 }
 


### PR DESCRIPTION
Replacing the Noticon reply icon with a Gridicon. I ended up rotate it to make more sense with the rest of the UX, specifically the visual treatment of nested comments being below (down) and indented (right).

Before `master`:
![screen shot 2016-01-27 at 3 34 57 pm](https://cloud.githubusercontent.com/assets/191598/12627391/926df156-c50b-11e5-989a-6b4301365833.png)

After:
![screen shot 2016-01-27 at 3 34 36 pm](https://cloud.githubusercontent.com/assets/191598/12627396/96f1e07a-c50b-11e5-88b9-1aa12c5dc07b.png)
