### PR TITLE
Upgrades: If theme purchased on signup, redirect to frontend

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -143,7 +143,12 @@ const CheckoutThankYou = React.createClass( {
 		if ( this.props.receipt.hasLoadedFromServer && getPurchases( this.props ).every( isTheme ) ) {
 			this.props.activatedTheme( getPurchases( this.props )[ 0 ].meta, this.props.selectedSite );
 
-			page.redirect( '/design/' + this.props.selectedSite.slug );
+			// If we're coming from the signup funnel, redirect to the frontend
+			if ( getPurchases( this.props )[0].source === 'signup-with-theme' ) {
+				page.redirect( this.props.selectedSite.URL );
+			} else {
+				page.redirect( '/design/' + this.props.selectedSite.slug );
+			}
 		}
 	},
 

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -254,5 +254,31 @@ module.exports = {
 
 			next();
 		};
+	},
+
+	redirectIfThemePurchased: function( context, next ) {
+		var CheckoutThankYouComponent = require( './checkout/thank-you' ),
+			cartItems = require( 'lib/cart-values' ).cartItems,
+			lastTransaction = CheckoutThankYouComponent.getLastTransaction(),
+			selectedSite = lastTransaction.selectedSite,
+			cart = lastTransaction.cart,
+			cartAllItems = cartItems.getAll( cart );
+
+		if ( cartItems.hasOnlyProductsOf( cart, 'premium_theme' ) ) {
+			const { meta, extra: { source } } = cartAllItems[ 0 ];
+			// TODO: When this section is migrated to Redux altogether,
+			// use react-redux to `connect()` components and `dispatch()` actions.
+			context.store.dispatch( activated( meta, selectedSite, source, true ) );
+
+			// If we're coming from the signup funnel, redirect to the frontend
+			if ( source === 'signup-with-theme' ) {
+				page.redirect( selectedSite.URL );
+			} else {
+				page.redirect( '/design/' + selectedSite.slug );
+			}
+			return;
+		}
+
+		next();
 	}
 };

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -254,31 +254,5 @@ module.exports = {
 
 			next();
 		};
-	},
-
-	redirectIfThemePurchased: function( context, next ) {
-		var CheckoutThankYouComponent = require( './checkout/thank-you' ),
-			cartItems = require( 'lib/cart-values' ).cartItems,
-			lastTransaction = CheckoutThankYouComponent.getLastTransaction(),
-			selectedSite = lastTransaction.selectedSite,
-			cart = lastTransaction.cart,
-			cartAllItems = cartItems.getAll( cart );
-
-		if ( cartItems.hasOnlyProductsOf( cart, 'premium_theme' ) ) {
-			const { meta, extra: { source } } = cartAllItems[ 0 ];
-			// TODO: When this section is migrated to Redux altogether,
-			// use react-redux to `connect()` components and `dispatch()` actions.
-			context.store.dispatch( activated( meta, selectedSite, source, true ) );
-
-			// If we're coming from the signup funnel, redirect to the frontend
-			if ( source === 'signup-with-theme' ) {
-				page.redirect( selectedSite.URL );
-			} else {
-				page.redirect( '/design/' + selectedSite.slug );
-			}
-			return;
-		}
-
-		next();
 	}
 };


### PR DESCRIPTION
It's not helpful for users when they get redirected to the showcase.

To test (logged out):
- Sandbox the store
- Signup with premium theme: http://calypso.localhost:3000/start/with-theme/?theme=mood&premium=true
- Purchase it
- Verify that you're redirected to the frontend site, instead of the Showcase
