### PR TITLE
Editor: Remove post-editor feature flag

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -255,7 +255,6 @@ function reduxStoreReady( reduxStore ) {
 		if ( /.php$/.test( path ) ||
 				/^\/?$/.test( path ) && ! config.isEnabled( 'reader' ) ||
 				/^\/my-stats/.test( path ) ||
-				/^\/(post\b|page\b)/.test( path ) && ! config.isEnabled( 'post-editor' ) ||
 				/^\/notifications/.test( path ) ||
 				/^\/themes/.test( path ) ||
 				/^\/manage/.test( path ) ||

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -8,7 +8,6 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import MasterbarItem from './item';
-import config from 'config';
 import SitesPopover from 'components/sites-popover';
 import paths from 'lib/paths';
 import viewport from 'lib/viewport';
@@ -49,7 +48,7 @@ export default React.createClass( {
 		const visibleSiteCount = this.props.user.get().visible_site_count;
 
 		// if multi-site and editor enabled, show site-selector
-		if ( visibleSiteCount > 1 && config.isEnabled( 'post-editor' ) ) {
+		if ( visibleSiteCount > 1 ) {
 			this.toggleSitesPopover();
 			event.preventDefault();
 			return;

--- a/client/lib/paths/index.js
+++ b/client/lib/paths/index.js
@@ -1,13 +1,8 @@
-/**
- * Internal dependencies
- */
-var config = require( 'config' );
-
 function editorPathFromSite( site ) {
 	var path = '',
 		siteSlug;
 
-	if ( config.isEnabled( 'post-editor' ) && site ) {
+	if ( site ) {
 		siteSlug = ( typeof site === 'object' ) ? site.slug : site;
 		path = '/' + siteSlug;
 	} else if ( site && typeof site === 'object' ) {
@@ -24,16 +19,8 @@ function editorPathFromSite( site ) {
  * @return {string}      URL to post editor
  */
 module.exports.newPost = function( site ) {
-	var sitePath = editorPathFromSite( site ),
-		url;
-
-	if ( config.isEnabled( 'post-editor' ) ) {
-		url = '/post' + sitePath;
-	} else {
-		url = '//wordpress.com/post' + sitePath;
-	}
-
-	return url;
+	var sitePath = editorPathFromSite( site );
+	return '/post' + sitePath;
 };
 
 /**
@@ -43,16 +30,8 @@ module.exports.newPost = function( site ) {
  * @return {string}      URL to page editor
  */
 module.exports.newPage = function( site ) {
-	var sitePath = editorPathFromSite( site ),
-		url;
-
-	if ( config.isEnabled( 'post-editor' ) ) {
-		url = '/page' + sitePath;
-	} else {
-		url = '//wordpress.com/page' + sitePath;
-	}
-
-	return url;
+	var sitePath = editorPathFromSite( site );
+	return '/page' + sitePath;
 };
 
 /**

--- a/client/lib/paths/test/index.js
+++ b/client/lib/paths/test/index.js
@@ -1,14 +1,12 @@
 /**
  * External dependencies
  */
-var expect = require( 'chai' ).expect,
-	sinon = require( 'sinon' );
+var expect = require( 'chai' ).expect;
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	paths = require( '../' );
+var paths = require( '../' );
 
 /**
  * Module variables
@@ -19,95 +17,29 @@ var DUMMY_SITE = {
 };
 
 describe( 'paths', function() {
-	var sandbox;
-
-	before( function() {
-		sandbox = sinon.sandbox.create();
-	} );
-
-	beforeEach( function() {
-		sandbox.restore();
-	} );
-
-	function stubPostEditorFeatureEnabled( isEnabled ) {
-		sandbox.stub( config, 'isEnabled', function( feature ) {
-			if ( 'post-editor' === feature ) {
-				return isEnabled;
-			}
-		} );
-	}
-
 	describe( '#newPost()', function() {
-		it( 'should return the live root post path if no site and feature disabled', function() {
-			var url;
-			stubPostEditorFeatureEnabled( false );
-
-			url = paths.newPost();
-
-			expect( url ).to.equal( '//wordpress.com/post' );
-		} );
-
-		it( 'should return a live site-prefixed post path if site exists, but feature disabled', function() {
-			var url;
-			stubPostEditorFeatureEnabled( false );
-
-			url = paths.newPost( DUMMY_SITE );
-
-			expect( url ).to.equal( '//wordpress.com/post/' + DUMMY_SITE.ID + '/new' );
-		} );
-
-		it( 'should return the Calypso root post path no site and featured enabled', function() {
-			var url;
-			stubPostEditorFeatureEnabled( true );
-
-			url = paths.newPost();
+		it( 'should return the Calypso root post path no site', function() {
+			var url = paths.newPost();
 
 			expect( url ).to.equal( '/post' );
 		} );
 
-		it( 'should return a Calypso site-prefixed post path if site exists and featured enabled', function() {
-			var url;
-			stubPostEditorFeatureEnabled( true );
-
-			url = paths.newPost( DUMMY_SITE );
+		it( 'should return a Calypso site-prefixed post path if site exists', function() {
+			var url = paths.newPost( DUMMY_SITE );
 
 			expect( url ).to.equal( '/post/' + DUMMY_SITE.slug );
 		} );
 	} );
 
 	describe( '#newPage()', function() {
-		it( 'should return the live root page path if no site and feature disabled', function() {
-			var url;
-			stubPostEditorFeatureEnabled( false );
-
-			url = paths.newPage();
-
-			expect( url ).to.equal( '//wordpress.com/page' );
-		} );
-
-		it( 'should return a live site-prefixed page path if site exists, but feature disabled', function() {
-			var url;
-			stubPostEditorFeatureEnabled( false );
-
-			url = paths.newPage( DUMMY_SITE );
-
-			expect( url ).to.equal( '//wordpress.com/page/' + DUMMY_SITE.ID + '/new' );
-		} );
-
-		it( 'should return the Calypso root page path no site and featured enabled', function() {
-			var url;
-			stubPostEditorFeatureEnabled( true );
-
-			url = paths.newPage();
+		it( 'should return the Calypso root page path no site', function() {
+			var url = paths.newPage();
 
 			expect( url ).to.equal( '/page' );
 		} );
 
-		it( 'should return a Calypso site-prefixed page path if site exists and featured enabled', function() {
-			var url;
-			stubPostEditorFeatureEnabled( true );
-
-			url = paths.newPage( DUMMY_SITE );
+		it( 'should return a Calypso site-prefixed page path if site exists', function() {
+			var url = paths.newPage( DUMMY_SITE );
 
 			expect( url ).to.equal( '/page/' + DUMMY_SITE.slug );
 		} );

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -9,21 +9,12 @@ var url = require( 'url' ),
  * Internal dependencies
  */
 var postNormalizer = require( 'lib/post-normalizer' ),
-	config = require( 'config' ),
 	sites = require( 'lib/sites-list' )();
 
 var utils = {
 
 	getEditURL: function( post, site ) {
-		var editURL;
-
-		if ( config.isEnabled( 'post-editor' ) ) {
-			editURL = `/${post.type}/${site.slug}/${post.ID}`;
-		} else {
-			editURL = `//wordpress.com/${post.type}/${site.ID}/${post.ID}/`;
-		}
-
-		return editURL;
+		return `/${post.type}/${site.slug}/${post.ID}`;
 	},
 
 	getPreviewURL: function( post ) {

--- a/client/my-sites/posts/post-controls.jsx
+++ b/client/my-sites/posts/post-controls.jsx
@@ -80,7 +80,7 @@ module.exports = React.createClass( {
 				text: this.translate( 'Edit' ),
 				className: 'post-controls__edit',
 				href: this.props.editURL,
-				target: config.isEnabled( 'post-editor' ) ? null : '_blank',
+				target: null,
 				onClick: this.edit,
 				icon: 'pencil'
 			} );

--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -19,7 +19,6 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	EmptyContent = require( 'components/empty-content' ),
 	InfiniteList = require( 'components/infinite-list' ),
 	NoResults = require( 'my-sites/no-results' ),
-	config = require( 'config' ),
 	route = require( 'lib/route' ),
 	mapStatus = route.mapPostStatus;
 
@@ -158,12 +157,7 @@ var Posts = React.createClass( {
 					} )	}
 			/>;
 		} else {
-
-			if ( config.isEnabled( 'post-editor' ) ) {
-				newPostLink = this.props.siteID ? '/post/' + this.props.siteID : '/post';
-			} else {
-				newPostLink = selectedSite ? '//wordpress.com/post/' + selectedSite.ID + '/new' : '//wordpress.com/post';
-			}
+			newPostLink = this.props.siteID ? '/post/' + this.props.siteID : '/post';
 
 			if ( this.props.hasRecentError ) {
 				attributes = {

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -8,8 +8,7 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	Card = require( 'components/card' ),
+var Card = require( 'components/card' ),
 	Gridicon = require( 'components/gridicon' ),
 	PostRelativeTimeStatus = require( 'my-sites/post-relative-time-status' ),
 	PostControls = require( './post-controls' ),
@@ -352,8 +351,7 @@ module.exports = React.createClass({
 	},
 
 	getContentLinkTarget: function() {
-		if ( config.isEnabled( 'post-editor' ) &&
-				utils.userCan( 'edit_post', this.props.post ) ) {
+		if ( utils.userCan( 'edit_post', this.props.post ) ) {
 			return null;
 		}
 

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -48,13 +48,7 @@ var PublishMenu = React.createClass( {
 	},
 
 	getDefaultMenuItems: function( site ) {
-		var newPostLink;
-
-		if ( config.isEnabled( 'post-editor' ) ) {
-			newPostLink = site ? '/post/' + site.slug : '/post';
-		} else {
-			newPostLink = site ? '//wordpress.com/post/' + site.ID + '/new' : '//wordpress.com/post';
-		}
+		var newPostLink = site ? '/post/' + site.slug : '/post';
 
 		return [
 			{

--- a/client/my-sites/site-settings/press-this-link.jsx
+++ b/client/my-sites/site-settings/press-this-link.jsx
@@ -7,7 +7,6 @@ import React, { PropTypes } from 'react';
  * Internal dependencies
  */
 import paths from 'lib/paths';
-import config from 'config';
 
 /**
  * Retrieves selection, title, and URL from current page and pops
@@ -85,9 +84,8 @@ class PressThisLink extends React.Component {
 	}
 
 	render() {
-		const pressThisLink = config.isEnabled( 'post-editor' ) ? this.buildPressThisLink() : this.pressThisWPAdmin();
 		return (
-			<a {...this.props} href={ pressThisLink }>
+			<a {...this.props} href={ this.buildPressThisLink() }>
 				{ this.props.children }
 			</a>
 		);

--- a/client/nux-welcome/welcome-message.jsx
+++ b/client/nux-welcome/welcome-message.jsx
@@ -45,7 +45,7 @@ module.exports = React.createClass( {
 			customizeEnabled = true;
 
 		if ( welcomeSite ) {
-			postLink = config.isEnabled( 'post-editor' ) ? '/post/' + welcomeSite.slug : '//wordpress.com/post/' + welcomeSite.ID + '/new';
+			postLink = '/post/' + welcomeSite.slug;
 			customizeLink = config.isEnabled( 'manage/customize' ) ? '/customize/' + welcomeSite.slug : adminURL + 'customize.php?return=' + encodeURIComponent( window.location.href );
 			sharingLink = config.isEnabled( 'manage/sharing' ) ? '/sharing/' + welcomeSite.slug : adminURL + 'options-general.php?page=sharing';
 		}

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -11,11 +11,9 @@ var config = require( 'config' ),
 	controller = require( './controller' );
 
 module.exports = function() {
-	if ( config.isEnabled( 'post-editor' ) ) {
-		page( '/post', controller.pressThis, sitesController.siteSelection, sitesController.sites );
-		page( '/post/new', () => page.redirect( '/post' ) ); // redirect from beep-beep-boop
-		page( '/post/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
-	}
+	page( '/post', controller.pressThis, sitesController.siteSelection, sitesController.sites );
+	page( '/post/new', () => page.redirect( '/post' ) ); // redirect from beep-beep-boop
+	page( '/post/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
 
 	if ( config.isEnabled( 'post-editor/pages' ) ) {
 		page( '/page', sitesController.siteSelection, sitesController.sites );

--- a/client/sections.js
+++ b/client/sections.js
@@ -122,19 +122,17 @@ if ( config.isEnabled( 'reader' ) ) {
 	} );
 }
 
-if ( config.isEnabled( 'post-editor' ) ) {
-	editorPaths = [ '/post' ];
+editorPaths = [ '/post' ];
 
-	if ( config.isEnabled( 'post-editor/pages' ) ) {
-		editorPaths.push( '/page' );
-	}
-
-	sections.push( {
-		name: 'post-editor',
-		paths: editorPaths,
-		module: 'post-editor'
-	} );
+if ( config.isEnabled( 'post-editor/pages' ) ) {
+	editorPaths.push( '/page' );
 }
+
+sections.push( {
+	name: 'post-editor',
+	paths: editorPaths,
+	module: 'post-editor'
+} );
 
 if ( config.isEnabled( 'devdocs' ) ) {
 	sections.push( {

--- a/client/sections.js
+++ b/client/sections.js
@@ -1,13 +1,18 @@
 var config = require( 'config' ),
 	readerPaths;
 
-var sections, editorPaths;
+var sections;
 
 sections = [
 	{
 		name: 'customize',
 		paths: [ '/customize' ],
 		module: 'my-sites/customize'
+	},
+	{
+		name: 'post-editor',
+		paths: [ '/post', '/page' ],
+		module: 'post-editor'
 	},
 	{
 		name: 'me',
@@ -121,18 +126,6 @@ if ( config.isEnabled( 'reader' ) ) {
 		module: 'reader'
 	} );
 }
-
-editorPaths = [ '/post' ];
-
-if ( config.isEnabled( 'post-editor/pages' ) ) {
-	editorPaths.push( '/page' );
-}
-
-sections.push( {
-	name: 'post-editor',
-	paths: editorPaths,
-	module: 'post-editor'
-} );
 
 if ( config.isEnabled( 'devdocs' ) ) {
 	sections.push( {

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -60,7 +60,6 @@
 		"olark_use_wpcom_configuration": false,
 		"persist-redux": false,
 		"phone_signup": true,
-		"post-editor": true,
 		"post-editor/author-selector": true,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -60,7 +60,6 @@
 		"olark_use_wpcom_configuration": true,
 		"persist-redux": false,
 		"phone_signup": true,
-		"post-editor": true,
 		"post-editor/author-selector": true,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,

--- a/config/development.json
+++ b/config/development.json
@@ -89,7 +89,6 @@
 		"perfmon": false,
 		"persist-redux": false,
 		"phone_signup": true,
-		"post-editor": true,
 		"post-editor-github-link": false,
 		"post-editor/contact-form": true,
 		"post-editor/iframe-preview": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -65,7 +65,6 @@
 		"perfmon": true,
 		"persist-redux": false,
 		"phone_signup": false,
-		"post-editor": true,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/pages": true,

--- a/config/production.json
+++ b/config/production.json
@@ -57,7 +57,6 @@
 		"olark_use_wpcom_configuration": true,
 		"perfmon": true,
 		"persist-redux": false,
-		"post-editor": true,
 		"post-editor/author-selector": true,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -61,7 +61,6 @@
 		"olark_use_wpcom_configuration": true,
 		"perfmon": true,
 		"persist-redux": false,
-		"post-editor": true,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/pages": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -70,7 +70,6 @@
 		"perfmon": true,
 		"persist-redux": false,
 		"phone_signup": true,
-		"post-editor": true,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/pages": true,


### PR DESCRIPTION
For #3676 - This branch removes all usage of the config flag `post-editor`.  Trying to keep PRs as small as possible for these flag removals, so I will follow up with other PRs for the remaining editor feature flags.

### To Test
Interact with various editor paths from calypso.  Open a new post to edit, click the edit button on a post in the posts list, and the ADD button in the sidebar and masterbar.