### PR TITLE
Reader: add tag not found message

### DIFF
--- a/client/components/empty-content/empty-content.jsx
+++ b/client/components/empty-content/empty-content.jsx
@@ -16,7 +16,10 @@ module.exports = React.createClass( {
 		] ),
 		illustration: React.PropTypes.string,
 		illustrationWidth: React.PropTypes.number,
-		line: React.PropTypes.string,
+		line: React.PropTypes.oneOfType( [
+			React.PropTypes.string,
+			React.PropTypes.array
+		] ),
 		action: React.PropTypes.oneOfType( [
 			React.PropTypes.string,
 			React.PropTypes.element

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -243,9 +243,9 @@ assign( FeedStream.prototype, {
 	},
 
 	/**
-	 * Checks if a recent error occured within the past minute. 
+	 * Checks if an error has occurred in the past minute.
 	 *
-	 * @param {string} errorType - Error type to check. If not passed in, will check for any errors and not specific one.
+	 * @param {string} errorType - Error type to check. If not provided, we'll check for errors of any type.
 	 */
 	hasRecentError: function( errorType ) {
 		var aMinuteAgo = Date.now() - ( 60 * 1000 );

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -242,10 +242,15 @@ assign( FeedStream.prototype, {
 		return date;
 	},
 
-	hasRecentError: function() {
+	/**
+	 * Checks if a recent error occured within the past minute. 
+	 *
+	 * @param {string} errorType - Error type to check. If not passed in, will check for any errors and not specific one.
+	 */
+	hasRecentError: function( errorType ) {
 		var aMinuteAgo = Date.now() - ( 60 * 1000 );
 		return this.errors.some( function( error ) {
-			return error.timestamp && error.timestamp > aMinuteAgo;
+			return ( error.timestamp && error.timestamp > aMinuteAgo ) && ( ! errorType || errorType === error.error );
 		} );
 	},
 

--- a/client/lib/reader-tags/actions.js
+++ b/client/lib/reader-tags/actions.js
@@ -1,5 +1,6 @@
 // External Dependencies
 var trim = require( 'lodash/string/trim' );
+var has = require( 'lodash/object/has' );
 
 // Internal Dependencies
 var Dispatcher = require( 'dispatcher' ),
@@ -37,6 +38,10 @@ var ReaderTagActions = {
 
 		wpcom.undocumented().readTag( { slug }, function( error, data ) {
 			delete tagsLoading[ slug ];
+
+			if ( ! error && ( data && has( data, 'tag' ) && has( data.tag, 'error_data' ) ) ) {
+				error = data.tag.error_data;
+			}
 
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_READER_TAG',

--- a/client/lib/reader-tags/actions.js
+++ b/client/lib/reader-tags/actions.js
@@ -39,7 +39,7 @@ var ReaderTagActions = {
 		wpcom.undocumented().readTag( { slug }, function( error, data ) {
 			delete tagsLoading[ slug ];
 
-			if ( ! error && ( data && has( data, 'tag' ) && has( data.tag, 'error_data' ) ) ) {
+			if ( ! error && ( data && has( data, 'tag.error_data' ) ) ) {
 				error = data.tag.error_data;
 			}
 

--- a/client/lib/reader-tags/tags.js
+++ b/client/lib/reader-tags/tags.js
@@ -1,10 +1,14 @@
-var forOwn = require( 'lodash/object/forOwn' );
-var has = require( 'lodash/object/has' );
-var isArray = require( 'lodash/lang/isArray' );
+/**
+ * External dependencies
+ */
+import forOwn from 'lodash/object/forOwn';
 
-var decodeEntities = require( 'lib/formatting' ).decodeEntities,
-	dispatcher = require( 'dispatcher' ),
-	emitter = require( 'lib/mixins/emitter' );
+/**
+ * Internal dependencies
+ */
+import { decodeEntities } from 'lib/formatting';
+import dispatcher from 'dispatcher';
+import emitter from 'lib/mixins/emitter';
 
 var tags = {};
 
@@ -20,7 +24,7 @@ function receiveTags( newTags ) {
 	forOwn( newTags, ( sub ) => {
 		sub.URL = '/tag/' + sub.slug;
 		sub.title = decodeEntities( sub.title );
-		sub.slug = sub.slug ? sub.slug.toLowerCase() : '';
+		sub.slug = sub.slug.toLowerCase();
 		tags[ sub.slug ] = sub;
 	} );
 	TagStore.emit( 'change' );

--- a/client/lib/reader-tags/tags.js
+++ b/client/lib/reader-tags/tags.js
@@ -1,4 +1,6 @@
 var forOwn = require( 'lodash/object/forOwn' );
+var has = require( 'lodash/object/has' );
+var isArray = require( 'lodash/lang/isArray' );
 
 var decodeEntities = require( 'lib/formatting' ).decodeEntities,
 	dispatcher = require( 'dispatcher' ),
@@ -18,7 +20,7 @@ function receiveTags( newTags ) {
 	forOwn( newTags, ( sub ) => {
 		sub.URL = '/tag/' + sub.slug;
 		sub.title = decodeEntities( sub.title );
-		sub.slug = sub.slug.toLowerCase();
+		sub.slug = sub.slug ? sub.slug.toLowerCase() : '';
 		tags[ sub.slug ] = sub;
 	} );
 	TagStore.emit( 'change' );

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -286,6 +286,10 @@
 	@include breakpoint( "<480px" ) {
 		margin-top: -72px;
 	}
+
+	.empty-content__illustration {
+		min-height: 100px;
+	}
 }
 
 .is-section-reader .empty-content__action {

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -411,11 +411,13 @@ module.exports = React.createClass( {
 	render: function() {
 		var store = this.props.store,
 			hasNoPosts = store.isLastPage() && ( ( ! this.state.posts ) || this.state.posts.length === 0 ),
-			body;
+			header, body;
 
-		if ( hasNoPosts ) {
+		if ( hasNoPosts || store.hasRecentError( 'invalid_tag' ) ) {
+			header = null;
 			body = this.props.emptyContent || ( <EmptyContent /> );
 		} else {
+			header = this.props.children;
 			body = ( <InfiniteList
 			ref={ ( c ) => this._list = c }
 			className="reader__content"
@@ -438,7 +440,7 @@ module.exports = React.createClass( {
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.handleUpdateClick } />
 
-				{ this.props.children }
+				{ header }
 
 				{ body }
 

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -5,6 +5,11 @@ var EmptyContent = require( 'components/empty-content' ),
 	discoverHelper = require( 'reader/discover/helper' );
 
 var TagEmptyContent = React.createClass( {
+
+	propTypes: {
+		tag: React.PropTypes.string
+	},
+
 	shouldComponentUpdate: function() {
 		return false;
 	},
@@ -20,16 +25,27 @@ var TagEmptyContent = React.createClass( {
 	},
 
 	render: function() {
-		var action = discoverHelper.isEnabled()
+		const action = ( <a
+			className="empty-content__action button is-primary"
+			onClick={ this.recordAction }
+			href="/">{ this.translate( 'Back to Following' ) }</a> );
+
+		const secondaryAction = discoverHelper.isEnabled()
 			? ( <a
 			className="empty-content__action button"
 			onClick={ this.recordSecondaryAction }
 			href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
 
+		const message = this.translate(
+			'No posts have recently been tagged with {{tagName /}} for your language.',
+			{ components: { tagName: <em>{ this.props.tag }</em> } }
+		);
+
 		return ( <EmptyContent
 			title={ this.translate( 'No recent posts…' ) }
-			line={ this.translate( 'No posts have recently been tagged with %(tag)s for your language', { args: { tag: this.props.tag } } ) }
+			line={ message }
 			action={ action }
+			secondaryAction={ secondaryAction }
 			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
 			illustrationWidth={ 500 }
 			/> );

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -28,7 +28,7 @@ var TagEmptyContent = React.createClass( {
 
 		return ( <EmptyContent
 			title={ this.translate( 'No recent posts…' ) }
-			line={ this.translate( 'No posts have recently been tagged with this tag for your language.' ) }
+			line={ this.translate( 'No posts have recently been tagged with %(tag)s for your language', { args: { tag: this.props.tag } } ) }
 			action={ action }
 			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
 			illustrationWidth={ 500 }

--- a/client/reader/tag-stream/index.jsx
+++ b/client/reader/tag-stream/index.jsx
@@ -11,6 +11,10 @@ var FollowingStream = require( 'reader/following-stream' ),
 
 var FeedStream = React.createClass( {
 
+	propTypes: {
+		tag: React.PropTypes.string
+	},
+
 	getInitialState: function() {
 		return {
 			title: this.getTitle(),

--- a/client/reader/tag-stream/index.jsx
+++ b/client/reader/tag-stream/index.jsx
@@ -74,7 +74,7 @@ var FeedStream = React.createClass( {
 
 	render: function() {
 		var tag = ReaderTags.get( this.props.tag ),
-			emptyContent = ( <EmptyContent /> );
+			emptyContent = ( <EmptyContent tag={ this.props.tag } /> );
 
 		if ( this.props.setPageTitle ) {
 			this.props.setPageTitle( this.state.title );


### PR DESCRIPTION
Provides a helpful error message when a tag is not found (`invalid_tag` response from API).

Fixes #658.

Massive props to @jjbskir, who did most of the legwork for this in #1865.

To test, try http://calypso.localhost:3000/tag/thistagisnotonethatexists and verify that you see an error message.

Before: 

<img width="1212" alt="screen shot 2016-01-29 at 10 40 36" src="https://cloud.githubusercontent.com/assets/17325/12659669/e2b9f1ae-c674-11e5-9623-1ca836966a73.png">

After:

<img width="1212" alt="screen shot 2016-01-29 at 10 41 09" src="https://cloud.githubusercontent.com/assets/17325/12659668/e2b67484-c674-11e5-9db0-7b7cde6ed742.png">
