### PR TITLE
Sharing: fix broken arrow on buttons in RTL

### DIFF
--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -780,12 +780,12 @@ $color-print: #f8f8f8;
 	&.is-top::after {
 		bottom: -7px;
 		border-top-width: 0;
-		border-left-width: 0  #{"/*rtl:ignore*/"};
+		border-left-width: 0;
 	}
 
 	&.is-bottom::after {
 		top: -7px;
-		border-right-width: 0  #{"/*rtl:ignore*/"};
+		border-right-width: 0;
 		border-bottom-width: 0;
 	}
 


### PR DESCRIPTION
Button arrows are broken in RTL:
![screen shot 2016-02-03 at 10 24 01](https://cloud.githubusercontent.com/assets/844866/12776816/97a5b6f8-ca61-11e5-9ee9-af119e74a2cc.png)

This has been broken since the switch to RTLCSS when the comment were added.
After patch:
![screen shot 2016-02-03 at 10 30 27](https://cloud.githubusercontent.com/assets/844866/12776894/07492c6a-ca62-11e5-85ec-68be81170dad.png)
