### PR TITLE
Users: Change on deletion sentence in /lib/users/store

### DIFF
--- a/client/lib/users/store.js
+++ b/client/lib/users/store.js
@@ -115,7 +115,7 @@ function deleteUserFromSite( siteId, userId ) {
 function deleteUserFromNamespaces( siteId, userId ) {
 	Object.keys( _userIDsByNamespace ).forEach( function( namespace ) {
 		if ( endsWith( namespace, 'siteId=' + siteId ) && _userIDsByNamespace[ namespace ].has( userId ) ) {
-			delete _userIDsByNamespace[ namespace ][ userId ];
+			_userIDsByNamespace[ namespace ].delete( userId );
 		}
 	} );
 }


### PR DESCRIPTION
The object _userIDsByNamespace has a Set structure by namespace, so the correct way to remove an entry from that set is with the delete method rather than the delete expression.
```js
delete _userIDsByNamespace[ namespace ][ userId ];
// to
_userIDsByNamespace[ namespace ].delete( userId );
```