### PR TITLE
Framework: clean up stray z-indexes

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -355,7 +355,7 @@ $sidebar-width-min: 228px;
 		left: -272px;
 	width: 272px;
 	overflow: hidden;
-	z-index: 10;
+	z-index: z-index( 'root', '.wp-secondary .site-selector' );
 	opacity: 0;
 	pointer-events: none;
 

--- a/assets/stylesheets/sections/_menus.scss
+++ b/assets/stylesheets/sections/_menus.scss
@@ -542,7 +542,7 @@
 	// If done properly, might be an alternative for mobile.
 	// Seems not working properly with -webkit-perspective turned on.
 	/*@include responsive( mobile ) {
-		z-index: 190; // Higher than masterbar?
+		z-index: ; // Add an entry to _z-index.scss
 		border: 0;
 		padding: 80px 0 0;
 		background: rgba(244, 248, 250, 0.9);

--- a/assets/stylesheets/sections/_menus.scss
+++ b/assets/stylesheets/sections/_menus.scss
@@ -538,21 +538,6 @@
 			}
 		}
 	}
-
-	// If done properly, might be an alternative for mobile.
-	// Seems not working properly with -webkit-perspective turned on.
-	/*@include responsive( mobile ) {
-		z-index: ; // Add an entry to _z-index.scss
-		border: 0;
-		padding: 80px 0 0;
-		background: rgba(244, 248, 250, 0.9);
-
-		position: fixed;
-		top: 0;
-		bottom: 0;
-		left: 0;
-		right: 0;
-	}*/
 }
 
 .menus__menu-item-open {

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -16,7 +16,7 @@
 // So before adding a new z-index:
 // 1. You'll want to make sure the element actually creates a stacking context
 // 2. Lookup what it's parent stacking context is
-// You can run this handy gist: https://gist.github.com/gwwar/2f661deec7b99a1a418b) in the console to find both.
+// You can run this handy gist: https://gist.github.com/gwwar/2f661deec7b99a1a418b in the console to find both.
 //
 // For readability please sort values from lowest to highest.
 //
@@ -78,6 +78,7 @@ $z-layers: (
 		'.auth__form .form-password-input__toggle-visibility': 4,
 		'.site-selector': 10,
 		'.editor-featured-image__preview.is-transient::after': 10,
+		'.wp-secondary .site-selector': 10,
 		'.range__label': 10,
 		'.sticky-panel.is-sticky .sticky-panel__content': 20,
 		'.editor-featured-image .editor-drawer-well__remove': 20,
@@ -135,7 +136,7 @@ $z-layers: (
 		'.environment-badge .bug-report': 1000
 	),
 	'.masterbar': (
-		'.masterbar .notifications.unread .notification-bubble': 99999
+		'.masterbar__notifications-bubble': 99999
 	),
 	'.detail-page__backdrop': (
 		'.detail-page__action-buttons': 200
@@ -176,9 +177,8 @@ $z-layers: (
 		'.editor-media-modal-gallery__preview-toggle': 100
 	),
 	'.following-edit': ( //aka 'main'
-		'.following-edit-sort-controls': 30,
-		'.following-edit .reader-list-item__card.is-search-result': 35,
-		'.following-edit__subscribe-form .gridicons-add-outline': 40
+		'.following-edit__subscribe-form .gridicons-add-outline': 23,
+		'.following-edit__subscribe-form .card.is-search-result': 35
 	),
 
 	// The following may be inserted into different areas.

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -75,6 +75,7 @@ $z-layers: (
 		'.site-indicator__button': 3,
 		'ul.module-content-list-item-actions.collapsed': 3,
 		'.auth__input-wrapper .gridicon': 3,
+		'.auth__self-hosted-instructions': 4,
 		'.auth__form .form-password-input__toggle-visibility': 4,
 		'.site-selector': 10,
 		'.editor-featured-image__preview.is-transient::after': 10,

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -175,7 +175,7 @@
 	border-radius: 8px;
 	padding: 40px;
 	position: absolute;
-	z-index: 4;
+	z-index: z-index( 'root', '.auth__self-hosted-instructions' );
 	top: 50%;
 	left: 50%;
 	transform: translate( -50%, -50% );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -182,7 +182,7 @@ $autobar-height: 20px;
 			top: 9px;
 			left: 50%;
 		width: 8px;
-		z-index: 99999;
+		z-index: z-index( '.masterbar', '.masterbar__notifications-bubble' );
 
 		// Animation
 		transform: translateZ(0);

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -142,7 +142,7 @@
 			top: 13px;
 			left: 18px;
 		fill: $blue-medium;
-		z-index: 23; // Higher than <Search>'s z-index: 22;
+		z-index: z-index( '.following-edit', '.following-edit__subscribe-form .gridicons-add-outline' );
 	}
 
 	.gridicons-add-outline {
@@ -163,7 +163,7 @@
 		position: absolute;
 			top: 68px;
 		width: 100%;
-		z-index: 35;
+		z-index: z-index( '.following-edit', '.following-edit__subscribe-form .card.is-search-result' );
 
 		@include breakpoint( "<480px" ) {
 			top: 59px;


### PR DESCRIPTION
Cleaned up a few z-index rules to match our guidelines: https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md#z-index

### Testing Instructions
1. Checkout the branch
2. Run Calypso
3. Save the generated file public/style.css
4. Perform a diff on this file compare to the one generated by master.

There should be no changes, except for the comment block I removed

It's on my TODO list to add a pre-commit hook for this in the future.

cc @shaunandrews @folletto @mtias @jasmussen 