### PR TITLE
Makefile: exclude node_modules in sub-directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ JS_FILES := $(shell \
 	find . \
 		-not \( -path './.git' -prune \) \
 		-not \( -path './build' -prune \) \
-		-not \( -path './node_modules' -prune \) \
+		-not \( -name 'node_modules' -prune \) \
 		-not \( -path './public' -prune \) \
 		-type f \
 		\( -name '*.js' -or -name '*.jsx' \) \
@@ -44,7 +44,7 @@ MD_FILES := $(shell \
 	find . \
 		-not \( -path './.git' -prune \) \
 		-not \( -path './build' -prune \) \
-		-not \( -path './node_modules' -prune \) \
+		-not \( -name 'node_modules' -prune \) \
 		-not \( -path './public' -prune \) \
 		-type f \
 		-name '*.md' \


### PR DESCRIPTION
This PR addresses issue #3024 by excluding `node_modules` directories anywhere in our source tree.

The new packages directory means we've got nearly 8991 files under `packages/react-interpolate-components/node_modules`, which we're currently including in the file lists we're building for linting and building devDocs.

The easiest way to see & verify the issue is to dump the results of the find statement into a file.  You can do this by adding a line like `> js_files.out \` just before the last closing brace of the `JS_FILES := ...` section.

Then run any make command (I recommend `make wiggle`) to evaluate it, and check for node_modules in that file: 

`cat js_files.out | grep node_modules | wc -l`.  We're looking for this to give 0, not 5699.


