### PR TITLE
Support User: Login dialog handles keyboard presses correctly

### DIFF
--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -37,6 +37,10 @@ module.exports = React.createClass( {
 		return this.props.submitting || this.state.hidePassword;
 	},
 
+	focus: function() {
+		this.refs.textField.focus();
+	},
+
 	render: function() {
 
 		var toggleVisibilityClasses = classNames( {
@@ -48,6 +52,7 @@ module.exports = React.createClass( {
 			<div className="form-password-input">
 				<FormTextInput { ...omit( this.props, 'hideToggle' ) }
 					autoComplete="off"
+					ref="textField"
 					type={ this.hidden() ? 'password' : 'text' } />
 
 				<span className={ toggleVisibilityClasses } onClick={ this.togglePasswordVisibility }>

--- a/client/support/support-user/login-dialog.jsx
+++ b/client/support/support-user/login-dialog.jsx
@@ -31,6 +31,26 @@ const SupportUserLoginDialog = React.createClass( {
 		this.setState( { supportPassword: '' } );
 	},
 
+	onInputKeyDown( event ) {
+		switch ( event.key ) {
+			case 'Enter':
+				event.preventDefault();
+				switch ( event.target.name ) {
+					case 'supportUser':
+						console.log( this.supportPasswordInput );
+						this.supportPasswordInput.focus();
+						break;
+					case 'supportPassword':
+						this.onChangeUser();
+						break;
+				}
+				return;
+			case 'Escape':
+				event.preventDefault();
+				this.props.onCloseDialog();
+		}
+	},
+
 	render() {
 		const { isVisible, isBusy, onCloseDialog, errorMessage } = this.props;
 
@@ -49,6 +69,8 @@ const SupportUserLoginDialog = React.createClass( {
 					Cancel
 			</FormButton>
 		];
+
+		const supportPasswordRef = ( ref ) => this.supportPasswordInput = ref;
 
 		return (
 			<Dialog
@@ -73,6 +95,7 @@ const SupportUserLoginDialog = React.createClass( {
 							name="supportUser"
 							id="supportUser"
 							placeholder="Username"
+							onKeyDown={ this.onInputKeyDown }
 							valueLink={ this.linkState( 'supportUser' ) } />
 					</FormLabel>
 
@@ -82,6 +105,8 @@ const SupportUserLoginDialog = React.createClass( {
 							name="supportPassword"
 							id="supportPassword"
 							placeholder="Password"
+							ref={ supportPasswordRef }
+							onKeyDown={ this.onInputKeyDown }
 							valueLink={ this.linkState( 'supportPassword' ) } />
 					</FormLabel>
 				</FormFieldset>

--- a/client/support/support-user/login-dialog.jsx
+++ b/client/support/support-user/login-dialog.jsx
@@ -26,28 +26,36 @@ const SupportUserLoginDialog = React.createClass( {
 		}
 	},
 
-	onChangeUser() {
+	onSubmit() {
 		this.props.onChangeUser( this.state.supportUser, this.state.supportPassword );
 		this.setState( { supportPassword: '' } );
+	},
+
+	onEnterKey( event ) {
+		event.preventDefault();
+
+		// Next action depends on which text field is active
+		switch ( event.target.name ) {
+			case 'supportUser':
+				this.supportPasswordInput.focus();
+				break;
+			case 'supportPassword':
+				this.onSubmit();
+				break;
+		}
+	},
+
+	onEscapeKey( event ) {
+		event.preventDefault();
+		this.props.onCloseDialog();
 	},
 
 	onInputKeyDown( event ) {
 		switch ( event.key ) {
 			case 'Enter':
-				event.preventDefault();
-				switch ( event.target.name ) {
-					case 'supportUser':
-						console.log( this.supportPasswordInput );
-						this.supportPasswordInput.focus();
-						break;
-					case 'supportPassword':
-						this.onChangeUser();
-						break;
-				}
-				return;
+				return this.onEnterKey( event );
 			case 'Escape':
-				event.preventDefault();
-				this.props.onCloseDialog();
+				return this.onEscapeKey( event );
 		}
 	},
 
@@ -58,7 +66,7 @@ const SupportUserLoginDialog = React.createClass( {
 			<FormButton
 				key="supportuser"
 				disabled={ isBusy }
-				onClick={ this.onChangeUser }>
+				onClick={ this.onSubmit }>
 					{ isBusy ? 'Switching...' : 'Change user' }
 			</FormButton>,
 			<FormButton

--- a/client/support/support-user/login-dialog.jsx
+++ b/client/support/support-user/login-dialog.jsx
@@ -100,6 +100,7 @@ const SupportUserLoginDialog = React.createClass( {
 						<span>Username</span>
 						<FormTextInput
 							autoFocus={ true }
+							disabled={ isBusy }
 							name="supportUser"
 							id="supportUser"
 							placeholder="Username"
@@ -112,6 +113,7 @@ const SupportUserLoginDialog = React.createClass( {
 						<FormPasswordInput
 							name="supportPassword"
 							id="supportPassword"
+							disabled={ isBusy }
 							placeholder="Password"
 							ref={ supportPasswordRef }
 							onKeyDown={ this.onInputKeyDown }


### PR DESCRIPTION
Before this change, pressing the Enter/Return key while focused on the support user login dialog had no effect, requiring the user to click on the submit button using the mouse.

#### Changes
1. When the username field is focused and the Enter/Return key is pressed, the focus is moved to the password field.
2. When the password field is focused and the Enter/Return key is pressed, a login is attempted.
3. Pressing the Escape key when any field is focused will close the dialog.

Depends on PR ~~#3242~~ #3651

See issue #3201