### PR TITLE
Checkout: Make it possible to expose jQuery for paygate.js script

### DIFF
--- a/client/lib/load-script/index.js
+++ b/client/lib/load-script/index.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependency.
+ */
+var config = require( 'config' );
+
+/**
  * A little module for loading a external script
  */
 
@@ -45,6 +50,11 @@ var loadScript = function( url, callback ) {
 };
 
 var loadjQueryDependentScript = function( scriptURL, callback ) {
+	// It is not possible to expose jQuery globally in Electron App: https://github.com/atom/electron/issues/254.
+	// It needs to be loaded using require and npm package.
+	if ( config.isEnabled( 'desktop' ) ) {
+		window.jQuery = require( 'jquery' );
+	}
 	if ( window.jQuery ) {
 		loadScript( scriptURL, callback );
 		return;


### PR DESCRIPTION
Fix for #3405.

It fixes the following issue:

> When I click the Pay button after filling the credit card details, a blue notice saying "Submitting payment" appears but nothing happens. I've tried several times and users are not charged, and nothing happens even after waiting 3-5 minutes.

This is part of Desktop app change. It should be tested together with: https://github.com/Automattic/wp-desktop/pull/93. More details there.
