### PR TITLE
Framework: turn off persistence until we can validate data

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -126,7 +126,7 @@
 		"help": true,
 		"support-user": true,
 
-		"persist-redux": true,
+		"persist-redux": false,
 
 		"notifications2beta": true,
 		"muse": true,


### PR DESCRIPTION
Redux persistence was causing issues for devs while switching between branches. We can flip this back on after #3101 lands 

cc @retrofox @rralian 