### PR TITLE
People: Remove normalization of successful invite validations

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -85,9 +85,6 @@ export default React.createClass( {
 	refreshValidation() {
 		const errors = InvitesCreateValidationStore.getErrors( this.props.site.ID, this.state.role ) || [];
 		let success = InvitesCreateValidationStore.getSuccess( this.props.site.ID, this.state.role ) || [];
-		if ( ! success.indexOf ) {
-			success = Object.keys( success ).map( key => success[ key ] );
-		}
 
 		this.setState( {
 			errors,


### PR DESCRIPTION
Alternative to #3293

Previously, the API returned either an array or an object of successful invite validations. Now that the API has been updated to always return an array for successful validations in r131590-wpcom, we can remove this normalization in Calypso.

To test:
- Checkout `update/people-invite-create-validate-normalizze` branch
- Go to `/people/new/$site`
- Attempt to add usernames or email addresses 
- Ensure that nothing is broken :)
- To test if validation works properly, you can test that tokens get a status by entering `localStorage.setItem( 'debug', 'calypso:my-sites:people:invites' );` in the console

cc @lezama  for review since he worked on the initial normalization and has a better handle on the issues.