### PR TITLE
Framework: Upgrade to page 1.6.4

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8959,19 +8959,13 @@
       }
     },
     "page": {
-      "version": "1.6.1",
-      "from": "page@1.6.1",
-      "resolved": "https://registry.npmjs.org/page/-/page-1.6.1.tgz",
+      "version": "1.6.4",
       "dependencies": {
         "path-to-regexp": {
-          "version": "1.0.3",
-          "from": "path-to-regexp@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.0.3.tgz",
+          "version": "1.2.1",
           "dependencies": {
             "isarray": {
-              "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              "version": "0.0.1"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "moment-timezone": "^0.4.0",
     "morgan": "1.2.0",
     "node-sass": "3.4.2",
-    "page": "1.6.1",
+    "page": "1.6.4",
     "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-8",
     "photon": "2.0.0",
     "q": "1.0.1",


### PR DESCRIPTION
Fixes the busted wildcard params that we use in the reader to spin up the subscriptions store.

To see the diff, set a breakpoint on loadSubscriptions in reader/controller.js and load http://calypso.localhost:3000/read/blog/feed/10838258. With the fix, the break will trip and subs will be loaded. Without, they will not.

Another way to verify is to load that URL and check the network tab. You should see requests to /read/following/mine flowing out, but you will not in prod.