### PR TITLE
Desktop: Add ping checks for desktop

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ if ( desktop.isForkedProcess() ) {
 	// We need to run it with an explicit hostname to avoid firewall warnings.
 	server.listen( { port, host }, function() {
 		// Tell the parent process that Calypso has booted.
-		desktop.sendBootSignal();
+		desktop.ready();
 	} );
 } else {
 	// Let non-forks listen on any host.

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var boot = require( 'boot' ),
  * Internal dependencies
  */
 var pkg = require( './package.json' ),
-	config = require( 'config' );
+	config = require( 'config' ),
+	desktop = require( 'desktop/process' );
 
 var start = Date.now(),
 	port = process.env.PORT || 3000,
@@ -24,11 +25,11 @@ console.info( chalk.cyan( '\nGetting bundles ready, hold on...' ) );
 server = http.createServer( app );
 
 // The desktop app runs Calypso in a fork.
-if ( process.env.CALYPSO_IS_FORK ) {
+if ( desktop.isForkedProcess() ) {
 	// We need to run it with an explicit hostname to avoid firewall warnings.
 	server.listen( { port, host }, function() {
 		// Tell the parent process that Calypso has booted.
-		process.send( { boot: 'ready' } );
+		desktop.sendBootSignal();
 	} );
 } else {
 	// Let non-forks listen on any host.

--- a/server/desktop/process.js
+++ b/server/desktop/process.js
@@ -1,0 +1,7 @@
+export function isForkedProcess() {
+	return process.env.CALYPSO_IS_FORK;
+}
+
+export function sendBootSignal() {
+	process.send( { boot: 'ready' } );
+}

--- a/server/desktop/process.js
+++ b/server/desktop/process.js
@@ -1,7 +1,39 @@
+const debug = require( 'debug' )( 'calypso:desktop:process' );
+
+let pingKillswitch = null;
+
 export function isForkedProcess() {
 	return process.env.CALYPSO_IS_FORK;
 }
 
-export function sendBootSignal() {
+export function ready() {
+	sendBootSignal();
+
+	process.on( 'message', ( message ) => {
+		debug( 'on.message: ' + message );
+
+		if ( message.ping ) {
+			sendPingSignal( message.ping );
+		}
+	} );
+}
+
+function sendBootSignal() {
 	process.send( { boot: 'ready' } );
+}
+
+function sendPingSignal( pingTimeout ) {
+	debug( 'Got ping from Electron. Clearing killswitch.' );
+	clearTimeout( pingKillswitch );
+
+	setTimeout( () => {
+		debug( 'Sending ping to Electron. Restarting killswitch.' );
+		process.send( { ping: pingTimeout } );
+		pingKillswitch = setTimeout( maybeKillswitch, ( pingTimeout * 3 ) );
+	}, pingTimeout );
+}
+
+function maybeKillswitch() {
+	debug( 'Failed to get ping from Electron; exiting.' );
+	process.exit();
 }


### PR DESCRIPTION
Electron will periodically send pings to Calypso to make sure the server is still running. If we fail to get a response, Electron can detect that and handle accordingly.

In the same vein, Electron may die (e.g. `kill -9`) but Calypso can continue running, which is not great.

When a ping comes in (where the value of the ping is the frequency in ms for the pings), we ping back with that same frequency. We also start a killswitch that will exit the process if we don't get a ping back in a certain amount of time. This way, Calypso can kill itself if its parent process disappears.

See https://github.com/Automattic/wp-desktop/issues/51 for testing instructions.