### PR TITLE
Plans: Fix Jetpack plans in `Plan`

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -12,6 +12,7 @@ var abtest = require( 'lib/abtest' ).abtest,
 	analytics = require( 'analytics' ),
 	testFeatures = require( 'lib/features-list/test-features' ),
 	Gridicon = require( 'components/gridicon' ),
+	isJetpackPlan = require( 'lib/products-values' ).isJetpackPlan,
 	JetpackPlanDetails = require( 'my-sites/plans/jetpack-plan-details' ),
 	PlanActions = require( 'components/plans/plan-actions' ),
 	PlanHeader = require( 'components/plans/plan-header' ),
@@ -225,6 +226,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
+		var shouldDisplayFeatureList = this.props.plan && ! isJetpackPlan( this.props.plan ) && abtest( 'plansFeatureList' ) === 'list';
 		return (
 			<Card className={ this.getClassNames() } key={ this.getProductSlug() } onClick={ this.showDetails }>
 				{ this.getPlanDiscountMessage() }
@@ -238,7 +240,7 @@ module.exports = React.createClass( {
 				</PlanHeader>
 				<div className="plan__plan-expand">
 					<div className="plan__plan-details">
-						{ abtest( 'plansFeatureList' ) === 'list' ? this.getFeatureList() : this.getDescription() }
+						{ shouldDisplayFeatureList ? this.getFeatureList() : this.getDescription() }
 					</div>
 					{ this.getPlanActions() }
 				</div>

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -88,6 +88,13 @@ function isEnterprise( product ) {
 	return product.product_slug === 'wpcom-enterprise';
 }
 
+function isJetpackPlan( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return 'jetpack' === product.product_type;
+}
+
 function isPlan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
@@ -263,6 +270,7 @@ module.exports = {
 	isDomainRedemption,
 	isDomainRegistration,
 	isEnterprise,
+	isJetpackPlan,
 	isFreePlan,
 	isFreeTrial,
 	isGoogleApps,

--- a/client/my-sites/plans/jetpack-plan-details/style.scss
+++ b/client/my-sites/plans/jetpack-plan-details/style.scss
@@ -4,4 +4,9 @@
 
 .jetpack_premium .plan__plan-details li, .jetpack_business .plan__plan-details li {
 	opacity: 1.0;
+
+	&:before {
+		@include noticon( '\f418', 16px );
+		vertical-align: middle;
+	}
 }


### PR DESCRIPTION
These were broken when the user is in the `list` variation of the features list a/b test.

props @roccotripaldi

**Testing**
- Add yourself to the `list` variation of the features list test by running this in your console: `localStorage.setItem( 'ABTests', '{"plansFeatureList_20040202":"list"}' );`
- Visit `/plans/:site` where `:site` is a Jetpack site.
- Assert that two Jetpack plans are rendered properly.