### PR TITLE
Reader: preserve linebreaks for excerpts on summary-only feeds

### DIFF
--- a/client/components/post-excerpt/index.jsx
+++ b/client/components/post-excerpt/index.jsx
@@ -1,31 +1,33 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classnames = require( 'classnames' );
+import React from 'react';
+import classnames from 'classnames';
+import striptags from 'striptags';
 
-var PostExcerpt = React.createClass( {
+const PostExcerpt = React.createClass( {
 
-	render: function() {
-		var text = this.props.text,
-			textClass = [ 'post-excerpt__text' ];
+	propTypes: {
+		content: React.PropTypes.string.isRequired
+	},
 
-		if ( ! text ) {
+	render() {
+		if ( ! this.props.content ) {
 			return null;
 		}
 
-		if ( text.length > 80 ) {
-			textClass.push( 'is-long' );
-		}
+		// Strip all non-linebreak tags
+		const preparedContent = striptags( this.props.content, [ 'p', 'br' ] );
 
-		textClass = textClass.join( ' ' );
+		const classes = classnames( {
+			'post-excerpt': true,
+			'is-long': ( preparedContent.length > 80 )
+		} );
 
 		return (
-			<div className={ classnames( this.props.className, 'post-excerpt' ) }>
-				<p className={ textClass }>{ text }</p>
-			</div>
+			<div className={ classes } dangerouslySetInnerHTML={{ __html: preparedContent }}></div> //eslint-disable-line react/no-danger
 		);
 	}
 } );
 
-module.exports = PostExcerpt;
+export default PostExcerpt;

--- a/client/components/post-excerpt/index.jsx
+++ b/client/components/post-excerpt/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import classnames from 'classnames';
-import striptags from 'striptags';
 
 const PostExcerpt = React.createClass( {
 
@@ -16,16 +15,13 @@ const PostExcerpt = React.createClass( {
 			return null;
 		}
 
-		// Strip all non-linebreak tags
-		const preparedContent = striptags( this.props.content, [ 'p', 'br' ] );
-
 		const classes = classnames( {
 			'post-excerpt': true,
-			'is-long': ( preparedContent.length > 80 )
+			'is-long': ( this.props.content.length > 80 )
 		} );
 
 		return (
-			<div className={ classes } dangerouslySetInnerHTML={{ __html: preparedContent }}></div> //eslint-disable-line react/no-danger
+			<div className={ classes } dangerouslySetInnerHTML={{ __html: this.props.content }}></div> //eslint-disable-line react/no-danger
 		);
 	}
 } );

--- a/client/components/post-excerpt/style.scss
+++ b/client/components/post-excerpt/style.scss
@@ -1,5 +1,4 @@
 .post-excerpt {
-	.post-excerpt__text {
 		@extend %content-font;
 		margin: 0;
 		position: relative;
@@ -33,5 +32,4 @@
 				}
 			}
 		}
-	}
 }

--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -32,6 +32,7 @@ const fastPostNormalizationRules = [
 		postNormalizer.safeImageProperties( READER_CONTENT_WIDTH ),
 		postNormalizer.firstPassCanonicalImage,
 		postNormalizer.withContentDOM( [
+			postNormalizer.content.createContentWithLinebreakElementsOnly,
 			postNormalizer.content.removeStyles,
 			postNormalizer.content.safeContentImages( READER_CONTENT_WIDTH ),
 			discoverFullBleedImages,

--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -31,7 +31,6 @@ const fastPostNormalizationRules = [
 		postNormalizer.pickPrimaryTag,
 		postNormalizer.safeImageProperties( READER_CONTENT_WIDTH ),
 		postNormalizer.firstPassCanonicalImage,
-		postNormalizer.createContentWithLinebreakElementsOnly,
 		postNormalizer.withContentDOM( [
 			postNormalizer.content.removeStyles,
 			postNormalizer.content.safeContentImages( READER_CONTENT_WIDTH ),
@@ -43,6 +42,7 @@ const fastPostNormalizationRules = [
 			postNormalizer.content.detectPolls,
 			postNormalizer.content.wordCountAndReadingTime
 		] ),
+		postNormalizer.createContentWithLinebreakElementsOnly,
 		classifyPost
 	],
 	slowPostNormalizationRules = [

--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -1,5 +1,5 @@
 /**
- * External Dependecies
+ * External Dependencies
  */
 const find = require( 'lodash/find' ),
 	forEach = require( 'lodash/forEach' ),
@@ -32,7 +32,6 @@ const fastPostNormalizationRules = [
 		postNormalizer.safeImageProperties( READER_CONTENT_WIDTH ),
 		postNormalizer.firstPassCanonicalImage,
 		postNormalizer.withContentDOM( [
-			postNormalizer.content.createContentWithLinebreakElementsOnly,
 			postNormalizer.content.removeStyles,
 			postNormalizer.content.safeContentImages( READER_CONTENT_WIDTH ),
 			discoverFullBleedImages,
@@ -41,6 +40,7 @@ const fastPostNormalizationRules = [
 			postNormalizer.content.disableAutoPlayOnMedia,
 			postNormalizer.content.detectEmbeds,
 			postNormalizer.content.detectPolls,
+			postNormalizer.content.createContentWithLinebreakElementsOnly,
 			postNormalizer.content.wordCountAndReadingTime
 		] ),
 		classifyPost

--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -31,6 +31,7 @@ const fastPostNormalizationRules = [
 		postNormalizer.pickPrimaryTag,
 		postNormalizer.safeImageProperties( READER_CONTENT_WIDTH ),
 		postNormalizer.firstPassCanonicalImage,
+		postNormalizer.createContentWithLinebreakElementsOnly,
 		postNormalizer.withContentDOM( [
 			postNormalizer.content.removeStyles,
 			postNormalizer.content.safeContentImages( READER_CONTENT_WIDTH ),
@@ -40,7 +41,6 @@ const fastPostNormalizationRules = [
 			postNormalizer.content.disableAutoPlayOnMedia,
 			postNormalizer.content.detectEmbeds,
 			postNormalizer.content.detectPolls,
-			postNormalizer.content.createContentWithLinebreakElementsOnly,
 			postNormalizer.content.wordCountAndReadingTime
 		] ),
 		classifyPost

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -22,8 +22,10 @@ var assign = require( 'lodash/assign' ),
 	uniqBy = require( 'lodash/uniqBy' ),
 	url = require( 'url' );
 
+import striptags from 'striptags';
+
 /**
- * Internal depedencies
+ * Internal dependencies
  */
 import i18n from 'lib/mixins/i18n';
 import formatting from 'lib/formatting';
@@ -468,6 +470,30 @@ normalizePost.withContentDOM = function( transforms ) {
 };
 
 normalizePost.content = {
+
+	createContentWithLinebreakElementsOnly: function createContentWithLinebreakElementsOnly( post, callback ) {
+		if ( ! post.__contentDOM ) {
+			throw new Error( 'this transform must be used as part of withContentDOM' );
+		}
+
+		post.content_with_linebreak_elements_only = striptags( post.content, [ 'p', 'br' ] );
+
+		// Spin up a new DOM for the linebreak markup
+		const dom = document.createElement( 'div' );
+		dom.innerHTML = post.content_with_linebreak_elements_only;
+
+		// Strip any empty p elements
+		let paragraphs = dom.querySelectorAll( 'p' );
+		forEach( paragraphs, function( element ) {
+			if ( element.innerHTML.length < 1 ) {
+				element.parentNode && element.parentNode.removeChild( element );
+			}
+		} );
+
+		post.content_with_linebreak_elements_only = dom.innerHTML;
+
+		callback();
+	},
 
 	removeStyles: function removeContentStyles( post, callback ) {
 		if ( ! post.__contentDOM ) {

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -438,7 +438,12 @@ normalizePost.pickCanonicalImage = function pickCanonicalImage( post, callback )
 };
 
 normalizePost.createContentWithLinebreakElementsOnly = function createContentWithLinebreakElementsOnly( post, callback ) {
-	let betterExcerpt = striptags( post.__contentDOM.innerHTML, [ 'p', 'br', 'noscript' ] );
+	if ( ! post || ! post.content ) {
+		callback();
+		return;
+	}
+
+	let betterExcerpt = striptags( post.content, [ 'p', 'br', 'noscript' ] );
 
 	// Spin up a new DOM for the linebreak markup
 	const dom = document.createElement( 'div' );

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -437,6 +437,29 @@ normalizePost.pickCanonicalImage = function pickCanonicalImage( post, callback )
 	callback();
 };
 
+normalizePost.createContentWithLinebreakElementsOnly = function createContentWithLinebreakElementsOnly( post, callback ) {
+	let betterExcerpt = striptags( post.__contentDOM.innerHTML, [ 'p', 'br', 'noscript' ] );
+
+	// Spin up a new DOM for the linebreak markup
+	const dom = document.createElement( 'div' );
+	dom.innerHTML = betterExcerpt;
+
+	// Strip any empty p elements from the beginning of the content
+	let paragraphs = dom.querySelectorAll( 'p' );
+	forEach( paragraphs, function( element ) {
+		if ( element.innerHTML.length > 0 ) {
+			return false;
+		}
+
+		element.parentNode && element.parentNode.removeChild( element );
+	} );
+
+	post.content_with_linebreak_elements_only = dom.innerHTML;
+	dom.innerHTML = '';
+
+	callback();
+},
+
 normalizePost.withContentDOM = function( transforms ) {
 	return function withContentDOM( post, callback ) {
 		if ( ! post || ! post.content || ! transforms ) {
@@ -470,32 +493,6 @@ normalizePost.withContentDOM = function( transforms ) {
 };
 
 normalizePost.content = {
-
-	createContentWithLinebreakElementsOnly: function createContentWithLinebreakElementsOnly( post, callback ) {
-		if ( ! post.__contentDOM ) {
-			throw new Error( 'this transform must be used as part of withContentDOM' );
-		}
-
-		post.content_with_linebreak_elements_only = striptags( post.__contentDOM.innerHTML, [ 'p', 'br', 'noscript' ] );
-
-		// Spin up a new DOM for the linebreak markup
-		const dom = document.createElement( 'div' );
-		dom.innerHTML = post.content_with_linebreak_elements_only;
-
-		// Strip any empty p elements from the beginning of the content
-		let paragraphs = dom.querySelectorAll( 'p' );
-		forEach( paragraphs, function( element ) {
-			if ( element.innerHTML.length > 0 ) {
-				return false;
-			}
-
-			element.parentNode && element.parentNode.removeChild( element );
-		} );
-
-		post.content_with_linebreak_elements_only = dom.innerHTML;
-
-		callback();
-	},
 
 	removeStyles: function removeContentStyles( post, callback ) {
 		if ( ! post.__contentDOM ) {

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -476,18 +476,20 @@ normalizePost.content = {
 			throw new Error( 'this transform must be used as part of withContentDOM' );
 		}
 
-		post.content_with_linebreak_elements_only = striptags( post.content, [ 'p', 'br' ] );
+		post.content_with_linebreak_elements_only = striptags( post.__contentDOM.innerHTML, [ 'p', 'br', 'noscript' ] );
 
 		// Spin up a new DOM for the linebreak markup
 		const dom = document.createElement( 'div' );
 		dom.innerHTML = post.content_with_linebreak_elements_only;
 
-		// Strip any empty p elements
+		// Strip any empty p elements from the beginning of the content
 		let paragraphs = dom.querySelectorAll( 'p' );
 		forEach( paragraphs, function( element ) {
-			if ( element.innerHTML.length < 1 ) {
-				element.parentNode && element.parentNode.removeChild( element );
+			if ( element.innerHTML.length > 0 ) {
+				return false;
 			}
+
+			element.parentNode && element.parentNode.removeChild( element );
 		} );
 
 		post.content_with_linebreak_elements_only = dom.innerHTML;

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -449,10 +449,11 @@ normalizePost.createContentWithLinebreakElementsOnly = function createContentWit
 	const dom = document.createElement( 'div' );
 	dom.innerHTML = betterExcerpt;
 
-	// Strip any empty p elements from the beginning of the content
-	let paragraphs = dom.querySelectorAll( 'p' );
-	forEach( paragraphs, function( element ) {
-		if ( element.innerHTML.length > 0 ) {
+	// Strip any empty p and br elements from the beginning of the content
+	// Also ditch any photo captions with the wp-caption-text class
+	let elements = dom.querySelectorAll( 'p, br' );
+	forEach( elements, function( element ) {
+		if ( element.innerHTML.length > 0 && ! element.className.includes( 'wp-caption-text' ) ) {
 			return false;
 		}
 

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -443,7 +443,7 @@ normalizePost.createContentWithLinebreakElementsOnly = function createContentWit
 		return;
 	}
 
-	let betterExcerpt = striptags( post.content, [ 'p', 'br', 'noscript' ] );
+	let betterExcerpt = striptags( post.content, [ 'p', 'br' ] );
 
 	// Spin up a new DOM for the linebreak markup
 	const dom = document.createElement( 'div' );

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -874,7 +874,8 @@ describe( 'post-normalizer', function() {
 		it( 'prepares a version of the post content with linebreak elements only', function( done ) {
 			normalizer(
 				{
-					content: '<p><img src="http://example.com/image.jpg"></p><p><a href="http://wikipedia.org">Giraffes</a> are <br>great</p><p></p>',
+					content: '<br><p class="wp-caption-text">caption</p><p><img src="http://example.com/image.jpg"></p>'
+					+ '<p><a href="http://wikipedia.org">Giraffes</a> are <br>great</p><p></p>',
 				},
 				[
 					normalizer.withContentDOM( [ normalizer.createContentWithLinebreakElementsOnly ] )

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -31,6 +31,7 @@ let normalizer = require( '../' ),
 			normalizer.content.detectEmbeds,
 			normalizer.content.wordCountAndReadingTime
 		] ),
+		normalizer.createContentWithLinebreakElementsOnly,
 		normalizer.waitForImagesToLoad,
 		normalizer.pickCanonicalImage,
 		normalizer.keepValidImages( 1, 1 )
@@ -876,7 +877,7 @@ describe( 'post-normalizer', function() {
 					content: '<p><img src="http://example.com/image.jpg"></p><p><a href="http://wikipedia.org">Giraffes</a> are <br>great</p><p></p>',
 				},
 				[
-					normalizer.withContentDOM( [ normalizer.content.createContentWithLinebreakElementsOnly ] )
+					normalizer.withContentDOM( [ normalizer.createContentWithLinebreakElementsOnly ] )
 				], function( err, normalized ) {
 					assert.strictEqual( normalized.content_with_linebreak_elements_only, '<p>Giraffes are <br>great</p><p></p>' );
 					done( err );

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -870,5 +870,18 @@ describe( 'post-normalizer', function() {
 				}
 			);
 		} );
+		it( 'prepares a version of the post content with linebreak elements only', function( done ) {
+			normalizer(
+				{
+					content: '<p><img src="http://example.com/image.jpg"></p><p><a href="http://wikipedia.org">Giraffes</a> are <br>great</p><p></p>',
+				},
+				[
+					normalizer.withContentDOM( [ normalizer.content.createContentWithLinebreakElementsOnly ] )
+				], function( err, normalized ) {
+					assert.strictEqual( normalized.content_with_linebreak_elements_only, '<p>Giraffes are <br>great</p><p></p>' );
+					done( err );
+				}
+			);
+		} );
 	} );
 } );

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -403,7 +403,7 @@ var Post = React.createClass( {
 
 				{ shouldUseFullExcerpt ?
 					<div key="full-post-inline" className="reader__full-post-content" dangerouslySetInnerHTML={{ __html: post.content }}></div> : //eslint-disable-line react/no-danger
-					<PostExcerpt content={ post.content } />
+					<PostExcerpt content={ post.content_with_linebreak_elements_only ? post.content_with_linebreak_elements_only : post.excerpt } />
 				}
 
 				{ shouldShowExcerptOnly ?

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -402,8 +402,8 @@ var Post = React.createClass( {
 				<PostByline post={ post } site={ this.props.site } />
 
 				{ shouldUseFullExcerpt ?
-					<div key="full-post-inline" className="reader__full-post-content" dangerouslySetInnerHTML={{ __html: post.content }} ></div> : //eslint-disable-line react/no-danger
-					<PostExcerpt text={ post.excerpt } />
+					<div key="full-post-inline" className="reader__full-post-content" dangerouslySetInnerHTML={{ __html: post.content }}></div> : //eslint-disable-line react/no-danger
+					<PostExcerpt content={ post.content } />
 				}
 
 				{ shouldShowExcerptOnly ?

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -47,6 +47,8 @@ var analytics = require( 'analytics' ),
 	readerRoute = require( 'reader/route' ),
 	showReaderFullPost = require( 'state/ui/reader/fullpost/actions' ).showReaderFullPost;
 
+import PostExcerpt from 'components/post-excerpt';
+
 var loadingPost = {
 		URL: '',
 		title: 'hi there',
@@ -187,12 +189,6 @@ FullPostView = React.createClass( {
 
 		articleClasses = articleClasses.join( ' ' );
 
-		if ( post.use_excerpt ) {
-			postContent = post.excerpt;
-		} else {
-			postContent = post.content;
-		}
-
 		/*eslint-disable react/no-danger*/
 		return (
 			<div>
@@ -219,7 +215,10 @@ FullPostView = React.createClass( {
 
 					<PostByline post={ post } site={ site } icon={ true }/>
 
-					<div className="reader__full-post-content" dangerouslySetInnerHTML={ { __html: postContent } }></div>
+					{ post.use_excerpt ?
+						<PostExcerpt content={ post.content_with_linebreak_elements_only ? post.content_with_linebreak_elements_only : post.excerpt } /> :
+						<div className="reader__full-post-content" dangerouslySetInnerHTML={{ __html: post.content }}></div> //eslint-disable-line react/no-danger
+					}
 
 					{ shouldShowExcerptOnly && ! isDiscoverPost ? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> : null }
 					{ isDiscoverPost ? <DiscoverVisitLink siteName={ discoverSiteName } siteUrl={ discoverSiteUrl } /> : null }


### PR DESCRIPTION
When displaying excerpts for standard wordpress.com feeds, we use `post.content` from the post object. Currently, we use `post.excerpt` for wordpress.com feeds set to 'summary only'. This means that all tags are stripped, and users have complained that linebreaks are lost (e.g. for poetry):

![4a85ec94-92cb-11e5-8849-e31119e585a9](https://cloud.githubusercontent.com/assets/17325/13207543/87613156-d974-11e5-932f-abcfa4d118d0.png)

This PR switches the PostExcerpt component to use `post.content` too, and strips tags except `p` and `br`.

We've explored backend solutions for this, such as the `enhanced_excerpt` plugin, but this seems a simpler fix. `post.content` has already been through the post normalizer, and it's used for all other excerpts already.

Fixes #696.

### To test
Pull up a feed set to summary only, and ensure that the excerpt is shown correctly. Examples:
http://calypso.localhost:3000/read/blog/feed/40474296
http://calypso.localhost:3000/read/blog/feed/38960801

<img width="760" alt="screen shot 2016-02-22 at 15 01 49" src="https://cloud.githubusercontent.com/assets/17325/13207619/3e3e1ede-d975-11e5-8636-c7d951a1a09a.png">