### PR TITLE
Themes: Have Signup link point to Calypso NUX flow

### DIFF
--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -12,8 +12,7 @@ var React = require( 'react' ),
  */
 var PopoverMenu = require( 'components/popover/menu' ),
 	PopoverMenuItem = require( 'components/popover/menu-item' ),
-	isOutsideCalypso = require( 'lib/url' ).isOutsideCalypso,
-	getSignupUrl = require( 'lib/themes/helpers' ).getSignupUrl;
+	isOutsideCalypso = require( 'lib/url' ).isOutsideCalypso;
 
 /**
  * Component
@@ -85,12 +84,7 @@ var ThemeMoreButton = React.createClass( {
 									onMouseOver={ this.focus }
 									key={ option.label }
 									href={ url }
-									target={ ( isOutsideCalypso( url ) &&
-										// We don't want to open a new tab for the signup flow
-										// TODO: Remove this hack once we can just hand over
-										// to Calypso's signup flow with a theme selected.
-										url !== getSignupUrl( this.props.theme ) )
-										? '_blank' : null }>
+									target={ isOutsideCalypso( url ) ? '_blank' : null }>
 									{ option.label }
 								</a>
 							);

--- a/client/lib/store/README.md
+++ b/client/lib/store/README.md
@@ -17,6 +17,4 @@ Combine multiple Flux stores into a single one. See inline JSDoc for details.
 
 Combined together, these helpers allow us to build drop-in wrappers to help with the transition to a Redux-based architecture.
 
-For real-world examples of both, check `/client/lib/themes`.
-
 [redux]: http://redux.js.org/

--- a/client/lib/themes/helpers.js
+++ b/client/lib/themes/helpers.js
@@ -12,8 +12,13 @@ var ThemesHelpers = {
 	oldShowcaseUrl: '//wordpress.com/themes/',
 
 	getSignupUrl( theme ) {
-		// TODO: Point to Calypso NUX (/start), passing it the theme id.
-		return '//signup.wordpress.com/signup/?source=calypso_showcase&theme=' + theme.id;
+		let url = '/start/with-theme?ref=calypshowcase&theme=' + theme.id;
+
+		if ( this.isPremium( theme ) ) {
+			url += '&premium=true';
+		}
+
+		return url;
 	},
 
 	getPreviewUrl( theme, site ) {


### PR DESCRIPTION
Now that we can use Calypso's signup flow with a theme preselected (#2747), let's connect the (logged-out) showcase's 'Choose this design' option to it.

To test:
* In an incognito browser window, open http://calypso.localhost:3000/design
* Click on a free theme's '...' button, and select 'Choose this design'
* Verify that you're redirect to Calypso's signup flow's domain selection step (i.e. http://calypso.localhost:3000/start/with-theme/domains), and that the page is rendered correctly (i.e. no unexpected cuts).
* Follow thru signup to set up a test site, and verify that it is set up with the theme you previously selected.
* Do the same for a premium theme, and verify that the flow works as before, with the additional step of being redirected after the regular signup flow.

(This PR had the same issue as https://github.com/Automattic/wp-calypso/pull/2786#issuecomment-176839089, which required it to be merged only after #2991, which is now in.)