### PR TITLE
Help: Fix warning that occurs on the help contact form

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -79,7 +79,7 @@ module.exports = React.createClass( {
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
-		if ( isEqual( nextProps.valueLink.value, this.state ) ) {
+		if ( ! nextProps.valueLink.value || isEqual( nextProps.valueLink.value, this.state ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This pull requests fixes a warning that occurs on the help contact form.

#### How to test
1. Navigate to http://calypso.localhost:3000/help/contact
2. View the javascript console
3. Notice the below warning

![screen shot 2016-02-03 at 7 00 31 pm](https://cloud.githubusercontent.com/assets/1854440/12801191/95900264-caa8-11e5-8908-4bdd5110fbf3.png)


Please note that this logic will be going away soon in preference for a redux store.