### PR TITLE
Posts: ensure a fetch on mounting for post-list-fetcher

### DIFF
--- a/client/components/post-list-fetcher/index.jsx
+++ b/client/components/post-list-fetcher/index.jsx
@@ -15,12 +15,7 @@ var postListStoreFactory = require( 'lib/posts/post-list-store-factory' ),
 var PostListFetcher;
 
 function dispatchQueryActions( postListStoreId, query ) {
-	var postListStore = postListStoreFactory( postListStoreId );
 	actions.queryPosts( query, postListStoreId );
-
-	if ( postListStore.getPage() === 0 ) {
-		actions.fetchNextPage( postListStoreId );
-	}
 }
 
 function queryPosts( props ) {
@@ -126,7 +121,7 @@ PostListFetcher = React.createClass( {
 
 	componentDidMount: function() {
 		var postListStore = postListStoreFactory( this.props.postListStoreId );
-		this._poller = pollers.add( postListStore, actions.fetchUpdated, { interval: 60000, leading: false } );
+		this._poller = pollers.add( postListStore, actions.fetchUpdated, { interval: 60000 } );
 	},
 
 	componentWillUnmount: function() {

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -480,6 +480,10 @@ PostActions = {
 
 		postListStore = postListStoreFactory( postListStoreId );
 
+		if ( postListStore.getPage() === 0 ) {
+			return PostActions.fetchNextPage( postListStoreId );
+		}
+
 		Dispatcher.handleViewAction( {
 			type: 'FETCH_UPDATED_POSTS',
 			postListStoreId: postListStoreId


### PR DESCRIPTION
This should address stale data that can otherwise be shown in the desktop app. I don't think this should have much of an impact on server load, like decreasing the polling interval would.

@blowery what do you think of this? I'm really not sure why we didn't want post-list-fetcher to trigger a fetch on mounting in the first place. Anything in the reader that you'd be concerned about?

### Testing
I was recreating a reported issue in the desktop app by doing the following in desktop and calypso master.

- open the desktop app, navigate to posts-list page
- in another browser change the title of the top post
- click to the reader, click back to the post-list page
- note that the post-list page can display outdated title for up to a full minute

Then by running the desktop app with this branch for calypso, if you do the same steps as above, you will still see the old title for a split-second, but then it should update to reflect the new title.