### PR TITLE
Reader: Post Sharing via Calypso Editor

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1355,3 +1355,27 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
+
+### https://github.com/ogt/valid-url
+```text
+Copyright (c) 2013 Odysseas Tsatalos and oDesk Corporation
+
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -141,9 +141,9 @@ var DialogBase = React.createClass( {
 			return;
 		}
 
-		this.props.onClickOutside( event );
+		const shouldStayOpen = this.props.onClickOutside( event );
 
-		if ( ! event.defaultPrevented ) {
+		if ( ! shouldStayOpen ) {
 			this._close();
 		}
 	},

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import clickOutside from 'click-outside';
+import defer from 'lodash/defer';
 import ReactDom from 'react-dom';
 import React from 'react';
 import omit from 'lodash/omit';
@@ -90,25 +91,29 @@ var Popover = React.createClass( {
 				);
 			}
 
+			// this schedules a render, but does not actually render the content
 			ReactDom.render( content, this._container );
 
 			if ( ! prevProps.isVisible ) {
-				const contextNode = ReactDom.findDOMNode( this.props.context );
-				if ( contextNode.nodeType !== Node.ELEMENT_NODE || contextNode.nodeName.toLowerCase() === 'svg' ) {
-					warn(
-						'Popover is attached to a %s element (nodeType %d).  '
-						+ 'This causes problems in IE11 - see 12168-gh-calypso-pre-oss.',
-						contextNode.nodeName,
-						contextNode.nodeType
-					);
-				}
+				// defer showing the content to give it a chance to render
+				defer( () => {
+					const contextNode = ReactDom.findDOMNode( this.props.context );
+					if ( contextNode.nodeType !== Node.ELEMENT_NODE || contextNode.nodeName.toLowerCase() === 'svg' ) {
+						warn(
+							'Popover is attached to a %s element (nodeType %d).  ' +
+							'This causes problems in IE11 - see 12168-gh-calypso-pre-oss.',
+							contextNode.nodeName,
+							contextNode.nodeType
+						);
+					}
 
-				this._tip.position( this.props.position, { auto: false } );
-				this._tip.show( contextNode );
+					this._tip.position( this.props.position, { auto: true } );
+					this._tip.show( contextNode );
 
-				if ( this.props.onShow ) {
-					this.props.onShow();
-				}
+					if ( this.props.onShow ) {
+						this.props.onShow();
+					}
+				} );
 
 				this._setupClickOutside();
 			}

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -28,6 +28,8 @@ export default React.createClass( {
 
 	propTypes: {
 		sites: React.PropTypes.object,
+		siteBasePath: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
+		siteQuerystring: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
 		showAddNewSite: React.PropTypes.bool,
 		showAllSites: React.PropTypes.bool,
 		indicator: React.PropTypes.bool,
@@ -45,6 +47,7 @@ export default React.createClass( {
 			showAddNewSite: false,
 			showAllSites: false,
 			siteBasePath: false,
+			siteQuerystring: false,
 			indicator: false,
 			hideSelected: false,
 			selected: null,
@@ -151,6 +154,10 @@ export default React.createClass( {
 
 			if ( this.props.siteBasePath ) {
 				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
+
+				if ( this.props.siteQuerystring ) {
+					siteHref += '?' + this.props.siteQuerystring;
+				}
 			}
 
 			const isSelected = this.isSelected( site );
@@ -222,6 +229,9 @@ export default React.createClass( {
 
 			if ( this.props.siteBasePath ) {
 				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
+				if ( this.props.siteQuerystring ) {
+					siteHref += '?' + this.props.siteQuerystring;
+				}
 			}
 
 			const isSelected = this.isSelected( site );
@@ -257,6 +267,9 @@ export default React.createClass( {
 
 			if ( this.props.siteBasePath ) {
 				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
+				if ( this.props.siteQuerystring ) {
+					siteHref += '?' + this.props.siteQuerystring;
+				}
 			}
 
 			return (

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -29,7 +29,6 @@ export default React.createClass( {
 	propTypes: {
 		sites: React.PropTypes.object,
 		siteBasePath: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
-		siteQuerystring: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
 		showAddNewSite: React.PropTypes.bool,
 		showAllSites: React.PropTypes.bool,
 		indicator: React.PropTypes.bool,
@@ -47,7 +46,6 @@ export default React.createClass( {
 			showAddNewSite: false,
 			showAllSites: false,
 			siteBasePath: false,
-			siteQuerystring: false,
 			indicator: false,
 			hideSelected: false,
 			selected: null,
@@ -78,7 +76,7 @@ export default React.createClass( {
 		}
 
 		// ignore mouse events as the default page() click event will handle navigation
-		if ( this.props.siteBasePath && event.type !== 'mouseup' ) {
+		if ( this.props.siteBasePath && ( ! ( event.type === 'mouseup' || event.type === 'touchend' ) ) ) {
 			page( event.currentTarget.pathname );
 		}
 	},
@@ -154,10 +152,6 @@ export default React.createClass( {
 
 			if ( this.props.siteBasePath ) {
 				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
-
-				if ( this.props.siteQuerystring ) {
-					siteHref += '?' + this.props.siteQuerystring;
-				}
 			}
 
 			const isSelected = this.isSelected( site );
@@ -229,9 +223,6 @@ export default React.createClass( {
 
 			if ( this.props.siteBasePath ) {
 				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
-				if ( this.props.siteQuerystring ) {
-					siteHref += '?' + this.props.siteQuerystring;
-				}
 			}
 
 			const isSelected = this.isSelected( site );
@@ -267,9 +258,6 @@ export default React.createClass( {
 
 			if ( this.props.siteBasePath ) {
 				siteHref = this.getSiteBasePath( site ) + '/' + site.slug;
-				if ( this.props.siteQuerystring ) {
-					siteHref += '?' + this.props.siteQuerystring;
-				}
 			}
 
 			return (

--- a/client/components/sites-popover/index.jsx
+++ b/client/components/sites-popover/index.jsx
@@ -17,7 +17,6 @@ module.exports = React.createClass( {
 
 	propTypes: {
 		sites: React.PropTypes.object,
-		siteQuerystring: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
 		context: React.PropTypes.object,
 		visible: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
@@ -82,7 +81,7 @@ module.exports = React.createClass( {
 					? <SiteSelector
 							sites={ this.props.sites }
 							siteBasePath="/post"
-							siteQuerystring={ this.props.siteQuerystring }
+							onSiteSelect={ this.props.onSiteSelect }
 							showAddNewSite={ false }
 							indicator={ false }
 							autoFocus={ ! hasTouch() }

--- a/client/components/sites-popover/index.jsx
+++ b/client/components/sites-popover/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	noop = require( 'lodash/noop' );
+	noop = require( 'lodash/noop' ),
+	classnames = require( 'classnames' );
 
 /**
  * Internal dependencies
@@ -16,11 +17,13 @@ module.exports = React.createClass( {
 
 	propTypes: {
 		sites: React.PropTypes.object,
+		siteQuerystring: React.PropTypes.oneOfType( [ React.PropTypes.string, React.PropTypes.bool ] ),
 		context: React.PropTypes.object,
 		visible: React.PropTypes.bool,
 		onClose: React.PropTypes.func,
 		position: React.PropTypes.string,
-		groups: React.PropTypes.bool
+		groups: React.PropTypes.bool,
+		className: React.PropTypes.string
 	},
 
 	getInitialState: function() {
@@ -34,7 +37,9 @@ module.exports = React.createClass( {
 			visible: false,
 			onClose: noop,
 			position: 'bottom left',
-			groups: false
+			groups: false,
+			siteQuerystring: false,
+			className: ''
 		};
 	},
 
@@ -55,22 +60,36 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
+		let classes = classnames(
+			this.props.className,
+			'popover sites-popover',
+			this.props.header && 'has-header' );
+
 		return (
 			<Popover
 				isVisible={ this.props.visible }
 				context={ this.props.context }
 				onClose={ this.props.onClose }
 				position={ this.props.position }
-				className="popover sites-popover">
-				{ this.state.popoverVisible ?
-					<SiteSelector
-						sites={ this.props.sites }
-						siteBasePath="/post"
-						showAddNewSite={ false }
-						indicator={ false }
-						autoFocus={ ! hasTouch() }
-						groups={ true }
-						onClose={ this.props.onClose } /> : null }
+				className={ classes }>
+				{ this.state.popoverVisible && this.props.header
+					? <div className="sites-popover__header">
+							{ this.props.header }
+						</div>
+					: null
+				}
+				{ this.state.popoverVisible
+					? <SiteSelector
+							sites={ this.props.sites }
+							siteBasePath="/post"
+							siteQuerystring={ this.props.siteQuerystring }
+							showAddNewSite={ false }
+							indicator={ false }
+							autoFocus={ ! hasTouch() }
+							groups={ true }
+							onClose={ this.props.onClose } />
+					: null
+				}
 			</Popover>
 		);
 	}

--- a/client/components/sites-popover/style.scss
+++ b/client/components/sites-popover/style.scss
@@ -15,9 +15,22 @@ $sites-popover-width: 300px;
 }
 
 .sites-popover .site-selector {
+	position: relative;
+
 	&.is-large {
 		padding-top: 50px;
 	}
+}
+
+.sites-popover.has-header .site-selector {
+	position: relative;
+}
+
+.sites-popover.has-header .sites-popover__header {
+	margin: 4px 16px;
+	font-size: 14px;
+	color: $blue-dark;
+	border-bottom: 1px solid $blue-dark;
 }
 
 .sites-popover .search {

--- a/client/components/sites-popover/style.scss
+++ b/client/components/sites-popover/style.scss
@@ -27,10 +27,11 @@ $sites-popover-width: 300px;
 }
 
 .sites-popover.has-header .sites-popover__header {
-	margin: 4px 16px;
-	font-size: 14px;
-	color: $blue-dark;
-	border-bottom: 1px solid $blue-dark;
+	border-bottom: 1px solid lighten( $gray, 30% );
+	color: darken( $gray, 10% );
+	font-size: 12px;
+	font-weight: bold;
+	padding: 10px 10px 8px 8px;
 }
 
 .sites-popover .search {

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -742,6 +742,8 @@ normalizePost.content = {
 				aspectRatio = Number( iframe.width ) / Number( iframe.height );
 			}
 
+			const embedUrl = iframe.getAttribute( 'data-wpcom-embed-url' );
+
 			do {
 				if ( ! node.className ) {
 					continue;
@@ -755,6 +757,8 @@ normalizePost.content = {
 
 			return {
 				type: embedType,
+				src: iframe.src,
+				embedUrl,
 				iframe: iframe.outerHTML,
 				aspectRatio: aspectRatio,
 				width: width,

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -25,10 +25,6 @@ const Card = require( 'components/card' ),
 	stats = require( 'lib/posts/stats' );
 import { setDate } from 'state/ui/editor/post/actions';
 
-function isPostEmpty( props ) {
-	return ( props.isNew && ! props.isDirty ) || ! props.hasContent;
-}
-
 const EditorGroundControl = React.createClass( {
 	displayName: 'EditorGroundControl',
 	propTypes: {
@@ -249,13 +245,15 @@ const EditorGroundControl = React.createClass( {
 	},
 
 	isPreviewEnabled: function() {
-		return ! isPostEmpty( this.props ) && ! this.props.isSaveBlocked;
+		return this.props.hasContent &&
+			! ( this.props.isNew && ! this.props.isDirty ) &&
+			! this.props.isSaveBlocked;
 	},
 
 	isPrimaryButtonEnabled: function() {
 		return ! this.props.isPublishing &&
-			! isPostEmpty( this.props ) &&
-			! this.props.isSaveBlocked;
+			! this.props.isSaveBlocked &&
+			this.props.hasContent
 	},
 
 	toggleAdvancedStatus: function() {

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -316,6 +316,12 @@ describe( 'EditorGroundControl', function() {
 			expect( tree.isPrimaryButtonEnabled() ).to.be.true;
 		} );
 
+		it( 'should return true if form is not publishind and post is new and has content, but is not dirty', function() {
+			var tree = ReactDom.render( <EditorGroundControl isPublishing={ false } post={ {} } hasContent isDirty={ false } isNew />, document.body );
+
+			expect( tree.isPrimaryButtonEnabled() ).to.be.true;
+		} );
+
 		it( 'should return false if form is publishing', function() {
 			var tree = ReactDom.render( <EditorGroundControl isPublishing />, document.body );
 
@@ -328,8 +334,8 @@ describe( 'EditorGroundControl', function() {
 			expect( tree.isPrimaryButtonEnabled() ).to.be.false;
 		} );
 
-		it( 'should return false if not dirty', function() {
-			var tree = ReactDom.render( <EditorGroundControl post={ {} } isDirty={ false } isNew />, document.body );
+		it( 'should return false if not dirty and has no content', function() {
+			var tree = ReactDom.render( <EditorGroundControl post={ {} } isDirty={ false } hasContent={ false } isNew />, document.body );
 
 			expect( tree.isPrimaryButtonEnabled() ).to.be.false;
 		} );

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -7,6 +7,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import get from 'lodash/get';
 import { translate } from 'lib/mixins/i18n';
+import noop from 'lodash/noop';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -28,13 +30,20 @@ function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts
 		'is-drafts-visible': showDrafts,
 		'is-loading': isCustomPostType && ! type
 	} );
-
-	let allPostsLabel;
-	switch ( typeSlug ) {
-		case 'post': allPostsLabel = translate( 'Posts' ); break;
-		case 'page': allPostsLabel = translate( 'Pages' ); break;
-		default: allPostsLabel = get( type, 'labels.menu_name' ) || translate( 'Loading…' );
+	const useBackButton = page.len > 0;
+	let closeLabel;
+	if ( useBackButton ) {
+		closeLabel = translate( 'Back' );
+	} else {
+		switch ( typeSlug ) {
+			case 'post': closeLabel = translate( 'Posts' ); break;
+			case 'page': closeLabel = translate( 'Pages' ); break;
+			default: closeLabel = get( type, 'labels.menu_name' ) || translate( 'Loading…' );
+		}
 	}
+	const closeButtonAction = useBackButton ? page.back : noop;
+	const closeButtonUrl = useBackButton ? '' : allPostsUrl;
+	const closeButtonAriaLabel = useBackButton ? translate( 'Go back' ) : translate( 'View list of posts' );
 
 	return (
 		<div className={ className }>
@@ -55,10 +64,11 @@ function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts
 				<Button
 					compact borderless
 					className="editor-sidebar__close"
-					href={ allPostsUrl }
-					aria-label={ translate( 'View list of posts' ) }>
+					href={ closeButtonUrl }
+					onClick={ closeButtonAction }
+					aria-label={ closeButtonAriaLabel }>
 					<Gridicon icon="arrow-left" size={ 18 } />
-					{ allPostsLabel }
+					{ closeLabel }
 				</Button>
 			) }
 			{ typeSlug === 'post' && siteId && (

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -312,7 +312,7 @@ module.exports = React.createClass( {
 
 	preventPopoverClose: function( event ) {
 		if ( closest( event.target, '.popover.is-dialog-visible' ) ) {
-			event.preventDefault();
+			return true;
 		}
 	},
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -588,7 +588,8 @@ const PostEditor = React.createClass( {
 	},
 
 	onClose: function() {
-		page( this.getAllPostsUrl() );
+		// go back if we can, if not, hit all posts
+		page.back( this.getAllPostsUrl() );
 	},
 
 	getAllPostsUrl: function() {

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -68,10 +68,6 @@ function trackScrollPage( path, title, category, readerView, pageNum ) {
 
 // Listen for route changes and remove the full post dialog when we navigate away from it
 pageNotifier( function removeFullPostOnLeave( newContext, oldContext ) {
-	if ( ! oldContext ) {
-		return;
-	}
-
 	const fullPostViewRegex = /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i;
 
 	if ( ( ! oldContext || oldContext.path.match( fullPostViewRegex ) ) && ! newContext.path.match( fullPostViewRegex ) ) {

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -6,6 +6,7 @@ var ReactDom = require( 'react-dom' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	defer = require( 'lodash/defer' ),
 	classes = require( 'component-classes' ),
+	closest = require( 'component-closest' ),
 	debug = require( 'debug' )( 'calypso:reader-full-post' ), //eslint-disable-line no-unused-vars
 	moment = require( 'moment' ),
 	omit = require( 'lodash/omit' ),
@@ -298,7 +299,9 @@ FullPostDialog = React.createClass( {
 	},
 
 	handleClickOutside: function( event ) {
-		event.preventDefault();
+		if ( closest( event.target, '.popover' ) ) {
+			return true;
+		}
 	},
 
 	render: function() {

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -334,7 +334,7 @@ FullPostDialog = React.createClass( {
 			}
 
 			if ( shouldShowShare ) {
-				buttons.push( <ShareButton post={ post } position="bottom left" tagName="div" /> );
+				buttons.push( <ShareButton post={ post } position="bottom" tagName="div" /> );
 			}
 		}
 

--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -1,15 +1,18 @@
 var React = require( 'react' ),
-	get = require( 'lodash/get' ),
 	url = require( 'url' ),
+	defer = require( 'lodash/defer' ),
 	config = require( 'config' ),
-	classnames = require( 'classnames' );
+	classnames = require( 'classnames' ),
+	qs = require( 'qs' );
 
 var PopoverMenu = require( 'components/popover/menu' ),
 	PopoverMenuItem = require( 'components/popover/menu-item' ),
 	Gridicon = require( 'components/gridicon' ),
 	sitesList = require( 'lib/sites-list' )(),
 	stats = require( 'reader/stats' ),
-	SocialLogo = require( 'components/social-logo' );
+	SocialLogo = require( 'components/social-logo' ),
+	SitesPopover = require( 'components/sites-popover' ),
+	sections = require( 'sections-preload' );
 
 var actionMap = {
 	twitter: function( post ) {
@@ -42,30 +45,31 @@ var actionMap = {
 		fackbookUrl = url.format( fackbookUrl );
 
 		window.open( fackbookUrl, 'facebook', 'width=626,height=436,resizeable,scrollbars' );
-	},
-	pressThis: function( post ) {
-		var primarySite = sitesList.getPrimary(),
-			wordpressUrl = get( primarySite, 'options.admin_url' );
-
-		if ( ! wordpressUrl ) {
-			return;
-		}
-
-		wordpressUrl = url.parse( url.resolve( primarySite.options.admin_url, 'press-this.php' ) );
-
-		delete wordpressUrl.search;
-		wordpressUrl.query = {
-			u: post.URL,
-			t: post.title
-		};
-
-		wordpressUrl = url.format( wordpressUrl );
-
-		window.open( wordpressUrl, 'pressThis', 'width=626,height=436,resizeable,scrollbars' );
 	}
 };
 
-var ReaderShare = React.createClass( {
+function buildQuerystringForPost( post ) {
+	const primarySite = sitesList.getPrimary();
+	if ( ! primarySite ) {
+		return;
+	}
+	const args = {};
+
+	if ( post.content_embeds && post.content_embeds.length ) {
+		args.embed = post.content_embeds[0].embedUrl || post.content_embeds[0].src;
+	}
+	if ( post.canonical_image && post.canonical_image.uri ) {
+		args.image = post.canonical_image.uri;
+	}
+
+	args.title = `${ post.title } — ${ post.site_name }`;
+	args.text = post.excerpt;
+	args.url = post.URL;
+
+	return qs.stringify( args );
+}
+
+const ReaderShare = React.createClass( {
 
 	getInitialState() {
 		return { showingMenu: false };
@@ -73,18 +77,52 @@ var ReaderShare = React.createClass( {
 
 	getDefaultProps() {
 		return {
-			position: 'top left',
+			position: 'top',
 			tagName: 'li'
 		};
 	},
 
-	toggle( event ) {
-		event.preventDefault();
-		this.setState( { showingMenu: ! this.state.showingMenu } );
+	componentWillUnmount() {
+		if ( this._closeHandle ) {
+			clearTimeout( this._closeHandle );
+			this._closeHandle = null;
+		}
 	},
 
-	closeMenu( action ) {
-		var actionFunc = actionMap[ action ];
+	toggle( event ) {
+		event.preventDefault();
+		if ( ! this.state.showingMenu ) {
+			const target = !! sitesList.getPrimary() ? 'wordpress' : 'external';
+			stats.recordAction( 'open_share' );
+			stats.recordGaEvent( 'Opened Share to ' + target );
+			stats.recordTrack( 'calypso_reader_share_opened', {
+				target
+			} );
+		}
+		this._closeHandle = defer( () => {
+			this.setState( { showingMenu: ! this.state.showingMenu } );
+		} );
+	},
+
+	closeMenu() {
+		// have to defer this to let the mouseup / click escape.
+		// If we don't defer and remove the DOM node on this turn of the event loop,
+		// Chrome (at least) will not fire the click
+		this._closeHandle = defer( () => {
+			this.setState( { showingMenu: false } );
+		} );
+	},
+
+	closeWordPressShareMenu() {
+		this.closeMenu();
+		stats.recordAction( 'share_wordpress' );
+		stats.recordGaEvent( 'Clicked on Share to WordPress' );
+		stats.recordTrack( 'calypso_reader_share_to_site' );
+	},
+
+	closeExternalShareMenu( action ) {
+		this.closeMenu();
+		const actionFunc = actionMap[ action ];
 		if ( actionFunc ) {
 			stats.recordAction( 'share_' + action );
 			stats.recordGaEvent( 'Clicked on Share to ' + action );
@@ -93,7 +131,10 @@ var ReaderShare = React.createClass( {
 			} );
 			actionFunc( this.props.post );
 		}
-		this.setState( { showingMenu: false } );
+	},
+
+	preloadEditor() {
+		sections.preload( 'post-editor' );
 	},
 
 	render() {
@@ -109,24 +150,39 @@ var ReaderShare = React.createClass( {
 		return React.createElement( this.props.tagName, {
 			className: 'reader-share',
 			onClick: this.toggle,
+			onTouchStart: this.preloadEditor,
+			onMouseEnter: this.preloadEditor,
 			ref: 'shareButton' },
 			[
 				( <span key="button" ref="shareButton" className={ buttonClasses }>
 					<Gridicon icon="share" size={ 24 } />
 					<span className="reader-share__button-label">{ this.translate( 'Share', { comment: 'Share the post' } ) }</span>
 				</span> ),
-				( <PopoverMenu key="menu" context={ this.refs && this.refs.shareButton }
-					isVisible={ this.state.showingMenu }
-					onClose={ this.closeMenu }
-					position={ this.props.position }
-					className="popover reader-share__popover">
-					{ canShareToWordpress ? <PopoverMenuItem action="pressThis" className="reader-share__popover-item">
-						<Gridicon icon="my-sites" size={ 24 } /> WordPress</PopoverMenuItem> : null }
-					<PopoverMenuItem action="twitter" className="reader-share__popover-item">
-						<SocialLogo icon="twitter" /> Twitter</PopoverMenuItem>
-					<PopoverMenuItem action="facebook" className="reader-share__popover-item">
-						<SocialLogo icon="facebook" /> Facebook</PopoverMenuItem>
-				</PopoverMenu> )
+				( this.state.showingMenu &&
+						( canShareToWordpress
+						? <SitesPopover
+								key="menu"
+								header={ <div>{ this.translate( 'Share on:' ) }</div> }
+								sites={ sitesList }
+								siteQuerystring={ buildQuerystringForPost( this.props.post ) }
+								context={ this.refs && this.refs.shareButton }
+								visible={ this.state.showingMenu }
+								groups={ true }
+								onClose={ this.closeWordPressShareMenu }
+								position={ this.props.position }
+								className="is-reader"/>
+						: <PopoverMenu key="menu" context={ this.refs && this.refs.shareButton }
+								isVisible={ this.state.showingMenu }
+								onClose={ this.closeExternalShareMenu }
+								position={ this.props.position }
+								className="popover reader-share__popover">
+								<PopoverMenuItem action="twitter" className="reader-share__popover-item">
+									<SocialLogo icon="twitter" /> Twitter</PopoverMenuItem>
+								<PopoverMenuItem action="facebook" className="reader-share__popover-item">
+									<SocialLogo icon="facebook" /> Facebook</PopoverMenuItem>
+							</PopoverMenu>
+						)
+					)
 			]
 		);
 	}

--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -3,7 +3,8 @@ var React = require( 'react' ),
 	defer = require( 'lodash/defer' ),
 	config = require( 'config' ),
 	classnames = require( 'classnames' ),
-	qs = require( 'qs' );
+	qs = require( 'qs' ),
+	page = require( 'page' );
 
 var PopoverMenu = require( 'components/popover/menu' ),
 	PopoverMenuItem = require( 'components/popover/menu-item' ),
@@ -104,6 +105,10 @@ const ReaderShare = React.createClass( {
 		} );
 	},
 
+	killClick( event ) {
+		event.preventDefault();
+	},
+
 	closeMenu() {
 		// have to defer this to let the mouseup / click escape.
 		// If we don't defer and remove the DOM node on this turn of the event loop,
@@ -113,11 +118,11 @@ const ReaderShare = React.createClass( {
 		} );
 	},
 
-	closeWordPressShareMenu() {
-		this.closeMenu();
+	pickSiteToShareTo( slug, event ) {
 		stats.recordAction( 'share_wordpress' );
 		stats.recordGaEvent( 'Clicked on Share to WordPress' );
 		stats.recordTrack( 'calypso_reader_share_to_site' );
+		page( `/post/${slug}?` + buildQuerystringForPost( this.props.post ) );
 	},
 
 	closeExternalShareMenu( action ) {
@@ -149,7 +154,8 @@ const ReaderShare = React.createClass( {
 		}
 		return React.createElement( this.props.tagName, {
 			className: 'reader-share',
-			onClick: this.toggle,
+			onClick: this.killClick,
+			onTouchTap: this.toggle,
 			onTouchStart: this.preloadEditor,
 			onMouseEnter: this.preloadEditor,
 			ref: 'shareButton' },
@@ -164,11 +170,11 @@ const ReaderShare = React.createClass( {
 								key="menu"
 								header={ <div>{ this.translate( 'Share on:' ) }</div> }
 								sites={ sitesList }
-								siteQuerystring={ buildQuerystringForPost( this.props.post ) }
 								context={ this.refs && this.refs.shareButton }
 								visible={ this.state.showingMenu }
 								groups={ true }
-								onClose={ this.closeWordPressShareMenu }
+								onSiteSelect={ this.pickSiteToShareTo }
+								onClose={ this.closeMenu }
 								position={ this.props.position }
 								className="is-reader"/>
 						: <PopoverMenu key="menu" context={ this.refs && this.refs.shareButton }

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -99,3 +99,7 @@
 		}
 	}
 }
+
+.sites-popover.is-reader .site-selector__sites {
+	max-height: 25vh;
+}

--- a/client/reader/share/style.scss
+++ b/client/reader/share/style.scss
@@ -25,7 +25,7 @@
 	}
 
 	.is-active {
-		color: $blue-dark;
+		color: $blue-wordpress;
 
 		.gridicon {
 			transform: rotate( 90deg );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8588,6 +8588,9 @@
     },
     "blob": {
       "version": "0.0.4"
+    },
+    "valid-url": {
+      "version": "1.0.9"
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1999,7 +1999,7 @@
       }
     },
     "component-tip": {
-      "version": "2.5.0",
+      "version": "3.0.0",
       "dependencies": {
         "bounding-client-rect": {
           "version": "1.0.5",
@@ -2065,6 +2065,9 @@
         },
         "component-query": {
           "version": "0.0.3"
+        },
+        "component-raf": {
+          "version": "1.2.0"
         },
         "domify": {
           "version": "1.3.0"

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "tween.js": "16.3.1",
     "twemoji": "1.3.2",
     "uglify-js": "2.6.1",
+    "valid-url": "1.0.9",
     "walk": "2.3.4",
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "component-classes": "1.2.1",
     "component-closest": "0.1.4",
     "component-file-picker": "0.2.1",
-    "component-tip": "2.5.0",
+    "component-tip": "3.0.0",
     "component-uid": "0.0.2",
     "cookie": "0.1.2",
     "cookie-parser": "1.3.2",


### PR DESCRIPTION
Pull out Press This support and use the editor inside Calypso.

To test this, open the Reader, find a post you like, hit the Share button and pick WordPress. You should be moved to the editor, with a sample post filled out.

If the post had an embed, the embed will be embedded at the top of the post. Hopefully.

If the post had a canonical image and no embed, the image will be at the top of the post. The image is hotlinked, which I don't love, but it's what Press This does too. 

The text is pulled from the post's excerpt. Would be nice to pull it from selected text, but little steps.

![sharing](https://cloud.githubusercontent.com/assets/14350/13304920/c35da9c0-db25-11e5-95ef-00190cdfed4a.gif)

