### PR TITLE
Make Follow button hover color consistent across pages

### DIFF
--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -34,12 +34,12 @@
 			background: none;
 
 			.gridicon {
-				fill: $alert-green;
+				fill: $blue-medium;
 			}
 
 			.follow-button__label {
 				cursor: pointer;
-				color: $alert-green;
+				color: $blue-medium;
 			}
 		}
 	}
@@ -53,12 +53,12 @@
 			background: none;
 
 			.gridicon {
-				fill: $gray;
+				fill: lighten( $gray, 10% );
 			}
 
 			.follow-button__label {
 				cursor: pointer;
-				color: $gray;
+				color: lighten( $gray, 10% );
 			}
 		}
 	}

--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -34,12 +34,12 @@
 			background: none;
 
 			.gridicon {
-				fill: $blue-medium;
+				fill: $alert-green;
 			}
 
 			.follow-button__label {
 				cursor: pointer;
-				color: $blue-medium;
+				color: $alert-green;
 			}
 		}
 	}

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -176,11 +176,6 @@
 		.follow-button {
 			cursor: default;
 			color: lighten( $gray, 20% );
-
-			&:hover,
-			&:active {
-				color: $blue-wordpress;
-			}
 		}
 
 		&.is-valid {

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -176,6 +176,11 @@
 		.follow-button {
 			cursor: default;
 			color: lighten( $gray, 20% );
+
+			&:hover,
+			&:active {
+				color: $blue-wordpress;
+			}
 		}
 
 		&.is-valid {

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -2,7 +2,7 @@
 .reader__full-post {
 	position: relative;
 	box-sizing: border-box;
-	padding: 56px 16px 48px 16px;
+	padding: 56px 16px 48px;
 	max-width: 700px;
 	margin: 0 auto;
 
@@ -64,6 +64,23 @@
 			top: 0;
 			right: 0;
 
+		.follow-button__label {
+			color: lighten( $gray, 10% );
+		}
+
+		&:hover {
+			background: none;
+
+			.gridicon {
+				fill: $blue-medium;
+			}
+
+			.follow-button__label {
+				cursor: pointer;
+				color: $blue-medium;
+			}
+		}
+
 		@include breakpoint( "<480px" ) {
 			.follow-button__label {
 				display: none;
@@ -71,8 +88,29 @@
 		}
 	}
 
+	.follow-button.is-following {
+		.follow-button__label {
+			color: $alert-green;
+		}
+
+		&:hover {
+			background: none;
+
+			.gridicon {
+				fill: lighten( $gray, 10% );
+			}
+
+			.follow-button__label {
+				cursor: pointer;
+				color: lighten( $gray, 10% );
+			}
+		}
+	}
+
 	.reader__post-time {
-		.reader__post-time-link, .reader__post-time-link:hover {
+
+		.reader__post-time-link,
+		.reader__post-time-link:hover {
 			color: inherit;
 			text-decoration: inherit;
 		}
@@ -127,29 +165,29 @@
 	h1 {
 		font-size: 28px;
 		font-weight: 700;
-		margin: 0 0 16px 0;
+		margin: 0 0 16px;
 	}
 
 	h2 {
 		font-size: 24px;
 		font-weight: 700;
-		margin: 0 0 8px 0;
+		margin: 0 0 8px;
 	}
 
 	h3 {
 		font-size: 20px;
 		font-weight: 700;
-		margin: 0 0 8px 0;
+		margin: 0 0 8px;
 	}
 
 	h4 {
 		font-size: 18px;
 		font-weight: 700;
-		margin: 0 0 8px 0;
+		margin: 0 0 8px;
 	}
 
 	p {
-		margin: 0 0 24px 0;
+		margin: 0 0 24px;
 
 		&:last-child {
 			margin-bottom: 0;
@@ -158,15 +196,15 @@
 
 	blockquote {
 		padding: 16px 24px;
-		margin: 16px 0 32px 0;
-		color: darken( $gray, 20 );
+		margin: 16px 0 32px;
+		color: darken( $gray, 20% );
 		font-weight: normal;
 		font-size: 20px;
 		background: transparent;
 	}
 
 	hr {
-		background: lighten( $gray, 30 );
+		background: lighten( $gray, 30% );
 		margin: 24px -32px;
 	}
 

--- a/client/reader/list-item/style.scss
+++ b/client/reader/list-item/style.scss
@@ -70,13 +70,46 @@
 
 .reader-list-item__actions {
 	position: absolute;
-	top: 16px;
-	bottom: 0;
-	right: 0;
+		bottom: 0;
+		right: 0;
+		top: 16px;
 
 	.follow-button {
+
+		.follow-button__label {
+			color: $gray;
+		}
+
 		.gridicon {
 			left: 18px;
+		}
+
+		&:hover {
+
+			.gridicon {
+				fill: $alert-green;
+			}
+
+			.follow-button__label {
+				color: $alert-green;
+			}
+		}
+	}
+
+	.follow-button.is-following {
+		.follow-button__label {
+			color: $alert-green;
+		}
+
+		&:hover {
+
+			.gridicon {
+				fill: lighten( $gray, 10% );
+			}
+
+			.follow-button__label {
+				color: lighten( $gray, 10% );
+			}
 		}
 	}
 }

--- a/client/reader/list-item/style.scss
+++ b/client/reader/list-item/style.scss
@@ -87,11 +87,11 @@
 		&:hover {
 
 			.gridicon {
-				fill: $alert-green;
+				fill: $blue-medium;
 			}
 
 			.follow-button__label {
-				color: $alert-green;
+				color: $blue-medium;
 			}
 		}
 	}


### PR DESCRIPTION
This PR makes the Follow button hover color consistent all throughout Reader. On the feed header, it's `$blue-medium` on hover, but everywhere else it's `$alert-green`.

**Before (hover state):**

Following Site (Manage):
![screenshot 2016-03-02 10 45 57](https://cloud.githubusercontent.com/assets/4924246/13471103/f9112914-e063-11e5-8a3d-4f20248385a2.png)

Recommendations:
![screenshot 2016-03-02 10 48 06](https://cloud.githubusercontent.com/assets/4924246/13471163/46c6ef7c-e064-11e5-8bf8-a0beb61cbfa2.png)

Feed header:
![screenshot 2016-03-02 11 05 39](https://cloud.githubusercontent.com/assets/4924246/13471752/bda1e3fc-e066-11e5-87e8-d226d0bd61d8.png)

Full-post view:
![screenshot 2016-03-02 11 08 14](https://cloud.githubusercontent.com/assets/4924246/13471898/7205dbdc-e067-11e5-9646-9016f1992e29.png)


**After (hover state):**

Following Site (Manage):
![screenshot 2016-03-02 10 47 22](https://cloud.githubusercontent.com/assets/4924246/13471138/2987a4c4-e064-11e5-892f-4baf360f65bc.png)

Recommendations:
![screenshot 2016-03-02 11 05 12](https://cloud.githubusercontent.com/assets/4924246/13471730/a8c55216-e066-11e5-9125-2e6afb58573e.png)

Full-post view:
![screenshot 2016-03-02 11 15 05](https://cloud.githubusercontent.com/assets/4924246/13472119/42f32506-e068-11e5-89f7-bac4f8707689.png)

**Other minor fixes:**
1. made default state colors of both gridicon and text `$gray` instead of 2 separate colors.
2. changed hover color of Following to `lighten( $gray, 10% );`. It was either using that or `$gray`.