### PR TITLE
Offline: enable sync-handler in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -74,6 +74,7 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
Turns on the sync-handler (api caching) in production. Do not merge until after https://github.com/Automattic/wp-calypso/pull/3682 has been merged to master.