### PR TITLE
Themes: Handle SERVER_DESERIALIZE actions in reducers

### DIFF
--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -7,7 +7,7 @@ import { Map, fromJS } from 'immutable';
  * Internal dependencies
  */
 import ActionTypes from '../action-types';
-import { DESERIALIZE, SERIALIZE } from '../../action-types';
+import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from '../../action-types';
 
 export default ( state = Map(), action ) => {
 	switch ( action.type ) {
@@ -18,6 +18,7 @@ export default ( state = Map(), action ) => {
 					author: action.themeAuthor
 				} ) )
 		case DESERIALIZE:
+		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:
 			return state.toJS();

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -8,7 +8,7 @@ import { Map, fromJS } from 'immutable';
  * Internal dependencies
  */
 import { RECEIVE_THEME_DETAILS } from '../../action-types';
-import { DESERIALIZE, SERIALIZE } from '../../../action-types';
+import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from '../../../action-types';
 import reducer from '../reducer';
 
 describe( 'reducer', () => {
@@ -54,6 +54,17 @@ describe( 'reducer', () => {
 				}
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
+			expect( state ).to.eql( fromJS( jsObject ) );
+		} );
+
+		it( 'converts state from server to immutable.js object', () => {
+			const jsObject = Object.freeze( {
+				mood: {
+					name: 'Mood',
+					author: 'Automattic'
+				}
+			} );
+			const state = reducer( jsObject, { type: SERVER_DESERIALIZE } );
 			expect( state ).to.eql( fromJS( jsObject ) );
 		} );
 

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -10,6 +10,7 @@ import { Map, fromJS } from 'immutable';
 import { RECEIVE_THEME_DETAILS } from '../../action-types';
 import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from '../../../action-types';
 import reducer from '../reducer';
+import deepFreeze from 'deep-freeze';
 
 describe( 'reducer', () => {
 	it( 'should default to an empty Immutable Map', () => {
@@ -36,7 +37,7 @@ describe( 'reducer', () => {
 		const initialState = Map();
 
 		it( 'persists state and converts to a plain JS object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				mood: {
 					name: 'Mood',
 					author: 'Automattic'
@@ -47,7 +48,7 @@ describe( 'reducer', () => {
 			expect( persistedState ).to.eql( jsObject );
 		} );
 		it( 'loads valid persisted state and converts to immutable.js object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				mood: {
 					name: 'Mood',
 					author: 'Automattic'
@@ -58,7 +59,7 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'converts state from server to immutable.js object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				mood: {
 					name: 'Mood',
 					author: 'Automattic'
@@ -69,7 +70,7 @@ describe( 'reducer', () => {
 		} );
 
 		it.skip( 'should ignore loading data with invalid keys ', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				missingKey: true,
 				mood: {
 					name: 'Mood',
@@ -81,7 +82,7 @@ describe( 'reducer', () => {
 		} );
 
 		it.skip( 'should ignore loading data with invalid values ', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				mood: 'foo',
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );

--- a/client/state/themes/themes-last-query/reducer.js
+++ b/client/state/themes/themes-last-query/reducer.js
@@ -7,7 +7,7 @@ import { fromJS } from 'immutable';
  * Internal dependencies
  */
 import ActionTypes from '../action-types';
-import { DESERIALIZE, SERIALIZE } from 'state/action-types';
+import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from 'state/action-types';
 
 export const initialState = fromJS( {
 	previousSiteId: 0,
@@ -27,6 +27,7 @@ export default ( state = initialState, action ) => {
 				.set( 'currentSiteId', action.site.ID )
 				.set( 'isJetpack', !! action.site.jetpack );
 		case DESERIALIZE:
+		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:
 			return state.toJS();

--- a/client/state/themes/themes-last-query/test/reducer.js
+++ b/client/state/themes/themes-last-query/test/reducer.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import { fromJS } from 'immutable';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ import reducer, { initialState } from '../reducer';
 describe( 'themes-last-query reducer', () => {
 	describe( 'persistence', () => {
 		it( 'persists state and converts to a plain JS object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				previousSiteId: 2123982,
 				isJetpack: false,
@@ -49,7 +50,7 @@ describe( 'themes-last-query reducer', () => {
 		} );
 
 		it( 'converts state from server to immutable.js object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				previousSiteId: 2123982,
 				isJetpack: false,
@@ -65,7 +66,7 @@ describe( 'themes-last-query reducer', () => {
 		} );
 
 		it.skip( 'should ignore loading data with invalid keys ', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				wrongkey: 2123982,
 				isJetpack: false,
@@ -81,7 +82,7 @@ describe( 'themes-last-query reducer', () => {
 		} );
 
 		it.skip( 'should ignore loading data with invalid values ', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				previousSiteId: 2123982,
 				isJetpack: false,

--- a/client/state/themes/themes-last-query/test/reducer.js
+++ b/client/state/themes/themes-last-query/test/reducer.js
@@ -9,7 +9,8 @@ import { fromJS } from 'immutable';
  */
 import {
 	SERIALIZE,
-	DESERIALIZE
+	DESERIALIZE,
+	SERVER_DESERIALIZE
 } from 'state/action-types';
 import reducer, { initialState } from '../reducer';
 
@@ -44,6 +45,22 @@ describe( 'themes-last-query reducer', () => {
 				}
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
+			expect( state ).to.eql( fromJS( jsObject ) );
+		} );
+
+		it( 'converts state from server to immutable.js object', () => {
+			const jsObject = Object.freeze( {
+				currentSiteId: 12345678,
+				previousSiteId: 2123982,
+				isJetpack: false,
+				lastParams: {
+					search: 'foo bar',
+					tier: 'all',
+					page: 0,
+					perPage: 20
+				}
+			} );
+			const state = reducer( jsObject, { type: SERVER_DESERIALIZE } );
 			expect( state ).to.eql( fromJS( jsObject ) );
 		} );
 

--- a/client/state/themes/themes-list/reducer.js
+++ b/client/state/themes/themes-list/reducer.js
@@ -9,7 +9,7 @@ import uniq from 'lodash/uniq'
  */
 import ActionTypes from '../action-types';
 import { PER_PAGE } from './constants';
-import { DESERIALIZE, SERIALIZE } from 'state/action-types';
+import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from 'state/action-types';
 
 const defaultQuery = fromJS( {
 	search: '',
@@ -91,6 +91,7 @@ export default ( state = initialState, action ) => {
 			// here.
 			return state.set( 'active', action.theme.id );
 		case DESERIALIZE:
+		case SERVER_DESERIALIZE:
 			return query( fromJS( state ) );
 		case SERIALIZE:
 			return state.toJS();

--- a/client/state/themes/themes-list/test/reducer.js
+++ b/client/state/themes/themes-list/test/reducer.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import { fromJS } from 'immutable';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ import reducer, { initialState, query } from '../reducer';
 describe( 'themes-last-query reducer', () => {
 	describe( 'persistence', () => {
 		it( 'persists state and converts to a plain JS object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				list: [ 'one', 'two', 'three' ],
 				nextId: 2,
 				query: {
@@ -38,7 +39,7 @@ describe( 'themes-last-query reducer', () => {
 			expect( persistedState ).to.eql( jsObject );
 		} );
 		it( 'loads valid persisted state and converts to immutable.js object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				list: [ 'one', 'two', 'three' ],
 				nextId: 2,
 				query: {
@@ -59,7 +60,7 @@ describe( 'themes-last-query reducer', () => {
 		} );
 
 		it( 'converts state from server to immutable.js object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				list: [ 'one', 'two', 'three' ],
 				nextId: 2,
 				query: {
@@ -80,7 +81,7 @@ describe( 'themes-last-query reducer', () => {
 		} );
 
 		it.skip( 'should ignore loading data with invalid keys ', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				foobar: [ 'one', 'two', 'three' ],
 				nextId: 2,
 				query: {
@@ -101,7 +102,7 @@ describe( 'themes-last-query reducer', () => {
 		} );
 
 		it.skip( 'should ignore loading data with invalid values ', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				list: [ 'one', 'two', 'three' ],
 				nextId: 2,
 				query: {

--- a/client/state/themes/themes-list/test/reducer.js
+++ b/client/state/themes/themes-list/test/reducer.js
@@ -9,7 +9,8 @@ import { fromJS } from 'immutable';
  */
 import {
 	SERIALIZE,
-	DESERIALIZE
+	DESERIALIZE,
+	SERVER_DESERIALIZE
 } from 'state/action-types';
 import reducer, { initialState, query } from '../reducer';
 
@@ -54,6 +55,27 @@ describe( 'themes-last-query reducer', () => {
 				active: 0
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
+			expect( state ).to.eql( query( fromJS( jsObject ) ) );
+		} );
+
+		it( 'converts state from server to immutable.js object', () => {
+			const jsObject = Object.freeze( {
+				list: [ 'one', 'two', 'three' ],
+				nextId: 2,
+				query: {
+					search: 'hello',
+					perPage: 20,
+					page: 1,
+					tier: 'all',
+					id: 5
+				},
+				queryState: {
+					isLastPage: true,
+					isFetchingNextPage: false
+				},
+				active: 0
+			} );
+			const state = reducer( jsObject, { type: SERVER_DESERIALIZE } );
 			expect( state ).to.eql( query( fromJS( jsObject ) ) );
 		} );
 

--- a/client/state/themes/themes/reducer.js
+++ b/client/state/themes/themes/reducer.js
@@ -8,7 +8,7 @@ import transform from 'lodash/transform';
  * Internal dependencies
  */
 import ActionTypes from '../action-types';
-import { DESERIALIZE, SERIALIZE } from 'state/action-types';
+import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from 'state/action-types';
 
 export const initialState = fromJS( {
 	themes: {},
@@ -39,6 +39,7 @@ export default ( state = initialState, action ) => {
 		case ActionTypes.ACTIVATED_THEME:
 			return state.update( 'themes', setActiveTheme.bind( null, action.theme.id ) );
 		case DESERIALIZE:
+		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:
 			return state.toJS();

--- a/client/state/themes/themes/test/reducer.js
+++ b/client/state/themes/themes/test/reducer.js
@@ -3,6 +3,7 @@
  */
 import { expect } from 'chai';
 import { fromJS } from 'immutable';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ import reducer, { initialState } from '../reducer';
 describe( 'themes reducer', () => {
 	describe( 'persistence', () => {
 		it( 'persists state and converts to a plain JS object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				themes: {
 					activetest: {
@@ -47,7 +48,7 @@ describe( 'themes reducer', () => {
 			expect( persistedState ).to.eql( jsObject );
 		} );
 		it( 'loads persisted state and converts to immutable.js object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				themes: {
 					activetest: {
@@ -77,7 +78,7 @@ describe( 'themes reducer', () => {
 		} );
 
 		it( 'converts state from server to immutable.js object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				themes: {
 					activetest: {
@@ -107,7 +108,7 @@ describe( 'themes reducer', () => {
 		} );
 
 		it.skip( 'should ignore loading data with invalid keys ', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				wrongkey: {
 					activetest: {
@@ -137,7 +138,7 @@ describe( 'themes reducer', () => {
 		} );
 
 		it.skip( 'should ignore loading data with invalid values ', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				themes: {
 					activetest: {

--- a/client/state/themes/themes/test/reducer.js
+++ b/client/state/themes/themes/test/reducer.js
@@ -9,7 +9,8 @@ import { fromJS } from 'immutable';
  */
 import {
 	SERIALIZE,
-	DESERIALIZE
+	DESERIALIZE,
+	SERVER_DESERIALIZE
 } from 'state/action-types';
 import reducer, { initialState } from '../reducer';
 
@@ -72,6 +73,36 @@ describe( 'themes reducer', () => {
 				}
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
+			expect( state ).to.eql( fromJS( jsObject ) );
+		} );
+
+		it( 'converts state from server to immutable.js object', () => {
+			const jsObject = Object.freeze( {
+				currentSiteId: 12345678,
+				themes: {
+					activetest: {
+						active: true,
+						id: 'activetest',
+						author: 'activetest author',
+						screenshot: 'http://example.com',
+						author_uri: 'http://example.com',
+						demo_uri: 'http://example.com',
+						name: 'active test',
+						stylesheet: 'premium',
+						price: '$79'
+					},
+					test: {
+						id: 'test',
+						author: 'test author',
+						screenshot: 'http://example.com',
+						author_uri: 'http://example.com',
+						demo_uri: 'http://example.com',
+						name: 'active test',
+						stylesheet: 'premium'
+					}
+				}
+			} );
+			const state = reducer( jsObject, { type: SERVER_DESERIALIZE } );
 			expect( state ).to.eql( fromJS( jsObject ) );
 		} );
 


### PR DESCRIPTION
Converts bootstrapped theme state from the server to immutable.js data.

No visual changes, unit tests added. Pre-req for #3279.

Pinging @gwwar for review.