### PR TITLE
Framework: add schema for sharing/publicize

### DIFF
--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -14,6 +14,8 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { connectionsSchema } from './schema';
+import { isValidStateWithSchema } from 'state/utils';
 
 /**
  * Track the current status for fetching connections. Maps site ID to the
@@ -55,8 +57,11 @@ export function connections( state = {}, action ) {
 		case PUBLICIZE_CONNECTIONS_RECEIVE:
 			return Object.assign( {}, state, keyBy( action.data.connections, 'ID' ) );
 		case SERIALIZE:
-			return {};
+			return state;
 		case DESERIALIZE:
+			if ( isValidStateWithSchema( state, connectionsSchema ) ) {
+				return state;
+			}
 			return {};
 	}
 

--- a/client/state/sharing/publicize/schema.js
+++ b/client/state/sharing/publicize/schema.js
@@ -1,0 +1,31 @@
+export const connectionsSchema = {
+	type: 'object',
+	patternProperties: {
+		'^\\d+$': {
+			type: 'object',
+			required: [ 'ID', 'site_ID' ],
+			properties: {
+				ID: { type: 'integer' },
+				site_ID: { type: 'integer' },
+				user_ID: { type: 'integer' },
+				keyring_connection_ID: { type: 'integer' },
+				keyring_connection_user_ID: { type: 'integer' },
+				shared: { type: 'boolean' },
+				service: { type: 'string' },
+				label: { type: 'string' },
+				issued: { type: 'string' },
+				expires: { type: 'string' },
+				external_ID: { type: [ 'string', 'null' ] },
+				external_name: { type: [ 'string', 'null' ] },
+				external_display: { type: [ 'string', 'null' ] },
+				external_profile_picture: { type: [ 'string', 'null' ] },
+				external_profile_URL: { type: [ 'string', 'null' ] },
+				external_follower_count: { type: [ 'integer', 'null' ] },
+				status: { type: 'string' },
+				refresh_URL: { type: 'string' },
+				meta: { type: 'object' }
+			}
+		}
+	},
+	additionalProperties: false
+};

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -122,18 +123,47 @@ describe( '#connections()', () => {
 	} );
 
 	describe( 'persistence', () => {
-		it( 'does not persist data because this is not implemented yet', () => {
+		before( () => {
+			sinon.stub( console, 'warn' );
+		} );
+		after( () => {
+			console.warn.restore();
+		} );
+
+		it( 'should persist data', () => {
 			const state = deepFreeze( {
 				1: { ID: 1, site_ID: 2916284 },
 				2: { ID: 2, site_ID: 2916284 }
 			} );
 			const persistedState = connections( state, { type: SERIALIZE } );
-			expect( persistedState ).to.eql( {} );
+			expect( persistedState ).to.eql( state );
 		} );
 
-		it( 'does not load persisted data because this is not implemented yet', () => {
+		it( 'should load valid data', () => {
 			const persistedState = deepFreeze( {
 				1: { ID: 1, site_ID: 2916284 },
+				2: { ID: 2, site_ID: 2916284 }
+			} );
+			const state = connections( persistedState, {
+				type: DESERIALIZE
+			} );
+			expect( state ).to.eql( persistedState );
+		} );
+
+		it( 'should ignore loading data with invalid keys', () => {
+			const persistedState = deepFreeze( {
+				foo: { ID: 1, site_ID: 2916284 },
+				bar: { ID: 2, site_ID: 2916284 }
+			} );
+			const state = connections( persistedState, {
+				type: DESERIALIZE
+			} );
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should ignore loading data with invalid values', () => {
+			const persistedState = deepFreeze( {
+				1: { ID: 1, site_ID: 'foo' },
 				2: { ID: 2, site_ID: 2916284 }
 			} );
 			const state = connections( persistedState, {


### PR DESCRIPTION
This PR adds a schema for sharing/publicize so we can avoid data shape changes as described in #3101. 

Thanks @aduth's refactors in #3417, we only need to persist connections. Other transient data like fetchingConnections will never be persisted.

## Testing Instructions
* In the console set localStorage.debug to `calypso:state`
* Make sure that your blog has some connections ( Connected to Facebook/Twitter/etc ).
* Navigate to the Editor
* Refresh the page.
* The app behaves normally and loads the persisted state/current-user from IndexedDB storage

To Validate that we can't get into an inconsistent state:
* Add a non-existent required property to `connectionsSchema`, like `foo`:
```javascript
export const connectionsSchema = {
	type: 'object',
	patternProperties: {
		'^\\d+$': {
			type: 'object',
			required: [ 'ID', 'site_ID', 'foo' ], //add a non-existent prop to test invalidations
			properties: {
				ID: { type: 'integer' },
				site_ID: { type: 'integer' },
				//...
			}
		}
	},
	additionalProperties: false
};
```
* Navigate to the Editor
* Refresh the page
* You should see a console warning that validation failed
* The Editor should load.

cc @aduth @mtias @rralian @blowery 