### PR TITLE
Posts: fix prop warning for PostExcerpt component

### DIFF
--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -193,9 +193,9 @@ module.exports = React.createClass({
 		}
 
 		if ( this.props.post.format === 'quote' ) {
-			excerptElement = <PostExcerpt text={ this.getTrimmedExcerpt() } className="post__quote" />;
+			excerptElement = <PostExcerpt content={ this.getTrimmedExcerpt() } className="post__quote" />;
 		} else {
-			excerptElement = <PostExcerpt text={ this.getTrimmedExcerpt() } />;
+			excerptElement = <PostExcerpt content={ this.getTrimmedExcerpt() } />;
 		}
 
 		return (


### PR DESCRIPTION
The name of the prop for PostExcerpt was changed in https://github.com/Automattic/wp-calypso/commit/4d36be66c055fc81d75c3ae762586af541bf1831 but not all of the usage was updated. There's use of that component in the post-list page. So that resulted in this prop warning and an empty PostExcerpt component.

![prop warning](https://cloudup.com/crVXADg_zuX+)

The fix is just to change the prop name. @bluefuton gentle reminder to check for all cases of a component usage if you make a change.