### PR TITLE
DevDocs: Sanitize markdown text in Snippets/summaries on DevDocs homepage

### DIFF
--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -1,28 +1,28 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	isFunction = require( 'lodash/isFunction' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import isFunction from 'lodash/isFunction';
 
 /**
  * Internal dependencies
  */
-var DocService = require( './service' ),
-	Card = require( 'components/card' ),
-	Main = require( 'components/main' ),
-	SearchCard = require( 'components/search-card' );
+import DocService from './service';
+import Card from 'components/card';
+import Main from 'components/main';
+import SearchCard from 'components/search-card';
+import { decodeEntities } from 'lib/formatting';
 
 var DEFAULT_FILES = [
-		'docs/guide/index.md',
-		'README.md',
-		'CONTRIBUTING.md',
-		'docs/coding-guidelines.md',
-		'client/lib/mixins/i18n/README.md',
-		'docs/coding-guidelines/javascript.md',
-		'docs/coding-guidelines/css.md',
-		'docs/coding-guidelines/html.md'
-	];
+	'docs/guide/index.md',
+	'README.md',
+	'CONTRIBUTING.md',
+	'docs/coding-guidelines.md',
+	'client/lib/mixins/i18n/README.md',
+	'docs/coding-guidelines/javascript.md',
+	'docs/coding-guidelines/css.md',
+	'docs/coding-guidelines/html.md'
+];
 
 module.exports = React.createClass( {
 	displayName: 'Devdocs',
@@ -130,17 +130,17 @@ module.exports = React.createClass( {
 
 	snippet: function( result ) {
 		// split around <mark> tags to avoid setting unescaped inner HTML
-		var parts = result.snippet.split(/(<mark>.*?<\/mark>)/);
+		var parts = result.snippet.split( /(<mark>.*?<\/mark>)/ );
 
 		return (
 			<div className="devdocs__result-snippet" key={ 'snippet' + result.path }>
 				{ parts.map( function( part, i ) {
 					var markMatch = part.match( /<mark>(.*?)<\/mark>/ );
 					if ( markMatch ) {
-						return <mark key={ 'mark' + i }>{markMatch[1]}</mark>;
-					} else {
-						return part;
+						return <mark key={ 'mark' + i }>{ markMatch[1] }</mark>;
 					}
+
+					return decodeEntities( part );
 				} ) }
 			</div>
 		);

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -1,20 +1,21 @@
 /**
  * Extenal dependencies
  */
-var express = require( 'express' ),
-	fs = require( 'fs' ),
-	fspath = require( 'path' ),
-	marked = require( 'marked' ),
-	lunr = require( 'lunr' ),
-	find = require( 'lodash/find' ),
-	escapeHTML = require( 'lodash/escape' );
+import express from 'express';
+import fs from 'fs';
+import fspath from 'path';
+import marked from 'marked';
+import lunr from 'lunr';
+import find from 'lodash/find';
+import escapeHTML from 'lodash/escape';
 
 /**
  * Internal dependencies
  */
-var	config = require( 'config' ),
-	root = fs.realpathSync( fspath.join( __dirname, '..', '..' ) ),
-	searchIndex = require( 'devdocs/search-index' ),
+import config from 'config';
+import searchIndex from 'devdocs/search-index';
+
+var	root = fs.realpathSync( fspath.join( __dirname, '..', '..' ) ),
 	docsIndex = lunr.Index.load( searchIndex.index ),
 	documents = searchIndex.documents;
 
@@ -59,18 +60,17 @@ function listDocs( filePaths ) {
 				title: doc.title,
 				snippet: defaultSnippet( doc )
 			};
-		} else {
-			return {
-				path: path,
-				title: 'Not found: ' + path,
-				snippet: ''
-			};
 		}
+		return {
+			path: path,
+			title: 'Not found: ' + path,
+			snippet: ''
+		};
 	} );
 	return results;
 }
 
-/**
+/*
  * Extract a snippet from a document, capturing text either side of
  * any term(s) featured in a whitespace-delimited search query.
  * We look for up to 3 matches in a document and concatenate them.
@@ -102,9 +102,8 @@ function makeSnippet( doc, query ) {
 
 	if ( snippets.length ) {
 		return '...' + snippets.join( ' ... ' ) + '...';
-	} else {
-		return defaultSnippet( doc );
 	}
+	return defaultSnippet( doc );
 }
 
 function escapeRegexString( str ) {

--- a/server/devdocs/index.js
+++ b/server/devdocs/index.js
@@ -8,6 +8,7 @@ import marked from 'marked';
 import lunr from 'lunr';
 import find from 'lodash/find';
 import escapeHTML from 'lodash/escape';
+import striptags from 'striptags';
 
 /**
  * Internal dependencies
@@ -113,7 +114,8 @@ function escapeRegexString( str ) {
 }
 
 function defaultSnippet( doc ) {
-	var content = doc.body.substring( 0, DEFAULT_SNIPPET_LENGTH );
+	var docBody = striptags( marked( doc.body ) );
+	var content = docBody.substring( 0, DEFAULT_SNIPPET_LENGTH );
 	return escapeHTML( content ) + '&hellip;';
 }
 


### PR DESCRIPTION
## Reviewers
@nb @bluefuton @blowery @lancewillett 

## Background
On [DevDocs](https://wpcalypso.wordpress.com/devdocs?), you will see text like the following under the Card "The Calypso Guide"

`Learn Calypso step-by-step. A work in progress… * [Development Values](0-values.md) * [Hello, World!&hellip;`

Clearly, this is not what we expect. The issue here is two-fold:
1. `&hellip;` is an html entity and should be converted into the `...` (horizontal ellipsis).
2. The snippet generated by the devdocs server is displaying markdown text making the snippet somewhat irrelevant.

The fix is simple:
1. Use decodeEntities from lib/formatting to convert the HTML entities into textual representation for display.
2. Convert the markdown text to HTML, then strip the HTML tags to obtain text representation of the information and leverage that to generate the snippet summaries.

Also note that there are some additional ESLint fixes done...

## Testing
Simply checkout the `fix/devdocs-html-snippet` branch and then launch [Calypso DevDocs](http://calypso.localhost:3000/).

You should now see the text under the card "The Calypso Guide" as:
`Learn Calypso step-by-step. A work in progress… Development Values Hello, World! The Technology Beh…`

## Closes Issues
#3429 