### PR TITLE
Support User: Enable on wpcalypso

### DIFF
--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -1,16 +1,11 @@
 /**
- * External dependencies
- */
-import compose from 'lodash/function/compose';
-
-/**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
 import User from 'lib/user';
 import userSettings from 'lib/user-settings';
 
-import { supportUserTokenFetch, supportUserRestore } from 'state/support/actions';
+import { supportUserRestore } from 'state/support/actions';
 import { getSupportUser, getSupportToken } from 'state/support/selectors';
 
 /**
@@ -25,8 +20,6 @@ import { getSupportUser, getSupportToken } from 'state/support/selectors';
  */
 export default function( reduxStore ) {
 	const user = new User();
-	const dispatch = reduxStore.dispatch.bind( reduxStore );
-	const getState = reduxStore.getState.bind( reduxStore );
 
 	// Called when the support user token was updated in wpcom
 	const onTokenChange = () => {
@@ -48,11 +41,4 @@ export default function( reduxStore ) {
 			onTokenChange();
 		}
 	} );
-
-	// For testing during development. Adds support user functions to
-	// the dev console. The UI will replace these functions in future PRs.
-	window.supportUser = {
-		login: compose( dispatch, supportUserTokenFetch ),
-		logout: compose( dispatch, supportUserRestore )
-	};
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,6 +91,7 @@
 		"me/find-friends": false,
 		"me/trophies": false,
 		"help": true,
+		"support-user": true,
 		"phone_signup": true,
 		"login": false,
 		"network-connection": true,


### PR DESCRIPTION
This change removes the development facilitation and enables the support user feature for testing on wpcalypso.

Note that it is not yet ready for use outside of a test user, there are still a few issues to sort out:
#3201, #3068, #3067, #3029

cc @dllh @apeatling