### PR TITLE
Checkout: Don't use localStorage to save product data for the thank you page

### DIFF
--- a/assets/stylesheets/sections/_checkout.scss
+++ b/assets/stylesheets/sections/_checkout.scss
@@ -771,7 +771,7 @@
 	}
 }
 
-.checkout-thank-you {
+.checkout__thank-you {
 	box-sizing: border-box;
 	position: static;
 	text-align: center;
@@ -848,11 +848,30 @@
 			border-bottom: 1px solid $blue-medium;
 		}
 	}
+
+	&.is-placeholder {
+		.checkout__thank-you-header,
+		.checkout__thank-you-subheader {
+			@include placeholder( 23% );
+
+			display: block;
+			margin: 0 auto;
+		}
+
+		.checkout__thank-you-header {
+			width: 50%;
+		}
+
+		.checkout__thank-you-subheader {
+			margin-top: 15px;
+			width: 40%;
+		}
+	}
 }
 
 // Mobile styles
 @include breakpoint( "<660px" ) {
-	.checkout-thank-you {
+	.checkout__thank-you {
 		background: transparent;
 		padding: 14px;
 
@@ -883,7 +902,7 @@
 
 // Desktop styles
 @include breakpoint( ">660px" ) {
-	.checkout-thank-you {
+	.checkout__thank-you {
 		.thank-you-message {
 			border-bottom: 1px solid lighten( $gray, 30% );
 

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -38,8 +38,16 @@ function formatProduct( product ) {
 		product_slug: product.product_slug || product.productSlug,
 		is_domain_registration: product.is_domain_registration !== undefined
 			? product.is_domain_registration
-			: product.isDomainRegistration
+			: product.isDomainRegistration,
+		free_trial: product.free_trial || product.freeTrial
 	} );
+}
+
+function isChargeback( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return product.product_slug === 'chargeback';
 }
 
 function isFreePlan( product ) {
@@ -93,6 +101,20 @@ function isJetpackPlan( product ) {
 	assertValidProduct( product );
 
 	return 'jetpack' === product.product_type;
+}
+
+function isJetpackBusiness( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return isBusiness( product ) && isJetpackPlan( product );
+}
+
+function isJetpackPremium( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return isPremium( product ) && isJetpackPlan( product );
 }
 
 function isJpphpBundle( product ) {
@@ -269,6 +291,7 @@ module.exports = {
 	formatProduct,
 	getDomainProductRanking,
 	isBusiness,
+	isChargeback,
 	isCredits,
 	isCustomDesign,
 	isDependentProduct,
@@ -281,6 +304,8 @@ module.exports = {
 	isFreeJetpackPlan,
 	isFreeTrial,
 	isGoogleApps,
+	isJetpackBusiness,
+	isJetpackPremium,
 	isJetpackPlan,
 	isJpphpBundle,
 	isNoAds,

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -135,7 +135,7 @@ const Checkout = React.createClass( {
 
 	getCheckoutCompleteRedirectPath: function() {
 		var renewalItem,
-			receiptId = this.props.transaction.step.data.receipt_id;
+			receiptId = ':receipt_id';
 
 		if ( cartItems.hasRenewalItem( this.props.cart ) ) {
 			clearPurchases();
@@ -149,10 +149,15 @@ const Checkout = React.createClass( {
 			return `/plans/${ this.props.sites.getSelectedSite().slug }/thank-you`;
 		}
 
-		this.props.fetchReceiptCompleted( receiptId, {
-			receipt_id: receiptId,
-			purchases: this.getPurchasesFromReceipt()
-		} );
+		if ( this.props.transaction.step.data && this.props.transaction.step.data.receipt_id ) {
+			receiptId = this.props.transaction.step.data.receipt_id;
+
+			this.props.fetchReceiptCompleted( receiptId, {
+				receipt_id: receiptId,
+				purchases: this.getPurchasesFromReceipt()
+			} );
+		}
+
 
 		return `/checkout/${ this.props.sites.getSelectedSite().slug }/${ receiptId }/thank-you`;
 	},

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -3,6 +3,7 @@
  */
 var connect = require( 'react-redux' ).connect,
 	Dispatcher = require( 'dispatcher' ),
+	forEach = require( 'lodash/forEach' ),
 	isEmpty = require( 'lodash/isEmpty' ),
 	isEqual = require( 'lodash/isEqual' ),
 	page = require( 'page' ),
@@ -17,6 +18,7 @@ var analytics = require( 'analytics' ),
 	DomainDetailsForm = require( './domain-details-form' ),
 	hasDomainDetails = require( 'lib/store-transactions' ).hasDomainDetails,
 	observe = require( 'lib/mixins/data-observe' ),
+	fetchReceiptCompleted = require( 'state/receipts/actions' ).fetchReceiptCompleted,
 	clearSitePlans = require( 'state/sites/plans/actions' ).clearSitePlans,
 	purchasePaths = require( 'me/purchases/paths' ),
 	SecurePaymentForm = require( './secure-payment-form' ),
@@ -118,6 +120,19 @@ const Checkout = React.createClass( {
 		return true;
 	},
 
+	getPurchasesFromReceipt: function() {
+		var purchases = this.props.transaction.step.data.purchases,
+			flatPurchases = [];
+
+		// purchases are of the format { [siteId]: [ { product_id: ... } ] },
+		// so we need to flatten them to get a list of purchases
+		forEach( purchases, sitePurchases => {
+			flatPurchases = flatPurchases.concat( sitePurchases );
+		} );
+
+		return flatPurchases;
+	},
+
 	getCheckoutCompleteRedirectPath: function() {
 		var renewalItem,
 			receiptId = this.props.transaction.step.data.receipt_id;
@@ -133,6 +148,11 @@ const Checkout = React.createClass( {
 
 			return `/plans/${ this.props.sites.getSelectedSite().slug }/thank-you`;
 		}
+
+		this.props.fetchReceiptCompleted( receiptId, {
+			receipt_id: receiptId,
+			purchases: this.getPurchasesFromReceipt()
+		} );
 
 		return `/checkout/${ this.props.sites.getSelectedSite().slug }/${ receiptId }/thank-you`;
 	},
@@ -200,6 +220,9 @@ module.exports = connect(
 		return {
 			clearSitePlans: function( siteId ) {
 				dispatch( clearSitePlans( siteId ) );
+			},
+			fetchReceiptCompleted: function( receiptId, data ) {
+				dispatch( fetchReceiptCompleted( receiptId, data ) );
 			}
 		};
 	}

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -135,7 +135,7 @@ const Checkout = React.createClass( {
 
 	getCheckoutCompleteRedirectPath: function() {
 		var renewalItem,
-			receiptId = ':receipt_id';
+			receiptId = ':receiptId';
 
 		if ( cartItems.hasRenewalItem( this.props.cart ) ) {
 			clearPurchases();
@@ -153,7 +153,7 @@ const Checkout = React.createClass( {
 			receiptId = this.props.transaction.step.data.receipt_id;
 
 			this.props.fetchReceiptCompleted( receiptId, {
-				receipt_id: receiptId,
+				receiptId: receiptId,
 				purchases: this.getPurchasesFromReceipt()
 			} );
 		}

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -119,7 +119,8 @@ const Checkout = React.createClass( {
 	},
 
 	getCheckoutCompleteRedirectPath: function() {
-		var renewalItem;
+		var renewalItem,
+			receiptId = this.props.transaction.step.data.receipt_id;
 
 		if ( cartItems.hasRenewalItem( this.props.cart ) ) {
 			clearPurchases();
@@ -133,8 +134,7 @@ const Checkout = React.createClass( {
 			return `/plans/${ this.props.sites.getSelectedSite().slug }/thank-you`;
 		}
 
-		// TODO: include the receipt ID in this URL when it is present
-		return `/checkout/${ this.props.sites.getSelectedSite().slug }/thank-you`;
+		return `/checkout/${ this.props.sites.getSelectedSite().slug }/${ receiptId }/thank-you`;
 	},
 
 	content: function() {

--- a/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/upgrades/checkout/paypal-payment-box.jsx
@@ -10,7 +10,6 @@ var assign = require( 'lodash/assign' ),
  */
 var analytics = require( 'analytics' ),
 	cartValues = require( 'lib/cart-values' ),
-	CheckoutThankYou = require( './thank-you' ),
 	CountrySelect = require( 'my-sites/upgrades/components/form/country-select' ),
 	Input = require( 'my-sites/upgrades/components/form/input' ),
 	notices = require( 'notices' ),
@@ -104,10 +103,6 @@ module.exports = React.createClass( {
 				} );
 				analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Paypal Button' );
 				analytics.tracks.recordEvent( 'calypso_checkout_with_paypal' );
-				CheckoutThankYou.setLastTransaction( {
-					cart: cart,
-					selectedSite: this.props.selectedSite
-				} );
 				window.location = paypalExpressURL;
 			}
 		}.bind( this ) );

--- a/client/my-sites/upgrades/checkout/purchase-detail.jsx
+++ b/client/my-sites/upgrades/checkout/purchase-detail.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import React from 'react';
 
 /**
@@ -8,24 +9,31 @@ import React from 'react';
  */
 import Button from 'components/button';
 
-const PurchaseDetail = ( { additionalClass, buttonText, description, onButtonClick, title } ) => (
-	<li className={ 'checkout__purchase-detail ' + additionalClass }>
-		<div className="checkout__purchase-detail-text">
-			<h3 className="checkout__purchase-detail-title">{ title }</h3>
-			<p className="checkout__purchase-detail-description">{ description }</p>
-		</div>
-		<Button onClick={ onButtonClick } primary>
-			{ buttonText }
-		</Button>
-	</li>
-);
+const PurchaseDetail = ( { additionalClass, buttonText, description, isPlaceholder, onButtonClick, title } ) => {
+	const classes = classNames( 'checkout__purchase-detail', additionalClass, {
+		'is-placeholder': isPlaceholder
+	} );
+
+	return (
+		<li className={ classes }>
+			<div className="checkout__purchase-detail-text">
+				<h3 className="checkout__purchase-detail-title">{ title }</h3>
+				<p className="checkout__purchase-detail-description">{ description }</p>
+			</div>
+			<Button className="checkout__purchase-detail-button" onClick={ onButtonClick } primary>
+				{ buttonText }
+			</Button>
+		</li>
+	);
+};
 
 PurchaseDetail.propTypes = {
 	additionalClass: React.PropTypes.string,
-	buttonText: React.PropTypes.string.isRequired,
-	description: React.PropTypes.string.isRequired,
-	onButtonClick: React.PropTypes.func.isRequired,
-	title: React.PropTypes.string.isRequired
+	buttonText: React.PropTypes.string,
+	description: React.PropTypes.string,
+	isPlaceholder: React.PropTypes.bool,
+	onButtonClick: React.PropTypes.func,
+	title: React.PropTypes.string
 };
 
 export default PurchaseDetail;

--- a/client/my-sites/upgrades/checkout/style.scss
+++ b/client/my-sites/upgrades/checkout/style.scss
@@ -108,15 +108,36 @@
 			@include noticon( '\f411' );
 		}
 	}
+
+	&.is-placeholder {
+		padding-top: 60px;
+
+		.checkout__purchase-detail-button,
+		.checkout__purchase-detail-description,
+		.checkout__purchase-detail-title {
+			@include placeholder( 23% );
+
+			display: block;
+		}
+
+		.checkout__purchase-detail-button {
+			border: none;
+			margin: 0 auto;
+			width: 50%;
+		}
+
+		.checkout__purchase-detail-description {
+			margin-top: 10px;
+		}
+
+		.checkout__purchase-detail-title {
+			margin: 0 auto;
+			width: 85%;
+		}
+	}
 }
 
 .checkout__purchase-detail-text {
-	&::before {
-		color: lighten( $gray, 20% );
-		@include noticon( '\f803' );
-		top: -8px;
-	}
-
 	@include breakpoint( ">660px" ) {
 		&::before {
 			font-size: 70px;
@@ -132,6 +153,14 @@
 			position: absolute;
 				left: 0;
 		}
+	}
+}
+
+.checkout__purchase-detail:not( .is-placeholder ) .checkout__purchase-detail-text {
+	&::before {
+		color: lighten( $gray, 20% );
+		@include noticon( '\f803' );
+		top: -8px;
 	}
 }
 

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -62,7 +62,7 @@ var CheckoutThankYou = React.createClass( {
 		this.redirectIfThemePurchased();
 		this.refreshSitesAndSitePlansIfPlanPurchased();
 
-		if ( ! this.props.receipt.hasLoadedFromServer && ! this.props.receipt.isRequesting ) {
+		if ( this.props.receiptId && ! this.props.receipt.hasLoadedFromServer && ! this.props.receipt.isRequesting ) {
 			this.props.fetchReceipt( this.props.receiptId );
 		}
 
@@ -87,6 +87,10 @@ var CheckoutThankYou = React.createClass( {
 		}
 	},
 
+	isDataLoaded: function() {
+		return ! this.props.receiptId || this.props.receipt.hasLoadedFromServer;
+	},
+
 	redirectIfThemePurchased: function() {
 		if ( this.props.receipt.hasLoadedFromServer && getPurchases( this.props ).every( isTheme ) ) {
 			this.props.activatedTheme( getPurchases( this.props )[ 0 ].meta, this.props.selectedSite );
@@ -96,7 +100,7 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	thankYouHeader: function() {
-		if ( ! this.props.receipt.hasLoadedFromServer ) {
+		if ( ! this.isDataLoaded() ) {
 			return <h1 className="checkout__thank-you-header">{ this.translate( 'Loading…' ) }</h1>;
 		}
 
@@ -116,7 +120,7 @@ var CheckoutThankYou = React.createClass( {
 		var productName,
 			headerText;
 
-		if ( ! this.props.receipt.hasLoadedFromServer ) {
+		if ( ! this.isDataLoaded() ) {
 			return <h2 className="checkout__thank-you-subheader">{ this.translate( 'Loading…' ) }</h2>;
 		}
 
@@ -144,7 +148,7 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	getSingleProductName() {
-		if ( getPurchases( this.props ).length ) {
+		if ( this.props.receiptId && getPurchases( this.props ).length ) {
 			return getPurchases( this.props )[ 0 ].productNameShort;
 		}
 
@@ -153,7 +157,7 @@ var CheckoutThankYou = React.createClass( {
 
 	render: function() {
 		var classes = classNames( 'checkout__thank-you', {
-			'is-placeholder': ! this.props.receipt.hasLoadedFromServer
+			'is-placeholder': ! this.isDataLoaded()
 		} );
 
 		return (
@@ -176,10 +180,18 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	freeTrialWasPurchased: function() {
+		if ( ! this.props.receiptId ) {
+			return false;
+		}
+
 		return getPurchases( this.props ).some( isFreeTrial );
 	},
 
 	jetpackPlanWasPurchased: function() {
+		if ( ! this.props.receiptId ) {
+			return false;
+		}
+
 		return getPurchases( this.props ).some( isJetpackPlan );
 	},
 
@@ -232,7 +244,7 @@ var CheckoutThankYou = React.createClass( {
 			componentClass,
 			domain;
 
-		if ( ! this.props.receipt.hasLoadedFromServer ) {
+		if ( ! this.isDataLoaded() ) {
 			return (
 				<div>
 					<PurchaseDetail isPlaceholder />
@@ -242,34 +254,38 @@ var CheckoutThankYou = React.createClass( {
 			);
 		}
 
-		purchases = getPurchases( this.props );
+		if ( this.props.receiptId ) {
+			purchases = getPurchases( this.props );
 
-		if ( purchases.some( isJetpackPremium ) ) {
-			componentClass = JetpackPremiumPlanDetails;
-		} else if ( purchases.some( isJetpackBusiness ) ) {
-			componentClass = JetpackBusinessPlanDetails;
-		} else if ( purchases.some( isPremium ) ) {
-			componentClass = PremiumPlanDetails;
-		} else if ( purchases.some( isBusiness ) ) {
-			componentClass = BusinessPlanDetails;
-		} else if ( purchases.some( isGoogleApps ) ) {
-			domain = find( purchases, isGoogleApps ).meta;
+			if ( purchases.some( isJetpackPremium ) ) {
+				componentClass = JetpackPremiumPlanDetails;
+			} else if ( purchases.some( isJetpackBusiness ) ) {
+				componentClass = JetpackBusinessPlanDetails;
+			} else if ( purchases.some( isPremium ) ) {
+				componentClass = PremiumPlanDetails;
+			} else if ( purchases.some( isBusiness ) ) {
+				componentClass = BusinessPlanDetails;
+			} else if ( purchases.some( isGoogleApps ) ) {
+				domain = find( purchases, isGoogleApps ).meta;
 
-			componentClass = GoogleAppsDetails;
-		} else if ( purchases.some( isDomainRegistration ) ) {
-			domain = find( purchases ).meta;
+				componentClass = GoogleAppsDetails;
+			} else if ( purchases.some( isDomainRegistration ) ) {
+				domain = find( purchases ).meta;
 
-			componentClass = DomainRegistrationDetails;
-		} else if ( purchases.some( isDomainMapping ) ) {
-			domain = find( purchases, isDomainMapping ).meta;
+				componentClass = DomainRegistrationDetails;
+			} else if ( purchases.some( isDomainMapping ) ) {
+				domain = find( purchases, isDomainMapping ).meta;
 
-			componentClass = DomainMappingDetails;
-		} else if ( purchases.some( isSiteRedirect ) ) {
-			domain = find( purchases, isSiteRedirect ).meta;
+				componentClass = DomainMappingDetails;
+			} else if ( purchases.some( isSiteRedirect ) ) {
+				domain = find( purchases, isSiteRedirect ).meta;
 
-			componentClass = SiteRedirectDetails;
-		} else if ( purchases.some( isChargeback ) ) {
-			componentClass = ChargebackDetails;
+				componentClass = SiteRedirectDetails;
+			} else if ( purchases.some( isChargeback ) ) {
+				componentClass = ChargebackDetails;
+			} else {
+				componentClass = GenericDetails;
+			}
 		} else {
 			componentClass = GenericDetails;
 		}

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	classNames = require( 'classnames' ),
 	connect = require( 'react-redux' ).connect,
 	find = require( 'lodash/collection/find' ),
 	page = require( 'page' );
@@ -95,20 +96,31 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	thankYouHeader: function() {
+		if ( ! this.props.receipt.hasLoadedFromServer ) {
+			return <h1 className="checkout__thank-you-header">{ this.translate( 'Loading…' ) }</h1>;
+		}
+
 		if ( this.freeTrialWasPurchased() ) {
 			return (
-				<h1>
+				<h1 className="checkout__thank-you-header">
 					{
 						this.translate( 'Your 14 day free trial starts today!' )
 					}
 				</h1>
 			);
 		}
-		return <h1>{ this.translate( 'Thank you for your purchase!' ) }</h1>
+		return <h1 className="checkout__thank-you-header">{ this.translate( 'Thank you for your purchase!' ) }</h1>
 	},
+
 	thankYouSubHeader: function() {
-		var productName = this.getSingleProductName(),
+		var productName,
 			headerText;
+
+		if ( ! this.props.receipt.hasLoadedFromServer ) {
+			return <h2 className="checkout__thank-you-subheader">{ this.translate( 'Loading…' ) }</h2>;
+		}
+
+		productName = this.getSingleProductName();
 
 		if ( this.freeTrialWasPurchased() && productName ) {
 			headerText = this.translate( 'We hope you enjoy %(productName)s. What\'s next? Take it for a spin!', {
@@ -128,8 +140,9 @@ var CheckoutThankYou = React.createClass( {
 			headerText = this.translate( 'You will receive an email confirmation shortly. What\'s next?' );
 		}
 
-		return <h2>{ headerText }</h2>
+		return <h2 className="checkout__thank-you-subheader">{ headerText }</h2>
 	},
+
 	getSingleProductName() {
 		if ( getPurchases( this.props ).length ) {
 			return getPurchases( this.props )[ 0 ].productNameShort;
@@ -139,8 +152,12 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	render: function() {
+		var classes = classNames( 'checkout__thank-you', {
+			'is-placeholder': ! this.props.receipt.hasLoadedFromServer
+		} );
+
 		return (
-			<Main className="checkout-thank-you">
+			<Main className={ classes }>
 				<Card>
 					<div className="thank-you-message">
 						<span className="receipt-icon"></span>
@@ -210,10 +227,22 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	productRelatedMessages: function() {
-		var purchases = getPurchases( this.props ),
-			selectedSite = this.props.selectedSite,
+		var selectedSite = this.props.selectedSite,
+			purchases,
 			componentClass,
 			domain;
+
+		if ( ! this.props.receipt.hasLoadedFromServer ) {
+			return (
+				<div>
+					<PurchaseDetail isPlaceholder />
+					<PurchaseDetail isPlaceholder />
+					<PurchaseDetail isPlaceholder />
+				</div>
+			);
+		}
+
+		purchases = getPurchases( this.props );
 
 		if ( purchases.some( isJetpackPremium ) ) {
 			componentClass = JetpackPremiumPlanDetails;
@@ -259,6 +288,10 @@ var CheckoutThankYou = React.createClass( {
 
 	supportRelatedMessages: function() {
 		var localeSlug = i18n.getLocaleSlug();
+
+		if ( ! this.props.receipt.hasLoadedFromServer ) {
+			return <p>{ this.translate( 'Loading…' ) }</p>;
+		}
 
 		if ( this.jetpackPlanWasPurchased() ) {
 			return (

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -9,7 +9,8 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var Button = require( 'components/button' ),
+var activated = require( 'state/themes/actions' ).activated,
+	Button = require( 'components/button' ),
 	config = require( 'config' ),
 	Dispatcher = require( 'dispatcher' ),
 	Card = require( 'components/card' ),
@@ -87,8 +88,7 @@ var CheckoutThankYou = React.createClass( {
 
 	redirectIfThemePurchased: function() {
 		if ( this.props.receipt.hasLoadedFromServer && getPurchases( this.props ).every( isTheme ) ) {
-			// TODO: move this to checkout.jsx
-			// context.store.dispatch( activated( meta, this.props.selectedSite, source, true ) );
+			this.props.activatedTheme( getPurchases( this.props )[ 0 ].meta, this.props.selectedSite );
 			page.redirect( '/design/' + this.props.selectedSite.slug );
 			return;
 		}
@@ -640,6 +640,9 @@ module.exports = connect(
 	},
 	function mapDispatchToProps( dispatch ) {
 		return {
+			activatedTheme: function( meta, selectedSite ) {
+				dispatch( activated( meta, selectedSite, 'calypstore', true ) );
+			},
 			fetchReceipt: function( receiptId ) {
 				dispatch( fetchReceipt( receiptId ) );
 			},

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -15,6 +15,7 @@ var Button = require( 'components/button' ),
 	Card = require( 'components/card' ),
 	Main = require( 'components/main' ),
 	analytics = require( 'analytics' ),
+	getReceiptById = require( 'state/receipts/selectors' ).getReceiptById,
 	isPlan = require( 'lib/products-values' ).isPlan,
 	{ getPrimaryDomain, isSubdomain } = require( 'lib/domains' ),
 	fetchReceipt = require( 'state/receipts/actions' ).fetchReceipt,
@@ -82,7 +83,9 @@ var CheckoutThankYou = React.createClass( {
 			} );
 		}
 
-		this.props.fetchReceipt( this.props.receiptId );
+		if ( ! this.props.receipt.hasLoadedFromServer && ! this.props.receipt.isRequesting ) {
+			this.props.fetchReceipt( this.props.receiptId );
+		}
 
 		analytics.tracks.recordEvent( 'calypso_checkout_thank_you_view' );
 	},
@@ -630,7 +633,7 @@ function goToDomainManagement( selectedSite, domain ) {
 module.exports = connect(
 	function mapStateToProps( state, props ) {
 		return {
-			receipts: state.receipts
+			receipt: getReceiptById( state, props.receiptId )
 		};
 	},
 	function mapDispatchToProps( dispatch ) {

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -17,6 +17,7 @@ var Button = require( 'components/button' ),
 	analytics = require( 'analytics' ),
 	isPlan = require( 'lib/products-values' ).isPlan,
 	{ getPrimaryDomain, isSubdomain } = require( 'lib/domains' ),
+	fetchReceipt = require( 'state/receipts/actions' ).fetchReceipt,
 	refreshSitePlans = require( 'state/sites/plans/actions' ).refreshSitePlans,
 	i18n = require( 'lib/mixins/i18n' ),
 	PurchaseDetail = require( './purchase-detail' ),
@@ -80,6 +81,8 @@ var CheckoutThankYou = React.createClass( {
 				type: 'FETCH_SITES'
 			} );
 		}
+
+		this.props.fetchReceipt( this.props.receiptId );
 
 		analytics.tracks.recordEvent( 'calypso_checkout_thank_you_view' );
 	},
@@ -625,10 +628,17 @@ function goToDomainManagement( selectedSite, domain ) {
 }
 
 module.exports = connect(
-	undefined,
+	function mapStateToProps( state, props ) {
+		return {
+			receipts: state.receipts
+		};
+	},
 	function mapDispatchToProps( dispatch ) {
 		return {
-			refreshSitePlans( siteId ) {
+			fetchReceipt: function( receiptId ) {
+				dispatch( fetchReceipt( receiptId ) );
+			},
+			refreshSitePlans: function( siteId ) {
 				dispatch( refreshSitePlans( siteId ) );
 			}
 		};

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -66,15 +66,12 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	componentDidMount: function() {
-		var lastTransaction = this.props.lastTransaction,
-			selectedSite;
+		var lastTransaction = this.props.lastTransaction;
 
 		if ( lastTransaction ) {
-			selectedSite = lastTransaction.selectedSite;
-
 			// Refresh selected site plans if the user just purchased a plan
 			if ( cartItems.hasPlan( lastTransaction.cart ) ) {
-				this.props.refreshSitePlans( selectedSite.ID );
+				this.props.refreshSitePlans( this.props.selectedSite.ID );
 			}
 
 			// Refresh the list of sites to update the `site.plan` property
@@ -206,7 +203,7 @@ var CheckoutThankYou = React.createClass( {
 
 	productRelatedMessages: function() {
 		var cart = this.props.lastTransaction.cart,
-			selectedSite = this.props.lastTransaction.selectedSite,
+			selectedSite = this.props.selectedSite,
 			componentClass,
 			domain;
 

--- a/client/my-sites/upgrades/checkout/thank-you.jsx
+++ b/client/my-sites/upgrades/checkout/thank-you.jsx
@@ -4,7 +4,7 @@
 var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	connect = require( 'react-redux' ).connect,
-	find = require( 'lodash/collection/find' ),
+	find = require( 'lodash/find' ),
 	page = require( 'page' );
 
 /**

--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -13,8 +13,7 @@ var React = require( 'react' ), // eslint-disable-line no-unused-vars
 /**
  * Internal dependencies
  */
-var CheckoutThankYou = require( './thank-you' ),
-	analytics = require( 'analytics' ),
+var analytics = require( 'analytics' ),
 	adTracking = require( 'analytics/ad-tracking' ),
 	notices = require( 'notices' ),
 	isFree = require( 'lib/cart-values' ).isFree,
@@ -165,11 +164,6 @@ var TransactionStepsMixin = {
 		if ( ! step.last || step.error ) {
 			return;
 		}
-
-		CheckoutThankYou.setLastTransaction( {
-			cart: cart,
-			selectedSite: selectedSite
-		} );
 
 		defer( () => {
 			// The Thank You page throws a rendering error if this is not in a defer.

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -168,7 +168,12 @@ module.exports = {
 			CartData = require( 'components/data/cart' ),
 			SecondaryCart = require( './cart/secondary-cart' ),
 			storedCards = require( 'lib/stored-cards' )(),
-			basePath = route.sectionify( context.path );
+			basePath = route.sectionify( context.path ),
+			planName = context.params.plan_name;
+
+		if ( 'thank-you' === planName ) {
+			return;
+		}
 
 		analytics.pageView.record( basePath, 'Checkout' );
 
@@ -185,7 +190,7 @@ module.exports = {
 				<CheckoutData>
 					<Checkout
 						cards={ storedCards }
-						planName={ context.params.plan_name }
+						planName={ planName }
 						plans={ plansList }
 						productsList={ productsList }
 						sites={ sites } />
@@ -207,6 +212,7 @@ module.exports = {
 
 	checkoutThankYou: function( context ) {
 		var CheckoutThankYouComponent = require( './checkout/thank-you' ),
+			CheckoutData = require( 'components/data/checkout' ),
 			lastTransaction = CheckoutThankYouComponent.getLastTransaction(),
 			basePath = route.sectionify( context.path );
 
@@ -222,10 +228,14 @@ module.exports = {
 		titleActions.setTitle( i18n.translate( 'Thank You' ) );
 
 		renderWithReduxStore(
-			React.createElement( CheckoutThankYouComponent, {
-				lastTransaction: lastTransaction,
-				productsList: productsList
-			} ),
+			(
+				<CheckoutData>
+					<CheckoutThankYouComponent
+						lastTransaction={ lastTransaction }
+						productsList={ productsList }
+						selectedSite={ sites.getSelectedSite() } />
+				</CheckoutData>
+			),
 			document.getElementById( 'primary' ),
 			context.store
 		);

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -212,7 +212,7 @@ module.exports = {
 	checkoutThankYou: function( context ) {
 		var CheckoutThankYouComponent = require( './checkout/thank-you' ),
 			basePath = route.sectionify( context.path ),
-			receiptId = Number( context.params.receipt_id );
+			receiptId = Number( context.params.receiptId );
 
 		analytics.pageView.record( basePath, 'Checkout Thank You' );
 		context.store.dispatch( setSection( 'checkout-thank-you', { hasSidebar: false } ) );

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -212,9 +212,9 @@ module.exports = {
 
 	checkoutThankYou: function( context ) {
 		var CheckoutThankYouComponent = require( './checkout/thank-you' ),
-			CheckoutData = require( 'components/data/checkout' ),
 			lastTransaction = CheckoutThankYouComponent.getLastTransaction(),
-			basePath = route.sectionify( context.path );
+			basePath = route.sectionify( context.path ),
+			receiptId = Number( context.params.receipt_id );
 
 		analytics.pageView.record( basePath, 'Checkout Thank You' );
 		context.store.dispatch( setSection( 'checkout-thank-you', { hasSidebar: false } ) );
@@ -229,12 +229,11 @@ module.exports = {
 
 		renderWithReduxStore(
 			(
-				<CheckoutData>
-					<CheckoutThankYouComponent
-						lastTransaction={ lastTransaction }
-						productsList={ productsList }
-						selectedSite={ sites.getSelectedSite() } />
-				</CheckoutData>
+				<CheckoutThankYouComponent
+					lastTransaction={ lastTransaction }
+					productsList={ productsList }
+					receiptId={ receiptId }
+					selectedSite={ sites.getSelectedSite() } />
 			),
 			document.getElementById( 'primary' ),
 			context.store
@@ -261,9 +260,16 @@ module.exports = {
 		var CheckoutThankYouComponent = require( './checkout/thank-you' ),
 			cartItems = require( 'lib/cart-values' ).cartItems,
 			lastTransaction = CheckoutThankYouComponent.getLastTransaction(),
-			selectedSite = lastTransaction.selectedSite,
-			cart = lastTransaction.cart,
-			cartAllItems = cartItems.getAll( cart );
+			selectedSite = sites.getSelectedSite,
+			cart,
+			cartAllItems;
+
+		if ( ! lastTransaction ) {
+			return next();
+		}
+
+		cart = lastTransaction.cart,
+		cartAllItems = cartItems.getAll( cart );
 
 		if ( cartItems.hasOnlyProductsOf( cart, 'premium_theme' ) ) {
 			const { meta, extra: { source } } = cartAllItems[ 0 ];

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -277,7 +277,7 @@ module.exports = function() {
 	if ( config.isEnabled( 'upgrades/checkout' ) ) {
 		page(
 			'/checkout/:site/:receiptId?/thank-you',
-			upgradesController.redirectIfThemePurchased,
+			controller.siteSelection,
 			upgradesController.checkoutThankYou
 		);
 

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -12,6 +12,7 @@ import notices from './notices/reducer';
 import posts from './posts/reducer';
 import postTypes from './post-types/reducer';
 import plugins from './plugins/reducer';
+import receipts from './receipts/reducer';
 import sharing from './sharing/reducer';
 import sites from './sites/reducer';
 import siteSettings from './site-settings/reducer';
@@ -30,6 +31,7 @@ export const reducer = combineReducers( {
 	notices,
 	posts,
 	postTypes,
+	receipts,
 	sharing,
 	sites,
 	siteSettings,

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -4,7 +4,7 @@ export function createReceiptObject( data ) {
 		purchases: data.purchases.map( purchase => {
 			return {
 				freeTrial: purchase.free_trial,
-				isDomainRegistration: Boolean( purchase.isDomainRegistration ),
+				isDomainRegistration: Boolean( purchase.is_domain_registration ),
 				meta: purchase.meta,
 				productId: purchase.product_id,
 				productSlug: purchase.product_slug,


### PR DESCRIPTION
Fixes #2235.

This PR updates the checkout process, and:
- Changes the route for the checkout thank you page from `/checkout/thank-you` to `/checkout/:site_slug/:receipt_id/thank-you`.
- Adds actions/a reducer/selector to fetch a receipt from the server and store it in the global state tree.
- Dispatches an action to store a receipt when a transaction is completed successfully.
- Fetches a receipt on the thank you page.
- Updates the thank you page to render using purchases from the receipt, instead of items from the last cart.
- Removes `lastTransaction` from local storage, and any logic that used to use that property.

#### Testing instructions - Credit card

1. Run `git checkout fix/thank-you-page` and start your server
2. Open the [`Plans` page](http://calypso.localhost:3000/plans/:site)
3. Purchase a plan with a credit credit card
4. Assert that you are redirect to the thank you page with the correct information on it
5. Navigate to another page (like reader)
6. Assert that clicking back reloads the thank you page

#### Testing instructions - PayPal

1. Run `git checkout fix/thank-you-page` and start your server
2. Open the [`Plans` page](http://calypso.localhost:3000/plans/:site)
3. Purchase a plan with paypal
4. Go through the paypal flow
4. Assert that you are redirect to the thank you page with the correct information on it
5. Navigate to another page (like reader)
6. Assert that clicking back reloads the thank you page

#### Testing instructions - generic thank you page
1. Visit `/checkout/:site/thank-you` for any site.
2. Assert that you see a [generic thank you page](https://cloudup.com/cpStlBbu7LJ).

#### Additional notes

Also worth testing:
- different plans
- premium themes
- domains

#### Reviews

- [x] Code
- [x] Product