### PR TITLE
Themes: use redux store in logged-out /design layout

### DIFF
--- a/client/layout/logged-out-design.jsx
+++ b/client/layout/logged-out-design.jsx
@@ -4,6 +4,8 @@
  * External dependencies
  */
 import React from 'react';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,21 +13,39 @@ import React from 'react';
 import MasterbarMinimal from 'layout/masterbar/minimal';
 import ThemesHead from 'my-sites/themes/head';
 
-const LayoutLoggedOutDesign = ( { tier = 'all' } ) => (
-	<div className="wp is-section-design has-no-sidebar">
-		<ThemesHead tier={ tier } />
-		<MasterbarMinimal url="/" />
-		<div id="content" className="wp-content">
-			<div id="primary" className="wp-primary wp-section" />
-			<div id="secondary" className="wp-secondary" />
+const LayoutLoggedOutDesign = ( { section, hasSidebar, tier = 'all' } ) => {
+	const sectionClass = section ? 'is-section-' + section : '';
+	const classes = classNames( 'wp', sectionClass, {
+		'has-no-sidebar': ! hasSidebar
+	} );
+
+	return (
+		<div className={ classes }>
+			<ThemesHead tier={ tier } />
+			<MasterbarMinimal url="/" />
+			<div id="content" className="wp-content">
+				<div id="primary" className="wp-primary wp-section" />
+				<div id="secondary" className="wp-secondary" />
+			</div>
+			<div id="tertiary" className="wp-overlay fade-background" />
 		</div>
-		<div id="tertiary" className="wp-overlay fade-background" />
-	</div>
-)
+	);
+}
 
 LayoutLoggedOutDesign.displayName = 'LayoutLoggedOutDesign';
 LayoutLoggedOutDesign.propTypes = {
+	section: React.PropTypes.string,
+	hasSidebar: React.PropTypes.bool,
 	tier: React.PropTypes.string
 }
 
-export default LayoutLoggedOutDesign;
+export default connect(
+	( state, props ) => Object.assign(
+		{},
+		props,
+		{
+			section: state.ui.section,
+			hasSidebar: state.ui.hasSidebar,
+		}
+	)
+)( LayoutLoggedOutDesign );

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -111,6 +111,8 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			script(type='text/javascript')!='var currentUser = ' + sanitize.jsonStringifyForHtml( user )
 		if app
 			script(type='text/javascript')!='var app = ' + sanitize.jsonStringifyForHtml( app )
+		if initialReduxState
+			script(type='text/javascript')!='var initialReduxState = ' + sanitize.jsonStringifyForHtml( initialReduxState )
 		if i18nLocaleScript
 			script(src=i18nLocaleScript)
 		if 'development' === env || isDebug

--- a/server/pages/test/index.js
+++ b/server/pages/test/index.js
@@ -4,16 +4,21 @@
 import { assert } from 'chai';
 import React from 'react';
 import ReactDomServer from 'react-dom/server';
+import { createReduxStore } from 'state';
 
 describe( 'Server pages:', function() {
 	context( 'when trying to renderToString() LayoutLoggedOutDesign ', function() {
 		before( function() {
 			const LayoutLoggedOutDesign = require( 'layout/logged-out-design' );
 			this.LayoutLoggedOutDesignFactory = React.createFactory( LayoutLoggedOutDesign );
+			this.props = {
+				tier: 'free',
+				store: createReduxStore(),
+			};
 		} );
 
 		it( "doesn't throw an exception", function() {
-			assert.doesNotThrow( ReactDomServer.renderToString.bind( ReactDomServer, this.LayoutLoggedOutDesignFactory() ) );
+			assert.doesNotThrow( ReactDomServer.renderToString.bind( ReactDomServer, this.LayoutLoggedOutDesignFactory( this.props ) ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
Props @ockham

Set the `is-section-...` class in the layout from the redux store and bootstrap the store to the client. This will allow the `is-section-...` class to be set when subsequently changing route on the client.

Will fix problems with signup page not laying out properly in #2786

No visible changes.

**To Test**
* Go to http://calypso.localhost:3000/design (logged-out)
* Verify that the `is-section-design` class is set on the `wp` div
<img width="692" alt="screen shot 2016-02-02 at 16 54 16" src="https://cloud.githubusercontent.com/assets/7767559/12756951/e3b74c76-c9cd-11e5-8ba0-75d2f76eee23.png">

**Todo**
- [x] fix the analytics middleware dependency on the server
