### PR TITLE
Use scrollIntoViewIfNeeded() on Reader comment box focus to prevent Android soft keyboard from obscuring textarea

### DIFF
--- a/client/reader/comments/form.jsx
+++ b/client/reader/comments/form.jsx
@@ -56,8 +56,13 @@ var PostCommentForm = React.createClass( {
 		this.updateCommentText();
 	},
 
-	handleFocus: function() {
+	handleFocus: function( event ) {
 		this.toggleButtonVisibility( true );
+
+		// Prevent Android devices obscuring the input with the on-screen keyboard
+		if ( Element.prototype.scrollIntoViewIfNeeded ) {
+			event.target.scrollIntoViewIfNeeded();
+		}
 	},
 
 	handleBlur: function() {


### PR DESCRIPTION
Currently, when focusing on the Reader comment box on some Android devices, the soft keyboard overlaps the comment box (see #2677).

This PR uses scrollIntoViewIfNeeded() where available to scroll the comment box into view on focus.

Fixes #2677.
