### PR TITLE
Build: Fix exit code of check-node-version

### DIFF
--- a/bin/check-node-version
+++ b/bin/check-node-version
@@ -4,5 +4,5 @@ const requiredVersion = require( '../package' ).engines.node,
 
 if ( ! semver.satisfies( process.version, requiredVersion ) ) {
 	console.error( 'wp-calypso requires node ' + requiredVersion + '. Please upgrade! See https://nodejs.org for instructions.' );
-	process.exitCode = 1;
+	process.exit( 1 );
 }


### PR DESCRIPTION
Currently `make node-version` does not actually abort the build for old Node.js versions as it should.  Ironically this is due to the `bin/check-node-version` script using the [old `process.exitCode` property](https://github.com/isaacs/exit-code) from Node.js 0.12.x.

To fix this, and make the build process abort early for old Node.js versions, call `process.exit` directly.

Probably the easiest way to test this change is to modify the `engines.node` field in `package.json` to specify a version of Node.js newer than your version, and run `make node-version` and ensure that it fails completely, rather than just printing a warning.

### Before

```
$ make node-version
wp-calypso requires node >=4.3.0. Please upgrade! See https://nodejs.org for instructions.
$ echo $?
0
```

### After

```
$ make node-version
wp-calypso requires node >=4.3.0. Please upgrade! See https://nodejs.org for instructions.
make: *** [node-version] Error 1
$ echo $?
2
```