### PR TITLE
Revert "Components: Fix incorrect button selector"

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -38,7 +38,7 @@
 	font-size: 14px;
 }
 
-.section-header__actions .button {
+.section-header__actions button {
 	background: none;
 	float: left;
 	margin-right: 8px;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#3009
This is causing issues with primary buttons in section headers.

![2016-02-03-003522_781x584_scrot](https://cloud.githubusercontent.com/assets/3392497/12768586/da382268-ca10-11e5-9221-cb83d555eb4f.png)


cc @artpi @ebinnion 