### PR TITLE
Domain Search: Add a/b test for showing 10 results instead of 4

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -28,6 +28,7 @@ var wpcom = require( 'lib/wp' ).undocumented(),
 	upgradesActions = require( 'lib/upgrades/actions' ),
 	cartItems = require( 'lib/cart-values/cart-items' ),
 	abtest = require( 'lib/abtest' ).abtest;
+
 // max amount of domain suggestions we should fetch/display
 var SUGGESTION_QUANTITY = 4,
 	INITIAL_SUGGESTION_QUANTITY = 2;
@@ -246,6 +247,10 @@ var RegisterDomainStep = React.createClass( {
 					} );
 				},
 				callback => {
+					if ( abtest( 'domainSearchResultsCount' ) === 'moreResults' ) {
+						SUGGESTION_QUANTITY = 10;
+					}
+
 					const params = {
 						quantity: SUGGESTION_QUANTITY,
 						includeWordPressDotCom: this.props.includeWordPressDotCom

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -99,4 +99,12 @@ module.exports = {
 		},
 		defaultVariation: 'allPlans'
 	},
+	domainSearchResultsCount: {
+		datestamp: '20160223',
+		variations: {
+			original: 50,
+			moreResults: 50
+		},
+		defaultVariation: 'original'
+	},
 };


### PR DESCRIPTION
This PR starts an A/B test for showing 10 domain search results instead of 4. 

`original` | `moreResults`
------------ | -------------
<img width="560" alt="screen shot 2016-02-23 at 6 51 04 am" src="https://cloud.githubusercontent.com/assets/3011211/13255677/fe48a894-d9fb-11e5-9f78-6f548eb3dd9a.png"> | <img width="556" alt="screen shot 2016-02-23 at 6 52 08 am" src="https://cloud.githubusercontent.com/assets/3011211/13255678/fe694cca-d9fb-11e5-98d9-fb71044ee43a.png">

To test:
- Original: `localStorage.setItem( 'ABTests', '{"domainSearchResultsCount_20160223":"original"}' );`
- Variation: `localStorage.setItem( 'ABTests', '{"domainSearchResultsCount_20160223":"moreResults"}' );`

cc: @lucasartoni @mikeshelton1503