### PR TITLE
Change domain registration details into contact information

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -65,7 +65,7 @@ export default React.createClass( {
 	},
 
 	componentDidMount() {
-		analytics.pageView.record( '/checkout/domain-registration-details', 'Checkout > Domain Registration Details' );
+		analytics.pageView.record( '/checkout/domain-contact-information', 'Checkout > Domain Contact Information' );
 	},
 
 	validate( fieldNames, onComplete ) {
@@ -149,7 +149,7 @@ export default React.createClass( {
 						'Registering this domain for a company? + Add Organization Name',
 						'Registering these domains for a company? + Add Organization Name',
 						{
-							context: 'Domain registration details page',
+							context: 'Domain contact information page',
 							comment: 'Count specifies the number of domain registrations',
 							count: this.getNumberOfDomainRegistrations(),
 							textOnly: true
@@ -272,9 +272,9 @@ export default React.createClass( {
 			<PaymentBox
 				classSet={ classSet }
 				title={ this.translate(
-					'Domain Registration Details',
+					'Domain Contact Information',
 					{
-						context: 'Domain registration details page',
+						context: 'Domain contact information page',
 						textOnly: true
 					} ) }>
 				{ this.content() }


### PR DESCRIPTION
This updates the copy as suggested in #2320. 

I'm not sure about the analytics code so if @gziolo could let me know that would be great. It also appears that some of the re-factoring @stephanethomas mentioned has already been done. Such as `validateDomainContactInformation` 

![screenshot_22-02-2016-19 33 30](https://cloud.githubusercontent.com/assets/150348/13241046/7380cbc4-d99c-11e5-9bec-035f32e4550b.png)


