### PR TITLE
Invites: Fix non-human error notice for users already on a site

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -158,6 +158,16 @@ let InviteAccept = React.createClass( {
 
 	renderError() {
 		debug( 'Rendering error: ' + JSON.stringify( this.state.error ) );
+		if ( this.state.error && this.state.error.error === 'already_member' ) {
+			return (
+				<EmptyContent
+					title={ this.translate( 'You are already a member of this blog.' ) }
+					line={ this.translate( 'Would you like to accept the invite with another account?' ) }
+					action={ this.translate( 'Switch User' ) }
+					actionURL={ config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href ) }
+					illustration={ '/calypso/images/drake/drake-whoops.svg' } />
+			);
+		}
 		return (
 			<EmptyContent
 				title={ this.getErrorTitle() }

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -158,15 +158,21 @@ let InviteAccept = React.createClass( {
 
 	renderError() {
 		debug( 'Rendering error: ' + JSON.stringify( this.state.error ) );
-		if ( this.state.error && this.state.error.error === 'already_member' ) {
-			return (
-				<EmptyContent
-					title={ this.translate( 'You are already a member of this blog.' ) }
-					line={ this.translate( 'Would you like to accept the invite with another account?' ) }
-					action={ this.translate( 'Switch User' ) }
-					actionURL={ config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href ) }
-					illustration={ '/calypso/images/drake/drake-whoops.svg' } />
-			);
+		if ( this.state.error ) {
+			const props = {
+				line: this.translate( 'Would you like to accept the invite with a different account?' ),
+				action: this.translate( 'Switch Accounts' ),
+				actionURL: config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href ),
+				illustration: '/calypso/images/drake/drake-whoops.svg'
+			};
+			switch ( this.state.error.error ) {
+				case 'already_member':
+					return ( <EmptyContent { ... props } title={ this.translate( 'You are already a member of this blog.' ) } /> );
+					break;
+				case 'already_subscribed':
+					return ( <EmptyContent { ... props } title={ this.translate( 'You are already a follower on this blog.' ) } /> );
+					break;
+			}
 		}
 		return (
 			<EmptyContent


### PR DESCRIPTION
Closes #2842

![image](https://cloud.githubusercontent.com/assets/104869/12656649/2a9089e4-c5de-11e5-8ed0-60ea8570e2dd.png)


__How To Test__

 * update/invites-already-member branch
 * Create an invite on a WP.com site at $site/wp-admin/users.php?page=wpcom-invite-users
Note: To get the correct invitation link, you will need to mark site as a test blog. Ping me for help if necessary.
 * In the invitation link, replace wordpress.com with calypso.localhost:3000
 * Assert that while logged in as a member of $site you see the above message
