### PR TITLE
Components: Fix web preview inability to scroll on iOS

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -68,12 +68,6 @@
 	}
 }
 
-.web-preview__frame {
-	background: $gray-light;
-	width: 100%;
-	height: 100%;
-}
-
 .web-preview__toolbar {
 	background: $white;
 	border-bottom: 1px solid lighten( $gray, 20% );
@@ -139,8 +133,12 @@
 }
 
 .web-preview__frame {
+	display: block;
+	width: 100%;
+	height: 100%;
 	opacity: 0;
 	transition: opacity 0.2s ease-in-out;
+	background: $gray-light;
 
 	.is-loaded & {
 		opacity: 1;
@@ -150,6 +148,8 @@
 .web-preview__placeholder {
 	width: 100%;
 	height: 100%;
+	overflow-y: auto;
+	-webkit-overflow-scrolling: touch;
 }
 
 .web-preview .spinner {


### PR DESCRIPTION
Fixes #2566 

This pull request seeks to resolve an issue where it is not possible to scroll a `<WebPreview />` component on an iOS touch device. Notably, this affects post editor and theme previews.

__Implementation notes:__

Only iOS behavior should be impacted. Other contexts should behave exactly the same as they do currently, though you should verify on both an iOS device (or simulator) and your primary browser.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Enter at title
4. (Mobile only) Click Actions in the editor header
5. Click Preview
6. Note that you can scroll the preview
 - On desktop browsers, confirm that if the page should scroll, a single scrollbar is visible

/cc @folletto 