### PR TITLE
Reader: Fetch feed info when spinning up a site stream.

### DIFF
--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -10,8 +10,12 @@ var FeedHeader = require( 'reader/feed-header' ),
 	SiteStoreActions = require( 'lib/reader-site-store/actions' ),
 	SiteState = require( 'lib/reader-site-store/constants' ).state,
 	FeedError = require( 'reader/feed-error' ),
+	FeedStore = require( 'lib/feed-store' ),
+	FeedStoreActions = require( 'lib/feed-store/actions' ),
+	FeedState = require( 'lib/feed-store/constants' ).state,
 	FeedStreamStoreActions = require( 'lib/feed-stream-store/actions' ),
-	feedStreamFactory = require( 'lib/feed-stream-store' );
+	feedStreamFactory = require( 'lib/feed-stream-store' ),
+	smartSetState = require( 'lib/react-smart-set-state' );
 
 function checkForRedirect( site ) {
 	if ( site && site.get( 'prefer_feed' ) && site.get( 'feed_ID' ) ) {
@@ -28,56 +32,73 @@ const SiteStream = React.createClass( {
 	},
 
 	getInitialState: function() {
-		const site = SiteStore.get( this.props.siteId );
-		checkForRedirect( site );
-		return {
-			site: SiteStore.get( this.props.siteId ),
-			title: this.getTitle()
-		};
+		return this.getState();
 	},
 
 	componentDidMount: function() {
 		SiteStore.on( 'change', this.updateState );
+		FeedStore.on( 'change', this.updateState );
 	},
 
 	componentWillUnmount: function() {
 		SiteStore.off( 'change', this.updateState );
+		FeedStore.off( 'change', this.updateState );
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
 		if ( nextProps.siteId !== this.props.siteId ) {
-			this.updateState();
+			this.updateState( nextProps );
 		}
 	},
 
-	updateState: function() {
-		var site = SiteStore.get( this.props.siteId ),
-			newTitle = this.getTitle();
+	smartSetState: smartSetState,
+
+	getState: function( props = this.props ) {
+		const { site, feed } = this.getSiteAndFeed( props.siteId );
 		checkForRedirect( site );
-		if ( newTitle !== this.state.title || site !== this.state.site ) {
-			this.setState( {
-				title: newTitle,
-				site: site
-			} );
-		}
+
+		let state = {
+			feed: feed,
+			site: site,
+			title: this.getTitle( site )
+		};
+
+		return state;
 	},
 
-	getSite: function() {
-		var site = SiteStore.get( this.props.siteId );
+	updateState: function( props = this.props ) {
+		var state = this.getState( props );
+		checkForRedirect( state.site );
+		this.smartSetState( state );
+	},
+
+	getSiteAndFeed: function( siteId ) {
+		var site = SiteStore.get( siteId ),
+			feed;
 
 		if ( ! site ) {
-			SiteStoreActions.fetch( this.props.siteId );
+			SiteStoreActions.fetch( siteId );
 		}
 
 		if ( site && site.get( 'state' ) !== SiteState.COMPLETE ) {
 			site = null; // don't accept an incomplete or error site
 		}
 
-		return site;
+		if ( site && site.get( 'feed_ID' ) ) {
+			feed = FeedStore.get( site.get( 'feed_ID' ) );
+			if ( ! feed ) {
+				setTimeout( () => {
+					FeedStoreActions.fetch( site.get( 'feed_ID' ) )
+				}, 0 );
+			} else if ( feed.state !== FeedState.COMPLETE ) {
+				feed = null;
+			}
+		}
+
+		return { site, feed };
 	},
 
-	getTitle: function() {
-		var site = this.getSite();
+	getTitle: function( site ) {
 		if ( ! site ) {
 			return;
 		}
@@ -122,7 +143,7 @@ const SiteStream = React.createClass( {
 		return (
 			<FollowingStream { ...this.props } listName={ title } emptyContent={ emptyContent }>
 				{ this.props.showBack && <HeaderBack /> }
-				<FeedHeader site={ this.state.site } />
+				<FeedHeader site={ this.state.site } feed={ this.state.feed }/>
 				{ featuredContent }
 			</FollowingStream>
 


### PR DESCRIPTION
This adds the Follow button back to site stream headers. Discover is a site stream, so it fixes that too.

To test, pull up the Discover stream and make sure a Follow button appears.