### PR TITLE
Server Side Rendering: Use lru-cache instead of LruMap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13335,58 +13335,9 @@
     },
     "jshashes": {
       "version": "1.0.5"
-	},
+    },
     "path-parser": {
       "version": "1.0.2"
-    },
-    "lru-map": {
-      "version": "1.2.0",
-      "dependencies": {
-        "coffee-script": {
-          "version": "1.10.0"
-        },
-        "es6-map": {
-          "version": "0.1.3",
-          "dependencies": {
-            "d": {
-              "version": "0.1.1"
-            },
-            "es5-ext": {
-              "version": "0.10.11",
-              "dependencies": {
-                "es6-symbol": {
-                  "version": "3.0.2"
-                }
-              }
-            },
-            "es6-iterator": {
-              "version": "2.0.0",
-              "dependencies": {
-                "es6-symbol": {
-                  "version": "3.0.2"
-                }
-              }
-            },
-            "es6-symbol": {
-              "version": "3.0.2"
-            },
-            "es6-set": {
-              "version": "0.1.4",
-              "dependencies": {
-                "es6-symbol": {
-                  "version": "3.0.2"
-                }
-              }
-            },
-            "event-emitter": {
-              "version": "0.3.4"
-            }
-          }
-        },
-        "es6-symbol": {
-          "version": "2.0.1"
-        }
-      }
     },
     "react-click-outside": {
       "version": "2.1.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "localforage": "1.3.3",
     "lodash": "3.10.1",
     "lru-cache": "4.0.0",
-    "lru-map": "1.2.0",
     "lunr": "0.5.7",
     "marked": "0.3.5",
     "moment": "2.10.6",

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -5,15 +5,15 @@ import ReactDomServer from 'react-dom/server';
 import Helmet from 'react-helmet';
 import memoize from 'lodash/function/memoize';
 import superagent from 'superagent';
-import LruMap from 'lru-map';
+import Lru from 'lru-cache';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
 
+const markupCache = new Lru( { max: 1000 } );
 const memoizedRenderToString = memoize( ReactDomServer.renderToString, element => JSON.stringify( element ) );
-memoizedRenderToString.cache = new LruMap( { maxSize: 1000 } );
 
 function bumpStat( group, name ) {
 	const url = `http://pixel.wp.com/g.gif?v=wpcom-no-pv&x_${ group }=${ name }&t=${ Math.random() }`;
@@ -24,6 +24,8 @@ function bumpStat( group, name ) {
 }
 
 export function render( element ) {
+	memoizedRenderToString.cache = markupCache;
+
 	if ( ! memoizedRenderToString.cache.has( element ) ) {
 		bumpStat( 'calypso-ssr', 'loggedout-design-cache-miss' );
 	}

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -26,7 +26,7 @@ function bumpStat( group, name ) {
 export function render( element ) {
 	memoizedRenderToString.cache = markupCache;
 
-	if ( ! memoizedRenderToString.cache.has( element ) ) {
+	if ( ! memoizedRenderToString.cache.has( JSON.stringify( element ) ) ) {
 		bumpStat( 'calypso-ssr', 'loggedout-design-cache-miss' );
 	}
 


### PR DESCRIPTION
We already have lru-cache, it's licensed as ISC, and doesn't cause build issues for desktop.

To test:
- Restart `make run`
- Visit http://calypso.localhost:3000/themes/blah
- Visit http://calypso.localhost:3000/themes/blah again, check for no server errors
- Optional: Add a console.log to the cache miss check, and check that there's only one cache miss

/cc @mkaz @mjangda 