### PR TITLE
sync-handler: add cache-invalidation process

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1330,3 +1330,27 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
+
+### https://github.com/guille/ms.js
+```text
+(The MIT License)
+
+Copyright (c) 2014 Guillermo Rauch <rauchg@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -42,6 +42,7 @@ var config = require( 'config' ),
 	setRouteAction = require( 'state/notices/actions' ).setRoute,
 	accessibleFocus = require( 'lib/accessible-focus' ),
 	TitleStore = require( 'lib/screen-title/store' ),
+	syncHandler = require( 'lib/wp/sync-handler' ),
 	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
 	bindWpLocaleState = require( 'lib/wp/localization' ).bindState,
 	// The following components require the i18n mixin, so must be required after i18n is initialized
@@ -51,6 +52,9 @@ function init() {
 	var i18nLocaleStringsObject = null;
 
 	debug( 'Starting Calypso. Let\'s do this.' );
+
+	// prune sync-handler records more than two days old
+	syncHandler.pruneRecordsFrom( '2 days' );
 
 	// Initialize i18n
 	if ( window.i18nLocaleStrings ) {

--- a/client/lib/wp/sync-handler/README.md
+++ b/client/lib/wp/sync-handler/README.md
@@ -19,3 +19,53 @@ const handler = new SyncHandler( wpcomXHRHandler );
 // create wpcom instance passing the wrapped handler
 const wpcom = wpcomUndocumented( handler );
 ```
+
+### Cache Invalidation
+
+`cache-index` stores the key and timestamp for all records stored by the
+`sync-handler` which allows us to prune records from our local cache. There are
+two methods to invalidate records:
+
+### syncHandler#pruneRecordsFrom( [lifetime] );
+Prune records older than the given `lifetime` (milliseconds or [natural
+language](https://github.com/rauchg/ms.js)). By default the value of the lifetime is `2 days`.
+
+```es6
+// prune the records that are older than one hour of life
+syncHandler.pruneRecordsFrom( 1000 * 60 * 60 );
+
+// prune older than 10 hours old
+syncHandler
+	.pruneRecordsFrom( '10 hours' )
+	.then( records => {
+		console.log( 'current records count: %s', records.length );
+	} );
+```
+
+### syncHandler.clearAll();
+clearAll the whole sync-handler data.
+
+### Testing and Debug
+
+In order to offer an API useful for testing and debug this module exposes two global vars: `syncHandler` and `cacheIndex`. It worth clarify that these ones are exposed only in the `development` environment.
+
+#### `syncHandler`
+
+It's the `SyncHandler` instance which wraps the wpcom request handler. You would  open the dev console in your browser and then make something like:
+
+```es6
+// add and then remove a testing record
+syncHandler
+  .storeRecord( 'testing-key', { description: 'testing record' } )
+  .then( () => syncHandler.removeRecord( 'testing-key' ) );
+```
+
+
+#### `cacheIndex`
+
+It allows access to `cache-index` API from the dev console. For instance:
+
+```es6
+// prune records older than 25 minutes of lifetime.
+cacheIndex.pruneRecordsFrom( '25 minutes' );
+```

--- a/client/lib/wp/sync-handler/cache-index.js
+++ b/client/lib/wp/sync-handler/cache-index.js
@@ -1,0 +1,148 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import ms from 'ms';
+
+import negate from 'lodash/negate';
+import matchesProperty from 'lodash/matchesProperty';
+import filter from 'lodash/filter';
+import difference from 'lodash/difference';
+
+/**
+ * Internal dependencies
+ */
+import { getLocalForage } from 'lib/localforage';
+
+/**
+ * Module variables
+ */
+const localforage = getLocalForage();
+const debug = debugFactory( 'calypso:sync-handler:cache' );
+
+const RECORDS_LIST_KEY = 'records-list';
+const SYNC_RECORD_REGEX = /^sync-record-\w+$/;
+const LIFETIME = '2 days';
+
+/**
+ * Check it the given key is a `sync-record-` key
+ *
+ * @param {String} key - record key
+ * @return {Boolean} `true` if it's a sync-record-<key>
+ */
+const isSyncRecordKey = key => SYNC_RECORD_REGEX.test( key );
+
+export const cacheIndex = {
+	getAll() {
+		return localforage.getItem( RECORDS_LIST_KEY );
+	},
+
+	/**
+	 * Retrieve all records except the record
+	 * that matches with the given key.
+	 *
+	 * @param {String} key - compare records with this key
+	 * @return {Promise} promise
+	 */
+	getAllExcluding( key ) {
+		const dropMatches = records => filter( records,
+			negate( matchesProperty( 'key', key ) )
+		);
+
+		return new Promise( ( resolve, reject ) => {
+			this.getAll()
+				.then( dropMatches )
+				.then( resolve )
+				.catch( reject );
+		} );
+	},
+
+	/**
+	 * Add the given `key` into the records-list object
+	 * adding at the same a timestamp (now).
+	 * If the pair key-timestamp already exists it will be updated.
+	 *
+	 * @param {String} key - record key
+	 * @return {Promise} promise
+	 */
+	addItem( key ) {
+		return this.getAllExcluding( key ).then( records => {
+			debug( 'adding %o record', key );
+			return localforage.setItem( RECORDS_LIST_KEY, [
+				...records,
+				{ key, timestamp: Date.now() }
+			] );
+		} );
+	},
+
+	removeItem( key ) {
+		return this.getAllExcluding( key ).then( records => {
+			debug( 'removing %o record', key );
+			return localforage.setItem( RECORDS_LIST_KEY, records );
+		} );
+	},
+
+	dropOlderThan( lifetime ) {
+		const dropElders = records => {
+			const droppedRecords = filter( records, rec => {
+				return Date.now() - lifetime > rec.timestamp;
+			} );
+
+			return {
+				droppedRecords,
+				filteredRecords: difference( records, droppedRecords )
+			}
+		};
+
+		return new Promise( ( resolve, reject ) => {
+			this.getAll()
+			.then( dropElders )
+			.then( resolve )
+			.catch( reject );
+		} );
+	},
+
+	/**
+	 * It's a cleaning method and it should be used to re-sync the whole data.
+	 * Calling this method all `sync-records-<key>` records will be
+	 * removed plus the `records-list` one.
+	 *
+	 * @return {Promise} promise
+	 */
+	clearAll() {
+		return localforage.keys().then( keys => {
+			const syncHandlerKeys = keys.filter( isSyncRecordKey );
+			const itemsPromises = syncHandlerKeys.map( key => localforage.removeItem( key ) );
+			const recordsPromise = localforage.removeItem( RECORDS_LIST_KEY );
+			return Promise.all( [ ...itemsPromises, recordsPromise ] )
+				.then( debug( '%o records removed', syncHandlerKeys.length + 1 ) );
+		} );
+	},
+
+	/**
+	 * Prune old records depending of the given lifetime
+	 *
+	 * @param {Number|String} lifetime - lifetime (ms or natural string)
+	 * @return {Promise} promise
+	 */
+	pruneRecordsFrom( lifetime = LIFETIME ) {
+		lifetime = typeof lifetime === 'number'
+			? lifetime
+			: ms( lifetime );
+
+		debug( 'start to prune records older than %s', ms( lifetime, { long: true } ) );
+
+		return this.dropOlderThan( lifetime ).then( data => {
+			const { droppedRecords, filteredRecords } = data;
+
+			if ( ! droppedRecords.length ) {
+				return debug( 'No records to prune' );
+			}
+
+			const droppedPromises = droppedRecords.map( item => localforage.removeItem( item.key ) );
+			const recordsListPromise = localforage.setItem( RECORDS_LIST_KEY, filteredRecords )
+			return Promise.all( [ ...droppedPromises, recordsListPromise ] )
+				.then( debug( '%o records removed', droppedRecords.length + 1 ) );
+		} );
+	}
+}

--- a/client/lib/wp/sync-handler/index.js
+++ b/client/lib/wp/sync-handler/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import config from 'config';
 import Hashes from 'jshashes';
 import debugFactory from 'debug';
 
@@ -30,6 +31,11 @@ export class SyncHandler {
 	 * @return {Function} sync-handler wrapper
 	 */
 	constructor( handler ) {
+		// expose `syncHandler` global var (dev mode)
+		if ( 'development' === config( 'env' ) ) {
+			window.syncHandler = this;
+		}
+
 		this.reqHandler = handler;
 		return this.syncHandlerWrapper( handler );
 	}
@@ -219,4 +225,9 @@ export const pruneRecordsFrom = lifetime => {
 
 export const clearAll = () => {
 	return cacheIndex.clearAll();
+}
+
+// expose `cacheIndex` global var (dev mode)
+if ( 'development' === config( 'env' ) ) {
+	window.cacheIndex = cacheIndex;
 }

--- a/client/lib/wp/sync-handler/index.js
+++ b/client/lib/wp/sync-handler/index.js
@@ -178,6 +178,8 @@ export class SyncHandler {
 			key = new Hashes.SHA1().hex( key );
 		}
 
+		key = 'sync-record-' + key;
+
 		debug( 'key: %o', key );
 		return key;
 	}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9742,6 +9742,9 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
+    },
+    "ms": {
+      "version": "0.7.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "moment": "2.10.6",
     "moment-timezone": "^0.4.0",
     "morgan": "1.2.0",
+    "ms": "0.7.1",
     "node-sass": "3.4.2",
     "page": "1.6.4",
     "path-parser": "1.0.2",


### PR DESCRIPTION
### First approach
It's the first step to start to control the data that are stored locally by `sync-handler` layer. Issue #3281. The idea here is find a way to discard those obsolete records reducing the amount of stored data.

In short every time that a new record is added we also add a new item into a `records-list` array which is stored locally as well. This item has the record `key` value and a `timestamp` (now).
In this way we'll have a trace history of all of the resources that we are using to sync the remote data.

The `records-list` array has this follow form:

```js
[
  { key: 'sync-record-<SHA1-hash>', timestamp: Date object instance },
  // ...
]
```


Once we have a filled `record-list` array we can start to prune some records depending of our needs. Specifically in this PR I've added `pruneRecordsFrom( lifetime )` method to syncHandler.

```es6
import syncHandler from 'lib/wp/sync-handler';

// prune records from yesterday
syncHandler.pruneRecordsFrom( '1 day'  );
```

This method is called in the boot process but we can move it to another place, run it frequently in an interval instance, etc.

### syncHandler changes

* add `sync-handler` prefix to records key name. In this way we can identify the records among the whole stored data.
* Making focus in `Promises` style
* use Date.now() to `synced` field

### Testing

First of all you have to get data stored locally. For that purpose just go to some page that is already being synced:
  * posts list page (`http://calypso.localhost:3000/posts/my/<your-blog>`)
  * settings page (`http://calypso.localhost:3000/me`)

You can see how the data is stored setting `localStorage.debug = 'calypso:sync-handler*` in the browser console.

****
![image](https://cloud.githubusercontent.com/assets/77539/13188765/4015474a-d732-11e5-8770-36c3074b9af8.png)

Also you can see the stored data opening `Resources` tab in the Developer Tools -> IndexedDB section:

![image](https://cloud.githubusercontent.com/assets/77539/13235432/a078e710-d99c-11e5-887f-17f2d83ead2a.png)

As I said above the data is _pruned_ in the boot process, so once you have data stored locally make a hard refresh and pay attention how some records are removed (watching debug lines in the console or the `Resources` tab)

### Expose syncHandler and cacheIndex to testing
#### `development` environment only

One useful thing to test/debug is have a global variable with which we can call some syncHandler methods. It's worth clarify that this var is only exposed in development environment.
So for instance if you wanna prune those records older than 3 minutes just make `syncHandler.pruneRecordsFrom( '1 minute' )`:


![image](https://cloud.githubusercontent.com/assets/77539/13322406/02ac14d0-dbb3-11e5-85fd-317fc5f578cc.png)

Also you can make `syncHandler.clearAll()` (hard way) to clean whole sync-handler data from local storing:

![image](https://cloud.githubusercontent.com/assets/77539/13322449/323a8506-dbb3-11e5-8741-68a3a67da516.png)
