### PR TITLE
Enable the importer in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -25,6 +25,7 @@
 		"manage/jetpack-plans": true,
 		"manage/menus": true,
 		"manage/menus-jetpack": true,
+		"manage/import": true,
 		"manage/option_sync_non_public_post_stati": false,
 		"manage/pages": true,
 		"manage/people": true,


### PR DESCRIPTION
The importer has been enabled in `wpcalypso` and `horizon` for the past week or so. This PR enables it in production.

I'm leaving the config flag in for two reasons:
 - This isn't enabled in the desktop client yet
 - The flag makes it easy to revert without changing a bunch of code.

After a period of successful deployment we can test in the desktop client and then remove the flag altogether.

**Testing**

No testing. The only change is only present in production :)