### PR TITLE
Use the in-product support UI on Delete Site screen

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -160,7 +160,7 @@ module.exports = React.createClass( {
 							this.translate( 'If you\'re unsure about what will be deleted or need any help, not to worry, our support team ' +
 								'is here to answer any questions you might have.' )
 						}</p>
-						<p><a className="settings-action-panel__body-text-link" href="https://en.support.wordpress.com/contact" target="_blank">{ strings.contactSupport }</a></p>
+						<p><a className="settings-action-panel__body-text-link" href="/help/contact">{ strings.contactSupport }</a></p>
 					</ActionPanelBody>
 					<ActionPanelFooter>
 						<Button


### PR DESCRIPTION
Repro:

1. Go to http://calypso.localhost:3000/settings/delete-site/:site:
2. Click the "Contact Support" link

At present, it looks like this and points to https://en.support.wordpress.com/contact/:

![contact-delete-site](https://cloud.githubusercontent.com/assets/2738252/13084070/cb928c36-d4a5-11e5-848c-d49c5003a624.png)

Since we now have a support experience inside Calypso, we should point there instead. I'm not super clear on whether we'd want to take over the current tab or still target `_blank`, though I feel like we probably want the former.

The change updates the link to point to `/help/contact`. With the change, clicking on the contact button will load the contact form in the current tab.

See also #3341, which is a very similar change and a bit of a slam dunk review. :)