### PR TITLE
Framework: enable redux persistence on horizon and dev

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -87,7 +87,7 @@
 		"olark": true,
 		"olark_use_wpcom_configuration": true,
 		"perfmon": false,
-		"persist-redux": false,
+		"persist-redux": true,
 		"phone_signup": true,
 		"post-editor": true,
 		"post-editor-github-link": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -63,7 +63,7 @@
 		"olark": true,
 		"olark_use_wpcom_configuration": true,
 		"perfmon": true,
-		"persist-redux": false,
+		"persist-redux": true,
 		"phone_signup": false,
 		"post-editor": true,
 		"post-editor/iframe-preview": true,


### PR DESCRIPTION
This PR turns on redux-persistence for horizon and development environments. 

## Before Merging:
- [x] #3267 update our approach to data doc
- [x] #3271 simple max age mechanism to throw out data
- [x] #3343 separate server state hydration

### State Tree Status

- [x] application - never persisted
- [x] current-user - persisted with schema checks
- [x] notices - never persisted
- [x] plugins - not persisted, needs schema PR
- [x] post-types - persisted with schema checks
- [x] posts - not persisted, in progress schema PR #3487
- [x] receipts -  not persisted, needs a schema PR
- [x] sharing/publicize - not persisted, in progress schema PR #3357
- [x] site-settings/exporter - not persisted, needs a schema PR
- [x] sites/plans - not persisted, schema PR blocked by #2757
- [x] sites - not persisted, see: #3624 #2757. Themes currently expects decorated sites decorated sites, and needs to be refactored.
- [x] support - not persisted, needs a schema PR
- [x] themes - not persisted, schema PR #3403
- [x] ui - never persisted #3337
- [x] users - not persisted, needs a schema PR

cc @rralian 