### PR TITLE
Add styles for sup and sub elements in Reader content

### DIFF
--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -17,6 +17,22 @@
 	}
 }
 
+.reader__content,
+.reader__full-post-content {
+	sup, sub {
+		position: relative;
+		font-size: 0.83em;
+	}
+
+	sup {
+		top: -0.5em;
+	}
+
+	sub {
+		bottom: -0.5em;
+	}
+}
+
 .reader__site-name {
 	clear: none;
 	color: darken( $gray, 20 );


### PR DESCRIPTION
In #2935 I noticed that we do not apply any styling on `<sup>` and `<sub>` elements in Reader content.

This PR adds styles for <sup>superscript</sup> and <sub>subscript</sub> text, without interfering with line height.

You can see this demonstrated on my test blog at:

http://calypso.localhost:3000/read/blog/id/104902009

(post: http://calypso.localhost:3000/read/post/id/104902009/4)

Tested in IE11, Chrome and Safari OSX.

<img width="760" alt="screen shot 2016-02-01 at 15 37 35" src="https://cloud.githubusercontent.com/assets/17325/12707899/83de77e0-c8fe-11e5-9d7e-b3e89f6eb644.png">

cc @shaunandrews 

Fixes #2935.