### PR TITLE
Token Field: modified padding and margins for consistency

### DIFF
--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -27,7 +27,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	align-items: flex-start;
-	padding: 7px 14px 0 0;
+	padding: 5px 14px 5px 0;
 }
 
 // Token input
@@ -35,8 +35,8 @@ input[type="text"].token-field__input {
 	display: inline-block;
 	width: auto;
 	max-width: 100%;
-	margin: 0 0 7px 5px;
-	padding: 2px 0 2px 7px;
+	margin: 0 0 0 4px;
+	padding: 2px 0 2px 4px;
 	background: inherit;
 	border: 0;
 	outline: none;


### PR DESCRIPTION
Previously the token field was inheriting some weird stuff that made a single row of tokens sit low in the input. The entire field was also a strange non-standard height with a single row of tokens (taller than a standard input field).

**Before:** 
<img width="268" alt="screen shot 2016-01-28 at 10 32 55 am" src="https://cloud.githubusercontent.com/assets/437258/12650365/8f759058-c5b0-11e5-9bfc-6252414f854a.png">

I modified the padding and margin to make a single row of tags aligned to the center of the input, also the input is now the exact same height (40px) as a standard input. The next token input field now has the same spacing to its left as the tokens do to each other.

**After:**
<img width="263" alt="screen shot 2016-01-28 at 11 16 49 am" src="https://cloud.githubusercontent.com/assets/437258/12650396/a831a942-c5b0-11e5-8718-41e5e6e5e109.png">

<img width="273" alt="screen shot 2016-01-28 at 11 09 41 am" src="https://cloud.githubusercontent.com/assets/437258/12650378/99534200-c5b0-11e5-8e01-94d8fd8fa624.png">

cc @folletto @kellychoffman @mtias 

