### PR TITLE
Signup: Headstart: Fix widgets being overwritten in Calypso signup.

### DIFF
--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -21,7 +21,6 @@ module.exports = {
 		props: {
 			useHeadstart: true,
 		},
-		apiRequestFunction: stepActions.setThemeOnSite,
 		dependencies: [ 'siteSlug' ],
 		providesDependencies: [ 'theme' ]
 	},


### PR DESCRIPTION
Calypso is setting the theme again after Headstart has already set up widgets, causing the `sidebars_widgets` option to be overwritten.