### PR TITLE
Checkout: Thank You: Fix `productName` argument

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header/index.jsx
@@ -37,7 +37,7 @@ const CheckoutThankYouHeader = React.createClass( {
 		if ( isFreeTrial( this.props.primaryPurchase ) ) {
 			return this.translate( "We hope you enjoy {{strong}}%(productName)s{{/strong}}. What's next? Take it for a spin!", {
 				args: {
-					productName: this.props.productName
+					productName: this.props.primaryPurchase.productName
 				},
 				components: {
 					strong: <strong/>
@@ -52,7 +52,7 @@ const CheckoutThankYouHeader = React.createClass( {
 			return this.translate(
 				"You will receive an email confirmation shortly for your purchase of {{strong}}%(productName)s{{/strong}}. What's next?", {
 					args: {
-						productName: this.props.productName
+						productName: this.props.primaryPurchase.productName
 					},
 					components: {
 						strong: <strong/>


### PR DESCRIPTION
One of the [commits to `CheckoutThankYouHeader`](https://github.com/Automattic/wp-calypso/commit/355bca156264ad12c4b2799663a7bf2559bc6610#diff-20c704ff8f001e52b9dba1448960591e) pulled in old code during a rebase to pull the product name from `props.productName` instead of `props.primaryPurchase.productName`. This only impacted free trials or non-plan purchases, and I missed this in my review of that PR - apologies.

This PR fixes that issue by accessing the product's name through the correct object in `CheckoutThankYouHeader`.

**Testing**
- Visit `/domains/add/:site` and add a domain registration or domain mapping item to your cart.
- Purchase the item.
- Assert that you see the name of the purchase (e.g. 'Domain Registration') in the blue header of the thank you page (like in [this screenshot](https://cloudup.com/c67Ai55WUcH)).