### PR TITLE
Recommendations: decode entities in recommendation reason

### DIFF
--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -18,6 +18,7 @@ import { fetchMore } from 'lib/recommended-sites-store/actions';
 import SiteStore from 'lib/reader-site-store';
 import { recordAction, recordGaEvent } from 'reader/stats';
 import { getSiteUrl } from 'reader/route';
+import { decodeEntities } from 'lib/formatting';
 
 const RecommendedForYou = React.createClass( {
 
@@ -112,7 +113,7 @@ const RecommendedForYou = React.createClass( {
 				<Title>
 					<a href={ siteUrl } onclick={ this.trackSiteClick }>{ title }</a>
 				</Title>
-				<Description>{ rec.reason }</Description>
+				<Description>{ decodeEntities( rec.reason ) }</Description>
 				<Actions>
 					<FollowButton siteUrl={ site.URL } />
 				</Actions>


### PR DESCRIPTION
When using a French test account, I noticed that we're not decoding HTML entities in the recommendation reason on http://calypso.localhost:3000/recommendations.

Before:
<img width="773" alt="screen shot 2016-02-17 at 12 31 00" src="https://cloud.githubusercontent.com/assets/17325/13094932/dba30290-d572-11e5-8efb-7cc00148f452.png">

After:
<img width="759" alt="screen shot 2016-02-17 at 12 31 27" src="https://cloud.githubusercontent.com/assets/17325/13094938/e47a16e2-d572-11e5-9871-75572391501e.png">
