### PR TITLE
Framework: re-added the missing duration property for notices

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -56,6 +56,7 @@ const NoticesList = React.createClass( {
 					<Notice
 						key={ 'notice-' + index }
 						status={ notice.status }
+						duration={ notice.duration || null }
 						text={ notice.text }
 						isCompact={ notice.isCompact }
 						onDismissClick={ this.removeNotice.bind( this, notice ) }


### PR DESCRIPTION
It seems that during the move to global notices, the `duration` got lost in the process.

/cc @artpi 