### PR TITLE
Help: Add track pings to contact form buttons

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -9,6 +9,7 @@ import isEqual from 'lodash/lang/isEqual';
 /**
  * Internal dependencies
  */
+import analytics from 'analytics';
 import FormLabel from 'components/forms/form-label';
 import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
@@ -94,6 +95,17 @@ module.exports = React.createClass( {
 		this.setState( { siteSlug } );
 	},
 
+	trackClickStats: function( selectionName, selectedOption ) {
+		const tracksEvent = {
+			howCanWeHelp: 'calypso_help_how_can_we_help_click',
+			howYouFeel: 'calypso_help_how_you_feel_click'
+		}[ selectionName ];
+
+		if ( tracksEvent ) {
+			analytics.tracks.recordEvent( tracksEvent, { selected_option: selectedOption } );
+		}
+	},
+
 	/**
 	 * Render both a SegmentedControl and SelectDropdown component.
 	 *
@@ -116,7 +128,8 @@ module.exports = React.createClass( {
 				value: option.value,
 				title: option.label,
 				onClick: () => {
-					this.setState( { [ selectionName ]: option.value } )
+					this.setState( { [ selectionName ]: option.value } );
+					this.trackClickStats( selectionName, option.value );
 				}
 			}
 		} ) );


### PR DESCRIPTION
This PR adds a Tracks event to the "How can we help?" and "Mind sharing how you feel?" selectors on [the Contact page](http://wordpress.com/help/contact). The specific event being added is `calypso_help_contact_form_click`, and we're also tracking the value of the button in a prop called `button_value`. 

To test: 

1. Load http://wordpress.com/help/contact
2. Click one of the selectors underneath either field

The event is recorded (I use `localStorage.setItem('debug', 'calypso:analytics');` in the console to confirm) with the appropriate prop.

Of note, it won't fire if users just leave the default selections on the form, which is fine in my mind. This way, we can see how many users are using the form alongside what they're selecting.

Fix for #1822.