### PR TITLE
Posts: handle deleted posts from a post-list request

### DIFF
--- a/client/lib/posts/post-list-store.js
+++ b/client/lib/posts/post-list-store.js
@@ -37,6 +37,35 @@ const debug = debugModule( 'calypso:posts-list' );
 
 let _nextId = 0;
 
+/**
+ * Find deleted posts based on ommissions in a new page of results.
+ * In some cases the new list may overlap with our stored list. And when
+ * this happens we can find elements that should be removed if they don't
+ * appear in the new post-list.
+ *
+ * @param  {array} currentList - stored list of PostIDs
+ * @param  {array} newPosts    - new page of postIDs
+ * @return {array}             - postIDs in currentList that should be deleted
+ */
+export function getRemovedPosts( currentList, newPosts ) {
+	if ( currentList.length < 3 || newPosts.length < 2 ) {
+		return [];
+	}
+
+	const overlapBegin = currentList.indexOf( newPosts[0] );
+	if ( overlapBegin === -1 ) {
+		return getRemovedPosts( currentList, newPosts.slice( 1 ) );
+	}
+
+	const overlapEnd = currentList.indexOf( newPosts.slice( -1 )[0] );
+	if ( overlapEnd === -1 ) {
+		return getRemovedPosts( currentList, newPosts.slice( 0, -1 ) );
+	}
+
+	const overlapList = currentList.slice( overlapBegin, ( overlapEnd + 1 ) );
+	return difference( overlapList, newPosts );
+}
+
 export default function( id ) {
 	if ( ! id ) {
 		throw new Error( 'must supply a post-list-store id' );
@@ -104,9 +133,9 @@ export default function( id ) {
 
 	/**
 	 * Sort the active list
-	 **/
+	 */
 	function sort() {
-		var key = _activeList.query.orderBy;
+		const key = _activeList.query.orderBy;
 
 		_activeList.postIds.sort( function( a, b ) {
 			var postA = PostsStore.get( a ),
@@ -164,7 +193,12 @@ export default function( id ) {
 		} );
 
 		if ( postIds.length ) {
-			// did we actually find any new posts?
+			// were some posts missing from the response?
+			const removedPosts = getRemovedPosts( _activeList.postIds, postIds );
+			if ( removedPosts.length ) {
+				_activeList.postIds = difference( _activeList.postIds, removedPosts );
+			}
+			// did we find any new posts?
 			postIds = difference( postIds, _activeList.postIds );
 			if ( postIds.length ) {
 				_activeList.postIds = _activeList.postIds.concat( postIds );
@@ -204,7 +238,7 @@ export default function( id ) {
 
 		if ( newPostIds.length ) {
 			_activeList.postIds = _activeList.postIds.concat( newPostIds );
-			sort( _activeList.postIds );
+			sort();
 		}
 	}
 

--- a/client/lib/posts/test/post-list-store.js
+++ b/client/lib/posts/test/post-list-store.js
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 import Dispatcher from 'dispatcher';
 import isPlainObject from 'lodash/lang/isPlainObject';
 import isArray from 'lodash/lang/isArray';
+import { getRemovedPosts } from '../post-list-store.js';
 
 /**
  * Mock Data
@@ -16,6 +17,24 @@ const TWO_POST_PAYLOAD = {
 		global_ID: 778
 	}, {
 		global_ID: 779
+	} ]
+};
+const THREE_POST_PAYLOAD = {
+	found: 2,
+	posts: [ {
+		global_ID: 778
+	}, {
+		global_ID: 779
+	}, {
+		global_ID: 780
+	} ]
+};
+const OMITTED_POST_PAYLOAD = {
+	found: 2,
+	posts: [ {
+		global_ID: 778
+	}, {
+		global_ID: 780
 	} ]
 };
 const DEFAULT_POST_LIST_ID = 'default';
@@ -159,6 +178,15 @@ describe( 'post-list-store', () => {
 		} );
 	} );
 
+	describe( '#getRemovedPosts', () => {
+		it( 'should remove ommitted posts from overlapping post-list response', () => {
+			const storedList = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+			const freshList = [ 3, 5, 7, 9 ];
+			const expectedResults = [ 4, 6, 8 ];
+			assert.deepEqual( getRemovedPosts( storedList, freshList ), expectedResults );
+		} );
+	} );
+
 	describe( '#getUpdatesParams', () => {
 		it( 'should return an object of params', () => {
 			assert.isTrue( isPlainObject( defaultPostListStore.getUpdatesParams() ) );
@@ -196,6 +224,13 @@ describe( 'post-list-store', () => {
 			assert.equal( defaultPostListStore.getAll().length, 1 );
 			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id, TWO_POST_PAYLOAD );
 			assert.equal( defaultPostListStore.getAll().length, 3 );
+		} );
+
+		it( 'should remove posts omitted in a follow-up post-list page', () => {
+			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id, THREE_POST_PAYLOAD );
+			assert.equal( defaultPostListStore.getAll().length, 3 );
+			dispatchReceivePostsPage( defaultPostListStore.getID(), defaultPostListStore.id, OMITTED_POST_PAYLOAD );
+			assert.equal( defaultPostListStore.getAll().length, 2 );
 		} );
 
 		it( 'should add only unique post.global_IDs postListStore', () => {


### PR DESCRIPTION
In certain cases we get data for post-lists that overlaps with data already in memory. Because this data is fresher than the in-memory data, we may have learned that a post currently in the list should no longer be in the list. This commit handles this case and removes the post from the list.

## Testing
For now the most important thing is to make sure post-list is working correctly. Load up a page of drafts or published posts, and scroll down enough to trigger a couple of extra fetches from the api. Ensure you get the same results as you do in master on wpcalypso.

This will come in handy if/when we try to respond optimistically to post-list requests with locally cached data. When we refresh the data with a callback from the server and run the callback again, this should clear out any items that should have been deleted.

/cc @retrofox 