### PR TITLE
Plans: Prevent persistent loading state on `Plans`

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -20,9 +20,10 @@ var observe = require( 'lib/mixins/data-observe' ),
 	analytics = require( 'analytics' ),
 	HeaderCake = require( 'components/header-cake' ),
 	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
-	getPlansBySiteId = require( 'state/sites/plans/selectors' ).getPlansBySiteId,
+	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
 	Card = require( 'components/card' ),
-	featuresListUtils = require( 'lib/features-list/utils' );
+	featuresListUtils = require( 'lib/features-list/utils' ),
+	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans;
 
 var PlansCompare = React.createClass( {
 	displayName: 'PlansCompare',
@@ -32,9 +33,7 @@ var PlansCompare = React.createClass( {
 	],
 
 	componentWillReceiveProps: function( nextProps ) {
-		if ( ! this.props.isInSignup && this.props.selectedSite.ID !== nextProps.selectedSite.ID ) {
-			this.props.fetchSitePlans( nextProps.selectedSite.ID );
-		}
+		this.props.fetchSitePlans( nextProps.sitePlans, nextProps.selectedSite );
 	},
 
 	getDefaultProps: function() {
@@ -49,7 +48,7 @@ var PlansCompare = React.createClass( {
 		} );
 
 		if ( ! this.props.isInSignup ) {
-			this.props.fetchSitePlans( this.props.selectedSite.ID );
+			this.props.fetchSitePlans( this.props.sitePlans, this.props.selectedSite );
 		}
 	},
 
@@ -241,18 +240,16 @@ var PlansCompare = React.createClass( {
 
 module.exports = connect(
 	function mapStateToProps( state, props ) {
-		if ( ! props.selectedSite ) {
-			return { sitePlans: null };
-		}
-
 		return {
-			sitePlans: getPlansBySiteId( state, props.selectedSite.ID )
+			sitePlans: getPlansBySite( state, props.selectedSite )
 		};
 	},
 	function mapDispatchToProps( dispatch ) {
 		return {
-			fetchSitePlans( siteId ) {
-				dispatch( fetchSitePlans( siteId ) );
+			fetchSitePlans( sitePlans, site ) {
+				if ( shouldFetchSitePlans( sitePlans, site ) ) {
+					dispatch( fetchSitePlans( site.ID ) );
+				}
 			}
 		};
 	}

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -53,3 +53,7 @@ export function getDaysUntilExpiry( plan ) {
 export function isInGracePeriod( plan ) {
 	return getDaysUntilUserFacingExpiry( plan ) <= 0;
 };
+
+export function shouldFetchSitePlans( sitePlans, selectedSite ) {
+	return ! sitePlans.hasLoadedFromServer && ! sitePlans.isFetching && selectedSite;
+}

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -56,4 +56,4 @@ export function isInGracePeriod( plan ) {
 
 export function shouldFetchSitePlans( sitePlans, selectedSite ) {
 	return ! sitePlans.hasLoadedFromServer && ! sitePlans.isFetching && selectedSite;
-}
+};

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -80,8 +80,8 @@ module.exports = {
 		ReactDom.render(
 			<ReduxProvider store={ context.store }>
 				<CartData>
-					<Plans sites={ sites }
-						selectedSite={ site }
+					<Plans
+						sites={ sites }
 						onSelectPlan={ onSelectPlan }
 						plans={ plans }
 						context={ context }

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -19,7 +19,8 @@ var CartBody = require( './cart-body' ),
 	isCredits = require( 'lib/products-values' ).isCredits,
 	Gridicon = require( 'components/gridicon' ),
 	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
-	getPlansBySiteId = require( 'state/sites/plans/selectors' ).getPlansBySiteId;
+	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
+	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans;
 
 var PopoverCart = React.createClass( {
 	propTypes: {
@@ -37,7 +38,7 @@ var PopoverCart = React.createClass( {
 	},
 
 	componentDidMount: function() {
-		this.props.fetchSitePlans( this.props.selectedSite.ID );
+		this.props.fetchSitePlans( this.props.sitePlans, this.props.selectedSite );
 	},
 
 	itemCount: function() {
@@ -157,12 +158,14 @@ var PopoverCart = React.createClass( {
 
 module.exports = connect(
 	function( state, props ) {
-		return { sitePlans: getPlansBySiteId( state, props.selectedSite.ID ) };
+		return { sitePlans: getPlansBySite( state, props.selectedSite ) };
 	},
 	function( dispatch ) {
 		return {
-			fetchSitePlans( siteId ) {
-				dispatch( fetchSitePlans( siteId ) );
+			fetchSitePlans( sitePlans, site ) {
+				if ( shouldFetchSitePlans( sitePlans, site ) ) {
+					dispatch( fetchSitePlans( site.ID ) );
+				}
 			}
 		};
 	}

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-var Dispatcher = require( 'dispatcher' ),
+var connect = require( 'react-redux' ).connect,
+	Dispatcher = require( 'dispatcher' ),
 	isEmpty = require( 'lodash/lang/isEmpty' ),
 	isEqual = require( 'lodash/lang/isEqual' ),
 	page = require( 'page' ),
@@ -16,15 +17,13 @@ var analytics = require( 'analytics' ),
 	DomainDetailsForm = require( './domain-details-form' ),
 	hasDomainDetails = require( 'lib/store-transactions' ).hasDomainDetails,
 	observe = require( 'lib/mixins/data-observe' ),
-	planActions = require( 'state/sites/plans/actions' ),
+	clearSitePlans = require( 'state/sites/plans/actions' ).clearSitePlans,
 	purchasePaths = require( 'me/purchases/paths' ),
 	SecurePaymentForm = require( './secure-payment-form' ),
 	getExitCheckoutUrl = require( 'lib/checkout' ).getExitCheckoutUrl,
 	upgradesActions = require( 'lib/upgrades/actions' );
 
-module.exports = React.createClass( {
-	displayName: 'Checkout',
-
+const Checkout = React.createClass( {
 	mixins: [ observe( 'sites', 'cards', 'productsList' ) ],
 
 	getInitialState: function() {
@@ -129,7 +128,7 @@ module.exports = React.createClass( {
 
 			return purchasePaths.managePurchaseDestination( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId, 'thank-you' );
 		} else if ( cartItems.hasFreeTrial( this.props.cart ) ) {
-			planActions.clearSitePlans( this.props.sites.getSelectedSite().ID );
+			this.props.clearSitePlans( this.props.sites.getSelectedSite().ID );
 
 			Dispatcher.handleViewAction( {
 				type: 'FETCH_SITES'
@@ -197,3 +196,14 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+module.exports = connect(
+	undefined,
+	function( dispatch ) {
+		return {
+			clearSitePlans: function( siteId ) {
+				dispatch( clearSitePlans( siteId ) );
+			}
+		};
+	}
+)( Checkout );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -180,7 +180,7 @@ module.exports = {
 
 		context.store.dispatch( setSection( null, { hasSidebar: true } ) );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			(
 				<CheckoutData>
 					<Checkout
@@ -191,7 +191,8 @@ module.exports = {
 						sites={ sites } />
 				</CheckoutData>
 			),
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 
 		ReactDom.render(

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -1,5 +1,9 @@
 import { initialSiteState } from './reducer';
 
-export function getPlansBySiteId( state, siteId ) {
-	return state.sites.plans[ siteId ] || initialSiteState;
+export function getPlansBySite( state, site ) {
+	if ( ! site ) {
+		return initialSiteState;
+	}
+
+	return state.sites.plans[ site.ID ] || initialSiteState;
 }


### PR DESCRIPTION
Previously, if `sites-list` was empty on an initial load, it would not trigger a render() on `Plans` when the sites eventually loaded. This is because `Plans` used its `selectedSite` prop to determine which site ID to request plans for, which is problematic:

- `selectedSite` is false when no site is selected or sites aren't loaded.
- When sites do load, `getSelectedSite()` isn't called in the controller, so `selectedSite` remains false until the given controller method is called again.

This PR:

- Removes `selectedSite` as a prop of `Plans`, in favor of using `sites.getSelectedSite()` inside that component.
- Updates `props.fetchSitePlans` to properly return the initial state of a site's plan before they are loaded and only request site plans when a selected site is present.
- Updates `Checkout` to actually clear the site plans when checking out with a free trial. We had code that was supposed to do this here, but it created a thunk without passing it to the dispatcher.

**Testing**
- Call `localStorage.clear()` in your console.
- Visit http://calypso.localhost:3000/plans/:site for any site and assert that the plans or trial hub loads. We should try this for sites with the free plan, sites with a paid plan, and sites with a free trial.

- [x] Product review
- [x] Code review