### PR TITLE
DevDocs: Fix the Sidebar to highlight the currently selected menu

### DIFF
--- a/client/devdocs/controller.js
+++ b/client/devdocs/controller.js
@@ -1,43 +1,45 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	qs = require( 'qs' ),
-	debounce = require( 'lodash/debounce' ),
-	page = require( 'page' ),
-	ReduxProvider = require( 'react-redux' ).Provider,
-	setSection = require( 'state/ui/actions' ).setSection,
-	EmptyContent = require( 'components/empty-content' );
+import ReactDom from 'react-dom';
+import React from 'react';
+import qs from 'qs';
+import debounce from 'lodash/debounce';
+import page from 'page';
+import { Provider as ReduxProvider } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-var DocsComponent = require( './main' ),
-	SingleDocComponent = require( './doc' ),
-	DesignAssetsComponent = require( './design' ),
-	AppComponents = require( './design/app-components' ),
-	Typography = require( './design/typography' ),
-	DevWelcome = require( './welcome' ),
-	Sidebar = require( './sidebar' ),
-	FormStateExamplesComponent = require( './form-state-examples' );
+import DocsComponent from './main';
+import SingleDocComponent from './doc';
+import DesignAssetsComponent from './design';
+import AppComponents from './design/app-components';
+import Typography from './design/typography';
+import DevWelcome from './welcome';
+import Sidebar from './sidebar';
+import FormStateExamplesComponent from './form-state-examples';
+import { setSection } from 'state/ui/actions';
+import EmptyContent from 'components/empty-content';
 
-var devdocs = {
+const devdocs = {
 
-	/**
+	/*
 	 * Documentation is rendered on #primary and doesn't expect a sidebar to exist
 	 * so #secondary needs to be cleaned up
 	 */
 	sidebar: function( context, next ) {
 		ReactDom.render(
-			React.createElement( Sidebar, {} ),
+			React.createElement( Sidebar, {
+				path: context.path,
+			} ),
 			document.getElementById( 'secondary' )
 		);
 
 		next();
 	},
 
-	/**
+	/*
 	 * Controller for page listing multiple developer docs
 	 */
 	devdocs: function( context ) {
@@ -68,7 +70,7 @@ var devdocs = {
 		);
 	},
 
-	/**
+	/*
 	 * Controller for single developer document
 	 */
 	singleDoc: function( context ) {

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -7,10 +7,10 @@ import PureRenderMixin from 'react-pure-render/mixin';
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
 import Sidebar from 'layout/sidebar';
 import SidebarHeading from 'layout/sidebar/heading';
 import SidebarMenu from 'layout/sidebar/menu';
+import SidebarItem from 'layout/sidebar/item';
 
 export default React.createClass( {
 
@@ -24,53 +24,60 @@ export default React.createClass( {
 				<h1 className="devdocs__title">Calypso Docs</h1>
 				<SidebarMenu>
 					<ul>
-						<li className="devdocs__navigation-item">
-							<Gridicon icon="search" />
-							<a className="devdocs__sidebar-item" href="/devdocs">
-								Search
-							</a>
-						</li>
-						<li className="devdocs__navigation-item">
-							<Gridicon icon="location" />
-							<a className="devdocs__sidebar-item" href="/devdocs/docs/guide/index.md">
-								The Calypso Guide
-							</a>
-						</li>
-						<li className="devdocs__navigation-item">
-							<Gridicon icon="pencil" />
-							<a className="devdocs__sidebar-item" href="/devdocs/CONTRIBUTING.md">
-								Contributing
-							</a>
-						</li>
+						<SidebarItem
+							className="devdocs__navigation-item"
+							icon="search"
+							label="Search"
+							link="/devdocs"
+							selected={ '/devdocs' === this.props.path }
+						/>
+						<SidebarItem
+							className="devdocs__navigation-item"
+							icon="location"
+							label="The Calypso Guide"
+							link="/devdocs/docs/guide/index.md"
+							selected={ '/devdocs/docs/guide/index.md' === this.props.path }
+						/>
+						<SidebarItem
+							className="devdocs__navigation-item"
+							icon="pencil"
+							label="Contributing"
+							link="/devdocs/CONTRIBUTING.md"
+							selected={ '/devdocs/CONTRIBUTING.md' === this.props.path }
+						/>
 					</ul>
 				</SidebarMenu>
 				<SidebarHeading>Live Docs</SidebarHeading>
 				<SidebarMenu>
 					<ul>
-						<li className="devdocs__navigation-item">
-							<Gridicon icon="layout-blocks" />
-							<a className="devdocs__sidebar-item" href="/devdocs/design">
-								UI Components
-							</a>
-						</li>
-						<li className="devdocs__navigation-item">
-							<Gridicon icon="custom-post-type" />
-							<a className="devdocs__sidebar-item" href="/devdocs/app-components">
-								App Components
-							</a>
-						</li>
-						<li className="devdocs__navigation-item">
-							<Gridicon icon="heading" />
-							<a className="devdocs__sidebar-item" href="/devdocs/design/typography">
-								Typography
-							</a>
-						</li>
-						<li className="devdocs__navigation-item">
-							<Gridicon icon="types" />
-							<a className="devdocs__sidebar-item" href="/devdocs/docs/icons.md">
-								Icons
-							</a>
-						</li>
+						<SidebarItem
+							className="devdocs__navigation-item"
+							icon="layout-blocks"
+							label="UI Components"
+							link="/devdocs/design"
+							selected={ '/devdocs/design' === this.props.path }
+						/>
+						<SidebarItem
+							className="devdocs__navigation-item"
+							icon="custom-post-type"
+							label="App Components"
+							link="/devdocs/app-components"
+							selected={ '/devdocs/app-components' === this.props.path }
+						/>
+						<SidebarItem
+							className="devdocs__navigation-item"
+							icon="heading"
+							label="Typography"
+							link="/devdocs/design/typography"
+							selected={ '/devdocs/design/typography' === this.props.path }
+						/>
+						<SidebarItem
+							className="devdocs__navigation-item"
+							icon="types"
+							label="Icons"
+							link="/devdocs/docs/icons.md"
+							selected={ '/devdocs/docs/icons.md' === this.props.path }
+						/>
 					</ul>
 				</SidebarMenu>
 			</Sidebar>


### PR DESCRIPTION
## Background
The DevDocs sidebar does not show the sidebar menu item that is currently selected.

## Testing
1. Launch the [devdocs](http://calypso.localhost:3000/devdocs?) link.
2. Click each menu item to make sure it navigates to the right destination and correctly highlights as being selected.

 - [Search](http://calypso.localhost:3000/devdocs?)
 - [The Calypso Guide](http://calypso.localhost:3000/devdocs/docs/guide/index.md)
 - [Contributing](http://calypso.localhost:3000/devdocs/CONTRIBUTING.md)
 - [UI Components](http://calypso.localhost:3000/devdocs/design)
 - [App Components](http://calypso.localhost:3000/devdocs/app-components)
 - [Typography](http://calypso.localhost:3000/devdocs/design/typography)
 - [Icons](http://calypso.localhost:3000/devdocs/docs/icons.md)

## Reviewers
@lancewillett @nb 

## Issues
Closes [DevDocs: sidebar navigation should highlight the selected element](https://github.com/Automattic/wp-calypso/issues/1422)