### PR TITLE
Reader: hide follow button in AFK posts

### DIFF
--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -169,6 +169,10 @@
 				top: 30px;
 				left: 44px;
 		}
+
+		.follow-button {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
When AFK posts appear in the My Likes stream, they currently have a full size follow button:

<img width="329" alt="screen shot 2016-02-05 at 17 52 55" src="https://cloud.githubusercontent.com/assets/17325/12838308/655d9324-cc31-11e5-9971-1be38b902b1f.png">

This PR hides the follow button in the stream for posts tagged as #afk.
