### PR TITLE
People: Show drake instead of invite form for Jetpack sites

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -28,6 +28,7 @@ import CountedTextarea from 'components/forms/counted-textarea';
 import { createInviteValidation } from 'lib/invites/actions';
 import InvitesCreateValidationStore from 'lib/invites/stores/invites-create-validation';
 import InvitesSentStore from 'lib/invites/stores/invites-sent';
+import EmptyContent from 'components/empty-content';
 
 /**
  * Module variables
@@ -200,7 +201,35 @@ const InvitePeople = React.createClass( {
 		);
 	},
 
+	renderNoJetpackSitesDrake() {
+		const adminUrl = get( this.props, 'site.options.admin_url' );
+
+		let emptyContentProps = {
+			title: this.translate( 'Jetpack Invites are Under Construction' ),
+			line: this.translate( 'In the meantime, please add users from WordPress admin.' ),
+			illustration: '/calypso/images/drake/drake-whoops.svg'
+		};
+
+		if ( adminUrl ) {
+			emptyContentProps = Object.assign( {}, emptyContentProps, {
+				action: this.translate( 'Add people with WP-Admin', { textOnly: true } ),
+				actionURL: adminUrl + 'user-new.php',
+				actionTarget: '_new'
+			} );
+		}
+
+		return (
+			<Main>
+				<EmptyContent { ... emptyContentProps } />
+			</Main>
+		);
+	},
+
 	render() {
+		if ( get( this.props, 'site.jetpack' ) ) {
+			return this.renderNoJetpackSitesDrake();
+		}
+
 		return (
 			<Main>
 				<HeaderCake isCompact onClick={ this.goBack }/>


### PR DESCRIPTION
Closes #3613

Because we are launching invites for WP.com sites before Jetpack sites, there is a chance that users could land on `/people/new/$site` where `$site` is a Jetpack site.

This **shouldn't** happen, since the "Add" button in the My Sites sidebar points to `wp-admin`, but we should still handle the case of a user being deep linked.

To test:
- Checkout `update/invites-jetpack-drake` branch
- Go to `/people/new/$site` where `$site` is a WP.com site
- Do you see the invite form?
- Go to `/people/new/$site` where `$site` is a Jetpack site
- Do you see something like below?

![screen shot 2016-03-01 at 1 15 48 pm](https://cloud.githubusercontent.com/assets/1126811/13438782/1ea5e98a-dfb0-11e5-916d-1d1005b59fd9.png)

cc @rickybanister for design review
