### PR TITLE
Reader: set up more sane URLs and redirect legacy routes

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -112,6 +112,27 @@ module.exports = {
 		next();
 	},
 
+	legacyRedirects: function( context, next ) {
+		const legacyPathRegexes = {
+			feed_stream: /\/read\/blog\/feed\/([0-9]+)/i,
+			feed_full_post: /\/read\/post\/feed\/([0-9]+)\/([0-9]+)/i,
+			blog_stream: /\/read\/blog\/id\/([0-9]+)/i,
+			blog_full_post: /\/read\/post\/id\/([0-9]+)\/([0-9]+)/i,
+		};
+
+		if ( context.path.match( legacyPathRegexes.feed_stream ) ) {
+			page.redirect( `/read/feeds/${context.params.feed_id}` );
+		} else if ( context.path.match( legacyPathRegexes.feed_full_post ) ) {
+			page.redirect( `/read/feeds/${context.params.feed_id}/posts/${context.params.post_id}` );
+		} else if ( context.path.match( legacyPathRegexes.blog_stream ) ) {
+			page.redirect( `/read/blogs/${context.params.blog_id}` );
+		} else if ( context.path.match( legacyPathRegexes.blog_full_post ) ) {
+			page.redirect( `/read/blogs/${context.params.blog_id}/posts/${context.params.post_id}` );
+		}
+
+		next();
+	},
+
 	loadSubscriptions: function( context, next ) {
 		// these three are included to ensure that the stores required have been loaded and can accept actions
 		const FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' ), // eslint-disable-line no-unused-vars

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -62,7 +62,7 @@ pageNotifier( function removeFullPostOnLeave( newContext, oldContext ) {
 		return;
 	}
 
-	const fullPostViewRegex = /\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)/i;
+	const fullPostViewRegex = /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i;
 
 	if ( ( ! oldContext || oldContext.path.match( fullPostViewRegex ) ) && ! newContext.path.match( fullPostViewRegex ) ) {
 		newContext.store.dispatch( hideReaderFullPost() );
@@ -105,9 +105,9 @@ module.exports = {
 		}
 
 		// Have we arrived at a URL ending in /posts? Redirect to feed stream/blog stream
-		if ( context.path.match( /\/read\/feeds\/([0-9]+)\/posts/i ) ) {
+		if ( context.path.match( /^\/read\/feeds\/([0-9]+)\/posts$/i ) ) {
 			redirect = `/read/feeds/${context.params.feed_id}`
-		} else if ( context.path.match( /\/read\/blogs\/([0-9]+)\/posts/i ) ) {
+		} else if ( context.path.match( /^\/read\/blogs\/([0-9]+)\/posts$/i ) ) {
 			redirect = `/read/blogs/${context.params.blog_id}`
 		}
 
@@ -120,10 +120,10 @@ module.exports = {
 
 	legacyRedirects: function( context, next ) {
 		const legacyPathRegexes = {
-			feedStream: /\/read\/blog\/feed\/([0-9]+)/i,
-			feedFullPost: /\/read\/post\/feed\/([0-9]+)\/([0-9]+)/i,
-			blogStream: /\/read\/blog\/id\/([0-9]+)/i,
-			blogFullPost: /\/read\/post\/id\/([0-9]+)\/([0-9]+)/i,
+			feedStream: /^\/read\/blog\/feed\/([0-9]+)$/i,
+			feedFullPost: /^\/read\/post\/feed\/([0-9]+)\/([0-9]+)$/i,
+			blogStream: /^\/read\/blog\/id\/([0-9]+)$/i,
+			blogFullPost: /^\/read\/post\/id\/([0-9]+)\/([0-9]+)$/i,
 		};
 
 		if ( context.path.match( legacyPathRegexes.feedStream ) ) {

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -95,20 +95,13 @@ function setPageTitle( title ) {
 }
 
 module.exports = {
-	redirects: function( context, next ) {
+	prettyRedirects: function( context, next ) {
 		// Do we have a 'pretty' site or feed URL?
 		let redirect;
 		if ( context.params.blog_id ) {
 			redirect = readerRoute.getPrettySiteUrl( context.params.blog_id );
 		} else if ( context.params.feed_id ) {
 			redirect = readerRoute.getPrettyFeedUrl( context.params.feed_id );
-		}
-
-		// Have we arrived at a URL ending in /posts? Redirect to feed stream/blog stream
-		if ( context.path.match( /^\/read\/feeds\/([0-9]+)\/posts$/i ) ) {
-			redirect = `/read/feeds/${context.params.feed_id}`
-		} else if ( context.path.match( /^\/read\/blogs\/([0-9]+)\/posts$/i ) ) {
-			redirect = `/read/blogs/${context.params.blog_id}`
 		}
 
 		if ( redirect ) {
@@ -134,6 +127,22 @@ module.exports = {
 			page.redirect( `/read/blogs/${context.params.blog_id}` );
 		} else if ( context.path.match( legacyPathRegexes.blogFullPost ) ) {
 			page.redirect( `/read/blogs/${context.params.blog_id}/posts/${context.params.post_id}` );
+		}
+
+		next();
+	},
+
+	incompleteUrlRedirects: function( context, next ) {
+		let redirect;
+		// Have we arrived at a URL ending in /posts? Redirect to feed stream/blog stream
+		if ( context.path.match( /^\/read\/feeds\/([0-9]+)\/posts$/i ) ) {
+			redirect = `/read/feeds/${context.params.feed_id}`
+		} else if ( context.path.match( /^\/read\/blogs\/([0-9]+)\/posts$/i ) ) {
+			redirect = `/read/blogs/${context.params.blog_id}`
+		}
+
+		if ( redirect ) {
+			return page.redirect( redirect );
 		}
 
 		next();

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -6,7 +6,6 @@ const ReactDom = require( 'react-dom' ),
 	page = require( 'page' ),
 	debug = require( 'debug' )( 'calypso:reader:controller' ),
 	trim = require( 'lodash/trim' ),
-	startsWith = require( 'lodash/startsWith' ),
 	moment = require( 'moment' ),
 	ReduxProvider = require( 'react-redux' ).Provider;
 
@@ -63,10 +62,9 @@ pageNotifier( function removeFullPostOnLeave( newContext, oldContext ) {
 		return;
 	}
 
-	const fullPostViewPrefix = '/read/post/';
+	const fullPostViewRegex = /\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)/i;
 
-	if ( startsWith( oldContext.path, fullPostViewPrefix ) &&
-		! startsWith( newContext.path, fullPostViewPrefix ) ) {
+	if ( oldContext.path.match( fullPostViewRegex ) && ! newContext.path.match( fullPostViewRegex ) ) {
 		oldContext.store.dispatch( hideReaderFullPost() );
 	}
 } );
@@ -198,7 +196,7 @@ module.exports = {
 
 	feedListing: function( context ) {
 		var FeedStream = require( 'reader/feed-stream' ),
-			basePath = '/read/blog/feed/:feed_id',
+			basePath = '/read/feeds/:feed_id',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Feed > ' + context.params.feed_id,
 			feedStore = feedStreamFactory( 'feed:' + context.params.feed_id ),
 			mcKey = 'blog';
@@ -233,7 +231,7 @@ module.exports = {
 
 	blogListing: function( context ) {
 		var SiteStream = require( 'reader/site-stream' ),
-			basePath = '/read/blog/id/:blog_id',
+			basePath = '/read/blogs/:blog_id',
 			fullAnalyticsPageTitle = analyticsPageTitle + ' > Site > ' + context.params.blog_id,
 			feedStore = feedStreamFactory( 'site:' + context.params.blog_id ),
 			mcKey = 'blog';
@@ -270,7 +268,7 @@ module.exports = {
 		var FullPostDialog = require( 'reader/full-post' ),
 			feedId = context.params.feed,
 			postId = context.params.post,
-			basePath = '/read/post/feed/:feed_id/:feed_item_id',
+			basePath = '/read/feeds/:feed_id/posts/:feed_item_id',
 			fullPageTitle = analyticsPageTitle + ' > Feed Post > ' + feedId + ' > ' + postId;
 
 		__lastTitle = TitleStore.getState().title;
@@ -308,7 +306,7 @@ module.exports = {
 		var FullPostDialog = require( 'reader/full-post' ),
 			blogId = context.params.blog,
 			postId = context.params.post,
-			basePath = '/read/post/id/:blog_id/:post_id',
+			basePath = '/read/blogs/:blog_id/posts/:post_id',
 			fullPageTitle = analyticsPageTitle + ' > Blog Post > ' + blogId + ' > ' + postId;
 
 		__lastTitle = TitleStore.getState().title;

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -98,11 +98,19 @@ function setPageTitle( title ) {
 
 module.exports = {
 	redirects: function( context, next ) {
+		// Do we have a 'pretty' site or feed URL?
 		let redirect;
 		if ( context.params.blog_id ) {
 			redirect = readerRoute.getPrettySiteUrl( context.params.blog_id );
 		} else if ( context.params.feed_id ) {
 			redirect = readerRoute.getPrettyFeedUrl( context.params.feed_id );
+		}
+
+		// Have we arrived at a URL ending in /posts? Redirect to feed stream/blog stream
+		if ( context.path.match( /\/read\/feeds\/([0-9]+)\/posts/i ) ) {
+			redirect = `/read/feeds/${context.params.feed_id}`
+		} else if ( context.path.match( /\/read\/blogs\/([0-9]+)\/posts/i ) ) {
+			redirect = `/read/blogs/${context.params.blog_id}`
 		}
 
 		if ( redirect ) {

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -120,19 +120,19 @@ module.exports = {
 
 	legacyRedirects: function( context, next ) {
 		const legacyPathRegexes = {
-			feed_stream: /\/read\/blog\/feed\/([0-9]+)/i,
-			feed_full_post: /\/read\/post\/feed\/([0-9]+)\/([0-9]+)/i,
-			blog_stream: /\/read\/blog\/id\/([0-9]+)/i,
-			blog_full_post: /\/read\/post\/id\/([0-9]+)\/([0-9]+)/i,
+			feedStream: /\/read\/blog\/feed\/([0-9]+)/i,
+			feedFullPost: /\/read\/post\/feed\/([0-9]+)\/([0-9]+)/i,
+			blogStream: /\/read\/blog\/id\/([0-9]+)/i,
+			blogFullPost: /\/read\/post\/id\/([0-9]+)\/([0-9]+)/i,
 		};
 
-		if ( context.path.match( legacyPathRegexes.feed_stream ) ) {
+		if ( context.path.match( legacyPathRegexes.feedStream ) ) {
 			page.redirect( `/read/feeds/${context.params.feed_id}` );
-		} else if ( context.path.match( legacyPathRegexes.feed_full_post ) ) {
+		} else if ( context.path.match( legacyPathRegexes.feedFullPost ) ) {
 			page.redirect( `/read/feeds/${context.params.feed_id}/posts/${context.params.post_id}` );
-		} else if ( context.path.match( legacyPathRegexes.blog_stream ) ) {
+		} else if ( context.path.match( legacyPathRegexes.blogStream ) ) {
 			page.redirect( `/read/blogs/${context.params.blog_id}` );
-		} else if ( context.path.match( legacyPathRegexes.blog_full_post ) ) {
+		} else if ( context.path.match( legacyPathRegexes.blogFullPost ) ) {
 			page.redirect( `/read/blogs/${context.params.blog_id}/posts/${context.params.post_id}` );
 		}
 

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -64,8 +64,8 @@ pageNotifier( function removeFullPostOnLeave( newContext, oldContext ) {
 
 	const fullPostViewRegex = /\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)/i;
 
-	if ( oldContext.path.match( fullPostViewRegex ) && ! newContext.path.match( fullPostViewRegex ) ) {
-		oldContext.store.dispatch( hideReaderFullPost() );
+	if ( ( ! oldContext || oldContext.path.match( fullPostViewRegex ) ) && ! newContext.path.match( fullPostViewRegex ) ) {
+		newContext.store.dispatch( hideReaderFullPost() );
 	}
 } );
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -232,7 +232,7 @@ module.exports = React.createClass( {
 	},
 
 	isPostFullScreen: function() {
-		return !! window.location.href.match( /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i );
+		return !! window.location.pathname.match( /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i );
 	},
 
 	selectNextItem: function() {

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -232,8 +232,7 @@ module.exports = React.createClass( {
 	},
 
 	isPostFullScreen: function() {
-		return window.location.href.indexOf( '/read/post/feed/' ) > -1 ||
-			window.location.href.indexOf( '/read/post/id' ) > -1;
+		return !! window.location.href.match( /\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)/i );
 	},
 
 	selectNextItem: function() {
@@ -333,9 +332,9 @@ module.exports = React.createClass( {
 		}
 		var method = options && options.replaceHistory ? 'replace' : 'show';
 		if ( post.feed_ID && post.feed_item_ID ) {
-			page[ method ]( '/read/post/feed/' + post.feed_ID + '/' + post.feed_item_ID + hashtag );
+			page[ method ]( '/read/feeds/' + post.feed_ID + '/posts/' + post.feed_item_ID + hashtag );
 		} else {
-			page[ method ]( '/read/post/id/' + post.site_ID + '/' + post.ID + hashtag );
+			page[ method ]( '/read/blogs/' + post.site_ID + '/posts/' + post.ID + hashtag );
 		}
 	},
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -232,7 +232,7 @@ module.exports = React.createClass( {
 	},
 
 	isPostFullScreen: function() {
-		return !! window.location.href.match( /\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)/i );
+		return !! window.location.href.match( /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i );
 	},
 
 	selectNextItem: function() {

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -33,15 +33,24 @@ module.exports = function() {
 		page( '/', updateLastRoute, controller.removePost, controller.sidebar, controller.following );
 		page( '/read/following', '/' );
 
-		page( '/read/blog/feed/:feed_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.feedListing );
-		page.exit( '/read/blog/feed/:feed_id', controller.resetTitle );
+		// Feed stream
+		page( '/read/blog/feed/:feed_id', controller.legacyRedirects );
+		page( '/read/feeds/:feed_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.feedListing );
+		page.exit( '/read/feeds/:feed_id', controller.resetTitle );
 
-		page( '/read/post/feed/:feed/:post', updateLastRoute, controller.feedPost );
-		page.exit( '/read/post/feed/:feed/:post', controller.resetTitle );
+		// Feed full post
+		page( '/read/post/feed/:feed_id/:post_id', controller.legacyRedirects );
+		page( '/read/feeds/:feed/posts/:post', updateLastRoute, controller.feedPost );
+		page.exit( '/read/feeds/:feed/posts/:post', controller.resetTitle );
 
-		page( '/read/blog/id/:blog_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.blogListing );
-		page( '/read/post/id/:blog/:post', updateLastRoute, controller.blogPost );
-		page.exit( '/read/post/id/:blog/:post', controller.resetTitle );
+		// Blog stream
+		page( '/read/blog/id/:blog_id', controller.legacyRedirects );
+		page( '/read/blogs/:blog_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.blogListing );
+
+		// Blog full post
+		page( '/read/post/id/:blog_id/:post_id', controller.legacyRedirects );
+		page( '/read/blogs/:blog/posts/:post', updateLastRoute, controller.blogPost );
+		page.exit( '/read/blogs/:blog/posts/:post', controller.resetTitle );
 
 		page( '/tag/:tag', updateLastRoute, controller.removePost, controller.sidebar, controller.tagListing );
 	}

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -35,6 +35,7 @@ module.exports = function() {
 
 		// Feed stream
 		page( '/read/blog/feed/:feed_id', controller.legacyRedirects );
+		page( '/read/feeds/:feed_id/posts', controller.redirects );
 		page( '/read/feeds/:feed_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.feedListing );
 		page.exit( '/read/feeds/:feed_id', controller.resetTitle );
 
@@ -45,6 +46,7 @@ module.exports = function() {
 
 		// Blog stream
 		page( '/read/blog/id/:blog_id', controller.legacyRedirects );
+		page( '/read/blogs/:blog_id/posts', controller.redirects );
 		page( '/read/blogs/:blog_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.blogListing );
 
 		// Blog full post

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -31,12 +31,20 @@ module.exports = function() {
 		page( '/tag/*', controller.loadSubscriptions );
 
 		page( '/', updateLastRoute, controller.removePost, controller.sidebar, controller.following );
+
+		// Old and incomplete paths that should be redirected to /
 		page( '/read/following', '/' );
+		page( '/read', '/' );
+		page( '/read/blogs', '/' );
+		page( '/read/feeds', '/' );
+		page( '/read/blog', '/' );
+		page( '/read/post', '/' );
+		page( '/read/feed', '/' );
 
 		// Feed stream
 		page( '/read/blog/feed/:feed_id', controller.legacyRedirects );
-		page( '/read/feeds/:feed_id/posts', controller.redirects );
-		page( '/read/feeds/:feed_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.feedListing );
+		page( '/read/feeds/:feed_id/posts', controller.incompleteUrlRedirects );
+		page( '/read/feeds/:feed_id', updateLastRoute, controller.prettyRedirects, controller.removePost, controller.sidebar, controller.feedListing );
 		page.exit( '/read/feeds/:feed_id', controller.resetTitle );
 
 		// Feed full post
@@ -46,8 +54,8 @@ module.exports = function() {
 
 		// Blog stream
 		page( '/read/blog/id/:blog_id', controller.legacyRedirects );
-		page( '/read/blogs/:blog_id/posts', controller.redirects );
-		page( '/read/blogs/:blog_id', updateLastRoute, controller.redirects, controller.removePost, controller.sidebar, controller.blogListing );
+		page( '/read/blogs/:blog_id/posts', controller.incompleteUrlRedirects );
+		page( '/read/blogs/:blog_id', updateLastRoute, controller.prettyRedirects, controller.removePost, controller.sidebar, controller.blogListing );
 
 		// Blog full post
 		page( '/read/post/id/:blog_id/:post_id', controller.legacyRedirects );

--- a/client/reader/route/index.js
+++ b/client/reader/route/index.js
@@ -1,5 +1,5 @@
-const FEED_URL_BASE = '/read/blog/feed/';
-const SITE_URL_BASE = '/read/blog/id/';
+const FEED_URL_BASE = '/read/feeds/';
+const SITE_URL_BASE = '/read/blogs/';
 
 const PRETTY_FEED_URLS = {
 	12733228: '/discover'

--- a/client/reader/route/test/index.js
+++ b/client/reader/route/test/index.js
@@ -11,17 +11,17 @@ var route = require( '../' );
 describe( 'reader/route', function() {
 	describe( 'getStreamUrlFromPost', function() {
 		it( 'should return url for post from feed', function() {
-			expect( route.getStreamUrlFromPost( { feed_ID: 1234 } ) ).to.equal( '/read/blog/feed/1234' );
+			expect( route.getStreamUrlFromPost( { feed_ID: 1234 } ) ).to.equal( '/read/feeds/1234' );
 		} );
 
 		it( 'should return url for post from site', function() {
-			expect( route.getStreamUrlFromPost( { site_ID: 1234 } ) ).to.equal( '/read/blog/id/1234' );
+			expect( route.getStreamUrlFromPost( { site_ID: 1234 } ) ).to.equal( '/read/blogs/1234' );
 		} );
 	} );
 
 	describe( 'getSiteUrl', function() {
 		it( 'should return site URL', function() {
-			expect( route.getSiteUrl( 1234 ) ).to.equal( '/read/blog/id/1234' );
+			expect( route.getSiteUrl( 1234 ) ).to.equal( '/read/blogs/1234' );
 		} );
 
 		it( 'should return pretty URL for discover', function() {
@@ -31,7 +31,7 @@ describe( 'reader/route', function() {
 
 	describe( 'getFeedUrl', function() {
 		it( 'should return site URL', function() {
-			expect( route.getFeedUrl( 1234 ) ).to.equal( '/read/blog/feed/1234' );
+			expect( route.getFeedUrl( 1234 ) ).to.equal( '/read/feeds/1234' );
 		} );
 
 		it( 'should return pretty URL for discover', function() {

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -83,7 +83,7 @@ export default React.createClass( {
 	},
 
 	getPostUrl( post ) {
-		return '/read/post/id/' + post.site_ID + '/' + post.ID;
+		return '/read/blogs/' + post.site_ID + '/posts/' + post.ID;
 	},
 
 	handleClick( postData ) {

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -20,7 +20,7 @@ var FeedHeader = require( 'reader/feed-header' ),
 function checkForRedirect( site ) {
 	if ( site && site.get( 'prefer_feed' ) && site.get( 'feed_ID' ) ) {
 		setTimeout( function() {
-			page.replace( '/read/blog/feed/' + site.get( 'feed_ID' ) )
+			page.replace( '/read/feeds/' + site.get( 'feed_ID' ) )
 		}, 0 );
 	}
 }

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -29,10 +29,10 @@ function getLocation() {
 	if ( path.indexOf( '/tag/' ) === 0 ) {
 		return 'topic_page';
 	}
-	if ( path.match( /\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)/i ) ) {
+	if ( path.match( /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i ) ) {
 		return 'single_post';
 	}
-	if ( path.match( /\/read\/(blogs|feeds)\/([0-9]+)/i ) ) {
+	if ( path.match( /^\/read\/(blogs|feeds)\/([0-9]+)$/i ) ) {
 		return 'blog_page';
 	}
 	if ( path.indexOf( '/read/list/' ) === 0 ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -29,11 +29,11 @@ function getLocation() {
 	if ( path.indexOf( '/tag/' ) === 0 ) {
 		return 'topic_page';
 	}
-	if ( path.indexOf( '/read/blog/' ) === 0 ) {
-		return 'blog_page';
-	}
-	if ( path.indexOf( '/read/post/' ) === 0 ) {
+	if ( path.match( /\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)/i ) ) {
 		return 'single_post';
+	}
+	if ( path.match( /\/read\/(blogs|feeds)\/([0-9]+)/i ) ) {
+		return 'blog_page';
 	}
 	if ( path.indexOf( '/read/list/' ) === 0 ) {
 		return 'list';


### PR DESCRIPTION
Our current Reader URL structure has been knocking around on wordpress.com for several years. It doesn't map very well to the resources involved, and the hierarchy for full posts is a bit odd. For example, a full post from a feed is `/read/post/feed/44902/935964996`.

This PR creates new better routes for Reader stream and full post pages, and adds redirects for the legacy routes.

Fixes #3521.

### The new routes

| Feature | Old path | New path |
|---------|----------|----------|
| Feed stream | /read/blog/feed/:feed_id | /read/feeds/:feed_id |
| Blog stream | /read/blog/id/:blog_id | /read/blogs/:blog_id |
| Feed full post | /read/post/feed/:feed_id/:feed_item_id | /read/feeds/:feed_id/posts/:feed_item_id |
| Feed full post | /read/post/id/:blog_id/:post_id | /read/blogs/:blog_id/posts/:post_id |

### To test

Verify that the new routes above are being used throughout in the Reader (without any redirects in normal use).

Check that the old paths are successfully redirected to the new ones.
