### PR TITLE
Sign Up: New flow to authorize Jetpack

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -62,7 +62,7 @@ const flows = {
 		description: 'Create an account and a blog and then add the business plan to the users cart.',
 		lastModified: '2016-01-21'
 	},
-
+	
 	free: {
 		steps: [ 'themes', 'domains', 'user' ],
 		destination: getSiteDestination,
@@ -216,6 +216,13 @@ const flows = {
 		lastModified: '2015-12-18'
 	},
 };
+
+if ( config.isEnabled( 'jetpack-connect' ) ) {
+	flows['jetpack-connect'] = {
+		steps: [ 'user', 'authorize-site' ],
+		destination: '/'
+	};
+}
 
 function removeUserStepFromFlow( flow ) {
 	if ( ! flow ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -9,6 +9,7 @@ var UserSignupComponent = require( 'signup/steps/user' ),
 	DomainsStepComponent = require( 'signup/steps/domains' ),
 	DesignTypeComponent = require( 'signup/steps/design-type' ),
 	SurveyStepComponent = require( 'signup/steps/survey' ),
+	JetpackAuthorizeSite = require( 'signup/steps/jetpack-authorize-site' ),
 	config = require( 'config' );
 
 module.exports = {
@@ -24,5 +25,6 @@ module.exports = {
 	'design-type': DesignTypeComponent,
 	'themes-headstart': ThemeSelectionComponent,
 	'domains-with-theme': DomainsStepComponent,
-	'jetpack-user': UserSignupComponent
+	'jetpack-user': UserSignupComponent,
+	'authorize-site': JetpackAuthorizeSite
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -112,5 +112,12 @@ module.exports = {
 			subHeaderText: i18n.translate( 'You\'re moments away from connecting Jetpack.' )
 		},
 		providesDependencies: [ 'bearer_token', 'username' ]
+	},
+
+	'authorize-site': {
+		stepName: 'authorize-site',
+		props: {
+			headerText: i18n.translate( 'Howdy! Jetpack would like to connect to your WordPress.com account.' ),
+		},
 	}
 };

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -10,6 +10,7 @@ import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
 
 const pluginURL = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
+const authURL = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true'
 
 export default React.createClass( {
 	displayName: 'JetpackConnectSiteURLStep',
@@ -33,8 +34,13 @@ export default React.createClass( {
 		window.location = 'http://' + this.refs.siteUrlInputRef.state.value + pluginURL;
 	},
 
+	goToRemoteAuth() {
+		window.location = this.refs.siteUrlInputRef.state.value + authURL;
+	},
+
 	onURLEnter() {
-		const stepToShow = Math.floor( ( Math.random() * 5 ) + 1 );
+		this.goToRemoteAuth();
+/*		const stepToShow = Math.floor( ( Math.random() * 5 ) + 1 );
 
 		if ( stepToShow === 1 ) {
 			this.setState( { siteStatus: 'notExist' } );
@@ -49,7 +55,7 @@ export default React.createClass( {
 			this.setState( { siteStatus: 'jetpackIsDisconnected' } );
 		} else if ( stepToShow === 5 ) {
 			this.setState( { siteStatus: 'jetpackIsValid' } );
-		}
+		}*/
 	},
 
 	onDismissClick() {
@@ -110,7 +116,8 @@ export default React.createClass( {
 						<SiteURLInput ref="siteUrlInputRef"
 							onClick={ this.onURLEnter }
 							onDismissClick={ this.onDismissClick }
-							isError={ this.state.isError } />
+							isError={ this.state.isError }
+							spinnerDuration={ 60000 } />
 					</Card>
 
 					<LoggedOutFormLinks>

--- a/client/signup/steps/jetpack-authorize-site/index.jsx
+++ b/client/signup/steps/jetpack-authorize-site/index.jsx
@@ -1,0 +1,101 @@
+/**
+ * Externals dependencies
+ */
+import React from 'react';
+import Debug from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import wpcom from 'lib/wp';
+
+/**
+ * Module variables
+ */
+const debug = new Debug( 'calypso:jetpack-authorize' );
+
+module.exports = React.createClass( {
+	displayName: 'JetpackAuthorizeSite',
+
+	getInitialState() {
+		return {
+			isSubmitting: false,
+			authorizeError: false,
+			authorizeSuccess: false
+		};
+	},
+
+	getHeaderText() {
+		return this.translate( 'Howdy! Jetpack would like to connect to your WordPress.com account.' );
+	},
+
+	getSubHeaderText() {
+		return this.translate( 'Because Jetpack is awesome.' );
+	},
+
+	handleSubmit() {
+		const { queryObject } = this.props;
+		debug( 'trying jetpack login', queryObject );
+		this.setState( { isSubmitting: true, authorizeError: false } );
+		wpcom.undocumented().jetpackLogin( queryObject, this.handleJetpackLoginComplete );
+	},
+
+	handleJetpackLoginComplete( error, data ) {
+		const { queryObject } = this.props;
+		if ( error ) {
+			debug( 'jetpack login error', error );
+			this.setState( { authorizeError: true, isSubmitting: false } );
+			return;
+		}
+		debug( 'jetpack login success. trying jetpack authorize.', queryObject.client_id, data );
+		wpcom.undocumented().jetpackAuthorize( queryObject.client_id, data.code, queryObject.state, queryObject.redirect_uri, queryObject.secret, this.handleAuthorizeComplete );
+	},
+
+	handleAuthorizeComplete( error, data ) {
+		if ( error ) {
+			debug( 'jetpack authorize error', error );
+			console.log( error );
+			this.setState( { authorizeError: true, isSubmitting: false } );
+			return;
+		}
+
+		debug( 'authorization complete!', data );
+		this.setState( { isSubmitting: false, authorizeSuccess: true } );
+	},
+
+	renderErrorMessage() {
+		if ( this.state.authorizeError ) {
+			return <p>Error connecting. Run `localStorage.setItem( 'debug', 'calypso:jetpack-authorize' );` and try again.</p>;
+		}
+		return null;
+	},
+
+	renderForm() {
+		if ( this.state.authorizeSuccess ) {
+			return <p>Jetpack Connected!</p>;
+		}
+
+		return(
+			<div>
+				<button disabled={ this.state.isSubmitting } onClick={ this.handleSubmit } className="button is-primary">
+					{ this.translate( 'Approve' ) }
+				</button>
+				{ this.renderErrorMessage() }
+			</div>
+		);
+	},
+
+	render() {
+		return(
+			<StepWrapper
+				flowName={ this.props.flowName }
+				stepName={ this.props.stepName }
+				headerText={ this.getHeaderText() }
+				subHeaderText={ this.getSubHeaderText() }
+				positionInFlow={ this.props.positionInFlow }
+				signupProgressStore={ this.props.signupProgressStore }
+				stepContent={ this.renderForm() } />
+		);
+	}
+} );

--- a/config/development.json
+++ b/config/development.json
@@ -36,6 +36,7 @@
 		"help": true,
 		"jetpack/calypso-first-signup-flow": true,
 		"jetpack_core_inline_update": true,
+		"jetpack-connect": true,
 		"keyboard-shortcuts": true,
 		"login": true,
 		"mailing-lists/unsubscribe": true,


### PR DESCRIPTION
Creating a new sign up flow for a jetpack connection. This PR will attempt to re-create in Calypso the well known Jetpack connection flow:
![screen shot 2016-02-01 at 10 06 48 pm](https://cloud.githubusercontent.com/assets/2694219/12738670/dfd4eade-c930-11e5-9480-59734a40a5f1.png)

We are currently testing out the API for this before moving fully into the design stage.