### PR TITLE
Dialog: Allow specifying the dialog content container tag

### DIFF
--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -70,7 +70,7 @@ var DialogBase = React.createClass( {
 
 		return (
 			<div className={ backdropClassName } ref="backdrop">
-				<Card className={ dialogClassName } role="dialog" ref="dialog">
+				<Card className={ dialogClassName } role="dialog" ref="dialog" tagName={ this.props.contentTagName }>
 					<div className={ classnames( this.props.className, contentClassName ) } ref="content" tabIndex="-1">
 						{ this.props.children }
 					</div>


### PR DESCRIPTION
### The problem
Let's say we have a dialog:
```js

const button = 
	<FormButton
		type="submit"
		onClick={ this.doSomething }>
			Submit
	</FormButton>;

<Dialog buttons={ button }>
	<FormFieldset>
		<FormLabel>
			<span>Full name</span>
			<FormTextInput
				name="fullname"
				id="fullname" />
		</FormLabel>
	</FormFieldset>
</Dialog>
```

When the text input has focus, pressing Enter/Return should trigger the Submit button action. To tell the browser that, we need to wrap a `<form>` element around both. But that's not currently possible, as the `buttons` are specified in a separate prop. We could wrap a `<form>` around the whole `<Dialog>` component, however this isn't triggering the submit button (Chrome 48)

### Solution
This PR allows the dialog container `<Card>`'s tag to be specified, so it can be set to a `<form>` tag - containing both the dialog content and the buttons.

### Example usage
See #3243, which depends on this PR

cc @mtias @dllh 