### PR TITLE
Support User: Don't clear the user data before fetching new data

### DIFF
--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -30,7 +30,6 @@ export default function( reduxStore ) {
 
 	// Called when the support user token was updated in wpcom
 	const onTokenChange = () => {
-		user.clear();
 		user.fetch();
 		userSettings.fetchSettings();
 	}


### PR DESCRIPTION
Prior to this change, after activating support user there was a period where the User object was empty, causing various errors to appear in the JS console:

> Warning: Failed propType: Invalid prop user of type array supplied to Gravatar, expected object. Check the render method of Masterbar.

This change allows the previous user data to persist until the refreshed data arrives.

This should fix #3066 ~~and #3067~~

cc @dllh