### PR TITLE
Add a "client" variable to /help requests.

### DIFF
--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -80,8 +80,9 @@ const olark = {
 			// change if they purchase upgrades or if their upgrades expire. There's also throttling that happens for unpaid users.
 			// There is lots to consider before storing this configuration
 			debug( 'Using rest api to get olark configuration' );
+			const clientSlug = config( 'client_slug' );
 
-			wpcomUndocumented.getOlarkConfiguration( ( error, configuration ) => {
+			wpcomUndocumented.getOlarkConfiguration( clientSlug, ( error, configuration ) => {
 				if ( error ) {
 					reject( error );
 					return;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1818,12 +1818,12 @@ Undocumented.prototype.cancelPlanTrial = function( planId, fn ) {
 	}, fn );
 };
 
-Undocumented.prototype.submitKayakoTicket = function( subject, message, locale, fn ) {
+Undocumented.prototype.submitKayakoTicket = function( subject, message, locale, client, fn ) {
 	debug( 'submitKayakoTicket' );
 
 	this.wpcom.req.post( {
 		path: '/help/tickets/kayako/new',
-		body: { subject, message, locale }
+		body: { subject, message, locale, client }
 	}, fn );
 };
 
@@ -1833,17 +1833,18 @@ Undocumented.prototype.submitKayakoTicket = function( subject, message, locale, 
  * @param {Function} fn The callback function
  * @api public
  */
-Undocumented.prototype.getOlarkConfiguration = function( fn ) {
+Undocumented.prototype.getOlarkConfiguration = function( client, fn ) {
 	this.wpcom.req.get( {
 		apiVersion: '1.1',
-		path: '/help/olark/mine'
+		path: '/help/olark/mine',
+		body: { client }
 	}, fn );
 };
 
-Undocumented.prototype.submitSupportForumsTopic = function( subject, message, fn ) {
+Undocumented.prototype.submitSupportForumsTopic = function( subject, message, client, fn ) {
 	this.wpcom.req.post( {
 		path: '/help/forums/support/topics/new',
-		body: { subject, message }
+		body: { subject, message, client }
 	}, fn );
 };
 

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -4,6 +4,8 @@
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' );
 
+import config from 'config';
+
 /**
  * Internal dependencies
  */
@@ -34,7 +36,7 @@ module.exports = {
 		analytics.pageView.record( basePath, 'Help > Contact' );
 
 		ReactDom.render(
-			<ContactComponent />,
+			<ContactComponent clientSlug={ config( 'client_slug' ) } />,
 			document.getElementById( 'primary' )
 		);
 	}

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -128,7 +128,7 @@ module.exports = React.createClass( {
 
 		this.setState( { isSubmitting: true } );
 
-		wpcom.submitKayakoTicket( subject, kayakoMessage, locale, ( error ) => {
+		wpcom.submitKayakoTicket( subject, kayakoMessage, locale, this.props.clientSlug, ( error ) => {
 			if ( error ) {
 				// TODO: bump a stat here
 				notices.error( error.message );
@@ -158,7 +158,7 @@ module.exports = React.createClass( {
 
 		this.setState( { isSubmitting: true } );
 
-		wpcom.submitSupportForumsTopic( subject, message, ( error, data ) => {
+		wpcom.submitSupportForumsTopic( subject, message, this.props.clientSlug, ( error, data ) => {
 			if ( error ) {
 				// TODO: bump a stat here
 				notices.error( error.message );


### PR DESCRIPTION
This will allow us to distinguish between browser, mobile, desktop, etc., for requests to these endpoints, which will let us respond differently as needed. For example, we might have a group of people very well suited to providing desktop vs. web client support, and by sending the client info along with the request, we can be sure to route any chats or tickets to the best group of support staff.

To test:

1. Make sure the developer console is open.
2. Load http://calypso.localhost:3000/help/contact.
3. Look for the /help/olark/mine http request.
4. Observe that it now has a `client` variable appended to the query string.

Before this PR:

![client-mine-before](https://cloud.githubusercontent.com/assets/2738252/13184263/c867022a-d708-11e5-9fcd-5e185f5a1aaf.png)

After:

<img width="1168" alt="client-mine-after" src="https://cloud.githubusercontent.com/assets/2738252/13184267/cd00618c-d708-11e5-87d5-83bc4b2a66d6.png">

We're also adding the `client` parameter to the POST for requests to create tickets and forum replies. To test:

1. Enable the dev console.
2. Load http://calypso.localhost:3000/help/contact when you know operators are not available.
3. Observe that you have the option to create a ticket or forum post (depending on your user).
4. Look for the /help/ticket* endpoint.
5. Observe that it now has a `client` variable in the POST data.

Before this PR:

![client-kayako-before](https://cloud.githubusercontent.com/assets/2738252/13184329/22d218da-d709-11e5-8d4d-2c09bb4ddcde.png)

After:

![client-kayako-after](https://cloud.githubusercontent.com/assets/2738252/13184332/299292ee-d709-11e5-828f-1af44d0a9340.png)

Cc @omarjackman @jordwest.