### PR TITLE
Reader: Move discover logged out URL to config

### DIFF
--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -9,6 +9,7 @@
 	"logout_url": "/logout",
 	"facebook_api_key": "249643311490",
 	"discover_blog_id": 53424024,
+	"discover_logged_out_redirect_url": "/",
 	"features": {
 		"desktop": true,
 		"fluid-width": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -9,6 +9,7 @@
 	"logout_url": "/logout",
 	"facebook_api_key": "249643311490",
 	"discover_blog_id": 53424024,
+	"discover_logged_out_redirect_url": "/",
 	"features": {
 		"desktop": true,
 		"fluid-width": true,

--- a/config/development.json
+++ b/config/development.json
@@ -25,6 +25,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_blog_id": 53424024,
+	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"code-splitting": true,
 		"server-side-rendering": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -11,6 +11,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_blog_id": 53424024,
+	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"code-splitting": true,
 		"server-side-rendering": true,

--- a/config/production.json
+++ b/config/production.json
@@ -9,6 +9,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_blog_id": 53424024,
+	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"code-splitting": true,
 		"server-side-rendering": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -11,6 +11,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_blog_id": 53424024,
+	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"code-splitting": true,
 		"server-side-rendering": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -11,6 +11,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"facebook_api_key": "249643311490",
 	"discover_blog_id": 53424024,
+	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"features": {
 		"code-splitting": true,
 		"server-side-rendering": true,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -466,7 +466,7 @@ module.exports = function() {
 			if ( req.cookies.wordpress_logged_in ) {
 				renderLoggedInRoute( req, res );
 			} else {
-				res.redirect( 'https://discover.wordpress.com' );
+				res.redirect( config( 'discover_logged_out_redirect_url' ) );
 			}
 		} );
 	}


### PR DESCRIPTION
We don't want to redirect to an external URL in the desktop app. This lets us set a different value instead, namely `/`

Fixes https://github.com/Automattic/wp-desktop/issues/77