### PR TITLE
Revert "Revert "Checkout: Add missing jquery dependency for paygate.js""

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "inherits": "2.0.1",
     "jade": "pugjs/jade#29784fd",
     "jed": "1.0.2",
+    "jquery": "1.11.3",
     "jshashes": "1.0.5",
     "json-loader": "0.5.4",
     "jstimezonedetect": "1.0.5",


### PR DESCRIPTION
Reverts Automattic/wp-calypso#3498

Production now builds fine. We should try to reapply this fix https://github.com/Automattic/wp-calypso/pull/3497