### PR TITLE
Revert "Support User: Refactor to remove singleton class, use individual fn exports instead"

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { setReduxStore as setSupportUserReduxStore } from 'lib/user/support-user-interop';
-
-/**
  * External dependencies
  */
 var React = require( 'react' ),
@@ -50,6 +45,7 @@ var config = require( 'config' ),
 	syncHandler = require( 'lib/wp/sync-handler' ),
 	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
 	bindWpLocaleState = require( 'lib/wp/localization' ).bindState,
+	supportUser = require( 'lib/user/support-user-interop' ),
 	// The following components require the i18n mixin, so must be required after i18n is initialized
 	Layout;
 
@@ -171,7 +167,7 @@ function reduxStoreReady( reduxStore ) {
 
 	bindWpLocaleState( reduxStore );
 
-	setSupportUserReduxStore( reduxStore );
+	supportUser.setReduxStore( reduxStore );
 
 	Layout = require( 'layout' );
 

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -11,6 +11,9 @@ import config from 'config';
 import store from 'store';
 import { supportUserTokenFetch, supportUserActivate, supportUserError } from 'state/support/actions';
 
+const debug = debugModule( 'calypso:support-user' );
+const STORAGE_KEY = 'boot_support_user';
+
 /**
  * Connects the Redux store and the low-level support user functions
  * of the wpcom library. When the support user token is changed in the
@@ -18,118 +21,120 @@ import { supportUserTokenFetch, supportUserActivate, supportUserError } from 'st
  * error occurs in a wpcom API call, the error is forwarded to the
  * Redux store via an action. This also forces any data refreshes
  * that are required due to the change of user.
+ *
+ * @param {Object}  reduxStore  The global redux store instance
  */
+class SupportUser {
+	constructor() {
+		debug( 'Support User is enabled in this environment' );
 
-const debug = debugModule( 'calypso:support-user' );
-const STORAGE_KEY = 'boot_support_user';
-
-export const isEnabled = () => config.isEnabled( 'support-user' );
-
-let _setReduxStore = null;
-const reduxStoreReady = new Promise( ( resolve ) => {
-	if ( ! isEnabled() ) {
-		return;
+		this.reduxStoreReady = new Promise( ( resolve ) => {
+			this.setReduxStore = ( reduxStore ) => resolve( reduxStore );
+		} );
 	}
 
-	_setReduxStore = ( reduxStore ) => resolve( reduxStore );
-} );
-export const setReduxStore = _setReduxStore;
+	fetchToken( user, password ) {
+		debug( 'Fetching support user token' );
 
-/**
- * Check if there's a support user to be activated on boot
- * @return {bool} true if a support user token is waiting to be injected on boot, false otherwise
- */
-export const shouldBoot = () => {
-	if ( ! isEnabled() ) {
+		return this.reduxStoreReady.then( ( reduxStore ) => {
+			reduxStore.dispatch( supportUserTokenFetch( user ) );
+
+			const setToken = ( response ) => {
+				this.rebootWithToken( response.username, response.token );
+			};
+
+			const errorFetchingToken = ( error ) => {
+				reduxStore.dispatch( supportUserError( error.message ) );
+			};
+
+			return wpcom.fetchSupportUserToken( user, password )
+				.then( setToken )
+				.catch( errorFetchingToken );
+		} );
+	}
+
+	/**
+	 * Reboot normally as the main user
+	 */
+	rebootNormally() {
+		debug( 'Rebooting Calypso normally' );
+
+		store.clear();
+		window.location.reload();
+	}
+
+	/**
+	  * Reboot Calypso as the support user
+	  * @param  {string} user  The support user's username
+	  * @param  {string} token The support token
+	  */
+	rebootWithToken( user, token ) {
+		debug( 'Rebooting Calypso with support user' );
+
+		store.set( STORAGE_KEY, { user, token } );
+		window.location.reload();
+	}
+
+	/**
+	 * Check if there's a support user to be activated on boot
+	 * @return {bool} true if a support user token is waiting to be injected on boot, false otherwise
+	 */
+	shouldBootToSupportUser() {
+		const supportUser = store.get( STORAGE_KEY );
+		if ( supportUser && supportUser.user && supportUser.token ) {
+			return true;
+		}
+
 		return false;
 	}
 
-	const supportUser = store.get( STORAGE_KEY );
-	if ( supportUser && supportUser.user && supportUser.token ) {
+	/**
+	 * Inject the support user token into all following API calls
+	 */
+	boot() {
+		const { user, token } = store.get( STORAGE_KEY );
+		debug( 'Booting Calypso with support user', user );
+
+		const errorHandler = ( error ) => this._onTokenError( error );
+
+		wpcom.setSupportUserToken( user, token, errorHandler );
+
+		// boot() is called before the redux store is ready, so we need to
+		// wait for it to become available
+		this.reduxStoreReady.then( ( reduxStore ) => {
+			reduxStore.dispatch( supportUserActivate() );
+		} );
+	}
+
+	// Called when an API call fails due to a token error
+	_onTokenError( error ) {
+		debug( 'Deactivating support user and rebooting due to token error', error.message );
+		this.rebootNormally();
+	}
+
+	isEnabled() {
 		return true;
 	}
+}
 
-	return false;
-};
-
-/**
- * Reboot normally as the main user
- */
-export const rebootNormally = () => {
-	if ( ! isEnabled() ) {
-		return;
+class DisabledSupportUser {
+	rebootNormally() {}
+	rebootWithToken() {}
+	setReduxStore() {}
+	shouldBootToSupportUser() {
+		return false;
 	}
-
-	debug( 'Rebooting Calypso normally' );
-
-	store.clear();
-	window.location.reload();
-};
-
-/**
-  * Reboot Calypso as the support user
-  * @param  {string} user  The support user's username
-  * @param  {string} token The support token
-  */
-export const rebootWithToken = ( user, token ) => {
-	if ( ! isEnabled() ) {
-		return;
+	boot() {}
+	isEnabled() {
+		return false;
 	}
+}
 
-	debug( 'Rebooting Calypso with support user' );
+let supportUser = null;
+if ( config.isEnabled( 'support-user' ) ) {
+	supportUser = new SupportUser();
+} else {
+	supportUser = new DisabledSupportUser();
+}
 
-	store.set( STORAGE_KEY, { user, token } );
-	window.location.reload();
-};
-
-// Called when an API call fails due to a token error
-const onTokenError = ( error ) => {
-	debug( 'Deactivating support user and rebooting due to token error', error.message );
-	rebootNormally();
-};
-
-/**
- * Inject the support user token into all following API calls
- */
-export const boot = () => {
-	if ( ! isEnabled() ) {
-		return;
-	}
-	
-	const { user, token } = store.get( STORAGE_KEY );
-	debug( 'Booting Calypso with support user', user );
-
-	const errorHandler = ( error ) => onTokenError( error );
-
-	wpcom.setSupportUserToken( user, token, errorHandler );
-
-	// boot() is called before the redux store is ready, so we need to
-	// wait for it to become available
-	reduxStoreReady.then( ( reduxStore ) => {
-		reduxStore.dispatch( supportUserActivate() );
-	} );
-};
-
-export const fetchToken = ( user, password ) => {
-	if ( ! isEnabled() ) {
-		return;
-	}
-
-	debug( 'Fetching support user token' );
-
-	return reduxStoreReady.then( ( reduxStore ) => {
-		reduxStore.dispatch( supportUserTokenFetch( user ) );
-
-		const setToken = ( response ) => {
-			rebootWithToken( response.username, response.token );
-		};
-
-		const errorFetchingToken = ( error ) => {
-			reduxStore.dispatch( supportUserError( error.message ) );
-		};
-
-		return wpcom.fetchSupportUserToken( user, password )
-			.then( setToken )
-			.catch( errorFetchingToken );
-	} );
-};
+export default supportUser;

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { shouldBoot as shouldBootToSupportUser, boot as supportUserBoot } from 'lib/user/support-user-interop';
-
-/**
  * External dependencies
  */
 var store = require( 'store' ),
@@ -18,6 +13,7 @@ var store = require( 'store' ),
 var wpcom = require( 'lib/wp' ),
 	Emitter = require( 'lib/mixins/emitter' ),
 	userUtils = require( './shared-utils' ),
+	supportUser = require( 'lib/user/support-user-interop' ),
 	getLocalForage = require( 'lib/localforage' ).getLocalForage;
 
 /**
@@ -50,8 +46,8 @@ User.prototype.initialize = function() {
 	this.fetching = false;
 	this.initialized = false;
 
-	if ( shouldBootToSupportUser() ) {
-		supportUserBoot();
+	if ( supportUser.shouldBootToSupportUser() ) {
+		supportUser.boot();
 		this.fetch();
 
 		// We're booting into support user mode, skip initialization of the main user.

--- a/client/support/support-user/index.jsx
+++ b/client/support/support-user/index.jsx
@@ -10,7 +10,7 @@ import flowRight from 'lodash/flowRight';
  */
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import SupportUserLoginDialog from './login-dialog';
-import { fetchToken, rebootNormally } from 'lib/user/support-user-interop';
+import supportUser from 'lib/user/support-user-interop';
 
 import { supportUserToggleDialog } from 'state/support/actions';
 
@@ -59,8 +59,8 @@ const mapStateToProps = ( state ) => {
 
 const mapDispatchToProps = ( dispatch ) => {
 	return {
-		supportUserTokenFetch: fetchToken,
-		supportUserRestore: rebootNormally,
+		supportUserTokenFetch: supportUser.fetchToken.bind( supportUser ),
+		supportUserRestore: supportUser.rebootNormally,
 		supportUserToggleDialog: flowRight( dispatch, supportUserToggleDialog ),
 	};
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#3587

Original PR broke staging:

`Uncaught TypeError: (0 , _libUserSupportUserInterop.setReduxStore) is not a function`