### PR TITLE
CPT: Add base list routes for types path

### DIFF
--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -1,0 +1,34 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import ReactDom from 'react-dom';
+import page from 'page';
+
+/**
+ * Internal Dependencies
+ */
+import { getSiteFragment, sectionify } from 'lib/route';
+import { pageView } from 'analytics';
+import { setTitle } from 'lib/screen-title/actions';
+import Types from './main';
+
+export function redirect() {
+	page.redirect( '/posts' );
+}
+
+export function list( context ) {
+	const siteId = getSiteFragment( context.path );
+
+	// [TODO]: Translate title text when settled upon
+	setTitle( 'Custom Post Type', { siteId: siteId } );
+
+	let baseAnalyticsPath = sectionify( context.path );
+	if ( siteId ) {
+		baseAnalyticsPath += '/:site';
+	}
+
+	pageView.record( baseAnalyticsPath, 'Custom Post Type' );
+
+	ReactDom.render( <Types />, document.getElementById( 'primary' ) );
+}

--- a/client/my-sites/types/index.js
+++ b/client/my-sites/types/index.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { siteSelection, navigation, sites } from 'my-sites/controller';
+import { list, redirect } from './controller';
+import config from 'config';
+
+export default function() {
+	if ( ! config.isEnabled( 'manage/custom-post-types' ) ) {
+		return;
+	}
+
+	page( '/types/:type/:site', siteSelection, navigation, list );
+	page( '/types/:type', siteSelection, sites );
+	page( '/types', redirect );
+};

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+
+export default function Types() {
+	return <Main>Custom Post Type Listing</Main>;
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -179,4 +179,12 @@ if ( config.isEnabled( 'mailing-lists/unsubscribe' ) ) {
 	} );
 }
 
+if ( config.isEnabled( 'manage/custom-post-types' ) ) {
+	sections.push( {
+		name: 'posts-custom',
+		paths: [ '/types' ],
+		module: 'my-sites/types'
+	} );
+}
+
 module.exports = sections;

--- a/config/development.json
+++ b/config/development.json
@@ -43,6 +43,7 @@
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,
+		"manage/custom-post-types": true,
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/export": true,


### PR DESCRIPTION
Closes #3691 

This pull request seeks to add a new `manage/custom-post-types` feature flag, enabled only in development environments, which adds new routes for custom post types. These routes are prefixed with `/types`, though this is subject to change (see #3689).

__Testing instructions:__

The included routes are only accessible via direct navigation. No existing content has been changed to direct users to these pages.

Verify the following instructions, and also that the routes do not exist if you were to change the feature flag to `false` in `development.json` and restart your Node process.

1. Navigate to http://calypso.localhost:3000/types
2. Note that you are redirected to `/posts`
 - This redirect is somewhat arbitrary, though there's not a good alternative "default" route to which to redirect if a type is not specified
3. Navigate to http://calypso.localhost:3000/types/jetpack-portfolio
4. Note that you are presented with a site picker
5. Choose a site
6. Note that the URL path includes the site fragment, and you are presented with the My Sites view, including the text "Custom Post Type Listing" in the main content area