### PR TITLE
Themes: Validate 'section' prop in theme sheets

### DIFF
--- a/client/my-sites/themes/controller/index.node.js
+++ b/client/my-sites/themes/controller/index.node.js
@@ -92,8 +92,8 @@ export function details( context, next ) {
 	} ) );
 
 	const ConnectedComponent = ( { themeSlug, contentSection } ) => (
-		<ThemeDetailsComponent id={ themeSlug } section={ contentSection } >
-			<ThemeSheetComponent />
+		<ThemeDetailsComponent id={ themeSlug } >
+			<ThemeSheetComponent section={ contentSection } />
 		</ThemeDetailsComponent>
 	);
 

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -50,17 +50,16 @@ var ThemesHelpers = {
 	},
 
 	getDetailsUrl: function( theme, site ) {
-		const baseUrl = config.isEnabled( 'manage/themes/details' ) ? '/theme/' : ThemesHelpers.oldShowcaseUrl;
-
-		if ( ! site ) {
-			return baseUrl + theme.id;
-		}
-
-		if ( site.jetpack ) {
+		if ( site && site.jetpack ) {
 			return site.options.admin_url + 'themes.php?theme=' + theme.id;
 		}
 
-		return baseUrl + `${ theme.id }/${ site.slug }`;
+		let baseUrl = ThemesHelpers.oldShowcaseUrl + `${ theme.id }`;
+		if ( config.isEnabled( 'manage/themes/details' ) ) {
+			baseUrl = `/theme/${ theme.id }/details`;
+		}
+
+		return baseUrl + ( site ? `/${ site.slug }` : '' );
 	},
 
 	getSupportUrl: function( theme, site ) {

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -54,7 +54,7 @@ var ThemesHelpers = {
 			return site.options.admin_url + 'themes.php?theme=' + theme.id;
 		}
 
-		let baseUrl = ThemesHelpers.oldShowcaseUrl + `${ theme.id }`;
+		let baseUrl = ThemesHelpers.oldShowcaseUrl + theme.id;
 		if ( config.isEnabled( 'manage/themes/details' ) ) {
 			baseUrl = `/theme/${ theme.id }/details`;
 		}

--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -73,6 +73,13 @@ export const ThemeSheet = React.createClass( {
 		return { priceElement, themeContentElement };
 	},
 
+	validateSection( section ) {
+		if ( [ 'details', 'support', 'documentation' ].indexOf( section ) === -1 ) {
+			return 'details';
+		}
+		return section;
+	},
+
 	renderBar() {
 		const placeholder = <span className="themes__sheet-placeholder">loading.....</span>;
 		const title = this.props.name || placeholder;
@@ -125,7 +132,7 @@ export const ThemeSheet = React.createClass( {
 			actionTitle = i18n.translate( 'Pick this design' );
 		}
 
-		const section = this.props.section || 'details';
+		const section = this.validateSection( this.props.section );
 		const { themeContentElement, priceElement } = this.getDangerousElements( section );
 
 		return (

--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -39,6 +39,10 @@ export const ThemeSheet = React.createClass( {
 		supportDocumentation: React.PropTypes.string,
 	},
 
+	getDefaultProps() {
+		return { section: 'details' };
+	},
+
 	onBackClick() {
 		page.back();
 	},


### PR DESCRIPTION
The route for a theme details page is:
`/theme/:slug/:section?/:site?`
where `section = ( details | support | documentation )`

* Validate the section prop at the sheet component level, assuming `details` if invalid
* Add a 'details' section when constructing internal links

**To Test**
1) Go to http://calypso.localhost:3000/design/ and check that the _Details_ option from the ... button for a theme brings up the new Calypso theme sheet
* For _all sites_ (or logged-out) the url should be `http://calypso.localhost:3000/theme/{theme}/details`
* For single site, the url should be `http://calypso.localhost:3000/theme/{theme}/details/{site}`

2) Manually enter a url such as `http://calypso.localhost:3000/theme/mood/blah` and check that the sheet displays with the *details* section highlighted

3) With `manage/themes/details` disabled in `config/development.json` check that the details button links to the old themes showcase


