### PR TITLE
Themes: Decouple client `router` and `renderer`

### DIFF
--- a/client/controller.js
+++ b/client/controller.js
@@ -26,10 +26,10 @@ const debug = debugFactory( 'calypso:controller' );
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	page( route, ...[ ...middlewares, render ] );
+	page( route, ...middlewares );
 }
 
-function render( context ) {
+export function clientRenderer( context ) {
 	context.layout
 		? renderSingleTree( context )
 		: renderSeparateTrees( context );

--- a/client/controller.js
+++ b/client/controller.js
@@ -21,14 +21,19 @@ const debug = debugFactory( 'calypso:controller' );
  * `server/bundler/loader`. Sections are free to either ignore it, or use it
  * instead of directly calling `page` for linking routes and middlewares in
  * order to be also usable for server-side rendering (and isomorphic routing).
- * `clientRouter` then also renders the element tree contained in `context.layout`
- * (or, if that is empty, in `context.primary`) to the respectively corresponding
- * divs.
  */
 export function clientRouter( route, ...middlewares ) {
 	page( route, ...middlewares );
 }
 
+/**
+ * Client side renderer
+ *
+ * @param { object } context -- Middleware context
+ *
+ * Middleware to render the element tree contained in `context.layout` (or, if
+ * that is empty, in `context.primary`) to the respectively corresponding divs.
+ */
 export function clientRenderer( context ) {
 	context.layout
 		? renderSingleTree( context )

--- a/client/controller.js
+++ b/client/controller.js
@@ -14,17 +14,12 @@ const debug = debugFactory( 'calypso:controller' );
 /**
  * Isomorphic routing helper, client side
  *
- * @param { string } route - A route path
- * @param { ...function } middlewares - Middleware to be invoked for route
- *
  * This function is passed to individual sections' controllers via
  * `server/bundler/loader`. Sections are free to either ignore it, or use it
  * instead of directly calling `page` for linking routes and middlewares in
  * order to be also usable for server-side rendering (and isomorphic routing).
  */
-export function clientRouter( route, ...middlewares ) {
-	page( route, ...middlewares );
-}
+export const clientRouter = page;
 
 /**
  * Client side renderer

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -86,7 +86,7 @@ function splitTemplate( path, module, chunkName ) {
 		'		}',
 		'		context.store.dispatch( { type: "SET_SECTION", isLoading: false } );',
 		'		if ( ! _loadedSections[ ' + JSON.stringify( module ) + ' ] ) {',
-		'			require( ' + JSON.stringify( module ) + ' )( controller.clientRouter );',
+		'			require( ' + JSON.stringify( module ) + ' )( controller.clientRouter, controller.clientRenderer );',
 		'			_loadedSections[ ' + JSON.stringify( module ) + ' ] = true;',
 		'		}',
 		'		layoutFocus.next();',
@@ -99,7 +99,7 @@ function splitTemplate( path, module, chunkName ) {
 }
 
 function requireTemplate( module ) {
-	return 'require( ' + JSON.stringify( module ) + ' )( controller.clientRouter );\n';
+	return 'require( ' + JSON.stringify( module ) + ' )( controller.clientRouter, controller.clientRenderer );\n';
 }
 
 function singleEnsure( chunkName ) {


### PR DESCRIPTION
Continuing the discussion from https://github.com/Automattic/wp-calypso/pull/3397#issuecomment-186373943 with this PR as a suggestion.

The main rationale here is separation of concerns, visibility, and DevX for folks writing section specific middleware. Before, `renderer` was just magically appended to the end of each route, adding another constraint to the way section middleware had to be written (i.e. less separation of concern -- e.g. catch-all routes -- was possible). Now, both `router` and `renderer` are building blocks that are available to section devs, and it's up to them how to use them. (This way, they don't actually need to render in every case -- they can conceivably even `redirect`. Also, different `render` functions can be passed to sections depending on whether we're logged-in or out.)

To test -- verify that everything still works as before.

/cc @mcsf @ehg @seear 