### PR TITLE
Importer: improve error messages

### DIFF
--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
+import Page from 'page';
 
 /**
  * Internal dependencies
@@ -22,6 +23,7 @@ export default React.createClass( {
 	contactSupport: function( event ) {
 		event.preventDefault();
 		event.stopPropagation();
+		Page( '/help' );
 	},
 
 	getImportError: function() {


### PR DESCRIPTION
close #3043 

`contactSupport` method in error-pane will now bring a user to wordpress.com/help

Error messaging is improved on phab-D1055

In my research, I do not think we have inline Live Chat links in Calypso yet, but i could be wrong. I think for now linking to /help should do the trick.

To test:

- try starting an import that results in an error, ie, using an invalid WXR file
- ensure that you get an error message with a 'Contact Support` link, that leads to /help

cc: @dmsnell
