### PR TITLE
Reader recommendations: hide placeholders if there are no more results available

### DIFF
--- a/client/lib/recommended-sites-store/store.js
+++ b/client/lib/recommended-sites-store/store.js
@@ -6,7 +6,8 @@ import Emitter from 'lib/mixins/emitter';
 import { ACTION_RECEIVE_SITE_RECOMMENDATIONS, ACTION_RECEIVE_SITE_RECOMMENDATIONS_ERROR } from './constants';
 
 var recommendations = OrderedSet(),
-	page = 1;
+	page = 1,
+	isLastPage = false;
 
 const store = {
 	get() {
@@ -14,6 +15,12 @@ const store = {
 	},
 	getPage() {
 		return page;
+	},
+	isLastPage() {
+		return isLastPage;
+	},
+	setIsLastPage( value ) {
+		isLastPage = !! value;
 	}
 };
 
@@ -21,6 +28,11 @@ function receiveRecommendations( data ) {
 	// consume the recommendations
 	const previousRecs = recommendations;
 	if ( data && data.blogs ) {
+		if ( data.blogs.length === 0 ) {
+			store.setIsLastPage( true );
+			store.emit( 'change' );
+			return;
+		}
 		const pruned = data.blogs.map( function( blog ) {
 			return pick( blog, [ 'blog_id', 'follow_reco_id', 'reason' ] );
 		} );

--- a/client/lib/recommended-sites-store/store.js
+++ b/client/lib/recommended-sites-store/store.js
@@ -9,6 +9,8 @@ var recommendations = OrderedSet(),
 	page = 1,
 	isLastPage = false;
 
+const MAX_RECOMMENDATIONS = 100;
+
 const store = {
 	get() {
 		return recommendations.toJS();
@@ -38,7 +40,11 @@ function receiveRecommendations( data ) {
 		} );
 
 		recommendations = recommendations.union( fromJS( pruned ) );
+
 		if ( recommendations !== previousRecs ) {
+			if ( recommendations.length >= MAX_RECOMMENDATIONS ) {
+				store.setIsLastPage( true );
+			}
 			page++;
 			store.emit( 'change' );
 		}

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -132,7 +132,7 @@ const RecommendedForYou = React.createClass( {
 				<InfiniteList
 					items={ this.state.recommendations }
 					fetchingNextPage={ this.state.fetching }
-					lastPage={ RecommendedSites.isLastPage() || this.state.recommendations.length >= 100 }
+					lastPage={ RecommendedSites.isLastPage() }
 					guessedItemHeight={ 300 }
 					fetchNextPage={ this.loadMore }
 					getItemRef={ this.getItemRef }

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -132,7 +132,7 @@ const RecommendedForYou = React.createClass( {
 				<InfiniteList
 					items={ this.state.recommendations }
 					fetchingNextPage={ this.state.fetching }
-					lastPage={ this.state.recommendations && this.state.recommendations.length >= 100 }
+					lastPage={ RecommendedSites.isLastPage() || this.state.recommendations.length >= 100 }
 					guessedItemHeight={ 300 }
 					fetchNextPage={ this.loadMore }
 					getItemRef={ this.getItemRef }


### PR DESCRIPTION
At the moment, we try and fetch 100 recommendations from the `/read/recommendations/mine` endpoint and stop displaying loading placeholders after 100 have been loaded.

Unfortunately, the endpoint doesn't always seem to have 100 recommendations to hand. In these cases, the placeholders stick around at the bottom of the list.

This PR adds a check to see if the current page of results contains any recommendations. If it doesn't, we declare that it's the last page, which stops placeholders from being loaded.

Before:

<img width="774" alt="screen shot 2016-02-19 at 11 38 34" src="https://cloud.githubusercontent.com/assets/17325/13160714/0ac972b6-d6fe-11e5-80ba-77e52c4d42e0.png">

After: 

<img width="784" alt="screen shot 2016-02-19 at 11 38 41" src="https://cloud.githubusercontent.com/assets/17325/13160717/0fbb56cc-d6fe-11e5-8172-f5abc440e125.png">

### To test

Visit http://calypso.localhost:3000/recommendations and scroll to the bottom of the list. Ensure there are no placeholders present.

For those testing within Automattic, you can force the endpoint to return less than 100 results by modifying the `WPCOM_JSON_API_Blogs_You_May_Like_Endpoint` to only return results for the first page:

```
if ( $exclude_blog_ids ) {
	$response['blogs'] = []; // For testing purposes, don't return any results after the first page
}
```

Fixes #3138.