### PR TITLE
Domains: update mx placholder

### DIFF
--- a/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
@@ -53,7 +53,7 @@ const MxRecord = React.createClass( {
 						name="data"
 						onChange={ this.props.onChange( 'data' ) }
 						value={ this.props.fieldValues.data }
-						placeholder={ this.translate( 'e.g. mail.my-provider.com', { context: 'MX DNS Record', textOnly: true } ) } />
+						placeholder={ this.translate( 'e.g. mail.your-provider.com', { context: 'MX DNS Record', textOnly: true } ) } />
 				</FormFieldset>
 
 				<FormFieldset>


### PR DESCRIPTION
The current placeholder text for adding an MX record is `mail.my-provider.com` as Automattic does not own this domain we should not use it as a placeholder. 

The domain `your-provider.com` has been bought and redirects to our custom domain store page. This PR updates the placeholder text. 