### PR TITLE
People: Normalize invite create validations in the reducer

### DIFF
--- a/client/lib/invites/reducers/invites-create-validation.js
+++ b/client/lib/invites/reducers/invites-create-validation.js
@@ -8,6 +8,16 @@ import { fromJS } from 'immutable';
  */
 import { action as ActionTypes } from 'lib/invites/constants';
 
+function normalizeSuccessValidations( validations ) {
+	if ( Array.isArray( validations ) ) {
+		return validations;
+	}
+
+	// Since success validations can be returned from the API as an object,
+	// let's normalize these so that we store an array.
+	return Object.keys( validations ).map( key => validations[ key ] );
+}
+
 const initialState = fromJS( {
 	success: {},
 	errors: {}
@@ -18,7 +28,7 @@ const reducer = ( state = initialState, payload ) => {
 	switch ( action.type ) {
 		case ActionTypes.RECEIVE_CREATE_INVITE_VALIDATION_SUCCESS:
 			return state
-				.setIn( [ 'success', action.siteId, action.role ], action.data.success )
+				.setIn( [ 'success', action.siteId, action.role ], normalizeSuccessValidations( action.data.success ) )
 				.setIn( [ 'errors', action.siteId, action.role ], action.data.errors );
 	}
 	return state;

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -85,9 +85,6 @@ export default React.createClass( {
 	refreshValidation() {
 		const errors = InvitesCreateValidationStore.getErrors( this.props.site.ID, this.state.role ) || [];
 		let success = InvitesCreateValidationStore.getSuccess( this.props.site.ID, this.state.role ) || [];
-		if ( ! success.indexOf ) {
-			success = Object.keys( success ).map( key => success[ key ] );
-		}
 
 		this.setState( {
 			errors,


### PR DESCRIPTION
Previously, successful validations were normalized when updating the state in the invite form component. But, that could be an issue if the data is needed in more than one place.

This PR normalizes the success validations, which can sometimes be return as an object or an array, in the reducer so that components can simply retrieve the data.

To test:
- Checkout `update/people-invite-create-validate-normalizze` branch
- Go to `/people/new/$site`
- Attempt to add usernames or email addresses 
- Ensure that nothing is broken :)
- To test if validation works properly, you can test that tokens get a status by entering `localStorage.setItem( 'debug', 'calypso:my-sites:people:invites' );` in the console

cc @lezama  for review since he worked on the initial normalization and has a better handle on the issues.