### PR TITLE
People: Remove debug UI from invite form

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -64,6 +64,12 @@ export default React.createClass( {
 
 		this.setState( { sendingInvites: true } );
 		sendInvites( this.props.site.ID, this.state.usernamesOrEmails, this.state.role, this.state.message, ( error, data ) => {
+			if ( error ) {
+				debug( 'Send invite error:' + JSON.stringify( error ) );
+			} else {
+				debug( 'Send invites response: ' + JSON.stringify( data ) );
+			}
+
 			this.setState( {
 				sendingInvites: false,
 				response: error ? error : data
@@ -97,19 +103,6 @@ export default React.createClass( {
 			<a target="_blank" href="http://en.support.wordpress.com/user-roles/">
 				{ this.translate( 'Learn more about roles' ) }
 			</a>
-		);
-	},
-
-	renderResponse() {
-		return (
-			<Card>
-				<label>Response:</label><br />
-				<code>
-					<pre>
-						{ JSON.stringify( this.state.response ) }
-					</pre>
-				</code>
-			</Card>
 		);
 	},
 
@@ -173,7 +166,6 @@ export default React.createClass( {
 						</FormButton>
 					</form>
 				</Card>
-				{ this.state.response && this.renderResponse() }
 			</Main>
 		);
 	}


### PR DESCRIPTION
Previously, we were stringifying the response returned from sending an invite and displaying that in a card on the invite page. This seemed fine at the time. But, as we get closer to shipping invites, let's use debug() instead.

To test:
- Checkout `update/people-invite-debug-code` branch
- Go to `/people/new/$site`
- Enter `localStorage.setItem( 'debug', 'calypso:my-sites:people:invite' )`
- Send an invite
- Ensure that response is logged in console

cc @lezama for review