### PR TITLE
Remove local tests before push because suite is too slow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ welcome:
 install: node_modules
 
 # Simply running `make run` will spawn the Node.js server instance.
-run: welcome githooks-commit install build
+run: welcome githooks install build
 	@$(NODE) build/bundle-$(CALYPSO_ENV).js
 
 node-version:

--- a/bin/pre-push
+++ b/bin/pre-push
@@ -2,16 +2,6 @@
 
 echo "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see CONTRIBUTING.md for details.\n\n"
 
-echo "\nRunning tests ...\n"
-make test
-if [ $? -ne 0 ]; then
-    printf "\n\n\033[41mPUSH NOT ALLOWED:\033[0m The tests are broken! Please fix them and try again.\n\n"
-    printf "(If you want to push anyway, you can repeat the command using --no-verify to skip this check)\n\n"
-    exit 1
-fi
-
-printf "\n\n\033[42mPUSH READY TO GO\033[0m\n\n"
-
 current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 if [ 'master' = $current_branch ]
 then


### PR DESCRIPTION
The ideal answer is to speed up our test suite, but people are skipping git hooks with the `--no-verify` flag. This removes local tests until it's speedy enough. We've already had a few instances where people have pushed to master directly.

cc @ockham @blowery @nb @rralian 