### PR TITLE
Signup: Simplify timestamp test

### DIFF
--- a/client/lib/signup/test/progress-store-test.js
+++ b/client/lib/signup/test/progress-store-test.js
@@ -15,6 +15,8 @@ var debug = require( 'debug' )( 'calypso:signup-progress-store:test' ), // eslin
 /**
  * Internal dependencies
  */
+import Dispatcher from 'dispatcher';
+
 var SignupProgressStore = require( '../progress-store' ),
 	SignupActions = require( '../actions' );
 
@@ -33,19 +35,25 @@ describe( 'SignupProgressStore', function() {
 		assert.equal( SignupProgressStore.get()[ 0 ].stepName, 'site-selection' );
 	} );
 
-	it( 'should add a timestamp to each step', function() {
-		var previousTimestamp,
-			clock = sinon.useFakeTimers();
+	describe( 'timestamps', function() {
+		beforeEach( () => {
+			this.clock = sinon.useFakeTimers( 12345 );
+		} );
 
-		SignupActions.saveSignupStep( { stepName: 'site-selection' } );
-		clock.tick( 100 );
-		previousTimestamp = SignupProgressStore.get()[ 0 ].lastUpdated;
+		afterEach( () => {
+			this.clock.restore();
+		} );
 
-		SignupActions.saveSignupStep( { stepName: 'site-selection' } );
-		clock.tick( 100 );
-		assert( SignupProgressStore.get()[ 0 ].lastUpdated > previousTimestamp );
+		it( 'should be updated at each step', function() {
+			Dispatcher.handleViewAction( {
+				type: 'SAVE_SIGNUP_STEP',
+				data: {
+					stepName: 'site-selection'
+				}
+			} );
 
-		clock.restore();
+			assert.equal( SignupProgressStore.get()[ 0 ].lastUpdated, 12345 );
+		} );
 	} );
 
 	it( 'should not store the same step twice', function() {


### PR DESCRIPTION
This change manually sets the time in a timestamp test, ensuring that the action updates the `lastUpdated` value in the store. No simulated passing of time is required, simplifying the test.

Also see #3362 and p1455745093000187-slack-calypso

cc @blowery @gwwar 