### PR TITLE
Plans: A/B test displaying features list vs. description in Plan v2

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -41,8 +41,8 @@ module.exports = React.createClass( {
 	},
 
 	getComparePlansUrl: function() {
-		const { site } = this.props;
-		var siteSuffix = site ? site.slug : '';
+		var site = this.props.site,
+			siteSuffix = site ? site.slug : '';
 
 		return this.props.comparePlansUrl ? this.props.comparePlansUrl : '/plans/compare/' + siteSuffix;
 	},

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -40,8 +40,14 @@ module.exports = React.createClass( {
 		}
 	},
 
+	getComparePlansUrl: function() {
+		const { site } = this.props;
+		var siteSuffix = site ? site.slug : '';
+
+		return this.props.comparePlansUrl ? this.props.comparePlansUrl : '/plans/compare/' + siteSuffix;
+	},
+
 	getDescription: function() {
-		var comparePlansUrl, siteSuffix;
 		const { plan, site } = this.props;
 
 		if ( this.isPlaceholder() ) {
@@ -54,9 +60,6 @@ module.exports = React.createClass( {
 			);
 		}
 
-		siteSuffix = site ? site.slug : '';
-		comparePlansUrl = this.props.comparePlansUrl ? this.props.comparePlansUrl : '/plans/compare/' + siteSuffix;
-
 		if ( site && site.jetpack ) {
 			return (
 				<JetpackPlanDetails plan={ plan } />
@@ -65,14 +68,16 @@ module.exports = React.createClass( {
 
 		return (
 			<WpcomPlanDetails
-				comparePlansUrl={ comparePlansUrl }
+				comparePlansUrl={ this.getComparePlansUrl() }
 				handleLearnMoreClick={ this.handleLearnMoreClick }
 				plan={ plan } />
 		);
 	},
 
 	getFeatureList: function() {
-		var features;
+		var features,
+			showMoreLink = false,
+			moreLink = '';
 
 		if ( this.isPlaceholder() ) {
 			return;
@@ -83,17 +88,34 @@ module.exports = React.createClass( {
 				'is-plan-specific': feature.planSpecific
 			} );
 
-			if ( abtest( 'plansFeatureList' ) !== 'andMore' || !feature.testVariable ) {
-				return (
-					<li className={ classes } key={ i }>
-						<Gridicon icon="checkmark" size={ 12 } />
-						{ feature.text }
-					</li>
-				);
+			if ( abtest( 'plansFeatureList' ) === 'andMore' && feature.testVariable ) {
+				showMoreLink = true;
+				return null;
 			}
+
+			return (
+				<li className={ classes } key={ i }>
+					<Gridicon icon="checkmark" size={ 12 } />
+					{ feature.text }
+				</li>
+			);
 		} );
 
-		return <ul className="plan__features">{ features }</ul>;
+		if ( showMoreLink ) {
+			moreLink = (
+				<li className="plan__feature is-plan-specific">
+					<Gridicon icon="checkmark" size={ 12 } />
+					<a href={ this.getComparePlansUrl() }>And more</a>
+				</li>
+			);
+		}
+
+		return (
+			<ul className="plan__features">
+				{ features }
+				{ moreLink }
+			</ul>
+		);
 	},
 
 	showDetails: function() {

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -83,12 +83,14 @@ module.exports = React.createClass( {
 				'is-plan-specific': feature.planSpecific
 			} );
 
-			return (
-				<li className={ classes } key={ i }>
-					<Gridicon icon="checkmark" size={ 12 } />
-					{ feature.text }
-				</li>
-			);
+			if ( abtest( 'plansFeatureList' ) !== 'andMore' || !feature.testVariable ) {
+				return (
+					<li className={ classes } key={ i }>
+						<Gridicon icon="checkmark" size={ 12 } />
+						{ feature.text }
+					</li>
+				);
+			}
 		} );
 
 		return <ul className="plan__features">{ features }</ul>;
@@ -226,7 +228,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var shouldDisplayFeatureList = this.props.plan && ! isJetpackPlan( this.props.plan ) && abtest( 'plansFeatureList' ) === 'list';
+		var shouldDisplayFeatureList = this.props.plan && ! isJetpackPlan( this.props.plan ) && abtest( 'plansFeatureList' ) !== 'description';
 		return (
 			<Card className={ this.getClassNames() } key={ this.getProductSlug() } onClick={ this.showDetails }>
 				{ this.getPlanDiscountMessage() }

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -19,7 +19,9 @@ var abtest = require( 'lib/abtest' ).abtest,
 	PlanPrice = require( 'components/plans/plan-price' ),
 	PlanDiscountMessage = require( 'components/plans/plan-discount-message' ),
 	Card = require( 'components/card' ),
-	WpcomPlanDetails = require( 'my-sites/plans/wpcom-plan-details' );
+	WpcomPlanDetails = require( 'my-sites/plans/wpcom-plan-details' ),
+	productsValues = require( 'lib/products-values' ),
+	isBusiness = productsValues.isBusiness;
 
 module.exports = React.createClass( {
 	displayName: 'Plan',
@@ -76,7 +78,6 @@ module.exports = React.createClass( {
 
 	getFeatureList: function() {
 		var features,
-			showMoreLink = false,
 			moreLink = '';
 
 		if ( this.isPlaceholder() ) {
@@ -89,7 +90,6 @@ module.exports = React.createClass( {
 			} );
 
 			if ( abtest( 'plansFeatureList' ) === 'andMore' && feature.testVariable ) {
-				showMoreLink = true;
 				return null;
 			}
 
@@ -101,7 +101,7 @@ module.exports = React.createClass( {
 			);
 		} );
 
-		if ( showMoreLink ) {
+		if ( abtest( 'plansFeatureList' ) === 'andMore' && isBusiness( this.props.plan ) ) {
 			moreLink = (
 				<li className="plan__feature is-plan-specific">
 					<Gridicon icon="checkmark" size={ 12 } />

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -57,10 +57,11 @@ module.exports = {
 		defaultVariation: 'original'
 	},
 	plansFeatureList: {
-		datestamp: '20040202',
+		datestamp: '20040214',
 		variations: {
-			list: 50,
-			description: 50
+			list: 33,
+			andMore: 33,
+			description: 34
 		},
 		defaultVariation: 'description'
 	},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -57,7 +57,7 @@ module.exports = {
 		defaultVariation: 'original'
 	},
 	plansFeatureList: {
-		datestamp: '20040214',
+		datestamp: '20160215',
 		variations: {
 			list: 33,
 			andMore: 33,

--- a/client/lib/features-list/test-features.js
+++ b/client/lib/features-list/test-features.js
@@ -75,7 +75,8 @@ const features = {
 		},
 		{
 			text: 'eCommerce',
-			planSpecific: true
+			planSpecific: true,
+			testVariable: true
 		},
 		{
 			text: 'Unlimited Premium Themes',
@@ -83,7 +84,8 @@ const features = {
 		},
 		{
 			text: 'Google Analytics',
-			planSpecific: true
+			planSpecific: true,
+			testVariable: true
 		},
 		{
 			text: 'Live Chat Support',


### PR DESCRIPTION
This is a second iteration on #2924 with a more focused hypothesis. Testing by adding a third variation to remove a few features from the list.

#### Hypothesis

eCommerce and Google Analytics are key drivers toward Business plan signups.

#### Variations

`description` | `list` | `andMore`
------------ | ------------- | -------
![683c9b2c-c366-11e5-88fa-ede8ee793b88](https://cloud.githubusercontent.com/assets/448298/13056907/94d9d9d4-d3e6-11e5-8d9f-bc6d7bd63755.png) | ![68747470733a2f2f7472656c6c6f2d6174746163686d656e74732e73332e616d617a6f6e6177732e636f6d2f3536393665643735646265313533373830616163303239392f373437783634372f65333566386563353232323436306533](https://cloud.githubusercontent.com/assets/448298/13056910/97ec500c-d3e6-11e5-8be5-d5fc7631f590.png) | ![image](https://cloud.githubusercontent.com/assets/448298/13056942/d40080d6-d3e6-11e5-8f2f-c7dd96ce5eb7.png)

#### Testing

_With description text_

* Visit http://calypso.localhost:3000/start in a new browsing session.
* Run `localStorage.setItem( 'ABTests', '{"plansFeatureList_20160215":"description"}' );` in your browser.
* Proceed through signup to the plans step.
* Assert that you see a sentence as the description for each plan.
* Assert that you see the same description on /plans/:site after signing up.

_With full features list_

* Visit http://calypso.localhost:3000/start in a new browsing session.
* Run `localStorage.setItem( 'ABTests', '{"plansFeatureList_20160215":"list"}' );` in your browser.
* Proceed through signup to the plans step.
* Assert that you see a list of features (like in the screenshot above) for each plan.
* Assert that you see the same list of features on /plans/:site after signing up.

_With truncated features list_

* Visit http://calypso.localhost:3000/start in a new browsing session.
* Run `localStorage.setItem( 'ABTests', '{"plansFeatureList_20160215":"andMore"}' );` in your browser.
* Proceed through signup to the plans step.
* Assert that you see a truncated list of features with "And more" link (like in the screenshot above) for Business plan.
* Assert that you see the same list of features on /plans/:site after signing up.