### PR TITLE
Domains: Send only one /domains request

### DIFF
--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -117,6 +117,7 @@ function deleteEmailForwarding( domainName, mailbox, onComplete ) {
 	} );
 }
 
+let _activefetchDomainsForSite = {};
 function fetchDomains( siteId ) {
 	if ( ! isDomainInitialized( DomainsStore.get(), siteId ) ) {
 		Dispatcher.handleViewAction( {
@@ -130,7 +131,12 @@ function fetchDomains( siteId ) {
 		siteId
 	} );
 
+	if ( _activefetchDomainsForSite[ siteId ] ) {
+		return;
+	}
+	_activefetchDomainsForSite[ siteId ] = true;
 	wpcom.site( siteId ).domains( function( error, data ) {
+		delete _activefetchDomainsForSite[ siteId ];
 		if ( error ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.DOMAINS_FETCH_FAILED,


### PR DESCRIPTION
If there are multiple `.fetchDomains` calls at the same time, we will not send another request to the server, but use the value coming from the first request. `/domains` endpoint is pretty slow (2 minutes for 20 domains),

/cc: @klimeryk @aidvu