### PR TITLE
Security: Avoid destructuring as it breaks `this` context

### DIFF
--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -76,14 +76,14 @@ const AccountPassword = React.createClass( {
 	},
 
 	submitForm: function( event ) {
-		const { userSettings: { saveSettings }, errorNotice: showErrorNotice } = this.props;
+		const { errorNotice: showErrorNotice } = this.props;
 		event.preventDefault();
 
 		this.setState( {
 			savingPassword: true
 		} );
 
-		saveSettings(
+		this.props.userSettings.saveSettings(
 			function( error, response ) {
 				this.setState( { savingPassword: false } );
 				this.markSaved();


### PR DESCRIPTION
This pull request seeks to resolve an error where the [update password form](http://calypso.localhost:3000/me/security) can result in an error when attempting to save a password. The object destructuring appears to alter the `this` context of `saveSettings` which is depended upon by [the callback to the user settings save](https://github.com/Automattic/wp-calypso/blob/2f7b89146b8a18e7af8b93437512b78075546786/client/lib/user-settings/index.js#L115).

__Testing instructions:__

1. Navigate to the [update password page](http://calypso.localhost:3000/me/security)
2. Enter a new password
3. Click Save Password
4. Note that a success notice is shown, and no errors exist in the developer tools console
5. Confirm that your password has changed successfully by logging out and in again