### PR TITLE
Framework: add "star" site functionality, site actions, and design

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1305,3 +1305,28 @@ This code is released into the "public domain" by its author(s).  Anybody may us
 
 If you find a bug or make an improvement, it would be courteous to let the author know, but it is not compulsory.
 ```
+
+### https://github.com/kentor/react-click-outside
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Kenneth Chung
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -368,6 +368,16 @@ $sidebar-width-min: 228px;
 		border-bottom: 1px solid lighten( $gray, 20% );
 	}
 
+	.site,
+	.all-sites {
+		.site__title,
+		.site__domain {
+			&::after {
+				@include long-content-fade( $color: lighten( $gray, 30% ) );
+			}
+		}
+	}
+
 	@include breakpoint( "<660px" ) {
 		width: 100vw;
 		left: -100vw;

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -245,7 +245,7 @@ export default React.createClass( {
 	renderStarredSites() {
 		const sites = this.props.sites.getStarred();
 
-		if ( ! sites || this.state.search || ! this.shouldShowGroups() ) {
+		if ( ! sites || this.state.search || ! this.shouldShowGroups() || ! this.props.sites.starred.length ) {
 			return null;
 		}
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -172,7 +172,7 @@ export default React.createClass( {
 		if ( this.shouldShowGroups() && ! this.state.search ) {
 			return (
 				<div>
-					<span className="site-selector__heading">{ this.translate( 'Sites' ) }</span>
+					{ this.renderRecentSites() }
 					{ siteElements }
 				</div>
 			);
@@ -236,12 +236,7 @@ export default React.createClass( {
 			return;
 		}
 
-		return (
-			<div>
-				<span className="site-selector__heading">{ this.translate( 'Recent Sites' ) }</span>
-				{ recentSites }
-			</div>
-		);
+		return recentSites;
 	},
 
 	renderStarredSites() {
@@ -271,10 +266,7 @@ export default React.createClass( {
 		}, this );
 
 		return (
-			<div>
-				<span className="site-selector__heading">
-					<Gridicon icon="star" size={ 18 } /> { this.translate( 'Starred' ) }
-				</span>
+			<div className="site-selector__starred">
 				{ starredSites }
 			</div>
 		);
@@ -298,7 +290,6 @@ export default React.createClass( {
 					<div className="site-selector__sites" ref="selector">
 						{ this.renderAllSites() }
 						{ this.renderStarredSites() }
-						{ this.renderRecentSites() }
 						{ this.renderSites() }
 					</div>
 					{ this.props.showAddNewSite && this.addNewSite() }

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -174,7 +174,7 @@ export default React.createClass( {
 		if ( this.shouldShowGroups() && ! this.state.search ) {
 			return (
 				<div>
-					{ this.renderRecentSites() }
+					{ user.get().visible_site_count > 12 && this.renderRecentSites() }
 					{ siteElements }
 				</div>
 			);

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -132,7 +132,7 @@ export default React.createClass( {
 		if ( this.state.search ) {
 			sites = this.props.sites.search( this.state.search );
 		} else {
-			sites = this.shouldShowGroups() ? this.props.sites.getVisibleAndNotRecent() : this.props.sites.getVisible();
+			sites = this.shouldShowGroups() ? this.props.sites.getVisibleAndNotRecentNorStarred() : this.props.sites.getVisible();
 		}
 
 		if ( this.props.filter ) {
@@ -218,7 +218,7 @@ export default React.createClass( {
 
 			const isSelected = this.isSelected( site );
 
-			if ( isSelected && this.props.hideSelected ) {
+			if ( this.props.sites.isStarred( site ) ) {
 				return;
 			}
 
@@ -242,6 +242,42 @@ export default React.createClass( {
 		);
 	},
 
+	renderStarredSites() {
+		const sites = this.props.sites.getStarred();
+
+		if ( ! sites || this.state.search || ! this.shouldShowGroups() ) {
+			return null;
+		}
+
+		const starredSites = sites.map( function( site ) {
+			var siteHref;
+
+			if ( this.props.siteBasePath ) {
+				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
+			}
+
+			return (
+				<Site
+					site={ site }
+					href={ siteHref }
+					key={ 'site-' + site.ID }
+					indicator={ this.props.indicator }
+					onSelect={ this.onSiteSelect.bind( this, site.slug ) }
+					isSelected={ this.isSelected( site ) }
+				/>
+			);
+		}, this );
+
+		return (
+			<div>
+				<span className="site-selector__heading">
+					<Gridicon icon="star" size={ 18 } /> { this.translate( 'Starred' ) }
+				</span>
+				{ starredSites }
+			</div>
+		);
+	},
+
 	render() {
 		const selectorClass = classNames( 'site-selector', 'sites-list', {
 			'is-large': user.get().site_count > 6,
@@ -259,6 +295,7 @@ export default React.createClass( {
 					/>
 					<div className="site-selector__sites" ref="selector">
 						{ this.renderAllSites() }
+						{ this.renderStarredSites() }
 						{ this.renderRecentSites() }
 						{ this.renderSites() }
 					</div>

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -209,7 +209,9 @@ export default React.createClass( {
 			return null;
 		}
 
-		const recentSites = sites.map( function( site ) {
+		const recentSites = sites.filter( function( site ) {
+			return ! this.props.sites.isStarred( site );
+		}, this ).map( function( site ) {
 			var siteHref;
 
 			if ( this.props.siteBasePath ) {
@@ -217,10 +219,6 @@ export default React.createClass( {
 			}
 
 			const isSelected = this.isSelected( site );
-
-			if ( this.props.sites.isStarred( site ) ) {
-				return;
-			}
 
 			return (
 				<Site
@@ -233,6 +231,10 @@ export default React.createClass( {
 				/>
 			);
 		}, this );
+
+		if ( ! recentSites.length ) {
+			return;
+		}
 
 		return (
 			<div>

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -119,7 +119,7 @@ export default React.createClass( {
 	},
 
 	shouldShowGroups() {
-		return this.props.groups && user.get().visible_site_count > 14;
+		return this.props.groups;
 	},
 
 	renderSites() {
@@ -132,7 +132,9 @@ export default React.createClass( {
 		if ( this.state.search ) {
 			sites = this.props.sites.search( this.state.search );
 		} else {
-			sites = this.shouldShowGroups() ? this.props.sites.getVisibleAndNotRecentNorStarred() : this.props.sites.getVisible();
+			sites = this.shouldShowGroups()
+				? this.props.sites.getVisibleAndNotRecentNorStarred()
+				: this.props.sites.getVisible();
 		}
 
 		if ( this.props.filter ) {

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -234,10 +234,6 @@ export default React.createClass( {
 			);
 		}, this );
 
-		if ( ! recentSites.length ) {
-			return;
-		}
-
 		return recentSites;
 	},
 

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -143,22 +143,6 @@
 	padding-top: 15px;
 }
 
-.site-selector__heading {
-	color: darken( $gray, 10% );
-	display: block;
-	font-weight: 600;
-	font-size: 12px;
-	margin: 6px 8px 6px 14px;
-
-	.gridicon {
-		vertical-align: sub;
-	}
-
-	.count {
-		margin-left: 8px;
-	}
-}
-
 .site-selector .all-sites {
 	border-bottom: 1px solid lighten( $gray, 20% );
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -27,6 +27,9 @@
 		.site__title,
 		.site__domain {
 			color: $white;
+			&::after {
+				@include long-content-fade( $color: $gray );
+			}
 		}
 
 		.count {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -24,6 +24,10 @@
 	.notouch &.is-selected:hover {
 		background-color: $gray;
 
+		.site__star-badge {
+			color: $white;
+		}
+
 		.site__title,
 		.site__domain {
 			color: $white;
@@ -153,4 +157,8 @@
 	.count {
 		margin-left: 8px;
 	}
+}
+
+.site-selector .all-sites {
+	border-bottom: 1px solid lighten( $gray, 20% );
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -51,6 +51,9 @@
 			.site__title,
 			.site__domain {
 				color: $blue-medium;
+				&::after {
+					@include long-content-fade( $color: $gray-light );
+				}
 			}
 		}
 	}

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -144,7 +144,11 @@
 	display: block;
 	font-weight: 600;
 	font-size: 12px;
-	margin: 16px 8px 6px 14px;
+	margin: 6px 8px 6px 14px;
+
+	.gridicon {
+		vertical-align: sub;
+	}
 
 	.count {
 		margin-left: 8px;

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -84,6 +84,9 @@
 			.site__title,
 			.site__domain {
 				color: white;
+				&::after {
+					@include long-content-fade( $color: $blue-medium );
+				}
 			}
 
 			.site__title:before {

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -81,6 +81,10 @@
 		&:hover {
 			background: $blue-medium;
 
+			.site__star-badge {
+				color: $white;
+			}
+
 			.site__title,
 			.site__domain {
 				color: white;

--- a/client/components/sites-popover/style.scss
+++ b/client/components/sites-popover/style.scss
@@ -60,6 +60,9 @@ $sites-popover-width: 300px;
 			.site__title,
 			.site__domain {
 				color: white;
+				&::after {
+					@include long-content-fade( $color: $blue-medium );
+				}
 			}
 
 			.site__title:before {

--- a/client/components/sites-popover/style.scss
+++ b/client/components/sites-popover/style.scss
@@ -36,6 +36,10 @@ $sites-popover-width: 300px;
 	text-decoration: none;
 }
 
+.sites-popover .site-selector__heading {
+	margin-top: 16px;
+}
+
 .sites-popover .site-selector .site {
 	&.is-selected {
 		background-color: $gray;
@@ -56,6 +60,10 @@ $sites-popover-width: 300px;
 	.notouch & {
 		&:hover {
 			background: $blue-medium;
+
+			.site__star-badge {
+				color: $white;
+			}
 
 			.site__title,
 			.site__domain {

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -392,7 +392,7 @@ SitesList.prototype.isSelected = function( site ) {
  * @api public
  */
 SitesList.prototype.isStarred = function( site ) {
-	return this.starred.indexOf( site.ID ) > -1 || site.primary;
+	return this.starred.indexOf( site.ID ) > -1;
 };
 
 SitesList.prototype.toggleStarred = function( siteID ) {
@@ -418,7 +418,7 @@ SitesList.prototype.getStarred = function() {
 	}
 
 	return this.get().filter( function( site ) {
-		return this.starred.indexOf( site.ID ) > -1 || site.primary;
+		return this.starred.indexOf( site.ID ) > -1;
 	}, this );
 };
 

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -413,6 +413,8 @@ SitesList.prototype.toggleStarred = function( siteID ) {
 };
 
 SitesList.prototype.getStarred = function() {
+	this.starred = PreferencesStore.get( 'starredSites' ) || [];
+
 	if ( ! this.initialized ) {
 		return false;
 	}

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -412,6 +412,16 @@ SitesList.prototype.toggleStarred = function( siteID ) {
 	this.emit( 'change' );
 };
 
+SitesList.prototype.getStarred = function() {
+	if ( ! this.initialized ) {
+		return false;
+	}
+
+	return this.get().filter( function( site ) {
+		return this.starred.indexOf( site.ID ) > -1 || site.primary;
+	}, this );
+};
+
 /**
  * Set recently selected site
  *
@@ -427,12 +437,18 @@ SitesList.prototype.setRecentlySelectedSite = function( siteID ) {
 		return;
 	}
 
+	const index = this.recentlySelected.indexOf( siteID );
+
 	// do not add duplicates
-	if ( this.recentlySelected.indexOf( siteID ) === -1 ) {
-		this.recentlySelected.unshift( siteID );
+	if ( index === -1 ) {
+		if ( ! this.isStarred( this.getSite( siteID ) ) ) {
+			this.recentlySelected.unshift( siteID );
+		}
 	} else {
-		this.recentlySelected.splice( this.recentlySelected.indexOf( siteID ), 1 );
-		this.recentlySelected.unshift( siteID );
+		this.recentlySelected.splice( index, 1 );
+		if ( ! this.isStarred( this.getSite( siteID ) ) ) {
+			this.recentlySelected.unshift( siteID );
+		}
 	}
 
 	if ( this.recentlySelected.length > 3 ) {
@@ -556,9 +572,9 @@ SitesList.prototype.getVisible = function() {
  *
  * @api public
  **/
-SitesList.prototype.getVisibleAndNotRecent = function() {
+SitesList.prototype.getVisibleAndNotRecentNorStarred = function() {
 	return this.get().filter( function( site ) {
-		return site.visible === true && this.recentlySelected.indexOf( site.ID ) === -1;
+		return site.visible === true && this.recentlySelected.indexOf( site.ID ) === -1 && ! this.isStarred( site );
 	}, this );
 };
 

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -38,6 +38,7 @@ function SitesList() {
 	this.selected = null;
 	this.lastSelected = null;
 	this.propagateChange = this.propagateChange.bind( this );
+	this.starred = PreferencesStore.get( 'starredSites' ) || [];
 }
 
 /**
@@ -383,6 +384,32 @@ SitesList.prototype.setSelectedSite = function( siteID ) {
  */
 SitesList.prototype.isSelected = function( site ) {
 	return this.selected === site.slug;
+};
+
+/**
+ * Is the site starred?
+ *
+ * @api public
+ */
+SitesList.prototype.isStarred = function( site ) {
+	return this.starred.indexOf( site.ID ) > -1 || site.primary;
+};
+
+SitesList.prototype.toggleStarred = function( siteID ) {
+	if ( ! siteID ) {
+		return;
+	}
+
+	// do not add duplicates
+	if ( this.starred.indexOf( siteID ) === -1 ) {
+		this.starred.unshift( siteID );
+	} else {
+		this.starred.splice( this.starred.indexOf( siteID ), 1 );
+	}
+
+	PreferencesActions.set( 'starredSites', this.starred );
+
+	this.emit( 'change' );
 };
 
 /**

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -576,7 +576,7 @@ SitesList.prototype.getVisible = function() {
  **/
 SitesList.prototype.getVisibleAndNotRecentNorStarred = function() {
 	return this.get().filter( function( site ) {
-		return site.visible === true && this.recentlySelected.indexOf( site.ID ) === -1 && ! this.isStarred( site );
+		return site.visible === true && this.recentlySelected && this.recentlySelected.indexOf( site.ID ) === -1 && ! this.isStarred( site );
 	}, this );
 };
 

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -39,6 +39,7 @@ function SitesList() {
 	this.lastSelected = null;
 	this.propagateChange = this.propagateChange.bind( this );
 	this.starred = PreferencesStore.get( 'starredSites' ) || [];
+	this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
 }
 
 /**
@@ -433,7 +434,7 @@ SitesList.prototype.setRecentlySelectedSite = function( siteID ) {
 		this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
 	}
 
-	if ( ! siteID || ! this.initialized || user.get().visible_site_count < 12 ) {
+	if ( ! siteID || ! this.initialized ) {
 		return;
 	}
 
@@ -574,6 +575,10 @@ SitesList.prototype.getVisible = function() {
  **/
 SitesList.prototype.getVisibleAndNotRecentNorStarred = function() {
 	return this.get().filter( function( site ) {
+		if ( user.get().visible_site_count < 12 ) {
+			return site.visible === true && ! this.isStarred( site );
+		}
+
 		return site.visible === true && this.recentlySelected && this.recentlySelected.indexOf( site.ID ) === -1 && ! this.isStarred( site );
 	}, this );
 };

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -419,9 +419,7 @@ SitesList.prototype.getStarred = function() {
 		return false;
 	}
 
-	return this.get().filter( function( site ) {
-		return this.starred.indexOf( site.ID ) > -1;
-	}, this );
+	return this.get().filter( this.isStarred, this );
 };
 
 /**

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -435,7 +435,7 @@ SitesList.prototype.setRecentlySelectedSite = function( siteID ) {
 		this.recentlySelected = PreferencesStore.get( 'recentSites' ) || [];
 	}
 
-	if ( ! siteID || ! this.initialized ) {
+	if ( ! siteID || ! this.initialized || user.get().visible_site_count < 12 ) {
 		return;
 	}
 

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -415,11 +415,6 @@ SitesList.prototype.toggleStarred = function( siteID ) {
 
 SitesList.prototype.getStarred = function() {
 	this.starred = PreferencesStore.get( 'starredSites' ) || [];
-
-	if ( ! this.initialized ) {
-		return false;
-	}
-
 	return this.get().filter( this.isStarred, this );
 };
 

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -73,6 +73,7 @@ module.exports = React.createClass( {
 		event.preventDefault();
 		event.stopPropagation();
 		layoutFocus.set( 'sites' );
+		this.refs.site.closeActions();
 
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked Switch Site' );
 	},
@@ -200,7 +201,8 @@ module.exports = React.createClass( {
 						homeLink={ true }
 						enableActions={ true }
 						externalLink={ true }
-						onSelect={ this.trackHomepageClick } />
+						onSelect={ this.trackHomepageClick }
+						ref="site" />
 					: <AllSites sites={ this.props.sites } />
 				}
 				{ this.getSiteNotices( site ) }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -198,6 +198,7 @@ module.exports = React.createClass( {
 					? <Site
 						site={ site }
 						homeLink={ true }
+						enableActions={ true }
 						externalLink={ true }
 						onSelect={ this.trackHomepageClick } />
 					: <AllSites sites={ this.props.sites } />

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -202,6 +202,7 @@ module.exports = React.createClass( {
 						site={ site }
 						homeLink={ true }
 						enableActions={ true }
+						disableStarring={ hasOneSite }
 						externalLink={ true }
 						onSelect={ this.trackHomepageClick }
 						ref="site" />

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -73,7 +73,9 @@ module.exports = React.createClass( {
 		event.preventDefault();
 		event.stopPropagation();
 		layoutFocus.set( 'sites' );
-		this.refs.site.closeActions();
+		if ( this.refs.site ) {
+			this.refs.site.closeActions();
+		}
 
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked Switch Site' );
 	},

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -32,6 +32,10 @@
 .current-site .site {
 	transition: opacity 0.15s ease-in-out;
 
+	.site__info {
+		animation: appear .3s ease-in-out;
+	}
+
 	.focus-sites & {
 		opacity: 0.2;
 		pointer-events: none;

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -3,6 +3,7 @@
  */
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
+	wrapWithClickOutside = require( 'react-click-outside' ),
 	noop = require( 'lodash/utility/noop' );
 
 /**
@@ -11,7 +12,7 @@ var ReactDom = require( 'react-dom' ),
 var SiteSelector = require( 'components/site-selector' ),
 	hasTouch = require( 'lib/touch-detect' ).hasTouch;
 
-module.exports = React.createClass( {
+const SitePicker = React.createClass( {
 	displayName: 'SitePicker',
 
 	propTypes: {
@@ -46,22 +47,7 @@ module.exports = React.createClass( {
 		}.bind( this ), 200 );
 	},
 
-	componentDidUpdate: function() {
-		// Register a document level event listener
-		// only when the picker is opened.
-		//
-		// This is used to detect clicks outside the picker
-		// in order to close it.
-		if ( this.props.layoutFocus && this.props.layoutFocus.getCurrent() === 'sites' ) {
-			document.addEventListener( 'click', this.closePickerOnOutsideClick );
-		} else {
-			document.removeEventListener( 'click', this.closePickerOnOutsideClick );
-		}
-	},
-
 	componentWillUnmount: function() {
-		document.removeEventListener( 'click', this.closePickerOnOutsideClick );
-
 		clearTimeout( this._autofocusTimeout );
 		this._autofocusTimeout = null;
 	},
@@ -77,11 +63,8 @@ module.exports = React.createClass( {
 		window.scrollTo( 0, 0 );
 	},
 
-	closePickerOnOutsideClick: function( event ) {
-		var pickerNode = ReactDom.findDOMNode( this.refs.siteSelector );
-
-		// If the user clicks outside the Picker, let's close it
-		if ( ! pickerNode.contains( event.target ) && event.target !== pickerNode ) {
+	handleClickOutside: function() {
+		if ( this.props.layoutFocus && this.props.layoutFocus.getCurrent() === 'sites' ) {
 			this.props.layoutFocus && this.props.layoutFocus.set( 'sidebar' );
 			this.scrollToTop();
 		}
@@ -105,3 +88,5 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+module.exports = wrapWithClickOutside( SitePicker );

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -276,17 +276,19 @@ export default React.createClass( {
 
 		return (
 			<div className={ indicatorClass }>
-				<button className="site-indicator__button" onClick={ this.toggleExpand }>
-					{ this.state.expand
-						? <Gridicon icon="cross" size={ 18 } />
-						: <Gridicon icon={ this.getIcon() } size={ 16 } nonStandardSize />
-					}
-				</button>
+				{ ! this.state.expand &&
+					<button className="site-indicator__button" onClick={ this.toggleExpand }>
+						<Gridicon icon={ this.getIcon() } size={ 16 } nonStandardSize />
+					</button>
+				}
 				{ this.state.expand
 					? <div className="site-indicator__message">
 						<div className={ textClass }>
 							{ this.getText() }
 						</div>
+						<button className="site-indicator__button" onClick={ this.toggleExpand }>
+							<Gridicon icon="cross" size={ 18 } />
+						</button>
 					</div>
 					: null }
 			</div>

--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -26,7 +26,6 @@
 	overflow: initial;
 	line-height: 28px;
 
-
 	&:focus {
 		box-shadow: none;
 	}
@@ -91,6 +90,7 @@
 		right: 0;
 		bottom: 0;
 	display: flex;
+	justify-content: space-between;
 
 	.is-warning &,
 	.is-update & {
@@ -98,13 +98,6 @@
 	}
 	.is-error & {
 		background: $alert-red;
-	}
-	&::before {
-		content: '';
-		display: inline-block;
-		height: 100%;
-		margin-right: -0.25em;
-		vertical-align: middle;
 	}
 }
 .site-indicator__action {

--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -8,6 +8,7 @@
 }
 
 .site-indicator__button {
+	align-self: center;
 	background: $gray-light;
 	border: none;
 	border-radius: 50%;
@@ -65,6 +66,10 @@
 				left: 6px;
 			}
 		}
+		.site-indicator__button {
+			position: absolute;
+				right: 0;
+		}
 	}
 
 	.notouch & {
@@ -78,12 +83,14 @@
 .site-indicator__message {
 	color: $white;
 	font-size: 12px;
-	padding: 5px 50px 5px 15px;
+	line-height: 1.4;
+	padding: 5px 16px 5px 16px;
 	position: absolute;
 		top: 0;
 		left: 0;
 		right: 0;
 		bottom: 0;
+	display: flex;
 
 	.is-warning &,
 	.is-update & {
@@ -101,6 +108,7 @@
 	}
 }
 .site-indicator__action {
+	align-self: center;
 	display: inline-block;
 	vertical-align: middle;
 

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -120,6 +120,10 @@ module.exports = React.createClass( {
 		return this.props.homeLink ? this.props.site.URL : this.props.href;
 	},
 
+	closeActions: function() {
+		this.setState( { showMoreActions: false } );
+	},
+
 	render: function() {
 		var site = this.props.site,
 			siteClass;

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -98,8 +98,14 @@ module.exports = React.createClass( {
 			return;
 		}
 
+		let url = getCustomizeUrl( null, this.props.site );
+
+		if ( ! this.props.site.jetpack && this.props.site.options ) {
+			url = this.props.site.options.admin_url + 'options-general.php';
+		}
+
 		return (
-			<a href={ getCustomizeUrl( null, this.props.site ) }
+			<a href={ url } target="_blank"
 				className="site__edit-icon">
 				{ this.translate( 'Edit Icon' ) }
 			</a>

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -15,6 +15,7 @@ var SiteIcon = require( 'components/site-icon' ),
 	sites = require( 'lib/sites-list' )();
 
 import { userCan } from 'lib/site/utils';
+import Tooltip from 'components/tooltip';
 
 module.exports = React.createClass( {
 	displayName: 'Site',
@@ -56,7 +57,8 @@ module.exports = React.createClass( {
 
 	getInitialState: function() {
 		return {
-			showActions: false
+			showActions: false,
+			starTooltip: false
 		};
 	},
 
@@ -84,11 +86,24 @@ module.exports = React.createClass( {
 		const isStarred = sites.isStarred( site );
 
 		return (
-			<button className="site__star" onClick={ this.starSite }>
+			<button
+				className="site__star"
+				onClick={ this.starSite }
+				onMouseEnter={ () => this.setState( { starTooltip: true } ) }
+				onMouseLeave={ () => this.setState( { starTooltip: false } ) }
+				ref="starButton"
+			>
 				{ isStarred
 					? <Gridicon icon="star" />
 					: <Gridicon icon="star-outline" />
 				}
+				<Tooltip
+					context={ this.refs && this.refs.starButton }
+					isVisible={ this.state.starTooltip && ! isStarred }
+					position="bottom"
+				>
+					{ this.translate( 'Star this site' ) }
+				</Tooltip>
 			</button>
 		);
 	},

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -188,6 +188,11 @@ module.exports = React.createClass( {
 								<Gridicon icon="house" size={ 18 } />
 							</span>
 						}
+						{ ! this.props.enableActions && sites.isStarred( this.props.site ) &&
+							<span className="site__star-badge">
+								<Gridicon icon="star" size={ 18 } />
+							</span>
+						}
 					</a>
 				:
 					<div className="site__content">
@@ -209,11 +214,6 @@ module.exports = React.createClass( {
 					>
 						<Gridicon icon="ellipsis" size={ 24 } />
 					</button>
-				}
-				{ ! this.props.enableActions && sites.isStarred( this.props.site ) &&
-					<span className="site__star-badge">
-						<Gridicon icon="star" size={ 18 } />
-					</span>
 				}
 			</div>
 		);

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -110,7 +110,7 @@ module.exports = React.createClass( {
 
 	renderEditIcon: function() {
 		if ( ! userCan( 'manage_options', this.props.site ) ) {
-			return;
+			return <span />;
 		}
 
 		let url = getCustomizeUrl( null, this.props.site );

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -11,7 +11,10 @@ var React = require( 'react' ),
 var SiteIcon = require( 'components/site-icon' ),
 	Gridicon = require( 'components/gridicon' ),
 	SiteIndicator = require( 'my-sites/site-indicator' ),
+	getCustomizeUrl = require( 'lib/themes/helpers' ).getCustomizeUrl,
 	sites = require( 'lib/sites-list' )();
+
+import { userCan } from 'lib/site/utils';
 
 module.exports = React.createClass( {
 	displayName: 'Site',
@@ -90,6 +93,19 @@ module.exports = React.createClass( {
 		);
 	},
 
+	renderEditIcon: function() {
+		if ( ! userCan( 'manage_options', this.props.site ) ) {
+			return;
+		}
+
+		return (
+			<a href={ getCustomizeUrl( null, this.props.site ) }
+				className="site__edit-icon">
+				{ this.translate( 'Edit Icon' ) }
+			</a>
+		);
+	},
+
 	getHref: function() {
 		if ( this.state.showMoreActions || ! this.props.site ) {
 			return null;
@@ -152,7 +168,7 @@ module.exports = React.createClass( {
 					<div className="site__content">
 						<SiteIcon site={ site } />
 						<div className="site__actions">
-							<span className="site__edit-icon">Edit Icon</span>
+							{ this.renderEditIcon() }
 							{ this.renderStar() }
 						</div>
 					</div>

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -34,7 +34,8 @@ module.exports = React.createClass( {
 			// Mark as selected or not
 			isSelected: false,
 
-			homeLink: false
+			homeLink: false,
+			enableActions: false
 		};
 	},
 
@@ -52,7 +53,7 @@ module.exports = React.createClass( {
 
 	getInitialState: function() {
 		return {
-			showMoreActions: false
+			showActions: false
 		};
 	},
 
@@ -143,7 +144,7 @@ module.exports = React.createClass( {
 						</div>
 						{ this.props.homeLink &&
 							<span className="site__home">
-								<Gridicon icon="house" size={ 12 } />
+								<Gridicon icon="house" size={ 18 } />
 							</span>
 						}
 					</a>
@@ -160,12 +161,14 @@ module.exports = React.createClass( {
 					? <SiteIndicator site={ site } onSelect={ this.props.onSelect } />
 					: null
 				}
-				<button
-					className="site__toggle-more-options"
-					onClick={ () => this.setState( { showMoreActions: ! this.state.showMoreActions } ) }
-				>
-					<Gridicon icon="ellipsis" size={ 24 } />
-				</button>
+				{ this.props.enableActions &&
+					<button
+						className="site__toggle-more-options"
+						onClick={ () => this.setState( { showMoreActions: ! this.state.showMoreActions } ) }
+					>
+						<Gridicon icon="ellipsis" size={ 24 } />
+					</button>
+				}
 			</div>
 		);
 	}

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -89,6 +89,14 @@ module.exports = React.createClass( {
 		);
 	},
 
+	getHref: function() {
+		if ( this.state.showMoreActions || ! this.props.site ) {
+			return null;
+		}
+
+		return this.props.homeLink ? this.props.site.URL : this.props.href;
+	},
+
 	render: function() {
 		var site = this.props.site,
 			siteClass;
@@ -110,41 +118,44 @@ module.exports = React.createClass( {
 
 		return (
 			<div className={ siteClass }>
-				<a className="site__content"
-					href={ this.props.homeLink ? site.URL : this.props.href }
-					target={ this.props.externalLink && '_blank' }
-					title={ this.props.homeLink
-						? this.translate( 'Visit "%(title)s"', { args: { title: site.title } } )
-						: site.title
-					}
-					onTouchTap={ this.onSelect }
-					onClick={ this.props.onClick }
-					onMouseEnter={ this.props.onMouseEnter }
-					onMouseLeave={ this.props.onMouseLeave }
-					aria-label={
-						this.translate( 'Open site %(domain)s in new tab', {
-							args: { domain: site.domain }
-						} )
-					}
-				>
-					<SiteIcon site={ site } />
-					{ this.state.showMoreActions ?
-						<div className="site__actions">
-							<span className="site__edit-icon">Edit Icon</span>
-							{ this.renderStar() }
-						</div>
-					:
+				{ ! this.state.showMoreActions ?
+					<a className="site__content"
+						href={ this.props.homeLink ? site.URL : this.props.href }
+						target={ this.props.externalLink && ! this.state.showMoreActions && '_blank' }
+						title={ this.props.homeLink
+							? this.translate( 'Visit "%(title)s"', { args: { title: site.title } } )
+							: site.title
+						}
+						onTouchTap={ this.onSelect }
+						onClick={ this.props.onClick }
+						onMouseEnter={ this.props.onMouseEnter }
+						onMouseLeave={ this.props.onMouseLeave }
+						aria-label={
+							this.translate( 'Open site %(domain)s in new tab', {
+								args: { domain: site.domain }
+							} )
+						}
+					>
+						<SiteIcon site={ site } />
 						<div className="site__info">
 							<div className="site__title">{ site.title }</div>
 							<div className="site__domain">{ site.domain }</div>
 						</div>
-					}
-					{ this.props.homeLink && ! this.state.showMoreActions &&
-						<span className="site__home">
-							<Gridicon icon="house" size={ 12 } />
-						</span>
-					}
-				</a>
+						{ this.props.homeLink &&
+							<span className="site__home">
+								<Gridicon icon="house" size={ 12 } />
+							</span>
+						}
+					</a>
+				:
+					<div className="site__content">
+						<SiteIcon site={ site } />
+						<div className="site__actions">
+							<span className="site__edit-icon">Edit Icon</span>
+							{ this.renderStar() }
+						</div>
+					</div>
+				}
 				{ this.props.indicator
 					? <SiteIndicator site={ site } onSelect={ this.props.onSelect } />
 					: null

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -10,7 +10,8 @@ var React = require( 'react' ),
  */
 var SiteIcon = require( 'components/site-icon' ),
 	Gridicon = require( 'components/gridicon' ),
-	SiteIndicator = require( 'my-sites/site-indicator' );
+	SiteIndicator = require( 'my-sites/site-indicator' ),
+	sites = require( 'lib/sites-list' )();
 
 module.exports = React.createClass( {
 	displayName: 'Site',
@@ -49,6 +50,12 @@ module.exports = React.createClass( {
 		onClick: React.PropTypes.func
 	},
 
+	getInitialState: function() {
+		return {
+			showMoreActions: false
+		};
+	},
+
 	onSelect: function( event ) {
 		if ( this.props.homeLink ) {
 			return;
@@ -56,6 +63,30 @@ module.exports = React.createClass( {
 
 		this.props.onSelect( event );
 		event.preventDefault(); // this doesn't actually do anything...
+	},
+
+	starSite: function() {
+		const site = sites.getSelectedSite();
+		sites.toggleStarred( site.ID );
+	},
+
+	renderStar: function() {
+		const site = this.props.site;
+
+		if ( ! site ) {
+			return null;
+		}
+
+		const isStarred = sites.isStarred( site );
+
+		return (
+			<button className="site__star" onClick={ this.starSite }>
+				{ isStarred
+					? <Gridicon icon="star" />
+					: <Gridicon icon="star-outline" />
+				}
+			</button>
+		);
 	},
 
 	render: function() {
@@ -73,7 +104,8 @@ module.exports = React.createClass( {
 			'is-primary': site.primary,
 			'is-private': site.is_private,
 			'is-redirect': site.options && site.options.is_redirect,
-			'is-selected': this.props.isSelected
+			'is-selected': this.props.isSelected,
+			'is-toggled': this.state.showMoreActions
 		} );
 
 		return (
@@ -96,11 +128,18 @@ module.exports = React.createClass( {
 					}
 				>
 					<SiteIcon site={ site } />
-					<div className="site__info">
-						<div className="site__title">{ site.title }</div>
-						<div className="site__domain">{ site.domain }</div>
-					</div>
-					{ this.props.homeLink &&
+					{ this.state.showMoreActions ?
+						<div className="site__actions">
+							<span className="site__edit-icon">Edit Icon</span>
+							{ this.renderStar() }
+						</div>
+					:
+						<div className="site__info">
+							<div className="site__title">{ site.title }</div>
+							<div className="site__domain">{ site.domain }</div>
+						</div>
+					}
+					{ this.props.homeLink && ! this.state.showMoreActions &&
 						<span className="site__home">
 							<Gridicon icon="house" size={ 12 } />
 						</span>
@@ -110,6 +149,12 @@ module.exports = React.createClass( {
 					? <SiteIndicator site={ site } onSelect={ this.props.onSelect } />
 					: null
 				}
+				<button
+					className="site__toggle-more-options"
+					onClick={ () => this.setState( { showMoreActions: ! this.state.showMoreActions } ) }
+				>
+					<Gridicon icon="ellipsis" size={ 24 } />
+				</button>
 			</div>
 		);
 	}

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -210,6 +210,11 @@ module.exports = React.createClass( {
 						<Gridicon icon="ellipsis" size={ 24 } />
 					</button>
 				}
+				{ ! this.props.enableActions && sites.isStarred( this.props.site ) &&
+					<span className="site__star-badge">
+						<Gridicon icon="star" size={ 18 } />
+					</span>
+				}
 			</div>
 		);
 	}

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -72,7 +72,7 @@ module.exports = React.createClass( {
 	},
 
 	starSite: function() {
-		const site = sites.getSelectedSite();
+		const site = this.props.site;
 		sites.toggleStarred( site.ID );
 	},
 
@@ -155,7 +155,8 @@ module.exports = React.createClass( {
 			'is-private': site.is_private,
 			'is-redirect': site.options && site.options.is_redirect,
 			'is-selected': this.props.isSelected,
-			'is-toggled': this.state.showMoreActions
+			'is-toggled': this.state.showMoreActions,
+			'has-edit-capabilities': userCan( 'manage_options', site )
 		} );
 
 		return (

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -39,7 +39,8 @@ module.exports = React.createClass( {
 			isSelected: false,
 
 			homeLink: false,
-			enableActions: false
+			enableActions: false,
+			disableStarring: false
 		};
 	},
 
@@ -52,7 +53,9 @@ module.exports = React.createClass( {
 		onMouseLeave: React.PropTypes.func,
 		isSelected: React.PropTypes.bool,
 		site: React.PropTypes.object.isRequired,
-		onClick: React.PropTypes.func
+		onClick: React.PropTypes.func,
+		enableActions: React.PropTypes.bool,
+		disableStarring: React.PropTypes.bool
 	},
 
 	getInitialState: function() {
@@ -79,7 +82,7 @@ module.exports = React.createClass( {
 	renderStar: function() {
 		const site = this.props.site;
 
-		if ( ! site ) {
+		if ( ! site || this.props.disableStarring ) {
 			return null;
 		}
 
@@ -122,7 +125,7 @@ module.exports = React.createClass( {
 		return (
 			<a href={ url } target="_blank" className="site__edit-icon">
 				<SiteIcon site={ this.props.site } />
-				{ this.translate( 'Edit Icon' ) }
+				<span className="site__edit-icon-text">{ this.translate( 'Edit Icon' ) }</span>
 			</a>
 		);
 	},

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -110,7 +110,7 @@ module.exports = React.createClass( {
 
 	renderEditIcon: function() {
 		if ( ! userCan( 'manage_options', this.props.site ) ) {
-			return <span />;
+			return <SiteIcon site={ this.props.site } />;
 		}
 
 		let url = getCustomizeUrl( null, this.props.site );
@@ -120,8 +120,8 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<a href={ url } target="_blank"
-				className="site__edit-icon">
+			<a href={ url } target="_blank" className="site__edit-icon">
+				<SiteIcon site={ this.props.site } />
 				{ this.translate( 'Edit Icon' ) }
 			</a>
 		);
@@ -197,9 +197,8 @@ module.exports = React.createClass( {
 					</a>
 				:
 					<div className="site__content">
-						<SiteIcon site={ site } />
+						{ this.renderEditIcon() }
 						<div className="site__actions">
-							{ this.renderEditIcon() }
 							{ this.renderStar() }
 						</div>
 					</div>

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -11,7 +11,7 @@ var React = require( 'react' ),
 var SiteIcon = require( 'components/site-icon' ),
 	Gridicon = require( 'components/gridicon' ),
 	SiteIndicator = require( 'my-sites/site-indicator' ),
-	getCustomizeUrl = require( 'lib/themes/helpers' ).getCustomizeUrl,
+	getCustomizeUrl = require( 'my-sites/themes/helpers' ).getCustomizeUrl,
 	sites = require( 'lib/sites-list' )();
 
 import { userCan } from 'lib/site/utils';

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -180,11 +180,15 @@
 	justify-content: space-between;
 }
 
-.site__edit-icon {
+.site__edit-icon,
+.site__edit-icon:visited {
 	color: darken( $gray, 10% );
 	font-weight: 600;
 	font-size: 11px;
 	text-transform: uppercase;
+	&:hover {
+		color: $blue-medium;
+	}
 }
 
 .site__star {

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -101,16 +101,15 @@
 		style: italic;
 	}
 	line-height: 1.4;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
 }
 
 .site__title,
 .site__domain {
 	overflow: hidden;
-	text-overflow: ellipsis;
 	white-space: nowrap;
+	&::after {
+		@include long-content-fade();
+	}
 }
 
 .site__home {
@@ -193,9 +192,8 @@
 	cursor: pointer;
 	line-height: 0;
 
-	&:hover .gridicon {
-		color: $blue-wordpress;
-		opacity: 1;
+	&:hover .gridicons-star-outline {
+		color: $alert-yellow;
 	}
 
 	.gridicons-star {

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -157,3 +157,48 @@
 .site__content:hover .site__home {
 	opacity: 1;
 }
+
+.site__toggle-more-options {
+	color: $gray;
+	cursor: pointer;
+	margin-right: 16px;
+	line-height: 0;
+	.gridicon {
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+	}
+}
+
+.site.is-toggled {
+	.site__toggle-more-options .gridicon {
+		transform: rotate( 90deg );
+	}
+}
+
+.site__actions {
+	align-items: center;
+	display: flex;
+	flex: 1 0 0;
+	justify-content: space-between;
+}
+
+.site__edit-icon {
+	color: darken( $gray, 10% );
+	font-weight: 600;
+	font-size: 11px;
+	text-transform: uppercase;
+}
+
+.site__star {
+	color: $gray;
+	cursor: pointer;
+	line-height: 0;
+
+	&:hover .gridicon {
+		color: $blue-wordpress;
+		opacity: 1;
+	}
+
+	.gridicons-star {
+		color: $blue-wordpress;
+	}
+}

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -113,23 +113,23 @@
 }
 
 .site__home {
-	align-self: center;
 	background: $blue-medium;
-	border-radius: 50%;
 	color: $white;
 	display: block;
-	width: 28px;
-	height: 28px;
+	width: 32px;
+	height: 32px;
 	text-align: center;
 	text-transform: none;
 	overflow: initial;
 	opacity: 0;
 	transition: opacity 0.2s;
 	transform: translate3d(0, 0, 0);
+	position: absolute;
+		left: 17px;
+		top: 17px;
 
 	.gridicon {
-		line-height: 28px;
-		margin: 1px 0 0 -1px;
+		margin-top: 5px;
 		vertical-align: middle;
 	}
 
@@ -197,6 +197,6 @@
 	}
 
 	.gridicons-star {
-		color: $blue-wordpress;
+		color: $blue-medium;
 	}
 }

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -56,7 +56,7 @@
 	display: flex;
 	justify-content: space-between;
 	overflow: hidden;
-	padding: 16px;
+	padding: 16px 4px 16px 16px;
 	position: relative;
 	width: 100%;
 
@@ -160,7 +160,7 @@
 .site__toggle-more-options {
 	color: $gray;
 	cursor: pointer;
-	margin-right: 16px;
+	padding-right: 16px;
 	line-height: 0;
 	.gridicon {
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
@@ -170,6 +170,10 @@
 .site.is-toggled {
 	.site__toggle-more-options .gridicon {
 		transform: rotate( 90deg );
+	}
+	.site-icon {
+		border: 1px dashed $gray-dark;
+		opacity: 0.8;
 	}
 }
 
@@ -201,6 +205,6 @@
 	}
 
 	.gridicons-star {
-		color: $blue-medium;
+		color: $alert-yellow;
 	}
 }

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -176,12 +176,15 @@
 	.site__toggle-more-options .gridicon {
 		transform: rotate( 90deg );
 	}
+	.site-indicator {
+		display: none;
+	}
+}
+
+.site.is-toggled.has-edit-capabilities {
 	.site-icon {
 		border: 1px dashed $gray-dark;
 		opacity: 0.8;
-	}
-	.site-indicator {
-		display: none;
 	}
 }
 

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -165,6 +165,11 @@
 	.gridicon {
 		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 	}
+	&:hover {
+		.gridicon {
+			color: darken( $gray, 20% );
+		}
+	}
 }
 
 .site.is-toggled {
@@ -182,6 +187,7 @@
 	display: flex;
 	flex: 1 0 0;
 	justify-content: space-between;
+	animation: appear .3s ease-in-out;
 }
 
 .site__edit-icon,

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -180,6 +180,9 @@
 		border: 1px dashed $gray-dark;
 		opacity: 0.8;
 	}
+	.site-indicator {
+		display: none;
+	}
 }
 
 .site__actions {
@@ -213,4 +216,11 @@
 	.gridicons-star {
 		color: $alert-yellow;
 	}
+}
+
+.site__star-badge {
+	align-self: center;
+	color: $gray;
+	padding-right: 16px;
+	line-height: 0;
 }

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -223,4 +223,5 @@
 	color: $gray;
 	padding-right: 16px;
 	line-height: 0;
+	position: relative;
 }

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -192,7 +192,7 @@
 	align-items: center;
 	display: flex;
 	flex: 1 0 0;
-	justify-content: space-between;
+	justify-content: flex-end;
 	animation: appear .3s ease-in-out;
 }
 
@@ -202,6 +202,8 @@
 	font-weight: 600;
 	font-size: 11px;
 	text-transform: uppercase;
+	display: flex;
+	align-items: center;
 	&:hover {
 		color: $blue-medium;
 	}

--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -196,6 +196,10 @@
 	animation: appear .3s ease-in-out;
 }
 
+.site__edit-icon-text {
+	animation: appear .3s ease-in-out;
+}
+
 .site__edit-icon,
 .site__edit-icon:visited {
 	color: darken( $gray, 10% );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13387,6 +13387,9 @@
           "version": "2.0.1"
         }
       }
+    },
+    "react-click-outside": {
+      "version": "2.1.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-addons-css-transition-group": "0.14.3",
     "react-addons-linked-state-mixin": "0.14.3",
     "react-addons-update": "0.14.3",
+    "react-click-outside": "2.1.0",
     "react-day-picker": "1.1.0",
     "react-dom": "0.14.3",
     "react-helmet": "2.2.0",


### PR DESCRIPTION
This PR begins working towards #375.

- Adds "actions" toggle that renders some extra actions on the `<Site>` component.
- Adds "starring" functionality that is persisted via preferences.
- Clean ups the design of the site component, adds content fade, moves home-link on top of site-icon.

State closed:
![image](https://cloud.githubusercontent.com/assets/548849/12640968/213454a6-c5ad-11e5-8c66-dd9cbf8702fe.png)

State open:
![image](https://cloud.githubusercontent.com/assets/548849/12640965/19659550-c5ad-11e5-8e6e-782fdc757edd.png)

State hover-link:
![image](https://cloud.githubusercontent.com/assets/548849/12640996/543d1784-c5ad-11e5-81fe-72584bdbc86d.png)

------

Concept:

<img width="476" alt="screen shot 2016-01-27 at 12 59 50 pm" src="https://cloud.githubusercontent.com/assets/437258/12623114/9daeca8c-c4f6-11e5-8316-bc3048ac9c4f.png">
