### PR TITLE
Desktop: Add stats for login success and failures

### DIFF
--- a/client/lib/oauth-store/actions.js
+++ b/client/lib/oauth-store/actions.js
@@ -8,6 +8,8 @@ import request from 'superagent';
  */
 import Dispatcher from 'dispatcher';
 import { actions } from './constants';
+import { errors as errorTypes } from './constants';
+import analytics from 'analytics';
 
 export function login( username, password, auth_code ) {
 	Dispatcher.handleViewAction( {
@@ -17,10 +19,41 @@ export function login( username, password, auth_code ) {
 	request.post( '/oauth' )
 		.send( { username, password, auth_code } )
 		.end( ( error, data ) => {
+			bumpStats( error, data );
+
 			Dispatcher.handleServerAction( {
 				type: actions.RECEIVE_AUTH_LOGIN,
 				data,
 				error
 			} );
 		} );
+}
+
+function bumpStats( error, data ) {
+	let errorType;
+
+	if ( error ) {
+		if ( data && data.body ) {
+			errorType = data.body.error;
+		} else {
+			errorType = 'status_' + error.status;
+		}
+	}
+
+	if ( errorType === errorTypes.ERROR_REQUIRES_2FA ) {
+		analytics.tracks.recordEvent( 'calypso_oauth_login_needs2fa' );
+		analytics.mc.bumpStat( 'calypso_oauth_login', 'success-needs-2fa' );
+	} else if ( errorType ) {
+		analytics.tracks.recordEvent( 'calypso_oauth_login_fail', {
+			error: error.error
+		} );
+
+		analytics.mc.bumpStat( {
+			calypso_oauth_login_error: errorType,
+			calypso_oauth_login: 'error'
+		} );
+	} else {
+		analytics.tracks.recordEvent( 'calypso_oauth_login_success' );
+		analytics.mc.bumpStat( 'calypso_oauth_login', 'success' );
+	}
 }

--- a/client/lib/oauth-store/constants.js
+++ b/client/lib/oauth-store/constants.js
@@ -9,4 +9,8 @@ module.exports = {
 		RECEIVE_AUTH_LOGIN: null,
 		AUTH_RESET: null
 	} ),
+	errors: {
+		ERROR_REQUIRES_2FA: 'needs_2fa',       // From WP.com API
+		ERROR_INVALID_OTP: 'invalid_otp'       // From WP.com API
+	}
 };

--- a/client/lib/oauth-store/index.js
+++ b/client/lib/oauth-store/index.js
@@ -8,6 +8,7 @@ var debug = require( 'debug' )( 'calypso:auth:store' );
  */
 import { createReducerStore } from 'lib/store';
 import { actions as ActionTypes } from './constants';
+import { errors as errorTypes } from './constants';
 import * as OAuthToken from 'lib/oauth-token';
 
 /**
@@ -20,9 +21,6 @@ const initialState = {
 	errorMessage: false
 };
 
-const ERROR_REQUIRES_2FA = 'needs_2fa';        // Comes from WP API
-const ERROR_INVALID_OTP = 'invalid_otp';       // Comes from WP API
-
 function handleAuthError( error, data ) {
 	let stateChanges = { errorLevel: 'is-error', requires2fa: false, inProgress: false };
 
@@ -31,10 +29,10 @@ function handleAuthError( error, data ) {
 	debug( 'Error processing login: ' + stateChanges.errorMessage );
 
 	if ( data && data.body ) {
-		if ( data.body.error === ERROR_REQUIRES_2FA ) {
+		if ( data.body.error === errorTypes.ERROR_REQUIRES_2FA ) {
 			stateChanges.requires2fa = true;
 			stateChanges.errorLevel = 'is-info';
-		} else if ( data.body.error === ERROR_INVALID_OTP ) {
+		} else if ( data.body.error === errorTypes.ERROR_INVALID_OTP ) {
 			stateChanges.requires2fa = true;
 		}
 	}

--- a/client/lib/oauth-store/test/oauth-store.js
+++ b/client/lib/oauth-store/test/oauth-store.js
@@ -13,7 +13,7 @@ var oAuthToken = require( 'lib/oauth-token' ),
 	testConstants = require( '../constants' );
 
 describe( 'oAuthStore', function() {
-	var oAuthStore
+	var oAuthStore;
 
 	beforeEach( function() {
 		oAuthStore = require( 'lib/oauth-store' );


### PR DESCRIPTION
So we can see how track where issue points in the login process might be.

### To Test

- Get the wp-desktop repo
- Switch the `calypso` submodule to this branch
- `make build` the desktop app
- Verify that you can sign in successfully with a non-2fa account and with a 2fa account
- Verify that you get an error with an invalid username and/or password