### PR TITLE
Domains: Update the icon we use for domains in the sidebar

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -294,7 +294,7 @@ module.exports = React.createClass( {
 		return (
 			<li className={ this.itemLinkClass( [ '/domains' ], 'domains' ) }>
 				<a onClick={ this.onNavigate } href={ domainsLink } target={ target }>
-					<Gridicon icon="cart" size={ 24 } />
+					<Gridicon icon="globe" size={ 24 } />
 					<span className="menu-link-text">{ this.translate( 'Domains' ) }</span>
 				</a>
 				{ addDomainButton }


### PR DESCRIPTION
When we launched the domain sidebar item, `globe` was being used for the "view site" link. That item has now been incorporated into the site card, so this PR updates the "domains" sidebar item to use the `globe` icon instead of `cart` (since this section includes domain management, not just purchases).

Before | After
------------ | -------------
<img width="278" alt="screen shot 2016-02-15 at 1 26 03 pm" src="https://cloud.githubusercontent.com/assets/3011211/13060627/b1318c84-d3e7-11e5-9c52-f0322827333f.png"> | <img width="279" alt="screen shot 2016-02-15 at 1 25 37 pm" src="https://cloud.githubusercontent.com/assets/3011211/13060626/b12b0b70-d3e7-11e5-8974-eef39bd774ff.png">