### PR TITLE
Themes: Handle SERVER_DESERIALIZE action for current-theme

### DIFF
--- a/client/state/themes/current-theme/reducer.js
+++ b/client/state/themes/current-theme/reducer.js
@@ -7,7 +7,7 @@ import { fromJS } from 'immutable';
  * Internal dependencies
  */
 import ActionTypes from '../action-types';
-import { DESERIALIZE, SERIALIZE } from 'state/action-types';
+import { DESERIALIZE, SERIALIZE, SERVER_DESERIALIZE } from 'state/action-types';
 
 export const initialState = fromJS( {
 	isActivating: false,
@@ -33,6 +33,7 @@ export default ( state = initialState, action ) => {
 		case ActionTypes.CLEAR_ACTIVATED_THEME:
 			return state.set( 'hasActivated', false );
 		case DESERIALIZE:
+		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:
 			return state.toJS();

--- a/client/state/themes/current-theme/test/reducer.js
+++ b/client/state/themes/current-theme/test/reducer.js
@@ -3,20 +3,22 @@
  */
 import { expect } from 'chai';
 import { fromJS } from 'immutable';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
  */
 import {
 	SERIALIZE,
-	DESERIALIZE
+	DESERIALIZE,
+	SERVER_DESERIALIZE
 } from 'state/action-types';
 import reducer, { initialState } from '../reducer';
 
 describe( 'current-theme reducer', () => {
 	describe( 'persistence', () => {
 		it( 'persists state and converts to a plain JS object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				isActivating: true,
 				hasActivated: false,
 				currentThemes: {
@@ -36,7 +38,7 @@ describe( 'current-theme reducer', () => {
 			expect( persistedState ).to.eql( jsObject );
 		} );
 		it( 'loads valid persisted state and converts to immutable.js object', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				isActivating: true,
 				hasActivated: false,
 				currentThemes: {
@@ -55,8 +57,28 @@ describe( 'current-theme reducer', () => {
 			expect( state ).to.eql( fromJS( jsObject ) );
 		} );
 
+		it( 'converts initial state from server to immutable.js object', () => {
+			const jsObject = deepFreeze( {
+				isActivating: true,
+				hasActivated: false,
+				currentThemes: {
+					123456: {
+						name: 'my test theme',
+						id: 'testtheme',
+						cost: {
+							currency: 'USD',
+							number: 0,
+							display: ''
+						}
+					}
+				}
+			} );
+			const state = reducer( jsObject, { type: SERVER_DESERIALIZE } );
+			expect( state ).to.eql( fromJS( jsObject ) );
+		} );
+
 		it.skip( 'should ignore loading data with invalid keys ', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				missingKey: true,
 				hasActivated: false,
 				currentThemes: {
@@ -76,7 +98,7 @@ describe( 'current-theme reducer', () => {
 		} );
 
 		it.skip( 'should ignore loading data with invalid values ', () => {
-			const jsObject = Object.freeze( {
+			const jsObject = deepFreeze( {
 				isActivating: true,
 				hasActivated: 'foo',
 				currentThemes: {


### PR DESCRIPTION
Necessary for converting initial state from server to immutable.js objects. Unit test added, no visual changes. Somehow missed from #3464.

Necessary from preventing errors such as this in #3279:
<img width="636" alt="screen shot 2016-02-26 at 13 37 01" src="https://cloud.githubusercontent.com/assets/7767559/13353716/12a0d9f8-dc8e-11e5-8ef4-db680ef59154.png">
