### PR TITLE
Update/importer/spinner not progress

### DIFF
--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -150,7 +150,7 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 
 		case actionTypes.START_IMPORTING:
 			newState = state
-				.setIn( [ 'importers', action.importerId, 'importerState' ], appStates.UPLOADING );
+				.setIn( [ 'importers', action.importerId, 'importerState' ], appStates.IMPORTING );
 			break;
 
 		case actionTypes.START_UPLOAD:

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -12,6 +12,7 @@ import { mapAuthor, startImporting } from 'lib/importer/actions';
 import { appStates } from 'lib/importer/constants';
 import ProgressBar from 'components/progress-bar';
 import MappingPane from './author-mapping-pane';
+import Spinner from 'components/spinner';
 
 export default React.createClass( {
 	displayName: 'SiteSettingsImportingPane',
@@ -112,7 +113,7 @@ export default React.createClass( {
 		const { site: { ID: siteId, name: siteName, single_user_site: hasSingleAuthor } } = this.props;
 		const { importerId, errorData, customData } = this.props.importerStatus;
 		const progressClasses = classNames( 'importer__import-progress', { 'is-complete': this.isFinished() } );
-		let { percentComplete = 0, statusMessage } = this.props.importerStatus;
+		let { percentComplete, statusMessage } = this.props.importerStatus;
 
 		if ( this.isError() ) {
 			statusMessage = errorData.description;
@@ -125,10 +126,10 @@ export default React.createClass( {
 
 		return (
 			<div className="importer__importing-pane">
-				{ ( this.isError() || this.isImporting() ) ?
+				{ ( this.isError() || this.isImporting() ) &&
 					<p>{ this.getHeadingText() }</p>
-				: null }
-				{ this.isMapping() ?
+				}
+				{ this.isMapping() &&
 					<MappingPane
 						hasSingleAuthor={ hasSingleAuthor }
 						onMap={ ( source, target ) => mapAuthor( importerId, source, target ) }
@@ -138,12 +139,13 @@ export default React.createClass( {
 						sourceTitle={ customData.siteTitle || this.translate( 'Original Site' ) }
 						targetTitle={ siteName }
 					/>
-				:
-					<div>
-						<ProgressBar className={ progressClasses } value={ percentComplete } />
-						<p className="importer__status-message">{ statusMessage }</p>
-					</div>
 				}
+				{ this.isImporting() && (
+					percentComplete
+						? <ProgressBar className={ progressClasses } value={ percentComplete } />
+						: <div><Spinner className="importer__import-spinner" /><br /></div>
+				) }
+				<div><p className="importer__status-message">{ statusMessage }</p></div>
 			</div>
 		);
 	}

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -118,6 +118,12 @@
 	}
 }
 
+.importer__import-spinner {
+	position: absolute;
+		left: 50%;
+	transform: translateX( -50% );
+}
+
 .importer__start {
 	float: none !important;
 }


### PR DESCRIPTION
<del>Currently this depends on #2900 and won't be ready to merge until that's in</del>

Importer: Replace progress bar witih spinner

Although the long-term plan is to provide feedback for how many objects have already been imporer during an import session, that information is currently unavailable. This means that the progress bar during the import session remains blank.

Now, in the absence of that progress information, a spinner shows up in its place to indicate that the process is currently working but not yet finished.

It would have been possible to strip out of the progress bar, but I have chosen to leave it in because it is already working given the appropriate data from the server, and because we plan on adding that data. Had this not already been tested with mock data, I would have removed the code. By leaving it in, we immediately benefit when that data becomes available and also have the added benefit that for certain importers where a progress indication is unavailable (stream importers) this should automatically show the right component for the task.

Fixed a bug where the spinner would show if the upload was complete.

Also rearranged some of the logic to meet newer Calypso standards

**Testing**
Start an import and watch for the spinner animation where the progress bar used to be. When the import finishes, the spinner should disappear.

![screen shot 2016-01-28 at 9 59 00 pm](https://cloud.githubusercontent.com/assets/5431237/12667567/6b0f91e6-c60a-11e5-8ba2-4beb9eba3649.png)

cc: @rralian @jordwest @dllh @rodrigoi @apeatling 