### PR TITLE
Site settings: Refactor to use locale rather than lang id

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -261,10 +261,14 @@ Undocumented.prototype.settings = function( siteId, method, data, fn ) {
 		data = {};
 	}
 
-	this.wpcom.req[ method ]( {
-		path: '/sites/' + siteId + '/settings',
-		body: data
-	}, fn );
+	const path = `/sites/${ siteId }/settings`;
+	const params = { apiVersion: '1.2' };
+
+	if ( 'get' === method ) {
+		this.wpcom.req.get( path , params, fn );
+	} else if ( 'post' === method ) {
+		this.wpcom.req.post( path, params, data, fn )
+	}
 };
 
 Undocumented.prototype._sendRequestWithLocale = function( originalParams, fn ) {

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -45,7 +45,7 @@ const FormGeneral = React.createClass( {
 		};
 
 		if ( site.settings ) {
-			settings.lang_id = site.settings.lang_id;
+			settings.locale = site.settings.locale;
 			settings.blog_public = site.settings.blog_public;
 			settings.admin_url = site.settings.admin_url;
 			settings.timezone_string = site.settings.timezone_string;
@@ -92,8 +92,8 @@ const FormGeneral = React.createClass( {
 			fetchingSettings: true,
 			blogname: '',
 			blogdescription: '',
-			lang_id: '',
 			timezone_string: '',
+			locale: '',
 			blog_public: '',
 			admin_url: '',
 			jetpack_relatedposts_allowed: false,
@@ -206,12 +206,13 @@ const FormGeneral = React.createClass( {
 		}
 		return (
 			<FormFieldset>
-				<FormLabel htmlFor="lang_id">{ this.translate( 'Language' ) }</FormLabel>
+				<FormLabel htmlFor="locale">{ this.translate( 'Language' ) }</FormLabel>
 				<LanguageSelector
-					name="lang_id"
-					id="lang_id"
+					name="locale"
+					id="locale"
 					languages={ config( 'languages' ) }
-					valueLink={ this.linkState( 'lang_id' ) }
+					valueKey="langSlug"
+					valueLink={ this.linkState( 'locale' ) }
 					disabled={ this.state.fetchingSettings }
 					onClick={ this.onRecordEvent( 'Clicked Language Field' ) } />
 				<FormSettingExplanation>


### PR DESCRIPTION
Lang ids depend on a hard coded config array, with meaningless values. We should use locale codes instead. 