### PR TITLE
Reader: Fix how we suppress featured images in full post view.

### DIFF
--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -80,10 +80,11 @@ function classifyPost( post, callback ) {
 				hostname: canonicalImageUrl.hostname,
 				pathname: canonicalImageUrl.pathname,
 				query: canonicalImageUrl.query
-			};
+			},
+			matcher = matches( canonicalImageUrlImportantParts );
 		if ( find( post.content_images, ( img ) => {
 			const imgUrl = url.parse( img.src, true, true );
-			return matches( imgUrl, canonicalImageUrlImportantParts );
+			return matcher( imgUrl );
 		} ) ) {
 			displayType ^= DISPLAY_TYPES.CANONICAL_IN_CONTENT;
 		}


### PR DESCRIPTION
Right now we're suppressing all of them. This patch fixes how we use the `matches` function in lodash, which doesn't actually check a match, but instead returns a function that checks a match.

As seen at https://wordpress.com/read/post/feed/25320833/916021218

Now 
![screenshot](https://cldup.com/6cf_CQiAAM.png)

With this patch, at http://calypso.localhost:3000/read/post/feed/25320833/916021218
![screenshot](https://cldup.com/cTSwSTWgqr.png)