### PR TITLE
Disable rubberband scroll for OSX

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -346,6 +346,10 @@ function reduxStoreReady( reduxStore ) {
 		require( 'lib/desktop' ).init();
 	}
 
+	if ( config.isEnabled( 'rubberband-scroll-disable' ) ) {
+		require( 'lib/rubberband-scroll-disable' )( document.body );
+	}
+
 	detectHistoryNavigation.start();
 	page.start();
 }

--- a/client/lib/rubberband-scroll-disable/README.md
+++ b/client/lib/rubberband-scroll-disable/README.md
@@ -1,0 +1,19 @@
+# Rubberband scroll disable
+
+This disable "rubberband" bounce effect on OSX machines.
+
+### Problem
+On OSX, Chrome and other browsers have a specific effect of "bounce" when coming to the edge of the screen.
+
+![](https://cldup.com/LQ7VNvnEkJ-3000x3000.png)
+
+### Solution
+This small utility library disables that effect, hooking into scroll event.
+
+## Example
+```js
+
+import rubberBandScrollDisable from 'lib/rubberband-scroll-disable';
+rubberBandScrollDisable( document.body );
+
+```

--- a/client/lib/rubberband-scroll-disable/index.js
+++ b/client/lib/rubberband-scroll-disable/index.js
@@ -1,0 +1,20 @@
+
+function preventScrollBounceOSX( body, event ) {
+	if (
+		( event.deltaY < 0 && body.scrollTop === 0 ) ||
+		( event.deltaY > 0 && body.scrollTop === body.scrollHeight - this.innerHeight )
+	) {
+		event.preventDefault()
+	}
+}
+
+export default function( body ) {
+	if (
+		window &&
+		window.navigator &&
+		window.navigator.userAgent &&
+		window.navigator.userAgent.indexOf( 'Macintosh' ) !== -1
+	) {
+		body.addEventListener( 'mousewheel', preventScrollBounceOSX.bind( window, body ) );
+	}
+}

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -76,6 +76,7 @@
 		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,
+		"rubberband-scroll-disable": true,
 		"settings/security/monitor": true,
 		"upgrades/checkout": false,
 		"upgrades/credit-cards": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -67,6 +67,7 @@
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/pages": true,
+		"rubberband-scroll-disable": true,
 		"reader": true,
 		"reader/activities": true,
 		"reader/discover": true,

--- a/config/development.json
+++ b/config/development.json
@@ -139,6 +139,7 @@
 		"phone_signup": true,
 		"login": true,
 
+		"rubberband-scroll-disable": false,
 		"network-connection": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -59,6 +59,7 @@
 		"reader/following-edit": true,
 		"reader/discover": true,
 		"reader/recommendations": true,
+		"rubberband-scroll-disable": false,
 
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/production.json
+++ b/config/production.json
@@ -80,6 +80,7 @@
 		"reader/following-edit": true,
 		"reader/discover": true,
 		"reader/recommendations": true,
+		"rubberband-scroll-disable": false,
 		"ad-tracking": true,
 		"desktop-promo": true,
 		"perfmon": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -84,6 +84,7 @@
 		"reader/following-edit": true,
 		"reader/discover": true,
 		"reader/recommendations": true,
+		"rubberband-scroll-disable": false,
 		"ad-tracking": false,
 		"desktop-promo": true,
 		"perfmon": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -60,6 +60,7 @@
 		"reader/following-edit": true,
 		"reader/recommendations": true,
 		"reader/discover": true,
+		"rubberband-scroll-disable": false,
 
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,


### PR DESCRIPTION
This is a new PR for this - now in wp-calypso, behind a flag.

# What are you talking about?

OSX has natively this effect of 'bounce' when you are scrolling to the edge of current window.
I HATE THIS in the app.

![](https://cldup.com/LQ7VNvnEkJ-3000x3000.png)

# Y u no CSS?
It is possible to achieve the same effect in CSS:
```css
html.is-desktop {
overflow:hidden;
}
html.is-desktop body {
overflow: auto;
}
```

But this hides the scrollbar under masterbar and also messes with scrollbar visibility (the scrollbar disappers, but scrolling is still working)

# Better solution
We discussed it with @rralian and decided that even better solution would be to play this video when while scrolling, we
**[push it to the limit / past the point of no return](https://youtu.be/kZu5iDTtNg0?t=24s)**
Unfortunately, this clip is not GPL :/

# Testing
Just scroll with swipe to the edge

CC @adambbecker @johngodley @dmsnell @gziolo @jasmussen  