### PR TITLE
Reader: Reposition post options popover in stream view

### DIFF
--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -312,7 +312,7 @@ FullPostDialog = React.createClass( {
 			shouldShowLikes = LikeHelper.shouldShowLikes( post );
 			shouldShowShare = ShareHelper.shouldShowShare( post );
 
-			buttons.push( <PostOptions key="post-options" post={ post } site={ site } onBlock={ this.props.onClose } /> );
+			buttons.push( <PostOptions key="post-options" position="bottom left" post={ post } site={ site } onBlock={ this.props.onClose } /> );
 
 			if ( shouldShowLikes ) {
 				buttons.push( <LikeButton key="like-button" siteId={ post.site_ID } postId={ post.ID } tagName="div" forceCounter={ true } /> );

--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -26,12 +26,15 @@ var PostOptions = React.createClass( {
 	},
 
 	getDefaultProps: function() {
-		return { onBlock: noop };
+		return {
+			onBlock: noop,
+			position: 'top left'
+		};
 	},
 
 	getInitialState: function() {
 		var state = this.getStateFromStores();
-		state.popoverPosition = 'top left';
+		state.popoverPosition = this.props.position;
 		state.showPopoverMenu = false;
 		return state;
 	},

--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -31,7 +31,7 @@ var PostOptions = React.createClass( {
 
 	getInitialState: function() {
 		var state = this.getStateFromStores();
-		state.popoverPosition = 'bottom left';
+		state.popoverPosition = 'top left';
 		state.showPopoverMenu = false;
 		return state;
 	},

--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -75,7 +75,7 @@ var ReaderShare = React.createClass( {
 
 	getDefaultProps() {
 		return {
-			position: 'top left',
+			position: 'top',
 			tagName: 'li'
 		};
 	},


### PR DESCRIPTION
The share popover displays ‘top’:
 
![screen shot 2016-02-04 at 11 44 02 am](https://cloud.githubusercontent.com/assets/191598/12822731/5fb90cc8-cb37-11e5-9aa0-e1dd4ec11a27.png)

while the more popover displays ‘bottom':

![screen shot 2016-02-04 at 11 43 56 am](https://cloud.githubusercontent.com/assets/191598/12822739/69799c6e-cb37-11e5-9dc0-bfaaffc2b357.png)

This PR updates the more popover to display ‘top’ to match the share popover:

![screen shot 2016-02-04 at 11 43 32 am](https://cloud.githubusercontent.com/assets/191598/12822744/703a54da-cb37-11e5-8d86-870ffee292fb.png)
