### PR TITLE
Checkout: Thank You: Fix the generic version of the thank you page

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/footer.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/footer.jsx
@@ -20,7 +20,7 @@ const CheckoutThankYouFooter = React.createClass( {
 			return this.translate( 'Loading…' );
 		}
 
-		if ( this.props.receipt.data.purchases.some( isJetpackPlan ) ) {
+		if ( this.props.receipt.data && this.props.receipt.data.purchases.some( isJetpackPlan ) ) {
 			return this.translate(
 				'Check out our {{supportDocsLink}}support docs{{/supportDocsLink}} ' +
 				'or {{contactLink}}contact us{{/contactLink}}.',

--- a/client/my-sites/upgrades/checkout-thank-you/generic-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/generic-details.jsx
@@ -13,7 +13,7 @@ const GenericDetails = ( { selectedSite } ) => {
 	return (
 		<div>
 			<Button href={ selectedSite.URL } primary>
-				{ i18n.translate( 'Back to my site' ) }
+				{ i18n.translate( 'Go to my site' ) }
 			</Button>
 		</div>
 	);

--- a/client/my-sites/upgrades/checkout-thank-you/header.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header.jsx
@@ -22,6 +22,10 @@ const CheckoutThankYouHeader = React.createClass( {
 			return this.translate( 'Loading…' );
 		}
 
+		if ( ! this.props.primaryPurchase ) {
+			return this.translate( 'Thank you for your purchase!' );
+		}
+
 		if ( isFreeTrial( this.props.primaryPurchase ) ) {
 			return this.translate( 'Way to go, your 14 day free trial starts now!' );
 		}
@@ -31,6 +35,10 @@ const CheckoutThankYouHeader = React.createClass( {
 
 	getText() {
 		if ( ! this.props.isDataLoaded ) {
+			return this.translate( "You will receive an email confirmation shortly. What's next?" );
+		}
+
+		if ( ! this.props.primaryPurchase ) {
 			return this.translate( "You will receive an email confirmation shortly. What's next?" );
 		}
 

--- a/client/my-sites/upgrades/checkout-thank-you/header.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header.jsx
@@ -30,11 +30,7 @@ const CheckoutThankYouHeader = React.createClass( {
 	},
 
 	getText() {
-		if ( ! this.props.isDataLoaded ) {
-			return this.translate( "You will receive an email confirmation shortly. What's next?" );
-		}
-
-		if ( ! this.props.primaryPurchase ) {
+		if ( ! this.props.isDataLoaded || ! this.props.primaryPurchase ) {
 			return this.translate( "You will receive an email confirmation shortly. What's next?" );
 		}
 

--- a/client/my-sites/upgrades/checkout-thank-you/header.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header.jsx
@@ -22,11 +22,7 @@ const CheckoutThankYouHeader = React.createClass( {
 			return this.translate( 'Loading…' );
 		}
 
-		if ( ! this.props.primaryPurchase ) {
-			return this.translate( 'Thank you for your purchase!' );
-		}
-
-		if ( isFreeTrial( this.props.primaryPurchase ) ) {
+		if ( this.props.primaryPurchase && isFreeTrial( this.props.primaryPurchase ) ) {
 			return this.translate( 'Way to go, your 14 day free trial starts now!' );
 		}
 

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -96,7 +96,7 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	goBack() {
-		if ( this.isDataLoaded() ) {
+		if ( this.isDataLoaded() && this.props.receiptId ) {
 			const purchases = getPurchases( this.props );
 
 			if ( purchases.some( isPlan ) ) {
@@ -134,7 +134,7 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	freeTrialWasPurchased: function() {
-		if ( ! this.isDataLoaded() ) {
+		if ( ! this.isDataLoaded() || ! this.props.receiptId ) {
 			return false;
 		}
 
@@ -148,7 +148,7 @@ var CheckoutThankYou = React.createClass( {
 	 * @returns {*[]} an array of varying size with the component instance, then an optional purchase object possibly followed by a domain name
 	 */
 	getComponentAndPrimaryPurchaseAndDomain: function() {
-		if ( this.isDataLoaded() ) {
+		if ( this.isDataLoaded() && this.props.receiptId ) {
 			const purchases = getPurchases( this.props );
 
 			const findPurchaseAndDomain = ( purchases, predicate ) => {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -84,7 +84,11 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	isDataLoaded: function() {
-		return ! this.props.receiptId || this.props.receipt.hasLoadedFromServer;
+		return this.isGenericReceipt() || this.props.receipt.hasLoadedFromServer;
+	},
+
+	isGenericReceipt: function() {
+		return ! this.props.receiptId;
 	},
 
 	redirectIfThemePurchased: function() {
@@ -96,7 +100,7 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	goBack() {
-		if ( this.isDataLoaded() && this.props.receiptId ) {
+		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			const purchases = getPurchases( this.props );
 
 			if ( purchases.some( isPlan ) ) {
@@ -134,7 +138,7 @@ var CheckoutThankYou = React.createClass( {
 	},
 
 	freeTrialWasPurchased: function() {
-		if ( ! this.isDataLoaded() || ! this.props.receiptId ) {
+		if ( ! this.isDataLoaded() || this.isGenericReceipt() ) {
 			return false;
 		}
 
@@ -148,7 +152,7 @@ var CheckoutThankYou = React.createClass( {
 	 * @returns {*[]} an array of varying size with the component instance, then an optional purchase object possibly followed by a domain name
 	 */
 	getComponentAndPrimaryPurchaseAndDomain: function() {
-		if ( this.isDataLoaded() && this.props.receiptId ) {
+		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			const purchases = getPurchases( this.props );
 
 			const findPurchaseAndDomain = ( purchases, predicate ) => {


### PR DESCRIPTION
`CheckoutThankYou` is rendered differently depending on three conditions:

- Data is loading
- Data is loaded for a given receipt
- Mounted with no receipt ID

The third case is a fallback for when the API doesn't return a receipt ID after completing the purchase. I have never witnessed this occur, but @peterbutler has mentioned that this can happen. In this case, we render a generic version of the thank you page at `/checkout/:site/thank-you`.

When refactoring the thank you page, we neglected to test for this case, and the page is currently broken. Thankfully, very few (if any) users should have seen this page.

This PR adds presence checks for `this.props.receiptId` to `CheckoutThankYou` to methods that would otherwise attempt to access data from an object when it is not present, and handles cases in `CheckoutThankYouHeader` where `primaryPurchase` is not provided as a prop.

**Testing**
*Data is loaded for a given receipt*
We should make sure that this did not change.
- Purchase a plan or domain.
- Assert that you are redirected to the thank you page with a receipt ID in the URL.

*Data is loading*
We should make sure that this did not change.
- After purchasing any item, on the thank you page, refresh the page (or purchase an item with PayPal).
- Assert that you see loading placeholders while the page loads.

*No receipt ID*
- Visit `/checkout/:site/thank-you` for any site.
- Assert that you see the [generic thank you page](https://cloudup.com/c8oqG52r-dL) and that no error is thrown.

- [x] Code review
- [x] Product review