### PR TITLE
Stats: Do not show no post on record when loading post details.

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -39,13 +39,16 @@ export default React.createClass( {
 		let title;
 
 		const post = this.props.postViewsList.response.post;
+		const isLoading = this.props.postViewsList.isLoading();
 		const postOnRecord = post && post.post_title !== null;
 
 		if ( postOnRecord ) {
 			if ( typeof post.post_title === 'string' && post.post_title.length ) {
 				title = <Emojify>{ post.post_title }</Emojify>;
 			}
-		} else {
+		}
+
+		if ( ! postOnRecord && ! isLoading ) {
 			title = this.translate( 'We don\'t have that post on record yet.' );
 		}
 
@@ -57,7 +60,7 @@ export default React.createClass( {
 
 				<SummaryChart
 					key="chart"
-					loading={ this.props.postViewsList.isLoading() }
+					loading={ isLoading }
 					dataList={ this.props.postViewsList }
 					barClick={ this.props.barClick }
 					activeKey="period"


### PR DESCRIPTION
Quick trash pick up on post detail pages - fixes #3358 by not showing the "We don't have that post on record yet." message while post stat details are being fetched from the API.

__To Test__
- Open a site stats page
- Click on a post or page from the Post & Pages module
- Note on the post details page that opens that no title is shown until the data is done loading
- You can change the post ID in the URL to an invalid post ID and note that the message is then shown

/cc @jancavan 