### PR TITLE
Bump xgettext-js to 0.3.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9163,19 +9163,13 @@
       "version": "0.3.4"
     },
     "xgettext-js": {
-      "version": "0.2.2",
-      "from": "xgettext-js@0.2.2",
-      "resolved": "https://registry.npmjs.org/xgettext-js/-/xgettext-js-0.2.2.tgz",
+      "version": "0.3.0",
       "dependencies": {
         "acorn": {
-          "version": "0.6.0",
-          "from": "acorn@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.6.0.tgz"
+          "version": "3.0.4"
         },
         "lodash": {
-          "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+          "version": "2.4.2"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "wpcom-proxy-request": "1.0.5",
     "wpcom-unpublished": "1.0.10",
     "wpcom-xhr-request": "0.3.4",
-    "xgettext-js": "0.2.2"
+    "xgettext-js": "0.3.0"
   },
   "engines": {
     "node": ">=4.3.0"


### PR DESCRIPTION
Will let us extract translations for the Desktop app.

See https://github.com/Automattic/xgettext-js/pull/9
See https://github.com/Automattic/wp-desktop/pull/105

## To Test

- `make distclean`.
- `make run`.
- Verify Calypso runs and works as expected for both English and non-English.
- Verify that `make translate` works.

/cc @deBhal 