### PR TITLE
JS Errors: Remove the content headers from the JS Errors API

### DIFF
--- a/catch-js-errors.js
+++ b/catch-js-errors.js
@@ -31,12 +31,18 @@
 			params = 'client_id=39911&client_secret=cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8&error=';
 			params += encodeURIComponent( JSON.stringify( savedErrors ) );
 
-			xhr.setRequestHeader( 'Content-length', params.length );
-			xhr.setRequestHeader( 'Connection', 'close' );
 			xhr.send( params );
 
 			savedErrors = [];
 		}
+	}
+
+	function errorToPlainObject( error ) {
+		var simpleObject = {};
+		Object.getOwnPropertyNames( error ).forEach( function( key ) {
+			simpleObject[ key ] = error[ key ];
+		} );
+		return simpleObject;
 	}
 
 	function handleError( error ) {
@@ -52,7 +58,7 @@
 
 		// add the message to the pack and reset flush timeout
 		clearTimeout( packTimeout );
-		savedErrors.push( error );
+		savedErrors.push( errorToPlainObject( error ) );
 
 		// if we can send the pack now, let's do it
 		if ( canSendNow ) {

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -75,7 +75,8 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 					span(class=['environment', 'is-docs'])
 						a(href=devDocsURL title='DevDocs') docs
 
-		script( src='/calypso/catch-js-errors.min.js' )
+		if 'development' !== env && 'production' !== env
+			script( src='/calypso/catch-js-errors.min.js' )
 
 		script.
 			(function() {

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -75,8 +75,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 					span(class=['environment', 'is-docs'])
 						a(href=devDocsURL title='DevDocs') docs
 
-		if 'development' !== env && 'production' !== env
-			script( src='/calypso/catch-js-errors.min.js' )
+		script( src='/calypso/catch-js-errors.min.js' )
 
 		script.
 			(function() {


### PR DESCRIPTION
This also converts the error to an object before we pass it to the array.
