### PR TITLE
Themes: Fix React root component replacement error

### DIFF
--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -123,7 +123,7 @@ export function details( context, next ) {
 		title: buildTitle(
 			i18n.translate( 'Theme Details', { textOnly: true } )
 		)
-	}
+	};
 
 	context.store.dispatch( setSection( 'themes', {
 		hasSidebar: false,

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -140,7 +140,7 @@ export function details( context, next ) {
 // Generic middleware -- move to client/controller.js?
 // lib/react-helpers isn't probably middleware-specific enough
 export function renderPrimary( context ) {
-	const { path } = context.params;
+	const { path } = context;
 	// FIXME: temporary hack until we have a proper isomorphic, one tree routing solution. Do NOT do this!
 	const sheetsDomElement = startsWith( path, '/themes' ) && document.getElementsByClassName( 'themes__sheet' )[0];
 	const mainDomElement = startsWith( path, '/design' ) && document.getElementsByClassName( 'themes main' )[0];


### PR DESCRIPTION
No visual changes.

Fixes a problem inspecting `context.path`.

**To Test**
1) Go to http://calypso.localhost:3000/themes/x (logged out)
2) Check that the following error does not appear in the console:
```
Warning: render(...): Replacing React-rendered children with a new root component. If you intended to update the children of this node, you should instead have the existing children update their state and render the new components instead of calling ReactDOM.render.
```
