### PR TITLE
SSR: Only render into DOM if component tree is not already there

### DIFF
--- a/client/components/ssrtest/index.jsx
+++ b/client/components/ssrtest/index.jsx
@@ -1,0 +1,22 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import Card from 'components/card';
+
+const SSRTest = () => (
+	<Main>
+		<Card>
+			<span>Rendered on the Server</span>
+		</Card>
+	</Main>
+)
+
+export default SSRTest;

--- a/client/components/ssrtest/index.jsx
+++ b/client/components/ssrtest/index.jsx
@@ -10,13 +10,27 @@ import React from 'react';
  */
 import Main from 'components/main';
 import Card from 'components/card';
+import Button from 'components/button';
 
-const SSRTest = () => (
-	<Main>
-		<Card>
-			<span>Rendered on the Server</span>
-		</Card>
-	</Main>
-)
+export default React.createClass( {
 
-export default SSRTest;
+	getInitialState() {
+		return { clicks: 0 };
+	},
+
+	click() {
+		this.setState( { clicks: this.state.clicks + 1 } );
+	},
+
+	render() {
+		return(
+			<Main>
+				<Card id="Themes" >
+					<span>Clicks: { this.state.clicks }</span>
+				</Card>
+				<Button onClick={ this.click }>Click</Button>
+			</Main>
+		)
+	},
+} );
+

--- a/client/layout/logged-out-design.jsx
+++ b/client/layout/logged-out-design.jsx
@@ -10,13 +10,16 @@ import React from 'react';
  */
 import MasterbarMinimal from 'layout/masterbar/minimal';
 import ThemesHead from 'my-sites/themes/head';
+import SSRTest from 'components/SSRTest';
 
 const LayoutLoggedOutDesign = ( { tier = 'all' } ) => (
 	<div className="wp is-section-design has-no-sidebar">
 		<ThemesHead tier={ tier } />
 		<MasterbarMinimal url="/" />
 		<div id="content" className="wp-content">
-			<div id="primary" className="wp-primary wp-section" />
+			<div id="primary" className="wp-primary wp-section" >
+				<SSRTest />
+			</div>
 			<div id="secondary" className="wp-secondary" />
 		</div>
 		<div id="tertiary" className="wp-overlay fade-background" />

--- a/client/layout/masterbar/minimal.jsx
+++ b/client/layout/masterbar/minimal.jsx
@@ -16,6 +16,8 @@ const MasterbarMinimal = ( { url } ) => (
 		<Item url={ url } icon="my-sites" className="masterbar__item-logo">
 			WordPress<span className="tld">.com</span>
 		</Item>
+		<Item url="/design">Themes</Item>
+		<Item url="/start">Signup</Item>
 	</Masterbar>
 );
 

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -15,7 +15,8 @@ var ThemesComponent = require( 'my-sites/themes/main' ),
 	i18n = require( 'lib/mixins/i18n' ),
 	trackScrollPage = require( 'lib/track-scroll-page' ),
 	getCurrentUser = require( 'state/current-user/selectors' ).getCurrentUser,
-	buildTitle = require( 'lib/screen-title/utils' );
+	buildTitle = require( 'lib/screen-title/utils' ),
+	SSRTest = require( 'components/SSRTest' );
 
 var controller = {
 
@@ -42,25 +43,8 @@ var controller = {
 		}
 
 		analytics.pageView.record( basePath, analyticsPageTitle );
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: context.store },
-				React.createElement( Head, { title, tier: tier || 'all' },
-					React.createElement( ThemesComponent, {
-						key: site_id,
-						siteId: site_id,
-						tier: tier,
-						search: context.query.s,
-						trackScrollPage: trackScrollPage.bind(
-							null,
-							basePath,
-							analyticsPageTitle,
-							'Themes'
-						)
-					} )
-				)
-			),
-			document.getElementById( 'primary' )
-		);
+
+		ReactDom.render( React.createElement( SSRTest ), document.getElementById( 'primary' ) );
 	}
 };
 

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -44,7 +44,9 @@ var controller = {
 
 		analytics.pageView.record( basePath, analyticsPageTitle );
 
-		ReactDom.render( React.createElement( SSRTest ), document.getElementById( 'primary' ) );
+		if ( ! document.getElementById( 'Themes' ) ) {
+			ReactDom.render( React.createElement( SSRTest ), document.getElementById( 'primary' ) );
+		}
 	}
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,7 @@ jsLoader = {
 };
 
 if ( CALYPSO_ENV === 'development' ) {
-	webpackConfig.plugins.push( new PragmaCheckPlugin() );
+//	webpackConfig.plugins.push( new PragmaCheckPlugin() );
 	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
 	webpackConfig.entry[ 'build-' + CALYPSO_ENV ] = [
 		'webpack-dev-server/client?/',


### PR DESCRIPTION
Experimental. Inside controller.js, only render into the DOM if the component tree is not already there. This eliminates problems with browser lockups when replacing server-rendered component trees inside the existing content divs.

As long as the initial client layout done in client/boot matches the server-layout, the necessary event-handlers will be hooked-up.

This PR uses a simple test component with a button that is rendered on the server at http://calypso.localhost:3000/design (logged-out). It adds a couple of links to the logged-out master bar to switch between logged-out routes.


