### PR TITLE
Themes: Remove spurious chars from logged-out

### DIFF
--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -91,7 +91,6 @@ var ThemesLoggedOut = React.createClass( {
 					tier={ this.props.tier }
 					queryParams={ this.props.queryParams }
 					themesList={ this.props.themesList } />
-				/> }
 			</Main>
 		);
 	}


### PR DESCRIPTION
There's a closing component-and-conditional `/> }` in logged-out which is a leftover from copying from `multi-site` where this is actually needed.

To test:
* Incognito window, calypso.localhost:3000/design
* The issue is visible on `master` if you search for a term that will return only few themes so you see the bottom of the page (try 'Espresso').
* Verify it's fixed on this branch