### PR TITLE
Account: Remove privacy notice and opt out for service no longer used

### DIFF
--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -40,7 +40,6 @@ import NoticeAction from 'components/notice/notice-action';
 import observe from 'lib/mixins/data-observe';
 import eventRecorder from 'me/event-recorder';
 import Main from 'components/main';
-import SectionHeader from 'components/section-header';
 import SitesDropdown from 'components/sites-dropdown';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { getLanguage } from 'lib/i18n-utils';

--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -166,13 +166,6 @@ const Account = React.createClass( {
 		</FormSettingExplanation> );
 	},
 
-	getOptoutText( website ) {
-		return this.translate( '%(website)s opt-out', {
-			args: { website: website },
-			context: 'A website address, formatted to look like "Website.com"'
-		} );
-	},
-
 	cancelEmailChange() {
 		this.props.userSettings.cancelPendingEmailChange( ( error, response ) => {
 			if ( error ) {

--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -650,15 +650,6 @@ const Account = React.createClass( {
 						</ReactCSSTransitionGroup>
 					</form>
 				</Card>
-				<SectionHeader label={ this.translate( 'Privacy' ) } />
-				<Card>
-					<p>{ this.translate( "We use some third party tools to collect data about how users interact with our site. You can find more information about how we use these tools in our privacy policy. If you'd prefer that we not track your interactions you may opt out by using the following link: " ) }</p>
-					<p>
-						<a href="https://www.inspectlet.com/optout" target="_blank" onClick={ this.recordClickEvent( 'Inspectlet Opt-out Link' ) }>
-							{ this.getOptoutText( 'Inspectlet.com' ) }
-						</a>
-					</p>
-				</Card>
 			</Main>
 		);
 	}


### PR DESCRIPTION
`/me/account` includes a card with a privacy notice and opt out link for a service called Inspectlet that WordPress.com doesn't use anymore. This PR removes the section header and card.

before: 
![screen shot 2016-02-09 at 2 43 47 pm](https://cloud.githubusercontent.com/assets/3966960/12908932/f91db156-cf3e-11e5-988e-bf64a15b800c.png)

after:
![screen shot 2016-02-09 at 2 49 58 pm](https://cloud.githubusercontent.com/assets/3966960/12908935/fff37ac4-cf3e-11e5-8698-b263efdd5c75.png)

cc @apeatling 