### PR TITLE
Desktop app auth: Add inline instructions for self-hosted

### DIFF
--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -118,12 +118,12 @@ module.exports = React.createClass( {
 	},
 
 	toggleSelfHostedInstructions: function () {
-	    var isShowing = !this.state.showingInstructions;
-	    this.setState({ showingInstructions: isShowing });
+	    var isShowing = !this.state.showInstructions;
+	    this.setState( { showInstructions: isShowing } );
 	},
 
 	render: function() {
-		const { requires2fa, inProgress, errorMessage, errorLevel, showingInstructions } = this.state;
+		const { requires2fa, inProgress, errorMessage, errorLevel, showInstructions } = this.state;
 
 		return (
 			<Main className="auth">
@@ -178,10 +178,10 @@ module.exports = React.createClass( {
 					<Gridicon icon="help" />
 				</a>
 				<div className="auth__links">
-					<a href="#" onClick={this.toggleSelfHostedInstructions}>{ this.translate( 'Add self-hosted site' ) }</a>
+					<a href="#" onClick={ this.toggleSelfHostedInstructions }>{ this.translate( 'Add self-hosted site' ) }</a>
 					<a href={ 'https://wordpress.com' + config( 'signup_url' ) } target="_blank">{ this.translate( 'Create account' ) }</a>
 				</div>
-				{ showingInstructions && <SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } /> }
+				{ showInstructions && <SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } /> }
 			</Main>
 		);
 	}

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -35,6 +35,27 @@ const LostPassword = React.createClass( {
 	}
 } );
 
+const SelfHostedInstructions = React.createClass( {
+
+	render: function() {
+		return (
+			<div className="auth__self-hosted-instructions">
+				<a href="#" onClick={ this.toggleSelfHostedInstructions } className="auth__self-hosted-instructions-close"><Gridicon icon="cross" size={ 24 } /></a>
+
+				<h2>{ this.translate( 'Add self-hosted site' ) }</h2>
+				<p>{ this.translate( 'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com' ) }</p>
+				<p>{ this.translate( 'If you\'d like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:' ) }</p>
+
+				<ol>
+					<li><strong>{ this.translate( 'Install the Jetpack plugin.' ) }</strong><br /><a href="http://jetpack.me/install/">{ this.translate( 'Please follow these instructions to install Jetpack' ) }</a>.</li>
+					<li>{ this.translate( 'Connect Jetpack to WordPress.com.' ) }</li>
+					<li>{ this.translate( 'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, and you can find your self-hosted site under the "My Sites" section.' ) }</li>
+				</ol>
+			</div>
+		);
+	}
+} );
+
 module.exports = React.createClass( {
 	displayName: 'Auth',
 
@@ -96,8 +117,13 @@ module.exports = React.createClass( {
 		return this.hasLoginDetails();
 	},
 
+	toggleSelfHostedInstructions: function () {
+	    var isShowing = !this.state.showingInstructions;
+	    this.setState({ showingInstructions: isShowing });
+	},
+
 	render: function() {
-		const { requires2fa, inProgress, errorMessage, errorLevel } = this.state;
+		const { requires2fa, inProgress, errorMessage, errorLevel, showingInstructions } = this.state;
 
 		return (
 			<Main className="auth">
@@ -152,9 +178,10 @@ module.exports = React.createClass( {
 					<Gridicon icon="help" />
 				</a>
 				<div className="auth__links">
-					<a href="https://jetpack.me/support/site-management/" target="_blank">{ this.translate( 'Add self-hosted site' ) }</a>
+					<a href="#" onClick={this.toggleSelfHostedInstructions}>{ this.translate( 'Add self-hosted site' ) }</a>
 					<a href={ 'https://wordpress.com' + config( 'signup_url' ) } target="_blank">{ this.translate( 'Create account' ) }</a>
 				</div>
+				{ showingInstructions && <SelfHostedInstructions /> }
 			</Main>
 		);
 	}

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -40,7 +40,7 @@ const SelfHostedInstructions = React.createClass( {
 	render: function() {
 		return (
 			<div className="auth__self-hosted-instructions">
-				<a href="#" onClick={ this.toggleSelfHostedInstructions } className="auth__self-hosted-instructions-close"><Gridicon icon="cross" size={ 24 } /></a>
+				<a href="#" onClick={ this.props.onClickClose } className="auth__self-hosted-instructions-close"><Gridicon icon="cross" size={ 24 } /></a>
 
 				<h2>{ this.translate( 'Add self-hosted site' ) }</h2>
 				<p>{ this.translate( 'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com' ) }</p>
@@ -181,7 +181,7 @@ module.exports = React.createClass( {
 					<a href="#" onClick={this.toggleSelfHostedInstructions}>{ this.translate( 'Add self-hosted site' ) }</a>
 					<a href={ 'https://wordpress.com' + config( 'signup_url' ) } target="_blank">{ this.translate( 'Create account' ) }</a>
 				</div>
-				{ showingInstructions && <SelfHostedInstructions /> }
+				{ showingInstructions && <SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } /> }
 			</Main>
 		);
 	}

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -181,8 +181,8 @@
 	transform: translate( -50%, -50% );
 	min-width: 320px;
 	max-width: 60%;
-	min-height: 60%;
-	max-height: 96%;
+	max-height: 80%;
+	overflow: auto;
 	text-align: left;
 	counter-reset: item;
 
@@ -247,7 +247,7 @@
 	}
 
 	.auth__self-hosted-instructions-close:hover {
-		color: $gray-light;
+		color: $blue-light;
 	}
 
 }

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -163,3 +163,93 @@
 	margin: 0 16px;
 	padding: 10px 0;
 }
+
+.auth__links a:hover,
+.auth__links a:focus {
+	color: $gray-light;
+}
+
+.auth__self-hosted-instructions {
+	color: #fff;
+	background: $blue-dark;
+	border-radius: 8px;
+	padding: 40px;
+	position: absolute;
+	z-index: 4;
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
+	min-width: 320px;
+	max-width: 60%;
+	min-height: 60%;
+	max-height: 96%;
+	text-align: left;
+	counter-reset: item;
+
+	@include breakpoint( "<480px" ) {
+		left: 0;
+		top: -8px;
+		right: 0;
+		bottom: -8px;
+		min-width: 0;
+		min-height: 0;
+		max-width: none;
+		max-height: none;
+		overflow: auto;
+		transform: translate( 0, 0 );
+		border-radius: 0;
+	}
+
+	ol {
+		list-style: none;
+		position: relative;
+	}
+
+	ol li {
+		counter-increment: item;
+		margin-bottom: 1.5em;
+	}
+
+	ol li:before {
+		margin-right: 2em;
+		content: counter(item);
+		background: $white;
+		border-radius: 100%;
+		color: $blue-dark;
+		width: 24px;
+		height: 24px;
+		text-align: center;
+		display: inline-block;
+		position: absolute;
+		left: -3em;
+		font-weight: bold;
+	}
+
+	h2 {
+		font-weight: bold;
+		margin-bottom: 1.5em;
+	}
+
+	a {
+		color: $blue-light;
+		text-decoration: underline;
+	}
+
+	.auth__self-hosted-instructions-close {
+		display: block;
+		width: 24px;
+		height: 24px;
+		position: absolute;
+		right: 10px;
+		top: 10px;
+		text-decoration: none;
+		color: $white;
+	}
+
+	.auth__self-hosted-instructions-close:hover {
+		color: $gray-light;
+	}
+
+}
+
+


### PR DESCRIPTION
This PR adds an inline modal dialog box with instructions for how to add self-hosted WordPress sites to Calypso. Previously the "Add self-hosted site" link just took you out to the browser. This keeps it all inline, neat and tidy.

Screenshot of current state:

![screen shot 2016-02-09 at 13 19 15](https://cloud.githubusercontent.com/assets/1204802/12916091/183f0c9c-cf30-11e5-9b8d-b404663ef09b.png)
