### PR TITLE
Framework: Add sync missing handler defaults

### DIFF
--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -105,6 +105,13 @@
 		"business_account_id": "3146-815-10-9343",
 		"business_group_id": "3033aa025c1a9648c703eb70132ff220"
 	},
+	"sync-handler-defaults": {
+		"name": "Calypso sync-handler",
+		"version": 1.0,
+		"driver": "INDEXEDDB",
+		"storeName": "calypso_sync_handler",
+		"description": "Request-handler wrapper used to catch REST-API responses"
+	},
 	"muse_supported_themes": [
 		"pub/twentytwelve",
 		"pub/twentythirteen",


### PR DESCRIPTION
Adds a missing default that was missed in #3230 and #2843

cc @rralian @retrofox @aduth 