### PR TITLE
Posts: Support requesting posts for current user in Redux posts state

### DIFF
--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -40,7 +40,7 @@ export function receivePosts( posts ) {
 /**
  * Triggers a network request to fetch posts for the specified site and query.
  *
- * @param  {Number}   siteId Site ID
+ * @param  {?Number}  siteId Site ID
  * @param  {String}   query  Post query
  * @return {Function}        Action thunk
  */
@@ -52,7 +52,14 @@ export function requestSitePosts( siteId, query = {} ) {
 			query
 		} );
 
-		return wpcom.site( siteId ).postsList( query ).then( ( { found, posts } ) => {
+		let source;
+		if ( siteId ) {
+			source = wpcom.site( siteId );
+		} else {
+			source = wpcom.me();
+		}
+
+		return source.postsList( query ).then( ( { found, posts } ) => {
 			dispatch( receivePosts( posts ) );
 			dispatch( {
 				type: POSTS_REQUEST_SUCCESS,
@@ -103,4 +110,15 @@ export function requestSitePost( siteId, postId ) {
 			} );
 		} );
 	};
+}
+
+/**
+ * Returns a function which, when invoked, triggers a network request to fetch
+ * posts across all of the current user's sites for the specified query.
+ *
+ * @param  {String}   query Post query
+ * @return {Function}       Action thunk
+ */
+export function requestPosts( query = {} ) {
+	return requestSitePosts( null, query );
 }

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -50,12 +50,7 @@ export function getSitePost( state, siteId, postId ) {
  * @return {Boolean}        Whether posts query is tracked for site
  */
 export function isTrackingSitePostsQuery( state, siteId, query ) {
-	const { siteQueries } = state.posts;
-	if ( ! siteQueries[ siteId ] ) {
-		return false;
-	}
-
-	return !! siteQueries[ siteId ][ getSerializedPostsQuery( query ) ];
+	return !! state.posts.queries[ getSerializedPostsQuery( query, siteId ) ];
 }
 
 /**
@@ -68,17 +63,16 @@ export function isTrackingSitePostsQuery( state, siteId, query ) {
  * @return {?Array}         Posts for the post query
  */
 export function getSitePostsForQuery( state, siteId, query ) {
-	const { siteQueries } = state.posts;
 	if ( ! isTrackingSitePostsQuery( state, siteId, query ) ) {
 		return null;
 	}
 
-	query = getSerializedPostsQuery( query );
-	if ( ! siteQueries[ siteId ][ query ].posts ) {
+	const serializedQuery = getSerializedPostsQuery( query, siteId );
+	if ( ! state.posts.queries[ serializedQuery ].posts ) {
 		return null;
 	}
 
-	return siteQueries[ siteId ][ query ].posts.map( ( globalId ) => {
+	return state.posts.queries[ serializedQuery ].posts.map( ( globalId ) => {
 		return getPost( state, globalId );
 	} );
 }
@@ -97,8 +91,8 @@ export function isRequestingSitePostsForQuery( state, siteId, query ) {
 		return false;
 	}
 
-	query = getSerializedPostsQuery( query );
-	return state.posts.siteQueries[ siteId ][ query ].fetching;
+	const serializedQuery = getSerializedPostsQuery( query, siteId );
+	return state.posts.queries[ serializedQuery ].fetching;
 }
 
 /**
@@ -111,13 +105,8 @@ export function isRequestingSitePostsForQuery( state, siteId, query ) {
  * @return {?Number}        Last posts page
  */
 export function getSitePostsLastPageForQuery( state, siteId, query ) {
-	const { siteQueriesLastPage } = state.posts;
-	if ( ! siteQueriesLastPage[ siteId ] ) {
-		return null;
-	}
-
-	const serializedQuery = getSerializedPostsQueryWithoutPage( query );
-	return siteQueriesLastPage[ siteId ][ serializedQuery ] || null;
+	const serializedQuery = getSerializedPostsQueryWithoutPage( query, siteId );
+	return state.posts.queriesLastPage[ serializedQuery ] || null;
 }
 
 /**

--- a/client/state/posts/test/actions.js
+++ b/client/state/posts/test/actions.js
@@ -22,7 +22,8 @@ import {
 	receivePost,
 	receivePosts,
 	requestSitePosts,
-	requestSitePost
+	requestSitePost,
+	requestPosts
 } from '../actions';
 
 describe( 'actions', () => {
@@ -151,6 +152,37 @@ describe( 'actions', () => {
 					siteId: 77203074,
 					query: {},
 					error: sinon.match( { message: 'User cannot access this private blog.' } )
+				} );
+			} );
+		} );
+	} );
+
+	describe( '#requestPosts()', () => {
+		before( () => {
+			nock( 'https://public-api.wordpress.com:443' )
+				.persist()
+				.get( '/rest/v1.1/me/posts' )
+				.reply( 200, {
+					found: 2,
+					posts: [
+						{ ID: 841, title: 'Hello World' },
+						{ ID: 413, title: 'Ribs & Chicken' }
+					]
+				} );
+		} );
+
+		after( () => {
+			nock.cleanAll();
+		} );
+
+		it( 'should dispatch posts receive action when request completes', () => {
+			return requestPosts()( spy ).then( () => {
+				expect( spy ).to.have.been.calledWith( {
+					type: POSTS_RECEIVE,
+					posts: [
+						{ ID: 841, title: 'Hello World' },
+						{ ID: 413, title: 'Ribs & Chicken' }
+					]
 				} );
 			} );
 		} );

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -152,6 +152,19 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should track post queries without specified site', () => {
+			const state = queries( undefined, {
+				type: POSTS_REQUEST,
+				query: { search: 'Hello' }
+			} );
+
+			expect( state ).to.eql( {
+				'{"search":"hello"}': {
+					fetching: true
+				}
+			} );
+		} );
+
 		it( 'should preserve previous query results when requesting again', () => {
 			const original = deepFreeze( {
 				'2916284:{"search":"hello"}': {
@@ -270,6 +283,21 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				'2916284:{"number":1}': 2
+			} );
+		} );
+
+		it( 'should track last page without specified site', () => {
+			const state = queriesLastPage( undefined, {
+				type: POSTS_REQUEST_SUCCESS,
+				query: { search: '', number: 1 },
+				found: 2,
+				posts: [
+					{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				]
+			} );
+
+			expect( state ).to.eql( {
+				'{"number":1}': 2
 			} );
 		} );
 

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -21,8 +21,8 @@ import {
 import {
 	items,
 	sitePosts,
-	siteQueries,
-	siteQueriesLastPage,
+	queries,
+	queriesLastPage,
 	siteRequests
 } from '../reducer';
 
@@ -131,82 +131,72 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	describe( '#siteQueries()', () => {
+	describe( '#queries()', () => {
 		it( 'should default to an empty object', () => {
-			const state = siteQueries( undefined, {} );
+			const state = queries( undefined, {} );
 
 			expect( state ).to.eql( {} );
 		} );
 
-		it( 'should track site post query request fetching', () => {
-			const state = siteQueries( undefined, {
+		it( 'should track post query request fetching', () => {
+			const state = queries( undefined, {
 				type: POSTS_REQUEST,
 				siteId: 2916284,
 				query: { search: 'Hello' }
 			} );
 
 			expect( state ).to.eql( {
-				2916284: {
-					'{"search":"hello"}': {
-						fetching: true
-					}
+				'2916284:{"search":"hello"}': {
+					fetching: true
 				}
 			} );
 		} );
 
 		it( 'should preserve previous query results when requesting again', () => {
 			const original = deepFreeze( {
-				2916284: {
-					'{"search":"hello"}': {
-						fetching: false,
-						posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-					}
+				'2916284:{"search":"hello"}': {
+					fetching: false,
+					posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
 				}
 			} );
-			const state = siteQueries( original, {
+			const state = queries( original, {
 				type: POSTS_REQUEST,
 				siteId: 2916284,
 				query: { search: 'Hello' }
 			} );
 
 			expect( state ).to.eql( {
-				2916284: {
-					'{"search":"hello"}': {
-						fetching: true,
-						posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-					}
+				'2916284:{"search":"hello"}': {
+					fetching: true,
+					posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
 				}
 			} );
 		} );
 
-		it( 'should accumulate site queries', () => {
+		it( 'should accumulate queries', () => {
 			const original = deepFreeze( {
-				2916284: {
-					'{"search":"hello"}': {
-						fetching: true
-					}
+				'2916284:{"search":"hello"}': {
+					fetching: true
 				}
 			} );
-			const state = siteQueries( original, {
+			const state = queries( original, {
 				type: POSTS_REQUEST,
 				siteId: 2916284,
 				query: { search: 'Hello W' }
 			} );
 
 			expect( state ).to.eql( {
-				2916284: {
-					'{"search":"hello"}': {
-						fetching: true
-					},
-					'{"search":"hello w"}': {
-						fetching: true
-					}
+				'2916284:{"search":"hello"}': {
+					fetching: true
+				},
+				'2916284:{"search":"hello w"}': {
+					fetching: true
 				}
 			} );
 		} );
 
-		it( 'should track site post query request success', () => {
-			const state = siteQueries( undefined, {
+		it( 'should track post query request success', () => {
+			const state = queries( undefined, {
 				type: POSTS_REQUEST_SUCCESS,
 				siteId: 2916284,
 				query: { search: 'Hello' },
@@ -217,17 +207,15 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				2916284: {
-					'{"search":"hello"}': {
-						fetching: false,
-						posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-					}
+				'2916284:{"search":"hello"}': {
+					fetching: false,
+					posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
 				}
 			} );
 		} );
 
-		it( 'should track site post query request failure', () => {
-			const state = siteQueries( undefined, {
+		it( 'should track post query request failure', () => {
+			const state = queries( undefined, {
 				type: POSTS_REQUEST_FAILURE,
 				siteId: 2916284,
 				query: { search: 'Hello' },
@@ -235,48 +223,42 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				2916284: {
-					'{"search":"hello"}': {
-						fetching: false
-					}
+				'2916284:{"search":"hello"}': {
+					fetching: false
 				}
 			} );
 		} );
 
 		it( 'never persists state because this is not implemented', () => {
 			const original = deepFreeze( {
-				2916284: {
-					'{"search":"hello"}': {
-						fetching: true
-					}
+				'2916284:{"search":"hello"}': {
+					fetching: true
 				}
 			} );
-			const state = siteQueries( original, { type: SERIALIZE } );
+			const state = queries( original, { type: SERIALIZE } );
 			expect( state ).to.eql( {} );
 		} );
 
 		it( 'never loads persisted state because this is not implemented', () => {
 			const original = deepFreeze( {
-				2916284: {
-					'{"search":"hello"}': {
-						fetching: true
-					}
+				'2916284:{"search":"hello"}': {
+					fetching: true
 				}
 			} );
-			const state = siteQueries( original, { type: DESERIALIZE } );
+			const state = queries( original, { type: DESERIALIZE } );
 			expect( state ).to.eql( {} );
 		} );
 	} );
 
-	describe( '#siteQueriesLastPage()', () => {
+	describe( '#queriesLastPage()', () => {
 		it( 'should default to an empty object', () => {
-			const state = siteQueriesLastPage( undefined, {} );
+			const state = queriesLastPage( undefined, {} );
 
 			expect( state ).to.eql( {} );
 		} );
 
-		it( 'should track site post query request success last page', () => {
-			const state = siteQueriesLastPage( undefined, {
+		it( 'should track post query request success last page', () => {
+			const state = queriesLastPage( undefined, {
 				type: POSTS_REQUEST_SUCCESS,
 				siteId: 2916284,
 				query: { search: '', number: 1 },
@@ -287,14 +269,12 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				2916284: {
-					'{"number":1}': 2
-				}
+				'2916284:{"number":1}': 2
 			} );
 		} );
 
 		it( 'should track last page regardless of page param', () => {
-			const state = siteQueriesLastPage( undefined, {
+			const state = queriesLastPage( undefined, {
 				type: POSTS_REQUEST_SUCCESS,
 				siteId: 2916284,
 				query: { search: '', number: 1, page: 2 },
@@ -305,14 +285,12 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				2916284: {
-					'{"number":1}': 2
-				}
+				'2916284:{"number":1}': 2
 			} );
 		} );
 
 		it( 'should consider no results as having last page of 1', () => {
-			const state = siteQueriesLastPage( undefined, {
+			const state = queriesLastPage( undefined, {
 				type: POSTS_REQUEST_SUCCESS,
 				siteId: 2916284,
 				query: { search: 'none', number: 1 },
@@ -321,19 +299,15 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				2916284: {
-					'{"search":"none","number":1}': 1
-				}
+				'2916284:{"search":"none","number":1}': 1
 			} );
 		} );
 
 		it( 'should accumulate site post request success', () => {
 			const original = deepFreeze( {
-				2916284: {
-					'{"search":"hello"}': 1
-				}
+				'2916284:{"search":"hello"}': 1
 			} );
-			const state = siteQueriesLastPage( original, {
+			const state = queriesLastPage( original, {
 				type: POSTS_REQUEST_SUCCESS,
 				siteId: 2916284,
 				query: { search: 'Ribs' },
@@ -344,30 +318,24 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				2916284: {
-					'{"search":"hello"}': 1,
-					'{"search":"ribs"}': 1
-				}
+				'2916284:{"search":"hello"}': 1,
+				'2916284:{"search":"ribs"}': 1
 			} );
 		} );
 
 		it( 'never persists state because this is not implemented', () => {
 			const original = deepFreeze( {
-				2916284: {
-					'{"search":"hello"}': 1
-				}
+				'2916284:{"search":"hello"}': 1
 			} );
-			const state = siteQueriesLastPage( original, { type: SERIALIZE } );
+			const state = queriesLastPage( original, { type: SERIALIZE } );
 			expect( state ).to.eql( {} );
 		} );
 
 		it( 'never loads persisted state because this is not implemented', () => {
 			const original = deepFreeze( {
-				2916284: {
-					'{"search":"hello"}': 1
-				}
+				'2916284:{"search":"hello"}': 1
 			} );
-			const state = siteQueriesLastPage( original, { type: DESERIALIZE } );
+			const state = queriesLastPage( original, { type: DESERIALIZE } );
 			expect( state ).to.eql( {} );
 		} );
 	} );

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -78,7 +78,7 @@ describe( 'selectors', () => {
 		it( 'should return false if the site has not been queried', () => {
 			const isTracking = isTrackingSitePostsQuery( {
 				posts: {
-					siteQueries: {}
+					queries: {}
 				}
 			}, 2916284, { search: 'Hello' } );
 
@@ -88,11 +88,9 @@ describe( 'selectors', () => {
 		it( 'should return false if the site has not been queried for the specific query', () => {
 			const isTracking = isTrackingSitePostsQuery( {
 				posts: {
-					siteQueries: {
-						2916284: {
-							'{"search":"hel"}': {
-								fetching: true
-							}
+					queries: {
+						'2916284:{"search":"hel"}': {
+							fetching: true
 						}
 					}
 				}
@@ -104,11 +102,9 @@ describe( 'selectors', () => {
 		it( 'should return true if the site has been queried for the specific query', () => {
 			const isTracking = isTrackingSitePostsQuery( {
 				posts: {
-					siteQueries: {
-						2916284: {
-							'{"search":"hello"}': {
-								fetching: true
-							}
+					queries: {
+						'2916284:{"search":"hello"}': {
+							fetching: true
 						}
 					}
 				}
@@ -122,7 +118,7 @@ describe( 'selectors', () => {
 		it( 'should return null if the site query is not tracked', () => {
 			const sitePosts = getSitePostsForQuery( {
 				posts: {
-					siteQueries: {}
+					queries: {}
 				}
 			}, 2916284, { search: 'Hello' } );
 
@@ -132,11 +128,9 @@ describe( 'selectors', () => {
 		it( 'should return null if the queried posts have not been received', () => {
 			const sitePosts = getSitePostsForQuery( {
 				posts: {
-					siteQueries: {
-						2916284: {
-							'{"search":"hello"}': {
-								fetching: true
-							}
+					queries: {
+						'2916284:{"search":"hello"}': {
+							fetching: true
 						}
 					}
 				}
@@ -151,12 +145,10 @@ describe( 'selectors', () => {
 					items: {
 						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
 					},
-					siteQueries: {
-						2916284: {
-							'{"search":"hello"}': {
-								fetching: false,
-								posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-							}
+					queries: {
+						'2916284:{"search":"hello"}': {
+							fetching: false,
+							posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
 						}
 					}
 				}
@@ -172,7 +164,7 @@ describe( 'selectors', () => {
 		it( 'should return false if the site query is not tracked', () => {
 			const isRequesting = isRequestingSitePostsForQuery( {
 				posts: {
-					siteQueries: {}
+					queries: {}
 				}
 			}, 2916284, { search: 'Hello' } );
 
@@ -182,11 +174,9 @@ describe( 'selectors', () => {
 		it( 'should return false if the site query is not fetching', () => {
 			const isRequesting = isRequestingSitePostsForQuery( {
 				posts: {
-					siteQueries: {
-						2916284: {
-							'{"search":"hello"}': {
-								fetching: false
-							}
+					queries: {
+						'2916284:{"search":"hello"}': {
+							fetching: false
 						}
 					}
 				}
@@ -198,11 +188,9 @@ describe( 'selectors', () => {
 		it( 'should return true if the site query is fetching', () => {
 			const isRequesting = isRequestingSitePostsForQuery( {
 				posts: {
-					siteQueries: {
-						2916284: {
-							'{"search":"hello"}': {
-								fetching: true
-							}
+					queries: {
+						'2916284:{"search":"hello"}': {
+							fetching: true
 						}
 					}
 				}
@@ -213,22 +201,10 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSitePostsLastPageForQuery()', () => {
-		it( 'should return null if the site ID is not tracked', () => {
-			const lastPage = getSitePostsLastPageForQuery( {
-				posts: {
-					siteQueriesLastPage: {}
-				}
-			}, 2916284, { search: 'Hello' } );
-
-			expect( lastPage ).to.be.null;
-		} );
-
 		it( 'should return null if the site query is not tracked', () => {
 			const lastPage = getSitePostsLastPageForQuery( {
 				posts: {
-					siteQueriesLastPage: {
-						2916284: {}
-					}
+					queriesLastPage: {}
 				}
 			}, 2916284, { search: 'Hello' } );
 
@@ -238,10 +214,8 @@ describe( 'selectors', () => {
 		it( 'should return the last page value for a site query', () => {
 			const lastPage = getSitePostsLastPageForQuery( {
 				posts: {
-					siteQueriesLastPage: {
-						2916284: {
-							'{"search":"hello"}': 4
-						}
+					queriesLastPage: {
+						'2916284:{"search":"hello"}': 4
 					}
 				}
 			}, 2916284, { search: 'Hello' } );
@@ -252,10 +226,8 @@ describe( 'selectors', () => {
 		it( 'should return the last page value for a site query, even if including page param', () => {
 			const lastPage = getSitePostsLastPageForQuery( {
 				posts: {
-					siteQueriesLastPage: {
-						2916284: {
-							'{"search":"hello"}': 4
-						}
+					queriesLastPage: {
+						'2916284:{"search":"hello"}': 4
 					}
 				}
 			}, 2916284, { search: 'Hello', page: 3 } );
@@ -268,7 +240,7 @@ describe( 'selectors', () => {
 		it( 'should return null if the last page is not known', () => {
 			const isLastPage = isSitePostsLastPageForQuery( {
 				posts: {
-					siteQueriesLastPage: {}
+					queriesLastPage: {}
 				}
 			}, 2916284, { search: 'Hello' } );
 
@@ -278,10 +250,8 @@ describe( 'selectors', () => {
 		it( 'should return false if the query explicit value is not the last page', () => {
 			const isLastPage = isSitePostsLastPageForQuery( {
 				posts: {
-					siteQueriesLastPage: {
-						2916284: {
-							'{"search":"hello"}': 4
-						}
+					queriesLastPage: {
+						'2916284:{"search":"hello"}': 4
 					}
 				}
 			}, 2916284, { search: 'Hello', page: 3 } );
@@ -292,10 +262,8 @@ describe( 'selectors', () => {
 		it( 'should return true if the query explicit value is the last page', () => {
 			const isLastPage = isSitePostsLastPageForQuery( {
 				posts: {
-					siteQueriesLastPage: {
-						2916284: {
-							'{"search":"hello"}': 4
-						}
+					queriesLastPage: {
+						'2916284:{"search":"hello"}': 4
 					}
 				}
 			}, 2916284, { search: 'Hello', page: 4 } );
@@ -306,10 +274,8 @@ describe( 'selectors', () => {
 		it( 'should return true if the query implicit value is the last page', () => {
 			const isLastPage = isSitePostsLastPageForQuery( {
 				posts: {
-					siteQueriesLastPage: {
-						2916284: {
-							'{"search":"hello"}': 1
-						}
+					queriesLastPage: {
+						'2916284:{"search":"hello"}': 1
 					}
 				}
 			}, 2916284, { search: 'Hello' } );
@@ -322,7 +288,7 @@ describe( 'selectors', () => {
 		it( 'should return null if the last page is not known', () => {
 			const isLastPage = isSitePostsLastPageForQuery( {
 				posts: {
-					siteQueriesLastPage: {}
+					queriesLastPage: {}
 				}
 			}, 2916284, { search: 'Hello' } );
 
@@ -336,22 +302,18 @@ describe( 'selectors', () => {
 						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
 						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
 					},
-					siteQueries: {
-						2916284: {
-							'{"number":1}': {
-								fetching: false,
-								posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-							},
-							'{"number":1,"page":2}': {
-								fetching: false,
-								posts: [ '6c831c187ffef321eb43a67761a525a3' ]
-							}
+					queries: {
+						'2916284:{"number":1}': {
+							fetching: false,
+							posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
+						},
+						'2916284:{"number":1,"page":2}': {
+							fetching: false,
+							posts: [ '6c831c187ffef321eb43a67761a525a3' ]
 						}
 					},
-					siteQueriesLastPage: {
-						2916284: {
-							'{"number":1}': 2
-						}
+					queriesLastPage: {
+						'2916284:{"number":1}': 2
 					}
 				}
 			}, 2916284, { search: '', number: 1 } );

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -43,6 +43,14 @@ describe( 'utils', () => {
 
 			expect( serializedQuery ).to.equal( '{"search":"hello"}' );
 		} );
+
+		it( 'should prefix site ID if specified', () => {
+			const serializedQuery = getSerializedPostsQuery( {
+				search: 'HeLlO'
+			}, 2916284 );
+
+			expect( serializedQuery ).to.equal( '2916284:{"search":"hello"}' );
+		} );
 	} );
 
 	describe( '#getSerializedPostsQueryWithoutPage()', () => {
@@ -62,6 +70,15 @@ describe( 'utils', () => {
 			} );
 
 			expect( serializedQuery ).to.equal( '{"search":"hello"}' );
+		} );
+
+		it( 'should prefix site ID if specified', () => {
+			const serializedQuery = getSerializedPostsQueryWithoutPage( {
+				search: 'HeLlO',
+				page: 2
+			}, 2916284 );
+
+			expect( serializedQuery ).to.equal( '2916284:{"search":"hello"}' );
 		} );
 	} );
 } );

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -22,22 +22,32 @@ export function getNormalizedPostsQuery( query ) {
 
 /**
  * Returns a serialized posts query, used as the key in the
- * `state.posts.siteQueries` state object.
+ * `state.posts.queries` state object.
  *
- * @param  {Object} query Posts query
- * @return {String}       Serialized posts query
+ * @param  {Object} query  Posts query
+ * @param  {Number} siteId Optional site ID
+ * @return {String}        Serialized posts query
  */
-export function getSerializedPostsQuery( query = {} ) {
-	return JSON.stringify( getNormalizedPostsQuery( query ) ).toLowerCase();
+export function getSerializedPostsQuery( query = {}, siteId ) {
+	const normalizedQuery = getNormalizedPostsQuery( query );
+	const serializedQuery = JSON.stringify( normalizedQuery ).toLowerCase();
+
+	if ( siteId ) {
+		return [ siteId, serializedQuery ].join( ':' );
+	}
+
+	return serializedQuery;
 }
 
 /**
  * Returns a serialized posts query, excluding any page parameter, used as the
- * key in the `state.posts.siteQueriesLastPage` state object.
+ * key in the `state.posts.queriesLastPage` state object.
  *
- * @param  {Object} query Posts query
- * @return {String}       Serialized posts query
+ * @param  {Object} query  Posts query
+ * @param  {Number} siteId Optional site ID
+ * @return {String}        Serialized posts query
  */
-export function getSerializedPostsQueryWithoutPage( query ) {
-	return JSON.stringify( omit( getNormalizedPostsQuery( query ), 'page' ) ).toLowerCase();
+export function getSerializedPostsQueryWithoutPage( query, siteId ) {
+	query = Object.assign( getNormalizedPostsQuery( query ), { siteId } );
+	return JSON.stringify( omit( query, 'page' ) ).toLowerCase();
 }

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -30,7 +30,7 @@ export function getNormalizedPostsQuery( query ) {
  */
 export function getSerializedPostsQuery( query = {}, siteId ) {
 	const normalizedQuery = getNormalizedPostsQuery( query );
-	const serializedQuery = JSON.stringify( normalizedQuery ).toLowerCase();
+	const serializedQuery = JSON.stringify( normalizedQuery ).toLocaleLowerCase();
 
 	if ( siteId ) {
 		return [ siteId, serializedQuery ].join( ':' );

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -48,6 +48,5 @@ export function getSerializedPostsQuery( query = {}, siteId ) {
  * @return {String}        Serialized posts query
  */
 export function getSerializedPostsQueryWithoutPage( query, siteId ) {
-	query = Object.assign( getNormalizedPostsQuery( query ), { siteId } );
-	return JSON.stringify( omit( query, 'page' ) ).toLowerCase();
+	return getSerializedPostsQuery( omit( query, 'page' ), siteId );
 }


### PR DESCRIPTION
This pull request seeks to update the posts Redux state handlers to offer an action creator for requesting all posts belonging to the current user.

__Implementation notes:__

The approach taken here was to convert the existing `siteQueries` and `siteQueriesLastPage` reducer keys to more generalized `queries` and `queriesLastPage`, incorporating the optional site designation as part of the logic for `getSerializedPostsQuery`. This has the added benefit of increasingly flattening the posts state structure.

__Testing instructions:__

Ensure that existing usage of the posts Redux state remains unaffected. Specifically, this includes the parent page selector in the [Calypso page editor](http://calypso.localhost:3000/page). Specifically, repeat testing instructions from #2350.

Verify that Mocha tests pass by running `make test` from the project root directory or directly from `client/state/posts`.