### PR TITLE
Global Notices: I missed a max-width for the widest breakpoint

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -23,7 +23,8 @@
 	}
 
 	@include breakpoint( ">1040px" ) {
-			right: 48px;
+			right: 32px;
+		max-width: calc( 100% - 64px );
 	}
 }
 


### PR DESCRIPTION
There is currently no left-margin around long notices.

This previously wasn't a problem because I'd added truncation, but that's been removed because it was cutting off too much important text.

Before:
<img width="1244" alt="screen shot 2016-02-02 at 4 03 44 pm" src="https://cloud.githubusercontent.com/assets/437258/12764291/e2fda2be-c9c6-11e5-86f1-c6d74ffb0b46.png">

After:
<img width="1151" alt="screen shot 2016-02-02 at 4 03 03 pm" src="https://cloud.githubusercontent.com/assets/437258/12764295/e973054e-c9c6-11e5-8744-d03388af832e.png">

cc @kellychoffman 