### PR TITLE
Reader/PostNorm: Leave https image srcs from non-wpcom hosts alone.

### DIFF
--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -46,7 +46,7 @@ describe( 'MediaUtils', function() {
 				photon: true
 			} );
 
-			expect( url ).to.equal( 'https://i2.wp.com/secure.gravatar.com/blavatar/4e21d703d81809d215ceaabbf07efbc6' );
+			expect( url ).to.equal( 'https://i2.wp.com/secure.gravatar.com/blavatar/4e21d703d81809d215ceaabbf07efbc6?ssl=1' );
 		} );
 
 		it( 'should generate the correct width-constrained photon URL', function() {
@@ -55,7 +55,7 @@ describe( 'MediaUtils', function() {
 				maxWidth: 450
 			} );
 
-			expect( url ).to.equal( 'https://i2.wp.com/secure.gravatar.com/blavatar/4e21d703d81809d215ceaabbf07efbc6?w=450' );
+			expect( url ).to.equal( 'https://i2.wp.com/secure.gravatar.com/blavatar/4e21d703d81809d215ceaabbf07efbc6?ssl=1&w=450' );
 		} );
 
 		it( 'should generate the correct width-constrained URL', function() {

--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -19,7 +19,7 @@ var photon = require( 'photon' ),
  * We special case gravatar, because we control them.
  *
  * @param  {string} url The URL to secure
- * @return {string}     The secured URL
+ * @return {string}     The secured URL, or null if we couldn't make it safe
  */
 function safeImageURL( url ) {
 	if ( typeof url !== 'string' ) {
@@ -38,13 +38,6 @@ function safeImageURL( url ) {
 		return url.replace( /^http:/, 'https:' );
 	}
 
-	// Photon doesn't support query strings
-	if ( parsed.query ) {
-		delete parsed.search;
-		delete parsed.query;
-		url = uri.format( parsed );
-	}
-	// run it through photon, even if it had a querystring we couldn't strip
 	return photon( url );
 }
 

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -18,18 +18,18 @@ describe( 'safe-image-url', function() {
 	} );
 
 	it( 'should make a non-wpcom https url safe', function() {
-		expect( safeImage( 'https://example.com/foo' ) ).to.eql( 'https://i1.wp.com/example.com/foo' );
+		expect( safeImage( 'https://example.com/foo' ) ).to.eql( 'https://i1.wp.com/example.com/foo?ssl=1' );
 	} );
 
 	it( 'should make wp-com like subdomain url safe', function() {
 		expect( safeImage( 'https://wordpress.com.example.com/foo' ) ).to.eql(
-			'https://i0.wp.com/wordpress.com.example.com/foo'
+			'https://i0.wp.com/wordpress.com.example.com/foo?ssl=1'
 		);
 	} );
 
 	it( 'should make domain ending by wp-com url safe', function() {
 		expect( safeImage( 'https://examplewordpress.com/foo' ) ).to.eql(
-			'https://i0.wp.com/examplewordpress.com/foo'
+			'https://i0.wp.com/examplewordpress.com/foo?ssl=1'
 		);
 	} );
 
@@ -58,11 +58,11 @@ describe( 'safe-image-url', function() {
 		expect( safeImage( 'https://gravatar.com/' ) ).to.eql( 'https://gravatar.com/' );
 	} );
 
-	it( 'should strip querystring args from photoned urls', function() {
-		expect( safeImage( 'https://example.com/foo?bar' ) ).to.eql( 'https://i1.wp.com/example.com/foo' );
-		expect( safeImage( 'https://example.com/foo.jpg?bar' ) ).to.eql( 'https://i0.wp.com/example.com/foo.jpg' );
-		expect( safeImage( 'https://example.com/foo.jpeg?bar' ) ).to.eql( 'https://i0.wp.com/example.com/foo.jpeg' );
-		expect( safeImage( 'https://example.com/foo.gif?bar' ) ).to.eql( 'https://i2.wp.com/example.com/foo.gif' );
-		expect( safeImage( 'https://example.com/foo.png?bar' ) ).to.eql( 'https://i0.wp.com/example.com/foo.png' );
+	it( 'should return null for urls with querystrings', function() {
+		expect( safeImage( 'https://example.com/foo?bar' ) ).to.be.null;
+		expect( safeImage( 'https://example.com/foo.jpg?bar' ) ).to.be.null;
+		expect( safeImage( 'https://example.com/foo.jpeg?bar' ) ).to.be.null;
+		expect( safeImage( 'https://example.com/foo.gif?bar' ) ).to.be.null;
+		expect( safeImage( 'https://example.com/foo.png?bar' ) ).to.be.null;
 	} );
 } );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8983,19 +8983,13 @@
       "resolved": "git+https://github.com/Automattic/node-phone.git#0a3a87cc2b70906c7367ba3a9c9a27915f335443"
     },
     "photon": {
-      "version": "1.0.4",
-      "from": "photon@1.0.4",
-      "resolved": "https://registry.npmjs.org/photon/-/photon-1.0.4.tgz",
+      "version": "2.0.0",
       "dependencies": {
         "crc32": {
-          "version": "0.2.2",
-          "from": "crc32@0.2.2",
-          "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
+          "version": "0.2.2"
         },
         "seed-random": {
-          "version": "2.2.0",
-          "from": "seed-random@2.2.0",
-          "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz"
+          "version": "2.2.0"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "node-sass": "3.4.2",
     "page": "1.6.1",
     "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-8",
-    "photon": "1.0.4",
+    "photon": "2.0.0",
     "q": "1.0.1",
     "qrcode.react": "0.5.2",
     "qs": "4.0.0",


### PR DESCRIPTION
This fixes images coming from private WPCOM sites and images from places like github and medium which block photon. It also fixes https images that rely on querystring arguments that photon cannot understand.

See #790 for a repro case