### PR TITLE
Pickup new xgettext version to fix #3239

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "wpcom-proxy-request": "1.0.5",
     "wpcom-unpublished": "1.0.8",
     "wpcom-xhr-request": "0.3.3",
-    "xgettext-js": "0.2.0"
+    "xgettext-js": "0.2.2"
   },
   "engines": {
     "node": ">=4.3.0"


### PR DESCRIPTION
We've updated xgettext-js https://github.com/Automattic/xgettext-js/pull/6.  Once we publish that package, this PR picks up the new version

To verify the fix:
1) run `make translate` in this branch
2) rename `calypso-strings.php`
3) `npm update xgettext-js`
4)  Run `make translate` again
5) diff the new `calypso-strings.php` against the old one.

We want to verify that:
1) We pick up the strings we were missing before (e.g. 'Arts & Entertainment')
2) We keep all the other strings we should.

P.S. I'm on holiday with my family at the moment, but need to get this in before the i18n weekly kit goes out on Monday.  If the PR looks good, I'd appreciate having it merged :)