### PR TITLE
Checkout: Make it possible to expose jQuery for paygate.js script

### DIFF
--- a/client/lib/load-script/index.js
+++ b/client/lib/load-script/index.js
@@ -2,6 +2,11 @@
  * A little module for loading a external script
  */
 
+/**
+ * Internal dependency.
+ */
+var config = require( 'config' );
+
 var JQUERY_URL = 'https://s0.wp.com/wp-includes/js/jquery/jquery.js',
 	callbacksForURLsInProgress = {};
 
@@ -45,6 +50,11 @@ var loadScript = function( url, callback ) {
 };
 
 var loadjQueryDependentScript = function( scriptURL, callback ) {
+	// It is not possible to expose jQuery globally in Electron App: https://github.com/atom/electron/issues/254.
+	// It needs to be loaded using require and npm package.
+	if ( config.isEnabled( 'desktop' ) ) {
+		window.$ = window.jQuery = require( 'jquery' );
+	}
 	if ( window.jQuery ) {
 		loadScript( scriptURL, callback );
 		return;

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "inherits": "2.0.1",
     "jade": "pugjs/jade#29784fd",
     "jed": "1.0.2",
+    "jquery": "1.11.3",
     "jshashes": "1.0.5",
     "json-loader": "0.5.4",
     "jstimezonedetect": "1.0.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,6 +88,9 @@ if ( CALYPSO_ENV === 'desktop' || CALYPSO_ENV === 'desktop-mac-app-store' ) {
 	webpackConfig.entry.vendor = [ 'react', 'store', 'page', 'wpcom-unpublished', 'jed', 'debug' ];
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( 'vendor', '[name].[hash].js' ) );
 	webpackConfig.plugins.push( new ChunkFileNamePlugin() );
+	// jquery is only needed in the build for the desktop app
+	// see electron bug: https://github.com/atom/electron/issues/254
+	webpackConfig.externals.push( 'jquery' );
 }
 
 jsLoader = {


### PR DESCRIPTION
Another try to fix https://github.com/Automattic/wp-calypso/issues/3405.

It fixes the following issue:

> When I click the Pay button after filling the credit card details, a blue notice saying "Submitting payment" appears but nothing happens. I've tried several times and users are not charged, and nothing happens even after waiting 3-5 minutes.

This is a well known bug when using Electron:
https://github.com/atom/electron/issues/254

### Testing Desktop
1. Checkout `fix/3405-paygate-jquery-issue` branch in `calypso` folder.
2. Checkout `master` branch in main folder.
3. Make sure you have store sandbox enabled.
4. Execute `make run`.
5. Try to purchase any upgrade.
6. Provide data for new credit card to finalise purchase.
7. Purchase should be possible.

### Testing Calypso web
1. Checkout `fix/3405-paygate-jquery-issue` in wp-calypso
2. Execute `make run`.
3. Navigate to http://calypso.localhost:3000/
4. Try to purchase any upgrade.
5. Provide data for new credit card to finalise purchase.
6. Purchase should be possible.

### Testing Production build
1. From wp-calypso, run `CALYPSO_ENV=production make build`
2. Build should not print any error

### Reviews
- [x] Product Review
- [x] Code Review

/cc @peterbutler @Tug 