### PR TITLE
Plugins: added a tooltip to the 'add a plugin' icon-only button

### DIFF
--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -20,6 +20,7 @@ import SelectDropdown from 'components/select-dropdown';
 import DropdownItem from 'components/select-dropdown/item';
 import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
+import Tooltip from 'components/tooltip';
 
 let _actionBarVisible = true;
 
@@ -62,7 +63,8 @@ export default React.createClass( {
 
 	getInitialState() {
 		return {
-			actionBarVisible: _actionBarVisible
+			actionBarVisible: _actionBarVisible,
+			addPluginTooltip: false
 		};
 	},
 
@@ -151,8 +153,22 @@ export default React.createClass( {
 
 				rightSideButtons.push(
 					<ButtonGroup key="plugin-list-header__buttons-browser">
-						<Button compact href={ browserUrl } onClick={ this.onBrowserLinkClick } className="plugin-list-header__browser-button">
+						<Button
+							compact
+							href={ browserUrl }
+							onClick={ this.onBrowserLinkClick }
+							className="plugin-list-header__browser-button"
+							onMouseEnter={ () => this.setState( { addPluginTooltip: true } ) }
+			 				onMouseLeave={ () => this.setState( { addPluginTooltip: false } ) }
+			 				ref="addPluginButton"
+			 				aria-label={ this.translate( 'Browse all plugins', { context: 'button label' } ) }>
 							<Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } />
+							<Tooltip
+								isVisible={ this.state.addPluginTooltip }
+								context={ this.refs && this.refs.addPluginButton }
+								position="bottom">
+								{ this.translate( 'Browse all plugins', { context: 'button tooltip' } ) }
+							</Tooltip>
 						</Button>
 					</ButtonGroup>
 				);


### PR DESCRIPTION
Previously we were relying on only an icon to explain what that button did and it had no aria label for screen readers. It now has a tooltip when you hover AND a screen reader label.

This issue was raised in #2257 

Thanks to @ebinnion for helping me figure out how to make this work!

Before:
There is simply no tooltip, nothing to see!

After:
<img width="237" alt="screen shot 2016-02-03 at 4 16 22 pm" src="https://cloud.githubusercontent.com/assets/437258/12797467/0e59bbac-ca92-11e5-8889-1a365421b606.png">
