### PR TITLE
i18nlint: add verbose flag

### DIFF
--- a/server/i18nlint/bin/i18nlint-cli.js
+++ b/server/i18nlint/bin/i18nlint-cli.js
@@ -22,6 +22,7 @@ program
 	.option( '-c, --color', 'Force color output', function() {
 		chalk.enabled = true;
 	} )
+	.option( '-v, --verbose', 'Print message for files with no errors')
 	.usage( 'inputFile' )
 	.on( '--help', function() {
 		console.log( 'i18nlint scans the given file for translation anti-patterns and offers suggestions to fix them' );
@@ -56,6 +57,8 @@ if ( warnings.length ) {
 			'\n    ' + warning.string );
 	} );
 	foundWarnings = true;
+} else if ( program.verbose ) {
+	console.log( chalk.green( inputFile + ' ok' ) );
 }
 
 if ( foundWarnings ) {


### PR DESCRIPTION
This PR adds a verbose (`-v` or `--verbose`) flag to i18nlint, so that it lists files as it's scanning them.

I needed this today, so I thought I should push it.