### PR TITLE
get-i18n: Return failure on error

### DIFF
--- a/server/i18n/bin/i18n-cli.js
+++ b/server/i18n/bin/i18n-cli.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies/
  */
-var fs = require( 'fs' ),
-	path = require( 'path' ),
+var path = require( 'path' ),
 	program = require( 'commander' );
 
 /**
@@ -15,7 +14,7 @@ var i18n = require( '../index' );
 /**
  * Internal variables/
  */
-var outputFile, arrayName, inputFiles, inputPaths;
+var outputFile, arrayName, inputFiles, inputPaths, verbose;
 
 function collect( val, memo ) {
 	memo.push( val );
@@ -23,16 +22,17 @@ function collect( val, memo ) {
 }
 
 program
-	.version( '0.0.1' )
+	.version( '0.1' )
 	.option( '-o, --output-file <file>', 'output file for WP-style translation functions' )
 	.option( '-a, --array-name <name>', 'name of variable in generated php file that contains array of method calls' )
 	.option( '-i, --input-file <filename>', 'files in which to search for translation methods', collect, [] )
-	.usage( 'outputFile arrayName inputFile [inputFile ...]' )
+	.option( '-v, --verbose', 'print messages and errors to the console' )
+	.usage( ' [-v] outputFile arrayName inputFile [inputFile ...]' )
 	.on( '--help', function() {
-		console.log( '  Examples' );
+		console.log( '  Examples:' );
 		console.log( '\n    $ get-i18n ./outputFile.txt calypso_i18n_strings ./inputFile.js ./inputFile2.js' );
 		console.log( '    $ get-i18n -i ./inputFile.js -i ./inputFile2.js -o ./outputFile.txt -a calypso_i18n_strings' );
-		console.log( '\n  Sample Output' );
+		console.log( '\n  Sample output file contents:' );
 		console.log( '\n    <?php' );
 		console.log( '    $calypso_i18n_strings = array (' );
 		console.log( '      __( \' Example1 \' ),' );
@@ -44,6 +44,7 @@ program
 
 outputFile = program.outputFile || program.args[0];
 arrayName = program.arrayName || program.args[1];
+verbose = program.verbose;
 inputFiles = ( program.inputFile.length ) ? program.inputFile : program.args.slice( 2 );
 
 if ( ! outputFile ) {
@@ -64,9 +65,11 @@ inputPaths = inputFiles.map( function( fileName ) {
 } );
 
 i18n( outputFile, arrayName, inputPaths, function() {
-	if ( process.exitCode ) {
-		console.log( 'get-i18n completed with errors.' );
-	} else {
-		console.log( 'get-i18n completed.' );
+	if ( verbose ) {
+		if ( process.exitCode ) {
+			console.log( 'get-i18n completed with errors.' );
+		} else {
+			console.log( 'get-i18n completed.' );
+		}
 	}
-} );
+}, verbose );

--- a/server/i18n/bin/i18n-cli.js
+++ b/server/i18n/bin/i18n-cli.js
@@ -46,14 +46,14 @@ outputFile = program.outputFile || program.args[0];
 arrayName = program.arrayName || program.args[1];
 inputFiles = ( program.inputFile.length ) ? program.inputFile : program.args.slice( 2 );
 
-if ( inputFiles.length === 0 ) {
-	throw new Error( 'Error: You must enter the input file. Run `get-i18n -h` for examples.' );
-}
 if ( ! outputFile ) {
 	throw new Error( 'Error: You must enter the output file. Run `get-i18n -h` for examples.' );
 }
 if ( ! arrayName ) {
 	throw new Error( 'Error: You must enter the php variable name for the array of translation calls.' );
+}
+if ( inputFiles.length === 0 ) {
+	throw new Error( 'Error: You must enter at least one input file. Run `get-i18n -h` for examples.' );
 }
 
 outputFile = path.resolve( process.env.PWD, outputFile );

--- a/server/i18n/bin/i18n-cli.js
+++ b/server/i18n/bin/i18n-cli.js
@@ -68,6 +68,7 @@ inputPaths = inputFiles.map( function( fileName ) {
 
 inputPaths.forEach( function( inputFile ) {
 	if ( ! fs.existsSync( inputFile ) ) {
+		process.exitCode = 1;
 		console.log( 'Error: inputFile, `' + inputFile + '`, does not exist' );
 	}
 } );

--- a/server/i18n/bin/i18n-cli.js
+++ b/server/i18n/bin/i18n-cli.js
@@ -63,10 +63,10 @@ inputPaths = inputFiles.map( function( fileName ) {
 	return path.resolve( process.env.PWD, fileName );
 } );
 
-inputPaths.forEach( function( inputFile ) {
-	if ( ! fs.existsSync( inputFile ) ) {
-		throw new Error( 'Error: inputFile "' + inputFile + '" does not exist' );
+i18n( outputFile, arrayName, inputPaths, function() {
+	if ( process.exitCode ) {
+		console.log( 'get-i18n completed with errors.' );
+	} else {
+		console.log( 'get-i18n completed.' );
 	}
 } );
-
-i18n( outputFile, arrayName, inputPaths );

--- a/server/i18n/bin/i18n-cli.js
+++ b/server/i18n/bin/i18n-cli.js
@@ -47,15 +47,12 @@ arrayName = program.arrayName || program.args[1];
 inputFiles = ( program.inputFile.length ) ? program.inputFile : program.args.slice( 2 );
 
 if ( inputFiles.length === 0 ) {
-	console.log( 'Error: You must enter the input file. Run `get-i18n -h` for examples.' );
 	throw new Error( 'Error: You must enter the input file. Run `get-i18n -h` for examples.' );
 }
 if ( ! outputFile ) {
-	console.log( 'Error: You must enter the output file. Run `get-i18n -h` for examples.' );
 	throw new Error( 'Error: You must enter the output file. Run `get-i18n -h` for examples.' );
 }
 if ( ! arrayName ) {
-	console.log( 'Error: You must enter the php variable name for the array of translation calls.' );
 	throw new Error( 'Error: You must enter the php variable name for the array of translation calls.' );
 }
 
@@ -68,8 +65,7 @@ inputPaths = inputFiles.map( function( fileName ) {
 
 inputPaths.forEach( function( inputFile ) {
 	if ( ! fs.existsSync( inputFile ) ) {
-		process.exitCode = 1;
-		console.log( 'Error: inputFile, `' + inputFile + '`, does not exist' );
+		throw new Error( 'Error: inputFile "' + inputFile + '" does not exist' );
 	}
 } );
 

--- a/server/i18n/index.js
+++ b/server/i18n/index.js
@@ -168,27 +168,27 @@ function buildPhpOutput( data, arrayName ) {
  * @param  {Function} done       - callback function
  */
 function readFile( outputFile, arrayName, inputFiles, done ) {
-	console.log( 'Reading inputFiles: ' + inputFiles.join( ', ' ) );
 	async.map( inputFiles, function( inputFile, callback ) {
 		fs.readFile( inputFile, 'utf8', function( err, data ) {
 			if ( err ) {
-				throw new Error( 'i18n: Error reading ' + inputFile );
+				console.log( 'i18n: Error reading ' + inputFile );
+				console.error( err );
+				process.exitCode = 1;
+				callback();
 			} else {
+				console.log( 'i18n: Reading ' + inputFile );
 				callback( null, data );
 			}
 		} );
 	}, function( err, data ) {
-		if ( err ) {
-			throw new Error( err );
-		}
 		fs.writeFile( outputFile, buildPhpOutput( data.join( '\n' ), arrayName ), 'utf8', function( error ) {
 			if ( error ) {
-				throw new Error( error );
-			} else {
-				console.log( 'get-i18n completed' );
-				if ( 'function' === typeof done ) {
-					done();
-				}
+				process.exitCode = 1;
+				console.log( 'i18n: Error writing ' + outputFile );
+				console.error( error );
+			}
+			if ( 'function' === typeof done ) {
+				done();
 			}
 		} );
 	} );

--- a/server/i18n/index.js
+++ b/server/i18n/index.js
@@ -172,22 +172,18 @@ function readFile( outputFile, arrayName, inputFiles, done ) {
 	async.map( inputFiles, function( inputFile, callback ) {
 		fs.readFile( inputFile, 'utf8', function( err, data ) {
 			if ( err ) {
-				process.exitCode = 1;
-				console.log( 'i18n: Error reading ' + inputFile );
-				callback( err );
+				throw new Error( 'i18n: Error reading ' + inputFile );
 			} else {
 				callback( null, data );
 			}
 		} );
 	}, function( err, data ) {
 		if ( err ) {
-			process.exitCode = 1;
-			return console.log( err );
+			throw new Error( err );
 		}
 		fs.writeFile( outputFile, buildPhpOutput( data.join( '\n' ), arrayName ), 'utf8', function( error ) {
 			if ( error ) {
-				process.exitCode = 1;
-				console.log( error );
+				throw new Error( error );
 			} else {
 				console.log( 'get-i18n completed' );
 				if ( 'function' === typeof done ) {

--- a/server/i18n/index.js
+++ b/server/i18n/index.js
@@ -166,26 +166,39 @@ function buildPhpOutput( data, arrayName ) {
  * @param  {string}   arrayName  - name of array to use inside php file
  * @param  {string}   inputFiles  - location of the javascript file to parse
  * @param  {Function} done       - callback function
+ * @param  {boolean}  verbose    - whether to output to console
  */
-function readFile( outputFile, arrayName, inputFiles, done ) {
+function readFile( outputFile, arrayName, inputFiles, done, verbose ) {
+	if ( typeof verbose === 'undefined' ) {
+		verbose = false;
+	}
 	async.map( inputFiles, function( inputFile, callback ) {
 		fs.readFile( inputFile, 'utf8', function( err, data ) {
 			if ( err ) {
-				console.log( 'i18n: Error reading ' + inputFile );
-				console.error( err );
+				if ( verbose ) {
+					console.log( 'i18n: Error reading ' + inputFile );
+					console.error( err );
+				}
 				process.exitCode = 1;
 				callback();
 			} else {
-				console.log( 'i18n: Reading ' + inputFile );
+				if ( verbose ) {
+					console.log( 'i18n: Reading ' + inputFile );
+				}
+
 				callback( null, data );
 			}
 		} );
-	}, function( err, data ) {
+	}, function( _, data ) {
 		fs.writeFile( outputFile, buildPhpOutput( data.join( '\n' ), arrayName ), 'utf8', function( error ) {
 			if ( error ) {
 				process.exitCode = 1;
-				console.log( 'i18n: Error writing ' + outputFile );
-				console.error( error );
+				if ( verbose ) {
+					console.log( 'i18n: Error writing ' + outputFile );
+					console.error( error );
+				}
+			} else if ( verbose ) {
+				console.log( 'i18n: Wrote to ' + outputFile );
 			}
 			if ( 'function' === typeof done ) {
 				done();

--- a/server/i18n/index.js
+++ b/server/i18n/index.js
@@ -172,6 +172,7 @@ function readFile( outputFile, arrayName, inputFiles, done ) {
 	async.map( inputFiles, function( inputFile, callback ) {
 		fs.readFile( inputFile, 'utf8', function( err, data ) {
 			if ( err ) {
+				process.exitCode = 1;
 				console.log( 'i18n: Error reading ' + inputFile );
 				callback( err );
 			} else {
@@ -180,10 +181,12 @@ function readFile( outputFile, arrayName, inputFiles, done ) {
 		} );
 	}, function( err, data ) {
 		if ( err ) {
+			process.exitCode = 1;
 			return console.log( err );
 		}
 		fs.writeFile( outputFile, buildPhpOutput( data.join( '\n' ), arrayName ), 'utf8', function( error ) {
 			if ( error ) {
+				process.exitCode = 1;
 				console.log( error );
 			} else {
 				console.log( 'get-i18n completed' );


### PR DESCRIPTION
This PR aims to have `get-i18n` fail and return a non-zero value if something goes wrong, as a first step towards getting `make translate` do the same to fix issue #3637.  Errors in `get-i18n` should bubble up through `xargs` and `make` automatically.

The error in #3637 is actually in the bundler stage, but there are several errors that get-i18n is currently ignoring.

To test these changes, introduce an error and run `make translate` and verify that the call fails.  You can check this easily with something like: `make translate && echo $'\n*** DONT\n*** PRINT\n*** THIS'`.  Pro tip: make translate includes a time-consuming bundler step that you can comment out after the first time.

There are a few ways that get-i18n can fail silently, mostly related to the file-system.

1. get-i18n could receive non-existent filenames:  We can simulate this by manipulating one of the input paths, e.g. `inputPaths[0] = 'not-' + inputPaths[0];` after the `inputFiles.map()` call in `server/i18n/bin/i18n-cli.js`.  This prints an error message, but the overall process should also fail because this probably means that we'll be missing strings in glotpress.  (By the way - you might notice the error message is wrong at this stage - I opened #4112).
2. A problem reading the files:  `sudo chmod -R u-r public`
3. A problem writing the file: `chmod u-w calypso-strings.php`

`get-i18n` should return an error code for any of these problems and cause the overall process and therefor `make translate` to fail.

Exceptions seem to be "working" in the sense that they end the process with a failure code, but keep an eye out for places that might not be true.