### PR TITLE
Signup: Add Headstart v2 flow for testing

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -48,8 +48,7 @@ module.exports = {
 			blog_name: siteUrl,
 			blog_title: siteUrl,
 			options: {
-				theme: dependencies.theme,
-				images: dependencies.images
+				theme: dependencies.theme
 			},
 			validate: false,
 			find_available_url: isPurchasingItem

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -106,6 +106,13 @@ const flows = {
 		lastModified: '2015-10-30'
 	},
 
+	headstart: {
+		steps: [ 'themes-headstart', 'domains-with-theme', 'plans', 'user' ],
+		destination: getCheckoutDestination,
+		description: 'Regular flow but with Headstart enabled to pre-populate site content',
+		lastModified: '2015-02-01'
+	},
+
 	desktop: {
 		steps: [ 'themes', 'site', 'user' ],
 		destination: '/me/next?welcome',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -20,5 +20,7 @@ module.exports = {
 	survey: SurveyStepComponent,
 	'survey-user': UserSignupComponent,
 	'design-type': DesignTypeComponent,
+	'themes-headstart': ThemeSelectionComponent,
+	'domains-with-theme': DomainsStepComponent,
 	'jetpack-user': UserSignupComponent
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -16,6 +16,16 @@ module.exports = {
 		dependencies: [ 'siteSlug' ]
 	},
 
+	'themes-headstart': {
+		stepName: 'themes-headstart',
+		props: {
+			useHeadstart: true,
+		},
+		apiRequestFunction: stepActions.setThemeOnSite,
+		dependencies: [ 'siteSlug' ],
+		providesDependencies: [ 'theme' ]
+	},
+
 	'design-type': {
 		stepName: 'design-type',
 		providesDependencies: [ 'themes' ]
@@ -65,6 +75,14 @@ module.exports = {
 		stepName: 'domains',
 		apiRequestFunction: stepActions.addDomainItemsToCart,
 		providesDependencies: [ 'siteSlug', 'domainItem' ],
+		delayApiRequestUntilComplete: true
+	},
+
+	'domains-with-theme': {
+		stepName: 'domains-with-theme',
+		apiRequestFunction: stepActions.addDomainItemsToCart,
+		providesDependencies: [ 'siteSlug', 'domainItem' ],
+		dependencies: [ 'theme' ],
 		delayApiRequestUntilComplete: true
 	},
 

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -47,9 +47,12 @@ module.exports = React.createClass( {
 		if ( true === this.props.useHeadstart && themeSlug ) {
 			analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: true } );
 
-			SignupActions.submitSignupStep( { stepName: this.props.stepName }, null, {
-				theme: 'pub/' + themeSlug,
-				images: undefined
+			SignupActions.submitSignupStep( {
+				stepName: this.props.stepName,
+				processingMessage: this.translate( 'Adding your theme' ),
+				themeSlug
+			}, null, {
+				theme: 'pub/' + themeSlug
 			} );
 		} else {
 			analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: false } );


### PR DESCRIPTION
Does not actually enable an A/B test yet. That will be a separate PR.

Headstart is a tool to automatically populate a new site with default content and settings to better match the demo site for its theme. This PR adds a new flow to signup, `/start/headstart`, which matches the default signup flow but creates the new site with Headstart enabled.

Previous Headstart tests have been run, but this one triggers v2 of the Headstart code which has many improvements.

## Testing

1. Visit http://calypso.localhost:3000/start/headstart and complete the signup flow.
2. Verify that the signup flow completes normally.
3. Verify that the new site has a lot of pre-populated content.

For example, here is the Boardwalk theme without Headstart:

<img width="959" alt="screen shot 2016-01-29 at 7 28 00 pm" src="https://cloud.githubusercontent.com/assets/2036909/12691907/7d0cb1c6-c6be-11e5-8d03-5188f590ef89.png">

...and with Headstart:

<img width="967" alt="screen shot 2016-01-29 at 7 28 13 pm" src="https://cloud.githubusercontent.com/assets/2036909/12691910/84068b00-c6be-11e5-85b5-390d6b104af5.png">
