### PR TITLE
Sidebar: Remove Plugins menu item for all sites except Jetpack ones

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -16,7 +16,6 @@ var wpcom = require( 'lib/wp' ),
 	JetpackSite = require( 'lib/site/jetpack' ),
 	Searchable = require( 'lib/mixins/searchable' ),
 	Emitter = require( 'lib/mixins/emitter' ),
-	isBusiness = require( 'lib/products-values' ).isBusiness,
 	isPlan = require( 'lib/products-values' ).isPlan,
 	PreferencesActions = require( 'lib/preferences/actions' ),
 	PreferencesStore = require( 'lib/preferences/store' ),
@@ -597,7 +596,7 @@ SitesList.prototype.getSelectedOrAllWithPlugins = function() {
 	return this.getSelectedOrAll().filter( site => {
 		return site.capabilities &&
 			site.capabilities.manage_options &&
-			( isBusiness( site.plan ) || site.jetpack ) &&
+			site.jetpack &&
 			( site.visible || this.selected )
 	} );
 };

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -220,10 +220,21 @@ module.exports = React.createClass( {
 		var site = this.getSelectedSite(),
 			pluginsLink = '/plugins' + this.siteSuffix(),
 			pluginsBrowseLink = '/plugins/browse' + this.siteSuffix(),
-			addPluginsButton;
+			addPluginsButton,
+			noticon,
+			target;
 
-		if ( ! this.isSingle() && ! config.isEnabled( 'manage/plugins' ) ) {
-			return null;
+		if ( ! config.isEnabled( 'manage/plugins' ) ) {
+			if ( ! this.isSingle() ) {
+				return null;
+			}
+
+			if ( site.options ) {
+				pluginsLink = site.options.admin_url + 'plugins.php';
+			}
+
+			target = '_blank';
+			noticon = <span className="noticon noticon-external" />;
 		}
 
 		if ( ! this.props.sites.canManageSelectedOrAll() ) {
@@ -234,10 +245,6 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		if ( ! config.isEnabled( 'manage/plugins' ) && site.options ) {
-			pluginsLink = site.options.admin_url + 'plugins.php';
-		}
-
 		if ( config.isEnabled( 'manage/plugins/browser' ) ) {
 			if ( ( this.isSingle() && site.jetpack ) || ( this.hasJetpackSites() && ! this.isSingle() ) ) {
 				addPluginsButton = <a onClick={ this.onNavigate } href={ pluginsBrowseLink } className="add-new">{ this.translate( 'Add' ) }</a>;
@@ -246,10 +253,10 @@ module.exports = React.createClass( {
 
 		return (
 			<li className={ this.itemLinkClass( '/plugins', 'plugins' ) }>
-				<a onClick={ this.onNavigate } href={ pluginsLink } target={ ! config.isEnabled( 'manage/plugins' ) ? '_blank' : null }>
+				<a onClick={ this.onNavigate } href={ pluginsLink } target={ target }>
 					<Gridicon icon="plugins" size={ 24 } />
 					<span className="menu-link-text">{ this.translate( 'Plugins' ) }</span>
-					{ ! config.isEnabled( 'manage/plugins' ) ? <span className="noticon noticon-external" /> : null }
+					{ noticon }
 				</a>
 				{ addPluginsButton }
 			</li>

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -240,7 +240,7 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		if ( ! this.props.sites.hasSiteWithPlugins() && ! this.isSingle() ) {
+		if ( ! this.props.sites.hasSiteWithPlugins() ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -262,7 +262,11 @@ module.exports = React.createClass( {
 			addDomainLink = '/domains/add' + this.siteSuffix(),
 			addDomainButton = '';
 
-		if ( ! site ) {
+		if ( ! config.isEnabled( 'manage/plans' ) ) {
+			return null;
+		}
+
+		if ( ! this.isSingle() ) {
 			return null;
 		}
 
@@ -271,14 +275,6 @@ module.exports = React.createClass( {
 		}
 
 		if ( site.capabilities && ! site.capabilities.manage_options ) {
-			return null;
-		}
-
-		if ( ! this.isSingle() && ! config.isEnabled( 'manage/plans' ) ) {
-			return null;
-		}
-
-		if ( ! config.isEnabled( 'manage/plans' ) ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -219,7 +219,6 @@ module.exports = React.createClass( {
 	plugins: function() {
 		var site = this.getSelectedSite(),
 			pluginsLink = '/plugins' + this.siteSuffix(),
-			pluginsBrowseLink = '/plugins/browse' + this.siteSuffix(),
 			addPluginsButton,
 			noticon,
 			target;
@@ -246,8 +245,8 @@ module.exports = React.createClass( {
 		}
 
 		if ( config.isEnabled( 'manage/plugins/browser' ) ) {
-			if ( ( this.isSingle() && site.jetpack ) || ( this.hasJetpackSites() && ! this.isSingle() ) ) {
-				addPluginsButton = <a onClick={ this.onNavigate } href={ pluginsBrowseLink } className="add-new">{ this.translate( 'Add' ) }</a>;
+			if ( ( this.isSingle() && site.jetpack ) || ( ! this.isSingle() && this.hasJetpackSites() ) ) {
+				addPluginsButton = <a onClick={ this.onNavigate } href={ '/plugins/browse' + this.siteSuffix() } className="add-new">{ this.translate( 'Add' ) }</a>;
 			}
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -258,7 +258,6 @@ module.exports = React.createClass( {
 
 	upgrades: function() {
 		var site = this.getSelectedSite(),
-			target = null,
 			domainsLink = '/domains' + this.siteSuffix(),
 			addDomainLink = '/domains/add' + this.siteSuffix(),
 			addDomainButton = '';
@@ -293,7 +292,7 @@ module.exports = React.createClass( {
 
 		return (
 			<li className={ this.itemLinkClass( [ '/domains' ], 'domains' ) }>
-				<a onClick={ this.onNavigate } href={ domainsLink } target={ target }>
+				<a onClick={ this.onNavigate } href={ domainsLink }>
 					<Gridicon icon="globe" size={ 24 } />
 					<span className="menu-link-text">{ this.translate( 'Domains' ) }</span>
 				</a>

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -548,7 +548,7 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		site = this.getSelectedSite()
+		site = this.getSelectedSite();
 		viplink = '/vip/deploys' + this.siteSuffix();
 
 		if ( ! site ) {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -1,30 +1,30 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
+var analytics = require( 'analytics' ),
 	classNames = require( 'classnames' ),
 	debug = require( 'debug' )( 'calypso:my-sites:sidebar' ),
-	analytics = require( 'analytics' ),
-	startsWith = require( 'lodash/startsWith' ),
 	has = require( 'lodash/has' ),
-	includes = require( 'lodash/includes' );
+	includes = require( 'lodash/includes' ),
+	React = require( 'react' ),
+	startsWith = require( 'lodash/startsWith' );
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	CurrentSite = require( 'my-sites/current-site' ),
-	PublishMenu = require( './publish-menu' ),
-	SiteStatsStickyLink = require( 'components/site-stats-sticky-link' ),
-	productsValues = require( 'lib/products-values' ),
-	getCustomizeUrl = require( '../themes/helpers' ).getCustomizeUrl,
+var abtest = require( 'lib/abtest' ).abtest,
 	AdsUtils = require( 'lib/ads/utils' ),
+	config = require( 'config' ),
+	CurrentSite = require( 'my-sites/current-site' ),
+	getCustomizeUrl = require( '../themes/helpers' ).getCustomizeUrl,
 	Gridicon = require( 'components/gridicon' ),
+	productsValues = require( 'lib/products-values' ),
+	PublishMenu = require( './publish-menu' ),
 	Sidebar = require( 'layout/sidebar' ),
 	SidebarHeading = require( 'layout/sidebar/heading' ),
 	SidebarItem = require( 'layout/sidebar/item' ),
 	SidebarMenu = require( 'layout/sidebar/menu' ),
-	abtest = require( 'lib/abtest' ).abtest;
+	SiteStatsStickyLink = require( 'components/site-stats-sticky-link' );
 
 module.exports = React.createClass( {
 	displayName: 'MySitesSidebar',


### PR DESCRIPTION
This pull request disables the `Plugins` menu item from the sidebar for all except Jetpack sites. This is a preliminary step to removing ecommerce plugins - it just makes sure the `Plugins` page is not linked from the sidebar for sites with a Business plan:

![screenshot](https://cloud.githubusercontent.com/assets/594356/12825442/97e8e87c-cb76-11e5-93d0-c8cbf66fa499.png)

#### Testing instructions

There are several conditions to test. First start with a single blog:

1. Run `git checkout remove/ecommerce-plugin-sidebar` and start your server
2. Get a test account with only one WordPress.com blog
3. Open any page from `My Sites`
4. Check that there is no `Plugins` menu item in the sidebar
5. Purchase a Business plan
6. Open any page from `My Sites`
7. Check that there is no `Plugins` menu item in the sidebar
8. Get a test account with only one Jetpack blog
9. Check that there is a `Plugins` menu item with a `Add` button in the sidebar

Now repeat the same steps for a test account with several blogs:

1. Get a test account with two WordPress.com blogs
2. Select any of these two blogs
3. Open any page from `My Sites`
4. Check that there is no `Plugins` menu item in the sidebar
5. Switches to the other blog
6. Check that there is no `Plugins` menu item in the sidebar
7. Purchase a Business plan
8. Open any page from `My Sites`
9. Check that there is no `Plugins` menu item in the sidebar
10. Switches to the former blog
11. Check that there is no `Plugins` menu item in the sidebar
12. Switches to `All My Sites`
13. Check that there is still no `Plugins` menu item in the sidebar

Finally let's add a Jetpack site to the mix:

1. Get a test account with one WordPress.com blog and one Jetpack blog
2. Select the WordPress.com blog
3. Open any page from `My Sites`
4. Check that there is no `Plugins` menu item in the sidebar
5. Purchase a Business plan
6. Open any page from `My Sites`
7. Check that there is no `Plugins` menu item in the sidebar
8. Switches to the Jetpack blog
9. Check that there is a `Plugins` menu item with a `Add` button in the sidebar
10. Switches to `All My Sites`
11. Check that there is a `Plugins` menu item with a `Add` button in the sidebar

#### Additional notes
 
The `Plugins` page is still accessible by entering the url directly in the browser.
 
#### Reviews
 
- [x] Code
- [x] Product