### PR TITLE
Post-editor reduxification: add redux actions #1

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -23,6 +23,13 @@ var actions = require( 'lib/posts/actions' ),
 	setSection = require( 'state/ui/actions' ).setSection,
 	analytics = require( 'analytics' );
 
+import {
+	setEditingMode,
+	startEditingNew,
+	startEditingExisting,
+	EDITING_MODES
+} from 'state/ui/editor/post/actions';
+
 function getPostID( context ) {
 	if ( ! context.params.post ) {
 		return null;
@@ -124,9 +131,13 @@ module.exports = {
 			// so kick it off here to minimize time spent waiting for it to load
 			// in the view components
 			if ( postID ) {
+				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 				actions.startEditingExisting( site, postID );
 				titleActions.setTitle( titleStrings.edit, { siteID: site.ID } );
 				analytics.pageView.record( '/' + postType + '/:blogid/:postid', titleStrings.ga + ' > Edit' );
+
+				context.store.dispatch( setEditingMode( EDITING_MODES.EXISTING, titleStrings.edit, { siteID: site.ID } ) );
+				context.store.dispatch( startEditingExisting( site, postID ) );
 			} else {
 				let postOptions = { type: postType };
 
@@ -140,9 +151,13 @@ module.exports = {
 					} );
 				}
 
+				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 				actions.startEditingNew( site, postOptions );
 				titleActions.setTitle( titleStrings.new, { siteID: site.ID } );
 				analytics.pageView.record( '/' + postType, titleStrings.ga + ' > New' );
+
+				context.store.dispatch( setEditingMode( EDITING_MODES.NEW, titleStrings.new, { siteID: site.ID } ) );
+				context.store.dispatch( startEditingNew( site, postOptions ) );
 			}
 		}
 

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+const React = require( 'react' ),
 	noop = require( 'lodash/utility/noop' );
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
  */
-var actions = require( 'lib/posts/actions' ),
+const actions = require( 'lib/posts/actions' ),
 	Button = require( 'components/button' ),
 	FormToggle = require( 'components/forms/form-toggle/compact' ),
 	Revisions = require( 'post-editor/editor-revisions' ),
@@ -20,15 +22,28 @@ var actions = require( 'lib/posts/actions' ),
 	postScheduleUtils = require( 'components/post-schedule/utils' ),
 	siteUtils = require( 'lib/site/utils' ),
 	stats = require( 'lib/posts/stats' );
+import {
+	toggleStickyStatus,
+	togglePendingStatus
+} from 'state/ui/editor/post/actions'
 
-var EditPostStatus = React.createClass( {
+const EditPostStatus = React.createClass( {
 	propTypes: {
+		togglePendingStatus: React.PropTypes.func,
+		toggleStickyStatus: React.PropTypes.func,
 		post: React.PropTypes.object,
 		savedPost: React.PropTypes.object,
 		type: React.PropTypes.string,
 		onSave: React.PropTypes.func,
 		onDateChange: React.PropTypes.func,
 		site: React.PropTypes.object
+	},
+
+	getDefaultProps: function() {
+		return {
+			togglePendingStatus: () => {},
+			toggleStickyStatus: () => {}
+		};
 	},
 
 	getInitialState: function() {
@@ -53,7 +68,9 @@ var EditPostStatus = React.createClass( {
 		stats.recordStat( stickyStat );
 		stats.recordEvent( 'Changed Sticky Setting', stickyEventLabel );
 
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( { sticky: ! this.props.post.sticky } );
+		this.props.toggleStickyStatus( this.props.post.sticky );
 	},
 
 	togglePendingStatus: function() {
@@ -62,7 +79,9 @@ var EditPostStatus = React.createClass( {
 		stats.recordStat( 'status_changed' );
 		stats.recordEvent( 'Changed Pending Status', pending ? 'Marked Draft' : 'Marked Pending' );
 
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( { status: pending ? 'draft' : 'pending' } );
+		this.props.togglePendingStatus( this.props.post.status );
 	},
 
 	togglePostSchedulePopover: function() {
@@ -233,4 +252,12 @@ var EditPostStatus = React.createClass( {
 	}
 } );
 
-module.exports = EditPostStatus;
+
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( {
+		toggleStickyStatus,
+		togglePendingStatus
+	}, dispatch )
+)( EditPostStatus );

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
-
+const React = require( 'react' );
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 /**
  * Internal dependencies
  */
-var Gravatar = require( 'components/gravatar' ),
+const Gravatar = require( 'components/gravatar' ),
 	user = require( 'lib/user' )(),
 	AuthorSelector = require( 'components/author-selector' ),
 	PostActions = require( 'lib/posts/actions' ),
@@ -14,9 +15,17 @@ var Gravatar = require( 'components/gravatar' ),
 	sites = require( 'lib/sites-list' )(),
 	config = require( 'config' ),
 	stats = require( 'lib/posts/stats' );
+import { setAuthor } from 'state/ui/editor/post/actions';
 
-var EditorAuthor = React.createClass( {
-
+const EditorAuthor = React.createClass( {
+	propTypes: {
+		setAuthor: React.PropTypes.func,
+	},
+	getDefaultProps: function() {
+		return {
+			setAuthor: () => {}
+		};
+	},
 	render: function() {
 		// if it's not a new post and we are still loading
 		// show a placeholder component
@@ -55,7 +64,9 @@ var EditorAuthor = React.createClass( {
 	onSelect: function( author ) {
 		stats.recordStat( 'advanced_author_changed' );
 		stats.recordEvent( 'Changed Author' );
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		PostActions.edit( { author: author } );
+		this.props.setAuthor( author );
 	},
 
 	userCanAssignAuthor: function() {
@@ -73,4 +84,7 @@ var EditorAuthor = React.createClass( {
 
 } );
 
-module.exports = EditorAuthor;
+export default connect(
+	null,
+	dispatch => bindActionCreators( { setAuthor }, dispatch )
+)( EditorAuthor );

--- a/client/post-editor/editor-categories/index.jsx
+++ b/client/post-editor/editor-categories/index.jsx
@@ -1,30 +1,37 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+const React = require( 'react' ),
 	without = require( 'lodash/array/without' ),
 	clone = require( 'lodash/lang/clone' ),
 	classNames = require( 'classnames' ),
 	debug = require( 'debug' )( 'calypso:post-editor:editor-categories' );
-
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 /**
  * Internal dependencies
  */
-var CategorySelector = require( 'my-sites/category-selector' ),
+const CategorySelector = require( 'my-sites/category-selector' ),
 	AddCategory = require( 'my-sites/category-selector/add-category' ),
 	CategoryList = require( 'components/data/category-list-data' ),
 	postActions = require( 'lib/posts/actions' ),
 	siteUtils = require( 'lib/site/utils' ),
 	stats = require( 'lib/posts/stats' );
+import { setCategories } from 'state/ui/editor/post/actions';
 
-module.exports = React.createClass( {
+const EditorCategories = React.createClass( {
 	displayName: 'EditorCategories',
 
 	propTypes: {
 		site: React.PropTypes.object,
-		post: React.PropTypes.object
+		post: React.PropTypes.object,
+		setCategories: React.PropTypes.func
 	},
-
+	getDefaultProps: function() {
+		return {
+			setCategories: () => {}
+		};
+	},
 	getInitialState: function() {
 		return {
 			searchTerm: null
@@ -78,9 +85,11 @@ module.exports = React.createClass( {
 		}
 
 		debug( 'setting selected to', selected );
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		postActions.edit( {
 			categories: selected
 		} );
+		this.props.setCategories( selected );
 	},
 
 	onSearch: function( searchTerm ) {
@@ -116,3 +125,8 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( { setCategories }, dispatch )
+)( EditorCategories );

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -3,6 +3,8 @@
  */
 import React from 'react';
 import classnames from 'classnames';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -12,14 +14,22 @@ import accept from 'lib/accept';
 import utils from 'lib/posts/utils';
 import Gridicon from 'components/gridicon';
 import Tooltip from 'components/tooltip';
+import { trashPost } from 'state/ui/editor/post/actions';
 
-export default React.createClass( {
+const EditorDeletePost = React.createClass( {
 	displayName: 'EditorDeletePost',
 
 	propTypes: {
 		site: React.PropTypes.object,
 		post: React.PropTypes.object,
-		onTrashingPost: React.PropTypes.func
+		onTrashingPost: React.PropTypes.func,
+		trashPost: React.PropTypes.func
+	},
+
+	getDefaultProps: function() {
+		return {
+			trashPost: () => {}
+		};
 	},
 
 	getInitialState: function() {
@@ -41,6 +51,8 @@ export default React.createClass( {
 		}.bind( this );
 
 		if ( utils.userCan( 'delete_post', this.props.post ) ) {
+			this.props.trashPost( this.props.post, handleTrashingPost );
+			// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 			actions.trash( this.props.post, handleTrashingPost );
 		}
 	},
@@ -95,3 +107,8 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( { trashPost }, dispatch )
+)( EditorDeletePost );

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -1,17 +1,19 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+const React = require( 'react' ),
 	pick = require( 'lodash/object/pick' );
-
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 /**
  * Internal dependencies
  */
-var EditorFieldset = require( 'post-editor/editor-fieldset' ),
+const EditorFieldset = require( 'post-editor/editor-fieldset' ),
 	FormCheckbox = require( 'components/forms/form-checkbox' ),
 	PostActions = require( 'lib/posts/actions' ),
 	InfoPopover = require( 'components/info-popover' ),
 	stats = require( 'lib/posts/stats' );
+import { setDiscussionSettings } from 'state/ui/editor/post/actions';
 
 function booleanToStatus( bool ) {
 	return bool ? 'open' : 'closed';
@@ -21,18 +23,20 @@ function statusToBoolean( status ) {
 	return 'open' === status;
 }
 
-module.exports = React.createClass( {
+const EditorDiscussion = React.createClass( {
 	displayName: 'EditorDiscussion',
 
 	propTypes: {
 		isNew: React.PropTypes.bool,
 		post: React.PropTypes.object,
-		site: React.PropTypes.object
+		site: React.PropTypes.object,
+		setDiscussionSettings: React.PropTypes.func
 	},
 
 	getDefaultProps: function() {
 		return {
-			isNew: false
+			isNew: false,
+			setDiscussionSettings: () => {}
 		};
 	},
 
@@ -72,6 +76,9 @@ module.exports = React.createClass( {
 		stats.recordStat( statName );
 		stats.recordEvent( gaEvent, newStatus );
 
+		this.props.setDiscussionSettings( discussion );
+
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		PostActions.edit( {
 			discussion: discussion
 		} );
@@ -107,3 +114,8 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( { setDiscussionSettings }, dispatch )
+)( EditorDiscussion );

--- a/client/post-editor/editor-discussion/test/index.jsx
+++ b/client/post-editor/editor-discussion/test/index.jsx
@@ -48,7 +48,7 @@ describe( 'EditorDiscussion', function() {
 			recordEvent: noop,
 			recordStat: noop
 		} );
-		EditorDiscussion = require( '../' );
+		EditorDiscussion = require( '../' ).WrappedComponent;
 		EditorDiscussion.prototype.__reactAutoBindMap.translate = sinon.stub().returnsArg( 0 );
 	} );
 
@@ -135,7 +135,7 @@ describe( 'EditorDiscussion', function() {
 			var tree, checkbox;
 
 			tree = TestUtils.renderIntoDocument(
-				<EditorDiscussion post={ post } site={ DUMMY_SITE } />
+				<EditorDiscussion post={ post } site={ DUMMY_SITE } setDiscussionSettings={ function() {} } />
 			);
 
 			checkbox = ReactDom.findDOMNode( tree ).querySelector( '[name=ping_status]' );
@@ -158,7 +158,7 @@ describe( 'EditorDiscussion', function() {
 			var tree, checkbox;
 
 			tree = TestUtils.renderIntoDocument(
-				<EditorDiscussion post={ post } site={ DUMMY_SITE } />
+				<EditorDiscussion post={ post } site={ DUMMY_SITE } setDiscussionSettings={ function() {} } />
 			);
 
 			checkbox = ReactDom.findDOMNode( tree ).querySelector( '[name=ping_status]' );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+const React = require( 'react' ),
 	find = require( 'lodash/collection/find' );
-
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 /**
  * Internal dependencies
  */
-var Accordion = require( 'components/accordion' ),
+const Accordion = require( 'components/accordion' ),
 	AccordionSection = require( 'components/accordion/section' ),
 	Gridicon = require( 'components/gridicon' ),
 	TaxonomiesAccordion = require( 'post-editor/editor-taxonomies/accordion' ),
@@ -32,14 +33,22 @@ var Accordion = require( 'components/accordion' ),
 	stats = require( 'lib/posts/stats' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	siteUtils = require( 'lib/site/utils' );
+import { setExcerpt } from 'state/ui/editor/post/actions';
 
-var EditorDrawer = React.createClass( {
+const EditorDrawer = React.createClass( {
 
 	propTypes: {
 		site: React.PropTypes.object,
 		post: React.PropTypes.object,
 		postTypes: React.PropTypes.object,
-		isNew: React.PropTypes.bool
+		isNew: React.PropTypes.bool,
+		setExcerpt: React.PropTypes.func
+	},
+
+	getDefaultProps: function() {
+		return {
+			setExcerpt: () => {}
+		};
 	},
 
 	mixins: [
@@ -47,7 +56,9 @@ var EditorDrawer = React.createClass( {
 	],
 
 	onExcerptChange: function( event ) {
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( { excerpt: event.target.value } );
+		this.props.setExcerpt( event.target.value );
 	},
 
 	currentPostTypeSupports: function( feature ) {
@@ -270,4 +281,7 @@ var EditorDrawer = React.createClass( {
 	}
 } );
 
-module.exports = EditorDrawer;
+export default connect(
+	null,
+	dispatch => bindActionCreators( { setExcerpt }, dispatch )
+)( EditorDrawer );

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+const React = require( 'react' ),
 	classnames = require( 'classnames' );
-
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 /**
  * Internal dependencies
  */
-var MediaLibrarySelectedData = require( 'components/data/media-library-selected-data' ),
+const MediaLibrarySelectedData = require( 'components/data/media-library-selected-data' ),
 	EditorMediaModal = require( 'post-editor/media-modal' ),
 	EditorDrawerWell = require( 'post-editor/editor-drawer-well' ),
 	PostActions = require( 'lib/posts/actions' ),
@@ -15,19 +16,27 @@ var MediaLibrarySelectedData = require( 'components/data/media-library-selected-
 	stats = require( 'lib/posts/stats' ),
 	AccordionSection = require( 'components/accordion/section' ),
 	EditorFeaturedImagePreviewContainer = require( './preview-container' );
+import {
+	setFeaturedImage,
+	removeFeaturedImage
+} from 'state/ui/editor/post/actions';
 
-var EditorFeaturedImage = React.createClass( {
+const EditorFeaturedImage = React.createClass( {
 
 	propTypes: {
 		maxWidth: React.PropTypes.number,
 		site: React.PropTypes.object,
-		post: React.PropTypes.object
+		post: React.PropTypes.object,
+		setFeaturedImage: React.PropTypes.func,
+		removeFeaturedImage: React.PropTypes.func
 	},
 
 	getDefaultProps: function() {
 		return {
 			editable: false,
-			maxWidth: 450
+			maxWidth: 450,
+			setFeaturedImage: () => {},
+			removeFeaturedImage: () => {}
 		};
 	},
 
@@ -50,6 +59,9 @@ var EditorFeaturedImage = React.createClass( {
 			return;
 		}
 
+		this.props.setFeaturedImage( items[0].ID );
+
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		PostActions.edit( {
 			featured_image: items[0].ID
 		} );
@@ -59,6 +71,9 @@ var EditorFeaturedImage = React.createClass( {
 	},
 
 	removeImage: function() {
+		this.props.removeFeaturedImage();
+
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		PostActions.edit( {
 			featured_image: ''
 		} );
@@ -133,4 +148,7 @@ var EditorFeaturedImage = React.createClass( {
 	}
 } );
 
-module.exports = EditorFeaturedImage;
+export default connect(
+	null,
+	dispatch => bindActionCreators( { setFeaturedImage, removeFeaturedImage }, dispatch )
+)( EditorFeaturedImage );

--- a/client/post-editor/editor-taxonomies/test/accordion.jsx
+++ b/client/post-editor/editor-taxonomies/test/accordion.jsx
@@ -34,6 +34,10 @@ mockery.enable( {
 mockery.registerMock( 'components/info-popover', MOCK_COMPONENT );
 mockery.registerSubstitute( 'matches-selector', 'component-matches-selector' );
 mockery.registerSubstitute( 'query', 'component-query' );
+// TODO: REDUX - add proper tests when whole post-editor is reduxified
+mockery.registerMock( 'react-redux', {
+	connect: () => component => component
+} );
 i18n.initialize();
 ReactInjection.Class.injectMixin( i18n.mixin );
 TaxonomiesAccordion = require( 'post-editor/editor-taxonomies/accordion' );

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -56,6 +56,10 @@ mockery.registerMock( 'my-sites/drafts/draft-list', MOCK_COMPONENT );
 mockery.registerMock( 'lib/layout-focus', {
 	set() {}
 } );
+// TODO: REDUX - add proper tests when whole post-editor is reduxified
+mockery.registerMock( 'react-redux', {
+	connect: () => component => component
+} );
 
 const PostEditor = require( '../post-editor' );
 

--- a/client/state/ui/editor/post/actions.js
+++ b/client/state/ui/editor/post/actions.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:ui:editor:post:actions' );
+
+export function setEditingMode( mode, modeTitle, site ) {
+	debug( 'setEditingMode', mode, modeTitle, site );
+	return { type: 'TODO' };
+}
+
+export function startEditingNew( site, postOptions ) {
+	debug( 'startEditingNew', site, postOptions );
+	return { type: 'TODO' };
+}
+
+export function startEditingExisting( site, postID ) {
+	debug( 'startEditingExisting', site, postID );
+	return { type: 'TODO' };
+}
+
+export function toggleStickyStatus( currentStatus ) {
+	debug( 'toggleStickyStatus', currentStatus );
+	return { type: 'TODO' };
+}
+
+export function togglePendingStatus( currentStatus ) {
+	debug( 'togglePendingStatus', currentStatus );
+	return { type: 'TODO' };
+}
+
+export function setAuthor( newAuthor ) {
+	debug( 'setAuthor', newAuthor );
+	return { type: 'TODO' };
+}
+
+export function setCategories( newCategories ) {
+	debug( 'setCategories', newCategories );
+	return { type: 'TODO' };
+}
+
+export function trashPost( post, callback ) {
+	debug( 'trashPost', post, callback );
+	return { type: 'TODO' };
+}
+
+export function setDiscussionSettings( newSettings ) {
+	debug( 'setDiscussionSettings', newSettings );
+	return { type: 'TODO' };
+}
+
+export function setExcerpt( newExcerpt ) {
+	debug( 'setExcerpt', newExcerpt );
+	return { type: 'TODO' };
+}
+
+export function setFeaturedImage( newImage ) {
+	debug( 'setFeaturedImage', newImage );
+	return { type: 'TODO' };
+}
+
+export function removeFeaturedImage() {
+	debug( 'removeFeaturedImage' );
+	return { type: 'TODO' };
+}
+
+export const EDITING_MODES = {
+	EXISTING: 'EDITING_MODE_EXISTING',
+	NEW: 'EDITING_MODE_NEW'
+};


### PR DESCRIPTION
# What?

Part of https://github.com/Automattic/wp-calypso/issues/2993

Introduces redux actions side-by-side flux actions

This is the first step in Editor reduxification

1. Duplicate redux actions
2. See what do they do when they are together
3. Work on reducers, action creators
4. Hook state back into these components
5. Phase out flux and libs

# This PR
This introduces a portion of actions and a groundwork.
Whole process can be split into several PRs, but this one has to be merged to lay the groundwork (actions file)

# Further work
Progress tracking in #2993