### PR TITLE
Relaunch: A/B test for a free by default signup flow"

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -91,4 +91,12 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
+	freePlansDefault: {
+		datestamp: '20160219',
+		variations: {
+			allPlans: 90,
+			skipForFree: 10
+		},
+		defaultVariation: 'allPlans'
+	},
 };

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -219,6 +219,22 @@ function filterFlowName( flowName ) {
 			return ( 'blog' === flowName ) ? 'blog-altthemes' : 'website-altthemes';
 		}
 	}
+
+	let isInPreviousTest = false;
+
+	if ( getABTestVariation( 'headstart' ) && getABTestVariation( 'headstart' ) !== 'notTested' ) {
+		isInPreviousTest = true;
+	}
+
+	if ( getABTestVariation( 'altThemes' ) && getABTestVariation( 'altThemes' ) !== 'notTested' ) {
+		isInPreviousTest = true;
+	}
+
+	const freePlansTestFlows = [ 'blog', 'website', 'main' ];
+	if ( includes( freePlansTestFlows, flowName ) && ! isInPreviousTest ) {
+		return 'skipForFree' === abtest( 'freePlansDefault' ) ? 'upgrade' : flowName;
+	}
+
 	return flowName;
 }
 

--- a/client/signup/test/lib/abtest/index.js
+++ b/client/signup/test/lib/abtest/index.js
@@ -1,5 +1,7 @@
 // abtest stub
 export default {
-	abtest() { return ''; }
+	abtest() { return ''; },
+
+	getABTestVariation() { return ''; }
 };
 


### PR DESCRIPTION
A/B Test definition for this signup flow: https://github.com/Automattic/wp-calypso/pull/3335

This depends on https://github.com/Automattic/wp-calypso/pull/3398 before it can be merged.

#### Testing instructions

1. Run `git checkout revert-3400-revert-3367-add/abtest-signup-paid-plans-only` and start your server
2. Add yourself to the ab test: `localStorage.setItem('ABTests','{"freePlansDefault_20160219":"skipForFree"}')`
2. Open the [`Signup` page](http://calypso.localhost:3000/start) in a private window
3. Assert that you are redirect to `/start/upgrade`


#### Reviews

- [x] Code
- [x] Product