### PR TITLE
Framework: Correctly import browser module for decodeEntities test (formatting)

### DIFF
--- a/client/lib/formatting/test/test.js
+++ b/client/lib/formatting/test/test.js
@@ -13,7 +13,7 @@ var chai = require( 'chai' ),
 var capitalPDangit = require( '../' ).capitalPDangit,
 	parseHtml = require( '../' ).parseHtml,
 	decodeEntitiesNode = require( '../decode-entities/node' ),
-	decodeEntitiesBrowser = require( '../decode-entities/node' );
+	decodeEntitiesBrowser = require( '../decode-entities/browser' );
 
 describe( 'capitalPDangit', function() {
 	it( 'should error when input is not a string', function() {


### PR DESCRIPTION
In #3227, I accidentally imported the same module twice in the test file, when the browser import should have been imported from its separate implementation.

__Testing instructions:__

Ensure Mocha tests pass by running `make test` from the project root directory, or directly from `client/lib/formatting`.

Since these changes only affect test files, there should be no impact on client behavior.