### PR TITLE
Signup: Headstart: Remove AB test i3.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -65,15 +65,6 @@ module.exports = {
 		},
 		defaultVariation: 'description'
 	},
-	headstart: {
-		datestamp: '20160215',
-		variations: {
-			original: 20,
-			notTested: 60,
-			headstart: 20
-		},
-		defaultVariation: 'original'
-	},
 	checkoutFooter: {
 		datestamp: '20160215',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -11,7 +11,6 @@ var assign = require( 'lodash/assign' ),
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
 	abtest = require( 'lib/abtest' ).abtest,
-	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	user = require( 'lib/user' )();
 
 function getCheckoutUrl( dependencies ) {
@@ -238,19 +237,8 @@ function removeUserStepFromFlow( flow ) {
 }
 
 function filterFlowName( flowName ) {
-	const headstartFlows = [ 'blog', 'website' ];
-	if ( includes( headstartFlows, flowName ) && 'headstart' === abtest( 'headstart' ) ) {
-		return 'headstart';
-	}
-
-	let isInPreviousTest = false;
-
-	if ( getABTestVariation( 'headstart' ) && getABTestVariation( 'headstart' ) !== 'notTested' ) {
-		isInPreviousTest = true;
-	}
-
 	const freePlansTestFlows = [ 'blog', 'website', 'main' ];
-	if ( includes( freePlansTestFlows, flowName ) && ! isInPreviousTest ) {
+	if ( includes( freePlansTestFlows, flowName ) ) {
 		return 'skipForFree' === abtest( 'freePlansDefault' ) ? 'upgrade' : flowName;
 	}
 


### PR DESCRIPTION
We'll keep the Headstart flow, as we'll be rolling it out in the coming weeks.

Also cc/ @scruffian as this could increase the number of potential users for the `freePlansDefault` test.