### PR TITLE
Themes: Render logged-out layout last

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -89,7 +89,6 @@ function setUpContext( layout, reduxStore ) {
 	page( '*', function( context, next ) {
 		var parsed = url.parse( location.href, true );
 
-		context.layout = layout;
 		context.store = reduxStore;
 
 		// Break routing and do full page load for logout link in /me

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -202,10 +202,10 @@ function reduxStoreReady( reduxStore ) {
 
 			if ( matchedRoutes.length ) {
 				props = { routeName: matchedRoutes[0].name, match: matchedRoutes[0].match };
-				Layout = require( 'layout/logged-out-design' );
+				Layout = require( 'layout/logged-out' );
 			}
 		} else if ( startsWith( window.location.pathname, '/design' ) ) {
-			Layout = require( 'layout/logged-out-design' );
+			Layout = require( 'layout/logged-out' );
 		}
 
 		layoutElement = React.createElement( Layout, Object.assign( {}, props, {

--- a/client/layout/logged-out-design.jsx
+++ b/client/layout/logged-out-design.jsx
@@ -11,11 +11,8 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import MasterbarMinimal from 'layout/masterbar/minimal';
-import ThemesHead from 'my-sites/themes/head';
-import ThemeSheetComponent from 'my-sites/themes/sheet';
 
-const LayoutLoggedOutDesign = ( { routeName, match, section, hasSidebar, isFullScreen, tier = 'all' } ) => {
-	const primary = routeName === 'themes' ? <ThemeSheetComponent themeSlug={ match.theme_slug } /> : null;
+const LayoutLoggedOutDesign = ( { primary, secondary, tertiary, section, hasSidebar, isFullScreen } ) => {
 	const sectionClass = section ? 'is-section-' + section : '';
 	const classes = classNames( 'wp layout', sectionClass, {
 		'focus-content': true,
@@ -25,15 +22,18 @@ const LayoutLoggedOutDesign = ( { routeName, match, section, hasSidebar, isFullS
 
 	return (
 		<div className={ classes }>
-			<ThemesHead tier={ tier } isSheet={ routeName === 'themes' } />
 			<MasterbarMinimal url="/" />
 			<div id="content" className="wp-content">
 				<div id="primary" className="wp-primary wp-section">
 					{ primary }
 				</div>
-				<div id="secondary" className="wp-secondary" />
+				<div id="secondary" className="wp-secondary">
+					{ secondary }
+				</div>
 			</div>
-			<div id="tertiary" className="wp-overlay fade-background" />
+			<div id="tertiary" className="wp-overlay fade-background">
+				{ tertiary }
+			</div>
 		</div>
 	);
 }
@@ -42,8 +42,7 @@ LayoutLoggedOutDesign.displayName = 'LayoutLoggedOutDesign';
 LayoutLoggedOutDesign.propTypes = {
 	section: React.PropTypes.string,
 	hasSidebar: React.PropTypes.bool,
-	isFullScreen: React.PropTypes.bool,
-	tier: React.PropTypes.string,
+	isFullScreen: React.PropTypes.bool
 }
 
 export default connect(

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
  */
 import MasterbarMinimal from 'layout/masterbar/minimal';
 
-const LayoutLoggedOutDesign = ( { primary, secondary, tertiary, section, hasSidebar, isFullScreen } ) => {
+const LayoutLoggedOut = ( { primary, secondary, tertiary, section, hasSidebar, isFullScreen } ) => {
 	const sectionClass = section ? 'is-section-' + section : '';
 	const classes = classNames( 'wp layout', sectionClass, {
 		'focus-content': true,
@@ -38,8 +38,8 @@ const LayoutLoggedOutDesign = ( { primary, secondary, tertiary, section, hasSide
 	);
 }
 
-LayoutLoggedOutDesign.displayName = 'LayoutLoggedOutDesign';
-LayoutLoggedOutDesign.propTypes = {
+LayoutLoggedOut.displayName = 'LayoutLoggedOut';
+LayoutLoggedOut.propTypes = {
 	section: React.PropTypes.string,
 	hasSidebar: React.PropTypes.bool,
 	isFullScreen: React.PropTypes.bool
@@ -55,4 +55,4 @@ export default connect(
 			isFullScreen: state.ui.isFullScreen,
 		}
 	)
-)( LayoutLoggedOutDesign );
+)( LayoutLoggedOut );

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -47,6 +47,9 @@ const LayoutLoggedOut = ( {
 
 LayoutLoggedOut.displayName = 'LayoutLoggedOut';
 LayoutLoggedOut.propTypes = {
+	primary: React.PropTypes.element,
+	secondary: React.PropTypes.element,
+	tertiary: React.PropTypes.element,
 	section: React.PropTypes.string,
 	hasSidebar: React.PropTypes.bool,
 	isFullScreen: React.PropTypes.bool

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -53,13 +53,9 @@ LayoutLoggedOut.propTypes = {
 }
 
 export default connect(
-	( state, props ) => Object.assign(
-		{},
-		props,
-		{
-			section: state.ui.section,
-			hasSidebar: state.ui.hasSidebar,
-			isFullScreen: state.ui.isFullScreen,
-		}
-	)
+	( state ) => ( {
+		section: state.ui.section,
+		hasSidebar: state.ui.hasSidebar,
+		isFullScreen: state.ui.isFullScreen,
+	} )
 )( LayoutLoggedOut );

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -12,7 +12,14 @@ import { connect } from 'react-redux';
  */
 import MasterbarMinimal from 'layout/masterbar/minimal';
 
-const LayoutLoggedOut = ( { primary, secondary, tertiary, section, hasSidebar, isFullScreen } ) => {
+const LayoutLoggedOut = ( {
+	primary,
+	secondary,
+	tertiary,
+	section,
+	hasSidebar = true,
+	isFullScreen = false
+} ) => {
 	const sectionClass = section ? 'is-section-' + section : '';
 	const classes = classNames( 'wp layout', sectionClass, {
 		'focus-content': true,

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -20,6 +20,7 @@ import { getAnalyticsData } from './helpers';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { setSection } from 'state/ui/actions';
 import ClientSideEffects from 'components/client-side-effects';
+import LayoutLoggedOutDesign from 'layout/logged-out-design';
 
 function getProps( context ) {
 	const { tier, site_id: siteId } = context.params;
@@ -66,6 +67,20 @@ function makeElement( ThemesComponent, Head, store, props ) {
 			</Head>
 		</ReduxProvider>
 	);
+};
+
+// Where do we put this? It's client/server-agnostic, so not in client/controller,
+// which requires ReactDom... Maybe in lib/react-helpers?
+export function makeLoggedOutLayout( context, next ) {
+	const { store, primary, secondary, tertiary } = context;
+	context.layout = (
+		<ReduxProvider store={ store }>
+			<LayoutLoggedOutDesign primary={ primary }
+				secondary={ secondary }
+				tertiary={ tertiary } />
+		</ReduxProvider>
+	);
+	next();
 };
 
 export function singleSite( context, next ) {

--- a/client/my-sites/themes/controller.js
+++ b/client/my-sites/themes/controller.js
@@ -20,7 +20,7 @@ import { getAnalyticsData } from './helpers';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { setSection } from 'state/ui/actions';
 import ClientSideEffects from 'components/client-side-effects';
-import LayoutLoggedOutDesign from 'layout/logged-out-design';
+import LayoutLoggedOut from 'layout/logged-out';
 
 function getProps( context ) {
 	const { tier, site_id: siteId } = context.params;
@@ -75,7 +75,7 @@ export function makeLoggedOutLayout( context, next ) {
 	const { store, primary, secondary, tertiary } = context;
 	context.layout = (
 		<ReduxProvider store={ store }>
-			<LayoutLoggedOutDesign primary={ primary }
+			<LayoutLoggedOut primary={ primary }
 				secondary={ secondary }
 				tertiary={ tertiary } />
 		</ReduxProvider>

--- a/client/my-sites/themes/index.js
+++ b/client/my-sites/themes/index.js
@@ -4,7 +4,7 @@
 import config from 'config';
 import userFactory from 'lib/user';;
 import { navigation, siteSelection } from 'my-sites/controller';
-import { singleSite, multiSite, loggedOut, details } from './controller';
+import { singleSite, multiSite, loggedOut, details, makeLoggedOutLayout } from './controller';
 
 const user = userFactory();
 
@@ -18,13 +18,17 @@ const designRoutes = isLoggedIn
 		'/design/type/:tier/:site_id': [ singleSite, navigation, siteSelection ],
 	}
 	: {
-		'/design': [ loggedOut ],
-		'/design/type/:tier': [ loggedOut ]
+		'/design': [ loggedOut, makeLoggedOutLayout ],
+		'/design/type/:tier': [ loggedOut, makeLoggedOutLayout ]
 	};
 
-const themesRoutes = {
-	'/themes/:slug/:section?/:site_id?': [ details ]
-};
+const themesRoutes = isLoggedIn
+	? {
+		'/themes/:slug/:section?/:site_id?': [ details ]
+	}
+	: {
+		'/themes/:slug/:section?/:site_id?': [ details, makeLoggedOutLayout ]
+	};
 
 const routes = Object.assign( {},
 	config.isEnabled( 'manage/themes' ) ? designRoutes : {},

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -19,7 +19,8 @@ var config = require( 'config' ),
 	render = require( 'render' ).render,
 	i18n = require( 'lib/mixins/i18n' ),
 	createReduxStore = require( 'state' ).createReduxStore,
-	setSection = require( 'state/ui/actions' ).setSection;
+	setSection = require( 'state/ui/actions' ).setSection,
+	ThemeSheetComponent = require( 'my-sites/themes/sheet' ).default;
 
 var HASH_LENGTH = 10,
 	URL_BASE_PATH = '/calypso',
@@ -374,7 +375,6 @@ module.exports = function() {
 	} );
 
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
-
 		app.get( '/themes/:theme_slug', function( req, res ) {
 			const context = getDefaultContext( req );
 
@@ -385,9 +385,11 @@ module.exports = function() {
 				store.dispatch( setSection( 'themes', { hasSidebar: false, isFullScreen: true } ) );
 				context.initialReduxState = pick( store.getState(), 'ui' );
 
+				const primary = <ThemeSheetComponent themeSlug={ req.params.theme_slug } />;
+
 				Object.assign( context, render( (
 					<ReduxProvider store={ store }>
-						<LayoutLoggedOutDesign store={ store } routeName={ 'themes' } match={ { theme_slug: req.params.theme_slug } } />
+						<LayoutLoggedOutDesign primary={ primary } />
 					</ReduxProvider>
 				) ) );
 			}

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -15,7 +15,7 @@ var config = require( 'config' ),
 	sanitize = require( 'sanitize' ),
 	utils = require( 'bundler/utils' ),
 	sections = require( '../../client/sections' ),
-	LayoutLoggedOutDesign = require( 'layout/logged-out-design' ),
+	LayoutLoggedOut = require( 'layout/logged-out' ),
 	render = require( 'render' ).render,
 	i18n = require( 'lib/mixins/i18n' ),
 	createReduxStore = require( 'state' ).createReduxStore,
@@ -389,7 +389,7 @@ module.exports = function() {
 
 				Object.assign( context, render( (
 					<ReduxProvider store={ store }>
-						<LayoutLoggedOutDesign primary={ primary } />
+						<LayoutLoggedOut primary={ primary } />
 					</ReduxProvider>
 				) ) );
 			}
@@ -415,7 +415,7 @@ module.exports = function() {
 				context.initialReduxState = pick( store.getState(), 'ui' );
 
 				Object.assign( context,
-					render( <LayoutLoggedOutDesign tier={ tier } store={ store } /> )
+					render( <LayoutLoggedOut tier={ tier } store={ store } /> )
 				);
 			}
 

--- a/server/pages/test/index.js
+++ b/server/pages/test/index.js
@@ -13,7 +13,7 @@ import noop from 'lodash/noop';
 import { createReduxStore } from 'state';
 
 describe( 'Server pages:', function() {
-	context( 'when trying to renderToString() LayoutLoggedOutDesign ', function() {
+	context( 'when trying to renderToString() LayoutLoggedOut ', function() {
 		before( function() {
 			mockery.enable( {
 				warnOnReplace: false,
@@ -22,10 +22,9 @@ describe( 'Server pages:', function() {
 
 			mockery.registerMock( 'analytics', noop );
 
-			const LayoutLoggedOutDesign = require( 'layout/logged-out-design' );
-			this.LayoutLoggedOutDesignFactory = React.createFactory( LayoutLoggedOutDesign );
+			const LayoutLoggedOut = require( 'layout/logged-out' );
+			this.LayoutLoggedOutFactory = React.createFactory( LayoutLoggedOut );
 			this.props = {
-				tier: 'free',
 				store: createReduxStore(),
 			};
 		} );
@@ -35,7 +34,7 @@ describe( 'Server pages:', function() {
 		} );
 
 		it( "doesn't throw an exception", function() {
-			assert.doesNotThrow( ReactDomServer.renderToString.bind( ReactDomServer, this.LayoutLoggedOutDesignFactory( this.props ) ) );
+			assert.doesNotThrow( ReactDomServer.renderToString.bind( ReactDomServer, this.LayoutLoggedOutFactory( this.props ) ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
When logged-out, make sure that child components that go to `primary`,
`secondary`, and `tertiary` are first added to `layout`, before that latter is
rendered. This is achieved by modifying `LayoutLoggedOutDesign` to accept those
three as props, and by adding a new `makeLoggedOutLayout` middleware, which
adds the `LayoutLoggedOutDesign` layout to `context.layout`, which is finally rendered
by `clientRouter` (falling back to rendering `primary` and `secondary`
as before if no `layout` is present).

This is necessary so we'll be able to use the same middleware on the server,
where the component we want to `renderToString()` needs to include all its
children at the time it's being rendered.

This PR also
* removes `context.layout` setting from `client/boot`, since that doesn't seem to have been in use, but it would collide with the `context.layout` we're setting for layout-last rendering, and
* renames `LayoutLoggedOutDesign` to `LayoutLoggedOut`, since it's generic now.

It doesn't touch logged-in layout yet, since that will be more complicated (e.g. needs to be connected to `users` and `sites`). I filed #3549 to track that.

No visual changes. To test: Try all possible permutations of themes related actions (`single-site`, `multi-site`, `logged-out` / clicking on a theme's Details menu item, navigating from/to different sections of Calypso, going back / landing directly on a page), and pay attention to layout (funky re-renders?), masterbar (logged-in and out versions as appropriate?), and title (SEO'd for tier when logged-out?). Also, disable JS and verify that the same page title as in `master` is set in logged-out `/design` and theme details sheet. _Seems like we could use even more e2e tests..._

/cc @mcsf @ehg @seear 