### PR TITLE
Editor: Resolve rogue cursors in iOS Safari

### DIFF
--- a/public/tinymce/skins/wordpress/wp-content.css
+++ b/public/tinymce/skins/wordpress/wp-content.css
@@ -4,11 +4,6 @@ html {
 	cursor: text;
 }
 
-.ios body#tinymce {
-	height: 200%;
-	max-width: none;
-}
-
 body {
 	font-family: Georgia, "Times New Roman", "Bitstream Charter", Times, serif;
 	font-size: 16px;

--- a/public/tinymce/skins/wordpress/wp-content.css
+++ b/public/tinymce/skins/wordpress/wp-content.css
@@ -4,10 +4,6 @@ html {
 	cursor: text;
 }
 
-html.ios {
-	height: 100%;
-}
-
 .ios body#tinymce {
 	height: 200%;
 	max-width: none;


### PR DESCRIPTION
Fixes #1723
Related: https://core.trac.wordpress.org/changeset/28626

This pull request attempts to resolve "rogue" cursors which can appear in iOS Safari after tapping below the editor area.

Before|After
---|---
![rogue-before](https://cloud.githubusercontent.com/assets/1779930/13267830/46ffcf94-da4d-11e5-82c1-c71fabf85905.gif)|![rogue-after](https://cloud.githubusercontent.com/assets/1779930/13267829/46efedb8-da4d-11e5-9046-74c10e786267.gif)

__Implementation notes:__

I don't even...

__Testing instructions:__

Verify on an iOS device and/or simulator that rogue cursors are not present after tapping below the editor.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Focus the editor area
4. Tap below the editor area

/cc @azaozz , @ryanboren 