### PR TITLE
Framework: Pass hostname to server

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,20 +13,26 @@ var pkg = require( './package.json' ),
 
 var start = Date.now(),
 	port = process.env.PORT || 3000,
-	host = config( 'hostname' ),
+	host = process.env.HOST || config( 'hostname' ),
 	app = boot(),
 	server,
 	hotReloader;
 
 console.log( chalk.yellow( '%s booted in %dms - http://%s:%s' ), pkg.name, ( Date.now() ) - start, host, port );
 console.info( chalk.cyan( '\nGetting bundles ready, hold on...' ) );
+
 server = http.createServer( app );
-server.listen( port );
 
 // The desktop app runs Calypso in a fork.
-// This tells the parent process that Calypso has booted.
 if ( process.env.CALYPSO_IS_FORK ) {
-	process.send( { boot: 'ready' } );
+	// We need to run it with an explicit hostname to avoid firewall warnings.
+	server.listen( { port, host }, function() {
+		// Tell the parent process that Calypso has booted.
+		process.send( { boot: 'ready' } );
+	} );
+} else {
+	// Let non-forks listen on any host.
+	server.listen( port );
 }
 
 // Enable hot reloader in development


### PR DESCRIPTION
For the desktop app, we need the app to run on a specific host
(127.0.0.1) to avoid firewall warnings. This passes the host value
(either from an environment variable, if set, or config) to the server
when it's started.