### PR TITLE
Fix console warnings caused by the lack of props of ReactCSSTransitionGroup

### DIFF
--- a/client/components/upgrades/google-apps/dialog/index.jsx
+++ b/client/components/upgrades/google-apps/dialog/index.jsx
@@ -89,7 +89,10 @@ var GoogleAppsDialog = React.createClass( {
 				<GoogleAppsProductDetails
 					price={ price }
 				/>
-				<ReactCSSTransitionGroup transitionName='google-apps-dialog__users'>
+				<ReactCSSTransitionGroup
+					transitionName='google-apps-dialog__users'
+					transitionEnterTimeout={ 200 }
+					transitionLeaveTimeout={ 200 }>
 					{ googleAppsUsers }
 				</ReactCSSTransitionGroup>
 				{ this.footer() }

--- a/client/lib/mixins/update-post-status/README.md
+++ b/client/lib/mixins/update-post-status/README.md
@@ -16,7 +16,10 @@ module.exports = React.createClass({
 
     return (
       <div className="regular-template">Regular template stuff</div>
-      <ReactCSSTransitionGroup transitionName="updated-trans">
+      <ReactCSSTransitionGroup
+        transitionName="updated-trans"
+        transitionEnterTimeout={ 300 }
+        transitionLeaveTimeout={ 300 }>
         { this.buildUpdateTemplate() }
       </ReactCSSTransitionGroup>
     );

--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -612,7 +612,10 @@ const Account = React.createClass( {
 						</FormFieldset>
 
 						{ /* This is how we animate showing/hiding the form field sections */ }
-						<ReactCSSTransitionGroup transitionName="account__username-form-toggle">
+						<ReactCSSTransitionGroup
+							transitionName="account__username-form-toggle"
+							transitionEnterTimeout={ 500 }
+							transitionLeaveTimeout={ 10 }>
 							{ renderUsernameForm ? this.renderUsernameFields() : this.renderAccountFields() }
 						</ReactCSSTransitionGroup>
 					</form>

--- a/client/my-sites/menus/menu-item-list.jsx
+++ b/client/my-sites/menus/menu-item-list.jsx
@@ -357,7 +357,10 @@ var MenuItem = React.createClass( {
 
 		return (
 			<div>
-				<ReactCSSTransitionGroup transitionName="menus__droptarget-slidevertical">
+				<ReactCSSTransitionGroup
+					transitionName="menus__droptarget-slidevertical"
+					transitionEnterTimeout={ 200 }
+					transitionLeaveTimeout={ 200 }>
 					{ this.renderDropTarget( 'before' ) }
 				</ReactCSSTransitionGroup>
 
@@ -366,10 +369,16 @@ var MenuItem = React.createClass( {
 				{ this.renderNewItem( 'after' ) }
 				{ this.renderNewItem( 'child' ) }
 
-				<ReactCSSTransitionGroup transitionName="menus__droptarget-slidevertical">
+				<ReactCSSTransitionGroup
+					transitionName="menus__droptarget-slidevertical"
+					transitionEnterTimeout={ 200 }
+					transitionLeaveTimeout={ 200 }>
 					{ this.renderDropTarget( 'after' ) }
 				</ReactCSSTransitionGroup>
-				<ReactCSSTransitionGroup transitionName="menus__droptarget-slidevertical">
+				<ReactCSSTransitionGroup
+					transitionName="menus__droptarget-slidevertical"
+					transitionEnterTimeout={ 200 }
+					transitionLeaveTimeout={ 200 }>
 					{ this.renderDropTarget( 'child' ) }
 				</ReactCSSTransitionGroup>
 

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -301,7 +301,10 @@ module.exports = React.createClass( {
 					{ this.getSendToTrashItem() }
 					{ this.popoverMoreInfo() }
 				</PopoverMenu>
-				<ReactCSSTransitionGroup transitionName="updated-trans">
+				<ReactCSSTransitionGroup
+					transitionName="updated-trans"
+					transitionEnterTimeout={ 300 }
+					transitionLeaveTimeout={ 300 }>
 					{ this.buildUpdateTemplate() }
 				</ReactCSSTransitionGroup>
 			</CompactCard>


### PR DESCRIPTION
Here are the warning messages.
<img width="808" alt="screenshot_2016-02-02" src="https://cloud.githubusercontent.com/assets/212034/12742598/91cc8cf8-c9ca-11e5-9e4c-67af97f96b70.png">

To see the warnings, just open My Sites > Menus (in the Personalize section).