### PR TITLE
Purchases: Preserve instance of `moment` in the purchases assembler

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import camelCase from 'lodash/camelCase';
-import merge from 'lodash/merge';
 
 /**
  * Internal dependencies
@@ -57,17 +56,17 @@ function createPurchaseObject( purchase ) {
 	};
 
 	if ( 'credit_card' === purchase.payment_type ) {
-		return merge( {}, object, {
-			payment: {
-				creditCard: {
-					id: Number( purchase.payment_card_id ),
-					type: purchase.payment_card_type,
-					number: Number( purchase.payment_details ),
-					expiryDate: purchase.payment_expiry,
-					expiryMoment: purchase.payment_expiry ? i18n.moment( purchase.payment_expiry, 'MM/YY' ) : null
-				}
+		const payment = Object.assign( {}, object.payment, {
+			creditCard: {
+				id: Number( purchase.payment_card_id ),
+				type: purchase.payment_card_type,
+				number: Number( purchase.payment_details ),
+				expiryDate: purchase.payment_expiry,
+				expiryMoment: purchase.payment_expiry ? i18n.moment( purchase.payment_expiry, 'MM/YY' ) : null
 			}
 		} );
+
+		return Object.assign( {}, object, { payment } );
 	}
 
 	return object;

--- a/client/me/purchases/list/item/index.jsx
+++ b/client/me/purchases/list/item/index.jsx
@@ -31,13 +31,13 @@ const PurchaseItem = React.createClass( {
 	renewsOrExpiresOn() {
 		const { purchase } = this.props;
 
-		// if ( showCreditCardExpiringWarning( purchase ) ) {
-		// 	return (
-		// 		<Notice isCompact status="is-error" icon="spam">
-		// 			{ this.translate( 'Credit card expiring soon' ) }
-		// 		</Notice>
-		// 	);
-		// }
+		if ( showCreditCardExpiringWarning( purchase ) ) {
+			return (
+				<Notice isCompact status="is-error" icon="spam">
+					{ this.translate( 'Credit card expiring soon' ) }
+				</Notice>
+			);
+		}
 
 		if ( isRenewing( purchase ) ) {
 			return this.translate( 'Renews on %s', {


### PR DESCRIPTION
When we normalize purchases in the purchases assembler, `lodash/merge` is converting an instance of a moment.js `Moment` to a plain object. This caused `/purchases` to break when there is at least one purchases with credit card data.

**Testing**
- Visit `/purchases` for an account that has made a purchase with a credit card.
- Assert that the list of purchases loads and that no error is thrown.