### PR TITLE
Make sure redux store is passed down the reader

### DIFF
--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -454,6 +454,16 @@ FullPostContainer = React.createClass( {
 		// as hidden, then set it to visible to trigger the animation.
 		process.nextTick( function() {
 			this.setState( { isVisible: true } ); //eslint-disable-line react/no-did-mount-set-state
+
+			if ( typeof this.props.removeAnimationHandlerSetter === 'function') {
+				this.props.removeAnimationHandlerSetter( function startRemoveAnimation() {
+					if ( ! this.isMounted() ) {
+						return;
+					}
+
+					this.setState( { isVisible: false } );
+				}.bind( this ) );
+			}
 		}.bind( this ) );
 	},
 


### PR DESCRIPTION
In order for react-redux ``connect()`` being able to connect the store to the
desired component it needs to have the redux store on the props/context,
that is being done via the ``<Provider />`` on the root rendered component,
however, doing somewhere in the middle ``ReacDom.render`` breaks the context
passing down the line, I've tried to fix it here specifically for the reader.

Because the the component being rendered is actually the ``<Provder />``, I had to replace direct calling of ``__fullPostInstance.setState()`` to a bit of a callback trickery.

I'm all in for suggestions regarding changing that =)