### PR TITLE
Domains: Icann Verification is visible for domains that are verified

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -204,7 +204,7 @@ const RegisteredDomain = React.createClass( {
 							onClick={ this.handlePaymentSettingsClick }/>
 					</Card>
 
-					<IcannVerificationCard selectedDomainName={ domain.name } selectedSite={ this.props.selectedSite } />
+					{ domain.isPendingIcannVerification && <IcannVerificationCard selectedDomainName={ domain.name } selectedSite={ this.props.selectedSite } /> }
 				</div>
 
 				{ this.getVerticalNav() }


### PR DESCRIPTION
To test:
1. Go to Domain Management, click on a domain which has a verified domain
2. Icann Verification shouldn't be there
3. Click a domain that's not verified
4. Icann Verification should be there

I introduced this bug with rebasing and it slipped undetected. The code was present in the previous PR.

See #3588