### PR TITLE
Framework: Fix the bundler in Desktop environment

### DIFF
--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -2,7 +2,7 @@ var config = require( 'config' ),
 	utils = require( './utils' );
 
 function getSectionsModule( sections ) {
-	var dependencies = '',
+	var dependencies,
 		loadSection = '',
 		sectionLoaders = '';
 
@@ -25,6 +25,7 @@ function getSectionsModule( sections ) {
 			} );
 		} );
 	} else {
+		dependencies = "var controller = require( 'controller' );\n";
 		sectionLoaders = getRequires( sections );
 	}
 
@@ -98,7 +99,7 @@ function splitTemplate( path, module, chunkName ) {
 }
 
 function requireTemplate( module ) {
-	return 'require( ' + JSON.stringify( module ) + ' )();\n';
+	return 'require( ' + JSON.stringify( module ) + ' )( controller.clientRouter );\n';
 }
 
 function singleEnsure( chunkName ) {


### PR DESCRIPTION
Currently, when trying to run wp-desktop on calypso's master, you will end up with the following error in your dev console:
```
Uncaught TypeError: Cannot read property 'apply' of undefined
```
Which happens because `router` is undefined here in `client/my-sites/themes/index.js` main function:
![image](https://cloud.githubusercontent.com/assets/230230/13296098/164878a8-db2c-11e5-9e3f-9d868669b767.png)

It seems that the `controller.clientRouter` object is not given to each modules when the `"code-splitting"` feature is set to `false`. I don't really know the reason why, but adding it seems to fix this bug.

#### Testing Instructions
- From wp-desktop, checkout calypso's master and `make run` wp-desktop
- Load the app and open dev tools to confirm that you have the same error
- Close the app, checkout this branch and relaunch the app
- Move around the app and check that the bug is gone

Please review the code and contribute here if you know why we shouldn't have this.

cc: @ockham @gziolo @drewblaisdell 