### PR TITLE
Token Field: Extend component such that it can also receive an array of objects

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -10,8 +10,7 @@ var take = require( 'lodash/array/take' ),
 	identity = require( 'lodash/utility/identity' ),
 	classNames = require( 'classnames' ),
 	debug = require( 'debug' )( 'calypso:token-field' ),
-	reject = require( 'lodash/collection/reject' ),
-	find = require( 'lodash/collection/find' ),
+	some = require( 'lodash/collection/some' ),
 	forEach = require( 'lodash/collection/forEach' );
 
 /**
@@ -131,13 +130,8 @@ var TokenField = React.createClass( {
 	},
 
 	_renderToken: function( token ) {
-		let value = token;
-		let status;
-
-		if ( 'object' === typeof token ) {
-			value = token.value;
-			status = token.status;
-		}
+		const value = this._getTokenValue( token );
+		const status = token.status ? token.status : undefined;
 
 		return (
 			<Token
@@ -455,13 +449,8 @@ var TokenField = React.createClass( {
 	},
 
 	_deleteToken: function( token ) {
-		const searchValue = 'object' === typeof token ? token.value : token;
-		let newTokens = reject( this.props.value, ( item ) => {
-			if ( 'object' === typeof item ) {
-				return item.value === searchValue;
-			}
-
-			return item === searchValue;
+		const newTokens = this.props.value.filter( ( item ) => {
+			return this._getTokenValue( item ) !== this._getTokenValue( token );
 		} );
 		this.props.onChange( newTokens );
 	},
@@ -509,15 +498,17 @@ var TokenField = React.createClass( {
 	},
 
 	_valueContainsToken( token ) {
-		let search = find( this.props.value, ( item ) => {
-			if ( 'object' === typeof item ) {
-				return item.value === token;
-			}
-
-			return item === token;
+		return some( this.props.value, ( item ) => {
+			return this._getTokenValue( token ) === this._getTokenValue( item );
 		} );
+	},
 
-		return !! search;
+	_getTokenValue( token ) {
+		if ( 'object' === typeof token ) {
+			return token.value;
+		}
+
+		return token;
 	},
 
 	_getIndexOfInput: function() {

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -10,7 +10,7 @@ var Token = React.createClass( {
 		value: React.PropTypes.string.isRequired,
 		displayTransform: React.PropTypes.func.isRequired,
 		onClickRemove: React.PropTypes.func,
-		status: React.PropTypes.oneOf( [ 'is-error', 'is-success' ] ),
+		status: React.PropTypes.oneOf( [ 'is-error', 'is-success', 'is-validating' ] ),
 		isBorderless: React.PropTypes.bool
 	},
 

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -10,7 +10,7 @@ var Token = React.createClass( {
 		value: React.PropTypes.string.isRequired,
 		displayTransform: React.PropTypes.func.isRequired,
 		onClickRemove: React.PropTypes.func,
-		status: React.PropTypes.oneOf( [ 'is-error', 'is-success', 'is-validating' ] ),
+		status: React.PropTypes.oneOf( [ 'error', 'success', 'validating' ] ),
 		isBorderless: React.PropTypes.bool
 	},
 
@@ -24,7 +24,10 @@ var Token = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	render: function() {
-		const tokenClasses = classNames( 'token-field__token', this.props.status, {
+		const tokenClasses = classNames( 'token-field__token', {
+			'is-error': 'error' === this.props.status,
+			'is-success': 'success' === this.props.status,
+			'is-validating': 'validating' === this.props.status,
 			'is-borderless': this.props.isBorderless
 		} );
 

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -6,6 +6,7 @@ import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import page from 'page';
 import get from 'lodash/object/get';
 import debugModule from 'debug';
+import contains from 'lodash/collection/contains';
 
 /**
  * Internal dependencies
@@ -62,9 +63,16 @@ export default React.createClass( {
 	},
 
 	onTokensChange( tokens ) {
-		this.setState( { usernamesOrEmails: tokens } );
 		const { role } = this.state;
-		createInviteValidation( this.props.site.ID, tokens, role );
+		const filteredTokens = tokens.map( ( value ) => {
+			if ( 'object' === typeof value ) {
+				return value.value;
+			}
+			return value;
+		} );
+
+		this.setState( { usernamesOrEmails: filteredTokens } );
+		createInviteValidation( this.props.site.ID, filteredTokens, role );
 	},
 
 	onMessageChange( event ) {
@@ -77,18 +85,36 @@ export default React.createClass( {
 		if ( ! success.indexOf ) {
 			success = Object.keys( success ).map( key => success[ key ] );
 		}
+
 		this.setState( {
-			getTokenStatus: ( value ) => {
-				if ( 'string' === typeof value ) {
-					if ( errors[ value ] ) {
-						return 'is-error';
-					}
-					if ( success.indexOf( value ) > -1 ) {
-						return 'is-success';
-					}
-				}
-			}
+			errors,
+			success
 		} );
+	},
+
+	getTokensWithStatus() {
+		const { success, errors } = this.state;
+
+		const tokens = this.state.usernamesOrEmails.map( ( value ) => {
+			let status;
+			if ( errors && errors[ value ] ) {
+				status = 'is-error';
+			} else if ( ! contains( success, value ) ) {
+				status = 'is-validating';
+			}
+
+			if ( status ) {
+				value = {
+					value,
+					status
+				};
+			}
+
+			return value;
+		} );
+
+		debug( 'Generated tokens: ' + JSON.stringify( tokens ) );
+		return tokens;
 	},
 
 	submitForm( event ) {
@@ -136,8 +162,7 @@ export default React.createClass( {
 							<FormLabel>{ this.translate( 'Usernames or Emails' ) }</FormLabel>
 							<TokenField
 								isBorderless
-								tokenStatus={ this.state.getTokenStatus }
-								value={ this.state.usernamesOrEmails }
+								value={ this.getTokensWithStatus() }
 								onChange={ this.onTokensChange } />
 							<FormSettingExplanation>
 								{ this.translate(

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -98,9 +98,9 @@ export default React.createClass( {
 		const tokens = this.state.usernamesOrEmails.map( ( value ) => {
 			let status;
 			if ( errors && errors[ value ] ) {
-				status = 'is-error';
+				status = 'error';
 			} else if ( ! contains( success, value ) ) {
-				status = 'is-validating';
+				status = 'validating';
 			}
 
 			if ( status ) {


### PR DESCRIPTION
For our work on people management, we have been working on adding statuses to the tokens in TokenField. Our initial pass at this was to use a callback. But, we ran into issues with the tokens updating properly after validation came back. While we got this working, we don't believe it to be an elegant solution.

So, this pass will allow us to create an array of objects that looks like `{ value: 'token value here', status: 'is-error' }` and send those in through the `value` prop.

To test:
- Checkout `update/token-field-array-objects` branch
- Go to `/devdocs/design/token-fields` and ensure token field works properly
- Go to `/post/$site` and make sure tags work properly
- Go to `/people/new/$site` where `$site` is a WP.com site, and ensure that you can add/remove tokens

Note: When you go to `/people/new/$site`, you won't see much. This is because we're still working on the visuals in #3191. But, you can merge that branch into this one for testing:

```
git checkout update/token-field-array-objects
git pull origin update/token-field-validation-borderless
```

Fix the merge conflict in `my-sites/people/invite-people`, and then reload the invite form at `/people/new/$site`. You should now be able to see the pending (light gray) state as well an error state. The easiest way to get a validation error is to select a non-follower role (ex. editor) and then type your own username into the field.

cc @aduth and @lezama for review.