### PR TITLE
Reader: Fix the url we send to the follow button in Full Post View

### DIFF
--- a/client/lib/feed-store/constants.js
+++ b/client/lib/feed-store/constants.js
@@ -1,11 +1,10 @@
 module.exports = {
-  action: {
-    FETCH: 'FEED_FETCH',
-    RECEIVE_FETCH: 'RECEIVE_FEED_FETCH'
-  },
-  state: {
-    PENDING: 1,
-    COMPLETE: 2,
-    ERROR: 4
-  }
+	action: {
+		FETCH: 'FEED_FETCH',
+		RECEIVE_FETCH: 'RECEIVE_FEED_FETCH'
+	},
+	state: {
+		COMPLETE: 2,
+		ERROR: 4
+	}
 };

--- a/client/lib/feed-store/index.js
+++ b/client/lib/feed-store/index.js
@@ -27,16 +27,6 @@ var feeds = {},
 		error: undefined
 	} );
 
-function changeState( feedId, newState ) {
-	var feed = feeds[ feedId ];
-	if ( ! feed ) {
-		feed = new FeedRecord( { feed_ID: feedId } );
-	}
-
-	feed = feed.set( 'state', newState );
-	setFeed( feedId, feed );
-}
-
 function setFeed( feedId, feed ) {
 	if ( feed !== feeds[ feedId ] ) {
 		feeds[ feedId ] = feed;
@@ -88,9 +78,6 @@ FeedStore.dispatchToken = Dispatcher.register( function( payload ) {
 	}
 
 	switch ( action.type ) {
-		case ActionType.FETCH:
-			changeState( action.feedId, State.PENDING );
-			break;
 		case ActionType.RECEIVE_FETCH:
 			if ( action.error ) {
 				receiveError( action.feedId, action.error );

--- a/client/lib/feed-store/test/feed-store-tests.js
+++ b/client/lib/feed-store/test/feed-store-tests.js
@@ -10,7 +10,6 @@ var FeedState = require( '../constants' ).state,
 	FeedStore, FeedStoreActions;
 
 describe( 'FeedStore', function() {
-
 	var readFeedStub,
 		mockWpcom = {
 			undocumented: function() {
@@ -42,7 +41,6 @@ describe( 'FeedStore', function() {
 		changeSpy.reset();
 	} );
 
-
 	it( 'should have a dispatch token', function() {
 		expect( FeedStore ).to.have.property( 'dispatchToken' );
 	} );
@@ -51,23 +49,12 @@ describe( 'FeedStore', function() {
 		expect( FeedStore.get( 'UNKNOWN' ) ).to.be.undefined;
 	} );
 
-	it( 'should create a pending record when sent REFRESH', function() {
-		FeedStoreActions.fetch( 'KNOWN' );
-
-		expect( readFeedStub.callCount ).to.equal( 1 );
-		expect( readFeedStub.args[ 0 ][ 0 ] ).to.eql( { ID: 'KNOWN', meta: 'site' } );
-
-		expect( FeedStore.get( 'KNOWN' ).state ).to.equal( FeedState.PENDING );
-		expect( changeSpy.callCount ).to.equal( 1 );
-	} );
-
-	it( 'should pass through the pending state and prevent double fetches', function() {
-
+	it( 'should prevent double fetches', function() {
 		FeedStoreActions.fetch( 'twice' );
 		FeedStoreActions.fetch( 'twice' );
 
 		expect( readFeedStub.callCount ).to.equal( 1 );
-		expect( changeSpy.callCount ).to.equal( 1 );
+		expect( changeSpy.callCount ).to.equal( 0 );
 	} );
 
 	it( 'should accept a good response', function() {
@@ -84,7 +71,7 @@ describe( 'FeedStore', function() {
 
 		FeedStoreActions.fetch( 1234 );
 
-		expect( changeSpy.callCount ).to.equal( 2 );
+		expect( changeSpy.callCount ).to.equal( 1 );
 
 		feedFromStore = FeedStore.get( 1234 );
 
@@ -94,7 +81,6 @@ describe( 'FeedStore', function() {
 		forOwn( feed, function( val, key ) {
 			expect( feedFromStore[ key ] ).to.eql( val );
 		} );
-
 	} );
 
 	it( 'should accept an error', function() {
@@ -104,7 +90,7 @@ describe( 'FeedStore', function() {
 
 		FeedStoreActions.fetch( 'BAD' );
 
-		expect( changeSpy.callCount ).to.equal( 2 );
+		expect( changeSpy.callCount ).to.equal( 1 );
 
 		feedFromStore = FeedStore.get( 'BAD' );
 
@@ -112,5 +98,4 @@ describe( 'FeedStore', function() {
 		expect( feedFromStore.state ).to.equal( FeedState.ERROR );
 		expect( feedFromStore.error ).to.equal( error );
 	} );
-
 } );

--- a/client/lib/react-smart-set-state/index.js
+++ b/client/lib/react-smart-set-state/index.js
@@ -1,6 +1,7 @@
 /**
  * A function that only sets the new state if it's different from the current state
  * @param  {object} newState The new state to set
+ * @returns {Boolean} True if new values found, false if not
  */
 export default function smartSetState( newState ) {
 	const hasNewValues = Object.keys( newState ).some( function( key ) {
@@ -8,5 +9,7 @@ export default function smartSetState( newState ) {
 	}, this );
 	if ( hasNewValues ) {
 		this.setState( newState );
+		return true;
 	}
+	return false;
 }

--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -11,7 +11,7 @@ const Dispatcher = require( 'dispatcher' ),
 	Immutable = require( 'immutable' ),
 	clone = require( 'lodash/clone' ),
 	map = require( 'lodash/map' ),
-	forEach = require( 'lodash/foreach' );
+	forEach = require( 'lodash/forEach' );
 
 // Internal Dependencies
 const Emitter = require( 'lib/mixins/emitter' ),

--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -140,9 +140,11 @@ var FeedSubscriptionStore = {
 			isLastPage = true;
 		}
 
+		subscriptions.list = subscriptions.list.asMutable();
 		forEach( subscriptionsWithState, function( subscription ) {
 			addSubscription( subscription.toJS(), false );
 		} );
+		subscriptions.list = subscriptions.list.asImmutable();
 
 		// Set the current page
 		currentPage = data.page;

--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -32,7 +32,7 @@ var subscriptions = clone( subscriptionsTemplate ),
 	currentPage = 0,
 	isLastPage = false,
 	isFetching = false,
-	totalSubscriptions,
+	totalSubscriptions = 0,
 	subscriptionTemplate = Immutable.Map( { // eslint-disable-line new-cap
 		state: States.SUBSCRIBED
 	} );
@@ -125,10 +125,6 @@ var FeedSubscriptionStore = {
 	},
 
 	receiveSubscriptions: function( data ) {
-		var currentSubscriptions = subscriptions,
-			newSubscriptions,
-			combinedSubscriptions;
-
 		if ( ! data.subscriptions ) {
 			return;
 		}
@@ -150,11 +146,6 @@ var FeedSubscriptionStore = {
 
 		// Set the current page
 		currentPage = data.page;
-
-		// Set total subscriptions for user on the first page only (we keep track of it in the store after that)
-		if ( currentPage === 1 ) {
-			totalSubscriptions = data.total_subscriptions;
-		}
 
 		FeedSubscriptionStore.emit( 'change' );
 	},
@@ -218,6 +209,7 @@ var FeedSubscriptionStore = {
 
 	clearSubscriptions: function() {
 		subscriptions = clone( subscriptionsTemplate );
+		totalSubscriptions = 0;
 	},
 
 	isLastPage: function() {
@@ -261,10 +253,7 @@ function addSubscription( subscription, addToTop = true ) {
 		subscriptions.list = subscriptions.list.push( newSubscription );
 	}
 	subscriptions.count++;
-
-	if ( totalSubscriptions > 0 ) {
-		totalSubscriptions++;
-	}
+	totalSubscriptions++;
 
 	return true;
 }
@@ -310,7 +299,7 @@ function updateSubscription( url, newSubscriptionInfo ) {
 
 	subscriptions.list = updatedSubscriptionsList;
 
-	if ( totalSubscriptions > 0 && existingSubscription.get( 'state' ) === States.UNSUBSCRIBED && updatedSubscription.get( 'state' ) === States.SUBSCRIBED ) {
+	if ( existingSubscription.get( 'state' ) === States.UNSUBSCRIBED && updatedSubscription.get( 'state' ) === States.SUBSCRIBED ) {
 		totalSubscriptions++;
 	}
 

--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -11,6 +11,7 @@ const Dispatcher = require( 'dispatcher' ),
 	Immutable = require( 'immutable' ),
 	clone = require( 'lodash/clone' ),
 	map = require( 'lodash/map' ),
+	moment = require( 'moment' ),
 	forEach = require( 'lodash/forEach' );
 
 // Internal Dependencies
@@ -144,6 +145,21 @@ var FeedSubscriptionStore = {
 		forEach( subscriptionsWithState, function( subscription ) {
 			_acceptSubscription( subscription, false );
 		} );
+		subscriptions.list = subscriptions.list.sort( function( a, b ) {
+			const aDate = moment( a.get( 'date_subscribed' ) ),
+				bDate = moment( b.get( 'date_subscribed' ) );
+
+			if ( aDate.isAfter( bDate ) ) {
+				return -1;
+			}
+
+			if ( aDate.isBefore( bDate ) ) {
+				return 1;
+			}
+
+			return b.get( 'feed_ID' ) - a.get( 'feed_ID' );
+		} );
+
 		subscriptions.list = subscriptions.list.asImmutable();
 
 		// Set the current page
@@ -152,6 +168,7 @@ var FeedSubscriptionStore = {
 		if ( currentPage === 1 ) {
 			totalSubscriptions = data.total_subscriptions;
 		}
+		subscriptions.count = subscriptions.list.count();
 
 		FeedSubscriptionStore.emit( 'change' );
 	},

--- a/client/lib/reader-feed-subscriptions/test/feed-subscription-store-test.js
+++ b/client/lib/reader-feed-subscriptions/test/feed-subscription-store-test.js
@@ -161,7 +161,7 @@ describe( 'feed-subscription-store', function() {
 			feed_ID: 123,
 			state: 'SUBSCRIBED'
 		} ) );
-		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 505 );
+		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 2 );
 
 		// Receiving second page (subscriptions should be merged)
 		Dispatcher.handleViewAction( {
@@ -246,13 +246,6 @@ describe( 'feed-subscription-store', function() {
 	it( 'should update the total subscription count during follow and unfollow', function() {
 		const siteUrl = 'http://www.mango.com';
 
-		// Receive initial total_subscriptions count
-		Dispatcher.handleViewAction( {
-			type: 'RECEIVE_FEED_SUBSCRIPTIONS',
-			data: { page: 1, total_subscriptions: 506, subscriptions: [ { ID: 3, URL: 'http://www.dragonfruit.com', feed_ID: 456 } ] },
-			error: null
-		} );
-
 		// Follow
 		Dispatcher.handleViewAction( {
 			type: 'FOLLOW_READER_FEED',
@@ -261,7 +254,7 @@ describe( 'feed-subscription-store', function() {
 			error: null
 		} );
 
-		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 507 );
+		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 1 );
 
 		// Unfollow
 		Dispatcher.handleViewAction( {
@@ -271,7 +264,7 @@ describe( 'feed-subscription-store', function() {
 			error: null
 		} );
 
-		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 506 );
+		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 0 );
 
 		// Re-follow (to check that the state change UNSUBSCRIBED->SUBSCRIBED updates the count correctly)
 		Dispatcher.handleViewAction( {
@@ -281,6 +274,6 @@ describe( 'feed-subscription-store', function() {
 			error: null
 		} );
 
-		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 507 );
+		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 1 );
 	} );
 } );

--- a/client/lib/reader-feed-subscriptions/test/feed-subscription-store-test.js
+++ b/client/lib/reader-feed-subscriptions/test/feed-subscription-store-test.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-var chai = require( 'chai' ),
+const chai = require( 'chai' ),
 	expect = chai.expect,
 	Dispatcher = require( 'dispatcher' ),
 	immutable = require( 'immutable' ),
@@ -9,7 +9,8 @@ var chai = require( 'chai' ),
 
 chai.use( chaiImmutable );
 
-const FeedSubscriptionStore = require( '../index' );
+const FeedActionTypes = require( 'lib/feed-store/constants' ).action,
+	FeedSubscriptionStore = require( '../index' );
 
 describe( 'feed-subscription-store', function() {
 	beforeEach( function() {
@@ -275,5 +276,64 @@ describe( 'feed-subscription-store', function() {
 		} );
 
 		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 1 );
+	} );
+
+	it( 'should pick up a subscription from a feed result', () => {
+		const feed_URL = 'http://example.com/atom';
+		Dispatcher.handleServerAction( {
+			type: FeedActionTypes.RECEIVE_FETCH,
+			data: {
+				feed_ID: 1,
+				is_following: true,
+				feed_URL
+			}
+		} );
+
+		expect( FeedSubscriptionStore.getSubscription( feed_URL ).get( 'feed_ID' ) ).to.eql( 1 );
+	} );
+
+	it( 'should sort existing subscriptions into the correct place when accepting them', () => {
+		// take a feed with no sub date
+		Dispatcher.handleServerAction( {
+			type: FeedActionTypes.RECEIVE_FETCH,
+			data: {
+				is_following: true,
+				feed_URL: 'http://example.com/atom',
+				feed_ID: 789
+			}
+		} );
+
+		// take a set of subs that do have dates
+		Dispatcher.handleServerAction( {
+			type: 'RECEIVE_FEED_SUBSCRIPTIONS',
+			data: {
+				page: 1,
+				total_subscriptions: 999,
+				subscriptions: [
+					{
+						ID: 1,
+						URL: 'http://www.dragonfruit.com',
+						feed_ID: 123,
+						date_subscribed: '2016-01-01T00:00:00Z'
+					},
+					{
+						ID: 2,
+						URL: 'http://example.com/atom',
+						feed_ID: 789,
+						date_subscribed: '2016-01-01T00:00:03Z'
+					},
+					{
+						ID: 3,
+						URL: 'http://www.dragonfruit3.com',
+						feed_ID: 456,
+						date_subscribed: '2016-01-01T00:00:03Z'
+					}
+				]
+			}
+		} );
+
+		expect( FeedSubscriptionStore.getSubscriptions().count ).to.eql( 3 );
+		expect( FeedSubscriptionStore.getSubscriptions().list.count() ).to.eql( 3 );
+		expect( FeedSubscriptionStore.getSubscriptions().list.get( 1 ).get( 'feed_ID' ) ).to.eql( 456 );
 	} );
 } );

--- a/client/lib/reader-feed-subscriptions/test/feed-subscription-store-test.js
+++ b/client/lib/reader-feed-subscriptions/test/feed-subscription-store-test.js
@@ -161,7 +161,7 @@ describe( 'feed-subscription-store', function() {
 			feed_ID: 123,
 			state: 'SUBSCRIBED'
 		} ) );
-		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 2 );
+		expect( FeedSubscriptionStore.getTotalSubscriptions() ).to.eq( 505 );
 
 		// Receiving second page (subscriptions should be merged)
 		Dispatcher.handleViewAction( {

--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -113,9 +113,7 @@ const PostOptions = React.createClass( {
 		const feed = FeedStore.get( feedId );
 
 		if ( ! feed ) {
-			setTimeout( function() {
-				FeedStoreActions.fetch( feedId );
-			}, 0 );
+			FeedStoreActions.fetch( feedId );
 		}
 
 		return feed;


### PR DESCRIPTION
This still has a big problem: the following state will be correct on load, but when the first page of results come in from the subscription sync, the following state will be dropped.

We need to change how we consume pages of subs in the feed-subscription-store, merging the page with current results, and possibly resorting the results by sub date.