### PR TITLE
Form Components: Allow password input focus to be set programmatically

### DIFF
--- a/client/components/forms/form-password-input/index.jsx
+++ b/client/components/forms/form-password-input/index.jsx
@@ -37,6 +37,10 @@ module.exports = React.createClass( {
 		return this.props.submitting || this.state.hidePassword;
 	},
 
+	focus: function() {
+		this.refs.textField.focus();
+	},
+
 	render: function() {
 
 		var toggleVisibilityClasses = classNames( {
@@ -48,6 +52,7 @@ module.exports = React.createClass( {
 			<div className="form-password-input">
 				<FormTextInput { ...omit( this.props, 'hideToggle' ) }
 					autoComplete="off"
+					ref="textField"
 					type={ this.hidden() ? 'password' : 'text' } />
 
 				<span className={ toggleVisibilityClasses } onClick={ this.togglePasswordVisibility }>


### PR DESCRIPTION
This change adds a method to `FormPasswordInput` for setting focus to the field programmatically, in the same way that it's currently possible to do with `FormTextInput`.

This will be used in #3243 to automatically focus the password field if the user presses return after the username has been entered.