### PR TITLE
Components: Fix PostSelector order for hierarchical posts

### DIFF
--- a/client/lib/create-selector/README.md
+++ b/client/lib/create-selector/README.md
@@ -5,10 +5,11 @@ This module exports a single function which creates a memoized state selector fo
 
 ## Usage
 
-`createSelector` accepts two arguments:
+`createSelector` accepts the following arguments:
 
 - A function which calculates the cached result given a state object and any number of variable arguments necessary to calculate the result
 - A function which returns an array of dependent state paths
+- _(Optional)_ A function to customize the cache key used by the inner memoized function
 
 For example, we might consider that our state contains post objects, each of which are assigned to a particular site. Retrieving an array of posts for a specific site would require us to filter over all of the known posts. While this would normally be an expensive operation, we can use `createSelector` to create a memoized function:
 

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -7,7 +7,25 @@ import shallowEqual from 'react-pure-render/shallowEqual';
 /**
  * Constants
  */
+
+/**
+ * Defines acceptable argument types for a memoized selector when using the
+ * default cache key generating function.
+ *
+ * @type {Array}
+ */
 const VALID_ARG_TYPES = [ 'number', 'boolean', 'string' ];
+
+/**
+ * Default behavior for determining whether current state differs from previous
+ * state, which is the basis upon which memoize cache is cleared. Should return
+ * a value or array of values to be shallowly compared for strict equality.
+ *
+ * @type   {Function}
+ * @param  {Object}    state Current state object
+ * @return {(Array|*)}       Value(s) to be shallow compared
+ */
+const DEFAULT_GET_DEPENDANTS = ( state ) => state;
 
 /**
  * At runtime, assigns a function which returns a cache key for the memoized
@@ -17,7 +35,7 @@ const VALID_ARG_TYPES = [ 'number', 'boolean', 'string' ];
  *
  * @type {Function} Function returning cache key for memoized selector
  */
-const getCacheKey = ( () => {
+const DEFAULT_GET_CACHE_KEY = ( () => {
 	let warn, includes;
 	if ( 'production' !== process.env.NODE_ENV ) {
 		// Webpack can optimize bundles if it can detect that a block will
@@ -47,9 +65,10 @@ const getCacheKey = ( () => {
  *
  * @param  {Function} selector      Function calculating cached result
  * @param  {Function} getDependants Function describing dependent state
+ * @param  {Function} getCacheKey   Function generating cache key for arguments
  * @return {Function}               Memoized selector
  */
-export default function createSelector( selector, getDependants = ( state ) => state ) {
+export default function createSelector( selector, getDependants = DEFAULT_GET_DEPENDANTS, getCacheKey = DEFAULT_GET_CACHE_KEY ) {
 	const memoizedSelector = memoize( selector, getCacheKey );
 	let lastDependants;
 

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -168,4 +168,16 @@ describe( '#createSelector', () => {
 
 		expect( selector ).to.have.been.calledTwice;
 	} );
+
+	it( 'should accept an optional custom cache key generating function', () => {
+		const getSitePostsWithCustomGetCacheKey = createSelector(
+			selector,
+			( state ) => state.posts,
+			( state, siteId ) => `CUSTOM${ siteId }`
+		);
+
+		getSitePostsWithCustomGetCacheKey( { posts: {} }, 2916284 );
+
+		expect( getSitePostsWithCustomGetCacheKey.memoizedSelector.cache.has( 'CUSTOM2916284' ) ).to.be.true;
+	} );
 } );

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -39,9 +39,10 @@ function buildTree( items ) {
 	const sortedPosts = [];
 
 	// clone objects to prevent mutating store data, set parent to number
-	items.forEach( function( item ) {
+	items.forEach( function( item, i ) {
 		let post = clone( item );
 		post.parent = post.parent ? post.parent.ID : 0;
+		post.order = i;
 		sortedPosts.push( post );
 	} );
 

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -6,8 +6,6 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import debounce from 'lodash/debounce';
-import sortBy from 'lodash/sortBy';
-import filter from 'lodash/filter';
 import camelCase from 'lodash/camelCase';
 import clone from 'lodash/clone';
 import throttle from 'lodash/throttle';
@@ -36,20 +34,6 @@ import QueryPosts from 'components/data/query-posts';
 const SEARCH_DEBOUNCE_TIME_MS = 500;
 const SCROLL_THROTTLE_TIME_MS = 400;
 const treeConverter = new TreeConvert( 'ID' );
-
-function sortBranch( items ) {
-	let menuOrders = filter( items, function( item ) {
-		return item.menu_order > 0;
-	} );
-
-	return sortBy( items, function( item ) {
-		if ( menuOrders.length ) {
-			return item.menu_order;
-		}
-
-		return item.title.toLowerCase();
-	} );
-}
 
 function buildTree( items ) {
 	const sortedPosts = [];
@@ -179,12 +163,11 @@ const PostSelectorPosts = React.createClass( {
 	},
 
 	renderHierarchy( items, isRecursive ) {
-		const sortedItems = this.props.lastPage ? sortBranch( items ) : items;
 		const listClass = isRecursive ? 'post-selector__nested-list' : 'post-selector__list';
 
 		return (
 			<ul className={ listClass }>
-				{ sortedItems.map( this.renderItem, this ) }
+				{ items.map( this.renderItem, this ) }
 				{
 					this.props.loading && ! isRecursive ?
 					this.renderPlaceholderItem() :

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -18,6 +18,7 @@ import analytics from 'analytics';
 import Search from './search';
 import { decodeEntities } from 'lib/formatting';
 import {
+	getSitePostsForQueryIgnoringPage,
 	getSitePostsHierarchyForQueryIgnoringPage,
 	isRequestingSitePostsForQuery,
 	isSitePostsLastPageForQuery
@@ -39,6 +40,7 @@ const PostSelectorPosts = React.createClass( {
 		siteId: PropTypes.number.isRequired,
 		query: PropTypes.object,
 		posts: PropTypes.array,
+		postsHierarchy: PropTypes.array,
 		page: PropTypes.number,
 		lastPage: PropTypes.bool,
 		loading: PropTypes.bool,
@@ -221,8 +223,8 @@ const PostSelectorPosts = React.createClass( {
 					null
 				}
 				<form className="post-selector__results">
-					{ this.props.posts
-						? this.renderHierarchy( this.props.posts )
+					{ this.props.postsHierarchy
+						? this.renderHierarchy( this.props.postsHierarchy )
 						: this.renderPlaceholder() }
 				</form>
 			</div>
@@ -233,7 +235,8 @@ const PostSelectorPosts = React.createClass( {
 export default connect( ( state, ownProps ) => {
 	const { siteId, query } = ownProps;
 	return {
-		posts: getSitePostsHierarchyForQueryIgnoringPage( state, siteId, query ),
+		posts: getSitePostsForQueryIgnoringPage( state, siteId, query ),
+		postsHierarchy: getSitePostsHierarchyForQueryIgnoringPage( state, siteId, query ),
 		lastPage: isSitePostsLastPageForQuery( state, siteId, query ),
 		loading: isRequestingSitePostsForQuery( state, siteId, query ),
 		postTypes: getPostTypes( state, siteId )


### PR DESCRIPTION
Blocks #3197
Cherry-picks f50a44c8e345a67570f23df0bc9af8450f847d45, 4c4d1725e545e1ae0704a6d7d1d578fb2ee0a7e5, 67b3a9de4e9dbb646960c7e4171e7e4978aabbc2 from #3197 

This pull request seeks to fix the ordering of `<PostSelector />` options which is currently inaccurate due to a custom sort function currently used in `<PostSelector />` and the lack of an `order` attribute being specified in the objects passed to `lib/tree-convert`.

The changes included here add a new memoized selector for generating a hierarchical posts array for a given query. Because `createSelector` cannot handle complex arguments (a query object), the `lib/create-selector` module has been enhanced to accept a third optional argument for specifying the behavior in generating a cache key for the memoized selector.

__Testing instructions:__

See https://github.com/Automattic/wp-calypso/pull/3197#issuecomment-186244482:

>With these changes, the ordering should exactly match that of wp-admin, with the exception of our `<PostSelector />` reflecting parent-child relationships in the display of options. It also allows rendering results with search terms as a hierarchy (detached children are shown as top-level).

Specifically, navigate to the [Calypso DevDocs App Components](http://calypso.localhost:3000/devdocs/app-components) page and verify that you can scroll the `<PostSelector />`, that order is preserved and reflective of the most recently updated post, and that hierarchy is indicated for child posts.

/cc @timmyc , @gwwar 