### PR TITLE
Reader: add stream header to empty streams

### DIFF
--- a/client/components/follow-button/style.scss
+++ b/client/components/follow-button/style.scss
@@ -87,8 +87,8 @@
 
 	.gridicon {
 		position: absolute;
-		top: 8px;
-		left: 13px;
+		top: 7px;
+		left: 18px;
 		fill: lighten( $gray, 10 );
 		transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 	}

--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -140,7 +140,7 @@
 .feed-header__details {
 	margin: 24px 0 46px 0;
 	text-align: center;
-	border-bottom: 1px solid lighten( $gray, 20 );
+	border-bottom: 1px solid lighten( $gray, 20% );
 }
 
 .feed-header__description {

--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -26,7 +26,7 @@
 		}
 
 		.gridicon {
-			top: 6px;
+			top: 5px;
 			left: 14px;
 		}
 

--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -25,6 +25,11 @@
 			color: $gray;
 		}
 
+		.gridicon {
+			top: 6px;
+			left: 14px;
+		}
+
 		&:hover {
 			background: none;
 
@@ -121,12 +126,13 @@
 .feed-header__follow {
 	.follow-button {
 		position: absolute;
-			top: 16px;
+			top: 12px;
 			right: 8px;
 
-		@include breakpoint( "<660px" ) {
-			top: 8px;
-			right: 0;
+		@include breakpoint( ">480px" ) {
+			position: absolute;
+				top: 20px;
+				right: 0;
 		}
 	}
 }

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -33,7 +33,7 @@ var FeedEmptyContent = React.createClass( {
 					href="/recommendations">{ this.translate( 'Get recommendations on who to follow' ) }</a> );
 
 		return ( <EmptyContent
-			title={ this.translate( 'No recent posts…' ) }
+			title={ this.translate( 'No recent posts' ) }
 			line={ this.translate( 'This site has not posted anything recently.' ) }
 			action={ action }
 			secondaryAction={ secondaryAction }

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -413,13 +413,11 @@ module.exports = React.createClass( {
 	render: function() {
 		var store = this.props.store,
 			hasNoPosts = store.isLastPage() && ( ( ! this.state.posts ) || this.state.posts.length === 0 ),
-			header, body;
+			body;
 
 		if ( hasNoPosts || store.hasRecentError( 'invalid_tag' ) ) {
-			header = null;
 			body = this.props.emptyContent || ( <EmptyContent /> );
 		} else {
-			header = this.props.children;
 			body = ( <InfiniteList
 			ref={ ( c ) => this._list = c }
 			className="reader__content"
@@ -441,7 +439,7 @@ module.exports = React.createClass( {
 				</MobileBackToSidebar>
 
 				<UpdateNotice count={ this.state.updateCount } onClick={ this.handleUpdateClick } />
-				{ header }
+				{ this.props.children }
 				{ body }
 			</Main>
 		);

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -31,7 +31,7 @@ var ListEmptyContent = React.createClass( {
 				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
 
 		return ( <EmptyContent
-			title={ this.translate( 'No recent posts…' ) }
+			title={ this.translate( 'No recent posts' ) }
 			line={ this.translate( 'The sites in this list have not posted anything recently.' ) }
 			action={ action }
 			secondaryAction={ secondaryAction }

--- a/client/reader/stream-header/style.scss
+++ b/client/reader/stream-header/style.scss
@@ -142,7 +142,7 @@
 		}
 
 		.gridicon {
-			top: 6px;
+			top: 5px;
 			left: 14px;
 		}
 	}

--- a/client/reader/stream-header/style.scss
+++ b/client/reader/stream-header/style.scss
@@ -134,11 +134,16 @@
 .stream-header__follow {
 	.follow-button {
 		position: absolute;
-			top: 12px;
+			top: 14px;
 			right: 8px;
 
 		@include breakpoint( "<660px" ) {
 			right: 0;
+		}
+
+		.gridicon {
+			top: 6px;
+			left: 14px;
 		}
 	}
 }

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -42,7 +42,7 @@ var TagEmptyContent = React.createClass( {
 		);
 
 		return ( <EmptyContent
-			title={ this.translate( 'No recent posts…' ) }
+			title={ this.translate( 'No recent posts' ) }
 			line={ message }
 			action={ action }
 			secondaryAction={ secondaryAction }


### PR DESCRIPTION
Even if a Reader stream has no posts, it should still have a stream header. This PR adds one to feed, blog, list and tag streams.

Before:

<img width="1137" alt="screen shot 2016-03-01 at 17 02 05" src="https://cloud.githubusercontent.com/assets/17325/13417320/6d9a34a0-dfcf-11e5-862a-464582e940dd.png">

After:

<img width="1130" alt="screen shot 2016-03-01 at 17 02 33" src="https://cloud.githubusercontent.com/assets/17325/13417321/7213b420-dfcf-11e5-8181-e43e543bf2af.png">

#### Examples

Empty feed stream: http://calypso.localhost:3000/read/feeds/20742056
Empty blog stream: http://calypso.localhost:3000/read/blogs/78990520
Empty list stream: http://calypso.localhost:3000/read/list/bluefuton/2016-01
Empty tag stream: http://calypso.localhost:3000/tag/discoverburt