### PR TITLE
People: Updates custom message in invite form to use CountedTextarea

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -11,7 +11,6 @@ import get from 'lodash/object/get';
  */
 import RoleSelect from 'my-sites/people/role-select';
 import TokenField from 'components/token-field';
-import FormTextArea from 'components/forms/form-textarea';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -20,6 +19,7 @@ import { sendInvites } from 'lib/invites/actions';
 import Card from 'components/card';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
+import CountedTextarea from 'components/forms/counted-textarea';
 
 export default React.createClass( {
 	displayName: 'InvitePeople',
@@ -46,6 +46,10 @@ export default React.createClass( {
 
 	onTokensChange( tokens ) {
 		this.setState( { usernamesOrEmails: tokens } );
+	},
+
+	onMessageChange( event ) {
+		this.setState( { message: event.target.value } );
 	},
 
 	submitForm( event ) {
@@ -119,10 +123,14 @@ export default React.createClass( {
 
 						<FormFieldset>
 							<FormLabel htmlFor="message">{ this.translate( 'Custom Message' ) }</FormLabel>
-							<FormTextArea
+							<CountedTextarea
 								name="message"
 								id="message"
-								valueLink={ this.linkState( 'message' ) }
+								showRemainingCharacters
+								maxLength={ 500 }
+								acceptableLength={ 500 }
+								onChange={ this.onMessageChange }
+								value={ this.state.message }
 								disabled={ this.state.sendingInvites } />
 							<FormSettingExplanation>
 								{ this.translate(


### PR DESCRIPTION
Closes #3124. In Slack, @rickybanister suggested that we make use of the `CountedTextarea` component instead of `FormTextarea` since we limit the number of characters for the custom message.

I also added a `maxLength={ 500 }` property so that we limit the textarea to ONLY be 500.  

![screen shot 2016-02-05 at 4 17 17 pm](https://cloud.githubusercontent.com/assets/1126811/12860784/86534b1c-cc24-11e5-9394-0e358a551f27.png)

To test:
- Checkout `update/invite-custom-message-countable` branch
- Go to `/people/new/$site`
- Enter a custom message.
  - Ensure that you can not go over 500 characters and that the count updates as you type.
- Send an invite.
- Ensure that you get a custom message in your email

cc @rickybanister for design review and @lezama for code review