### PR TITLE
Signup: Add new flow that defaults to the free plan

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -66,6 +66,13 @@ const flows = {
 		lastModified: '2016-01-21'
 	},
 
+	free: {
+		steps: [ 'themes', 'domains', 'user' ],
+		destination: getSiteDestination,
+		description: 'Create an account and a blog and default to the free plan.',
+		lastModified: '2016-02-29'
+	},
+
 	businessv2: {
 		steps: ['domains', 'user' ],
 		destination: function( dependencies ) {


### PR DESCRIPTION
This PR introduces a new signup flow at `/start/free` that defaults to the free plan (i.e. does _not_ show a plan step). 

It will be linked to from landing pages where the user is selecting the free plan from the landing page itself (Premium and Business equivalents already exist).

cc: @drewblaisdell or @scruffian for review