### PR TITLE
Signup: Headstart: Update dependencies in the domains step.

### DIFF
--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -81,7 +81,7 @@ module.exports = {
 	'domains-with-theme': {
 		stepName: 'domains-with-theme',
 		apiRequestFunction: stepActions.addDomainItemsToCart,
-		providesDependencies: [ 'siteSlug', 'domainItem' ],
+		providesDependencies: [ 'siteSlug', 'domainItem', 'themeItem' ],
 		dependencies: [ 'theme' ],
 		delayApiRequestUntilComplete: true
 	},


### PR DESCRIPTION
This fixes a fatal error introduced by 752fa72346341b12978f402e9f78891306586f49.

To test:
* Switch to this branch, then load the Headstart flow at `calypso.localhost:3000/start/headstart`.
* Complete signup, making sure you don't see this error in the console: `Uncaught Error: This step (domains-with-theme) provides an unspecified dependency [themeItem]. Make sure to specify it in /signup/config/steps.js, using the providesDependencies property.`