### PR TITLE
Checkout: Add missing jquery dependency for paygate.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "inherits": "2.0.1",
     "jade": "pugjs/jade#29784fd",
     "jed": "1.0.2",
+    "jquery": "1.11.3",
     "jshashes": "1.0.5",
     "json-loader": "0.5.4",
     "jstimezonedetect": "1.0.5",


### PR DESCRIPTION
Fixes missing jQuery dependency introduced in #3456.

<img width="802" alt="screen shot 2016-02-23 at 10 09 44" src="https://cloud.githubusercontent.com/assets/699132/13249352/14b2ce34-da24-11e5-9468-a2e6ffa192bf.png">

### Testing wp-calypso
It shouldn't show up anymore when executing `make run` in wp-calypso`.

### Testing wp-desktop
1. Checkout `fix/3456-add-missing-jquery-dependency` branch in `calypso` folder.
3. Execute `make run`.
4. Try to purchase any upgrade.
5. Provide data for new credit card to finalise purchase and click purchase button.
6. Purchase should complete.