### PR TITLE
Help: Disable automatically hiding the olark chat widget

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -348,9 +348,6 @@ module.exports = React.createClass( {
 			}
 		);
 
-		// Hide the olark widget in the bottom right corner.
-		olarkActions.hideBox();
-
 		return <HelpContactForm { ...contactFormProps } />;
 	},
 


### PR DESCRIPTION
This pull request disables hiding of the olark chat widget when displaying the contact form. This will allow the chatbox to function in its widget state in the event that there is some error preventing it from being inlined correctly on the contact form.

Previously the code had been used to prevent the offline chat widget from displaying at the same time as the offline contact form.