### PR TITLE
i18n: Make texts easier to translate with fewer components

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -57,17 +57,16 @@ const RemovePurchase = React.createClass( {
 
 				if ( isDomainRegistration( purchase ) ) {
 					notices.success(
-						this.translate( 'The domain {{em}}%(domain)s{{/em}} was removed from your account.', {
-							args: { domain: productName },
-							components: { em: <em /> }
+						this.translate( 'The domain {{domain/}} was removed from your account.', {
+							components: { domain: <em>{ productName }</em> }
 						} ),
 						{ persistent: true }
 					);
 				} else {
 					notices.success(
-						this.translate( '%(productName)s was removed from {{em}}%(siteSlug)s{{/em}}.', {
-							args: { productName, siteSlug: selectedSite.slug },
-							components: { em: <em /> }
+						this.translate( '%(productName)s was removed from {{siteName/}}.', {
+							args: { productName },
+							components: { siteName: <em>{ selectedSite.slug }</em> }
 						} ),
 						{ persistent: true }
 					);
@@ -149,10 +148,9 @@ const RemovePurchase = React.createClass( {
 				<p>
 					{
 						this.translate(
-							'The domain associated with this plan, {{em}}%(domain)s{{/em}}, will not be removed. It will remain active on your site, unless also removed.',
+							'The domain associated with this plan, {{domain/}}, will not be removed. It will remain active on your site, unless also removed.',
 							{
-								args: { domain: getIncludedDomain( purchase ) },
-								components: { em: <em /> }
+								components: { domain: <em>{ getIncludedDomain( purchase ) }</em> }
 							}
 						)
 					}
@@ -164,14 +162,13 @@ const RemovePurchase = React.createClass( {
 			<div>
 				<p>
 					{
-						this.translate( 'Are you sure you want to remove %(productName)s from {{em}}%(siteSlug)s{{/em}}?', {
-							args: { productName, siteSlug: this.props.selectedSite.slug },
-							components: { em: <em /> }
+						this.translate( 'Are you sure you want to remove %(productName)s from {{siteName/}}?', {
+							args: { productName },
+							components: { siteName: <em>{ this.props.selectedSite.slug }</em> }
 						} )
 					}
 					{ ' ' }
 					{ this.translate( 'You will not be able to reuse it again without purchasing a new subscription.', {
-						context: "Removal confirmation on Manage Purchase page",
 						comment: "'it' refers to a product purchased by a user"
 					} ) }
 				</p>


### PR DESCRIPTION
In these texts we have quite a few components of the form: `{{tag}}%(variable){{/tag}`

To a translator this is potentially very confusing text. Therefore, if a tag includes only a variable, we can make the whole thing a component: `{{variable/}}` and use `{ components: { variable: <tag>{ variable }</tag> } }`

@drewblaisdell this affects your strings at "Remove Purchase" but I have a hard time testing the strings if my approach really works. Could you please try? Thanks!