### PR TITLE
Purchases: Update support link to use new Calypso Help page

### DIFF
--- a/client/me/purchases/cancel-purchase/support-box.jsx
+++ b/client/me/purchases/cancel-purchase/support-box.jsx
@@ -21,7 +21,7 @@ const CancelPurchaseSupportBox = React.createClass( {
 	},
 
 	render() {
-		const contactSupportUrl = 'https://support.wordpress.com/';
+		const contactSupportUrl = '/help/contact';
 
 		return (
 			<div className="cancel-purchase-support-box">


### PR DESCRIPTION
Currently, when users are cancelling a product, they're directed to contact support at the old URL https://support.wordpress.com/.

<img width="754" alt="screen shot 2016-02-22 at 16 58 00" src="https://cloud.githubusercontent.com/assets/7240478/13237001/7c3e18a0-d985-11e5-8c01-d573013286ba.png">

This updates the value of `contactSupportUrl` to the new URL https://wordpress.com/help/contact. I chose https://wordpress.com/help/contact instead of https://wordpress.com/help/ since the former is what I would expect to reach if I clicked a link for "Contact Support."