### PR TITLE
Plans: Remove ecommerce plugin mentions from test data

### DIFF
--- a/client/lib/features-list/test-features.js
+++ b/client/lib/features-list/test-features.js
@@ -74,11 +74,6 @@ const features = {
 			planSpecific: false
 		},
 		{
-			text: 'eCommerce',
-			planSpecific: true,
-			testVariable: true
-		},
-		{
 			text: 'Unlimited Premium Themes',
 			planSpecific: true
 		},

--- a/client/lib/features-list/test/data.js
+++ b/client/lib/features-list/test/data.js
@@ -8,12 +8,6 @@ var features = [
 		1008: true
 	},
 	{
-		product_slug: 'ecommerce',
-		title: 'eCommerce',
-		description: 'Sell stuff right on your blog with Ecwid and Shopify.',
-		1008: true
-	},
-	{
 		product_slug: 'custom-domain',
 		title: 'A Custom Site Address',
 		description: 'Register a new domain name (with private whois records) or map a domain you already own.',

--- a/client/lib/plans-list/test/data.js
+++ b/client/lib/plans-list/test/data.js
@@ -52,7 +52,7 @@ var plans = [
 	},
 	"product_slug":"business-bundle",
 	"tagline":"Build a great website",
-	"description":"All you need to build a great website: live chat support, unlimited premium themes, easy ecommerce, unlimited storage, and a custom domain name.",
+	"description":"All you need to build a great website: live chat support, unlimited premium themes, unlimited storage, and a custom domain name.",
 	"capability":"manage_options",
 	"cost":299,
 	"bill_period":365,


### PR DESCRIPTION
This pull request removes ecommerce mentions from test data to be in line with the removal of the ecommerce feature on the `Compare Plans` page.