### PR TITLE
OFFLINE: Gravatar fallback for offline

### DIFF
--- a/client/components/gravatar/index.jsx
+++ b/client/components/gravatar/index.jsx
@@ -27,6 +27,12 @@ module.exports = React.createClass( {
 		};
 	},
 
+	getInitialState: function() {
+		return {
+			failedToLoad: false
+		}
+	},
+
 	_getResizedImageURL: function( imageURL ) {
 		var parsedURL, query;
 
@@ -44,18 +50,24 @@ module.exports = React.createClass( {
 		return url.format( parsedURL );
 	},
 
+	onError: function() {
+		this.setState( { failedToLoad: true } );
+	},
+
 	render: function() {
 		const size = this.props.size;
 
 		if ( ! this.props.user ) {
 			return <span className="gravatar is-placeholder" style={ { width: size, height: size } } />;
+		} else if ( this.state.failedToLoad ) {
+			return <span className="gravatar is-missing" />;
 		}
 
 		const alt = this.props.alt || this.props.user.display_name;
 		const avatarURL = this._getResizedImageURL( safeImageURL( this.props.user.avatar_URL ) );
 
 		return (
-			<img alt={ alt } className="gravatar" src={ avatarURL } width={ size } height={ size } />
+			<img alt={ alt } className="gravatar" src={ avatarURL } width={ size } height={ size } onError={ this.onError } />
 		);
 	}
 


### PR DESCRIPTION
We always load gravatars from CDN and they are not cached for some reason
Also, gravatar does not support CORS so any caching attempts with serviceWorkers have failed.
![](https://cldup.com/JVX2dx7Si9.png)

This is the most straightforward approach to add a gravatar fallback for both APP and WEB.

I'm just hooking into onError event.

@rralian @mtias @johngodley @gziolo