### PR TITLE
Framework: Move scroll root to avoid a scrollbar interfering with the Masterbar

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -243,13 +243,22 @@ html.iframed {
 $sidebar-width-max: 272px;
 $sidebar-width-min: 228px;
 
+html {
+	overflow-y: hidden;
+}
+
 .wp-content {
 	@include clear-fix;
 	position: relative;
 	margin: 47px 0 0 0;
 	padding: 32px 32px 32px ( $sidebar-width-max + 32px );
 	box-sizing: border-box;
-	overflow: hidden;
+	overflow-x: hidden;
+
+	@include breakpoint( ">480px" ) {
+		overflow-y: auto;
+		height: calc( 100vh - 47px );
+	}
 
 	.has-no-sidebar & {
 		padding-left: 32px;

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -68,7 +68,8 @@ export default React.createClass( {
 				guessedItemHeight={ 69 }
 				getItemRef={ blog => `blog-${ blog.ID }` }
 				renderItem={ renderBlog }
-				renderLoadingPlaceholders={ () => <Placeholder /> } />
+				renderLoadingPlaceholders={ () => <Placeholder /> }
+				context={ document.getElementById( 'content' ) } />
 		);
 	}
 } );

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -85,7 +85,8 @@ var Team = React.createClass( {
 					getItemRef={ this._getPersonRef }
 					renderLoadingPlaceholders={ this._renderLoadingPeople }
 					renderItem={ this._renderPerson }
-					guessedItemHeight={ 126 }>
+					guessedItemHeight={ 126 }
+					context={ document.getElementById( 'content' ) }>
 				</InfiniteList>
 			);
 		} else {

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -138,7 +138,8 @@ let Viewers = React.createClass( {
 					getItemRef={ this.getViewerRef }
 					renderLoadingPlaceholders={ this.renderPlaceholders }
 					renderItem={ this.renderViewer }
-					guessedItemHeight={ 126 }>
+					guessedItemHeight={ 126 }
+					context={ document.getElementById( 'content' ) }>
 				</InfiniteList>
 			);
 		} else {

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -245,6 +245,7 @@ var Posts = React.createClass( {
 					getItemRef={ this.getPostRef }
 					renderItem={ this.renderPost }
 					renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
+					context={ document.getElementById( 'content' ) }
 				/>
 			);
 

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -391,7 +391,8 @@ const FollowingEdit = React.createClass( {
 					fetchNextPage={ this.fetchNextPage }
 					getItemRef= { this.getSubscriptionRef }
 					renderItem={ this.renderSubscription }
-					renderLoadingPlaceholders={ this.renderLoadingPlaceholders } />
+					renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
+					context={ document.getElementById( 'content' ) } />
 				}
 			</Main>
 		);

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -429,7 +429,8 @@ module.exports = React.createClass( {
 			getItemRef= { this.getPostRef }
 			renderItem={ this.renderPost }
 			selectedIndex={ this.props.store.getSelectedIndex()}
-			renderLoadingPlaceholders={ this.renderLoadingPlaceholders } /> );
+			renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
+			context={ document.getElementById( 'content' ) } /> );
 		}
 
 		return (

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -137,6 +137,7 @@ const RecommendedForYou = React.createClass( {
 					getItemRef={ this.getItemRef }
 					renderItem={ this.renderItem }
 					renderLoadingPlaceholders={ this.renderPlaceholders }
+					context={ document.getElementById( 'content' ) }
 					/>
 				</Main>
 			);


### PR DESCRIPTION
The main goal of this PR is to avoid having a scrollbar interfere with the Masterbar, specifically in the context of the OS X app—but this could work well on the web as well. Here's a quick image to explain:

![scrollbars](https://cloud.githubusercontent.com/assets/191598/12789346/505439a8-ca95-11e5-9250-d1ca1b1f366f.png)

The top image shows `master`. Notice that the scrollbar appears over top of the Masterbar. In the bottom image, which shows this branch, the scrollbar doesn't affect the Masterbar.

One big advantage to this in the OS X app, is that it would allow us to consider a more unified Masterbar with the OS-level close/min/zoom buttons appearing within:

![screen shot 2016-02-03 at 11 47 16 am](https://cloud.githubusercontent.com/assets/191598/12789479/ec1a3a4a-ca95-11e5-8847-ad14cd4201b1.png)
