### PR TITLE
Account: only offer community translator for non-English locales

### DIFF
--- a/client/me/account/index.jsx
+++ b/client/me/account/index.jsx
@@ -110,7 +110,9 @@ const Account = React.createClass( {
 	},
 
 	communityTranslator() {
-		if ( config.isEnabled( 'community-translator' ) ) {
+		const userLocale = this.props.userSettings.getSetting( 'language' );
+		const showTranslator = userLocale && userLocale !== 'en';
+		if ( config.isEnabled( 'community-translator' ) && showTranslator ) {
 			return (
 				<FormFieldset>
 					<FormLegend>{ this.translate( 'Community Translator' ) }</FormLegend>


### PR DESCRIPTION
The Community Translator can't be activated when the locale is English, so we're effectively showing English users a useless checkbox.

This PR adds a locale check so we only offer the community translator to users who can use it.