### PR TITLE
Plans: Start a new test for the plans item on the sidebar

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -46,10 +46,13 @@ module.exports = {
 		defaultVariation: 'yearly'
 	},
 	plansUpgradeButton: {
-		datestamp: '20160129',
+		datestamp: '20160212', // Update to the day of deploy
 		variations: {
-			original: 50,
-			button: 50
+			original: 20,
+			free: 20,
+			add: 20,
+			info: 20,
+			change: 20
 		},
 		defaultVariation: 'original'
 	},

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -332,9 +332,26 @@ module.exports = React.createClass( {
 		let planName = site.plan.product_name_short,
 			labelClass = 'plan-name';
 
-		if ( abtest( 'plansUpgradeButton' ) === 'button' && productsValues.isFreePlan( site.plan ) ) {
+		const testVariation = abtest( 'plansUpgradeButton' );
+
+		if ( testVariation !== 'original' && productsValues.isFreePlan( site.plan ) ) {
 			labelClass = 'add-new';
-			planName = 'More'; // TODO: translate this string if the test is removed
+
+			if ( testVariation === 'free' ) {
+				planName = 'Free'; // TODO: translate this string if the test is removed
+			}
+
+			if ( testVariation === 'add' ) {
+				planName = 'Add'; // TODO: translate this string if the test is removed
+			}
+
+			if ( testVariation === 'info' ) {
+				planName = 'Info'; // TODO: translate this string if the test is removed
+			}
+
+			if ( testVariation === 'change' ) {
+				planName = 'Change'; // TODO: translate this string if the test is removed
+			}
 		}
 
 		if ( productsValues.isFreeTrial( site.plan ) ) {


### PR DESCRIPTION
This creates a multi-variant test for the text on button in the plans item in the sidebar.

<img width="229" alt="screen shot 2016-02-11 at 16 36 38" src="https://cloud.githubusercontent.com/assets/275961/12982689/c36daf7a-d0dd-11e5-8e87-08240fc5e014.png">
<img width="229" alt="screen shot 2016-02-11 at 16 31 25" src="https://cloud.githubusercontent.com/assets/275961/12982691/c375e9a6-d0dd-11e5-8a85-9d2ddbc78dab.png">
<img width="230" alt="screen shot 2016-02-11 at 16 31 05" src="https://cloud.githubusercontent.com/assets/275961/12982690/c3753970-d0dd-11e5-91b5-c704cf5e22ab.png">
<img width="233" alt="screen shot 2016-02-11 at 16 30 50" src="https://cloud.githubusercontent.com/assets/275961/12982692/c37c0e4e-d0dd-11e5-9b53-fe53ed009e97.png">
 
#### Testing instructions

1. Run `git checkout update/plans-sidebar-button-test` and start your server
2. Create a new account, or change the test date to be a long time in the past.
3. Add yourself to the test `localStorage.setItem('ABTests','{"plansUpgradeButton_20160211":"free"}')`
4. Open the [`Plans` page](http://calypso.localhost:3000/plans/:site)
5. Check that the button in the sidebar says "Free".

Repeat steps 3-5 for "add", "change" and "info".

#### Reviews

- [x] Code
- [x] Product