### PR TITLE
Reader: Prefer to link to the feed ID based stream.

### DIFF
--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -29,10 +29,10 @@ module.exports = {
 			return null;
 		}
 
-		if ( siteData ) {
-			return getSiteUrl( siteData.get( 'ID' ) );
+		if ( feedData ) {
+			return getFeedUrl( feedData.feed_ID );
 		}
 
-		return getFeedUrl( feedData.feed_ID );
+		return getSiteUrl( siteData.get( 'ID' ) )
 	}
 };

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -15,7 +15,9 @@ var FeedHeader = require( 'reader/feed-header' ),
 
 function checkForRedirect( site ) {
 	if ( site && site.get( 'prefer_feed' ) && site.get( 'feed_ID' ) ) {
-		page.redirect( '/read/blog/feed/' + site.get( 'feed_ID' ) );
+		setTimeout( function() {
+			page.replace( '/read/blog/feed/' + site.get( 'feed_ID' ) )
+		}, 0 );
 	}
 }
 

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -1,4 +1,5 @@
-var React = require( 'react' );
+var React = require( 'react' ),
+	page = require( 'page' );
 
 var FeedHeader = require( 'reader/feed-header' ),
 	FeedFeatured = require( './featured' ),
@@ -12,13 +13,21 @@ var FeedHeader = require( 'reader/feed-header' ),
 	FeedStreamStoreActions = require( 'lib/feed-stream-store/actions' ),
 	feedStreamFactory = require( 'lib/feed-stream-store' );
 
-var SiteStream = React.createClass( {
+function checkForRedirect( site ) {
+	if ( site && site.get( 'prefer_feed' ) && site.get( 'feed_ID' ) ) {
+		page.redirect( '/read/blog/feed/' + site.get( 'feed_ID' ) );
+	}
+}
+
+const SiteStream = React.createClass( {
 
 	getDefaultProps: function() {
 		return { showBack: true };
 	},
 
 	getInitialState: function() {
+		const site = SiteStore.get( this.props.siteId );
+		checkForRedirect( site );
 		return {
 			site: SiteStore.get( this.props.siteId ),
 			title: this.getTitle()
@@ -42,6 +51,7 @@ var SiteStream = React.createClass( {
 	updateState: function() {
 		var site = SiteStore.get( this.props.siteId ),
 			newTitle = this.getTitle();
+		checkForRedirect( site );
 		if ( newTitle !== this.state.title || site !== this.state.site ) {
 			this.setState( {
 				title: newTitle,


### PR DESCRIPTION
Redirect some streams to the feed version because the site version is unreliable. For instance, https://wordpress.com/read/blog/id/64146350 should redirect to https://wordpress.com/read/blog/feed/19091453, but does not. With this patch, it does.

Fixes #2212 

