### PR TITLE
Stats: update Post & Pages info panel messaging

### DIFF
--- a/client/my-sites/stats/stats-detail-months/index.jsx
+++ b/client/my-sites/stats/stats-detail-months/index.jsx
@@ -133,11 +133,11 @@ export default React.createClass( {
 				</div>
 				<StatsModuleContent className="module-content-text-info">
 					<p>
-						{ this.translate( 'This panel gives you an overview of how many views your website gets on average.', { context: 'Info box description for post stats page in Stats' } ) }
+						{ this.translate( 'This table gives you an overview of how many views your post or page has received.', { context: 'Info box description for post stats page in Stats' } ) }
 					</p>
 					<span className="legend achievement">{
 						this.translate(
-							'%(value)s = The all-time highest value.',
+							'%(value)s = The all-time highest value',
 							{ args:
 								{ value: ( this.numberFormat( highest ) ) },
 								context: 'Legend for post stats page in Stats'

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -171,10 +171,10 @@ export default React.createClass( {
 					</ul>
 				</div>
 				<StatsModuleContent className="module-content-text-info">
-					<p>{ this.translate( 'This panel gives you an overview of how many views your website is getting recently.' ) }</p>
+					<p>{ this.translate( 'This table gives you an overview of how many views your post or page has received in the recent weeks.' ) }</p>
 					<span className="legend achievement">{
 						this.translate(
-							'%(value)s = The highest recent value.',
+							'%(value)s = The highest recent value',
 							{ args: { value: ( this.numberFormat( highest ) ) },
 							context: 'Legend for post stats page in Stats' }
 						)


### PR DESCRIPTION
This PR updates the info panel messaging on the Post & Pages Summary page. 

Previously, it says "how many views your *website* gets" when it's really just referring to your stats for a particular post/page, not your entire website.

**Before:**
![before](https://cloud.githubusercontent.com/assets/4924246/12658617/f265af96-c5be-11e5-8e17-bc1e72d3e5b8.png)

**After:**
![screenshot 2016-01-28 12 59 32](https://cloud.githubusercontent.com/assets/4924246/12658626/ff899d36-c5be-11e5-9a4f-561e11ed692e.png)