### PR TITLE
Framework: Make create-selector call dependant state getter with arguments

### DIFF
--- a/client/lib/create-selector/README.md
+++ b/client/lib/create-selector/README.md
@@ -8,7 +8,7 @@ This module exports a single function which creates a memoized state selector fo
 `createSelector` accepts the following arguments:
 
 - A function which calculates the cached result given a state object and any number of variable arguments necessary to calculate the result
-- A function which returns an array of dependent state paths
+- A function which returns an array of dependent state given the state and the same arguments as the selector
 - _(Optional)_ A function to customize the cache key used by the inner memoized function
 
 For example, we might consider that our state contains post objects, each of which are assigned to a particular site. Retrieving an array of posts for a specific site would require us to filter over all of the known posts. While this would normally be an expensive operation, we can use `createSelector` to create a memoized function:

--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -73,7 +73,7 @@ export default function createSelector( selector, getDependants = DEFAULT_GET_DE
 	let lastDependants;
 
 	return Object.assign( function( state, ...args ) {
-		let currentDependants = getDependants( state );
+		let currentDependants = getDependants( state, ...args );
 		if ( ! Array.isArray( currentDependants ) ) {
 			currentDependants = [ currentDependants ];
 		}

--- a/client/lib/create-selector/test/index.js
+++ b/client/lib/create-selector/test/index.js
@@ -180,4 +180,14 @@ describe( '#createSelector', () => {
 
 		expect( getSitePostsWithCustomGetCacheKey.memoizedSelector.cache.has( 'CUSTOM2916284' ) ).to.be.true;
 	} );
+
+	it( 'should call dependant state getter with arguments', () => {
+		const getDeps = sinon.spy();
+		const memoizedSelector = createSelector( () => null, getDeps );
+		const state = {};
+
+		memoizedSelector( state, 1, 2, 3 );
+
+		expect( getDeps ).to.have.been.calledWithExactly( state, 1, 2, 3 );
+	} );
 } );


### PR DESCRIPTION
Consider the following selector, which goal is to build a comments tree for a given post from a list of comments which are stored in a structure:

```javascript
state.comments[ getCommentParentKey( siteId, postId ) ]  = [...comments...];
```

```javascript
export const getPostCommentItems = ( state, siteId, postId ) => state.comments.items.get( getCommentParentKey( siteId, postId ) );

export const getPostCommentsTree = createSelector(
	( state, siteId, postId ) => {
		const items = getPostCommentItems( state, siteId, postId );
		return items ? buildCommentsTree( items ) : undefined;
	},
	getPostCommentItems
);
```

In order to get the dependent state in an efficient manner, the arguments should be passed to the dependant state getter.
We can't simply return `state.comments`, that will invalidate all of the post's comments trees even if only one comments list is changed.