### PR TITLE
Domains: Improve TXT record's validation

### DIFF
--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -70,7 +70,7 @@ function isValidData( data, type ) {
 		case 'MX':
 			return isValidDomain( data );
 		case 'TXT':
-			return data.length < 256;
+			return data.length > 0 && data.length < 256;
 	}
 }
 

--- a/client/my-sites/upgrades/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/dns-add-new.jsx
@@ -34,7 +34,8 @@ const DnsAddNew = React.createClass( {
 	getInitialState() {
 		return {
 			show: false,
-			fields: null
+			fields: null,
+			type: 'A'
 		};
 	},
 
@@ -54,13 +55,9 @@ const DnsAddNew = React.createClass( {
 		return assign( {}, Component.initialFields, { type } );
 	},
 
-	getInitialFields() {
-		return this.getFieldsForType( 'A' );
-	},
-
 	componentWillMount() {
 		this.formStateController = formState.Controller( {
-			initialFields: this.getInitialFields(),
+			initialFields: this.getFieldsForType( this.state.type ),
 			onNewState: this.setFormState,
 			validatorFunction: ( fieldValues, onComplete ) => {
 				onComplete( null, validateAllFields( fieldValues, this.props.selectedDomainName ) );
@@ -91,7 +88,7 @@ const DnsAddNew = React.createClass( {
 				formState.getAllFieldValues( this.state.fields ),
 				this.props.selectedDomainName
 			);
-			this.formStateController.resetFields( this.getInitialFields() );
+			this.formStateController.resetFields( this.getFieldsForType( this.state.type ) );
 
 			upgradesActions.addDns( this.props.selectedDomainName, normalizedData, ( error ) => {
 				if ( error ) {
@@ -107,14 +104,17 @@ const DnsAddNew = React.createClass( {
 	},
 
 	onChange( event ) {
+		const { name, value } = event.target,
+			skipNormalization = name === 'data' && this.state.type === 'TXT';
 		this.formStateController.handleFieldChange( {
-			name: event.target.name,
-			value: event.target.value.trim().toLowerCase()
+			name,
+			value: skipNormalization ? value : value.trim().toLowerCase(),
 		} );
 	},
 
 	changeType( event ) {
 		const fields = this.getFieldsForType( event.target.value );
+		this.setState( { type: event.target.value } );
 		this.formStateController.resetFields( fields );
 	},
 


### PR DESCRIPTION
 * Don't normalize TXT record's data, only name. Fixes regression introduced when we started normalizing every field of a DNS record before saving.
 * Don't allow empty value for the TXT record.

A nice side-effect of this change is that the selected record does not reset to 'A' after every submit.

Fixes #3328 

/cc @umurkontaci @aidvu for code review
@andrewspittle for testing