### PR TITLE
Plugins: Fix back button when navigatin between sites

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -144,7 +144,13 @@ const SinglePlugin = React.createClass( {
 	},
 
 	getPreviousListUrl() {
-		return this.props.prevPath + '/' +
+		const splitPluginUrl = this.props.prevPath.split( '/' + this.props.pluginSlug + '/' );
+		let previousPath = this.props.prevPath;
+
+		if ( splitPluginUrl[1] ) { // Strip out the site url part.
+			previousPath = splitPluginUrl[0];
+		}
+		return previousPath + '/' +
 			( this.props.siteUrl || '' ) +
 			( this.props.prevQuerystring ? '?' + this.props.prevQuerystring : '' );
 	},


### PR DESCRIPTION
Currently when you go to directly to
https://wordpress.com/plugins/hello-dolly/example.com 
and then use the sidebar to navigate to a different site that has plugins. 
and then click the back button you end up on a url like the following
https://wordpress.com/plugins/hello-dolly/example.com/example2.com

This PR fixes this by making sure that if the previous URL was also the same plugin but on a different site that you we strip out the site url part ( by splitting the previous url by the plugin slug ) and then 
rebuild it. 

To test:
Try the above steps and make sure that they work as expected. 
try navigating the single plugin page in different combinations. 
Start from the plugin browser, different tabs, try searching for plugins etc. 

Everything else should work as expected. 

cc: @johnHackworth 

