### PR TITLE
Reader: hide post header for feed and blog streams

### DIFF
--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -138,7 +138,7 @@
 		font-family: $sans;
 		font-size: 15px;
 		padding-top: 5px;
-		border-top: 1px solid lighten( $gray, 30 );
+		border-top: 1px solid lighten( $gray, 30% );
 
 		a {
 			padding: 5px 10px;

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -144,7 +144,7 @@ var FeedStream = React.createClass( {
 		}
 
 		return (
-			<FollowingStream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } >
+			<FollowingStream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent }>
 				{ this.props.showBack && <HeaderBack /> }
 				<FeedHeader feed={ feed } site={ this.state.site } />
 			</FollowingStream>

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -144,7 +144,7 @@ var FeedStream = React.createClass( {
 		}
 
 		return (
-			<FollowingStream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent }>
+			<FollowingStream { ...this.props } listName={ this.state.title } emptyContent={ emptyContent } showPostHeader={ false }>
 				{ this.props.showBack && <HeaderBack /> }
 				<FeedHeader feed={ feed } site={ this.state.site } />
 			</FollowingStream>

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -2,7 +2,7 @@
 .reader__card.card {
 	padding: 16px;
 	transition: all 0.1s ease-in-out;
-	margin-bottom: 8px;
+	margin-bottom: 15px;
 
 	@include breakpoint( ">480px" ) {
 		padding: 16px 24px 24px 24px;
@@ -15,7 +15,7 @@
 		&.tag-afk.is-selected,
 		&.tag-afk:hover {
 			box-shadow: 0 0 0 1px $gray,
-						0 2px 4px lighten( $gray, 20 );
+						0 2px 4px lighten( $gray, 20% );
 		}
 	}
 
@@ -45,7 +45,7 @@
 		margin: 8px 0;
 		padding: 0;
 		font-size: 14px;
-		color: lighten( $gray, 10 );
+		color: lighten( $gray, 10% );
 
 		.gravatar {
 			height: 16px;
@@ -91,11 +91,11 @@
 
 	&.is-headerless {
 		@include breakpoint( ">480px" ) {
-			padding-top: 24px;
+			padding-top: 25px;
 		}
 
 		.reader__post-title {
-			margin-top: 0px;
+			margin-top: 0;
 		}
 
 		&.has-featured-image {

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -89,6 +89,20 @@
 		}
 	}
 
+	&.is-headerless {
+		padding-top: 0;
+
+		.reader__post-title {
+			padding-top: 16px;
+		}
+
+		&.has-featured-image {
+			.reader__post-title {
+				padding-top: 0;
+			}
+		}
+	}
+
 	.post-excerpt-only {
 		p {
 			margin-bottom: 1em;

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -5,7 +5,7 @@
 	margin-bottom: 8px;
 
 	@include breakpoint( ">480px" ) {
-		padding: 16px 24px 24px;
+		padding: 16px 24px 24px 24px;
 		margin-bottom: 24px;
 
 		&.is-selected,
@@ -90,16 +90,16 @@
 	}
 
 	&.is-headerless {
-		padding-top: 0;
+		@include breakpoint( ">480px" ) {
+			padding-top: 24px;
+		}
 
 		.reader__post-title {
-			padding-top: 16px;
+			margin-top: 0px;
 		}
 
 		&.has-featured-image {
-			.reader__post-title {
-				padding-top: 0;
-			}
+			padding-top: 0;
 		}
 	}
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -438,13 +438,10 @@ module.exports = React.createClass( {
 				</MobileBackToSidebar>
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.handleUpdateClick } />
-
 				{ header }
-
 				{ body }
-
 			</Main>
-			);
+		);
 	}
 
 } );

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -56,6 +56,7 @@ module.exports = React.createClass( {
 		store: React.PropTypes.object.isRequired,
 		trackScrollPage: React.PropTypes.func.isRequired,
 		suppressSiteNameLink: React.PropTypes.bool,
+		showPostHeader: React.PropTypes.bool,
 		showFollowInHeader: React.PropTypes.bool,
 		onUpdatesShown: React.PropTypes.func,
 		emptyContent: React.PropTypes.object,
@@ -64,6 +65,7 @@ module.exports = React.createClass( {
 
 	getDefaultProps: function() {
 		return {
+			showPostHeader: true,
 			suppressSiteNameLink: false,
 			showFollowInHeader: false,
 			onShowUpdates: noop,
@@ -302,7 +304,7 @@ module.exports = React.createClass( {
 			placeholders = [];
 
 		times( count, function( i ) {
-			placeholders.push( <PostPlaceholder key={'feed-post-placeholder-' + i} /> );
+			placeholders.push( <PostPlaceholder key={ 'feed-post-placeholder-' + i } /> );
 		} );
 
 		return placeholders;
@@ -326,11 +328,11 @@ module.exports = React.createClass( {
 
 	showFullPost: function( post, options ) {
 		options = options || {};
-		var hashtag = '';
-		if ( options[ 'comments' ] ) {
+		let hashtag = '';
+		if ( options.comments ) {
 			hashtag += '#comments';
 		}
-		var method = options && options.replaceHistory ? 'replace' : 'show';
+		const method = options && options.replaceHistory ? 'replace' : 'show';
 		if ( post.feed_ID && post.feed_item_ID ) {
 			page[ method ]( '/read/feeds/' + post.feed_ID + '/posts/' + post.feed_item_ID + hashtag );
 		} else {
@@ -353,8 +355,8 @@ module.exports = React.createClass( {
 					if ( isSelected ) {
 						this._selectedGap = c;
 					}
-				}}
-				key={'gap-' + postKey.from + '-' + postKey.to}
+				} }
+				key={ 'gap-' + postKey.from + '-' + postKey.to }
 				gap={ postKey }
 				selected={ isSelected }
 				store={ this.props.store } />
@@ -372,10 +374,10 @@ module.exports = React.createClass( {
 
 		switch ( postState ) {
 			case 'pending':
-				content = <PostPlaceholder key={'feed-post-placeholder-' + itemKey} />;
+				content = <PostPlaceholder key={ 'feed-post-placeholder-' + itemKey } />;
 				break;
 			case 'error':
-				content = <PostUnavailable key={'feed-post-unavailable-' + itemKey} post={ post } />;
+				content = <PostUnavailable key={ 'feed-post-unavailable-' + itemKey } post={ post } />;
 				break;
 			default:
 				PostClass = cardClassForPost( post );
@@ -398,6 +400,7 @@ module.exports = React.createClass( {
 						isSelected: isSelected,
 						xPostedTo: this.props.store.getSitesCrossPostedTo( post.URL ),
 						suppressSiteNameLink: this.props.suppressSiteNameLink,
+						showPostHeader: this.props.showPostHeader,
 						showFollowInHeader: this.props.showFollowInHeader,
 						handleClick: this.showFullPost
 					} );
@@ -421,13 +424,13 @@ module.exports = React.createClass( {
 			ref={ ( c ) => this._list = c }
 			className="reader__content"
 			items={ this.state.posts }
-			lastPage={ this.props.store.isLastPage()}
-			fetchingNextPage={ this.props.store.isFetchingNextPage()}
+			lastPage={ this.props.store.isLastPage() }
+			fetchingNextPage={ this.props.store.isFetchingNextPage() }
 			guessedItemHeight={ GUESSED_POST_HEIGHT }
 			fetchNextPage={ this.fetchNextPage }
 			getItemRef= { this.getPostRef }
 			renderItem={ this.renderPost }
-			selectedIndex={ this.props.store.getSelectedIndex()}
+			selectedIndex={ this.props.store.getSelectedIndex() }
 			renderLoadingPlaceholders={ this.renderLoadingPlaceholders } /> );
 		}
 

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -57,9 +57,10 @@ const Post = React.createClass( {
 		isSelected: React.PropTypes.bool.isRequired,
 		xPostedTo: React.PropTypes.array,
 		suppressSiteNameLink: React.PropTypes.bool,
+		showPostHeader: React.PropTypes.bool,
 		showFollowInHeader: React.PropTypes.bool,
 		additionalClasses: React.PropTypes.object,
-		handleClick: React.PropTypes.func.isRequired
+		handleClick: React.PropTypes.func.isRequired,
 	},
 
 	smartSetState: smartSetState,
@@ -386,7 +387,7 @@ const Post = React.createClass( {
 
 				<PostErrors post={ post } />
 
-				<PostHeader site={ site } siteUrl={ post.site_URL } showFollow={ this.props.showFollowInHeader } onSiteSelect={ this.pickSite } onSiteClick={ this.handleSiteClick } />
+				{ this.props.showPostHeader ? <PostHeader site={ site } siteUrl={ post.site_URL } showFollow={ this.props.showFollowInHeader } onSiteSelect={ this.pickSite } onSiteClick={ this.handleSiteClick } /> : null }
 
 				{ featuredImage }
 

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-var ReactDom = require( 'react-dom' ),
+const ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	assign = require( 'lodash/assign' ),
@@ -18,17 +18,17 @@ var ReactDom = require( 'react-dom' ),
 /**
  * Internal Dependencies
  */
-var Card = require( 'components/card' ),
+const Card = require( 'components/card' ),
 	CommentButton = require( 'components/comment-button' ),
 	DISPLAY_TYPES = require( 'lib/feed-post-store/display-types' ),
 	LikeButton = require( 'reader/like-button' ),
 	ObserveWindowSizeMixin = require( 'lib/mixins/observe-window-resize' ),
+	PostHeader = require( 'reader/post-header' ),
 	PostByline = require( 'reader/post-byline' ),
 	PostImages = require( 'reader/post-images' ),
 	PostOptions = require( 'reader/post-options' ),
 	PostErrors = require( 'reader/post-errors' ),
 	PostExcerpt = require( 'components/post-excerpt' ),
-	Site = require( 'my-sites/site' ),
 	SiteStore = require( 'lib/reader-site-store' ),
 	SiteStoreActions = require( 'lib/reader-site-store/actions' ),
 	Share = require( 'reader/share' ),
@@ -45,11 +45,10 @@ var Card = require( 'components/card' ),
 	DiscoverSiteAttribution = require( 'reader/discover/site-attribution' ),
 	DiscoverHelper = require( 'reader/discover/helper' ),
 	FeedPostStore = require( 'lib/feed-post-store' ),
-	FollowButton = require( 'reader/follow-button' ),
 	Gridicon = require( 'components/gridicon' ),
 	smartSetState = require( 'lib/react-smart-set-state' );
 
-var Post = React.createClass( {
+const Post = React.createClass( {
 
 	mixins: [ PureRenderMixin, ObserveWindowSizeMixin ],
 
@@ -387,13 +386,7 @@ var Post = React.createClass( {
 
 				<PostErrors post={ post } />
 
-				<div className="reader__post-header">
-					{ this.props.showFollowInHeader ? <FollowButton siteUrl={ post.site_URL } /> : null }
-					<Site site={ site }
-						href={ post.site_URL }
-						onSelect={ this.pickSite }
-						onClick={ this.handleSiteClick } />
-				</div>
+				<PostHeader site={ site } siteUrl={ post.site_URL } showFollow={ this.props.showFollowInHeader } onSiteSelect={ this.pickSite } onSiteClick={ this.handleSiteClick } />
 
 				{ featuredImage }
 

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -358,6 +358,10 @@ const Post = React.createClass( {
 			articleClasses[ 'feed-' + post.feed_ID ] = true;
 		}
 
+		if ( ! this.props.showPostHeader ) {
+			articleClasses[ 'is-headerless' ] = true;
+		}
+
 		forOwn( post.tags, ( { slug } ) => {
 			articleClasses[ 'tag-' + slug ] = true;
 		} );

--- a/client/reader/post-header/index.jsx
+++ b/client/reader/post-header/index.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import Site from 'my-sites/site';
+import FollowButton from 'reader/follow-button';
+
+const PostHeader = ( { site, siteUrl, showFollow, onSiteSelect, onSiteClick } ) => (
+	<div className="reader__post-header">
+		{ showFollow ? <FollowButton siteUrl={ siteUrl } /> : null }
+		<Site site={ site }
+			href={ siteUrl }
+			onSelect={ onSiteSelect }
+			onClick={ onSiteClick } />
+	</div>
+);
+
+PostHeader.propTypes = {
+	site: React.PropTypes.object,
+	siteUrl: React.PropTypes.string,
+	showFollow: React.PropTypes.bool,
+	onSiteSelect: React.PropTypes.func,
+	onSiteClick: React.PropTypes.func
+};
+
+PostHeader.defaultProps = {
+	showFollow: false,
+	onSiteSelect: noop,
+	onSiteClick: noop
+};
+
+export default PostHeader;

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -141,7 +141,7 @@ const SiteStream = React.createClass( {
 		}
 
 		return (
-			<FollowingStream { ...this.props } listName={ title } emptyContent={ emptyContent }>
+			<FollowingStream { ...this.props } listName={ title } emptyContent={ emptyContent } showPostHeader={ false }>
 				{ this.props.showBack && <HeaderBack /> }
 				<FeedHeader site={ this.state.site } feed={ this.state.feed }/>
 				{ featuredContent }


### PR DESCRIPTION
On feed and blog streams, the post card header has no purpose, and clicking it doesn't take you anywhere. This PR removes it for those streams only.

Before:

<img width="783" alt="screen shot 2016-03-01 at 11 57 06" src="https://cloud.githubusercontent.com/assets/17325/13411930/c2bca66e-dfa4-11e5-8db0-e3e6c4897e9d.png">

After:

<img width="780" alt="screen shot 2016-03-01 at 12 46 56" src="https://cloud.githubusercontent.com/assets/17325/13412962/c425126e-dfab-11e5-8d77-14847481cf22.png">
<img width="793" alt="screen shot 2016-03-01 at 12 47 10" src="https://cloud.githubusercontent.com/assets/17325/13412963/c4273896-dfab-11e5-8f57-7beb866846e7.png">

Example streams:

http://calypso.localhost:3000/read/feeds/40474296
http://calypso.localhost:3000/read/blogs/82798297

Fixes #3639.