### PR TITLE
Purchases: Temporarily disable expiration notice display

### DIFF
--- a/client/me/purchases/list/item/index.jsx
+++ b/client/me/purchases/list/item/index.jsx
@@ -31,13 +31,13 @@ const PurchaseItem = React.createClass( {
 	renewsOrExpiresOn() {
 		const { purchase } = this.props;
 
-		if ( showCreditCardExpiringWarning( purchase ) ) {
-			return (
-				<Notice isCompact status="is-error" icon="spam">
-					{ this.translate( 'Credit card expiring soon' ) }
-				</Notice>
-			);
-		}
+		// if ( showCreditCardExpiringWarning( purchase ) ) {
+		// 	return (
+		// 		<Notice isCompact status="is-error" icon="spam">
+		// 			{ this.translate( 'Credit card expiring soon' ) }
+		// 		</Notice>
+		// 	);
+		// }
 
 		if ( isRenewing( purchase ) ) {
 			return this.translate( 'Renews on %s', {


### PR DESCRIPTION
Related: #3288

This is a temporary patch to resolve the `/purchases` page failing to load for users when credit card expiration logic is run.

/cc @Tug 