### PR TITLE
Revert "Site Selector: enter key select"

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -63,20 +63,6 @@ export default React.createClass( {
 		this.setState( { search: terms } );
 	},
 
-	onKeyDown( event ) {
-		var filteredSites;
-
-		if ( event.keyCode === 13 ) {
-			// enter key
-			filteredSites = this.getFilteredSites();
-
-			if ( filteredSites.length === 1 && this.props.siteBasePath ) {
-				this.onSiteSelect( filteredSites[ 0 ].slug, event );
-				page( this.getSiteBasePath( filteredSites[ 0 ] ) + '/' + filteredSites[ 0 ].slug );
-			}
-		}
-	},
-
 	onSiteSelect( siteSlug, event ) {
 		this.closeSelector();
 		this.props.onSiteSelect( siteSlug );
@@ -90,7 +76,6 @@ export default React.createClass( {
 	},
 
 	closeSelector() {
-		this.refs.siteSearch.clear();
 		this.refs.siteSearch.blur();
 	},
 
@@ -127,22 +112,6 @@ export default React.createClass( {
 		return siteBasePath;
 	},
 
-	getFilteredSites() {
-		var sites;
-
-		if ( this.state.search ) {
-			sites = this.props.sites.search( this.state.search );
-		} else {
-			sites = this.shouldShowGroups() ? this.props.sites.getVisibleAndNotRecent() : this.props.sites.getVisible();
-		}
-
-		if ( this.props.filter ) {
-			sites = sites.filter( this.props.filter );
-		}
-
-		return sites;
-	},
-
 	isSelected( site ) {
 		var selectedSite = this.props.selected || this.props.sites.selected;
 		return selectedSite === site.domain || selectedSite === site.slug;
@@ -157,11 +126,20 @@ export default React.createClass( {
 	},
 
 	renderSites() {
-		var sites = this.getFilteredSites(),
-			siteElements;
+		var sites, siteElements;
 
 		if ( ! this.props.sites.initialized ) {
 			return <SitePlaceholder key="site-placeholder" />;
+		}
+
+		if ( this.state.search ) {
+			sites = this.props.sites.search( this.state.search );
+		} else {
+			sites = this.shouldShowGroups() ? this.props.sites.getVisibleAndNotRecent() : this.props.sites.getVisible();
+		}
+
+		if ( this.props.filter ) {
+			sites = sites.filter( this.props.filter );
 		}
 
 		// Render sites
@@ -278,7 +256,6 @@ export default React.createClass( {
 				<Search
 					ref="siteSearch"
 					onSearch={ this.onSearch }
-					onKeyDown={ this.onKeyDown }
 					autoFocus={ this.props.autoFocus }
 					disabled={ ! this.props.sites.initialized }
 				/>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#2646

Broke site selection in picker after you search for a site.