### PR TITLE
Invite Brazilian Users to fill out a survey.

### DIFF
--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -4,6 +4,10 @@
 	padding: 24px 18px 0;
 	margin-bottom: 66px;
 	box-shadow: none;
+	// Copy max-width and auto margin settings from .main
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 720px;
 	&:before {
 		content: '';
 		position: absolute;
@@ -18,7 +22,7 @@
 	.close-button {
 		padding: 6px;
 	}
-	.gridicons-globe {
+	.translator-invitation__decoration {
 		// copied from noticons styling
 		background-color: $gray-light;
 		color: $gray;
@@ -76,12 +80,10 @@
 
 .translator-invitation__actions {
 	flex-grow: 100%;
-	margin-left: 2%;
-	> .button:last-of-type {
+	> .button:last-child {
 		margin-right: 0;
 	}
 }
-
 
 @include breakpoint( ">660px" ) {
 	.translator-invitation {
@@ -97,22 +99,29 @@
 		.button {
 			display: inline-block;
 			width: auto;
+			margin-bottom: 0px;
 			padding: 7px 24px;
-			margin-right: 24px;
+			margin-right: 12px;
 		}
 	}
 
 	.translator-invitation__intro {
-		flex: 0 1 auto
+		flex: 0 1 auto;
+		margin-bottom: 0px;
 	}
 
 	.translator-invitation__actions {
-		flex: 0 0 auto
+		flex: 0 0 auto;
+		margin-left: 2%;
 	}
 
 	.translator-invitation__secondary-content {
+		align-items: center;
 		display: flex;
 		flex-direction: row;
 		justify-content: flex-start;
+		margin-bottom: 0px;
+		margin-left: 0px;
+		margin-right: 0px;
 	}
 }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -17,6 +17,8 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	translator = require( 'lib/translator-jumpstart' ),
 	TranslatorInvitation = require( './community-translator/invitation' ),
 	TranslatorLauncher = require( './community-translator/launcher' ),
+	PollInvitation = require( './poll-invitation' ),
+	PreferencesData = require( 'components/data/preferences-data' ),
 	EmailVerificationNotice = require( 'components/email-verification/email-verification-notice' ),
 	Welcome = require( 'my-sites/welcome/welcome' ),
 	WelcomeMessage = require( 'nux-welcome/welcome-message' ),
@@ -114,7 +116,8 @@ Layout = React.createClass( {
 		var translatorInvitation = this.props.translatorInvitation,
 			showInvitation,
 			showWelcome,
-			newestSite;
+			newestSite,
+			disablePollInvitation;
 
 		if ( ! this.props.user ) {
 			return null;
@@ -125,6 +128,7 @@ Layout = React.createClass( {
 		showInvitation = ! showWelcome &&
 				translatorInvitation.isPending() &&
 				translatorInvitation.isValidSection( this.props.section.name );
+		disablePollInvitation = showWelcome || showInvitation;
 
 		return (
 			<span>
@@ -132,6 +136,9 @@ Layout = React.createClass( {
 					<WelcomeMessage welcomeSite={ newestSite } />
 				</Welcome>
 				<TranslatorInvitation isVisible={ showInvitation } />
+				<PreferencesData>
+					<PollInvitation isVisible={ ! disablePollInvitation } section={ this.props.section } />
+				</PreferencesData>
 			</span>
 		);
 	},

--- a/client/layout/poll-invitation/index.js
+++ b/client/layout/poll-invitation/index.js
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import snakeCase from 'lodash/snakeCase';
+import includes from 'lodash/includes';
+import once from 'lodash/once';
+import debugModule from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import userModule from 'lib/user';
+import { ga as googleAnalytics } from 'analytics';
+import Gridicon from 'components/gridicon';
+import { tracks } from 'analytics';
+import config from 'config';
+import preferencesActions from 'lib/preferences/actions';
+import Button from 'components/button';
+
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:poll-invitation' );
+const user = userModule();
+const _dismissedPreferenceKey = 'dismissedBrazilianSurvey';
+const _sectionWhiteList = [ 'reader', 'sites' ];
+
+function shouldDisplay() {
+	return 'pt-br' === user.get().localeSlug;
+}
+
+function recordEvent( eventAction ) {
+	googleAnalytics.recordEvent( 'Brazil Survey Invitation', eventAction );
+	const tracksEventName = 'calypso_poll_invitation_' + snakeCase( eventAction );
+	debug( 'recording event ' + tracksEventName );
+	tracks.recordEvent( tracksEventName );
+}
+
+const recordDisplayedEventOnce = once( () => recordEvent( 'Displayed' ) );
+
+export default React.createClass( {
+	displayName: 'PollInvitation',
+
+	propTypes: {
+		isVisible: React.PropTypes.bool
+	},
+
+	getInitialState: function() {
+		return {
+			disabled: ! shouldDisplay()
+		};
+	},
+
+	getDefaultProps: function() {
+		return {
+			isVisible: true
+		};
+	},
+
+	render: function() {
+		var surveyUrl = 'http://9372672.polldaddy.com/s/brazilian-portuguese-user-survey';
+		if ( this.state.disabled ) {
+			debug( 'hiding: has been disabled' );
+			return null;
+		}
+
+		if ( ! this.props.isVisible ) {
+			debug( 'hiding: hidden by parent' );
+			return null;
+		}
+
+		if ( ! config.isEnabled( 'brazil-survey-invitation' ) ) {
+			debug( 'hiding: not enabled in config' );
+			return null;
+		}
+
+		if ( ! this.props.preferences ) {
+			debug( 'hiding: user preferences not loaded' );
+			return null;
+		}
+
+		if ( this.props.preferences[ _dismissedPreferenceKey ] ) {
+			debug( 'hiding: user has dismissed invitation' );
+			return null;
+		}
+
+		if ( ! includes( _sectionWhiteList, this.props.section.name ) ) {
+			debug( 'hiding: invalid section', this.props.section.name );
+			return null;
+		}
+
+		recordDisplayedEventOnce();
+
+		return (
+			<div className="translator-invitation welcome-message">
+				<div className="translator-invitation__primary-content">
+					<h3 className="translator-invitation__title">Como está o nosso trabalho no Brasil?</h3> { /* no translate(), pt-br only */ }
+
+					<div className="translator-invitation__secondary-content">
+						<p className="translator-invitation__intro">
+							Nós gostaríamos de lhe fazer 7 perguntas sobre o WordPress.com no Brasil.{ /* no translate(), pt-br only */ }
+						</p>
+						<div className="translator-invitation__actions">
+							<Button	onClick={ this.trackRejectAndDismiss }>
+								{ 'Não, obrigado' /* no translate(), pt-br only */ }
+							</Button>
+							<Button	primary	href={ surveyUrl } target="_blank"
+								onClick={ this.trackAcceptAndDismiss }>
+								{ 'Responder a pesquisa' /* no translate(), pt-br only */ }
+							</Button>
+						</div>
+					</div>
+				</div>
+				<Gridicon className="translator-invitation__decoration" icon="globe" />
+			</div>
+		);
+	},
+
+	trackAcceptAndDismiss: function() {
+		debug( 'accept button clicked' );
+		recordEvent( 'Clicked Accept Button' );
+		this.dismiss();
+	},
+
+	trackRejectAndDismiss: function() {
+		debug( 'dismiss button clicked' );
+		recordEvent( 'Clicked Dismiss Button' );
+		this.dismiss();
+	},
+
+	dismiss: function() {
+		debug( 'dismissed' );
+		this.setState( { disabled: true } );
+		recordEvent( 'dismissed' );
+		preferencesActions.set( _dismissedPreferenceKey, true );
+	}
+} );

--- a/config/development.json
+++ b/config/development.json
@@ -28,6 +28,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"brazil-survey-invitation": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -14,6 +14,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"brazil-survey-invitation": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -14,6 +14,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
+		"brazil-survey-invitation": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,


### PR DESCRIPTION
This PR adds a pop-up banner (currently an "Invitation", but needs a new name) to invite Brazilian users to fill out a survey about our recent focus on Brazil.  This invitation is intended to be run for a few weeks and then disabled.

There are a number of boxes to check:
- The invitation should only appear when the user locale is set to 'pt-BR'.
- Clicking on the Accept button should open the Brazilian survey in a new window.
- The invitation should only appear in the reader and my-sites sections (not in the editor or settings sections, for example)
- The invitation should not reappear after either the accept or dismiss buttons are pressed
- There should be tracks events for displaying, accepting and dismissing the invitation
- The invitation should look ok and work on mobile
- The invitation should not appear in production yet

To restore the invitation after clicking on a button, clear it out of the user preferences:
`require('lib/preferences/actions').set( 'dismissedBrazilianSurvey', null );`

It may help to turn debugging on for the invitation and for analytics:
`localStorage.debug = localStorage.debug + ', calypso:analytics, calypso:poll-invitation'`



