### PR TITLE
Domains: small improvements to DNS editor

### DIFF
--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -350,6 +350,7 @@ module.exports = {
 	setFieldErrors: setFieldErrors,
 	getErrorMessages: getErrorMessages,
 	getFieldErrorMessages: getFieldErrorMessages,
+	hasErrors: hasErrors,
 	isFieldDisabled: isFieldDisabled,
 	isFieldInvalid: isFieldInvalid,
 	isFieldPendingValidation: isFieldPendingValidation,

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -48,9 +48,9 @@ function Controller( options ) {
 	this._debouncedSanitize = debounce( this.sanitize, debounceWait );
 	this._debouncedValidate = debounce( this.validate, debounceWait );
 
-	this._hideFieldErrorsOnChange = isUndefined( options.hideFieldErrorsOnChange ) ?
-		false :
-		options.hideFieldErrorsOnChange;
+	this._hideFieldErrorsOnChange = isUndefined( options.hideFieldErrorsOnChange )
+		? false
+		: options.hideFieldErrorsOnChange;
 
 	if ( this._loadFunction ) {
 		this._loadFieldValues();

--- a/client/my-sites/upgrades/domain-management/dns/a-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/a-record.jsx
@@ -45,6 +45,7 @@ const ARecord = React.createClass( {
 					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
+						placeholder={ this.translate( 'Enter subdomain (required)', { context: 'Placeholder shown when entering the required subdomain part of a new DNS record' } ) }
 						isError={ ! isNameValid }
 						onChange={ onChange }
 						value={ fieldValues.name }

--- a/client/my-sites/upgrades/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/cname-record.jsx
@@ -40,6 +40,7 @@ const CnameRecord = React.createClass( {
 					<FormLabel>{ this.translate( 'Host', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
+						placeholder={ this.translate( 'Enter subdomain (required)', { context: 'Placeholder shown when entering the required subdomain part of a new DNS record' } ) }
 						isError={ ! isNameValid }
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.name }

--- a/client/my-sites/upgrades/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/cname-record.jsx
@@ -37,7 +37,7 @@ const CnameRecord = React.createClass( {
 		return (
 			<div className={ classes }>
 				<FormFieldset>
-					<FormLabel>{ this.translate( 'Host', { context: 'Dns Record' } ) }</FormLabel>
+					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
 						placeholder={ this.translate( 'Enter subdomain (required)', { context: 'Placeholder shown when entering the required subdomain part of a new DNS record' } ) }

--- a/client/my-sites/upgrades/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-add-new.jsx
@@ -148,7 +148,10 @@ const DnsAddNew = React.createClass( {
 		const classes = classnames( 'form-content', { 'is-hidden': ! this.state.show } ),
 			options = [ 'A', 'AAAA', 'CNAME', 'MX', 'SRV', 'TXT' ].map( function( type ) {
 				return <option key={ type }>{ type }</option>;
-			} );
+			} ),
+			isSubmitDisabled = formState.isSubmitButtonDisabled( this.state.fields ) ||
+				this.props.isSubmittingForm ||
+				formState.hasErrors( this.state.fields );
 
 		return (
 			<form className="dns__add-new">
@@ -166,7 +169,7 @@ const DnsAddNew = React.createClass( {
 
 				<FormFooter>
 					<FormButton
-						disabled={ formState.isSubmitButtonDisabled( this.state.fields ) || this.props.isSubmittingForm }
+						disabled={ this.state.show ? isSubmitDisabled : false }
 						onClick={ this.onAddDnsRecord }>
 						{ this.translate( 'Add New DNS Record' ) }
 					</FormButton>

--- a/client/my-sites/upgrades/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-add-new.jsx
@@ -6,8 +6,6 @@ import classnames from 'classnames';
 import includes from 'lodash/includes';
 import assign from 'lodash/assign';
 import find from 'lodash/find';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -26,7 +24,6 @@ import formState from 'lib/form-state';
 import notices from 'notices';
 import * as upgradesActions from 'lib/upgrades/actions';
 import { validateAllFields, getNormalizedData } from 'lib/domains/dns';
-import { successNotice } from 'state/notices/actions';
 
 const DnsAddNew = React.createClass( {
 	propTypes: {
@@ -100,7 +97,7 @@ const DnsAddNew = React.createClass( {
 				if ( error ) {
 					notices.error( error.message || this.translate( 'The DNS record has not been added.' ) );
 				} else {
-					this.props.successNotice( this.translate( 'The DNS record has been added.' ), {
+					notices.success( this.translate( 'The DNS record has been added.' ), {
 						duration: 5000
 					} );
 					this.setState( { show: true } );
@@ -191,7 +188,4 @@ const DnsAddNew = React.createClass( {
 	}
 } );
 
-export default connect(
-	null,
-	dispatch => bindActionCreators( { successNotice }, dispatch )
-)( DnsAddNew );
+export default DnsAddNew;

--- a/client/my-sites/upgrades/domain-management/dns/dns-list.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-list.jsx
@@ -43,7 +43,11 @@ const DnsList = React.createClass( {
 	addDns: function( record ) {
 		addDnsAction( this.props.selectedDomainName, record, ( error ) => {
 			if ( error ) {
-				notices.error( error.message );
+				notices.error( error.message || this.translate( 'The DNS record could not be restored.' ) );
+			} else {
+				this.props.successNotice( this.translate( 'The DNS record has been restored.' ), {
+					duration: 5000
+				} );
 			}
 		} );
 	},

--- a/client/my-sites/upgrades/domain-management/dns/dns-list.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-list.jsx
@@ -2,15 +2,13 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+
 /**
  * Internal dependencies
  */
 import DnsRecord from './dns-record';
 import notices from 'notices';
 import { deleteDns as deleteDnsAction, addDns as addDnsAction } from 'lib/upgrades/actions';
-import { successNotice } from 'state/notices/actions';
 
 const DnsList = React.createClass( {
 	propTypes: {
@@ -45,7 +43,7 @@ const DnsList = React.createClass( {
 			if ( error ) {
 				notices.error( error.message || this.translate( 'The DNS record could not be restored.' ) );
 			} else {
-				this.props.successNotice( this.translate( 'The DNS record has been restored.' ), {
+				notices.success( this.translate( 'The DNS record has been restored.' ), {
 					duration: 5000
 				} );
 			}
@@ -70,7 +68,4 @@ const DnsList = React.createClass( {
 	}
 } );
 
-export default connect(
-	null,
-	dispatch => bindActionCreators( { successNotice }, dispatch )
-)( DnsList );
+export default DnsList;

--- a/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
@@ -44,6 +44,7 @@ const MxRecord = React.createClass( {
 					<FormLabel>{ this.translate( 'Host', { context: 'MX Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
+						placeholder={ this.translate( 'Enter subdomain (optional)', { context: 'Placeholder shown when entering the optional subdomain part of a new DNS record' } ) }
 						isError={ ! isNameValid }
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.name }

--- a/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
@@ -41,7 +41,7 @@ const MxRecord = React.createClass( {
 		return (
 			<div className={ classes }>
 				<FormFieldset>
-					<FormLabel>{ this.translate( 'Host', { context: 'MX Dns Record' } ) }</FormLabel>
+					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
 						placeholder={ this.translate( 'Enter subdomain (optional)', { context: 'Placeholder shown when entering the optional subdomain part of a new DNS record' } ) }

--- a/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
@@ -54,6 +54,7 @@ const SrvRecord = React.createClass( {
 					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
+						placeholder={ this.translate( 'Enter subdomain (optional)', { context: 'Placeholder shown when entering the optional subdomain part of a new DNS record' } ) }
 						isError={ ! isNameValid }
 						onChange={ this.props.onChange }
 						value={ name }

--- a/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
@@ -42,6 +42,7 @@ const TxtRecord = React.createClass( {
 					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record TXT' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
+						placeholder={ this.translate( 'Enter subdomain (optional)', { context: 'Placeholder shown when entering the optional subdomain part of a new DNS record' } ) }
 						isError={ ! isNameValid }
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.name }

--- a/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
@@ -39,7 +39,7 @@ const TxtRecord = React.createClass( {
 		return (
 			<div className={ classes }>
 				<FormFieldset>
-					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record TXT' } ) }</FormLabel>
+					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
 						placeholder={ this.translate( 'Enter subdomain (optional)', { context: 'Placeholder shown when entering the optional subdomain part of a new DNS record' } ) }


### PR DESCRIPTION
This PR collects small, mostly visual improvements to the DNS editor:

* improve messaging when removing a DNS record (#3149)
* disable the submit button, when the form is invalid (#2283)
* improve placeholders (as suggested in https://github.com/Automattic/wp-calypso/issues/1604#issuecomment-170755762 by @breezyskies)
* use the `Name` label consistently throughout the editor (before we had `Host` on some records, while `Name` on others)

cc @umurkontaci @aidvu