### PR TITLE
Export: Automatically fetch advanced settings when switching to exporter

### DIFF
--- a/client/my-sites/exporter/advanced-settings.jsx
+++ b/client/my-sites/exporter/advanced-settings.jsx
@@ -2,12 +2,15 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import OptionFieldset from 'my-sites/exporter/option-fieldset';
 import SpinnerButton from './spinner-button';
+
+import { advancedSettings } from 'state/site-settings/exporter/selectors';
 
 /**
  * Displays additional options for customising an export
@@ -16,7 +19,7 @@ import SpinnerButton from './spinner-button';
  * exported. Posts and Pages can also be filtered by Authors, Statuses,
  * and Date.
  */
-export default React.createClass( {
+const AdvancedSettings = React.createClass( {
 	displayName: 'AdvancedSettings',
 
 	propTypes: {
@@ -56,7 +59,8 @@ export default React.createClass( {
 			legend: legends[ key ],
 			isEnabled: this.props.postType === key,
 			menus: menus[ key ],
-			onSelect: () => this.props.onSelectPostType( key )
+			onSelect: () => this.props.onSelectPostType( key ),
+			shouldShowPlaceholders: this.props.shouldShowPlaceholders
 		} );
 
 		return (
@@ -81,7 +85,7 @@ export default React.createClass( {
 				</div>
 				<SpinnerButton
 					className="exporter__export-button"
-					disabled={ !this.props.postType }
+					disabled={ ! this.props.postType }
 					loading={ this.props.shouldShowProgress }
 					isPrimary={ true }
 					onClick={ this.props.onClickExport }
@@ -91,3 +95,13 @@ export default React.createClass( {
 		);
 	}
 } );
+
+const mapStateToProps = ( state ) => {
+	const siteId = state.ui.selectedSiteId;
+	return {
+		siteId: siteId,
+		shouldShowPlaceholders: ! advancedSettings( state, siteId )
+	};
+};
+
+export default connect( mapStateToProps )( AdvancedSettings );

--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -16,9 +16,21 @@ export default React.createClass( {
 	propTypes: {
 		startExport: PropTypes.func.isRequired,
 		setPostType: PropTypes.func.isRequired,
+		advancedSettingsFetch: PropTypes.func.isRequired,
 
 		shouldShowProgress: PropTypes.bool.isRequired,
-		postType: PropTypes.string
+		postType: PropTypes.string,
+		siteId: PropTypes.number
+	},
+
+	componentWillMount() {
+		this.props.advancedSettingsFetch( this.props.siteId );
+	},
+
+	componentWillReceiveProps( newProps ) {
+		if ( newProps.siteId !== this.props.siteId ) {
+			this.props.advancedSettingsFetch( newProps.siteId );
+		}
 	},
 
 	render: function() {

--- a/client/my-sites/exporter/index.jsx
+++ b/client/my-sites/exporter/index.jsx
@@ -12,11 +12,15 @@ import {
 	shouldShowProgress,
 	getSelectedPostType,
 } from 'state/site-settings/exporter/selectors';
-import { setPostType, startExport } from 'state/site-settings/exporter/actions';
+import {
+	setPostType,
+	startExport,
+	advancedSettingsFetch
+} from 'state/site-settings/exporter/actions';
 
-function mapStateToProps( state, ownProps ) {
+function mapStateToProps( state ) {
 	return {
-		site: ownProps.site,
+		siteId: state.ui.selectedSiteId,
 		postType: getSelectedPostType( state ),
 		shouldShowProgress: shouldShowProgress( state )
 	};
@@ -25,7 +29,8 @@ function mapStateToProps( state, ownProps ) {
 function mapDispatchToProps( dispatch ) {
 	return {
 		setPostType: compose( dispatch, setPostType ),
-		startExport: () => startExport()( dispatch )
+		startExport: () => startExport()( dispatch ),
+		advancedSettingsFetch: compose( dispatch, advancedSettingsFetch )
 	};
 }
 

--- a/client/my-sites/exporter/option-fieldset.jsx
+++ b/client/my-sites/exporter/option-fieldset.jsx
@@ -27,7 +27,8 @@ module.exports = React.createClass( {
 		onSelect: PropTypes.func,
 
 		legend: PropTypes.string.isRequired,
-		isEnabled: PropTypes.bool.isRequired
+		isEnabled: PropTypes.bool.isRequired,
+		shouldShowPlaceholders: PropTypes.bool.isRequired,
 	},
 
 	getDefaultProps() {
@@ -37,6 +38,20 @@ module.exports = React.createClass( {
 	},
 
 	render() {
+		const placeholderMap = ( menu, menuIndex ) => (
+			<div key={ menuIndex } className="exporter__placeholder-text">
+				{ this.translate( 'Loading options…' ) }
+			</div>
+		)
+
+		const selectMap = ( menu, menuIndex ) => (
+			<Select key={ menuIndex } disabled={ ! this.props.isEnabled }>
+				{ menu.options.map( ( option, optionIndex ) => (
+					<option value={ optionIndex } key={ optionIndex }>{ option }</option>
+				) ) }
+			</Select>
+		)
+
 		return (
 			<div className="exporter__option-fieldset">
 
@@ -54,13 +69,9 @@ module.exports = React.createClass( {
 				}
 
 				<div className="exporter__option-fieldset-fields">
-					{ this.props.menus.map( ( menu, menuIndex ) => (
-						<Select key={ menuIndex } disabled={ !this.props.isEnabled }>
-							{ menu.options.map( ( option, optionIndex ) => (
-								<option value={ optionIndex } key={ optionIndex }>{ option }</option>
-							) ) }
-						</Select>
-					) ) }
+					{ this.props.menus.map(
+						this.props.shouldShowPlaceholders ? placeholderMap : selectMap
+					) }
 				</div>
 
 			</div>

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -26,6 +26,17 @@
 	float: right;
 }
 
+.exporter__placeholder-text {
+	padding-left: 24px;
+	padding-right: 24px;
+	margin-bottom: 24px;
+	height: 32px;
+
+	color: transparent;
+	background-color: lighten( $gray, 30% );
+	animation: loading-fade 1.6s ease-in-out infinite;
+}
+
 .exporter__advanced-settings {
 	padding-bottom: 50px;
 }

--- a/client/state/site-settings/exporter/actions.js
+++ b/client/state/site-settings/exporter/actions.js
@@ -35,7 +35,15 @@ export function setPostType( postType ) {
  * @return {thunk}        An action thunk for fetching the advanced settings
  */
 export function advancedSettingsFetch( siteId ) {
-	return ( dispatch ) => {
+	return ( dispatch, getState ) => {
+		if ( siteId === null || typeof siteId === 'undefined' ) {
+			return;
+		}
+
+		if ( getState().siteSettings.exporter.fetchingAdvancedSettings[ siteId ] === true ) {
+			return;
+		}
+
 		dispatch( {
 			type: EXPORT_ADVANCED_SETTINGS_FETCH,
 			siteId
@@ -50,7 +58,7 @@ export function advancedSettingsFetch( siteId ) {
 		return wpcom.undocumented()
 			.getExportSettings( siteId )
 			.then( updateExportSettings )
-			.catch( fetchFail )
+			.catch( fetchFail );
 	}
 }
 

--- a/client/state/site-settings/exporter/reducers.js
+++ b/client/state/site-settings/exporter/reducers.js
@@ -7,6 +7,8 @@ import { combineReducers } from 'redux';
  * Internal dependencies
  */
 import {
+	EXPORT_ADVANCED_SETTINGS_FAIL,
+	EXPORT_ADVANCED_SETTINGS_FETCH,
 	EXPORT_ADVANCED_SETTINGS_RECEIVE,
 	SET_EXPORT_POST_TYPE,
 	REQUEST_START_EXPORT,
@@ -49,6 +51,31 @@ export function exportingState( state = States.READY, action ) {
 }
 
 /**
+ * Tracks whether the advanced settings for a site are currently being fetched
+ * @param  {Object} state  Current global state tree
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function fetchingAdvancedSettings( state = {}, action ) {
+	switch ( action.type ) {
+		case EXPORT_ADVANCED_SETTINGS_FETCH:
+			return Object.assign( {}, state, {
+				[ action.siteId ]: true
+			} );
+		case EXPORT_ADVANCED_SETTINGS_FAIL:
+		case EXPORT_ADVANCED_SETTINGS_RECEIVE:
+			return Object.assign( {}, state, {
+				[ action.siteId ]: false
+			} );
+		case SERIALIZE:
+			return {};
+		case DESERIALIZE:
+			return {};
+	}
+	return state;
+}
+
+/**
  * Tracks available advanced settings for sites.
  * @param  {Object} state  Current global state tree
  * @param  {Object} action Action payload
@@ -72,5 +99,6 @@ export function advancedSettings( state = {}, action ) {
 export default combineReducers( {
 	selectedPostType,
 	exportingState,
+	fetchingAdvancedSettings,
 	advancedSettings
 } );

--- a/client/state/site-settings/exporter/selectors.js
+++ b/client/state/site-settings/exporter/selectors.js
@@ -17,3 +17,4 @@ export const shouldShowProgress = ( state ) => {
 
 export const getSelectedPostType = ( state ) => state.siteSettings.exporter.selectedPostType;
 export const getExportingState = ( state ) => state.siteSettings.exporter.exportingState;
+export const advancedSettings = ( state, siteId ) => state.siteSettings.exporter.advancedSettings[ siteId ];

--- a/client/state/site-settings/exporter/test/actions.js
+++ b/client/state/site-settings/exporter/test/actions.js
@@ -28,6 +28,11 @@ Chai.use( sinonChai );
 
 describe( '#advancedSettingsFetch()', () => {
 	const spy = sinon.spy();
+	const getState = () => ( {
+		siteSettings: { exporter: {
+			fetchingAdvancedSettings: {}
+		} }
+	} );
 
 	before( () => {
 		nock( 'https://public-api.wordpress.com:443' )
@@ -45,7 +50,7 @@ describe( '#advancedSettingsFetch()', () => {
 	} );
 
 	it( 'should dispatch fetch action when thunk triggered', () => {
-		advancedSettingsFetch( 100658273 )( spy );
+		advancedSettingsFetch( 100658273 )( spy, getState );
 
 		expect( spy ).to.have.been.calledWith( {
 			type: EXPORT_ADVANCED_SETTINGS_FETCH,
@@ -54,7 +59,7 @@ describe( '#advancedSettingsFetch()', () => {
 	} );
 
 	it( 'should dispatch receive action when request completes', ( done ) => {
-		advancedSettingsFetch( 100658273 )( spy ).then( () => {
+		advancedSettingsFetch( 100658273 )( spy, getState ).then( () => {
 			expect( spy ).to.have.been.calledWithMatch( {
 				type: EXPORT_ADVANCED_SETTINGS_RECEIVE,
 				siteId: 100658273,
@@ -66,7 +71,7 @@ describe( '#advancedSettingsFetch()', () => {
 	} );
 
 	it( 'should dispatch fail action when request fails', ( done ) => {
-		advancedSettingsFetch( 0 )( spy ).then( () => {
+		advancedSettingsFetch( 0 )( spy, getState ).then( () => {
 			expect( spy ).to.have.been.calledWithMatch( {
 				type: EXPORT_ADVANCED_SETTINGS_FETCH_FAIL,
 				siteId: 0

--- a/client/state/site-settings/exporter/test/reducer.js
+++ b/client/state/site-settings/exporter/test/reducer.js
@@ -7,6 +7,8 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	EXPORT_ADVANCED_SETTINGS_FAIL,
+	EXPORT_ADVANCED_SETTINGS_FETCH,
 	EXPORT_ADVANCED_SETTINGS_RECEIVE,
 	DESERIALIZE,
 	SERIALIZE
@@ -14,7 +16,8 @@ import {
 import {
 	selectedPostType,
 	exportingState,
-	advancedSettings
+	advancedSettings,
+	fetchingAdvancedSettings
 } from '../reducers';
 import {
 	SAMPLE_ADVANCED_SETTINGS,
@@ -44,6 +47,57 @@ describe( 'reducer', () => {
 		it( 'ignores persisted state since server side checking is not implemented yet', () => {
 			const state = exportingState( States.EXPORTING, { type: DESERIALIZE } );
 			expect( state ).to.eql( States.READY );
+		} );
+	} );
+
+	describe( '#fetchingAdvancedSettings()', () => {
+		it( 'should not persist state', () => {
+			const state = fetchingAdvancedSettings( { 100658273: true }, { type: SERIALIZE } );
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should not load persisted state', () => {
+			const state = fetchingAdvancedSettings( { 100658273: true }, { type: DESERIALIZE } );
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should index fetching status by site ID', () => {
+			const state = fetchingAdvancedSettings( null, {
+				type: EXPORT_ADVANCED_SETTINGS_FETCH,
+				siteId: 100658273
+			} );
+			expect( state ).to.eql( { 100658273: true } );
+		} );
+
+		it( 'should reset fetching status after receive', () => {
+			const state = fetchingAdvancedSettings( null, {
+				type: EXPORT_ADVANCED_SETTINGS_RECEIVE,
+				siteId: 100658273,
+				advancedSettings: {}
+			} );
+			expect( state ).to.eql( { 100658273: false } );
+		} );
+
+		it( 'should reset fetching status after fail', () => {
+			const state = fetchingAdvancedSettings( null, {
+				type: EXPORT_ADVANCED_SETTINGS_FAIL,
+				siteId: 100658273,
+				advancedSettings: {}
+			} );
+			expect( state ).to.eql( { 100658273: false } );
+		} );
+
+		it( 'should not replace fetching status with other site', () => {
+			const state = fetchingAdvancedSettings( {
+				100658273: true
+			}, {
+				type: EXPORT_ADVANCED_SETTINGS_FETCH,
+				siteId: 12345
+			} );
+			expect( state ).to.eql( {
+				100658273: true,
+				12345: true
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
This PR triggers a fetch of the export advanced settings when:
 - The user switches to the export page
 - The user changes sites while viewing the export page

### Automated Testing
```
(cd client/state/site-settings/exporter && make test)
```

### Browser Testing
1. Open the Redux developer console, then go to a site's **Settings > Export** page.
2. Check that the `EXPORT_ADVANCED_SETTINGS_FETCH` and `EXPORT_ADVANCED_SETTINGS_RECEIVE` actions have fired in the Redux developer console:
![screen_shot_2016-02-08_at_6_11_03_pm](https://cloud.githubusercontent.com/assets/416133/12881281/4edb0ac2-ce94-11e5-86fd-35b8a5ca4dd0.png)
3. Pop open the advanced export settings by clicking the down arrow beside the **Export All** button.
4. Keep an eye on the dropdowns as you switch to another site.
5. The dropdowns should be replaced with pulsing placeholders while the settings for that site are fetched:
![screen shot 2016-02-09 at 7 37 26 am](https://cloud.githubusercontent.com/assets/416133/12900063/18eb5c66-cf00-11e5-9e01-d08bc580e4e1.png)
6. The dropdowns should then reappear. Note that they are not yet populated in this PR.
7. Switch to the original site.
8. This time, the placeholders should not appear - the previous fetched settings are loaded immediately from the store. You should however see a new `EXPORT_ADVANCED_SETTINGS_FETCH` action fire - this is to refresh the settings in the background to ensure they are up to date.