### PR TITLE
Purchases: Fix site domain so that it aligns with the corresponding site name

### DIFF
--- a/client/me/purchases/list/site/style.scss
+++ b/client/me/purchases/list/site/style.scss
@@ -7,7 +7,7 @@
 		}
 
 		&.card {
-			align-items: baseline;
+			align-items: stretch;
 		}
 	}
 }


### PR DESCRIPTION
Fixes issue [#2690](https://github.com/Automattic/wp-calypso/issues/2690).

PR [#2359](https://github.com/Automattic/wp-calypso/pull/2359) added site domains to the Section Headers in Purchases.

In Firefox, the site domain did not appear to align with the site name.

The misalignment was less noticeable in Chrome and Safari.

**To test:**

1. Navigate to [https://wordpress.com/me](https://wordpress.com/me)
2. Click on "Manage Purchases"
3. Check if the site name on the left aligns properly with the site domain on the right


**Before: (in Firefox)**
![screen shot 2016-01-29 at 2 28 29 pm](https://cloud.githubusercontent.com/assets/4932671/12686326/152747b4-c697-11e5-87bd-34b55733842e.png)



**After: (in Firefox)**
![screen shot 2016-01-29 at 2 27 47 pm](https://cloud.githubusercontent.com/assets/4932671/12686330/1a46ccb0-c697-11e5-91fb-6f831d2d0f0d.png)

cc @breezyskies 