### PR TITLE
Help: Fix subject autofill error

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -258,7 +258,7 @@ module.exports = React.createClass( {
 	 * Auto fill the subject with the first five words contained in the message field of the contact form.
 	 */
 	autofillSubject: function() {
-		if ( ! savedContactForm.message || savedContactForm.subject ) {
+		if ( ! savedContactForm || ! savedContactForm.message || savedContactForm.subject ) {
 			return;
 		}
 


### PR DESCRIPTION
This pull request closes a hole in which a javascript error could occur that I found while reviewing the code in the help section. The error could potentially happen when a chat has ended and operators are no longer available.

#### How to test
1. Navigate to http://calypso.localhost:3000/help/contact
2. Start a chat
3. Have all operators become unavailable.
4. Have the operator end the chat
5. Notice that the chatbox disappears.

The chatbox disappears because there is a silent javascript error that is occurring in one of the callbacks for `api.chat.onOperatorsAvailable`