### PR TITLE
State: Filter connections by site via selector in place of reducer key

### DIFF
--- a/client/state/sharing/README.md
+++ b/client/state/sharing/README.md
@@ -33,10 +33,6 @@ An object mapping site ID to connection fetching status for that site.
 
 All known connections, indexed by connection ID.
 
-#### `connectionsBySiteId`
-
-An object mapping site ID to an array of connection IDs for that site.
-
 ### Selectors
 
 Selectors are intended to assist in extracting data from the global state tree for consumption by other modules.

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -63,32 +63,7 @@ export function connections( state = {}, action ) {
 	return state;
 }
 
-/**
- * Tracks known connections for a site. Maps site ID to an array of connection
- * IDs. When new connections are received, existing known connections for the
- * site ID contained in the action payload are destroyed.
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
- */
-export function connectionsBySiteId( state = {}, action ) {
-	switch ( action.type ) {
-		case PUBLICIZE_CONNECTIONS_RECEIVE:
-			return Object.assign( {}, state, {
-				[ action.siteId ]: action.data.connections.map( ( connection ) => connection.ID )
-			} );
-		case SERIALIZE:
-			return state;
-		case DESERIALIZE:
-			return state;
-	}
-
-	return state;
-}
-
 export default combineReducers( {
 	fetchingConnections,
-	connections,
-	connectionsBySiteId
+	connections
 } );

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import filter from 'lodash/filter';
+
+/**
  * Returns an array of known connections for the given site ID.
  *
  * @param  {Object} state  Global state tree
@@ -6,15 +11,7 @@
  * @return {Array}         Site connections
  */
 export function getConnectionsBySiteId( state, siteId ) {
-	const { connectionsBySiteId, connections } = state.sharing.publicize;
-
-	if ( ! connectionsBySiteId[ siteId ] ) {
-		return [];
-	}
-
-	return connectionsBySiteId[ siteId ].map( ( connectionId ) => {
-		return connections[ connectionId ];
-	} );
+	return filter( state.sharing.publicize.connections, { site_ID: siteId } );
 }
 
 /**
@@ -27,10 +24,9 @@ export function getConnectionsBySiteId( state, siteId ) {
  * @return {Array}         User connections
  */
 export function getSiteUserConnections( state, siteId, userId ) {
-	const connectionsBySiteId = getConnectionsBySiteId( state, siteId );
-
-	return connectionsBySiteId.filter( ( connection ) => {
-		return connection.shared || connection.keyring_connection_user_ID === userId;
+	return filter( state.sharing.publicize.connections, ( connection ) => {
+		const { site_ID, shared, keyring_connection_user_ID } = connection;
+		return site_ID === siteId && ( shared || keyring_connection_user_ID === userId );
 	} );
 }
 

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -15,8 +15,7 @@ import {
 } from 'state/action-types';
 import {
 	fetchingConnections,
-	connections,
-	connectionsBySiteId
+	connections
 } from '../reducer';
 
 describe( '#fetchingConnections()', () => {
@@ -175,106 +174,6 @@ describe( '#connections()', () => {
 				2: { ID: 2, site_ID: 2916284 }
 			} );
 			const state = connections( persistedState, {
-				type: DESERIALIZE
-			} );
-			expect( state ).to.eql( {} );
-		} );
-	} );
-} );
-
-describe( '#connectionsBySiteId()', () => {
-	it( 'should map site ID to connection IDs', () => {
-		const state = connectionsBySiteId( null, {
-			type: PUBLICIZE_CONNECTIONS_RECEIVE,
-			siteId: 2916284,
-			data: {
-				connections: [
-					{ ID: 1, site_ID: 2916284 },
-					{ ID: 2, site_ID: 2916284 }
-				]
-			}
-		} );
-
-		expect( state ).to.eql( {
-			2916284: [ 1, 2 ]
-		} );
-	} );
-
-	it( 'should replace previous known connections for site', () => {
-		const state = connectionsBySiteId( {
-			2916284: [ 1, 2 ]
-		}, {
-			type: PUBLICIZE_CONNECTIONS_RECEIVE,
-			siteId: 2916284,
-			data: {
-				connections: [
-					{ ID: 1, site_ID: 2916284 }
-				]
-			}
-		} );
-
-		expect( state ).to.eql( {
-			2916284: [ 1 ]
-		} );
-	} );
-
-	it( 'should not replace known connections for unrelated sites', () => {
-		const state = connectionsBySiteId( {
-			77203074: [ 1, 2 ]
-		}, {
-			type: PUBLICIZE_CONNECTIONS_RECEIVE,
-			siteId: 2916284,
-			data: {
-				connections: [
-					{ ID: 1, site_ID: 2916284 }
-				]
-			}
-		} );
-
-		expect( state ).to.eql( {
-			77203074: [ 1, 2 ],
-			2916284: [ 1 ]
-		} );
-	} );
-
-	describe( 'persistence', () => {
-		it( 'should persist data', () => {
-			const state = Object.freeze( {
-				77203074: [ 1, 2 ],
-				2916284: [ 1 ]
-			} );
-			const persistedState = connectionsBySiteId( state, { type: SERIALIZE } );
-			expect( persistedState ).to.eql( state );
-		} );
-
-		it( 'should load valid data', () => {
-			const persistedState = Object.freeze( {
-				77203074: [ 1, 2 ],
-				2916284: [ 1 ]
-			} );
-			const state = connectionsBySiteId( persistedState, {
-				type: DESERIALIZE
-			} );
-			expect( state ).to.eql( persistedState );
-		} );
-
-		it.skip( 'should ignore loading data with invalid keys', () => {
-			const persistedState = Object.freeze( {
-				77203074: [ 1, 2 ],
-				foo: [ 1 ]
-			} );
-			const state = connectionsBySiteId( persistedState, {
-				type: DESERIALIZE
-			} );
-			expect( state ).to.eql( {} );
-		} );
-
-		it.skip( 'should ignore loading data with invalid values', () => {
-			const persistedState = Object.freeze( {
-				77203074: [ 1, 'bar' ],
-				2916284: [ 1 ]
-			} );
-			const state = connectionsBySiteId( persistedState, {
 				type: DESERIALIZE
 			} );
 			expect( state ).to.eql( {} );


### PR DESCRIPTION
Related: #3357

This pull request seeks to remove the `state.sharing.publicize.connectionsBySiteId` reducer key, replacing it with filter logic contained within `getConnectionsBySiteId` and `getSiteUserConnections`.

__Testing instructions:__

Repeat testing instructions from #338.

Ensure that Mocha tests continue to pass by running `make test` from `client/state/sharing/publicize`.

/cc @gwwar 