### PR TITLE
Checkout: Update `SitesList` with new plans during checkout

### DIFF
--- a/client/lib/sites-list/index.js
+++ b/client/lib/sites-list/index.js
@@ -29,6 +29,11 @@ module.exports = function() {
 				case 'FETCH_SITES':
 					_sites.fetch(); // refetch the sites from .com
 					break;
+				case 'TRANSACTION_STEP_SET':
+					if ( 'received-wpcom-response' === action.step.name && action.step.data ) {
+						_sites.updatePlans( action.step.data.purchases );
+					}
+					break;
 			}
 		} );
 	}

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -17,6 +17,7 @@ var wpcom = require( 'lib/wp' ),
 	Searchable = require( 'lib/mixins/searchable' ),
 	Emitter = require( 'lib/mixins/emitter' ),
 	isBusiness = require( 'lib/products-values' ).isBusiness,
+	isPlan = require( 'lib/products-values' ).isPlan,
 	PreferencesActions = require( 'lib/preferences/actions' ),
 	PreferencesStore = require( 'lib/preferences/store' ),
 	user = require( 'lib/user' )();
@@ -231,6 +232,27 @@ SitesList.prototype.update = function( sites ) {
 	}
 
 	return changed;
+};
+
+/**
+ * Updates the `plan` property of existing sites.
+ *
+ * @param {array} purchases - Array of purchases indexed by site IDs
+ */
+SitesList.prototype.updatePlans = function( purchases ) {
+	this.data = this.data.map( function( site ) {
+		var plan;
+
+		if ( purchases[ site.ID ] ) {
+			plan = find( purchases[ site.ID ], isPlan );
+
+			if ( plan ) {
+				site.set( { plan: plan } );
+			}
+		}
+
+		return site;
+	} );
 };
 
 /**

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -130,10 +130,6 @@ const Checkout = React.createClass( {
 		} else if ( cartItems.hasFreeTrial( this.props.cart ) ) {
 			this.props.clearSitePlans( this.props.sites.getSelectedSite().ID );
 
-			Dispatcher.handleViewAction( {
-				type: 'FETCH_SITES'
-			} );
-
 			return `/plans/${ this.props.sites.getSelectedSite().slug }/thank-you`;
 		}
 


### PR DESCRIPTION
Fixes #2818. Blocker for #2816.

Previously, when checking out with a plan, the site that received the new plan didn't have this applied to its object in `SitesList`. This left the user with stale data immediately after checking out with a plan, and many parts of the site (visiting `/plugins` or the label next to 'Plan' in the sidebar) did not reflect the plan the user just purchased.

This PR updates `SitesList` to update the `plan` property of sites based on the `purchases` property of the response from the transactions endpoint.

**Testing**
- Apply this patch to your sandbox: D958-code
- Purchase a plan.
- Click 'My Sites' as soon as you reach the 'Thank You' page.
- Assert that the label next to 'Plan' is accurate. On master, there is usually a delay while `sites-list` is refetched.

- [x] Product review
- [x] Code review