### PR TITLE
Framework: Cache and reuse element for decoding (formatting)

### DIFF
--- a/client/lib/formatting/decode-entities/browser.js
+++ b/client/lib/formatting/decode-entities/browser.js
@@ -1,5 +1,14 @@
-module.exports = function( text ) {
-	var textarea = document.createElement( 'textarea' );
-	textarea.innerHTML = text;
-	return textarea.textContent;
+let element = ( () => {
+	if ( document.implementation && document.implementation.createHTMLDocument ) {
+		return document.implementation.createHTMLDocument( '' ).createElement( 'textarea' );
+	}
+
+	return document.createElement( 'textarea' );
+} )();
+
+export default function decodeEntities( text ) {
+	element.innerHTML = text;
+	let decoded = element.textContent;
+	element.innerHTML = '';
+	return decoded;
 };

--- a/client/lib/formatting/decode-entities/package.json
+++ b/client/lib/formatting/decode-entities/package.json
@@ -4,7 +4,7 @@
   "description": "Decode HTML entities",
   "main": "node.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cd .. && make test"
   },
   "browser": "./browser.js"
 }

--- a/client/lib/formatting/test/test.js
+++ b/client/lib/formatting/test/test.js
@@ -1,15 +1,19 @@
+/* eslint-disable vars-on-top */
+require( 'lib/react-test-env-setup' )();
+
 /**
  * External dependencies
  */
-var chai = require( 'chai' );
+var chai = require( 'chai' ),
+	each = require( 'lodash/collection/each' );
 
 /**
  * Internal Dependencies
  */
 var capitalPDangit = require( '../' ).capitalPDangit,
-	parseHtml = require( '../' ).parseHtml;
-
-require( 'lib/react-test-env-setup' )();
+	parseHtml = require( '../' ).parseHtml,
+	decodeEntitiesNode = require( '../decode-entities/node' ),
+	decodeEntitiesBrowser = require( '../decode-entities/node' );
 
 describe( 'capitalPDangit', function() {
 	it( 'should error when input is not a string', function() {
@@ -88,6 +92,25 @@ describe( 'parseHtml', function() {
 		strings.forEach( function( string ) {
 			var link = parseHtml( string ).querySelectorAll( 'a' );
 			chai.assert.equal( link[ 0 ].innerHTML, 'hello world' );
+		} );
+	} );
+} );
+
+describe( '#decodeEntities()', () => {
+	each( {
+		node: decodeEntitiesNode,
+		browser: decodeEntitiesBrowser
+	}, ( decodeEntities, env ) => {
+		describe( env, () => {
+			it( 'should decode entities', () => {
+				const decoded = decodeEntities( 'Ribs &gt; Chicken' );
+				chai.assert.equal( decoded, 'Ribs > Chicken' );
+			} );
+
+			it( 'should not alter already-decoded entities', () => {
+				const decoded = decodeEntities( 'Ribs > Chicken. Truth &amp; Liars.' );
+				chai.assert.equal( decoded, 'Ribs > Chicken. Truth & Liars.' );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to improve the formatting `decodeEntities` function to reuse a single DOM element, rather than create a new one for each invocation. It also adds previously lacking tests to ensure that existing behavior remains unaffected.

__Testing instructions:__

Verify that new tests pass by running `make test` in the project root directory or directly from `client/lib/formatting`.

Ensure that existing usage of `decodeEntities` remains unaffected (e.g. [`<PostSelector />`](http://calypso.localhost:3000/devdocs/app-components) post titles).

/cc @blowery 