### PR TITLE
Support User: Autofocus first field in login form

### DIFF
--- a/client/support/support-user/index.jsx
+++ b/client/support/support-user/index.jsx
@@ -25,7 +25,11 @@ const SupportUser = React.createClass( {
 		KeyboardShortcuts.off( 'open-support-user', this.onKeyboardShortcut );
 	},
 
-	onKeyboardShortcut: function() {
+	onKeyboardShortcut: function( e ) {
+		// Because the username field is auto-focused, this prevents
+		// the shortcut key being entered into the field
+		e.preventDefault();
+
 		if ( this.props.isSupportUser ) {
 			this.props.supportUserRestore();
 		} else {

--- a/client/support/support-user/login-dialog.jsx
+++ b/client/support/support-user/login-dialog.jsx
@@ -55,6 +55,7 @@ const SupportUserLoginDialog = React.createClass( {
 				isVisible={ isVisible }
 				onClose={ onCloseDialog }
 				buttons={ buttons }
+				autoFocus={ false }
 				additionalClassNames="support-user__login-dialog">
 				<h2 className="support-user__heading">Support user</h2>
 				{ errorMessage &&
@@ -68,6 +69,7 @@ const SupportUserLoginDialog = React.createClass( {
 					<FormLabel>
 						<span>Username</span>
 						<FormTextInput
+							autoFocus={ true }
 							name="supportUser"
 							id="supportUser"
 							valueLink={ this.linkState( 'supportUser' ) } />


### PR DESCRIPTION
This change sets focus to the username field when the support user login dialog appears.

See #3201 