### PR TITLE
Debug: Forward the command line debug environment variable to the browser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,16 +37,27 @@ Errors and warning appear in the normal places – the terminal where you ran `m
 
 ### Debugging
 
-Calypso uses the [debug](https://github.com/visionmedia/debug) module to handle debug messaging. To turn on debug mode for all modules in both browser and the console, start the server with the following command:
+Calypso uses the [debug](https://github.com/visionmedia/debug) module to handle debug messaging. By default, the filter will show all server and browser messages matching `calypso:*`. To disable all messages, set the filter to blank via a local config value
 
-```bash
-DEBUG=* make run
+#### `/config/development.local.json`
+```json
+{
+  "debug_filter": ""
+}
 ```
 
 You can also limit the debugging to a particular scope
 
+```json
+{
+  "debug_filter": "calypso:your-feature*"
+}
+```
+
+If a `DEBUG` environment variable is passed to the server, the config value will be ignored. For example
+
 ```bash
-DEBUG=calypso:* make run
+DEBUG=calypso:your-feature make run
 ```
 
 ## Pull Requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,25 +37,13 @@ Errors and warning appear in the normal places – the terminal where you ran `m
 
 ### Debugging
 
-Calypso uses the [debug](https://github.com/visionmedia/debug) module to handle debug messaging. To turn on debug mode for all modules, type the following in the browser console:
-
-```js
-localStorage.setItem( 'debug', '*' );
-```
-
-You can also limit the debugging to a particular scope
-
-```js
-localStorage.setItem( 'debug', 'calypso:*' );
-```
-
-The `node` server uses the `DEBUG` environment variable instead of `localStorage`. `make run` will pass along it’s environment, so you can turn on all debug messages with
+Calypso uses the [debug](https://github.com/visionmedia/debug) module to handle debug messaging. To turn on debug mode for all modules in both browser and the console, start the server with the following command:
 
 ```bash
 DEBUG=* make run
 ```
 
-or limit it as before with
+You can also limit the debugging to a particular scope
 
 ```bash
 DEBUG=calypso:* make run

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -52,6 +52,10 @@ var config = require( 'config' ),
 function init() {
 	var i18nLocaleStringsObject = null;
 
+	if ( window.app && window.app.debugFilter ) {
+		localStorage.setItem( 'debug', window.app.debugFilter );
+	}
+
 	debug( 'Starting Calypso. Let\'s do this.' );
 
 	// prune sync-handler records more than two days old

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -52,10 +52,6 @@ var config = require( 'config' ),
 function init() {
 	var i18nLocaleStringsObject = null;
 
-	if ( window.app && window.app.debugFilter ) {
-		localStorage.setItem( 'debug', window.app.debugFilter );
-	}
-
 	debug( 'Starting Calypso. Let\'s do this.' );
 
 	// prune sync-handler records more than two days old

--- a/config/development.json
+++ b/config/development.json
@@ -4,6 +4,7 @@
 	"hostname": "calypso.localhost",
 	"port": 3000,
 	"i18n_default_locale_slug": "en",
+	"debug_filter": "calypso:*",
 	"wpcom_user_bootstrap": false,
 	"rtl": false,
 	"jetpack_min_version": "3.3",

--- a/index.js
+++ b/index.js
@@ -21,6 +21,12 @@ var start = Date.now(),
 console.log( chalk.yellow( '%s booted in %dms - http://%s:%s' ), pkg.name, ( Date.now() ) - start, host, port );
 console.info( chalk.cyan( '\nGetting bundles ready, hold on...' ) );
 
+// Set up the console logging filter for the npm `debug` package
+if ( config( 'env' ) === 'development' && 'undefined' === typeof process.env.DEBUG ) {
+	// Use the default debug filter from the configuration files
+	process.env.DEBUG = config( 'debug_filter' );
+}
+
 server = http.createServer( app );
 
 // The desktop app runs Calypso in a fork.

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -117,6 +117,11 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			script(type='text/javascript')!='var currentUser = ' + sanitize.jsonStringifyForHtml( user )
 		if app
 			script(type='text/javascript')!='var app = ' + sanitize.jsonStringifyForHtml( app )
+		if 'development' === env
+			script.
+				if ( window.app && window.app.debugFilter && localStorage ) {
+					localStorage.setItem( 'debug', window.app.debugFilter )
+				}
 		if initialReduxState
 			script(type='text/javascript')!='var initialReduxState = ' + sanitize.jsonStringifyForHtml( initialReduxState )
 		if i18nLocaleScript

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -193,6 +193,7 @@ function getDefaultContext( request ) {
 		context.faviconURL = '/calypso/images/favicons/favicon-development.ico';
 		context.branchName = getCurrentBranchName();
 		context.commitChecksum = getCurrentCommitShortChecksum();
+		context.app.debugFilter = process.env.DEBUG;
 	}
 
 	if ( config.isEnabled( 'code-splitting' ) ) {


### PR DESCRIPTION
#### Why?
 - Don't lose the debug filter when localStorage is cleared (this happens every time the current user changes)
 - Set both the console debug message filter **and** the browser debug filter at the same time.
 - No more manually setting `debug` in localStorage each time you work on a different feature.
 - Capture boot/initialization debug messages from the first boot.

#### Changes

This change allows setting the debug output filter at the command line to have it passed to the browser:
```sh
DEBUG=calypso:* make run
```

Then get this in the browser:
![screen shot 2016-03-02 at 1 01 26 pm](https://cloud.githubusercontent.com/assets/416133/13449405/ed5b222e-e076-11e5-833e-05fb76dad039.png)

This will be set on each page request, avoiding the need to manually set the localStorage value each time the user changes/logs in/logs out.