### PR TITLE
i18n: reverse direction of some gridicons in RTL

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -100,6 +100,19 @@ body.rtl,
 	font-family: $sans;
 }
 
+/*rtl:ignore*/
+.rtl {
+	.gridicon {
+		&.gridicons-chevron-left,
+		&.gridicons-chevron-right,
+		&.gridicons-arrow-left,
+		&.gridicons-arrow-right {
+			transform: scaleX( -1 );
+		}
+
+	}
+}
+
 .notifications {
 	display: inherit;
 }

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -85,10 +85,6 @@
 	}
 }
 
-.rtl .current-site__switch-sites .gridicon {
-	transform: rotate( 180deg );
-}
-
 .current-site .notice {
 	margin: 0 8px 8px;
 }


### PR DESCRIPTION
Across the codebase, we're often using specific gridicons to emphasis directionality: for example, `chevron-right` to expand a compact card, or `arrow-left` for back links. In RTL, those icons needs to be reversed.

The best semantical solution would be to abstract the arrows into a direction aware component, and then make sure we use this component everywhere. However, I feel this would add too much complexity, and propose a workaround we've used before: reverse using css.

This fixes #1734, and also other various issues (see screenshots below) 

**Before patch**

Issue in domains list compact card: 
<img width="804" alt="screen shot 2016-02-02 at 10 06 50" src="https://cloud.githubusercontent.com/assets/844866/12743820/0e3213da-c999-11e5-8118-db2a30b126ba.png">

Issue in domains back link: 
<img width="760" alt="screen shot 2016-02-02 at 10 39 05" src="https://cloud.githubusercontent.com/assets/844866/12743833/388b6a32-c999-11e5-8684-7aad3e4667f3.png">

Issue in editor back link:
<img width="292" alt="screen shot 2015-10-21 at 3 32 01 pm" src="https://cloud.githubusercontent.com/assets/5835847/10649315/f421bab8-7808-11e5-9c0c-808cc13072d9.png">

**After patch:**
domains list compact card: 
<img width="791" alt="screen shot 2016-02-02 at 10 06 29" src="https://cloud.githubusercontent.com/assets/844866/12743874/842f23de-c999-11e5-8577-5207f58d0ae3.png">

domains back link: 
<img width="758" alt="screen shot 2016-02-02 at 10 41 40" src="https://cloud.githubusercontent.com/assets/844866/12743885/9b654b00-c999-11e5-98ca-11ac2d358435.png">


editor back link:
<img width="283" alt="screen shot 2016-02-02 at 10 40 52" src="https://cloud.githubusercontent.com/assets/844866/12743872/7a90c530-c999-11e5-9901-b1346d9dab48.png">