### PR TITLE
Framework: Add fn to remove sidebar

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -21,6 +21,7 @@ import Sidebar from './sidebar';
 import FormStateExamplesComponent from './form-state-examples';
 import { setSection } from 'state/ui/actions';
 import EmptyContent from 'components/empty-content';
+import { removeSidebar } from 'lib/react-helpers';
 
 const devdocs = {
 
@@ -133,11 +134,7 @@ const devdocs = {
 	},
 
 	pleaseLogIn: function( context ) {
-		context.store.dispatch( setSection( 'devdocs-start', {
-			hasSidebar: false
-		} ) );
-
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+		removeSidebar( context, { section: 'devdocs-start' } );
 
 		ReactDom.render(
 			React.createElement( EmptyContent, {

--- a/client/lib/react-helpers/index.js
+++ b/client/lib/react-helpers/index.js
@@ -5,6 +5,11 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
+/**
+ * Internal dependencies
+ */
+import { setSection } from 'state/ui/actions';
+
 export default {
 	renderWithReduxStore( reactElement, domContainer, reduxStore ) {
 		const domContainerNode = ( 'string' === typeof domContainer )
@@ -15,5 +20,25 @@ export default {
 			React.createElement( ReduxProvider, { store: reduxStore }, reactElement ),
 			domContainerNode
 		);
+	},
+
+	removeSidebar(
+		context,
+		options = {
+			section: null,
+			isFullScreen: null
+		}
+	) {
+		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+
+		let sectionOptions = {
+			hasSidebar: false
+		};
+
+		if ( options.isFullScreen !== null ) {
+			sectionOptions.isFullScreen = options.isFullScreen;
+		}
+
+		context.store.dispatch( setSection( options.section, sectionOptions ) );
 	}
 };

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import ReactDom from 'react-dom';
 import React from 'react';
 import includes from 'lodash/includes';
 import page from 'page';
@@ -21,6 +20,7 @@ import userSettings from 'lib/user-settings';
 import titleActions from 'lib/screen-title/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { setSection } from 'state/ui/actions';
+import { removeSidebar } from 'lib/react-helpers';
 
 const ANALYTICS_PAGE_TITLE = 'Me',
 	devices = devicesFactory(),
@@ -332,8 +332,7 @@ export default {
 		titleActions.setTitle( i18n.translate( 'Next Steps', { textOnly: true } ) );
 
 		if ( isWelcome ) {
-			ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-			context.store.dispatch( setSection( null, { hasSidebar: false } ) );
+			removeSidebar( context );
 		}
 
 		analytics.tracks.recordEvent( 'calypso_me_next_view', { is_welcome: isWelcome } );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -20,7 +20,8 @@ var user = require( 'lib/user' )(),
 	config = require( 'config' ),
 	analytics = require( 'analytics' ),
 	siteStatsStickyTabActions = require( 'lib/site-stats-sticky-tab/actions' ),
-	trackScrollPage = require( 'lib/track-scroll-page' );
+	trackScrollPage = require( 'lib/track-scroll-page' ),
+	removeSidebar = require( 'lib/react-helpers' ).removeSidebar;
 
 /**
  * The main navigation of My Sites consists of a component with
@@ -43,18 +44,10 @@ function renderNavigation( context, allSitesPath, siteBasePath ) {
 	);
 }
 
-function removeSidebar( context ) {
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-
-	context.store.dispatch( uiActions.setSection( 'sites', {
-		hasSidebar: false
-	} ) );
-}
-
 function renderEmptySites( context ) {
 	var NoSitesMessage = require( 'components/empty-content/no-sites-message' );
 
-	removeSidebar( context );
+	removeSidebar( context, { section: 'sites' } );
 
 	ReactDom.render(
 		React.createElement( NoSitesMessage ),
@@ -67,7 +60,7 @@ function renderNoVisibleSites( context ) {
 		currentUser = user.get(),
 		hiddenSites = currentUser.site_count - currentUser.visible_site_count;
 
-	removeSidebar( context );
+	removeSidebar( context, { section: 'sites' } );
 
 	ReactDom.render(
 		React.createElement( EmptyContentComponent, {
@@ -271,10 +264,8 @@ module.exports = {
 		 * Sites is rendered on #primary but it doesn't expect a sidebar to exist
 		 * so section needs to be set explicitly and #secondary cleaned up
 		 */
-		context.store.dispatch( uiActions.setSection( 'sites', {
-			hasSidebar: false
-		} ) );
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+		removeSidebar( context, { section: 'sites' } );
+
 		layoutFocus.set( 'content' );
 
 		// This path sets the URL to be visited once a site is selected

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import ReactDom from 'react-dom';
 import React from 'react';
 import store from 'store';
 import page from 'page';
@@ -12,7 +11,6 @@ import page from 'page';
 import i18n from 'lib/mixins/i18n';
 import titleActions from 'lib/screen-title/actions';
 import InviteAccept from 'my-sites/invites/invite-accept';
-import { setSection } from 'state/ui/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 import { acceptInvite as acceptInviteAction } from 'lib/invites/actions';
@@ -21,6 +19,7 @@ import i18nUtils from 'lib/i18n-utils';
 import pick from 'lodash/pick';
 import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
+import { removeSidebar } from 'lib/react-helpers';
 
 /**
  * Module variables
@@ -65,8 +64,7 @@ export function acceptInvite( context ) {
 
 	titleActions.setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) );
 
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
+	removeSidebar( context );
 
 	renderWithReduxStore(
 		React.createElement(

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -18,7 +18,8 @@ var analytics = require( 'analytics' ),
 	setSection = require( 'state/ui/actions' ).setSection,
 	plansList = require( 'lib/plans-list' )(),
 	productsList = require( 'lib/products-list' )(),
-	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore;
+	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
+	removeSidebar = require( 'lib/react-helpers' ).removeSidebar;
 
 module.exports = {
 
@@ -211,7 +212,6 @@ module.exports = {
 			receiptId = Number( context.params.receiptId );
 
 		analytics.pageView.record( basePath, 'Checkout Thank You' );
-		context.store.dispatch( setSection( 'checkout-thank-you', { hasSidebar: false } ) );
 
 		titleActions.setTitle( i18n.translate( 'Thank You' ) );
 
@@ -226,7 +226,7 @@ module.exports = {
 			context.store
 		);
 
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+		removeSidebar( context, { section: 'checkout-thank-you'} );
 	},
 
 	redirectIfNoSite: function( redirectTo ) {

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -20,8 +20,8 @@ var actions = require( 'lib/posts/actions' ),
 	titleActions = require( 'lib/screen-title/actions' ),
 	sites = require( 'lib/sites-list' )(),
 	user = require( 'lib/user' )(),
-	setSection = require( 'state/ui/actions' ).setSection,
-	analytics = require( 'analytics' );
+	analytics = require( 'analytics' ),
+	removeSidebar = require( 'lib/react-helpers' ).removeSidebar;
 
 import {
 	setEditingMode,
@@ -44,9 +44,8 @@ function determinePostType( context ) {
 }
 
 function renderEditor( context, postType ) {
-	context.store.dispatch( setSection( 'post' ) );
+	removeSidebar( context, { section: 'post' } );
 
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 	ReactDom.render(
 		React.createElement( ReduxProvider, { store: context.store },
 			React.createElement( PreferencesData, null,

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -21,7 +21,7 @@ import JetpackConnect from './jetpack-connect';
 import utils from './utils';
 import userModule from 'lib/user';
 import titleActions from 'lib/screen-title/actions';
-import { setSection } from 'state/ui/actions';
+import { removeSidebar } from 'lib/react-helpers';
 const user = userModule();
 
 /**
@@ -85,14 +85,11 @@ export default {
 
 		analytics.pageView.record( basePath, basePageTitle + ' > Start > ' + flowName + ' > ' + stepName );
 
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+		removeSidebar( context, { section: 'signup' } );
+
 		layoutFocus.set( 'content' );
 
 		titleActions.setTitle( i18n.translate( 'Create an account' ) );
-
-		context.store.dispatch( setSection( 'signup', {
-			hasSidebar: false
-		} ) );
 
 		ReactDom.render(
 			React.createElement( ReduxProvider, { store: context.store },


### PR DESCRIPTION
At many places in Calypso codebase, the same two lines were repeated.
They were meant to remove (hide) sidebar. I've created a helper method
which removes (hides) the sidebar and refactored the whole Calypso
codebase to use this new method.

## Testing

Checkout the `add/remove-sidebar` branch and visit all the touched parts of the code. Is the sidebar properly hidden?