### PR TITLE
Domains: Fix flexbox setting on CTA buttons so longer translations don't get cut off

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -59,6 +59,7 @@
 }
 
 .domain-suggestion__action {
+	flex: 1 0 auto;
 	margin: 1px 0 0 5%;
 	min-width: 100px;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/2417.

Before | After
------------ | -------------
![screen shot 2016-02-09 at 10 35 45 am](https://cloud.githubusercontent.com/assets/3011211/12926706/830a2a28-cf19-11e5-8617-9c4c264ea092.png) | ![screen shot 2016-02-09 at 10 35 29 am](https://cloud.githubusercontent.com/assets/3011211/12926707/830aa430-cf19-11e5-83d5-c43569803781.png)

cc: @klimeryk 