### PR TITLE
Framework: Fix logged-out /design render with persistence enabled

### DIFF
--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -67,7 +67,7 @@ export function section( state = false, action ) {
 		case SERIALIZE:
 			return false;
 		case DESERIALIZE:
-			return false;
+			return state;
 	}
 	return state;
 }
@@ -79,7 +79,7 @@ export function hasSidebar( state = true, action ) {
 		case SERIALIZE:
 			return true;
 		case DESERIALIZE:
-			return true;
+			return state;
 	}
 	return state;
 }

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -65,7 +65,7 @@ export function section( state = false, action ) {
 		case SET_SECTION:
 			return ( action.section !== undefined ) ? action.section : state;
 		case SERIALIZE:
-			return false;
+			return state;
 		case DESERIALIZE:
 			return state;
 	}
@@ -77,7 +77,7 @@ export function hasSidebar( state = true, action ) {
 		case SET_SECTION:
 			return ( action.hasSidebar !== undefined ) ? action.hasSidebar : state;
 		case SERIALIZE:
-			return true;
+			return state;
 		case DESERIALIZE:
 			return state;
 	}

--- a/client/state/ui/test/reducer.js
+++ b/client/state/ui/test/reducer.js
@@ -78,38 +78,38 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#section()', () => {
-		it( 'should not persist data because this is not implemented', () => {
+		it( 'should persist data', () => {
 			const state = section( 'hello', {
 				type: SERIALIZE
 			} );
 
-			expect( state ).to.eql( false );
+			expect( state ).to.eql( 'hello' );
 		} );
 
-		it( 'should not load persisted state because this is not implemented', () => {
+		it( 'should load persisted state', () => {
 			const state = section( 'hello', {
 				type: DESERIALIZE
 			} );
 
-			expect( state ).to.eql( false );
+			expect( state ).to.eql( 'hello' );
 		} );
 	} );
 
 	describe( '#hasSidebar()', () => {
-		it( 'should not persist data because this is not implemented', () => {
+		it( 'should persist data', () => {
 			const state = hasSidebar( false, {
 				type: SERIALIZE
 			} );
 
-			expect( state ).to.eql( true );
+			expect( state ).to.eql( false );
 		} );
 
-		it( 'should not load persisted state because this is not implemented', () => {
+		it( 'should load persisted state', () => {
 			const state = hasSidebar( false, {
 				type: DESERIALIZE
 			} );
 
-			expect( state ).to.eql( true );
+			expect( state ).to.eql( false );
 		} );
 	} );
 


### PR DESCRIPTION
**Before**
<img width="1200" alt="screen shot 2016-02-08 at 17 59 46" src="https://cloud.githubusercontent.com/assets/7767559/12894315/d646d6c8-ce8d-11e5-9970-dee5a312802e.png">

**After**
<img width="1199" alt="screen shot 2016-02-08 at 17 52 26" src="https://cloud.githubusercontent.com/assets/7767559/12894317/d7895e2a-ce8d-11e5-9a7e-7593330764f9.png">

**To Test**
1) Set `persist-redux` to `true` in `config/development.json`
2) Go to http://calypso.localhost:3000/design and check there is no sidebar-sized gap on the left

When the `persist-redux` flag is enabled, redux state bootstrapped from the server (on the logged-out /design route) is passed through the `DESERIALIZE` actions. This change preserves the state passed through those actions for `section` and `hasSidebar`, which are the two fields needed for the client render of logged-out /design.

/cc @gwwar 

An alternative to tweaking the `DESERIALIZE` actions would be to merge in the bootstrapped state after deserialization. The downside to that approach being that we would not be taking advantage of the immutable conversions.