### PR TITLE
Framework: Fix error during build in desktop environment

### DIFF
--- a/server/user-bootstrap/shared-utils.js
+++ b/server/user-bootstrap/shared-utils.js
@@ -1,1 +1,1 @@
-export * from 'client/lib/user/shared-utils';
+export * from 'lib/user/shared-utils';


### PR DESCRIPTION
This PR fixes the following error which appears when building calypso for the desktop environment:
```
ERROR in ./calypso/server/user-bootstrap/shared-utils.js
Module not found: Error: Cannot resolve module 'client/lib/user/shared-utils' in /Users/tug/Work/Automattic/wp-desktop/calypso/server/user-bootstrap
 @ ./calypso/server/user-bootstrap/shared-utils.js 11:32-71
```

#### Testing Instructions
From wp-desktop:
- `cd calypso && git fetch -a && git checkout fix/cannot-resolve-shared-utils && cd ..`
- `make run`
Assert that this removes this error which currently appears during the build (it does not seem to make the build stop or the app crash at the moment)

cc: @mkaz, @scruffian 