### PR TITLE
Framework: add schemas for themes state tree

### DIFF
--- a/client/state/themes/current-theme/reducer.js
+++ b/client/state/themes/current-theme/reducer.js
@@ -8,6 +8,8 @@ import { fromJS } from 'immutable';
  */
 import ActionTypes from '../action-types';
 import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from 'state/action-types';
+import { isValidStateWithSchema } from 'state/utils';
+import { currentThemeSchema } from './schema';
 
 export const initialState = fromJS( {
 	isActivating: false,
@@ -33,6 +35,10 @@ export default ( state = initialState, action ) => {
 		case ActionTypes.CLEAR_ACTIVATED_THEME:
 			return state.set( 'hasActivated', false );
 		case DESERIALIZE:
+			if ( isValidStateWithSchema( state, currentThemeSchema ) ) {
+				return fromJS( state );
+			}
+			return initialState;
 		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:

--- a/client/state/themes/current-theme/schema.js
+++ b/client/state/themes/current-theme/schema.js
@@ -1,0 +1,22 @@
+export const currentThemeSchema = {
+	type: 'object',
+	properties: {
+		isActivating: { type: 'boolean' },
+		hasActivated: { type: 'boolean' },
+		currentThemes: {
+			type: 'object',
+			patternProperties: {
+				//be careful to escape regexes properly
+				'^\\d+$': {
+					type: 'object',
+					properties: {
+						name: { type: 'string' },
+						id: { type: 'string' },
+						cost: { type: 'object' }
+					}
+				}
+			},
+			additionalProperties: false
+		}
+	}
+};

--- a/client/state/themes/current-theme/test/reducer.js
+++ b/client/state/themes/current-theme/test/reducer.js
@@ -4,6 +4,7 @@
 import { expect } from 'chai';
 import { fromJS } from 'immutable';
 import deepFreeze from 'deep-freeze';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -17,6 +18,12 @@ import reducer, { initialState } from '../reducer';
 
 describe( 'current-theme reducer', () => {
 	describe( 'persistence', () => {
+		before( () => {
+			sinon.stub( console, 'warn' );
+		} );
+		after( () => {
+			console.warn.restore();
+		} );
 		it( 'persists state and converts to a plain JS object', () => {
 			const jsObject = deepFreeze( {
 				isActivating: true,
@@ -77,7 +84,7 @@ describe( 'current-theme reducer', () => {
 			expect( state ).to.eql( fromJS( jsObject ) );
 		} );
 
-		it.skip( 'should ignore loading data with invalid keys ', () => {
+		it( 'should ignore loading data with invalid keys ', () => {
 			const jsObject = deepFreeze( {
 				missingKey: true,
 				hasActivated: false,
@@ -97,14 +104,14 @@ describe( 'current-theme reducer', () => {
 			expect( state ).to.eql( initialState );
 		} );
 
-		it.skip( 'should ignore loading data with invalid values ', () => {
+		it( 'should ignore loading data with invalid values ', () => {
 			const jsObject = deepFreeze( {
 				isActivating: true,
-				hasActivated: 'foo',
+				hasActivated: true,
 				currentThemes: {
 					123456: {
 						name: 'my test theme',
-						id: 'testtheme',
+						id: 2345,
 						cost: {
 							currency: 'USD',
 							number: 0,

--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -8,6 +8,8 @@ import { Map, fromJS } from 'immutable';
  */
 import ActionTypes from '../action-types';
 import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from '../../action-types';
+import { themeDetailsSchema } from './schema';
+import { isValidStateWithSchema } from 'state/utils';
 
 export default ( state = Map(), action ) => {
 	switch ( action.type ) {
@@ -16,8 +18,12 @@ export default ( state = Map(), action ) => {
 				.set( action.themeId, Map( {
 					name: action.themeName,
 					author: action.themeAuthor
-				} ) )
+				} ) );
 		case DESERIALIZE:
+			if ( isValidStateWithSchema( state, themeDetailsSchema ) ) {
+				return fromJS( state );
+			}
+			return Map();
 		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:

--- a/client/state/themes/theme-details/schema.js
+++ b/client/state/themes/theme-details/schema.js
@@ -1,0 +1,15 @@
+export const themeDetailsSchema = {
+	type: 'object',
+	patternProperties: {
+		//be careful to escape regexes properly
+		'^\\S+$': {
+			type: 'object',
+			required: [ 'name', 'author' ],
+			properties: {
+				name: { type: 'string' },
+				author: { type: 'string' }
+			}
+		}
+	},
+	additionalProperties: false
+};

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -3,6 +3,8 @@
  */
 import { expect } from 'chai';
 import { Map, fromJS } from 'immutable';
+import deepFreeze from 'deep-freeze';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -10,7 +12,6 @@ import { Map, fromJS } from 'immutable';
 import { RECEIVE_THEME_DETAILS } from '../../action-types';
 import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from '../../../action-types';
 import reducer from '../reducer';
-import deepFreeze from 'deep-freeze';
 
 describe( 'reducer', () => {
 	it( 'should default to an empty Immutable Map', () => {
@@ -34,8 +35,13 @@ describe( 'reducer', () => {
 	} );
 
 	describe( 'persistence', () => {
+		before( () => {
+			sinon.stub( console, 'warn' );
+		} );
+		after( () => {
+			console.warn.restore();
+		} );
 		const initialState = Map();
-
 		it( 'persists state and converts to a plain JS object', () => {
 			const jsObject = deepFreeze( {
 				mood: {
@@ -69,7 +75,7 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( fromJS( jsObject ) );
 		} );
 
-		it.skip( 'should ignore loading data with invalid keys ', () => {
+		it( 'should ignore loading data with invalid keys ', () => {
 			const jsObject = deepFreeze( {
 				missingKey: true,
 				mood: {
@@ -81,9 +87,9 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( initialState );
 		} );
 
-		it.skip( 'should ignore loading data with invalid values ', () => {
+		it( 'should ignore loading data with invalid values ', () => {
 			const jsObject = deepFreeze( {
-				mood: 'foo',
+				mood: 'foo'
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
 			expect( state ).to.eql( initialState );

--- a/client/state/themes/themes-last-query/reducer.js
+++ b/client/state/themes/themes-last-query/reducer.js
@@ -8,6 +8,8 @@ import { fromJS } from 'immutable';
  */
 import ActionTypes from '../action-types';
 import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from 'state/action-types';
+import { themesLastQuerySchema } from './schema';
+import { isValidStateWithSchema } from 'state/utils';
 
 export const initialState = fromJS( {
 	previousSiteId: 0,
@@ -27,6 +29,10 @@ export default ( state = initialState, action ) => {
 				.set( 'currentSiteId', action.site.ID )
 				.set( 'isJetpack', !! action.site.jetpack );
 		case DESERIALIZE:
+			if ( isValidStateWithSchema( state, themesLastQuerySchema ) ) {
+				return fromJS( state );
+			}
+			return initialState;
 		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:

--- a/client/state/themes/themes-last-query/schema.js
+++ b/client/state/themes/themes-last-query/schema.js
@@ -1,0 +1,17 @@
+export const themesLastQuerySchema = {
+	type: 'object',
+	properties: {
+		previousSiteId: { type: 'integer' },
+		currentSiteId: { type: 'integer' },
+		isJetpack: { type: 'boolean' },
+		lastParams: {
+			type: 'object',
+			properties: {
+				tier: { type: 'string' },
+				page: { type: 'integer' },
+				perPage: { type: 'integer' }
+			}
+		}
+	},
+	additionalProperties: false
+};

--- a/client/state/themes/themes-last-query/test/reducer.js
+++ b/client/state/themes/themes-last-query/test/reducer.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import { fromJS } from 'immutable';
+import sinon from 'sinon';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -17,6 +18,12 @@ import reducer, { initialState } from '../reducer';
 
 describe( 'themes-last-query reducer', () => {
 	describe( 'persistence', () => {
+		before( () => {
+			sinon.stub( console, 'warn' );
+		} );
+		after( () => {
+			console.warn.restore();
+		} );
 		it( 'persists state and converts to a plain JS object', () => {
 			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
@@ -34,7 +41,7 @@ describe( 'themes-last-query reducer', () => {
 			expect( persistedState ).to.eql( jsObject );
 		} );
 		it( 'loads valid persisted state and converts to immutable.js object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				previousSiteId: 2123982,
 				isJetpack: false,
@@ -65,7 +72,7 @@ describe( 'themes-last-query reducer', () => {
 			expect( state ).to.eql( fromJS( jsObject ) );
 		} );
 
-		it.skip( 'should ignore loading data with invalid keys ', () => {
+		it( 'should ignore loading data with invalid keys ', () => {
 			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				wrongkey: 2123982,
@@ -81,14 +88,14 @@ describe( 'themes-last-query reducer', () => {
 			expect( state ).to.eql( initialState );
 		} );
 
-		it.skip( 'should ignore loading data with invalid values ', () => {
+		it( 'should ignore loading data with invalid values ', () => {
 			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				previousSiteId: 2123982,
 				isJetpack: false,
 				lastParams: {
 					search: 'foo bar',
-					tier: 'unknown tier',
+					tier: 1234,
 					page: 0,
 					perPage: 20
 				}

--- a/client/state/themes/themes-list/reducer.js
+++ b/client/state/themes/themes-list/reducer.js
@@ -91,10 +91,11 @@ export default ( state = initialState, action ) => {
 			// here.
 			return state.set( 'active', action.theme.id );
 		case DESERIALIZE:
+			return initialState;
 		case SERVER_DESERIALIZE:
 			return query( fromJS( state ) );
 		case SERIALIZE:
-			return state.toJS();
+			return initialState;
 	}
 
 	return state;

--- a/client/state/themes/themes-list/test/reducer.js
+++ b/client/state/themes/themes-list/test/reducer.js
@@ -15,9 +15,9 @@ import {
 } from 'state/action-types';
 import reducer, { initialState, query } from '../reducer';
 
-describe( 'themes-last-query reducer', () => {
+describe( 'themes-list reducer', () => {
 	describe( 'persistence', () => {
-		it( 'persists state and converts to a plain JS object', () => {
+		it( 'does not persist data', () => {
 			const jsObject = deepFreeze( {
 				list: [ 'one', 'two', 'three' ],
 				nextId: 2,
@@ -36,9 +36,9 @@ describe( 'themes-last-query reducer', () => {
 			} );
 			const state = fromJS( jsObject );
 			const persistedState = reducer( state, { type: SERIALIZE } );
-			expect( persistedState ).to.eql( jsObject );
+			expect( persistedState ).to.eql( initialState );
 		} );
-		it( 'loads valid persisted state and converts to immutable.js object', () => {
+		it( 'does not load persisted data', () => {
 			const jsObject = deepFreeze( {
 				list: [ 'one', 'two', 'three' ],
 				nextId: 2,
@@ -56,7 +56,7 @@ describe( 'themes-last-query reducer', () => {
 				active: 0
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
-			expect( state ).to.eql( query( fromJS( jsObject ) ) );
+			expect( state ).to.eql( initialState );
 		} );
 
 		it( 'converts state from server to immutable.js object', () => {
@@ -79,47 +79,6 @@ describe( 'themes-last-query reducer', () => {
 			const state = reducer( jsObject, { type: SERVER_DESERIALIZE } );
 			expect( state ).to.eql( query( fromJS( jsObject ) ) );
 		} );
-
-		it.skip( 'should ignore loading data with invalid keys ', () => {
-			const jsObject = deepFreeze( {
-				foobar: [ 'one', 'two', 'three' ],
-				nextId: 2,
-				query: {
-					search: 'hello',
-					perPage: 20,
-					page: 1,
-					tier: 'all',
-					id: 5
-				},
-				queryState: {
-					isLastPage: true,
-					isFetchingNextPage: false
-				},
-				active: 0
-			} );
-			const state = reducer( jsObject, { type: DESERIALIZE } );
-			expect( state ).to.eql( initialState );
-		} );
-
-		it.skip( 'should ignore loading data with invalid values ', () => {
-			const jsObject = deepFreeze( {
-				list: [ 'one', 'two', 'three' ],
-				nextId: 2,
-				query: {
-					search: null,
-					perPage: 20,
-					page: 1,
-					tier: 'all',
-					id: 5
-				},
-				queryState: {
-					isLastPage: 'wrongvalue',
-					isFetchingNextPage: false
-				},
-				active: 0
-			} );
-			const state = reducer( jsObject, { type: DESERIALIZE } );
-			expect( state ).to.eql( initialState );
-		} );
+		
 	} );
 } );

--- a/client/state/themes/themes/reducer.js
+++ b/client/state/themes/themes/reducer.js
@@ -9,6 +9,8 @@ import transform from 'lodash/transform';
  */
 import ActionTypes from '../action-types';
 import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from 'state/action-types';
+import { themesSchema } from './schema';
+import { isValidStateWithSchema } from 'state/utils';
 
 export const initialState = fromJS( {
 	themes: {},
@@ -39,6 +41,10 @@ export default ( state = initialState, action ) => {
 		case ActionTypes.ACTIVATED_THEME:
 			return state.update( 'themes', setActiveTheme.bind( null, action.theme.id ) );
 		case DESERIALIZE:
+			if ( isValidStateWithSchema( state, themesSchema ) ) {
+				return fromJS( state );
+			}
+			return initialState;
 		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:

--- a/client/state/themes/themes/schema.js
+++ b/client/state/themes/themes/schema.js
@@ -1,0 +1,29 @@
+export const themesSchema = {
+	type: 'object',
+	properties: {
+		currentSiteId: { type: 'integer' },
+		themes: {
+			type: 'object',
+			patternProperties: {
+				//be careful to escape regexes properly
+				'^[a-zA-Z0-9-_]+$': {
+					type: 'object',
+					required: [ 'id', 'author' ],
+					properties: {
+						id: { type: 'string' },
+						author: { type: 'string' },
+						screenshot: { type: 'string' },
+						author_uri: { type: 'string' },
+						demo_uri: { type: 'string' },
+						name: { type: 'string' },
+						stylesheet: { type: 'string' },
+						price: { type: 'string' },
+						active: { type: 'boolean' }
+					}
+				}
+			},
+			additionalProperties: false
+		}
+	},
+	additionalProperties: false
+};

--- a/client/state/themes/themes/test/reducer.js
+++ b/client/state/themes/themes/test/reducer.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import { fromJS } from 'immutable';
+import sinon from 'sinon';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -17,6 +18,12 @@ import reducer, { initialState } from '../reducer';
 
 describe( 'themes reducer', () => {
 	describe( 'persistence', () => {
+		before( () => {
+			sinon.stub( console, 'warn' );
+		} );
+		after( () => {
+			console.warn.restore();
+		} );
 		it( 'persists state and converts to a plain JS object', () => {
 			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
@@ -107,7 +114,7 @@ describe( 'themes reducer', () => {
 			expect( state ).to.eql( fromJS( jsObject ) );
 		} );
 
-		it.skip( 'should ignore loading data with invalid keys ', () => {
+		it( 'should ignore loading data with invalid keys ', () => {
 			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				wrongkey: {
@@ -137,7 +144,7 @@ describe( 'themes reducer', () => {
 			expect( state ).to.eql( initialState );
 		} );
 
-		it.skip( 'should ignore loading data with invalid values ', () => {
+		it( 'should ignore loading data with invalid values ', () => {
 			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				themes: {


### PR DESCRIPTION
This adds JSON Schemas to themes, so we can avoid data shape change errors as described in #3101

* I persisted every sub-tree in themes except `themes-list` because of transient `isFetchingNextPage`state. We can persist this subtree after that is moved someplace else.
* ~~It doesn't appear that `theme-details` is currently in use.~~

## Testing Instructions
* Start Calypso with: 
```ENABLE_FEATURES=persist-redux make run```
* In the console set localStorage.debug to `calypso:state`
* Navigate to calypso.localhost:3000/design
* Refresh the page.
* Themes behaves normally and loads the persisted themes data from IndexedDB storage

Bonus:
* Invalidate one of the themes schema by adding `required: [ 'foo' ]`
```javascript
{
    type: 'object',
    required: [ 'foo' ],
    properties: { 
         //.... 
    }
}
```
* Navigate to calypso.localhost:3000/design
* Refresh the page.
* A console warning is printed, letting us know that themes had some invalid data.
* The Themes page still loads and works normally.


cc @ockham @aduth @artpi @retrofox @mtias @rralian 