### PR TITLE
Reader: Hide like and share labels on mobile

### DIFF
--- a/assets/stylesheets/layout/_detail-page.scss
+++ b/assets/stylesheets/layout/_detail-page.scss
@@ -122,12 +122,6 @@
 		}
 	}
 
-	@include breakpoint( "<660px" ) {
-		.reader-share_button span {
-			display: none;
-		}
-	}
-
 	.post-options {
 		float: right;
 		margin-right: 4px;

--- a/client/components/like-button/_style.scss
+++ b/client/components/like-button/_style.scss
@@ -62,6 +62,10 @@
 		}
 	}
 
+	.like-button__label-count {
+		margin-right: 4px;
+	}
+
 	@include breakpoint( "<480px" ) {
 		.like-button__label-status {
 			display: none;

--- a/client/components/like-button/_style.scss
+++ b/client/components/like-button/_style.scss
@@ -61,4 +61,10 @@
 			color: $orange-jazzy;
 		}
 	}
+
+	@include breakpoint( "<480px" ) {
+		.like-button__label-status {
+			display: none;
+		}
+	}
 }

--- a/client/components/like-button/button.jsx
+++ b/client/components/like-button/button.jsx
@@ -70,6 +70,7 @@ var LikeButton = React.createClass( {
 		// Override the label with a counter
 		if ( likeCount > 0 || this.props.showCount ) {
 			likeLabel = this.translate( 'Like', 'Likes', {
+				count: likeCount,
 				comment: 'Displayed when a person "likes" a post.'
 			} );
 		}
@@ -81,8 +82,8 @@ var LikeButton = React.createClass( {
 		containerClasses = classnames( containerClasses );
 
 		labelElement = ( <span className="like-button__label">
-			<span className="like-button__label-count">{ likeCount }</span>
-			<span className="like-button__label-status"> { likeLabel }</span>
+			{ likeCount > 0 ? <span className="like-button__label-count">{ likeCount }</span> : null }
+			<span className="like-button__label-status">{ likeLabel }</span>
 		</span> );
 
 		return (

--- a/client/components/like-button/button.jsx
+++ b/client/components/like-button/button.jsx
@@ -69,9 +69,7 @@ var LikeButton = React.createClass( {
 
 		// Override the label with a counter
 		if ( likeCount > 0 || this.props.showCount ) {
-			likeLabel = this.translate( '%d Like', '%d Likes', {
-				args: [ likeCount ],
-				count: likeCount,
+			likeLabel = this.translate( 'Like', 'Likes', {
 				comment: 'Displayed when a person "likes" a post.'
 			} );
 		}
@@ -82,7 +80,10 @@ var LikeButton = React.createClass( {
 
 		containerClasses = classnames( containerClasses );
 
-		labelElement = ( <span className="like-button__label">{ likeLabel }</span> );
+		labelElement = ( <span className="like-button__label">
+			<span className="like-button__label-count">{ likeCount }</span>
+			<span className="like-button__label-status"> { likeLabel }</span>
+		</span> );
 
 		return (
 		React.createElement(

--- a/client/reader/comments/style.scss
+++ b/client/reader/comments/style.scss
@@ -247,6 +247,12 @@
 			}
 		}
 	}
+
+	@include breakpoint( "<480px" ) {
+		.like-button .like-button__label-status {
+			display: inline;
+		}
+	}
 }
 
 .comment__actions-reply {

--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -112,7 +112,7 @@ var ReaderShare = React.createClass( {
 			[
 				( <span key="button" ref="shareButton" className={ buttonClasses }>
 					<Gridicon icon="share" size={ 24 } />
-					{ this.translate( 'Share', { comment: 'Share the post' } ) }
+					<span className="reader-share__button-label">{ this.translate( 'Share', { comment: 'Share the post' } ) }</span>
 				</span> ),
 				( <PopoverMenu key="menu" context={ this.refs && this.refs.shareButton }
 					isVisible={ this.state.showingMenu }

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -28,6 +28,12 @@
 	}
 }
 
+@include breakpoint( "<480px" ) {
+	.reader-share__button-label {
+		display: none;
+	}
+}
+
 .reader-share__popover-item {
 	span {
 		display: inline-block;

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -1,11 +1,12 @@
 .reader-share {
 	display: inline-block;
-	padding: 4px 4px 4px 27px;
+	padding: 4px 4px 4px 32px;
 	color: lighten( $gray, 10 );
 	position: relative;
 	box-sizing: border-box;
 	transition: color 0.15s linear;
 	cursor: pointer;
+	min-height: 32px;
 
 	&:hover, &:focus, &:active {
 		cursor: pointer;
@@ -16,7 +17,7 @@
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 		position: absolute;
 			top: 3px;
-			left: -3px;
+			left: 3px;
 	}
 
 	.is-active {
@@ -29,6 +30,10 @@
 }
 
 @include breakpoint( "<480px" ) {
+	.reader-share .gridicon {
+		left: 6px;
+	}
+	
 	.reader-share__button-label {
 		display: none;
 	}


### PR DESCRIPTION
Hiding the share and like labels (not like count) on mobile to avoid an overflow in the post footer in streams.

Before on `master`:
![screen shot 2016-01-27 at 4 07 16 pm](https://cloud.githubusercontent.com/assets/191598/12628225/1eaffaca-c510-11e5-8902-15b7455b3957.png)

After:
![screen shot 2016-01-27 at 4 07 27 pm](https://cloud.githubusercontent.com/assets/191598/12628229/23d4666c-c510-11e5-9679-d10226204095.png)
