### PR TITLE
Reader: Fix slideout sidebar not working on narrow viewports

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -1,5 +1,4 @@
 .following-edit {
-	position: relative;
 
 	ul {
 		list-style-type: none;
@@ -40,7 +39,6 @@
 	}
 }
 
-
 .section-header.following-edit__header {
 	margin-bottom: 24px;
 
@@ -60,7 +58,6 @@
 		}
 	}
 }
-
 
 // More Options
 .following-edit__more-options {
@@ -107,16 +104,14 @@
 
 // Add to Following
 .following-edit__subscribe-form {
-	position: absolute;
-		top: 60px;
-		right: 0;
-		left: 0;
+	position: relative;
+	margin-top: -58px;
 	opacity: 0;
 	pointer-events: none;
 	transition: all 0.15s ease-in-out;
 
-	@include breakpoint( ">660px" ) {
-		top: 0;
+	@include breakpoint( ">480px" ) {
+		margin-top: -74px;
 	}
 
 	.search {
@@ -152,13 +147,30 @@
 			top: 51px;
 		width: 100%;
 
-		.gridicon__follow {
-			fill: lighten( $gray, 20% );
-		}
-
 		.follow-button {
+
 			cursor: default;
-			color: lighten( $gray, 20% );
+
+			.gridicon {
+				fill: lighten( $gray, 20% );
+			}
+
+			.follow-button__label {
+				cursor: default;
+				color: lighten( $gray, 20% );
+			}
+
+			&:hover,
+			&:active {
+
+				.gridicon {
+					fill: lighten( $gray, 20% );
+				}
+
+				.follow-button__label {
+					color: lighten( $gray, 20% );
+				}
+			}
 		}
 
 		&.is-valid {
@@ -182,27 +194,31 @@
 	}
 }
 
-
 // Search Followed Sites
 .following-edit .search-card {
-	margin-bottom: 1px;
-}
+	margin: 30px 0 1px;
 
+	@include breakpoint( ">660px" ) {
+		margin-top: 50px;
+	}
+}
 
 // Search Results Placeholder
 .following-edit__subscribe-form-blank {
 	position: absolute;
 		top: 51px;
 	width: 100%;
-	height: 75px;
 	box-sizing: border-box;
-	padding: 26px 32px 0;
+	padding: 30px 32px;
 	text-align: center;
 	color: darken( $gray, 10% );
 	background: lighten( $gray, 30% );
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 );
-}
 
+	@include breakpoint( ">480px" ) {
+		padding: 26px 32px;
+	}
+}
 
 // Followed Sites and Search Transitions
 .following-edit__sites,
@@ -269,11 +285,10 @@
 .following-edit__notification-settings-card {
 	background-color: $gray-light;
 	position: relative;
-	color: #2e4453;
+	color: $gray-dark;
 
 	&.is-compact {
-		padding-top: 10px;
-		padding-bottom: 10px;
+		padding: 10px 0;
 
 		@include breakpoint( ">660px" ) {
 			padding-left: 105px;
@@ -299,7 +314,7 @@
 
 	.following-edit__form-toggle-wrapper {
 		position: absolute;
-		right: 16px;
+			right: 16px;
 	}
 
 	.following-edit__form-toggle-status {
@@ -326,15 +341,15 @@
 		left: 0;
 		top: 0;
 	cursor: pointer;
-	padding: 26px 8px 20px 8px;
+	padding: 26px 8px 20px;
 
 	.gridicon {
 		fill: $gray;
-		transform: rotate(0deg);
-		transition: transform .15s cubic-bezier(0.175, .885, .32, 1.275), color .20s ease-in;
+		transform: rotate( 0deg );
+		transition: transform .15s cubic-bezier( 0.175, .885, .32, 1.275 ), color .20s ease-in;
 
 		.is-expanded & {
-			transform: rotate(90deg);
+			transform: rotate( 90deg );
 		}
 	}
 }
@@ -342,7 +357,6 @@
 .following-edit__notification-settings-error {
 	margin-top: 12px;
 }
-
 
 @include breakpoint( ">660px" ) {
 	.following-edit {

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -152,30 +152,23 @@
 			cursor: default;
 
 			.gridicon {
+				cursor: default;
 				fill: lighten( $gray, 20% );
 			}
 
 			.follow-button__label {
-				cursor: default;
 				color: lighten( $gray, 20% );
-			}
-
-			&:hover,
-			&:active {
-
-				.gridicon {
-					fill: lighten( $gray, 20% );
-				}
-
-				.follow-button__label {
-					color: lighten( $gray, 20% );
-				}
 			}
 		}
 
 		&.is-valid {
-			.gridicon__follow {
+			.gridicon {
 				fill: $blue-medium;
+
+				&:hover,
+				&:active {
+					cursor: pointer;
+				}
 			}
 
 			.follow-button {

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -148,7 +148,6 @@
 		width: 100%;
 
 		.follow-button {
-
 			cursor: default;
 
 			.gridicon {


### PR DESCRIPTION
This PR fixes the slideout sidebar which isn't working on viewports `<660px`:

**Steps to reproduce:**
1. make sure you're in a viewport that's less than `660px`
2. click "Manage Followed Sites" back button
3. notice how the you're not taken to the sidebar (it's being displayed underneath the elements of the Manage Following page):

![screenshot 2016-03-02 15 54 17](https://cloud.githubusercontent.com/assets/4924246/13479987/ac32ec32-e08f-11e5-8f24-5111b6167b9e.png)

**Additional small fix:**
The search results "Follow" button when adding a URL to follow has a hover and active state even on a deactivated state. This PR fixes that as well.

Before (hover and active states):
![screenshot 2016-03-02 15 46 32](https://cloud.githubusercontent.com/assets/4924246/13480056/0b758a92-e090-11e5-8153-25120460652e.png)

After (hover and active states):
![screenshot 2016-03-02 16 01 58](https://cloud.githubusercontent.com/assets/4924246/13480069/1cf6c07e-e090-11e5-88c9-ef692d26bebe.png)

