### PR TITLE
People: Update invite validation after changing role

### DIFF
--- a/client/lib/invites/reducers/invites-create-validation.js
+++ b/client/lib/invites/reducers/invites-create-validation.js
@@ -17,7 +17,9 @@ const reducer = ( state = initialState, payload ) => {
 	const { action } = payload;
 	switch ( action.type ) {
 		case ActionTypes.RECEIVE_CREATE_INVITE_VALIDATION_SUCCESS:
-			return state.setIn( [ 'success', action.siteId ], action.data.success ).setIn( [ 'errors', action.siteId ], action.data.errors );
+			return state
+				.setIn( [ 'success', action.siteId, action.role ], action.data.success )
+				.setIn( [ 'errors', action.siteId, action.role ], action.data.errors );
 	}
 	return state;
 }

--- a/client/lib/invites/stores/invites-create-validation.js
+++ b/client/lib/invites/stores/invites-create-validation.js
@@ -6,7 +6,7 @@ import { reducer, initialState } from 'lib/invites/reducers/invites-create-valid
 
 const InvitesCreateValidationStore = createReducerStore( reducer, initialState );
 
-InvitesCreateValidationStore.getSuccess = ( siteId ) => InvitesCreateValidationStore.get().getIn( [ 'success', siteId ] );
-InvitesCreateValidationStore.getErrors = ( siteId ) => InvitesCreateValidationStore.get().getIn( [ 'errors', siteId ] );
+InvitesCreateValidationStore.getSuccess = ( siteId, role ) => InvitesCreateValidationStore.get().getIn( [ 'success', siteId, role ] );
+InvitesCreateValidationStore.getErrors = ( siteId, role ) => InvitesCreateValidationStore.get().getIn( [ 'errors', siteId, role ] );
 
 export default InvitesCreateValidationStore;

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import LinkedStateMixin from 'react-addons-linked-state-mixin';
 import page from 'page';
 import get from 'lodash/object/get';
 import debugModule from 'debug';
@@ -32,8 +31,6 @@ const debug = debugModule( 'calypso:my-sites:people:invite' );
 
 export default React.createClass( {
 	displayName: 'InvitePeople',
-
-	mixins: [ LinkedStateMixin ],
 
 	componentDidMount() {
 		InvitesCreateValidationStore.on( 'change', this.refreshValidation );
@@ -79,9 +76,15 @@ export default React.createClass( {
 		this.setState( { message: event.target.value } );
 	},
 
+	onRoleChange( event ) {
+		const role = event.target.value;
+		this.setState( { role } );
+		createInviteValidation( this.props.site.ID, this.state.usernamesOrEmails, role );
+	},
+
 	refreshValidation() {
-		const errors = InvitesCreateValidationStore.getErrors( this.props.site.ID ) || [];
-		let success = InvitesCreateValidationStore.getSuccess( this.props.site.ID ) || [];
+		const errors = InvitesCreateValidationStore.getErrors( this.props.site.ID, this.state.role ) || [];
+		let success = InvitesCreateValidationStore.getSuccess( this.props.site.ID, this.state.role ) || [];
 		if ( ! success.indexOf ) {
 			success = Object.keys( success ).map( key => success[ key ] );
 		}
@@ -178,7 +181,8 @@ export default React.createClass( {
 							key="role"
 							includeFollower
 							siteId={ this.props.site.ID }
-							valueLink={ this.linkState( 'role' ) }
+							onChange={ this.onRoleChange }
+							value={ this.state.role }
 							disabled={ this.state.sendingInvites }
 							explanation={ this.renderRoleExplanation() }
 							/>


### PR DESCRIPTION
Previously, usernames and email addresses were not validated again after changing a role. This led to stale, incorrect validation.

For example, if I were to try to send a follower invite to a blog I was an admin of, that would validate because I wasn't already a follower. But, if I then switched the role to say 'editor', no error would show. :scream: 

This PR fixes that by ensuring that we also check the role when setting and retrieving validations.

To test:
- Checkout `update/people-invites-create-validation-role`
- Go to `/people/new/$site`
- In the console, run `localStorage.setItem( 'debug', 'calypso:my-sites:people:invite' );`
- Add a user to send an invite to
- Change role
- Ensure that validation is updated

cc @lezama for review
