### PR TITLE
Plans: Update REST API endpoint to sync better with mobile app

### DIFF
--- a/client/lib/plans-list/test/data.js
+++ b/client/lib/plans-list/test/data.js
@@ -2,7 +2,6 @@ var plans = [
 	{
 		"product_id":1003,
 		"product_name":"WordPress.com Premium",
-		"product_name_en":"WordPress.com Premium",
 		"prices":{
 			"USD":99,
 			"NZD":139,
@@ -14,8 +13,7 @@ var plans = [
 		},
 		"product_slug":"value_bundle",
 		"tagline":"Blog, supercharged",
-		"shortdesc":"Save up to 40% on our most popular upgrades. Get all of these great features to super-charge your blog in one simple purchase.",
-		"description":"Save up to 40% on our most popular upgrades. Get all of these great features to super-charge your blog in one simple purchase. Includes a domain name of your choice or domain mapping for an existing domain, VideoPress, Custom Design, 10GB Space Upgrade, and No Ads.",
+		"description":"Save up to 40% on our most popular upgrades. Get all of these great features to super-charge your blog in one simple purchase.",
 		"capability":"manage_options",
 		"cost":99,
 		"bill_period":365,
@@ -43,7 +41,6 @@ var plans = [
 	{
 	"product_id":1008,
 	"product_name":"WordPress.com Business",
-	"product_name_en":"WordPress.com Business",
 	"prices":{
 		"USD":299,
 		"NZD":399,
@@ -55,8 +52,7 @@ var plans = [
 	},
 	"product_slug":"business-bundle",
 	"tagline":"Build a great website",
-	"shortdesc":"All you need to build a great website: live chat support, unlimited premium themes, easy ecommerce, unlimited storage, and a custom domain name.",
-	"description":"All you need to build a great website:<ul><li>Chat live with a WordPress.com specialist, Monday to Friday between 7am and 7pm Eastern time.<\/li><li>Try any premium theme and change as often as you like, no extra charge.<\/li><li>Upload all the video and audio files you want with unlimited storage.<\/li><\/ul>Including all the features of WordPress.com Premium:<ul><li>A domain of your choice to replace your site\u2019s default address<\/li><li>Custom Design to customize your site\u2019s appearance and choose unique fonts and colors<\/li><li>VideoPress to embed beautiful HD video straight from your dashboard or from your mobile device<\/li><li>Hides all ads on your site<\/li><\/ul>",
+	"description":"All you need to build a great website: live chat support, unlimited premium themes, easy ecommerce, unlimited storage, and a custom domain name.",
 	"capability":"manage_options",
 	"cost":299,
 	"bill_period":365,
@@ -83,7 +79,6 @@ var plans = [
 	{
 	"product_id":1,
 	"product_name":"Beginner",
-	"product_name_en":"Beginner",
 	"prices":{
 		"USD":0,
 		"AUD":0,
@@ -94,8 +89,7 @@ var plans = [
 	},
 	"product_slug":"free_plan",
 	"tagline":"Get started",
-	"shortdesc":"Get a free blog and be on your way to publishing your first post in less than five minutes.",
-	"description":"Just start blogging: get a free blog and be on your way to publishing your first post in less than five minutes.",
+	"description":"Get a free blog and be on your way to publishing your first post in less than five minutes.",
 	"capability":"manage_options",
 	"cost":0,
 	"bill_period":-1,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -336,18 +336,17 @@ Undocumented.prototype.settings = function( siteId, method, data, fn ) {
 };
 
 Undocumented.prototype._sendRequestWithLocale = function( originalParams, fn ) {
-	var locale = i18n.getLocaleSlug(),
-		updatedParams;
+	const { apiVersion, body = {}, method } = originalParams,
+		locale = i18n.getLocaleSlug(),
+		updatedParams = omit( originalParams, [ 'apiVersion', 'method' ] );
 
-	updatedParams = clone( originalParams );
-	if ( originalParams.body ) {
-		updatedParams.body = clone( originalParams.body );
-		updatedParams.body.locale = locale;
+	updatedParams.body = Object.assign( {}, body, { locale } );
+
+	if ( apiVersion ) {
+		this.wpcom.req[ method.toLowerCase() ]( updatedParams, { apiVersion }, fn );
 	} else {
-		updatedParams.body = { locale: locale };
+		this.wpcom.req[ method.toLowerCase() ]( updatedParams, fn );
 	}
-
-	this.wpcom.req[ updatedParams.method.toLowerCase() ]( updatedParams, fn );
 };
 
 /**

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -343,6 +343,7 @@ Undocumented.prototype._sendRequestWithLocale = function( originalParams, fn ) {
 	updatedParams.body = Object.assign( {}, body, { locale } );
 
 	if ( apiVersion ) {
+		// TODO: temporary solution for apiVersion until https://github.com/Automattic/wpcom.js/issues/152 is resolved
 		this.wpcom.req[ method.toLowerCase() ]( updatedParams, { apiVersion }, fn );
 	} else {
 		this.wpcom.req[ method.toLowerCase() ]( updatedParams, fn );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -534,7 +534,8 @@ Undocumented.prototype.getPlans = function( fn ) {
 	debug( '/plans query' );
 	this._sendRequestWithLocale( {
 		path: '/plans',
-		method: 'get'
+		method: 'get',
+		apiVersion: '1.2'
 	}, fn );
 };
 

--- a/client/my-sites/plans/jetpack-plan-details/index.jsx
+++ b/client/my-sites/plans/jetpack-plan-details/index.jsx
@@ -9,7 +9,7 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 			<div>
-				<p>{ this.props.plan.shortdesc }</p>
+				<p>{ this.props.plan.description }</p>
 				<ul>
 					<li>{ this.props.plan.feature_1 }</li>
 					<li>{ this.props.plan.feature_2 }</li>

--- a/client/my-sites/plans/wpcom-plan-details/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-details/index.jsx
@@ -9,7 +9,7 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 			<div>
-				<p>{ this.props.plan.shortdesc }</p>
+				<p>{ this.props.plan.description }</p>
 				<a href={ this.props.comparePlansUrl } onClick={ this.props.handleLearnMoreClick }
 					className="plan__learn-more">{ this.translate( 'Learn more', { context: 'Find out more details about a plan' } ) }</a>
 			</div>


### PR DESCRIPTION
Fixes #3116.

It requires backend changes to be applied: `D1086`.

### Testing
1. Go to http://calypso.localhost:3000/plans.
2. Select a regular Site.
3. You should see the same plan descriptions as before.
4. Switch to a Jetpack Site.
5. You should see the same plan descriptions as before.
