### PR TITLE
Adding support for Discover's fullbleed class.

### DIFF
--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -4,17 +4,30 @@
 var assign = require( 'lodash/object/assign' ),
 	omit = require( 'lodash/object/omit' ),
 	url = require( 'url' );
+
+const IMAGE_SCALE_FACTOR = ( typeof window !== 'undefined' && window.devicePixelRatio && window.devicePixelRatio > 1 ) ? 2 : 1;
+
 /**
  * Changes the sizing parameters on a URL. Works for wpcom and photon.
  * @param {string} imageUrl The URL to add sizing params to
  * @param {object} params The parameters to add
+ * @returns {string} The resized URL
  */
 function resizeImageUrl( imageUrl, params ) {
 	var parsedUrl = url.parse( imageUrl, true, true );
 
 	parsedUrl.query = omit( parsedUrl.query, [ 'w', 'h', 'resize', 'fit' ] );
 
-	parsedUrl.query = assign( parsedUrl.query, params );
+	const localParams = assign( {}, params );
+	if ( localParams.w ) {
+		localParams.w *= IMAGE_SCALE_FACTOR;
+	}
+
+	if ( localParams.h ) {
+		localParams.h *= IMAGE_SCALE_FACTOR;
+	}
+
+	parsedUrl.query = assign( parsedUrl.query, localParams );
 
 	delete parsedUrl.search;
 

--- a/client/lib/resize-image-url/test/test.js
+++ b/client/lib/resize-image-url/test/test.js
@@ -1,12 +1,11 @@
 // External Dependencies
-var assert = require('chai').assert;
+var assert = require( 'chai' ).assert;
 
 var resizeImageUrl = require( '..' ),
 	safeImageUrl = 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?w=1000&h=1000';
 
 // helper functions
 describe( 'resizeImageUrl', function() {
-	
 	it( 'should strip the w and h query params', function() {
 		var resizedImageUrl = resizeImageUrl( safeImageUrl );
 		assert.equal( resizedImageUrl, 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg' );

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -359,4 +359,13 @@
 			}
 		}
 	}
+
+	.fullbleed {
+		@media ( min-width: 1132px ) {
+			position: relative;
+			left: -( 175px + 32px );
+			width: ( 668px + 414px );
+			max-width: ( 668px + 414px );
+		}
+	}
 }


### PR DESCRIPTION
When Discover editors apply a `fullbleed` class to images on discover.wordpress.com, we extend the images outside the boundaries of the text column. We’d like to bring this behavior to the Reader as well. 

Extends the width by 175px in each direction, aligning with the Discover sidenotes from PR #2729. Larger viewports only: no change to screens under 1132px.

Examples:
Article: https://discover.wordpress.com/2015/12/28/rob-turpin-interview/
Reader: http://calypso.localhost:3000/read/post/id/53424024/1661
<img width="1353" alt="example1" src="https://cloud.githubusercontent.com/assets/1202812/12725910/f6b9196c-c8e2-11e5-8d72-44b79cf612d4.png">

 
Article: https://discover.wordpress.com/2016/01/21/fennabee/
Reader: http://calypso.localhost:3000/read/post/id/53424024/9037
<img width="1354" alt="example2" src="https://cloud.githubusercontent.com/assets/1202812/12725913/fa7a5e76-c8e2-11e5-9871-6d9d8b006734.png">
