### PR TITLE
Token Field: Adds tokenStatus callback to add status to tokens

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -11,8 +11,7 @@ var take = require( 'lodash/array/take' ),
 	each = require( 'lodash/collection/each' ),
 	identity = require( 'lodash/utility/identity' ),
 	classNames = require( 'classnames' ),
-	debug = require( 'debug' )( 'calypso:token-field' ),
-	noop = require( 'lodash/utility/noop' );
+	debug = require( 'debug' )( 'calypso:token-field' );
 
 /**
  * Internal dependencies
@@ -42,7 +41,7 @@ var TokenField = React.createClass( {
 				return token.trim();
 			},
 			onChange: function() {},
-			tokenStatus: noop
+			tokenStatus: function() {}
 		};
 	},
 

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -11,7 +11,8 @@ var take = require( 'lodash/array/take' ),
 	each = require( 'lodash/collection/each' ),
 	identity = require( 'lodash/utility/identity' ),
 	classNames = require( 'classnames' ),
-	debug = require( 'debug' )( 'calypso:token-field' );
+	debug = require( 'debug' )( 'calypso:token-field' ),
+	noop = require( 'lodash/utility/noop' );
 
 /**
  * Internal dependencies
@@ -27,7 +28,8 @@ var TokenField = React.createClass( {
 		value: React.PropTypes.array,
 		displayTransform: React.PropTypes.func,
 		saveTransform: React.PropTypes.func,
-		onChange: React.PropTypes.func
+		onChange: React.PropTypes.func,
+		tokenStatus: React.PropTypes.func
 	},
 
 	getDefaultProps: function() {
@@ -39,7 +41,8 @@ var TokenField = React.createClass( {
 			saveTransform: function( token ) {
 				return token.trim();
 			},
-			onChange: function() {}
+			onChange: function() {},
+			tokenStatus: noop
 		};
 	},
 
@@ -115,6 +118,7 @@ var TokenField = React.createClass( {
 			<Token
 				key={ 'token-' + token }
 				value={ token }
+				status={ this.props.tokenStatus( token ) }
 				displayTransform={ this.props.displayTransform }
 				onClickRemove={ this._onTokenClickRemove }
 			/>

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -57,6 +57,18 @@ input[type="text"].token-field__input {
 	padding: 0;
 	color: $white;
 	overflow: hidden;
+
+	&.is-success {
+		.token-field__token-text, .token-field__remove-token {
+			background: $alert-green;
+		}
+	}
+
+	&.is-error {
+		.token-field__token-text, .token-field__remove-token {
+			background: $alert-red;
+		}
+	}
 }
 
 .token-field__token-text, .token-field__remove-token {

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -3,7 +3,6 @@
  */
 var React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	noop = require( 'lodash/utility/noop' ),
 	classNames = require( 'classnames' );
 
 var Token = React.createClass( {
@@ -16,7 +15,7 @@ var Token = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
-			onClickRemove: noop
+			onClickRemove: function() {}
 		};
 	},
 

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -3,13 +3,15 @@
  */
 var React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
-	noop = require( 'lodash/utility/noop' );
+	noop = require( 'lodash/utility/noop' ),
+	classNames = require( 'classnames' );
 
 var Token = React.createClass( {
 	propTypes: {
 		value: React.PropTypes.string.isRequired,
 		displayTransform: React.PropTypes.func.isRequired,
-		onClickRemove: React.PropTypes.func
+		onClickRemove: React.PropTypes.func,
+		status: React.PropTypes.oneOf( [ 'is-error', 'is-success' ] )
 	},
 
 	getDefaultProps: function() {
@@ -21,8 +23,10 @@ var Token = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	render: function() {
+		const tokenClasses = classNames( 'token-field__token', this.props.status );
+
 		return (
-			<span className="token-field__token" tabIndex="-1">
+			<span className={ tokenClasses } tabIndex="-1">
 				<span className="token-field__token-text">
 					{ this.props.displayTransform( this.props.value ) }
 				</span>

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -69,11 +69,16 @@ export default React.createClass( {
 	},
 
 	getTokenStatus( value ) {
-		if ( 'string' === typeof value && -1 < value.indexOf( 'error' ) ) {
-			return 'is-error';
+		let status;
+		if ( 'string' === typeof value ) {
+			if ( -1 < value.indexOf( 'error' ) ) {
+				status = 'is-error';
+			} else if ( -1 < value.indexOf( 'success' ) ) {
+				status = 'is-success';
+			}
 		}
 
-		return 'is-success';
+		return status;
 	},
 
 	renderRoleExplanation() {

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -68,6 +68,14 @@ export default React.createClass( {
 		page.back( fallback );
 	},
 
+	getTokenStatus( value ) {
+		if ( 'string' === typeof value && -1 < value.indexOf( 'error' ) ) {
+			return 'is-error';
+		}
+
+		return 'is-success';
+	},
+
 	renderRoleExplanation() {
 		return (
 			<a target="_blank" href="http://en.support.wordpress.com/user-roles/">
@@ -98,6 +106,7 @@ export default React.createClass( {
 						<FormFieldset>
 							<FormLabel>{ this.translate( 'Usernames or Emails' ) }</FormLabel>
 							<TokenField
+								tokenStatus={ this.getTokenStatus }
 								value={ this.state.usernamesOrEmails }
 								onChange={ this.onTokensChange } />
 							<FormSettingExplanation>


### PR DESCRIPTION
Closes #3086

As part of our work on people management, specifically around invite users to join WP.com sites, we are working on adding validation username and email that have been added to a token field.

What I've got so far is a first pass that is ready for some early design feedback.

![screen shot 2016-02-04 at 5 26 01 pm](https://cloud.githubusercontent.com/assets/1126811/12833246/f46fa70a-cb64-11e5-9d1e-cb0cf415be0f.png)

It currently feels a bit like Christmas! :stuck_out_tongue_closed_eyes: But, I imagine that we can tweak the colors. Also, I believe those colors will look better when combined with the `isBorderless` token styles that are being worked on in #3090.

To test:
- Go to `/people/new/$site` in development
- In the `Usernames or Email Addresses` field, type the following tokens:
  - "test", "success", "error"
- You should see blue, green, and red tokens respectively

cc @rickybanister for early design review