### PR TITLE
Update node-phone version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8972,9 +8972,8 @@
       }
     },
     "phone": {
-      "version": "1.0.4-3",
-      "from": "git+https://github.com/Automattic/node-phone.git#0a3a87cc2b70906c7367ba3a9c9a27915f335443",
-      "resolved": "git+https://github.com/Automattic/node-phone.git#0a3a87cc2b70906c7367ba3a9c9a27915f335443"
+      "version": "1.0.4-9",
+      "resolved": "git+https://github.com/Automattic/node-phone.git#1.0.4-9"
     },
     "photon": {
       "version": "2.0.0",
@@ -13335,7 +13334,7 @@
     },
     "jshashes": {
       "version": "1.0.5"
-	},
+    },
     "path-parser": {
       "version": "1.0.2"
     },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "node-sass": "3.4.2",
     "page": "1.6.4",
     "path-parser": "1.0.2",
-    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-8",
+    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-9",
     "photon": "2.0.0",
     "q": "1.0.1",
     "qrcode.react": "0.5.2",


### PR DESCRIPTION
A user from Mauritius reports that our phone validation is incorrect. We've updated node-phone to make sure we're allowing phone numbers beginning with 5 or 87 and 7 or 8 digits long, which should cover valid Mauritiusian phone numbers. Before the change, entering a well-formed number results in this error:

![screen shot 2016-02-17 at 11 30 45 am](https://cloud.githubusercontent.com/assets/2738252/13116537/4de4fbd2-d56a-11e5-815a-6bba23ae1f5d.png)

To test:

1. Go to http://calypso.localhost:3000/me/security/two-step
2. Select Mauritius as the country.
3. Enter invalid phone numbers (e.g. 51111 or 61111). They should fail.
4. Enter well-formed phone numbers (e.g. 8711111, 87111111, 5111111, or 51111111). They should not show the red validation error.

The versioning in package.json and the shrinkwrap file is automated. When I saved the config using `npm install` and `clingwrap`, I specified the version number, and it picked up the hash. I'm not sure whether there's a way to override that or not.

Cc @ebinnion @jmdodd @gwwar (who may be able to shed light on the shrinkwrap question)