### PR TITLE
Section Header: Corrects selector for section header button

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -38,8 +38,7 @@
 	font-size: 14px;
 }
 
-.section-header__actions button {
-	background: none;
+.section-header__actions .button {
 	float: left;
 	margin-right: 8px;
 


### PR DESCRIPTION
I previously commited #3009 to replace `.section-header__actions button` with `.section-header__actions .button`, but that caused styling issues with primary buttons. @klimeryk reverted in #3018.

After some testing, I found the issue to be caused by the `background: none` that was now actually being applied.

To test:
- Checkout `update/section-header-selector-primary` branch.
- Go to `/plugins/$site` where `$site` is a Jetpack site and verify that section header styles are as expected.
- Go to `/domains/manage/$site` where `$site` is a WP.com site and has a custom domain. Verify that styles are correct.

cc @alternatekev @rickybanister @breezyskies @klimeryk 

After screenshots:

![screen shot 2016-02-02 at 6 23 05 pm](https://cloud.githubusercontent.com/assets/1126811/12769070/1d2a0eb0-c9da-11e5-970e-18ff5ce3b802.png)
![screen shot 2016-02-02 at 6 23 12 pm](https://cloud.githubusercontent.com/assets/1126811/12769071/1d330880-c9da-11e5-944a-37d9e0bbfccf.png)
