### PR TITLE
Post normalizer: detect Polldaddy embeds and link to each poll

### DIFF
--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -39,6 +39,7 @@ const fastPostNormalizationRules = [
 			postNormalizer.content.disableAutoPlayOnEmbeds,
 			postNormalizer.content.disableAutoPlayOnMedia,
 			postNormalizer.content.detectEmbeds,
+			postNormalizer.content.detectPolls,
 			postNormalizer.content.wordCountAndReadingTime
 		] ),
 		classifyPost

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -25,8 +25,9 @@ var assign = require( 'lodash/object/assign' ),
 /**
  * Internal depedencies
  */
-var formatting = require( 'lib/formatting' ),
-	safeImageURL = require( 'lib/safe-image-url' );
+import i18n from 'lib/mixins/i18n';
+import formatting from 'lib/formatting';
+import safeImageURL from 'lib/safe-image-url';
 
 const DEFAULT_PHOTON_QUALITY = 80, // 80 was chosen after some heuristic testing as the best blend of size and quality
 	READING_WORDS_PER_SECOND = 250 / 60; // Longreads says that people can read 250 words per minute. We want the rate in words per second.
@@ -730,6 +731,32 @@ normalizePost.content = {
 				srcUrl.query = stripAutoPlays( srcUrl.query );
 				srcUrl.search = null;
 				embed.src = url.format( srcUrl );
+			}
+		} );
+
+		callback();
+	},
+
+	// Attempt to find embedded Polldaddy polls - and link to any we find
+	detectPolls( post, callback ) {
+		if ( ! post.__contentDOM ) {
+			throw new Error( 'this transform must be used as part of withContentDOM' );
+		}
+
+		// Polldaddy embed markup isn't very helpfully structured, but we can look for the noscript tag,
+		// which contains the information we need, and replace it with a paragraph.
+		let noscripts = toArray( post.__contentDOM.querySelectorAll( 'noscript' ) );
+
+		noscripts.forEach( function( noscript ) {
+			if ( ! noscript.firstChild ) {
+				return;
+			}
+			let firstChildData = formatting.decodeEntities( noscript.firstChild.data );
+			let match = firstChildData.match( '^<a href="http:\/\/polldaddy.com\/poll\/([0-9]+)' );
+			if ( match ) {
+				let p = document.createElement( 'p' );
+				p.innerHTML = '<a rel="external" target="_blank" href="http://polldaddy.com/poll/' + match[1] + '">' + i18n.translate( 'Take our poll' ) + '</a>';
+				noscript.parentNode.replaceChild( p, noscript );
 			}
 		} );
 

--- a/client/lib/post-normalizer/test/lib/mixins/i18n.js
+++ b/client/lib/post-normalizer/test/lib/mixins/i18n.js
@@ -1,0 +1,12 @@
+/**
+ * Stub i18n
+ */
+
+function I18n() {
+}
+
+I18n.translate = function( string ) {
+	return string;
+};
+
+module.exports = I18n;

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -865,7 +865,7 @@ describe( 'post-normalizer', function() {
 				[
 					normalizer.withContentDOM( [ normalizer.content.detectPolls ] )
 				], function( err, normalized ) {
-					assert.include( normalized.content, '<p><a href="http://polldaddy.com/poll/8980420">Take our poll</a></p>' );
+					assert.include( normalized.content, '<p><a rel="external" target="_blank" href="http://polldaddy.com/poll/8980420">Take our poll</a></p>' );
 					done( err );
 				}
 			);

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -6,7 +6,7 @@ require( 'lib/react-test-env-setup' )();
 
 // Uncomment this require to use the blanket coverage tests.
 //require( 'blanket' )( {
-//	pattern: /post-normalizer\//
+//  pattern: /post-normalizer\//
 //} );
 
 const assert = require( 'chai' ).assert,
@@ -849,6 +849,23 @@ describe( 'post-normalizer', function() {
 					normalizer.withContentDOM( [ normalizer.content.detectEmbeds ] )
 				], function( err, normalized ) {
 					assert.isUndefined( normalized.content_embeds, 'No content_embeds should have been found' );
+					done( err );
+				}
+			);
+		} );
+		it( 'links to embedded Polldaddy polls', function( done ) {
+			normalizer(
+				{
+					content: '<a name="pd_a_8980420"></a>' +
+					'<div class="PDS_Poll" id="PDI_container8980420" style="display:inline-block;"></div>' +
+					'<div id="PD_superContainer"></div>' +
+					'<script type="text/javascript" charset="UTF-8" src="//static.polldaddy.com/p/8980420.js"></script>' +
+					'<noscript><a href="http://polldaddy.com/poll/8980420">Take Our Poll</a></noscript>',
+				},
+				[
+					normalizer.withContentDOM( [ normalizer.content.detectPolls ] )
+				], function( err, normalized ) {
+					assert.include( normalized.content, '<p><a href="http://polldaddy.com/poll/8980420">Take our poll</a></p>' );
 					done( err );
 				}
 			);


### PR DESCRIPTION
As noted in #698, we currently don't display anything when a Polldaddy poll is embedded in a post.

As a basic solution, this PR changes the post normalizer to look for Polldaddy polls in the post content, and adds an external link to any polls found with the text 'Take our poll' (which can be translated).

There is no wrapper element around the Polldaddy markup, so we replace the `noscript` tag with our `p` containing an external link.

Before:

<img width="709" alt="screen shot 2016-02-18 at 14 12 57" src="https://cloud.githubusercontent.com/assets/17325/13130548/c620810e-d649-11e5-96f8-5b57874aac81.png">

After: 

<img width="713" alt="screen shot 2016-02-18 at 14 11 25" src="https://cloud.githubusercontent.com/assets/17325/13130563/e20dbc92-d649-11e5-9bf5-2642a1653781.png">

Test posts:
http://calypso.localhost:3000/read/post/feed/40474296/932431000
http://calypso.localhost:3000/read/post/id/72040772/1919 (from the issue ticket)

Fixes #698.