### PR TITLE
Export: Simplify state tree - remove Immutable.js

### DIFF
--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -8,16 +8,16 @@ import { compose } from 'lodash';
  * Internal dependencies
  */
 import Exporter from './exporter';
-import { getUIState, shouldShowProgress } from 'state/site-settings/exporter/selectors';
+import {
+	shouldShowProgress,
+	getSelectedPostType,
+} from 'state/site-settings/exporter/selectors';
 import { setPostType, startExport } from 'state/site-settings/exporter/actions';
 
 function mapStateToProps( state, ownProps ) {
-	const uiState = getUIState( state );
-
 	return {
 		site: ownProps.site,
-		postType: uiState.postType,
-		advancedSettings: uiState.advancedSettings,
+		postType: getSelectedPostType( state ),
 		shouldShowProgress: shouldShowProgress( state )
 	};
 }

--- a/client/state/site-settings/exporter/reducers.js
+++ b/client/state/site-settings/exporter/reducers.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import Immutable from 'immutable';
 
 /**
  * Internal dependencies
@@ -19,42 +18,36 @@ import {
 
 import { States } from './constants';
 
-export const initialUIState = Immutable.fromJS( {
-	exportingState: States.READY,
-	postType: null
-} );
-
-/**
- * Reducer for managing the exporter UI
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
- */
-export function ui( state = initialUIState, action ) {
+export function selectedPostType( state = null, action ) {
 	switch ( action.type ) {
 		case SET_EXPORT_POST_TYPE:
-			return state.set( 'postType', action.postType );
+			return action.postType;
+		case SERIALIZE:
+			return state;
+		case DESERIALIZE:
+			return state;
+	}
+	return state;
+}
 
+export function exportingState( state = States.READY, action ) {
+	switch ( action.type ) {
 		case REQUEST_START_EXPORT:
-			return state.set( 'exportingState', States.STARTING );
-
+			return States.STARTING;
 		case REPLY_START_EXPORT:
-			return state.set( 'exportingState', States.EXPORTING );
-
+			return States.EXPORTING;
 		case FAIL_EXPORT:
 		case COMPLETE_EXPORT:
-			return state.set( 'exportingState', States.READY );
+			return States.READY;
 		case SERIALIZE:
-			return {};
+			return state;
 		case DESERIALIZE:
-			return initialUIState;
-
+			return States.READY;
 	}
-
 	return state;
 }
 
 export default combineReducers( {
-	ui
+	selectedPostType,
+	exportingState
 } );

--- a/client/state/site-settings/exporter/selectors.js
+++ b/client/state/site-settings/exporter/selectors.js
@@ -6,18 +6,11 @@ import { States } from './constants.js';
  * @param  {Object} state    Global state tree
  * @return {boolean}         true if activity is in progress
  */
-export function shouldShowProgress( state ) {
-	const exportingState = state.siteSettings.exporter.ui.get( 'exportingState' );
+export const shouldShowProgress = ( state ) => {
+	const exportingState = state.siteSettings.exporter.exportingState;
 
 	return ( exportingState === States.STARTING || exportingState === States.EXPORTING );
 }
 
-/**
- * Return the exporter UI state as a plain JS object.
- *
- * @param  {Object} state    Global state tree
- * @return {Object}          Exporter UI state
- */
-export function getUIState( state ) {
-	return state.siteSettings.exporter.ui.toJS();
-}
+export const getSelectedPostType = ( state ) => state.siteSettings.exporter.selectedPostType;
+export const getExportingState = ( state ) => state.siteSettings.exporter.exportingState;

--- a/client/state/site-settings/exporter/test/reducer.js
+++ b/client/state/site-settings/exporter/test/reducer.js
@@ -7,19 +7,34 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { DESERIALIZE, SERIALIZE } from 'state/action-types';
-import { ui, initialUIState } from '../reducers';
+import {
+	selectedPostType,
+	exportingState
+} from '../reducers';
+import { States } from '../constants';
 
 describe( 'reducer', () => {
-	describe( 'ui', () => {
-		it( 'never persists state because this is not implemented', () => {
-			const plugins = { my: { ui: { shape: {} } } };
-			const state = ui( plugins, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
+	describe( 'selectedPostType', () => {
+		it( 'persists state', () => {
+			const postType = 'feedback';
+			const state = selectedPostType( postType, { type: SERIALIZE } );
+			expect( state ).to.eql( 'feedback' );
 		} );
-		it( 'never loads persisted state because this is not implemented', () => {
-			const plugins = { my: { ui: { shape: {} } } };
-			const state = ui( plugins, { type: DESERIALIZE } );
-			expect( state ).to.eql( initialUIState );
+		it( 'loads persisted state', () => {
+			const postType = 'feedback';
+			const state = selectedPostType( postType, { type: DESERIALIZE } );
+			expect( state ).to.eql( 'feedback' );
+		} );
+	} );
+
+	describe( 'exportingState', () => {
+		it( 'persists state', () => {
+			const state = exportingState( States.EXPORTING, { type: SERIALIZE } );
+			expect( state ).to.eql( States.EXPORTING );
+		} );
+		it( 'ignores persisted state since server side checking is not implemented yet', () => {
+			const state = exportingState( States.EXPORTING, { type: DESERIALIZE } );
+			expect( state ).to.eql( States.READY );
 		} );
 	} );
 } );


### PR DESCRIPTION
This change removes Immutable.js objects from the Exporter, moving instead to plain JS objects. There should be no functionality changes.

This change was prompted for a few reasons:
 - The rest of the state tree has moved forward with plain JS objects
 - Simpler serialization/deserialization as introduced in #2754 
 - Simpler, standard and idiomatic reducer functions

Testing:
1. Go to `/settings/export`, click the **Export All** button. Ensure a success message is displayed.
2. Run `(cd client/state/site-settings/exporter && make test)` ensuring tests pass

cc @dllh @aduth @dmsnell 