### PR TITLE
Reader: add /read/following redirect to /

### DIFF
--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -31,6 +31,7 @@ module.exports = function() {
 		page( '/tag/*', controller.loadSubscriptions );
 
 		page( '/', updateLastRoute, controller.removePost, controller.sidebar, controller.following );
+		page( '/read/following', '/' );
 
 		page( '/read/blog/feed/:feed_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.feedListing );
 		page.exit( '/read/blog/feed/:feed_id', controller.resetTitle );


### PR DESCRIPTION
In the previous codebase, `/read/following` navigated the user to Followed Sites in the Reader. 

@nickmomrik mentioned that he had an old bookmark pointing to `/read/following/`, and we still have a number of links in the wordpress.com codebase pointing there.

This PR adds a redirect from `/read/following` to `/`.