### PR TITLE
Reader: if user has blocked email delivery completely, don't offer email notification settings in Manage Following

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -26,6 +26,8 @@ var i18n = require( 'lib/mixins/i18n' ),
 	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' ),
 	readerRoute = require( 'reader/route' );
 
+import userSettings from 'lib/user-settings';
+
 // This is a tri-state.
 // null == nothing instantiated, nothing pending
 // false === waiting for transitions to end so we can unmount
@@ -465,7 +467,8 @@ module.exports = {
 				key: 'following-edit',
 				initialFollowUrl: context.query.follow,
 				search: search,
-				context: context
+				context: context,
+				userSettings: userSettings
 			} ),
 			document.getElementById( 'primary' )
 		);

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -39,7 +39,8 @@ const FollowingEdit = React.createClass( {
 
 	propTypes: {
 		initialFollowUrl: React.PropTypes.string,
-		search: React.PropTypes.string
+		search: React.PropTypes.string,
+		userSettings: React.PropTypes.object
 	},
 
 	getInitialState: function() {
@@ -205,6 +206,7 @@ const FollowingEdit = React.createClass( {
 
 	renderSubscription: function( subscription ) {
 		const subscriptionKey = this.getSubscriptionRef( subscription );
+		const isEmailBlocked = this.props.userSettings.getSetting( 'subscription_delivery_email_blocked' );
 
 		return (
 			<SubscriptionListItem
@@ -213,7 +215,8 @@ const FollowingEdit = React.createClass( {
 				subscription={ subscription }
 				onNotificationSettingsOpen={ this.handleNotificationSettingsOpen }
 				onNotificationSettingsClose={ this.handleNotificationSettingsClose }
-				openCards={ this.state.openCards } />
+				openCards={ this.state.openCards }
+				isEmailBlocked={ isEmailBlocked } />
 		);
 	},
 

--- a/client/reader/following-edit/list-item.jsx
+++ b/client/reader/following-edit/list-item.jsx
@@ -30,7 +30,8 @@ var SubscriptionListItem = React.createClass( {
 		classNames: React.PropTypes.string,
 		onNotificationSettingsOpen: React.PropTypes.func,
 		onNotificationSettingsClose: React.PropTypes.func,
-		openCards: React.PropTypes.object
+		openCards: React.PropTypes.object,
+		isEmailBlocked: React.PropTypes.bool
 	},
 
 	mixins: [ PureRenderMixin ],
@@ -122,7 +123,7 @@ var SubscriptionListItem = React.createClass( {
 				className={ this.props.classNames }
 				expanded={ isCardExpanded }
 			>
-				{ isFollowing ? <FollowingEditNotificationSettings subscription={ subscription } /> : null }
+				{ isFollowing ? <FollowingEditNotificationSettings subscription={ subscription } isEmailBlocked={ this.props.isEmailBlocked } /> : null }
 			</FoldableCard>
 		);
 	}

--- a/client/reader/following-edit/notification-settings.jsx
+++ b/client/reader/following-edit/notification-settings.jsx
@@ -22,7 +22,10 @@ const DELIVERY_FREQUENCY_INSTANTLY = 'instantly',
 
 var FollowingEditNotificationSettings = React.createClass( {
 
-	propTypes: { subscription: React.PropTypes.object.isRequired },
+	propTypes: {
+		subscription: React.PropTypes.object.isRequired,
+		isEmailBlocked: React.PropTypes.bool
+	},
 
 	getInitialState: function() {
 		return this.getStateFromStores();
@@ -135,8 +138,24 @@ var FollowingEditNotificationSettings = React.createClass( {
 
 		if ( isExternal ) {
 			return (
-				<Card className="is-compact is-external following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
+				<Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
 					<p>{ this.translate( 'RSS feeds do not allow for email notifications.' ) }</p>
+				</Card>
+			);
+		}
+
+		if ( this.props.isEmailBlocked ) {
+			return (
+				<Card className="is-compact is-impossible-to-send-email following-edit__notification-settings-card" key={ 'notification-settings-comments-' + subscription.get( 'ID' ) }>
+					<p>{ this.translate( 'You have blocked all email updates from your subscribed blogs.' ) }</p>
+					<p>{ this.translate( 'You can change this in your {{settingsLink}}Notification Settings{{/settingsLink}}.',
+							{
+								components: {
+									settingsLink: <a href="/me/notifications/subscriptions" />
+								}
+							} )
+						}
+					</p>
 				</Card>
 			);
 		}

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -297,7 +297,7 @@
 		}
 	}
 
-	&.is-external {
+	&.is-impossible-to-send-email {
 		color: $gray;
 		padding-left: 22px;
 


### PR DESCRIPTION
In Me > Notifications > Reader Subscriptions, it's possible to block email delivery completely:

<img width="755" alt="screen shot 2016-01-29 at 13 13 07" src="https://cloud.githubusercontent.com/assets/17325/12663122/2273a514-c68a-11e5-98a5-7ed457dac1b5.png">

Until now, we hadn't take account of this when showing email notification options in Manage Following.

This PR adds a check for the `subscription_delivery_email_blocked` setting, and shows a message in place of the email notification settings if it's turned on:

<img width="779" alt="screen shot 2016-01-29 at 13 13 29" src="https://cloud.githubusercontent.com/assets/17325/12663127/28a6a9b8-c68a-11e5-801a-0bf20982352c.png">

### To test
- Activate 'Block all email updates from blogs you’re following on WordPress.com' on http://calypso.localhost:3000/me/notifications/subscriptions.
- Go to Manage Following at http://calypso.localhost:3000/following/edit and open the foldable card for a WordPress.com site
- Ensure that the message above is displayed, with a link to the Notification Settings
- Deactivate 'Block all email updates from blogs you’re following on WordPress.com' and return to Manage Following. Ensure that the usual notification controls are shown, and that your settings for that blog were preserved while you had email blocking enabled.

Fixes #1276.