### PR TITLE
Reader: Fix spacing around feed and stream headers

### DIFF
--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -1,11 +1,5 @@
 @include breakpoint( "<660px" ) {
 	.feed-header {
-		margin-top: 24px;
-
-		.follow-button {
-			right: 10px;
-		}
-
 		.follow-button__label {
 			display: none;
 		}
@@ -80,7 +74,7 @@
 }
 
 .is-section-reader .card.feed-header__site { // Extra specific to override the :hover
-	min-height: 85px;
+	//min-height: 85px;
 
 	&:hover {
 		cursor: default;
@@ -129,11 +123,12 @@
 .feed-header__follow {
 	.follow-button {
 		position: absolute;
-			top: 17px;
-			right: 24px;
+			top: 16px;
+			right: 8px;
 
 		@include breakpoint( "<660px" ) {
-			right: 8px;
+			top: 8px;
+			right: 0;
 		}
 	}
 }

--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -74,8 +74,6 @@
 }
 
 .is-section-reader .card.feed-header__site { // Extra specific to override the :hover
-	//min-height: 85px;
-
 	&:hover {
 		cursor: default;
 		box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),

--- a/client/reader/stream-header/style.scss
+++ b/client/reader/stream-header/style.scss
@@ -1,11 +1,5 @@
 @include breakpoint( "<660px" ) {
 	.stream-header {
-		margin-top: 24px;
-
-		.follow-button {
-			right: 10px;
-		}
-
 		.follow-button__label {
 			display: none;
 		}
@@ -137,10 +131,10 @@
 	.follow-button {
 		position: absolute;
 			top: 12px;
-			right: 24px;
+			right: 8px;
 
 		@include breakpoint( "<660px" ) {
-			right: 8px;
+			right: 0;
 		}
 	}
 }


### PR DESCRIPTION
This fixed #2796, which concerns the spacing around feed and stream headers like the on found on Discover.

Before:
![screen shot 2016-01-28 at 1 09 29 pm](https://cloud.githubusercontent.com/assets/191598/12654555/8d2d37c6-c5c2-11e5-941b-c17f790cd8af.png)

After:
![screen shot 2016-01-28 at 1 09 19 pm](https://cloud.githubusercontent.com/assets/191598/12654559/9413e10c-c5c2-11e5-8a1f-a4fdaf39508f.png)
