### PR TITLE
Notices: fix Safari display bug

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -199,7 +199,8 @@
 	.notice__icon {
 		align-self: center;
 		flex-shrink: 0;
-		padding: 0 0 0 8px;
+		margin: 0 0 0 8px;
+		padding: 0;
 		width: 14px;
 		height: 14px;
 		vertical-align: middle;


### PR DESCRIPTION
For some reason Safari is struggling with flex-box and padding in this case. Switching to margin fixes it.

Before
![image](https://cloud.githubusercontent.com/assets/548849/12915008/4359ee22-cf28-11e5-885d-94bf6581bd04.png)

After
![image](https://cloud.githubusercontent.com/assets/548849/12915018/59bb72e4-cf28-11e5-8997-b8368202eadf.png)
