### PR TITLE
Editor: remove post-editor/pages feature flag.

### DIFF
--- a/client/my-sites/pages/helpers.js
+++ b/client/my-sites/pages/helpers.js
@@ -1,19 +1,10 @@
-/**
- * Internal dependencies
- */
-var config = require( 'config' );
-
 module.exports = {
 	editLinkForPage: function( page, site ) {
 		if ( ! ( page && page.ID ) || ! ( site && site.ID ) ) {
 			return null;
 		}
 
-		if ( config.isEnabled( 'post-editor/pages' ) ) {
-			return '/page/' + site.slug + '/' + page.ID;
-		}
-
-		return 'https://wordpress.com/page/' + site.ID + '/' + page.ID;
+		return '/page/' + site.slug + '/' + page.ID;
 	},
 
 	isFrontPage: function( page, site ) {

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -16,8 +16,7 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	NoResults = require( 'my-sites/no-results' ),
 	actions = require( 'lib/posts/actions' ),
 	Placeholder = require( './placeholder' ),
-	mapStatus = require( 'lib/route' ).mapPostStatus,
-	config = require( 'config' );
+	mapStatus = require( 'lib/route' ).mapPostStatus;
 
 var PageList = React.createClass( {
 
@@ -132,11 +131,7 @@ var Pages = React.createClass({
 			/>;
 		} else {
 
-			if ( config.isEnabled( 'post-editor/pages' ) ) {
-				newPageLink = this.props.siteID ? '/page/' + this.props.siteID : '/page';
-			} else {
-				newPageLink = selectedSite ? '//wordpress.com/page/' + selectedSite.ID + '/new' : '//wordpress.com/page';
-			}
+			newPageLink = this.props.siteID ? '/page/' + this.props.siteID : '/page';
 
 			if ( this.props.hasRecentError ) {
 				attributes = {

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -17,7 +17,6 @@ var updatePostStatus = require( 'lib/mixins/update-post-status' ),
 	helpers = require( './helpers' ),
 	i18n = require( 'lib/mixins/i18n' ),
 	analytics = require( 'analytics' ),
-	config = require( 'config' ),
 	utils = require( 'lib/posts/utils' );
 
 function recordEvent( eventAction ) {
@@ -135,7 +134,7 @@ module.exports = React.createClass( {
 		// This is technically if you can edit the current page, not the parent.
 		// Capabilities are not exposed on the parent page.
 		parentHref = utils.userCan( 'edit_post', this.props.page ) ? helpers.editLinkForPage( page.parent, site ) : page.parent.URL;
-		parentLink = <a target={ config.isEnabled( 'post-editor/pages' ) ? null : '_blank' } href={ parentHref }>{ parentTitle }</a>;
+		parentLink = <a href={ parentHref }>{ parentTitle }</a>;
 
 		return ( <div className="page__popover-more-info">{
 			this.translate( "Child of {{PageTitle/}}", {
@@ -279,7 +278,6 @@ module.exports = React.createClass( {
 					title={ canEdit ?
 						this.translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } ) :
 						this.translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } ) }
-					target={ config.isEnabled( 'post-editor/pages' ) ? null : '_blank' }
 					onClick={ this.analyticsEvents.pageTitle }
 					>
 					{ depthIndicator }

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -41,10 +41,7 @@ var PublishMenu = React.createClass( {
 	},
 
 	getNewPageLink: function( site ) {
-		if ( config.isEnabled( 'post-editor/pages' ) ) {
-			return site ? '/page/' + site.slug : '/page';
-		}
-		return site ? '//wordpress.com/page/' + site.ID + '/new' : '//wordpress.com/page';
+		return site ? '/page/' + site.slug : '/page';
 	},
 
 	getDefaultMenuItems: function( site ) {

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -6,8 +6,7 @@ var page = require( 'page' );
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	sitesController = require( 'my-sites/controller' ),
+var sitesController = require( 'my-sites/controller' ),
 	controller = require( './controller' );
 
 module.exports = function() {
@@ -15,9 +14,7 @@ module.exports = function() {
 	page( '/post/new', () => page.redirect( '/post' ) ); // redirect from beep-beep-boop
 	page( '/post/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
 
-	if ( config.isEnabled( 'post-editor/pages' ) ) {
-		page( '/page', sitesController.siteSelection, sitesController.sites );
-		page( '/page/new', () => page.redirect( '/page' ) ); // redirect from beep-beep-boop
-		page( '/page/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
-	}
+	page( '/page', sitesController.siteSelection, sitesController.sites );
+	page( '/page/new', () => page.redirect( '/page' ) ); // redirect from beep-beep-boop
+	page( '/page/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
 };

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -63,7 +63,6 @@
 		"post-editor/author-selector": true,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
-		"post-editor/pages": true,
 		"press-this": false,
 		"reader": true,
 		"reader/activities": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -63,7 +63,6 @@
 		"post-editor/author-selector": true,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
-		"post-editor/pages": true,
 		"press-this": false,
 		"reader": true,
 		"reader/activities": true,

--- a/config/development.json
+++ b/config/development.json
@@ -94,7 +94,6 @@
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
 		"post-editor/media-advanced": true,
-		"post-editor/pages": true,
 		"post-editor/post-type-switch": false,
 		"press-this": true,
 		"reader": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -67,7 +67,6 @@
 		"phone_signup": false,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
-		"post-editor/pages": true,
 		"press-this": true,
 		"reader": true,
 		"reader/activities": true,

--- a/config/production.json
+++ b/config/production.json
@@ -60,7 +60,6 @@
 		"post-editor/author-selector": true,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
-		"post-editor/pages": true,
 		"press-this": true,
 		"reader": true,
 		"reader/activities": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -63,7 +63,6 @@
 		"persist-redux": false,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
-		"post-editor/pages": true,
 		"press-this": true,
 		"reader": true,
 		"reader/activities": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -72,7 +72,6 @@
 		"phone_signup": true,
 		"post-editor/iframe-preview": true,
 		"post-editor/live-image-updates": true,
-		"post-editor/pages": true,
 		"press-this": true,
 		"reader": true,
 		"reader/activities": true,


### PR DESCRIPTION
For #3676 this branch removes the `post-editor/pages` feature flag which is set to `true` in all configs.  To test, interact with the `/pages/{ site }` list - specifically select edit from the menu. 