### PR TITLE
Framework: add schema for current user

### DIFF
--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -7,6 +7,8 @@ import { combineReducers } from 'redux';
  * Internal dependencies
  */
 import { CURRENT_USER_ID_SET, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import { isValidStateWithSchema } from 'state/utils';
+import { idSchema } from './schema';
 
 /**
  * Tracks the current user ID.
@@ -23,7 +25,10 @@ export function id( state = null, action ) {
 		case SERIALIZE:
 			return state;
 		case DESERIALIZE:
-			return state;
+			if ( isValidStateWithSchema( state, idSchema ) ) {
+				return state;
+			}
+			return null;
 	}
 
 	return state;

--- a/client/state/current-user/schema.js
+++ b/client/state/current-user/schema.js
@@ -1,0 +1,4 @@
+export const idSchema = {
+	type: [ 'integer', 'null' ],
+	minimum: 0
+};

--- a/client/state/current-user/test/reducer.js
+++ b/client/state/current-user/test/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -27,13 +28,21 @@ describe( 'reducer', () => {
 		} );
 
 		describe( 'persistence', () => {
-			it.skip( 'should validate ID is positive', () => {
+			before( () => {
+				sinon.stub( console, 'warn' );
+			} );
+
+			after( () => {
+				console.warn.restore();
+			} );
+
+			it( 'should validate ID is positive', () => {
 				const state = id( -1, {
 					type: DESERIALIZE
 				} );
 				expect( state ).to.equal( null );
 			} );
-			it.skip( 'should validate ID is a number', () => {
+			it( 'should validate ID is a number', () => {
 				const state = id( 'foobar', {
 					type: DESERIALIZE
 				} );

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -2,24 +2,21 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import mockery from 'mockery';
+import sinon from 'sinon';
 import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
 import { SITE_RECEIVE, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import { items } from '../reducer';
 
-let items;
 describe( 'reducer', () => {
 	before( function() {
-		mockery.registerMock( 'lib/warn', () => {} );
-		mockery.enable( { warnOnReplace: false, warnOnUnregistered: false } );
-		items = require( '../reducer' ).items;
+		sinon.stub( console, 'warn' );
 	} );
 	after( function() {
-		mockery.deregisterAll();
-		mockery.disable();
+		console.warn.restore();
 	} );
 	describe( '#items()', () => {
 		it( 'should default to an empty object', () => {


### PR DESCRIPTION
This adds a schema for current-user to avoid data shape changing errors, as described in #3101  Also tidies up a test to use sinon rather than mockery.

## Testing Instructions
* Start Calypso with: 
```ENABLE_FEATURES=persist-redux make run```
* In the console set localStorage.debug to `calypso:state`
* Refresh the page a few times and navigate to a few sections.
* The app behaves normally and loads the persisted state/current-user from IndexedDB storage

cc @rralian @aduth @artpi @mtias 