### PR TITLE
Checkout: Update thank you page to use new copy when purchasing the premium/business plan

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -17,9 +17,18 @@ const BusinessPlanDetails = ( { isFreeTrial, selectedSite } ) => {
 			{ showGetFreeDomainTip
 			? <PurchaseDetail
 					additionalClass="get-free-domain"
-					title={ i18n.translate( 'Get a free domain' ) }
-					description={ i18n.translate( 'WordPress.com Business includes a free domain for your site.' ) }
-					buttonText={ i18n.translate( 'Add Free Domain' ) }
+					title={ i18n.translate( 'Get your custom domain' ) }
+					description={
+						i18n.translate(
+							"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
+							'A free domain is included with your plan.',
+							{
+								args: { siteDomain: selectedSite.domain },
+								components: { em: <em /> }
+							}
+						)
+					}
+					buttonText={ i18n.translate( 'Claim your free domain' ) }
 					href={ '/domains/add/' + selectedSite.slug } />
 			: <PurchaseDetail
 					additionalClass="live-chat"
@@ -32,15 +41,15 @@ const BusinessPlanDetails = ( { isFreeTrial, selectedSite } ) => {
 
 			<PurchaseDetail
 				additionalClass="unlimited-premium-themes"
-				title={ i18n.translate( 'Browse Themes' ) }
-				description={ i18n.translate( 'Browse our collection of beautiful and amazing themes for your site.' ) }
-				buttonText={ i18n.translate( 'Find a New Theme' ) }
+				title={ i18n.translate( 'Find a new theme' ) }
+				description={ i18n.translate( 'All our premium themes, normally ranging $18 to $175 in price, are now available at no extra cost.' ) }
+				buttonText={ i18n.translate( 'Browse premium themes' ) }
 				href={ '/design/' + selectedSite.slug } />
 
 			<PurchaseDetail
 				additionalClass="connect-google-analytics"
-				title={ i18n.translate( 'Integrate Google Analytics' ) }
-				description={ i18n.translate( 'Connect your site to your existing Google Analytics account.' ) }
+				title={ i18n.translate( 'Stats from Google Analytics' ) }
+				description={ i18n.translate( 'Connect to Google Analytics for the perfect complement to WordPress.com stats.' ) }
 				buttonText={ i18n.translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug } />
 		</ul>

--- a/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
@@ -7,15 +7,18 @@ import React from 'react';
 const CheckoutThankYouHeader = React.createClass( {
 	propTypes: {
 		isDataLoaded: React.PropTypes.bool.isRequired,
-		isFreeTrial: React.PropTypes.bool.isRequired,
-		productName: React.PropTypes.string
+		isFreeTrial: React.PropTypes.bool,
+		primaryPurchase: React.PropTypes.object,
+		selectedSite: React.PropTypes.object
 	},
 
 	renderHeading() {
 		if ( ! this.props.isDataLoaded ) {
 			return this.translate( 'Loading…' );
-		} else if ( this.props.isFreeTrial ) {
-			return this.translate( 'Your 14 day free trial starts today!' );
+		}
+
+		if ( this.props.isFreeTrial ) {
+			return this.translate( 'Way to go, your 14 day free trial starts now!' );
 		}
 
 		return this.translate( 'Thank you for your purchase!' );
@@ -24,22 +27,24 @@ const CheckoutThankYouHeader = React.createClass( {
 	renderText() {
 		if ( ! this.props.isDataLoaded ) {
 			return this.translate( 'Loading…' );
-		} else if ( this.props.productName ) {
-			if ( this.props.isFreeTrial ) {
-				return this.translate( "We hope you enjoy %(productName)s. What's next? Take it for a spin!", {
+		}
+
+		if ( this.props.isFreeTrial ) {
+			return this.translate( "We hope you enjoy %(productName)s. What's next? Take it for a spin!", {
+				args: {
+					productName: this.props.primaryPurchase.productShort
+				}
+			} );
+		}
+
+		if ( this.props.primaryPurchase ) {
+			return this.translate(
+				"You will receive an email confirmation shortly for your purchase of %(productName)s. What's next?", {
 					args: {
-						productName: this.props.productName
+						productName: this.props.primaryPurchase.productName
 					}
-				} );
-			} else {
-				return this.translate(
-					"You will receive an email confirmation shortly for your purchase of %(productName)s. What's next?", {
-						args: {
-							productName: this.props.productName
-						}
-					}
-				);
-			}
+				}
+			);
 		}
 
 		return this.translate( "You will receive an email confirmation shortly. What's next?" );

--- a/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
@@ -4,6 +4,11 @@
 import classNames from 'classnames';
 import React from 'react';
 
+/**
+ * External dependencies
+ */
+import { isPlan } from 'lib/products-values';
+
 const CheckoutThankYouHeader = React.createClass( {
 	propTypes: {
 		isDataLoaded: React.PropTypes.bool.isRequired,
@@ -29,11 +34,10 @@ const CheckoutThankYouHeader = React.createClass( {
 			return this.translate( 'Loading…' );
 		}
 
-		if ( this.props.isFreeTrial ) {
-			return this.translate( "We hope you enjoy %(productName)s. What's next? Take it for a spin!", {
-				args: {
-					productName: this.props.primaryPurchase.productShort
-				}
+		if ( isPlan( this.props.primaryPurchase ) ) {
+			return this.translate( "Your site is now on the {{strong}}%(productName)s{{/strong}} plan. It's doing somersaults in excitement!", {
+				args: { productName: this.props.primaryPurchase.productName },
+				components: { strong: <strong /> }
 			} );
 		}
 

--- a/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
@@ -17,7 +17,7 @@ const CheckoutThankYouHeader = React.createClass( {
 		selectedSite: React.PropTypes.object
 	},
 
-	renderHeading() {
+	getHeading() {
 		if ( ! this.props.isDataLoaded ) {
 			return this.translate( 'Loading…' );
 		}
@@ -29,7 +29,7 @@ const CheckoutThankYouHeader = React.createClass( {
 		return this.translate( 'Thank you for your purchase!' );
 	},
 
-	renderText() {
+	getText() {
 		if ( ! this.props.isDataLoaded ) {
 			return this.translate( 'Loading…' );
 		}
@@ -59,14 +59,17 @@ const CheckoutThankYouHeader = React.createClass( {
 			'checkout-thank-you-header': true,
 			'is-placeholder': ! this.props.isDataLoaded
 		}
+
 		return (
 			<div className={ classNames( classes ) }>
-				<span className="checkout-thank-you-header__icon"/>
+				<span className="checkout-thank-you-header__icon" />
+
 				<h1 className="checkout-thank-you-header__heading">
-					{ this.renderHeading() }
+					{ this.getHeading() }
 				</h1>
+
 				<h2 className="checkout-thank-you-header__text">
-					{ this.renderText() }
+					{ this.getText() }
 				</h2>
 			</div>
 		);

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -162,7 +162,7 @@ var CheckoutThankYou = React.createClass( {
 				return [
 					DomainRegistrationDetails,
 					find( purchases, isDomainRegistration ),
-					find( purchases ).meta
+					find( purchases, isDomainRegistration ).meta
 				];
 			} else if ( purchases.some( isDomainMapping ) ) {
 				return [

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -127,57 +127,63 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	getComponentAndPrimaryPurchaseAndDomain: function() {
-		var primaryPurchase = null,
-			purchases,
-			componentClass,
-			domain;
+		var purchases;
 
 		if ( this.isDataLoaded() ) {
 			purchases = getPurchases( this.props );
 
 			if ( purchases.some( isJetpackPremium ) ) {
-				componentClass = JetpackPremiumPlanDetails;
-				primaryPurchase = find( purchases, isJetpackPremium );
+				return [
+					JetpackPremiumPlanDetails,
+					find( purchases, isJetpackPremium )
+				];
 			} else if ( purchases.some( isJetpackBusiness ) ) {
-				componentClass = JetpackBusinessPlanDetails;
-				primaryPurchase = find( purchases, isJetpackBusiness );
+				return [
+					JetpackBusinessPlanDetails,
+					find( purchases, isJetpackBusiness )
+				];
 			} else if ( purchases.some( isPremium ) ) {
-				componentClass = PremiumPlanDetails;
-				primaryPurchase = find( purchases, isPremium );
+				return [
+					PremiumPlanDetails,
+					find( purchases, isPremium )
+				];
 			} else if ( purchases.some( isBusiness ) ) {
-				componentClass = BusinessPlanDetails;
-				primaryPurchase = find( purchases, isBusiness );
+				return [
+					BusinessPlanDetails,
+					find( purchases, isBusiness )
+				];
 			} else if ( purchases.some( isGoogleApps ) ) {
-				domain = find( purchases, isGoogleApps ).meta;
-
-				componentClass = GoogleAppsDetails;
-				primaryPurchase = find( purchases, isGoogleApps );
+				return [
+					GoogleAppsDetails,
+					find( purchases, isGoogleApps ),
+					find( purchases, isGoogleApps ).meta
+				];
 			} else if ( purchases.some( isDomainRegistration ) ) {
-				domain = find( purchases ).meta;
-
-				componentClass = DomainRegistrationDetails;
-				primaryPurchase = find( purchases, isDomainRegistration );
+				return [
+					DomainRegistrationDetails,
+					find( purchases, isDomainRegistration ),
+					find( purchases ).meta
+				];
 			} else if ( purchases.some( isDomainMapping ) ) {
-				domain = find( purchases, isDomainMapping ).meta;
-
-				componentClass = DomainMappingDetails;
-				primaryPurchase = find( purchases, isDomainMapping );
+				return [
+					DomainMappingDetails,
+					find( purchases, isDomainMapping ),
+					find( purchases, isDomainMapping ).meta
+				];
 			} else if ( purchases.some( isSiteRedirect ) ) {
-				domain = find( purchases, isSiteRedirect ).meta;
-
-				componentClass = SiteRedirectDetails;
-				primaryPurchase = find( purchases, isSiteRedirect );
+				return [
+					SiteRedirectDetails,
+					find( purchases, isSiteRedirect ),
+					find( purchases, isSiteRedirect ).meta
+				];
 			} else if ( purchases.some( isChargeback ) ) {
-				componentClass = ChargebackDetails;
-				primaryPurchase = find( purchases, isChargeback );
-			} else {
-				componentClass = GenericDetails;
+				return [
+					ChargebackDetails,
+					find( purchases, isChargeback ) ];
 			}
-		} else {
-			componentClass = GenericDetails;
 		}
 
-		return [ componentClass, primaryPurchase, domain ];
+		return [ GenericDetails ];
 	},
 
 	productRelatedMessages: function() {
@@ -247,7 +253,8 @@ var CheckoutThankYou = React.createClass( {
 					'or {{contactLink}}contact us{{/contactLink}}.',
 					{
 						components: {
-							supportDocsLink: <a href={ 'http://' + localeSlug + '.support.wordpress.com' } target="_blank" />,
+							supportDocsLink: <a href={ 'http://' + localeSlug + '.support.wordpress.com' }
+								target="_blank" />,
 							forumLink: <a href={ 'http://' + localeSlug + '.forums.wordpress.com' } target="_blank" />,
 							contactLink: <a href={ '/help/contact' } />
 						}

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -126,11 +126,21 @@ var CheckoutThankYou = React.createClass( {
 		return getPurchases( this.props ).some( isJetpackPlan );
 	},
 
+	/**
+	 * Retrieves the component (and any corresponding data) that should be displayed according to the type of purchase
+	 * just performed by the user.
+	 *
+	 * @returns {*[]} an array of varying size with the component instance, then an optional purchase followed possibly by a domain name
+	 */
 	getComponentAndPrimaryPurchaseAndDomain: function() {
-		var purchases;
-
 		if ( this.isDataLoaded() ) {
-			purchases = getPurchases( this.props );
+			const purchases = getPurchases( this.props );
+
+			const findPurchaseAndDomain = ( purchases, predicate ) => {
+				const purchase = find( purchases, predicate );
+
+				return [ purchase, purchase.meta ];
+			};
 
 			if ( purchases.some( isJetpackPremium ) ) {
 				return [
@@ -155,26 +165,22 @@ var CheckoutThankYou = React.createClass( {
 			} else if ( purchases.some( isGoogleApps ) ) {
 				return [
 					GoogleAppsDetails,
-					find( purchases, isGoogleApps ),
-					find( purchases, isGoogleApps ).meta
+					...findPurchaseAndDomain( purchases, isGoogleApps )
 				];
 			} else if ( purchases.some( isDomainRegistration ) ) {
 				return [
 					DomainRegistrationDetails,
-					find( purchases, isDomainRegistration ),
-					find( purchases, isDomainRegistration ).meta
+					...findPurchaseAndDomain( purchases, isDomainRegistration )
 				];
 			} else if ( purchases.some( isDomainMapping ) ) {
 				return [
 					DomainMappingDetails,
-					find( purchases, isDomainMapping ),
-					find( purchases, isDomainMapping ).meta
+					...findPurchaseAndDomain( purchases, isDomainMapping )
 				];
 			} else if ( purchases.some( isSiteRedirect ) ) {
 				return [
 					SiteRedirectDetails,
-					find( purchases, isSiteRedirect ),
-					find( purchases, isSiteRedirect ).meta
+					...findPurchaseAndDomain( purchases, isSiteRedirect )
 				];
 			} else if ( purchases.some( isChargeback ) ) {
 				return [

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -107,11 +107,6 @@ var CheckoutThankYou = React.createClass( {
 		return (
 			<Main className={ classes }>
 				<Card>
-					<CheckoutThankYouHeader
-						isDataLoaded={ this.isDataLoaded() }
-						isFreeTrial={ this.freeTrialWasPurchased() }
-						productName={ this.getSingleProductName() } />
-
 					{ this.productRelatedMessages() }
 				</Card>
 
@@ -141,6 +136,7 @@ var CheckoutThankYou = React.createClass( {
 
 	productRelatedMessages: function() {
 		var selectedSite = this.props.selectedSite,
+			primaryPurchase = null,
 			purchases,
 			componentClass,
 			domain;
@@ -148,6 +144,9 @@ var CheckoutThankYou = React.createClass( {
 		if ( ! this.isDataLoaded() ) {
 			return (
 				<div>
+					<CheckoutThankYouHeader
+						isDataLoaded={ false }
+						selectedSite={ this.props.selectedSite } />
 					<PurchaseDetail isPlaceholder />
 					<PurchaseDetail isPlaceholder />
 					<PurchaseDetail isPlaceholder />
@@ -160,30 +159,39 @@ var CheckoutThankYou = React.createClass( {
 
 			if ( purchases.some( isJetpackPremium ) ) {
 				componentClass = JetpackPremiumPlanDetails;
+				primaryPurchase = find( purchases, isJetpackPremium );
 			} else if ( purchases.some( isJetpackBusiness ) ) {
 				componentClass = JetpackBusinessPlanDetails;
+				primaryPurchase = find( purchases, isJetpackBusiness );
 			} else if ( purchases.some( isPremium ) ) {
 				componentClass = PremiumPlanDetails;
+				primaryPurchase = find( purchases, isPremium );
 			} else if ( purchases.some( isBusiness ) ) {
 				componentClass = BusinessPlanDetails;
+				primaryPurchase = find( purchases, isBusiness );
 			} else if ( purchases.some( isGoogleApps ) ) {
 				domain = find( purchases, isGoogleApps ).meta;
 
 				componentClass = GoogleAppsDetails;
+				primaryPurchase = find( purchases, isGoogleApps );
 			} else if ( purchases.some( isDomainRegistration ) ) {
 				domain = find( purchases ).meta;
 
 				componentClass = DomainRegistrationDetails;
+				primaryPurchase = find( purchases, isDomainRegistration );
 			} else if ( purchases.some( isDomainMapping ) ) {
 				domain = find( purchases, isDomainMapping ).meta;
 
 				componentClass = DomainMappingDetails;
+				primaryPurchase = find( purchases, isDomainMapping );
 			} else if ( purchases.some( isSiteRedirect ) ) {
 				domain = find( purchases, isSiteRedirect ).meta;
 
 				componentClass = SiteRedirectDetails;
+				primaryPurchase = find( purchases, isSiteRedirect );
 			} else if ( purchases.some( isChargeback ) ) {
 				componentClass = ChargebackDetails;
+				primaryPurchase = find( purchases, isChargeback );
 			} else {
 				componentClass = GenericDetails;
 			}
@@ -193,6 +201,12 @@ var CheckoutThankYou = React.createClass( {
 
 		return (
 			<div>
+				<CheckoutThankYouHeader
+					isDataLoaded={ this.isDataLoaded() }
+					isFreeTrial={ this.freeTrialWasPurchased() }
+					primaryPurchase={ primaryPurchase }
+					selectedSite={ this.props.selectedSite } />
+
 				{ React.createElement( componentClass, {
 					selectedSite: selectedSite,
 					isFreeTrial: this.freeTrialWasPurchased(),

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -134,27 +134,13 @@ var CheckoutThankYou = React.createClass( {
 		return getPurchases( this.props ).some( isJetpackPlan );
 	},
 
-	productRelatedMessages: function() {
-		var selectedSite = this.props.selectedSite,
-			primaryPurchase = null,
+	getPrimaryPurchaseAndComponentAndDomain: function() {
+		var primaryPurchase = null,
 			purchases,
 			componentClass,
 			domain;
 
-		if ( ! this.isDataLoaded() ) {
-			return (
-				<div>
-					<CheckoutThankYouHeader
-						isDataLoaded={ false }
-						selectedSite={ this.props.selectedSite } />
-					<PurchaseDetail isPlaceholder />
-					<PurchaseDetail isPlaceholder />
-					<PurchaseDetail isPlaceholder />
-				</div>
-			);
-		}
-
-		if ( this.props.receiptId ) {
+		if ( this.isDataLoaded() ) {
 			purchases = getPurchases( this.props );
 
 			if ( purchases.some( isJetpackPremium ) ) {
@@ -197,6 +183,26 @@ var CheckoutThankYou = React.createClass( {
 			}
 		} else {
 			componentClass = GenericDetails;
+		}
+
+		return [ primaryPurchase, componentClass, domain ];
+	},
+
+	productRelatedMessages: function() {
+		var selectedSite = this.props.selectedSite,
+			[ primaryPurchase, componentClass, domain ] = this.getPrimaryPurchaseAndComponentAndDomain();
+
+		if ( ! this.isDataLoaded() ) {
+			return (
+				<div>
+					<CheckoutThankYouHeader
+						isDataLoaded={ false }
+						selectedSite={ this.props.selectedSite } />
+					<PurchaseDetail isPlaceholder />
+					<PurchaseDetail isPlaceholder />
+					<PurchaseDetail isPlaceholder />
+				</div>
+			);
 		}
 
 		return (

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -126,7 +126,7 @@ var CheckoutThankYou = React.createClass( {
 		return getPurchases( this.props ).some( isJetpackPlan );
 	},
 
-	getPrimaryPurchaseAndComponentAndDomain: function() {
+	getComponentAndPrimaryPurchaseAndDomain: function() {
 		var primaryPurchase = null,
 			purchases,
 			componentClass,
@@ -177,12 +177,12 @@ var CheckoutThankYou = React.createClass( {
 			componentClass = GenericDetails;
 		}
 
-		return [ primaryPurchase, componentClass, domain ];
+		return [ componentClass, primaryPurchase, domain ];
 	},
 
 	productRelatedMessages: function() {
 		var selectedSite = this.props.selectedSite,
-			[ primaryPurchase, componentClass, domain ] = this.getPrimaryPurchaseAndComponentAndDomain();
+			[ componentClass, primaryPurchase, domain ] = this.getComponentAndPrimaryPurchaseAndDomain();
 
 		if ( ! this.isDataLoaded() ) {
 			return (

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -91,14 +91,6 @@ var CheckoutThankYou = React.createClass( {
 		}
 	},
 
-	getSingleProductName() {
-		if ( this.isDataLoaded() && getPurchases( this.props ).length ) {
-			return getPurchases( this.props )[ 0 ].productNameShort;
-		}
-
-		return null;
-	},
-
 	render: function() {
 		var classes = classNames( 'checkout-thank-you', {
 			'is-placeholder': ! this.isDataLoaded()

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -130,7 +130,7 @@ var CheckoutThankYou = React.createClass( {
 	 * Retrieves the component (and any corresponding data) that should be displayed according to the type of purchase
 	 * just performed by the user.
 	 *
-	 * @returns {*[]} an array of varying size with the component instance, then an optional purchase followed possibly by a domain name
+	 * @returns {*[]} an array of varying size with the component instance, then an optional purchase object possibly followed by a domain name
 	 */
 	getComponentAndPrimaryPurchaseAndDomain: function() {
 		if ( this.isDataLoaded() ) {
@@ -143,49 +143,23 @@ var CheckoutThankYou = React.createClass( {
 			};
 
 			if ( purchases.some( isJetpackPremium ) ) {
-				return [
-					JetpackPremiumPlanDetails,
-					find( purchases, isJetpackPremium )
-				];
+				return [ JetpackPremiumPlanDetails, find( purchases, isJetpackPremium ) ];
 			} else if ( purchases.some( isJetpackBusiness ) ) {
-				return [
-					JetpackBusinessPlanDetails,
-					find( purchases, isJetpackBusiness )
-				];
+				return [ JetpackBusinessPlanDetails, find( purchases, isJetpackBusiness ) ];
 			} else if ( purchases.some( isPremium ) ) {
-				return [
-					PremiumPlanDetails,
-					find( purchases, isPremium )
-				];
+				return [ PremiumPlanDetails, find( purchases, isPremium ) ];
 			} else if ( purchases.some( isBusiness ) ) {
-				return [
-					BusinessPlanDetails,
-					find( purchases, isBusiness )
-				];
+				return [ BusinessPlanDetails, find( purchases, isBusiness ) ];
 			} else if ( purchases.some( isGoogleApps ) ) {
-				return [
-					GoogleAppsDetails,
-					...findPurchaseAndDomain( purchases, isGoogleApps )
-				];
+				return [ GoogleAppsDetails, ...findPurchaseAndDomain( purchases, isGoogleApps ) ];
 			} else if ( purchases.some( isDomainRegistration ) ) {
-				return [
-					DomainRegistrationDetails,
-					...findPurchaseAndDomain( purchases, isDomainRegistration )
-				];
+				return [ DomainRegistrationDetails, ...findPurchaseAndDomain( purchases, isDomainRegistration ) ];
 			} else if ( purchases.some( isDomainMapping ) ) {
-				return [
-					DomainMappingDetails,
-					...findPurchaseAndDomain( purchases, isDomainMapping )
-				];
+				return [ DomainMappingDetails, ...findPurchaseAndDomain( purchases, isDomainMapping ) ];
 			} else if ( purchases.some( isSiteRedirect ) ) {
-				return [
-					SiteRedirectDetails,
-					...findPurchaseAndDomain( purchases, isSiteRedirect )
-				];
+				return [ SiteRedirectDetails, ...findPurchaseAndDomain( purchases, isSiteRedirect ) ];
 			} else if ( purchases.some( isChargeback ) ) {
-				return [
-					ChargebackDetails,
-					find( purchases, isChargeback ) ];
+				return [ ChargebackDetails, find( purchases, isChargeback ) ];
 			}
 		}
 

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -45,7 +45,7 @@ const PremiumPlanDetails = ( { isFreeTrial, selectedSite } ) => {
 
 			<PurchaseDetail
 				additionalClass="customize-fonts-and-colors"
-				title={ i18n.translate( 'Customize Fonts & Colors' ) }
+				title={ i18n.translate( 'Customize your theme' ) }
 				description={
 					i18n.translate(
 						"You now have direct control over your site's fonts and colors in the customizer. " +
@@ -58,16 +58,16 @@ const PremiumPlanDetails = ( { isFreeTrial, selectedSite } ) => {
 
 			<PurchaseDetail
 				additionalClass="upload-to-videopress"
-				title={ i18n.translate( 'Upload to VideoPress' ) }
+				title={ i18n.translate( 'Video and audio posts' ) }
 				description={
 					i18n.translate(
-						'Upload video and audio files directly to your site, with no ads or limits. ' +
-						'The Premium plan also adds 10GB of file storage.'
+						'Enrich your posts with video and audio, uploaded directly on your site. ' +
+						'No ads or limits. The Premium plan also adds 10GB of file storage.'
 					)
 				}
-				buttonText={ i18n.translate( 'Upload files' ) }
-				href={ selectedSite.URL + '/wp-admin/media-new.php' }
-				target="_blank" />
+				buttonText={ i18n.translate( 'Start a new post' ) }
+				href={ '/post/' + selectedSite.URL } />
+
 		</ul>
 	);
 };

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -21,15 +21,24 @@ const PremiumPlanDetails = ( { isFreeTrial, selectedSite } ) => {
 				showGetFreeDomainTip
 				? <PurchaseDetail
 						additionalClass="get-free-domain"
-						title={ i18n.translate( 'Get a free domain' ) }
-						description={ i18n.translate( 'WordPress.com Premium includes a free domain for your site.' ) }
-						buttonText={ i18n.translate( 'Add Free Domain' ) }
+						title={ i18n.translate( 'Get your custom domain' ) }
+						description={
+							i18n.translate(
+								"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
+								'A free domain is included with your plan.',
+								{
+									args: { siteDomain: selectedSite.domain },
+									components: { em: <em /> }
+								}
+							)
+						}
+						buttonText={ i18n.translate( 'Claim your free domain' ) }
 						href={ '/domains/add/' + selectedSite.slug } />
 				: <PurchaseDetail
 						additionalClass="ads-have-been-removed"
 						title={ i18n.translate( 'Ads have been removed!' ) }
 						description={ i18n.translate( 'WordPress.com ads will not show up on your blog.' ) }
-						buttonText={ i18n.translate( 'View Your Site' ) }
+						buttonText={ i18n.translate( 'View your site' ) }
 						href={ selectedSite.URL }
 						target="_blank" />
 			}
@@ -37,16 +46,26 @@ const PremiumPlanDetails = ( { isFreeTrial, selectedSite } ) => {
 			<PurchaseDetail
 				additionalClass="customize-fonts-and-colors"
 				title={ i18n.translate( 'Customize Fonts & Colors' ) }
-				description={ i18n.translate( 'You now have access to full font and CSS editing capabilites.' ) }
-				buttonText={ i18n.translate( 'Customize Your Site' ) }
+				description={
+					i18n.translate(
+						"You now have direct control over your site's fonts and colors in the customizer. " +
+						"Change your site's entire look in a few clicks."
+					)
+				}
+				buttonText={ i18n.translate( 'Start customizing' ) }
 				href={ customizeLink }
 				target={ config.isEnabled( 'manage/customize' ) ? undefined : '_blank' } />
 
 			<PurchaseDetail
 				additionalClass="upload-to-videopress"
 				title={ i18n.translate( 'Upload to VideoPress' ) }
-				description={ i18n.translate( "Uploading videos to your blog couldn't be easier." ) }
-				buttonText={ i18n.translate( 'Start Using VideoPress' ) }
+				description={
+					i18n.translate(
+						'Upload video and audio files directly to your site, with no ads or limits. ' +
+						'The Premium plan also adds 10GB of file storage.'
+					)
+				}
+				buttonText={ i18n.translate( 'Upload files' ) }
 				href={ selectedSite.URL + '/wp-admin/media-new.php' }
 				target="_blank" />
 		</ul>

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -66,7 +66,7 @@ const PremiumPlanDetails = ( { isFreeTrial, selectedSite } ) => {
 					)
 				}
 				buttonText={ i18n.translate( 'Start a new post' ) }
-				href={ '/post/' + selectedSite.URL } />
+				href={ '/post/' + selectedSite.slug } />
 
 		</ul>
 	);

--- a/client/my-sites/upgrades/checkout-thank-you/purchase-detail.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/purchase-detail.jsx
@@ -42,7 +42,10 @@ const PurchaseDetail = ( {
 PurchaseDetail.propTypes = {
 	additionalClass: React.PropTypes.string,
 	buttonText: React.PropTypes.string,
-	description: React.PropTypes.string,
+	description: React.PropTypes.oneOfType( [
+		React.PropTypes.array,
+		React.PropTypes.string,
+	] ),
 	href: React.PropTypes.string,
 	isPlaceholder: React.PropTypes.bool,
 	target: React.PropTypes.string,

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -8,6 +8,7 @@ export function createReceiptObject( data ) {
 				meta: purchase.meta,
 				productId: purchase.product_id,
 				productSlug: purchase.product_slug,
+				productName: purchase.product_name,
 				productNameShort: purchase.product_name_short
 			};
 		} )


### PR DESCRIPTION
![screen shot 2016-02-24 at 3 41 19 pm](https://cloud.githubusercontent.com/assets/1130674/13305174/473ef4d2-db0e-11e5-8f50-a5d25546ee1d.png)

This PR:

- Updates `CheckoutThankYouHeader` to display different header copy for both plans.
- Updates `BusinessPlanDetails` to use the new copy.
- Updates `PremiumPlanDetails` to use the new copy.

The new copy can be found in [this document](https://docs.google.com/document/d/1GmR-hw3gv63Lj8VT7hXirgneRHQ-Awyy19x2X3zLOA8/edit).

**Testing**
- Visit `/plans/:site`.
- Purchase the business plan.
- Assert that you are taken to checkout properly and that the copy matches the doc/image above. The _What now?_ heading should be added by #3511.
- Follow the instructions above again for a premium plan, and assert that the copy matches the doc/[this image](https://cloudup.com/cmBzteJcYNu)

- [ ] Code review
- [x] Product review