### PR TITLE
Domains: allow different variations of root domain for supported records

### DIFF
--- a/client/my-sites/upgrades/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-add-new.jsx
@@ -66,7 +66,7 @@ const DnsAddNew = React.createClass( {
 			initialFields: this.getInitialFields(),
 			onNewState: this.setFormState,
 			validatorFunction: ( fieldValues, onComplete ) => {
-				onComplete( null, validateAllFields( fieldValues ) );
+				onComplete( null, validateAllFields( fieldValues, this.props.selectedDomainName ) );
 			}
 		}	);
 


### PR DESCRIPTION
Before, we only supported an empty name (subdomain) as means of inputting the root domain. Since some users might by mistake or out of habit input other variations, this change will treat the following the same as empty subdomain and add a root domain (for records that it's allowed):
* `@`
* `@.example.com`
* `@.example.com.`
* `example.com`
* `example.com.`

This fixes #3318

/cc
@umurkontaci @aidvu for code review
@BandonRandon for additional testing