### PR TITLE
Editor: Use Redux post types state for determining page feature support

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -62,12 +62,9 @@ const EditorDrawer = React.createClass( {
 
 	currentPostTypeSupports: function( feature ) {
 		const { site, postTypes, type } = this.props;
-		if ( ! site ) {
-			return false;
-		}
 
 		// Default to true until post types are known
-		if ( ! postTypes ) {
+		if ( ! site || ! postTypes ) {
 			return true;
 		}
 

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -60,8 +60,19 @@ const EditorDrawer = React.createClass( {
 		this.props.setExcerpt( event.target.value );
 	},
 
+	currentPostTypeSupportsAll: function() {
+		// We explicitly hard-code posts as supporting all features, which is a
+		// hack that saves us a network request. While technically possible for
+		// a theme to remove feature support for posts, this is very rare. If
+		// encountered, we should consider removing this shortcut.
+		return 'post' === this.props.type;
+	},
+
 	currentPostTypeSupports: function( feature ) {
 		const { site, postTypes, type } = this.props;
+		if ( this.currentPostTypeSupportsAll() ) {
+			return true;
+		}
 
 		// Default to true until post types are known
 		if ( ! site || ! postTypes ) {
@@ -79,7 +90,7 @@ const EditorDrawer = React.createClass( {
 	renderTaxonomies: function() {
 		var element;
 
-		if ( 'post' !== this.props.type && ! this.currentPostTypeSupports( 'tags' ) ) {
+		if ( ! this.currentPostTypeSupports( 'tags' ) ) {
 			return;
 		}
 
@@ -142,7 +153,7 @@ const EditorDrawer = React.createClass( {
 	renderExcerpt: function() {
 		var excerpt;
 
-		if ( 'post' !== this.props.type && ! this.currentPostTypeSupports( 'excerpt' ) ) {
+		if ( ! this.currentPostTypeSupports( 'excerpt' ) ) {
 			return;
 		}
 
@@ -177,7 +188,7 @@ const EditorDrawer = React.createClass( {
 			return;
 		}
 
-		if ( 'post' !== this.props.type && ! this.currentPostTypeSupports( 'geo-location' ) ) {
+		if ( ! this.currentPostTypeSupports( 'geo-location' ) ) {
 			return;
 		}
 
@@ -190,7 +201,7 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderDiscussion: function() {
-		if ( 'post' !== this.props.type && ! this.currentPostTypeSupports( 'comments' ) ) {
+		if ( ! this.currentPostTypeSupports( 'comments' ) ) {
 			return;
 		}
 
@@ -206,11 +217,12 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderMoreOptions: function() {
-		if ( 'post' !== this.props.type &&
+		if (
 			! this.currentPostTypeSupports( 'excerpt' ) &&
 			! this.currentPostTypeSupports( 'geo-location' ) &&
 			! this.currentPostTypeSupports( 'comments' ) &&
-			! siteUtils.isPermalinkEditable( this.props.site ) ) {
+			! siteUtils.isPermalinkEditable( this.props.site )
+		) {
 			return;
 		}
 
@@ -276,7 +288,9 @@ const EditorDrawer = React.createClass( {
 
 		return (
 			<div className="editor-drawer">
-				{ site && <QueryPostTypes siteId={ site.ID } /> }
+				{ site && ! this.currentPostTypeSupportsAll() && (
+					<QueryPostTypes siteId={ site.ID } />
+				) }
 				{ 'page' === type
 					? this.renderPageDrawer()
 					: this.renderPostDrawer() }

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -9,37 +9,36 @@ import { bindActionCreators } from 'redux';
 /**
  * Internal dependencies
  */
-const Accordion = require( 'components/accordion' ),
-	AccordionSection = require( 'components/accordion/section' ),
-	Gridicon = require( 'components/gridicon' ),
-	TaxonomiesAccordion = require( 'post-editor/editor-taxonomies/accordion' ),
-	CategoryListData = require( 'components/data/category-list-data' ),
-	TagListData = require( 'components/data/tag-list-data' ),
-	FeaturedImage = require( 'post-editor/editor-featured-image' ),
-	EditorSharingAccordion = require( 'post-editor/editor-sharing/accordion' ),
-	FormTextarea = require( 'components/forms/form-textarea' ),
-	PostFormatsData = require( 'components/data/post-formats-data' ),
-	PostFormatsAccordion = require( 'post-editor/editor-post-formats/accordion' ),
-	Location = require( 'post-editor/editor-location' ),
-	Discussion = require( 'post-editor/editor-discussion' ),
-	PageParent = require( 'post-editor/editor-page-parent' ),
-	EditorMoreOptionsSlug = require( 'post-editor/editor-more-options/slug' ),
-	InfoPopover = require( 'components/info-popover' ),
-	PageTemplatesData = require( 'components/data/page-templates-data' ),
-	PageTemplates = require( 'post-editor/editor-page-templates' ),
-	PageOrder = require( 'post-editor/editor-page-order' ),
-	PostMetadata = require( 'lib/post-metadata' ),
-	TrackInputChanges = require( 'components/track-input-changes' ),
-	actions = require( 'lib/posts/actions' ),
-	stats = require( 'lib/posts/stats' ),
-	siteUtils = require( 'lib/site/utils' );
+import Accordion from 'components/accordion';
+import AccordionSection from 'components/accordion/section';
+import Gridicon from 'components/gridicon';
+import TaxonomiesAccordion from 'post-editor/editor-taxonomies/accordion';
+import CategoryListData from 'components/data/category-list-data';
+import TagListData from 'components/data/tag-list-data';
+import FeaturedImage from 'post-editor/editor-featured-image';
+import EditorSharingAccordion from 'post-editor/editor-sharing/accordion';
+import FormTextarea from 'components/forms/form-textarea';
+import PostFormatsData from 'components/data/post-formats-data';
+import PostFormatsAccordion from 'post-editor/editor-post-formats/accordion';
+import Location from 'post-editor/editor-location';
+import Discussion from 'post-editor/editor-discussion';
+import PageParent from 'post-editor/editor-page-parent';
+import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
+import InfoPopover from 'components/info-popover';
+import PageTemplatesData from 'components/data/page-templates-data';
+import PageTemplates from 'post-editor/editor-page-templates';
+import PageOrder from 'post-editor/editor-page-order';
+import PostMetadata from 'lib/post-metadata';
+import TrackInputChanges from 'components/track-input-changes';
+import actions from 'lib/posts/actions';
+import stats from 'lib/posts/stats';
+import siteUtils from 'lib/site/utils';
 import { setExcerpt } from 'state/ui/editor/post/actions';
 import QueryPostTypes from 'components/data/query-post-types';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
 
 const EditorDrawer = React.createClass( {
-
 	propTypes: {
 		site: React.PropTypes.object,
 		post: React.PropTypes.object,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -48,8 +48,8 @@ const actions = require( 'lib/posts/actions' ),
 	i18n = require( 'lib/mixins/i18n' ),
 	EditorPreview = require( './editor-preview' ),
 	stats = require( 'lib/posts/stats' ),
-	analytics = require( 'analytics' ),
-	postTypesList = require( 'lib/post-types-list')();
+	analytics = require( 'analytics' );
+
 import {
 	setContent,
 	setExcerpt,
@@ -449,7 +449,6 @@ const PostEditor = React.createClass( {
 								type={ this.props.type }
 								site={ site }
 								post={ this.state.post }
-								postTypes={ postTypesList }
 								isNew={ this.state.isNew }
 							/>
 


### PR DESCRIPTION
Related: #3264, #3197

This pull request seeks to convert existing editor code using legacy `lib/post-types-list` to using Redux-based state and query components. This will become especially relevant with #3197, as otherwise the two approaches would make separate requests for post types from the REST API. 

__Implementation notes:__

There is significant overlap between this pull request and #3264. In fact, this pull request cherry-picks 079f8b5, 19b11d0, and 776afa8 to incorporate `<QueryPostTypes />`. Whichever pull request is merged first, the other will be rebased to remove the redundant commits.

__Testing instructions:__

Verify that post type support continues to behave as expected. This can be dependent upon the current theme of the site, but typically posts support "all" features, whereas a page type will usually not support tags.

1. Navigate to the [post editor](http://calypso.localhost:3000/post) or [post editor](http://calypso.localhost:3000/page)
2. Select a site, if prompted
3. Note that sidebar options are reflective of the features supported by the current type
 - Feature detection includes: Tags, excerpt, geolocation, and comments
 - If you're unfamiliar with supported features for your theme, check against the `/sites/%s/post-types` endpoint for your site ([example](https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.com/post-types?pretty=1))