### PR TITLE
API: Power post-types-list with WP-API

### DIFF
--- a/client/lib/post-types-list/list.js
+++ b/client/lib/post-types-list/list.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 var debug = require( 'debug' )( 'calypso:post-types-list' );
-var omit = require( 'lodash/object/omit' );
-var values = require( 'lodash/object/values' );
+var omit = require( 'lodash/omit' );
+var values = require( 'lodash/values' );
 
 /**
  * Internal dependencies

--- a/client/lib/post-types-list/list.js
+++ b/client/lib/post-types-list/list.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 var debug = require( 'debug' )( 'calypso:post-types-list' );
+var omit = require( 'lodash/object/omit' );
+var values = require( 'lodash/object/values' );
 
 /**
  * Internal dependencies
@@ -52,13 +54,13 @@ PostTypesList.prototype.fetch = function( siteId ) {
 
 		debug( 'getting PostTypesList from api' );
 		wpcom
+		.undocumented()
 		.site( siteId )
-		.postTypesList( function( error, data ) {
+		.postTypesList( { context: 'edit' }, function( error, data ) {
 			if ( error ) {
 				debug( 'error fetching PostTypesList from api', error );
 				return;
 			}
-
 			this.data = this.parse( data );
 			this.emit( 'change' );
 			this.fetching = false;
@@ -73,7 +75,7 @@ PostTypesList.prototype.fetch = function( siteId ) {
  * @return {array} services
  **/
 PostTypesList.prototype.parse = function( data ) {
-	return data.post_types;
+	return values( omit( data, '_headers' ) );
 };
 
 /**

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -21,7 +21,8 @@ var resources = [
 	[ 'sshCredentialsMine', 'ssh-credentials/mine', '1.1' ],
 	[ 'sshCredentialsMineDelete', 'ssh-credentials/mine/delete', '1.1', 'post' ],
 	[ 'sshScanToggle', 'ssh-credentials/mine', '1.1', 'post' ],
-	[ 'getOption', 'option/' ]
+	[ 'getOption', 'option/' ],
+	[ 'postTypesList', 'types', '2' ]
 ];
 
 var list = function( resourceOptions ) {
@@ -40,9 +41,19 @@ var list = function( resourceOptions ) {
 			return '/';
 		} );
 
+		if ( typeof query === 'function' ) {
+			fn = query;
+			query = {};
+		}
+
 		query.apiVersion = resourceOptions.apiVersion;
 
 		path = '/sites/' + this._id + '/' + subpath;
+
+		// wp-api resources
+		if ( '2' === query.apiVersion ) {
+			path = '/sites/' + this._id + '/wp/v2/' + subpath;
+		}
 
 		debug( 'calling undocumented site api path', path );
 		debug( 'query', query );

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -53,6 +53,7 @@ var list = function( resourceOptions ) {
 		// wp-api resources
 		if ( '2' === query.apiVersion ) {
 			path = '/sites/' + this._id + '/wp/v2/' + subpath;
+			query.apiNamespace = 'wp';
 			query.locale = i18n.getLocaleSlug();
 		}
 

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -53,6 +53,7 @@ var list = function( resourceOptions ) {
 		// wp-api resources
 		if ( '2' === query.apiVersion ) {
 			path = '/sites/' + this._id + '/wp/v2/' + subpath;
+			query.locale = i18n.getLocaleSlug();
 		}
 
 		debug( 'calling undocumented site api path', path );

--- a/client/my-sites/menus/menu-item-types.js
+++ b/client/my-sites/menus/menu-item-types.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var find = require( 'lodash/find' );
+var findIndex = require( 'lodash/findIndex';
 
 /**
  * Internal dependencies
@@ -65,70 +66,69 @@ MenuItemTypes.prototype.init = function( site ) {
 
 /**
  * Returns an array of default item types
- *
- * @return {array} itemTypes
  */
 MenuItemTypes.prototype.initializeDefaultTypes = function() {
+	this._excludedItemTypes = [ 'attachment' ];
 	this._defaultItemTypes = [
-			{
-				name: 'page',
-				family: 'post_type',
-				icon: 'document',
-				renderer: 'renderPostOptions',
-				show: true,
-				label: i18n.translate( 'Page' ),
-				createLink: '//wordpress.com/page/' + this.site.ID  + '/new',
-				gaEventLabel: 'Page'
-			},
-			{
-				name: 'custom',
-				family: 'custom',
-				icon: 'link',
-				renderer: 'renderLinkOptions',
-				show: true,
-				label: i18n.translate( 'Link' ),
-				gaEventLabel: 'Link'
-			},
-			{
-				name: 'category',
-				family: 'taxonomy',
-				icon: 'category',
-				renderer: 'renderCategoryOptions',
-				show: true,
-				label: i18n.translate( 'Category' ),
-				createLink: this.site.options.admin_url + 'edit-tags.php?taxonomy=category',
-				gaEventLabel: 'Category'
-			},
-			{
-				name: 'post_tag',
-				family: 'taxonomy',
-				icon: 'tag',
-				contentsList: new TagsList( this.site.ID ),
-				renderer: 'renderTaxonomyOptions',
-				show: true,
-				label: i18n.translate( 'Tag' ),
-				createLink: this.site.options.admin_url + 'edit-tags.php?taxonomy=post_tag',
-				gaEventLabel: 'Tag'
-			},
-			{
-				name: 'post_format',
-				family: 'taxonomy',
-				icon: 'summary',
-				renderer: 'renderTaxonomyContents',
-				show: false,
-				label: i18n.translate( 'Post Format' ),
-				gaEventLabel: 'Post Format'
-			},
-			{
-				name: 'post',
-				family: 'post_type',
-				icon: 'standard',
-				renderer: 'renderPostOptions',
-				show: true,
-				label: i18n.translate( 'Post' ),
-				createLink: '//wordpress.com/post/' + this.site.ID  + '/new',
-				gaEventLabel: 'Post'
-			}
+		{
+			name: 'page',
+			family: 'post_type',
+			icon: 'document',
+			renderer: 'renderPostOptions',
+			show: true,
+			label: i18n.translate( 'Page' ),
+			createLink: '//wordpress.com/page/' + this.site.ID + '/new',
+			gaEventLabel: 'Page'
+		},
+		{
+			name: 'custom',
+			family: 'custom',
+			icon: 'link',
+			renderer: 'renderLinkOptions',
+			show: true,
+			label: i18n.translate( 'Link' ),
+			gaEventLabel: 'Link'
+		},
+		{
+			name: 'category',
+			family: 'taxonomy',
+			icon: 'category',
+			renderer: 'renderCategoryOptions',
+			show: true,
+			label: i18n.translate( 'Category' ),
+			createLink: this.site.options.admin_url + 'edit-tags.php?taxonomy=category',
+			gaEventLabel: 'Category'
+		},
+		{
+			name: 'post_tag',
+			family: 'taxonomy',
+			icon: 'tag',
+			contentsList: new TagsList( this.site.ID ),
+			renderer: 'renderTaxonomyOptions',
+			show: true,
+			label: i18n.translate( 'Tag' ),
+			createLink: this.site.options.admin_url + 'edit-tags.php?taxonomy=post_tag',
+			gaEventLabel: 'Tag'
+		},
+		{
+			name: 'post_format',
+			family: 'taxonomy',
+			icon: 'summary',
+			renderer: 'renderTaxonomyContents',
+			show: false,
+			label: i18n.translate( 'Post Format' ),
+			gaEventLabel: 'Post Format'
+		},
+		{
+			name: 'post',
+			family: 'post_type',
+			icon: 'standard',
+			renderer: 'renderPostOptions',
+			show: true,
+			label: i18n.translate( 'Post' ),
+			createLink: '//wordpress.com/post/' + this.site.ID + '/new',
+			gaEventLabel: 'Post'
+		}
 	];
 };
 
@@ -171,23 +171,23 @@ MenuItemTypes.prototype.parse = function() {
 	this.fetched = true;
 
 	newTypes = types.filter( function( type ) {
-		return find( this._defaultItemTypes, { name: type.name } ) === undefined &&
-				type.api_queryable === true &&
-				type.map_meta_cap === true;
+		// With WP-API, post types self register via the `show_in_rest` flag, which replaces `api_queryable` from wpcom api
+		return ( find( this._defaultItemTypes, { name: type.slug } ) === undefined ) &&
+				( -1 === findIndex( this._excludedItemTypes, type.slug ) );
 	}, this );
 
 	debug( 'Found some new types', newTypes );
 
 	newTypes.forEach( function( type ) {
 		this.data.push( {
-			name: type.name,
+			name: type.slug,
 			family: 'post_type',
 			icon: 'standard',
 			renderer: 'renderPostOptions',
 			show: true,
-			label: type.label, //FIXME: how do we handle i18n here?
-			createLink: this.site.options.admin_url + 'post-new.php?post_type=' + type.name,
-			gaEventLabel: type.label
+			label: type.name, //FIXME: how do we handle i18n here?
+			createLink: this.site.options.admin_url + 'post-new.php?post_type=' + type.slug,
+			gaEventLabel: type.name
 		} );
 	}, this );
 

--- a/client/my-sites/menus/menu-item-types.js
+++ b/client/my-sites/menus/menu-item-types.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var find = require( 'lodash/find' );
-var findIndex = require( 'lodash/findIndex';
 
 /**
  * Internal dependencies
@@ -173,7 +172,7 @@ MenuItemTypes.prototype.parse = function() {
 	newTypes = types.filter( function( type ) {
 		// With WP-API, post types self register via the `show_in_rest` flag, which replaces `api_queryable` from wpcom api
 		return ( find( this._defaultItemTypes, { name: type.slug } ) === undefined ) &&
-				( -1 === findIndex( this._excludedItemTypes, type.slug ) );
+				( ! find( this._excludedItemTypes, type.slug ) );
 	}, this );
 
 	debug( 'Found some new types', newTypes );

--- a/client/my-sites/sharing/buttons/options.jsx
+++ b/client/my-sites/sharing/buttons/options.jsx
@@ -75,13 +75,13 @@ module.exports = React.createClass( {
 	getPostTypeLabel: function( postType ) {
 		var label;
 
-		switch ( postType.name ) {
+		switch ( postType.slug ) {
 			case 'index': label = this.translate( 'Front Page, Archive Pages, and Search Results', { context: 'jetpack' } ); break;
 			case 'post': label = this.translate( 'Posts' ); break;
 			case 'page': label = this.translate( 'Pages' ); break;
 			case 'attachment': label = this.translate( 'Media' ); break;
 			case 'portfolio': label = this.translate( 'Portfolio Items' ); break;
-			default: label = postType.label;
+			default: label = postType.name;
 		}
 
 		return label;
@@ -92,7 +92,7 @@ module.exports = React.createClass( {
 			{ name: 'index' }
 		].concat( this.props.postTypes ).map( function( postType ) {
 			return {
-				value: postType.name,
+				value: postType.slug,
 				label: this.getPostTypeLabel( postType )
 			};
 		}, this );

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -183,9 +183,9 @@ var PublishMenu = React.createClass( {
 
 		customMenuItems = customPostTypes.map( function( postType ) {
 			return {
-				name: postType.name,
-				label: postType.labels ? postType.labels.menu_name : postType.label,
-				className: postType.name,
+				name: postType.slug,
+				label: postType.name,
+				className: postType.slug,
 
 				//If the API endpoint doesn't send the .capabilities property (e.g. because the site's Jetpack
 				//version isn't up-to-date), silently assume we don't have the capability to edit this CPT.
@@ -196,9 +196,9 @@ var PublishMenu = React.createClass( {
 
 				// Required to build the menu item class name. Must be discernible from other
 				// items' paths in the same section for item highlighting to work properly.
-				link: '/' + postType.name,
+				link: '/' + postType.slug,
 				buttonLink: '',
-				wpAdminLink: 'edit.php?post_type=' + postType.name,
+				wpAdminLink: 'edit.php?post_type=' + postType.slug,
 				showOnAllMySites: false,
 			};
 		} );

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -178,13 +178,13 @@ var PublishMenu = React.createClass( {
 			customPostTypes;
 
 		customPostTypes = this.state.postTypes.filter( function( type ) {
-			return ! some( menuItems, { name: type.name } );
+			return ! some( menuItems, { name: type.slug } );
 		} );
 
 		customMenuItems = customPostTypes.map( function( postType ) {
 			return {
 				name: postType.slug,
-				label: postType.name,
+				label: postType.labels ? postType.labels.menu_name : postType.name,
 				className: postType.slug,
 
 				//If the API endpoint doesn't send the .capabilities property (e.g. because the site's Jetpack


### PR DESCRIPTION
__WP-API Powered Post Types__
Herein lies the first bits of code to integrate calypso with the WP-API.  /ht to @nylen for help with this and his initial proof of concept that included a reduxification.  In this PR I opted to change the legacy `post-types-list` component to test out the new WP-API `/types` endpoint throughout Calypso.

__Undocumented?__
After some research and discussion with @retrofox - I opted to do these initial POC endpoints within the `wpcom-undocumented` module.  This will allow us to quickly test out WP-API endpoints in calypso while we finalize a more long-term solution either in [wpcom.js](https://github.com/Automattic/wpcom.js) or possibly leveraging [wordpress-rest-api](https://github.com/kadamwhite/wordpress-rest-api).

__To Test__
If you are eager to test this, and have a sandbox, please get in touch and I will help you get all the parts in place in order to test - or just wait a few days and hopefully it will be as simple as pulling this branch down :key: .

The `post-types-list` currently powers three different areas within Calypso, so all three will need to be tested to ensure everything works as it does now:

_Menu Item Types_
![menus_ _trout_bummin_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/12860623/ea3b1996-cc12-11e5-8276-468ce6e1555a.png)

_Sidebar Publish Menu_
![menus_ _trout_bummin_ _wordpress_com 2](https://cloud.githubusercontent.com/assets/22080/12860636/f71677e6-cc12-11e5-81a4-702e279b11fe.png)

_Sharing Button Configuration_
![sharing_ _trout_bummin_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/12860641/ffd2fa4e-cc12-11e5-94ec-5b01ddedb8ea.png)

Detailed testing steps will be added when this branch is ready for review.