### PR TITLE
Signup: Skip for free plan view

### DIFF
--- a/client/signup/steps/paid-plans-only/style.scss
+++ b/client/signup/steps/paid-plans-only/style.scss
@@ -1,4 +1,4 @@
-.paid-plans-with-free-trials .plan-list {
+.paid-plans-only .plan-list {
 	margin: 0 auto;
 	max-width: 458px;
 }


### PR DESCRIPTION
The paid plans only component should have a limited width. The CSS for this was using the old component name, so the width wasn't being inherited. This PR fixes the class name so it is now inherited.

Before:
<img width="842" alt="screen shot 2016-02-18 at 22 42 31" src="https://cloud.githubusercontent.com/assets/275961/13160693/e79f17d6-d690-11e5-8f85-669df8a75961.png">


After:
<img width="563" alt="screen shot 2016-02-18 at 22 41 26" src="https://cloud.githubusercontent.com/assets/275961/13160677/d27b8ee8-d690-11e5-98d2-8fa0a45015a6.png">