### PR TITLE
Invites: Adds error key to analytics when action fails

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -51,7 +51,9 @@ export function fetchInvite( siteId, inviteKey ) {
 		} );
 
 		if ( error ) {
-			analytics.tracks.recordEvent( 'calypso_invite_validation_failure' );
+			analytics.tracks.recordEvent( 'calypso_invite_validation_failure', {
+				error: error.error
+			} );
 		}
 	} );
 }
@@ -68,7 +70,9 @@ export function createAccount( userData, invite, callback ) {
 					if ( error.message ) {
 						dispatch( errorNotice( error.message ) );
 					}
-					analytics.tracks.recordEvent( 'calypso_invite_account_creation_failed' );
+					analytics.tracks.recordEvent( 'calypso_invite_account_creation_failed', {
+						error: error.error
+					} );
 				} else {
 					analytics.tracks.recordEvent( 'calypso_invite_account_created' );
 				}
@@ -97,7 +101,9 @@ export function acceptInvite( invite, callback ) {
 					if ( error.message ) {
 						dispatch( errorNotice( error.message, { displayOnNextPage: true } ) );
 					}
-					analytics.tracks.recordEvent( 'calypso_invite_accept_failed' );
+					analytics.tracks.recordEvent( 'calypso_invite_accept_failed', {
+						error: error.error
+					} );
 				} else {
 					dispatch( successNotice( ... acceptedNotice( invite ) ) );
 					analytics.tracks.recordEvent( 'calypso_invite_accepted' );


### PR DESCRIPTION
We are noticing several failed invite validation, but don't have much insight into why invites aren't validating. Adding the error code when tracking the failure should give us a better idea of why invites aren't validating as well as any other API failures.

To test:
- Checkout `invites/add-error-to-api-failures` branch
- In console, set `localStorage.setItem( 'debug', 'calypso:analytics );`
- Go to `/accept-invite/site/test` (which shouldn't validate).
- Open console and verify that an error prop was passed to analytics
- Verify there are no JS errors

cc @lezama for review