### PR TITLE
Sharing: Fix sharing button order received error

### DIFF
--- a/client/lib/sharing-buttons-list/index.js
+++ b/client/lib/sharing-buttons-list/index.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 var debug = require( 'debug' )( 'calypso:sharing-buttons-list' ),
-	uniq = require( 'lodash/uniq' ),
-	sortBy = require( 'lodash/sortBy' ),
+	uniqBy = require( 'lodash/uniqBy' ),
+	orderBy = require( 'lodash/orderBy' ),
 	findIndex = require( 'lodash/findIndex' );
 
 /**
@@ -149,10 +149,8 @@ SharingButtonsList.prototype.saveAll = function( siteId, buttons, callback ) {
 		// 4. Only take the first value of each ID (#) encountered
 		//   - [ 1Y, 3Y, 2N, 4N, 5N ]
 
-		data.updated = sortBy( data.updated, function( a, b ) {
-			return a.enabled === b.enabled ? 0 : a.enabled ? -1 : 1;
-		} );
-		this.data = uniq( data.updated.concat( this.data ), 'ID' );
+		data.updated = orderBy( data.updated, 'enabled', 'desc' );
+		this.data = uniqBy( data.updated.concat( this.data ), 'ID' );
 		this.emit( 'change' );
 		this.saving = false;
 		callback( null );


### PR DESCRIPTION
Related: #3288

This pull request seeks to resolve a regression introduced in #3288, which causes an error to occur when attempting to save changes applied to sharing buttons.

Specifically, there are two issues:

- [`uniq`](https://lodash.com/docs#uniq) operates on arrays, not collections of objects, for which the original intent was intended to pull unique objects by `ID` property ([`uniqBy`](https://lodash.com/docs#uniqBy) is the correct method to use)
- [`sortBy`](https://lodash.com/docs#sortBy) appears to have changed to not pass two objects (like `Array.prototype.sort`), though I cannot find a documented change for this behavior. Instead, we recreate the original behavior by applying a [`orderBy`](https://lodash.com/docs#orderBy) descending sort on the `enabled` property.

__Testing instructions:__

1. Navigate to the [sharing buttons screen](http://calypso.localhost:3000/sharing/buttons)
2. Select a site, if prompted
3. Click Edit Sharing Buttons
4. Enable, disable, or reorder sharing buttons
5. Click Save Changes
6. Note that no duplicate key warnings are logged to the console (resolving first of the issues noted above)
7. Note that no errors occur and that the save completes successfully (resolving second of the issues noted above)
8. Note that order is preserved (if reordered, saved order preserved, disabled and enabled options are otherwise grouped)

/cc @blowery 