### PR TITLE
Plugins: Make actionbar visible

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -320,7 +320,7 @@ export default React.createClass( {
 				<SelectDropdown compact
 					className="plugin-list-header__actions_dropdown"
 					key="plugin-list-header__actions_dropdown"
-					selectedText="Actions">
+					selectedText={ this.translate( 'Actions' ) }>
 					{ options }
 				</SelectDropdown>
 			);

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -22,7 +22,6 @@ import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
 
 let _actionBarVisible = true;
-let _actionBarDomElement = null;
 
 // If the Action
 const MAX_ACTIONBAR_HEIGHT = 50;
@@ -69,7 +68,6 @@ export default React.createClass( {
 
 	componentDidMount() {
 		this.debouncedAfterResize = debounce( this.afterResize, 100 );
-		_actionBarDomElement = findDOMNode( this );
 		window.addEventListener( 'resize', this.debouncedAfterResize );
 	},
 
@@ -84,12 +82,13 @@ export default React.createClass( {
 	},
 
 	maybeMakeActionBarVisible() {
-		if ( _actionBarDomElement.offsetWidth < MIN_ACTIONBAR_WIDTH ) {
+		const actionBarDomElement = findDOMNode( this );
+		if ( actionBarDomElement.offsetWidth < MIN_ACTIONBAR_WIDTH ) {
 			return;
 		}
 		this.setState( { actionBarVisible: true } );
 		setTimeout( () => {
-			const actionBarVisible = _actionBarDomElement.offsetHeight <= MAX_ACTIONBAR_HEIGHT;
+			const actionBarVisible = actionBarDomElement.offsetHeight <= MAX_ACTIONBAR_HEIGHT;
 			this.setState( { actionBarVisible } );
 		}, 1 );
 	},

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -22,9 +22,11 @@ import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
 
 let _actionBarVisible = true;
+let _actionBarDomElement = null;
 
-// Below this width the action bar turns into a select dropdown.
-const MIN_VIEWPORT_WIDTH = 719;
+// If the Action
+const MAX_ACTIONBAR_HEIGHT = 50;
+const MIN_ACTIONBAR_WIDTH = 600;
 
 export default React.createClass( {
 	displayName: 'Plugins-list-header',
@@ -67,9 +69,8 @@ export default React.createClass( {
 
 	componentDidMount() {
 		this.debouncedAfterResize = debounce( this.afterResize, 100 );
-
+		_actionBarDomElement = findDOMNode( this );
 		window.addEventListener( 'resize', this.debouncedAfterResize );
-		_actionBarVisible = findDOMNode( this ).offsetWidth > MIN_VIEWPORT_WIDTH;
 	},
 
 	componentWillUnmount() {
@@ -77,8 +78,26 @@ export default React.createClass( {
 	},
 
 	afterResize() {
-		const actionBarVisible = findDOMNode( this ).offsetWidth > MIN_VIEWPORT_WIDTH;
-		this.setState( { actionBarVisible } );
+		if ( this.props.isBulkManagementActive ) {
+			this.maybeMakeActionBarVisible();
+		}
+	},
+
+	maybeMakeActionBarVisible() {
+		if ( _actionBarDomElement.offsetWidth < MIN_ACTIONBAR_WIDTH ) {
+			return;
+		}
+		this.setState( { actionBarVisible: true } );
+		setTimeout( () => {
+			const actionBarVisible = _actionBarDomElement.offsetHeight <= MAX_ACTIONBAR_HEIGHT;
+			this.setState( { actionBarVisible } );
+		}, 1 );
+	},
+
+	toggleBulkManagement() {
+		this.props.toggleBulkManagement();
+
+		this.maybeMakeActionBarVisible();
 	},
 
 	onBrowserLinkClick() {
@@ -122,7 +141,7 @@ export default React.createClass( {
 			}
 			rightSideButtons.push(
 				<ButtonGroup key="plugin-list-header__buttons-bulk-management">
-					<Button compact onClick={ this.props.toggleBulkManagement }>
+					<Button compact onClick={ this.toggleBulkManagement }>
 						{ this.translate( 'Edit All', { context: 'button label' } ) }
 					</Button>
 				</ButtonGroup>

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -47,13 +47,14 @@
 	@include breakpoint( '>660px' ) {
 		padding-right: 16px;
 	}
-
-	&.is-action-bar-visible {
-		.plugin-list-header__actions_dropdown {
-			display: none;
-		}
-		.plugin-list-header__action-buttons {
-			display: flex;
+	@include breakpoint( '>960px' ) {
+		&.is-action-bar-visible {
+			.plugin-list-header__actions_dropdown {
+				display: none;
+			}
+			.plugin-list-header__action-buttons {
+				display: flex;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Check if action bar should be visible every time we jump into bulk edit
mode and based on the height of the action bar determine if we should
display it as a drop down instead.

To test:
Go to http://calypso.localhost:3000/plugins
You should never see the action bar that is when a drop down is more appropriate.

cc: @johnHackworth and @lezama for testing in spanish 