### PR TITLE
Checkout: Update `thank-you` page route

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -133,7 +133,8 @@ const Checkout = React.createClass( {
 			return `/plans/${ this.props.sites.getSelectedSite().slug }/thank-you`;
 		}
 
-		return '/checkout/thank-you';
+		// TODO: include the receipt ID in this URL when it is present
+		return `/checkout/${ this.props.sites.getSelectedSite().slug }/thank-you`;
 	},
 
 	content: function() {

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -276,7 +276,7 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'upgrades/checkout' ) ) {
 		page(
-			'/checkout/thank-you',
+			'/checkout/:site/:receiptId?/thank-you',
 			upgradesController.redirectIfThemePurchased,
 			upgradesController.checkoutThankYou
 		);


### PR DESCRIPTION
Before #3270 is merged, the API needs to be updated to redirect users to the new thank you page route at `/checkout/:site/:receipt_id/thank-you`. Before the API can be updated to redirect users to this new route, this route needs to work in Calypso.

This PR updates `Checkout` and the upgrades index to render the thank you page on `/checkout/:site/:receipt_id/thank-you`. This route works for any value of `:site` or `:receipt_id`, as the checkout process is still reliant on data in local storage. This is necessary to prevent errors for users before or after the patch that this PR depends on is deployed.

That patch is here: D1083-code
**Note:** You must point `foobar.wordpress.com` at your sandbox's IP in your hosts file, where *foobar* is the site slug of the site you are purchasing a plan (or other item) for when testing.

**Testing**
We need to assert that it is possible to reach the thank you page with and without the patch applied, with a credit card or with PayPal.

*Without the patch applied*
- Purchase an item (e.g. a plan) with a credit card.
- Assert that you land on the thank you page at `/checkout/:site/thank-you`, where `:site` is the slug of the site you checked out for.
- Purchase an item (e.g. a plan) with PayPal.
- Assert that you land on the thank you page at `/checkout/:site/thank-you`, where `:site` is the slug of the site you checked out for.

*With the patch applied*
- Purchase an item (e.g. a plan) with a credit card.
- Assert that you land on the thank you page at `/checkout/:site/thank-you`, where `:site` is the slug of the site you checked out for.
- Purchase an item (e.g. a plan) with PayPal.
- Assert that you land on the thank you page at `/checkout/:site/:receipt_id/thank-you`, where `:site` is the slug of the site you checked out for and `:receipt_id` is the ID of the receipt that was emailed to you.

- [x] Code review
- [x] Product review