### PR TITLE
Reader: Adjust in-stream blockquote font-size

### DIFF
--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -201,6 +201,7 @@
 		blockquote {
 			margin-left: 0;
 			margin-right: 0;
+			font-size: 16px;
 		}
 
 		p {


### PR DESCRIPTION
Bringing down the font-size of blockquotes in stream cards so they’re not too overpowering.

Before:
![screen shot 2016-01-28 at 4 06 19 pm](https://cloud.githubusercontent.com/assets/191598/12658926/e00f5462-c5d9-11e5-80da-da0b8c540f1c.png)

After:
![screen shot 2016-01-28 at 4 06 27 pm](https://cloud.githubusercontent.com/assets/191598/12658928/e4a2cedc-c5d9-11e5-9a98-721700245386.png)
