### PR TITLE
Invites: Update logged out route after including locale

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -428,7 +428,7 @@ module.exports = function() {
 		}
 	} );
 
-	app.get( '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?', function( req, res ) {
+	app.get( '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?', function( req, res ) {
 		if ( req.cookies.wordpress_logged_in ) {
 			// the user is probably logged in
 			renderLoggedInRoute( req, res );


### PR DESCRIPTION
We just deployed #2870, which adds locale support for logged out invites. But, since we didn't update the logged out routing, locale support is not working for environments other than development.

This will fix that.

To test:
- Verify that this patch matches what is in [client/my-sites/invites/index.js](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/invites/index.js#L13)