### PR TITLE
Offline: enables sync-handler in the staging environment

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -79,6 +79,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
+		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-management/contacts-privacy": true,


### PR DESCRIPTION
Enables the sync-handler (api caching layer) in our staging environment. It's already been enabled in development, wpcalypso, and horizon. I'm going to merge this in, as there isn't really anything to review.