### PR TITLE
Token Field: ESLint fix

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -152,40 +152,40 @@ var TokenField = React.createClass( {
 		if ( stillActive ) {
 			debug( '_onBlur but component still active; not doing anything' );
 			return; // we didn't leave the component, so don't do anything
-		} else {
-			debug( '_onBlur before timeout setting component inactive' );
-			this.setState( {
-				isActive: false
-			} );
-			/* When the component blurs, we need to add the current text, or
-			 * the selected suggestion (if any).
-			 *
-			 * Two reasons to set a timeout rather than do this immediately:
-			 *  - Some other user action (like tapping on a suggestion) may
-			 *    have caused this blur.  If there is another user-triggered
-			 *    event, we need to give it a chance to complete first.
-			 *  - At one point, using the right arrow key to move the text
-			 *    input was causing a blur to outside the component?! (left
-			 *    arrow key does not do this).  So, we delay the resetting of
-			 *    the state and cancel it if we get focus back quick enough.
-			 */
-			debug( '_onBlur waiting to add current token' );
-			this._blurTimeoutID = window.setTimeout( function() {
-				// Add the current token, UNLESS the text input is empty and
-				// there is a suggested token selected.  In that case, we don't
-				// want to add it, because it's easy to inadvertently hover
-				// over a suggestion.
-				if ( this._inputHasValidValue() ) {
-					debug( '_onBlur after timeout adding current token' );
-					this._addCurrentToken();
-				} else {
-					debug( '_onBlur after timeout not adding current token' );
-				}
-				debug( '_onBlur resetting component state' );
-				this.setState( this.getInitialState() );
-				this._clearBlurTimeout();
-			}.bind( this ), 0 );
 		}
+
+		debug( '_onBlur before timeout setting component inactive' );
+		this.setState( {
+			isActive: false
+		} );
+		/* When the component blurs, we need to add the current text, or
+		 * the selected suggestion (if any).
+		 *
+		 * Two reasons to set a timeout rather than do this immediately:
+		 *  - Some other user action (like tapping on a suggestion) may
+		 *    have caused this blur.  If there is another user-triggered
+		 *    event, we need to give it a chance to complete first.
+		 *  - At one point, using the right arrow key to move the text
+		 *    input was causing a blur to outside the component?! (left
+		 *    arrow key does not do this).  So, we delay the resetting of
+		 *    the state and cancel it if we get focus back quick enough.
+		 */
+		debug( '_onBlur waiting to add current token' );
+		this._blurTimeoutID = window.setTimeout( function() {
+			// Add the current token, UNLESS the text input is empty and
+			// there is a suggested token selected.  In that case, we don't
+			// want to add it, because it's easy to inadvertently hover
+			// over a suggestion.
+			if ( this._inputHasValidValue() ) {
+				debug( '_onBlur after timeout adding current token' );
+				this._addCurrentToken();
+			} else {
+				debug( '_onBlur after timeout not adding current token' );
+			}
+			debug( '_onBlur resetting component state' );
+			this.setState( this.getInitialState() );
+			this._clearBlurTimeout();
+		}.bind( this ), 0 );
 	},
 
 	_clearBlurTimeout: function() {


### PR DESCRIPTION
Previously there was an ESLint fix issue about having an `else` after a `return`. This PR fixes that.

To test:
- Checkout `fix/token-eslint-fix` branch
- Visit `/devdocs/design/token-fields` and ensure component works as expected
- VisIt `/post/$site` and verify that tags work as expected

cc @nylen, who seems to have done some work in this file, for review. 