### PR TITLE
Framework: Update wpcom-unpublished to 1.0.9

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8484,207 +8484,574 @@
       }
     },
     "wpcom-unpublished": {
-      "version": "1.0.8",
-      "from": "wpcom-unpublished@1.0.8",
-      "resolved": "https://registry.npmjs.org/wpcom-unpublished/-/wpcom-unpublished-1.0.8.tgz",
+      "version": "1.0.9",
       "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1"
+            }
+          }
+        },
+        "inherits": {
+          "version": "2.0.1"
+        },
+        "qs": {
+          "version": "4.0.0"
+        },
         "wpcom": {
-          "version": "4.8.3",
-          "from": "wpcom@4.8.3",
-          "resolved": "https://registry.npmjs.org/wpcom/-/wpcom-4.8.3.tgz",
+          "version": "4.8.4",
           "dependencies": {
             "babel": {
               "version": "5.8.35",
-              "from": "babel@>=5.8.23 <6.0.0",
-              "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.35.tgz",
               "dependencies": {
+                "babel-core": {
+                  "version": "5.8.35",
+                  "dependencies": {
+                    "babel-plugin-constant-folding": {
+                      "version": "1.0.1"
+                    },
+                    "babel-plugin-dead-code-elimination": {
+                      "version": "1.0.2"
+                    },
+                    "babel-plugin-eval": {
+                      "version": "1.0.1"
+                    },
+                    "babel-plugin-inline-environment-variables": {
+                      "version": "1.0.1"
+                    },
+                    "babel-plugin-jscript": {
+                      "version": "1.0.4"
+                    },
+                    "babel-plugin-member-expression-literals": {
+                      "version": "1.0.1"
+                    },
+                    "babel-plugin-property-literals": {
+                      "version": "1.0.1"
+                    },
+                    "babel-plugin-proto-to-assign": {
+                      "version": "1.0.4"
+                    },
+                    "babel-plugin-react-constant-elements": {
+                      "version": "1.0.3"
+                    },
+                    "babel-plugin-react-display-name": {
+                      "version": "1.0.3"
+                    },
+                    "babel-plugin-remove-console": {
+                      "version": "1.0.1"
+                    },
+                    "babel-plugin-remove-debugger": {
+                      "version": "1.0.1"
+                    },
+                    "babel-plugin-runtime": {
+                      "version": "1.0.7"
+                    },
+                    "babel-plugin-undeclared-variables-check": {
+                      "version": "1.0.2",
+                      "dependencies": {
+                        "leven": {
+                          "version": "1.0.2"
+                        }
+                      }
+                    },
+                    "babel-plugin-undefined-to-void": {
+                      "version": "1.1.6"
+                    },
+                    "babylon": {
+                      "version": "5.8.35"
+                    },
+                    "bluebird": {
+                      "version": "2.10.2"
+                    },
+                    "chalk": {
+                      "version": "1.1.1",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.0",
+                          "dependencies": {
+                            "color-convert": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    },
+                    "core-js": {
+                      "version": "1.2.6"
+                    },
+                    "detect-indent": {
+                      "version": "3.0.1",
+                      "dependencies": {
+                        "get-stdin": {
+                          "version": "4.0.1"
+                        },
+                        "minimist": {
+                          "version": "1.2.0"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2"
+                    },
+                    "globals": {
+                      "version": "6.4.1"
+                    },
+                    "home-or-tmp": {
+                      "version": "1.0.0",
+                      "dependencies": {
+                        "os-tmpdir": {
+                          "version": "1.0.1"
+                        },
+                        "user-home": {
+                          "version": "1.1.1"
+                        }
+                      }
+                    },
+                    "is-integer": {
+                      "version": "1.0.6",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "js-tokens": {
+                      "version": "1.0.1"
+                    },
+                    "json5": {
+                      "version": "0.4.0"
+                    },
+                    "line-numbers": {
+                      "version": "0.2.0",
+                      "dependencies": {
+                        "left-pad": {
+                          "version": "0.0.3"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "private": {
+                      "version": "0.1.6"
+                    },
+                    "regenerator": {
+                      "version": "0.8.40",
+                      "dependencies": {
+                        "commoner": {
+                          "version": "0.10.4",
+                          "dependencies": {
+                            "detective": {
+                              "version": "4.3.1",
+                              "dependencies": {
+                                "acorn": {
+                                  "version": "1.2.2"
+                                },
+                                "defined": {
+                                  "version": "1.0.0"
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "4.1.3"
+                            },
+                            "iconv-lite": {
+                              "version": "0.4.13"
+                            },
+                            "mkdirp": {
+                              "version": "0.5.1",
+                              "dependencies": {
+                                "minimist": {
+                                  "version": "0.0.8"
+                                }
+                              }
+                            },
+                            "q": {
+                              "version": "1.4.1"
+                            }
+                          }
+                        },
+                        "defs": {
+                          "version": "1.1.1",
+                          "dependencies": {
+                            "alter": {
+                              "version": "0.2.0",
+                              "dependencies": {
+                                "stable": {
+                                  "version": "0.1.5"
+                                }
+                              }
+                            },
+                            "ast-traverse": {
+                              "version": "0.1.1"
+                            },
+                            "breakable": {
+                              "version": "1.0.0"
+                            },
+                            "simple-fmt": {
+                              "version": "0.1.0"
+                            },
+                            "simple-is": {
+                              "version": "0.2.0"
+                            },
+                            "stringmap": {
+                              "version": "0.2.2"
+                            },
+                            "stringset": {
+                              "version": "0.2.1"
+                            },
+                            "tryor": {
+                              "version": "0.1.2"
+                            },
+                            "yargs": {
+                              "version": "3.27.0",
+                              "dependencies": {
+                                "camelcase": {
+                                  "version": "1.2.1"
+                                },
+                                "cliui": {
+                                  "version": "2.1.0",
+                                  "dependencies": {
+                                    "center-align": {
+                                      "version": "0.1.3",
+                                      "dependencies": {
+                                        "align-text": {
+                                          "version": "0.1.4",
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.0.2",
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.2"
+                                                }
+                                              }
+                                            },
+                                            "longest": {
+                                              "version": "1.0.1"
+                                            },
+                                            "repeat-string": {
+                                              "version": "1.5.2"
+                                            }
+                                          }
+                                        },
+                                        "lazy-cache": {
+                                          "version": "1.0.3"
+                                        }
+                                      }
+                                    },
+                                    "right-align": {
+                                      "version": "0.1.3",
+                                      "dependencies": {
+                                        "align-text": {
+                                          "version": "0.1.4",
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.0.2",
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.2"
+                                                }
+                                              }
+                                            },
+                                            "longest": {
+                                              "version": "1.0.1"
+                                            },
+                                            "repeat-string": {
+                                              "version": "1.5.2"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "wordwrap": {
+                                      "version": "0.0.2"
+                                    }
+                                  }
+                                },
+                                "decamelize": {
+                                  "version": "1.1.2",
+                                  "dependencies": {
+                                    "escape-string-regexp": {
+                                      "version": "1.0.5"
+                                    }
+                                  }
+                                },
+                                "os-locale": {
+                                  "version": "1.4.0",
+                                  "dependencies": {
+                                    "lcid": {
+                                      "version": "1.0.0",
+                                      "dependencies": {
+                                        "invert-kv": {
+                                          "version": "1.0.0"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "window-size": {
+                                  "version": "0.1.4"
+                                },
+                                "y18n": {
+                                  "version": "3.2.0"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb"
+                        },
+                        "recast": {
+                          "version": "0.10.33",
+                          "dependencies": {
+                            "ast-types": {
+                              "version": "0.8.12"
+                            }
+                          }
+                        },
+                        "through": {
+                          "version": "2.3.8"
+                        }
+                      }
+                    },
+                    "regexpu": {
+                      "version": "1.3.0",
+                      "dependencies": {
+                        "esprima": {
+                          "version": "2.7.2"
+                        },
+                        "recast": {
+                          "version": "0.10.43",
+                          "dependencies": {
+                            "esprima-fb": {
+                              "version": "15001.1001.0-dev-harmony-fb"
+                            },
+                            "ast-types": {
+                              "version": "0.8.15"
+                            }
+                          }
+                        },
+                        "regenerate": {
+                          "version": "1.2.1"
+                        },
+                        "regjsgen": {
+                          "version": "0.2.0"
+                        },
+                        "regjsparser": {
+                          "version": "0.1.5",
+                          "dependencies": {
+                            "jsesc": {
+                              "version": "0.5.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "resolve": {
+                      "version": "1.1.7"
+                    },
+                    "shebang-regex": {
+                      "version": "1.0.0"
+                    },
+                    "source-map-support": {
+                      "version": "0.2.10",
+                      "dependencies": {
+                        "source-map": {
+                          "version": "0.1.32",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.1"
+                    },
+                    "trim-right": {
+                      "version": "1.0.1"
+                    },
+                    "try-resolve": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
                 "chokidar": {
                   "version": "1.4.2",
-                  "from": "chokidar@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
                   "dependencies": {
                     "anymatch": {
                       "version": "1.3.0",
-                      "from": "anymatch@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                       "dependencies": {
                         "arrify": {
-                          "version": "1.0.1",
-                          "from": "arrify@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "micromatch": {
                           "version": "2.3.7",
-                          "from": "micromatch@>=2.1.5 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
                           "dependencies": {
                             "arr-diff": {
                               "version": "2.0.0",
-                              "from": "arr-diff@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                               "dependencies": {
                                 "arr-flatten": {
-                                  "version": "1.0.1",
-                                  "from": "arr-flatten@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                                  "version": "1.0.1"
                                 }
                               }
                             },
                             "array-unique": {
-                              "version": "0.2.1",
-                              "from": "array-unique@>=0.2.1 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                              "version": "0.2.1"
                             },
                             "braces": {
                               "version": "1.8.3",
-                              "from": "braces@>=1.8.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
                               "dependencies": {
                                 "expand-range": {
                                   "version": "1.8.1",
-                                  "from": "expand-range@>=1.8.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                                   "dependencies": {
                                     "fill-range": {
                                       "version": "2.2.3",
-                                      "from": "fill-range@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                                       "dependencies": {
                                         "is-number": {
-                                          "version": "2.1.0",
-                                          "from": "is-number@>=2.1.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                          "version": "2.1.0"
                                         },
                                         "isobject": {
                                           "version": "2.0.0",
-                                          "from": "isobject@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                                           "dependencies": {
                                             "isarray": {
-                                              "version": "0.0.1",
-                                              "from": "isarray@0.0.1",
-                                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                              "version": "0.0.1"
                                             }
                                           }
                                         },
                                         "randomatic": {
-                                          "version": "1.1.5",
-                                          "from": "randomatic@>=1.1.3 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                          "version": "1.1.5"
                                         },
                                         "repeat-string": {
-                                          "version": "1.5.2",
-                                          "from": "repeat-string@>=1.5.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                          "version": "1.5.2"
                                         }
                                       }
                                     }
                                   }
                                 },
                                 "preserve": {
-                                  "version": "0.2.0",
-                                  "from": "preserve@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                                  "version": "0.2.0"
                                 },
                                 "repeat-element": {
-                                  "version": "1.1.2",
-                                  "from": "repeat-element@>=1.1.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                                  "version": "1.1.2"
                                 }
                               }
                             },
                             "expand-brackets": {
-                              "version": "0.1.4",
-                              "from": "expand-brackets@>=0.1.4 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                              "version": "0.1.4"
                             },
                             "extglob": {
-                              "version": "0.3.2",
-                              "from": "extglob@>=0.3.1 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                              "version": "0.3.2"
                             },
                             "filename-regex": {
-                              "version": "2.0.0",
-                              "from": "filename-regex@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                              "version": "2.0.0"
                             },
                             "is-extglob": {
-                              "version": "1.0.0",
-                              "from": "is-extglob@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                              "version": "1.0.0"
                             },
                             "kind-of": {
                               "version": "3.0.2",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                               "dependencies": {
                                 "is-buffer": {
-                                  "version": "1.1.2",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                  "version": "1.1.2"
                                 }
                               }
                             },
                             "normalize-path": {
-                              "version": "2.0.1",
-                              "from": "normalize-path@>=2.0.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                              "version": "2.0.1"
                             },
                             "object.omit": {
                               "version": "2.0.0",
-                              "from": "object.omit@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                               "dependencies": {
                                 "for-own": {
                                   "version": "0.1.3",
-                                  "from": "for-own@>=0.1.3 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                                   "dependencies": {
                                     "for-in": {
-                                      "version": "0.1.4",
-                                      "from": "for-in@>=0.1.4 <0.2.0",
-                                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                      "version": "0.1.4"
                                     }
                                   }
                                 },
                                 "is-extendable": {
-                                  "version": "0.1.1",
-                                  "from": "is-extendable@>=0.1.1 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                                  "version": "0.1.1"
                                 }
                               }
                             },
                             "parse-glob": {
                               "version": "3.0.4",
-                              "from": "parse-glob@>=3.0.4 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                               "dependencies": {
                                 "glob-base": {
-                                  "version": "0.3.0",
-                                  "from": "glob-base@>=0.3.0 <0.4.0",
-                                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                                  "version": "0.3.0"
                                 },
                                 "is-dotfile": {
-                                  "version": "1.0.2",
-                                  "from": "is-dotfile@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                                  "version": "1.0.2"
                                 }
                               }
                             },
                             "regex-cache": {
                               "version": "0.4.2",
-                              "from": "regex-cache@>=0.4.2 <0.5.0",
-                              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                               "dependencies": {
                                 "is-equal-shallow": {
-                                  "version": "0.1.3",
-                                  "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                                  "version": "0.1.3"
                                 },
                                 "is-primitive": {
-                                  "version": "2.0.0",
-                                  "from": "is-primitive@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                                  "version": "2.0.0"
                                 }
                               }
                             }
@@ -8693,68 +9060,44 @@
                       }
                     },
                     "async-each": {
-                      "version": "0.1.6",
-                      "from": "async-each@>=0.1.6 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                      "version": "0.1.6"
                     },
                     "glob-parent": {
-                      "version": "2.0.0",
-                      "from": "glob-parent@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "is-binary-path": {
                       "version": "1.0.1",
-                      "from": "is-binary-path@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                       "dependencies": {
                         "binary-extensions": {
-                          "version": "1.4.0",
-                          "from": "binary-extensions@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                          "version": "1.4.0"
                         }
                       }
                     },
                     "is-glob": {
                       "version": "2.0.1",
-                      "from": "is-glob@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                       "dependencies": {
                         "is-extglob": {
-                          "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     },
                     "readdirp": {
                       "version": "2.0.0",
-                      "from": "readdirp@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
-                          "version": "4.1.3",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                          "version": "4.1.3"
                         },
                         "minimatch": {
                           "version": "2.0.10",
-                          "from": "minimatch@>=2.0.10 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.3",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                               "dependencies": {
                                 "balanced-match": {
-                                  "version": "0.3.0",
-                                  "from": "balanced-match@>=0.3.0 <0.4.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                  "version": "0.3.0"
                                 },
                                 "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                  "version": "0.0.1"
                                 }
                               }
                             }
@@ -8762,33 +9105,21 @@
                         },
                         "readable-stream": {
                           "version": "2.0.5",
-                          "from": "readable-stream@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                              "version": "1.0.2"
                             },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "0.0.1"
                             },
                             "process-nextick-args": {
-                              "version": "1.0.6",
-                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                              "version": "1.0.6"
                             },
                             "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                              "version": "0.10.31"
                             },
                             "util-deprecate": {
-                              "version": "1.0.2",
-                              "from": "util-deprecate@>=1.0.1 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                              "version": "1.0.2"
                             }
                           }
                         }
@@ -8796,521 +9127,317 @@
                     },
                     "fsevents": {
                       "version": "1.0.7",
-                      "from": "fsevents@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.7.tgz",
                       "dependencies": {
                         "nan": {
-                          "version": "2.2.0",
-                          "from": "nan@>=2.1.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+                          "version": "2.2.0"
                         },
                         "node-pre-gyp": {
                           "version": "0.6.19",
-                          "from": "node-pre-gyp@>=0.6.17 <0.7.0",
-                          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.19.tgz",
                           "dependencies": {
                             "nopt": {
                               "version": "3.0.6",
-                              "from": "nopt@~3.0.1",
-                              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                               "dependencies": {
                                 "abbrev": {
-                                  "version": "1.0.7",
-                                  "from": "abbrev@1",
-                                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                                  "version": "1.0.7"
                                 }
                               }
                             }
                           }
                         },
                         "ansi": {
-                          "version": "0.3.0",
-                          "from": "ansi@~0.3.0",
-                          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-                        },
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "ansi-regex@^2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                          "version": "0.3.0"
                         },
                         "ansi-styles": {
-                          "version": "2.1.0",
-                          "from": "ansi-styles@^2.1.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                          "version": "2.1.0"
                         },
                         "are-we-there-yet": {
-                          "version": "1.0.5",
-                          "from": "are-we-there-yet@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz"
+                          "version": "1.0.5"
+                        },
+                        "ansi-regex": {
+                          "version": "2.0.0"
                         },
                         "asn1": {
-                          "version": "0.2.3",
-                          "from": "asn1@>=0.2.3 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                          "version": "0.2.3"
                         },
                         "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "assert-plus@^0.1.5",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                          "version": "0.1.5"
                         },
                         "async": {
-                          "version": "1.5.1",
-                          "from": "async@^1.4.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
+                          "version": "1.5.1"
                         },
                         "aws-sign2": {
-                          "version": "0.6.0",
-                          "from": "aws-sign2@~0.6.0",
-                          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                          "version": "0.6.0"
                         },
                         "bl": {
-                          "version": "1.0.0",
-                          "from": "bl@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                          "version": "1.0.0"
                         },
                         "block-stream": {
-                          "version": "0.0.8",
-                          "from": "block-stream@*",
-                          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                          "version": "0.0.8"
                         },
                         "boom": {
-                          "version": "2.10.1",
-                          "from": "boom@2.x.x",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                        },
-                        "chalk": {
-                          "version": "1.1.1",
-                          "from": "chalk@^1.1.1",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                          "version": "2.10.1"
                         },
                         "caseless": {
-                          "version": "0.11.0",
-                          "from": "caseless@~0.11.0",
-                          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                          "version": "0.11.0"
+                        },
+                        "chalk": {
+                          "version": "1.1.1"
                         },
                         "combined-stream": {
-                          "version": "1.0.5",
-                          "from": "combined-stream@~1.0.5",
-                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                          "version": "1.0.5"
                         },
                         "commander": {
-                          "version": "2.9.0",
-                          "from": "commander@^2.9.0",
-                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-                        },
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "dashdash": {
-                          "version": "1.11.0",
-                          "from": "dashdash@>=1.10.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.11.0.tgz"
+                          "version": "2.9.0"
                         },
                         "cryptiles": {
-                          "version": "2.0.5",
-                          "from": "cryptiles@2.x.x",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                          "version": "2.0.5"
+                        },
+                        "dashdash": {
+                          "version": "1.11.0"
                         },
                         "debug": {
-                          "version": "0.7.4",
-                          "from": "debug@~0.7.2",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                          "version": "0.7.4"
+                        },
+                        "core-util-is": {
+                          "version": "1.0.2"
                         },
                         "deep-extend": {
-                          "version": "0.4.0",
-                          "from": "deep-extend@~0.4.0",
-                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                          "version": "0.4.0"
                         },
                         "delayed-stream": {
-                          "version": "1.0.0",
-                          "from": "delayed-stream@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                          "version": "1.0.0"
                         },
                         "delegates": {
-                          "version": "0.1.0",
-                          "from": "delegates@^0.1.0",
-                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                          "version": "0.1.0"
                         },
                         "escape-string-regexp": {
-                          "version": "1.0.4",
-                          "from": "escape-string-regexp@^1.0.2",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                          "version": "1.0.4"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1"
                         },
                         "extend": {
-                          "version": "3.0.0",
-                          "from": "extend@~3.0.0",
-                          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                          "version": "3.0.0"
                         },
                         "extsprintf": {
-                          "version": "1.0.2",
-                          "from": "extsprintf@1.0.2",
-                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                          "version": "1.0.2"
                         },
                         "forever-agent": {
-                          "version": "0.6.1",
-                          "from": "forever-agent@~0.6.1",
-                          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                          "version": "0.6.1"
                         },
                         "form-data": {
-                          "version": "1.0.0-rc3",
-                          "from": "form-data@~1.0.0-rc3",
-                          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                          "version": "1.0.0-rc3"
                         },
                         "fstream": {
-                          "version": "1.0.8",
-                          "from": "fstream@^1.0.2",
-                          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                          "version": "1.0.8"
                         },
                         "gauge": {
-                          "version": "1.2.2",
-                          "from": "gauge@~1.2.0",
-                          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+                          "version": "1.2.2"
                         },
                         "generate-function": {
-                          "version": "2.0.0",
-                          "from": "generate-function@^2.0.0",
-                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "from": "generate-object-property@^1.1.0",
-                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                          "version": "2.0.0"
                         },
                         "graceful-fs": {
-                          "version": "4.1.2",
-                          "from": "graceful-fs@^4.1.2",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                        },
-                        "graceful-readlink": {
-                          "version": "1.0.1",
-                          "from": "graceful-readlink@>= 1.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                          "version": "4.1.2"
                         },
                         "har-validator": {
-                          "version": "2.0.3",
-                          "from": "har-validator@~2.0.2",
-                          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
+                          "version": "2.0.3"
+                        },
+                        "graceful-readlink": {
+                          "version": "1.0.1"
                         },
                         "has-ansi": {
-                          "version": "2.0.0",
-                          "from": "has-ansi@^2.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                          "version": "2.0.0"
                         },
                         "has-unicode": {
-                          "version": "1.0.1",
-                          "from": "has-unicode@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "hawk": {
-                          "version": "3.1.2",
-                          "from": "hawk@~3.1.0",
-                          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
-                        },
-                        "hoek": {
-                          "version": "2.16.3",
-                          "from": "hoek@2.x.x",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                          "version": "3.1.2"
                         },
                         "http-signature": {
-                          "version": "1.1.0",
-                          "from": "http-signature@~1.1.0",
-                          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+                          "version": "1.1.0"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0"
+                        },
+                        "hoek": {
+                          "version": "2.16.3"
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@*",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.1"
                         },
                         "ini": {
-                          "version": "1.3.4",
-                          "from": "ini@~1.3.0",
-                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                          "version": "1.3.4"
                         },
                         "is-my-json-valid": {
-                          "version": "2.12.3",
-                          "from": "is-my-json-valid@^2.12.3",
-                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+                          "version": "2.12.3"
                         },
                         "is-property": {
-                          "version": "1.0.2",
-                          "from": "is-property@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                          "version": "1.0.2"
                         },
                         "is-typedarray": {
-                          "version": "1.0.0",
-                          "from": "is-typedarray@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                          "version": "1.0.0"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "isstream": {
-                          "version": "0.1.2",
-                          "from": "isstream@~0.1.2",
-                          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                          "version": "0.1.2"
                         },
                         "jodid25519": {
-                          "version": "1.0.2",
-                          "from": "jodid25519@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                          "version": "1.0.2"
                         },
                         "jsbn": {
-                          "version": "0.1.0",
-                          "from": "jsbn@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                          "version": "0.1.0"
                         },
                         "json-schema": {
-                          "version": "0.2.2",
-                          "from": "json-schema@0.2.2",
-                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                          "version": "0.2.2"
                         },
                         "json-stringify-safe": {
-                          "version": "5.0.1",
-                          "from": "json-stringify-safe@~5.0.1",
-                          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                          "version": "5.0.1"
                         },
                         "jsonpointer": {
-                          "version": "2.0.0",
-                          "from": "jsonpointer@2.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                          "version": "2.0.0"
                         },
                         "jsprim": {
-                          "version": "1.2.2",
-                          "from": "jsprim@^1.2.2",
-                          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                          "version": "1.2.2"
                         },
                         "lodash._basetostring": {
-                          "version": "3.0.1",
-                          "from": "lodash._basetostring@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-                        },
-                        "lodash.pad": {
-                          "version": "3.1.1",
-                          "from": "lodash.pad@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+                          "version": "3.0.1"
                         },
                         "lodash._createpadding": {
-                          "version": "3.6.1",
-                          "from": "lodash._createpadding@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+                          "version": "3.6.1"
+                        },
+                        "lodash.pad": {
+                          "version": "3.1.1"
                         },
                         "lodash.padleft": {
-                          "version": "3.1.1",
-                          "from": "lodash.padleft@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                          "version": "3.1.1"
                         },
                         "lodash.padright": {
-                          "version": "3.1.1",
-                          "from": "lodash.padright@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                          "version": "3.1.1"
                         },
                         "lodash.repeat": {
-                          "version": "3.0.1",
-                          "from": "lodash.repeat@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                          "version": "3.0.1"
                         },
                         "mime-db": {
-                          "version": "1.21.0",
-                          "from": "mime-db@~1.21.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                          "version": "1.21.0"
                         },
                         "mime-types": {
-                          "version": "2.1.9",
-                          "from": "mime-types@~2.1.7",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                          "version": "2.1.9"
                         },
                         "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                          "version": "0.0.8"
                         },
                         "mkdirp": {
-                          "version": "0.5.1",
-                          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                          "version": "0.5.1"
                         },
                         "node-uuid": {
-                          "version": "1.4.7",
-                          "from": "node-uuid@~1.4.7",
-                          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                          "version": "1.4.7"
                         },
                         "npmlog": {
-                          "version": "2.0.0",
-                          "from": "npmlog@~2.0.0",
-                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
+                          "version": "2.0.0"
                         },
                         "oauth-sign": {
-                          "version": "0.8.0",
-                          "from": "oauth-sign@~0.8.0",
-                          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                          "version": "0.8.0"
                         },
                         "once": {
-                          "version": "1.1.1",
-                          "from": "once@~1.1.1",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                          "version": "1.1.1"
                         },
                         "pinkie": {
-                          "version": "2.0.1",
-                          "from": "pinkie@^2.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                          "version": "2.0.1"
                         },
                         "pinkie-promise": {
-                          "version": "2.0.0",
-                          "from": "pinkie-promise@^2.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                          "version": "2.0.0"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "process-nextick-args@~1.0.6",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "version": "1.0.6"
                         },
                         "qs": {
-                          "version": "5.2.0",
-                          "from": "qs@~5.2.0",
-                          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                          "version": "5.2.0"
                         },
                         "readable-stream": {
-                          "version": "2.0.5",
-                          "from": "readable-stream@^2.0.0 || ^1.1.13",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                          "version": "2.0.5"
                         },
                         "request": {
-                          "version": "2.67.0",
-                          "from": "request@2.x",
-                          "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+                          "version": "2.67.0"
                         },
                         "semver": {
-                          "version": "5.1.0",
-                          "from": "semver@~5.1.0",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                          "version": "5.1.0"
                         },
                         "sntp": {
-                          "version": "1.0.9",
-                          "from": "sntp@1.x.x",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                          "version": "1.0.9"
                         },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "0.10.31"
                         },
                         "stringstream": {
-                          "version": "0.0.5",
-                          "from": "stringstream@~0.0.4",
-                          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                          "version": "0.0.5"
                         },
                         "strip-ansi": {
-                          "version": "3.0.0",
-                          "from": "strip-ansi@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-                        },
-                        "strip-json-comments": {
-                          "version": "1.0.4",
-                          "from": "strip-json-comments@~1.0.4",
-                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                          "version": "3.0.0"
                         },
                         "supports-color": {
-                          "version": "2.0.0",
-                          "from": "supports-color@^2.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                          "version": "2.0.0"
+                        },
+                        "strip-json-comments": {
+                          "version": "1.0.4"
                         },
                         "tar": {
-                          "version": "2.2.1",
-                          "from": "tar@~2.2.0",
-                          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                          "version": "2.2.1"
                         },
                         "tough-cookie": {
-                          "version": "2.2.1",
-                          "from": "tough-cookie@~2.2.0",
-                          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                          "version": "2.2.1"
                         },
                         "tunnel-agent": {
-                          "version": "0.4.2",
-                          "from": "tunnel-agent@~0.4.1",
-                          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                          "version": "0.4.2"
                         },
                         "tweetnacl": {
-                          "version": "0.13.2",
-                          "from": "tweetnacl@>=0.13.0 <1.0.0",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
-                        },
-                        "uid-number": {
-                          "version": "0.0.3",
-                          "from": "uid-number@0.0.3",
-                          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                          "version": "0.13.2"
                         },
                         "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@~1.0.1",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                          "version": "1.0.2"
+                        },
+                        "uid-number": {
+                          "version": "0.0.3"
                         },
                         "verror": {
-                          "version": "1.3.6",
-                          "from": "verror@1.3.6",
-                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                          "version": "1.3.6"
                         },
                         "xtend": {
-                          "version": "4.0.1",
-                          "from": "xtend@^4.0.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                          "version": "4.0.1"
                         },
                         "rc": {
                           "version": "1.1.6",
-                          "from": "rc@~1.1.0",
-                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
                           "dependencies": {
                             "minimist": {
-                              "version": "1.2.0",
-                              "from": "minimist@^1.2.0",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                              "version": "1.2.0"
                             }
                           }
                         },
                         "sshpk": {
                           "version": "1.7.2",
-                          "from": "sshpk@^1.7.0",
-                          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.2.tgz",
                           "dependencies": {
                             "assert-plus": {
-                              "version": "0.2.0",
-                              "from": "assert-plus@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                              "version": "0.2.0"
                             }
                           }
                         },
                         "fstream-ignore": {
                           "version": "1.0.3",
-                          "from": "fstream-ignore@~1.0.3",
-                          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
                           "dependencies": {
                             "minimatch": {
                               "version": "3.0.0",
-                              "from": "minimatch@^3.0.0",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.2",
-                                  "from": "brace-expansion@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                                   "dependencies": {
                                     "balanced-match": {
-                                      "version": "0.3.0",
-                                      "from": "balanced-match@^0.3.0",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                      "version": "0.3.0"
                                     },
                                     "concat-map": {
-                                      "version": "0.0.1",
-                                      "from": "concat-map@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                      "version": "0.0.1"
                                     }
                                   }
                                 }
@@ -9320,50 +9447,32 @@
                         },
                         "rimraf": {
                           "version": "2.5.0",
-                          "from": "rimraf@~2.5.0",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
                           "dependencies": {
                             "glob": {
                               "version": "6.0.3",
-                              "from": "glob@^6.0.1",
-                              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
                               "dependencies": {
                                 "inflight": {
                                   "version": "1.0.4",
-                                  "from": "inflight@^1.0.4",
-                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                                   "dependencies": {
                                     "wrappy": {
-                                      "version": "1.0.1",
-                                      "from": "wrappy@1",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                      "version": "1.0.1"
                                     }
                                   }
                                 },
                                 "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@~2.0.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                  "version": "2.0.1"
                                 },
                                 "minimatch": {
                                   "version": "3.0.0",
-                                  "from": "minimatch@2 || 3",
-                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                                   "dependencies": {
                                     "brace-expansion": {
                                       "version": "1.1.2",
-                                      "from": "brace-expansion@^1.0.0",
-                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                                       "dependencies": {
                                         "balanced-match": {
-                                          "version": "0.3.0",
-                                          "from": "balanced-match@^0.3.0",
-                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                          "version": "0.3.0"
                                         },
                                         "concat-map": {
-                                          "version": "0.0.1",
-                                          "from": "concat-map@0.0.1",
-                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                          "version": "0.0.1"
                                         }
                                       }
                                     }
@@ -9371,20 +9480,14 @@
                                 },
                                 "once": {
                                   "version": "1.3.3",
-                                  "from": "once@^1.3.0",
-                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                                   "dependencies": {
                                     "wrappy": {
-                                      "version": "1.0.1",
-                                      "from": "wrappy@1",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                      "version": "1.0.1"
                                     }
                                   }
                                 },
                                 "path-is-absolute": {
-                                  "version": "1.0.0",
-                                  "from": "path-is-absolute@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                                  "version": "1.0.0"
                                 }
                               }
                             }
@@ -9392,55 +9495,35 @@
                         },
                         "tar-pack": {
                           "version": "3.1.2",
-                          "from": "tar-pack@~3.1.0",
-                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.2.tgz",
                           "dependencies": {
                             "rimraf": {
                               "version": "2.4.5",
-                              "from": "rimraf@~2.4.4",
-                              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                               "dependencies": {
                                 "glob": {
                                   "version": "6.0.3",
-                                  "from": "glob@^6.0.1",
-                                  "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
                                   "dependencies": {
                                     "inflight": {
                                       "version": "1.0.4",
-                                      "from": "inflight@^1.0.4",
-                                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                                       "dependencies": {
                                         "wrappy": {
-                                          "version": "1.0.1",
-                                          "from": "wrappy@1",
-                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                          "version": "1.0.1"
                                         }
                                       }
                                     },
                                     "inherits": {
-                                      "version": "2.0.1",
-                                      "from": "inherits@2",
-                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                      "version": "2.0.1"
                                     },
                                     "minimatch": {
                                       "version": "3.0.0",
-                                      "from": "minimatch@2 || 3",
-                                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                                       "dependencies": {
                                         "brace-expansion": {
                                           "version": "1.1.2",
-                                          "from": "brace-expansion@^1.0.0",
-                                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                                           "dependencies": {
                                             "balanced-match": {
-                                              "version": "0.3.0",
-                                              "from": "balanced-match@^0.3.0",
-                                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                              "version": "0.3.0"
                                             },
                                             "concat-map": {
-                                              "version": "0.0.1",
-                                              "from": "concat-map@0.0.1",
-                                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                              "version": "0.0.1"
                                             }
                                           }
                                         }
@@ -9448,20 +9531,14 @@
                                     },
                                     "once": {
                                       "version": "1.3.3",
-                                      "from": "once@^1.3.0",
-                                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                                       "dependencies": {
                                         "wrappy": {
-                                          "version": "1.0.1",
-                                          "from": "wrappy@1",
-                                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                          "version": "1.0.1"
                                         }
                                       }
                                     },
                                     "path-is-absolute": {
-                                      "version": "1.0.0",
-                                      "from": "path-is-absolute@^1.0.0",
-                                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                                      "version": "1.0.0"
                                     }
                                   }
                                 }
@@ -9475,62 +9552,40 @@
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.6.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "convert-source-map": {
-                  "version": "1.1.3",
-                  "from": "convert-source-map@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+                  "version": "1.1.3"
                 },
                 "fs-readdir-recursive": {
-                  "version": "0.1.2",
-                  "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+                  "version": "0.1.2"
                 },
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.5 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "version": "0.3.0"
                             },
                             "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "version": "0.0.1"
                             }
                           }
                         }
@@ -9538,66 +9593,127 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
                   }
                 },
                 "lodash": {
-                  "version": "3.10.1",
-                  "from": "lodash@>=3.2.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                  "version": "3.10.1"
                 },
                 "output-file-sync": {
                   "version": "1.1.1",
-                  "from": "output-file-sync@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                          "version": "0.0.8"
                         }
                       }
                     },
                     "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                      "version": "4.0.1"
                     }
                   }
                 },
                 "path-exists": {
-                  "version": "1.0.0",
-                  "from": "path-exists@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "source-map": {
-                  "version": "0.5.3",
-                  "from": "source-map@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                  "version": "0.5.3"
                 },
                 "slash": {
-                  "version": "1.0.0",
-                  "from": "slash@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "5.8.12",
+              "dependencies": {
+                "core-js": {
+                  "version": "0.9.18"
+                }
+              }
+            },
+            "json-loader": {
+              "version": "0.5.4"
+            },
+            "wpcom-xhr-request": {
+              "version": "0.3.3",
+              "dependencies": {
+                "superagent": {
+                  "version": "1.2.0",
+                  "dependencies": {
+                    "qs": {
+                      "version": "2.3.3"
+                    },
+                    "formidable": {
+                      "version": "1.0.14"
+                    },
+                    "mime": {
+                      "version": "1.3.4"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2"
+                    },
+                    "methods": {
+                      "version": "1.0.1"
+                    },
+                    "cookiejar": {
+                      "version": "2.0.1"
+                    },
+                    "reduce-component": {
+                      "version": "1.0.1"
+                    },
+                    "extend": {
+                      "version": "1.2.1"
+                    },
+                    "form-data": {
+                      "version": "0.2.0",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.9.2"
+                        },
+                        "combined-stream": {
+                          "version": "0.0.7",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5"
+                            }
+                          }
+                        },
+                        "mime-types": {
+                          "version": "2.0.14",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.12.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.27-1",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2"
+                        },
+                        "isarray": {
+                          "version": "0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",
     "wpcom-proxy-request": "1.0.5",
-    "wpcom-unpublished": "1.0.8",
+    "wpcom-unpublished": "1.0.9",
     "wpcom-xhr-request": "0.3.3",
     "xgettext-js": "0.2.2"
   },


### PR DESCRIPTION
Version bump of `wpcom-unpublished` to bring in some changes to `wpcomjs` that add in support for a new "special" param of `apiNamespace`.  Much like `apiVersion`, `apiNamespace` will allow us to route api requests to WP-API endpoints vs legacy wpcom endpoints.

The new param is really the only change to wpcom.js - so a quick test would be to checkout the branch and ensure various pages still load up fine in calypso.

/cc @retrofox @gwwar 