### PR TITLE
Ad Tracking: Track revenue with Bing/Google

### DIFF
--- a/client/analytics/ad-tracking.js
+++ b/client/analytics/ad-tracking.js
@@ -161,11 +161,13 @@ function recordPurchase( product ) {
 		}
 	);
 
-	// record the purchase w/ Bing
-	window.uetq.push( {
-		ec: 'purchase',
-		gv: product.cost
-	} );
+	// record the purchase w/ Bing if it is made with USD - Bing doesn't handle multiple currencies
+	if ( 'USD' === product.currency ) {
+		window.uetq.push( {
+			ec: 'purchase',
+			gv: product.cost
+		} );
+	}
 
 	// record the purchase w/ Google
 	window.google_trackConversion( {

--- a/client/analytics/ad-tracking.js
+++ b/client/analytics/ad-tracking.js
@@ -28,6 +28,8 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 	BING_TRACKING_SCRIPT_URL = 'https://bat.bing.com/bat.js',
 	GOOGLE_CONVERSION_ID = config( 'google_adwords_conversion_id' ),
 	TRACKING_IDS = {
+		bingInit: '4074038',
+
 		facebookInit: '823166884443641',
 
 		freeSignup: {
@@ -39,8 +41,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		},
 
 		premiumSignup: {
-			google: 'UMSeCIyYmFwQ1uXz_AM',
-			bing: '4074038'
+			google: 'UMSeCIyYmFwQ1uXz_AM'
 		},
 
 		businessTrial: {
@@ -48,8 +49,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		},
 
 		businessSignup: {
-			google: 'JxKBCKK-m1wQ1uXz_AM',
-			bing: '4074039'
+			google: 'JxKBCKK-m1wQ1uXz_AM'
 		},
 
 		retargeting: '823166884443641'
@@ -106,6 +106,19 @@ function loadTrackingScripts( callback ) {
 		if ( ! some( errors ) ) {
 			// update Facebook's tracking global
 			window.fbq( 'init', TRACKING_IDS.facebookInit );
+
+			// update Bing's tracking global
+			const bingConfig = {
+				ti: TRACKING_IDS.bingInit
+			};
+
+			bingConfig.q = window.uetq;
+
+			if ( typeof UET !== 'undefined' ) {
+				// bing's script creates the UET global for us
+				window.uetq = new UET( bingConfig ); // eslint-disable-line
+				window.uetq.push( 'pageLoad' );
+			}
 
 			if ( typeof callback === 'function' ) {
 				callback();
@@ -190,6 +203,12 @@ function recordPurchase( product ) {
 		}
 	);
 
+	// record the purchase w/ Bing
+	window.uetq.push( {
+		ec: 'purchase',
+		gv: product.cost
+	} );
+
 	// record the purchase w/ Google if a tracking ID is present
 	if ( TRACKING_IDS[ type ] && TRACKING_IDS[ type ].google ) {
 		window.google_trackConversion( {
@@ -197,16 +216,6 @@ function recordPurchase( product ) {
 			google_conversion_label: TRACKING_IDS[ type ].google,
 			google_remarketing_only: false
 		} );
-	}
-
-	// record the purchase w/ Bing if a tracking ID is present
-	if ( TRACKING_IDS[ type ] && TRACKING_IDS[ type ].bing && typeof UET !== 'undefined' ) {
-		window.uetq = new UET( { // eslint-disable-line no-undef
-			ti: TRACKING_IDS[ type ].bing,
-			o: window.uetq
-		} );
-		window.uetq.push( 'pageLoad' );
-		window.uetq.push( { ec: 'conversion' } );
 	}
 }
 

--- a/client/analytics/ad-tracking.js
+++ b/client/analytics/ad-tracking.js
@@ -12,7 +12,6 @@ const debug = debugFactory( 'calypso:ad-tracking' );
  */
 import loadScript from 'lib/load-script';
 import config from 'config';
-import { isBusiness, isPremium } from 'lib/products-values';
 
 /**
  * Module variables
@@ -29,28 +28,8 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 	GOOGLE_CONVERSION_ID = config( 'google_adwords_conversion_id' ),
 	TRACKING_IDS = {
 		bingInit: '4074038',
-
 		facebookInit: '823166884443641',
-
-		freeSignup: {
-			google: 'd-fNCIe7m1wQ1uXz_AM'
-		},
-
-		premiumTrial: {
-			google: '_q3ECJ--m1wQ1uXz_AM'
-		},
-
-		premiumSignup: {
-			google: 'UMSeCIyYmFwQ1uXz_AM'
-		},
-
-		businessTrial: {
-			google: 'm9zRCNO8m1wQ1uXz_AM'
-		},
-
-		businessSignup: {
-			google: 'JxKBCKK-m1wQ1uXz_AM'
-		}
+		googleConversionLabel: 'MznpCMGHr2MQ1uXz_AM'
 	};
 
 /**
@@ -107,10 +86,9 @@ function loadTrackingScripts( callback ) {
 
 			// update Bing's tracking global
 			const bingConfig = {
-				ti: TRACKING_IDS.bingInit
+				ti: TRACKING_IDS.bingInit,
+				q: window.uetq
 			};
-
-			bingConfig.q = window.uetq;
 
 			if ( typeof UET !== 'undefined' ) {
 				// bing's script creates the UET global for us
@@ -162,8 +140,6 @@ function recordAddToCart( cartItem ) {
 }
 
 function recordPurchase( product ) {
-	let type;
-
 	if ( ! config.isEnabled( 'ad-tracking' ) ) {
 		return;
 	}
@@ -172,23 +148,7 @@ function recordPurchase( product ) {
 		return loadTrackingScripts( recordPurchase.bind( null, product ) );
 	}
 
-	if ( isPremium( product ) ) {
-		if ( 0 === product.cost ) {
-			type = 'premiumTrial';
-		} else {
-			type = 'premiumSignup';
-		}
-	}
-
-	if ( isBusiness( product ) ) {
-		if ( 0 === product.cost ) {
-			type = 'businessTrial';
-		} else {
-			type = 'businessSignup';
-		}
-	}
-
-	debug( 'Recorded purchase', type );
+	debug( 'Recording purchase', product );
 
 	// record the purchase w/ Facebook
 	window.fbq(
@@ -207,14 +167,17 @@ function recordPurchase( product ) {
 		gv: product.cost
 	} );
 
-	// record the purchase w/ Google if a tracking ID is present
-	if ( TRACKING_IDS[ type ] && TRACKING_IDS[ type ].google ) {
-		window.google_trackConversion( {
-			google_conversion_id: GOOGLE_CONVERSION_ID,
-			google_conversion_label: TRACKING_IDS[ type ].google,
-			google_remarketing_only: false
-		} );
-	}
+	// record the purchase w/ Google
+	window.google_trackConversion( {
+		google_conversion_id: GOOGLE_CONVERSION_ID,
+		google_conversion_label: TRACKING_IDS.googleConversionLabel,
+		google_conversion_value: product.cost,
+		google_conversion_currency: product.currency,
+		google_custom_params: {
+			product_slug: product.product_slug
+		},
+		google_remarketing_only: false
+	} );
 }
 
 module.exports = {

--- a/client/analytics/ad-tracking.js
+++ b/client/analytics/ad-tracking.js
@@ -50,9 +50,7 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 
 		businessSignup: {
 			google: 'JxKBCKK-m1wQ1uXz_AM'
-		},
-
-		retargeting: '823166884443641'
+		}
 	};
 
 /**


### PR DESCRIPTION
Fixes #2829.

Previously, Bing conversions didn't include revenue, and Google conversions were associated with specific products and didn't include revenue. Now, Bing/Google conversions fire for each product and include revenue.

**Testing**
- Set `ad-tracking` to true in `config/development.json`.
- Open the network pane of the developer tools.
- Visit a store-related route, like `/plans/:site`.
- Assert that you see two requests (one to a `bing.com` domain and one to an `msn.com` domain) with `evt=pageLoad` as part of the querystring. I entered 'bat' in the search to filter these out: https://cloudup.com/cQZAjr_TZ65
- Go through the checkout for a plan (or other product).
- Assert that you see another image request to `bing.com` with `ev=purchase&gv=[revenue]` as part of the querystring, where `[revenue]` is a number representing the cost of the product that was just purchased ([screenshot](https://cloudup.com/cm4Z3Cn2UF7)).
- Assert that you see another image request to `google.com` with an encoded `data` parameter that contains the currency, product slug, and value of each product purchase (e.g. `data=currency%3DUSD%3Bproduct_slug%3Dvalue_bundle%3Bvalue%3D99` when purchasing the premium plan - [screenshot](https://cloudup.com/cKn83XWNOL0)).

**Note:** I'm seeing [errors](https://cloudup.com/cQAMzLrcneh) in my console when enabling ad-tracking locally, on master or this branch. I think this is because Facebook is rejecting pixel requests from `calypso.localhost`, and won't be an issue on production (as evidenced by the fact that it isn't currently).

- [x] Product review
- [x] Code review