### PR TITLE
Help: Fix formatting of olark chat notifications.

### DIFF
--- a/assets/stylesheets/shared/_livechat.scss
+++ b/assets/stylesheets/shared/_livechat.scss
@@ -832,11 +832,15 @@
 	color:$gray-dark!important;
 }
 
+#habla_conversation_div .habla_conversation_notification_nickname {
+	display: none;
+}
+
 #habla_conversation_div .habla_conversation_notification {
-	float: left;
 	color: $gray;
 	font-style: italic;
 	margin: 1em 0;
+	display: block;
 }
 
 @-webkit-keyframes pulse {


### PR DESCRIPTION
This pull request fixes the issue outlined in #1817. It prevents wrapping of subsequent messages after a notification is received.

How to test:

1. Start chatting from http://calypso.localhost:3000/help/contact/
2. Have the operator end the chat (but remain available).
3. Observe that the embedded chat form sends a "your chat has ended" message, but since opers are available, you can type another message to resume the chat.
4. Type a message.
5. Notice how the message no longer sticks to the right of the notification.


#### Before:
![screen shot 2016-01-29 at 7 49 54 pm](https://cloud.githubusercontent.com/assets/1854440/12692613/7f70680a-c6c7-11e5-9fb5-c4f3c99777b0.png)

![screen shot 2016-01-29 at 8 00 18 pm](https://cloud.githubusercontent.com/assets/1854440/12692611/742c4a72-c6c7-11e5-9c3a-5ad8159ae35a.png)

#### After:
![screen shot 2016-01-29 at 7 53 23 pm](https://cloud.githubusercontent.com/assets/1854440/12692665/6652fd6e-c6c8-11e5-9f77-997e28e119fe.png)

![screen shot 2016-01-29 at 7 58 40 pm](https://cloud.githubusercontent.com/assets/1854440/12692667/6b5a3a02-c6c8-11e5-9c1e-35e9bd3b54a7.png)



Fixes #1817 