### PR TITLE
Post normalizer: in pickPrimaryTag, fix use of maxBy for lodash 4.x

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -21,7 +21,8 @@ var assign = require( 'lodash/assign' ),
 	toArray = require( 'lodash/toArray' ),
 	trim = require( 'lodash/trim' ),
 	uniqBy = require( 'lodash/uniqBy' ),
-	url = require( 'url' );
+	url = require( 'url' ),
+	values = require( 'lodash/values' );
 
 import striptags from 'striptags';
 
@@ -309,7 +310,7 @@ normalizePost.makeSiteIDSafeForAPI = function makeSiteIDSafeForAPI( post, callba
 
 normalizePost.pickPrimaryTag = function assignPrimaryTag( post, callback ) {
 	// if we hand max an invalid or empty array, it returns -Infinity
-	post.primary_tag = maxBy( post.tags, function( tag ) {
+	post.primary_tag = maxBy( values( post.tags ), function( tag ) {
 		return tag.post_count;
 	} );
 
@@ -453,7 +454,6 @@ normalizePost.createBetterExcerpt = function createBetterExcerpt( post, callback
 	// Spin up a new DOM for the linebreak markup
 	const dom = document.createElement( 'div' );
 	dom.innerHTML = betterExcerpt;
-
 
 	// Ditch any photo captions with the wp-caption-text class
 	forEach( dom.querySelectorAll( '.wp-caption-text' ), removeElement );

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -255,40 +255,40 @@ describe( 'post-normalizer', function() {
 	describe( 'pickPrimaryTag', function() {
 		it( 'can pick the primary tag by taking the tag with the highest post_count as the primary', function( done ) {
 			var post = {
-				tags: [
-					{
+				tags: {
+					first: {
 						name: 'first',
 						post_count: 2
 					},
-					{
+					second: {
 						name: 'second',
 						post_count: 200
 					}
-				]
+				}
 			};
 
 			normalizer( post, [ normalizer.pickPrimaryTag ], function( err, normalized ) {
-				assert.deepEqual( normalized.primary_tag, post.tags[ 1 ] );
+				assert.deepEqual( normalized.primary_tag, post.tags.second );
 				done( err );
 			} );
 		} );
 
 		it( 'can pick the primary tag by taking the first tag as primary if there is a tie', function( done ) {
 			var post = {
-				tags: [
-					{
+				tags: {
+					first: {
 						name: 'first',
 						post_count: 200
 					},
-					{
+					second: {
 						name: 'second',
 						post_count: 200
 					}
-				]
+				}
 			};
 
 			normalizer( post, [ normalizer.pickPrimaryTag ], function( err, normalized ) {
-				assert.deepEqual( normalized.primary_tag, post.tags[ 0 ] );
+				assert.deepEqual( normalized.primary_tag, post.tags.first );
 				done( err );
 			} );
 		} );


### PR DESCRIPTION
In lodash 4.x, `maxBy` no longer works with objects, only arrays. As a result, `pickPrimaryTag` in the post normalizer was not returning anything, and the primary tag was missing from Reader posts.

I've used the solution suggested by lodash's author: https://github.com/lodash/lodash/issues/1812

## To test

Load up a post with tags in the Reader, and ensure that a primary tag is displayed. For example:

http://calypso.localhost:3000/read/blog/feed/40474296

<img width="345" alt="screen shot 2016-02-26 at 15 18 44" src="https://cloud.githubusercontent.com/assets/17325/13341289/42faf8dc-dc9c-11e5-98d5-003e73fa4593.png">
