### PR TITLE
Olark: Restyle live chat

### DIFF
--- a/assets/stylesheets/shared/_livechat.scss
+++ b/assets/stylesheets/shared/_livechat.scss
@@ -386,7 +386,7 @@
 }
 
 #habla_window_div #habla_conversation_div {
-	padding:6px 10px 0;
+	padding:6px 10px 10px;
 	margin:-6px -10px 0;
 }
 
@@ -489,8 +489,7 @@
 	background:0 0;
 	color:#000;
 	padding:0;
-	margin:0 0 0 20px;
-	text-indent:-20px;
+	margin: 8px 0 0 0;
 	overflow:visible;
 }
 
@@ -841,6 +840,51 @@
 	font-style: italic;
 	margin: 1em 0;
 	display: block;
+}
+
+#habla_conversation_div .habla_conversation_text_span {
+	display: block;
+	margin-left: 48px;
+}
+
+#habla_conversation_div .hbl_pal_local_fg,
+#habla_conversation_div .hbl_pal_remote_fg {
+	font: 14px/20px $sans;
+	font-weight: bold;
+	color: $gray-dark;
+	text-transform: capitalize;
+	display: inline-block;
+	white-space: nowrap;
+}
+
+#habla_conversation_div .habla_conversation_p_item:not(:first-child) .hbl_pal_local_fg,
+#habla_conversation_div .habla_conversation_p_item:not(:first-child) .hbl_pal_remote_fg {
+	margin-top: 16px;
+}
+
+#habla_conversation_div .olrk_avatar {
+	display: none;
+}
+
+#habla_conversation_div .gravatar {
+	width: 32px;
+	height: 32px;
+	line-height: 32px;
+	border-radius: 50%;
+	margin-bottom: -20px;
+	margin-right: 16px;
+}
+
+#habla_conversation_div .staff-label {
+	border-radius: 2px;
+	background-color: $blue-medium;
+	color: $white;
+	font: 11px/14px $sans;
+	font-weight: bold;
+	text-transform: uppercase;
+	display: inline-block;
+	margin-left: 3px;
+	padding: 1px 4px;
 }
 
 @-webkit-keyframes pulse {

--- a/client/me/help/help-contact/style.scss
+++ b/client/me/help/help-contact/style.scss
@@ -53,5 +53,10 @@
 		#habla_middle_div {
 			padding-bottom: 0px;
 		}
+
+		#habla_conversation_div .habla_conversation_p_item {
+			margin-left: 14px;
+			margin-right: 10px;
+		}
 	}
 }


### PR DESCRIPTION
This pull request finishes up the work started in #2687 by adding user gravatars and extra formatting to livechat.

How to test
1. Navigate to http://calypso.localhost:3000/help/contact
2. Start chatting
3. Notice that your gravatar is now displayed.
4. Have the operator respond.
5. Notice that their avatar is now displayed.
6. Have the operator transfer the chat to another operator.
7. Have the next operator respond.
8. Notice how the second operator has their avatar displayed.

#### Before:
![screen shot 2016-01-30 at 1 29 46 am](https://cloud.githubusercontent.com/assets/1854440/12694149/16076416-c6f1-11e5-8b3a-42dee3eec822.png)

#### After:
![screen shot 2016-01-30 at 1 28 49 am](https://cloud.githubusercontent.com/assets/1854440/12694147/10fefe52-c6f1-11e5-9d48-9c457bc2e346.png)

#### Original design:
![chat-full1](https://cloud.githubusercontent.com/assets/1854440/12501942/48c6f56c-c091-11e5-9efd-58212a1c7d7a.png)

#### Notes:
I omitted the timestamp that appears on the original design because olark doesn't provide one that can be displayed. The design also depicted an emoji which I think if its necessary should be added in a separate pull request.

*For whoever reviews this note that I wrote `updateOlarkFormatting` in such a way that it could be reused without modification on wp-admin (no es6 sugar)*