### PR TITLE
Signup: Re-enable headstart test

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var assign = require( 'lodash/object/assign' ),
+	includes = require( 'lodash/collection/includes' ),
 	reject = require( 'lodash/collection/reject' );
 
 /**
@@ -9,6 +10,7 @@ var assign = require( 'lodash/object/assign' ),
 */
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
+	abtest = require( 'lib/abtest' ).abtest,
 	user = require( 'lib/user' )();
 
 function getCheckoutDestination( dependencies ) {
@@ -180,6 +182,10 @@ function removeUserStepFromFlow( flow ) {
 }
 
 function filterFlowName( flowName ) {
+	const headstartFlows = [ 'blog', 'website' ];
+	if ( includes( headstartFlows, flowName ) && 'headstart' === abtest( 'headstart' ) ) {
+		return 'headstart';
+	}
 	return flowName;
 }
 


### PR DESCRIPTION
Requires #3216 to be merged first.

The Headstart test was broken by #2774 because there are now two "default" flows instead of one, so there are no longer any users being routed to the headstart flow.

#3216 refactors how the current flow is calculated, and this PR will re-enable the headstart test using the new `filterFlowName` function.