### PR TITLE
Invites: Update production config to launch accept invite

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -82,7 +82,7 @@
 		"desktop-promo": true,
 		"perfmon": false,
 		"mailing-lists/unsubscribe": true,
-		"accept-invite": false
+		"accept-invite": true
 	},
 	"rtl": false,
 	"jetpack_min_version": "3.3",


### PR DESCRIPTION
Huzzah! :tada: 

This PR will handle the Calypso side of launching the accept invite flow, but we'll also need to:
- get in touch with systems for enabling the routes in production
- update invitation links that get sent out to users