### PR TITLE
SyncHandler: fix bug removing  `_headers` key

### DIFF
--- a/client/lib/wp/sync-handler/index.js
+++ b/client/lib/wp/sync-handler/index.js
@@ -123,8 +123,9 @@ export class SyncHandler {
 			 * @param {Object} serverResponse - server response object
 			 */
 			const cacheResponse = serverResponse => {
-				// remove _headers from server response
-				delete serverResponse._headers;
+				// get response object without _headers property
+				let responseWithoutHeaders = Object.assign( {}, serverResponse );
+				delete responseWithoutHeaders._headers;
 
 				let storingData = {
 					__sync: {
@@ -132,7 +133,7 @@ export class SyncHandler {
 						synced: Date.now(),
 						syncing: false
 					},
-					body: serverResponse,
+					body: responseWithoutHeaders,
 					params: reqParams
 				};
 

--- a/client/lib/wp/sync-handler/whitelist-handler.js
+++ b/client/lib/wp/sync-handler/whitelist-handler.js
@@ -8,7 +8,7 @@ const debug = debugFactory( 'calypso:sync-handler:whitelist' );
 const whitelist = [
 	/^\/me\/posts$/,
 	/^\/me\/settings/,
-	/^\/sites\/[\w.]+\/posts/
+	/^\/sites\/[\w.]+\/posts$/
 ];
 
 export const isWhitelisted = params => {


### PR DESCRIPTION
In this PR:

* #3596 is fixed - This bug occurs when a non-configurable property attempts to be removed from an object in _strict mode_.
* Stop to sync single post request. We are syncing the single post requests. We prefer stay away to this for a while.

/cc @rralian @gwwar 