### PR TITLE
People: Fixes RoleSelect issue with localStorage cleared

### DIFF
--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -20,7 +20,7 @@ import sitesList from 'lib/sites-list';
 /**
  * Module variables
  */
-const debug = debugFactory( 'calypso:role-select' );
+const debug = debugFactory( 'calypso:my-sites:people:role-select' );
 const sites = sitesList();
 
 export default React.createClass( {
@@ -42,6 +42,8 @@ export default React.createClass( {
 	},
 
 	componentWillReceiveProps( nextProps ) {
+		const siteId = nextProps.siteId || this.props.siteId;
+		this.fetchRoles( siteId );
 		this.refreshRoles( nextProps );
 	},
 
@@ -77,16 +79,18 @@ export default React.createClass( {
 		}
 	},
 
-	fetchRoles() {
-		const siteId = this.props.siteId || null;
+	fetchRoles( siteId = this.props.siteId ) {
 		if ( ! siteId ) {
+			debug( 'siteId not set' );
 			return;
 		}
 
-		if ( RolesStore.getRoles( siteId ).length ) {
+		if ( Object.keys( RolesStore.getRoles( siteId ) ).length ) {
 			debug( 'initial fetch not necessary' );
 			return;
 		}
+
+		debug( 'Fetching roles for ' + siteId );
 
 		// defer fetch requests to avoid dispatcher conflicts
 		setTimeout( function() {


### PR DESCRIPTION
Fixes #3442

Previously, the RoleSelect did not work properly when going to `/people/new/$site` with a cleared `localStorage`. After some digging, this seems to have been because we were not re-fetching once site was set properly. :scream: 

This PR fixes that by ensuring that we fetch in `componentWillReceiveProps`. Note that while we call `this.fetchRoles()` each time we receive new props, we do not in fact fetch each time. If a site already has roles, `fetchRoles()` bails early.

To test:
- Checkout `update/people-invites-localstorage` branch
- Go to `/people/new/$site` where `$site` is a WP.com site
- In console, `localStorage.clear()`
- Refresh
- Ensure that all site roles load
- Go to `/people/team/$site` where `$site` is a WP.com or Jetpack site
- Ensure that roles load properly

cc @lezama for review