### PR TITLE
Plans: Remove ecommerce feature from Plan Overview page

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-features/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-features/index.jsx
@@ -34,12 +34,6 @@ const PlanFeatures = React.createClass( {
 					willBeRemoved={ willBeRemoved } />
 
 				<PlanFeature
-					button={ { label: this.translate( 'Set up eCommerce' ), href: `/plugins/${ this.props.selectedSite.slug }` } }
-					description={ this.translate( 'Connect your Shopify, Ecwid, or Gumroad account to your WordPress.com site.' ) }
-					heading={ this.translate( 'eCommerce Integration' ) }
-					willBeRemoved={ willBeRemoved } />
-
-				<PlanFeature
 					button={ { label: this.translate( 'Set up Analytics' ), href: `/settings/analytics/${ this.props.selectedSite.slug }` } }
 					description={ this.translate( 'Connect your Google Analytics account.' ) }
 					heading={ this.translate( 'Google Analytics Integration' ) }


### PR DESCRIPTION
This pull request removes the ecommerce feature section from the `Plan Overview` page:

![screenshot](https://cloud.githubusercontent.com/assets/594356/12792025/21829a38-caaa-11e5-8a25-faea59775327.png)

#### Testing instructions
 
1. Run `git checkout remove/ecommerce-plan-overview` and start your server
2. Get a test account with a new blog
3. Open the [`Plans` page](http://calypso.localhost:3000/plans)
4. Execute `localStorage.setItem( 'ABTests', '{"freeTrials_20160120":"offered"}' )` in your browser's console
5. Select the Business plan by clicking the `Start Free Trial` button on the [`Plans` page](http://calypso.localhost:3000/plans)
6. Click the `Start 14 Day Free Trial` button on the `Secure Payment` page
7. Check that you are redirected to the `Plans` page which should now display the `Plan Overview` variant
8. Check that ecommerce is no longer present in the list of features
 
#### Reviews
 
- [x] Code
- [x] Product