### PR TITLE
Add issue template to aid in better bug reporting

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,29 @@
+<!--
+Thank you for contributing to Calypso!
+
+Docs & troubleshooting:
+=======================
+https://github.com/Automattic/wp-calypso/blob/master/CONTRIBUTING.md
+https://github.com/Automattic/wp-calypso/blob/master/docs/troubleshooting.md
+
+Think you found a bug?
+======================
+Use the template below to log a new bug. If you want to prefix the title with a “Question:”, “Bug:”, or the general area of the application, that would be helpful, but by no means mandatory. If you have write access, add the appropriate labels.
+
+Have a feature request?
+=======================
+If you want to prefix the title with “Question:”, “Feature Request:”, or the general area of the application, that would be helpful. For example, "Editor: add ability to choose from most popular tags" would make a great title.
+-->
+
+<!-- BUG TEMPLATE -->
+## URL:
+
+## What I expected
+
+## What happened instead
+
+## Steps to reproduce
+
+## Browser OS version
+
+## Screenshots/Video


### PR DESCRIPTION
Props @adambbecker for this idea.

> A new GitHub feature just silently launched today called “issue templates”, might be useful :simple_smile: Here’s the discussion around it https://github.com/dear-github/dear-github/issues/125 & here’s an example https://github.com/reactjs/react-router/blob/master/issue_template.md

> Basically we can just put an `issue_template.md` in the root directory and that will act as the template for whenever someone clicks the “new issue” button.

Tagging @hoverduck for a review of the file + text.