### PR TITLE
Signup: Update Default Themes in Signup

### DIFF
--- a/client/my-sites/themes/jetpack-manage-disabled-message.jsx
+++ b/client/my-sites/themes/jetpack-manage-disabled-message.jsx
@@ -29,14 +29,15 @@ export default React.createClass( {
 
 	renderMockThemes() {
 		const exampleThemesData = [
-			{ name: 'Boardwalk', slug: 'boardwalk' },
-			{ name: 'Cubic', slug: 'cubic' },
-			{ name: 'Edin', slug: 'edin' },
-			{ name: 'Minnow', slug: 'minnow' },
-			{ name: 'Sequential', slug: 'sequential' },
+			{ name: 'Dyad', slug: 'dyad' },
+			{ name: 'Independent Publisher', slug: 'independent-publisher' },
+			{ name: 'Sela', slug: 'sela' },
+			{ name: 'Hemingway Rewritten', slug: 'hemingway-rewritten' },
+			{ name: 'Twenty Sixteen', slug: 'twentysixteen' },
 			{ name: 'Penscratch', slug: 'penscratch' },
-			{ name: 'Intergalactic', slug: 'intergalactic' },
-			{ name: 'Eighties', slug: 'eighties' }
+			{ name: 'Edin', slug: 'edin' },
+			{ name: 'Publication', slug: 'publication' },
+			{ name: 'Harmonic', slug: 'harmonic' },
 		];
 		const themes = exampleThemesData.map( function( theme ) {
 			return {

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -26,15 +26,15 @@ module.exports = React.createClass( {
 	getDefaultProps: function() {
 		return {
 			themes: [
-				{ name: 'Boardwalk', slug: 'boardwalk' },
-				{ name: 'Cubic', slug: 'cubic' },
-				{ name: 'Edin', slug: 'edin' },
-				{ name: 'Cols', slug: 'cols' },
-				{ name: 'Minnow', slug: 'minnow' },
-				{ name: 'Sequential', slug: 'sequential' },
+				{ name: 'Dyad', slug: 'dyad' },
+				{ name: 'Independent Publisher', slug: 'independent-publisher' },
+				{ name: 'Sela', slug: 'sela' },
+				{ name: 'Hemingway Rewritten', slug: 'hemingway-rewritten' },
+				{ name: 'Twenty Sixteen', slug: 'twentysixteen' },
 				{ name: 'Penscratch', slug: 'penscratch' },
-				{ name: 'Intergalactic', slug: 'intergalactic' },
-				{ name: 'Eighties', slug: 'eighties' },
+				{ name: 'Edin', slug: 'edin' },
+				{ name: 'Publication', slug: 'publication' },
+				{ name: 'Harmonic', slug: 'harmonic' },
 			],
 
 			useHeadstart: false


### PR DESCRIPTION
The recent A/B test #3284 showed us that the new selection didn't negatively impact the conversion, therefore there is no reason to not to update with more modern and solid themes.

Since this is going to be the default, all flows that use `theme` step as it is will affect by this update. So, if this is a concern for your tests currently running, please let me know.

I have a question though. The current default themes are also listed in `/client/my-sites/themes/jetpack-manage-disabled-message.jsx` I'm not familiar with what it does, do we also need to update it?

**New Selection**
![screen shot 2016-03-02 at 22 56 22](https://cloud.githubusercontent.com/assets/908665/13478681/13a93ce2-e0ca-11e5-96c7-a9420f244904.png)

