### PR TITLE
Importer: improving button styles

### DIFF
--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -77,8 +77,8 @@ export default React.createClass( {
 
 	render: function() {
 		const { importerStatus: { importerState }, icon, isEnabled, title, description } = this.props;
-		const isPrimary = includes( [ ...cancelStates, ...stopStates ], importerState );
 		const canCancel = isEnabled && ! includes( [ appStates.UPLOADING ], importerState );
+		const isScary = includes( [ ...stopStates, ...cancelStates ], importerState );
 
 		return (
 			<header className="importer-service">
@@ -86,7 +86,8 @@ export default React.createClass( {
 				<Button
 					className="importer__master-control"
 					disabled={ ! canCancel }
-					isPrimary={ isPrimary }
+					isPrimary={ false }
+					scary={ isScary }
 					onClick={ this.controlButtonClicked }
 				>
 					{ this.getButtonText() }


### PR DESCRIPTION
The header button is not the primary action button, so it should
never be 'is-primary', and when that button functions to stop or
cancel an import, it should be 'is-scary'.

closes #3077

To test:
- go through the import flow, and ensure the header button is styled as perscribed in #3077