### PR TITLE
Signup: Allow currentFlowName to be a function reference

### DIFF
--- a/client/signup/test/signup/config/flows.js
+++ b/client/signup/test/signup/config/flows.js
@@ -18,6 +18,11 @@ flows.__set__( 'flows', {
 	account: {
 		steps: [ 'user', 'site' ],
 		destination: '/'
+	},
+
+	other: {
+		steps: [ 'user', 'site' ],
+		destination: '/'
 	}
 } );
 

--- a/client/signup/test/utils-test.js
+++ b/client/signup/test/utils-test.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var debug = require( 'debug' )( 'calypso:client:signup:controller-utils:test' ), // eslint-disable-line no-unused-vars
+	sinon = require( 'sinon' ),
 	assert = require( 'assert' );
 
 /**
@@ -40,12 +41,32 @@ describe( 'utils.getStepName', function() {
 } );
 
 describe( 'utils.getFlowName', function() {
+	afterEach( function() {
+		flows.currentFlowName = 'account';
+	} );
+
 	it( 'should find the flow name in the flowName fragment if present', function() {
-		assert.equal( utils.getFlowName( { flowName: 'account' } ), 'account' );
+		assert.equal( utils.getFlowName( { flowName: 'other' } ), 'other' );
 	} );
 
 	it( 'should return the current flow if the flow is missing', function() {
 		assert.equal( utils.getFlowName( {} ), 'account' );
+	} );
+
+	it( 'should call the currentFlowName if it is a function and the flow is missing', function() {
+		flows.currentFlowName = sinon.stub().returns( 'called' );
+		assert.equal( utils.getFlowName( {} ), 'called' );
+	} );
+
+	it( 'should call the currentFlowName with the requested flow if it is a function and the flow is not valid', function() {
+		flows.currentFlowName = sinon.stub().returns( 'called' );
+		utils.getFlowName( { flowName: 'invalid' } );
+		assert( flows.currentFlowName.calledWith( 'invalid' ) );
+	} );
+
+	it( 'should not call currentFlowName if it is a function and the flow is present', function() {
+		flows.currentFlowName = sinon.stub().returns( 'called' );
+		assert.equal( utils.getFlowName( { flowName: 'other' } ), 'other' );
 	} );
 } );
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -22,6 +22,10 @@ function getFlowName( parameters ) {
 		return parameters.flowName;
 	}
 
+	if ( typeof currentFlowName === 'function' ) {
+		currentFlowName = currentFlowName( parameters.flowName );
+	}
+
 	if ( ! isFlowName( parameters.flowName ) && currentFlowName === defaultFlowName ) {
 		return defaultFlowName;
 	}

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -26,10 +26,6 @@ function getFlowName( parameters ) {
 		currentFlowName = currentFlowName( parameters.flowName );
 	}
 
-	if ( ! isFlowName( parameters.flowName ) && currentFlowName === defaultFlowName ) {
-		return defaultFlowName;
-	}
-
 	return currentFlowName;
 }
 


### PR DESCRIPTION
This changes `flows.currentFlowName` so that if `currentFlowName` is a reference to a function instead of a string, it will be called to determine the name of the current flow when there is no valid flow passed to `utils.getFlowName()`.

This allows function calls with side-effects (e.g., using the `abtest()` function) to be avoided if a specific flow is being requested.