### PR TITLE
Themes: ssr-ready modules needed for Showcase

### DIFF
--- a/client/components/button/index.jsx
+++ b/client/components/button/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */
@@ -29,7 +31,7 @@ module.exports = React.createClass( {
 		if ( this.props.href ) {
 			element = 'a';
 			linkIndicator = <Gridicon
-				className='card__link-indicator'
+				className="card__link-indicator"
 				icon={ this.props.target ? 'external' : 'chevron-right' } />;
 		}
 

--- a/client/components/count/index.jsx
+++ b/client/components/count/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */
@@ -9,6 +11,8 @@ import classNames from 'classnames';
  */
 import ObserveWindowSizeMixin from 'lib/mixins/observe-window-resize';
 import Gridicon from 'components/gridicon';
+import i18n from 'lib/mixins/i18n';
+import viewport from 'lib/viewport';
 
 /**
  * Module variables
@@ -38,8 +42,8 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { text = this.translate( 'Back' ), href, onClick, spacer } = this.props;
-		const windowWidth = window.innerWidth;
+		const { text = i18n.translate( 'Back' ), href, onClick, spacer } = this.props;
+		const windowWidth = viewport.getWindowInnerWidth();
 		const hideText = windowWidth <= HIDE_BACK_CRITERIA.windowWidth && text.length >= HIDE_BACK_CRITERIA.characterLength || windowWidth <= 300;
 		const linkClasses = classNames( {
 			'header-cake__back': true,

--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */
@@ -14,15 +16,20 @@ import analytics from 'analytics';
 import Spinner from 'components/spinner';
 import Gridicon from 'components/gridicon';
 import { isMobile } from 'lib/viewport';
+import i18n from 'lib/mixins/i18n';
+
 /**
  * Internal variables
  */
-var _instance = 1,
-	SEARCH_DEBOUNCE_MS = 300;
+var SEARCH_DEBOUNCE_MS = 300;
 
-module.exports = React.createClass( {
+const Search = React.createClass( {
 
 	displayName: 'Search',
+
+	statics: {
+		instances: 0
+	},
 
 	propTypes: {
 		additionalClasses: React.PropTypes.string,
@@ -68,11 +75,9 @@ module.exports = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		this.id = _instance;
-		_instance++;
-		this.onSearch = this.props.delaySearch
-			? debounce( this.props.onSearch, this.props.delayTimeout )
-			: this.props.onSearch;
+		this.setState( {
+			instanceId: ++Search.instances
+		} );
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
@@ -116,6 +121,10 @@ module.exports = React.createClass( {
 	},
 
 	componentDidMount: function() {
+		this.onSearch = this.props.delaySearch
+			? debounce( this.props.onSearch, this.props.delayTimeout )
+			: this.props.onSearch;
+
 		if ( this.props.autoFocus ) {
 			this.focus();
 		}
@@ -223,7 +232,7 @@ module.exports = React.createClass( {
 		var searchClass,
 			searchValue = this.state.keyword,
 			placeholder = this.props.placeholder ||
-				this.translate( 'Search…', { textOnly: true } ),
+				i18n.translate( 'Search…', { textOnly: true } ),
 
 			enableOpenIcon = this.props.pinned && ! this.state.isOpen,
 			isOpenUnpinnedOrQueried = this.state.isOpen ||
@@ -255,13 +264,13 @@ module.exports = React.createClass( {
 						? this._keyListener.bind( this, 'openSearch' )
 						: null
 					}
-					aria-controls={ 'search-component-' + this.id }
-					aria-label={ this.translate( 'Open Search', { context: 'button label' } ) }>
+					aria-controls={ 'search-component-' + this.state.instanceId }
+					aria-label={ i18n.translate( 'Open Search', { context: 'button label' } ) }>
 				<Gridicon icon="search" className="search-open__icon"/>
 				</div>
 				<input
 					type="search"
-					id={ 'search-component-' + this.id }
+					id={ 'search-component-' + this.state.instanceId }
 					className="search__input"
 					placeholder={ placeholder }
 					role="search"
@@ -287,8 +296,8 @@ module.exports = React.createClass( {
 				onTouchTap={ this.closeSearch }
 				tabIndex="0"
 				onKeyDown={ this._keyListener.bind( this, 'closeSearch' ) }
-				aria-controls={ 'search-component-' + this.id }
-				aria-label={ this.translate( 'Close Search', { context: 'button label' } ) }>
+				aria-controls={ 'search-component-' + this.state.instanceId }
+				aria-label={ i18n.translate( 'Close Search', { context: 'button label' } ) }>
 			<Gridicon icon="cross" className="search-close__icon"/>
 			</span>
 		);
@@ -303,3 +312,5 @@ module.exports = React.createClass( {
 		}
 	}
 } );
+
+module.exports = Search;

--- a/client/components/search/test/index.jsx
+++ b/client/components/search/test/index.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import sinon from 'sinon';
 import mockery from 'mockery';
+import noop from 'lodash/noop';
 
 const EMPTY_COMPONENT = React.createClass( {
 	render: function() {
@@ -18,19 +19,17 @@ const EMPTY_COMPONENT = React.createClass( {
 describe( 'Search', function() {
 	beforeEach( function() {
 		mockery.registerMock( 'analytics', {} );
+		mockery.registerMock( 'lib/mixins/i18n', { translate: noop } );
 		mockery.registerMock( 'components/gridicon', EMPTY_COMPONENT );
 		mockery.enable();
 		mockery.warnOnUnregistered( false );
 
 		this.searchClass = require( '../' );
-		this.searchClass.prototype.__reactAutoBindMap.translate = sinon.stub();
 	} );
 
 	afterEach( function() {
-		mockery.deregisterMock( 'analytics' );
+		mockery.deregisterAll();
 		mockery.disable();
-
-		delete this.searchClass.prototype.__reactAutoBindMap.translate;
 	} );
 
 	describe( 'initialValue', function() {

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -10,7 +10,8 @@ var ReactDom = require( 'react-dom' ),
  * Internal Dependencies
  */
 var SelectDropdown = require( 'components/select-dropdown' ),
-	DropdownItem = require( 'components/select-dropdown/item' );
+	DropdownItem = require( 'components/select-dropdown/item' ),
+	viewport = require( 'lib/viewport' );
 
 /**
  * Internal Variables
@@ -68,6 +69,8 @@ var NavTabs = React.createClass( {
 			'has-siblings': this.props.hasSiblingControls
 		} );
 
+		var innerWidth = viewport.getWindowInnerWidth();
+
 		return (
 			<div className="section-nav-group" ref="navGroup">
 				<div className={ tabsClassName }>
@@ -86,7 +89,7 @@ var NavTabs = React.createClass( {
 
 					{
 						this.state.isDropdown &&
-						window.innerWidth > MOBILE_PANEL_THRESHOLD &&
+						innerWidth > MOBILE_PANEL_THRESHOLD &&
 						this.getDropdown()
 					}
 				</div>

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External Dependencies
  */
@@ -18,11 +20,6 @@ var DropdownItem = require( 'components/select-dropdown/item' ),
 	Count = require( 'components/count' );
 
 var noop = () => {};
-
-/**
- * Internal variables
- */
-var _instance = 1;
 
 /**
  * SelectDropdown
@@ -48,6 +45,10 @@ var SelectDropdown = React.createClass( {
 		)
 	},
 
+	statics: {
+		instances: 0
+	},
+
 	getDefaultProps: function() {
 		return {
 			onSelect: noop,
@@ -70,8 +71,9 @@ var SelectDropdown = React.createClass( {
 	},
 
 	componentWillMount: function() {
-		this.id = _instance;
-		_instance++;
+		this.setState( {
+			instanceId: ++SelectDropdown.instances
+		} );
 	},
 
 	componentWillReceiveProps: function() {
@@ -131,14 +133,14 @@ var SelectDropdown = React.createClass( {
 			if ( ! item ) {
 				return (
 					<DropdownSeparator
-						key={ 'dropdown-separator-' + this.id + '-' + index }
+						key={ 'dropdown-separator-' + this.state.instanceId + '-' + index }
 					/>
 				);
 			}
 
 			let dropdownItem = (
 				<DropdownItem
-					key={ 'dropdown-item-' + this.id + '-' + item.value }
+					key={ 'dropdown-item-' + this.state.instanceId + '-' + item.value }
 					ref={ 'item-' + refIndex }
 					selected={ this.state.selected === item.value }
 					onClick={ this.selectItem.bind( this, item ) }
@@ -182,13 +184,13 @@ var SelectDropdown = React.createClass( {
 					onKeyDown={ this.navigateItem }
 					tabIndex={ this.props.tabIndex || 0 }
 					aria-haspopup="true"
-					aria-owns={ 'select-submenu-' + this.id }
-					aria-controls={ 'select-submenu-' + this.id }
+					aria-owns={ 'select-submenu-' + this.state.instanceId }
+					aria-controls={ 'select-submenu-' + this.state.instanceId }
 					aria-expanded={ this.state.isOpen }
 					onClick={ this.toggleDropdown }
 				>
 					<div
-						id={ 'select-dropdown-' + this.id }
+						id={ 'select-dropdown-' + this.state.instanceId }
 						className="select-dropdown__header"
 					>
 						<span className="select-dropdown__header-text">
@@ -201,10 +203,10 @@ var SelectDropdown = React.createClass( {
 					</div>
 
 					<ul
-						id={ 'select-submenu-' + this.id }
+						id={ 'select-submenu-' + this.state.instanceId }
 						className="select-dropdown__options"
 						role="menu"
-						aria-labelledby={ 'select-dropdown-' + this.id }
+						aria-labelledby={ 'select-dropdown-' + this.state.instanceId }
 						aria-expanded={ this.state.isOpen }
 					>
 						{ this.dropdownOptions() }

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External Dependencies
  */

--- a/client/components/select-dropdown/separator.jsx
+++ b/client/components/select-dropdown/separator.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External Dependencies
  */

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */
@@ -43,7 +45,8 @@ Spinner = React.createClass( {
 	 *                   elements, or false otherwise.
 	 */
 	isSVGCSSAnimationSupported: function() {
-		return ! /(MSIE |Trident\/)/.test( global.window.navigator.userAgent );
+		const navigator = global.window ? global.window.navigator.userAgent : ''; // FIXME: replace with UA from server
+		return ! /(MSIE |Trident\/)/.test( navigator );
 	},
 
 	getClassName: function() {

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/lib/mixins/observe-window-resize/index.js
+++ b/client/lib/mixins/observe-window-resize/index.js
@@ -1,8 +1,9 @@
+/** @ssr-ready **/
+
 /**
  * External Dependencies
  */
 var throttle = require( 'lodash/throttle' );
-
 
 /**
  * A mixin that listens for window::resize events and informs a component
@@ -10,7 +11,7 @@ var throttle = require( 'lodash/throttle' );
  * The host should expose a `onWindowResize` method to be called when the window resizes
  */
 var ObserveWindowSizeMixin = {
-	componentWillMount: function() {
+	componentDidMount: function() {
 		// the throttled function has to be per instance
 		this._handleWindowResize = throttle( this.onWindowResize, 100 );
 		window.addEventListener( 'resize', this._handleWindowResize );

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/lib/products-values/sort.js
+++ b/client/lib/products-values/sort.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/lib/viewport/index.js
+++ b/client/lib/viewport/index.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 // Determine whether a user is viewing calypso from a device within a
 // particular mobile-first responsive breakpoint, matching our existing media
 // queries. [1]
@@ -28,7 +30,7 @@
 // [1] https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md#media-queries
 //
 function isWithinBreakpoint( breakpoint ) {
-	var screenWidth = window.innerWidth,
+	var screenWidth = getWindowInnerWidth(),
 		breakpoints = {
 			'<480px': function() { return screenWidth <= 480; },
 			'<660px': function() { return screenWidth <= 660; },
@@ -43,7 +45,7 @@ function isWithinBreakpoint( breakpoint ) {
 
 	if ( ! breakpoints.hasOwnProperty( breakpoint ) ) {
 		try{
-			window.console.warn( 'Undefined breakpoint used in `mobile-first-breakpoint`', breakpoint );
+			global.window.console.warn( 'Undefined breakpoint used in `mobile-first-breakpoint`', breakpoint );
 		}catch( e ){}
 		return undefined;
 	}
@@ -58,8 +60,15 @@ function isDesktop() {
 	return isWithinBreakpoint( '>960px' );
 }
 
+// FIXME: We can't detect window size on the server, so until we have more intelligent detection,
+// use 769, which is just above the general maximum mobile screen width.
+function getWindowInnerWidth() {
+	return global.window ? global.window.innerWidth : 769;
+}
+
 module.exports = {
 	isMobile: isMobile,
 	isDesktop: isDesktop,
-	isWithinBreakpoint: isWithinBreakpoint
+	isWithinBreakpoint: isWithinBreakpoint,
+	getWindowInnerWidth: getWindowInnerWidth,
 };

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/state/themes/action-types.js
+++ b/client/state/themes/action-types.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/state/themes/current-theme/selectors.js
+++ b/client/state/themes/current-theme/selectors.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 export function getCurrentTheme( state, siteId ) {
 	return state.themes.currentTheme.get( 'currentThemes' ).get( siteId );
 }

--- a/client/state/themes/themes-last-query/selectors.js
+++ b/client/state/themes/themes-last-query/selectors.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 export function isJetpack( state ) {
 	return !! state.themes.themesLastQuery.get( 'isJetpack' );
 }

--- a/client/state/themes/themes-list/selectors.js
+++ b/client/state/themes/themes-list/selectors.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 export function isFetchingNextPage( state ) {
 	return state.themes.themesList.getIn( [ 'queryState', 'isFetchingNextPage' ] );
 }

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * Returns the site object for the currently selected site.
  *

--- a/server/pragma-checker/index.js
+++ b/server/pragma-checker/index.js
@@ -10,7 +10,14 @@ var includes = require( 'lodash/includes' );
 
 var PLUGIN_TITLE = 'PragmaChecker';
 var SSR_READY = '/** @ssr-ready **/';
-var IGNORED_MODULES = [ 'config' ];
+var IGNORED_MODULES = [
+	'config', // Different modules on client & server
+	'lib/wp', // Different modules on client & server
+	'analytics', // nooped on the server until we develop an isomorphic version
+	'lib/route', // nooped on the server until we can extract the isomorphic bits
+	'lib/upgrades/actions', // nooped on the server as it still uses the singleton Flux architecture
+	'lib/mixins/i18n', // ignore this until we make it work properly on the server
+];
 
 function PragmaCheckPlugin( options ) {
 	this.options = options || {};

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -73,7 +73,10 @@ module.exports = {
 	},
 	plugins: [
 		// Require source-map-support at the top, so we get source maps for the bundle
-		new webpack.BannerPlugin( 'require( "source-map-support" ).install();', { raw: true, entryOnly: false } )
+		new webpack.BannerPlugin( 'require( "source-map-support" ).install();', { raw: true, entryOnly: false } ),
+		new webpack.NormalModuleReplacementPlugin( /^analytics$/, 'lodash/noop' ), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin( /^lib\/upgrades\/actions$/, 'lodash/noop' ), // Uses Flux dispatcher
+		new webpack.NormalModuleReplacementPlugin( /^lib\/route$/, 'lodash/noop' ) // Depends too much on page.js
 	],
 	externals: getExternals()
 };


### PR DESCRIPTION
In #3279 & #3333 we're using a bunch more modules on the server. This means we have to check they're compatible with server-side-rendering, and proceed as per https://github.com/Automattic/wp-calypso/tree/master/docs/server-side-rendering.md

Here we:
- `@ssr-ready` what we need for the aforementioned PRs
- Set viewports on the server to a default of 1024 — contentious!
- `noop` certain modules with webpack's NMR, that won't work on the server (yet) <sup>1</sup>
- Ignore any `noop`ed module in the webpack `PragmaCheckerPlugin`
- Ignore `wp` in webpack `PragmaCheckerPlugin`, as it's a client/server split module
- Ignore `lib/mixins/i18n`, as it runs OK now, and we'll be getting to making it isomorphic in the very near future
- Get rid of non-`setState` asynchronous calls in componentDidMount
- Convert `Search` and `SelectDropdown` to use saner instance id method.
- Directly use `i18n` mixin, instead of relying on it being mixed in via injection (the server hates this)

Components with modified code:
- `HeaderCake`
- `Search`
- `SelectDropdown`
- `mixins/observe-window-resize`
- `lib/viewport`

To test:
- Check that all the modified components still work as expected (ARIA included)

<sup>1</sup> NMR === NormalModuleReplacementPlugin. We replace the module in the server bundle with something like `lodash`'s `noop`. We do this because converting every single ssr-incompatible module at once is extremely difficult, so this is a piecemeal approach. It is **not** a long term solution.

/cc @mcsf @ockham @seear 