### PR TITLE
Token Field: Combines is-borderless and validation styles

### DIFF
--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -68,6 +68,12 @@ input[type="text"].token-field__input {
 			background: $alert-red;
 		}
 	}
+
+	&.is-validating {
+		.token-field__token-text, .token-field__remove-token {
+			background: $gray;
+		}
+	}
 }
 
 .token-field__token.is-borderless {
@@ -91,6 +97,12 @@ input[type="text"].token-field__input {
 	&.is-error {
 		.token-field__token-text {
 			color: $alert-red;
+		}
+	}
+
+	&.is-validating {
+		.token-field__token-text {
+			color: $gray;
 		}
 	}
 }

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -81,6 +81,18 @@ input[type="text"].token-field__input {
 		color: $gray;
 		padding: 0 2px;
 	}
+
+	&.is-success {
+		.token-field__token-text {
+			color: $alert-green;
+		}
+	}
+
+	&.is-error {
+		.token-field__token-text {
+			color: $alert-red;
+		}
+	}
 }
 
 .token-field__token-text, .token-field__remove-token {

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -79,7 +79,7 @@ input[type="text"].token-field__input {
 .token-field__token.is-borderless {
 	.token-field__token-text {
 		background: transparent;
-		color: $gray-dark;
+		color: $blue-wordpress;
 	}
 
 	.token-field__remove-token {
@@ -102,15 +102,17 @@ input[type="text"].token-field__input {
 
 	&.is-validating {
 		.token-field__token-text {
-			color: $gray;
+			color: $gray-dark;
 		}
 	}
 }
 
-.token-field__token-text, .token-field__remove-token {
+.token-field__token-text,
+.token-field__remove-token {
 	display: inline-block;
 	line-height: 24px;
 	background: darken( $gray, 20% );
+	transition: all .2s cubic-bezier( .4, 1, .4, 1 );
 }
 
 .token-field__token-text {


### PR DESCRIPTION
Continuing work from #3090, this PR combines the `is-borderless` style with the `is-success` and `is-error` styles.

@rickybanister suggested in Slack, that we use `$gray` for a pending validation state and then `$gray-dark` for the success state.

I'm not sure how this affects the validation styles of other tokens. Should we drop the `is-success` status?