### PR TITLE
Plugins: Remove browser feature flag

### DIFF
--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -11,10 +11,8 @@ var controller = require( 'my-sites/controller' ),
 	pluginsController = require( './controller' );
 
 module.exports = function() {
-	if ( config.isEnabled( 'manage/plugins/browser' ) ) {
-		page( '/plugins/browse/:category/:site', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
-		page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
-	}
+	page( '/plugins/browse/:category/:site', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
+	page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
 		page( '/plugins/setup', controller.siteSelection, controller.navigation, pluginsController.setupPlugins );

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -11,15 +11,14 @@ var controller = require( 'my-sites/controller' ),
 	pluginsController = require( './controller' );
 
 module.exports = function() {
-	page( '/plugins/browse/:category/:site', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
-	page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
-
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
 		page( '/plugins/setup', controller.siteSelection, controller.navigation, pluginsController.setupPlugins );
 		page( '/plugins/setup/:site', controller.siteSelection, controller.navigation, pluginsController.setupPlugins );
 	}
 
 	if ( config.isEnabled( 'manage/plugins' ) ) {
+		page( '/plugins/browse/:category/:site', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
+		page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
 		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {
 			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import debounce from 'lodash/debounce';
-import config from 'config';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
 import analytics from 'analytics';
@@ -97,10 +96,6 @@ export default React.createClass( {
 		analytics.ga.recordEvent( 'Plugins', 'Clicked Add New Plugins' );
 	},
 
-	canAddNewPlugins() {
-		return config.isEnabled( 'manage/plugins/browser' );
-	},
-
 	canUpdatePlugins() {
 		return this.props.selected.some( plugin => plugin.sites.some( site => site.canUpdateFiles ) );
 	},
@@ -137,32 +132,30 @@ export default React.createClass( {
 					</Button>
 				</ButtonGroup>
 			);
-			if ( this.canAddNewPlugins() ) {
-				const selectedSite = this.props.sites.getSelectedSite();
-				const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
+			const selectedSite = this.props.sites.getSelectedSite();
+			const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
 
-				rightSideButtons.push(
-					<ButtonGroup key="plugin-list-header__buttons-browser">
-						<Button
-							compact
-							href={ browserUrl }
-							onClick={ this.onBrowserLinkClick }
-							className="plugin-list-header__browser-button"
-							onMouseEnter={ () => this.setState( { addPluginTooltip: true } ) }
-							onMouseLeave={ () => this.setState( { addPluginTooltip: false } ) }
-							ref="addPluginButton"
-							aria-label={ this.translate( 'Browse all plugins', { context: 'button label' } ) }>
-							<Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } />
-							<Tooltip
-								isVisible={ this.state.addPluginTooltip }
-								context={ this.refs && this.refs.addPluginButton }
-								position="bottom">
-								{ this.translate( 'Browse all plugins', { context: 'button tooltip' } ) }
-							</Tooltip>
-						</Button>
-					</ButtonGroup>
-				);
-			}
+			rightSideButtons.push(
+				<ButtonGroup key="plugin-list-header__buttons-browser">
+					<Button
+						compact
+						href={ browserUrl }
+						onClick={ this.onBrowserLinkClick }
+						className="plugin-list-header__browser-button"
+						onMouseEnter={ () => this.setState( { addPluginTooltip: true } ) }
+						onMouseLeave={ () => this.setState( { addPluginTooltip: false } ) }
+						ref="addPluginButton"
+						aria-label={ this.translate( 'Browse all plugins', { context: 'button label' } ) }>
+						<Gridicon key="plus-icon" icon="plus-small" size={ 12 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } />
+						<Tooltip
+							isVisible={ this.state.addPluginTooltip }
+							context={ this.refs && this.refs.addPluginButton }
+							position="bottom">
+							{ this.translate( 'Browse all plugins', { context: 'button tooltip' } ) }
+						</Tooltip>
+					</Button>
+				</ButtonGroup>
+			);
 		} else {
 			const updateButton = (
 				<Button

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -118,7 +118,7 @@ export default React.createClass( {
 	},
 
 	getInstallButton() {
-		if ( this.hasInstallButton() && config.isEnabled( 'manage/plugins/browser' ) ) {
+		if ( this.hasInstallButton() ) {
 			return <PluginInstallButton { ...this.props } />;
 		}
 	},

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import config from 'config';
 
 /**
  * Internal dependencies
@@ -155,8 +154,7 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		if ( this.props.plugin.slug === 'jetpack' ||
-				! config.isEnabled( 'manage/plugins/browser' ) ) {
+		if ( this.props.plugin.slug === 'jetpack' ) {
 			return null;
 		}
 

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -209,12 +209,9 @@ const SinglePlugin = React.createClass( {
 	},
 
 	getPluginDoesNotExistView( selectedSite ) {
-		let actionUrl,
-			action;
-		if ( config.isEnabled( 'manage/plugins/browser' ) ) {
-			actionUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
+		let actionUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' ),
 			action = this.translate( 'Browse all plugins' );
-		}
+
 		return (
 			<MainComponent>
 				<JetpackManageErrorPage

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -244,10 +244,8 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		if ( config.isEnabled( 'manage/plugins/browser' ) ) {
-			if ( ( this.isSingle() && site.jetpack ) || ( ! this.isSingle() && this.hasJetpackSites() ) ) {
-				addPluginsButton = <a onClick={ this.onNavigate } href={ '/plugins/browse' + this.siteSuffix() } className="add-new">{ this.translate( 'Add' ) }</a>;
-			}
+		if ( ( this.isSingle() && site.jetpack ) || ( ! this.isSingle() && this.hasJetpackSites() ) ) {
+			addPluginsButton = <a onClick={ this.onNavigate } href={ '/plugins/browse' + this.siteSuffix() } className="add-new">{ this.translate( 'Add' ) }</a>;
 		}
 
 		return (

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -34,7 +34,6 @@
 		"manage/people/readers": true,
 		"manage/plans": true,
 		"manage/plugins": true,
-		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,
 		"manage/posts": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -34,7 +34,6 @@
 		"manage/people/readers": true,
 		"manage/plans": true,
 		"manage/plugins": true,
-		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,
 		"manage/posts": true,

--- a/config/development.json
+++ b/config/development.json
@@ -58,7 +58,6 @@
 		"manage/people/readers": true,
 		"manage/plans": true,
 		"manage/plugins": true,
-		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/compatibility-warning": false,
 		"manage/plugins/setup": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -37,7 +37,6 @@
 		"manage/people/readers": true,
 		"manage/plans": true,
 		"manage/plugins": true,
-		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,
 		"manage/posts": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -34,7 +34,6 @@
 		"manage/people/readers": true,
 		"manage/plans": true,
 		"manage/plugins": true,
-		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,
 		"manage/posts": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -40,7 +40,6 @@
 		"manage/people/readers": true,
 		"manage/plans": true,
 		"manage/plugins": true,
-		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,
 		"manage/posts": true,


### PR DESCRIPTION
Plugin Browser feature flag was already open in every config file. This PR removes any reference to it and let the main plugins flag control also the routes related to the browser

How to test
=========
1. You need at least jetpack site for plugins browser to show
2. Check that the "add" button appears on the plugins menu link on the sidebar
3. Check you get to the browser when you click on it, and that everything there is ok (you can click on plugins, search, click on categories, etc)

ping @enejb @umurkontaci 