### PR TITLE
Global Notices: removed css that was truncating long notice-text strings

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -32,7 +32,6 @@
 	margin-bottom: 0;
 
 	@include breakpoint( ">660px" ) {
-		float: right;
 		border-radius: 20px;
 		display: inline-flex;
 		margin-bottom: 24px;
@@ -51,9 +50,6 @@
 
 	@include breakpoint( ">660px" ) {
 		padding: 9px 13px;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
 	}
 }
 

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -22,7 +22,7 @@
 		max-width: calc( 100% - 48px );
 	}
 
-	@include breakpoint( ">1040" ) {
+	@include breakpoint( ">1040px" ) {
 			right: 48px;
 	}
 }


### PR DESCRIPTION
Long notice strings were truncated and hiding info from users. That css is now gone. We can revisit keeping these notices to a single line when we've shortened all the global notice strings a bit more.

Before:
![](https://cloud.githubusercontent.com/assets/6681919/12756017/ba5b2568-c9c9-11e5-8d8e-a676ef496a96.png)

After:
<img width="1312" alt="screen shot 2016-02-02 at 3 02 52 pm" src="https://cloud.githubusercontent.com/assets/437258/12762708/7c1d745a-c9be-11e5-94cd-56740fa78340.png">

Closes #2990

cc @mtias @mikeshelton1503 @iannuttall 