### PR TITLE
Checkout: Remove ecommerce feature from Thank You page

### DIFF
--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -55,12 +55,6 @@
 		}
 	}
 
-	&.ecommerce {
-		.checkout__purchase-detail-text::before {
-			@include noticon( '\f447' );
-		}
-	}
-
 	&.live-chat {
 		.checkout__purchase-detail-text::before {
 			@include noticon( '\f108' );

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -67,6 +67,12 @@
 		}
 	}
 
+	&.connect-google-analytics {
+		.checkout__purchase-detail-text::before {
+			@include noticon( '\f806' ); //.noticon-milestone
+		}
+	}
+
 	&.important {
 		.checkout__purchase-detail-text::before {
 			@include noticon( '\f303' );

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -403,6 +403,13 @@ BusinessPlanDetails = React.createClass( {
 					description={ this.translate( 'Browse our collection of beautiful and amazing themes for your site.' ) }
 					buttonText={ this.translate( 'Find a New Theme' ) }
 					href={ '/design/' + this.props.selectedSite.slug } />
+
+				<PurchaseDetail
+					additionalClass="connect-google-analytics"
+					title={ this.translate( 'Integrate Google Analytics' ) }
+					description={ this.translate( 'Connect your site to your existing Google Analytics account.' ) }
+					buttonText={ this.translate( 'Connect Google Analytics' ) }
+					href={ '/settings/analytics/' + this.props.selectedSite.slug } />
 			</ul>
 		);
 	}

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -388,24 +388,13 @@ BusinessPlanDetails = React.createClass( {
 						description={ this.translate( 'WordPress.com Business includes a free domain for your site.' ) }
 						buttonText={ this.translate( 'Add Free Domain' ) }
 						href={ '/domains/add/' + this.props.selectedSite.slug } />
-					: null }
-
-				<PurchaseDetail
-					additionalClass="ecommerce"
-					title={ this.translate( 'Add eCommerce' ) }
-					description={ this.translate( 'Connect your Ecwid or Shopify store with your WordPress.com site.' ) }
-					buttonText={ this.translate( 'Set Up eCommerce' ) }
-					href={ '/plugins/' + this.props.selectedSite.slug } />
-
-				{ ! showGetFreeDomainTip
-				? <PurchaseDetail
+				: <PurchaseDetail
 						additionalClass="live-chat"
 						title={ this.translate( 'Start a Live Chat' ) }
 						description={ this.translate( 'Have a question? Chat live with WordPress.com Happiness Engineers.' ) }
 						buttonText={ this.translate( 'Talk to an Operator' ) }
 						href="//support.wordpress.com/live-chat/"
 						target="_blank" />
-					: null
 				}
 
 				<PurchaseDetail


### PR DESCRIPTION
This pull request removes the ecommerce feature section from the `Thank You` page:

![screenshot](https://cloud.githubusercontent.com/assets/594356/12792609/f78ed630-caac-11e5-9ed6-74cf1e01279e.png)

#### Testing instructions
 
1. Run `git checkout remove/ecommerce-thank-you` and start your server
2. Select the Business plan by clicking the `Upgrade Now` button on the [`Plans` page](http://calypso.localhost:3000/plans)
3. Click the submit button on the `Secure Payment` page
4. Check that you are redirected to the `Thank You` page
5. Check that ecommerce is no longer present in the list of features
6. Check that Google Analytics is present instead and that clicking on it redirects to the GA config page

#### Reviews
 
- [x] Code
- [x] Product
- [x] Design