### PR TITLE
Try/isomorphic routing

### DIFF
--- a/client/layout/logged-out-design.jsx
+++ b/client/layout/logged-out-design.jsx
@@ -12,10 +12,8 @@ import { connect } from 'react-redux';
  */
 import MasterbarMinimal from 'layout/masterbar/minimal';
 import ThemesHead from 'my-sites/themes/head';
-import ThemeSheetComponent from 'my-sites/themes/sheet';
 
-const LayoutLoggedOutDesign = ( { routeName, match, section, hasSidebar, isFullScreen, tier = 'all' } ) => {
-	const primary = routeName === 'themes' ? <ThemeSheetComponent themeSlug={ match.theme_slug } /> : null;
+const LayoutLoggedOutDesign = ( { primary, section, hasSidebar, isFullScreen, tier = 'all' } ) => {
 	const sectionClass = section ? 'is-section-' + section : '';
 	const classes = classNames( 'wp layout', sectionClass, {
 		'focus-content': true,
@@ -25,7 +23,7 @@ const LayoutLoggedOutDesign = ( { routeName, match, section, hasSidebar, isFullS
 
 	return (
 		<div className={ classes }>
-			<ThemesHead tier={ tier } isSheet={ routeName === 'themes' } />
+			<ThemesHead tier={ tier } isSheet={ section === 'themes' } />
 			<MasterbarMinimal url="/" />
 			<div id="content" className="wp-content">
 				<div id="primary" className="wp-primary wp-section">

--- a/client/sections.js
+++ b/client/sections.js
@@ -69,7 +69,8 @@ sections = [
 		name: 'themes',
 		paths: [ '/design', '/themes' ],
 		module: 'my-sites/themes',
-		enableLoggedOut: config.isEnabled( 'manage/themes/logged-out' )
+		enableLoggedOut: config.isEnabled( 'manage/themes/logged-out' ),
+		routing: config( 'env' ) === 'development' ? 'isomorphic' : ''
 	},
 	{
 		name: 'upgrades',

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -1,0 +1,87 @@
+/**
+ * External dependecies
+ */
+var React = require( 'react' ),
+	ReduxProvider = require( 'react-redux' ).Provider,
+	pick = require( 'lodash/object/pick' ),
+	isEmpty = require( 'lodash/lang/isEmpty' );
+
+/**
+ * Internal dependecies
+ */
+var config = require( 'config' ),
+	sections = require( '../../client/sections' ),
+	LayoutLoggedOutDesign = require( 'layout/logged-out-design' ),
+	render = require( 'render' ).render,
+	createReduxStore = require( 'state' ).createReduxStore,
+	setSection = require( 'state/ui/actions' ).setSection;
+
+function getEnhancedContext( context, req ) {
+	return Object.assign( {}, context, {
+		path: req.path,
+		params: Object.assign( {}, context.params, req.params ),
+		query: {}
+	} );
+}
+
+module.exports = function( expressApp, getDefaultContext ) {
+	sections
+		.filter( function( section ) {
+			return section.routing === 'isomorphic';
+		} )
+		.forEach( function( section ) {
+			// Since each middleware can mutate context, we need to set it up here
+			// and preserve it over iterations. If this turns out to be too complex,
+			// we might want to resort to the inverse approach, i.e. using
+			// https://github.com/kethinov/page.js-express-mapper.js on the client side.
+			let context = {};
+			let store = createReduxStore();
+
+			function setUpRoute( req, res, next ) {
+				context.isServerSide = true;
+				context.isLoggedIn = req.cookies.wordpress_logged_in;
+
+				store.dispatch( setSection( section.name, { hasSidebar: false, isFullScreen: true } ) ); // FIXME
+				context.initialReduxState = pick( store.getState(), 'ui' );
+				next();
+			};
+
+			function liftMiddleware( pageMiddleware ) {
+				return function( req, res, next ) {
+					if ( isEmpty( context ) ) {
+						context = getDefaultContext( req );
+					}
+					getEnhancedContext( context, req ); // Update path etc.
+					pageMiddleware( context, next );
+				}
+			};
+
+			function serverRouter( route, ...mws ) {
+				expressApp.get( route, mws.map( liftMiddleware ) );
+			};
+
+			function serverRender( req, res ) {
+				if ( config.isEnabled( 'server-side-rendering' ) ) {
+					Object.assign( context, render( (
+						<ReduxProvider store={ store }>
+							<LayoutLoggedOutDesign store={ store } primary={ context.primary } />
+						</ReduxProvider>
+					) ) ); // FIXME: tier (general props), Head
+				}
+				res.render( 'index.jade', context );
+			};
+
+			// Maybe inline those functions below?
+
+			// Top-level routes
+			section.paths.forEach( function( path ) {
+				expressApp.get( path, setUpRoute );
+			} );
+			// Individual routes from chunk
+			require( 'client/' + section.module )( serverRouter ); // possibly also pass context.isLoggedIn/isServerSide?
+			// Render!
+			section.paths.forEach( function( path ) {
+				expressApp.get( path, serverRender );
+			} );
+		} );
+};

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -25,7 +25,7 @@ function getEnhancedContext( context, req ) {
 }
 
 module.exports = function( expressApp, getDefaultContext ) {
-	sections
+	sections.get()
 		.filter( function( section ) {
 			return section.routing === 'isomorphic';
 		} )
@@ -78,7 +78,7 @@ module.exports = function( expressApp, getDefaultContext ) {
 				expressApp.get( path, setUpRoute );
 			} );
 			// Individual routes from chunk
-			require( 'client/' + section.module )( serverRouter ); // possibly also pass context.isLoggedIn/isServerSide?
+			sections.require( section.module )( serverRouter ); // possibly also pass context.isLoggedIn/isServerSide?
 			// Render!
 			section.paths.forEach( function( path ) {
 				expressApp.get( path, serverRender );

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import pick from 'lodash/object/pick';
-import isEmpty from 'lodash/lang/isEmpty';
 
 /**
  * Internal dependencies
@@ -17,70 +16,68 @@ import { render } from 'render';
 import { createReduxStore } from 'state';
 import { setSection } from 'state/ui/actions';
 
-function getEnhancedContext( context, req ) {
+function getEnhancedContext( context, req, res ) {
 	return Object.assign( {}, context, {
+		isLoggedIn: req.cookies.wordpress_logged_in,
+		isServerSide: true,
 		path: req.path,
 		params: Object.assign( {}, context.params, req.params ),
-		query: {}
+		query: {},
+		store: createReduxStore(),
+		res,
 	} );
+}
+
+function applyMiddlewares( context, mws ) {
+	const liftedMws = mws.map( mw => next => mw( context, next ) );
+	compose( ...liftedMws )();
+}
+
+function compose( ...fns ) {
+	return fns.reduceRight( ( composed, f ) => (
+		next => f( composed ) // eslint-disable-line no-unused-vars
+	), () => {} );
 }
 
 export default function( expressApp, getDefaultContext ) {
 	sections.get()
 		.filter( section => section.routing === 'isomorphic' )
 		.forEach( section => {
-			// Since each middleware can mutate context, we need to set it up here
-			// and preserve it over iterations. If this turns out to be too complex,
-			// we might want to resort to the inverse approach, i.e. using
-			// https://github.com/kethinov/page.js-express-mapper.js on the client side.
-			let context = {};
-			let store = createReduxStore();
+			section.require( section.module )( serverRouter );
 
-			// Maybe inline those functions below?
+			function serverRouter( route, ...middlewares ) {
+				expressApp.get( route, combinedMiddlewares );
 
-			// Top-level routes
-			section.paths.forEach( path => expressApp.get( path, setUpRoute ) );
-			// Individual routes from chunk
-			sections.require( section.module )( serverRouter ); // possibly also pass context.isLoggedIn/isServerSide?
-			// Render!
-			section.paths.forEach( path => expressApp.get( path, serverRender ) );
+				function combinedMiddlewares( req ) {
+					const context = getDefaultContext( req );
+					getEnhancedContext( context );
+					applyMiddlewares( context, ...[
+						setUpRoute,
+						...middlewares,
+						serverRender
+					] );
+				}
+			}
 
-			function setUpRoute( req, res, next ) {
+			function setUpRoute( context, next ) {
 				i18n.initialize();
-				context.isServerSide = true;
-				context.isLoggedIn = req.cookies.wordpress_logged_in;
-
-				store.dispatch( setSection( section.name, {
+				context.store.dispatch( setSection( section.name, {
 					hasSidebar: false,
 					isFullScreen: true
 				} ) ); // FIXME
-				context.initialReduxState = pick( store.getState(), 'ui' );
+				context.initialReduxState = pick( context.store.getState(), 'ui' );
 				next();
 			}
 
-			function liftMiddleware( pageMiddleware ) {
-				return ( req, res, next ) => {
-					if ( isEmpty( context ) ) {
-						context = getDefaultContext( req );
-					}
-					getEnhancedContext( context, req ); // Update path etc.
-					pageMiddleware( context, next );
-				}
-			}
-
-			function serverRouter( route, ...mws ) {
-				expressApp.get( route, mws.map( liftMiddleware ) );
-			}
-
-			function serverRender( req, res ) {
+			function serverRender( context ) {
 				if ( config.isEnabled( 'server-side-rendering' ) ) {
 					Object.assign( context, render( (
-						<ReduxProvider store={ store }>
-							<LayoutLoggedOutDesign store={ store } primary={ context.primary } />
+						<ReduxProvider store={ context.store }>
+							<LayoutLoggedOutDesign store={ context.store } primary={ context.primary } />
 						</ReduxProvider>
 					) ) ); // FIXME: tier (general props), Head
 				}
-				res.render( 'index.jade', context );
+				context.res.render( 'index.jade', context );
 			}
 		} );
 };

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -1,5 +1,5 @@
 /**
- * External dependecies
+ * External dependencies
  */
 var React = require( 'react' ),
 	ReduxProvider = require( 'react-redux' ).Provider,
@@ -7,10 +7,11 @@ var React = require( 'react' ),
 	isEmpty = require( 'lodash/lang/isEmpty' );
 
 /**
- * Internal dependecies
+ * Internal dependencies
  */
 var config = require( 'config' ),
 	sections = require( '../../client/sections' ),
+	i18n = require( 'lib/mixins/i18n' ),
 	LayoutLoggedOutDesign = require( 'layout/logged-out-design' ),
 	render = require( 'render' ).render,
 	createReduxStore = require( 'state' ).createReduxStore,
@@ -38,6 +39,7 @@ module.exports = function( expressApp, getDefaultContext ) {
 			let store = createReduxStore();
 
 			function setUpRoute( req, res, next ) {
+				i18n.initialize();
 				context.isServerSide = true;
 				context.isLoggedIn = req.cookies.wordpress_logged_in;
 

--- a/server/isomorphic-routing/loader.js
+++ b/server/isomorphic-routing/loader.js
@@ -1,0 +1,38 @@
+function getSectionsModule( sections ) {
+	var caseSections = ''
+	sections.forEach( function( section ) {
+		if ( section.routing === 'isomorphic' ) {
+			caseSections += 'case ' + JSON.stringify( section.module ) + ': return require( ' + JSON.stringify( section.module ) + ' );\n';
+		}
+	} );
+
+	return [
+		'module.exports = {',
+		'	get: function() {',
+		'		return ' + JSON.stringify( sections ) + ';',
+		'	},',
+		' require: function( module ) {',
+		'		switch ( module ) {',
+					caseSections,
+		'			default:',
+		'				return null;',
+		'   }',
+		' }',
+		'};'
+	].join( '\n' );
+}
+
+module.exports = function( content ) {
+	var sections;
+
+	this.cacheable && this.cacheable();
+
+	sections = require( this.resourcePath );
+
+	if ( ! Array.isArray( sections ) ) {
+		this.emitError( 'Chunks module is not an array' );
+		return content;
+	}
+
+	return getSectionsModule( sections );
+};

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -10,7 +10,7 @@ var express = require( 'express' ),
 var config = require( 'config' ),
 	sanitize = require( 'sanitize' ),
 	utils = require( 'bundler/utils' ),
-	sections = require( '../../client/sections' ),
+	sections = require( '../../client/sections' ).get(),
 	isomorphicRouting = require( 'isomorphic-routing' );
 
 var HASH_LENGTH = 10,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -5,21 +5,13 @@ var express = require( 'express' ),
 	execSync = require( 'child_process' ).execSync,
 	cookieParser = require( 'cookie-parser' ),
 	i18nUtils = require( 'lib/i18n-utils' ),
-	debug = require( 'debug' )( 'calypso:pages' ),
-	includes = require( 'lodash/includes' ),
-	React = require( 'react' ),
-	ReduxProvider = require( 'react-redux' ).Provider,
-	pick = require( 'lodash/pick' );
+	debug = require( 'debug' )( 'calypso:pages' );
 
 var config = require( 'config' ),
 	sanitize = require( 'sanitize' ),
 	utils = require( 'bundler/utils' ),
 	sections = require( '../../client/sections' ),
-	LayoutLoggedOutDesign = require( 'layout/logged-out-design' ),
-	render = require( 'render' ).render,
-	i18n = require( 'lib/mixins/i18n' ),
-	createReduxStore = require( 'state' ).createReduxStore,
-	setSection = require( 'state/ui/actions' ).setSection;
+	isomorphicRouting = require( 'isomorphic-routing' );
 
 var HASH_LENGTH = 10,
 	URL_BASE_PATH = '/calypso',
@@ -373,53 +365,8 @@ module.exports = function() {
 		}
 	} );
 
-	if ( config.isEnabled( 'manage/themes/details' ) ) {
-
-		app.get( '/themes/:theme_slug', function( req, res ) {
-			const context = getDefaultContext( req );
-
-			if ( config.isEnabled( 'server-side-rendering' ) ) {
-				i18n.initialize();
-				const store = createReduxStore();
-
-				store.dispatch( setSection( 'themes', { hasSidebar: false, isFullScreen: true } ) );
-				context.initialReduxState = pick( store.getState(), 'ui' );
-
-				Object.assign( context, render( (
-					<ReduxProvider store={ store }>
-						<LayoutLoggedOutDesign store={ store } routeName={ 'themes' } match={ { theme_slug: req.params.theme_slug } } />
-					</ReduxProvider>
-				) ) );
-			}
-
-			res.render( 'index.jade', context );
-		} );
-	}
-
-	app.get( '/design(/type/:themeTier)?', function( req, res ) {
-		if ( req.cookies.wordpress_logged_in || ! config.isEnabled( 'manage/themes/logged-out' ) ) {
-			// the user is probably logged in
-			renderLoggedInRoute( req, res );
-		} else {
-			const context = getDefaultContext( req );
-			const tier = includes( [ 'all', 'free', 'premium' ], req.params.themeTier )
-				? req.params.themeTier
-				: 'all';
-
-			if ( config.isEnabled( 'server-side-rendering' ) ) {
-				const store = createReduxStore();
-				i18n.initialize();
-				store.dispatch( setSection( 'design', { hasSidebar: false } ) );
-				context.initialReduxState = pick( store.getState(), 'ui' );
-
-				Object.assign( context,
-					render( <LayoutLoggedOutDesign tier={ tier } store={ store } /> )
-				);
-			}
-
-			res.render( 'index.jade', context );
-		}
-	} );
+	// Move getDefaultContext definition to a file of its own?
+	isomorphicRouting( app, getDefaultContext );
 
 	app.get( '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?', function( req, res ) {
 		if ( req.cookies.wordpress_logged_in ) {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -51,6 +51,11 @@ module.exports = {
 	module: {
 		loaders: [
 			{
+				test: /sections.js$/,
+				exclude: 'node_modules',
+				loader: path.join( __dirname, 'server', 'isomorphic-routing', 'loader' )
+			},
+			{
 				test: /\.jsx?$/,
 				exclude: /(node_modules|devdocs\/search-index)/,
 				loader: 'babel-loader?optional[]=runtime'


### PR DESCRIPTION
**Do not merge.**

The goal of this PR is isomorphic routing and rendering, i.e. having a single middleware for element tree creation for a given route that is used both client- and server-side. That element tree is then rendered by a section-agnostic rendering middleware that is specific to either the server, or the client.

The first section that's going to be isomorphicized is `themes`. We'll need to do the following:

* #3516: Have `my-sites/themes#details` create a full-fledged `Layout` component tree in `context.layout` (instead of just a primary element tree inside `context.primary`), and render that to `#wpcom` in `client/controller#renderElements` (possibly rename). (It's actually sufficient to have a full-fledged layout tree at the end of the `/themes/:slug/:section?/:site_id?` route, so we could have layout creation in a separate middleware, as in `'/themes/:slug/:section?/:site_id?': [ details, detailsLayout ]`)
 * Modify `LayoutLoggedOutDesign` accordingly.
 * Drop the `secondary` unmounting hack.
* #3562: In the `/themes` route in `server/pages`, use `my-sites/themes` to create a theme sheet element tree in `context.layout`, and `renderToString()` that.
 * Adapt `express`'s `req` context to be able to use it with middleware that otherwise operates on `page`'s `context`.
 * Add a `package.json` that sets different entry points on the server and in the browser (not everything required by `my-sites/themes/index.js` is SSR-ready yet, so we need a pruned version for the server).


To make this fully generic, we then need to:
* #4086: Make the above SSR related stuff section-agnostic. Only then will we need the loader (1b86bfe8d1fbc8ec2e0f4cc3ed528a9973837c29).
 * In `server/pages`, filter sections with `routing: 'isomorphic'` and loop over them.

Might make sense to do that in two passes (i.e. PRs, 1 themes-specific, 2 section-agnostic). The current state of this PR was starting from the section-agnostic side, but I think the other way round makes more sense. There might still be some stuff in here that we can re-use even if we start with themes-specific.