### PR TITLE
Editor: Constrain editor width at container

### DIFF
--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -11,7 +11,10 @@
 	}
 }
 
-.mce-tinymce {
+.mce-container.mce-tinymce {
+	max-width: 700px;
+	margin: 0 auto;
+
 	& > .mce-container-body {
 		&:after {
 			margin-top: 1px;
@@ -62,8 +65,8 @@
 		margin: 0 auto;
 
 		@include breakpoint( ">960px" ) {
-			border-width: 1px;
-			max-width: 700px;
+			border-left-width: 1px;
+			border-right-width: 1px;
 		}
 	}
 

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -64,7 +64,7 @@
 		overflow-x: auto;
 		margin: 0 auto;
 
-		@include breakpoint( ">960px" ) {
+		@media screen and ( min-width: ( 700px + $sidebar-width-min ) ) {
 			border-left-width: 1px;
 			border-right-width: 1px;
 		}

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -240,7 +240,7 @@
 	}
 
 	@include breakpoint( ">1040px" ) {
-		right: -1px;
+		right: 0;
 	}
 }
 
@@ -278,11 +278,12 @@
 
 .editor__header-divider {
 	background-color: lighten( $gray, 25% );
-	margin: 0;
-}
+	max-width: 700px;
+	margin: 0 auto;
 
-.editor .mce-tinymce {
-	margin-top: -1px;
+	& ~ .mce-tinymce {
+		margin-top: -1px;
+	}
 }
 
 .post-editor .drafts__list + .infinite-scroll-end::after {


### PR DESCRIPTION
Fixes #3461 

This pull request seeks to assign a maximum width at the editor container element, rather than both at the editable area and the toolbar. This incidentally fixes an issue in Internet Explorer 11 where the toolbar would be left-aligned.

For consistency between editing modes, the divider between the mode selector and the editor will never be shown wider than 700 pixels.

Also includes a revised, more accurate, media query for determining when to collapse the toolbar borders. Currently, there's a small gap between "960px" and the point at which the borders should be collapsed where borders are not present but the toolbar is not flush with the edges of the screen.

__Testing instructions:__

Ensure that the toolbar displays as expected both in your preferred browser, and in Internet Explorer 11.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Change to the HTML editing mode
4. Note that the divider below the mode switcher is centered at a maximum of 700 pixels wide
3. Change to the Visual editing mode
4. Note that the toolbar is centered at a maximum of 700 pixels wide
5. Shrink the screen to ~950 pixels.
6. Note that the toolbar left and right borders are still present
7. Shrink the screen to ~900 pixels.
8. Note that the toolbar left and right borders are removed

/cc @mtias 