### PR TITLE
DevDocs\Theme: Add ThemesList example app-component

### DIFF
--- a/client/components/themes-list/README.md
+++ b/client/components/themes-list/README.md
@@ -10,4 +10,4 @@ information about those themes.
 
 Each item in the `themes` array prop must contain theme attributes that can be used by the `Theme` component.
 Other accepted props are two boolean flags and a callback, all of which are related to pagination.
-For a complete list of props along with their types, please refer to the `ThemeList` component's `propTypes` member.
+For a complete list of props along with their types, please refer to the `ThemesList` component's `propTypes` member.

--- a/client/components/themes-list/docs/example.jsx
+++ b/client/components/themes-list/docs/example.jsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ThemesList from 'components/themes-list';
+
+const demoThemes = [ {
+	id: 'twentyfourteen',
+	name: 'Twenty Fourteen',
+	screenshot: '//i1.wp.com/theme.wordpress.com/wp-content/themes/pub/twentyfourteen/screenshot.png',
+	actionLabel: 'Click Action Theme 1',
+},
+{	id: 'twentyfifteen',
+	name: 'Twenty Fifteen',
+	screenshot: '//i1.wp.com/theme.wordpress.com/wp-content/themes/pub/twentyfifteen/screenshot.png',
+	actionLabel: 'Click Action Theme 2',
+},
+{	id: 'twentysixteen',
+	name: 'Twenty Sixteen',
+	screenshot: '//i1.wp.com/theme.wordpress.com/wp-content/themes/pub/twentysixteen/screenshot.png',
+	actionLabel: 'Click Action Theme 3',
+} ];
+
+export default React.createClass( {
+	displayName: 'ThemesListExample',
+
+	getActionLabel( theme ) {
+		return theme.actionLabel;
+	},
+
+	getButtonOptions( theme ) {
+		return {
+			action1: {
+				label: 'Menu Item 1',
+				action: function() {
+					console.log( `Menu Item 1 for theme ${ theme.name } selected` );
+				}
+			},
+			action2: {
+				label: 'Menu Item 2',
+				action: function() {
+					console.log( `Menu Item 2 for theme ${ theme.name } selected` );
+				}
+			}
+		}
+	},
+
+	themeScreenshotClick( theme, index ) {
+		console.log( `Theme ${ theme.id } at ${ index } clicked` );
+	},
+
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/app-components/themes-list-example">Themes List</a>
+				</h2>
+				<ThemesList
+					themes={ demoThemes }
+					getButtonOptions={ this.getButtonOptions }
+					getActionLabel={ this.getActionLabel }
+					onScreenshotClick={ this.themeScreenshotClick }
+				/>
+			</div>
+		);
+	}
+} );

--- a/client/devdocs/design/app-components.jsx
+++ b/client/devdocs/design/app-components.jsx
@@ -9,20 +9,22 @@ import trim from 'lodash/trim';
 /**
  * Internal dependencies
  */
+import HeaderCake from 'components/header-cake';
 import SearchCard from 'components/search-card';
 import CommentButtons from 'components/comment-button/docs/example';
-import PostSelector from 'my-sites/post-selector/docs/example';
-import LikeButtons from 'components/like-button/docs/example';
 import FollowButtons from 'components/follow-button/docs/example';
+import LikeButtons from 'components/like-button/docs/example';
+import PostSchedule from 'components/post-schedule/docs/example';
+import PostSelector from 'my-sites/post-selector/docs/example';
 import Sites from 'lib/sites-list/docs/example';
 import SitesDropdown from 'components/sites-dropdown/docs/example';
 import Theme from 'components/theme/docs/example';
-import PostSchedule from 'components/post-schedule/docs/example';
-import HeaderCake from 'components/header-cake';
 import Collection from 'devdocs/design/search-collection';
 import HappinessSupport from 'components/happiness-support/docs/example';
+import ThemesListExample from 'components/themes-list/docs/example';
 
 export default React.createClass( {
+
 	displayName: 'AppComponents',
 
 	getInitialState() {
@@ -62,6 +64,7 @@ export default React.createClass( {
 					<Sites />
 					<SitesDropdown />
 					<Theme />
+					<ThemesListExample />
 				</Collection>
 			</div>
 		);


### PR DESCRIPTION
## Background

- Add the `ThemesList` application component example to the [devdocs\design\app-components](https://wpcalypso.wordpress.com/devdocs/app-components) page.
- Also, make the list of application components in alphabetical in order to have a better visual experience when applying search filtering at the top of the page.

## Testing
1. Load the [app-components](http://calypso.localhost:3000/devdocs/app-components) page.
2. Scroll down to ensure you see the `Themes List` example.

![image](https://cloud.githubusercontent.com/assets/14303849/13371509/ef8ae734-dcf5-11e5-8d94-f58e55976239.png)
3. Search for `Themes` in the search box at the top of the page to ensure filtering works.
4. Click on the `Themes List` link to make sure it takes you to a page with ONLY the `Themes List` component i.e., [app-components/themes-list](http://calypso.localhost:3000/devdocs/app-components/themes-list).
5. Hover over each of the three Themes in the `ThemesList` component. Make sure this shows you individual Action labels for each theme e.g. `CLICK ACTION THEME 1` or `CLICK ACTION THEME 2`.
6. Click on each theme and view the developer console logs to make sure it prints individual messages for each theme e.g., `Theme twentyfourteen at 0 clicked`. This tells you the theme id and index of that theme in the `ThemesList` that was clicked.
7. Click on the More Buttons `...` link on any of the themes to make sure they work and when you click one of the links that pop-up you should see a message in the Developer console as `Menu Item 1 selected`.

## Reviewers
@designsimply, @nb, @folletto, @ockham 

## Issues
Closes #2119 