### PR TITLE
Invites: Updates decline button to use "Cancel"

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -118,7 +118,7 @@ let InviteAcceptLoggedIn = React.createClass( {
 					</div>
 					<div className="invite-accept-logged-in__button-bar">
 						<Button onClick={ this.decline } disabled={ this.state.submitting }>
-							{ this.translate( 'Decline', { context: 'button' } ) }
+							{ this.translate( 'Cancel', { context: 'button' } ) }
 						</Button>
 						<Button primary onClick={ this.accept } disabled={ this.state.submitting }>
 							{ this.getButtonText() }


### PR DESCRIPTION
Closes #2840

To test:
- Checkout `update/invite-logged-in-decline-button` branch
- Invite yourself to a site
- While logged in, click invitation link and replace `wordpress.com` with `calypso.localhost:3000`
- You should see "Cancel" instead of "Decline"

![cancel-button](https://cloud.githubusercontent.com/assets/1126811/12763091/3048d32c-c9b8-11e5-97e4-e5ec2ea99124.png)

cc @rickybanister for a review