### PR TITLE
Editor: Fix broken week display when week starts not on a Sunday

### DIFF
--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -80,7 +80,7 @@ module.exports = React.createClass( {
 				},
 
 				getFirstDayOfWeek: function() {
-					return localeData.firstDayOfWeek();
+					return Number( localeData.firstDayOfWeek() );
 				}
 			};
 


### PR DESCRIPTION
This fixes the calendar view for scheduled posts when the week doesn't start on a Sunday.

Old:
![jdp7vj9int-3000x3000](https://cloud.githubusercontent.com/assets/203408/12836840/9e424cea-cbbc-11e5-8dd8-c3426b8c44bb.png)

New:
<img width="282" alt="screen shot 2016-02-05 at 03 58 38" src="https://cloud.githubusercontent.com/assets/203408/12836857/ca9b6a74-cbbc-11e5-8674-a745944d1fc4.png">

Problem was a strict compare between string and number.