### PR TITLE
Purchases: Clear purchases when canceling a subscription

### DIFF
--- a/client/components/data/purchases/edit-card-details/index.jsx
+++ b/client/components/data/purchases/edit-card-details/index.jsx
@@ -10,6 +10,7 @@ import CountriesList from 'lib/countries-list';
 import { fetchStoredCards, fetchUserPurchases } from 'lib/upgrades/actions';
 import observe from 'lib/mixins/data-observe';
 import PurchasesStore from 'lib/purchases/store';
+import { shouldFetchPurchases } from 'lib/purchases';
 import StoreConnection from 'components/data/store-connection';
 import StoredCardsStore from 'lib/purchases/stored-cards/store';
 import userFactory from 'lib/user';
@@ -53,7 +54,9 @@ const EditCardDetailsData = React.createClass( {
 
 	componentWillMount() {
 		fetchStoredCards();
-		fetchUserPurchases( user.get().ID );
+		if ( shouldFetchPurchases( PurchasesStore.get() ) ) {
+			fetchUserPurchases( user.get().ID );
+		}
 	},
 
 	render() {

--- a/client/components/data/purchases/index.jsx
+++ b/client/components/data/purchases/index.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import { fetchUserPurchases } from 'lib/upgrades/actions';
 import observe from 'lib/mixins/data-observe';
 import PurchasesStore from 'lib/purchases/store';
+import { shouldFetchPurchases } from 'lib/purchases';
 import StoreConnection from 'components/data/store-connection';
 import userFactory from 'lib/user';
 
@@ -36,7 +37,9 @@ const PurchasesData = React.createClass( {
 	mixins: [ observe( 'sites' ) ],
 
 	componentDidMount() {
-		fetchUserPurchases( user.get().ID );
+		if ( shouldFetchPurchases( PurchasesStore.get() ) ) {
+			fetchUserPurchases( user.get().ID );
+		}
 	},
 
 	render() {

--- a/client/components/data/purchases/manage-purchase/index.jsx
+++ b/client/components/data/purchases/manage-purchase/index.jsx
@@ -10,6 +10,7 @@ import CartStore from 'lib/cart/store';
 import { fetchUserPurchases } from 'lib/upgrades/actions';
 import observe from 'lib/mixins/data-observe';
 import PurchasesStore from 'lib/purchases/store';
+import { shouldFetchPurchases } from 'lib/purchases';
 import StoreConnection from 'components/data/store-connection';
 import userFactory from 'lib/user';
 
@@ -47,7 +48,9 @@ const ManagePurchaseData = React.createClass( {
 	mixins: [ observe( 'sites' ) ],
 
 	componentWillMount() {
-		fetchUserPurchases( user.get().ID );
+		if ( shouldFetchPurchases( PurchasesStore.get() ) ) {
+			fetchUserPurchases( user.get().ID );
+		}
 	},
 
 	render() {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -211,6 +211,10 @@ function purchaseType( purchase ) {
 	return null;
 }
 
+function shouldFetchPurchases( purchases ) {
+	return ! purchases.hasLoadedFromServer && ! purchases.isFetching;
+}
+
 function showCreditCardExpiringWarning( purchase ) {
 	return ! isIncludedWithPlan( purchase ) &&
 		isPaidWithCreditCard( purchase ) &&
@@ -241,5 +245,6 @@ export {
 	isRenewing,
 	paymentLogoType,
 	purchaseType,
+	shouldFetchPurchases,
 	showCreditCardExpiringWarning,
 }

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -24,6 +24,10 @@ function cancelPurchase( purchaseId, onComplete ) {
 
 		const success = ! error && data.success;
 
+		if ( success ) {
+			clearPurchases();
+		}
+
 		onComplete( success );
 	} );
 }

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -52,6 +52,7 @@ const CancelPurchaseButton = React.createClass( {
 						}
 					}
 				), { persistent: true } );
+
 				page( paths.list() );
 			} else {
 				notices.error( this.translate(

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -16,7 +16,10 @@ import titles from 'me/purchases/titles';
 const CancelPurchaseLoadingPlaceholder = React.createClass( {
 	propTypes: {
 		purchaseId: React.PropTypes.string.isRequired,
-		selectedSite: React.PropTypes.object.isRequired
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.object,
+			React.PropTypes.bool
+		] ).isRequired
 	},
 
 	render() {


### PR DESCRIPTION
Fixes #2746.

When we successfully cancel a purchase, the purchases data in memory is stale until purchases are fetched again. This PR updates `CancelPurchase` to clear the purchases in memory after a purchase is canceled.

**Testing**
- Visit `/purchases/:site/:purchaseId` for a purchase that is outside of the refund window (i.e. the button reads "Cancel [product]", not "Cancel and Refund [product]").
- Click the "Cancel [product]" link, which takes you to `CancelPurchase`.
- Click the "Cancel [product]" button at the bottom of this page.
- Assert that you are redirected to `/purchases` with a success notice, and that placeholders are displayed as the purchases are fetched.

- [x] Product review
- [x] Code review