### PR TITLE
Importer: Allow manually expiring an import session.

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -25,6 +25,9 @@ const ID_GENERATOR_PREFIX = 'local-generated-id-';
 /** Creates a request object to cancel an importer */
 const cancelOrder = ( siteId, importerId ) => toApi( { importerId, importerState: appStates.CANCEL_PENDING, site: { ID: siteId } } );
 
+/** Creates a request to expire an importer session */
+const expiryOrder = ( siteId, importerId ) => toApi( { importerId, importerState: appStates.EXPIRE_PENDING, site: { ID: siteId } } );
+
 /** Creates a request object to start performing the actual import */
 const importOrder = importerStatus => toApi( Object.assign( {}, importerStatus, { importerState: appStates.IMPORTING } ) );
 
@@ -126,6 +129,14 @@ export function resetImport( siteId, importerId ) {
 		importerId,
 		siteId
 	} );
+
+	apiStart();
+	wpcom
+		.updateImporter( siteId, expiryOrder( siteId, importerId ) )
+		.then( apiSuccess )
+		.then( fromApi )
+		.then( receiveImporterStatus )
+		.catch( apiFailure );
 }
 
 // Use when developing to force a new state into the store

--- a/client/lib/importer/common.js
+++ b/client/lib/importer/common.js
@@ -7,6 +7,7 @@ const importerStateMap = [
 	[ appStates.CANCEL_PENDING, 'cancel' ],
 	[ appStates.DEFUNCT, 'importStopped' ],
 	[ appStates.DISABLED, 'disabled' ],
+	[ appStates.EXPIRE_PENDING, 'expire' ],
 	[ appStates.IMPORT_FAILURE, 'importFailure' ],
 	[ appStates.IMPORT_SUCCESS, 'importSuccess' ],
 	[ appStates.IMPORTING, 'importing' ],

--- a/client/lib/importer/constants.js
+++ b/client/lib/importer/constants.js
@@ -2,6 +2,7 @@ export const appStates = Object.freeze( {
 	CANCEL_PENDING: 'importer-canceling',
 	DEFUNCT: 'importer-defunct',
 	DISABLED: 'importer-disabled',
+	EXPIRE_PENDING: 'importer-expire-pending',
 	IMPORT_FAILURE: 'importer-import-failure',
 	IMPORT_SUCCESS: 'importer-import-success',
 	IMPORTING: 'importer-importing',


### PR DESCRIPTION
Depends on D984
Should close #3019 in cooperation with D984

After an import finishes, the information representing its session
continues to live in the server and is passed back to the UI with the
successful state. This caused problems because the import screen would
show stale data for imports that were expired.

Now, by clicking the "Done" button we send a request to the server to
expire the import session so that it will get the new
"IMPORT_STATUS_EXPIRED" state and the UI can safely ignore that.

**To test**, apply D984 and sandbox `public-api.wordpress.com`, run an
import, and after it is finished, click on the "Done" button. In the
**master** branch, if you reload the page then the already finished
importer will reappear. In this branch, it shouldn't come back. Note
that you will need to test this across two separate import sessions to
confirm, or test in **master** first to see that the "Done" button is
ineffective.

N.B. Testing imports will take at least fifteen minutes to run due to
the way the current system handles imports. Do not be surprised when it
takes a long time.

cc: @apeatling @rralian @dllh @omarjackman @jordwest @roundhill 