### PR TITLE
Remove the `utils.regExpToString` polyfill

### DIFF
--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -61,7 +61,7 @@ function splitTemplate( path, module, chunkName ) {
 		path = JSON.stringify( path );
 	} else {
 		regex = utils.pathToRegExp( path );
-		path = '/' + utils.regExpToString( regex.toString().slice( 1, -1 ) ) + '/';
+		path = '/' + regex.toString().slice( 1, -1 ) + '/';
 	}
 
 	result = [

--- a/server/bundler/utils.js
+++ b/server/bundler/utils.js
@@ -18,22 +18,7 @@ function pathToRegExp( path ) {
 	return new RegExp( '^' + path + '(/.*)?$' );
 }
 
-/**
- * Node 0.x does not correctly escape slashes in `RegExp.prototype.toString`,
- * but node 4.x does. This is a polyfill that should return the escaped string
- * in either version. It can also accept any other object that has a `toString`
- * method (like Strings).
- */
-function regExpToString( exp ) {
-	var str = exp.toString();
-	if ( /\\\//.test( str ) ) {
-		return str;
-	}
-	return str.replace( /\//g, '\\/' );
-}
-
 module.exports = {
 	getAssets: getAssets,
-	pathToRegExp: pathToRegExp,
-	regExpToString: regExpToString
+	pathToRegExp: pathToRegExp
 };


### PR DESCRIPTION
That was needed for node 0.x, which we no longer support.

This is basically reverting commit f472d91e5b3f3764acbb4d8471d7f1073644d323 from
the old repo (`calypso-pre-oss`).

To test -- verify that the app still works (specifically, code-splitting/bundling for various routes).

CC @sirbrillig for review :tea: