### PR TITLE
Domains: Contact Info: Privacy Protection State

### DIFF
--- a/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
@@ -15,7 +15,8 @@ import SectionHeader from 'components/section-header';
 const ContactsPrivacyCard = React.createClass( {
 	propTypes: {
 		contactInformation: React.PropTypes.object.isRequired,
-		privacyProtectionEnabled: React.PropTypes.bool.isRequired,
+		privateDomain: React.PropTypes.bool.isRequired,
+		hasPrivacyProtection: React.PropTypes.bool.isRequired,
 		selectedDomainName: React.PropTypes.string.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
@@ -51,7 +52,7 @@ const ContactsPrivacyCard = React.createClass( {
 	},
 
 	getNotice() {
-		if ( this.props.privacyProtectionEnabled ) {
+		if ( this.props.hasPrivacyProtection && this.props.privateDomain ) {
 			return (
 				<Notice status="is-success" showDismiss={ false }>
 					{ this.translate(
@@ -65,6 +66,23 @@ const ContactsPrivacyCard = React.createClass( {
 					) }
 				</Notice>
 			);
+		} else if ( this.props.hasPrivacyProtection && ! this.props.privateDomain ) {
+			return (
+				<Notice status="is-warning" showDismiss={ false }>
+					{ this.translate(
+						'{{strong}}Privacy Protection{{/strong}} is temporarily ' +
+						'disabled for this domain while the domain is being transferred. ' +
+						'Your contact information is {{strong}}public{{/strong}}. ' +
+						'{{a}}Cancel Transfer and Enable Privacy Protection{{/a}}',
+						{
+							components: {
+								strong: <strong />,
+								a: <a href={ paths.domainManagementTransfer( this.props.selectedSite.slug, this.props.selectedDomainName ) } />
+							}
+						}
+					) }
+				</Notice>
+			)
 		}
 
 		return (

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/card.jsx
@@ -1,17 +1,16 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	page = require( 'page' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-const CompactCard = require( 'components/card/compact' ),
-	ContactDisplay = require( './contact-display' ),
-	Notice = require( 'components/notice' ),
-	paths = require( 'my-sites/upgrades/paths' ),
-	SectionHeader = require( 'components/section-header' );
+import CompactCard from 'components/card/compact';
+import ContactDisplay from './contact-display';
+import Notice from 'components/notice';
+import paths from 'my-sites/upgrades/paths';
+import SectionHeader from 'components/section-header';
 
 const ContactsPrivacyCard = React.createClass( {
 	propTypes: {
@@ -54,14 +53,13 @@ const ContactsPrivacyCard = React.createClass( {
 	getNotice() {
 		if ( this.props.privacyProtectionEnabled ) {
 			return (
-				<Notice status={ 'is-success' } showDismiss={ false }>
+				<Notice status="is-success" showDismiss={ false }>
 					{ this.translate(
-						'{{strong1}}Privacy Protection{{/strong1}} is turned on for this domain. ' +
-						'Your contact information is {{strong2}}private{{/strong2}}. ',
+						'{{strong}}Privacy Protection{{/strong}} is turned on for this domain. ' +
+						'Your contact information is {{strong}}private{{/strong}}. ',
 						{
 							components: {
-								strong1: <strong />,
-								strong2: <strong />
+								strong: <strong />
 							}
 						}
 					) }
@@ -70,27 +68,22 @@ const ContactsPrivacyCard = React.createClass( {
 		}
 
 		return (
-			<Notice status={ 'is-warning' } showDismiss={ false }>
+			<Notice status="is-warning" showDismiss={ false }>
 				{ this.translate(
-					'{{strong1}}Privacy Protection{{/strong1}} is turned off for this domain. ' +
-					'Your contact information is {{strong2}}public{{/strong2}}. ' +
+					'{{strong}}Privacy Protection{{/strong}} is turned off for this domain. ' +
+					'Your contact information is {{strong}}public{{/strong}}. ' +
 					'{{a}}Enable Privacy Protection{{/a}}',
 					{
 						components: {
-							strong1: <strong />,
-							strong2: <strong />,
-							a: <a href="" onClick={ this.goToPrivacyProtection } />
+							strong: <strong />,
+							a: <a
+								href={ paths.domainManagementPrivacyProtection(
+									this.props.selectedSite.slug, this.props.selectedDomainName ) } />
 						}
 					}
 				) }
 			</Notice>
 		);
-	},
-
-	goToPrivacyProtection( event ) {
-		event.preventDefault();
-
-		page( paths.domainManagementPrivacyProtection( this.props.selectedSite.domain, this.props.selectedDomainName ) );
 	}
 } );
 

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/index.jsx
@@ -67,12 +67,8 @@ const ContactsPrivacy = React.createClass( {
 		return ( ! getSelectedDomain( this.props ) || ! this.props.whois.hasLoadedFromServer );
 	},
 
-	isPrivacyProtectionEnabled() {
-		const domain = getSelectedDomain( this.props );
 
 		return domain && domain.hasPrivacyProtection;
-	},
-
 	goToEdit() {
 		page( paths.domainManagementEdit( this.props.selectedSite.domain, this.props.selectedDomainName ) );
 	}

--- a/client/my-sites/upgrades/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/upgrades/domain-management/contacts-privacy/index.jsx
@@ -32,6 +32,9 @@ const ContactsPrivacy = React.createClass( {
 			return <DomainMainPlaceholder goBack={ this.goToEdit } />;
 		}
 
+		const domain = getSelectedDomain( this.props ),
+			{ hasPrivacyProtection, privateDomain } = domain;
+
 		return (
 			<Main className="domain-management-contacts-privacy">
 				<Header
@@ -45,14 +48,15 @@ const ContactsPrivacy = React.createClass( {
 						contactInformation= { this.props.whois.data }
 						selectedDomainName={ this.props.selectedDomainName }
 						selectedSite={ this.props.selectedSite }
-						privacyProtectionEnabled={ this.isPrivacyProtectionEnabled() } />
+						hasPrivacyProtection={ hasPrivacyProtection }
+						privateDomain={ privateDomain } />
 
 					<VerticalNavItem
 							path={ paths.domainManagementEditContactInfo( this.props.selectedSite.domain, this.props.selectedDomainName ) }>
 						{ this.translate( 'Edit Contact Info' ) }
 					</VerticalNavItem>
 
-					{ this.isPrivacyProtectionEnabled() ? null : (
+					{ ! hasPrivacyProtection && (
 						<VerticalNavItem
 							path={ paths.domainManagementPrivacyProtection( this.props.selectedSite.domain, this.props.selectedDomainName ) }>
 							{ this.translate( 'Privacy Protection' ) }
@@ -67,8 +71,6 @@ const ContactsPrivacy = React.createClass( {
 		return ( ! getSelectedDomain( this.props ) || ! this.props.whois.hasLoadedFromServer );
 	},
 
-
-		return domain && domain.hasPrivacyProtection;
 	goToEdit() {
 		page( paths.domainManagementEdit( this.props.selectedSite.domain, this.props.selectedDomainName ) );
 	}


### PR DESCRIPTION
Fixes #2909.

This fixes showing the wrong state for Privacy Protection in Contacts & Privacy Page. (See #2899 #2133 for context -- tl;dr: We have 3 states for Privacy Protection: on, off, disabled for transfer). I've added a copy for the message if the users land to this page while their Privacy Protection is disabled, but that shouldn't happen very often, as we don't link to this page when it's disabled. Though they still land here through bookmarks or browser history. 

#### The looks:
![image](https://cloud.githubusercontent.com/assets/991022/12735460/ffa4bbb6-c8fc-11e5-9027-9b0aef9d9ddd.png)
(Link goes to the transfer page)

/cc: @ranh for copy, @klimeryk for code
