### PR TITLE
Fix eslint errors in i18nlint directory

### DIFF
--- a/server/i18nlint/bin/i18nlint-cli.js
+++ b/server/i18nlint/bin/i18nlint-cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+/* eslint  no-process-exit:0 */
+
 /**
  * External dependencies
  */
@@ -15,22 +17,23 @@ var i18nlint = require( '../i18nlint.js' );
 /**
  * Global variables
  */
-var foundWarnings = false;
+var inputFile,
+	warnings = [],
+	foundWarnings = false;
 
 program
 	.version( '0.1.0' )
 	.option( '-c, --color', 'Force color output', function() {
 		chalk.enabled = true;
 	} )
-	.option( '-v, --verbose', 'Print message for files with no errors')
+	.option( '-v, --verbose', 'Print message for files with no errors' )
 	.usage( 'inputFile' )
 	.on( '--help', function() {
 		console.log( 'i18nlint scans the given file for translation anti-patterns and offers suggestions to fix them' );
 	} )
 	.parse( process.argv );
 
-var inputFile = program.args[ 0 ],
-	warnings = [];
+inputFile = program.args[ 0 ];
 
 if ( ! inputFile ) {
 	console.log( 'Error: You must enter an input file.' );

--- a/server/i18nlint/i18nlint.js
+++ b/server/i18nlint/i18nlint.js
@@ -343,7 +343,7 @@ function auditASTNodeForVariablesInTranslateArguments( node, properties, warning
 		if ( isNotAcceptableTranslateArgument( node.arguments[ i ] ) ) {
 			warnings.push( {
 				string: "We can't pass variables or functions to translate() (only string literals).\n" +
-					"    See https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only",
+					'    See https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only',
 				original: originalString,
 				location: node.arguments[ i ].loc.start
 			} );
@@ -361,7 +361,7 @@ function auditASTNodeForVariablesInTranslateArguments( node, properties, warning
 				warnings.push( {
 					string: "'" + keyName( releventProperties[ i ] ) + "' " +
 						"option in translate() can't be a variable or function (it must be a string literal).\n" +
-						"    See https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only",
+						'    See https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only',
 					original: originalString,
 					location: releventProperties[ i ].value.loc.start
 				} );

--- a/server/i18nlint/test/testfiles/non-literal-translate-arguments.js
+++ b/server/i18nlint/test/testfiles/non-literal-translate-arguments.js
@@ -20,5 +20,5 @@ translate( 'comment must be a string literal.',
 translate( 'options containing a comment must be an object literal.',
 	argsWithComment );
 translate( 'options containing a context must be an object literal.', argsWithContext );
-translate( 'string literal keys are ok', { 'context': contextVariable } );
-translate( 'string literal keys are ok', { 'comment': commentVariable } );
+translate( 'string literal keys are ok', { 'context': contextVariable } );  // eslint-disable-line quote-props
+translate( 'string literal keys are ok', { 'comment': commentVariable } );  // eslint-disable-line quote-props


### PR DESCRIPTION
This PR fixes eslint errors in the `server/i18nlint` directory.

We ignore the quoted keys in the testfile because we explicitly want to handle that (we've had bugs in the past where we didn't).

It seems like the no-process-exit rule is intended to stop modules from ending processes, and that process.exit() is an appropriate in CLI scripts like this.  This is potentially a little controversial.