### PR TITLE
Reader: Fix back button to prevent it from overlapping share icon

### DIFF
--- a/assets/stylesheets/layout/_detail-page.scss
+++ b/assets/stylesheets/layout/_detail-page.scss
@@ -87,6 +87,10 @@
 			bottom: 0;
 			left: 0;
 		min-width: 200px;
+		
+		@include breakpoint( "<480px" ) {
+			min-width: initial;
+		}
 
 		.detail-page__button-label {
 			display: none;


### PR DESCRIPTION
Fixes [#2856](https://github.com/Automattic/wp-calypso/issues/2856).

In narrow browsers (Chrome and Safari on iOS, and Chrome on Mac) the single post view back button color overlaps share icon when hovered or tapped.

**To test:**
1. Open a post in Reader. For example, [this one](https://wordpress.com/read/post/id/39898339/3756).
2. Resize the browser so that it is less than 480px wide
3. Hover your mouse over the back button, or, on a mobile device, tap the back button
4. The back button color should no longer overlap the share icon


**Before**
![screen shot 2016-01-27 at 5 57 59 pm](https://cloud.githubusercontent.com/assets/4932671/12631547/e8eadea4-c51f-11e5-98e6-a4b3d5370bfd.png)


**After**
![screen shot 2016-01-27 at 5 58 33 pm](https://cloud.githubusercontent.com/assets/4932671/12631556/ef615592-c51f-11e5-84b7-bbc83a640e80.png)