### PR TITLE
Editor: Fix broken connection notice styling

### DIFF
--- a/client/post-editor/editor-sharing/style.scss
+++ b/client/post-editor/editor-sharing/style.scss
@@ -43,27 +43,7 @@ input[type="text"].editor-sharing__shortlink-field {
 }
 
 .editor-sharing__broken-publicize-connection {
-	padding: 8px 16px 8px 41px;
 	margin: 8px -16px;
-
-	@include breakpoint( "<660px" ) {
-		padding-left: 16px;
-	}
-
-	&:before {
-		top: 21px;
-		left: 22px;
-		font-size: 20px;
-	}
-
-	.notice__text {
-		padding: 0;
-	}
-
-	.gridicon {
-		float: right;
-		margin: 1px 0 0 4px;
-	}
 }
 
 .editor-sharing__broken-publicize-connection-button {


### PR DESCRIPTION
This pull request seeks to resolve an issue where the "Reconnect" notice would be misaligned at all display sizes. It's assumed that recent changes to `<Notice />` styling were not accounting for customizations in the editor. The changes here limit those customizations, relying more on default notice styling for an improved display.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/13410353/4be7e534-df05-11e5-9eb3-931b0e65dcea.png)|![After](https://cloud.githubusercontent.com/assets/1779930/13410358/56a55cd6-df05-11e5-8b6e-b3d16079ea9e.png)

__Testing instructions:__

Verify that the reconnect notice displays correctly. This might require some forethought, as connection status is cached for ~6hrs. Twitter is easy to test, by adding a new Twitter connection then proceeding to https://twitter.com/settings/applications and revoking the WordPress application authorization.