### PR TITLE
Sites: no sidebar when sites empty

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -43,10 +43,18 @@ function renderNavigation( context, allSitesPath, siteBasePath ) {
 	);
 }
 
-function renderEmptySites() {
+function removeSidebar( context ) {
+	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+
+	context.store.dispatch( uiActions.setSection( 'sites', {
+		hasSidebar: false
+	} ) );
+}
+
+function renderEmptySites( context ) {
 	var NoSitesMessage = require( 'components/empty-content/no-sites-message' );
 
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+	removeSidebar( context );
 
 	ReactDom.render(
 		React.createElement( NoSitesMessage ),
@@ -54,12 +62,12 @@ function renderEmptySites() {
 	);
 }
 
-function renderNoVisibleSites() {
+function renderNoVisibleSites( context ) {
 	var EmptyContentComponent = require( 'components/empty-content' ),
 		currentUser = user.get(),
 		hiddenSites = currentUser.site_count - currentUser.visible_site_count;
 
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+	removeSidebar( context );
 
 	ReactDom.render(
 		React.createElement( EmptyContentComponent, {
@@ -99,12 +107,12 @@ module.exports = {
 		}
 
 		if ( currentUser && currentUser.site_count === 0 ) {
-			renderEmptySites();
+			renderEmptySites( context );
 			return analytics.pageView.record( basePath, analyticsPageTitle + ' > No Sites' );
 		}
 
 		if ( currentUser && currentUser.visible_site_count === 0 ) {
-			renderNoVisibleSites();
+			renderNoVisibleSites( context );
 			return analytics.pageView.record( basePath, analyticsPageTitle + ' > All Sites Hidden' );
 		}
 

--- a/server/pages/404.jade
+++ b/server/pages/404.jade
@@ -15,7 +15,7 @@ html(lang='en')
 		link(rel='stylesheet', href=urls['style.css'])
 	body
 		#wpcom.wpcom-site
-			div.wp
+			div.wp(class='has-no-sidebar')
 				div(class='wp-content', id='content')
 					div(class='wp-primary wp-section', id='primary')
 						div.empty-content


### PR DESCRIPTION
Related to #2824, currently, the empty sites message is not centered when a user has no sites:

![screen shot 2016-02-02 at 9 25 43 am](https://cloud.githubusercontent.com/assets/7240478/12755999/f387660c-c98e-11e5-918f-4b9b09d5c932.png)

This PR adds context (is that necessary?) and sets `hasSidebar` to false in <a href="https://github.com/Automattic/wp-calypso/blob/2f8352a5688556945515deee90b00f5a6438ce2c/client/my-sites/controller.js#L101">`client/my-sites/controller.js`</a>. With `hasSidebar` set to false, the class `.has-no-sidebar` is added resulting in a centered layout:

![screen shot 2016-02-02 at 9 29 10 am](https://cloud.githubusercontent.com/assets/7240478/12756099/70e2a36e-c98f-11e5-8ea9-3c849b671683.png)

@kjbenk also noticed in the issue that our 404 page wasn't centered so I added the `.has-no-sidebar` class to [`server/pages/404.jade`](https://github.com/Automattic/wp-calypso/blob/a7478174b0441760c332fcb4b8c454f5b8d73dfc/server/pages/404.jade).

Before:

![screen shot 2016-02-02 at 9 30 21 am](https://cloud.githubusercontent.com/assets/7240478/12756144/9de7de1a-c98f-11e5-902d-b4a9df7143e7.png)

After:

![screen shot 2016-02-02 at 9 29 52 am](https://cloud.githubusercontent.com/assets/7240478/12756131/8bc71296-c98f-11e5-8dd6-bbd8389a2783.png)

To test:
1. Log into an account with no sites
2. Click "My Sites" in the top menu
3. Without PR, Drake isn't centered. PR centers Drake.

Inadvertently, I also removed a space in `client/layout/index.jsx`. If this PR looks good, I'll re-add the space, rebase, and squash.