### PR TITLE
Checkout: Fix icons on `CheckoutThankYou`

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -258,7 +258,6 @@
 @import 'my-sites/themes/style';
 @import 'my-sites/themes/themes-search-card/style';
 @import 'my-sites/upgrades/cart/style';
-@import 'my-sites/upgrades/checkout/style';
 @import 'my-sites/upgrades/checkout/stored-card';
 @import 'my-sites/upgrades/checkout/subscription-text';
 @import 'my-sites/upgrades/checkout-thank-you/style';

--- a/client/my-sites/upgrades/checkout-thank-you/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/style.scss
@@ -259,6 +259,10 @@
 			margin-top: 10px;
 		}
 
+		.checkout-thank-you__purchase-detail-text::before {
+			content: none;
+		}
+
 		.checkout-thank-you__purchase-detail-title {
 			margin: 0 auto;
 			width: 85%;
@@ -276,6 +280,12 @@
 }
 
 .checkout-thank-you__purchase-detail-text {
+	&::before {
+		color: lighten( $gray, 20% );
+		@include noticon( '\f803' );
+		top: -8px;
+	}
+
 	@include breakpoint( ">660px" ) {
 		&::before {
 			font-size: 70px;
@@ -295,14 +305,6 @@
 			position: absolute;
 				left: 0;
 		}
-	}
-}
-
-.checkout-thank-you__purchase-detail:not( .is-placeholder ) .checkout-thank-you__purchase-detail-text {
-	&::before {
-		color: lighten( $gray, 20% );
-		@include noticon( '\f803' );
-		top: -8px;
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/3462.

https://github.com/Automattic/wp-calypso/pull/3270 added some overly specific CSS that overwrote the icons on the thank you page. This PR updates the CSS so that the correct icons are displayed on the thank you page.

**Testing**
- Visit `/plans` and purchase a plan.
- Assert that you are taken to the thank you page.
- Assert that you see [different icons](https://cloud.githubusercontent.com/assets/594356/13221783/596fcf60-d97d-11e5-9277-118525fd8977.png) instead of the [checkmark icon](https://cloud.githubusercontent.com/assets/594356/13221778/50d956aa-d97d-11e5-8104-15b0a92a4ccc.png).

- [x] Product review
- [x] Code review