### PR TITLE
Me - Notifications: don't use rel="external" to link to /following/edit now it's in Calypso

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -59,7 +59,7 @@ module.exports = React.createClass( {
 							{ this.translate( '{{readerLink}}Use the Reader{{/readerLink}} to adjust delivery settings for your existing subscriptions.',
 								{
 									components: {
-										readerLink: <a rel="external" href="https://wordpress.com/following/edit/" onClick={ this.recordClickEvent( 'Edit Subscriptions in Reader Link' ) } />
+										readerLink: <a href="/following/edit" onClick={ this.recordClickEvent( 'Edit Subscriptions in Reader Link' ) } />
 									}
 								} )
 							}


### PR DESCRIPTION
http://calypso.localhost:3000/me/notifications/subscriptions currently uses rel="external" to link to Manage Following, which results in a full page reload.

This PR changes to a relative URL without `rel` since Manage Following is now live in Calypso.

To test: 
- Navigate to http://calypso.localhost:3000/me/notifications/subscriptions
- Click the 'Use the Reader' link and ensure that you reach /following/edit without a full page reload