### PR TITLE
Checkout: Thank you: Don't assume we have a primaryProduct in the props

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
@@ -34,14 +34,14 @@ const CheckoutThankYouHeader = React.createClass( {
 			return this.translate( 'Loading…' );
 		}
 
-		if ( isPlan( this.props.primaryPurchase ) ) {
-			return this.translate( "Your site is now on the {{strong}}%(productName)s{{/strong}} plan. It's doing somersaults in excitement!", {
-				args: { productName: this.props.primaryPurchase.productName },
-				components: { strong: <strong /> }
-			} );
-		}
-
 		if ( this.props.primaryPurchase ) {
+			if ( isPlan( this.props.primaryPurchase ) ) {
+				return this.translate( "Your site is now on the {{strong}}%(productName)s{{/strong}} plan. It's doing somersaults in excitement!", {
+					args: { productName: this.props.primaryPurchase.productName },
+					components: { strong: <strong /> }
+				} );
+			}
+
 			return this.translate(
 				"You will receive an email confirmation shortly for your purchase of %(productName)s. What's next?", {
 					args: {


### PR DESCRIPTION
This pull request fixes #3591 by checking that the primaryProduct prop is set before we use it.
 
#### Testing instructions

1. Purchase a Premium theme from /design.
2. In /checkout, click the Pay button. You'll see the Submitting Payment notice. When it fades away, you can notice the Premium theme no longer shows in the cart on the left of the page.
3. Notice you are redirected back to /design/:site
4. Assert that you were charged from /me/billing.

#### Reviews

- [x] Code
- [x] Product