### PR TITLE
sync-handler: setup localforage in constructor()

### DIFF
--- a/client/lib/wp/sync-handler/index.js
+++ b/client/lib/wp/sync-handler/index.js
@@ -28,7 +28,10 @@ export class SyncHandler {
 			setup = {};
 		}
 
+		// setup localforage configuration
 		this.setup = Object.assign( {}, defaults, setup );
+		localforage.config( this.setup );
+
 		this.reqHandler = handler;
 		return this.syncHandlerWrapper( handler );
 	}
@@ -178,19 +181,16 @@ export class SyncHandler {
 	}
 
 	retrieveRecord( key, fn = () => {} ) {
-		localforage.config( this.setup );
 		debug( 'getting data from %o key\n', key );
 		return localforage.getItem( key, fn );
 	}
 
 	storeRecord( key, data, fn = () => {} ) {
-		localforage.config( this.setup );
 		debug( 'storing data in %o key\n', key );
 		return localforage.setItem( key, data, fn );
 	}
 
 	removeRecord( key, fn = () => {} ) {
-		localforage.config( this.setup );
 		debug( 'removing %o key\n', key );
 		return localforage.removeItem( key, fn );
 	}


### PR DESCRIPTION
No make sense set up the localforage config every time that we're interacting with it. For now it will be configured when a SyncHandler instance is created. The final soluction will be creating a new component for this (#3282)

> [Set and persist localForage options. This must be called before any other calls to localForage are made, but can be called after localForage is loaded. If you set any config values with this method they will persist after driver changes, so you can call config() then setDriver()
](https://mozilla.github.io/localForage/#config)

cc @rralian @gwwar 