### PR TITLE
Framework: rename schema export to match convention

### DIFF
--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -12,7 +12,7 @@ import omit from 'lodash/omit';
  */
 import { plans } from './plans/reducer';
 import { SITE_RECEIVE, SERIALIZE, DESERIALIZE } from 'state/action-types';
-import schema from './schema';
+import { sitesSchema } from './schema';
 import { isValidStateWithSchema } from 'state/utils';
 
 /**
@@ -37,7 +37,10 @@ export function items( state = {}, action ) {
 			} );
 			return keyBy( sites, 'ID' );
 		case DESERIALIZE:
-			return isValidStateWithSchema( state, schema ) ? state : {};
+			if ( isValidStateWithSchema( state, sitesSchema ) ) {
+				return state;
+			}
+			return {};
 	}
 	return state;
 }

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -1,4 +1,4 @@
-export default {
+export const sitesSchema = {
 	type: 'object',
 	patternProperties: {
 		//be careful to escape regexes properly


### PR DESCRIPTION
This updates our named export values to be more consistent. As discussed in https://github.com/Automattic/wp-calypso/pull/3357#discussion_r53176215

## Testing Instructions
* Start Calypso with: 
```ENABLE_FEATURES=persist-redux make run```
* In the console set localStorage.debug to `calypso:state`
* Click on 'My Sites', then switch to a few different sites through the site picker
* Click on Themes. Reload the page.
* The app behaves normally and loads the sites subtree from IndexedDB storage

cc @aduth @artpi @retrofox 