### PR TITLE
Checkout: Domains: Use Inline Form Validation for Contact Information Form

### DIFF
--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -194,7 +194,7 @@ function updateFields( formState, callback ) {
 
 function initializeFields( formState, fieldValues ) {
 	return updateFields( formState, function( name ) {
-		return { value: fieldValues[ name ] || '' };
+		return { value: fieldValues[ name ] || '', name };
 	} );
 }
 
@@ -308,10 +308,13 @@ function isFieldValidating( formState, fieldName ) {
 	return field.isValidating;
 }
 
-function getErrorMessages( formState ) {
-	var invalidFields = filter( formState, function( field, name ) {
-		return isFieldInvalid( formState, name );
+function getInvalidFields( formState ) {
+	return filter( formState, function( field ) {
+		return isFieldInvalid( formState, field.name );
 	} );
+}
+function getErrorMessages( formState ) {
+	var invalidFields = getInvalidFields( formState );
 
 	return flatten( map( invalidFields, 'errors' ) );
 }
@@ -349,6 +352,7 @@ module.exports = {
 	setFieldsValidating: setFieldsValidating,
 	setFieldErrors: setFieldErrors,
 	getErrorMessages: getErrorMessages,
+	getInvalidFields: getInvalidFields,
 	getFieldErrorMessages: getFieldErrorMessages,
 	isFieldDisabled: isFieldDisabled,
 	isFieldInvalid: isFieldInvalid,

--- a/client/lib/scroll-into-viewport/index.js
+++ b/client/lib/scroll-into-viewport/index.js
@@ -1,0 +1,40 @@
+/**
+ * Walks from a given node with `nextNodeProp` as the next node in a graph, summing the values in `valueProp`.
+ * e.g. recursivelyWalkAndSum( node, 'offsetTop', 'offsetParent' ).
+ * @param {Object} node - The node to start walking
+ * @param {string} valueProp - The name of the property to fetch the value from
+ * @param {string} nextNodeProp - The name of the property for the next node
+ * @param {number} [value=0} - The initial value
+ * @returns {number} - Summed value at the end of the walk
+ */
+function recursivelyWalkAndSum( node, valueProp, nextNodeProp, value = 0 ) {
+	value += node[ valueProp ];
+	if ( ! node[ nextNodeProp ] ) {
+		return value
+	}
+	return recursivelyWalkAndSum( node[ nextNodeProp ], valueProp, value );
+}
+
+/**
+ * Checks whether the given bounds are within the viewport
+ * @param {number} elementStart
+ * @param {number} elementEnd
+ * @returns {boolean}
+ */
+function isInViewportRange( elementStart, elementEnd ) {
+	var viewportStart = window.scrollY,
+		viewportEnd = document.documentElement.clientHeight + window.scrollY;
+	return elementStart > viewportStart && elementEnd < viewportEnd;
+}
+
+/**
+ * Scroll an element into the viewport if it's not already inside the viewport
+ * @param {HTMLElement} element
+ */
+function scrollIntoViewport( element ) {
+	var elementStartY = recursivelyWalkAndSum( element, 'offsetTop', 'offsetParent' ),
+		elementEndY = elementStartY + element.offsetHeight;
+	! isInViewportRange( elementStartY, elementEndY ) && window.scrollTo( 0, elementStartY );
+}
+
+export default scrollIntoViewport;

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -164,7 +164,7 @@ export default React.createClass( {
 				{ this.showFax() && <Input label={ this.translate( 'Fax', { textOnly } ) } { ...fieldProps( 'fax' ) }/> }
 				<Input label={ this.translate( 'Address', { textOnly } ) } { ...fieldProps( 'address-1' ) }/>
 
-				<Input
+				<HiddenInput
 					label={ this.translate( 'Address Line 2', { textOnly } ) }
 					text={ this.translate( '+ Add Address Line 2', { textOnly } ) }
 					{ ...fieldProps( 'address-2' ) }/>

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -157,7 +157,7 @@ export default React.createClass( {
 				<Input label={ this.translate( 'Phone', { textOnly } ) } { ...fieldProps( 'phone' ) }/>
 
 				<CountrySelect
-					label={ this.translate( 'County', { textOnly } ) }
+					label={ this.translate( 'Country', { textOnly } ) }
 					countriesList={ countriesList }
 					{ ...fieldProps( 'country-code' ) }/>
 

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -2,9 +2,12 @@
  * External dependencies
  */
 import React from 'react';
+import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import map from 'lodash/map';
 import camelCase from 'lodash/camelCase';
+import kebabCase from 'lodash/kebabCase';
+import head from 'lodash/head';
 
 /**
  * Internal dependencies
@@ -108,6 +111,7 @@ export default React.createClass( {
 	getFieldProps( name ) {
 		return {
 			name,
+			ref: name,
 			additionalClasses: 'checkout-field',
 			value: formState.getFieldValue( this.state.form, name ),
 			invalid: formState.isFieldInvalid( this.state.form, name ),
@@ -215,6 +219,7 @@ export default React.createClass( {
 			this.recordSubmit();
 
 			if ( hasErrors ) {
+				this.refs[ kebabCase( head( map( formState.getInvalidFields( this.state.form ), 'name' ) ) ) ].focus();
 				return;
 			}
 

--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -15,8 +15,6 @@ import PaymentBox from './payment-box';
 import { cartItems } from 'lib/cart-values';
 import { forDomainRegistrations as countriesListForDomainRegistrations } from 'lib/countries-list';
 import { forDomainRegistrations as statesListForDomainRegistrations } from 'lib/states-list';
-import notices from 'notices';
-import ValidationErrorList from 'notices/validation-error-list';
 import analytics from 'analytics';
 import formState from 'lib/form-state';
 import upgradesActions from 'lib/upgrades/actions';
@@ -80,18 +78,7 @@ export default React.createClass( {
 		if ( ! this.isMounted() ) {
 			return;
 		}
-
-		const errorMessages = formState.getErrorMessages( form );
-
-		if ( errorMessages.length > 0 ) {
-			const notice = notices.error( <ValidationErrorList messages={ errorMessages } /> );
-			this.setState( { form, notice } );
-		} else {
-			if ( this.state.notice ) {
-				notices.removeNotice( this.state.notice );
-			}
-			this.setState( { form } );
-		}
+		this.setState( { form } );
 	},
 
 	handleFormControllerError( error ) {
@@ -120,11 +107,16 @@ export default React.createClass( {
 
 	getFieldProps( name ) {
 		return {
+			name,
 			additionalClasses: 'checkout-field',
 			value: formState.getFieldValue( this.state.form, name ),
 			invalid: formState.isFieldInvalid( this.state.form, name ),
 			disabled: formState.isFieldDisabled( this.state.form, name ),
 			onChange: this.handleChangeEvent,
+			// The keys are mapped to snake_case when going to API and camelCase when the response is parsed and we are using
+			// kebab-case for HTML, so instead of using different variations all over the place, this accepts kebab-case and
+			// converts it to camelCase which is the format stored in the formState.
+			errorMessage: ( formState.getFieldErrorMessages( this.state.form, camelCase( name ) ) || [] ).join( '\n' ),
 			eventFormName: 'Checkout Form'
 		};
 	},
@@ -141,14 +133,13 @@ export default React.createClass( {
 		return (
 			<div>
 				<Input
-					name="first-name"
 					autofocus
 					label={ this.translate( 'First Name', { textOnly } ) }
 					{ ...fieldProps( 'first-name' ) }/>
-				<Input name="last-name" label={ this.translate( 'Last Name', { textOnly } ) } { ...fieldProps( 'last-name' ) }/>
+
+				<Input label={ this.translate( 'Last Name', { textOnly } ) } { ...fieldProps( 'last-name' ) }/>
 
 				<HiddenInput
-					name="organization"
 					label={ this.translate( 'Organization' ) }
 					text={ this.translate(
 						'Registering this domain for a company? + Add Organization Name',
@@ -159,36 +150,34 @@ export default React.createClass( {
 							count: this.getNumberOfDomainRegistrations(),
 							textOnly: true
 						}
-					) }/>
+					) }
+					{ ...fieldProps( 'organization' ) }/>
 
-				<Input name="email" label={ this.translate( 'Email', { textOnly } ) } { ...fieldProps( 'email' ) }/>
-				<Input name="phone" label={ this.translate( 'Phone', { textOnly } ) } { ...fieldProps( 'phone' ) }/>
+				<Input label={ this.translate( 'Email', { textOnly } ) } { ...fieldProps( 'email' ) }/>
+				<Input label={ this.translate( 'Phone', { textOnly } ) } { ...fieldProps( 'phone' ) }/>
 
 				<CountrySelect
-					name="country-code"
 					label={ this.translate( 'County', { textOnly } ) }
 					countriesList={ countriesList }
 					{ ...fieldProps( 'country-code' ) }/>
 
-				{ this.showFax() && <Input name="fax" label={ this.translate( 'Fax', { textOnly } ) } { ...( 'fax' ) }/> }
-				<Input name="address-1" label={ this.translate( 'Address', { textOnly } ) } { ...fieldProps( 'address-1' ) }/>
+				{ this.showFax() && <Input label={ this.translate( 'Fax', { textOnly } ) } { ...fieldProps( 'fax' ) }/> }
+				<Input label={ this.translate( 'Address', { textOnly } ) } { ...fieldProps( 'address-1' ) }/>
 
 				<Input
-					name="address-2"
 					label={ this.translate( 'Address Line 2', { textOnly } ) }
 					text={ this.translate( '+ Add Address Line 2', { textOnly } ) }
 					{ ...fieldProps( 'address-2' ) }/>
 
-				<Input name="city" label={ this.translate( 'City', { textOnly } ) } { ...fieldProps( 'city' ) }/>
+				<Input label={ this.translate( 'City', { textOnly } ) } { ...fieldProps( 'city' ) }/>
 
 				<StateSelect
-					name="state"
 					label={ this.translate( 'State', { textOnly: true } ) }
 					countryCode={ countryCode }
 					statesList={ statesList }
 					{ ...fieldProps( 'state' ) }/>
 
-				<Input name="postal-code" label={ this.translate( 'Postal Code', { textOnly } ) } { ...fieldProps( 'postal-code' ) }/>
+				<Input label={ this.translate( 'Postal Code', { textOnly } ) } { ...fieldProps( 'postal-code' ) }/>
 
 				<PrivacyProtection
 					cart={ this.props.cart }

--- a/client/my-sites/upgrades/components/form/country-select.jsx
+++ b/client/my-sites/upgrades/components/form/country-select.jsx
@@ -12,6 +12,7 @@ var React = require( 'react' ),
 var analytics = require( 'analytics' ),
 	FocusMixin = require( './focus-mixin.js' ),
 	FormLabel = require( 'components/forms/form-label' ),
+	FormInputValidation = require( 'components/forms/form-input-validation' ),
 	FormSelect = require( 'components/forms/form-select' );
 
 module.exports = React.createClass( {
@@ -71,6 +72,7 @@ module.exports = React.createClass( {
 						} ) }
 					</FormSelect>
 				</div>
+				{ this.props.errorMessage && <FormInputValidation text={ this.props.errorMessage } isError /> }
 			</div>
 		);
 	}

--- a/client/my-sites/upgrades/components/form/country-select.jsx
+++ b/client/my-sites/upgrades/components/form/country-select.jsx
@@ -14,6 +14,7 @@ var analytics = require( 'analytics' ),
 	FocusMixin = require( './focus-mixin.js' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormInputValidation = require( 'components/forms/form-input-validation' ),
+	scrollIntoViewport = require( 'lib/scroll-into-viewport' ),
 	FormSelect = require( 'components/forms/form-select' );
 
 module.exports = React.createClass( {
@@ -28,7 +29,9 @@ module.exports = React.createClass( {
 	},
 
 	focus() {
-		ReactDom.findDOMNode( this.refs.input ).focus();
+		var node = ReactDom.findDOMNode( this.refs.input );
+		node.focus();
+		scrollIntoViewport( node );
 	},
 
 	render() {

--- a/client/my-sites/upgrades/components/form/country-select.jsx
+++ b/client/my-sites/upgrades/components/form/country-select.jsx
@@ -4,6 +4,7 @@
 var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	isEmpty = require( 'lodash/isEmpty' ),
+	ReactDom = require( 'react-dom' ),
 	observe = require( 'lib/mixins/data-observe' );
 
 /**
@@ -20,13 +21,17 @@ module.exports = React.createClass( {
 
 	mixins: [ FocusMixin( 'input' ), observe( 'countriesList' ) ],
 
-	recordCountrySelectClick: function() {
+	recordCountrySelectClick() {
 		if ( this.props.eventFormName ) {
 			analytics.ga.recordEvent( 'Upgrades', `Clicked ${ this.props.eventFormName } Country Select` );
 		}
 	},
 
-	render: function() {
+	focus() {
+		ReactDom.findDOMNode( this.refs.input ).focus();
+	},
+
+	render() {
 		var classes = classNames( this.props.additionalClasses, 'country', {
 				focus: this.state.focus,
 				invalid: this.props.invalid

--- a/client/my-sites/upgrades/components/form/index.jsx
+++ b/client/my-sites/upgrades/components/form/index.jsx
@@ -1,0 +1,13 @@
+import CountrySelect from './country-select';
+import FocusMixin from './focus-mixin';
+import HiddenInput from './hidden-input';
+import Input from './input';
+import StateSelect from './state-select'
+
+export {
+	CountrySelect,
+	FocusMixin,
+	HiddenInput,
+	Input,
+	StateSelect
+}

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -8,6 +8,8 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+
+import FormInputValidation from 'components/forms/form-input-validation';
 import analytics from 'analytics';
 import FocusMixin from './focus-mixin';
 
@@ -85,6 +87,7 @@ export default React.createClass( {
 					onClick={ this.recordFieldClick }
 					onBlur={ this.handleBlur }
 					onFocus={ this.handleFocus } />
+				{ this.props.errorMessage && <FormInputValidation text={ this.props.errorMessage } isError /> }
 			</div>
 		);
 	}

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -1,32 +1,32 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	classNames = require( 'classnames' );
+import ReactDom from 'react-dom';
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'analytics' ),
-	FocusMixin = require( './focus-mixin.js' );
+import analytics from 'analytics';
+import FocusMixin from './focus-mixin';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'Input',
 
 	mixins: [ FocusMixin( 'input' ) ],
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return { type: 'text', autofocus: false };
 	},
 
-	componentDidMount: function() {
+	componentDidMount() {
 		this.setupInputModeHandlers();
 		this.autofocusInput();
 	},
 
-	setupInputModeHandlers: function() {
-		var inputElement = ReactDom.findDOMNode( this.refs.input );
+	setupInputModeHandlers() {
+		const inputElement = ReactDom.findDOMNode( this.refs.input );
 
 		if ( this.props.inputMode === 'numeric' ) {
 			// This forces mobile browsers to use a numeric keyboard. We have to
@@ -35,15 +35,10 @@ module.exports = React.createClass( {
 			//
 			// This workaround is based on the following StackOverflow post:
 			// http://stackoverflow.com/a/19998430/821706
-			inputElement.addEventListener( 'touchstart', function() {
-				inputElement.pattern = '\\d*';
-			} );
+			inputElement.addEventListener( 'touchstart', () => inputElement.pattern = '\\d*' );
 
-			[ 'keydown', 'blur' ].forEach( function( eventName ) {
-				inputElement.addEventListener( eventName, function() {
-					inputElement.pattern = '.*';
-				} );
-			} );
+			[ 'keydown', 'blur' ].forEach( ( eventName ) =>
+				inputElement.addEventListener( eventName, () => inputElement.pattern = '.*' ) );
 		}
 	},
 
@@ -61,14 +56,14 @@ module.exports = React.createClass( {
 		}
 	},
 
-	recordFieldClick: function() {
+	recordFieldClick() {
 		if ( this.props.eventFormName ) {
 			analytics.ga.recordEvent( 'Upgrades', `Clicked ${ this.props.eventFormName } Field`, this.props.name );
 		}
 	},
 
-	render: function() {
-		var classes = classNames( this.props.additionalClasses, this.props.name, this.props.labelClass, {
+	render() {
+		const classes = classNames( this.props.additionalClasses, this.props.name, this.props.labelClass, {
 			focus: this.state.focus,
 			active: Boolean( this.props.value ),
 			invalid: this.props.invalid

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 import FormInputValidation from 'components/forms/form-input-validation';
 import analytics from 'analytics';
 import FocusMixin from './focus-mixin';
+import scrollIntoViewport from 'lib/scroll-into-viewport';
 
 export default React.createClass( {
 	displayName: 'Input',
@@ -53,7 +54,9 @@ export default React.createClass( {
 	},
 
 	focus() {
-		ReactDom.findDOMNode( this.refs.input ).focus();
+		var node = ReactDom.findDOMNode( this.refs.input );
+		node.focus();
+		scrollIntoViewport( node );
 	},
 
 	autofocusInput() {

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -52,9 +52,13 @@ export default React.createClass( {
 		}
 	},
 
+	focus() {
+		ReactDom.findDOMNode( this.refs.input ).focus();
+	},
+
 	autofocusInput() {
 		if ( this.props.autofocus ) {
-			ReactDom.findDOMNode( this.refs.input ).focus();
+			this.focus();
 		}
 	},
 

--- a/client/my-sites/upgrades/components/form/state-select.jsx
+++ b/client/my-sites/upgrades/components/form/state-select.jsx
@@ -13,6 +13,7 @@ var analytics = require( 'analytics' ),
 	FocusMixin = require( './focus-mixin.js' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormSelect = require( 'components/forms/form-select' ),
+	FormInputValidation = require( 'components/forms/form-input-validation' ),
 	Input = require( './input' );
 
 module.exports = React.createClass( {
@@ -66,6 +67,7 @@ module.exports = React.createClass( {
 						} ) }
 						</FormSelect>
 					</div>
+					{ this.props.errorMessage && <FormInputValidation text={ this.props.errorMessage } isError /> }
 				</div>
 			);
 		}

--- a/client/my-sites/upgrades/components/form/state-select.jsx
+++ b/client/my-sites/upgrades/components/form/state-select.jsx
@@ -4,6 +4,7 @@
 var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	isEmpty = require( 'lodash/isEmpty' ),
+	ReactDom = require( 'react-dom' ),
 	observe = require( 'lib/mixins/data-observe' );
 
 /**
@@ -25,6 +26,10 @@ module.exports = React.createClass( {
 		if ( this.props.eventFormName ) {
 			analytics.ga.recordEvent( 'Upgrades', `Clicked ${ this.props.eventFormName } State Select` );
 		}
+	},
+
+	focus() {
+		ReactDom.findDOMNode( this.refs.input ).focus();
 	},
 
 	render: function() {
@@ -55,6 +60,7 @@ module.exports = React.createClass( {
 					<div>
 						<FormLabel htmlFor={ this.props.name }>{ this.props.label }</FormLabel>
 						<FormSelect
+							ref="input"
 							name={ this.props.name }
 							value={ this.props.value }
 							disabled={ this.props.disabled }

--- a/client/my-sites/upgrades/components/form/state-select.jsx
+++ b/client/my-sites/upgrades/components/form/state-select.jsx
@@ -15,6 +15,7 @@ var analytics = require( 'analytics' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormSelect = require( 'components/forms/form-select' ),
 	FormInputValidation = require( 'components/forms/form-input-validation' ),
+	scrollIntoViewport = require( 'lib/scroll-into-viewport' ),
 	Input = require( './input' );
 
 module.exports = React.createClass( {
@@ -29,7 +30,9 @@ module.exports = React.createClass( {
 	},
 
 	focus() {
-		ReactDom.findDOMNode( this.refs.input ).focus();
+		var node = ReactDom.findDOMNode( this.refs.input );
+		node.focus();
+		scrollIntoViewport( node );
 	},
 
 	render: function() {


### PR DESCRIPTION
This fixes #2866.

With this change, we are now using inline error messages instead of showing all the error messages at the top.

Screenshot
-
![image](https://cloud.githubusercontent.com/assets/991022/12877032/07aa75e4-cdc1-11e5-99ad-65e0500bf6b2.png)


Testing
-

- Go try to buy a domain and land on the contact information form.
- Ensure the form behaves as before, but the errors show at the bottom of every field instead of the top.

/cc: @klimeryk @aidvu 