### PR TITLE
Framework: remove unused posts.sitePosts from Redux tree

### DIFF
--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -44,33 +44,6 @@ export function items( state = {}, action ) {
 }
 
 /**
- * Returns the updated site posts state after an action has been dispatched.
- * The state reflects a mapping of site ID, post ID pairing to global post ID.
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
- */
-export function sitePosts( state = {}, action ) {
-	switch ( action.type ) {
-		case POSTS_RECEIVE:
-			state = Object.assign( {}, state );
-			action.posts.forEach( ( post ) => {
-				if ( ! state[ post.site_ID ] ) {
-					state[ post.site_ID ] = {};
-				}
-
-				state[ post.site_ID ][ post.ID ] = post.global_ID;
-			} );
-			return state;
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
-	}
-	return state;
-}
-
-/**
  * Returns the updated site post requests state after an action has been
  * dispatched. The state reflects a mapping of site ID, post ID pairing to a
  * boolean reflecting whether a request for the post is in progress.
@@ -165,7 +138,6 @@ export function queriesLastPage( state = {}, action ) {
 
 export default combineReducers( {
 	items,
-	sitePosts,
 	siteRequests,
 	queries,
 	queriesLastPage

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -24,23 +24,6 @@ export function getPost( state, globalId ) {
 }
 
 /**
- * Returns a post object by site ID, post ID pair.
- *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @param  {String}  postId Post ID
- * @return {?Object}        Post object
- */
-export function getSitePost( state, siteId, postId ) {
-	const { sitePosts } = state.posts;
-	if ( ! sitePosts[ siteId ] || ! sitePosts[ siteId ][ postId ] ) {
-		return null;
-	}
-
-	return getPost( state, sitePosts[ siteId ][ postId ] );
-}
-
-/**
  * Returns true if the specified posts query is being tracked for the site, or
  * false otherwise.
  *

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -20,7 +20,6 @@ import {
 } from 'state/action-types';
 import {
 	items,
-	sitePosts,
 	queries,
 	queriesLastPage,
 	siteRequests
@@ -91,42 +90,6 @@ describe( 'reducer', () => {
 				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
 			} );
 			const state = items( original, { type: DESERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-	} );
-
-	describe( '#sitePosts()', () => {
-		it( 'should default to an empty object', () => {
-			const state = sitePosts( undefined, {} );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should map site ID, post ID pair to global ID', () => {
-			const state = sitePosts( null, {
-				type: POSTS_RECEIVE,
-				posts: [ { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' } ]
-			} );
-
-			expect( state ).to.eql( {
-				2916284: {
-					841: '3d097cb7c5473c169bba0eb8e3c6cb64'
-				}
-			} );
-		} );
-		it( 'never persists state because this is not implemented', () => {
-			const original = deepFreeze( {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-			} );
-			const state = sitePosts( original, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'never loads persisted state because this is not implemented', () => {
-			const original = deepFreeze( {
-				'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-			} );
-			const state = sitePosts( original, { type: DESERIALIZE } );
 			expect( state ).to.eql( {} );
 		} );
 	} );

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -8,7 +8,6 @@ import { expect } from 'chai';
  */
 import {
 	getPost,
-	getSitePost,
 	isTrackingSitePostsQuery,
 	getSitePostsForQuery,
 	isRequestingSitePostsForQuery,
@@ -28,47 +27,6 @@ describe( 'selectors', () => {
 					}
 				}
 			}, '3d097cb7c5473c169bba0eb8e3c6cb64' );
-
-			expect( post ).to.eql( { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' } );
-		} );
-	} );
-
-	describe( '#getSitePost()', () => {
-		it( 'should return null if the site has not received any posts', () => {
-			const post = getSitePost( {
-				posts: {
-					sitePosts: {}
-				}
-			}, 2916284, 841 );
-
-			expect( post ).to.be.null;
-		} );
-
-		it( 'should return null if the post is not known for the site', () => {
-			const post = getSitePost( {
-				posts: {
-					sitePosts: {
-						2916284: {}
-					}
-				}
-			}, 2916284, 841 );
-
-			expect( post ).to.be.null;
-		} );
-
-		it( 'should return the object for the post site ID, post ID pair', () => {
-			const post = getSitePost( {
-				posts: {
-					items: {
-						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-					},
-					sitePosts: {
-						2916284: {
-							841: '3d097cb7c5473c169bba0eb8e3c6cb64'
-						}
-					}
-				}
-			}, 2916284, 841 );
 
 			expect( post ).to.eql( { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' } );
 		} );


### PR DESCRIPTION
This PR removes sitePosts from the posts subtree because it was never used and was composed of derived data. If we need this in the future, we can recreate it as a memoized selector: see #3522 

## Testing
- No changes to ui, since this was never in use.
- Build passes

cc @aduth @rralian 