### PR TITLE
jadejs dependency: use pugjs/jade repo rather than jadejs/jade

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "immutable": "3.7.5",
     "imports-loader": "0.6.5",
     "inherits": "2.0.1",
-    "jade": "jadejs/jade#29784fd",
+    "jade": "pugjs/jade#29784fd",
     "jed": "1.0.2",
     "json-loader": "0.5.4",
     "jstimezonedetect": "1.0.5",


### PR DESCRIPTION
As pointed out in #2931, jadejs is failing to install. We're pinning a specific commit:

`"jade": "jadejs/jade#29784fd",`

The jadejs repo now [only contains a `gh-pages` branch.](https://github.com/jadejs/jade/branches/all) This may be related to the rename of the project from jade to pug: 

https://github.com/pugjs/jade/issues/2184

This PR switches to use the `pugjs/jade` repo instead, which does contain our pinned commit.

cc @ockham 