### PR TITLE
Editor: fixed alignment of categories/tags info-popover icons

### DIFF
--- a/client/post-editor/editor-categories/style.scss
+++ b/client/post-editor/editor-categories/style.scss
@@ -5,7 +5,7 @@
 	padding: 8px;
 	overflow: hidden;
 	overflow-y: auto;
-	margin: 8px 0 0 0;
+	margin: 0;
 
 	&.no-add-button {
 		border-bottom: 1px solid lighten( $gray, 20% );

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -40,10 +40,15 @@
 	}
 }
 
+.editor-drawer__label {
+	@include clear-fix;
+}
+
 .editor-drawer__label-text {
 	color: $gray;
 	display: block;
 	font-size: 11px;
+	line-height: 18px;
 	margin-bottom: 4px;
 	text-transform: uppercase;
 }
@@ -53,7 +58,7 @@
 }
 
 .editor-drawer__heading {
-	font-weight: bold;
+	font-weight: 600;
 	margin-bottom: 4px;
 }
 


### PR DESCRIPTION
Previously the info icon for tags was too close to the token field and the category selector had different spacing. Both of their labels were misaligned with their respective info-icons. I increased the line-height of the labels to make room for the icon and removed excess top margin from the category editor. A clearfix was also reqired since the icons are floated right.

**Before:**
<img width="260" alt="screen shot 2016-02-05 at 3 53 16 pm" src="https://cloud.githubusercontent.com/assets/437258/12858968/2bc9bd64-cc21-11e5-8500-f2802db88d74.png">

**After:**
<img width="266" alt="screen shot 2016-02-05 at 3 53 03 pm" src="https://cloud.githubusercontent.com/assets/437258/12858972/33940f90-cc21-11e5-983d-9f9aa44cd4d8.png">

cc @kellychoffman (please cc any more relevant person)