### PR TITLE
Checkout: Extract header from Thank You page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -261,6 +261,7 @@
 @import 'my-sites/upgrades/checkout/stored-card';
 @import 'my-sites/upgrades/checkout/subscription-text';
 @import 'my-sites/upgrades/checkout-thank-you/style';
+@import 'my-sites/upgrades/checkout-thank-you/header/style';
 @import 'my-sites/upgrades/domain-management/transfer/style';
 @import 'my-sites/stats/stats-list/style';
 @import 'notices/style';

--- a/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const CheckoutThankYouHeader = React.createClass( {
+	propTypes: {
+		isDataLoaded: React.PropTypes.bool.isRequired,
+		isFreeTrial: React.PropTypes.bool.isRequired,
+		productName: React.PropTypes.string.isRequired
+	},
+
+	renderHeading() {
+		let heading = this.translate( 'Thank you for your purchase!' );
+
+		if ( ! this.props.isDataLoaded ) {
+			heading = this.translate( 'Loading…' );
+		} else if ( this.props.isFreeTrial ) {
+			heading = this.translate( 'Your 14 day free trial starts today!' );
+		}
+
+		return (
+			<h1 className="checkout-thank-you-header__heading">
+				{ heading }
+			</h1>
+		);
+	},
+
+	renderText: function() {
+		let text = this.translate( "You will receive an email confirmation shortly. What's next?" );
+
+		if ( ! this.props.isDataLoaded ) {
+			text = this.translate( 'Loading…' );
+		} else if ( this.props.productName ) {
+			if ( this.props.isFreeTrial ) {
+				text = this.translate( "We hope you enjoy %(productName)s. What's next? Take it for a spin!", {
+					args: {
+						productName: this.props.productName
+					}
+				} );
+			} else {
+				text = this.translate(
+					"You will receive an email confirmation shortly for your purchase of %(productName)s. What's next?", {
+						args: {
+							productName: this.props.productName
+						}
+					}
+				);
+			}
+		}
+
+		return (
+			<h2 className="checkout-thank-you-header__text">
+				{ text }
+			</h2>
+		);
+	},
+
+	render() {
+		return (
+			<div className="checkout-thank-you-header">
+				<span className="checkout-thank-you-header__icon"></span>
+				{ this.renderHeading() }
+				{ this.renderText() }
+			</div>
+		);
+	}
+} );
+
+export default CheckoutThankYouHeader;

--- a/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classNames';
 import React from 'react';
 
 const CheckoutThankYouHeader = React.createClass( {
@@ -45,8 +46,12 @@ const CheckoutThankYouHeader = React.createClass( {
 	},
 
 	render() {
+		const classes = {
+			'checkout-thank-you-header': true,
+			'is-placeholder': ! this.props.isDataLoaded
+		}
 		return (
-			<div className="checkout-thank-you-header">
+			<div className={ classNames( classes ) }>
 				<span className="checkout-thank-you-header__icon"/>
 				<h1 className="checkout-thank-you-header__heading">
 					{ this.renderHeading() }

--- a/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
@@ -11,35 +11,27 @@ const CheckoutThankYouHeader = React.createClass( {
 	},
 
 	renderHeading() {
-		let heading = this.translate( 'Thank you for your purchase!' );
-
 		if ( ! this.props.isDataLoaded ) {
-			heading = this.translate( 'Loading…' );
+			return this.translate( 'Loading…' );
 		} else if ( this.props.isFreeTrial ) {
-			heading = this.translate( 'Your 14 day free trial starts today!' );
+			return this.translate( 'Your 14 day free trial starts today!' );
 		}
 
-		return (
-			<h1 className="checkout-thank-you-header__heading">
-				{ heading }
-			</h1>
-		);
+		return this.translate( 'Thank you for your purchase!' );
 	},
 
-	renderText: function() {
-		let text = this.translate( "You will receive an email confirmation shortly. What's next?" );
-
+	renderText() {
 		if ( ! this.props.isDataLoaded ) {
-			text = this.translate( 'Loading…' );
+			return this.translate( 'Loading…' );
 		} else if ( this.props.productName ) {
 			if ( this.props.isFreeTrial ) {
-				text = this.translate( "We hope you enjoy %(productName)s. What's next? Take it for a spin!", {
+				return this.translate( "We hope you enjoy %(productName)s. What's next? Take it for a spin!", {
 					args: {
 						productName: this.props.productName
 					}
 				} );
 			} else {
-				text = this.translate(
+				return this.translate(
 					"You will receive an email confirmation shortly for your purchase of %(productName)s. What's next?", {
 						args: {
 							productName: this.props.productName
@@ -49,19 +41,19 @@ const CheckoutThankYouHeader = React.createClass( {
 			}
 		}
 
-		return (
-			<h2 className="checkout-thank-you-header__text">
-				{ text }
-			</h2>
-		);
+		return this.translate( "You will receive an email confirmation shortly. What's next?" );
 	},
 
 	render() {
 		return (
 			<div className="checkout-thank-you-header">
-				<span className="checkout-thank-you-header__icon"></span>
-				{ this.renderHeading() }
-				{ this.renderText() }
+				<span className="checkout-thank-you-header__icon"/>
+				<h1 className="checkout-thank-you-header__heading">
+					{ this.renderHeading() }
+				</h1>
+				<h2 className="checkout-thank-you-header__text">
+					{ this.renderText() }
+				</h2>
 			</div>
 		);
 	}

--- a/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
@@ -7,7 +7,7 @@ const CheckoutThankYouHeader = React.createClass( {
 	propTypes: {
 		isDataLoaded: React.PropTypes.bool.isRequired,
 		isFreeTrial: React.PropTypes.bool.isRequired,
-		productName: React.PropTypes.string.isRequired
+		productName: React.PropTypes.string
 	},
 
 	renderHeading() {

--- a/client/my-sites/upgrades/checkout-thank-you/header/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/header/style.scss
@@ -1,0 +1,71 @@
+.checkout-thank-you-header {
+	border-bottom: 1px solid lighten( $gray, 30% );
+	padding-bottom: 20px;
+}
+
+.checkout-thank-you-header__icon {
+	display: inline-block;
+	position: relative;
+
+	&::before {
+		@include noticon( '\f425', 70px );
+		color: lighten( $gray, 20% );
+	}
+
+	&::after {
+		@include noticon( '\f418', 18px );
+		background: #53b66c;
+		border-radius: 18px;
+		color: $white;
+		position: absolute;
+		top: 6px;
+		right: 15px;
+		width: 18px;
+		height: 18px;
+	}
+}
+
+.checkout-thank-you-header__heading {
+	font-size: 25px;
+	font-weight: 100;
+	margin: 0;
+}
+
+.checkout-thank-you-header__text {
+	font-size: 20px;
+	font-weight: 200;
+	opacity: 0.6;
+	margin: auto;
+	max-width: 50%;
+}
+
+.checkout-thank-you-header__heading,
+.checkout-thank-you-header__text {
+	color: $gray-dark;
+
+	@include breakpoint( "<660px" ) {
+		font-size: 17px;
+		max-width: 100%;
+	}
+}
+
+.checkout-thank-you {
+	&.is-placeholder {
+		.checkout-thank-you-header__heading,
+		.checkout-thank-you-header__text {
+			@include placeholder( 23% );
+
+			display: block;
+			margin: 0 auto;
+		}
+
+		.checkout-thank-you-header__heading {
+			width: 50%;
+		}
+
+		.checkout-thank-you-header__text {
+			margin-top: 15px;
+			width: 40%;
+		}
+	}
+}

--- a/client/my-sites/upgrades/checkout-thank-you/header/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/header/style.scss
@@ -49,23 +49,21 @@
 	}
 }
 
-.checkout-thank-you {
-	&.is-placeholder {
-		.checkout-thank-you-header__heading,
-		.checkout-thank-you-header__text {
-			@include placeholder( 23% );
+.checkout-thank-you-header.is-placeholder {
+	.checkout-thank-you-header__heading,
+	.checkout-thank-you-header__text {
+		@include placeholder( 23% );
 
-			display: block;
-			margin: 0 auto;
-		}
+		display: block;
+		margin: 0 auto;
+	}
 
-		.checkout-thank-you-header__heading {
-			width: 50%;
-		}
+	.checkout-thank-you-header__heading {
+		width: 50%;
+	}
 
-		.checkout-thank-you-header__text {
-			margin-top: 15px;
-			width: 40%;
-		}
+	.checkout-thank-you-header__text {
+		margin-top: 15px;
+		width: 40%;
 	}
 }

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -17,6 +17,7 @@ var activated = require( 'state/themes/actions' ).activated,
 	analytics = require( 'analytics' ),
 	BusinessPlanDetails = require( './business-plan-details' ),
 	ChargebackDetails = require( './chargeback-details' ),
+	CheckoutThankYouHeader = require( './header' ),
 	DomainMappingDetails = require( './domain-mapping-details' ),
 	DomainRegistrationDetails = require( './domain-registration-details' ),
 	getReceiptById = require( 'state/receipts/selectors' ).getReceiptById,
@@ -90,54 +91,6 @@ var CheckoutThankYou = React.createClass( {
 		}
 	},
 
-	thankYouHeader: function() {
-		if ( ! this.isDataLoaded() ) {
-			return <h1 className="checkout-thank-you__header">{ this.translate( 'Loading…' ) }</h1>;
-		}
-
-		if ( this.freeTrialWasPurchased() ) {
-			return (
-				<h1 className="checkout-thank-you__header">
-					{
-						this.translate( 'Your 14 day free trial starts today!' )
-					}
-				</h1>
-			);
-		}
-		return <h1 className="checkout-thank-you__header">{ this.translate( 'Thank you for your purchase!' ) }</h1>
-	},
-
-	thankYouSubHeader: function() {
-		var productName,
-			headerText;
-
-		if ( ! this.isDataLoaded() ) {
-			return <h2 className="checkout-thank-you__subheader">{ this.translate( 'Loading…' ) }</h2>;
-		}
-
-		productName = this.getSingleProductName();
-
-		if ( this.freeTrialWasPurchased() && productName ) {
-			headerText = this.translate( 'We hope you enjoy %(productName)s. What\'s next? Take it for a spin!', {
-				args: {
-					productName: productName
-				}
-			} );
-		} else if ( productName ) {
-			headerText = this.translate( 'You will receive an email confirmation shortly for your purchase of ' +
-				"%(productName)s. What's next?", {
-					args: {
-						productName: productName
-					}
-				}
-			);
-		} else {
-			headerText = this.translate( 'You will receive an email confirmation shortly. What\'s next?' );
-		}
-
-		return <h2 className="checkout-thank-you__subheader">{ headerText }</h2>
-	},
-
 	getSingleProductName() {
 		if ( this.props.receiptId && getPurchases( this.props ).length ) {
 			return getPurchases( this.props )[ 0 ].productNameShort;
@@ -154,11 +107,11 @@ var CheckoutThankYou = React.createClass( {
 		return (
 			<Main className={ classes }>
 				<Card>
-					<div className="checkout-thank-you__message">
-						<span className="checkout-thank-you__receipt-icon"></span>
-						{ this.thankYouHeader() }
-						{ this.thankYouSubHeader() }
-					</div>
+					<CheckoutThankYouHeader
+						isDataLoaded={ this.isDataLoaded() }
+						isFreeTrial={ this.freeTrialWasPurchased() }
+						productName={ this.getSingleProductName() } />
+
 					{ this.productRelatedMessages() }
 				</Card>
 

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -92,7 +92,7 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	getSingleProductName() {
-		if ( this.props.receiptId && getPurchases( this.props ).length ) {
+		if ( this.isDataLoaded() && getPurchases( this.props ).length ) {
 			return getPurchases( this.props )[ 0 ].productNameShort;
 		}
 
@@ -124,7 +124,7 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	freeTrialWasPurchased: function() {
-		if ( ! this.props.receiptId ) {
+		if ( ! this.isDataLoaded() ) {
 			return false;
 		}
 

--- a/client/my-sites/upgrades/checkout-thank-you/style.scss
+++ b/client/my-sites/upgrades/checkout-thank-you/style.scss
@@ -8,25 +8,6 @@
 		max-width: 960px;
 	}
 
-	&.is-placeholder {
-		.checkout-thank-you__header,
-		.checkout-thank-you__subheader {
-			@include placeholder( 23% );
-
-			display: block;
-			margin: 0 auto;
-		}
-
-		.checkout-thank-you__header {
-			width: 50%;
-		}
-
-		.checkout-thank-you__subheader {
-			margin-top: 15px;
-			width: 40%;
-		}
-	}
-
 	@include breakpoint( "<660px" ) {
 		background: transparent;
 		padding: 14px;
@@ -73,30 +54,6 @@
 	}
 }
 
-.checkout-thank-you__header {
-	font-size: 25px;
-	font-weight: 100;
-	margin: 0;
-}
-
-.checkout-thank-you__subheader {
-	font-size: 20px;
-	font-weight: 200;
-	opacity: 0.6;
-	margin: auto;
-	max-width: 50%;
-}
-
-.checkout-thank-you__header,
-.checkout-thank-you__subheader {
-	color: $gray-dark;
-
-	@include breakpoint( "<660px" ) {
-		font-size: 17px;
-		max-width: 100%;
-	}
-}
-
 .checkout-thank-you__purchase-details-list {
 	list-style: none;
 	margin: 0;
@@ -105,33 +62,6 @@
 	@include breakpoint( "<660px" ) {
 		display: inline-block;
 		margin: 0 0 10px 0;
-	}
-}
-
-.checkout-thank-you__message {
-	border-bottom: 1px solid lighten( $gray, 30% );
-	padding-bottom: 20px;
-}
-
-.checkout-thank-you__receipt-icon {
-	display: inline-block;
-	position: relative;
-
-	&::before {
-		@include noticon( '\f425', 70px );
-		color: lighten( $gray, 20% );
-	}
-
-	&::after {
-		@include noticon( '\f418', 18px );
-		background: #53b66c;
-		border-radius: 18px;
-		color: $white;
-		position: absolute;
-			top: 6px;
-			right: 15px;
-		width: 18px;
-		height: 18px;
 	}
 }
 


### PR DESCRIPTION
This pull request addresses part of #2484 by moving the code for the header of the `Thank You` page into its own component. This is an attempt at reducing the size of the `<CheckoutThankYou />` component as well as preparing the ground for the redesign of this page. This new component will indeed receive additional logic soon to be able to handle more products.
 
![Screenshot](https://cloud.githubusercontent.com/assets/3011211/9550612/308ccb6e-4d61-11e5-91a9-960994a81555.png)
  
#### Testing instructions
 
1. Run `git checkout add/header-thank-you-page` and start your server
2. Purchase any type of product
3. Check that the `Thank You` page displays as usual
 
#### Reviews
 
- [x] Code
- [x] Product
