### PR TITLE
fraework: set `wpcom` global var only in development env

### DIFF
--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -45,6 +45,11 @@ if ( config.isEnabled( 'support-user' ) ) {
 	wpcom = wpcomSupport( wpcom );
 }
 
+// expose wpcom global var only in development
+if ( 'development' === config( 'env' ) ) {
+	window.wpcom = wpcom;
+}
+
 // Inject localization helpers to `wpcom` instance
 wpcom = injectLocalization( wpcom );
 


### PR DESCRIPTION
This PR set `wpcom` like a global var **only** in development environment.
Many times I've had to test some stuff related with the wpcom library and one thing that I usually do is exposing this var globally. So in the console we can do something like the following:

![image](https://cloud.githubusercontent.com/assets/77539/13117818/3a3bd0fe-d580-11e5-8bb7-10e7df2ee96b.png)

### Testing
* run calypso doing `make run`. Open the browser console to start to play with the `WPCOM` instance.
* change the environment doing `NODE_ENV=production make run`. `wpcom` shouldn't be a WPCOM instance.
