### PR TITLE
Remove image elements that cannot be made safe.

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -514,7 +514,9 @@ normalizePost.content = {
 
 				removeUnsafeAttributes( image );
 
-				if ( imageShouldBeRemovedFromContent( imgSource ) ) {
+				safeSource = safeImageURL( imgSource );
+
+				if ( ! safeSource || imageShouldBeRemovedFromContent( imgSource ) ) {
 					image.parentNode.removeChild( image );
 					// fun fact: removing the node from the DOM will not prevent it from loading. You actually have to
 					// change out the src to change what loads. The following is a 1x1 transparent gif as a data URL
@@ -523,19 +525,18 @@ normalizePost.content = {
 					return;
 				}
 
-				safeSource = safeImageURL( imgSource );
-				if ( safeSource && maxWidth ) {
+				if ( maxWidth ) {
 					safeSource = maxWidthPhotonishURL( safeSource, maxWidth );
 				}
 
-				image.setAttribute( 'src', safeSource || TRANSPARENT_GIF );
+				image.setAttribute( 'src', safeSource );
 
 				if ( image.hasAttribute( 'srcset' ) ) {
 					const imgSrcSet = srcset.parse( image.getAttribute( 'srcset' ) ).map( imgSrc => {
 						if ( ! url.parse( imgSrc.url, false, true ).hostname ) {
 							imgSrc.url = url.resolve( post.URL, imgSrc.url );
 						}
-						imgSrc.url = safeImageURL( imgSrc.url ) || TRANSPARENT_GIF;
+						imgSrc.url = safeImageURL( imgSrc.url );
 						return imgSrc;
 					} );
 					image.setAttribute( 'srcset', srcset.stringify( imgSrcSet ) );

--- a/client/lib/post-normalizer/test/lib/safe-image-url.js
+++ b/client/lib/post-normalizer/test/lib/safe-image-url.js
@@ -1,6 +1,18 @@
 /**
  * A stub that makes safe-image-url deterministic
  */
-module.exports = function( url ) {
-	return url + '-SAFE';
-};
+var returnValue;
+
+function makeSafe( url ) {
+	return returnValue !== undefined ? returnValue : ( url + '-SAFE' );
+}
+
+makeSafe.setReturns = function( val ) {
+	returnValue = val;
+}
+
+makeSafe.undoReturns = function() {
+	returnValue = undefined;
+}
+
+module.exports = makeSafe;

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -15,6 +15,7 @@ const assert = require( 'chai' ).assert,
  * Internal dependencies
  */
 let normalizer = require( '../' ),
+	safeImageUrlFake = require( 'lib/safe-image-url' ),
 	allTransforms = [
 		normalizer.decodeEntities,
 		normalizer.stripHTML,
@@ -427,6 +428,20 @@ describe( 'post-normalizer', function() {
 					done( err );
 				}
 			);
+		} );
+
+		it( 'can remove images that cannot be made safe', function( done ) {
+			safeImageUrlFake.setReturns( null );
+			normalizer(
+				{
+					content: '<img width="700" height="700" src="http://example.com/example.jpg?nope">'
+				},
+				[ normalizer.withContentDOM( [ normalizer.content.safeContentImages( 400 ) ] ) ], function( err, normalized ) {
+					assert.equal( normalized.content, '' );
+					done( err );
+				}
+			);
+			safeImageUrlFake.undoReturns();
 		} );
 
 		it( 'removes event handlers from content images', function( done ) {


### PR DESCRIPTION
Add tests for photon safe-image-url returning null, which indicates that an image cannot be made safe.