### PR TITLE
client/boot: Fix startsWith() argument order

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -202,7 +202,7 @@ function reduxStoreReady( reduxStore ) {
 				props = { routeName: matchedRoutes[0].name, match: matchedRoutes[0].match };
 				Layout = require( 'layout/logged-out-design' );
 			}
-		} else if ( startsWith( '/design', window.location.pathname ) ) {
+		} else if ( startsWith( window.location.pathname, '/design' ) ) {
 			Layout = require( 'layout/logged-out-design' );
 		}
 


### PR DESCRIPTION
We really want to check if `window.location.pathname` starts with `design/`,
not the other way round.

See https://lodash.com/docs#startsWith

cc @ehg