### PR TITLE
Token Field: First pass at isBorderless

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -28,7 +28,8 @@ var TokenField = React.createClass( {
 		displayTransform: React.PropTypes.func,
 		saveTransform: React.PropTypes.func,
 		onChange: React.PropTypes.func,
-		tokenStatus: React.PropTypes.func
+		tokenStatus: React.PropTypes.func,
+		isBorderless: React.PropTypes.bool
 	},
 
 	getDefaultProps: function() {
@@ -41,7 +42,8 @@ var TokenField = React.createClass( {
 				return token.trim();
 			},
 			onChange: function() {},
-			tokenStatus: function() {}
+			tokenStatus: function() {},
+			isBorderless: false
 		};
 	},
 
@@ -120,6 +122,7 @@ var TokenField = React.createClass( {
 				status={ this.props.tokenStatus( token ) }
 				displayTransform={ this.props.displayTransform }
 				onClickRemove={ this._onTokenClickRemove }
+				isBorderless={ this.props.isBorderless }
 			/>
 		);
 	},

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -71,6 +71,13 @@ input[type="text"].token-field__input {
 	}
 }
 
+.token-field__token.is-borderless {
+	.token-field__token-text, .token-field__remove-token {
+		background: transparent;
+		color: $gray;
+	}
+}
+
 .token-field__token-text, .token-field__remove-token {
 	display: inline-block;
 	line-height: 24px;
@@ -97,7 +104,6 @@ input[type="text"].token-field__input {
 		background: darken( $gray, 10% );
 	}
 }
-
 
 // Suggestion list
 .token-field__suggestions-list {

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -72,7 +72,12 @@ input[type="text"].token-field__input {
 }
 
 .token-field__token.is-borderless {
-	.token-field__token-text, .token-field__remove-token {
+	.token-field__token-text {
+		background: transparent;
+		color: $gray-dark;
+	}
+
+	.token-field__remove-token {
 		background: transparent;
 		color: $gray;
 	}

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -34,7 +34,6 @@ input[type="text"].token-field__input {
 	width: auto;
 	max-width: 100%;
 	margin: 2px 0 2px 8px;
-	// padding: 2px 0 2px 4px;
 	padding: 0 0 0 6px;
 	line-height: 24px;
 	background: inherit;

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -9,8 +9,6 @@
 	border: 1px solid lighten( $gray, 20% );
 	color: $gray-dark;
 	cursor: text;
-	font-size: 16px;
-	line-height: 1.5;
 	transition: all .15s ease-in-out;
 
 	&:hover {
@@ -35,8 +33,10 @@ input[type="text"].token-field__input {
 	display: inline-block;
 	width: auto;
 	max-width: 100%;
-	margin: 0 0 0 4px;
-	padding: 2px 0 2px 4px;
+	margin: 2px 0 2px 8px;
+	// padding: 2px 0 2px 4px;
+	padding: 0 0 0 6px;
+	line-height: 24px;
 	background: inherit;
 	border: 0;
 	outline: none;
@@ -80,6 +80,7 @@ input[type="text"].token-field__input {
 	.token-field__remove-token {
 		background: transparent;
 		color: $gray;
+		padding: 0 2px;
 	}
 }
 

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -10,19 +10,23 @@ var Token = React.createClass( {
 		value: React.PropTypes.string.isRequired,
 		displayTransform: React.PropTypes.func.isRequired,
 		onClickRemove: React.PropTypes.func,
-		status: React.PropTypes.oneOf( [ 'is-error', 'is-success' ] )
+		status: React.PropTypes.oneOf( [ 'is-error', 'is-success' ] ),
+		isBorderless: React.PropTypes.bool
 	},
 
 	getDefaultProps: function() {
 		return {
-			onClickRemove: function() {}
+			onClickRemove: function() {},
+			isBorderless: false
 		};
 	},
 
 	mixins: [ PureRenderMixin ],
 
 	render: function() {
-		const tokenClasses = classNames( 'token-field__token', this.props.status );
+		const tokenClasses = classNames( 'token-field__token', this.props.status, {
+			'is-borderless': this.props.isBorderless
+		} );
 
 		return (
 			<span className={ tokenClasses } tabIndex="-1">

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -122,6 +122,7 @@ export default React.createClass( {
 						<FormFieldset>
 							<FormLabel>{ this.translate( 'Usernames or Emails' ) }</FormLabel>
 							<TokenField
+								isBorderless
 								tokenStatus={ this.getTokenStatus }
 								value={ this.state.usernamesOrEmails }
 								onChange={ this.onTokensChange } />


### PR DESCRIPTION
Closes #3084 by adding an `isBorderless` prop to remove the background color from tokens. This is a WIP.

To test
- Checkout `update/token-field-borderless` branch
- Go to `/people/new/$site` in development
- Enter tokens. Notice the borderless style
- Go to `/post/$site` and enter tags/tokens
  - These should be unchanged

![screen shot 2016-02-04 at 3 17 39 pm](https://cloud.githubusercontent.com/assets/1126811/12830040/d239fb84-cb52-11e5-8505-7b753dcdd83e.png)

cc @rickybanister for early design review
