### PR TITLE
Themes: Avoid DOM reconciliation for existing themes on scroll

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -2,10 +2,10 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	classNames = require( 'classnames' ),
 	noop = require( 'lodash/utility/noop' ),
-	isEmpty = require( 'lodash/lang/isEmpty' );
+	isEmpty = require( 'lodash/lang/isEmpty' ),
+	isEqual = require( 'lodash/lang/isEqual' );
 
 /**
  * Internal dependencies
@@ -18,7 +18,6 @@ var Card = require( 'components/card' ),
  * Component
  */
 var Theme = React.createClass( {
-	mixins: [ PureRenderMixin ],
 
 	propTypes: {
 		theme: React.PropTypes.shape( {
@@ -60,6 +59,10 @@ var Theme = React.createClass( {
 		index: React.PropTypes.number,
 		// Label to show on screenshot hover.
 		actionLabel: React.PropTypes.string
+	},
+
+	shouldComponentUpdate: function( nextProps ) {
+		return ! isEqual( nextProps.theme, this.props.theme );
 	},
 
 	getDefaultProps: function() {


### PR DESCRIPTION
**Before**
<img width="1151" alt="screen shot 2016-01-29 at 12 12 08" src="https://cloud.githubusercontent.com/assets/7767559/12675620/765dcab2-c683-11e5-91ab-a5531a2ad3a0.png">

**After**
<img width="1156" alt="screen shot 2016-01-29 at 12 02 11" src="https://cloud.githubusercontent.com/assets/7767559/12675614/705af5e0-c683-11e5-8626-cb348b0bea81.png">

These tables show time wasted reconciling component tree sections that have not changed. The start/stops have been placed around the `fetchNextPage()` call in the [`<themes-list-fetcher/>`](https://github.com/Automattic/wp-calypso/blob/515770044a4bfcf839a085349cc3703c9b12e79d/client/components/data/themes-list-fetcher/index.jsx#L101), like this:

```
		Perf.start();
		this.props.fetchNextPage( site );
		Perf.stop();
		let measurements = Perf.getLastMeasurements();
		Perf.printWasted( measurements );
```

This prints a table every time a scroll causes the next page of themes to be fetched and rendered. The tables above are towards the end of the entire set of themes.

The theme component was using the pure render mixin to avoid
reconciliation on re-render. Due to the complex nature of the
props, the reconciliation was never being short-circuited.

This PR Implements a custom shouldComponentUpdate method that does a deep
comparison on the theme object prop. We can see from the second table that no time is now wasted attempting to reconcile the huge amount of existing themes on the page.

**To Test**
* Go to http://calypso.localhost:3000/design
* Test theme scroll
* Test theme activation and verify that he activated theme gets a blue border and changed button options of activation
* Anything else that should update in the theme component?