### PR TITLE
RootChild: Fix lint warnings and spelling of descendants.

### DIFF
--- a/client/components/root-child/README.md
+++ b/client/components/root-child/README.md
@@ -1,9 +1,9 @@
 Root Child
 ==========
 
-Root Child is a React component which will render its children as decendents 
-of the root `<body>` element. This is handy in cases where you want to fix 
-an element to the bounds of the page, without worrying that an ancestor 
+Root Child is a React component which will render its children as descendants
+of the root `<body>` element. This is handy in cases where you want to fix
+an element to the bounds of the page, without worrying that an ancestor
 positioning may impact the child's style.
 
 ## Usage
@@ -30,7 +30,7 @@ module.exports = React.createClass( {
 
 ## Notes
 
-The `<RootChild />` children are wrapped in a single `<div />` element, 
-so they are not truly direct descendents of the `<body>` element. 
+The `<RootChild />` children are wrapped in a single `<div />` element,
+so they are not truly direct descendants of the `<body>` element.
 Passing props to a `<RootChild />` will further nest the child in 
 another `<div />` element to which the props are applied.

--- a/client/components/root-child/test/index.jsx
+++ b/client/components/root-child/test/index.jsx
@@ -3,19 +3,19 @@ require( 'lib/react-test-env-setup' )();
 /**
  * External dependencies
  */
-var expect = require( 'chai' ).expect,
+const expect = require( 'chai' ).expect,
 	ReactDom = require( 'react-dom' ),
 	React = require( 'react' );
 
 /**
  * Internal dependencies
  */
-var RootChild = require( '../' );
+const RootChild = require( '../' );
 
 /**
  * Module variables
  */
-var Greeting = React.createClass( {
+const Greeting = React.createClass( {
 	getDefaultProps: function() {
 		return { toWhom: 'World' };
 	},
@@ -45,7 +45,7 @@ describe( 'RootChild', function() {
 	} );
 
 	describe( 'rendering', function() {
-		it( 'should render any children as descendents of body', function() {
+		it( 'should render any children as descendants of body', function() {
 			var tree = ReactDom.render( React.createElement( Greeting ), container );
 
 			expect( tree.refs.parentChild

--- a/client/components/root-child/test/index.jsx
+++ b/client/components/root-child/test/index.jsx
@@ -3,14 +3,14 @@ require( 'lib/react-test-env-setup' )();
 /**
  * External dependencies
  */
-const expect = require( 'chai' ).expect,
-	ReactDom = require( 'react-dom' ),
-	React = require( 'react' );
+import { expect } from 'chai';
+import ReactDom from 'react-dom';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-const RootChild = require( '../' );
+import RootChild from '../';
 
 /**
  * Module variables


### PR DESCRIPTION
See http://grammarist.com/usage/descendant-descendent/

Either way, it trips the spell checker in my editor and was bugging me.