### PR TITLE
Posts: enable polling with leading fetch

### DIFF
--- a/client/components/post-list-fetcher/index.jsx
+++ b/client/components/post-list-fetcher/index.jsx
@@ -126,7 +126,7 @@ PostListFetcher = React.createClass( {
 
 	componentDidMount: function() {
 		var postListStore = postListStoreFactory( this.props.postListStoreId );
-		this._poller = pollers.add( postListStore, actions.fetchUpdated, { interval: 60000, leading: false } );
+		this._poller = pollers.add( postListStore, actions.fetchUpdated, { interval: 60000 } );
 	},
 
 	componentWillUnmount: function() {

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -441,7 +441,7 @@ PostActions = {
 
 		postListStore = postListStoreFactory( postListStoreId );
 
-		if ( postListStore.isLastPage() ) {
+		if ( postListStore.isLastPage() || postListStore.isFetchingNextPage() ) {
 			return;
 		}
 
@@ -479,6 +479,10 @@ PostActions = {
 		var id, params, siteID, postListStore;
 
 		postListStore = postListStoreFactory( postListStoreId );
+
+		if ( postListStore.isFetchingNextPage() ) {
+			return;
+		}
 
 		Dispatcher.handleViewAction( {
 			type: 'FETCH_UPDATED_POSTS',


### PR DESCRIPTION
I tried this in https://github.com/Automattic/wp-calypso/pull/2965 but I had to revert before it hit production. It worked fine on mounting, for pagination, and for polling queries, but I had removed the mechanism by which the component triggered a new query with different props. Whoops.

So now I'm using a leading polling query, but I've added some protection against double-fetching. The check in `fetchNextPage` isn't strictly necessary for my purposes, but seems like a good protection to have in general.

/cc @gwwar 