### PR TITLE
Revert "Checkout: Make it possible to expose jQuery for paygate.js script"

### DIFF
--- a/client/lib/load-script/index.js
+++ b/client/lib/load-script/index.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependency.
- */
-var config = require( 'config' );
-
-/**
  * A little module for loading a external script
  */
 
@@ -50,11 +45,6 @@ var loadScript = function( url, callback ) {
 };
 
 var loadjQueryDependentScript = function( scriptURL, callback ) {
-	// It is not possible to expose jQuery globally in Electron App: https://github.com/atom/electron/issues/254.
-	// It needs to be loaded using require and npm package.
-	if ( config.isEnabled( 'desktop' ) ) {
-		window.jQuery = require( 'jquery' );
-	}
 	if ( window.jQuery ) {
 		loadScript( scriptURL, callback );
 		return;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#3456

Breaks the build in production
```
ERROR in ./client/lib/load-script/index.js
Module not found: Error: Cannot resolve module 'jquery' in /Users/tug/Work/Automattic/wp-calypso/client/lib/load-script
 @ ./client/lib/load-script/index.js 58:18-35
```