### PR TITLE
Signup: Add headstart test to default signup flow

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -87,7 +87,7 @@ module.exports = {
 		defaultVariation: 'description'
 	},
 	headstart: {
-		datestamp: '20160204',
+		datestamp: '20160205',
 		variations: {
 			original: 20,
 			notTested: 60,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -85,5 +85,14 @@ module.exports = {
 			description: 50
 		},
 		defaultVariation: 'description'
-	}
+	},
+	headstart: {
+		datestamp: '20160204',
+		variations: {
+			original: 20,
+			notTested: 60,
+			headstart: 20
+		},
+		defaultVariation: 'original'
+	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var assign = require( 'lodash/object/assign' ),
+	page = require( 'page' ),
 	reject = require( 'lodash/collection/reject' );
 
 /**
@@ -9,6 +10,7 @@ var assign = require( 'lodash/object/assign' ),
 */
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
+	abtest = require( 'lib/abtest' ).abtest,
 	user = require( 'lib/user' )();
 
 function getCheckoutDestination( dependencies ) {
@@ -179,13 +181,16 @@ function removeUserStepFromFlow( flow ) {
 	} );
 }
 
-function getCurrentFlowNameFromTest() {
-	// No tests currently running
+function getCurrentFlowName( currentUrl ) {
+	// Headstart test - Only consider users from the homepage
+	if ( '/start/en?ref=homepage' === currentUrl && 'headstart' === abtest( 'headstart' ) ) {
+		return 'headstart';
+	}
 	return 'main';
 }
 
 module.exports = {
-	currentFlowName: getCurrentFlowNameFromTest(),
+	currentFlowName: getCurrentFlowName( page.current ),
 
 	defaultFlowName: 'main',
 


### PR DESCRIPTION
Headstart is a tool to automatically populate a new site with default content and settings to better match the demo site for its theme.

This PR sends a percentage of users visiting the default signup flow through an identical flow that uses Headstart on the server to pre-populate the new site.

Follow-up to #2925 which enabled the flow.

## Testing

1. Using a logged-out browser (eg: Chrome incognito), visit http://calypso.localhost:3000/start
2. As you are assigned to a flow, your URL will be changed to include the name of the first step in the flow. If you are assigned to the `headstart` flow, the URL will become http://calypso.localhost:3000/start/themes-headstart If instead you see http://calypso.localhost:3000/start/themes, try closing the window and starting again at step 1.
3. If you are assigned to the `headstart` flow, complete the flow to create a new site.
4. Verify that the new site has a lot of pre-populated content (posts, menus, widgets).

For example, here is the Boardwalk theme without Headstart:

<img width="959" alt="screen shot 2016-01-29 at 7 28 00 pm" src="https://cloud.githubusercontent.com/assets/2036909/12691907/7d0cb1c6-c6be-11e5-8d03-5188f590ef89.png">

...and with Headstart:

<img width="967" alt="screen shot 2016-01-29 at 7 28 13 pm" src="https://cloud.githubusercontent.com/assets/2036909/12691910/84068b00-c6be-11e5-85b5-390d6b104af5.png">
