### PR TITLE
Jetpack: Fix lodash warning in jetpack-manage-error-page

### DIFF
--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react'
-import merge from 'lodash/merge'
 
 /**
  * Internal dependencies
@@ -61,7 +60,7 @@ module.exports = React.createClass( {
 			},
 			default: {}
 		};
-		return merge( defaults[ this.props.template ] || defaults.default, this.props );
+		return Object.assign( {}, defaults[ this.props.template ] || defaults.default, this.props );
 	},
 
 	render() {


### PR DESCRIPTION
The problem
=========
`lodash/merge` was throwing a warning when rendering jetpack-manage-error-page components, probably related with the version bump:

![image](https://cloud.githubusercontent.com/assets/1554855/13328422/d11689b4-dbee-11e5-9109-ef10bef2187b.png)

The solution
=========
Just use Object.assign :D 

![image](https://cloud.githubusercontent.com/assets/1554855/13328434/e518f9a6-dbee-11e5-8621-be464291cdef.png)



How to test
=======
1. You need a jetpack site with manage turned off
2. Go to http://calypso.localhost:3000/plugins/ and select this site
3. You shouldn't get any warning in the developer console

ping @enejb @lezama 