### PR TITLE
Site Picker: move undefined site fix to getRecentlySelected()

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -212,10 +212,6 @@ export default React.createClass( {
 		const recentSites = sites.map( function( site ) {
 			var siteHref;
 
-			if ( ! site ) {
-				return null;
-			}
-
 			if ( this.props.siteBasePath ) {
 				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
 			}

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -432,7 +432,8 @@ SitesList.prototype.getRecentlySelected = function() {
 		}, this )[0];
 	}, this );
 
-	return sites;
+	// remove undefined sites
+	return sites.filter( site => site );
 };
 
 /**


### PR DESCRIPTION
This is an improvement to the fix in https://github.com/Automattic/wp-calypso/pull/3073. The issue is that your "recently selected" sites could potentially contain a site that has been removed from your list. And this had resulted in `getRecentlySelected()` including `undefined` for one of the sites in the array. Rather than protecting against having an undefined site in the component, it would be better if `getRecentlySelected` just filtered out invalid results.

/cc @blowery or @retrofox no rush, but I think this is a better solution. I've tested this using the account from the originally reported issue and it works fine.