### PR TITLE
Checkout: Thank You: Display Jetpack thank you page when purchasing a Jetpack plan

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -38,6 +38,7 @@ function assertValidProduct( product ) {
 function formatProduct( product ) {
 	return assign( {}, product, {
 		product_slug: product.product_slug || product.productSlug,
+		product_type: product.product_type || product.productType,
 		is_domain_registration: product.is_domain_registration !== undefined
 			? product.is_domain_registration
 			: product.isDomainRegistration,

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -8,6 +8,7 @@ export function createReceiptObject( data ) {
 				meta: purchase.meta,
 				productId: purchase.product_id,
 				productSlug: purchase.product_slug,
+				productType: purchase.product_type,
 				productName: purchase.product_name,
 				productNameShort: purchase.product_name_short
 			};


### PR DESCRIPTION
Currently, we display the same thank you page for .com and Jetpack business plan purchases. This is because [this call](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/upgrades/checkout-thank-you/index.jsx#L175) to `isJetpackPremium` (and the `isJetpackBusiness` call below) check a `product_type`, which is not currently returned by the API, or caught in the receipts assembler.

**Testing**
- Visit `/plans/:site` for a Jetpack site and purchase a Jetpack plan.
- Assert that the thank you page displays [Jetpack-specific information](https://cloudup.com/cLotsAZJyvj), instead of the same thank you page as the premium or business plan ([premium screenshot](https://cloudup.com/c8xlmHBs8wT)). The generic icons will be updated by #3578 (although I can't find a record of these icons ever _not_ being the default in the commit record).

- [x] Code review
- [x] Product review