### PR TITLE
Make the name of the client property in config files more generic.

### DIFF
--- a/client/analytics/super-props.js
+++ b/client/analytics/super-props.js
@@ -16,7 +16,7 @@ module.exports = {
 				environment: config( 'env' ),
 				site_count: sites.data ? sites.data.length : 0,
 				site_id_label: 'wpcom',
-				client: config( 'tracks_client_prop' )
+				client: config( 'client_slug' )
 			};
 
 		if ( selectedSite ) {

--- a/config/client.json
+++ b/config/client.json
@@ -1,6 +1,6 @@
 [
   "env",
-  "tracks_client_prop",
+  "client_slug",
   "hostname",
   "wpcom_user_bootstrap",
   "oauth_response_type",

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -1,6 +1,6 @@
 {
 	"env": "production",
-	"tracks_client_prop": "mac-app-store",
+	"client_slug": "mac-app-store",
 	"hostname": "127.0.0.1",
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -1,6 +1,6 @@
 {
 	"env": "production",
-	"tracks_client_prop": "desktop",
+	"client_slug": "desktop",
 	"hostname": "127.0.0.1",
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": false,

--- a/config/development.json
+++ b/config/development.json
@@ -1,6 +1,6 @@
 {
 	"env": "development",
-	"tracks_client_prop": "browser",
+	"client_slug": "browser",
 	"hostname": "calypso.localhost",
 	"port": 3000,
 	"i18n_default_locale_slug": "en",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -1,6 +1,6 @@
 {
 	"env": "production",
-	"tracks_client_prop": "browser",
+	"client_slug": "browser",
 	"hostname": "horizon.wordpress.com",
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": true,

--- a/config/production.json
+++ b/config/production.json
@@ -1,6 +1,6 @@
 {
 	"env": "production",
-	"tracks_client_prop": "browser",
+	"client_slug": "browser",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -1,6 +1,6 @@
 {
 	"env": "production",
-	"tracks_client_prop": "browser",
+	"client_slug": "browser",
 	"hostname": "wordpress.com",
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -1,6 +1,6 @@
 {
 	"env": "production",
-	"tracks_client_prop": "browser",
+	"client_slug": "browser",
 	"hostname": "wpcalypso.wordpress.com",
 	"i18n_default_locale_slug": "en",
 	"wpcom_user_bootstrap": true,


### PR DESCRIPTION
This lets us reuse the value in places besides its current use in Tracks without just using the Tracks-specific name, which would ultimately become confusing and inaccurate.

The use case that led me to propose this change is that we'd like to be able to send information to the REST API about the client software when fetching information about live chat, so that we can send back info that will route desktop user chats differently than web user chats. Rather than adding some kind of janky user agent or oauth app id check to the REST API, I'd like to send a parameter along with the request that will tell the API how to respond.

Since this client property already exists, I thought I'd rename it to genericize it rather than adding another property with the same value.

I tested by running loading some screens within the client and confirming that Tracks pings landed with the client event property intact.

Of course, now that I look back at blame for the config files to see who to ping for review, I see that @mjangda made pretty much the exact opposite commit in the pre-oss repo (renaming `client` to `tracks_client_prop` to be more explicit). Since we now have another use for this property, maybe it's time to be more general now. :)