### PR TITLE
Components: Fix incorrect button selector

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -38,7 +38,7 @@
 	font-size: 14px;
 }
 
-.section-header__actions button {
+.section-header__actions .button {
 	background: none;
 	float: left;
 	margin-right: 8px;


### PR DESCRIPTION
In #2864 , we incorrectly used `.section-header__actions button` instead of `.section-header__actions .button`.

This PR fixes that.

To test:
- Checkout `fix/section-header-button-style`
- Visit routes where section headers contain buttons. Ex. `/plugins`
- Do the style appear correct?

cc @mtias and @alternatekev for review.

![screen shot 2016-02-02 at 3 21 25 pm](https://cloud.githubusercontent.com/assets/1126811/12764853/774efcc0-c9c1-11e5-8aa1-0be0c1e4c555.png)
