### PR TITLE
Themes: Bootstrap theme-details store for theme sheets

### DIFF
--- a/client/components/data/theme-details/index.js
+++ b/client/components/data/theme-details/index.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */
@@ -23,6 +25,10 @@ const ThemeDetailsData = React.createClass( {
 		// Connected props
 		name: React.PropTypes.string,
 		author: React.PropTypes.string,
+		screenshot: React.PropTypes.string,
+		description: React.PropTypes.string,
+		descriptionLong: React.PropTypes.string,
+		supportDocumentation: React.PropTypes.string,
 		fetchThemeDetails: React.PropTypes.func.isRequired
 	},
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1471,10 +1471,11 @@ Undocumented.prototype.themes = function( site, query, fn ) {
 };
 
 Undocumented.prototype.themeDetails = function( themeId, fn ) {
+	const path = `/themes/${ themeId }`;
 	debug( '/themes/:theme_id' );
-	this.wpcom.req.get( {
+	this.wpcom.req.get( path, {
 		apiVersion: '1.1',
-		path: '/themes/' + themeId
+		extended: 'true',
 	}, fn );
 };
 

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -12,6 +12,7 @@ import SingleSiteComponent from 'my-sites/themes/single-site';
 import MultiSiteComponent from 'my-sites/themes/multi-site';
 import LoggedOutComponent from 'my-sites/themes/logged-out';
 import { ThemeSheet as ThemeSheetComponent } from 'my-sites/themes/sheet';
+import ThemeDetailsComponent from 'components/data/theme-details';
 import analytics from 'analytics';
 import i18n from 'lib/mixins/i18n';
 import trackScrollPage from 'lib/track-scroll-page';
@@ -145,7 +146,16 @@ export function details( context, next ) {
 		isFullScreen: true
 	} ) );
 
-	context.primary = makeElement( ThemeSheetComponent, Head, context.store, props );
 	context.secondary = null; // When we're logged in, we need to remove the sidebar.
+	//TODO: use makeElement()
+	context.primary = (
+		<ReduxProvider store={ context.store } >
+			<Head title={ props.title } isSheet>
+				<ThemeDetailsComponent id={ props.themeSlug } section={ props.contentSection } >
+					<ThemeSheetComponent />
+				</ThemeDetailsComponent>
+			</Head>
+		</ReduxProvider>
+	);
 	next();
 }

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -88,7 +88,12 @@ export function fetchThemeDetails( id ) {
 					type: ActionTypes.RECEIVE_THEME_DETAILS,
 					themeId: data.id,
 					themeName: data.name,
-					themeAuthor: data.author
+					themeAuthor: data.author,
+					themePrice: data.price ? data.price.display : undefined,
+					themeScreenshot: data.screenshot,
+					themeDescription: data.description,
+					themeDescriptionLong: data.description_long,
+					themeSupportDocumentation: data.extended ? data.extended.support_documentation : undefined,
 				} );
 			}
 		};

--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -15,8 +15,13 @@ export default ( state = Map(), action ) => {
 			return state
 				.set( action.themeId, Map( {
 					name: action.themeName,
-					author: action.themeAuthor
-				} ) )
+					author: action.themeAuthor,
+					price: action.themePrice,
+					screenshot: action.themeScreenshot,
+					description: action.themeDescription,
+					descriptionLong: action.themeDescriptionLong,
+					supportDocumentation: action.themeSupportDocumentation,
+				} ) );
 		case DESERIALIZE:
 		case SERVER_DESERIALIZE:
 			return fromJS( state );

--- a/client/state/themes/theme-details/selectors.js
+++ b/client/state/themes/theme-details/selectors.js
@@ -1,3 +1,6 @@
+/** @ssr-ready **/
+
 export function getThemeDetails( state, id ) {
-	return state.themes.themeDetails.get( id ).toJS();
+	const theme = state.themes.themeDetails.get( id );
+	return theme ? theme.toJS() : undefined;
 }

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -24,12 +24,22 @@ describe( 'reducer', () => {
 			type: RECEIVE_THEME_DETAILS,
 			themeId: 'mood',
 			themeName: 'Mood',
-			themeAuthor: 'Automattic'
+			themeAuthor: 'Automattic',
+			themeScreenshot: 'mood.jpg',
+			themePrice: '$20',
+			themeDescription: 'the best theme ever invented',
+			themeDescriptionLong: 'the plato form of a theme',
+			themeSupportDocumentation: 'support comes from within',
 		} );
 
 		expect( state.get( 'mood' ).toJS() ).to.eql( {
 			name: 'Mood',
-			author: 'Automattic'
+			author: 'Automattic',
+			screenshot: 'mood.jpg',
+			price: '$20',
+			description: 'the best theme ever invented',
+			descriptionLong: 'the plato form of a theme',
+			supportDocumentation: 'support comes from within',
 		} );
 	} );
 


### PR DESCRIPTION
* Add the theme-details data component to the layout
* Fetch and cache theme details server-side and bootstrap to the client

![screen shot 2016-02-23 at 21 24 01](https://cloud.githubusercontent.com/assets/215074/13267174/cd739670-da73-11e5-90fa-85bd87690d45.png)

**To Test**
Go to http://calypso.localhost:3000/themes/{theme} both logged-in and logged-out
