### PR TITLE
People: Reset invite form after successfully sending invites

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -117,7 +117,7 @@ export function acceptInvite( invite, callback ) {
 	}
 }
 
-export function sendInvites( siteId, usernamesOrEmails, role, message, callback ) {
+export function sendInvites( siteId, usernamesOrEmails, role, message, formId ) {
 	return dispatch => {
 		Dispatcher.handleViewAction( {
 			type: ActionTypes.SENDING_INVITES,
@@ -131,6 +131,7 @@ export function sendInvites( siteId, usernamesOrEmails, role, message, callback 
 				usernamesOrEmails,
 				role,
 				message,
+				formId,
 				data
 			} );
 
@@ -151,7 +152,6 @@ export function sendInvites( siteId, usernamesOrEmails, role, message, callback 
 				) ) );
 				analytics.tracks.recordEvent( 'calypso_invite_send_success' );
 			}
-			callback( error, data );
 		} );
 	}
 }

--- a/client/lib/invites/reducers/invites-sent.js
+++ b/client/lib/invites/reducers/invites-sent.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { fromJS } from 'immutable';
+
+/**
+ * Internal dependencies
+ */
+import { action as ActionTypes } from 'lib/invites/constants';
+
+const initialState = fromJS( {
+	success: {},
+	errors: {}
+} );
+
+const reducer = ( state = initialState, payload ) => {
+	const { action } = payload;
+	switch ( action.type ) {
+		case ActionTypes.RECEIVE_SENDING_INVITES_SUCCESS:
+			return state.setIn( [ 'success', action.formId ], action.data );
+		case ActionTypes.RECEIVE_SENDING_INVITES_ERROR:
+			return state.setIn( [ 'error', action.formId ], action.data );
+	}
+	return state;
+}
+
+export { initialState, reducer };

--- a/client/lib/invites/stores/invites-sent.js
+++ b/client/lib/invites/stores/invites-sent.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { createReducerStore } from 'lib/store';
+import { reducer, initialState } from 'lib/invites/reducers/invites-sent';
+
+const InvitesSentStore = createReducerStore( reducer, initialState );
+
+InvitesSentStore.getSuccess = ( formId ) => InvitesSentStore.get().getIn( [ 'success', formId ] );
+InvitesSentStore.getError = ( formId ) => InvitesSentStore.get().getIn( [ 'error', formId ] );
+
+export default InvitesSentStore;


### PR DESCRIPTION
Addresses part of #3441

After sending invitations, we should clear the form. This will allow the user to send invites for another role as well as act as an visual indicator that the form was acted on.

To test:
- Checkout `update/people-invites-after-submit` branch
- Go to `/people/new/$site` where `$site` is a WP.com site
- Submit the form
- Does the form clear successfully?
- Fill the form out again
- In Chrome emulator, turn off network traffic
- Submit form
- Does form error? Does form recover from error?