### PR TITLE
Plans: Fix `sitePlans` fetching on site switch

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -31,6 +31,10 @@ module.exports = React.createClass( {
 			return this.shouldOfferFreeTrial() ? this.freeTrialActions() : this.upgradeActions();
 		}
 
+		if ( ! this.props.sitePlan ) {
+			return null;
+		}
+
 		if ( this.siteHasThisPlan() ) {
 			if ( this.props.sitePlan.freeTrial ) {
 				return this.upgradeActions();
@@ -261,10 +265,6 @@ module.exports = React.createClass( {
 	},
 
 	getCurrentPlanHint: function() {
-		if ( ! this.props.sitePlan ) {
-			return;
-		}
-
 		return (
 			<div>
 				<span className="plan-actions__current-plan-label" onClick={ this.recordCurrentPlanClick }>

--- a/client/components/plans/plan-features/index.jsx
+++ b/client/components/plans/plan-features/index.jsx
@@ -12,7 +12,8 @@ var PlanHeader = require( 'components/plans/plan-header' ),
 	PlanFeatureCell = require( 'components/plans/plan-feature-cell' ),
 	PlanActions = require( 'components/plans/plan-actions' ),
 	PlanPrice = require( 'components/plans/plan-price' ),
-	PlanDiscountMessage = require( 'components/plans/plan-discount-message' );
+	PlanDiscountMessage = require( 'components/plans/plan-discount-message' ),
+	isJetpackPlan = require( 'lib/products-values' ).isJetpackPlan;
 
 module.exports = React.createClass( {
 	displayName: 'PlanFeatures',
@@ -31,8 +32,12 @@ module.exports = React.createClass( {
 	headerText: function() {
 		return (
 			<span className="header-text">
-				WordPress.com
-				<br />
+				{ ! isJetpackPlan( this.props.plan ) &&
+					<div>
+						WordPress.com
+						<br />
+					</div>
+				}
 				{ this.props.plan.product_name_short }
 			</span>
 		);

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -30,13 +30,9 @@ module.exports = React.createClass( {
 			plans = this.props.plans,
 			isLoadingSitePlans = ! this.props.isInSignup && ! this.props.sitePlans.hasLoadedFromServer,
 			numberOfPlaceholders = 3,
-			site,
+			site = this.props.site,
 			plansList,
 			currentPlan;
-
-		if ( this.props.sites ) {
-			site = this.props.sites.getSelectedSite();
-		}
 
 		if ( this.props.hideFreePlan || ( site && site.jetpack ) ) {
 			numberOfPlaceholders = 2;

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -4,7 +4,6 @@
 var page = require( 'page' ),
 	ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
-	ReduxProvider = require( 'react-redux' ).Provider,
 	defer = require( 'lodash/defer' );
 
 /**
@@ -17,6 +16,7 @@ var sites = require( 'lib/sites-list' )(),
 	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	plans = require( 'lib/plans-list' )(),
 	config = require( 'config' ),
+	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
 	upgradesActions = require( 'lib/upgrades/actions' ),
 	titleActions = require( 'lib/screen-title/actions' );
 
@@ -74,18 +74,17 @@ module.exports = {
 		analytics.tracks.recordEvent( 'calypso_plans_view' );
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
-		ReactDom.render(
-			<ReduxProvider store={ context.store }>
-				<CartData>
-					<Plans
-						sites={ sites }
-						onSelectPlan={ handlePlanSelect }
-						plans={ plans }
-						context={ context }
-						destinationType={ context.params.destinationType }/>
-				</CartData>
-			</ReduxProvider>,
-			document.getElementById( 'primary' )
+		renderWithReduxStore(
+			<CartData>
+				<Plans
+					sites={ sites }
+					onSelectPlan={ handlePlanSelect }
+					plans={ plans }
+					context={ context }
+					destinationType={ context.params.destinationType } />
+			</CartData>,
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 
@@ -116,21 +115,20 @@ module.exports = {
 			siteID: context.params.domain
 		} );
 
-		ReactDom.render(
+		renderWithReduxStore(
 			<Main className="plans has-sidebar">
-				<ReduxProvider store={ context.store }>
-					<CartData>
-						<PlansCompare
-							enableFreeTrials={ getABTestVariation( 'freeTrials' ) === 'offered' }
-							selectedSite={ site }
-							onSelectPlan={ handlePlanSelect }
-							plans={ plans }
-							features={ features }
-							productsList={ productsList } />
-					</CartData>
-				</ReduxProvider>
+				<CartData>
+					<PlansCompare
+						enableFreeTrials={ getABTestVariation( 'freeTrials' ) === 'offered' }
+						selectedSite={ site }
+						onSelectPlan={ handlePlanSelect }
+						plans={ plans }
+						features={ features }
+						productsList={ productsList } />
+				</CartData>
 			</Main>,
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 	},
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -39,11 +39,16 @@ var Plans = React.createClass( {
 	},
 
 	componentDidMount: function() {
-		this.props.fetchSitePlans( this.props.sitePlans, this.props.sites.getSelectedSite() );
+		this.updateSitePlans();
 	},
 
 	componentWillReceiveProps: function() {
-		this.props.fetchSitePlans( this.props.sitePlans, this.props.sites.getSelectedSite() );
+		this.updateSitePlans();
+	},
+
+	updateSitePlans: function() {
+		var selectedSite = this.props.sites.getSelectedSite();
+		this.props.fetchSitePlans( this.props.sitePlans, selectedSite );
 	},
 
 	openPlan: function( planId ) {
@@ -163,12 +168,12 @@ var Plans = React.createClass( {
 						<UpgradesNavigation
 							path={ this.props.context.path }
 							cart={ this.props.cart }
-							selectedSite={ this.props.sites.getSelectedSite() } />
+							selectedSite={ selectedSite } />
 
 						{ this.renderTrialCopy() }
 
 						<PlanList
-							sites={ this.props.sites }
+							site={ selectedSite }
 							plans={ this.props.plans.get() }
 							enableFreeTrials={ getABTestVariation( 'freeTrials' ) === 'offered' }
 							sitePlans={ this.props.sitePlans }


### PR DESCRIPTION
Fixes #2610 

### Description of the issue
Switching site from the Plans page is failing when switching from a Jetpack site to a WordPress.com site. A fatal error is visible in the console:
```
Uncaught TypeError: Cannot read property 'freeTrial' of undefined
Uncaught TypeError: Cannot read property 'remove' of undefined
```
This happens because in `components/plan`, `sitePlans` still contains the data for jetpack plans while the new site's `sitePlans` data is being fetched. This is not handled in PlanAction which expects a valid `sitePlan` props and test for the `freeTrial` property in it.

### Description of the fix
This removes the use of data observers and fixes the Redux connector in Plans' main.
We're adding here a `site` props so `componentWillReceiveProps` will be called on site change.
Also `shouldFetchSitePlans` is removed because we want to fetch sitePlans on each site change and the `site` props should never be `null`.
Edit: actually, as reported by @drewblaisdell, this won't work if the data is not loaded. So we have to keep the data observers in for now (until we move `sites-list` to the global state tree).

### Testing instructions
- Checkout this branch with `git checkout fix/2610-siteplans-switch` and run your server

#### Test 1 - Existing user with multiple sites
- Go to the Plans page on one of your site and try to switch site. Switch to a jetpack site then back to a wordpress.com site, it shouldn't throw any error
- Do the same for the Plans Compare page

#### Test 2 - New user
- In incognito mode, go to http://calypso.localhost:3000/start and check that nothing broke in the Plan Select and Plan Compare page

#### Test 3 - New site
- Using an existing account, go to http://calypso.localhost:3000/start and check that nothing broke in the Plan Select and Plan Compare page

Reviews
- [ ] Code Review
- [x] Product Review
