### PR TITLE
Post Editor: Publicize message container width is off  

### DIFF
--- a/client/post-editor/editor-sharing/publicize-message.scss
+++ b/client/post-editor/editor-sharing/publicize-message.scss
@@ -21,7 +21,7 @@
 
 .info-popover__tooltip.publicize-message-counter-info {
 	.tip-inner {
-		max-width: 245px;
+		max-width: 220px;
 		text-align: left;
 	}
 }


### PR DESCRIPTION
* FIXED: Publicize message container had a max-width that was larger
than its container causing it to overflow to the left.

https://github.com/Automattic/wp-calypso/issues/2736
