### PR TITLE
Add a copy of the `main` signup flow for `delta-new` landing campaign

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -165,6 +165,13 @@ const flows = {
 		lastModified: null
 	},
 
+	'delta-new': {
+		steps: [ 'themes', 'domains', 'plans', 'user' ],
+		destination: getSiteDestination,
+		description: 'A copy of the `main` flow for the delta-new landing campaign',
+		lastModified: '2016-03-01'
+	},
+
 	'site-user': {
 		steps: [ 'site', 'user' ],
 		destination: '/me/next?welcome',


### PR DESCRIPTION
Adds a copy of the `main` signup flow called `delta-new`. It will be used to track the performance of an upcoming landing page variation. Having a copy also allows us to experiment with the flow steps and
their order should the need arise. 

cc @blowery because `blame` says you know this file a bit. :smile: 