### PR TITLE
Reader: Make the excerpt creator a bit smarter

### DIFF
--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -42,7 +42,7 @@ const fastPostNormalizationRules = [
 			postNormalizer.content.detectPolls,
 			postNormalizer.content.wordCountAndReadingTime
 		] ),
-		postNormalizer.createContentWithLinebreakElementsOnly,
+		postNormalizer.createBetterExcerpt,
 		classifyPost
 	],
 	slowPostNormalizationRules = [

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -31,7 +31,7 @@ let normalizer = require( '../' ),
 			normalizer.content.detectEmbeds,
 			normalizer.content.wordCountAndReadingTime
 		] ),
-		normalizer.createContentWithLinebreakElementsOnly,
+		normalizer.createBetterExcerpt,
 		normalizer.waitForImagesToLoad,
 		normalizer.pickCanonicalImage,
 		normalizer.keepValidImages( 1, 1 )
@@ -871,19 +871,30 @@ describe( 'post-normalizer', function() {
 				}
 			);
 		} );
-		it( 'prepares a version of the post content with linebreak elements only', function( done ) {
-			normalizer(
-				{
-					content: '<br><p class="wp-caption-text">caption</p><p><img src="http://example.com/image.jpg"></p>'
-					+ '<p><a href="http://wikipedia.org">Giraffes</a> are <br>great</p><p></p>',
-				},
-				[
-					normalizer.withContentDOM( [ normalizer.createContentWithLinebreakElementsOnly ] )
-				], function( err, normalized ) {
-					assert.strictEqual( normalized.content_with_linebreak_elements_only, '<p>Giraffes are <br>great</p><p></p>' );
-					done( err );
-				}
-			);
+	} );
+	describe( 'The fancy excerpt creator', function() {
+		function assertExcerptBecomes( source, expected, done ) {
+			normalizer( { content: source }, [ normalizer.createBetterExcerpt ], function( err, normalized ) {
+				assert.strictEqual( normalized.better_excerpt, expected );
+				done( err );
+			} );
+		}
+
+		it( 'strips empty elements and leading and trailing brs', function( done ) {
+			assertExcerptBecomes( `<br>
+<p>&nbsp;</p>
+<p class="wp-caption-text">caption</p>
+<p><img src="http://example.com/image.jpg"></p>
+<p><a href="http://wikipedia.org">Giraffes</a> are <br>great</p>
+<p></p>`, '<p>Giraffes are <br>great</p>', done );
+		} );
+
+		it( 'limits the excerpt to 3 elements', function( done ) {
+			assertExcerptBecomes( '<p>one</p><p>two</p><p>three</p><p>four</p>', '<p>one</p><p>two</p><p>three</p>', done );
+		} );
+
+		it( 'limits the excerpt to 3 elements after trimming', function( done ) {
+			assertExcerptBecomes( '<br /><p></p><p>one</p><p>two</p><p></p><br><p>three</p><p>four</p><br><p></p>', '<p>one</p><p>two</p><br>', done );
 		} );
 	} );
 } );

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -403,7 +403,7 @@ var Post = React.createClass( {
 
 				{ shouldUseFullExcerpt ?
 					<div key="full-post-inline" className="reader__full-post-content" dangerouslySetInnerHTML={{ __html: post.content }}></div> : //eslint-disable-line react/no-danger
-					<PostExcerpt content={ post.content_with_linebreak_elements_only ? post.content_with_linebreak_elements_only : post.excerpt } />
+					<PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
 				}
 
 				{ shouldShowExcerptOnly ?

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -216,7 +216,7 @@ FullPostView = React.createClass( {
 					<PostByline post={ post } site={ site } icon={ true }/>
 
 					{ post.use_excerpt ?
-						<PostExcerpt content={ post.content_with_linebreak_elements_only ? post.content_with_linebreak_elements_only : post.excerpt } /> :
+						<PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } /> :
 						<div className="reader__full-post-content" dangerouslySetInnerHTML={{ __html: post.content }}></div> //eslint-disable-line react/no-danger
 					}
 


### PR DESCRIPTION
Teach it to remove `wp-caption-text` safely and to strip all blank paragraph tags, but not embedded line breaks.

Change name to `create_better_excerpt` / `better_excerpt`.