### PR TITLE
Importer: Update UI to match API data

### DIFF
--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -8,7 +8,7 @@ const importerStateMap = [
 	[ appStates.DEFUNCT, 'importStopped' ],
 	[ appStates.DISABLED, 'disabled' ],
 	[ appStates.IMPORT_FAILURE, 'importer-import-failure' ],
-	[ appStates.IMPORT_SUCCESS, 'importer-import-success' ],
+	[ appStates.IMPORT_SUCCESS, 'importSuccess' ],
 	[ appStates.IMPORTING, 'importing' ],
 	[ appStates.INACTIVE, 'importer-inactive' ],
 	[ appStates.MAP_AUTHORS, 'importer-map-authors' ],

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -57,13 +57,13 @@ export default React.createClass( {
 	},
 
 	getSuccessText: function() {
-		const { site: { slug }, counts: { pages, posts } } = this.props.importerStatus,
+		const { site: { slug }, progress: { page, post } } = this.props.importerStatus,
 			pageLink = <a href={ '/pages/' + slug } />,
 			pageText = this.translate( 'Pages', { context: 'noun' } ),
 			postLink = <a href={ '/posts/' + slug } />,
 			postText = this.translate( 'Posts', { context: 'noun' } );
 
-		if ( pages && posts ) {
+		if ( page && post ) {
 			return this.translate(
 				'All done! Check out {{a}}Posts{{/a}} or ' +
 				'{{b}}Pages{{/b}} to see your imported content.', {
@@ -75,12 +75,12 @@ export default React.createClass( {
 			);
 		}
 
-		if ( pages || posts ) {
+		if ( page || post ) {
 			return this.translate(
 				'All done! Check out {{a}}%(articles)s{{/a}} ' +
 				'to see your imported content.', {
-					components: { a: pages ? pageLink : postLink },
-					args: { articles: pages ? pageText : postText }
+					components: { a: page ? pageLink : postLink },
+					args: { articles: page ? pageText : postText }
 				}
 			);
 		}


### PR DESCRIPTION
Previously, after an import finished, the UI would not reflect the
change because it was not receiving the import status from the API.

Now the status is reflected in both the mapping between the local and
server-side status values and also in the success message, which
formerly used outdated references (`counts` vs `progress`)

**Testing**
Start an import. When it finishes, in **master** it won't update the progress indicator. However, after you have received the "import complete" email, in this branch it should update with a message linking to the site's post or pages, also saying that the import is "Done" (according to the button on the header).

cc: @rralian @apeatling @jordwest @dllh 