### PR TITLE
Signup: Allow filtering of flow name

### DIFF
--- a/client/lib/signup/test/signup/config/flows.js
+++ b/client/lib/signup/test/signup/config/flows.js
@@ -25,8 +25,6 @@ var flows = {
 };
 
 module.exports = {
-	currentFlowName: 'simple_flow',
-
 	defaultFlowName: 'simple_flow',
 
 	getFlow: function( flowName ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var assign = require( 'lodash/object/assign' ),
-	page = require( 'page' ),
 	reject = require( 'lodash/collection/reject' );
 
 /**
@@ -10,7 +9,6 @@ var assign = require( 'lodash/object/assign' ),
 */
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
-	abtest = require( 'lib/abtest' ).abtest,
 	user = require( 'lib/user' )();
 
 function getCheckoutDestination( dependencies ) {
@@ -181,16 +179,12 @@ function removeUserStepFromFlow( flow ) {
 	} );
 }
 
-function getCurrentFlowName( currentUrl ) {
-	// Headstart test - Only consider users from the homepage
-	if ( '/start/en?ref=homepage' === currentUrl && 'headstart' === abtest( 'headstart' ) ) {
-		return 'headstart';
-	}
-	return 'main';
+function filterFlowName( flowName ) {
+	return flowName;
 }
 
 module.exports = {
-	currentFlowName: getCurrentFlowName( page.current ),
+	filterFlowName: filterFlowName,
 
 	defaultFlowName: 'main',
 

--- a/client/signup/test/signup/config/flows.js
+++ b/client/signup/test/signup/config/flows.js
@@ -18,7 +18,17 @@ flows.__set__( 'flows', {
 	account: {
 		steps: [ 'user', 'site' ],
 		destination: '/'
+	},
+
+	other: {
+		steps: [ 'user', 'site' ],
+		destination: '/'
+	},
+
+	filtered: {
+		steps: [ 'user', 'site' ],
+		destination: '/'
 	}
 } );
 
-module.exports = assign( {}, flows, { currentFlowName: 'account', defaultFlowName: 'main' } );
+module.exports = assign( {}, flows, { defaultFlowName: 'main' } );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -17,16 +17,18 @@ var i18nUtils = require( 'lib/i18n-utils' ),
 	formState = require( 'lib/form-state' );
 
 function getFlowName( parameters ) {
-	var currentFlowName = flows.currentFlowName;
-	if ( parameters.flowName && isFlowName( parameters.flowName ) ) {
-		return parameters.flowName;
-	}
+	const flow = ( parameters.flowName && isFlowName( parameters.flowName ) ) ? parameters.flowName : defaultFlowName;
+	return maybeFilterFlowName( flow, flows.filterFlowName );
+}
 
-	if ( ! isFlowName( parameters.flowName ) && currentFlowName === defaultFlowName ) {
-		return defaultFlowName;
+function maybeFilterFlowName( flowName, filterCallback ) {
+	if ( filterCallback && typeof filterCallback === 'function' ) {
+		const filteredFlow = filterCallback( flowName );
+		if ( isFlowName( filteredFlow ) ) {
+			return filteredFlow;
+		}
 	}
-
-	return currentFlowName;
+	return flowName;
 }
 
 function isFlowName( pathFragment ) {


### PR DESCRIPTION
First of all, some background: in the signup flows config, there are two parameters returned, `currentFlowName` and `defaultFlowName`. To the best of my ability to tell, they're misnamed. By behavior, `currentFlowName` is actually the default flow name, and `defaultFlowName` is not used for anything.

This PR renames `currentFlowName` to `defaultFlowName` so it is more clear how that works.

Secondly, for testing we've been using `currentFlowName` (remember, that's actually the default) as a way to send users to various A/B testing flows (e.g.: headstart, dss, verticals). The intent for those tests was to send the user to the testing flows only if the requested flow (the flow in the URL) was the default flow. This worked in most cases because we were checking the URL explicitly before assigning the test, but it's not a valid hack since the verticals flows were added in #2774. 

The reason for this is that the we've changed the WordPress.com home page to send all `en` language users to one of two, new, "default" flows, `/start/website` and `/start/blog`. Users without the `en` locale, or who end up in the signup flow from other places (e.g.: the "make a new wordpress" button in the Calypso sidebar) will still be directed to the default flow (`/start`). This means that there are now *three* default flows, so conditions to redirect users based on A/B testing are much more complicated.

Furthermore, the conditions testing for A/B tests happen only on `currentFlowName` (which, remember, is the default flow), so they won't apply to any URL with a specific flow (e.g.: `blog`), even if we consider that flow "default" for the purposes of a test.

This PR attempts to clarify all of that by adding a new parameter in the flows config called `filterFlowName`. If that param is set to a function, any result of `getFlowName` will be passed through `filterFlowName` before `getFlowName` returns. The filter function will be called regardless of the flow, even if it is the default. This gives us a lot of flexibility in determining what flow to send users to, all from the config file.

Whatever the result of `filterFlowName`, that is the flow a user will actually see (unless the result of `filterFlowName` is not a valid flow).