### PR TITLE
Reader: Fix immutable usage in the recommended-sites-store.

### DIFF
--- a/client/lib/recommended-sites-store/store.js
+++ b/client/lib/recommended-sites-store/store.js
@@ -42,7 +42,7 @@ function receiveRecommendations( data ) {
 		recommendations = recommendations.union( fromJS( pruned ) );
 
 		if ( recommendations !== previousRecs ) {
-			if ( recommendations.length >= MAX_RECOMMENDATIONS ) {
+			if ( recommendations.count() >= MAX_RECOMMENDATIONS ) {
 				store.setIsLastPage( true );
 			}
 			page++;


### PR DESCRIPTION
Length has been deprecated for count() - or size?. Use count() because it's less fraught with peril.

Fixes #3493