### PR TITLE
Framework: Introduce custom ESLint rules, including Lodash import restrictions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,8 @@ module.exports = {
 		'modules': true
 	},
 	'plugins': [
-		'eslint-plugin-react'
+		'eslint-plugin-react',
+		'eslint-plugin-wpcalypso'
 	],
 	'rules': {
 		'brace-style': [ 1, '1tbs' ],
@@ -89,6 +90,8 @@ module.exports = {
 		'valid-jsdoc': [ 1, { 'requireReturn': false } ],
 		// Common top-of-file requires, expressions between external, interal
 		'vars-on-top': 1,
-		'yoda': 0
+		'yoda': 0,
+		// Custom rules
+		"wpcalypso/no-lodash-import": 2
 	}
 };

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { compose } from 'lodash';
+import compose from 'lodash/function/compose';
 
 /**
  * Internal dependencies
@@ -43,7 +43,7 @@ export default function( reduxStore ) {
 	// update the wpcom API interceptor accordingly.
 	reduxStore.subscribe( () => {
 		const state = reduxStore.getState();
-		
+
 		if ( wpcom.setSupportUserToken( getSupportUser( state ), getSupportToken( state ) ) ) {
 			onTokenChange();
 		}

--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { compose } from 'lodash';
+import compose from 'lodash/function/compose';
 
 /**
  * Internal dependencies

--- a/client/my-sites/exporter/spinner-button.jsx
+++ b/client/my-sites/exporter/spinner-button.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import { omit } from 'lodash';
+import omit from 'lodash/object/omit';
 
 /**
  * Internal dependencies

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import uniqueId from 'lodash/utility/uniqueId';
+
+/**
  * Internal dependencies
  */
 import {
@@ -6,8 +11,6 @@ import {
 	REMOVE_NOTICE,
 	SET_ROUTE
 } from 'state/action-types';
-
-import { uniqueId } from 'lodash';
 
 export function removeNotice( noticeId ) {
 	return {

--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -979,7 +979,7 @@ More about:
 
 ## ESLint
 
-To help encourages folks to follow the coding standards, there is a [ESLint](http://eslint.org/) configuration file ```.eslintrc``` that configures ESLint to detect code that doesn't follow the guidelines. ESLint also catches basic syntax errors, and natively supports both ES6 and JSX. It can be extended by plugins, such as [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react), which we use in our configuration.
+To help encourages folks to follow the coding standards, there is a [ESLint](http://eslint.org/) configuration file ```.eslintrc``` that configures ESLint to detect code that doesn't follow the guidelines. ESLint also catches basic syntax errors, and natively supports both ES6 and JSX. It can be extended by plugins, such as [`eslint-plugin-wpcalypso`](https://github.com/yannickcr/eslint-plugin-wpcalypso), which we use in our configuration.
 
 There are [integrations](http://eslint.org/docs/user-guide/integrations) for many editors that will automatically detect the configuration file and run the checks.
 
@@ -1044,7 +1044,7 @@ If you are using Sublime Text, you can use the `SublimeLinter-eslint` plugin to 
 Before following these instructions, you'll want to globally install ESLint and related dependencies by running the following command in your terminal:
 
 ```bash
-npm install -g eslint eslint-plugin-react babel-eslint
+npm install -g eslint eslint-plugin-wpcalypso eslint-plugin-react babel-eslint
 ```
 
 #### Identifying Spaces with Sublime Text

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13321,6 +13321,14 @@
           }
         }
       }
+    },
+    "eslint-plugin-wpcalypso": {
+      "version": "1.0.0",
+      "dependencies": {
+        "requireindex": {
+          "version": "1.1.0"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "esformatter-special-bangs": "1.0.1",
     "eslint": "1.10.3",
     "eslint-plugin-react": "3.11.3",
+    "eslint-plugin-wpcalypso": "1.0.0",
     "jsdom": "7.2.0",
     "localStorage": "1.0.2",
     "lodash-deep": "1.5.3",

--- a/server/i18nlint/i18nlint.js
+++ b/server/i18nlint/i18nlint.js
@@ -10,8 +10,8 @@ var fs = require( 'fs' ),
 	preProcessXGettextJSMatch = require( '../i18n/preprocess-xgettextjs-match.js' ),
 	SourceMapConsumer = require( 'source-map' ).SourceMapConsumer,
 	tokenize = require( '../../client/lib/interpolate-components/tokenize.js' ),
-	contains = require( 'lodash' ).contains,
-	flow = require( 'lodash' ).flow;
+	contains = require( 'lodash/collection/contains' ),
+	flow = require( 'lodash/function/flow' );
 
 /*
  * Module variables


### PR DESCRIPTION
This pull request seeks to include the newly published [`eslint-plugin-wpcalypso` package](https://github.com/Automattic/eslint-plugin-wpcalypso) in introducing custom ESLint rules to the Calypso project. Currently, the plugin only contains a single rule: [`no-lodash-import`](https://github.com/Automattic/eslint-plugin-wpcalypso/blob/master/docs/rules/no-lodash-import.md). This rule intends to prevent an undesirable increase in bundle size as a consequence of importing modules from the root Lodash package, which has been fixed once before in #735. New ESLint rules can be added to the `eslint-plugin-wpcalypso` package as needs arise.

__Testing instructions:__

Ensure that Lodash replacements are valid.

Verify that `make lint` passes (reflected by CircleCI tests passing).

Test that introducing an import from the root Lodash package results in an ESLint error:

1. Edit any file to include `import { compose } from 'lodash';`
2. Save the file
3. Run `./node_modules/.bin/eslint [filename]` in your Terminal
4. Note that the file fails linting with the appropriate error message

Depending on how you use ESLint in your development workflow, you may need to install the `eslint-plugin-wpcalypso` package globally (using the -g flag). This will be the case if you have installed the base `eslint` package globally.