### PR TITLE
Analytics: Prevent tracking of free trials purchases

### DIFF
--- a/client/analytics/README.md
+++ b/client/analytics/README.md
@@ -22,7 +22,7 @@ Automatticians may refer to internal documentation for more information about MC
 
 ```js
 // require the module
-var analytics = require( 'analytics' );
+import analytics from 'analytics';
 
 ```
 
@@ -30,7 +30,7 @@ var analytics = require( 'analytics' );
 
 ### analytics#pageView#record( pageURL, pageTitle )
 
-Record a pageview:
+Record a pageview both in Google Analytics and Tracks:
 
 ```js
 analytics.pageView.record( '/posts/draft', 'Posts > Drafts' );

--- a/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
+++ b/client/my-sites/upgrades/checkout/transaction-steps-mixin.jsx
@@ -121,7 +121,11 @@ var TransactionStepsMixin = {
 						success: false
 					} );
 				} else if ( step.data ) {
-					cartValue.products.map( adTracking.recordPurchase );
+					// Makes sure free trials are not recorded as purchases in ad trackers since they are products with
+					// zero-value cost and would thus lead to a wrong computation of conversions
+					if ( ! cartItems.hasFreeTrial( cartValue ) ) {
+						cartValue.products.map( adTracking.recordPurchase );
+					}
 
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_success', {
 						coupon_code: cartValue.coupon,


### PR DESCRIPTION
This pull request fixes #3188 by updating the checkout to make sure free trials are not recorded as purchases in ad trackers since they are products with zero-value cost and would thus lead to a wrong computation of conversions. Here is an example of such tracking:
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/13219738/4268a8b0-d972-11e5-91a9-9a920d89dd07.png)

#### Testing instructions
 
1. Run `git checkout update/ad-tracking`
2. Enable ad tracking in development by setting the [`ad-tracking` property](https://github.com/Automattic/wp-calypso/blob/update/ad-tracking/config/development.json#L30) to `true`
3. Start your server (or restart it to take that change into account)
4. Open the [`Plans` page](http://calypso.localhost:3000/plans)
5. Enable free trials from your browser's console:

  ```javascript
  localStorage.setItem( 'ABTests', '{"freeTrials_20160120":"offered"}' )
  ```
6. Enable logging for the ad tracking module in your browser's console with:

  ```javascript
  localStorage.setItem('debug', 'calypso:ad-tracking');
  ```
7. Reload the `Plans` page and check that you see the following in your browser's console:

  ```
  calypso:ad-tracking Retargeting initialized +0ms
  ```
8. Click the `Start Free Trial` button for any plan
9. Check that you see this message in the console upon loading the `Checkout` page:

  ```
  calypso:ad-tracking Recorded that this item was added to the cart +2m 
  ```
8. Click the `Start 14 Day Free Trial` button
9. Check that you don't see any debug message in the browser's console
10. Check that you don't see any call to Facebook, Bing, and Google trackers in the network panel of your browser
 
#### Additional notes
 
I've been thinking of adding this check in the [`ad-tracking` module](https://github.com/Automattic/wp-calypso/blob/update/ad-tracking/client/analytics/ad-tracking.js#L142). However I'm not sure we should add such rules in a library like this. Another approach would be to update the module not to track product with zero-value cost. Any feedback is welcome :).

#### Reviews
 
- [x] Code
- [x] Product