### PR TITLE
Reader: fix placement of 'no results' message when adding a feed in Manage Following

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -228,7 +228,8 @@
 
 // Followed Sites and Search Transitions
 .following-edit__sites,
-.following-edit .search-card {
+.following-edit .search-card,
+.following-edit .no-results {
 	transition: all 0.2s ease-in-out;
 }
 
@@ -239,6 +240,10 @@
 	pointer-events: none;
 }
 
+.is-adding .no-results {
+	opacity: 0.3;
+	margin-top: 85px;
+}
 
 // Followed Site Cards
 .following-edit .reader-list-item__card {


### PR DESCRIPTION
Before: 

<img width="760" alt="screen shot 2016-02-15 at 12 39 05" src="https://cloud.githubusercontent.com/assets/17325/13037261/c48283f2-d3e1-11e5-8ca0-ae540bc748db.png">

After:

<img width="786" alt="screen shot 2016-02-15 at 12 39 16" src="https://cloud.githubusercontent.com/assets/17325/13037262/c482d92e-d3e1-11e5-8572-3a5f0c64e9ad.png">

### To test

1. Load Manage Following and enter a search term that doesn't exist in your subscriptions (this should do it: http://calypso.localhost:3000/following/edit?s=thisisdefinitelynotinyoursubscriptions)
2. Click 'Follow Site' at the top right, and ensure that the 'no results' message appears in the correct position
3. Close the Follow Site input by pressing 'X' and ensure that the 'no results' message still appears in the correct position

Fixes #3234.