### PR TITLE
Framework: fix edit post url regression

### DIFF
--- a/client/post-editor/editor-slug/index.jsx
+++ b/client/post-editor/editor-slug/index.jsx
@@ -6,8 +6,6 @@ import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal Dependencies
@@ -16,15 +14,13 @@ import actions from 'lib/posts/actions';
 import TrackInputChanges from 'components/track-input-changes';
 import FormTextInput from 'components/forms/form-text-input';
 import { recordStat, recordEvent } from 'lib/posts/stats';
-import { setSlug } from 'state/ui/editor/post/actions';
 
-const PostEditorSlug = React.createClass( {
+export default React.createClass( {
 	displayName: 'PostEditorSlug',
 
 	mixins: [ PureRenderMixin ],
 
 	propTypes: {
-		setSlug: PropTypes.func,
 		path: PropTypes.string,
 		slug: PropTypes.string,
 		onEscEnter: PropTypes.func,
@@ -36,7 +32,6 @@ const PostEditorSlug = React.createClass( {
 
 	getDefaultProps() {
 		return {
-			setSlug: () => {},
 			onEscEnter: noop,
 			isEditable: true
 		};
@@ -49,10 +44,7 @@ const PostEditorSlug = React.createClass( {
 	},
 
 	onSlugChange( event ) {
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( { slug: event.target.value } );
-
-		this.props.setSlug( event.target.value );
 	},
 
 	onSlugKeyDown( event ) {
@@ -135,8 +127,3 @@ const PostEditorSlug = React.createClass( {
 		);
 	}
 } );
-
-export default connect(
-	null,
-	dispatch => bindActionCreators( { setSlug }, dispatch )
-)( PostEditorSlug );


### PR DESCRIPTION
This PR fixes #3408. #3202 caused a regression where we are unable to edit a post url.

## Testing Instructions

* Navigate to /posts
* Edit an existing post
* Click on the 
![edit](https://cloud.githubusercontent.com/assets/1270189/13185675/3b710f98-d6f7-11e5-94f0-9d20e93088bf.png)
* You should be able to edit the post url without js errors

cc @mtias @artpi @starxedsteph 