### PR TITLE
Plans: AB Test: Promote free domains

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -13,6 +13,7 @@ var abtest = require( 'lib/abtest' ).abtest,
 	testFeatures = require( 'lib/features-list/test-features' ),
 	Gridicon = require( 'components/gridicon' ),
 	isJetpackPlan = require( 'lib/products-values' ).isJetpackPlan,
+	isPlan = require( 'lib/products-values' ).isPlan,
 	JetpackPlanDetails = require( 'my-sites/plans/jetpack-plan-details' ),
 	PlanActions = require( 'components/plans/plan-actions' ),
 	PlanHeader = require( 'components/plans/plan-header' ),
@@ -249,6 +250,25 @@ module.exports = React.createClass( {
 		);
 	},
 
+	getFreeDomainMessage: function() {
+		if ( abtest( 'promoteFreeDomain' ) !== 'freeDomain' ) {
+			return null;
+		}
+
+		if ( this.props.plan && isPlan( this.props.plan ) ) {
+			return (
+				<div className="plan__free-domain-message">
+					<Gridicon icon="checkmark" size={ 12 } />
+					{ this.translate( 'Includes a free domain' ) }
+				</div>
+			);
+		}
+
+		return (
+			<div className="plan__free-plan-message">&nbsp;</div>
+		);
+	},
+
 	render: function() {
 		var shouldDisplayFeatureList = this.props.plan && ! isJetpackPlan( this.props.plan ) && abtest( 'plansFeatureList' ) !== 'description';
 		return (
@@ -261,6 +281,7 @@ module.exports = React.createClass( {
 
 					{ this.getImagePlanAction() }
 					{ this.getPlanPrice() }
+					{ this.getFreeDomainMessage() }
 				</PlanHeader>
 				<div className="plan__plan-expand">
 					<div className="plan__plan-details">

--- a/client/components/plans/plan/style.scss
+++ b/client/components/plans/plan/style.scss
@@ -169,3 +169,27 @@
 		left: -5px;
 		top: 2px;
 }
+
+.plan__free-plan-message {
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+}
+
+.plan__free-domain-message {
+	color: $alert-green;
+	font-size: 13px;
+
+	@include breakpoint( "<660px" ) {
+		padding-left: 40px;
+	}
+
+	@include breakpoint( ">660px" ) {
+		margin-top: 5px;
+		text-align: center;
+	}
+
+	.gridicon {
+		margin-right: 5px;
+	}
+}

--- a/client/components/plans/plan/style.scss
+++ b/client/components/plans/plan/style.scss
@@ -97,6 +97,14 @@
 		border-top: 2px solid lighten( $gray, 20% );
 		float: left;
 	}
+
+	.plan__free-plan-message {
+		display: none;
+	}
+
+	.plan__free-domain-message {
+		padding-left: 40px;
+	}
 }
 
 @mixin plans-in-three-columns() {
@@ -132,6 +140,11 @@
 			flex-direction: row;
 			flex-wrap: nowrap;
 			justify-content: center;
+	}
+
+	.plan__free-domain-message {
+		margin-top: 5px;
+		text-align: center;
 	}
 }
 
@@ -170,24 +183,9 @@
 		top: 2px;
 }
 
-.plan__free-plan-message {
-	@include breakpoint( "<660px" ) {
-		display: none;
-	}
-}
-
 .plan__free-domain-message {
 	color: $alert-green;
 	font-size: 13px;
-
-	@include breakpoint( "<660px" ) {
-		padding-left: 40px;
-	}
-
-	@include breakpoint( ">660px" ) {
-		margin-top: 5px;
-		text-align: center;
-	}
 
 	.gridicon {
 		margin-right: 5px;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,4 +98,14 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
+	promoteFreeDomain: {
+		datestamp: '20160302',
+		variations: {
+			original: 50,
+			freeDomain: 50
+		},
+		defaultVariation: 'original',
+		excludeSitesWithPaidPlan: true
+	},
+
 };


### PR DESCRIPTION
This add some text promoting free plans to the plan selection page.

We are AB Testing this change.

<img width="587" alt="screen shot 2016-03-01 at 12 58 18" src="https://cloud.githubusercontent.com/assets/275961/13427651/4f57bdea-dfad-11e5-9c0e-e809ce19e7ab.png">
<img width="773" alt="screen shot 2016-03-01 at 12 58 10" src="https://cloud.githubusercontent.com/assets/275961/13427650/4f576b92-dfad-11e5-98ac-4f8174e62854.png">
 
#### Testing instructions

1. Run `git checkout fix/3590-free-domain-test` and start your server
2. Open the [`Signup` page](http://calypso.localhost:3000/start) in a private window
3. Set yourself to be in the AB test: `localStorage.setItem('ABTests','{"promoteFreeDomain_20160301":"freeDomain"}')`
3. Check that you see the "Includes a free domain" text under the plan name
3. Remove yourself from the AB test: `localStorage.setItem('ABTests','{"promoteFreeDomain_20160301":"original"}')`
3. Check that you don't see the "Includes a free domain" text under the plan name

#### Reviews

- [ ] Code
- [x] Product

pinging @breezyskies and @lucasartoni for review