### PR TITLE
People: Redirect invite form to team for Jetpack sites

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -5,6 +5,7 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import page from 'page';
 import route from 'lib/route';
+import get from 'lodash/get';
 
 /**
  * Internal Dependencies
@@ -74,15 +75,23 @@ function renderPeopleList( filter, context ) {
 }
 
 function renderInvitePeople( context ) {
+	const site = sites.getSelectedSite();
+	const isJetpack = get( site, 'jetpack' );
+
 	if ( ! sites.initialized ) {
 		sites.once( 'change', () => page( context.path ) );
+	}
+
+	if ( isJetpack ) {
+		layoutFocus.setNext( layoutFocus.getCurrent() );
+		page.redirect( '/people/team/' + site.slug );
 	}
 
 	titleActions.setTitle( i18n.translate( 'Invite People', { textOnly: true } ), { siteID: route.getSiteFragment( context.path ) } );
 
 	renderWithReduxStore(
 		React.createElement( InvitePeople, {
-			site: sites.getSelectedSite()
+			site: site
 		} ),
 		document.getElementById( 'primary' ),
 		context.store


### PR DESCRIPTION
Closes #3613

Alternative solution to #3706. Instead of showing a Drake when a user lands on the invite form route for a Jetpack site, let's redirect them to `/people/team/$site`. Then, if the user decides to "Add" a user, the "Add" button in the "My Sites" sidebar properly links to WP-Admin.

To test:
- Checkout `update/people-invites-redirect-jetpack-sites` branch
- Go to `/people/new/$site` where `$site` is a WP.com site
- You should see the invite people form
- Switch sites to a Jetpack site
- You should be redirected to `/people/team/$site`
- Clear `localStorage`
- Go to `/people/new/$site` where `$site` is a Jetpack site
- You should be redirected to `/people/team/$site`
