### PR TITLE
Jetpack logo component

### DIFF
--- a/client/components/jetpack-logo/docs/example.jsx
+++ b/client/components/jetpack-logo/docs/example.jsx
@@ -1,0 +1,31 @@
+/**
+* External dependencies
+*/
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackLogo from 'components/jetpack-logo';
+import Card from 'components/card';
+
+module.exports = React.createClass( {
+	displayName: 'JetpackLogos',
+
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/design/jetpack-logo">Jetpack Logo</a>
+				</h2>
+				<Card>
+					<div>
+						<JetpackLogo size={ 200 } />
+						<JetpackLogo size={ 100 } />
+						<JetpackLogo size={ 36 } />
+					</div>
+				</Card>
+			</div>
+		);
+	}
+} );

--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+
+export default React.createClass( {
+
+	displayName: 'JetpackLogo',
+
+	mixins: [ PureRenderMixin ],
+
+	getDefaultProps() {
+		return {
+			size: 72
+		};
+	},
+
+	propTypes: {
+		size: React.PropTypes.number
+	},
+
+	render() {
+		return (
+			<svg className="jetpack-logo" height={ this.props.size } width={ this.props.size } viewBox="0 0 18 18">
+				<path d="M13.0046359,9.25823605 L9.48604166,15.3539915 L9.48604166,6.8984007 L12.313015,7.61796343 C13.0301435,7.80052635 13.3746179,8.61738309 13.0046359,9.25823605 L13.0046359,9.25823605 Z M8.64939166,11.1015993 L5.82241837,10.3820366 C5.10528979,10.1994736 4.76081543,9.38261691 5.13079742,8.74176395 L8.64939166,2.6460085 L8.64939166,11.1015993 Z M9.00006073,0 C4.02947547,0 0,4.0293812 0,9 C0,13.9706188 4.02947547,18 9.00006073,18 C13.9705245,18 18,13.9706188 18,9 C18,4.0293812 13.9705245,0 9.00006073,0 L9.00006073,0 Z"></path>
+			</svg>
+		);
+	}
+} );

--- a/client/components/wordpress-logo/docs/example.jsx
+++ b/client/components/wordpress-logo/docs/example.jsx
@@ -1,0 +1,31 @@
+/**
+* External dependencies
+*/
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import WordPressLogo from 'components/wordpress-logo';
+import Card from 'components/card';
+
+module.exports = React.createClass( {
+	displayName: 'WordPressLogo',
+
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/design/wordpress-logo">WordPress Logo</a>
+				</h2>
+				<Card>
+					<div>
+						<WordPressLogo size={ 200 } />
+						<WordPressLogo size={ 100 } />
+						<WordPressLogo size={ 36 } />
+					</div>
+				</Card>
+			</div>
+		);
+	}
+} );

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -47,6 +47,8 @@ var SearchCard = require( 'components/search-card' ),
 	BulkSelect = require( 'components/bulk-select/docs/example' ),
 	ExternalLink = require( 'components/external-link/docs/example' ),
 	FeatureGate = require( 'components/feature-example/docs/example' ),
+	WordPressLogo = require( 'components/wordpress-logo/docs/example' ),
+	JetpackLogo = require( 'components/jetpack-logo/docs/example' ),
 	Collection,
 	FilterSummary,
 	Hider;
@@ -206,6 +208,8 @@ module.exports = React.createClass( {
 					<SectionNav />
 					<TimezoneDropdown />
 					<FoldableCard />
+					<WordPressLogo />
+					<JetpackLogo />
 				</Collection>
 			</div>
 		);

--- a/client/devdocs/design/style.scss
+++ b/client/devdocs/design/style.scss
@@ -70,3 +70,12 @@
 	text-align: center;
 	cursor: default;
 }
+
+
+.design-assets__group {
+	.wordpress-logo,
+	.jetpack-logo {
+		fill: darken( $gray, 20% );
+		margin-right: 16px;
+	}
+}


### PR DESCRIPTION
As proposed by @mtias  in https://github.com/Automattic/wp-calypso/pull/3375, I'm adding a new component for rendering jetpack logo. This PR also add the example of the already existant `WordPressLogo` component to devdocs:

![image](https://cloud.githubusercontent.com/assets/1554855/13398266/cbf27ec2-defd-11e5-9c41-6029a08a30d2.png)

How to test: 
=====
1. Go to http://calypso.dev:3000/devdocs/design/wordpress-logo 
2. You should see 3 WordPress logos in different sizes
3. Go to http://calypso.dev:3000/devdocs/design/jetpack-logo
4. You should see 3 Jetpack Logos in different sizes