### PR TITLE
Themes: Modularize routing

### DIFF
--- a/client/controller.js
+++ b/client/controller.js
@@ -1,0 +1,47 @@
+/**
+ * External Dependencies
+ */
+import ReactDom from 'react-dom';
+import startsWith from 'lodash/startsWith';
+
+/**
+ * Internal Dependencies
+ */
+ import sections from './sections';
+
+export function ensureMiddleware( ctx, next ) {
+	console.log( 'ensureMiddleware' );
+	sections.loadSection( 'themes', () => {
+		console.log( 'loaded!' );
+		next();
+	} );
+}
+
+export function renderElements( context ) {
+	renderPrimary( context );
+	renderSecondary( context );
+}
+
+function renderPrimary( context ) {
+	const { path } = context.params;
+	// FIXME: temporary hack until we have a proper isomorphic, one tree routing solution. Do NOT do this!
+	const sheetsDomElement = startsWith( path, '/themes' ) && document.getElementsByClassName( 'themes__sheet' )[0];
+	const mainDomElement = startsWith( path, '/design' ) && document.getElementsByClassName( 'themes main' )[0];
+	if ( ! sheetsDomElement && ! mainDomElement ) {
+		ReactDom.render(
+			context.primary,
+			document.getElementById( 'primary' )
+		);
+	}
+}
+
+function renderSecondary( context ) {
+	if ( context.secondary === null ) {
+		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+	} else if ( context.secondary !== undefined ) {
+		ReactDom.render(
+			context.secondary,
+			document.getElementById( 'secondary' )
+		);
+	}
+}

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -130,16 +130,19 @@ export function details( context, next ) {
 		isFullScreen: true
 	} ) );
 
-	// When we're logged in, we need to remove the sidebar.
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-
 	context.primary = makeElement( ThemeSheetComponent, Head, context.store, props );
+	context.secondary = null; // When we're logged in, we need to remove the sidebar.
 	next();
 }
 
 // Generic middleware -- move to client/controller.js?
 // lib/react-helpers isn't probably middleware-specific enough
-export function renderPrimary( context ) {
+export function renderElements( context ) {
+	renderPrimary( context );
+	renderSecondary( context );
+}
+
+function renderPrimary( context ) {
 	const { path } = context.params;
 	// FIXME: temporary hack until we have a proper isomorphic, one tree routing solution. Do NOT do this!
 	const sheetsDomElement = startsWith( path, '/themes' ) && document.getElementsByClassName( 'themes__sheet' )[0];
@@ -148,6 +151,17 @@ export function renderPrimary( context ) {
 		ReactDom.render(
 			context.primary,
 			document.getElementById( 'primary' )
+		);
+	}
+}
+
+function renderSecondary( context ) {
+	if ( context.secondary === null ) {
+		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+	} else if ( context.secondary !== undefined ) {
+		ReactDom.render(
+			context.secondary,
+			document.getElementById( 'secondary' )
 		);
 	}
 }

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -1,11 +1,9 @@
 /**
  * External Dependencies
  */
-import ReactDom from 'react-dom';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import omit from 'lodash/omit';
-import startsWith from 'lodash/startsWith';
 
 /**
  * Internal Dependencies
@@ -133,35 +131,4 @@ export function details( context, next ) {
 	context.primary = makeElement( ThemeSheetComponent, Head, context.store, props );
 	context.secondary = null; // When we're logged in, we need to remove the sidebar.
 	next();
-}
-
-// Generic middleware -- move to client/controller.js?
-// lib/react-helpers isn't probably middleware-specific enough
-export function renderElements( context ) {
-	renderPrimary( context );
-	renderSecondary( context );
-}
-
-function renderPrimary( context ) {
-	const { path } = context.params;
-	// FIXME: temporary hack until we have a proper isomorphic, one tree routing solution. Do NOT do this!
-	const sheetsDomElement = startsWith( path, '/themes' ) && document.getElementsByClassName( 'themes__sheet' )[0];
-	const mainDomElement = startsWith( path, '/design' ) && document.getElementsByClassName( 'themes main' )[0];
-	if ( ! sheetsDomElement && ! mainDomElement ) {
-		ReactDom.render(
-			context.primary,
-			document.getElementById( 'primary' )
-		);
-	}
-}
-
-function renderSecondary( context ) {
-	if ( context.secondary === null ) {
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-	} else if ( context.secondary !== undefined ) {
-		ReactDom.render(
-			context.secondary,
-			document.getElementById( 'secondary' )
-		);
-	}
 }

--- a/client/my-sites/themes/index.js
+++ b/client/my-sites/themes/index.js
@@ -1,15 +1,10 @@
 /**
- * External dependencies
- */
-import page from 'page';
-
-/**
  * Internal dependencies
  */
 import config from 'config';
 import userFactory from 'lib/user';;
 import { navigation, siteSelection } from 'my-sites/controller';
-import { singleSite, multiSite, loggedOut, details, renderPrimary } from './controller';
+import { singleSite, multiSite, loggedOut, details } from './controller';
 
 const user = userFactory();
 
@@ -27,16 +22,14 @@ const routes = isLoggedIn
 		'/design/type/:tier': [ loggedOut ]
 	};
 
-export default function() {
+export default function( router ) {
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		// Does iterating over Object.keys preserve order? If it doesn't, use lodash's mapValues
 		Object.keys( routes ).forEach( route => {
-			page( route, ...routes[ route ] );
+			router( route, ...routes[ route ] );
 		} )
-		page( '/design*', renderPrimary ); // Call explicitly here because client-specific
 	}
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		page( '/themes/:slug/:site_id?', details );
-		page( '/themes*', renderPrimary ); // Call explicitly here because client-specific
+		router( '/themes/:slug/:site_id?', details );
 	}
 };

--- a/client/my-sites/themes/index.js
+++ b/client/my-sites/themes/index.js
@@ -58,8 +58,7 @@ function ensureMiddleware( ctx, next ) {
 	} );
 }
 
-function renderMiddleware( ctx ) {
-	debugger;
+function renderMiddleware( ctx, next ) {
 	if ( ctx.primary ) {
 		console.log( 'renderMiddleware: rendering' );
 		ReactDom.render(
@@ -67,4 +66,5 @@ function renderMiddleware( ctx ) {
 			document.getElementById( 'primary' )
 		);
 	}
+	next();
 }

--- a/client/my-sites/themes/index.js
+++ b/client/my-sites/themes/index.js
@@ -5,7 +5,7 @@ import config from 'config';
 import sections from 'sections';
 import userFactory from 'lib/user';;
 import { navigation, siteSelection } from 'my-sites/controller';
-import { singleSite, multiSite, loggedOut, details, renderPrimary } from './controller';
+import { singleSite, multiSite, loggedOut, details, renderElements } from './controller';
 
 const user = userFactory();
 
@@ -31,15 +31,15 @@ export default function( router ) {
 			router( route, ...[
 				ensureMiddleware,
 				...routes[ route ],
-				renderPrimary,
+				renderElements,
 			] );
 		} );
-		router( '/design*', renderPrimary );
+		router( '/design*', renderElements );
 	}
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
 		router( '/themes*', ensureMiddleware );
 		router( '/themes/:slug/:site_id?', details );
-		router( '/themes*', renderPrimary );
+		router( '/themes*', renderElements );
 	}
 
 	console.log( 'themes routes set up!' );

--- a/client/my-sites/themes/index.js
+++ b/client/my-sites/themes/index.js
@@ -1,16 +1,11 @@
 /**
- * External dependencies
- */
-import ReactDom from 'react-dom';
-
-/**
  * Internal dependencies
  */
 import config from 'config';
 import sections from 'sections';
 import userFactory from 'lib/user';;
 import { navigation, siteSelection } from 'my-sites/controller';
-import { singleSite, multiSite, loggedOut, details } from './controller';
+import { singleSite, multiSite, loggedOut, details, renderPrimary } from './controller';
 
 const user = userFactory();
 
@@ -36,15 +31,15 @@ export default function( router ) {
 			router( route, ...[
 				ensureMiddleware,
 				...routes[ route ],
-				renderMiddleware,
+				renderPrimary,
 			] );
 		} );
-		router( '/design*', renderMiddleware );
+		router( '/design*', renderPrimary );
 	}
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
 		router( '/themes*', ensureMiddleware );
 		router( '/themes/:slug/:site_id?', details );
-		router( '/themes*', renderMiddleware );
+		router( '/themes*', renderPrimary );
 	}
 
 	console.log( 'themes routes set up!' );
@@ -56,15 +51,4 @@ function ensureMiddleware( ctx, next ) {
 		console.log( 'loaded!' );
 		next();
 	} );
-}
-
-function renderMiddleware( ctx, next ) {
-	if ( ctx.primary ) {
-		console.log( 'renderMiddleware: rendering' );
-		ReactDom.render(
-			ctx.primary,
-			document.getElementById( 'primary' )
-		);
-	}
-	next();
 }

--- a/client/my-sites/themes/index.js
+++ b/client/my-sites/themes/index.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import config from 'config';
-import sections from 'sections';
 import userFactory from 'lib/user';;
 import { navigation, siteSelection } from 'my-sites/controller';
-import { singleSite, multiSite, loggedOut, details, renderElements } from './controller';
+import { singleSite, multiSite, loggedOut, details } from './controller';
+import { ensureMiddleware, renderElements } from 'controller';
 
 const user = userFactory();
 
@@ -44,11 +44,3 @@ export default function( router ) {
 
 	console.log( 'themes routes set up!' );
 };
-
-function ensureMiddleware( ctx, next ) {
-	console.log( 'ensureMiddleware' );
-	sections.loadSection( 'themes', () => {
-		console.log( 'loaded!' );
-		next();
-	} );
-}

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -11,6 +11,7 @@ function getSectionsModule( sections ) {
 			"var page = require( 'page' ),",
 			"\tlayoutFocus = require( 'lib/layout-focus' ),",
 			"\tReact = require( 'react' ),",
+			"\tReactDom = require( 'react-dom' ),",
 			"\tLoadingError = require( 'layout/error' ),",
 			"\tclasses = require( 'component-classes' );",
 			'\n',
@@ -84,7 +85,17 @@ function splitTemplate( path, module, chunkName ) {
 		'		}',
 		'		context.store.dispatch( { type: "SET_SECTION", isLoading: false } );',
 		'		if ( ! _loadedSections[ ' + JSON.stringify( module ) + ' ] ) {',
-		'			require( ' + JSON.stringify( module ) + ' )();',
+		'			require( ' + JSON.stringify( module ) + ' )( page );',
+		'			page( function( context, next ) {',
+						// FIXME: Remove the DOM check once we have a proper isomorphic, one tree routing solution.
+		'				if ( context.primary && ! document.getElementById( "primary" ).hasChildNodes() ) {',
+		'					ReactDom.render(',
+		'						context.primary,',
+		'						document.getElementById( "primary" )',
+		'					);',
+		'				}',
+		'				next();',
+		'			} );',
 		'			_loadedSections[ ' + JSON.stringify( module ) + ' ] = true;',
 		'		}',
 		'		layoutFocus.next();',
@@ -126,4 +137,3 @@ module.exports = function( content ) {
 
 	return getSectionsModule( sections );
 };
-

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -392,44 +392,6 @@ module.exports = function() {
 		} );
 	}
 
-	const declareServerSide = ( ctx, next ) => {
-		ctx.isServerSide = true
-		//ctx.isLoggedIn = (look at cookies)
-		next()
-	}
-
-	const serverRender = ( ctx ) => {
-		/*
-		if ( cacheHit( ctx.layoutFactory, ctx.props ) ) {
-			ctx.layout = cacheGet( ctx.layoutFactory, ctx.props )
-		} else {
-			ctx.layout = ctx.layoutFactory( ctx.props )
-			cacheSet( ctx.layoutFactory, ctx.props, ctx.layout )
-		}
-		*/
-	}
-
-///
-	const setUpServerSideRouting = ( expressApp ) => {
-		const liftMiddleware = ( ctxBasedFn ) => {
-			return ( req, res, next ) => {
-				//const mockCtx = {
-				//	...getDefaultContext( req ),
-				//	//...getEnhancedContext( req ),
-				//}
-				ctxBasedFn( mockCtx, next )
-			}
-		}
-
-		function serverRouter( route, ...mws ) {
-			app.get( route, mws.map( liftMiddleware ) );
-		}
-
-		app.get( '/design*', declareServerSide, blankRender );
-		themes( serverRouter );
-		app.get( '/design*', serverRender );
-	}
-
 	app.get( '/design(/type/:themeTier)?', function( req, res ) {
 		if ( req.cookies.wordpress_logged_in || ! config.isEnabled( 'manage/themes/logged-out' ) ) {
 			// the user is probably logged in

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -392,6 +392,44 @@ module.exports = function() {
 		} );
 	}
 
+	const declareServerSide = ( ctx, next ) => {
+		ctx.isServerSide = true
+		//ctx.isLoggedIn = (look at cookies)
+		next()
+	}
+
+	const serverRender = ( ctx ) => {
+		/*
+		if ( cacheHit( ctx.layoutFactory, ctx.props ) ) {
+			ctx.layout = cacheGet( ctx.layoutFactory, ctx.props )
+		} else {
+			ctx.layout = ctx.layoutFactory( ctx.props )
+			cacheSet( ctx.layoutFactory, ctx.props, ctx.layout )
+		}
+		*/
+	}
+
+///
+	const setUpServerSideRouting = ( expressApp ) => {
+		const liftMiddleware = ( ctxBasedFn ) => {
+			return ( req, res, next ) => {
+				const mockCtx = {
+					...getDefaultContext( req ),
+					//...getEnhancedContext( req ),
+				}
+				ctxBasedFn( mockCtx, next )
+			}
+		}
+
+		function serverRouter( route, ...mws ) {
+			app.get( route, mws.map( liftMiddleware ) );
+		}
+
+		app.get( '/design*', declareServerSide, blankRender );
+		themes( serverRouter );
+		app.get( '/design*', serverRender );
+	}
+
 	app.get( '/design(/type/:themeTier)?', function( req, res ) {
 		if ( req.cookies.wordpress_logged_in || ! config.isEnabled( 'manage/themes/logged-out' ) ) {
 			// the user is probably logged in

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -413,10 +413,10 @@ module.exports = function() {
 	const setUpServerSideRouting = ( expressApp ) => {
 		const liftMiddleware = ( ctxBasedFn ) => {
 			return ( req, res, next ) => {
-				const mockCtx = {
-					...getDefaultContext( req ),
-					//...getEnhancedContext( req ),
-				}
+				//const mockCtx = {
+				//	...getDefaultContext( req ),
+				//	//...getEnhancedContext( req ),
+				//}
 				ctxBasedFn( mockCtx, next )
 			}
 		}


### PR DESCRIPTION
The objective of this PR is to separate concerns by splitting existing middleware into more modular units. This way, we'll be able to implement server-side routing further down the road by re-using applicable middleware, omitting client-side specific and adding server-side specific middleware. It will hopefully also allow us to ship more quickly something that preserves current functionality, and iterate by generalizing the approach applied here to themes.

Another aspect of this PR is also to declare route/middleware relations as terse as possible, leveraging `page.js`'s features related to [separation of concerns](https://github.com/visionmedia/page.js#separating-concerns).

_This PR is also starting to explore layout-last rendering._

Next steps:
* [ ] `server/pages`: scan `sections.js` for `isomorphic: true`, and set up isomorphic routes for that
* [ ] `my-sites/controller`: From `navigation()` and `siteSelection()`, extract `create...Element()` and `render{Primary|Secondary}()` middleware. Only use `create...Element()` mw in `themes/index.js`.