### PR TITLE
Enable OAuth flag in development

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -84,6 +84,7 @@
 		"muse": true,
 		"network-connection": true,
 		"notifications2beta": true,
+		"oauth": true,
 		"olark": true,
 		"olark_use_wpcom_configuration": true,
 		"perfmon": false,


### PR DESCRIPTION
To start using OAuth in development, all I think we need to do is update the config. Everything seems to still work fine. We should eventually do this in production, but lets do it in dev first, then wpcalypso, then horizon, then staging so we catch issues earlier.

### Testing instructions
- Checkout the branch: `git checkout update/use-oauth-in-dev`
- Create a `config/secrets.json` file following this procedure https://github.com/Automattic/wp-desktop/blob/master/docs/secrets.md (or copy it from your desktop app)
- Run your server locally: `make run`
- These changes mean that we don't use the iframe proxy to make requests to the API any more. You can verify this by looking for this in your console:
<img width="570" alt="screen shot 2016-02-26 at 13 18 55" src="https://cloud.githubusercontent.com/assets/275961/13353378/dc345dba-dc8b-11e5-84fe-1d52a0977a53.png">
If you don't see it then we don't load the rest proxy.
- Test logging in with an existing account
- Test going to calypso.localhost:3000/start and creating an account