### PR TITLE
Reader: Update popover position to prevent cutoff in narrower viewports

### DIFF
--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -326,7 +326,7 @@ FullPostDialog = React.createClass( {
 			}
 
 			if ( shouldShowShare ) {
-				buttons.push( <ShareButton post={ post } position="bottom right" tagName="div" /> );
+				buttons.push( <ShareButton post={ post } position="bottom left" tagName="div" /> );
 			}
 		}
 

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -326,7 +326,7 @@ FullPostDialog = React.createClass( {
 			}
 
 			if ( shouldShowShare ) {
-				buttons.push( <ShareButton post={ post } position="bottom left" tagName="div" /> );
+				buttons.push( <ShareButton post={ post } position="bottom right" tagName="div" /> );
 			}
 		}
 

--- a/client/reader/post-options/_style.scss
+++ b/client/reader/post-options/_style.scss
@@ -25,7 +25,7 @@
 		color: $blue-medium;
 
 		.gridicon__ellipsis {
-			fill: $blue-medium;
+			fill: $blue-dark;
 			transform: rotate( 90deg );
 		}
 	}

--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -119,8 +119,7 @@ var ReaderShare = React.createClass( {
 					onClose={ this.closeMenu }
 					position={ this.props.position }
 					className="popover reader-share__popover">
-					{ canShareToWordpress ?
-					<PopoverMenuItem action="pressThis" className="reader-share__popover-item">
+					{ canShareToWordpress ? <PopoverMenuItem action="pressThis" className="reader-share__popover-item">
 						<Gridicon icon="my-sites" size={ 24 } /> WordPress</PopoverMenuItem> : null }
 					<PopoverMenuItem action="twitter" className="reader-share__popover-item">
 						<SocialLogo icon="twitter" /> Twitter</PopoverMenuItem>

--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -75,7 +75,7 @@ var ReaderShare = React.createClass( {
 
 	getDefaultProps() {
 		return {
-			position: 'top',
+			position: 'top left',
 			tagName: 'li'
 		};
 	},
@@ -117,8 +117,10 @@ var ReaderShare = React.createClass( {
 				( <PopoverMenu key="menu" context={ this.refs && this.refs.shareButton }
 					isVisible={ this.state.showingMenu }
 					onClose={ this.closeMenu }
-					position={ this.props.position }>
-					{ canShareToWordpress ? <PopoverMenuItem action="pressThis" className="reader-share__popover-item">
+					position={ this.props.position }
+					className="popover reader-share__popover">
+					{ canShareToWordpress ?
+					<PopoverMenuItem action="pressThis" className="reader-share__popover-item">
 						<Gridicon icon="my-sites" size={ 24 } /> WordPress</PopoverMenuItem> : null }
 					<PopoverMenuItem action="twitter" className="reader-share__popover-item">
 						<SocialLogo icon="twitter" /> Twitter</PopoverMenuItem>

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -33,7 +33,7 @@
 	.reader-share .gridicon {
 		left: 6px;
 	}
-	
+
 	.reader-share__button-label {
 		display: none;
 	}

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -18,6 +18,10 @@
 		position: absolute;
 			top: 3px;
 			left: 3px;
+
+		@include breakpoint( "<480px" ) {
+			left: 6px;
+		}
 	}
 
 	.is-active {
@@ -29,31 +33,50 @@
 	}
 }
 
-@include breakpoint( "<480px" ) {
-	.reader-share .gridicon {
-		left: 6px;
-	}
+.reader-share__button-label {
 
-	.reader-share__button-label {
+	@include breakpoint( "<480px" ) {
 		display: none;
 	}
 }
 
+.reader-share__popover {
+
+	@include breakpoint( "<480px" ) {
+		width: 152px;
+		padding-right: 2px;
+	}
+}
+
 .reader-share__popover-item {
+
+	@include breakpoint( "<480px" ) {
+		width: 150px;
+	}
+
 	span {
 		display: inline-block;
 		line-height: 24px;
-		margin-left: 32px;
+		margin-left: 34px;
+
+		@include breakpoint( ">480px" ) {
+			margin-left: 27px;
+		}
 	}
+
 	.gridicon,
 	.social-logo {
 		height: 24px;
 		width: 24px;
 		position: absolute;
 			top: 8px;
-			left: 16px;
+			left: 18px;
 		padding: 0;
 		fill: $gray;
+
+		@include breakpoint( ">480px" ) {
+			left: 11px;
+		}
 	}
 
 	.gridicons-my-sites {


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/2725

**Before:**

iOS:
![ios-share-before](https://cloud.githubusercontent.com/assets/4924246/13232684/1cb78c92-d965-11e5-9949-9452e24060d6.jpg)

Android:
![android-share-before](https://cloud.githubusercontent.com/assets/4924246/13232690/21e5a622-d965-11e5-86d0-e7b908a7c26b.jpg)

**After:**

iOS:
![ios-share-after](https://cloud.githubusercontent.com/assets/4924246/13232723/428c586c-d965-11e5-95b7-8e68362682ba.jpg)

Android:
![android-sharing-after](https://cloud.githubusercontent.com/assets/4924246/13232730/4bd1bc46-d965-11e5-944a-13dac1d1e76f.jpg)

**EDIT:**
The Share popover gets cut off much more in narrow screens - meaning, there's a much larger crop on an iPhone 5 vs a 6, but I tested on both. For Android, tested on a Samsung Note 4.

