### PR TITLE
Docs: Fixes a typo

### DIFF
--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -259,7 +259,7 @@ It's important that selectors always be pure functions, meaning that the functio
 
 What are a few common use-cases for selectors?
 
-- Resolving references: A [normalized state tree](#data-normalization) is ideal from the standpoint of minimizing redundancy and syncronization concerns, but is not as developer-friendly to use. Selectors can be helpful in restoring convenient access to useful objects.
+- Resolving references: A [normalized state tree](#data-normalization) is ideal from the standpoint of minimizing redundancy and synchronization concerns, but is not as developer-friendly to use. Selectors can be helpful in restoring convenient access to useful objects.
 - Derived data: A normalized state tree avoids storing duplicated data. However, it can be useful to request a value which is calculated based on state data. For example, it might be valuable to retrieve the hostname for a site, which can be calculated based on its URL property.
 - Filtering data: You can use a selector to return a subset of a state tree value. For example, a `getJetpackSites` selector could return an array of all known sites filtered to only those which are Jetpack-enabled. 
  - __Side-note:__ In this case, you could achieve a similar effect with a reducer function aggregating an array of Jetpack site IDs. If you were to take this route, you'd probably want a complementary selector anyways. Caching concerns on selectors can be overcome by using memoization techniques (for example, with a library like [`reselect`](https://github.com/rackt/reselect)).


### PR DESCRIPTION
`syncronization` → `synchronization`