### PR TITLE
Themes: Change theme details route from /themes to /theme

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -196,7 +196,7 @@ function reduxStoreReady( reduxStore ) {
 		if ( config.isEnabled( 'manage/themes/details' ) ) {
 			const themesRoutes = [
 				{ name: 'design', path: new Path( '/design' ) },
-				{ name: 'themes', path: new Path( '/themes/:theme_slug' ) },
+				{ name: 'theme', path: new Path( '/theme/:theme_slug' ) },
 			];
 
 			const matchedRoutes = themesRoutes

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -189,31 +189,17 @@ function reduxStoreReady( reduxStore ) {
 			translatorInvitation: translatorInvitation
 		} );
 	} else {
-		let props = {};
 		analytics.setSuperProps( superProps );
 
-		// TODO(ehg): Delete this mini-router when we have an isomorphic, single render tree routing solution
-		if ( config.isEnabled( 'manage/themes/details' ) ) {
-			const themesRoutes = [
-				{ name: 'design', path: new Path( '/design' ) },
-				{ name: 'theme', path: new Path( '/theme/:theme_slug' ) },
-			];
+		const isRoute = function( path ) {
+			return startsWith( window.location.pathname, path );
+		};
 
-			const matchedRoutes = themesRoutes
-				.map( r => ( Object.assign( {}, r, { match: r.path.partialMatch( window.location.pathname ) } ) ) )
-				.filter( r => r.match !== null );
-
-			if ( matchedRoutes.length ) {
-				props = { routeName: matchedRoutes[0].name, match: matchedRoutes[0].match };
-				Layout = require( 'layout/logged-out' );
-			}
-		} else if ( startsWith( window.location.pathname, '/design' ) ) {
+		if ( isRoute( '/design' ) ||
+			( config.isEnabled( 'manage/themes/details' ) && isRoute( '/theme' ) ) ) {
 			Layout = require( 'layout/logged-out' );
 		}
-
-		layoutElement = React.createElement( Layout, Object.assign( {}, props, {
-			focus: layoutFocus
-		} ) );
+		layoutElement = React.createElement( Layout, { focus: layoutFocus } );
 	}
 
 	if ( config.isEnabled( 'perfmon' ) ) {

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -50,7 +50,7 @@ var ThemesHelpers = {
 	},
 
 	getDetailsUrl: function( theme, site ) {
-		const baseUrl = config.isEnabled( 'manage/themes/details' ) ? '/themes/' : ThemesHelpers.oldShowcaseUrl;
+		const baseUrl = config.isEnabled( 'manage/themes/details' ) ? '/theme/' : ThemesHelpers.oldShowcaseUrl;
 
 		if ( ! site ) {
 			return baseUrl + theme.id;

--- a/client/my-sites/themes/index.js
+++ b/client/my-sites/themes/index.js
@@ -24,10 +24,10 @@ const designRoutes = isLoggedIn
 
 const themesRoutes = isLoggedIn
 	? {
-		'/themes/:slug/:section?/:site_id?': [ details ]
+		'/theme/:slug/:section?/:site_id?': [ details ],
 	}
 	: {
-		'/themes/:slug/:section?/:site_id?': [ details, makeLoggedOutLayout ]
+		'/theme/:slug/:section?': [ details, makeLoggedOutLayout ],
 	};
 
 const routes = Object.assign( {},

--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -113,9 +113,9 @@ export const ThemeSheet = React.createClass( {
 						<div className="themes__sheet-content">
 							<SectionNav className="themes__sheet-section-nav" selectedText={ filterStrings[section] }>
 								<NavTabs label="Details" >
-									<NavItem path={ `/themes/${ this.props.id }/details` } selected={ section === 'details' } >{ i18n.translate( 'Details' ) }</NavItem>
-									<NavItem path={ `/themes/${ this.props.id }/documentation` } selected={ section === 'documentation' } >{ i18n.translate( 'Documentation' ) }</NavItem>
-									<NavItem path={ `/themes/${ this.props.id }/support` } selected={ section === 'support' } >{ i18n.translate( 'Support' ) }</NavItem>
+									<NavItem path={ `/theme/${ this.props.id }/details` } selected={ section === 'details' } >{ i18n.translate( 'Details' ) }</NavItem>
+									<NavItem path={ `/theme/${ this.props.id }/documentation` } selected={ section === 'documentation' } >{ i18n.translate( 'Documentation' ) }</NavItem>
+									<NavItem path={ `/theme/${ this.props.id }/support` } selected={ section === 'support' } >{ i18n.translate( 'Support' ) }</NavItem>
 								</NavTabs>
 							</SectionNav>
 							<Card className="themes__sheet-content">{ themeContentElement }</Card>

--- a/client/sections.js
+++ b/client/sections.js
@@ -67,7 +67,7 @@ sections = [
 	},
 	{
 		name: 'themes',
-		paths: [ '/design', '/themes' ],
+		paths: [ '/design', '/theme' ],
 		module: 'my-sites/themes',
 		enableLoggedOut: config.isEnabled( 'manage/themes/logged-out' )
 	},

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -380,7 +380,7 @@ module.exports = function() {
 	} );
 
 	if ( config.isEnabled( 'manage/themes/details' ) ) {
-		app.get( '/themes/:theme_slug/:section?', function( req, res ) {
+		app.get( '/theme/:theme_slug/:section?', function( req, res ) {
 			function updateRenderCache( themeSlug ) {
 				wpcom.undocumented().themeDetails( themeSlug, ( error, data ) => {
 					if ( error ) {


### PR DESCRIPTION
Use /theme route to give more flexibility (allowing /themes to be used in the future for other things), and to allow deployment to production without a clash with Theme Showcase v4.

**To Test**
(compare against `master` branch or wpcalypso.wordpress.com)

1. check that old routes no longer work e.g. http://calypso.localhost:3000/themes/marquee/ (logged in/out)
2. check that new routes work e.g. http://calypso.localhost:3000/theme/marquee/ (logged in/out)
3. go to http://calypso.localhost:3000/design and check that the _details_ link in the ... button works for a theme
