### PR TITLE
Remove unused feature flags for upgrades/*

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -89,14 +89,10 @@ module.exports = React.createClass( {
 	},
 
 	getSiteRedirectNotice: function( site ) {
-		const isSiteRedirected = site.options && site.options.is_redirect;
-
-		if ( ! isSiteRedirected ) {
+		if ( ! ( site.options && site.options.is_redirect ) ) {
 			return null;
 		}
 		const { hostname } = url.parse( site.URL );
-		let href = paths.domainManagementList( site.domain );
-
 		return (
 			<Notice
 				showDismiss={ false }
@@ -105,7 +101,7 @@ module.exports = React.createClass( {
 					args: { url: hostname },
 					components: { a: <a href={ site.URL }/> }
 				} ) }>
-				<NoticeAction href={ href }>
+				<NoticeAction href={ paths.domainManagementList( site.domain ) }>
 					{ this.translate( 'Edit' ) }
 				</NoticeAction>
 			</Notice>

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -95,11 +95,7 @@ module.exports = React.createClass( {
 			return null;
 		}
 		const { hostname } = url.parse( site.URL );
-		let href = 'https://wordpress.com/my-domains';
-
-		if ( config.isEnabled( 'upgrades/domain-management/list' ) ) {
-			href = paths.domainManagementList( site.domain );
-		}
+		let href = paths.domainManagementList( site.domain );
 
 		return (
 			<Notice
@@ -192,7 +188,7 @@ module.exports = React.createClass( {
 					? this.addNewWordPressButton()
 					: <span className="current-site__switch-sites">
 						<Button compact borderless onClick={ this.switchSites }>
-							<Gridicon icon="arrow-left" size={ 16 } />
+							<Gridicon icon="arrow-left" size={ 18 } />
 							{ this.translate( 'Switch Site' ) }
 						</Button>
 					</span>

--- a/client/my-sites/upgrades/checkout-thank-you/utils.js
+++ b/client/my-sites/upgrades/checkout-thank-you/utils.js
@@ -1,20 +1,15 @@
 /**
  * Internal dependencies
  */
-import config from 'config';
 import paths from 'my-sites/upgrades/paths';
 
 function getDomainManagementUrl( selectedSite, domain ) {
 	let url;
 
-	if ( config.isEnabled( 'upgrades/domain-management/list' ) ) {
-		if ( domain ) {
-			url = paths.domainManagementEdit( selectedSite.domain, domain );
-		} else {
-			url = paths.domainManagementList( selectedSite.domain );
-		}
+	if ( domain ) {
+		url = paths.domainManagementEdit( selectedSite.domain, domain );
 	} else {
-		url = '/my-domains/' + selectedSite.ID;
+		url = paths.domainManagementList( selectedSite.domain );
 	}
 
 	return url;

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -22,10 +22,6 @@ var analytics = require( 'analytics' ),
 
 module.exports = {
 
-	domainSearchIndex: function() {
-		page.redirect( '/domains/add' + ( sites.getSelectedSite() ? ( '/' + sites.getSelectedSite().slug ) : '' ) );
-	},
-
 	domainsAddHeader: function( context, next ) {
 		context.getSiteSelectionHeaderText = function() {
 			return i18n.translate( 'Select a site to add a domain' );

--- a/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
@@ -7,7 +7,6 @@ const React = require( 'react' );
  * Internal dependencies
  */
 const analyticsMixin = require( 'lib/mixins/analytics' ),
-	config = require( 'config' ),
 	Card = require( 'components/card/compact' ),
 	Header = require( './card/header' ),
 	Property = require( './card/property' ),
@@ -92,9 +91,6 @@ const MappedDomain = React.createClass( {
 	},
 
 	dnsRecordsNavItem() {
-		if ( ! config.isEnabled( 'upgrades/domain-management/name-servers' ) ) {
-			return null;
-		}
 
 		const path = paths.domainManagementDns(
 			this.props.selectedSite.domain,

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -8,7 +8,6 @@ import React from 'react';
  */
 import analyticsMixin from 'lib/mixins/analytics';
 import Card from 'components/card/compact';
-import config from 'config';
 import Notice from 'components/notice';
 import DomainWarnings from 'my-sites/upgrades/components/domain-warnings';
 import Header from './card/header';
@@ -130,10 +129,6 @@ const RegisteredDomain = React.createClass( {
 	},
 
 	nameServersNavItem() {
-		if ( ! config.isEnabled( 'upgrades/domain-management/name-servers' ) ) {
-			return null;
-		}
-
 		const path = paths.domainManagementNameServers(
 			this.props.selectedSite.domain,
 			this.props.domain.name

--- a/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/registered-domain.jsx
@@ -147,9 +147,6 @@ const RegisteredDomain = React.createClass( {
 	},
 
 	contactsPrivacyNavItem() {
-		if ( ! config.isEnabled( 'upgrades/domain-management/contacts-privacy' ) ) {
-			return null;
-		}
 
 		const path = paths.domainManagementContactsPrivacy(
 			this.props.selectedSite.domain,

--- a/client/my-sites/upgrades/domain-management/edit/site-redirect.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/site-redirect.jsx
@@ -67,10 +67,6 @@ const SiteRedirect = React.createClass( {
 	},
 
 	siteRedirectNavItem() {
-		if ( ! config.isEnabled( 'upgrades/domain-management/site-redirect' ) ) {
-			return;
-		}
-
 		return (
 			<VerticalNavItem path={ paths.domainManagementRedirectSettings( this.props.selectedSite.domain, this.props.domain.name ) }>
 				{ this.translate( 'Redirect Settings' ) }

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -112,37 +112,35 @@ module.exports = function() {
 		domainManagementController.domainManagementTransfer
 	);
 
-	if ( config.isEnabled( 'upgrades/domain-management/list' ) ) {
-		page(
-			paths.domainManagementRoot(),
-			controller.siteSelection,
-			controller.sites
-		);
+	page(
+		paths.domainManagementRoot(),
+		controller.siteSelection,
+		controller.sites
+	);
 
-		page(
-			paths.domainManagementList( ':site' ),
-			...getCommonHandlers(),
-			domainManagementController.domainManagementList
-		);
+	page(
+		paths.domainManagementList( ':site' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementList
+	);
 
-		page(
-			paths.domainManagementEdit( ':site', ':domain' ),
-			...getCommonHandlers(),
-			domainManagementController.domainManagementEdit
-		);
+	page(
+		paths.domainManagementEdit( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementEdit
+	);
 
-		page(
-			paths.domainManagementPrivacyProtection( ':site', ':domain' ),
-			...getCommonHandlers( { warnIfJetpack: false } ),
-			domainManagementController.domainManagementPrivacyProtection
-		);
+	page(
+		paths.domainManagementPrivacyProtection( ':site', ':domain' ),
+		...getCommonHandlers( { warnIfJetpack: false } ),
+		domainManagementController.domainManagementPrivacyProtection
+	);
 
-		page(
-			paths.domainManagementPrimaryDomain( ':site', ':domain' ),
-			...getCommonHandlers(),
-			domainManagementController.domainManagementPrimaryDomain
-		);
-	}
+	page(
+		paths.domainManagementPrimaryDomain( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementPrimaryDomain
+	);
 
 	if ( config.isEnabled( 'upgrades/domain-search' ) ) {
 		page(
@@ -218,38 +216,19 @@ module.exports = function() {
 		);
 	}
 
-	if ( config.isEnabled( 'upgrades/domain-management/list' ) ) {
-		page(
-			'/domains',
-			controller.siteSelection,
-			controller.sites
-		);
+	page(
+		'/domains',
+		controller.siteSelection,
+		controller.sites
+	);
 
-		page(
-			'/domains/:site',
-			controller.siteSelection,
-			controller.navigation,
-			controller.jetPackWarning,
-			domainManagementController.domainManagementIndex
-		);
-	} else {
-		page(
-			'/domains',
-			adTracking.retarget,
-			controller.siteSelection,
-			upgradesController.domainsAddHeader,
-			controller.jetPackWarning,
-			controller.sites
-		);
-
-		page( '/domains/:domain',
-			adTracking.retarget,
-			controller.siteSelection,
-			controller.navigation,
-			controller.jetPackWarning,
-			upgradesController.domainSearchIndex
-		);
-	}
+	page(
+		'/domains/:site',
+		controller.siteSelection,
+		controller.navigation,
+		controller.jetPackWarning,
+		domainManagementController.domainManagementIndex
+	);
 
 	if ( config.isEnabled( 'upgrades/checkout' ) ) {
 		page(

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -92,19 +92,17 @@ module.exports = function() {
 		domainManagementController.domainManagementEditContactInfo
 	);
 
-	if ( config.isEnabled( 'upgrades/domain-management/name-servers' ) ) {
-		page(
-			paths.domainManagementDns( ':site', ':domain' ),
-			...getCommonHandlers(),
-			domainManagementController.domainManagementDns
-		);
+	page(
+		paths.domainManagementDns( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementDns
+	);
 
-		page(
-			paths.domainManagementNameServers( ':site', ':domain' ),
-			...getCommonHandlers(),
-			domainManagementController.domainManagementNameServers
-		);
-	}
+	page(
+		paths.domainManagementNameServers( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementNameServers
+	);
 
 	page(
 		paths.domainManagementTransfer( ':site', ':domain' ),

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -82,19 +82,17 @@ module.exports = function() {
 		);
 	}
 
-	if ( config.isEnabled( 'upgrades/domain-management/contacts-privacy' ) ) {
-		page(
-			paths.domainManagementContactsPrivacy( ':site', ':domain' ),
-			...getCommonHandlers(),
-			domainManagementController.domainManagementContactsPrivacy
-		);
+	page(
+		paths.domainManagementContactsPrivacy( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementContactsPrivacy
+	);
 
-		page(
-			paths.domainManagementEditContactInfo( ':site', ':domain' ),
-			...getCommonHandlers(),
-			domainManagementController.domainManagementEditContactInfo
-		);
-	}
+	page(
+		paths.domainManagementEditContactInfo( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementEditContactInfo
+	);
 
 	if ( config.isEnabled( 'upgrades/domain-management/name-servers' ) ) {
 		page(

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -72,13 +72,11 @@ module.exports = function() {
 		domainManagementController.domainManagementEmailForwarding
 	);
 
-	if ( config.isEnabled( 'upgrades/domain-management/site-redirect' ) ) {
-		page(
-			paths.domainManagementRedirectSettings( ':site', ':domain' ),
-			...getCommonHandlers(),
-			domainManagementController.domainManagementRedirectSettings
-		);
-	}
+	page(
+		paths.domainManagementRedirectSettings( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementRedirectSettings
+	);
 
 	page(
 		paths.domainManagementContactsPrivacy( ':site', ':domain' ),

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -38,41 +38,39 @@ function getCommonHandlers( { noSitePath = paths.domainManagementRoot(), warnIfJ
 module.exports = function() {
 	SiftScience.recordUser();
 
-	if ( config.isEnabled( 'upgrades/domain-management/email' ) ) {
-		page(
-			paths.domainManagementEmail(),
-			controller.siteSelection,
-			controller.sites
-		);
+	page(
+		paths.domainManagementEmail(),
+		controller.siteSelection,
+		controller.sites
+	);
 
-		registerMultiPage( {
-			paths: [
-				paths.domainManagementEmail( ':site', ':domain' ),
-				paths.domainManagementEmail( ':site' )
-			],
-			handlers: [
-				...getCommonHandlers( { noSitePath: paths.domainManagementEmail() } ),
-				domainManagementController.domainManagementEmail
-			]
-		} );
+	registerMultiPage( {
+		paths: [
+			paths.domainManagementEmail( ':site', ':domain' ),
+			paths.domainManagementEmail( ':site' )
+		],
+		handlers: [
+			...getCommonHandlers( { noSitePath: paths.domainManagementEmail() } ),
+			domainManagementController.domainManagementEmail
+		]
+	} );
 
-		registerMultiPage( {
-			paths: [
-				paths.domainManagementAddGoogleApps( ':site', ':domain' ),
-				paths.domainManagementAddGoogleApps( ':site' )
-			],
-			handlers: [
-				...getCommonHandlers(),
-				domainManagementController.domainManagementAddGoogleApps
-			]
-		} );
-
-		page(
-			paths.domainManagementEmailForwarding( ':site', ':domain' ),
+	registerMultiPage( {
+		paths: [
+			paths.domainManagementAddGoogleApps( ':site', ':domain' ),
+			paths.domainManagementAddGoogleApps( ':site' )
+		],
+		handlers: [
 			...getCommonHandlers(),
-			domainManagementController.domainManagementEmailForwarding
-		);
-	}
+			domainManagementController.domainManagementAddGoogleApps
+		]
+	} );
+
+	page(
+		paths.domainManagementEmailForwarding( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementEmailForwarding
+	);
 
 	if ( config.isEnabled( 'upgrades/domain-management/site-redirect' ) ) {
 		page(

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": false,
 		"upgrades/credit-cards": false,
-		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": false,
 		"upgrades/credit-cards": false,
-		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": false,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": false,
 		"upgrades/credit-cards": false,
-		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": false,
 		"upgrades/domain-search": false,
 		"upgrades/in-app-purchase": true,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": false,
 		"upgrades/credit-cards": false,
-		"upgrades/domain-management/transfer": false,
 		"upgrades/domain-search": false,
 		"upgrades/in-app-purchase": true,
 		"upgrades/paypal": false,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": false,
 		"upgrades/credit-cards": false,
-		"upgrades/domain-management/contacts-privacy": true,
 		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": false,
 		"upgrades/credit-cards": false,
-		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": false,
 		"upgrades/domain-search": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": false,
 		"upgrades/domain-search": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/contacts-privacy": true,
 		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": false,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -79,7 +79,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/transfer": false,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": false,

--- a/config/development.json
+++ b/config/development.json
@@ -116,7 +116,6 @@
 		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": true,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,

--- a/config/development.json
+++ b/config/development.json
@@ -116,7 +116,6 @@
 		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/contacts-privacy": true,
 		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,

--- a/config/development.json
+++ b/config/development.json
@@ -116,7 +116,6 @@
 		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/transfer": true,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,

--- a/config/development.json
+++ b/config/development.json
@@ -116,7 +116,6 @@
 		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,

--- a/config/development.json
+++ b/config/development.json
@@ -116,7 +116,6 @@
 		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": true,
 		"upgrades/domain-search": true,

--- a/config/development.json
+++ b/config/development.json
@@ -116,7 +116,6 @@
 		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-management/transfer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,

--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/contacts-privacy": true,
 		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,

--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,

--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,

--- a/config/production.json
+++ b/config/production.json
@@ -77,7 +77,6 @@
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -81,7 +81,6 @@
 		"settings/security/scan": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/contacts-privacy": true,
 		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -81,7 +81,6 @@
 		"settings/security/scan": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -81,7 +81,6 @@
 		"settings/security/scan": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -81,7 +81,6 @@
 		"settings/security/scan": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -81,7 +81,6 @@
 		"settings/security/scan": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-search": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,7 +91,6 @@
 		"support-user": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/contacts-privacy": true,
 		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,7 +91,6 @@
 		"support-user": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/email": true,
 		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,7 +91,6 @@
 		"support-user": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,7 +91,6 @@
 		"support-user": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,7 +91,6 @@
 		"support-user": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
-		"upgrades/domain-management/list": true,
 		"upgrades/domain-management/name-servers": true,
 		"upgrades/domain-management/site-redirect": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
Fixes #1301.

This removes feature flags that are enabled for all environments under upgrades/*

No behaviour changes.

Testing:
- Ensure URLs load properly
- Ensure there are no remaining references to the removed flags anywhere in the code.

/cc: @stephanethomas @klimeryk 