### PR TITLE
Themes: Fix render bug when local storage is empty

### DIFF
--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -70,7 +70,7 @@ var ThemesSingleSite = React.createClass( {
 					action: theme => dispatch( Action.activate( theme, site, 'showcase' ) ),
 					hideForTheme: theme => theme.active || ( theme.price && ! theme.purchased )
 				},
-				customize: site.isCustomizable()
+				customize: site && site.isCustomizable()
 					? {
 						action: theme => dispatch( Action.customize( theme, site ) ),
 						hideForTheme: theme => ! theme.active
@@ -184,7 +184,7 @@ export default connect(
 		{
 			queryParams: ThemesListSelectors.getQueryParams( state ),
 			themesList: ThemesListSelectors.getThemesList( state ),
-			selectedSite: getSelectedSite( state )
+			selectedSite: getSelectedSite( state ) || false,
 		}
 	)
 )( ThemesSingleSite );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -31,10 +31,16 @@ var Main = require( 'components/main' ),
 var ThemesSingleSite = React.createClass( {
 	propTypes: {
 		siteId: React.PropTypes.string,
+		tier: React.PropTypes.string,
+		search: React.PropTypes.string,
+		trackScrollPage: React.PropTypes.func,
+		// Connected Props
+		queryParams: React.PropTypes.object,
+		themesList: React.PropTypes.array,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.bool
-		] ).isRequired
+		] ).isRequired,
 	},
 
 	getInitialState: function() {


### PR DESCRIPTION
To reproduce bug:
1) Go to https://wordpress.com/design/{site}
2) Enter `localStorage.clear()` in the JS console
3) Refresh the page

**Before**
<img width="1144" alt="screen shot 2016-02-10 at 17 54 49" src="https://cloud.githubusercontent.com/assets/7767559/12956347/7932b9fa-d01f-11e5-919a-9e39b1fc5651.png">

**After**
<img width="1145" alt="screen shot 2016-02-10 at 17 57 03" src="https://cloud.githubusercontent.com/assets/7767559/12956398/be0ddd2a-d01f-11e5-9caf-36b82aef2d7e.png">

@ockham: can you give this a review?
