### PR TITLE
Framework: Update/disable persistence without schemas

### DIFF
--- a/client/state/receipts/reducer.js
+++ b/client/state/receipts/reducer.js
@@ -9,7 +9,9 @@ import { combineReducers } from 'redux';
 import {
 	RECEIPT_FETCH,
 	RECEIPT_FETCH_COMPLETED,
-	RECEIPT_FETCH_FAILED
+	RECEIPT_FETCH_FAILED,
+	SERIALIZE,
+	DESERIALIZE
 } from 'state/action-types';
 
 export const initialReceiptState = {
@@ -51,6 +53,10 @@ export function items( state = {}, action ) {
 				error: action.error,
 				isRequesting: false
 			} );
+		case SERIALIZE:
+			return {};
+		case DESERIALIZE:
+			return {};
 	}
 
 	return state;

--- a/client/state/receipts/test/reducer.js
+++ b/client/state/receipts/test/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -9,7 +10,9 @@ import { expect } from 'chai';
 import {
 	RECEIPT_FETCH,
 	RECEIPT_FETCH_COMPLETED,
-	RECEIPT_FETCH_FAILED
+	RECEIPT_FETCH_FAILED,
+	SERIALIZE,
+	DESERIALIZE
 } from 'state/action-types';
 import { items } from '../reducer';
 
@@ -84,6 +87,32 @@ describe( 'reducer', () => {
 					hasLoadedFromServer: true,
 					isRequesting: false
 				}
+			} );
+		} );
+		describe( 'persistence', () => {
+			it( 'does not persist data because this is not implemented yet', () => {
+				const original = deepFreeze( {
+					11111111: {
+						data: { amount: 10 },
+						error: null,
+						hasLoadedFromServer: true,
+						isRequesting: true
+					}
+				} );
+				const state = items( original, { type: SERIALIZE } );
+				expect( state ).to.eql( {} );
+			} );
+			it( 'does not load persisted data because this is not implemented yet', () => {
+				const original = deepFreeze( {
+					11111111: {
+						data: { amount: 10 },
+						error: null,
+						hasLoadedFromServer: true,
+						isRequesting: true
+					}
+				} );
+				const state = items( original, { type: DESERIALIZE } );
+				expect( state ).to.eql( {} );
 			} );
 		} );
 	} );

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -35,9 +35,9 @@ export function fetchingConnections( state = {}, action ) {
 				[ siteId ]: PUBLICIZE_CONNECTIONS_REQUEST === type
 			} );
 		case SERIALIZE:
-			return state;
+			return {};
 		case DESERIALIZE:
-			return state;
+			return {};
 	}
 
 	return state;
@@ -55,9 +55,9 @@ export function connections( state = {}, action ) {
 		case PUBLICIZE_CONNECTIONS_RECEIVE:
 			return Object.assign( {}, state, keyBy( action.data.connections, 'ID' ) );
 		case SERIALIZE:
-			return state;
+			return {};
 		case DESERIALIZE:
-			return state;
+			return {};
 	}
 
 	return state;

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
 
 /**
  * Internal dependencies
@@ -47,42 +48,26 @@ describe( '#fetchingConnections()', () => {
 	} );
 
 	describe( 'persistence', () => {
-		it( 'should load valid persisted data', () => {
-			const persistedState = Object.freeze( {
+		it( 'never loads persisted data', () => {
+			const persistedState = deepFreeze( {
 				2916284: false,
 				123456: undefined
 			} );
 			const state = fetchingConnections( persistedState, {
 				type: DESERIALIZE
 			} );
-			expect( state ).to.eql( { 2916284: false, 123456: undefined } );
-		} );
-
-		it.skip( 'should ignore loading data with invalid keys', () => {
-			const persistedState = Object.freeze( { foo: false } );
-			const state = fetchingConnections( persistedState, {
-				type: DESERIALIZE
-			} );
 			expect( state ).to.eql( {} );
 		} );
 
-		it.skip( 'should ignore loading data with invalid values', () => {
-			const persistedState = Object.freeze( { 2916284: 'foo' } );
-			const state = fetchingConnections( persistedState, {
-				type: DESERIALIZE
-			} );
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should persists data', () => {
-			const state = Object.freeze( {
+		it( 'never persists data', () => {
+			const state = deepFreeze( {
 				2916284: false,
 				123456: undefined
 			} );
 			const persistedState = fetchingConnections( state, {
 				type: SERIALIZE
 			} );
-			expect( persistedState ).to.eql( state );
+			expect( persistedState ).to.eql( {} );
 		} );
 	} );
 } );
@@ -137,40 +122,18 @@ describe( '#connections()', () => {
 	} );
 
 	describe( 'persistence', () => {
-		it( 'should persist data', () => {
-			const state = Object.freeze( {
+		it( 'does not persist data because this is not implemented yet', () => {
+			const state = deepFreeze( {
 				1: { ID: 1, site_ID: 2916284 },
 				2: { ID: 2, site_ID: 2916284 }
 			} );
 			const persistedState = connections( state, { type: SERIALIZE } );
-			expect( persistedState ).to.eql( state );
+			expect( persistedState ).to.eql( {} );
 		} );
 
-		it( 'should load valid data', () => {
-			const persistedState = Object.freeze( {
+		it( 'does not load persisted data because this is not implemented yet', () => {
+			const persistedState = deepFreeze( {
 				1: { ID: 1, site_ID: 2916284 },
-				2: { ID: 2, site_ID: 2916284 }
-			} );
-			const state = connections( persistedState, {
-				type: DESERIALIZE
-			} );
-			expect( state ).to.eql( persistedState );
-		} );
-
-		it.skip( 'should ignore loading data with invalid keys', () => {
-			const persistedState = Object.freeze( {
-				foo: { ID: 1, site_ID: 2916284 },
-				bar: { ID: 2, site_ID: 2916284 }
-			} );
-			const state = connections( persistedState, {
-				type: DESERIALIZE
-			} );
-			expect( state ).to.eql( {} );
-		} );
-
-		it.skip( 'should ignore loading data with invalid values', () => {
-			const persistedState = Object.freeze( {
-				1: { ID: 1, site_ID: 'foo' },
 				2: { ID: 2, site_ID: 2916284 }
 			} );
 			const state = connections( persistedState, {

--- a/client/state/site-settings/exporter/reducers.js
+++ b/client/state/site-settings/exporter/reducers.js
@@ -108,9 +108,9 @@ export function advancedSettings( state = {}, action ) {
 				[ action.siteId ]: action.advancedSettings
 			} );
 		case SERIALIZE:
-			return state;
+			return {};
 		case DESERIALIZE:
-			return state;
+			return {};
 	}
 	return state;
 }

--- a/client/state/site-settings/exporter/test/reducer.js
+++ b/client/state/site-settings/exporter/test/reducer.js
@@ -102,16 +102,16 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#advancedSettings()', () => {
-		it( 'should persist state', () => {
+		it( 'does not persist data because this is not implemented yet', () => {
 			const settings = { 100658273: SAMPLE_ADVANCED_SETTINGS };
 			const state = advancedSettings( settings, { type: SERIALIZE } );
-			expect( state ).to.eql( settings );
+			expect( state ).to.eql( {} );
 		} );
 
-		it( 'should load persisted state', () => {
+		it( 'does not load persisted data because this is not implemented yet', () => {
 			const settings = { 100658273: SAMPLE_ADVANCED_SETTINGS };
 			const state = advancedSettings( settings, { type: DESERIALIZE } );
-			expect( state ).to.eql( settings );
+			expect( state ).to.eql( {} );
 		} );
 
 		it( 'should index settings by site ID', () => {

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -2,18 +2,12 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import pickBy from 'lodash/pickBy';
-import keyBy from 'lodash/keyBy';
-import isFunction from 'lodash/isFunction';
-import omit from 'lodash/omit';
 
 /**
  * Internal dependencies
  */
 import { plans } from './plans/reducer';
 import { SITE_RECEIVE, SERIALIZE, DESERIALIZE } from 'state/action-types';
-import { sitesSchema } from './schema';
-import { isValidStateWithSchema } from 'state/utils';
 
 /**
  * Tracks all known site objects, indexed by site ID.
@@ -29,17 +23,8 @@ export function items( state = {}, action ) {
 				[ action.site.ID ]: action.site
 			} );
 		case SERIALIZE:
-			// scrub _events, _maxListeners, and other misc functions
-			const sites = Object.keys( state ).map( ( siteID ) => {
-				let plainJSObject = pickBy( state[ siteID ], ( value ) => ! isFunction( value ) );
-				plainJSObject = omit( plainJSObject, [ '_events', '_maxListeners'] );
-				return plainJSObject;
-			} );
-			return keyBy( sites, 'ID' );
+			return {};
 		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, sitesSchema ) ) {
-				return state;
-			}
 			return {};
 	}
 	return state;

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -65,7 +65,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 		describe( 'persistence', () => {
-			it( 'should return a js object on SERIALIZE', () => {
+			it( 'does not persist state because this is not implemented yet', () => {
 				const original = deepFreeze( {
 					2916284: {
 						ID: 2916284,
@@ -75,11 +75,9 @@ describe( 'reducer', () => {
 					}
 				} );
 				const state = items( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {
-					2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
-				} );
+				expect( state ).to.eql( {} );
 			} );
-			it( 'validates state on DESERIALIZE', () => {
+			it( 'does not load persisted state because this is not implemented yet', () => {
 				const original = deepFreeze( {
 					2916284: {
 						ID: 2916284,
@@ -91,25 +89,16 @@ describe( 'reducer', () => {
 					}
 				} );
 				const state = items( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {
-					2916284: {
-						ID: 2916284,
-						name: 'WordPress.com Example Blog'
-					},
-					2916285: {
-						ID: 2916285,
-						name: 'WordPress.com Example Blog 2'
-					}
-				} );
+				expect( state ).to.eql( {} );
 			} );
-			it( 'returns initial state when state is missing required properties', () => {
+			it.skip( 'returns initial state when state is missing required properties', () => {
 				const original = deepFreeze( {
 					2916284: { name: 'WordPress.com Example Blog' }
 				} );
 				const state = items( original, { type: DESERIALIZE } );
 				expect( state ).to.eql( {} );
 			} );
-			it( 'returns initial state when state has invalid keys', () => {
+			it.skip( 'returns initial state when state has invalid keys', () => {
 				const original = deepFreeze( {
 					foobar: { name: 'WordPress.com Example Blog' }
 				} );

--- a/client/state/support/reducer.js
+++ b/client/state/support/reducer.js
@@ -60,6 +60,10 @@ export function errorMessage( state = null, action ) {
 			return action.errorMessage;
 		case SUPPORT_USER_ACTIVATE:
 			return null;
+		case SERIALIZE:
+			return null;
+		case DESERIALIZE:
+			return null;
 	}
 
 	return state;

--- a/client/state/support/test/reducer.js
+++ b/client/state/support/test/reducer.js
@@ -13,13 +13,16 @@ import {
 } from 'state/action-types';
 import {
 	isSupportUser,
+	isTransitioning,
+	showDialog,
+	errorMessage
 } from '../reducer';
 
 describe( 'reducer', () => {
 	describe( '#isSupportUser()', () => {
 		it( 'should set to true after activate', () => {
 			const state = isSupportUser( false, {
-				type: SUPPORT_USER_ACTIVATE,
+				type: SUPPORT_USER_ACTIVATE
 			} );
 
 			expect( state ).to.equal( true );
@@ -37,6 +40,51 @@ describe( 'reducer', () => {
 				type: DESERIALIZE
 			} );
 			expect( state ).to.equal( false );
+		} );
+	} );
+	describe( '#isTransitioning()', () => {
+		it( 'should never persist state', () => {
+			const state = isTransitioning( true, {
+				type: SERIALIZE
+			} );
+			expect( state ).to.equal( false );
+		} );
+
+		it( 'should never load persisted state', () => {
+			const state = isTransitioning( true, {
+				type: DESERIALIZE
+			} );
+			expect( state ).to.equal( false );
+		} );
+	} );
+	describe( '#showDialog()', () => {
+		it( 'should never persist state', () => {
+			const state = showDialog( true, {
+				type: SERIALIZE
+			} );
+			expect( state ).to.equal( false );
+		} );
+
+		it( 'should never load persisted state', () => {
+			const state = showDialog( true, {
+				type: DESERIALIZE
+			} );
+			expect( state ).to.equal( false );
+		} );
+	} );
+	describe( '#errorMessage()', () => {
+		it( 'should never persist state', () => {
+			const state = errorMessage( true, {
+				type: SERIALIZE
+			} );
+			expect( state ).to.equal( null );
+		} );
+
+		it( 'should never load persisted state', () => {
+			const state = errorMessage( true, {
+				type: DESERIALIZE
+			} );
+			expect( state ).to.equal( null );
 		} );
 	} );
 } );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -54,26 +54,21 @@ describe( 'initial-state', () => {
 					state,
 					savedState = {
 						currentUser: { id: 123456789 },
-						users: {
+						postTypes: {
 							items: {
-								123456789: {
-									ID: 123456789,
-									username: 'testuser'
-								},
-								111111111: {
-									ID: 111111111,
-									username: 'testuser2'
+								2916284: {
+									post: { name: 'post', label: 'Posts' },
+									page: { name: 'page', label: 'Pages' }
 								}
 							}
 						},
 						_timestamp: Date.now()
 					},
 					serverState = {
-						users: {
+						postTypes: {
 							items: {
-								123456789: {
-									ID: 123456789,
-									username: 'updatedtestuser'
+								77203074: {
+									post: { name: 'post', label: 'Posts' }
 								}
 							}
 						}
@@ -111,7 +106,7 @@ describe( 'initial-state', () => {
 					expect( state._timestamp ).to.equal( undefined );
 				} );
 				it( 'server state shallowly overrides local forage state', () => {
-					expect( state.users ).to.equal( serverState.users );
+					expect( state.postTypes.items ).to.equal( serverState.postTypes.items );
 				} );
 			} );
 			describe( 'with stale persisted data and initial server data', () => {
@@ -121,26 +116,21 @@ describe( 'initial-state', () => {
 					state,
 					savedState = {
 						currentUser: { id: 123456789 },
-						users: {
+						postTypes: {
 							items: {
-								123456789: {
-									ID: 123456789,
-									username: 'testuser'
-								},
-								111111111: {
-									ID: 111111111,
-									username: 'testuser2'
+								2916284: {
+									post: { name: 'post', label: 'Posts' },
+									page: { name: 'page', label: 'Pages' }
 								}
 							}
 						},
 						_timestamp: Date.now() - MAX_AGE
 					},
 					serverState = {
-						users: {
+						postTypes: {
 							items: {
-								123456789: {
-									ID: 123456789,
-									username: 'updatedtestuser'
+								77203074: {
+									post: { name: 'post', label: 'Posts' }
 								}
 							}
 						}
@@ -172,7 +162,7 @@ describe( 'initial-state', () => {
 					expect( consoleSpy.called ).to.equal( false );
 				} );
 				it( 'builds using server state', () => {
-					expect( state.users ).to.equal( serverState.users );
+					expect( state.postTypes.items ).to.equal( serverState.postTypes.items );
 				} );
 				it( 'does not build using local forage state', () => {
 					expect( state.currentUser.id ).to.equal( null );
@@ -188,15 +178,11 @@ describe( 'initial-state', () => {
 					state,
 					savedState = {
 						currentUser: { id: 123456789 },
-						users: {
+						postTypes: {
 							items: {
-								123456789: {
-									ID: 123456789,
-									username: 'testuser'
-								},
-								111111111: {
-									ID: 111111111,
-									username: 'testuser2'
+								2916284: {
+									post: { name: 'post', label: 'Posts' },
+									page: { name: 'page', label: 'Pages' }
 								}
 							}
 						},
@@ -231,7 +217,7 @@ describe( 'initial-state', () => {
 				} );
 				it( 'builds state using local forage state', () => {
 					expect( state.currentUser.id ).to.equal( 123456789 );
-					expect( state.users ).to.equal( savedState.users );
+					expect( state.postTypes.items ).to.equal( savedState.postTypes.items );
 				} );
 				it( 'does not add timestamp to store', () => {
 					expect( state._timestamp ).to.equal( undefined );

--- a/client/state/themes/current-theme/reducer.js
+++ b/client/state/themes/current-theme/reducer.js
@@ -33,10 +33,11 @@ export default ( state = initialState, action ) => {
 		case ActionTypes.CLEAR_ACTIVATED_THEME:
 			return state.set( 'hasActivated', false );
 		case DESERIALIZE:
+			return initialState;
 		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:
-			return state.toJS();
+			return {};
 	}
 	return state;
 };

--- a/client/state/themes/current-theme/test/reducer.js
+++ b/client/state/themes/current-theme/test/reducer.js
@@ -17,7 +17,7 @@ import reducer, { initialState } from '../reducer';
 
 describe( 'current-theme reducer', () => {
 	describe( 'persistence', () => {
-		it( 'persists state and converts to a plain JS object', () => {
+		it( 'does not persist state because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {
 				isActivating: true,
 				hasActivated: false,
@@ -35,9 +35,9 @@ describe( 'current-theme reducer', () => {
 			} );
 			const state = fromJS( jsObject );
 			const persistedState = reducer( state, { type: SERIALIZE } );
-			expect( persistedState ).to.eql( jsObject );
+			expect( persistedState ).to.eql( {} );
 		} );
-		it( 'loads valid persisted state and converts to immutable.js object', () => {
+		it( 'does not load persisted state because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {
 				isActivating: true,
 				hasActivated: false,
@@ -54,7 +54,7 @@ describe( 'current-theme reducer', () => {
 				}
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
-			expect( state ).to.eql( fromJS( jsObject ) );
+			expect( state ).to.eql( initialState );
 		} );
 
 		it( 'converts initial state from server to immutable.js object', () => {

--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -23,10 +23,11 @@ export default ( state = Map(), action ) => {
 					supportDocumentation: action.themeSupportDocumentation,
 				} ) );
 		case DESERIALIZE:
+			return Map();
 		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:
-			return state.toJS();
+			return {};
 	}
 	return state;
 };

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -46,7 +46,7 @@ describe( 'reducer', () => {
 	describe( 'persistence', () => {
 		const initialState = Map();
 
-		it( 'persists state and converts to a plain JS object', () => {
+		it( 'does not persist state because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {
 				mood: {
 					name: 'Mood',
@@ -55,9 +55,9 @@ describe( 'reducer', () => {
 			} );
 			const state = fromJS( jsObject );
 			const persistedState = reducer( state, { type: SERIALIZE } );
-			expect( persistedState ).to.eql( jsObject );
+			expect( persistedState ).to.eql( {} );
 		} );
-		it( 'loads valid persisted state and converts to immutable.js object', () => {
+		it( 'does not load persisted state because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {
 				mood: {
 					name: 'Mood',
@@ -65,7 +65,7 @@ describe( 'reducer', () => {
 				}
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
-			expect( state ).to.eql( fromJS( jsObject ) );
+			expect( state ).to.eql( Map() );
 		} );
 
 		it( 'converts state from server to immutable.js object', () => {
@@ -93,7 +93,7 @@ describe( 'reducer', () => {
 
 		it.skip( 'should ignore loading data with invalid values ', () => {
 			const jsObject = deepFreeze( {
-				mood: 'foo',
+				mood: 'foo'
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
 			expect( state ).to.eql( initialState );

--- a/client/state/themes/themes-last-query/reducer.js
+++ b/client/state/themes/themes-last-query/reducer.js
@@ -27,10 +27,11 @@ export default ( state = initialState, action ) => {
 				.set( 'currentSiteId', action.site.ID )
 				.set( 'isJetpack', !! action.site.jetpack );
 		case DESERIALIZE:
+			return initialState;
 		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:
-			return state.toJS();
+			return {};
 	}
 
 	return state;

--- a/client/state/themes/themes-last-query/test/reducer.js
+++ b/client/state/themes/themes-last-query/test/reducer.js
@@ -17,7 +17,7 @@ import reducer, { initialState } from '../reducer';
 
 describe( 'themes-last-query reducer', () => {
 	describe( 'persistence', () => {
-		it( 'persists state and converts to a plain JS object', () => {
+		it( 'does not persist data because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				previousSiteId: 2123982,
@@ -31,9 +31,9 @@ describe( 'themes-last-query reducer', () => {
 			} );
 			const state = fromJS( jsObject );
 			const persistedState = reducer( state, { type: SERIALIZE } );
-			expect( persistedState ).to.eql( jsObject );
+			expect( persistedState ).to.eql( {} );
 		} );
-		it( 'loads valid persisted state and converts to immutable.js object', () => {
+		it( 'does not load persisted data because this is not implemented yet', () => {
 			const jsObject = Object.freeze( {
 				currentSiteId: 12345678,
 				previousSiteId: 2123982,
@@ -46,7 +46,7 @@ describe( 'themes-last-query reducer', () => {
 				}
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
-			expect( state ).to.eql( fromJS( jsObject ) );
+			expect( state ).to.eql( initialState );
 		} );
 
 		it( 'converts state from server to immutable.js object', () => {

--- a/client/state/themes/themes-list/reducer.js
+++ b/client/state/themes/themes-list/reducer.js
@@ -91,10 +91,11 @@ export default ( state = initialState, action ) => {
 			// here.
 			return state.set( 'active', action.theme.id );
 		case DESERIALIZE:
+			return initialState;
 		case SERVER_DESERIALIZE:
 			return query( fromJS( state ) );
 		case SERIALIZE:
-			return state.toJS();
+			return {};
 	}
 
 	return state;

--- a/client/state/themes/themes-list/test/reducer.js
+++ b/client/state/themes/themes-list/test/reducer.js
@@ -17,7 +17,7 @@ import reducer, { initialState, query } from '../reducer';
 
 describe( 'themes-last-query reducer', () => {
 	describe( 'persistence', () => {
-		it( 'persists state and converts to a plain JS object', () => {
+		it( 'does not persist state because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {
 				list: [ 'one', 'two', 'three' ],
 				nextId: 2,
@@ -36,9 +36,9 @@ describe( 'themes-last-query reducer', () => {
 			} );
 			const state = fromJS( jsObject );
 			const persistedState = reducer( state, { type: SERIALIZE } );
-			expect( persistedState ).to.eql( jsObject );
+			expect( persistedState ).to.eql( {} );
 		} );
-		it( 'loads valid persisted state and converts to immutable.js object', () => {
+		it( 'does not load persisted state because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {
 				list: [ 'one', 'two', 'three' ],
 				nextId: 2,
@@ -56,7 +56,7 @@ describe( 'themes-last-query reducer', () => {
 				active: 0
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
-			expect( state ).to.eql( query( fromJS( jsObject ) ) );
+			expect( state ).to.eql( initialState );
 		} );
 
 		it( 'converts state from server to immutable.js object', () => {

--- a/client/state/themes/themes/reducer.js
+++ b/client/state/themes/themes/reducer.js
@@ -39,10 +39,11 @@ export default ( state = initialState, action ) => {
 		case ActionTypes.ACTIVATED_THEME:
 			return state.update( 'themes', setActiveTheme.bind( null, action.theme.id ) );
 		case DESERIALIZE:
+			return initialState;
 		case SERVER_DESERIALIZE:
 			return fromJS( state );
 		case SERIALIZE:
-			return state.toJS();
+			return {};
 	}
 	return state;
 };

--- a/client/state/themes/themes/test/reducer.js
+++ b/client/state/themes/themes/test/reducer.js
@@ -17,7 +17,7 @@ import reducer, { initialState } from '../reducer';
 
 describe( 'themes reducer', () => {
 	describe( 'persistence', () => {
-		it( 'persists state and converts to a plain JS object', () => {
+		it( 'does not persist state because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				themes: {
@@ -45,9 +45,9 @@ describe( 'themes reducer', () => {
 			} );
 			const state = fromJS( jsObject );
 			const persistedState = reducer( state, { type: SERIALIZE } );
-			expect( persistedState ).to.eql( jsObject );
+			expect( persistedState ).to.eql( {} );
 		} );
-		it( 'loads persisted state and converts to immutable.js object', () => {
+		it( 'does not load persisted state because this is not implemented yet', () => {
 			const jsObject = deepFreeze( {
 				currentSiteId: 12345678,
 				themes: {
@@ -74,7 +74,7 @@ describe( 'themes reducer', () => {
 				}
 			} );
 			const state = reducer( jsObject, { type: DESERIALIZE } );
-			expect( state ).to.eql( fromJS( jsObject ) );
+			expect( state ).to.eql( initialState );
 		} );
 
 		it( 'converts state from server to immutable.js object', () => {

--- a/client/state/users/reducer.js
+++ b/client/state/users/reducer.js
@@ -26,9 +26,9 @@ export function items( state = {}, action ) {
 				[ action.user.ID ]: action.user
 			} );
 		case DESERIALIZE:
-			return state;
+			return {};
 		case SERIALIZE:
-			return state;
+			return {};
 	}
 
 	return state;

--- a/client/state/users/test/reducer.js
+++ b/client/state/users/test/reducer.js
@@ -62,7 +62,7 @@ describe( 'reducer', () => {
 		} );
 
 		describe( 'persistence', () => {
-			it( 'persists state', () => {
+			it( 'does not persist state because this is not implemented yet', () => {
 				const state = Object.freeze( {
 					73705554: {
 						ID: 73705554,
@@ -87,10 +87,10 @@ describe( 'reducer', () => {
 					}
 				} );
 				const persistedState = items( state, { type: SERIALIZE } );
-				expect( persistedState ).to.eql( state );
+				expect( persistedState ).to.eql( {} );
 			} );
 
-			it( 'loads valid persisted state', () => {
+			it( 'does not load persisted state because this is not implemented yet', () => {
 				const persistedState = Object.freeze( {
 					73705554: {
 						ID: 73705554,
@@ -115,7 +115,7 @@ describe( 'reducer', () => {
 					}
 				} );
 				const state = items( persistedState, { type: DESERIALIZE } );
-				expect( state ).to.eql( persistedState );
+				expect( state ).to.eql( {} );
 			} );
 
 			it.skip( 'should ignore loading data with invalid keys ', () => {


### PR DESCRIPTION
Before turning on persistence in Horizon in #3483, this PR turns off persistence for subtrees that are missing JSON Schemas. If it makes sense to do so, we will add them in future individual PRs.

## Testing
- Start Calypso with `ENABLE_FEATURES=persist-redux make run`
- In the console set localStorage.debug to `calypso:state`
- Refresh the page
- We do not load state for subtrees that are missing JSON Schemas
- No functional changes
- All tests pass

cc @rralian @aduth @seear @drewblaisdell @jordwest 