### PR TITLE
Checkout: Add A/B test for not showing the footer text in checkout

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -73,4 +73,12 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
+	checkoutFooter: {
+		datestamp: '20160215',
+		variations: {
+			original: 50,
+			noFooter: 50
+		},
+		defaultVariation: 'original'
+	},
 };

--- a/client/my-sites/upgrades/checkout/supporting-text.jsx
+++ b/client/my-sites/upgrades/checkout/supporting-text.jsx
@@ -8,7 +8,8 @@ var React = require( 'react' );
 var cartValues = require( 'lib/cart-values' ),
 	getRefundPolicy = cartValues.getRefundPolicy,
 	cartItems = cartValues.cartItems,
-	hasFreeTrial = cartItems.hasFreeTrial;
+	hasFreeTrial = cartItems.hasFreeTrial,
+	abtest = require( 'lib/abtest' ).abtest;
 
 var SupportingText = React.createClass( {
 
@@ -70,6 +71,10 @@ var SupportingText = React.createClass( {
 	},
 
 	render: function() {
+		if ( abtest( 'checkoutFooter' ) === 'noFooter' ) {
+			return null;
+		}
+
 		return hasFreeTrial( this.props.cart )
 		? null : (
 				<ul className="supporting-text">


### PR DESCRIPTION
Starts a new A/B test for not showing the footer on the checkout page.

Original | Variation
------------ | -------------
<img width="755" alt="screen shot 2016-02-15 at 7 15 51 am" src="https://cloud.githubusercontent.com/assets/3011211/13052488/fc188a42-d3b3-11e5-86e7-ee696d14678c.png"> | <img width="765" alt="screen shot 2016-02-15 at 7 15 41 am" src="https://cloud.githubusercontent.com/assets/3011211/13052489/fc1a4d6e-d3b3-11e5-892f-96e87411a0ce.png">

cc: @lucasartoni 