### PR TITLE
Domains: improve button order in DNS editor on mobile

### DIFF
--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -25,27 +25,36 @@
 	border-top: 1px solid $gray-light;
 	margin: 16px -16px -16px -16px;
 	padding: 16px;
+	display: flex;
+	justify-content: flex-end;
 
 	@include breakpoint('>480px') {
 		padding: 24px;
 		margin: 24px -24px -24px -24px;
 	}
 
+	@include breakpoint( '<480px' ) {
+		flex-direction: column;
+	}
+
 	.button {
-		float: right;
 		margin: 0;
 
-		+ .button {
-			margin: 15px 0 0 0;
+		&.is-primary {
+			margin: 0 0 15px 0;
 
 			@include breakpoint('>480px') {
 				margin: 0 15px 0 0;
 			}
+
+			@include breakpoint( '<480px' ) {
+				order: 1;
+			}
 		}
 
 		@include breakpoint( '<480px' ) {
-			text-align: center;
 			width: 100%;
+			order: 2;
 		}
 	}
 }


### PR DESCRIPTION
The primary button should be on top on mobile (where the buttons are arranged horizontally), with a margin between it and the cancel button.
This also fixes the same issue in the view for setting the Primary Domain.

cc @breezyskies