### PR TITLE
PostNorm: When limiting to three elements, only count the top level

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -453,6 +453,7 @@ normalizePost.createBetterExcerpt = function createBetterExcerpt( post, callback
 
 	// Spin up a new DOM for the linebreak markup
 	const dom = document.createElement( 'div' );
+	dom.id = '__better_excerpt__';
 	dom.innerHTML = betterExcerpt;
 
 	// Ditch any photo captions with the wp-caption-text class
@@ -475,7 +476,7 @@ normalizePost.createBetterExcerpt = function createBetterExcerpt( post, callback
 	} );
 
 	// now limit it to the first three elements
-	forEach( dom.querySelectorAll( 'p, br' ), function( element, index ) {
+	forEach( dom.querySelectorAll( '#__better_excerpt__ > p, #__better_excerpt__ > br' ), function( element, index ) {
 		if ( index >= 3 ) {
 			element.parentNode && element.parentNode.removeChild( element );
 		}

--- a/client/lib/post-normalizer/test/post-normalizer-test.js
+++ b/client/lib/post-normalizer/test/post-normalizer-test.js
@@ -896,5 +896,9 @@ describe( 'post-normalizer', function() {
 		it( 'limits the excerpt to 3 elements after trimming', function( done ) {
 			assertExcerptBecomes( '<br /><p></p><p>one</p><p>two</p><p></p><br><p>three</p><p>four</p><br><p></p>', '<p>one</p><p>two</p><br>', done );
 		} );
+
+		it( 'only trims top-level breaks', function( done ) {
+			assertExcerptBecomes( '<p></p><p>one<br>two</p>', '<p>one<br>two</p>', done );
+		} );
 	} );
 } );


### PR DESCRIPTION
This was counting nested breaks inside of the main p tag. Only count top level elements.

This doesn't entirely fix poetry style posts, but it's better than it was.

Fixes #696