### PR TITLE
Importer: pre-select author when site has only one author

### DIFF
--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -32,6 +32,14 @@ export default React.createClass( {
 		} ).isRequired
 	},
 
+	componentWillMount() {
+		const { hasSingleAuthor, onSelect: selectAuthor } = this.props;
+
+		if ( hasSingleAuthor ) {
+			selectAuthor( this.getCurrentUser() );
+		}
+	},
+
 	getCurrentUser() {
 		const currentUser = user().get();
 


### PR DESCRIPTION
Issue #3272 was happening because a selected author was only being
saved to the state when chosen via the authorSelect component. Sites
with only one author do not show authorSelect, and in that case, we
need to automatically pre-select the one-and-only author.

Closes #3272 

To test:

1. on master, try to complete an import on a site that has only one author, and note that the error described in #3272 occours
2. checkout this branch
3. try to complete an import again, and celebrate it's completion

cc: @dmsnell 