### PR TITLE
Domains: Privacy Protection State in Domain Details

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -73,7 +73,7 @@ const RegisteredDomain = React.createClass( {
 					icon: 'notice',
 					href: transferPath,
 					message: this.translate( 'Disabled for Transfer', {
-						context: 'An icon label when Privacy Protection is enabled.'
+						context: 'An icon label when Privacy Protection is temporarily disabled for transfer.'
 					} )
 				} );
 			}
@@ -84,7 +84,7 @@ const RegisteredDomain = React.createClass( {
 			icon: 'notice',
 			href: privacyPath,
 			message: this.translate( 'None', {
-				context: 'An icon label when Privacy Protection is disabled.'
+				context: 'An icon label when Privacy Protection is not purchased by the user.'
 			} )
 		} );
 	},

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -39,44 +39,54 @@ const RegisteredDomain = React.createClass( {
 		);
 	},
 
-	getPrivacyProtection() {
-		if ( this.props.domain.hasPrivacyProtection ) {
-			const path = paths.domainManagementContactsPrivacy(
-				this.props.selectedSite.domain,
-				this.props.domain.name
-			);
-
-			return (
-				<a href={ path }>
-					<Notice
-						isCompact
-						status="is-success"
-						icon="lock">
-						{ this.translate( 'On', {
-							context: 'An icon label when Privacy Protection is enabled.'
-						} ) }
-					</Notice>
-				</a>
-			);
-		}
-
-		const path = paths.domainManagementPrivacyProtection(
-			this.props.selectedSite.domain,
-			this.props.domain.name
-		);
-
+	getLabel( { status, icon, message, href } ) {
 		return (
-			<a href={ path } onClick={ this.recordEvent( 'noneClick', this.props.domain ) }>
+			<a href={ href }>
 				<Notice
 					isCompact
-					status="is-warning"
-					icon="notice">
-					{ this.translate( 'None', {
-						context: 'An icon label when Privacy Protection is disabled.'
-					} ) }
+					status={ status }
+					icon={ icon }>{ message }
 				</Notice>
 			</a>
 		);
+	},
+
+	getPrivacyProtection() {
+		const { hasPrivacyProtection, privateDomain, name } = this.props.domain,
+			{ slug } = this.props.selectedSite,
+			privacyPath = paths.domainManagementContactsPrivacy( slug, name ),
+			transferPath = paths.domainManagementTransfer( slug, name );
+
+		if ( hasPrivacyProtection ) {
+			if ( privateDomain ) {
+				return this.getLabel( {
+					status: 'is-success',
+					icon: 'lock',
+					href: privacyPath,
+					message: this.translate( 'On', {
+						context: 'An icon label when Privacy Protection is enabled.'
+					} )
+				} );
+			} else {
+				return this.getLabel( {
+					status: 'is-warning',
+					icon: 'notice',
+					href: transferPath,
+					message: this.translate( 'Disabled for Transfer', {
+						context: 'An icon label when Privacy Protection is enabled.'
+					} )
+				} );
+			}
+		}
+
+		return this.getLabel( {
+			status: 'is-warning',
+			icon: 'notice',
+			href: privacyPath,
+			message: this.translate( 'None', {
+				context: 'An icon label when Privacy Protection is disabled.'
+			} )
+		} );
 	},
 
 	handlePaymentSettingsClick() {
@@ -87,7 +97,7 @@ const RegisteredDomain = React.createClass( {
 		return <DomainWarnings
 			domain={ this.props.domain }
 			selectedSite={ this.props.selectedSite }
-			ruleWhiteList={ [ 'expiredDomains', 'expiringDomains', 'newDomainsWithPrimary', 'newDomains' ] } />;
+			ruleWhiteList={ [ 'expiredDomains', 'expiringDomains', 'newDomainsWithPrimary', 'newDomains' ] }/>;
 	},
 
 	getVerticalNav() {
@@ -190,7 +200,7 @@ const RegisteredDomain = React.createClass( {
 						</Property>
 
 						<SubscriptionSettings
-							onClick={ this.handlePaymentSettingsClick } />
+							onClick={ this.handlePaymentSettingsClick }/>
 					</Card>
 				</div>
 


### PR DESCRIPTION
Previously, Privacy Protection label under domain detail was always "On" if the user has purchased Privacy Protection, regardless of whether that has been enabled or not.

This wasn't a biggie since we didn't let the users to disable Privacy Protection through UI, but we're now (through transfer). As a result, we need to show the correct state.

![image](https://cloud.githubusercontent.com/assets/991022/12659963/4451e386-c5c6-11e5-8402-d87bcc63d29d.png)


#### Testing
##### Domain with Privacy Protection Purchased and Enabled
- Ensure the state is "On" and link goes to `Contacts and Privacy` page

##### Domain with Privacy Protection Purchased and Disabled
- Ensure the state is "Disabled for Transfer" and the link goes to "Transfers" page
(You can disable privacy though admin panel or just being initiating a transfer)

##### Domain without Privacy Protection
- Ensure the state is "None" and the link goes to `Contact and Privacy` page, which offers Privacy Protection.

/cc: @breezyskies for design review, @klimeryk for code review