### PR TITLE
Framework: move temporary fetching plugin state to another subtree

### DIFF
--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -426,7 +426,7 @@ const PluginsMain = React.createClass( {
 export default connect(
 	state => {
 		return {
-			wporgPlugins: state.plugins.wporg
+			wporgPlugins: state.plugins.wporg.items
 		};
 	},
 	dispatch => bindActionCreators( { wporgFetchPluginData }, dispatch )

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -195,7 +195,7 @@ const SinglePlugin = React.createClass( {
 	},
 
 	isFetching() {
-		return ! this.props.isWpcomPlugin && WporgPluginsSelectors.isFetching( this.props.wporgPlugins, this.props.pluginSlug );
+		return ! this.props.isWpcomPlugin && this.props.wporgFetching;
 	},
 
 	isFetched() {
@@ -392,9 +392,10 @@ const SinglePlugin = React.createClass( {
 } );
 
 export default connect(
-	state => {
+	( state, props ) => {
 		return {
-			wporgPlugins: state.plugins.wporg
+			wporgPlugins: state.plugins.wporg.items,
+			wporgFetching: WporgPluginsSelectors.isFetching( state.plugins.wporg.fetchingItems, props.pluginSlug )
 		};
 	},
 	dispatch => bindActionCreators( { wporgFetchPluginData }, dispatch )

--- a/client/state/plugins/wporg/reducer.js
+++ b/client/state/plugins/wporg/reducer.js
@@ -7,6 +7,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { combineReducers } from 'redux';
 
 function updatePluginState( state = {}, pluginSlug, attributes ) {
 	return Object.assign( {},
@@ -15,17 +16,29 @@ function updatePluginState( state = {}, pluginSlug, attributes ) {
 	);
 }
 
-function reducer( state = {}, action ) {
+export function fetchingItems( state = {}, action ) {
+	switch ( action.type ) {
+		case FETCH_WPORG_PLUGIN_DATA:
+			return Object.assign( {}, state, { [ action.pluginSlug ]: true } );
+		case WPORG_PLUGIN_DATA_RECEIVE:
+			return Object.assign( {}, state, { [ action.pluginSlug ]: false } );
+		case SERIALIZE:
+			return {};
+		case DESERIALIZE:
+			return {};
+	}
+	return state;
+}
+
+export function items( state = {}, action ) {
 	const { type, pluginSlug } = action;
 	switch ( type ) {
 		case WPORG_PLUGIN_DATA_RECEIVE:
 			if ( action.data ) {
-				return updatePluginState( state, pluginSlug, Object.assign( { isFetching: false, fetched: true, wporg: true }, action.data ) );
+				return updatePluginState( state, pluginSlug, Object.assign( { fetched: true, wporg: true }, action.data ) );
 			}
-			return updatePluginState( state, pluginSlug, Object.assign( { isFetching: false, fetched: false, wporg: false } ) );
+			return updatePluginState( state, pluginSlug, Object.assign( { fetched: false, wporg: false } ) );
 
-		case FETCH_WPORG_PLUGIN_DATA:
-			return updatePluginState( state, pluginSlug, Object.assign( { isFetching: true } ) );
 		case SERIALIZE:
 			return {};
 		case DESERIALIZE:
@@ -35,4 +48,7 @@ function reducer( state = {}, action ) {
 	}
 }
 
-export default reducer;
+export default combineReducers( {
+	items,
+	fetchingItems
+} );

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -6,13 +6,12 @@ const getPlugin = function( state, pluginSlug ) {
 };
 
 const isFetching = function( state, pluginSlug ) {
-	const plugin = getPlugin( state, pluginSlug );
-	// if the plugin or the `isFetching` attribute doesn't exist yet,
+	// if the `isFetching` attribute doesn't exist yet,
 	// we assume we are still launching the fetch action, so it's true
-	if ( ! plugin || typeof plugin.isFetching === 'undefined' ) {
+	if ( typeof state[ pluginSlug ] === 'undefined' ) {
 		return true;
 	}
-	return plugin.isFetching;
+	return state[ pluginSlug ];
 };
 
 const isFetched = function( state, pluginSlug ) {

--- a/client/state/plugins/wporg/test/reducer.js
+++ b/client/state/plugins/wporg/test/reducer.js
@@ -2,26 +2,100 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
 import {
+	WPORG_PLUGIN_DATA_RECEIVE,
+	FETCH_WPORG_PLUGIN_DATA,
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import reducer from '../reducer';
+import { items, fetchingItems } from '../reducer';
 
-describe( 'reducer', () => {
-	describe( 'plugins', () => {
+describe( 'wporg reducer', () => {
+	describe( 'items', () => {
+		it( 'should store plugin', () => {
+			const state = items( undefined, {
+				type: WPORG_PLUGIN_DATA_RECEIVE,
+				pluginSlug: 'akismet',
+				data: { name: 'Akismet' }
+			} );
+			expect( state ).to.deep.equal( { akismet: { name: 'Akismet', wporg: true, fetched: true } } );
+		} );
+		it( 'should store plugin without data', () => {
+			const state = items( undefined, {
+				type: WPORG_PLUGIN_DATA_RECEIVE,
+				pluginSlug: 'dolly'
+			} );
+			expect( state ).to.deep.equal( { dolly: { wporg: false, fetched: false } } );
+		} );
+		it( 'should store multiple plugins', () => {
+			const originalState = deepFreeze( { dolly: { wporg: false, fetched: false } } );
+			const state = items( originalState, {
+				type: WPORG_PLUGIN_DATA_RECEIVE,
+				pluginSlug: 'akismet',
+				data: { name: 'Akismet' }
+			} );
+			expect( state ).to.deep.equal(
+				{
+					akismet: { name: 'Akismet', wporg: true, fetched: true },
+					dolly: { wporg: false, fetched: false }
+				} );
+		} );
 		it( 'never persists state because this is not implemented', () => {
 			const plugins = { my: { plugin: { shape: {} } } };
-			const state = reducer( plugins, { type: SERIALIZE } );
+			const state = items( plugins, { type: SERIALIZE } );
 			expect( state ).to.eql( {} );
 		} );
 		it( 'never loads persisted state because this is not implemented', () => {
 			const plugins = { my: { plugin: { shape: {} } } };
-			const state = reducer( plugins, { type: DESERIALIZE } );
+			const state = items( plugins, { type: DESERIALIZE } );
+			expect( state ).to.eql( {} );
+		} );
+	} );
+	describe( 'fetchingItems', () => {
+		it( 'should track when fetches start', () => {
+			const state = fetchingItems( undefined, {
+				type: FETCH_WPORG_PLUGIN_DATA,
+				pluginSlug: 'akismet'
+			} );
+			expect( state ).to.deep.equal( { akismet: true } );
+		} );
+		it( 'keeps track of multiple plugins', () => {
+			const originalState = deepFreeze( { akismet: true } );
+			const state = fetchingItems( originalState, {
+				type: FETCH_WPORG_PLUGIN_DATA,
+				pluginSlug: 'dolly'
+			} );
+			expect( state ).to.deep.equal( { akismet: true, dolly: true } );
+		} );
+		it( 'should track when fetches end', () => {
+			const originalState = deepFreeze( { akismet: true } );
+			const state = fetchingItems( originalState, {
+				type: WPORG_PLUGIN_DATA_RECEIVE,
+				pluginSlug: 'akismet'
+			} );
+			expect( state ).to.deep.equal( { akismet: false } );
+		} );
+		it( 'should track when fetches end for many plugins', () => {
+			const originalState = deepFreeze( { akismet: true } );
+			const state = fetchingItems( originalState, {
+				type: WPORG_PLUGIN_DATA_RECEIVE,
+				pluginSlug: 'dolly'
+			} );
+			expect( state ).to.deep.equal( { akismet: true, dolly: false } );
+		} );
+		it( 'never persists state', () => {
+			const plugins = { my: { plugin: { shape: {} } } };
+			const state = fetchingItems( plugins, { type: SERIALIZE } );
+			expect( state ).to.eql( {} );
+		} );
+		it( 'never loads persisted state', () => {
+			const plugins = { my: { plugin: { shape: {} } } };
+			const state = fetchingItems( plugins, { type: DESERIALIZE } );
 			expect( state ).to.eql( {} );
 		} );
 	} );

--- a/client/state/plugins/wporg/test/test-selectors.js
+++ b/client/state/plugins/wporg/test/test-selectors.js
@@ -2,18 +2,25 @@
  * External dependencies
  */
 import { assert } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
 import selectors from '../selectors';
 
-const state = {
-	test: Object.freeze( { slug: 'test', isFetching: false } ),
-	fetchingTest: Object.freeze( { slug: 'fetchingTest', isFetching: true } ),
-	fetchedTest: Object.freeze( { slug: 'fetchingTest', isFetching: false, fetched: true } ),
-	fetchedTest2: Object.freeze( { slug: 'fetchingTest', isFetching: true, fetched: true } )
-};
+const items = deepFreeze( {
+	test: { slug: 'test'},
+	fetchingTest: { slug: 'fetchingTest' },
+	fetchedTest: { slug: 'fetchingTest', fetched: true },
+	fetchedTest2: { slug: 'fetchingTest', fetched: true }
+} );
+const fetchingItems = deepFreeze( {
+	test: false,
+	fetchingTest: true,
+	fetchedTest: false,
+	fetchedTest2: true
+} );
 
 describe( 'WPorg Selectors', function() {
 	it( 'Should contain getPlugin method', function() {
@@ -26,49 +33,49 @@ describe( 'WPorg Selectors', function() {
 
 	describe( 'getPlugin', function() {
 		it( 'Should get null if the requested plugin is not in the current state', function() {
-			assert.equal( selectors.getPlugin( state, 'no-test' ), null );
+			assert.equal( selectors.getPlugin( items, 'no-test' ), null );
 		} );
 
 		it( 'Should get the plugin if the requested plugin is in the current state', function() {
-			assert.equal( selectors.getPlugin( state, 'test' ).slug, 'test' );
+			assert.equal( selectors.getPlugin( items, 'test' ).slug, 'test' );
 		} );
 
 		it( 'Should return a new object with no pointers to the one stored in state', function() {
-			let plugin = selectors.getPlugin( state, 'test' );
-			plugin.isFetching = true;
-			assert.equal( selectors.getPlugin( state, 'test' ).isFetching, false );
+			let plugin = selectors.getPlugin( items, 'fetchedTest' );
+			plugin.fetched = false;
+			assert.equal( selectors.getPlugin( items, 'fetchedTest' ).fetched, true );
 		} );
 	} );
 
 	describe( 'isFetching', function() {
 		it( 'Should get `true` if the requested plugin is not in the current state', function() {
-			assert.equal( selectors.isFetching( state, 'no.test' ), true );
+			assert.equal( selectors.isFetching( fetchingItems, 'no.test' ), true );
 		} );
 
 		it( 'Should get `false` if the requested plugin is not being fetched', function() {
-			assert.equal( selectors.isFetching( state, 'test' ), false );
+			assert.equal( selectors.isFetching( fetchingItems, 'test' ), false );
 		} );
 
 		it( 'Should get `true` if the requested plugin is being fetched', function() {
-			assert.equal( selectors.isFetching( state, 'fetchingTest' ), true );
+			assert.equal( selectors.isFetching( fetchingItems, 'fetchingTest' ), true );
 		} );
 	} );
 
 	describe( 'isFetched', function() {
 		it( 'Should get `false` if the requested plugin is not in the current state', function() {
-			assert.equal( selectors.isFetched( state, 'no.test' ), false );
+			assert.equal( selectors.isFetched( items, 'no.test' ), false );
 		} );
 
 		it( 'Should get `false` if the requested plugin has not being fetched', function() {
-			assert.equal( selectors.isFetched( state, 'test' ), false );
+			assert.equal( selectors.isFetched( items, 'test' ), false );
 		} );
 
 		it( 'Should get `true` if the requested plugin has being fetched', function() {
-			assert.equal( selectors.isFetched( state, 'fetchedTest' ), true );
+			assert.equal( selectors.isFetched( items, 'fetchedTest' ), true );
 		} );
 
 		it( 'Should get `true` if the requested plugin has being fetched even if it\'s being fetche again', function() {
-			assert.equal( selectors.isFetched( state, 'fetchedTest2' ), true );
+			assert.equal( selectors.isFetched( items, 'fetchedTest2' ), true );
 		} );
 	} );
 } );


### PR DESCRIPTION
This is prep work for redux persistence. I noticed some that we were storing fetch state directly in each plugin item. This PR proposes that we move fetching state to fetchingItems.

So the data structure changes from:
```javascript
{ plugins: 
      { wporg: 
          {
              akismet: { name: 'Akismet', isFetching: false, fetched: true, wporg: true }
          }
      }
}
```

to:
```javascript
{ plugins: 
      { wporg: 
             {  
                items: {  akismet: { name: 'Akismet', fetched: true, wporg: true } },
                fetchingItems: { akismet: false } 
             }
      }
}
```

## Testing Instructions
- Make sure you have a connected jetpack site
- Switch sites to your jetpack site
- Navigate to MySites
- Click on Plugins
- Plugins load and work as expected.

cc @johnHackworth @aduth @rralian 