### PR TITLE
Themes: Record pageView() on Details page

### DIFF
--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -18,7 +18,6 @@ import analytics from 'analytics';
 import i18n from 'lib/mixins/i18n';
 import trackScrollPage from 'lib/track-scroll-page';
 import buildTitle from 'lib/screen-title/utils';
-import route from 'lib/route';
 import { getAnalyticsData } from './helpers';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { setSection } from 'state/ui/actions';
@@ -116,14 +115,9 @@ export function loggedOut( context, next ) {
 
 function getDetailsProps( context ) {
 	const { slug, section } = context.params;
-
-	let basePath = route.sectionify( context.path );
-	let analyticsPageTitle = 'Themes';
-
-	if ( slug ) {
-		basePath = basePath + '/:slug';
-		analyticsPageTitle += ' > Details Sheet';
-	}
+	const user = getCurrentUser( context.store.getState() );
+	const basePath = '/themes/:slug';
+	const analyticsPageTitle = 'Themes > Details Sheet';
 
 	const runClientAnalytics = function() {
 		analytics.pageView.record( basePath, analyticsPageTitle );

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -18,6 +18,7 @@ import analytics from 'analytics';
 import i18n from 'lib/mixins/i18n';
 import trackScrollPage from 'lib/track-scroll-page';
 import buildTitle from 'lib/screen-title/utils';
+import route from 'lib/route';
 import { getAnalyticsData } from './helpers';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { setSection } from 'state/ui/actions';
@@ -113,19 +114,38 @@ export function loggedOut( context, next ) {
 	next();
 }
 
+function getDetailsProps( context ) {
+	const { slug, section } = context.params;
+
+	let basePath = route.sectionify( context.path );
+	let analyticsPageTitle = 'Themes';
+
+	if ( slug ) {
+		basePath = basePath + '/:slug';
+		analyticsPageTitle += ' > Details Sheet';
+	}
+
+	const runClientAnalytics = function() {
+		analytics.pageView.record( basePath, analyticsPageTitle );
+	};
+
+	return {
+		themeSlug: slug,
+		contentSection: section,
+		title: buildTitle(
+			i18n.translate( 'Theme Details', { textOnly: true } )
+		),
+		isLoggedIn: !! user,
+		runClientAnalytics
+	}
+}
+
 export function details( context, next ) {
 	const user = getCurrentUser( context.store.getState() );
 	const Head = user
 		? require( 'layout/head' )
 		: require( 'my-sites/themes/head' );
-	const props = {
-		themeSlug: context.params.slug,
-		contentSection: context.params.section,
-		title: buildTitle(
-			i18n.translate( 'Theme Details', { textOnly: true } )
-		),
-		isLoggedIn: !! user
-	};
+	const props = getDetailsProps( context );
 
 	context.store.dispatch( setSection( 'themes', {
 		hasSidebar: false,

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -141,8 +141,12 @@ var ThemesHelpers = {
 		let basePath = route.sectionify( path );
 		let analyticsPageTitle = 'Themes';
 
+		if ( tier ) {
+			basePath += '/type/:tier';
+		}
+
 		if ( site_id ) {
-			basePath = basePath + '/:site_id';
+			basePath += '/:site_id';
 			analyticsPageTitle += ' > Single Site';
 		}
 


### PR DESCRIPTION
Add a `pageView.record()` when hitting a Details page (`/themes/:slug`).

Also, add `/type/:tier` to `/design`'s `pageView.record()` path.

Please review for wording -- see my comments.

To test:
* In the console: type `localStorage.setItem( 'debug', 'calypso:analytics*' );`
* Land on a theme details page (try directly, and via a theme's 'Details' link). Verify that an event like `Recording Page View ~ [URL: /themes/owari/:slug] [Title: Themes > Details Sheet]` is tracked.

TODO:
* [ ] Use `PageViewTracker`, drop `ClientSideEffects` altogether -- #4566
* [ ] Doesn't track when landing via a theme's 'Details' link yet :-/
* [ ] ThemesHead is probably wrong here (related -- #3425)