### PR TITLE
Signup: Fix sites-list first time fetching

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -37,10 +37,9 @@ function fetchSitesAndUser( siteSlug, onComplete ) {
 		},
 		callback => {
 			user.once( 'change', callback );
+			user.fetch();
 		}
 	], onComplete );
-
-	user.fetch();
 }
 
 module.exports = {

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -87,9 +87,9 @@ SitesList.prototype.fetch = function() {
 	this.fetching = true;
 	debug( 'getting SitesList from api' );
 	wpcom.me().sites( { site_visibility: siteVisiblity }, function( error, data ) {
+		this.fetching = false;
 		if ( error ) {
 			debug( 'error fetching SitesList from api', error );
-			this.fetching = false;
 			return;
 		}
 		this.sync( data );
@@ -111,7 +111,6 @@ SitesList.prototype.sync = function( data ) {
 			debug( 'SitesList changed via update' );
 			this.emit( 'change' );
 		}
-		this.fetching = false;
 		store.set( 'SitesList', sites );
 	}
 }


### PR DESCRIPTION
Fixes #2828 

#### Fix Summary
The bug is that when sites-list is fetching for the first time, `initialized` will be `false` so `this.sync` won't ever switch back `fetching` to `false`. Further calls to `fetch` would then return immediately.

#### Testing instructions
- Do the signup flow as a logged in user
- Ensure you do not get stuck at the "Adding your domain step"

#### Review
- [x] Code Review
- [x] Product Review