### PR TITLE
Framework: Upgrade `async` dependency, fixing PostNormalizer regressions

### DIFF
--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -52,6 +52,18 @@ function asyncTransform( post, callback ) {
 }
 
 describe( 'post-normalizer', function() {
+	before( () => {
+		sinon.stub( console, 'warn' );
+	} );
+
+	beforeEach( () => {
+		console.warn.reset();
+	} );
+
+	after( () => {
+		console.warn.restore();
+	} );
+
 	it( 'should export a function', function() {
 		assert.equal( typeof normalizer, 'function' );
 	} );
@@ -71,23 +83,25 @@ describe( 'post-normalizer', function() {
 		} );
 	} );
 
-	it( 'should allow synchronous invocation', () => {
+	it( 'should allow synchronous invocation', ( done ) => {
 		const post = {};
 		const normalized = normalizer( post, [ identifyTransform ] );
 
 		assert.notStrictEqual( normalized, post );
 		assert.deepEqual( normalized, post );
+
+		process.nextTick( () => {
+			assert.isFalse( console.warn.called );
+			done();
+		} );
 	} );
 
 	it( 'should warn about asynchronous usage in synchronous mode in non-production environments', ( done ) => {
 		const post = {};
-		sinon.stub( console, 'warn' );
-
 		normalizer( post, [ asyncTransform ] );
 
 		process.nextTick( () => {
 			assert.isTrue( console.warn.called );
-			console.warn.restore();
 			done();
 		} );
 	} );

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -10,7 +10,8 @@ require( 'lib/react-test-env-setup' )();
 //} );
 
 const assert = require( 'chai' ).assert,
-	Spy = require( 'sinon' ).spy;
+	sinon = require( 'sinon' ),
+	Spy = sinon.spy;
 /**
  * Internal dependencies
  */
@@ -67,6 +68,27 @@ describe( 'post-normalizer', function() {
 		normalizer( post, [ identifyTransform ], function( err, normalized ) {
 			assert.notStrictEqual( normalized, post );
 			done( err );
+		} );
+	} );
+
+	it( 'should allow synchronous invocation', () => {
+		const post = {};
+		const normalized = normalizer( post, [ identifyTransform ] );
+
+		assert.notStrictEqual( normalized, post );
+		assert.deepEqual( normalized, post );
+	} );
+
+	it( 'should warn about asynchronous usage in synchronous mode in non-production environments', ( done ) => {
+		const post = {};
+		sinon.stub( console, 'warn' );
+
+		normalizer( post, [ asyncTransform ] );
+
+		process.nextTick( () => {
+			assert.isTrue( console.warn.called );
+			console.warn.restore();
+			done();
 		} );
 	} );
 

--- a/client/lib/posts/posts-store.js
+++ b/client/lib/posts/posts-store.js
@@ -29,10 +29,7 @@ function normalizePost( attributes ) {
 		return;
 	}
 
-	// these methods are synchronous
-	utils.normalizeSync( attributes, function( error, post ) {
-		setPost( post );
-	} );
+	setPost( utils.normalizeSync( attributes ) );
 }
 
 function setAll( posts ) {

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -116,9 +116,9 @@ var utils = {
 		return post && 'page' === post.type;
 	},
 
-	normalizeSync: function( post, callback ) {
+	normalizeSync: function( post ) {
 		var imageWidth = 653;
-		postNormalizer(
+		return postNormalizer(
 			post,
 			[
 				postNormalizer.decodeEntities,
@@ -129,8 +129,7 @@ var utils = {
 					postNormalizer.content.removeStyles,
 					postNormalizer.content.safeContentImages( imageWidth )
 				] )
-			],
-			callback
+			]
 		);
 	},
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,9 +3,7 @@
   "version": "0.17.0",
   "dependencies": {
     "async": {
-      "version": "0.9.0",
-      "from": "async@0.9.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+      "version": "1.5.2"
     },
     "atob": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "async": "0.9.0",
+    "async": "1.5.2",
     "atob": "1.1.2",
     "autoprefixer": "4.0.0",
     "autosize": "3.0.7",


### PR DESCRIPTION
Related: #3577

This pull request seeks to upgrade `async` from `0.9.0` to the latest version, `1.5.2`. While the [package changelog](https://github.com/caolan/async/blob/v1.5.2/CHANGELOG.md) does not indicate any backwards-incompatible changes in this upgrade, it was found that our expectation that `eachSeries` could be used synchronously was unfounded, and was causing `PostsListStore` tests to fail by virtue of the upgrade alone.

These changes implement intentional support for synchronous usage of the `normalizePost` function, including development helpers to warn against asynchronous transforms being used in the context of a synchronous usage of the function.

__Testing instructions:__

Verify that no regressions exist in areas of the application which make use of `async` (particularly `post-normalizer`).

Ensure that Mocha tests pass by running `make test` from `client/lib/posts` and `client/lib/post-normalizer`.

/cc @rralian , @blowery 