### PR TITLE
Notification Settings: Add duration to notice after successfully saving

### DIFF
--- a/client/me/notification-settings/index.jsx
+++ b/client/me/notification-settings/index.jsx
@@ -49,7 +49,7 @@ const NotificationSettings = React.createClass( {
 		}
 
 		if ( state.status === 'success' ) {
-			this.props.successNotice( this.translate( 'Settings saved successfully!' ) );
+			this.props.successNotice( this.translate( 'Settings saved successfully!' ), { duration: 4000 } );
 		}
 
 		this.setState( state );


### PR DESCRIPTION
Addresses part of the issue in #3203.

This "should" cause the notices to disappear after a 4 second timeout. Although, in testing, I'm still noticing that a notice will stick around. I'm not sure why this is yet. And until we figure that out, it's pretty awkward that some notices will disappear while one or more won't.

@artpi suggested that this section be refactored such that the notices are included inline with each site's settings. cc @rickybanister for thoughts on that.

To test:
- Checkout `update/me-notification-settings-notices` branch
- Go to `/me/notifications`
- Update a setting for one of your site's and save.
- Update another setting and save. (quickly)

cc @rodrigoi who I believe wrote most of notification settings.