### PR TITLE
Importer: CSS tweaks

### DIFF
--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -83,7 +83,7 @@ export default React.createClass( {
 		return (
 			<header className="importer-service">
 				{ includes( [ 'wordpress' ], icon )
-					? <SocialLogo className="importer__service-icon" icon={ icon } size={ 50 } />
+					? <SocialLogo className="importer__service-icon" icon={ icon } size={ 48 } />
 					: <svg className="importer__service-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" /> }
 				<Button
 					className="importer__master-control"

--- a/client/my-sites/importer/importer-wordpress.jsx
+++ b/client/my-sites/importer/importer-wordpress.jsx
@@ -39,7 +39,7 @@ export default React.createClass( {
 	render: function() {
 		importerData.description = this.translate(
 			'Import posts, pages, and media ' +
-			'from a WordPress export file.'
+			'from a WordPress export\u00A0file.'
 		);
 
 		importerData.uploadDescription = this.translate(

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -24,30 +24,30 @@
 }
 
 .importer__service-icon {
-	width: 48px;
-	height: 48px;
+	box-sizing: border-box;
+	float: left;
+	width: 40px;
+	height: 40px;
 	padding: 2px;
-
-	position: absolute;
-		left: 20px;
-		top: 18px;
+	margin-right: 16px;
 
 	background-color: $gray-dark;
-	stroke: $white;
-	stroke-width: 0.1;
 	fill: $white;
-	border-radius: 5px;
+	border-radius: 4px;
 
 	&.wordpress {
 		background-color: $blue-wordpress;
 	}
+	
+	@include breakpoint(">960px") {
+		width: 56px;
+		height: 56px;
+		padding: 4px;
+	}
 }
 
 .importer__service-info {
-	padding-top: 70px;
-
 	@include breakpoint(">480px") {
-		padding-top: inherit;
 		margin-left: 60px;
 	}
 }


### PR DESCRIPTION
- Updating CSS so that the importer icon is smaller at smaller widths. 
- Added a non-breaking space to eliminate widows.
- Altered the size of the svg to be standard.
- Used floats instead of absolute positioning for the icon.

cc @dmsnell 

Before:
![gng claaqpqgaiuoaafkecb8i7wpxhrymbacbvvaaaaaelftksuqmcc](https://cloud.githubusercontent.com/assets/618551/13300488/0f1791c0-db06-11e5-9a99-504d261c23c5.png)
![wckzvx7xkpjnwaaaabjru5erkjggg](https://cloud.githubusercontent.com/assets/618551/13300495/170cb02c-db06-11e5-9bf6-b8dff7a5bf9d.png)

After:
![k2ogbrrss386w2wfs7twfizv8mzvzl81ym279ess xsvq7i7esmiuo7ogaaqgaaeiqaaceiaabakhwp8ae4sq5gxuhwiaaaaasuvork5cyii](https://cloud.githubusercontent.com/assets/618551/13300500/1c8d79f0-db06-11e5-9f7f-bb18f6641718.png)
![0491tdvxkkyodci2t0ubclcaahsgaaxaebblubggezwuqxdqwiwxeqed7sl4iav6urlzucouylv0urxtp8ci6pgqxvjh64hdwjsrhzab7lbtxoox6xzhu9wcymg8sowrlm1ebawdipx70rahy0xftr48oguoqaekuiacflbu4p8djvhxxsttq9aaaaaasuvork5cyii](https://cloud.githubusercontent.com/assets/618551/13300508/21aaaf8e-db06-11e5-883c-842db4dc8a32.png)