### PR TITLE
Editor: Fix padding around the Add Media button

### DIFF
--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -583,7 +583,7 @@ div.mce-path {
 }
 
 .mce-toolbar-grp:not( .mce-inline-toolbar-grp ) .mce-btn-group .mce-btn.mce-first {
-	margin-left: 8px;
+	margin-left: 4px;
 }
 
 #wp-fullscreen-buttons .mce-btn:hover,

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -215,6 +215,10 @@
 	margin-right: 4px;
 }
 
+.mce-toolbar .mce-wpcom-button.mce-contact-form svg {
+	margin-left: 4px;
+}
+
 .mce-toolbar .mce-wpcom-button.mce-contact-form:hover svg,
 .mce-toolbar .mce-wpcom-button.mce-media:hover svg {
 	fill: $gray-dark;


### PR DESCRIPTION
While writing my last post, I noticed the spacing around the Add Media button was a bit off. When fixing it locally, I also noticed a similar thing was happening to the contact form button. 

Before:
<img width="215" alt="before - media" src="https://cloud.githubusercontent.com/assets/5835847/12968600/f90b3486-d0d8-11e5-9897-b98d7c247d7b.png">

After: 
<img width="199" alt="after - media" src="https://cloud.githubusercontent.com/assets/5835847/12968599/f908f1c6-d0d8-11e5-9d97-afe6db0191f8.png">

After: (dev only)
<img width="251" alt="contact button" src="https://cloud.githubusercontent.com/assets/5835847/12968594/ddf57bc0-d0d8-11e5-84cc-e0b18be183a7.png">

Ping @hugobaeta and/or @mtias for review