### PR TITLE
Domains: Allow empty names for TXT and MX records

### DIFF
--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -46,18 +46,10 @@ function isValidDomain( name ) {
 }
 
 function isValidName( name, type ) {
-	switch ( type ) {
-		case 'SRV':
-			return (
-				name === '' ||
-				isValidSubdomain( name )
-			);
-		default:
-			return isValidSubdomain( name, type );
+	if ( isNameEmptyAndItsAllowed( name, type ) ) {
+		return true;
 	}
-}
 
-function isValidSubdomain( name, type ) {
 	switch ( type ) {
 		case 'A':
 		case 'AAAA':
@@ -93,10 +85,9 @@ function getNormalizedData( record, selectedDomainName ) {
 }
 
 function getNormalizedName( name, type, selectedDomainName ) {
-	const isSrvWithEmptyName = 'SRV' === type && ! name,
-		endsWithDomain = endsWith( name, '.' + selectedDomainName );
+	const endsWithDomain = endsWith( name, '.' + selectedDomainName );
 
-	if ( isSrvWithEmptyName ) {
+	if ( isNameEmptyAndItsAllowed( name, type ) ) {
 		return name;
 	}
 
@@ -113,6 +104,10 @@ function getNormalizedName( name, type, selectedDomainName ) {
 
 function isIpRecord( type ) {
 	return includes( [ 'A', 'AAAA' ], type );
+}
+
+function isNameEmptyAndItsAllowed( name, type ) {
+	return ! name && includes( [ 'MX', 'SRV', 'TXT' ], type );
 }
 
 function getFieldWithDot( field ) {

--- a/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-record.jsx
@@ -89,7 +89,7 @@ var DnsRecord = React.createClass( {
 			return name.slice( 0, -1 );
 		}
 
-		return name + '.' + domain;
+		return name ? name + '.' + domain : domain;
 	},
 
 	isBeingProcessed: function() {


### PR DESCRIPTION
This partially fixes #234.
A separate PR is needed to add editing protected records (root A/AAAA or MX when email forwarding is enabled).

cc @umurkontaci @aidvu @bikedorkjon 