### PR TITLE
Signup: Headstart: Restart the Headstart i3 AB test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -65,7 +65,7 @@ module.exports = {
 		defaultVariation: 'description'
 	},
 	headstart: {
-		datestamp: '20160205',
+		datestamp: '20160215',
 		variations: {
 			original: 20,
 			notTested: 60,


### PR DESCRIPTION
Test users that selected themes with many placeholder posts were getting tagged as spam on WordPress.com. With that fixed, we now just need to restart for clean test data.