### PR TITLE
People: Update remove follower alert text

### DIFF
--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -48,9 +48,9 @@ let Followers = React.createClass( {
 			store = 'email' === this.props.type ? EmailFollowersStore : FollowersStore,
 			page = this.props.currentPage + 1,
 			paginationData = store.getPaginationData( this.props.fetchOptions ),
-			analyticsAction = 'email' === this.props.type ?
-				'Fetched more email followers with infinite list' :
-				'Fetched more followers with infinite list';
+			analyticsAction = 'email' === this.props.type
+				? 'Fetched more email followers with infinite list'
+				: 'Fetched more followers with infinite list';
 
 		if ( paginationData && paginationData.followersCurrentPage ) {
 			page = paginationData.followersCurrentPage + 1;
@@ -91,14 +91,18 @@ let Followers = React.createClass( {
 	},
 
 	renderFollower( follower ) {
+		const removeFollower = () => {
+			this.removeFollower( follower );
+		};
+
 		return (
 			<PeopleListItem
 				key={ follower.ID }
 				user={ follower }
-				type='follower'
+				type="follower"
 				site={ this.props.site }
 				isSelectable={ this.state.bulkEditing }
-				onRemove={ this.removeFollower.bind( this, follower ) }
+				onRemove={ removeFollower }
 			/>
 		);
 	},
@@ -132,7 +136,7 @@ let Followers = React.createClass( {
 		if ( this.noFollowerSearchResults() ) {
 			return (
 				<NoResults
-					image='/calypso/images/people/mystery-person.svg'
+					image="/calypso/images/people/mystery-person.svg"
 					text={
 						this.translate( 'No results found for {{em}}%(searchTerm)s{{/em}}',
 							{

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -124,7 +124,7 @@ let Followers = React.createClass( {
 
 	render() {
 		let key = deterministicStringify( omit( this.props.fetchOptions, [ 'max', 'page' ] ) ),
-			headerText = this.translate( this.props.label, { context: 'A navigation label.' } ),
+			headerText = this.props.label,
 			listClass = ( this.state.bulkEditing ) ? 'bulk-editing' : null,
 			followers,
 			emptyTitle;

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -69,7 +69,7 @@ let Followers = React.createClass( {
 				<p>
 				{
 					this.translate(
-						'If you remove this follower, he or she will no longer receive notifications about this site unless they re-follow.'
+						'If removed, this follower will stop receiving notifications about this site, unless they re-follow.'
 					)
 				}
 				</p>


### PR DESCRIPTION
This PR fixed the `he or she` language as mentioned in https://github.com/Automattic/wp-calypso/issues/2672#issuecomment-174085957 which was originally committed in #2673. It updates the message shown in the confirm alert when removing a follower:
![screenshot_05-02-2016-09 52 05](https://cloud.githubusercontent.com/assets/150348/12854356/27ee2848-cbee-11e5-80c3-b5909d0dba53.png)
It also fixes a translation error on line 127. 
`headerText = this.props.label,` instead of `headerText = this.translate( this.props.label, { context: 'A navigation label.' } ),`

cc: @ebinnion 
