### PR TITLE
Reader comments: decode HTML entities on author name

### DIFF
--- a/client/reader/comments/index.jsx
+++ b/client/reader/comments/index.jsx
@@ -16,6 +16,8 @@ var Gravatar = require( 'components/gravatar' ),
 	PostCommentContent = require( './post-comment-content' ),
 	Gridicon = require( 'components/gridicon' );
 
+import { decodeEntities } from 'lib/formatting';
+
 var PostComment = React.createClass( {
 
 	propTypes: {
@@ -145,6 +147,8 @@ var PostComment = React.createClass( {
 		if ( comment.state && comment.state === CommentStates.PENDING ) {
 			comment.author = User;
 			comment.author.name = User.display_name;
+		} else {
+			comment.author.name = decodeEntities( comment.author.name );
 		}
 
 		// If we have an error, render the error component instead


### PR DESCRIPTION
If the author's public display name includes a &, we're currently displaying it as & amp;. This PR fixes that.

For example:

http://calypso.localhost:3000/read/post/feed/13072509/913388333

(See comment from Arts &amp; Rhymes.)

<img width="1196" alt="screen shot 2016-01-29 at 11 28 09" src="https://cloud.githubusercontent.com/assets/17325/12660947/a255616e-c67b-11e5-8689-2ae08010b41c.png">
