### PR TITLE
post-counts-store: replace lodash/sum with our own function

### DIFF
--- a/client/lib/posts/post-counts-store.js
+++ b/client/lib/posts/post-counts-store.js
@@ -3,9 +3,15 @@
  * External dependencies
  */
 
-var sum = require( 'lodash/sum' ),
-	isEqual = require( 'lodash/isEqual' ),
+var isEqual = require( 'lodash/isEqual' ),
 	debug = require( 'debug' )( 'calypso:posts:post-counts-store' );
+
+const sum = obj => {
+	return Object.keys( obj )
+		.reduce( function( _sum, key ) {
+			return _sum + parseFloat( obj[ key ] );
+		}, 0 );
+}
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Seems like the new `sum` function of lodash doesn't accept an object like argument.
https://lodash.com/docs#sum

### Testing
go to posts list page and the post counts bar should be shown

/cc @blowery @aduth @adambbecker 