### PR TITLE
Free trials: Stop assigning people to the free trials AB test

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -11,10 +11,8 @@ import isEmpty from 'lodash/lang/isEmpty';
 /**
  * Internal Dependencies
  */
-import { abtest } from 'lib/abtest';
 import i18n from 'lib/mixins/i18n';
 import config from 'config';
-import { defaultFlowName } from 'signup/config/flows';
 import route from 'lib/route';
 import analytics from 'analytics';
 import layoutFocus from 'lib/layout-focus';
@@ -71,10 +69,6 @@ export default {
 	},
 
 	redirectToFlow( context, next ) {
-		if ( utils.getFlowName( context.params ) === defaultFlowName && abtest( 'freeTrials' ) === 'offered' ) {
-			return page.redirect( utils.getValidPath( { flowName: 'free-trial' } ) );
-		}
-
 		if ( context.path !== utils.getValidPath( context.params ) ) {
 			return page.redirect( utils.getValidPath( context.params ) );
 		}


### PR DESCRIPTION
The results of this test are inconclusive. Until we know better what's going on, lets stop assigning users to it.

#### Testing instructions

1. Run `git checkout update/remove-trials` and start your server
2. Open the [`Signup` page](http://calypso.dev:3000/start) in an incognito window
3. Run `localStorage.getItem( 'ABTests' )` in your console
3. Check that you aren't assigned a to the `freeTrials_20160120` abtest.

#### Reviews

- [x] Code
- [x] Product