### PR TITLE
Domains: fix error on NS page - FormToggle uses bool now for checked

### DIFF
--- a/client/my-sites/upgrades/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/upgrades/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -30,7 +30,7 @@ const NameserversToggle = React.createClass( {
 						name="wp-nameservers"
 						onChange={ this.handleToggle }
 						type="checkbox"
-						checked={ this.props.enabled ? 'checked' : '' }
+						checked={ this.props.enabled }
 						value="active"/>
 				</form>
 				{ this.renderExplanation() }


### PR DESCRIPTION
`FormToggle`'s `checked` property now uses bool directly, while on the NS page (`/domains/manage/:site/name-servers/:domain`) we still passed a string causing an error to be printed in the console:
```
Warning: Failed propType: Invalid prop `checked` of type `string` supplied to `FormToggle`, expected `boolean`. Check the render method of `NameserversToggle`.
```

**Testing:**
verify that visiting the `Name Servers and DNS` page does not trigger any errors in the console.