### PR TITLE
Editor: Pass store context to Popover component

### DIFF
--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -6,6 +6,7 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import omit from 'lodash/omit';
 import Tip from 'component-tip';
+import { Provider as ReduxProvider } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -33,6 +34,10 @@ var Popover = React.createClass( {
 		onClose: React.PropTypes.func.isRequired,
 		position: React.PropTypes.string,
 		ignoreContext: React.PropTypes.shape( { getDOMNode: React.PropTypes.function } ),
+	},
+
+	contextTypes: {
+		store: React.PropTypes.object
 	},
 
 	getDefaultProps: function() {
@@ -73,10 +78,19 @@ var Popover = React.createClass( {
 		}
 
 		if ( this.props.isVisible && this.props.context ) {
-			ReactDom.render(
-				<Content { ...omit( this.props, 'className' ) } onClose={ this._close } />,
-				this._container
-			);
+			let content = <Content { ...omit( this.props, 'className' ) } onClose={ this._close } />;
+
+			// Context is lost when creating a new render hierarchy, so ensure
+			// that we preserve the context that we care about
+			if ( this.context.store ) {
+				content = (
+					<ReduxProvider store={ this.context.store }>
+						{ content }
+					</ReduxProvider>
+				);
+			}
+
+			ReactDom.render( content, this._container );
 
 			if ( ! prevProps.isVisible ) {
 				const contextNode = ReactDom.findDOMNode( this.props.context );

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-var clickOutside = require( 'click-outside' ),
-	ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	omit = require( 'lodash/omit' ),
-	Tip = require( 'component-tip' );
+import clickOutside from 'click-outside';
+import ReactDom from 'react-dom';
+import React from 'react';
+import omit from 'lodash/omit';
+import Tip from 'component-tip';
 
 /**
  * Internal dependencies
  */
-var closeOnEsc = require( 'lib/mixins/close-on-esc' ),
-	warn = require( 'lib/warn' );
+import closeOnEsc from 'lib/mixins/close-on-esc';
+import warn from 'lib/warn';
 
 var Content = React.createClass( {
 	mixins: [ closeOnEsc( '_close' ) ],

--- a/client/post-editor/editor-slug/index.jsx
+++ b/client/post-editor/editor-slug/index.jsx
@@ -6,6 +6,8 @@ import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
 /**
  * Internal Dependencies
@@ -14,13 +16,15 @@ import actions from 'lib/posts/actions';
 import TrackInputChanges from 'components/track-input-changes';
 import FormTextInput from 'components/forms/form-text-input';
 import { recordStat, recordEvent } from 'lib/posts/stats';
+import { setSlug } from 'state/ui/editor/post/actions';
 
-export default React.createClass( {
+const PostEditorSlug = React.createClass( {
 	displayName: 'PostEditorSlug',
 
 	mixins: [ PureRenderMixin ],
 
 	propTypes: {
+		setSlug: PropTypes.func,
 		path: PropTypes.string,
 		slug: PropTypes.string,
 		onEscEnter: PropTypes.func,
@@ -32,6 +36,7 @@ export default React.createClass( {
 
 	getDefaultProps() {
 		return {
+			setSlug: () => {},
 			onEscEnter: noop,
 			isEditable: true
 		};
@@ -44,7 +49,10 @@ export default React.createClass( {
 	},
 
 	onSlugChange( event ) {
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.edit( { slug: event.target.value } );
+
+		this.props.setSlug( event.target.value );
 	},
 
 	onSlugKeyDown( event ) {
@@ -127,3 +135,8 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( { setSlug }, dispatch )
+)( PostEditorSlug );


### PR DESCRIPTION
Reverts #3415 
Fixes #3408

This pull request seeks to implement a fix for the issue which had led to #3408, which received a temporary patch fix in #3415. This pull request reverts the changes in #3415, adding the necessary store context handling to avoid the error which had occurred previously.

__Testing instructions:__

Repeat the testing instructions from #3415, confirming that the popover continues to display without errors.