### PR TITLE
Components: Prevent web preview from being obscured by master bar

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -54,7 +54,6 @@
 	@include breakpoint( "<660px" ) {
 		left: 0;
 		right: 0;
-		top: 0;
 		width: 100%;
 	}
 }


### PR DESCRIPTION
Fixes #3339

This pull request seeks to resolve an issue where the master bar would obscure the `<WebPreview />` component at small viewports.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/13093131/8ab1c7dc-d4d1-11e5-9425-43498bdbc10a.png)|![After](https://cloud.githubusercontent.com/assets/1779930/13093068/345c5f0a-d4d1-11e5-95d8-2d9ac91858e2.png)

__Design Notes:__

@mtias @folletto : Do you recall if the intent was for the Web Preview to be shown above the master bar? In which case, this may be a `z-index` issue. 

__Testing instructions:__

Due to the nature of the changes, this should not affect larger displays, but it may be worth verifying all the same.

Ensure that the preview in the post editor or theme preview is not obscured by the master bar.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Enter at title
4. (Mobile only) Click Actions in the editor header
5. Click Preview
6. Note that the preview is not obscured

/cc @ryanboren 