### PR TITLE
Sites: remove limit for only keeping track of 3 recent sites.

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -447,10 +447,6 @@ SitesList.prototype.setRecentlySelectedSite = function( siteID ) {
 		}
 	}
 
-	if ( this.recentlySelected.length > 3 ) {
-		this.recentlySelected.pop();
-	}
-
 	PreferencesActions.set( 'recentSites', this.recentlySelected );
 
 	this.emit( 'change' );


### PR DESCRIPTION
Without the header dividers we can lift the limit and let the whole list be sorted by recency.