### PR TITLE
i18n meetup project: Thank translation contributors

### DIFF
--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -43,6 +43,7 @@ import Main from 'components/main';
 import SectionHeader from 'components/section-header';
 import SitesDropdown from 'components/sites-dropdown';
 import { successNotice, errorNotice } from 'state/notices/actions';
+import { getLanguage } from 'lib/i18n-utils';
 
 import _sites from 'lib/sites-list';
 import _user from 'lib/user';
@@ -136,6 +137,34 @@ const Account = React.createClass( {
 				</FormFieldset>
 			);
 		}
+	},
+
+	thankTranslationContributors() {
+		let locale = this.props.userSettings.getSetting( 'language' );
+		if ( ! locale || locale === 'en' ) {
+			return;
+		}
+
+		const language = getLanguage( locale );
+		if ( ! language ) {
+			return;
+		}
+
+		// Config names are like 'fr - Francais', so strip the slug off
+		const languageName = language.name.replace( /^[a-zA-Z-]* - /, '' );
+		const url = 'https://en.support.wordpress.com/translators/?contributor_locale=' + locale;
+
+		return ( <FormSettingExplanation> {
+			this.translate( 'Thanks to {{a}}all our community members who helped translate to {{language/}}{{/a}}!', {
+				components: {
+					a: <a
+							target="_blank"
+							href={ url }
+					/>,
+					language: <span>{ languageName }</span>
+				}
+			} ) }
+		</FormSettingExplanation> );
 	},
 
 	getOptoutText( website ) {
@@ -457,6 +486,7 @@ const Account = React.createClass( {
 						onFocus={ this.recordFocusEvent( 'Interface Language Field' ) }
 						valueKey="langSlug"
 						valueLink={ this.updateLanguage() } />
+					{ this.thankTranslationContributors() }
 				</FormFieldset>
 
 				{ this.communityTranslator() }


### PR DESCRIPTION
This PR adds a "thank you" message with a link to a list of contributors under the language selector in [/me/account](http://calypso.localhost:3000/me/account):

![account_settings_ _wordpress_com](https://cloud.githubusercontent.com/assets/5952255/12912143/08eec88e-cf5a-11e5-96c7-95d810bc6c86.jpg)

The message should change with the language, and disappear for English, and the link should be to `https://en.support.wordpress.com/translators/?contributor_locale=<locale_slug>` e.g. [fr](https://en.support.wordpress.com/translators/?contributor_locale=fr)

Two quick notes:
1)  Because of the way the string is being created, the language name will be translated even if the string isn't, as you can see in the screen shot.  That's ok.

2) There's a bug with three-letter locales (and they won't work), which will is fixed in a different PR