### PR TITLE
Reader: in Manage Following, remove add gridicon in Follow Site input

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -107,16 +107,17 @@
 
 // Add to Following
 .following-edit__subscribe-form {
+	box-shadow: 0 1px 2px lighten( $gray, 30% );
 	position: absolute;
-		top: 0;
+		top: 60px;
 		right: 0;
 		left: 0;
 	opacity: 0;
 	pointer-events: none;
 	transition: all 0.15s ease-in-out;
 
-	@include breakpoint( "<480px" ) {
-		top: 62px;
+	@include breakpoint( ">660px" ) {
+		top: 0;
 	}
 
 	.search {
@@ -192,20 +193,15 @@
 // Search Results Placeholder
 .following-edit__subscribe-form-blank {
 	position: absolute;
-		top: 68px;
+		top: 51px;
 	width: 100%;
 	height: 75px;
 	box-sizing: border-box;
-	padding: 26px 32px 0 32px;
+	padding: 26px 32px 0;
 	text-align: center;
-	color: darken( $gray, 10 );
-	background: lighten( $gray, 30 );
-	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20 ), .5 );
-
-	@include breakpoint( "<480px" ) {
-		padding: 16px 42px 0 42px;
-		top: 59px;
-	}
+	color: darken( $gray, 10% );
+	background: lighten( $gray, 30% );
+	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 );
 }
 
 
@@ -235,10 +231,6 @@
 		.reader-list-item__title,
 		.reader-list-item__description {
 			margin-left: 92px;
-
-			@include breakpoint( ">660px" ) {
-				margin-left: 80px;
-			}
 		}
 
 		.following-edit__list-title {
@@ -256,6 +248,7 @@
 		padding-left: 12px;
 		margin-left: 80px;
 		margin-right: 100px;
+
 		@include breakpoint( ">660px" ) {
 			padding-left: 0;
 		}
@@ -263,7 +256,6 @@
 
 	.reader-list-item__icon {
 		top: 14px;
-		left: 40px;
 	}
 }
 
@@ -284,6 +276,7 @@
 	&.is-compact {
 		padding-top: 10px;
 		padding-bottom: 10px;
+
 		@include breakpoint( ">660px" ) {
 			padding-left: 105px;
 		}

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -126,6 +126,7 @@
 	.search__input[type="search"] {
 		height: 50px;
 		border: 1px solid transparent;
+		padding-left: 20px;
 
 		&:focus {
 			border-color: $blue-wordpress;
@@ -135,19 +136,6 @@
 
 	.search-open__icon {
 		display: none;
-	}
-
-	.gridicons-add-outline {
-		position: absolute;
-			top: 13px;
-			left: 18px;
-		fill: $blue-medium;
-		z-index: z-index( '.following-edit', '.following-edit__subscribe-form .gridicons-add-outline' );
-	}
-
-	.gridicons-add-outline {
-		transform: translateX( 30px );
-		transition: all 0.15s ease-in-out;
 	}
 
 	.is-adding & {

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -149,13 +149,8 @@
 
 	.card.is-search-result {
 		position: absolute;
-			top: 68px;
+			top: 51px;
 		width: 100%;
-		z-index: z-index( '.following-edit', '.following-edit__subscribe-form .card.is-search-result' );
-
-		@include breakpoint( "<480px" ) {
-			top: 59px;
-		}
 
 		.gridicon__follow {
 			fill: lighten( $gray, 20% );

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -246,7 +246,6 @@
 	.reader-list-item__title,
 	.reader-list-item__description {
 		padding-left: 12px;
-		margin-left: 80px;
 		margin-right: 100px;
 
 		@include breakpoint( ">660px" ) {

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -107,7 +107,6 @@
 
 // Add to Following
 .following-edit__subscribe-form {
-	box-shadow: 0 1px 2px lighten( $gray, 30% );
 	position: absolute;
 		top: 60px;
 		right: 0;

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -8,9 +8,7 @@ const React = require( 'react' ),
 // Internal dependencies
 const Search = require( 'components/search' ),
 	FollowingEditSubscribeFormResult = require( './subscribe-form-result' ),
-	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' ),
-	Gridicon = require( 'components/gridicon' ),
-	stats = require( 'reader/stats' );
+	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' );
 
 const minSearchLength = 8; // includes protocol
 
@@ -53,10 +51,6 @@ var FollowingEditSubscribeForm = React.createClass( {
 
 		// Call onFollow method on the parent
 		this.props.onFollow( this.state.searchString );
-	},
-
-	handleFollowIconClick: function() {
-		this.refs.followingEditSubscriptionSearch.focus();
 	},
 
 	handleKeyDown: function( event ) {
@@ -142,7 +136,6 @@ var FollowingEditSubscribeForm = React.createClass( {
 
 		return (
 			<div className="following-edit__subscribe-form">
-				<Gridicon icon="add-outline" onClick={ this.handleFollowIconClick } />
 				<Search
 					isOpen={ true }
 					key="newSubscriptionSearch"


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/issues/3437, @apeatling notes:

> I think there is a disconnect between typing in a site URL and the card below showing the details. They are not sure where to hit follow. The icon to the left in the follow URL box looks like a button to them.

In a small attempt to make things clearer, this PR removes the add gridicon from the input.

Before:

<img width="765" alt="screen shot 2016-03-02 at 16 28 49" src="https://cloud.githubusercontent.com/assets/17325/13449828/e5fe8422-e093-11e5-9841-28423ecdf1fd.png">

After:

<img width="776" alt="screen shot 2016-03-02 at 16 30 53" src="https://cloud.githubusercontent.com/assets/17325/13449865/2be17f08-e094-11e5-8c8e-363c942b7f6c.png">
