### PR TITLE
Signup: Fix race condition causing unit test to fail occasionally

### DIFF
--- a/client/lib/signup/test/progress-store-test.js
+++ b/client/lib/signup/test/progress-store-test.js
@@ -3,6 +3,8 @@ global.localStorage = require( 'localStorage' );
 /**
  * External dependencies
  */
+import sinon from 'sinon';
+
 var debug = require( 'debug' )( 'calypso:signup-progress-store:test' ), // eslint-disable-line no-unused-vars
 	assert = require( 'assert' ),
 	omit = require( 'lodash/object/omit' ),
@@ -31,17 +33,19 @@ describe( 'SignupProgressStore', function() {
 		assert.equal( SignupProgressStore.get()[ 0 ].stepName, 'site-selection' );
 	} );
 
-	it( 'should add a timestamp to each step', function( done ) {
-		var previousTimestamp;
+	it( 'should add a timestamp to each step', function() {
+		var previousTimestamp,
+			clock = sinon.useFakeTimers();
 
 		SignupActions.saveSignupStep( { stepName: 'site-selection' } );
+		clock.tick( 100 );
 		previousTimestamp = SignupProgressStore.get()[ 0 ].lastUpdated;
 
-		setTimeout( function() {
-			SignupActions.saveSignupStep( { stepName: 'site-selection' } );
-			assert( SignupProgressStore.get()[ 0 ].lastUpdated > previousTimestamp );
-			done();
-		}, 5 );
+		SignupActions.saveSignupStep( { stepName: 'site-selection' } );
+		clock.tick( 100 );
+		assert( SignupProgressStore.get()[ 0 ].lastUpdated > previousTimestamp );
+
+		clock.restore();
 	} );
 
 	it( 'should not store the same step twice', function() {


### PR DESCRIPTION
In one test under `lib/signup/test/progress-store-test`, on rare occasions the clock did not advance before a setTimeout was called. An assertion to check that the time had advanced was failing, causing the build to fail on CircleCI:

![screen shot 2016-02-17 at 7 32 28 pm](https://cloud.githubusercontent.com/assets/416133/13105298/49757d08-d5ae-11e5-8741-05b61187a988.png)

This change uses [sinon's fake timer](http://sinonjs.org/docs/#clock) to override the Date object and manually control the passing of time, ensuring a consistent clock for testing. This also has the advantage of cutting out the 5ms delay in this test.

To run the tests:
```
(cd client/lib/signup && make test)
```

To confirm it fails without time passing, remove the `clock.tick( 100 );` lines and run the tests again - you should see the test fail as in the screenshot above.