### PR TITLE
Domains: adding/removing domain to cart leads to js error

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -363,7 +363,7 @@ function themeItem( themeSlug, source ) {
  * @returns {Object} the new item as `CartItemValue` object
  */
 function domainRegistration( properties ) {
-	return domainItem( properties.productSlug, properties.domain );
+	return extend( domainItem( properties.productSlug, properties.domain ), { is_domain_registration: true } );
 }
 
 /**


### PR DESCRIPTION
There is a JS error when removing a domain from the cart, see the gif:
![registration](https://cloud.githubusercontent.com/assets/82778/12672345/45ca2a8a-c67e-11e5-83ea-7546a85b036e.gif)

To reproduce, add/remove the default domains that appear when you go to /domains/add/site