### PR TITLE
Plans: redesign plan comparison page for better organization and readability

### DIFF
--- a/client/components/plans/plan-feature-cell/style.scss
+++ b/client/components/plans/plan-feature-cell/style.scss
@@ -1,15 +1,42 @@
 .plan-feature-cell {
-	border-bottom: 1px solid lighten( $gray, 20% );
 	display: table;
 	height: 54px;
 	vertical-align: middle;
 	width: 100%;
+
+	&:nth-child(even) {
+		background: $gray-light;
+	}
 }
 
 .plan-feature-cell__feature-text {
 	display: table-cell;
 	vertical-align: middle;
 	font-size: 12px;
+
+	.gridicon {
+		color: $alert-green;
+	}
+}
+
+.feature-list {
+	&.is-placeholder {
+		.plan-feature-cell__feature-text {
+			span {
+				@include placeholder( 23% );
+				display: block;
+				width: 65%;
+			}
+		}
+	}
+
+	.plan-feature-cell {
+		padding-left: 16px;
+
+		@include breakpoint( ">480px" ) {
+			padding-left: 24px;
+		}
+	}
 }
 
 .feature-list.is-placeholder {
@@ -33,13 +60,12 @@
 
 .plan-features .plan-feature-cell__feature-text {
 	color: darken( $gray, 10% );
-	opacity: .7;
+	opacity: .9;
 }
 
 .plan-features:not(:nth-child(2)) {
 	.plan-feature-cell__feature-text {
 		color: $gray-dark;
-		opacity: .9;
 		font-weight: bold;
 	}
 }

--- a/client/components/plans/plan-features/index.jsx
+++ b/client/components/plans/plan-features/index.jsx
@@ -12,7 +12,8 @@ var PlanHeader = require( 'components/plans/plan-header' ),
 	PlanFeatureCell = require( 'components/plans/plan-feature-cell' ),
 	PlanActions = require( 'components/plans/plan-actions' ),
 	PlanPrice = require( 'components/plans/plan-price' ),
-	PlanDiscountMessage = require( 'components/plans/plan-discount-message' );
+	PlanDiscountMessage = require( 'components/plans/plan-discount-message' ),
+	Gridicon = require( 'components/gridicon' );
 
 module.exports = React.createClass( {
 	displayName: 'PlanFeatures',
@@ -20,7 +21,7 @@ module.exports = React.createClass( {
 	featureIncludedString: function( feature ) {
 		var included = feature[ this.props.plan.product_id ];
 		if ( 'boolean' === typeof included && included ) {
-			return ( <span className="plan-features__included no-text"></span> );
+			return ( <Gridicon icon="checkmark-circle" size={ 24 } /> );
 		}
 		if ( 'string' === typeof included ) {
 			return ( <span className="plan-features__included">{ included }</span> );
@@ -29,7 +30,7 @@ module.exports = React.createClass( {
 	},
 
 	headerText: function() {
-		return <span className="header-text">{ this.props.plan.product_name }</span>;
+		return <span className="header-text">{ this.props.plan.product_name_short }</span>;
 	},
 
 	render: function() {
@@ -50,12 +51,13 @@ module.exports = React.createClass( {
 
 		return (
 			<div key={ this.props.plan.product_id } className={ classes }>
-				<PlanHeader text={ this.headerText() } />
+				<PlanHeader text={ this.headerText() }>
+					<PlanPrice
+						plan={ this.props.plan }
+						sitePlan={ sitePlan }
+						site={ this.props.site } />
+				</PlanHeader>
 				{ features }
-				<PlanPrice
-					plan={ this.props.plan }
-					sitePlan={ sitePlan }
-					site={ this.props.site } />
 				<PlanActions
 					enableFreeTrials={ this.props.enableFreeTrials }
 					onSelectPlan={ this.props.onSelectPlan }

--- a/client/components/plans/plan-features/style.scss
+++ b/client/components/plans/plan-features/style.scss
@@ -19,20 +19,3 @@
 .plan-features__included {
 	color: $gray-dark;
 }
-
-.plan-features__included.no-text {
-	&:before {
-		color: $alert-green;
-
-		@include noticon( '\f418', 24px );
-	}
-}
-
-.plan-features__not-included.no-text {
-	&:before {
-		color: darken( $gray, 10% );
-
-		@include noticon( '-', 24px );
-		vertical-align: inherit;
-	}
-}

--- a/client/components/plans/plan-header/style.scss
+++ b/client/components/plans/plan-header/style.scss
@@ -91,7 +91,7 @@
 .plans-compare {
 	.plan-header {
 		border-bottom: 2px solid lighten( $gray, 20% );
-		height: 7.5em;
+		height: 9.5em;
 		padding: 10px 15px;
 
 		&:after {
@@ -105,7 +105,9 @@
 			line-height: 18px;
 
 			&:before {
-				top: 10px;
+				position: static;
+				display: block;
+				margin-bottom: 5px;
 			}
 
 			.header-text {
@@ -149,16 +151,10 @@
 
 	.plans-compare {
 		.plan-header {
-			height: 6em;
-			
-			.plan-header__title:before {
-				display: inline-block;
-			}
+			height: 9.5em;
 
-			.plan-header__title,
-			.plan-price {
-				padding: 0 0 0 40px;
-				text-align: left;
+			.plan-header__title:before {
+				display: block;
 			}
 		}
 	}
@@ -176,17 +172,6 @@
 			}
 			.plan-actions {
 				display: none;
-			}
-		}
-	}
-
-	.plans-compare {
-		.plan-header {
-			.plan-header__title {
-				&:before {
-					position: static;
-					margin-bottom: 5px;
-				}
 			}
 		}
 	}

--- a/client/components/plans/plan-header/style.scss
+++ b/client/components/plans/plan-header/style.scss
@@ -30,7 +30,8 @@
 	}
 }
 
-.plan {
+.plan,
+.plans-compare {
 	.plan-header {
 		background: $white;
 		width: 100%;
@@ -54,6 +55,7 @@
 			display: block;
 			font-size: 17px;
 			line-height: 16px;
+			text-align: center;
 
 			&:before {
 				left: 10px;
@@ -89,15 +91,22 @@
 .plans-compare {
 	.plan-header {
 		border-bottom: 2px solid lighten( $gray, 20% );
-		height: 3em;
-		padding: 0 15px 10px 15px;
+		height: 7.5em;
+		padding: 10px 15px;
+
+		&:after {
+			display: none;
+		}
 
 		.plan-header__title {
+			padding: 0;
 			text-align: center;
-			color: $gray-dark;
-			font-size: 14px;
-			font-weight: 600;
+			color: $blue-wordpress;
 			line-height: 18px;
+
+			&:before {
+				top: 10px;
+			}
 
 			.header-text {
 				&:first-line {
@@ -134,7 +143,22 @@
 
 			.plan-header__title {
 				line-height: 20px;
-				text-align: center;
+			}
+		}
+	}
+
+	.plans-compare {
+		.plan-header {
+			height: 6em;
+			
+			.plan-header__title:before {
+				display: inline-block;
+			}
+
+			.plan-header__title,
+			.plan-price {
+				padding: 0 0 0 40px;
+				text-align: left;
 			}
 		}
 	}
@@ -159,8 +183,9 @@
 	.plans-compare {
 		.plan-header {
 			.plan-header__title {
-				.header-text {
-					display: none;
+				&:before {
+					position: static;
+					margin-bottom: 5px;
 				}
 			}
 		}

--- a/client/components/plans/plan-price/style.scss
+++ b/client/components/plans/plan-price/style.scss
@@ -40,7 +40,7 @@
 	}
 
 	.plan-price__billing-period {
-		display: block;
+		display: inline;
 		opacity: .7;
 	}
 
@@ -57,6 +57,12 @@
 	.plan-price__billing-period {
 		margin-left: 3px;
 	}
+
+	.plans-compare {
+		.plan-header .plan-price {
+			padding: 0;
+		}
+	}
 }
 
 @mixin plans-in-three-columns() {
@@ -67,6 +73,12 @@
 
 	.plan-price__billing-period {
 		display: block;
+	}
+
+	.plans-compare {
+		.plan-header .plan-price {
+			font-size: 16px;
+		}
 	}
 }
 

--- a/client/components/plans/plan-price/style.scss
+++ b/client/components/plans/plan-price/style.scss
@@ -28,7 +28,7 @@
 .plans-compare {
 	.plan-price {
 		font-size: 10px;
-		padding: 1em 0;
+		padding: .25em 0;
 
 		@include breakpoint( ">480px" ) {
 			font-size: 12px;
@@ -78,6 +78,11 @@
 	.plans-compare {
 		.plan-header .plan-price {
 			font-size: 16px;
+
+			.plan-price__billing-period {
+				display: inline;
+				margin-left: 3px;
+			}
 		}
 	}
 }

--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -15,3 +15,11 @@
 	text-align: right;
 	margin-top: 15px;
 }
+
+.plans-compare {
+	margin: -16px;
+
+	@include breakpoint( ">480px" ) {
+		margin: -24px;
+	}
+}

--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -1,4 +1,5 @@
 .plan-feature-column {
+	box-sizing: border-box;
 	display: inline-block;
 	font-size: .9em;
 	vertical-align: top;


### PR DESCRIPTION
The plan comparison page is very outdated and needs a bit of a refresh. Current problems include outdated icons, bad feature organization making readability difficult, and tiny mobile view. This tries to remedy that with a few changes.

### Mobile

Condensing the table removes the plan names and increases cognitive load needed to remember icon:plan representation. I propose instead to use tabs. This makes it easier to read and scan each plan while still providing the ability to compare (almost) side-by-side.

![compare plans - mobile v1 3](https://cloud.githubusercontent.com/assets/448298/12656210/eeb115fa-c5ca-11e5-9c3c-1c51584813b8.png)

### Desktop

Update the visual UI to a more pleasing aesthetic, update the icons to use the proper Gridicons, and reorganize the list of features to make scanning easier. Reorganizing this way also enables the user to clearly see each plan builds upon the previous one.

![compare plans - desktop v1 3](https://cloud.githubusercontent.com/assets/448298/12656262/4e724a0e-c5cb-11e5-80ee-b8b02e26c256.png)

_Note: I've updated the copy for the list of features in the mockups, but we're not quite ready to do that across the board, so we should keep the current copy. Also, the plans in the mockup all use the same icon - obviously this will not be the case._