### PR TITLE
Me: Add logged out page redirect param to log out button

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -39,8 +39,8 @@ module.exports = React.createClass( {
 		
 		// If user is using en locale, redirect to app promo page on sign out
 		const isEnLocale = ( currentUser && currentUser.localeSlug === 'en' );
-		const logout = userUtilities.logout( isEnLocale ? '/?apppromo' : '' );
-		this.recordClickEvent( 'Sidebar Sign Out Link', logout );
+		userUtilities.logout( isEnLocale ? '/?apppromo' : '' );
+		this.recordClickEvent( 'Sidebar Sign Out Link' );
 	},
 
 	render: function() {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -34,6 +34,15 @@ module.exports = React.createClass( {
 		window.scrollTo( 0, 0 );
 	},
 
+	onSignOut: function() {
+		const currentUser = this.props.user.get();
+		
+		// If user is using en locale, redirect to app promo page on sign out
+		const isEnLocale = ( currentUser && currentUser.localeSlug === 'en' );
+		const logout = userUtilities.logout( isEnLocale ? '/?apppromo' : '' );
+		this.recordClickEvent( 'Sidebar Sign Out Link', logout );
+	},
+
 	render: function() {
 		var context = this.props.context,
 			filterMap = {
@@ -69,7 +78,7 @@ module.exports = React.createClass( {
 				<FormButton
 					className="me-sidebar__menu__signout"
 					isPrimary={ false }
-					onClick={ this.recordClickEvent( 'Sidebar Sign Out Link', userUtilities.logout ) }
+					onClick={ this.onSignOut }
 					title={ this.translate( 'Sign out of WordPress.com', { textOnly: true } ) }
 				>
 					{ this.translate( 'Sign Out' ) }


### PR DESCRIPTION
Passing an ?apppromo param to the redirect URL when logging out of WordPress.com using the me sidebar button. This will show them the new app promo screen as their logged out page.