### PR TITLE
Use the in-product support contact form from Start Over

### DIFF
--- a/client/my-sites/site-settings/start-over/index.jsx
+++ b/client/my-sites/site-settings/start-over/index.jsx
@@ -63,10 +63,8 @@ module.exports = React.createClass( {
 					<ActionPanelFooter>
 						<Button
 							className="settings-action-panel__support-button"
-							href="https://en.support.wordpress.com/contact"
-							target="_blank">
+							href="/help/contact">
 							{ strings.contactSupport }
-							<Gridicon icon="external" />
 						</Button>
 					</ActionPanelFooter>
 				</ActionPanel>


### PR DESCRIPTION
Repro:

1. Go to http://calypso.localhost:3000/settings/start-over/:site:
2. Click the "Contact Support" link

At present, it looks like this and points to https://en.support.wordpress.com/contact/:

![contact-start-over](https://cloud.githubusercontent.com/assets/2738252/13155723/0fa255fc-d64d-11e5-919f-5468eca8ef3d.png)

Since we now have a support experience inside Calypso, we should point there instead. I'm not super clear on whether we'd want to take over the current tab or still target `_blank`, though I feel like we probably want the former.

The change updates the link to point to `/help/contact`and removes the external link gridicon. With the change, clicking on the contact button will load the contact form in the current tab.

See also #3342, which is a very similar change and a bit of a slam dunk review. :)