### PR TITLE
Domain Search: A/B test for the placeholder text and examples for the domains search field

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -166,6 +166,12 @@ var RegisterDomainStep = React.createClass( {
 	},
 
 	searchForm: function() {
+		var placeholderText = this.translate( 'Enter a domain or keyword', { textOnly: true } );
+
+		if ( abtest( 'domainSearchPlaceholderText' ) === 'searchForADomain' ) {
+			placeholderText = this.translate( 'Search for a domain', { textOnly: true } );
+		}
+
 		return (
 			<div className="register-domain-step__search">
 				<SearchCard
@@ -175,7 +181,7 @@ var RegisterDomainStep = React.createClass( {
 					onSearch={ this.onSearch }
 					onSearchChange={ this.onSearchChange }
 					onBlur={ this.save }
-					placeholder={ this.translate( 'Enter a domain or keyword', { textOnly: true } ) }
+					placeholder={ placeholderText }
 					autoFocus={ true }
 					delaySearch={ true }
 					delayTimeout={ 2000 }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -166,10 +166,10 @@ var RegisterDomainStep = React.createClass( {
 	},
 
 	searchForm: function() {
-		var placeholderText = this.translate( 'Enter a domain or keyword', { textOnly: true } );
+		var placeholderText = this.translate( 'Enter a domain or keyword' );
 
 		if ( abtest( 'domainSearchPlaceholderText' ) === 'searchForADomain' ) {
-			placeholderText = this.translate( 'Search for a domain', { textOnly: true } );
+			placeholderText = this.translate( 'Search for a domain' );
 		}
 
 		return (

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -174,7 +174,7 @@ var RegisterDomainStep = React.createClass( {
 
 			exampleDomains = (
 				<div className="register-domain-step__search-examples">
-					<strong>{ this.translate( 'Example' ) }:</strong> example.com, example.net
+					{ this.translate( 'e.g.' ) } example.com, example.net
 				</div>
 			);
 		}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -170,11 +170,11 @@ var RegisterDomainStep = React.createClass( {
 			exampleDomains = '';
 
 		if ( ! this.props.isInSigup && abtest( 'domainSearchPlaceholderText' ) === 'searchForADomain' ) {
-			placeholderText = this.translate( 'Search for a domain' );
+			placeholderText = 'Search for a domain';
 
 			exampleDomains = (
 				<div className="register-domain-step__search-examples">
-					{ this.translate( 'e.g.' ) } example.com, example.net
+					e.g. example.com, example.net
 				</div>
 			);
 		}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -166,10 +166,17 @@ var RegisterDomainStep = React.createClass( {
 	},
 
 	searchForm: function() {
-		var placeholderText = this.translate( 'Enter a domain or keyword' );
+		var placeholderText = this.translate( 'Enter a domain or keyword' ),
+			exampleDomains = '';
 
-		if ( abtest( 'domainSearchPlaceholderText' ) === 'searchForADomain' ) {
+		if ( ! this.props.isInSigup && abtest( 'domainSearchPlaceholderText' ) === 'searchForADomain' ) {
 			placeholderText = this.translate( 'Search for a domain' );
+
+			exampleDomains = (
+				<div className="register-domain-step__search-examples">
+					<strong>{ this.translate( 'Example' ) }:</strong> example.com, example.net
+				</div>
+			);
 		}
 
 		return (
@@ -186,6 +193,7 @@ var RegisterDomainStep = React.createClass( {
 					delaySearch={ true }
 					delayTimeout={ 2000 }
 				/>
+				{ exampleDomains }
 			</div>
 		);
 	},

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -26,6 +26,13 @@
 	}
 }
 
+.register-domain-step__search-examples {
+	color: $gray;
+	font-size: 13px;
+	font-style: italic;
+	margin: 8px 0 0 0;
+}
+
 @keyframes shake {
 	0%, 100% {
 	    transform: translate3d( 0, 0, 0 );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -80,7 +80,7 @@ module.exports = {
 		excludeSitesWithPaidPlan: true
 	},
 	domainSearchPlaceholderText: {
-		datestamp: '20160302',
+		datestamp: '20160304',
 		variations: {
 			original: 50,
 			searchForADomain: 50

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -80,7 +80,7 @@ module.exports = {
 		excludeSitesWithPaidPlan: true
 	},
 	domainSearchPlaceholderText: {
-		datestamp: '20000302',
+		datestamp: '20160302',
 		variations: {
 			original: 50,
 			searchForADomain: 50

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -79,5 +79,12 @@ module.exports = {
 		defaultVariation: 'original',
 		excludeSitesWithPaidPlan: true
 	},
-
+	domainSearchPlaceholderText: {
+		datestamp: '20000302',
+		variations: {
+			original: 50,
+			searchForADomain: 50
+		},
+		defaultVariation: 'original'
+	},
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -163,7 +163,8 @@ module.exports = React.createClass( {
 				offerMappingOption
 				analyticsSection="signup"
 				includeWordPressDotCom
-				showExampleSuggestions />
+				showExampleSuggestions
+				isInSigup />
 		);
 	},
 


### PR DESCRIPTION
This PR introduces a new A/B test for showing different placeholder text and examples for the domain search field.

`original`:
<img width="738" alt="screen shot 2016-03-02 at 9 07 58 am" src="https://cloud.githubusercontent.com/assets/3011211/13468173/581df44a-e056-11e5-84a0-04deca45e078.png">

`searchForADomain`:
<img width="736" alt="screen shot 2016-03-02 at 7 50 57 pm" src="https://cloud.githubusercontent.com/assets/3011211/13484156/20c95e44-e0b0-11e5-8b46-727f10ffc480.png">

To test:
- Original: `localStorage.setItem( 'ABTests', '{"domainSearchPlaceholderText_20160302":"original"}' );`
- Variation: `localStorage.setItem( 'ABTests', '{"domainSearchPlaceholderText_20160302":"searchForADomain"}' );`

Note that this is only shown at `/domains/add` and not in signup (since the goal is to increase domain searches and the signup step requires a search even if you are just opting for the `*.wordpress.com` domain).