### PR TITLE
Site Selector: recently selected sites contains an undefined site

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -212,6 +212,10 @@ export default React.createClass( {
 		const recentSites = sites.map( function( site ) {
 			var siteHref;
 
+			if ( ! site ) {
+				return null;
+			}
+
 			if ( this.props.siteBasePath ) {
 				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
 			}


### PR DESCRIPTION
there should be a deeper fix for this, but it's breaking production for some users, so want to get this fix in right away.