### PR TITLE
Domain Management: Email: Select site redirects to manage domains

### DIFF
--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -14,8 +14,8 @@ const controller = require( 'my-sites/controller' ),
 	paths = require( './paths' ),
 	adTracking = require( 'analytics/ad-tracking' );
 
-function registerMultiPage( { routes, handlers } ) {
-	routes.forEach( path => page( path, ...handlers ) );
+function registerMultiPage( { paths, handlers } ) {
+	paths.forEach( path => page( path, ...handlers ) );
 }
 
 function getCommonHandlers( { noSitePath = paths.domainManagementRoot(), warnIfJetpack = true } = {} ) {
@@ -46,7 +46,7 @@ module.exports = function() {
 		);
 
 		registerMultiPage( {
-			routes: [
+			paths: [
 				paths.domainManagementEmail( ':site', ':domain' ),
 				paths.domainManagementEmail( ':site' )
 			],
@@ -57,7 +57,7 @@ module.exports = function() {
 		} );
 
 		registerMultiPage( {
-			routes: [
+			paths: [
 				paths.domainManagementAddGoogleApps( ':site', ':domain' ),
 				paths.domainManagementAddGoogleApps( ':site' )
 			],

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -17,55 +17,18 @@ const controller = require( 'my-sites/controller' ),
 module.exports = function() {
 	SiftScience.recordUser();
 
-	if ( config.isEnabled( 'upgrades/domain-management/list' ) ) {
+	if ( config.isEnabled( 'upgrades/domain-management/email' ) ) {
 		page(
-			paths.domainManagementRoot(),
+			paths.domainManagementEmail(),
 			controller.siteSelection,
 			controller.sites
 		);
 
 		page(
-			paths.domainManagementList( ':site' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
-			domainManagementController.domainManagementList
-		);
-
-		page(
-			paths.domainManagementEdit( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
-			domainManagementController.domainManagementEdit
-		);
-
-		page(
-			paths.domainManagementPrivacyProtection( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			domainManagementController.domainManagementPrivacyProtection
-		);
-
-		page(
-			paths.domainManagementPrimaryDomain( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
-			domainManagementController.domainManagementPrimaryDomain
-		);
-	}
-
-	if ( config.isEnabled( 'upgrades/domain-management/email' ) ) {
-		page(
 			paths.domainManagementEmail( ':site', ':domain' ),
 			controller.siteSelection,
 			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
+			upgradesController.redirectIfNoSite( paths.domainManagementEmail() ),
 			controller.jetPackWarning,
 			domainManagementController.domainManagementEmail
 		);
@@ -74,7 +37,7 @@ module.exports = function() {
 			paths.domainManagementEmail( ':site' ),
 			controller.siteSelection,
 			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
+			upgradesController.redirectIfNoSite( paths.domainManagementEmail() ),
 			controller.jetPackWarning,
 			domainManagementController.domainManagementEmail
 		);
@@ -166,6 +129,49 @@ module.exports = function() {
 		controller.jetPackWarning,
 		domainManagementController.domainManagementTransfer
 	);
+
+	if ( config.isEnabled( 'upgrades/domain-management/list' ) ) {
+		page(
+			paths.domainManagementRoot(),
+			controller.siteSelection,
+			controller.sites
+		);
+
+		page(
+			paths.domainManagementList( ':site' ),
+			controller.siteSelection,
+			controller.navigation,
+			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
+			controller.jetPackWarning,
+			domainManagementController.domainManagementList
+		);
+
+		page(
+			paths.domainManagementEdit( ':site', ':domain' ),
+			controller.siteSelection,
+			controller.navigation,
+			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
+			controller.jetPackWarning,
+			domainManagementController.domainManagementEdit
+		);
+
+		page(
+			paths.domainManagementPrivacyProtection( ':site', ':domain' ),
+			controller.siteSelection,
+			controller.navigation,
+			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
+			domainManagementController.domainManagementPrivacyProtection
+		);
+
+		page(
+			paths.domainManagementPrimaryDomain( ':site', ':domain' ),
+			controller.siteSelection,
+			controller.navigation,
+			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
+			controller.jetPackWarning,
+			domainManagementController.domainManagementPrimaryDomain
+		);
+	}
 
 	if ( config.isEnabled( 'upgrades/domain-search' ) ) {
 		page(

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -14,6 +14,27 @@ const controller = require( 'my-sites/controller' ),
 	paths = require( './paths' ),
 	adTracking = require( 'analytics/ad-tracking' );
 
+function registerMultiPage( { routes, handlers } ) {
+	routes.forEach( path => page( path, ...handlers ) );
+}
+
+function getCommonHandlers( { noSitePath = paths.domainManagementRoot(), warnIfJetpack = true } ) {
+	const handlers = [
+		controller.siteSelection,
+		controller.navigation
+	];
+
+	if ( noSitePath ) {
+		handlers.push( upgradesController.redirectIfNoSite( noSitePath ) );
+	}
+
+	if ( warnIfJetpack ) {
+		handlers.push( controller.jetPackWarning );
+	}
+
+	return handlers;
+}
+
 module.exports = function() {
 	SiftScience.recordUser();
 
@@ -24,48 +45,31 @@ module.exports = function() {
 			controller.sites
 		);
 
-		page(
-			paths.domainManagementEmail( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementEmail() ),
-			controller.jetPackWarning,
-			domainManagementController.domainManagementEmail
-		);
+		registerMultiPage( {
+			routes: [
+				paths.domainManagementEmail( ':site', ':domain' ),
+				paths.domainManagementEmail( ':site' )
+			],
+			handlers: [
+				...getCommonHandlers( { noSitePath: paths.domainManagementEmail() } ),
+				domainManagementController.domainManagementEmail
+			]
+		} );
 
-		page(
-			paths.domainManagementEmail( ':site' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementEmail() ),
-			controller.jetPackWarning,
-			domainManagementController.domainManagementEmail
-		);
-
-		page(
-			paths.domainManagementAddGoogleApps( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
-			domainManagementController.domainManagementAddGoogleApps
-		);
-
-		page(
-			paths.domainManagementAddGoogleApps( ':site' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
-			domainManagementController.domainManagementAddGoogleApps
-		);
+		registerMultiPage( {
+			routes: [
+				paths.domainManagementAddGoogleApps( ':site', ':domain' ),
+				paths.domainManagementAddGoogleApps( ':site' )
+			],
+			handlers: [
+				...getCommonHandlers(),
+				domainManagementController.domainManagementAddGoogleApps
+			]
+		} );
 
 		page(
 			paths.domainManagementEmailForwarding( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
+			...getCommonHandlers(),
 			domainManagementController.domainManagementEmailForwarding
 		);
 	}
@@ -73,10 +77,7 @@ module.exports = function() {
 	if ( config.isEnabled( 'upgrades/domain-management/site-redirect' ) ) {
 		page(
 			paths.domainManagementRedirectSettings( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
+			...getCommonHandlers(),
 			domainManagementController.domainManagementRedirectSettings
 		);
 	}
@@ -84,19 +85,13 @@ module.exports = function() {
 	if ( config.isEnabled( 'upgrades/domain-management/contacts-privacy' ) ) {
 		page(
 			paths.domainManagementContactsPrivacy( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
+			...getCommonHandlers(),
 			domainManagementController.domainManagementContactsPrivacy
 		);
 
 		page(
 			paths.domainManagementEditContactInfo( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
+			...getCommonHandlers(),
 			domainManagementController.domainManagementEditContactInfo
 		);
 	}
@@ -104,29 +99,20 @@ module.exports = function() {
 	if ( config.isEnabled( 'upgrades/domain-management/name-servers' ) ) {
 		page(
 			paths.domainManagementDns( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
+			...getCommonHandlers(),
 			domainManagementController.domainManagementDns
 		);
 
 		page(
 			paths.domainManagementNameServers( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
+			...getCommonHandlers(),
 			domainManagementController.domainManagementNameServers
 		);
 	}
 
 	page(
 		paths.domainManagementTransfer( ':site', ':domain' ),
-		controller.siteSelection,
-		controller.navigation,
-		upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-		controller.jetPackWarning,
+		...getCommonHandlers(),
 		domainManagementController.domainManagementTransfer
 	);
 
@@ -139,36 +125,25 @@ module.exports = function() {
 
 		page(
 			paths.domainManagementList( ':site' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
+			...getCommonHandlers(),
 			domainManagementController.domainManagementList
 		);
 
 		page(
 			paths.domainManagementEdit( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
+			...getCommonHandlers(),
 			domainManagementController.domainManagementEdit
 		);
 
 		page(
 			paths.domainManagementPrivacyProtection( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
+			...getCommonHandlers( { warnIfJetpack: false } ),
 			domainManagementController.domainManagementPrivacyProtection
 		);
 
 		page(
 			paths.domainManagementPrimaryDomain( ':site', ':domain' ),
-			controller.siteSelection,
-			controller.navigation,
-			upgradesController.redirectIfNoSite( paths.domainManagementRoot() ),
-			controller.jetPackWarning,
+			...getCommonHandlers(),
 			domainManagementController.domainManagementPrimaryDomain
 		);
 	}

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -18,7 +18,7 @@ function registerMultiPage( { routes, handlers } ) {
 	routes.forEach( path => page( path, ...handlers ) );
 }
 
-function getCommonHandlers( { noSitePath = paths.domainManagementRoot(), warnIfJetpack = true } ) {
+function getCommonHandlers( { noSitePath = paths.domainManagementRoot(), warnIfJetpack = true } = {} ) {
 	const handlers = [
 		controller.siteSelection,
 		controller.navigation


### PR DESCRIPTION
This PR fixes #855: If you go to `/domains/manage/email` it will not redirect you to `/domains/manage` but will show all sites under `/domains/manage/email`, so that once you select a site, you will land on the email page.

I also did some refactoring for the routes to reduce duplicate code.

/cc: @klimeryk for review
/cc2: @breezyskies for reporting the original issue and @mtias since he suggested the solution 