### PR TITLE
People: First pass at disabling the invite form until invitee added

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -139,6 +139,11 @@ export default React.createClass( {
 		} );
 	},
 
+	isSubmitDisabled() {
+		const invitees = Array.isArray( this.state.usernamesOrEmails ) ? this.state.usernamesOrEmails : [];
+		return this.state.sendingInvites || ! invitees.length;
+	},
+
 	goBack() {
 		const siteSlug = get( this.props, 'site.slug' );
 		const fallback = siteSlug ? ( '/people/team/' + siteSlug ) : '/people/team';
@@ -205,7 +210,7 @@ export default React.createClass( {
 							</FormSettingExplanation>
 						</FormFieldset>
 
-						<FormButton disabled={ this.state.sendingInvites }>
+						<FormButton disabled={ this.isSubmitDisabled() }>
 							{ this.translate(
 								'Send Invitation',
 								'Send Invitations', {

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -6,6 +6,7 @@ import page from 'page';
 import get from 'lodash/get';
 import debugModule from 'debug';
 import includes from 'lodash/includes';
+import some from 'lodash/some';
 
 /**
  * Internal dependencies
@@ -140,8 +141,23 @@ export default React.createClass( {
 	},
 
 	isSubmitDisabled() {
-		const invitees = Array.isArray( this.state.usernamesOrEmails ) ? this.state.usernamesOrEmails : [];
-		return this.state.sendingInvites || ! invitees.length;
+		const { errors, success, usernamesOrEmails } = this.state;
+		const invitees = Array.isArray( usernamesOrEmails ) ? usernamesOrEmails : [];
+
+		// If there are no invitees, then don't allow submitting the form
+		if ( this.state.sendingInvites || ! invitees.length ) {
+			return true;
+		}
+
+		if ( errors && errors.length ) {
+			return true;
+		}
+
+		// If there are invitees, and there are no errors, let's check
+		// if there are any pending validations.
+		return some( usernamesOrEmails, ( value ) => {
+			return ! includes( success, value );
+		} );
 	},
 
 	goBack() {


### PR DESCRIPTION
Previously, a user could land on the `/people/new/$site` route and submit the form right away. This change ensure that there is at least one username or email address before allowing submission.

In the near future, we'll also want to handle these conditions.

- [x] Are all invitations valid?
- <strike>What happens after a form is submitted? Disable the form until another username or email is added?</strike>
- <strike>What if `localStorage` was cleared and site is not set?</strike>