### PR TITLE
People: Implement notices for sending invitations

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -135,14 +135,12 @@ export function sendInvites( siteId, usernamesOrEmails, role, message, callback 
 			} );
 
 			if ( error ) {
-				if ( error.message ) {
-					dispatch( errorNotice( i18n.translate(
-						'Invitation failed to send',
-						'Invitations failed to send', {
-							count: usernamesOrEmails.length
-						}
-					) ) );
-				}
+				dispatch( errorNotice( i18n.translate(
+					'Invitation failed to send',
+					'Invitations failed to send', {
+						count: usernamesOrEmails.length
+					}
+				) ) );
 				analytics.tracks.recordEvent( 'calypso_invite_send_failed' );
 			} else {
 				dispatch( successNotice( i18n.translate(

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -21,6 +21,7 @@ import UsersActions from 'lib/users/actions';
 import PeopleLogStore from 'lib/people/log-store';
 import titleActions from 'lib/screen-title/actions';
 import InvitePeople from './invite-people';
+import { renderWithReduxStore } from 'lib/react-helpers';
 
 /**
  * Module variables
@@ -79,11 +80,12 @@ function renderInvitePeople( context ) {
 
 	titleActions.setTitle( i18n.translate( 'Invite People', { textOnly: true } ), { siteID: route.getSiteFragment( context.path ) } );
 
-	ReactDom.render(
+	renderWithReduxStore(
 		React.createElement( InvitePeople, {
 			site: sites.getSelectedSite()
 		} ),
-		document.getElementById( 'primary' )
+		document.getElementById( 'primary' ),
+		context.store
 	);
 }
 

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -7,6 +7,8 @@ import get from 'lodash/get';
 import debugModule from 'debug';
 import includes from 'lodash/includes';
 import some from 'lodash/some';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -30,7 +32,7 @@ import InvitesCreateValidationStore from 'lib/invites/stores/invites-create-vali
  */
 const debug = debugModule( 'calypso:my-sites:people:invite' );
 
-export default React.createClass( {
+const InvitePeople = React.createClass( {
 	displayName: 'InvitePeople',
 
 	componentDidMount() {
@@ -74,7 +76,7 @@ export default React.createClass( {
 			usernamesOrEmails: filteredTokens,
 			errorToDisplay: includes( filteredTokens, errorToDisplay ) && errorToDisplay
 		} );
-		createInviteValidation( this.props.site.ID, filteredTokens, role );
+		this.props.createInviteValidation( this.props.site.ID, filteredTokens, role );
 	},
 
 	onMessageChange( event ) {
@@ -84,7 +86,7 @@ export default React.createClass( {
 	onRoleChange( event ) {
 		const role = event.target.value;
 		this.setState( { role } );
-		createInviteValidation( this.props.site.ID, this.state.usernamesOrEmails, role );
+		this.props.createInviteValidation( this.props.site.ID, this.state.usernamesOrEmails, role );
 	},
 
 	refreshValidation() {
@@ -138,7 +140,7 @@ export default React.createClass( {
 		debug( 'Submitting invite form. State: ' + JSON.stringify( this.state ) );
 
 		this.setState( { sendingInvites: true } );
-		sendInvites( this.props.site.ID, this.state.usernamesOrEmails, this.state.role, this.state.message, ( error, data ) => {
+		this.props.sendInvites( this.props.site.ID, this.state.usernamesOrEmails, this.state.role, this.state.message, ( error, data ) => {
 			if ( error ) {
 				debug( 'Send invite error:' + JSON.stringify( error ) );
 			} else {
@@ -253,3 +255,8 @@ export default React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( { sendInvites, createInviteValidation }, dispatch )
+)( InvitePeople );

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -76,7 +76,7 @@ const InvitePeople = React.createClass( {
 			usernamesOrEmails: filteredTokens,
 			errorToDisplay: includes( filteredTokens, errorToDisplay ) && errorToDisplay
 		} );
-		this.props.createInviteValidation( this.props.site.ID, filteredTokens, role );
+		createInviteValidation( this.props.site.ID, filteredTokens, role );
 	},
 
 	onMessageChange( event ) {
@@ -86,7 +86,7 @@ const InvitePeople = React.createClass( {
 	onRoleChange( event ) {
 		const role = event.target.value;
 		this.setState( { role } );
-		this.props.createInviteValidation( this.props.site.ID, this.state.usernamesOrEmails, role );
+		createInviteValidation( this.props.site.ID, this.state.usernamesOrEmails, role );
 	},
 
 	refreshValidation() {
@@ -258,5 +258,5 @@ const InvitePeople = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { sendInvites, createInviteValidation }, dispatch )
+	dispatch => bindActionCreators( { sendInvites }, dispatch )
 )( InvitePeople );


### PR DESCRIPTION
Closes #2848

<strike>This PR currently doesn't work, but is meant to add notices that fire after sending invitations.</strike>

To test:
- Checkout `update/people-invites-notices` branch
- Go to `/people/new/$site`
- Fill in form and send invites
- Do you see a success notice? 
- In Chrome emulator, turn off wifi and then submit form.
- Do you see an error notice?