### PR TITLE
TokenField: Add disabled prop

### DIFF
--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -15,6 +15,11 @@
 		border-color: lighten( $gray, 10% );
 	}
 
+	&.is-disabled {
+		background: $gray-light;
+		border-color: lighten( $gray, 30% );
+	}
+
 	&.is-active {
 		border-color: $blue-wordpress;
 		box-shadow: 0 0 0 2px $blue-light;
@@ -121,6 +126,16 @@ input[type="text"].token-field__input {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+.token-field.is-disabled .token-field__token-text {
+	border-radius: 4px;
+	padding: 0 6px;
+}
+
+.token-field.is-disabled .token-field__token.is-error .token-field__token-text {
+	border-radius: 4px 0 0 4px;
+	padding: 0 4px 0 6px;
 }
 
 .token-field__remove-token {

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -58,7 +58,7 @@ input[type="text"].token-field__input {
 	font-size: 14px;
 	display: flex;
 	margin: 2px 0 2px 8px;
-	padding: 0;
+	padding: 0 16px 0 0;
 	color: $white;
 	overflow: hidden;
 
@@ -84,6 +84,8 @@ input[type="text"].token-field__input {
 	}
 
 	&.is-borderless {
+		position: relative;
+
 		.token-field__token-text {
 			background: transparent;
 			color: $blue-wordpress;
@@ -92,7 +94,9 @@ input[type="text"].token-field__input {
 		.token-field__remove-token {
 			background: transparent;
 			color: $gray;
-			padding: 1px 2px;
+			position: absolute;
+			top: 1px;
+			right: 0;
 		}
 
 		&.is-success {

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -97,7 +97,7 @@ input[type="text"].token-field__input {
 		.token-field__remove-token {
 			background: transparent;
 			color: $gray;
-			padding: 0 2px;
+			padding: 1px 2px;
 		}
 
 		&.is-success {

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -18,11 +18,6 @@
 	&.is-disabled {
 		background: $gray-light;
 		border-color: lighten( $gray, 30% );
-
-		.token-field__token-text {
-			border-radius: 4px;
-			padding: 0 6px;
-		}
 	}
 
 	&.is-active {
@@ -120,6 +115,12 @@ input[type="text"].token-field__input {
 			}
 		}
 	}
+
+	&.is-disabled {
+		.token-field__remove-token {
+			cursor: default;
+		}
+	}
 }
 
 .token-field__token-text,
@@ -136,16 +137,6 @@ input[type="text"].token-field__input {
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
-
-.token-field.is-disabled .token-field__token-text {
-	border-radius: 4px;
-	padding: 0 6px;
-}
-
-.token-field.is-disabled .token-field__token.is-error .token-field__token-text {
-	border-radius: 4px 0 0 4px;
-	padding: 0 4px 0 6px;
 }
 
 .token-field__remove-token {

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -18,6 +18,11 @@
 	&.is-disabled {
 		background: $gray-light;
 		border-color: lighten( $gray, 30% );
+
+		.token-field__token-text {
+			border-radius: 4px;
+			padding: 0 6px;
+		}
 	}
 
 	&.is-active {
@@ -63,51 +68,56 @@ input[type="text"].token-field__input {
 	overflow: hidden;
 
 	&.is-success {
-		.token-field__token-text, .token-field__remove-token {
+		.token-field__token-text,
+		.token-field__remove-token {
 			background: $alert-green;
 		}
 	}
 
 	&.is-error {
-		.token-field__token-text, .token-field__remove-token {
+		.token-field__token-text,
+		.token-field__remove-token {
 			background: $alert-red;
 		}
 	}
 
 	&.is-validating {
-		.token-field__token-text, .token-field__remove-token {
+		.token-field__token-text,
+		.token-field__remove-token {
 			background: $gray;
 		}
 	}
-}
 
-.token-field__token.is-borderless {
-	.token-field__token-text {
-		background: transparent;
-		color: $blue-wordpress;
-	}
-
-	.token-field__remove-token {
-		background: transparent;
-		color: $gray;
-		padding: 0 2px;
-	}
-
-	&.is-success {
+	&.is-borderless {
 		.token-field__token-text {
-			color: $alert-green;
+			background: transparent;
+			color: $blue-wordpress;
 		}
-	}
 
-	&.is-error {
-		.token-field__token-text {
-			color: $alert-red;
+		.token-field__remove-token {
+			background: transparent;
+			color: $gray;
+			padding: 0 2px;
 		}
-	}
 
-	&.is-validating {
-		.token-field__token-text {
-			color: $gray-dark;
+		&.is-success {
+			.token-field__token-text {
+				color: $alert-green;
+			}
+		}
+
+		&.is-error {
+			.token-field__token-text {
+				color: $alert-red;
+				border-radius: 4px 0 0 4px;
+				padding: 0 4px 0 6px;
+			}
+		}
+
+		&.is-validating {
+			.token-field__token-text {
+				color: $gray-dark;
+			}
 		}
 	}
 }

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -8,14 +8,16 @@ var TokenInput = React.createClass( {
 	propTypes: {
 		onChange: React.PropTypes.func,
 		onBlur: React.PropTypes.func,
-		value: React.PropTypes.string
+		value: React.PropTypes.string,
+		disabled: React.PropTypes.bool
 	},
 
 	getDefaultProps: function() {
 		return {
 			onChange: function() {},
 			onBlur: function() {},
-			value: ''
+			value: '',
+			disabled: false
 		};
 	},
 
@@ -32,7 +34,6 @@ var TokenInput = React.createClass( {
 				onBlur={ this.props.onBlur }
 				onChange={ this._onChange }
 				className="token-field__input"
-				disabled={ this.props.disabled }
 			/>
 		);
 	},

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -32,6 +32,7 @@ var TokenInput = React.createClass( {
 				onBlur={ this.props.onBlur }
 				onChange={ this._onChange }
 				className="token-field__input"
+				disabled={ this.props.disabled }
 			/>
 		);
 	},

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -20,13 +20,15 @@ export default React.createClass( {
 		onClickRemove: React.PropTypes.func,
 		status: React.PropTypes.oneOf( [ 'error', 'success', 'validating' ] ),
 		isBorderless: React.PropTypes.bool,
-		tooltip: React.PropTypes.string
+		tooltip: React.PropTypes.string,
+		disabled: React.PropTypes.bool
 	},
 
 	getDefaultProps() {
 		return {
 			onClickRemove: () => {},
-			isBorderless: false
+			isBorderless: false,
+			disabled: false
 		};
 	},
 
@@ -38,7 +40,8 @@ export default React.createClass( {
 			'is-error': 'error' === status,
 			'is-success': 'success' === status,
 			'is-validating': 'validating' === status,
-			'is-borderless': isBorderless
+			'is-borderless': isBorderless,
+			'is-disabled': this.props.disabled
 		} );
 
 		return (
@@ -50,14 +53,16 @@ export default React.createClass( {
 				<span className="token-field__token-text">
 					{ displayTransform( value ) }
 				</span>
-				<span
-					className="token-field__remove-token noticon noticon-close-alt"
-					onClick={ this._onClickRemove } />
-			{ tooltip &&
-				<Tooltip context={ this } status={ status } isVisible={ true } position="bottom">
-						{ tooltip }
-				</Tooltip>
-			}
+				{ ! this.props.disabled &&
+					<span
+						className="token-field__remove-token noticon noticon-close-alt"
+						onClick={ this._onClickRemove } />
+				}
+				{ tooltip &&
+					<Tooltip context={ this } status={ status } isVisible={ true } position="bottom">
+							{ tooltip }
+					</Tooltip>
+				}
 			</span>
 		);
 	},

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -58,7 +58,7 @@ export default React.createClass( {
 					onClick={ ! this.props.disabled && this._onClickRemove } />
 				{ tooltip &&
 					<Tooltip context={ this } status={ status } isVisible={ true } position="bottom">
-							{ tooltip }
+						{ tooltip }
 					</Tooltip>
 				}
 			</span>

--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -53,11 +53,9 @@ export default React.createClass( {
 				<span className="token-field__token-text">
 					{ displayTransform( value ) }
 				</span>
-				{ ! this.props.disabled &&
-					<span
-						className="token-field__remove-token noticon noticon-close-alt"
-						onClick={ this._onClickRemove } />
-				}
+				<span
+					className="token-field__remove-token noticon noticon-close-alt"
+					onClick={ ! this.props.disabled && this._onClickRemove } />
 				{ tooltip &&
 					<Tooltip context={ this } status={ status } isVisible={ true } position="bottom">
 							{ tooltip }

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -11,6 +11,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import uniqueId from 'lodash/uniqueId';
 import groupBy from 'lodash/groupBy';
+import filter from 'lodash/filter';
+import pickBy from 'lodash/pickBy';
 
 /**
  * Internal dependencies
@@ -83,7 +85,7 @@ const InvitePeople = React.createClass( {
 	},
 
 	onTokensChange( tokens ) {
-		const { role, errorToDisplay, usernamesOrEmails } = this.state;
+		const { role, errorToDisplay, usernamesOrEmails, errors, success } = this.state;
 		const filteredTokens = tokens.map( value => {
 			if ( 'object' === typeof value ) {
 				return value.value;
@@ -91,8 +93,18 @@ const InvitePeople = React.createClass( {
 			return value;
 		} );
 
+		const filteredErrors = pickBy( errors, ( error, key ) => {
+			return includes( filteredTokens, key );
+		} );
+
+		const filteredSuccess = filter( success, ( successfulValidation ) => {
+			return includes( filteredTokens, successfulValidation );
+		} );
+
 		this.setState( {
 			usernamesOrEmails: filteredTokens,
+			errors: filteredErrors,
+			success: filteredSuccess,
 			errorToDisplay: includes( filteredTokens, errorToDisplay ) && errorToDisplay
 		} );
 		createInviteValidation( this.props.site.ID, filteredTokens, role );
@@ -270,7 +282,7 @@ const InvitePeople = React.createClass( {
 								value={ this.getTokensWithStatus() }
 								onChange={ this.onTokensChange }
 								onFocus={ this.onFocusTokenField }
-								disabled={ this.state.sendingInvites || this.hasValidationErrors() }/>
+								disabled={ this.state.sendingInvites }/>
 							<FormSettingExplanation>
 								{ this.translate(
 									'Invite up to 10 email addresses and/or WordPress.com usernames. ' +

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -64,7 +64,9 @@ const InvitePeople = React.createClass( {
 			message: '',
 			sendingInvites: false,
 			getTokenStatus: () => {},
-			errorToDisplay: false
+			errorToDisplay: false,
+			errors: {},
+			success: []
 		} );
 	},
 
@@ -212,7 +214,7 @@ const InvitePeople = React.createClass( {
 	},
 
 	isSubmitDisabled() {
-		const { errors, success, usernamesOrEmails } = this.state;
+		const { success, usernamesOrEmails } = this.state;
 		const invitees = Array.isArray( usernamesOrEmails ) ? usernamesOrEmails : [];
 
 		// If there are no invitees, then don't allow submitting the form
@@ -220,7 +222,7 @@ const InvitePeople = React.createClass( {
 			return true;
 		}
 
-		if ( errors && errors.length ) {
+		if ( this.hasValidationErrors() ) {
 			return true;
 		}
 
@@ -229,6 +231,13 @@ const InvitePeople = React.createClass( {
 		return some( usernamesOrEmails, ( value ) => {
 			return ! includes( success, value );
 		} );
+	},
+
+	hasValidationErrors() {
+		const { errors } = this.state;
+		const errorKeys = errors && Object.keys( errors );
+
+		return !! errorKeys.length;
 	},
 
 	goBack() {
@@ -260,7 +269,8 @@ const InvitePeople = React.createClass( {
 								maxLength={ 10 }
 								value={ this.getTokensWithStatus() }
 								onChange={ this.onTokensChange }
-								onFocus={ this.onFocusTokenField } />
+								onFocus={ this.onFocusTokenField }
+								disabled={ this.state.sendingInvites || this.hasValidationErrors() }/>
 							<FormSettingExplanation>
 								{ this.translate(
 									'Invite up to 10 email addresses and/or WordPress.com usernames. ' +


### PR DESCRIPTION
Related to #3441. While submitting invites, we want to disable the TokenField so that changes can not be made.

<strike>So far, this PR does disable the TokenField, but there are no styling changes as of yet.

For the main TokenField component, I plan on duplicating the disabled styled for inputs, but I am not sure how to handle the token styles. Perhaps a light gray color? cc @rickybanister </strike>

To test:
- Checkout `update/token-field-disabled` branch
- Go to `/people/new/$site` and submit invite form
- Upon submitting, `TokenField` component at top of invite form should disable while API call is being made

Alternatively, you can open `invite-people/index.jsx` and force the `disabled` prop of `TokenField` to be true.