### PR TITLE
Signup: Headstart: Fix the theme selection step's Skip button.

### DIFF
--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -94,7 +94,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		const defaultDependencies = this.props.useHeadstart ? { theme: 'pub/twentyfifteen', images: null } : undefined;
+		const defaultDependencies = this.props.useHeadstart ? { theme: 'pub/twentyfifteen' } : undefined;
 		return (
 			<StepWrapper
 				fallbackHeaderText={ this.translate( 'Choose a theme.' ) }


### PR DESCRIPTION
The Headstart theme step was passing an invalid `images` dependency, a hold-over from DSS. Removing the empty `images` dependency fixes the Skip button.