### PR TITLE
Posts: add shouldComponentUpdate to skip unnecessary updates

### DIFF
--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -5,7 +5,8 @@ var React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	debug = require( 'debug' )( 'calypso:my-sites:posts' ),
 	debounce = require( 'lodash/function/debounce' ),
-	omit = require( 'lodash/object/omit' );
+	omit = require( 'lodash/object/omit' ),
+	isEqual = require( 'lodash/lang/isEqual' );
 
 /**
  * Internal dependencies
@@ -101,6 +102,25 @@ var Posts = React.createClass( {
 
 	componentWillUnmount: function() {
 		window.removeEventListener( 'resize', this.debouncedAfterResize );
+	},
+
+	shouldComponentUpdate: function( nextProps ) {
+		if ( nextProps.loading !== this.props.loading ) {
+			return true;
+		}
+		if ( nextProps.hasRecentError !== this.props.hasRecentError ) {
+			return true;
+		}
+		if ( nextProps.lastPage !== this.props.lastPage ) {
+			return true;
+		}
+		if ( nextProps.statusSlug !== this.props.statusSlug ) {
+			return true;
+		}
+		if ( ! isEqual( nextProps.posts.map( post => post.ID ), this.props.posts.map( post => post.ID ) ) ) {
+			return true;
+		}
+		return false;
 	},
 
 	afterResize: function() {


### PR DESCRIPTION
Addresses #3259.

The entire post-list was getting updated each time one of the items in the list was updated. By adding shouldComponentUpdate to the post-list component, we can skip re-rendering the entire list just because one of the items has updated, and instead just let that item get re-rendered individually. This allows the post-list to render items significantly faster than 

There are still some forced updates happening from observing sites-list. That can/should be addressed separately.

## Testing
It's easiest to test by comparison. So you can start by switching `master` and then _temporarily_ adding this feature-flag in `config/development.json`:
```
"render-visualizer": true,
```
Restart the server to pickup this config change. Then go to [http://calypso.localhost:3000/posts](http://calypso.localhost:3000/posts) and you will see that your posts each get rendered 20+ times.

![20-plus](https://cloudup.com/cI_BZisFm2y+)

Now switch to this branch and again temporarily add the feature flag in `config/development.json`
```
"render-visualizer": true,
```
Restart your server and go back to that same page. This time you should see the post items get updated only a handful of times.

![handful of updates](https://cloudup.com/cbtPx481Vya+)

As a more qualitative thing, you should notice (especially after turning "render-visualizer" back off, because it's slow), that the post-list page loads much more quickly.

Also, make sure that any posts that rendered images in the post-list page still continues to do so. It's the post-normalizing that validates images that was causing all of these re-renders in the first place.

/cc @retrofox 
