### PR TITLE
i18nlint: explain terminology in literal check

### DIFF
--- a/server/i18nlint/i18nlint.js
+++ b/server/i18nlint/i18nlint.js
@@ -342,7 +342,8 @@ function auditASTNodeForVariablesInTranslateArguments( node, properties, warning
 	for ( i = 0; i < numberOfArgsToCheck; i++ ) {
 		if ( isNotAcceptableTranslateArgument( node.arguments[ i ] ) ) {
 			warnings.push( {
-				string: 'Arguments to translate() must be literals, because we use static analysis to build translation data.',
+				string: "We can't pass variables or functions to translate() (only string literals).\n" +
+					"    See https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only",
 				original: originalString,
 				location: node.arguments[ i ].loc.start
 			} );
@@ -358,8 +359,9 @@ function auditASTNodeForVariablesInTranslateArguments( node, properties, warning
 		for ( i = 0; i < releventProperties.length; i++ ) {
 			if ( isNotAcceptableTranslateArgument( releventProperties[ i ].value ) ) {
 				warnings.push( {
-					string: '\'' + keyName( releventProperties[ i ] ) + '\' ' +
-						'option must be literal, because we use static analysis to build translation data.',
+					string: "'" + keyName( releventProperties[ i ] ) + "' " +
+						"option in translate() can't be a variable or function (it must be a string literal).\n" +
+						"    See https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only",
 					original: originalString,
 					location: releventProperties[ i ].value.loc.start
 				} );

--- a/server/i18nlint/test/test-i18nlint.js
+++ b/server/i18nlint/test/test-i18nlint.js
@@ -7,7 +7,7 @@ var assert = require( 'chai' ).assert,
  */
 var unqualifiedPlaceholdersSnippet = 'multiple placeholders in a translation should be named.',
 	missingSingularPlaceholderSnippet = 'Placeholders in the plural and singular strings should match',
-	variableTranslateArgumentsSnippet = 'must be literal';
+	variableTranslateArgumentsSnippet = 'literal';
 
 describe( 'i18nlint.auditString', function() {
 	it( 'should not find problems with an ok string \'%(s)s%(t)s\'', function() {
@@ -80,8 +80,8 @@ describe( 'i18nlint', function() {
 	it( 'should warn about non-literal arguments to translate()', function() {
 		var i, specificProblems,
 			warnings = i18nlint.scanFile( 'test/testfiles/non-literal-translate-arguments.js' ),
-			// snippets
-			args = 'Arguments',
+			// snippets to differentiate error messages
+			args = 'to translate()',
 			context = 'context',
 			comment = 'comment';
 


### PR DESCRIPTION
The old i18nlint warning about using variables in translate() calls is confusing without some background in fairly abstract programming, so this PR re-words it to make it useful for a wider audience.

The issue that the warning is about is that we pull translations out of the source code (without running it), so we don't know what values variables or functions could have, and we need to use plain strings with quotes around them.  We've already got a pretty good explanation in the devdocs ( https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only ), so the trick is giving enough information for people to fix the problem in a line or two.

We've got testfiles so you can see the warnings by running this from the calypso root directory:
` ./bin/i18nlint server/i18nlint/test/testfiles/non-literal-translate-arguments.js `

the new errors look like this:

    server/i18nlint/test/testfiles/non-literal-translate-arguments.js
    line 10, col 41: translate( 'Plural must be literal too', stringVariable, { count: 12 } )
        We can't pass variables or functions to translate() (only string literals).
        More information at https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only
    server/i18nlint/test/testfiles/non-literal-translate-arguments.js
    line 14, col 11: translate( 'context must be a string literal.', { comment: 'a nice, literal comment', context: contextVariable } )
        'context' option in translate() can't be a variable or function (it must be a string literal).
        More information at https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only

@shaunandrews I'd love your input.  Is this any better?