### PR TITLE
Components: Display post type adjacent PostSelector option title

### DIFF
--- a/client/components/data/query-post-types/README.md
+++ b/client/components/data/query-post-types/README.md
@@ -1,0 +1,40 @@
+Query Post Types
+================
+
+`<QueryPostTypes />` is a React component used in managing network requests for post types.
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import QueryPostTypes from 'components/data/query-post-types';
+import MyPostTypesListItem from './list-item';
+
+export default function MyPostTypesList( { postTypes } ) {
+	return (
+		<div>
+			<QueryPostTypes siteId={ 3584907 } />
+			{ postTypes.map( ( postType ) => {
+				return (
+					<MyPostTypesListItem
+						key={ postType.name }
+						postType={ postType } />
+				);
+			} }
+		</div>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+The site ID for which post types should be requested.

--- a/client/components/data/query-post-types/index.jsx
+++ b/client/components/data/query-post-types/index.jsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingPostTypes } from 'state/post-types/selectors';
+import { requestPostTypes } from 'state/post-types/actions';
+
+class QueryPostTypes extends Component {
+	componentWillMount() {
+		if ( ! this.props.requestingPostTypes && this.props.siteId ) {
+			this.props.requestPostTypes( this.props.siteId );
+		}
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.requestingPostTypes ||
+				! nextProps.siteId ||
+				( this.props.siteId === nextProps.siteId ) ) {
+			return;
+		}
+
+		nextProps.requestPostTypes( nextProps.siteId );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryPostTypes.propTypes = {
+	siteId: PropTypes.number,
+	requestingPostTypes: PropTypes.bool,
+	requestPostTypes: PropTypes.func
+};
+
+QueryPostTypes.defaultProps = {
+	requestPostTypes: () => {}
+};
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			requestingPostTypes: isRequestingPostTypes( state, ownProps.siteId )
+		};
+	},
+	( dispatch ) => {
+		return bindActionCreators( {
+			requestPostTypes
+		}, dispatch );
+	}
+)( QueryPostTypes );

--- a/client/my-sites/post-selector/README.md
+++ b/client/my-sites/post-selector/README.md
@@ -121,3 +121,12 @@ A message to be shown if no posts are found.
 </table>
 
 A link to be shown if the search results in no found posts.
+
+### `showTypeLabels`
+
+<table>
+	<tr><th>Type</th><td>Boolean</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Whether post type labels should be shown adjacent to post options results. If omitted, default behavior is to show the labels only if query `type` is set to `any`.

--- a/client/my-sites/post-selector/docs/example.jsx
+++ b/client/my-sites/post-selector/docs/example.jsx
@@ -10,9 +10,16 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import PostSelector from '../';
 import observe from 'lib/mixins/data-observe';
 import sites from 'lib/sites-list';
+import FormLabel from 'components/forms/form-label';
 
 const PostSelectorExample = React.createClass( {
 	mixins: [ observe( 'sites' ), PureRenderMixin ],
+
+	getInitialState() {
+		return {
+			showTypeLabels: true
+		};
+	},
 
 	render() {
 		const primary = this.props.sites.getPrimary();
@@ -23,12 +30,20 @@ const PostSelectorExample = React.createClass( {
 					<a href="/devdocs/app-components/post-selector">Post Selector</a>
 				</h2>
 				<div style={ { width: 300 } }>
+					<FormLabel>
+						<input
+							type="checkbox"
+							checked={ this.state.showTypeLabels }
+							onChange={ () => this.setState( { showTypeLabels: ! this.state.showTypeLabels } ) } />
+						Show Type Labels
+					</FormLabel>
 					{ this.props.sites.initialized && (
 						<PostSelector
 							siteId={ primary ? primary.ID : 3584907 }
 							type="any"
 							orderBy="date"
-							order="DESC" />
+							order="DESC"
+							showTypeLabels={ this.state.showTypeLabels } />
 					) }
 				</div>
 			</div>

--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -27,7 +27,8 @@ export default React.createClass( {
 		emptyMessage: PropTypes.string,
 		createLink: PropTypes.string,
 		orderBy: PropTypes.oneOf( [ 'title', 'date', 'modified', 'comment_count', 'ID' ] ),
-		order: PropTypes.oneOf( [ 'ASC', 'DESC' ] )
+		order: PropTypes.oneOf( [ 'ASC', 'DESC' ] ),
+		showTypeLabels: PropTypes.bool
 	},
 
 	getDefaultProps() {
@@ -85,7 +86,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { siteId, multiple, onChange, emptyMessage, createLink, selected } = this.props;
+		const { siteId, multiple, onChange, emptyMessage, createLink, selected, showTypeLabels } = this.props;
 
 		return (
 			<PostSelectorPosts
@@ -98,6 +99,7 @@ export default React.createClass( {
 				emptyMessage={ emptyMessage }
 				createLink={ createLink }
 				selected={ selected }
+				showTypeLabels={ showTypeLabels }
 			/>
 		);
 	}

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -80,7 +80,8 @@ const PostSelectorPosts = React.createClass( {
 		onSearch: PropTypes.func,
 		onChange: PropTypes.func,
 		onNextPage: PropTypes.func,
-		multiple: PropTypes.bool
+		multiple: PropTypes.bool,
+		showTypeLabel: PropTypes.bool
 	},
 
 	getInitialState() {
@@ -219,7 +220,6 @@ const PostSelectorPosts = React.createClass( {
 	render() {
 		const numberPosts = this.props.posts ? this.props.posts.length : 0;
 		const showSearch = ( numberPosts > this.props.searchThreshold ) || this.state.searchTerm;
-		const isAnyType = 'any' === this.props.query.type;
 		let posts;
 
 		if ( this.props.posts ) {
@@ -227,19 +227,26 @@ const PostSelectorPosts = React.createClass( {
 			posts = ( this.props.lastPage && ! this.state.searchTerm ) ? buildTree( this.props.posts ) : this.props.posts;
 		}
 
+		let showTypeLabels;
+		if ( 'boolean' === typeof this.props.showTypeLabels ) {
+			showTypeLabels = this.props.showTypeLabels;
+		} else {
+			showTypeLabels = 'any' === this.props.query.type;
+		}
+
 		const classes = classNames(
 			'post-selector',
 			this.props.className, {
 				'is-loading': this.props.loading,
 				'is-compact': ! showSearch && ! this.props.loading,
-				'is-any-type': isAnyType
+				'is-type-labels-visible': showTypeLabels
 			}
 		);
 
 		return (
 			<div className={ classes } onScroll={ this.checkScrollPosition }>
 				<QueryPosts siteId={ this.props.siteId } query={ this.props.query } />
-				{ isAnyType && <QueryPostTypes siteId={ this.props.siteId } /> }
+				{ showTypeLabels && <QueryPostTypes siteId={ this.props.siteId } /> }
 				{ showSearch ?
 					<Search searchTerm={ this.state.searchTerm } onSearch={ this.onSearch } /> :
 					null

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -94,7 +94,7 @@ input[type=checkbox].post-selector__input {
 	margin-left: 24px;
 	margin-top: 2px;
 
-	.post-selector.is-any-type & {
+	.post-selector.is-type-labels-visible & {
 		display: flex;
 		justify-content: space-between;
 	}
@@ -112,7 +112,7 @@ input[type=checkbox].post-selector__input {
 	text-transform: uppercase;
 	color: $gray;
 
-	.post-selector.is-any-type & {
+	.post-selector.is-type-labels-visible & {
 		display: block;
 	}
 }

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -89,12 +89,30 @@ input[type=checkbox].post-selector__input {
 }
 
 .post-selector__label {
+	position: relative;
 	display: block;
 	margin-left: 24px;
 	margin-top: 2px;
 
+	.post-selector.is-any-type & {
+		display: flex;
+		justify-content: space-between;
+	}
+
 	.post-selector.is-compact & {
 		font-size: 14px;
 		margin-top: 0;
+	}
+}
+
+.post-selector__label-type {
+	display: none;
+	margin-left: 8px;
+	font-size: 11px;
+	text-transform: uppercase;
+	color: $gray;
+
+	.post-selector.is-any-type & {
+		display: block;
 	}
 }

--- a/client/state/post-types/actions.js
+++ b/client/state/post-types/actions.js
@@ -39,7 +39,7 @@ export function requestPostTypes( siteId ) {
 			siteId
 		} );
 
-		return wpcom.site( siteId ).postTypesList().then( ( { post_types: types } ) => {
+		return wpcom.withLocale().site( siteId ).postTypesList().then( ( { post_types: types } ) => {
 			dispatch( receivePostTypes( siteId, types ) );
 			dispatch( {
 				type: POST_TYPES_REQUEST_SUCCESS,

--- a/client/state/post-types/selectors.js
+++ b/client/state/post-types/selectors.js
@@ -1,0 +1,11 @@
+/**
+ * Returns true if current requesting post types for the specified site ID, or
+ * false otherwise.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {Boolean}        Whether post types are being requested
+ */
+export function isRequestingPostTypes( state, siteId ) {
+	return !! state.postTypes.requesting[ siteId ];
+}

--- a/client/state/post-types/selectors.js
+++ b/client/state/post-types/selectors.js
@@ -9,3 +9,14 @@
 export function isRequestingPostTypes( state, siteId ) {
 	return !! state.postTypes.requesting[ siteId ];
 }
+
+/**
+ * Returns the known post types for a site.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Object}        Site post types
+ */
+export function getPostTypes( state, siteId ) {
+	return state.postTypes.items[ siteId ] || null;
+}

--- a/client/state/post-types/test/selectors.js
+++ b/client/state/post-types/test/selectors.js
@@ -6,7 +6,10 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { isRequestingPostTypes } from '../selectors';
+import {
+	isRequestingPostTypes,
+	getPostTypes
+} from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#isRequestingPostTypes()', () => {
@@ -42,6 +45,34 @@ describe( 'selectors', () => {
 			}, 2916284 );
 
 			expect( isRequesting ).to.be.true;
+		} );
+	} );
+
+	describe( '#getPostTypes()', () => {
+		it( 'should return null if the site is not tracked', () => {
+			const postTypes = getPostTypes( {
+				postTypes: {
+					items: {}
+				}
+			}, 2916284 );
+
+			expect( postTypes ).to.be.null;
+		} );
+
+		it( 'should return the post types for a site', () => {
+			const postTypes = getPostTypes( {
+				postTypes: {
+					items: {
+						2916284: {
+							post: { name: 'post', label: 'Posts' }
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( postTypes ).to.eql( {
+				post: { name: 'post', label: 'Posts' }
+			} )
 		} );
 	} );
 } );

--- a/client/state/post-types/test/selectors.js
+++ b/client/state/post-types/test/selectors.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingPostTypes } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( '#isRequestingPostTypes()', () => {
+		it( 'should return false if the site is not tracked', () => {
+			const isRequesting = isRequestingPostTypes( {
+				postTypes: {
+					requesting: {}
+				}
+			}, 2916284 );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return false if the site is not fetching', () => {
+			const isRequesting = isRequestingPostTypes( {
+				postTypes: {
+					requesting: {
+						2916284: false
+					}
+				}
+			}, 2916284 );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return true if the site is fetching', () => {
+			const isRequesting = isRequestingPostTypes( {
+				postTypes: {
+					requesting: {
+						2916284: true
+					}
+				}
+			}, 2916284 );
+
+			expect( isRequesting ).to.be.true;
+		} );
+	} );
+} );


### PR DESCRIPTION
Related: #3197, #3251

This pull request seeks to update the `<PostSelector />` component to display an option's type if the selector query is set to request any post type.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/12992545/189373ea-d0e3-11e5-8cd7-b9492cfd4b05.png)|![After](https://cloud.githubusercontent.com/assets/1779930/12992529/053f7abe-d0e3-11e5-9507-337ab20c062b.png)

__Testing instructions:__

Verify that the post type is shown for `<PostSelector />` options, but only if the selector is set to retrieve any post type for the site. Specifically, you should find that the Calypso page editor instance of `<PostSelector />` should not display the type (since it only queries pages), whereas the App Components demo should display the type.

Page editor:

1. Navigate to the [Calypso page editor](http://calypso.localhost:3000/page)
2. Select a site, if prompted
3. Expand the Page Options sidebar accordion
4. Note that the type is not shown adjacent the option title

App Components demo:

1. Navigate to the [Calypso DevDocs App Components page](http://calypso.localhost:3000/devdocs/app-components)
4. Note that types are not shown adjacent the option title in the Post Selector demo