### PR TITLE
Signup: Enable signup in the desktop app

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -29,7 +29,7 @@ module.exports = {
 
 	checkToken: function( context, next ) {
 		// Check we have an OAuth token, otherwise redirect to login page
-		if ( OAuthToken.getToken() === false && ! startsWith( context.path, '/login' ) && ! startsWith( context.path, '/oauth' ) ) {
+		if ( OAuthToken.getToken() === false && ! startsWith( context.path, '/login' ) && ! startsWith( context.path, '/oauth' ) && ! startsWith( context.path, '/start' ) ) {
 			page( '/login' );
 		} else {
 			next();

--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -28,8 +28,11 @@ module.exports = {
 	},
 
 	checkToken: function( context, next ) {
+		const loggedOutRoutes = [ '/login', '/oauth', '/start' ],
+			isValidSection = loggedOutRoutes.some( route => startsWith( context.path, route ) );
+
 		// Check we have an OAuth token, otherwise redirect to login page
-		if ( OAuthToken.getToken() === false && ! startsWith( context.path, '/login' ) && ! startsWith( context.path, '/oauth' ) && ! startsWith( context.path, '/start' ) ) {
+		if ( OAuthToken.getToken() === false && ! isValidSection ) {
 			page( '/login' );
 		} else {
 			next();

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -179,7 +179,7 @@ module.exports = React.createClass( {
 				</a>
 				<div className="auth__links">
 					<a href="#" onClick={ this.toggleSelfHostedInstructions }>{ this.translate( 'Add self-hosted site' ) }</a>
-					<a href={ 'https://wordpress.com' + config( 'signup_url' ) } target="_blank">{ this.translate( 'Create account' ) }</a>
+					<a href={ config( 'signup_url' ) }>{ this.translate( 'Create account' ) }</a>
 				</div>
 				{ showInstructions && <SelfHostedInstructions onClickClose={ this.toggleSelfHostedInstructions } /> }
 			</Main>

--- a/client/lib/wpcom-undocumented/index.js
+++ b/client/lib/wpcom-undocumented/index.js
@@ -29,7 +29,7 @@ function WPCOMUndocumented( token, reqHandler ) {
 	if ( 'function' === typeof token ) {
 		reqHandler = token;
 		token = null;
-	} else {
+	} else if ( token ) {
 		this.loadToken( token );
 	}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -21,6 +21,10 @@ function getCheckoutDestination( dependencies ) {
 	return 'https://' + dependencies.siteSlug;
 }
 
+function getPostsDestination( dependencies ) {
+	return '/posts/' + dependencies.siteSlug;
+}
+
 const flows = {
 	/* Production flows*/
 
@@ -139,7 +143,7 @@ const flows = {
 
 	desktop: {
 		steps: [ 'themes', 'site', 'user' ],
-		destination: '/me/next?welcome',
+		destination: getPostsDestination,
 		description: 'Signup flow for desktop app',
 		lastModified: '2015-11-05'
 	},


### PR DESCRIPTION
Currently, the clicking 'Create Account' on the login screen in the desktop app opens a browser window on `/start/desktop`. This PR updates this link to target the current window, and makes other changes necessary to enable signup in the desktop app.

#### Testing instructions

1. Install the desktop app locally (https://github.com/Automattic/wp-desktop/blob/master/docs/install.md)
1. Run `git checkout add/signup-in-desktop` inside the calypso directory
2. Start the app, and click on "create a site" from the splash screen (you may need to log in)
3. Go through the signup flow and check that you are redirected to `/posts/:site`

#### Reviews

- [x] Code
- [x] Product