### PR TITLE
State: Split post query fetching status from result mapping

### DIFF
--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -77,8 +77,36 @@ export function siteRequests( state = {}, action ) {
 }
 
 /**
+ * Returns the updated post query requesting state after an action has been
+ * dispatched. The state reflects a mapping of serialized query to whether a
+ * network request is in-progress for that query.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function queryRequests( state = {}, action ) {
+	switch ( action.type ) {
+		case POSTS_REQUEST:
+		case POSTS_REQUEST_SUCCESS:
+		case POSTS_REQUEST_FAILURE:
+			const serializedQuery = getSerializedPostsQuery( action.query, action.siteId );
+			return Object.assign( {}, state, {
+				[ serializedQuery ]: POSTS_REQUEST === action.type
+			} );
+
+		case SERIALIZE:
+		case DESERIALIZE:
+			return {};
+	}
+
+	return state;
+}
+
+/**
  * Returns the updated post query state after an action has been dispatched.
- * The state reflects a mapping of serialized query key to query status.
+ * The state reflects a mapping of serialized query key to an array of post
+ * global IDs for the query, if a query response was successfully received.
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Action payload
@@ -86,31 +114,13 @@ export function siteRequests( state = {}, action ) {
  */
 export function queries( state = {}, action ) {
 	switch ( action.type ) {
-		case POSTS_REQUEST:
 		case POSTS_REQUEST_SUCCESS:
-		case POSTS_REQUEST_FAILURE:
-			const { type, siteId, posts } = action;
-			const serializedQuery = getSerializedPostsQuery( action.query, siteId );
-
-			state = Object.assign( {}, state, {
-				[ serializedQuery ]: Object.assign( {}, state[ serializedQuery ], {
-					// Only the initial request should be tracked as fetching.
-					// Success or failure types imply that fetching has completed.
-					fetching: ( POSTS_REQUEST === type )
-				} )
+			const serializedQuery = getSerializedPostsQuery( action.query, action.siteId );
+			return Object.assign( {}, state, {
+				[ serializedQuery ]: action.posts.map( ( post ) => post.global_ID )
 			} );
-
-			// When a request succeeds, map the received posts to state.
-			if ( POSTS_REQUEST_SUCCESS === type ) {
-				state[ serializedQuery ].posts = posts.map( ( post ) => post.global_ID );
-			}
-
-			return state;
-
-		case SERIALIZE:
-		case DESERIALIZE:
-			return {};
 	}
+
 	return state;
 }
 
@@ -144,6 +154,7 @@ export function queriesLastPage( state = {}, action ) {
 export default combineReducers( {
 	items,
 	siteRequests,
+	queryRequests,
 	queries,
 	queriesLastPage
 } );

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -23,7 +23,7 @@ import {
 	getSerializedPostsQueryWithoutPage
 } from './utils';
 import { DEFAULT_POST_QUERY } from './constants';
-import { itemsSchema } from './schema';
+import { itemsSchema, queriesSchema } from './schema';
 import { isValidStateWithSchema } from 'state/utils';
 
 /**
@@ -119,6 +119,13 @@ export function queries( state = {}, action ) {
 			return Object.assign( {}, state, {
 				[ serializedQuery ]: action.posts.map( ( post ) => post.global_ID )
 			} );
+
+		case DESERIALIZE:
+			if ( isValidStateWithSchema( state, queriesSchema ) ) {
+				return state;
+			}
+
+			return {};
 	}
 
 	return state;

--- a/client/state/posts/schema.js
+++ b/client/state/posts/schema.js
@@ -51,3 +51,17 @@ export const itemsSchema = {
 	},
 	additionalProperties: false
 };
+
+export const queriesSchema = {
+	type: 'object',
+	patternProperties: {
+		// Queries are JSON strings, optionally prepended by a site ID
+		'^(\\d+:)?\\{[^\\}]*\\}$': {
+			type: 'array',
+			items: {
+				type: 'string'
+			}
+		}
+	},
+	additionalProperties: false
+};

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -26,19 +26,6 @@ export function getPost( state, globalId ) {
 }
 
 /**
- * Returns true if the specified posts query is being tracked for the site, or
- * false otherwise.
- *
- * @param  {Object}  state  Global state tree
- * @param  {Number}  siteId Site ID
- * @param  {Object}  query  Post query object
- * @return {Boolean}        Whether posts query is tracked for site
- */
-export function isTrackingSitePostsQuery( state, siteId, query ) {
-	return !! state.posts.queries[ getSerializedPostsQuery( query, siteId ) ];
-}
-
-/**
  * Returns an array of posts for the posts query, or null if no posts have been
  * received.
  *
@@ -48,16 +35,12 @@ export function isTrackingSitePostsQuery( state, siteId, query ) {
  * @return {?Array}         Posts for the post query
  */
 export function getSitePostsForQuery( state, siteId, query ) {
-	if ( ! isTrackingSitePostsQuery( state, siteId, query ) ) {
-		return null;
-	}
-
 	const serializedQuery = getSerializedPostsQuery( query, siteId );
-	if ( ! state.posts.queries[ serializedQuery ].posts ) {
+	if ( ! state.posts.queries[ serializedQuery ] ) {
 		return null;
 	}
 
-	return state.posts.queries[ serializedQuery ].posts.map( ( globalId ) => {
+	return state.posts.queries[ serializedQuery ].map( ( globalId ) => {
 		return getPost( state, globalId );
 	} );
 }
@@ -72,12 +55,8 @@ export function getSitePostsForQuery( state, siteId, query ) {
  * @return {Boolean}        Whether posts are being requested
  */
 export function isRequestingSitePostsForQuery( state, siteId, query ) {
-	if ( ! isTrackingSitePostsQuery( state, siteId, query ) ) {
-		return false;
-	}
-
 	const serializedQuery = getSerializedPostsQuery( query, siteId );
-	return state.posts.queries[ serializedQuery ].fetching;
+	return !! state.posts.queryRequests[ serializedQuery ];
 }
 
 /**

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -28,6 +28,14 @@ import {
 } from '../reducer';
 
 describe( 'reducer', () => {
+	before( () => {
+		sinon.stub( console, 'warn' );
+	} );
+
+	after( () => {
+		console.warn.restore();
+	} );
+
 	describe( '#items()', () => {
 		it( 'should default to an empty object', () => {
 			const state = items( undefined, {} );
@@ -80,13 +88,6 @@ describe( 'reducer', () => {
 		} );
 
 		describe( 'persistence', () => {
-			before( () => {
-				sinon.stub( console, 'warn' );
-			} );
-			after( () => {
-				console.warn.restore();
-			} );
-
 			it( 'persists state', () => {
 				const original = deepFreeze( {
 					'3d097cb7c5473c169bba0eb8e3c6cb64': {
@@ -289,6 +290,16 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
 			} );
+		} );
+
+		it( 'should not load invalid persisted state', () => {
+			const original = deepFreeze( {
+				2916284: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
+			} );
+
+			const state = queries( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( {} );
 		} );
 	} );
 

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -21,6 +21,7 @@ import {
 } from 'state/action-types';
 import {
 	items,
+	queryRequests,
 	queries,
 	queriesLastPage,
 	siteRequests
@@ -127,81 +128,108 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	describe( '#queries()', () => {
+	describe( '#queryRequests()', () => {
 		it( 'should default to an empty object', () => {
-			const state = queries( undefined, {} );
+			const state = queryRequests( undefined, {} );
 
 			expect( state ).to.eql( {} );
 		} );
 
 		it( 'should track post query request fetching', () => {
-			const state = queries( undefined, {
+			const state = queryRequests( undefined, {
 				type: POSTS_REQUEST,
 				siteId: 2916284,
 				query: { search: 'Hello' }
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': {
-					fetching: true
-				}
+				'2916284:{"search":"hello"}': true
 			} );
 		} );
 
 		it( 'should track post queries without specified site', () => {
-			const state = queries( undefined, {
+			const state = queryRequests( undefined, {
 				type: POSTS_REQUEST,
 				query: { search: 'Hello' }
 			} );
 
 			expect( state ).to.eql( {
-				'{"search":"hello"}': {
-					fetching: true
-				}
-			} );
-		} );
-
-		it( 'should preserve previous query results when requesting again', () => {
-			const original = deepFreeze( {
-				'2916284:{"search":"hello"}': {
-					fetching: false,
-					posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-				}
-			} );
-			const state = queries( original, {
-				type: POSTS_REQUEST,
-				siteId: 2916284,
-				query: { search: 'Hello' }
-			} );
-
-			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': {
-					fetching: true,
-					posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-				}
+				'{"search":"hello"}': true
 			} );
 		} );
 
 		it( 'should accumulate queries', () => {
 			const original = deepFreeze( {
-				'2916284:{"search":"hello"}': {
-					fetching: true
-				}
+				'2916284:{"search":"hello"}': true
 			} );
-			const state = queries( original, {
+
+			const state = queryRequests( original, {
 				type: POSTS_REQUEST,
 				siteId: 2916284,
 				query: { search: 'Hello W' }
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': {
-					fetching: true
-				},
-				'2916284:{"search":"hello w"}': {
-					fetching: true
-				}
+				'2916284:{"search":"hello"}': true,
+				'2916284:{"search":"hello w"}': true
 			} );
+		} );
+
+		it( 'should track post query request success', () => {
+			const state = queryRequests( undefined, {
+				type: POSTS_REQUEST_SUCCESS,
+				siteId: 2916284,
+				query: { search: 'Hello' },
+				found: 1,
+				posts: [
+					{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				]
+			} );
+
+			expect( state ).to.eql( {
+				'2916284:{"search":"hello"}': false
+			} );
+		} );
+
+		it( 'should track post query request failure', () => {
+			const state = queryRequests( undefined, {
+				type: POSTS_REQUEST_FAILURE,
+				siteId: 2916284,
+				query: { search: 'Hello' },
+				error: new Error()
+			} );
+
+			expect( state ).to.eql( {
+				'2916284:{"search":"hello"}': false
+			} );
+		} );
+
+		it( 'should never persist state', () => {
+			const original = deepFreeze( {
+				'2916284:{"search":"hello"}': true
+			} );
+
+			const state = queryRequests( original, { type: SERIALIZE } );
+
+			expect( state ).to.eql( {} );
+		} );
+
+		it( 'should never load persisted state', () => {
+			const original = deepFreeze( {
+				'2916284:{"search":"hello"}': true
+			} );
+
+			const state = queryRequests( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( {} );
+		} );
+	} );
+
+	describe( '#queries()', () => {
+		it( 'should default to an empty object', () => {
+			const state = queries( undefined, {} );
+
+			expect( state ).to.eql( {} );
 		} );
 
 		it( 'should track post query request success', () => {
@@ -216,46 +244,51 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': {
-					fetching: false,
-					posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-				}
+				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
 			} );
 		} );
 
-		it( 'should track post query request failure', () => {
-			const state = queries( undefined, {
-				type: POSTS_REQUEST_FAILURE,
+		it( 'should accumulate query request success', () => {
+			const original = deepFreeze( {
+				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
+			} );
+			const state = queries( original, {
+				type: POSTS_REQUEST_SUCCESS,
 				siteId: 2916284,
-				query: { search: 'Hello' },
-				error: new Error()
+				query: { search: 'Hello W' },
+				posts: [
+					{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				]
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': {
-					fetching: false
-				}
+				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
+				'2916284:{"search":"hello w"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
 			} );
 		} );
 
-		it( 'never persists state because this is not implemented', () => {
+		it( 'should persist state', () => {
 			const original = deepFreeze( {
-				'2916284:{"search":"hello"}': {
-					fetching: true
-				}
+				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
 			} );
+
 			const state = queries( original, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
+
+			expect( state ).to.eql( {
+				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
+			} );
 		} );
 
-		it( 'never persists state because this is not implemented', () => {
+		it( 'should load persisted state', () => {
 			const original = deepFreeze( {
-				'2916284:{"search":"hello"}': {
-					fetching: true
-				}
+				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
 			} );
+
 			const state = queries( original, { type: DESERIALIZE } );
-			expect( state ).to.eql( {} );
+
+			expect( state ).to.eql( {
+				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
+			} );
 		} );
 	} );
 

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -8,7 +8,6 @@ import { expect } from 'chai';
  */
 import {
 	getPost,
-	isTrackingSitePostsQuery,
 	getSitePostsForQuery,
 	isRequestingSitePostsForQuery,
 	getSitePostsLastPageForQuery,
@@ -33,65 +32,11 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( '#isTrackingSitePostsQuery()', () => {
-		it( 'should return false if the site has not been queried', () => {
-			const isTracking = isTrackingSitePostsQuery( {
-				posts: {
-					queries: {}
-				}
-			}, 2916284, { search: 'Hello' } );
-
-			expect( isTracking ).to.be.false;
-		} );
-
-		it( 'should return false if the site has not been queried for the specific query', () => {
-			const isTracking = isTrackingSitePostsQuery( {
-				posts: {
-					queries: {
-						'2916284:{"search":"hel"}': {
-							fetching: true
-						}
-					}
-				}
-			}, 2916284, { search: 'Hello' } );
-
-			expect( isTracking ).to.be.false;
-		} );
-
-		it( 'should return true if the site has been queried for the specific query', () => {
-			const isTracking = isTrackingSitePostsQuery( {
-				posts: {
-					queries: {
-						'2916284:{"search":"hello"}': {
-							fetching: true
-						}
-					}
-				}
-			}, 2916284, { search: 'Hello' } );
-
-			expect( isTracking ).to.be.true;
-		} );
-	} );
-
 	describe( '#getSitePostsForQuery()', () => {
 		it( 'should return null if the site query is not tracked', () => {
 			const sitePosts = getSitePostsForQuery( {
 				posts: {
 					queries: {}
-				}
-			}, 2916284, { search: 'Hello' } );
-
-			expect( sitePosts ).to.be.null;
-		} );
-
-		it( 'should return null if the queried posts have not been received', () => {
-			const sitePosts = getSitePostsForQuery( {
-				posts: {
-					queries: {
-						'2916284:{"search":"hello"}': {
-							fetching: true
-						}
-					}
 				}
 			}, 2916284, { search: 'Hello' } );
 
@@ -105,10 +50,7 @@ describe( 'selectors', () => {
 						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
 					},
 					queries: {
-						'2916284:{"search":"hello"}': {
-							fetching: false,
-							posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-						}
+						'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
 					}
 				}
 			}, 2916284, { search: 'Hello' } );
@@ -120,23 +62,21 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#isRequestingSitePostsForQuery()', () => {
-		it( 'should return false if the site query is not tracked', () => {
+		it( 'should return false if the site has not been queried', () => {
 			const isRequesting = isRequestingSitePostsForQuery( {
 				posts: {
-					queries: {}
+					queryRequests: {}
 				}
 			}, 2916284, { search: 'Hello' } );
 
 			expect( isRequesting ).to.be.false;
 		} );
 
-		it( 'should return false if the site query is not fetching', () => {
+		it( 'should return false if the site has not been queried for the specific query', () => {
 			const isRequesting = isRequestingSitePostsForQuery( {
 				posts: {
-					queries: {
-						'2916284:{"search":"hello"}': {
-							fetching: false
-						}
+					queryRequests: {
+						'2916284:{"search":"hel"}': true
 					}
 				}
 			}, 2916284, { search: 'Hello' } );
@@ -144,18 +84,28 @@ describe( 'selectors', () => {
 			expect( isRequesting ).to.be.false;
 		} );
 
-		it( 'should return true if the site query is fetching', () => {
+		it( 'should return true if the site has been queried for the specific query', () => {
 			const isRequesting = isRequestingSitePostsForQuery( {
 				posts: {
-					queries: {
-						'2916284:{"search":"hello"}': {
-							fetching: true
-						}
+					queryRequests: {
+						'2916284:{"search":"hello"}': true
 					}
 				}
 			}, 2916284, { search: 'Hello' } );
 
 			expect( isRequesting ).to.be.true;
+		} );
+
+		it( 'should return false if the site has previously, but is not currently, querying for the specified query', () => {
+			const isRequesting = isRequestingSitePostsForQuery( {
+				posts: {
+					queryRequests: {
+						'2916284:{"search":"hello"}': false
+					}
+				}
+			}, 2916284, { search: 'Hello' } );
+
+			expect( isRequesting ).to.be.false;
 		} );
 	} );
 
@@ -262,14 +212,8 @@ describe( 'selectors', () => {
 						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
 					},
 					queries: {
-						'2916284:{"number":1}': {
-							fetching: false,
-							posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-						},
-						'2916284:{"number":1,"page":2}': {
-							fetching: false,
-							posts: [ '6c831c187ffef321eb43a67761a525a3' ]
-						}
+						'2916284:{"number":1}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
+						'2916284:{"number":1,"page":2}': [ '6c831c187ffef321eb43a67761a525a3' ]
 					},
 					queriesLastPage: {
 						'2916284:{"number":1}': 2
@@ -308,18 +252,9 @@ describe( 'selectors', () => {
 						'f0cb4eb16f493c19b627438fdc18d57c': { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak & Eggs', parent: { ID: 413 } } // eslint-disable-line
 					},
 					queries: {
-						'2916284:{"number":1}': {
-							fetching: false,
-							posts: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-						},
-						'2916284:{"number":1,"page":2}': {
-							fetching: false,
-							posts: [ '6c831c187ffef321eb43a67761a525a3' ]
-						},
-						'2916284:{"number":1,"page":3}': {
-							fetching: false,
-							posts: [ 'f0cb4eb16f493c19b627438fdc18d57c' ]
-						}
+						'2916284:{"number":1}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
+						'2916284:{"number":1,"page":2}': [ '6c831c187ffef321eb43a67761a525a3' ],
+						'2916284:{"number":1,"page":3}': [ 'f0cb4eb16f493c19b627438fdc18d57c' ]
 					},
 					queriesLastPage: {
 						'2916284:{"number":1}': 3


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/pull/3487#issuecomment-189542813

This pull request seeks to split the `posts.queries` state subtree, which currently tracks both fetching status and response results for a query, to separate subtrees (`posts.queries` and `post.queryRequests`). Benefits include:

- Fetching status should not be persisted, whereas query results should. Separating them makes this more feasible.
- Simplifies structure of state tree, removing need to check for whether query is "tracked" before return result from selector. Also leads to simpler-to-follow reducer logic and decreased nesting (fewer `Object.assign`).

__Testing instructions:__

Verify that there are no regressions, particularly around the `<PostSelector />` component, and ensure that fetching status is properly tracked such to avoid unnecessary excessive requests.

Repeat testing instructions from #2350.

Ensure Mocha tests pass by running `make test` from `client/state/posts`. 

Verify state persistence behaves as expected. See https://github.com/Automattic/wp-calypso/pull/3671#issuecomment-190810267 .

__Follow-up tasks:__

- [ ] Rename `posts.query` to `posts.queryResults`
- [ ] Rename `posts.queriesLastPage` to `posts.queryLastPage`
- [ ] Add tests to ensure that reducer keys are included on the default export (easy to miss)

/cc @gwwar 