### PR TITLE
Enable Perfmon in production

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -373,7 +373,7 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<div>
+			<div className={ this.state.fetchingSettings ? 'is-loading' : '' }>
 				<SectionHeader label={ this.translate( 'Site Profile' ) }>
 					<Button
 						compact={ true }

--- a/config/production.json
+++ b/config/production.json
@@ -80,7 +80,7 @@
 		"reader/recommendations": true,
 		"ad-tracking": true,
 		"desktop-promo": true,
-		"perfmon": false,
+		"perfmon": true,
 		"mailing-lists/unsubscribe": true,
 		"accept-invite": false
 	},


### PR DESCRIPTION
This PR just enables the "perfmon" performance monitor in production.

It's been running in staging for a few weeks without any issues being reported, so I think this is a safe change.

Given that we're in the process of implementing some new caching features, it would be good to see whether this allows us to capture a baseline of where (and for how long) users are waiting for data to load so that we can evaluate the impact of any improvements.

It's also possible that this doesn't give us good enough data, in which case we can just rip it out :)

This also includes a change which adds a class to the settings for that allows us to detect when it's loading remote values.

cc @rralian @nb 