### PR TITLE
Fix the name of the classnames lib

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import classNames from 'classNames';
+import classNames from 'classnames';
 import React from 'react';
 
 const CheckoutThankYouHeader = React.createClass( {


### PR DESCRIPTION
This is broken in staging right now.

For some reason the npm module names aren't case sensitive in development, but they are in production.

To test go to 
http://calypso.localhost:3000/checkout/:site/thank-you