### PR TITLE
Purchases: Update links to theme showcase

### DIFF
--- a/client/me/purchases/cancel-purchase/product-information.jsx
+++ b/client/me/purchases/cancel-purchase/product-information.jsx
@@ -10,7 +10,7 @@ import { domainManagementEdit } from 'my-sites/upgrades/paths';
 import { googleAppsSettingsUrl } from 'lib/google-apps';
 import Gridicon from 'components/gridicon';
 import { isBusiness, isGoogleApps, isPlan, isTheme } from 'lib/products-values';
-import { oldShowcaseUrl } from 'lib/themes/helpers';
+import { getDetailsUrl as getThemeDetailsUrl } from 'lib/themes/helpers';
 
 const CancelPurchaseProductInformation = React.createClass( {
 	propTypes: {
@@ -149,8 +149,8 @@ const CancelPurchaseProductInformation = React.createClass( {
 
 	renderThemeInformation() {
 		const { domain, meta, productName, siteName } = this.props.purchase,
-			themeDetailsUrl = `${ oldShowcaseUrl }${ domain }/${ meta }`,
-			themeSelectUrl = `${ oldShowcaseUrl }${ domain }`;
+			themeDetailsUrl = getThemeDetailsUrl( { id: meta }, { slug: domain } ),
+			themeSelectUrl = `/design/${ domain }`;
 
 		return (
 			<p>

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -20,7 +20,7 @@ import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import { oldShowcaseUrl } from 'lib/themes/helpers';
+import { getDetailsUrl as getThemeDetailsUrl } from 'lib/themes/helpers';
 import paths from '../paths';
 import PaymentLogo from 'components/payment-logo';
 import RemovePurchase from '../remove-purchase';
@@ -299,7 +299,7 @@ const ManagePurchase = React.createClass( {
 		}
 
 		if ( isTheme( purchase ) ) {
-			url = oldShowcaseUrl + purchase.domain + '/' + purchase.meta;
+			url = getThemeDetailsUrl( { id: purchase.meta }, { slug: purchase.domain } );
 			text = this.translate( 'Theme Details' );
 		}
 


### PR DESCRIPTION
* Point to the new showcase (`/design/${ domain }`) to select a theme for a site.
* Use the `getDetailsUrl()` helper from `lib/themes` for the theme details link.
  This way, the URL is guaranteed to remain correct once we re-wire that helper
  to point to the new showcase.

No visual changes.

To test:
* Purchase a premium theme for any of your sites.
* Navigate to calypso.localhost:3000/purchases/, and select the corresponding purchase.
* Verify that the 'Theme Details' link points to the same URL as on the master branch, i.e. `http://wordpress.com/themes/[site]/[theme]`

Note that I haven't yet found out how to test the changes in `client/me/purchases/cancel-purchase/product-information.jsx`, since apparently I can't cancel a premium theme I purchased using free credits.

CC @drew and @gziolo for review. 