### PR TITLE
Framework: put the old notices in a different "namespace"

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -54,7 +54,7 @@ const NoticesList = React.createClass( {
 		let noticesList = noticesRaw.map( function( notice, index ) {
 				return (
 					<Notice
-						key={ 'notice-' + index }
+						key={ 'notice-old-' + index }
 						status={ notice.status }
 						text={ notice.text }
 						isCompact={ notice.isCompact }


### PR DESCRIPTION
If we show old and new (from redux store) notices, we'll get conflicting keys (like `notice-0`), which are used by React during reder passes. This will trigger an error in the console and, more importantly, prevent one of the conflicting notices from showing.
This change changes the old notices' key prefix to a different one than for the new, reduxified ones, thus preventing the conflict.

Fixes #2946 

/cc @artpi 