### PR TITLE
i18n: Unify translatable example strings

### DIFF
--- a/client/components/upgrades/google-apps/dialog/users.jsx
+++ b/client/components/upgrades/google-apps/dialog/users.jsx
@@ -57,16 +57,15 @@ var GoogleAppsUsers = React.createClass( {
 	},
 
 	inputsForUser: function( user, index ) {
-		var domain = this.props.domain;
+		const contactText = this.translate( 'contact', { context: 'part of e-mail address', comment: 'As it would be part of an e-mail address contact@example.com' } ),
+			domain = this.props.domain;
 
 		return (
 			<fieldset className="google-apps-dialog__user-fields" key={ index }>
 				<input
 					className={ this.fieldClasses( user.email, 'google-apps-dialog__user-email' ) }
 					type="text"
-					placeholder={ this.translate( 'e.g. contact@%(domain)s', {
-						args: { domain: domain }
-					} ) }
+					placeholder={ this.translate( 'e.g. %(example)s', { args: { example: contactText + '@' + domain } } ) }
 					value={ user.email.value }
 					onChange={ this.updateField.bind( this, index, 'email' ) }
 					onBlur={ this.props.onBlur }

--- a/client/me/constants.js
+++ b/client/me/constants.js
@@ -4,16 +4,7 @@
 import i18n from 'lib/mixins/i18n';
 
 export default {
-	sixDigit2faPlaceholder: i18n.translate( 'e.g. 123456', {
-		context: '6 digit two factor code placeholder.',
-		textOnly: true
-	} ),
-	sevenDigit2faPlaceholder: i18n.translate( 'e.g. 1234567', {
-		context: '7 digit two factor code placeholder.',
-		textOnly: true
-	} ),
-	eightDigitBackupCodePlaceholder: i18n.translate( 'e.g. 12345678', {
-		context: '8 digit two factor backup code placeholder.',
-		textOnly: true
-	} )
+	sixDigit2faPlaceholder: i18n.translate( 'e.g. %(example)s', { args: { example: '123456' } } ),
+	sevenDigit2faPlaceholder: i18n.translate( 'e.g. %(example)s', { args: { example: '1234567' } } ),
+	eightDigitBackupCodePlaceholder: i18n.translate( 'e.g. %(example)s', { args: { example: '12345678' } } )
 };

--- a/client/my-sites/upgrades/domain-management/add-google-apps/add-email-addresses-card.jsx
+++ b/client/my-sites/upgrades/domain-management/add-google-apps/add-email-addresses-card.jsx
@@ -133,7 +133,8 @@ const AddEmailAddressesCard = React.createClass( {
 	},
 
 	emailAddressFieldset( index ) {
-		const field = this.state.fieldsets[ index ];
+		const field = this.state.fieldsets[ index ],
+			contactText = this.translate( 'contact', { context: 'part of e-mail address', comment: 'As it would be part of an e-mail address contact@example.com' } );
 		let suffix, select;
 
 		if ( this.props.selectedDomainName ) {
@@ -153,7 +154,7 @@ const AddEmailAddressesCard = React.createClass( {
 				<FormTextInputWithAffixes
 					onChange={ this.handleFieldChange.bind( this, 'username', index ) }
 					onFocus={ this.handleFieldFocus.bind( this, 'Email', index ) }
-					placeholder={ this.translate( 'e.g. contact', { textOnly: true, comment: 'Placeholder example email username: contact@...' } ) }
+					placeholder={ this.translate( 'e.g. %(example)s', { args: { example: contactText } } ) }
 					suffix={ suffix }
 					type="text"
 					value={ field.username.value } />

--- a/client/my-sites/upgrades/domain-management/dns/a-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/a-record.jsx
@@ -33,10 +33,10 @@ const ARecord = React.createClass( {
 			{ fieldValues, isValid, onChange, selectedDomainName } = this.props,
 			isNameValid = isValid( 'name' ),
 			isDataValid = isValid( 'data' );
-		let placeholder = this.translate( 'e.g. 123.45.78.9', { context: 'A DNS Record', textOnly: true } );
+		let placeholder = this.translate( 'e.g. %(example)s', { args: { example: '123.45.78.9' } } );
 
 		if ( this.props.fieldValues.type === 'AAAA' ) {
-			placeholder = this.translate( 'e.g. 2001:500:84::b', { context: 'AAAA DNS Record', textOnly: true } );
+			placeholder = this.translate( 'e.g. %(example)s', { args: { example: '2001:500:84::b' } } );
 		}
 
 		return (

--- a/client/my-sites/upgrades/domain-management/dns/cname-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/cname-record.jsx
@@ -55,7 +55,7 @@ const CnameRecord = React.createClass( {
 						isError={ ! isDataValid }
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.data }
-						placeholder={ this.translate( 'e.g. example.com', { context: 'CName DNS Record', textOnly: true } ) } />
+						placeholder={ this.translate( 'e.g. %(example)s', { args: { example: 'example.com' } } ) } />
 					{ ! isDataValid ? <FormInputValidation text={ this.translate( 'Invalid Target Host' ) } isError={ true } /> : null }
 				</FormFieldset>
 			</div>

--- a/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
@@ -59,7 +59,7 @@ const MxRecord = React.createClass( {
 						isError={ ! isDataValid }
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.data }
-						placeholder={ this.translate( 'e.g. mail.your-provider.com', { context: 'MX DNS Record', textOnly: true } ) } />
+						placeholder={ this.translate( 'e.g. %(example)s', { args: { example: 'mail.your-provider.com' } } ) } />
 					{ ! isDataValid ? <FormInputValidation text={ this.translate( 'Invalid Mail Server' ) } isError={ true } /> : null }
 				</FormFieldset>
 

--- a/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/srv-record.jsx
@@ -69,7 +69,7 @@ const SrvRecord = React.createClass( {
 						isError={ ! isServiceValid }
 						onChange={ this.props.onChange }
 						value={ service }
-						placeholder={ this.translate( 'e.g. sip', { context: 'SRV Dns Record', textOnly: true } ) } />
+						placeholder={ this.translate( 'e.g. %(example)s', { args: { example: 'sip' } } ) } />
 					{ ! isServiceValid ? <FormInputValidation text={ this.translate( 'Invalid Service' ) } isError={ true } /> : null }
 				</FormFieldset>
 
@@ -113,7 +113,7 @@ const SrvRecord = React.createClass( {
 						isError={ ! isTargetValid }
 						onChange={ this.props.onChange }
 						value={ target }
-						placeholder={ this.translate( 'e.g. sip.your-provider.com', { context: 'SRV Dns Record', textOnly: true } ) } />
+						placeholder={ this.translate( 'e.g. %(example)s', { args: { example: 'sip.your-provider.com' } } ) } />
 					{ ! isTargetValid ? <FormInputValidation text={ this.translate( 'Invalid Target Host' ) } isError={ true } /> : null }
 				</FormFieldset>
 
@@ -124,7 +124,7 @@ const SrvRecord = React.createClass( {
 						isError={ ! isPortValid }
 						onChange={ this.props.onChange }
 						value={ port }
-						placeholder={ this.translate( 'e.g. 5060', { context: 'SRV Dns Record', textOnly: true } ) } />
+						placeholder={ this.translate( 'e.g. %(example)s', { args: { example: '5060' } } ) } />
 					{ ! isPortValid ? <FormInputValidation text={ this.translate( 'Invalid Target Port' ) } isError={ true } /> : null }
 				</FormFieldset>
 			</div>

--- a/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/txt-record.jsx
@@ -56,7 +56,7 @@ const TxtRecord = React.createClass( {
 						name="data"
 						onChange={ this.props.onChange }
 						value={ this.props.fieldValues.data }
-						placeholder={ this.translate( 'e.g. a=b; verification-key=something', { context: 'TXT DNS Record', textOnly: true } ) } />
+						placeholder={ this.translate( 'e.g. %(example)s', { args: { example: 'v=spf1 include:example.com ~all' } } ) } />
 					{ ! isDataValid ? <FormInputValidation text={ this.translate( 'Invalid TXT Record' ) } isError={ true } /> : null }
 				</FormFieldset>
 			</div>

--- a/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-add-new.jsx
+++ b/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-add-new.jsx
@@ -117,10 +117,8 @@ const EmailForwardingAddNew = React.createClass( {
 	},
 
 	formFields() {
-		const exampleEmailText = this.translate( 'e.g. contact', {
-			textOnly: true,
-			comment: 'Placeholder text with an example email address'
-		} );
+		const contactText = this.translate( 'contact', { context: 'part of e-mail address', comment: 'As it would be part of an e-mail address contact@example.com' } ),
+			exampleEmailText = this.translate( 'e.g. %(example)s', { args: { example: contactText } } );
 
 		if ( ! this.shouldShowForm() ) {
 			return null;


### PR DESCRIPTION
Let's relieve our translators from potentially being confused by example strings.

For example `e.g. mail.your-provider.com` poses the question whether to translate the domain name (which we don't as potentially a user could simply copy the domain, and for `your-provider.com` that is ok-ish becaues we own the domain).

Most of these example strings have been introduced on our DNS settings pages.

Testing:
Check the instances where these `e.g.` strings are shown:
 * E-Mail address placeholder of the Google Apps users dialog
 * 2FA example placeholders
 * E-Mail address placeholder in the Domains upgrade
 * hostname placeholder in the CNAME record
 * hostname placeholder in the MX record
 * name, hostname, port placeholder in the SRV record
 * hostname placeholder in the A record
 * hostname placeholder in the TXT record

PS: I have removed several instances of `textOnly: true` because it is no longer needed (we overwrite the toString method to provide a proper string).