### PR TITLE
Signup: Add alternative theme selection AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,4 +81,13 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
+	altThemes: {
+		datestamp: '20160215',
+		variations: {
+			original: 20,
+			altThemes: 20,
+			notTested: 60
+		},
+		defaultVariation: 'original'
+	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -11,6 +11,7 @@ var assign = require( 'lodash/object/assign' ),
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
 	abtest = require( 'lib/abtest' ).abtest,
+	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	user = require( 'lib/user' )();
 
 function getCheckoutDestination( dependencies ) {
@@ -172,7 +173,21 @@ const flows = {
 		destination: getCheckoutDestination,
 		description: 'Signup flow for free trials',
 		lastModified: '2015-12-18'
-	}
+	},
+
+	'website-altthemes': {
+		steps: [ 'survey', 'altthemes', 'domains', 'plans', 'user' ],
+		destination: getCheckoutDestination,
+		description: 'Alternative theme selection for the users who clicked "Create Website" on the two-button homepage.',
+		lastModified: '2016-02-12'
+	},
+
+	'blog-altthemes': {
+		steps: [ 'survey', 'altthemes', 'domains', 'plans', 'user' ],
+		destination: getCheckoutDestination,
+		description: 'Alternative theme selection for the users who clicked "Create blog" on the two-button homepage.',
+		lastModified: '2016-02-12'
+	},
 };
 
 function removeUserStepFromFlow( flow ) {
@@ -189,6 +204,13 @@ function filterFlowName( flowName ) {
 	const headstartFlows = [ 'blog', 'website' ];
 	if ( includes( headstartFlows, flowName ) && 'headstart' === abtest( 'headstart' ) ) {
 		return 'headstart';
+	}
+
+	const altThemesFlows = [ 'blog', 'website' ];
+	if ( includes( altThemesFlows, flowName ) && 'notTested' === getABTestVariation( 'headstart' ) ) {
+		if ( 'altThemes' === abtest( 'altThemes' ) ) {
+			return ( 'blog' === flowName ) ? 'blog-altthemes' : 'website-altthemes';
+		}
 	}
 	return flowName;
 }

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -22,6 +22,7 @@ module.exports = {
 	survey: SurveyStepComponent,
 	'design-type': DesignTypeComponent,
 	'themes-headstart': ThemeSelectionComponent,
+	altthemes: ThemeSelectionComponent,
 	'domains-with-theme': DomainsStepComponent,
 	'jetpack-user': UserSignupComponent
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -25,6 +25,25 @@ module.exports = {
 		providesDependencies: [ 'theme' ]
 	},
 
+	altthemes: {
+		stepName: 'altthemes',
+		props: {
+			themes: [
+				{ name: 'Dyad', slug: 'dyad' },
+				{ name: 'Independent Publisher', slug: 'independent-publisher' },
+				{ name: 'Sela', slug: 'sela' },
+				{ name: 'Hemingway Rewritten', slug: 'hemingway-rewritten' },
+				{ name: 'Twenty Sixteen', slug: 'twentysixteen' },
+				{ name: 'Penscratch', slug: 'penscratch' },
+				{ name: 'Edin', slug: 'edin' },
+				{ name: 'Publication', slug: 'publication' },
+				{ name: 'Harmonic', slug: 'harmonic' },
+			],
+		},
+		apiRequestFunction: stepActions.setThemeOnSite,
+		dependencies: [ 'siteSlug' ]
+	},
+
 	'design-type': {
 		stepName: 'design-type',
 		providesDependencies: [ 'themes' ]


### PR DESCRIPTION
The current default theme selection (Boardwalk, Cubic, etc.) is way overdue for a update. We need more recent themes for it and start to iterate on it and improve it. This is a first step of the effort and I'd like to test with the following new themes.

![screen shot 2016-02-12 at 18 05 16](https://cloud.githubusercontent.com/assets/908665/13015850/439ceaf0-d1b3-11e5-97f0-8f7580e20ea1.png)

Currently, Headstart test is going on (#3233), and to avoid to break the test, this alternative theme test will only be conducted with the user who are not in the Headtstart test, and who are coming from the two button WordPress.com homepage. This might make the sample size smaller but will avoid variations that could disturb analysing the data we get.

### Testing Instraction:

1. Change `active-tests.js`L77 and L86 and set it to a high number, to force the assignments.
2. Log out if you're logged-in. (Or just use the incognito mode)
3. Visit the signup flow `/start/website/en/?ref=homepage`and verify that you see the survey.
4. Choose some categories, and verify that you see the new themes as shown in the screenshot above.
5. Complete the signup flow and verify that the new site is created correctly.
6. Repeat all steps with the blog flow `/start/blog/en/?ref=homepage`.