### PR TITLE
Domains: Update placeholder text in domain management

### DIFF
--- a/client/my-sites/upgrades/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/cname-record.jsx
@@ -54,7 +54,7 @@ const CnameRecord = React.createClass( {
 						isError={ ! isDataValid }
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.data }
-						placeholder={ this.translate( 'e.g. mydomain.com', { context: 'CName DNS Record', textOnly: true } ) } />
+						placeholder={ this.translate( 'e.g. example.com', { context: 'CName DNS Record', textOnly: true } ) } />
 					{ ! isDataValid ? <FormInputValidation text={ this.translate( 'Invalid Target Host' ) } isError={ true } /> : null }
 				</FormFieldset>
 			</div>

--- a/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
@@ -112,7 +112,7 @@ const SrvRecord = React.createClass( {
 						isError={ ! isTargetValid }
 						onChange={ this.props.onChange }
 						value={ target }
-						placeholder={ this.translate( 'e.g. sip.myprovider.com', { context: 'SRV Dns Record', textOnly: true } ) } />
+						placeholder={ this.translate( 'e.g. sip.your-provider.com', { context: 'SRV Dns Record', textOnly: true } ) } />
 					{ ! isTargetValid ? <FormInputValidation text={ this.translate( 'Invalid Target Host' ) } isError={ true } /> : null }
 				</FormFieldset>
 


### PR DESCRIPTION
Like #3104  this PR updates the placeholder text for SRV to us `your-provider.com` instead of `myprovider.com` to keep things consitent and prevent linking to domains we don't own. 

This also changes the placeholder in CNAME area from `mydomain.com` to `example.com` for the same reason of not wanting to link to domains we don't own. 

CC @klimeryk as I know you're currently working in Domains Management 
CC @gwwar since you helped with the original PR  