### PR TITLE
Domains: A/B test for using Select as CTA during domain registration

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -9,6 +9,7 @@ var React = require( 'react' ),
  */
 var DomainSuggestion = require( 'components/domains/domain-suggestion' ),
 	cartItems = require( 'lib/cart-values/cart-items' ),
+	abtest = require( 'lib/abtest' ).abtest,
 	DomainSuggestionFlag = require( 'components/domains/domain-suggestion-flag' );
 
 var DomainRegistrationSuggestion = React.createClass( {
@@ -25,6 +26,12 @@ var DomainRegistrationSuggestion = React.createClass( {
 
 		if ( isAdded ) {
 			return null;
+		}
+
+		if ( abtest( 'domainRegistrationCta' ) === 'select' ) {
+			return this.translate( 'Select', {
+				context: 'Select a domain registration to be added to the shopping cart'
+			} );
 		}
 
 		return this.translate( 'Add', {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -68,5 +68,13 @@ module.exports = {
 			minimal: 50
 		},
 		defaultVariation: 'original'
-	}
+	},
+	domainRegistrationCta: {
+		datestamp: '20160128',
+		variations: {
+			add: 50,
+			select: 50
+		},
+		defaultVariation: 'add'
+	},
 };


### PR DESCRIPTION
Trying `Select` on the domain registration suggestion's button.

Before:
<img width="822" alt="screen shot 2016-01-28 at 21 09 28" src="https://cloud.githubusercontent.com/assets/3392497/12657458/b3d711e4-c603-11e5-971f-444c8b4c5788.png">
After:
<img width="773" alt="screen shot 2016-01-28 at 21 10 21" src="https://cloud.githubusercontent.com/assets/3392497/12657463/b82fffb2-c603-11e5-8fb7-f59f5f64b76e.png">
I'll update the A/B test's date before merging, left in the past for ease of testing.

/cc @lucasartoni @breezyskies 