### PR TITLE
Customizer / Posts: load the Customizer and post previews on sites that disallow iframes

### DIFF
--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -49,6 +49,12 @@ var utils = {
 			if ( site.options.is_mapped_domain ) {
 				previewUrl = previewUrl.replace( site.URL, site.options.unmapped_url );
 			}
+			if ( site.options && site.options.frame_nonce ) {
+				parsed = url.parse( previewUrl, true );
+				parsed.query['frame-nonce'] = site.options.frame_nonce;
+				delete parsed.search;
+				previewUrl = url.format( parsed );
+			}
 		}
 
 		return previewUrl;

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -197,11 +197,15 @@ var Customize = React.createClass( {
 	buildCustomizerQuery: function() {
 		var protocol = window.location.protocol,
 			host = window.location.host,
-			query = cloneDeep( this.props.query );
+			query = cloneDeep( this.props.query ),
+			site = this.getSite();
 
 		query.return = protocol + '//' + host + this.getPreviousPath();
 		query.calypso = true;
 		query.calypsoOrigin = protocol + '//' + host;
+		if ( site.options && site.options.frame_nonce ) {
+			query['frame-nonce'] = site.options.frame_nonce;
+		}
 
 		return Qs.stringify( query );
 	},


### PR DESCRIPTION
We have some higher-security sites that always force the `x-frame-options: SAMEORIGIN`
HTTP header, breaking the Customizer and post previewing. We allow unsetting this header
through a nonce, which is now included in REST API responses for sites.

This may pave the way for increasing the security for everyone by enabling said HTTP
header on all WP.com sites.

## To Test

Someone from Automattic will need to try post previews and/or the Customizer with an internal site. You may need to clear out your `localStorage` to ensure that your site responses are fresh and contain the nonce (`site.options.frame_nonce`)