### PR TITLE
Framework: Make content full-width on mobile screens.

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -291,10 +291,10 @@ $sidebar-width-min: 228px;
 @include breakpoint( "<660px" ) {
 	.wp-content {
 		margin-left: 0;
-		padding: 8px;
+		padding: 0;
 
 		.has-no-sidebar & {
-			padding-left: 8px;
+			padding-left: 0;
 		}
 	}
 }

--- a/assets/stylesheets/sections/_menus.scss
+++ b/assets/stylesheets/sections/_menus.scss
@@ -63,9 +63,12 @@
 	width: 100%;
 	box-sizing: border-box;
 	overflow: hidden;
-	margin-top: -8px;
 	padding: 3%;
 	box-shadow: 0 -2px 0 lighten( $gray, 10% ) inset;
+
+	@include breakpoint( "<480px" ) {
+		margin-top: -8px;
+	}
 }
 
 .menus__pickers-conjunction {
@@ -164,6 +167,10 @@
 	display: flex;
 	flex-direction: row;
 	margin: 24px 8px 8px 16px;
+
+	@include breakpoint( "<480px" ) {
+		margin: 24px 8px 8px 16px;
+	}
 
 	.menus__menu-name {
 		flex: 1 1 auto;

--- a/assets/stylesheets/sections/_menus.scss
+++ b/assets/stylesheets/sections/_menus.scss
@@ -63,7 +63,7 @@
 	width: 100%;
 	box-sizing: border-box;
 	overflow: hidden;
-
+	margin-top: -8px;
 	padding: 3%;
 	box-shadow: 0 -2px 0 lighten( $gray, 10% ) inset;
 }
@@ -163,7 +163,7 @@
 .menus__menu-header {
 	display: flex;
 	flex-direction: row;
-	margin: 20px 0;
+	margin: 24px 8px 8px 16px;
 
 	.menus__menu-name {
 		flex: 1 1 auto;

--- a/client/components/mobile-back-to-sidebar/style.scss
+++ b/client/components/mobile-back-to-sidebar/style.scss
@@ -1,6 +1,6 @@
 // Mobile Back to Sidebar
 .mobile-back-to-sidebar {
-	margin: -8px -8px 8px -8px;
+	margin: 0 0 8px 0;
 	padding: 15px 0 15px 36px;
 	position: relative;
 	background: $white;

--- a/client/my-sites/sidebar-navigation/style.scss
+++ b/client/my-sites/sidebar-navigation/style.scss
@@ -3,7 +3,7 @@
  */
 .current-section {
 	position: relative;
-	margin: -8px -8px 8px -8px;
+	margin: 0 0 8px 0;
 
 	@include breakpoint( ">660px" ) {
 		display: none;

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -2,10 +2,11 @@
 .reader__card.card {
 	padding: 16px;
 	transition: all 0.1s ease-in-out;
-	margin-bottom: 24px;
+	margin-bottom: 8px;
 
 	@include breakpoint( ">480px" ) {
 		padding: 16px 24px 24px;
+		margin-bottom: 24px;
 
 		&.is-selected,
 		&:hover,

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -8,6 +8,10 @@
 	position: absolute;
 		left: 0;
 		right: 0;
+
+	@include breakpoint( "<480px" ) {
+		margin: 0;
+	}
 }
 
 .signup__step-enter {


### PR DESCRIPTION
Removing the padding on wp-content on mobile screens. Here's a few before/after screens:

![artboard 1](https://cloud.githubusercontent.com/assets/191598/12680260/cfea06ca-c676-11e5-8cae-e1ff7c11731d.png)

This could use some testing, specifically around signup and NUX.