### PR TITLE
Stats: updates to Recent Weeks table

### DIFF
--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -434,14 +434,14 @@
 	}
 
 	.tip-inner {
-		border: 0px;
+		border: 0;
 		box-shadow: none;
 		border-radius: 2px;
 		color: $white;
 		background: darken( $gray, 30% );
 		font-size: 11px;
 		padding: 6px 10px;
-		margin-top: 5px;
+		margin-top: 4px;
 		width: 230px;
 		text-align: left;
 

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -100,8 +100,8 @@ export default React.createClass( {
 
 					return (
 						<td key={ dayIndex } className={ cellClass }>
-							<span className="date">{ day.format( 'MMM D' ) }</span>
-							<span className="value">{ this.numberFormat( event.count ) }</span>
+							<span className="stats-detail-weeks__date">{ day.format( 'MMM D' ) }</span>
+							<span className="stats-detail-weeks__value">{ this.numberFormat( event.count ) }</span>
 						</td>
 					);
 				}, this );
@@ -134,7 +134,7 @@ export default React.createClass( {
 
 					cells.push( <td key={ 'average' + index }>
 						{ this.numberFormat( week.average ) }
-							<span className={ 'value ' + changeClass } key={ 'change' + index }>
+							<span className={ 'stats-detail-weeks__value ' + changeClass } key={ 'change' + index }>
 								{ iconType ? <Gridicon icon={ iconType } size={ 18 } /> : null }
 								{ this.numberFormat( week.change, 2 ) }%
 							</span></td>

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -70,7 +70,6 @@ export default React.createClass( {
 						<th>{ this.translate( 'Sun' ) }</th>
 						<th>{ this.translate( 'Total' ) }</th>
 						<th>{ this.translate( 'Average' ) }</th>
-						<th>{ this.translate( 'Change', { context: 'Stats: noun - change over a period in weekly numbers' } ) }</th>
 					</tr>
 				</thead>
 			);
@@ -117,12 +116,12 @@ export default React.createClass( {
 				}
 
 				cells.push( <td key={ 'total' + index }>{ this.numberFormat( week.total ) }</td> );
-				cells.push( <td key={ 'average' + index }>{ this.numberFormat( week.average ) }</td> );
 
 				if ( 'number' === typeof ( week.change ) ) {
 					let changeClass = classNames( {
-						'value-rising': week.change > 0,
-						'value-falling': week.change < 0
+						'is-rising': week.change > 0,
+						'is-falling': week.change < 0,
+						'is-same': week.change === 0
 					} );
 
 					if ( week.change > 0 ) {
@@ -133,16 +132,14 @@ export default React.createClass( {
 						iconType = 'arrow-down';
 					}
 
-					cells.push(
-						<td className={ changeClass } key={ 'change' + index }>
-							<span className="value">
+					cells.push( <td key={ 'average' + index }>
+						{ this.numberFormat( week.average ) }
+							<span className={ 'value ' + changeClass } key={ 'change' + index }>
 								{ iconType ? <Gridicon icon={ iconType } size={ 18 } /> : null }
 								{ this.numberFormat( week.change, 2 ) }%
-							</span>
-						</td>
-					);
-				} else if ( 'object' === typeof ( week.change ) && null !== week.change && week.change.isInfinity ) {
-					cells.push( <td key={ 'change' + index }>&infin;</td> );
+							</span></td>
+						);
+
 				} else {
 					cells.push( <td className="no-data" key={ 'change' + index }></td> );
 				}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -390,7 +390,7 @@ ul.module-header-actions {
 	th {
 		border-bottom: 1px solid $gray-light;
 		border-right: 1px solid $gray-light;
-		font-size: 14px;
+		font-size: 12px;
 		padding: 8px 12px;
 		white-space: nowrap; // 1
 
@@ -413,11 +413,6 @@ ul.module-header-actions {
 		background: $white;
 		position: absolute;
 		z-index: z-index( 'root', '.module-content-table tbody th:first-child' );
-
-		// Disable fixed legend for mobile
-		@include breakpoint( "<480px" ) {
-			position: static;
-		}
 	}
 
 	// Left this modifier as-is because these tables are likely going to change
@@ -446,12 +441,12 @@ ul.module-header-actions {
 		color: transparent;
 	}
 
-	.date,
-	.value {
+	.stats-detail-weeks__date,
+	.stats-detail-weeks__value {
 		white-space: nowrap;
 	}
 
-	.value {
+	.stats-detail-weeks__value {
 		display: block;
 		font-size: 12px;
 
@@ -474,17 +469,17 @@ ul.module-header-actions {
 		}
 
 		.gridicon {
-			margin-bottom: -4px;
+			margin: 0 2px -3px -4px;
 			width: 15px;
 		}
 	}
 
 	thead th,
-	.date {
+	.stats-detail-weeks__date {
 		color: $gray;
 	}
 
-	.date {
+	.stats-detail-weeks__date {
 		display: block;
 		font-size: 11px;
 		letter-spacing: .1em;
@@ -496,7 +491,6 @@ ul.module-header-actions {
 	// 2: Much wider to show horizontal scrolling better (since the window loads scrolled to the left)
 	&::before,
 	&::after {
-		background-image: linear-gradient(to left, $transparent 0%, $white 90%);
 		content: "";
 		display: block;
 		position: absolute;
@@ -508,9 +502,9 @@ ul.module-header-actions {
 	}
 
 	&::after {
-		background-image: linear-gradient(to right, $transparent 0%, $white 90%);
 		left: auto;
 		right: 0;
 		width: 60px; // 2
+		@include long-content-fade( $color: $white, $size: 15% );
 	}
 }

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -474,7 +474,7 @@ ul.module-header-actions {
 		}
 
 		.gridicon {
-			margin-bottom: -4px;
+			margin: 0 0 -4px -3px;
 			width: 15px;
 		}
 	}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -108,8 +108,8 @@
 	.right {
 		color: $gray;
 		position: absolute;
-		right: 24px;
-		top: 0;
+			right: 24px;
+			top: 0;
 	}
 }
 
@@ -156,8 +156,8 @@ ul.module-header-actions {
 	list-style: none;
 	margin: 0;
 	position: absolute;
-	right: 0;
-	top: 0;
+		right: 0;
+		top: 0;
 
 	// Fade really long module titles
 	&::before {
@@ -500,9 +500,9 @@ ul.module-header-actions {
 		content: "";
 		display: block;
 		position: absolute;
-			top: 0;
 			bottom: 16px; // 1
 			left: 0;
+			top: 0;
 		width: 20px;
 		z-index: z-index( 'root', '.module-content-table::after' );
 	}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -474,7 +474,7 @@ ul.module-header-actions {
 		}
 
 		.gridicon {
-			margin: 0 0 -4px -3px;
+			margin-bottom: -4px;
 			width: 15px;
 		}
 	}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -78,11 +78,11 @@
 
 	a {
 		@extend %mobile-link-element;
-		position: relative;
-		display: block;
-		padding: 0 24px;
 		border-top: 1px solid $gray-light;
+		display: block;
 		font-size: 14px;
+		padding: 0 24px;
+		position: relative;
 
 		// Hover state
 		@include breakpoint( ">480px" ) {
@@ -116,11 +116,11 @@
 // Module Header
 
 .module-header {
-	position: relative;
 	background: $white;
-	line-height: 40px;
 	height: 40px;
+	line-height: 40px;
 	padding-left: 24px;
+	position: relative;
 
 	.stats-module.is-loading & {
 		cursor: default;
@@ -139,12 +139,11 @@
 	@extend %mobile-interface-element;
 	@extend %placeholder;
 
-	width: auto;
-	font-weight: bold;
+	color: $gray-dark;
 	font-weight: 600;
 	height: 40px; // 1
 	overflow: hidden; // 1
-	color: $gray-dark;
+	width: auto;
 }
 
 // Module Header Actions
@@ -152,13 +151,13 @@
 // 2: So the focus outline isn't covered by the fading pseudo-element
 
 ul.module-header-actions {
-	position: absolute;
-	list-style: none;
-	top: 0;
-	right: 0;
-	height: 40px;
-	margin: 0;
 	background: $white;
+	height: 40px;
+	list-style: none;
+	margin: 0;
+	position: absolute;
+	right: 0;
+	top: 0;
 
 	// Fade really long module titles
 	&::before {
@@ -187,14 +186,14 @@ ul.module-header-actions {
 
 	.module-header-action-link {
 		@extend %mobile-interface-element;
-		height: 40px;
-		min-width: 40px;
-		line-height: 40px;
-		display: inline-block;
-		text-align: center;
-		position: relative; // 2
-		z-index: z-index( 'root', 'ul.module-header-actions .module-header-action-link' ); // 2
 		color: $gray;
+		display: inline-block;
+		height: 40px;
+		line-height: 40px;
+		min-width: 40px;
+		position: relative; // 2
+		text-align: center;
+		z-index: z-index( 'root', 'ul.module-header-actions .module-header-action-link' ); // 2
 
 		.stats-module.is-loading & {
 			cursor: default;
@@ -273,11 +272,11 @@ ul.module-header-actions {
 
 	// Hidden info box
 	&-info {
+		background: $gray-light;
+		box-shadow: inset 0 1px 0 $gray-light;
+		color: $gray-dark;
 		display: none;
 		position: relative;
-		background: $gray-light;
-		color: $gray-dark;
-		box-shadow: inset 0 1px 0 $gray-light;
 
 		.stats-module.is-showing-info & {
 			display: inline-block; // 1
@@ -295,8 +294,8 @@ ul.module-header-actions {
 
 	// Representation of what the published status looks like within a list of posts and pages
 	.legend.published {
-		padding-left: 12px;
 		border-left: 4px solid $orange-jazzy;
+		padding-left: 12px;
 	}
 
 	.legend.achievement {
@@ -318,8 +317,8 @@ ul.module-header-actions {
 		list-style: none;
 
 		li {
-			line-height: 2em;
 			font-size: 14px;
+			line-height: 2em;
 
 			@include breakpoint( ">960px" ) {
 				.module-list & {
@@ -331,7 +330,7 @@ ul.module-header-actions {
 				border-bottom: 1px solid $gray-light;
 
 				&:last-child {
-					border: none;
+					border: 0;
 					margin-bottom: -12px;
 				}
 			}
@@ -378,10 +377,10 @@ ul.module-header-actions {
 	position: relative;
 
 	.module-content-table-scroll {
+		min-height: 210px;
 		overflow: auto;
 		overflow-x: auto;
 		overflow-y: visible;
-		min-height: 210px;
 	}
 
 	// Table cells
@@ -389,10 +388,10 @@ ul.module-header-actions {
 	// 2: Make right padding much greater to accommodate for increased gradient
 	td,
 	th {
-		font-size: 14px;
-		padding: 8px 12px;
 		border-bottom: 1px solid $gray-light;
 		border-right: 1px solid $gray-light;
+		font-size: 14px;
+		padding: 8px 12px;
 		white-space: nowrap; // 1
 
 		&:first-child {
@@ -400,8 +399,8 @@ ul.module-header-actions {
 		}
 
 		&:last-child {
-			padding-right: 60px; // 2
 			border-right: none;
+			padding-right: 60px; // 2
 		}
 	}
 
@@ -439,8 +438,8 @@ ul.module-header-actions {
 	}
 
 	.stats-module & td.highest-count {
-		position: relative;
 		color: $alert-yellow;
+		position: relative;
 	}
 
 	.spacer {
@@ -453,21 +452,31 @@ ul.module-header-actions {
 	}
 
 	.value {
-		display: inline-block;
-	}
+		display: block;
+		font-size: 12px;
 
-	.value-rising,
-	.value-falling {
-		color: $alert-green;
+		&.is-rising {
+			color: $alert-green;
+		}
+
+		&.is-falling {
+			color: $alert-red;
+		}
+
+		&.is-same {
+			color: $gray;
+		}
+
+		&.is-rising,
+		&.is-falling,
+		&.is-same {
+			margin-top: -2px;
+		}
 
 		.gridicon {
-			margin-right: 4px;
-			margin-bottom: -2px;
+			margin-bottom: -4px;
+			width: 15px;
 		}
-	}
-
-	.value-falling {
-		color: $alert-red;
 	}
 
 	thead th,
@@ -478,8 +487,8 @@ ul.module-header-actions {
 	.date {
 		display: block;
 		font-size: 11px;
-		text-transform: uppercase;
 		letter-spacing: .1em;
+		text-transform: uppercase;
 	}
 
 	// Fade out sides of tables to hint at horizontal scrolling
@@ -487,21 +496,21 @@ ul.module-header-actions {
 	// 2: Much wider to show horizontal scrolling better (since the window loads scrolled to the left)
 	&::before,
 	&::after {
+		background-image: linear-gradient(to left, $transparent 0%, $white 90%);
 		content: "";
 		display: block;
 		position: absolute;
 			top: 0;
 			bottom: 16px; // 1
 			left: 0;
-		z-index: z-index( 'root', '.module-content-table::after' );
 		width: 20px;
-		background-image: linear-gradient(to left, $transparent 0%, $white 90%);
+		z-index: z-index( 'root', '.module-content-table::after' );
 	}
 
 	&::after {
-		right: 0;
-		left: auto;
-		width: 60px; // 2
 		background-image: linear-gradient(to right, $transparent 0%, $white 90%);
+		left: auto;
+		right: 0;
+		width: 60px; // 2
 	}
 }


### PR DESCRIPTION
This fixes items 3 and 4 on this issue: https://github.com/Automattic/wp-calypso/issues/2894

**Before:**
![screenshot 2016-02-11 14 38 10](https://cloud.githubusercontent.com/assets/4924246/12993096/1c5bc6dc-d0cd-11e5-9cf0-eee143d726eb.png)

**After:**
![screenshot 2016-02-11 14 37 46](https://cloud.githubusercontent.com/assets/4924246/12993100/25646c66-d0cd-11e5-8c06-a0472d7fd560.png)

**Changes made:**
1. Moved percent change from Change column to Average
2. Removed infinity symbol
3. Did a bit of clean up to stats module CSS

I haven't explored separating or changing the background color of the Total and Average columns yet to make them stand out a bit more. Will cover that in a separate PR.

/cc @jblz @timmyc 