### PR TITLE
SectionHeader: Update default font size

### DIFF
--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -38,25 +38,6 @@ var Cards = React.createClass( {
 						{ this.translate( 'Add' ) }
 					</Button>
 				</SectionHeader>
-
-				<br />
-
-				<SectionHeader compactLabel label={ this.translate( 'Team' ) } count={ 10 }>
-					<Button compact primary>
-						{ this.translate( 'Primary Action' ) }
-					</Button>
-					<Button compact>
-						{ this.translate( 'Manage' ) }
-					</Button>
-					<Button
-						compact
-						onClick={ function() {
-							alert( 'Clicked add button' );
-						} }
-					>
-						{ this.translate( 'Add' ) }
-					</Button>
-				</SectionHeader>
 			</div>
 		);
 	}

--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -38,6 +38,25 @@ var Cards = React.createClass( {
 						{ this.translate( 'Add' ) }
 					</Button>
 				</SectionHeader>
+
+				<br />
+
+				<SectionHeader compactLabel label={ this.translate( 'Team' ) } count={ 10 }>
+					<Button compact primary>
+						{ this.translate( 'Primary Action' ) }
+					</Button>
+					<Button compact>
+						{ this.translate( 'Manage' ) }
+					</Button>
+					<Button
+						compact
+						onClick={ function() {
+							alert( 'Clicked add button' );
+						} }
+					>
+						{ this.translate( 'Add' ) }
+					</Button>
+				</SectionHeader>
 			</div>
 		);
 	}

--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -13,13 +13,22 @@ var CompactCard = require( 'components/card/compact' ),
 var PeopleSectionHeader = React.createClass( {
 	getDefaultProps: function() {
 		return {
-			label: ''
+			label: '',
+			compactLabel: false
 		};
 	},
 
 	render: function() {
+		const classes = classNames(
+			this.props.className,
+			'section-header',
+			{
+				'header-is-compact': this.props.compactLabel
+			}
+		);
+
 		return (
-			<CompactCard className={ classNames( this.props.className, 'section-header' ) }>
+			<CompactCard className={ classes }>
 				<div className="section-header__label">
 					{ this.props.label }
 					{

--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -1,30 +1,26 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var CompactCard = require( 'components/card/compact' ),
-	Count = require( 'components/count' );
+import CompactCard from 'components/card/compact';
+import Count from 'components/count';
 
-var PeopleSectionHeader = React.createClass( {
-	getDefaultProps: function() {
+export default React.createClass( {
+	getDefaultProps() {
 		return {
 			label: '',
-			compactLabel: false
 		};
 	},
 
-	render: function() {
+	render() {
 		const classes = classNames(
 			this.props.className,
-			'section-header',
-			{
-				'header-is-compact': this.props.compactLabel
-			}
+			'section-header'
 		);
 
 		return (
@@ -43,5 +39,3 @@ var PeopleSectionHeader = React.createClass( {
 		);
 	}
 } );
-
-module.exports = PeopleSectionHeader;

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -38,11 +38,6 @@
 	font-size: 14px;
 }
 
-.section-header.header-is-compact .section-header__label {
-	font-size: 11px;
-	text-transform: uppercase;
-}
-
 .section-header__actions button {
 	background: none;
 	float: left;

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -43,7 +43,7 @@
 	text-transform: uppercase;
 }
 
-.section-header__button {
+.section-header__actions button {
 	background: none;
 	float: left;
 	margin-right: 8px;

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -35,6 +35,10 @@
 
 .section-header__label {
 	color: $gray;
+	font-size: 14px;
+}
+
+.section-header.header-is-compact .section-header__label {
 	font-size: 11px;
 	text-transform: uppercase;
 }


### PR DESCRIPTION
Currently, the SectionHeaders use a pretty small font size by default:

<img width="748" alt="screen shot 2016-01-27 at 3 21 39 pm" src="https://cloud.githubusercontent.com/assets/1084656/12630448/aed3c886-c509-11e5-8da9-4c4916aa1d61.png">
<img width="744" alt="screen shot 2016-01-27 at 3 21 56 pm" src="https://cloud.githubusercontent.com/assets/1084656/12630454/bb17469a-c509-11e5-8864-2237d61dd7cb.png">

We discussed the possible improvement to the font size of the SectionHeader's default label (I used 14px here, 15px seemed too big), and adding a way to set a compactHeader prop to get the previous 11px sizing. This PR handles that, which looks like this:

<img width="715" alt="screen shot 2016-01-27 at 3 19 30 pm" src="https://cloud.githubusercontent.com/assets/1084656/12630518/18f3919c-c50a-11e5-8c3e-c430586d100a.png">

<img width="741" alt="screen shot 2016-01-27 at 3 24 18 pm" src="https://cloud.githubusercontent.com/assets/1084656/12630523/1f580f86-c50a-11e5-842b-df0282a4e3e2.png">

<img width="751" alt="screen shot 2016-01-27 at 3 24 27 pm" src="https://cloud.githubusercontent.com/assets/1084656/12630531/243ef4ce-c50a-11e5-9641-6b547dfb25d1.png">

With the combination of #2863, Stats would change to look like:

<img width="744" alt="screen shot 2016-01-27 at 2 58 55 pm" src="https://cloud.githubusercontent.com/assets/1084656/12630548/32cf2d9c-c50a-11e5-990c-5c0494870bae.png">
 
cc @rickybanister @folletto @mtias 