### PR TITLE
A/B test for a free by default signup flow

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -91,7 +91,7 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
-	paidPlansOnly: {
+	freePlansDefault: {
 		datestamp: '20160217',
 		variations: {
 			allPlans: 90,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -92,7 +92,7 @@ module.exports = {
 		defaultVariation: 'original'
 	},
 	freePlansDefault: {
-		datestamp: '20160217',
+		datestamp: '20160218',
 		variations: {
 			allPlans: 90,
 			skipForFree: 10

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -91,4 +91,12 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
+	paidPlansOnly: {
+		datestamp: '20160217',
+		variations: {
+			allPlans: 90,
+			skipForFree: 10
+		},
+		defaultVariation: 'allPlans'
+	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -220,8 +220,19 @@ function filterFlowName( flowName ) {
 		}
 	}
 
-	if ( 'skipForFree' === abtest( 'freePlansDefault' ) ) {
-		return 'upgrade';
+	let isInPreviousTest = false;
+
+	if ( getABTestVariation( 'headstart' ) && getABTestVariation( 'headstart' ) !== 'notTested' ) {
+		isInPreviousTest = true;
+	}
+
+	if ( getABTestVariation( 'altThemes' ) && getABTestVariation( 'altThemes' ) !== 'notTested' ) {
+		isInPreviousTest = true;
+	}
+
+	const freePlansTestFlows = [ 'blog', 'website', 'main' ];
+	if ( includes( freePlansTestFlows, flowName ) && ! isInPreviousTest ) {
+		return 'skipForFree' === abtest( 'freePlansDefault' ) ? 'upgrade' : flowName;
 	}
 
 	return flowName;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -219,6 +219,11 @@ function filterFlowName( flowName ) {
 			return ( 'blog' === flowName ) ? 'blog-altthemes' : 'website-altthemes';
 		}
 	}
+
+	if ( 'skipForFree' === abtest( 'freePlansDefault' ) ) {
+		return 'upgrade';
+	}
+
 	return flowName;
 }
 

--- a/client/signup/test/lib/abtest/index.js
+++ b/client/signup/test/lib/abtest/index.js
@@ -1,5 +1,7 @@
 // abtest stub
 export default {
-	abtest() { return ''; }
+	abtest() { return ''; },
+
+	getABTestVariation() { return ''; }
 };
 


### PR DESCRIPTION
A/B Test definition for this signup flow: https://github.com/Automattic/wp-calypso/pull/3335

#### Testing instructions

1. Run `git checkout [branch]` and start your server
2. Add yourself to the ab test: `localStorage.setItem('ABTests','{"freePlansDefault_20160217":"skipForFree"}')`
2. Open the [`Signup` page](http://calypso.localhost:3000/start) in a private window
3. Assert that you are redirect to `/start/upgrade`


#### Reviews

- [x] Code
- [x] Product