### PR TITLE
Framework: Deserialize bootstrapped state to allow conversion to immutable data

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -73,7 +73,7 @@ export default function createReduxStoreFromPersistedInitialState( reduxStoreRea
 			.then( reduxStoreReady );
 	} else {
 		debug( 'persist-redux is not enabled, building state from scratch' );
-		reduxStoreReady( createReduxStore( getInitialServerState() ) );
+		reduxStoreReady( loadInitialState( {} ) );
 	}
 }
 


### PR DESCRIPTION
Bootstrap the entire (empty) redux state tree to the client for the logged out /design route, using the _deserialize_ reducers on the client side to handle conversion to immutable.

Bootstrapping the whole state tree is required for server-rendering theme sheets in #3053.

@gwwar: this would mean deserialization being used in a production route. Is that wise at this point?

No visible changes

**To Test**
1) `make clean && make run`
2) In a new incognito browser window, go to http://calypso.localhost:3000/design
Check that there are no errors in the JS console