### PR TITLE
Jetpack-connect: Create routes & main component

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -56,7 +56,7 @@ sections = [
 	},
 	{
 		name: 'signup',
-		paths: [ '/start', '/phone', '/log-in' ],
+		paths: [ '/start', '/phone', '/log-in', '/jetpack' ],
 		module: 'signup',
 		enableLoggedOut: true
 	},

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -19,6 +19,7 @@ import route from 'lib/route';
 import analytics from 'analytics';
 import layoutFocus from 'lib/layout-focus';
 import SignupComponent from './main';
+import JetpackConnect from './jetpack-connect';
 import utils from './utils';
 import userModule from 'lib/user';
 import titleActions from 'lib/screen-title/actions';
@@ -147,6 +148,13 @@ export default {
 				path: context.path,
 				locale: context.params.lang
 			} ),
+			document.getElementById( 'primary' )
+		);
+	},
+
+	jetpackConnect( context ) {
+		ReactDom.render(
+			React.createElement( JetpackConnect, {} ),
 			document.getElementById( 'primary' )
 		);
 	}

--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -28,4 +28,8 @@ module.exports = function() {
 	if ( config.isEnabled( 'login' ) ) {
 		page( '/log-in/:lang?', controller.login );
 	}
+
+	if ( config.isEnabled( 'jetpack/calypso-first-signup-flow' ) ) {
+		page( '/jetpack/connect', controller.jetpackConnect );
+	}
 };

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+module.exports = React.createClass( {
+	displayName: 'JetpackConnect',
+
+	render: function() {
+		return (
+			<div>
+				Jetpack Connect
+			</div>
+		);
+	}
+} );

--- a/config/development.json
+++ b/config/development.json
@@ -146,7 +146,9 @@
 
 		"accept-invite": true,
 		"perfmon": false,
-		"mailing-lists/unsubscribe": true
+		"mailing-lists/unsubscribe": true,
+
+		"jetpack/calypso-first-signup-flow": true
 	},
 	"muse_supported_themes": [
 		"pub/twentytwelve",


### PR DESCRIPTION
This PR just adds the scaffolding and route management for the new calypso-first jetpack signup flow.  There's nothing to test, and everything is under `jetpack/calypso-first-signup-flow' feature flag, which is only active in development. 

I'm mergin this branch so @alternatekev can start working on it on different branches and we don't end with a huge single PR.