### PR TITLE
Sites: fix placeholder showing fading effects for overflow text.

### DIFF
--- a/client/my-sites/site/style.scss
+++ b/client/my-sites/site/style.scss
@@ -39,6 +39,11 @@
 			animation: pulse-light 0.8s ease-in-out infinite;
 			background-color: lighten( $gray, 30% );
 			color: transparent;
+			width: 95%;
+
+			&::after {
+				display: none;
+			}
 		}
 
 		.notouch .sites-popover &:hover {


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/548849/13076161/b5fde996-d4b0-11e5-872a-35e8a31584bf.png)

After:
![image](https://cloud.githubusercontent.com/assets/548849/13076142/94c9f030-d4b0-11e5-9179-53435b4a7a55.png)
