### PR TITLE
Reader: Stop fetching subs once we hit 2000.

### DIFF
--- a/client/lib/reader-feed-subscriptions/index.js
+++ b/client/lib/reader-feed-subscriptions/index.js
@@ -137,7 +137,7 @@ var FeedSubscriptionStore = {
 		} );
 
 		// Is it the last page?
-		if ( data.number === 0 ) {
+		if ( data.number === 0 || data.page === 40 ) {
 			isLastPage = true;
 		}
 


### PR DESCRIPTION
Right now we try to pull in _all_ of the subs. If a user has 10K+ subs, that gets silly after a while and brings the browser to a crawl.