### PR TITLE
Stats: display "No Change" instead of 0.00%

### DIFF
--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -145,7 +145,6 @@ export default React.createClass( {
 								{ displayValue }
 							</span></td>
 						);
-
 				} else {
 					cells.push( <td className="no-data" key={ 'change' + index }></td> );
 				}

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -124,6 +124,8 @@ export default React.createClass( {
 						'is-same': week.change === 0
 					} );
 
+					let displayValue = this.numberFormat( week.change, 2 ) + '%';
+
 					if ( week.change > 0 ) {
 						iconType = 'arrow-up';
 					}
@@ -133,14 +135,14 @@ export default React.createClass( {
 					}
 
 					if ( week.change === 0 ) {
-
+						displayValue = this.translate( 'No change', { context: 'Stats: No change in stats value from prior period' } );
 					}
 
 					cells.push( <td key={ 'average' + index }>
 						{ this.numberFormat( week.average ) }
 							<span className={ 'stats-detail-weeks__value ' + changeClass } key={ 'change' + index }>
 								{ iconType ? <Gridicon icon={ iconType } size={ 18 } /> : null }
-								{ this.numberFormat( week.change, 2 ) }%
+								{ displayValue }
 							</span></td>
 						);
 

--- a/client/my-sites/stats/stats-detail-weeks/index.jsx
+++ b/client/my-sites/stats/stats-detail-weeks/index.jsx
@@ -132,6 +132,10 @@ export default React.createClass( {
 						iconType = 'arrow-down';
 					}
 
+					if ( week.change === 0 ) {
+
+					}
+
 					cells.push( <td key={ 'average' + index }>
 						{ this.numberFormat( week.average ) }
 							<span className={ 'stats-detail-weeks__value ' + changeClass } key={ 'change' + index }>


### PR DESCRIPTION
This PR fixes item number 5 on: https://github.com/Automattic/wp-calypso/issues/2894

/cc @timmyc 

As discussed, need help on how to display `No change` instead of `0.00%` :)

![screenshot 2016-02-26 10 33 58](https://cloud.githubusercontent.com/assets/4924246/13362111/6565c91c-dc77-11e5-9bb1-01ae14d603ea.png)
