### PR TITLE
Reader: fix list creation redirect

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -85,7 +85,7 @@ const ReaderSidebar = React.createClass( {
 
 	highlightNewList( list ) {
 		list = ReaderListsStore.get( list.owner, list.slug );
-		window.location.href = url.resolve( 'https://wordpress.com', url.resolve( list.URL, 'edit' ) );
+		window.location.href = url.resolve( 'https://wordpress.com', list.URL + '/edit' );
 	},
 
 	highlightNewTag( tag ) {


### PR DESCRIPTION
After merging #724, I noticed that the redirect to the list edit page (still pre-Calypso) was incorrect on the staging environment - specifically, the slug was missing from the URL.

This PR fixes the redirect to the new list edit page.