### PR TITLE
Revert "SyncHandler: enable in horizon"

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,6 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": false,
-		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/in-app-purchase": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -89,7 +89,6 @@
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
 		"support-user": true,
-		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-management/contacts-privacy": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#3612