### PR TITLE
Editor: Prevent visibility from defaulting to 'public'

### DIFF
--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -72,10 +72,20 @@ const EditorVisibility = React.createClass( {
 		};
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
-		if ( this.props.visibility !== this.state.visibility && this.state.passwordIsValid ) {
+	componentWillMount() {
+		this.setVisibility( this.props );
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.state.passwordIsValid ) {
+			this.setVisibility( nextProps );
+		}
+	},
+
+	setVisibility( props ) {
+		if ( props.visibility !== this.state.visibility ) {
 			this.setState( {
-				visibility: this.props.visibility
+				visibility: props.visibility
 			} );
 		}
 	},


### PR DESCRIPTION
This is an anticipated fix for #3486, but I'm running into a little snag that I would love some advice on. The original issue was caused because we are using `visibility: 'public'` currently when we get the initial state, which means each post defaults to public regardless of the saved visibility. This PR uses `this.props.visibility` instead. Now, opening a post or refreshing a post maintains the visibility:

![editor](https://cloud.githubusercontent.com/assets/7240478/13375460/46707a0c-dd5d-11e5-830a-537d1a97a880.gif)

To test that piece:

1. Start a new post
2. Change the visibility to anything but public.
3. Refresh and/or exit/re-enter the editor for that post

Previously, you'll find that the post flipped to public. Now, it should maintain the set visibility. 

This created a second issue though that's been a bit of a bugger. When you use the 'Quick Add' icon in the masterbar to start a new post, the props are maintained so the new post opens up with the same visibility of the old post when I would expect it to be public by default. Here's a GIF of that happening:

![editor2](https://cloud.githubusercontent.com/assets/7240478/13375470/bd87dd6a-dd5d-11e5-9af4-f2b5f61b1a3a.gif)

That's a bigger issue to me than the original issue this intended to fix :)

I've tried:

1. Using `componentDidUpdate` to set the visibility back to 'public' when the editor loads for the new post. This did work, but I had to call `setState` inside of `componentDidUpdate`, which isn't the best and causes a lot of potential re-rendering.
2. I imported `isNew()` and used `PostEditStore.isNew()` to determine whether a post was new or not. If it was new, I set the visibility to 'public'. This worked as well, but it causes another issue when you first load a post. Since `isNew()` is true until the post is saved, the visibility constantly toggles back to 'public' before the autosave kicks in. An edge case most likely, but still something to consider.
3. Using a ternary operator in `getInitialState` to set visibility to 'public' if `isNew()` is true. The issue is that `getInitialState` isn't called because the page doesn't re-render when you use the 'Quick Add'.

Am I overlooking something simple?