### PR TITLE
Posts: controls mobile alignment fix

### DIFF
--- a/assets/stylesheets/sections/_posts-controls.scss
+++ b/assets/stylesheets/sections/_posts-controls.scss
@@ -10,6 +10,10 @@
 	position: relative;
 	width: 100%;
 	height: (45 / 15) * 1em;
+
+	@include breakpoint( "<660px" ) {
+		height: (45 / 13) * 1em;
+	}
 }
 
 .post-controls__pane {


### PR DESCRIPTION
Places text back into the center of the cell on post cards. Fixes #2945

Before | After
------------ | -------------
![screen shot 2016-02-01 at 3 44 35 pm](https://cloud.githubusercontent.com/assets/1427136/12730735/47385156-c8fb-11e5-9f1a-1352d03e32d4.png) | ![screen shot 2016-02-01 at 3 44 14 pm](https://cloud.githubusercontent.com/assets/1427136/12730740/4ce99056-c8fb-11e5-86bd-d9ba62c0c27a.png)

/cc @danhauk, @mtias 

---

Sidenote: there seems to be a good bit of visual clean up needed for the post cards which I'll tackle in the not too distant future, but wanted to keep this PR super small for the time being.