### PR TITLE
Editor: Prevent optimistic embed rendering

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/views/embed/view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/embed/view.jsx
@@ -10,7 +10,6 @@ import { Container } from 'flux/utils';
  */
 import ResizableIframe from 'components/resizable-iframe';
 import EmbedsStore from 'lib/embeds/store';
-import actions from 'lib/embeds/actions';
 
 class EmbedView extends Component {
 	static getStores() {
@@ -22,10 +21,6 @@ class EmbedView extends Component {
 	}
 
 	componentDidMount() {
-		if ( ! this.state.status || this.state.status === 'ERROR' ) {
-			setTimeout( () => actions.fetch( this.props.siteId, this.props.content ), 0 );
-		}
-
 		this.setState( {
 			wrapper: this.refs.view
 		}, this.setHtml );

--- a/client/components/tinymce/plugins/wpcom-view/views/embed/view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/embed/view.jsx
@@ -21,7 +21,13 @@ class EmbedView extends Component {
 	}
 
 	componentDidMount() {
-		this.setState( {
+		// Rendering the frame follows a specific set of steps, whereby an
+		// initial rendering pass is made, at which time the frame is rendered
+		// in a second pass, before finally setting the frame markup.
+		//
+		// TODO: Investigate and evaluate whether we need to avoid rendering
+		//       the iframe on the initial render pass
+		this.setState( { // eslint-disable-line react/no-did-mount-set-state
 			wrapper: this.refs.view
 		}, this.setHtml );
 	}


### PR DESCRIPTION
This pull request seeks to prevent optimistic rendering of embed views until the embed render request has finished successfully. This is to address specific circumstances when an oEmbed provider intentionally returns an error response from their oEmbed endpoint to indicate that a specific URL pattern is not supported (see [§ 2.3.5 of the oEmbed specification](http://oembed.com/#section2.3)). This behavior is consistent with the wp-admin editor, which correctly accommodates oEmbed errors. This is arguably a better user experience, since a link will not be replaced until the embed markup is known, contrasting with the current experience where an empty frame is immediately rendered in place of any matched embed URL.

__Testing instructions:__

Verify that embeds are rendered only when the embed service returns a successful oEmbed markup response.

Examples:

- Vimeo matching supported URL: https://vimeo.com/59431658
- Vimeo matching unsupported URL: https://vimeo.com/settings
- Non-matched URL: https://google.com

Steps:

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Paste one of the two URLs above, or another URL (vary by matching, supported, or neither)
4. Note that...
 - If the URL is not a matched pattern for the site, the text remains unaffected
 - If the URL is a matched pattern for the site, but the oEmbed service does not support the specific URL, the text remains unaffected
 - If the URL is a matched pattern for the site and the oEmbed service supports the URL, the text is replaced with an embed view after the embed request succeeds