### PR TITLE
People: Send invites from section header

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -192,6 +192,7 @@
 @import 'my-sites/people/people-list-item/style';
 @import 'my-sites/people/people-profile/style';
 @import 'my-sites/people/people-notices/style';
+@import 'my-sites/people/people-section-header/style';
 @import 'my-sites/plans/style';
 @import 'my-sites/plans/plan-overview/style';
 @import 'my-sites/plans/plan-overview/plan-feature/style';

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -82,7 +82,7 @@ var TokenField = React.createClass( {
 				onFocus={ this._onFocus }
 			>
 				<div ref="tokensAndInput"
-					className="token-field__input-container"
+					className={ classNames( 'token-field__input-container', { 'is-empty': ( this.props.value.length === 0 ) } ) }
 					onClick={ this._onClick }
 					tabIndex="-1"
 				>

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -127,7 +127,8 @@ var TokenField = React.createClass( {
 				ref="input"
 				key="input"
 				value={ this.state.incompleteTokenValue }
-				onChange={ this._onInputChange } />
+				onChange={ this._onInputChange }
+				placeholder={ this._getPlaceHolder() } />
 		);
 	},
 
@@ -152,40 +153,39 @@ var TokenField = React.createClass( {
 		if ( stillActive ) {
 			debug( '_onBlur but component still active; not doing anything' );
 			return; // we didn't leave the component, so don't do anything
-		} else {
-			debug( '_onBlur before timeout setting component inactive' );
-			this.setState( {
-				isActive: false
-			} );
-			/* When the component blurs, we need to add the current text, or
-			 * the selected suggestion (if any).
-			 *
-			 * Two reasons to set a timeout rather than do this immediately:
-			 *  - Some other user action (like tapping on a suggestion) may
-			 *    have caused this blur.  If there is another user-triggered
-			 *    event, we need to give it a chance to complete first.
-			 *  - At one point, using the right arrow key to move the text
-			 *    input was causing a blur to outside the component?! (left
-			 *    arrow key does not do this).  So, we delay the resetting of
-			 *    the state and cancel it if we get focus back quick enough.
-			 */
-			debug( '_onBlur waiting to add current token' );
-			this._blurTimeoutID = window.setTimeout( function() {
-				// Add the current token, UNLESS the text input is empty and
-				// there is a suggested token selected.  In that case, we don't
-				// want to add it, because it's easy to inadvertently hover
-				// over a suggestion.
-				if ( this._inputHasValidValue() ) {
-					debug( '_onBlur after timeout adding current token' );
-					this._addCurrentToken();
-				} else {
-					debug( '_onBlur after timeout not adding current token' );
-				}
-				debug( '_onBlur resetting component state' );
-				this.setState( this.getInitialState() );
-				this._clearBlurTimeout();
-			}.bind( this ), 0 );
 		}
+		debug( '_onBlur before timeout setting component inactive' );
+		this.setState( {
+			isActive: false
+		} );
+		/* When the component blurs, we need to add the current text, or
+		 * the selected suggestion (if any).
+		 *
+		 * Two reasons to set a timeout rather than do this immediately:
+		 *  - Some other user action (like tapping on a suggestion) may
+		 *    have caused this blur.  If there is another user-triggered
+		 *    event, we need to give it a chance to complete first.
+		 *  - At one point, using the right arrow key to move the text
+		 *    input was causing a blur to outside the component?! (left
+		 *    arrow key does not do this).  So, we delay the resetting of
+		 *    the state and cancel it if we get focus back quick enough.
+		 */
+		debug( '_onBlur waiting to add current token' );
+		this._blurTimeoutID = window.setTimeout( function() {
+			// Add the current token, UNLESS the text input is empty and
+			// there is a suggested token selected.  In that case, we don't
+			// want to add it, because it's easy to inadvertently hover
+			// over a suggestion.
+			if ( this._inputHasValidValue() ) {
+				debug( '_onBlur after timeout adding current token' );
+				this._addCurrentToken();
+			} else {
+				debug( '_onBlur after timeout not adding current token' );
+			}
+			debug( '_onBlur resetting component state' );
+			this.setState( this.getInitialState() );
+			this._clearBlurTimeout();
+		}.bind( this ), 0 );
 	},
 
 	_clearBlurTimeout: function() {
@@ -296,6 +296,13 @@ var TokenField = React.createClass( {
 		}
 
 		return preventDefault;
+	},
+
+	_getPlaceHolder: function() {
+		if ( ! this.props.placeHolder || this.props.value.length > 0 ) {
+			return null;
+		}
+		return this.props.placeHolder;
 	},
 
 	_getMatchingSuggestions: function() {

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -28,6 +28,13 @@
 	flex-wrap: wrap;
 	align-items: flex-start;
 	padding: 5px 14px 5px 0;
+
+	&.is-empty {
+
+		input[type="text"].token-field__input {
+			width: 100%;
+		}
+	}
 }
 
 // Token input

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -27,10 +27,11 @@ var TokenInput = React.createClass( {
 				ref="input"
 				type="text"
 				value={ this.props.value }
-			 	size={ this.props.value.length + 1 }
+				size={ this.props.value.length + 1 }
 				onBlur={ this.props.onBlur }
 				onChange={ this._onChange }
 				className="token-field__input"
+				placeholder={ this.props.placeholder }
 			/>
 		);
 	},

--- a/client/my-sites/people/people-section-header/index.jsx
+++ b/client/my-sites/people/people-section-header/index.jsx
@@ -69,4 +69,4 @@ export default React.createClass( {
 			</SectionHeader>
 		);
 	}
- } );
+} );

--- a/client/my-sites/people/people-section-header/index.jsx
+++ b/client/my-sites/people/people-section-header/index.jsx
@@ -1,0 +1,71 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import ClassNames from 'classnames';
+
+/**
+ * Internal Dependencies
+ */
+import config from 'config';
+import SectionHeader from 'components/section-header';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import InviteForm from 'my-sites/people/people-section-header/invite-form';
+
+export default React.createClass( {
+	displayName: 'PeopleSectionHeader',
+
+	getInitialState() {
+		return {
+			inviteOpen: false
+		};
+	},
+
+	openInvite() {
+		this.setState( { inviteOpen: true } );
+	},
+
+	closeInvite() {
+		this.setState( { inviteOpen: false } );
+	},
+
+	getProps() {
+		if ( this.state.inviteOpen ) {
+			return {};
+		}
+		return this.props;
+	},
+
+	renderHeaderContent() {
+		if ( ! config.isEnabled( 'manage/add-people' ) ) {
+			return null;
+		}
+
+		if ( this.state.inviteOpen ) {
+			return (
+				<div>
+					<Gridicon icon="add-outline" size={ 24 } />
+					<InviteForm site={ this.props.site } />
+					<Button className="is-link" onClick={ this.closeInvite }>
+						<Gridicon icon="cross-small" size={ 24 } />
+					</Button>
+				</div>
+			);
+		}
+		return (
+			<Button compact onClick={ this.openInvite }>
+				<Gridicon icon="add-outline" size={ 24 } />
+			</Button>
+		);
+	},
+
+	render() {
+		return (
+			<SectionHeader { ...this.getProps() }
+				className={ ClassNames( 'people-section-header', { 'invite-open': this.state.inviteOpen } ) }>
+				{ this.renderHeaderContent() }
+			</SectionHeader>
+		);
+	}
+ } );

--- a/client/my-sites/people/people-section-header/index.jsx
+++ b/client/my-sites/people/people-section-header/index.jsx
@@ -38,16 +38,17 @@ export default React.createClass( {
 	},
 
 	renderHeaderContent() {
-		if ( ! config.isEnabled( 'manage/add-people' ) ) {
+		const { site } = this.props;
+		if ( ! config.isEnabled( 'manage/add-people' ) || ( site && site.jetpack ) ) {
 			return null;
 		}
 
 		if ( this.state.inviteOpen ) {
 			return (
 				<div>
-					<Gridicon icon="add-outline" size={ 24 } />
-					<InviteForm site={ this.props.site } />
-					<Button className="is-link" onClick={ this.closeInvite }>
+					<Gridicon icon="add-outline" size={ 24 } className="people-section-header__icon" />
+					<InviteForm site={ site } />
+					<Button className="people-section-header__close is-link" onClick={ this.closeInvite }>
 						<Gridicon icon="cross-small" size={ 24 } />
 					</Button>
 				</div>

--- a/client/my-sites/people/people-section-header/invite-form.jsx
+++ b/client/my-sites/people/people-section-header/invite-form.jsx
@@ -10,7 +10,7 @@ import LinkedStateMixin from 'react-addons-linked-state-mixin';
  */
 import RoleSelect from 'my-sites/people/role-select';
 import TokenField from 'components/token-field';
-import FormButton from 'components/forms/form-button';
+import Button from 'components/button';
 
 /**
  * Module Variable
@@ -49,25 +49,32 @@ export default React.createClass( {
 
 	render() {
 		return (
-			<div className="people-section-header__invite-form">
-				<TokenField
-					value={ this.state.usernamesOrEmails }
-					onChange={ this.onTokensChange }
-					placeHolder={ this.translate( 'Username or Email' ) } />
-				<RoleSelect
-					id="role"
-					name="role"
-					key="role"
-					siteId={ this.props.site.ID }
-					valueLink={ this.linkState( 'role' ) }
-					disabled={ this.state.sendingInvites }
-					hideLabel={ true }
-					appendRoles={ { role: {}, follower: {} } } />
-				<FormButton
-					onClick={ this.submitForm }
-					disabled={ this.state.sendingInvites }>
-						{ this.translate( 'Invite' ) }
-				</FormButton>
+			<div className="invite-form">
+				<div className="invite-form__fieldset">
+					<TokenField
+						value={ this.state.usernamesOrEmails }
+						onChange={ this.onTokensChange }
+						placeHolder={ this.translate( 'Username or Email' ) } />
+				</div>
+				<div className="invite-form__fieldset">
+					<RoleSelect
+						id="role"
+						name="role"
+						key="role"
+						siteId={ this.props.site.ID }
+						valueLink={ this.linkState( 'role' ) }
+						disabled={ this.state.sendingInvites }
+						hideLabel={ true }
+						appendRoles={ { role: {}, follower: {} } } />
+					<Button
+						compact
+						primary
+						onClick={ this.submitForm }
+						className="invite-form__submit"
+						disabled={ this.state.sendingInvites }>
+							{ this.translate( 'Invite' ) }
+					</Button>
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/people/people-section-header/invite-form.jsx
+++ b/client/my-sites/people/people-section-header/invite-form.jsx
@@ -11,11 +11,12 @@ import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import RoleSelect from 'my-sites/people/role-select';
 import TokenField from 'components/token-field';
 import Button from 'components/button';
+import { sendInvites } from 'lib/invites/actions';
 
 /**
  * Module Variable
  */
-const debug = new Debug( 'calypso:people-section-header:invite-form' );
+const debug = new Debug( 'calypso:invite-people-form' );
 
 export default React.createClass( {
 	displayName: 'InviteForm',
@@ -34,7 +35,6 @@ export default React.createClass( {
 			usernamesOrEmails: [],
 			role: '',
 			message: '',
-			response: false,
 			sendingInvites: false
 		} );
 	},
@@ -44,7 +44,14 @@ export default React.createClass( {
 	},
 
 	submitForm() {
-		debug( 'Sending invites', this.state );
+		debug( 'Sending invites.', this.state );
+		this.setState( { sendingInvites: true } );
+		sendInvites( this.props.site.ID, this.state.usernamesOrEmails, this.state.role, this.state.message, this.handleResponse );
+	},
+
+	handleResponse( error, data ) {
+		debug( 'Request to send invites complete. Results:', error, data );
+		this.setState( this.resetState() );
 	},
 
 	render() {

--- a/client/my-sites/people/people-section-header/invite-form.jsx
+++ b/client/my-sites/people/people-section-header/invite-form.jsx
@@ -1,0 +1,74 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import Debug from 'debug';
+import LinkedStateMixin from 'react-addons-linked-state-mixin';
+
+/**
+ * Internal Dependencies
+ */
+import RoleSelect from 'my-sites/people/role-select';
+import TokenField from 'components/token-field';
+import FormButton from 'components/forms/form-button';
+
+/**
+ * Module Variable
+ */
+const debug = new Debug( 'calypso:people-section-header:invite-form' );
+
+export default React.createClass( {
+	displayName: 'InviteForm',
+	mixins: [ LinkedStateMixin ],
+
+	componentWillReceiveProps() {
+		this.setState( this.resetState() );
+	},
+
+	getInitialState() {
+		return this.resetState();
+	},
+
+	resetState() {
+		return ( {
+			usernamesOrEmails: [],
+			role: '',
+			message: '',
+			response: false,
+			sendingInvites: false
+		} );
+	},
+
+	onTokensChange( tokens ) {
+		this.setState( { usernamesOrEmails: tokens } );
+	},
+
+	submitForm() {
+		debug( 'Sending invites', this.state );
+	},
+
+	render() {
+		return (
+			<div className="people-section-header__invite-form">
+				<TokenField
+					value={ this.state.usernamesOrEmails }
+					onChange={ this.onTokensChange }
+					placeHolder={ this.translate( 'Username or Email' ) } />
+				<RoleSelect
+					id="role"
+					name="role"
+					key="role"
+					siteId={ this.props.site.ID }
+					valueLink={ this.linkState( 'role' ) }
+					disabled={ this.state.sendingInvites }
+					hideLabel={ true }
+					appendRoles={ { role: {}, follower: {} } } />
+				<FormButton
+					onClick={ this.submitForm }
+					disabled={ this.state.sendingInvites }>
+						{ this.translate( 'Invite' ) }
+				</FormButton>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/people/people-section-header/style.scss
+++ b/client/my-sites/people/people-section-header/style.scss
@@ -1,0 +1,9 @@
+.people-section-header {
+	
+	&.invite-open {
+
+		.section-header__label {
+			display: none;
+		}
+	}
+}

--- a/client/my-sites/people/people-section-header/style.scss
+++ b/client/my-sites/people/people-section-header/style.scss
@@ -5,5 +5,73 @@
 		.section-header__label {
 			display: none;
 		}
+
+		.section-header__actions {
+			width: 100%;
+		}
+
+		.people-section-header__icon {
+			position: absolute;
+			top: 0;
+			left: -12px;
+
+			@include breakpoint( ">660px" ) {
+				left: -16px;
+			}
+		}
+
+		.people-section-header__close {
+			position: absolute;
+			top: -8px;
+			right: -12px;
+
+			@include breakpoint( ">660px" ) {
+				right: -16px;
+			}
+		}
+	}
+
+	.invite-form {
+		padding: 0 16px;
+		height: 88px;
+		flex-wrap: wrap;
+		display: flex;
+		justify-content: space-between;
+
+		@include breakpoint( ">660px" ) {
+			height: 40px;
+		}
+
+		.invite-form__fieldset {
+			height: 40px;
+			width: 100%;
+			display: flex;
+
+			@include breakpoint( ">660px" ) {
+				width: 40%;
+
+				&:first-child {
+					margin-bottom: 8px;
+					width: 60%;
+				}
+			}
+
+			.role-select {
+				width: 70%;
+				text-align: left;
+
+				@include breakpoint( ">660px" ) {
+					text-align: center;
+				}
+			}
+
+			.invite-form__submit {
+				width: 30%;
+			}
+		}
 	}
 }
+
+
+
+

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -90,7 +90,7 @@ module.exports = React.createClass( {
 	render: function() {
 		var roles = Object.keys( this.state.roles );
 		return (
-			<FormFieldset key={ this.props.key } disabled={ ! roles.length }>
+			<FormFieldset className="role-select" key={ this.props.key } disabled={ ! roles.length }>
 				{ this.renderLabel() }
 				<FormSelect { ...omit( this.props, [ 'site', 'key' ] ) }>
 					{

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -40,11 +40,14 @@ module.exports = React.createClass( {
 	},
 
 	refreshRoles: function( nextProps ) {
-		var siteId = nextProps && nextProps.siteId ? nextProps.siteId : this.props.siteId;
-
+		var siteId = nextProps && nextProps.siteId ? nextProps.siteId : this.props.siteId,
+			appendRoles,
+			siteRoles;
 		if ( siteId ) {
+			siteRoles = RolesStore.getRoles( siteId );
+			appendRoles = this.props.appendRoles || {};
 			this.setState( {
-				roles: RolesStore.getRoles( siteId )
+				roles: Object.assign( {}, appendRoles, siteRoles )
 			} );
 		}
 	},
@@ -70,15 +73,25 @@ module.exports = React.createClass( {
 		}, 0 );
 	},
 
+	renderLabel: function() {
+		if ( this.props.hideLabel ) {
+			return null;
+		}
+
+		return (
+			<FormLabel htmlFor={ this.props.id }>
+				{ this.translate( 'Role', {
+					context: 'Text that is displayed in a label of a form.'
+				} ) }
+			</FormLabel>
+		);
+	},
+
 	render: function() {
 		var roles = Object.keys( this.state.roles );
 		return (
 			<FormFieldset key={ this.props.key } disabled={ ! roles.length }>
-				<FormLabel htmlFor={ this.props.id }>
-					{ this.translate( 'Role', {
-						context: 'Text that is displayed in a label of a form.'
-					} ) }
-				</FormLabel>
+				{ this.renderLabel() }
 				<FormSelect { ...omit( this.props, [ 'site', 'key' ] ) }>
 					{
 						roles.map( function( role ) {

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -9,14 +9,14 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var Card = require( 'components/card' ),
-	SectionHeader = require( 'components/section-header' ),
 	PeopleListItem = require( 'my-sites/people/people-list-item' ),
 	SiteUsersFetcher = require( 'components/site-users-fetcher' ),
 	UsersActions = require( 'lib/users/actions' ),
 	InfiniteList = require( 'components/infinite-list' ),
 	deterministicStringify = require( 'lib/deterministic-stringify' ),
 	NoResults = require( 'my-sites/no-results' ),
-	analytics = require( 'analytics' );
+	analytics = require( 'analytics' ),
+	PeopleSectionHeader = require( 'my-sites/people/people-section-header' );
 
 /**
  * Module Variables
@@ -43,7 +43,7 @@ var Team = React.createClass( {
 		if ( this.props.fetchInitialized && ! this.props.users.length && this.props.fetchOptions.search && ! this.props.fetchingUsers ) {
 			return (
 				<NoResults
-					image='/calypso/images/people/mystery-person.svg'
+					image="/calypso/images/people/mystery-person.svg"
 					text={
 						this.translate( 'No results found for {{em}}%(searchTerm)s{{/em}}',
 							{
@@ -94,7 +94,10 @@ var Team = React.createClass( {
 
 		return (
 			<div>
-				<SectionHeader label={ headerText } count={ this.props.fetchingUsers || this.props.fetchOptions.search ? undefined : this.props.totalUsers } />
+				<PeopleSectionHeader
+					label={ headerText }
+					count={ this.props.fetchingUsers || this.props.fetchOptions.search ? undefined : this.props.totalUsers }
+					site={ this.props.site } />
 				<Card className={ listClass }>
 					{ people }
 				</Card>
@@ -108,7 +111,7 @@ var Team = React.createClass( {
 			<PeopleListItem
 				key={ user.ID }
 				user={ user }
-				type='user'
+				type="user"
 				site={ this.props.site }
 				isSelectable={ this.state.bulkEditing } />
 		);


### PR DESCRIPTION
This PR adds an invitation form, which can be toggled from the section header of the Team section. 

![screen shot 2016-02-03 at 12 51 03 pm](https://cloud.githubusercontent.com/assets/2694219/12791473/451e765e-ca75-11e5-96d4-50f3268fd1d8.png)

![screen shot 2016-02-03 at 12 51 18 pm](https://cloud.githubusercontent.com/assets/2694219/12791479/49b393b6-ca75-11e5-92cb-cedae17d7682.png)

![screen shot 2016-02-03 at 12 51 36 pm](https://cloud.githubusercontent.com/assets/2694219/12791486/4d9a4c54-ca75-11e5-9212-aeddb7267db3.png)


To test:
 - Checkout this branch and `make run`
 - Go to calypso.localhost:3000/people/team/$site where site is a wpcom site ( not currently supported for Jetpack sites )
 - In your JS console run `localStorage.setItem( 'debug', 'calypso:invite-people-form' );`
 - Reload the page
 - Click the Plus Icon in the section header
 - Try sending out some invites, and note the messages in your console

Still ToDo ( handle in an other PR )
 - handle success and error notices after clicking 'Invite'
 - support adding a [custom message via modal](https://cloudup.com/iTWYfW7jZcb)
 - add to the section header for the other sections, 'followers', etc.
 - decide what happens when you click 'People > Add' in the sidebar
 - fine tune the design to be closer to [Rick's mocks](https://cloudup.com/csNs2HjStVB)

CC @ebinnion @lezama @rickybanister 