### PR TITLE
Signup: Pass the chosen survey answers as user attributes on user creation.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -84,14 +84,14 @@ const flows = {
 
 	/* WP.com homepage flows */
 	website: {
-		steps: [ 'survey', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getCheckoutDestination,
 		description: 'This flow is used for the users who clicked "Create Website" on the two-button homepage.',
 		lastModified: '2016-01-28'
 	},
 
 	blog: {
-		steps: [ 'survey', 'themes', 'domains', 'plans', 'user' ],
+		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getCheckoutDestination,
 		description: 'This flow is used for the users who clicked "Create Blog" on the two-button homepage.',
 		lastModified: '2016-01-28'

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -22,6 +22,7 @@ module.exports = {
 	'select-plan-or-skip': PaidPlansWithSkip,
 	domains: DomainsStepComponent,
 	survey: SurveyStepComponent,
+	'survey-user': UserSignupComponent,
 	'design-type': DesignTypeComponent,
 	'themes-headstart': ThemeSelectionComponent,
 	altthemes: ThemeSelectionComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -74,6 +74,14 @@ module.exports = {
 		providesDependencies: [ 'surveySiteType', 'surveyQuestion' ]
 	},
 
+	'survey-user': {
+		stepName: 'survey-user',
+		apiRequestFunction: stepActions.createAccount,
+		providesToken: true,
+		dependencies: [ 'surveySiteType', 'surveyQuestion' ],
+		providesDependencies: [ 'bearer_token', 'username' ]
+	},
+
 	plans: {
 		stepName: 'plans',
 		apiRequestFunction: stepActions.addPlanToCart,


### PR DESCRIPTION
The user's responses in the `survey` step of signup have not been getting saved because the regular `user` step has no listed dependency for those answers. Adding a new users step with these dependencies will get the `nux_q_site_type` and `nux_q_question_primary` user attributes properly saved.