### PR TITLE
Reader feed subscriptions: handle autodiscovered feed URLs that differ from site URLs

### DIFF
--- a/client/lib/feed-store/actions.js
+++ b/client/lib/feed-store/actions.js
@@ -6,7 +6,7 @@ var ActionType = require( './constants' ).action,
 
 var FeedStoreActions = {
 	fetch: function( feedId ) {
-		var feed = FeedStore.get( feedId );
+		const feed = FeedStore.get( feedId );
 
 		if ( feed && feed.state === FeedState.PENDING ) {
 			return;

--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -17,7 +17,8 @@ const Emitter = require( 'lib/mixins/emitter' ),
 	ActionTypes = require( './constants' ).action,
 	ErrorTypes = require( './constants' ).error,
 	FeedSubscriptionHelper = require( './helper' ),
-	States = require( './constants' ).state;
+	States = require( './constants' ).state,
+	FeedActionTypes = require( 'lib/feed-store/constants' ).action;
 
 const subscriptionsTemplate = {
 	list: Immutable.List(), // eslint-disable-line new-cap
@@ -372,6 +373,14 @@ FeedSubscriptionStore.dispatchToken = Dispatcher.register( function( payload ) {
 		case ActionTypes.RECEIVE_FEED_SUBSCRIPTIONS:
 			if ( action.data && ! action.data.errors ) {
 				FeedSubscriptionStore.receiveSubscriptions( action.data );
+			}
+			break;
+		case FeedActionTypes.RECEIVE_FETCH:
+			if ( action.data && action.data.is_following ) {
+				let subscription = action.data;
+				// Use the feed URL in as the primary URL
+				subscription.URL = subscription.feed_URL;
+				addSubscription( subscription );
 			}
 			break;
 	}

--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -16,7 +16,6 @@ const Dispatcher = require( 'dispatcher' ),
 const Emitter = require( 'lib/mixins/emitter' ),
 	ActionTypes = require( './constants' ).action,
 	ErrorTypes = require( './constants' ).error,
-	PostStoreActionTypes = require( 'lib/feed-post-store/constants' ).action,
 	FeedSubscriptionHelper = require( './helper' ),
 	States = require( './constants' ).state;
 
@@ -121,20 +120,6 @@ var FeedSubscriptionStore = {
 		if ( addSubscription( { URL: action.url } ) ) {
 			FeedSubscriptionStore.emit( 'change' );
 		}
-	},
-
-	receivePost: function( post ) {
-		if ( ! ( post && post.site_URL ) ) {
-			return;
-		}
-
-		const siteUrl = FeedSubscriptionHelper.prepareSiteUrl( post.site_URL );
-		debug( 'receivePost: ' + siteUrl );
-		if ( ( post.is_following ) && ! this.getIsFollowingBySiteUrl( siteUrl ) ) {
-			addSubscription( { URL: siteUrl } );
-		}
-
-		FeedSubscriptionStore.emit( 'change' );
 	},
 
 	receiveSubscriptions: function( data ) {
@@ -383,11 +368,6 @@ FeedSubscriptionStore.dispatchToken = Dispatcher.register( function( payload ) {
 			break;
 		case ActionTypes.DISMISS_FOLLOW_ERROR:
 			FeedSubscriptionStore.dismissError( action );
-			break;
-		case PostStoreActionTypes.RECEIVE_FEED_POST:
-			if ( action.data && ! action.data.errors ) {
-				FeedSubscriptionStore.receivePost( action.data );
-			}
 			break;
 		case ActionTypes.RECEIVE_FEED_SUBSCRIPTIONS:
 			if ( action.data && ! action.data.errors ) {

--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -377,9 +377,8 @@ FeedSubscriptionStore.dispatchToken = Dispatcher.register( function( payload ) {
 			break;
 		case FeedActionTypes.RECEIVE_FETCH:
 			if ( action.data && action.data.is_following ) {
-				let subscription = action.data;
 				// Use the feed URL in as the primary URL
-				subscription.URL = subscription.feed_URL;
+				const subscription = Object.assign( {}, action.data, { URL: action.data.feed_URL } );
 				addSubscription( subscription );
 			}
 			break;

--- a/client/lib/reader-feed-subscriptions/test/feed-subscription-store-test.js
+++ b/client/lib/reader-feed-subscriptions/test/feed-subscription-store-test.js
@@ -181,14 +181,13 @@ describe( 'feed-subscription-store', function() {
 	} );
 
 	it( 'should not add duplicate subscriptions', function() {
+		const siteUrl = 'http://www.tomato.com';
+
+		// The initial action from the UI
 		Dispatcher.handleViewAction( {
-			type: 'RECEIVE_FEED_POST',
-			data: { is_following: true, site_URL: 'http://www.tomato.com' },
-			error: null
-		} );
-		Dispatcher.handleViewAction( {
-			type: 'RECEIVE_FEED_POST',
-			data: { is_following: true, site_URL: 'http://www.tomato.com' },
+			type: 'FOLLOW_READER_FEED',
+			url: siteUrl,
+			data: { url: siteUrl },
 			error: null
 		} );
 

--- a/client/reader/following-edit/list-item.jsx
+++ b/client/reader/following-edit/list-item.jsx
@@ -23,7 +23,9 @@ const Icon = require( 'reader/list-item/icon' ),
 	FeedStore = require( 'lib/feed-store' ),
 	smartSetState = require( 'lib/react-smart-set-state' );
 
-var SubscriptionListItem = React.createClass( {
+import ExternalLink from 'components/external-link';
+
+const SubscriptionListItem = React.createClass( {
 
 	propTypes: {
 		subscription: React.PropTypes.object.isRequired,
@@ -92,7 +94,8 @@ var SubscriptionListItem = React.createClass( {
 			siteData = this.state.site,
 			feedData = this.state.feed,
 			iconUrl = siteData && siteData.get( 'icon' ),
-			displayUrl = FeedDisplayHelper.formatUrlForDisplay( subscription.get( 'URL' ) ),
+			siteUrl = FeedDisplayHelper.getSiteUrl( siteData, feedData, subscription ),
+			displayUrl = FeedDisplayHelper.formatUrlForDisplay( siteUrl ),
 			isFollowing = this.isFollowing(),
 			feedTitle = decodeEntities( FeedDisplayHelper.getFeedTitle( siteData, feedData, displayUrl ) );
 
@@ -102,7 +105,7 @@ var SubscriptionListItem = React.createClass( {
 				<Title>
 					<a href={ FeedDisplayHelper.getFeedStreamUrl( siteData, feedData, displayUrl ) }>{ feedTitle }</a>
 				</Title>
-				<Description><a href={ subscription.get( 'URL' ) }>{ displayUrl }</a></Description>
+				<Description><ExternalLink icon={ true } href={ siteUrl } target="_blank" iconSize={ 12 }>{ displayUrl }</ExternalLink></Description>
 				<Actions>
 					<ReaderFollowButton following={ isFollowing } onFollowToggle={ this.handleFollowToggle } isButtonOnly={ true } siteUrl={ subscription.get( 'URL' ) } />
 				</Actions>

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -34,6 +34,10 @@
 	.reader-list-item__description {
 		margin-right: 0;
 	}
+
+	.external-link .gridicons-external {
+		margin-left: 4px;
+	}
 }
 
 

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -28,6 +28,7 @@ module.exports = function() {
 	if ( config.isEnabled( 'reader' ) ) {
 		page( '/', controller.loadSubscriptions );
 		page( '/read/*', controller.loadSubscriptions );
+		page( '/tag/*', controller.loadSubscriptions );
 
 		page( '/', updateLastRoute, controller.removePost, controller.sidebar, controller.following );
 
@@ -73,6 +74,6 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'reader/discover' ) ) {
-		page( '/discover', updateLastRoute, controller.removePost, controller.sidebar, controller.discover );
+		page( '/discover', updateLastRoute, controller.loadSubscriptions, controller.removePost, controller.sidebar, controller.discover );
 	}
 };

--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -34,5 +34,19 @@ module.exports = {
 		}
 
 		return getSiteUrl( siteData.get( 'ID' ) )
+	},
+
+	getSiteUrl: function( siteData, feedData, subscription ) {
+		var siteUrl;
+
+		if ( siteData && siteData.get( 'URL' ) ) {
+			siteUrl = siteData.get( 'URL' );
+		} else if ( feedData && feedData.URL ) {
+			siteUrl = feedData.URL;
+		} else if ( subscription && subscription.get( 'URL' ) ) {
+			siteUrl = subscription.get( 'URL' );
+		}
+
+		return siteUrl;
 	}
 };

--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -1,24 +1,28 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+const React = require( 'react' ),
 	noop = require( 'lodash/utility/noop' ),
 	page = require( 'page' );
+
+import get from 'lodash/object/get';
 
 /**
  * Internal dependencies
  */
-var PopoverMenu = require( 'components/popover/menu' ),
+const PopoverMenu = require( 'components/popover/menu' ),
 	PopoverMenuItem = require( 'components/popover/menu-item' ),
 	FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions/index' ),
 	SiteStore = require( 'lib/reader-site-store' ),
+	FeedStore = require( 'lib/feed-store' ),
+	FeedStoreActions = require( 'lib/feed-store/actions' ),
 	SiteBlockStore = require( 'lib/reader-site-blocks/index' ),
 	SiteBlockActions = require( 'lib/reader-site-blocks/actions' ),
 	postUtils = require( 'lib/posts/utils' ),
 	FollowButton = require( 'reader/follow-button' ),
 	stats = require( 'reader/stats' );
 
-var PostOptions = React.createClass( {
+const PostOptions = React.createClass( {
 
 	propTypes: {
 		post: React.PropTypes.object.isRequired,
@@ -42,20 +46,24 @@ var PostOptions = React.createClass( {
 	componentDidMount: function() {
 		SiteBlockStore.on( 'change', this.updateState );
 		FeedSubscriptionStore.on( 'change', this.updateState );
+		FeedStore.on( 'change', this.updateState );
 	},
 
 	componentWillUnmount: function() {
 		SiteBlockStore.off( 'change', this.updateState );
 		FeedSubscriptionStore.off( 'change', this.updateState );
+		FeedStore.on( 'change', this.updateState );
 	},
 
 	getStateFromStores: function() {
-		var siteId = this.props.post.site_ID;
+		const siteId = this.props.post.site_ID;
+		const followUrl = this.getFollowUrl();
 
 		return {
 			isBlocked: SiteBlockStore.getIsBlocked( siteId ),
 			blockError: SiteBlockStore.getLastErrorBySite( siteId ),
-			followError: FeedSubscriptionStore.getLastErrorBySiteUrl( this.props.post.site_URL )
+			feed: this.getFeed(),
+			followError: FeedSubscriptionStore.getLastErrorBySiteUrl( followUrl )
 		};
 	},
 
@@ -85,6 +93,27 @@ var PostOptions = React.createClass( {
 		stats.recordGaEvent( 'Clicked Report Post', 'post_options' );
 
 		window.open( 'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ), '_blank' );
+	},
+
+	getFollowUrl() {
+		return this.state && this.state.feed ? this.state.feed.get( 'feed_URL' ) : this.props.post.site_URL;
+	},
+
+	getFeed() {
+		const feedId = get( this.props, 'post.feed_ID' );
+		if ( ! feedId || feedId < 1 ) {
+			return;
+		}
+
+		const feed = FeedStore.get( feedId );
+
+		if ( ! feed ) {
+			setTimeout( function() {
+				FeedStoreActions.fetch( feedId );
+			}, 0 );
+		}
+
+		return feed;
 	},
 
 	_showPopoverMenu: function() {
@@ -157,7 +186,7 @@ var PostOptions = React.createClass( {
 						position={ this.state.popoverPosition }
 						context={ this.refs && this.refs.popoverMenuButton }>
 
-					<FollowButton tagName={ PopoverMenuItem } siteUrl={ post.site_URL } />
+					<FollowButton tagName={ PopoverMenuItem } siteUrl={ this.getFollowUrl() } />
 
 					{ isEditPossible ? <PopoverMenuItem onClick={ this.editPost } className="post-options__edit has-icon">
 						<svg className="gridicon gridicon__edit" height="20" width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M4 15v5h5l9-9-5-5-9 9zM16 3l-2 2 5 5 2-2-5-5z"/></g></svg>

--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -52,17 +52,19 @@ const PostOptions = React.createClass( {
 	componentWillUnmount: function() {
 		SiteBlockStore.off( 'change', this.updateState );
 		FeedSubscriptionStore.off( 'change', this.updateState );
-		FeedStore.on( 'change', this.updateState );
+		FeedStore.off( 'change', this.updateState );
 	},
 
 	getStateFromStores: function() {
-		const siteId = this.props.post.site_ID;
-		const followUrl = this.getFollowUrl();
+		const siteId = this.props.post.site_ID,
+			feed = this.getFeed(),
+			followUrl = this.getFollowUrl( feed );
 
 		return {
 			isBlocked: SiteBlockStore.getIsBlocked( siteId ),
 			blockError: SiteBlockStore.getLastErrorBySite( siteId ),
 			feed: this.getFeed(),
+			followUrl: followUrl,
 			followError: FeedSubscriptionStore.getLastErrorBySiteUrl( followUrl )
 		};
 	},
@@ -95,8 +97,8 @@ const PostOptions = React.createClass( {
 		window.open( 'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ), '_blank' );
 	},
 
-	getFollowUrl() {
-		return this.state && this.state.feed ? this.state.feed.get( 'feed_URL' ) : this.props.post.site_URL;
+	getFollowUrl( feed ) {
+		return feed ? feed.get( 'feed_URL' ) : this.props.post.site_URL;
 	},
 
 	getFeed() {
@@ -186,7 +188,7 @@ const PostOptions = React.createClass( {
 						position={ this.state.popoverPosition }
 						context={ this.refs && this.refs.popoverMenuButton }>
 
-					<FollowButton tagName={ PopoverMenuItem } siteUrl={ this.getFollowUrl() } />
+					<FollowButton tagName={ PopoverMenuItem } siteUrl={ this.state.followUrl } />
 
 					{ isEditPossible ? <PopoverMenuItem onClick={ this.editPost } className="post-options__edit has-icon">
 						<svg className="gridicon gridicon__edit" height="20" width="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M4 15v5h5l9-9-5-5-9 9zM16 3l-2 2 5 5 2-2-5-5z"/></g></svg>


### PR DESCRIPTION
Due to inconsistent use of feed URLs in the reader-feed-subscriptions store, users have been unable to unfollow some feeds (e.g. Youtube channels - see #2064).

This PR ensures that all feed URLs are run through `FeedSubscriptionHelper.prepareSiteUrl` before being used, and that we update the URL for the feed if the API hands us back a new URL after feed autodiscovery.

### To test
- Follow a Youtube channel in Manage Following (/following/edit), e.g. http://www.youtube.com/channel/UCBJycsmduvYEL83R_U4JriQ
- Unsubscribe from the channel using the 'Following' button
- Hard refresh the Manage Following page and verify that the subscription has disappeared

Fixes #2064 and #945.