### PR TITLE
Domain Management: DNS: Allow root A records to be updated

### DIFF
--- a/client/lib/domains/dns/test/data/index.js
+++ b/client/lib/domains/dns/test/data/index.js
@@ -1,9 +1,9 @@
 export const DOMAIN_NAME = 'dummy.com';
 
 export const RECORD_A = {
-	data: '12.34.56.78',
+	data: '',
 	id: '23466069',
-	name: 'test',
+	name: 'dummy.com.',
 	type: 'A'
 };
 

--- a/client/lib/domains/dns/test/reducer.js
+++ b/client/lib/domains/dns/test/reducer.js
@@ -35,7 +35,7 @@ describe( 'reducer', () => {
 	it( 'should return state without record passed in the delete action', () => {
 		const state = deepFreeze( {
 				[ DOMAIN_NAME ]: {
-					records: [ RECORD_TXT ]
+					records: [ RECORD_A, RECORD_TXT ]
 				}
 			} ),
 			payload = {
@@ -48,14 +48,14 @@ describe( 'reducer', () => {
 
 		const result = reducer( state, payload );
 
-		expect( result ).to.be.eql( { [ DOMAIN_NAME ]: { records: [] } } );
+		expect( result ).to.be.eql( { [ DOMAIN_NAME ]: { records: [ RECORD_A ] } } );
 	} );
 
 	it( 'should return state without record (having no id) passed in the delete action', () => {
 		const RECORD_TXT_WITHOUT_ID = pick( RECORD_TXT, [ 'data', 'name', 'type' ] ),
 			state = deepFreeze( {
 				[ DOMAIN_NAME ]: {
-					records: [ RECORD_TXT_WITHOUT_ID ]
+					records: [ RECORD_A, RECORD_TXT_WITHOUT_ID ]
 				}
 			} ),
 			payload = {
@@ -68,6 +68,6 @@ describe( 'reducer', () => {
 
 		const result = reducer( state, payload );
 
-		expect( result ).to.be.eql( { [ DOMAIN_NAME ]: { records: [] } } );
+		expect( result ).to.be.eql( { [ DOMAIN_NAME ]: { records: [ RECORD_A ] } } );
 	} );
 } );

--- a/client/my-sites/upgrades/domain-management/dns/a-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/a-record.jsx
@@ -45,7 +45,7 @@ const ARecord = React.createClass( {
 					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
-						placeholder={ this.translate( 'Enter subdomain (required)', { context: 'Placeholder shown when entering the required subdomain part of a new DNS record' } ) }
+						placeholder={ this.translate( 'Enter subdomain (optional)', { context: 'Placeholder shown when entering the required subdomain part of a new DNS record' } ) }
 						isError={ ! isNameValid }
 						onChange={ onChange }
 						value={ fieldValues.name }


### PR DESCRIPTION
**StoreP2 Post: p2MSmN-4LL-p2**

With this patch and D1197-code, it will be possible to update the root A records for a domain through Calypso.

This fixes p2MSmN-49z-p2.

![dns](https://cloud.githubusercontent.com/assets/11401/13443525/3b67b9d0-dfb6-11e5-8725-a1aea2f5218e.gif)
