### PR TITLE
People: Set maxLength of invitees to 10

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -29,6 +29,7 @@ var TokenField = React.createClass( {
 		onChange: React.PropTypes.func,
 		tokenStatus: React.PropTypes.func,
 		isBorderless: React.PropTypes.bool,
+		maxLength: React.PropTypes.number,
 		value: function( props ) {
 			const value = props.value;
 			if ( ! Array.isArray( value ) ) {
@@ -148,10 +149,12 @@ var TokenField = React.createClass( {
 	},
 
 	_renderInput: function() {
+		const { maxLength, value } = this.props;
 		return (
 			<TokenInput
 				ref="input"
 				key="input"
+				disabled={ maxLength && value.length >= maxLength }
 				value={ this.state.incompleteTokenValue }
 				onChange={ this._onInputChange } />
 		);

--- a/client/components/token-field/token-input.jsx
+++ b/client/components/token-field/token-input.jsx
@@ -26,8 +26,9 @@ var TokenInput = React.createClass( {
 			<input
 				ref="input"
 				type="text"
+				disabled={ this.props.disabled }
 				value={ this.props.value }
-			 	size={ this.props.value.length + 1 }
+				size={ this.props.value.length + 1 }
 				onBlur={ this.props.onBlur }
 				onChange={ this._onChange }
 				className="token-field__input"

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -210,6 +210,7 @@ const InvitePeople = React.createClass( {
 							<FormLabel>{ this.translate( 'Usernames or Emails' ) }</FormLabel>
 							<TokenField
 								isBorderless
+								maxLength={ 10 }
 								value={ this.getTokensWithStatus() }
 								onChange={ this.onTokensChange } />
 							<FormSettingExplanation>


### PR DESCRIPTION
Closes #3615 

Adds a `maxLength` prop to `TokenField` and sets the `maxLength` of invitees to 10.

To test:
- Checkout `update/token-field-add-max-length` branch
- Go to `/people/new/$site` where `$site` is a WP.com site
- Attempt to enter more than 10 invitees
- You should only be able to enter 10
- Remove a token by clicking the "x"
- Now you should be able to add another token

cc @lezama for review