### PR TITLE
Plans: Install & activate a set of plugins automatically

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -244,6 +244,12 @@ PluginsActions = {
 					.then( responseData => dispatchMessage( 'RECEIVE_INSTALLED_PLUGIN', responseData ) )
 					.catch( manageError );
 			}
+			if ( error.name === 'ActivationErrorError' ) {
+				return autoupdate( plugin )
+					.then( responseData => dispatchMessage( 'RECEIVE_INSTALLED_PLUGIN', responseData ) )
+					.catch( manageError );
+			}
+
 			dispatchMessage( 'RECEIVE_INSTALLED_PLUGIN', null, error );
 		}
 

--- a/client/my-sites/plugins/plan-setup/index.jsx
+++ b/client/my-sites/plugins/plan-setup/index.jsx
@@ -1,20 +1,22 @@
 /**
 * External dependencies
 */
-import React from 'react'
+import React from 'react';
 
 /**
 * Internal dependencies
 */
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import PluginInstallation from './installation';
 
 module.exports = React.createClass( {
 
 	displayName: 'PlanSetup',
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			keys: {},
+			plugin: '',
 			status: 'not-started', // installing $plugin, configuring $plugin, finished, error
 		};
 	},
@@ -25,7 +27,7 @@ module.exports = React.createClass( {
 				site={ this.props.selectedSite }
 				template={ 'optInManage' }
 				title={ this.translate( 'Oh no! We can\'t automatically install your new plugins.' ) }
-			section={ 'plugins' }
+				section={ 'plugins' }
 				illustration={ '/calypso/images/jetpack/jetpack-manage.svg' } />
 		);
 	},
@@ -39,6 +41,25 @@ module.exports = React.createClass( {
 		);
 	},
 
+	componentDidMount() {
+		this.runInstall();
+	},
+
+	runInstall() {
+		let steps = PluginInstallation.start( {
+			site: this.props.selectedSite,
+			plugins: [ 'akismet', 'vaultpress' ]
+		} );
+
+		steps.on( 'data', ( step ) => {
+			if ( 'undefined' === typeof step.name ) {
+				this.setState( { status: 'finished', plugin: '' } );
+			} else {
+				this.setState( { status: step.name, plugin: step.plugin } );
+			}
+		} );
+	},
+
 	render() {
 		if ( ! this.props.selectedSite || ! this.props.selectedSite.jetpack ) {
 			return this.renderNoJetpackSiteSelected();
@@ -50,7 +71,7 @@ module.exports = React.createClass( {
 			<div>
 				<h1>Setting up your plan…</h1>
 				<p>Most of this will happen automatically, in steps, so we can notify the user what&apos;s happening</p>
-				<p>Currently… { this.state.status }</p>
+				<p>Currently… { this.state.status } { this.state.plugin }</p>
 			</div>
 		)
 	}

--- a/client/my-sites/plugins/plan-setup/installation.js
+++ b/client/my-sites/plugins/plan-setup/installation.js
@@ -89,8 +89,10 @@ InstallationFlow.prototype.install = function( slug, next ) {
 	// Install the plugin. `installer` is a promise, so we can wait for the install
 	// to finish before trying to configure the plugin.
 	let installer = PluginsActions.installPlugin( site, plugin );
-	installer.then( () => {
-		// @todo Handle failed installs
+	installer.then( ( response ) => {
+		if ( 'undefined' !== typeof response.error ) {
+			// @todo Handle failed installs
+		}
 		// @todo Registration keys will be set here.
 		next();
 	} );

--- a/client/my-sites/plugins/plan-setup/installation.js
+++ b/client/my-sites/plugins/plan-setup/installation.js
@@ -80,7 +80,7 @@ InstallationFlow.prototype.install = function( slug, next ) {
 
 	// Install the plugin. `installer` is a promise, so we can wait for the install
 	// to finish before trying to configure the plugin.
-	let installer = PluginsActions.installPlugin( site, { slug: slug } );
+	let installer = PluginsActions.installPlugin( site, { slug: slug, id: slug + '/' + slug } );
 	installer.then( () => {
 		// @todo Handle failed installs - most likely the plugin already exists,
 		// and needs to be activated.

--- a/client/my-sites/plugins/plan-setup/installation.js
+++ b/client/my-sites/plugins/plan-setup/installation.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+var Readable = require( 'stream' ).Readable,
+	inherits = require( 'inherits' );
+
+/**
+ * Internal dependencies
+ */
+var PluginsActions = require( 'lib/plugins/actions' );
+
+/**
+ * Start provisioning premium plugins for a given site
+ *
+ * @returns {Readable} A stream of installation steps.
+ *
+ * @param {object} params - List of initial data passed to Installation process
+ * @param {JetpackSite} params.site - The site where plugins should be installed
+ * @param {array} params.plugins - List of the plugins to install
+ */
+function start( params ) {
+	return new InstallationFlow( params );
+}
+
+function InstallationFlow( initialData ) {
+	Readable.call( this, { objectMode: true } );
+	this._initialData = initialData;
+	this._hasStarted = false;
+}
+inherits( InstallationFlow, Readable );
+
+/**
+ * Pushes new data onto the stream. Whenever someone wants to read from the
+ * stream of steps, this method will get called because we inherited the
+ * functionality of `Readable`.
+ *
+ * Our goal is to capture the flow of the asynchronous callback functions as a
+ * linear sequence of steps. When we get the first request for data, we begin
+ * the chain of asynchronous functions. On future requests for data, there is
+ * no need to start another asynchronous process, so we just return immediately
+ * while the first one finises.
+ *
+ * @see TransactionFlow
+ */
+InstallationFlow.prototype._read = function() {
+	if ( this._hasStarted ) {
+		return false;
+	}
+	this._hasStarted = true;
+
+	this.installAll( this._initialData.plugins );
+};
+
+InstallationFlow.prototype._pushStep = function( options ) {
+	var defaults = {
+		timestamp: Date.now()
+	};
+
+	this.push( Object.assign( defaults, options ) );
+};
+
+// Install each plugin sequentially via a recursive callback
+InstallationFlow.prototype.installAll = function( slugs ) {
+	let slug;
+	let installNext = () => {
+		if ( slugs.length > 0 ) {
+			slug = slugs.shift();
+			this.install( slug, installNext );
+		} else {
+			this._pushStep( null );
+		}
+	};
+
+	installNext();
+}
+
+InstallationFlow.prototype.install = function( slug, next ) {
+	this._pushStep( { name: 'install-plugin', plugin: slug } );
+	let site = this._initialData.site;
+
+	// Install the plugin. `installer` is a promise, so we can wait for the install
+	// to finish before trying to configure the plugin.
+	let installer = PluginsActions.installPlugin( site, { slug: slug } );
+	installer.then( () => {
+		// @todo Handle failed installs - most likely the plugin already exists,
+		// and needs to be activated.
+		// @todo Registration keys will be set here.
+		next();
+	} );
+}
+
+module.exports = {
+	start: start,
+};


### PR DESCRIPTION
This PR transparently installs & activates a given set of plugins (currently hardcoded, will switch to be based on the purchased plan). You can test this by visiting `plugins/setup/$site`. It'll check if your site is a jetpack site, then try to install & activate akismet and vaultpress.

This is one step in the automatic setup for premium plugins. See #2244 for more context.