### PR TITLE
Reader: Add hover to Site component in post headers

### DIFF
--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -18,36 +18,6 @@
 		}
 	}
 
-	.site {
-		margin-right: 96px;
-	}
-
-	.site__content {
-		padding: 0;
-	}
-
-	.site__title::before {
-		font-size: 14px;
-	}
-
-	.site__domain {
-		font-style: normal;
-	}
-
-	.follow-button {
-		position: absolute;
-			top: -5px;
-			right: 0;
-		z-index: z-index( 'reader-card-follow-button-parent', '.reader__card.card .follow-button' );
-		padding-right: 0;
-
-		@include breakpoint( "<480px" ) {
-			top: 0;
-			right: 8px;
-		}
-
-	}
-
 	.reader-post-byline {
 		margin: 8px 0;
 		padding: 0;
@@ -181,9 +151,9 @@
 	position: relative;
 		top: 0;
 		left: -16px;
+	margin-top: 16px;
 	margin-bottom: 16px;
 	border-bottom: 1px solid lighten( $gray, 20 );
-	box-shadow: inset 0 0 2px 2px rgba( lighten( $gray, 10 ), 0.1 );
 	background: rgba( lighten( $gray, 30 ), 0.3 );
 
 	@include breakpoint( ">480px" ) {
@@ -294,11 +264,46 @@
 }
 
 .reader__post-header {
-	margin: 0 0 16px 0;
-	padding: 0;
+	margin: -16px -24px;
 	position: relative;
 	line-height: 16px;
 	@include clear-fix;
+
+	&.has-follow-button {
+		.site {
+			margin-right: 132px;
+		}
+	}
+
+	.site__content {
+		padding: 16px 24px;
+
+		&:hover {
+			background: lighten( $gray, 30 );
+		}
+	}
+
+	.site__title::before {
+		font-size: 14px;
+	}
+
+	.site__domain {
+		font-style: normal;
+	}
+
+	.follow-button {
+		position: absolute;
+			top: 15px;
+			right: 8px;
+		margin-top: 0;
+		z-index: z-index( 'reader-card-follow-button-parent', '.reader__card.card .follow-button' );
+
+		@include breakpoint( "<480px" ) {
+			top: 0;
+			right: 8px;
+		}
+
+	}
 }
 
 .reader__post-byline {

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -319,6 +319,10 @@ var Post = React.createClass( {
 				'has-featured-image': hasFeaturedImage,
 				'hide-xpost': this.props.xPostedTo
 			}, this.additionalClasses ),
+			headerClasses = {
+				"reader__post-header": true,
+				"has-follow-button": this.props.showFollowInHeader
+			},
 			primaryTag = post.primary_tag,
 			tagClasses = {
 				'reader__post-tag': true,
@@ -366,6 +370,8 @@ var Post = React.createClass( {
 
 		tagClasses = classnames( tagClasses );
 
+		headerClasses = classnames( headerClasses );
+
 		if ( isDiscoverPost ) {
 			discoverSiteUrl = DiscoverHelper.getSiteUrl( post );
 		}
@@ -387,7 +393,7 @@ var Post = React.createClass( {
 
 				<PostErrors post={ post } />
 
-				<div className="reader__post-header">
+				<div className={ headerClasses }>
 					{ this.props.showFollowInHeader ? <FollowButton siteUrl={ post.site_URL } /> : null }
 					<Site site={ site }
 						href={ post.site_URL }

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -6,11 +6,6 @@
 	max-width: 700px;
 	margin: 0 auto;
 
-	@include breakpoint( ">660px" ) {
-		padding-top: calc( 56px + 6vh );
-		padding-bottom: calc( 48px + 6vh );
-	}
-
 	&.is-placeholder {
 		.reader__post-options,
 		.reader__post-time,
@@ -43,30 +38,35 @@
 	}
 
 	.full-post__header {
+		margin: 0 -24px;
 		position: relative;
-	}
 
-	.site {
-		.site__content {
-			padding: 0;
-			border-radius: 0;
-			text-decoration: none;
-			margin-right: 80px;
+		.follow-button {
+			position: absolute;
+				top: 16px;
+				right: 0;
 
-			@include breakpoint( ">480px" ) {
-				margin-right: 120px;
+			@include breakpoint( "<480px" ) {
+				.follow-button__label {
+					display: none;
+				}
 			}
 		}
-	}
 
-	.follow-button {
-		position: absolute;
-			top: 0;
-			right: 0;
+		.site {
+			.site__content {
+				padding: 16px 24px;
+				border-radius: 0;
+				text-decoration: none;
+				margin-right: 80px;
 
-		@include breakpoint( "<480px" ) {
-			.follow-button__label {
-				display: none;
+				@include breakpoint( ">480px" ) {
+					margin-right: 120px;
+				}
+				
+				&:hover {
+					background: lighten( $gray, 30 );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Its not always obvious that the site favicon, title, and url are clickable. Here's me hovering my mouse on the site component in `master`:

![screen shot 2016-02-05 at 11 29 57 am](https://cloud.githubusercontent.com/assets/191598/12852212/dee29cb6-cbfb-11e5-9514-795ffab91f70.png)

Some times this can cause accidental clicks, when the user intends to read the post. This PR adds a hover affect to hopefully make it more obvious what a user is about to click on:

![screen shot 2016-02-05 at 11 29 38 am](https://cloud.githubusercontent.com/assets/191598/12852232/eb00793c-cbfb-11e5-8ea0-1d77211895ff.png)
