### PR TITLE
Help: switch to using SectionHeader

### DIFF
--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -9,6 +9,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
  */
 import CompactCard from 'components/card/compact';
 import HelpResult from './item';
+import SectionHeader from 'components/section-header';
 
 module.exports = React.createClass( {
 	displayName: 'HelpResults',
@@ -22,13 +23,9 @@ module.exports = React.createClass( {
 
 		return (
 			<div className="help-results">
-				<CompactCard className="help-results__header">
-					<span className="help-results__header-text">
-						{ this.props.header }
-					</span>
-				</CompactCard>
+				<SectionHeader label={ this.props.header }/>
 				{ this.props.helpLinks.map( helpLink => <HelpResult key={ helpLink.link } helpLink={ helpLink } iconPathDescription={ this.props.iconPathDescription } /> ) }
-				<a href={ this.props.searchLink } target="__blank" >
+				<a href={ this.props.searchLink } target="__blank">
 					<CompactCard className="help-results__footer">
 						<span className="help-results__footer-text">
 							{ this.props.footer }

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -1,29 +1,14 @@
 .help-results {
-	margin-top: 1px;
+	margin-bottom: 16px;
 }
 
 .help-results__header.card.is-compact,
 .help-results__footer.card.is-compact {
 	padding: 8px 16px;
 }
-.help-results__footer.card.is-compact {
-	padding-left: 56px;
-	@include breakpoint( "<480px" ) {
-		padding-left: 48px;
-	}
-}
-
-.help-results__header {
-	font: 11px/16px $sans;
-	font-weight: 600;
-	text-transform: uppercase;
-	color: darken( $gray, 20% );
-	background: $gray-light;
-}
 
 .help-results__footer {
 	font: 14px/24px $sans;
-	color: $gray;
 }
 
 .help-result {

--- a/client/me/help/help-search/style.scss
+++ b/client/me/help/help-search/style.scss
@@ -1,13 +1,5 @@
 .help-search {
-	margin-bottom: 30px;
-}
-
-.help-search .search-card {
-	margin-bottom: 0px;
-}
-
-.help-search__no-results {
-	margin-top: 1px;
+	margin-bottom: 16px;
 }
 
 .help-search .no-results {
@@ -18,18 +10,11 @@
 }
 
 .help-results__placeholder {
-	.help-results__header,
-	.help-results__header-text,
+	.section-header__label,
 	.help-result__icon,
 	.help-result__title,
 	.help-result__description {
 		@include placeholder();
-	}
-	.help-results__header, {
-		background: $gray-light;
-	}
-	.help-results__header-text, {
-		background-color: lighten( $gray, 20% );
 	}
 	.help-results__footer {
 		display: none;


### PR DESCRIPTION
I made a few changes, but all of them with the overall goal of using `SectionHeader` instead of a more custom gray-on-gray header in help search results. This achieves a couple of things: `SectionHeader` is the standard, I gave each section a bottom margin so it's easier to tell the various types of documentation apart, and allowed the footer link to look like a link instead of a text input. Also was able to remove a bunch of margin overrides so this is all a bit more sustainable.

**Before:**
<img width="767" alt="screen shot 2016-02-04 at 5 17 35 pm" src="https://cloud.githubusercontent.com/assets/437258/12831628/4c91b9fc-cb63-11e5-8450-78c07b1ae964.png">

<img width="753" alt="screen shot 2016-02-04 at 5 17 44 pm" src="https://cloud.githubusercontent.com/assets/437258/12831629/4c9ea766-cb63-11e5-8e6c-4e3f2c738649.png">

**After:**
<img width="746" alt="screen shot 2016-02-04 at 5 15 49 pm" src="https://cloud.githubusercontent.com/assets/437258/12831617/43abada2-cb63-11e5-8287-65915dc35075.png">

<img width="766" alt="screen shot 2016-02-04 at 5 15 40 pm" src="https://cloud.githubusercontent.com/assets/437258/12831616/43aaa2a4-cb63-11e5-87cc-656a4951776f.png">

cc @dllh @mrheston @omarjackman (since some of this will affect #1458) @alternatekev 