### PR TITLE
Plugins: List view should interpret false as plugin slug

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -185,7 +185,7 @@ controller = {
 		var isWpcomPlugin = 'business' === context.params.business_plugin,
 			siteUrl = route.getSiteFragment( context.path );
 
-		if ( context.params.plugin && context.params.plugin === siteUrl.toString() ) {
+		if ( siteUrl && context.params.plugin && context.params.plugin === siteUrl.toString() ) {
 			controller.plugins( 'all', context );
 			return;
 		}


### PR DESCRIPTION
Currently when you go to https://wordpress.com/plugins/false 
The expected behaviour is to go to the single plugin view with the plugins slug set as false. 

This PR fixes this.

To test: 
Go to http://calypso.localhost:3000/plugins/false notice you end up on the single plugin view.
Make sure that everything else works as expected. You are able to navigate to each of the different sections. 
