### PR TITLE
Plugins: Replace link with button to enable jetpack manage

### DIFF
--- a/client/my-sites/plugins/plugin-site-disabled-manage/index.jsx
+++ b/client/my-sites/plugins/plugin-site-disabled-manage/index.jsx
@@ -7,6 +7,7 @@ var React = require( 'react' );
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
+	Button = require( 'components/button' ),
 	DisconnectJetpackButton = require( 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button' );
 
 module.exports = React.createClass( {
@@ -30,7 +31,7 @@ module.exports = React.createClass( {
 		return (
 			<span className="plugin-site-disabled-manage">
 				<span className="plugin-site-disabled-manage__label">{ message }</span>
-				<a className="plugin-site-disabled-manage__link" href={ url } onClick={ analytics.ga.recordEvent.bind( analytics, 'Jetpack Manage', 'Clicked Enable Jetpack Manage Link' ) }> { this.translate( 'Enable' ) } </a>
+				<Button compact={ true } className="plugin-site-disabled-manage__link" href={ url } onClick={ analytics.ga.recordEvent.bind( analytics, 'Jetpack Manage', 'Clicked Enable Jetpack Manage Link' ) }> { this.translate( 'Enable' ) } </Button>
 			</span>
 		);
 	}


### PR DESCRIPTION
Fixes #2808 

Before:
<img width="469" alt="screen shot 2016-01-28 at 08 07 10" src="https://cloud.githubusercontent.com/assets/115071/12650050/2afefdcc-c596-11e5-8a39-517d56a2dee2.png">

After:
<img width="489" alt="screen shot 2016-01-28 at 08 06 49" src="https://cloud.githubusercontent.com/assets/115071/12650060/32c15988-c596-11e5-92b0-e51b33dc869a.png">

To test:
Disable Jetpack manage on your of your sites. 
Visit a single plugin that that is also present on that site. 
http://calypso.localhost:3000/plugins/akismet

cc: @rickybanister 