### PR TITLE
Segmented Control: playing with colors

### DIFF
--- a/client/components/segmented-control/docs/example.jsx
+++ b/client/components/segmented-control/docs/example.jsx
@@ -20,7 +20,8 @@ var SegmentedControlDemo = React.createClass( {
 
 	getInitialState: function() {
 		return {
-			childSelected: 'all'
+			childSelected: 'all',
+			compact: false
 		};
 	},
 
@@ -36,6 +37,10 @@ var SegmentedControlDemo = React.createClass( {
 		};
 	},
 
+	toggleCompact: function() {
+		this.setState( { compact: ! this.state.compact } );
+	},
+
 	render: function() {
 		var controlDemoStyles = { maxWidth: 386 };
 
@@ -43,6 +48,9 @@ var SegmentedControlDemo = React.createClass( {
 			<div className="design-assets__group">
 				<h2>
 					<a href="/devdocs/design/segmented-control">Segmented Control</a>
+					<a className="design-assets__toggle button" onClick={ this.toggleCompact }>
+						{ this.state.compact ? 'Normal' : 'Compact' }
+					</a>
 				</h2>
 
 				<h3>Items passed as options prop</h3>
@@ -50,12 +58,15 @@ var SegmentedControlDemo = React.createClass( {
 					options={ this.props.options }
 					onSelect={ this.selectSegment }
 					style={ controlDemoStyles }
+					compact={ this.state.compact }
 				/>
 
-				<h3 style={ { marginTop: 20 } }>items passed as children</h3>
+				<h3 style={ { marginTop: 20 } }>Primary version</h3>
 				<SegmentedControl
 					selectedText={ this.state.childSelected }
 					style={ controlDemoStyles }
+					primary={ true }
+					compact={ this.state.compact }
 				>
 					<ControlItem
 						selected={ this.state.childSelected === 'all' }
@@ -93,9 +104,9 @@ var SegmentedControlDemo = React.createClass( {
 					</ControlItem>
 				</SegmentedControl>
 
-				<h3 style={ { marginTop: 20 } }>Compact version of segmented control</h3>
+				<h3 style={ { marginTop: 20 } }>Three items</h3>
 				<SegmentedControl
-					compact={ true }
+					compact={ this.state.compact }
 					selectedText={ this.state.childSelected }
 					style={ { maxWidth: 280 } }
 				>

--- a/client/components/segmented-control/index.jsx
+++ b/client/components/segmented-control/index.jsx
@@ -68,7 +68,8 @@ var SegmentedControl = React.createClass( {
 		var segmentedClasses = {
 			'segmented-control': true,
 			'keyboard-navigation': this.state.keyboardNavigation,
-			'is-compact': this.props.compact
+			'is-compact': this.props.compact,
+			'is-primary': this.props.primary
 		};
 
 		if ( this.props.className ) {

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -23,7 +23,7 @@
 
 	&:last-of-type {
 		.segmented-control__link {
-			border-right: solid 1px $gray;
+			border-right: solid 1px lighten( $gray, 20% );
 			border-top-right-radius: 4px;
 			border-bottom-right-radius: 4px;
 		}
@@ -39,7 +39,7 @@
 .segmented-control__link {
 	display: block;
 	padding: 8px 12px;
-	border: solid 1px $gray;
+	border: solid 1px lighten( $gray, 20% );
 	border-right: none;
 	font-size: 14px;
 	line-height: 18px;
@@ -51,7 +51,7 @@
 		outline: none;
 
 		.keyboard-navigation & .segmented-control__text {
-			outline: dotted 1px $blue-wordpress;
+			outline: dotted 1px $gray-dark;
 		}
 	}
 
@@ -63,10 +63,11 @@
 
 	.segmented-control__item.is-selected & {
 		border-color: $gray-dark;
-		background-color: $gray-light;
 		color: $gray-dark;
 	}
 }
+
+
 
 .segmented-control__text {
 	display: block;
@@ -81,5 +82,25 @@
 	.segmented-control__link {
 		font-size: 13px;
 		padding: 4px 8px;
+	}
+}
+
+//Primary variation
+.segmented-control.is-primary {
+
+	.segmented-control__item {
+
+		&.is-selected {
+
+			.segmented-control__link {
+		  	border-color: $blue-medium;
+		 		background-color: $blue-medium;
+		 		color: $white;
+		  }
+
+			+ .segmented-control__item .segmented-control__link {
+				border-left-color: $blue-medium;
+			}
+		}
 	}
 }


### PR DESCRIPTION
I updated the segmented control to use blue-medium (our more standard 'this thing is selected' color) and blue-wordpress/link-highlight for the non-selected options since they are clickable link-like things. It also much more closely matches the iOS segmented control that inspired it in the first place.

**Before:**
<img width="696" alt="screen shot 2016-02-02 at 3 47 26 pm" src="https://cloud.githubusercontent.com/assets/437258/12763778/4ecb4f94-c9c4-11e5-99bf-6a7dbcdf040b.png">

**After:**
<img width="700" alt="screen shot 2016-02-02 at 3 34 32 pm" src="https://cloud.githubusercontent.com/assets/437258/12763783/53b66e26-c9c4-11e5-8070-9a62a820bc6e.png">

This might benefit from some additional work on tabbing through options and focus/hover styles, but I think it's much more friendly now and matches our iOS app more closely.

cc @mtias @drw158 @andrewspittle (who originally suggested updating the colors since they didn't quite match our form field colors nor much other interface)
