### PR TITLE
Global Notices: fixed notice__action for global notices

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -35,6 +35,7 @@
 	@include breakpoint( ">660px" ) {
 		border-radius: 20px;
 		display: inline-flex;
+		overflow: hidden;
 		margin-bottom: 24px;
 	}
 }
@@ -51,6 +52,13 @@
 
 	@include breakpoint( ">660px" ) {
 		padding: 9px 13px;
+	}
+}
+
+.global-notices .notice a.notice__action {
+	@include breakpoint( ">660px" ) {
+		font-size: 14px;
+		padding: 9px 16px;
 	}
 }
 

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -58,6 +58,64 @@
 	}
 }
 
+.notice__button {
+	cursor: pointer;
+	margin-left: 0.428em;
+}
+
+// "X" for dismissing a notice
+.notice__dismiss {
+	display: flex;
+	padding: 11px 16px;
+	cursor: pointer;
+	color: $gray;
+
+	@include breakpoint( ">660px" ) {
+		padding: 13px 16px;
+	}
+
+	&:hover,
+	&:focus {
+		color: $gray-dark;
+	}
+
+	.notice & {
+		color: $gray;
+		opacity: 0.85;
+
+		&:hover,
+		&:focus {
+			opacity: 1;
+		}
+	}
+}
+
+// specificity for general `a` elements within notice is too great
+.notice a.notice__action {
+	background: rgba( 0, 0, 0, 0.2 );
+	box-sizing: border-box;
+	color: $white;
+	cursor: pointer;
+	display: flex;
+		align-items: center;
+	font-size: 15px;
+	font-weight: 400;
+	margin-left: auto; // forces the element to the right;
+	padding: 13px 16px;
+	text-decoration: none;
+	white-space: nowrap;
+
+	.gridicon {
+		margin-left: 8px;
+		opacity: 0.7;
+	}
+
+	&:hover,
+	&:focus {
+		background: rgba( 255, 255, 255, 0.2 );
+	}
+}
+
 // General styles for html elements
 // rendered inside a notice
 .notice {
@@ -115,38 +173,6 @@
 
 		.notice__dismiss {
 			color: $white;
-		}
-	}
-}
-
-.notice__button {
-	cursor: pointer;
-	margin-left: 0.428em;
-}
-
-// "X" for dismissing a notice
-.notice__dismiss {
-	display: flex;
-	padding: 11px 16px;
-	cursor: pointer;
-	color: $gray;
-
-	@include breakpoint( ">660px" ) {
-		padding: 13px 16px;
-	}
-
-	&:hover,
-	&:focus {
-		color: $gray-dark;
-	}
-
-	.notice & {
-		color: $gray;
-		opacity: 0.85;
-
-		&:hover,
-		&:focus {
-			opacity: 1;
 		}
 	}
 }
@@ -211,29 +237,4 @@
 	}
 }
 
-// ArrowLink sub-component
-// specificity for general `a` elements within notice is too great
-.notice a.notice__action {
-	background: rgba( 0, 0, 0, 0.2 );
-	box-sizing: border-box;
-	color: $white;
-	cursor: pointer;
-	display: flex;
-		align-items: center;
-	font-size: 15px;
-	font-weight: 400;
-	margin-left: auto; // forces the element to the right;
-	padding: 13px 16px;
-	text-decoration: none;
-	white-space: nowrap;
 
-	.gridicon {
-		margin-left: 8px;
-		opacity: 0.7;
-	}
-
-	&:hover,
-	&:focus {
-		background: rgba( 255, 255, 255, 0.2 );
-	}
-}


### PR DESCRIPTION
The fade background was overflowing the round corners and the font-size was incorrect and the padding was off. I also reorganized the notices stylesheet to make more sense.

Closes #3119

cc @mtias @scruffian 

Before:
<img src="https://cloud.githubusercontent.com/assets/275961/12854197/305b80f6-cc30-11e5-9425-4040a3f641c8.png" />

After:
<img width="297" alt="screen shot 2016-02-05 at 2 04 11 pm" src="https://cloud.githubusercontent.com/assets/437258/12856268/128475a6-cc12-11e5-8f1a-9f0791bed7c1.png">

