### PR TITLE
People: Invite followers via the RoleSelect component

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -37,7 +37,7 @@ export default React.createClass( {
 	resetState() {
 		return ( {
 			usernamesOrEmails: [],
-			role: '',
+			role: 'follower',
 			message: '',
 			response: false,
 			sendingInvites: false
@@ -54,6 +54,8 @@ export default React.createClass( {
 
 	submitForm( event ) {
 		event.preventDefault();
+
+		console.log( this.state );
 
 		this.setState( { sendingInvites: true } );
 		sendInvites( this.props.site.ID, this.state.usernamesOrEmails, this.state.role, this.state.message, ( error, data ) => {
@@ -119,6 +121,7 @@ export default React.createClass( {
 							siteId={ this.props.site.ID }
 							valueLink={ this.linkState( 'role' ) }
 							disabled={ this.state.sendingInvites }
+							appendRoles={ { follower: {} } } // adds a pseudo-role of follower
 							explanation={ this.renderRoleExplanation() }/>
 
 						<FormFieldset>

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import page from 'page';
 import get from 'lodash/object/get';
+import debugModule from 'debug';
 
 /**
  * Internal dependencies
@@ -20,6 +21,11 @@ import Card from 'components/card';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import CountedTextarea from 'components/forms/counted-textarea';
+
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:my-sites:people:invite' );
 
 export default React.createClass( {
 	displayName: 'InvitePeople',
@@ -54,8 +60,7 @@ export default React.createClass( {
 
 	submitForm( event ) {
 		event.preventDefault();
-
-		console.log( this.state );
+		debug( 'Submitting invite form. State: ' + JSON.stringify( this.state ) );
 
 		this.setState( { sendingInvites: true } );
 		sendInvites( this.props.site.ID, this.state.usernamesOrEmails, this.state.role, this.state.message, ( error, data ) => {

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -123,10 +123,10 @@ export default React.createClass( {
 							id="role"
 							name="role"
 							key="role"
+							includeFollower
 							siteId={ this.props.site.ID }
 							valueLink={ this.linkState( 'role' ) }
 							disabled={ this.state.sendingInvites }
-							appendRoles={ { follower: {} } } // adds a pseudo-role of follower
 							explanation={ this.renderRoleExplanation() }/>
 
 						<FormFieldset>

--- a/client/my-sites/people/role-select/README.md
+++ b/client/my-sites/people/role-select/README.md
@@ -6,3 +6,4 @@ This component listens to changes from the `RolesStore` and displays a select of
 ### Props
 * siteId - (int) siteId for site from which to fetch roles
 * explanation - (string) Optional explanation to be displayed below select in a FormSettingExplanation
+* includeFollower - (bool) Optional property which will include the WordPress.com Follower or Viewer pseudo roles

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -41,11 +41,15 @@ module.exports = React.createClass( {
 	},
 
 	refreshRoles: function( nextProps ) {
-		var siteId = nextProps && nextProps.siteId ? nextProps.siteId : this.props.siteId;
+		var siteId = nextProps && nextProps.siteId ? nextProps.siteId : this.props.siteId,
+			appendRoles,
+			siteRoles;
 
 		if ( siteId ) {
+			siteRoles = RolesStore.getRoles( siteId );
+			appendRoles = this.props.appendRoles || {};
 			this.setState( {
-				roles: RolesStore.getRoles( siteId )
+				roles: Object.assign( {}, appendRoles, siteRoles )
 			} );
 		}
 	},

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -1,43 +1,47 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debugFactory = require( 'debug' ),
-	omit = require( 'lodash/object/omit' ),
-	map = require( 'lodash/collection/map' );
-
-var RolesStore = require( 'lib/site-roles/store' ),
-	RolesActions = require( 'lib/site-roles/actions' ),
-	FormFieldset = require( 'components/forms/form-fieldset' ),
-	FormLabel = require( 'components/forms/form-label' ),
-	FormSelect = require( 'components/forms/form-select' ),
-	FormSettingExplanation = require( 'components/forms/form-setting-explanation' ),
-	sites = require( 'lib/sites-list' )();
-
-var debug = debugFactory( 'calypso:role-select' );
+import React from 'react';
+import debugFactory from 'debug';
+import omit from 'lodash/object/omit';
+import map from 'lodash/collection/map';
 
 /**
  * Internal dependencies
  */
-module.exports = React.createClass( {
+import RolesStore from 'lib/site-roles/store';
+import RolesActions from 'lib/site-roles/actions';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import sitesList from 'lib/sites-list';
+
+/**
+ * Module variables
+ */
+const debug = debugFactory( 'calypso:role-select' );
+const sites = sitesList();
+
+export default React.createClass( {
 	displayName: 'RoleSelect',
 
-	getInitialState: function() {
+	getInitialState() {
 		return ( {
 			roles: this.props.siteId ? RolesStore.getRoles( this.props.siteId ) : {}
 		} );
 	},
 
-	componentDidMount: function() {
+	componentDidMount() {
 		RolesStore.on( 'change', this.refreshRoles );
 		this.fetchRoles();
 	},
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		RolesStore.removeListener( 'change', this.refreshRoles );
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		this.refreshRoles( nextProps );
 	},
 
@@ -57,12 +61,11 @@ module.exports = React.createClass( {
 		};
 	},
 
-	refreshRoles: function( nextProps ) {
-		var siteId = nextProps && nextProps.siteId ? nextProps.siteId : this.props.siteId,
-			siteRoles;
+	refreshRoles( nextProps ) {
+		const siteId = nextProps && nextProps.siteId ? nextProps.siteId : this.props.siteId;
 
 		if ( siteId ) {
-			siteRoles = RolesStore.getRoles( siteId );
+			let siteRoles = RolesStore.getRoles( siteId );
 
 			if ( this.props.includeFollower ) {
 				siteRoles = Object.assign( {}, this.getWPCOMFollowerRole(), siteRoles )
@@ -74,8 +77,8 @@ module.exports = React.createClass( {
 		}
 	},
 
-	fetchRoles: function() {
-		var siteId = this.props.siteId || null;
+	fetchRoles() {
+		const siteId = this.props.siteId || null;
 		if ( ! siteId ) {
 			return;
 		}
@@ -87,7 +90,7 @@ module.exports = React.createClass( {
 
 		// defer fetch requests to avoid dispatcher conflicts
 		setTimeout( function() {
-			var fetching = RolesStore.isFetching( siteId );
+			const fetching = RolesStore.isFetching( siteId );
 			if ( fetching ) {
 				return;
 			}
@@ -95,8 +98,8 @@ module.exports = React.createClass( {
 		}, 0 );
 	},
 
-	render: function() {
-		var roleKeys = Object.keys( this.state.roles );
+	render() {
+		const roleKeys = Object.keys( this.state.roles );
 		return (
 			<FormFieldset key={ this.props.key } disabled={ ! roleKeys.length }>
 				<FormLabel htmlFor={ this.props.id }>


### PR DESCRIPTION
The `RoleSelect` component should accept an `appendRoles` property so that we can add the pseudo-role of Follower, which will allow folks to invite followers to their site. This PR also sets the initial role for the invite to 'follower'.

To test: 
 - checkout the branch and `make run`
 - go to http://calypso.localhost:3000/people/new/$site - where site is a wpcom site
 - ensure that 'Follower' is the default role for the invite, and that you can switch to other roles
 - ensure that you can send and accept a Follower invite

cc: @ebinnion 