### PR TITLE
Fix attempt to parse null URL

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -98,7 +98,11 @@ function normalizePost( post, transforms, callback ) {
 }
 
 function maxWidthPhotonishURL( imageURL, width ) {
-	var parsedURL = url.parse( imageURL, true, true ), // true, true means allow protocol-less hosts and parse the querystring
+	if ( ! imageURL ) {
+		return imageURL;
+	}
+
+	let parsedURL = url.parse( imageURL, true, true ), // true, true means allow protocol-less hosts and parse the querystring
 		isGravatar, sizeParam;
 
 	if ( ! parsedURL.host ) {


### PR DESCRIPTION
@shaunandrews reported a stack break when we try to parse a null image url. This should avoid trying to do so.