### PR TITLE
Editor: Fix height of page editor sidebar header

### DIFF
--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -27,7 +27,7 @@
 	display: flex;
 	justify-content: flex-end;
 	align-items: center;
-	padding: 8px 8px 8px 16px;
+	padding: 8px;
 
 	@include breakpoint( ">660px" ) {
 		justify-content: space-between;
@@ -95,14 +95,18 @@
 .post-editor__close.button.is-compact.is-borderless {
 	display: none;
 	align-self: center;
-	line-height: 14px;
-	padding: 0;
+	line-height: 12px;
+	padding: 8px;
 	white-space: nowrap;
 	max-width: 50%;
 
 	@include breakpoint( ">660px" ) {
 		display: block;
 	}
+}
+
+.post-editor .drafts-button {
+	padding: 3px 8px;
 }
 
 .post-editor .draft .post-relative-time-status {


### PR DESCRIPTION
Currently, the sidebar header shrinks when editing a page, because the drafts button in the posts editor sidebar header is responsible for controlling the height of the header. The changes herein seek to align the height of the sidebar header between the post editor, page editor, and My Sites sidebar (44px). Additional vertical padding on the close button has the added benefit of making it easier to click/tap.

__Before:__

![Before](https://cloud.githubusercontent.com/assets/1779930/12928622/7f3c69ba-cf3c-11e5-8a30-36e267abd3ad.png)

__After:__

![After](https://cloud.githubusercontent.com/assets/1779930/12928614/6e5b14f2-cf3c-11e5-857d-61bc37c9bcbb.png)

__Testing instructions:__

Verify that the heights of the sidebar header are consistent between:

1. [Post editor](http://calypso.localhost:3000/post)
2. [Page editor](http://calypso.localhost:3000/page)
3. [My Sites](http://calypso.localhost:3000/stats)

/cc @mtias 