### PR TITLE
Framework: Don't redirect to apppromo for desktop

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -39,7 +39,11 @@ module.exports = React.createClass( {
 		
 		// If user is using en locale, redirect to app promo page on sign out
 		const isEnLocale = ( currentUser && currentUser.localeSlug === 'en' );
-		userUtilities.logout( isEnLocale ? '/?apppromo' : '' );
+		let redirect = null;
+		if ( isEnLocale && !config.isEnabled( 'desktop' ) ) {
+			redirect = '/?apppromo';
+		}
+		userUtilities.logout( redirect );
 		this.recordClickEvent( 'Sidebar Sign Out Link' );
 	},
 


### PR DESCRIPTION
Update to the apppromo redirect added in #3553

Doesn't make much sense for desktop users since they're already using the app, plus it ends up breaking the logout.

/cc @mkaz @apeatling @roundhill 