### PR TITLE
Build: make sure we are using our pre-* hooks on every run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,12 +174,12 @@ translate: node_modules $(CLIENT_CONFIG_FILE)
 githooks: githooks-commit githooks-push
 
 # install git pre-commit hook
-githooks-commit:
-	@if [ ! -e .git/hooks/pre-commit ]; then ln -s ../../bin/pre-commit .git/hooks/pre-commit; fi
+githooks-commit: bin/pre-commit
+	@ln -sf ../../$< .git/hooks/pre-commit
 
 # install git pre-push hook
-githooks-push:
-	@if [ ! -e .git/hooks/pre-push ]; then ln -s ../../bin/pre-push .git/hooks/pre-push; fi
+githooks-push: bin/pre-push
+	@ln -sf ../../$< .git/hooks/pre-push
 
 # rule that can be used as a prerequisite for other rules to force them to always run
 FORCE:


### PR DESCRIPTION
Previously, the git hooks for `pre-commit` and `pre-push` could be overridden by the user and we wouldn't notice. This change ensures on every build that the installed hooks are ours.
If the hook is not installed - it will be installed (linked).
If the hook is different than ours (updated) - it will get overridden by ours.

This should lower the probability that someone pushes to the master their branch by mistake.