### PR TITLE
Editor: Enable linking to existing content

### DIFF
--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -22,6 +22,7 @@ import Gridicon from 'components/gridicon';
 import PostSelector from 'my-sites/post-selector';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSitePosts } from 'state/posts/selectors';
+import { decodeEntities } from 'lib/formatting';
 
 /**
  * Module variables
@@ -273,7 +274,9 @@ var LinkDialog = React.createClass( {
 		);
 
 		if ( shouldSetLinkText ) {
-			Object.assign( state, { linkText: post.title } );
+			Object.assign( state, {
+				linkText: decodeEntities( post.title )
+			} );
 		}
 
 		this.setState( state );

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import tinymce from 'tinymce/tinymce';
 import { connect } from 'react-redux';
 import find from 'lodash/find';
@@ -31,9 +31,28 @@ var REGEXP_EMAIL = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i,
 	REGEXP_STANDALONE_URL = /^(?:[a-z]+:|#|\?|\.|\/)/;
 
 var LinkDialog = React.createClass( {
+	propTypes: {
+		visible: PropTypes.bool,
+		editor: PropTypes.object,
+		onClose: PropTypes.func,
+		site: PropTypes.object,
+		sitePosts: PropTypes.array
+	},
 
 	getInitialState: function() {
 		return this.getState();
+	},
+
+	getDefaultProps() {
+		return {
+			onClose: () => {}
+		};
+	},
+
+	componentWillReceiveProps: function( nextProps ) {
+		if ( nextProps.visible && ! this.props.visible ) {
+			this.setState( this.getState() );
+		}
 	},
 
 	getLink: function() {
@@ -94,12 +113,6 @@ var LinkDialog = React.createClass( {
 		this.closeDialog();
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
-		if ( nextProps.visible && ! this.state.showDialog ) {
-			this.setState( this.getState() );
-		}
-	},
-
 	hasSelectedText: function( linkNode ) {
 		var editor = this.props.editor,
 			html = editor.selection.getContent(),
@@ -157,7 +170,6 @@ var LinkDialog = React.createClass( {
 			linkNode = editor.dom.getParent( selectedNode, 'a[href]' ),
 			onlyText = this.hasSelectedText( linkNode ),
 			nextState = {
-				showDialog: true,
 				isNew: true,
 				newWindow: false,
 				showLinkText: true,
@@ -186,8 +198,7 @@ var LinkDialog = React.createClass( {
 	},
 
 	closeDialog: function() {
-		this.props.editor.focus();
-		this.setState( { showDialog: false } );
+		this.props.onClose();
 	},
 
 	setUrl: function( event ) {
@@ -270,7 +281,7 @@ var LinkDialog = React.createClass( {
 	render: function() {
 		return (
 			<Dialog
-				isVisible={ this.state.showDialog }
+				isVisible={ this.props.visible }
 				onClose={ this.closeDialog }
 				buttons={ this.getButtons() }
 				autoFocus={ false }

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -4,6 +4,9 @@
 var React = require( 'react' ),
 	tinymce = require( 'tinymce/tinymce' );
 
+import { connect } from 'react-redux';
+import find from 'lodash/find';
+
 /**
  * Internal dependencies
  */
@@ -18,6 +21,9 @@ var MediaSerialization = require( 'lib/media-serialization' ),
 	FormFieldset = require( 'components/forms/form-fieldset' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	Gridicon = require( 'components/gridicon' );
+
+import PostSelector from 'my-sites/post-selector';
+import { getSitePosts } from 'state/posts/selectors';
 
 /**
  * Module variables
@@ -246,6 +252,24 @@ var LinkDialog = React.createClass( {
 		return buttons;
 	},
 
+	setExistingContent( post ) {
+		this.setState( {
+			linkText: post.title,
+			url: post.URL
+		} );
+	},
+
+	getSelectedPostId() {
+		if ( ! this.state.url || ! this.props.sitePosts ) {
+			return;
+		}
+
+		const selectedPost = find( this.props.sitePosts, { URL: this.state.url } );
+		if ( selectedPost ) {
+			return selectedPost.ID;
+		}
+	},
+
 	render: function() {
 		return (
 			<Dialog
@@ -283,9 +307,27 @@ var LinkDialog = React.createClass( {
 						<span>{ this.translate( 'Open link in a new window/tab' ) }</span>
 					</FormLabel>
 				</FormFieldset>
+				<FormFieldset>
+					<FormLabel>
+						<span>{ this.translate( 'Link to existing content' ) }</span>
+						<PostSelector
+							siteId={ this.props.siteId }
+							type="any"
+							status="publish"
+							orderBy="date"
+							order="DESC"
+							selected={ this.getSelectedPostId() }
+							onChange={ this.setExistingContent } />
+					</FormLabel>
+				</FormFieldset>
 			</Dialog>
 		);
 	}
 } );
 
-module.exports = LinkDialog;
+export default connect( ( state ) => {
+	return {
+		siteId: state.ui.selectedSiteId,
+		sitePosts: getSitePosts( state, state.ui.selectedSiteId )
+	};
+} )( LinkDialog );

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -174,7 +174,8 @@ var LinkDialog = React.createClass( {
 				newWindow: false,
 				showLinkText: true,
 				linkText: '',
-				url: ''
+				url: '',
+				isUserDefinedLinkText: false
 			};
 
 		if ( linkNode ) {
@@ -206,7 +207,10 @@ var LinkDialog = React.createClass( {
 	},
 
 	setLinkText: function( event ) {
-		this.setState( { linkText: event.target.value } );
+		this.setState( {
+			linkText: event.target.value,
+			isUserDefinedLinkText: true
+		} );
 	},
 
 	setNewWindow: function( event ) {
@@ -261,10 +265,18 @@ var LinkDialog = React.createClass( {
 	},
 
 	setExistingContent( post ) {
-		this.setState( {
-			linkText: post.title,
-			url: post.URL
-		} );
+		let state = { url: post.URL };
+		const shouldSetLinkText = (
+			! this.state.isUserDefinedLinkText &&
+			! this.props.editor.selection.getContent() &&
+			! this.getLink()
+		);
+
+		if ( shouldSetLinkText ) {
+			Object.assign( state, { linkText: post.title } );
+		}
+
+		this.setState( state );
 	},
 
 	getSelectedPostId() {

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -1,26 +1,24 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	tinymce = require( 'tinymce/tinymce' );
-
+import React from 'react';
+import tinymce from 'tinymce/tinymce';
 import { connect } from 'react-redux';
 import find from 'lodash/find';
 
 /**
  * Internal dependencies
  */
-var MediaSerialization = require( 'lib/media-serialization' ),
-	MediaStore = require( 'lib/media/store' ),
-	MediaUtils = require( 'lib/media/utils' ),
-	Dialog = require( 'components/dialog' ),
-	FormTextInput = require( 'components/forms/form-text-input' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
-	FormButton = require( 'components/forms/form-button' ),
-	FormFieldset = require( 'components/forms/form-fieldset' ),
-	FormLabel = require( 'components/forms/form-label' ),
-	Gridicon = require( 'components/gridicon' );
-
+import * as MediaSerialization from 'lib/media-serialization';
+import MediaStore from 'lib/media/store';
+import MediaUtils from 'lib/media/utils';
+import Dialog from 'components/dialog';
+import FormTextInput from 'components/forms/form-text-input';
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import Gridicon from 'components/gridicon';
 import PostSelector from 'my-sites/post-selector';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSitePosts } from 'state/posts/selectors';

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -23,6 +23,7 @@ import PostSelector from 'my-sites/post-selector';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSitePosts } from 'state/posts/selectors';
 import { decodeEntities } from 'lib/formatting';
+import { recordEvent, recordStat } from 'lib/posts/stats';
 
 /**
  * Module variables
@@ -278,6 +279,9 @@ var LinkDialog = React.createClass( {
 				linkText: decodeEntities( post.title )
 			} );
 		}
+
+		recordStat( 'link-existing-content' );
+		recordEvent( 'Set link to existing content' );
 
 		this.setState( state );
 	},

--- a/client/components/tinymce/plugins/wplink/plugin.js
+++ b/client/components/tinymce/plugins/wplink/plugin.js
@@ -22,6 +22,23 @@ var LinkDialog = require( './dialog' );
 function wpLink( editor ) {
 	var node, toolbar;
 
+	function render( visible = true ) {
+		ReactDom.render(
+			React.createElement( ReduxProvider, { store: editor.getParam( 'redux_store' ) },
+				React.createElement( LinkDialog, {
+					visible: visible,
+					editor: editor,
+					onClose: () => render( false )
+				} )
+			),
+			node
+		);
+
+		if ( ! visible ) {
+			editor.focus();
+		}
+	}
+
 	editor.on( 'init', function() {
 		node = editor.getContainer().appendChild(
 			document.createElement( 'div' )
@@ -34,14 +51,7 @@ function wpLink( editor ) {
 		node = null;
 	} );
 
-	editor.addCommand( 'WP_Link', function() {
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: editor.getParam( 'redux_store' ) },
-				React.createElement( LinkDialog, { visible: true, editor: editor } )
-			),
-			node
-		);
-	} );
+	editor.addCommand( 'WP_Link', render );
 
 	// WP default shortcut
 	editor.addShortcut( 'access+a', '', 'WP_Link' );

--- a/client/components/tinymce/plugins/wplink/plugin.js
+++ b/client/components/tinymce/plugins/wplink/plugin.js
@@ -12,6 +12,8 @@ var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	tinymce = require( 'tinymce/tinymce' );
 
+import { Provider as ReduxProvider } from 'react-redux';
+
 /**
  * Internal dependencies
  */
@@ -34,10 +36,9 @@ function wpLink( editor ) {
 
 	editor.addCommand( 'WP_Link', function() {
 		ReactDom.render(
-			React.createElement( LinkDialog, {
-				visible: true,
-				editor: editor
-			} ),
+			React.createElement( ReduxProvider, { store: editor.getParam( 'redux_store' ) },
+				React.createElement( LinkDialog, { visible: true, editor: editor } )
+			),
 			node
 		);
 	} );

--- a/client/components/tinymce/plugins/wplink/style.scss
+++ b/client/components/tinymce/plugins/wplink/style.scss
@@ -21,3 +21,12 @@
 		margin-bottom: -3px;
 	}
 }
+
+.wplink__dialog .form-fieldset {
+	margin-bottom: 8px;
+}
+
+.wplink__dialog .post-selector__results {
+	height: 24vh;
+	max-height: none;
+}

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -3,6 +3,7 @@
  */
 import range from 'lodash/range';
 import createSelector from 'lib/create-selector';
+import filter from 'lodash/filter';
 
 /**
  * Internal dependencies
@@ -24,6 +25,18 @@ import { DEFAULT_POST_QUERY } from './constants';
 export function getPost( state, globalId ) {
 	return state.posts.items[ globalId ];
 }
+
+/**
+ * Returns an array of post objects by site ID.
+ *
+ * @param  {Object} state  Global state tree
+ * @param  {Number} siteId Site ID
+ * @return {Array}         Site posts
+ */
+export const getSitePosts = createSelector(
+	( state, siteId ) => filter( state.posts.items, { site_ID: siteId } ),
+	( state ) => [ state.posts.items ]
+);
 
 /**
  * Returns an array of posts for the posts query, or null if no posts have been

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getPost,
+	getSitePosts,
 	getSitePostsForQuery,
 	isRequestingSitePostsForQuery,
 	getSitePostsLastPageForQuery,
@@ -29,6 +30,29 @@ describe( 'selectors', () => {
 			}, '3d097cb7c5473c169bba0eb8e3c6cb64' );
 
 			expect( post ).to.eql( { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' } );
+		} );
+	} );
+
+	describe( '#getSitePosts()', () => {
+		beforeEach( () => {
+			getSitePosts.memoizedSelector.cache.clear();
+		} );
+
+		it( 'should return an array of post objects for the site', () => {
+			const state = {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
+						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' },
+						'0fcb4eb16f493c19b627438fdc18d57c': { ID: 120, site_ID: 77203074, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak & Eggs' }
+					}
+				}
+			};
+
+			expect( getSitePosts( state, 2916284 ) ).to.have.members( [
+				state.posts.items[ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
+				state.posts.items[ '6c831c187ffef321eb43a67761a525a3' ]
+			] );
 		} );
 	} );
 


### PR DESCRIPTION
Closes #303 
Blocked by ~~#3193~~, ~~#3575~~
~~Cherry-picks dcc54689123a09985fb9cf9f208ff3ac6fd95521 from #2472~~

This pull request seeks to enable a user to add a link by selecting existing content from their site to which the link should target.

![Link to existing](https://cloud.githubusercontent.com/assets/1779930/12965636/b3598194-d025-11e5-87b1-ed365084c25c.png)

__Testing instructions:__

~~Note that there are design flaws that cause the post selector to occupy more space than desirable, likely preventing you from confirming the link selection. These will be remedied with the merge of #3193.~~

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. (Optional) Enter text in the post content area and highlight it
4. Click Add / Insert Link in the editor toolbar
5. Note that a selector field is made available to choose existing site content
6. Click an option from the post selector
7. Note that the URL field is populated with the URL of the selected content
8. Note that if you are not adding a link to existing text, i.e. you skipped Step 3, that the title of the content is used as the Text field
9. Note that the radio option is selected for the chosen content