### PR TITLE
Build: Make sure npm has an updated shrinkwrap to work with

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV     NODE_PATH /calypso/server:/calypso/client
 
 # Install base npm packages to take advantage of the docker cache
 COPY    ./package.json /calypso/package.json
+COPY    ./npm-shrinkwrap.json /calypso/npm-shrinkwrap.json
 RUN     npm install --production
 
 COPY     . /calypso


### PR DESCRIPTION
~~Hopefully avoids failed builds in the scenario when `npm` is working with a new package.json, but an old npm-shrinkwrap.json.~~

The problem with #3300 was that, in the `Dockerfile`, `npm install` is run before the local dependencies are copied.

The other failed builds I'm not sure of, as I don't think 'old' shrinkwraps persist between builds, but I could be wrong. /cc @nb 

I think this PR is still worth pursuing, as not having the `npm-shrinkwrap.json` available for `npm install` kind of defeats the purpose of using shrinkwrap. /cc @gwwar  Also, I've noted errors using a shrinkwrap with `npm shrinkwrap --dev` in the vagrant Docker setup, as some dev dependencies fail due to expecting a `darwin` arch.