### PR TITLE
AB test: Plans: Remove the skipForFree test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -73,14 +73,6 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
-	freePlansDefault: {
-		datestamp: '20160219',
-		variations: {
-			allPlans: 90,
-			skipForFree: 10
-		},
-		defaultVariation: 'allPlans'
-	},
 	domainSearchResultsCount: {
 		datestamp: '20160223',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -237,11 +237,6 @@ function removeUserStepFromFlow( flow ) {
 }
 
 function filterFlowName( flowName ) {
-	const freePlansTestFlows = [ 'blog', 'website', 'main' ];
-	if ( includes( freePlansTestFlows, flowName ) ) {
-		return 'skipForFree' === abtest( 'freePlansDefault' ) ? 'upgrade' : flowName;
-	}
-
 	return flowName;
 }
 


### PR DESCRIPTION
This test has finished running now, so we can remove it.
 
#### Testing instructions

1. Run `git checkout delete/skip-for-free-test` and start your server
2. Open the [`Start` page](http://calypso.localhost:3000/start) in a private window
3. Check that the signup flow works as expected

#### Reviews

- [x] Code
- [x] Product