### PR TITLE
i18nUtils: accept 3-letter locale slugs

### DIFF
--- a/client/lib/i18n-utils/test/utils-test.js
+++ b/client/lib/i18n-utils/test/utils-test.js
@@ -76,5 +76,10 @@ describe( 'i18n-utils', function() {
 		it( 'should return undefined when we lookup random words', function() {
 			expect( getLanguage( 'themes' ) ).to.equal( undefined );
 		} );
+
+		it( 'should return a language with a three letter country code', function() {
+			expect( getLanguage( 'ast' ).langSlug ).to.equal( 'ast' );
+		} );
+
 	} );
 } );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -8,8 +8,8 @@ import find from 'lodash/collection/find';
  */
 import config from 'config';
 
-const localeRegex = /^[A-Z]{2}$/i;
-const localeWithRegionRegex = /^[A-Z]{2}-[A-Z]{2}$/i;
+const localeRegex = /^[A-Z]{2,3}$/i;
+const localeWithRegionRegex = /^[A-Z]{2,3}-[A-Z]{2,3}$/i;
 
 function getPathParts( path ) {
 	// Remove trailing slash then split. If there is a trailing slash,


### PR DESCRIPTION
This PR fixes #3175, by updating the regex filter in i18nUtils.getLanguage() to accept locales with three-letter slugs.

If you run `config('languages').forEach( (lang) => i18nUtils.getLanguage( lang.langSlug ) ? null : console.log(lang.name) )` (e.g. by adding it to the bottom of `client/lib/i18n-utils/utils.js` and calling `make test`) you see a list of languages that occur in the config but return null from getLanguage():

    als - Alemannisch
    arc - ܕܥܒܪܸܝܛ
    ast - Asturianu
    csb - Kaszëbsczi
    fil - Filipino
    fur - Furlan
    ilo - Ilokano
    mwl - Mirandés
    nah - Nahuatl
    nap - Nnapulitano
    nds - Plattdüütsch
    non - Norrǿna
    rup - Armãneashce
    tir - ትግርኛ
    udm - Удмурт
    vec - Vèneto
    xal - Хальмг

These languages all have 3 letter slugs, so I've updated the filter in `i18n-utils` to allow them and added a test for one of them.