### PR TITLE
Invites: Add locale support for logged out invites

### DIFF
--- a/client/lib/i18n-utils/test/utils-test.js
+++ b/client/lib/i18n-utils/test/utils-test.js
@@ -26,6 +26,17 @@ describe( 'i18n-utils', function() {
 		it( 'should not remove the :step part of the URL', function() {
 			assert.equal( removeLocaleFromPath( '/start/flow/step' ), '/start/flow/step' );
 		} );
+
+		it( 'should not remove keys from an invite', function() {
+			assert.equal(
+				removeLocaleFromPath( '/accept-invite/site.wordpress.com/123456/es' ),
+				'/accept-invite/site.wordpress.com/123456'
+			);
+			assert.equal(
+				removeLocaleFromPath( '/accept-invite/site.wordpress.com/123456/123456/123456/es' ),
+				'/accept-invite/site.wordpress.com/123456/123456/123456'
+			);
+		} );
 	} );
 	describe( 'getLanguage', function() {
 		it( 'should return a language', function() {

--- a/client/lib/i18n-utils/test/utils-test.js
+++ b/client/lib/i18n-utils/test/utils-test.js
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { removeLocaleFromPath, getLanguage } from 'lib/i18n-utils';
+import { removeLocaleFromPath, getLanguage, getLocaleFromPath } from 'lib/i18n-utils';
 
 describe( 'i18n-utils', function() {
 	describe( 'removeLocaleFromPath', function() {
@@ -38,6 +38,18 @@ describe( 'i18n-utils', function() {
 			);
 		} );
 	} );
+
+	describe( 'getLocaleFromPath', function() {
+		it( 'should return undefined when no locale at end of path', function() {
+			assert.equal( getLocaleFromPath( '/start' ), undefined );
+		} );
+
+		it( 'should return locale string when at end of path', function() {
+			assert.equal( getLocaleFromPath( '/start/es' ), 'es' );
+			assert.equal( getLocaleFromPath( '/accept-invite/site.wordpress.com/123456/123456/123456/es' ), 'es' );
+		} );
+	} );
+
 	describe( 'getLanguage', function() {
 		it( 'should return a language', function() {
 			expect( getLanguage( 'ja' ).langSlug ).to.equal( 'ja' );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -11,6 +11,12 @@ import config from 'config';
 const localeRegex = /^[A-Z]{2}$/i;
 const localeWithRegionRegex = /^[A-Z]{2}-[A-Z]{2}$/i;
 
+function getPathParts( path ) {
+	// Remove trailing slash then split. If there is a trailing slash,
+	// then the end of the array could contain an empty string.
+	return path.replace( /\/$/, '' ).split( '/' );
+}
+
 const i18nUtils = {
 	getLanguage: function( langSlug ) {
 		let language;
@@ -41,9 +47,7 @@ const i18nUtils = {
 	 * @return {string|undefined} The locale slug if present or undefined
 	 */
 	getLocaleFromPath: function( path ) {
-		// Remove trailing slash then split. If there is a trailing slash,
-		// then the end of the array could contain an empty string.
-		const parts = path.replace( /\/$/, '' ).split( '/' );
+		const parts = getPathParts( path );
 		const locale = parts.pop();
 
 		return ( 'undefined' === typeof i18nUtils.getLanguage( locale ) ) ? undefined : locale;
@@ -56,9 +60,7 @@ const i18nUtils = {
 	 * @returns {string} original path minus locale slug
 	 */
 	removeLocaleFromPath: function( path ) {
-		// Remove trailing slash then split. If there is a trailing slash,
-		// then the end of the array could contain an empty string.
-		const parts = path.replace( /\/$/, '' ).split( '/' );
+		const parts = getPathParts( path );
 		const locale = parts.pop();
 
 		if ( 'undefined' === typeof i18nUtils.getLanguage( locale ) ) {

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -42,12 +42,16 @@ const i18nUtils = {
 	 * @returns {string} original path minus locale slug
 	 */
 	removeLocaleFromPath: function( path ) {
-		return path.replace( /([A-z-\/]+)(.*\/)([A-z-]+)(?!.*\/)/, function( match, p1, p2, p3 ) {
-			if ( 'undefined' === typeof i18nUtils.getLanguage( p3 ) ) {
-				return p1 + p2 + p3;
-			}
-			return p1;
-		} );
+		// Remove trailing slash then split. If there is a trailing slash,
+		// then the end of the array could contain an empty string.
+		const parts = path.replace( /\/$/, '' ).split( '/' );
+		const locale = parts.pop();
+
+		if ( 'undefined' === typeof i18nUtils.getLanguage( locale ) ) {
+			parts.push( locale );
+		}
+
+		return parts.join( '/' );
 	}
 };
 export default i18nUtils;

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -36,6 +36,20 @@ const i18nUtils = {
 	},
 
 	/**
+	 * Assuming that locale is adding at the end of path, retrieves the locale if present.
+	 * @param {string} path - original path
+	 * @return {string|undefined} The locale slug if present or undefined
+	 */
+	getLocaleFromPath: function( path ) {
+		// Remove trailing slash then split. If there is a trailing slash,
+		// then the end of the array could contain an empty string.
+		const parts = path.replace( /\/$/, '' ).split( '/' );
+		const locale = parts.pop();
+
+		return ( 'undefined' === typeof i18nUtils.getLanguage( locale ) ) ? undefined : locale;
+	},
+
+	/**
 	 * Removes the trailing locale slug from the path, if it is present.
 	 * '/start/en' => '/start', '/start' => '/start', '/start/flow/fr' => '/start/flow', '/start/flow' => '/start/flow'
 	 * @param {string} path - original path

--- a/client/my-sites/invites/index.js
+++ b/client/my-sites/invites/index.js
@@ -6,11 +6,12 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { acceptInvite } from './controller';
+import { acceptInvite, redirectWithoutLocaleifLoggedIn } from './controller';
 
 export default () => {
 	page(
-		'/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?',
+		'/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',
+		redirectWithoutLocaleifLoggedIn,
 		acceptInvite
 	);
 };

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -190,13 +190,13 @@ let InviteAccept = React.createClass( {
 	},
 
 	render() {
-		const classes = classNames( 'invite-accept', { 'is-error': !! this.isInvalidInvite() } ),
+		const formClasses = classNames( 'invite-accept__form', { 'is-error': !! this.isInvalidInvite() } ),
 			{ invite, matchEmailError } = this.state;
 
 		return (
-			<div>
+			<div className="invite-accept">
 				{ this.localeSuggestions() }
-				<div className={ classes }>
+				<div className={ formClasses }>
 					{ matchEmailError &&
 						<Notice
 							text={ this.translate( 'This invite is only valid for %(email)s.', { args: { email: invite.sentTo } } ) }

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -25,6 +25,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import config from 'config';
 import userUtils from 'lib/user/utils';
+import LocaleSuggestions from 'signup/locale-suggestions';
 
 /**
  * Module variables
@@ -126,6 +127,16 @@ let InviteAccept = React.createClass( {
 		userUtils.logout( window.location.href );
 	},
 
+	localeSuggestions() {
+		if ( this.state.user || ! this.props.locale ) {
+			return;
+		}
+
+		return (
+			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+		);
+	},
+
 	renderForm() {
 		const { invite, user, matchEmailError } = this.state;
 		if ( ! invite ) {
@@ -183,17 +194,20 @@ let InviteAccept = React.createClass( {
 			{ invite, matchEmailError } = this.state;
 
 		return (
-			<div className={ classes }>
-				{ matchEmailError &&
-					<Notice
-						text={ this.translate( 'This invite is only valid for %(email)s.', { args: { email: invite.sentTo } } ) }
-						status="is-error"
-						showDismiss={ false } >
-						{ this.renderNoticeAction() }
-					</Notice>
-				}
-				{ ! this.isInvalidInvite() && <InviteHeader { ... invite } /> }
-				{ this.isInvalidInvite() ? this.renderError() : this.renderForm() }
+			<div>
+				{ this.localeSuggestions() }
+				<div className={ classes }>
+					{ matchEmailError &&
+						<Notice
+							text={ this.translate( 'This invite is only valid for %(email)s.', { args: { email: invite.sentTo } } ) }
+							status="is-error"
+							showDismiss={ false } >
+							{ this.renderNoticeAction() }
+						</Notice>
+					}
+					{ ! this.isInvalidInvite() && <InviteHeader { ... invite } /> }
+					{ this.isInvalidInvite() ? this.renderError() : this.renderForm() }
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/invites/invite-accept/style.scss
+++ b/client/my-sites/invites/invite-accept/style.scss
@@ -1,4 +1,8 @@
-.invite-accept {
+.invite-accept .locale-suggestions {
+	margin-top: 0;
+}
+
+.invite-accept__form {
 	margin: 0 auto;
 	max-width: 400px;
 


### PR DESCRIPTION
Fixes #2845 by adding locale support for logged out invites.

To test:
- Checkout `add/invites-locale-support` branch
- Create an invite on a WP.com site at `$site/wp-admin/users.php?page=wpcom-invite-users`
  - Note: To get the correct invitation link, you will need to mark site as a test blog. Ping me for help if necessary.
- In the invitation link, replace `wordpress.com` with `calypso.localhost:3000`
- While logged out, add `/es` (or any other language slug)
  - You should be shown an interface in Spanish (or you chosen language), along with a notice to switch back to another language.
- While logged in, add `/es` (or another language slug) to the end of the URL
  - The language slug should automatically be removed and you should see the interface in whatever language is set for your user

Ping @scruffian @drewblaisdell for thoughts on implementation.
Ping @lezama for code review and @rickybanister for design review.

Note: I added some utilities to `i18n-utils` that we could begin using in `signup/utils.js`. But, I believe that to be out of the scope of this PR.

![logged-out-locale-mobile](https://cloud.githubusercontent.com/assets/1126811/12654536/0f7c6db8-c5ba-11e5-989f-ec6991711af6.png)
![logged-out-locale](https://cloud.githubusercontent.com/assets/1126811/12654535/0f7884be-c5ba-11e5-9260-6123e1bdf7f3.png)
