### PR TITLE
Plans: Hide the checkmark for Jetpack plans since we're hiding the image icon

### DIFF
--- a/client/components/plans/plan/style.scss
+++ b/client/components/plans/plan/style.scss
@@ -132,6 +132,10 @@
 	.plan-list .jetpack_premium, .plan-list .jetpack_business {
 		width: 49%;
 	}
+
+	.plan-list .jetpack_premium .gridicons-checkmark-circle, .plan-list .jetpack_business .gridicons-checkmark-circle {
+		display: none;
+	}
 }
 
 .plans.has-sidebar {


### PR DESCRIPTION
Because in [this PR](https://github.com/Automattic/wp-calypso/pull/2629) we're hiding the plan icons temporarily for Jetpack plans, the green check mark is just floating around oddly.

I'd like to just hide the checkmark in the same way and then revisit when we create new icons specific to JP.

