### PR TITLE
Plans: Display issue of localized plan names

### DIFF
--- a/client/components/plans/plan-features/index.jsx
+++ b/client/components/plans/plan-features/index.jsx
@@ -29,7 +29,13 @@ module.exports = React.createClass( {
 	},
 
 	headerText: function() {
-		return <span className="header-text">{ this.props.plan.product_name }</span>;
+		return (
+			<span className="header-text">
+				WordPress.com
+				<br />
+				{ this.props.plan.product_name_short }
+			</span>
+		);
 	},
 
 	render: function() {


### PR DESCRIPTION
This pull request fixes #2434 by splitting the header text of the plan features header into two lines:
the first line contains only the "WordPress.com" and the second line contains the short name of a product. This is especially useful for locales such as zh_TW so the text wrapping always happens after "WordPress.com"

Before:
![](https://i.imgur.com/f3RtGG4.png)

After:
![](https://i.imgur.com/cbJnUbs.png)

## Testing instructions

1. Run `git checkout fix/2434-display-issue-localized-plan-names` and start your server
2. Change the interface language to zh_TW
3. Open [http://calypso.localhost:3000/start/themes]()
4. Go to the /plans step and open the compare screen
5. Check that the plan names always wrap after "WordPress.com" and not any other word.

cc @scruffian @nb 