### PR TITLE
Feed post store: remove posts when unfollowing a feed

### DIFF
--- a/client/components/follow-button/index.jsx
+++ b/client/components/follow-button/index.jsx
@@ -9,7 +9,8 @@ var React = require( 'react' ),
  */
 var FollowButton = require( './button' ),
 	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' ),
-	FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' );
+	FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' ),
+	FeedPostStore = require( 'lib/feed-post-store' );
 
 var FollowButtonContainer = React.createClass( {
 	propTypes: {
@@ -38,6 +39,7 @@ var FollowButtonContainer = React.createClass( {
 
 	componentWillUnmount: function() {
 		FeedSubscriptionStore.off( 'change', this.onStoreChange );
+		FeedPostStore.removePostsMarkedForRemoval();
 	},
 
 	onStoreChange: function() {

--- a/client/components/follow-button/index.jsx
+++ b/client/components/follow-button/index.jsx
@@ -9,8 +9,7 @@ var React = require( 'react' ),
  */
 var FollowButton = require( './button' ),
 	FeedSubscriptionActions = require( 'lib/reader-feed-subscriptions/actions' ),
-	FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' ),
-	FeedPostStore = require( 'lib/feed-post-store' );
+	FeedSubscriptionStore = require( 'lib/reader-feed-subscriptions' );
 
 var FollowButtonContainer = React.createClass( {
 	propTypes: {
@@ -39,7 +38,6 @@ var FollowButtonContainer = React.createClass( {
 
 	componentWillUnmount: function() {
 		FeedSubscriptionStore.off( 'change', this.onStoreChange );
-		FeedPostStore.removePostsMarkedForRemoval();
 	},
 
 	onStoreChange: function() {

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -46,6 +46,7 @@ FeedPostStore = {
 
 	removePostsMarkedForRemoval() {
 		_postsForBlogs = removeBlogPostsMarkedForRemoval();
+		_posts = removeFeedPostsMarkedForRemoval();
 	}
 };
 
@@ -121,8 +122,9 @@ FeedPostStore.dispatchToken = Dispatcher.register( function( payload ) {
 		case FeedSubscriptionActionType.RECEIVE_UNFOLLOW_READER_FEED:
 			if ( action.blogId ) {
 				markBlogPostsForRemoval( action.blogId );
+			} else {
+				markFeedPostsForRemoval( action.feedId );
 			}
-			debug( _postsForBlogs );
 			break;
 	}
 } );
@@ -308,6 +310,23 @@ function markBlogPostsForRemoval( blogId ) {
 
 function removeBlogPostsMarkedForRemoval() {
 	return filter( _postsForBlogs, function( post ) {
+		return ! post.is_marked_for_removal;
+	} );
+}
+
+function markFeedPostsForRemoval( feedId ) {
+	forOwn( _posts, function( post ) {
+		var newPost;
+		if ( post.feed_ID === feedId && ! post.is_marked_for_removal ) {
+			newPost = clone( post );
+			newPost.is_marked_for_removal = true;
+			setPost( newPost.feed_item_ID, newPost );
+		}
+	} );
+}
+
+function removeFeedPostsMarkedForRemoval() {
+	return filter( _posts, function( post ) {
 		return ! post.is_marked_for_removal;
 	} );
 }

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -8,7 +8,7 @@ var assign = require( 'lodash/assign' ),
 	isEqual = require( 'lodash/isEqual' ),
 	forOwn = require( 'lodash/forOwn' ),
 	clone = require( 'lodash/clone' ),
-	filter = require( 'lodash/filter' );
+	pickBy = require( 'lodash/pickBy' );
 
 /**
  * Internal dependencies
@@ -299,7 +299,9 @@ function markBlockedSitePosts( siteId, isSiteBlocked ) {
 
 function markBlogPostsForRemoval( blogId ) {
 	forOwn( _postsForBlogs, function( post ) {
-		if ( post.site_ID === blogId && ! post.is_marked_for_removal ) {
+		if ( +post.site_ID === +blogId && ! post.is_marked_for_removal ) {
+			debug( 'marking blog post for removal' );
+			debug( post );
 			markPostForRemoval( post );
 		}
 	} );
@@ -307,7 +309,9 @@ function markBlogPostsForRemoval( blogId ) {
 
 function markFeedPostsForRemoval( feedId ) {
 	forOwn( _posts, function( post ) {
-		if ( post.feed_ID === feedId && ! post.is_marked_for_removal ) {
+		if ( +post.feed_id === +feedId && ! post.is_marked_for_removal ) {
+			debug( 'marking feed post for removal' );
+			debug( post );
 			markPostForRemoval( post );
 		}
 	} );
@@ -319,13 +323,9 @@ function markPostForRemoval( post ) {
 }
 
 function removePostsMarkedForRemoval( posts ) {
-	if ( ! posts ) {
-		return;
-	}
-
-	return filter( posts, function( post ) {
+	return pickBy( posts, function( post ) {
 		return ! post.is_marked_for_removal;
 	} );
 }
 
-module.exports = FeedPostStore;
+export default FeedPostStore;

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -319,8 +319,13 @@ function markPostForRemoval( post ) {
 }
 
 function removePostsMarkedForRemoval( posts ) {
+	if ( ! posts ) {
+		return;
+	}
+
 	return filter( posts, function( post ) {
 		return ! post.is_marked_for_removal;
 	} );
 }
+
 module.exports = FeedPostStore;

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -45,8 +45,9 @@ FeedPostStore = {
 	},
 
 	removePostsMarkedForRemoval() {
-		_postsForBlogs = removeBlogPostsMarkedForRemoval();
-		_posts = removeFeedPostsMarkedForRemoval();
+		_postsForBlogs = removePostsMarkedForRemoval( _postsForBlogs );
+		_posts = removePostsMarkedForRemoval( _posts );
+		FeedPostStore.emit( 'change' );
 	}
 };
 
@@ -296,39 +297,30 @@ function markBlockedSitePosts( siteId, isSiteBlocked ) {
 	} );
 }
 
-// @todo extract property update into a helper method
 function markBlogPostsForRemoval( blogId ) {
 	forOwn( _postsForBlogs, function( post ) {
-		var newPost;
 		if ( post.site_ID === blogId && ! post.is_marked_for_removal ) {
-			newPost = clone( post );
-			newPost.is_marked_for_removal = true;
-			setPost( newPost.feed_item_ID, newPost );
+			markPostForRemoval( post );
 		}
-	} );
-}
-
-function removeBlogPostsMarkedForRemoval() {
-	return filter( _postsForBlogs, function( post ) {
-		return ! post.is_marked_for_removal;
 	} );
 }
 
 function markFeedPostsForRemoval( feedId ) {
 	forOwn( _posts, function( post ) {
-		var newPost;
 		if ( post.feed_ID === feedId && ! post.is_marked_for_removal ) {
-			newPost = clone( post );
-			newPost.is_marked_for_removal = true;
-			setPost( newPost.feed_item_ID, newPost );
+			markPostForRemoval( post );
 		}
 	} );
 }
 
-function removeFeedPostsMarkedForRemoval() {
-	return filter( _posts, function( post ) {
+function markPostForRemoval( post ) {
+	const newPost = assign( {}, post, { is_marked_for_removal: true } );
+	setPost( newPost.feed_item_ID, newPost );
+}
+
+function removePostsMarkedForRemoval( posts ) {
+	return filter( posts, function( post ) {
 		return ! post.is_marked_for_removal;
 	} );
 }
-
 module.exports = FeedPostStore;

--- a/client/lib/feed-post-store/test/feed-post-store-test.js
+++ b/client/lib/feed-post-store/test/feed-post-store-test.js
@@ -167,6 +167,8 @@ describe( 'feed-post-store', function() {
 			blogId: blogId
 		} );
 
+		FeedPostStore.removePostsMarkedForRemoval();
+
 		expect( FeedPostStore.get( {
 			blogId: blogId,
 			postId: 3

--- a/client/lib/feed-post-store/test/feed-post-store-test.js
+++ b/client/lib/feed-post-store/test/feed-post-store-test.js
@@ -174,4 +174,38 @@ describe( 'feed-post-store', function() {
 			postId: 3
 		} ) ).to.be.undefined;
 	} );
+
+	it( 'should remove posts when a feed is unfollowed', function() {
+		const feedId = 123;
+		const postId = 3;
+		Dispatcher.handleServerAction( {
+			type: FeedPostActionType.RECEIVE_FEED_POST,
+			data: {
+				feed_id: feedId,
+				feed_item_ID: postId,
+				title: 'a sample post'
+			},
+			feedId: feedId,
+			postId: postId,
+			error: null
+		} );
+
+		expect( FeedPostStore.get( {
+			feedId: feedId,
+			postId: postId
+		} ) ).to.be.ok;
+
+		// Fire off the unfollow API response
+		Dispatcher.handleServerAction( {
+			type: FeedSubscriptionActionType.RECEIVE_UNFOLLOW_READER_FEED,
+			feedId: feedId
+		} );
+
+		FeedPostStore.removePostsMarkedForRemoval();
+
+		expect( FeedPostStore.get( {
+			feedId: feedId,
+			postId: postId
+		} ) ).to.be.undefined;
+	} );
 } );

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -204,7 +204,7 @@ assign( FeedStream.prototype, {
 	},
 
 	getLastItemWithDate: function() {
-		var i, key, date;
+		var i, key, date, post;
 
 		i = this.postKeys.length - 1;
 		if ( i === -1 ) {
@@ -214,7 +214,10 @@ assign( FeedStream.prototype, {
 		do {
 			key = this.postKeys[ i ];
 			if ( ! key.isGap ) {
-				date = FeedPostStore.get( key )[ this.dateProperty ];
+				post = FeedPostStore.get( key );
+				if ( post ) {
+					date = post[ this.dateProperty ];
+				}
 			}
 			--i;
 		} while ( ! date && i !== -1 );

--- a/client/lib/feed-stream-store/feed-stream.js
+++ b/client/lib/feed-stream-store/feed-stream.js
@@ -236,8 +236,9 @@ assign( FeedStream.prototype, {
 
 		do {
 			key = this.postKeys[ i ];
-			if ( ! key.isGap ) {
-				date = FeedPostStore.get( key )[ this.dateProperty ];
+			let post = FeedPostStore.get( key );
+			if ( ! key.isGap && post ) {
+				date = post[ this.dateProperty ];
 			}
 			++i;
 		} while ( ! date && i < this.postKeys.length );

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import Main from 'components/main';
 import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
 import SiteStore from 'lib/reader-site-store';
+import FeedPostStore from 'lib/feed-post-store';
 import FeedStore from 'lib/feed-store';
 import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
 import EmptyContent from 'components/empty-content';
@@ -94,6 +95,7 @@ const FollowingEdit = React.createClass( {
 		FeedSubscriptionStore.off( 'change', this.handleChange );
 		FeedSubscriptionStore.off( 'remove', this.handleRemove );
 		window.removeEventListener( 'resize', this.handleResize );
+		FeedPostStore.removePostsMarkedForRemoval();
 	},
 
 	componentWillReceiveProps: function( nextProps ) {

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -32,7 +32,8 @@ var Main = require( 'components/main' ),
 	CommentStore = require( 'lib/comment-store/comment-store' ),
 	KeyboardShortcuts = require( 'lib/keyboard-shortcuts' ),
 	scrollTo = require( 'lib/scroll-to' ),
-	XPostHelper = require( 'reader/xpost-helper' );
+	XPostHelper = require( 'reader/xpost-helper' ),
+	FeedPostStore = require( 'lib/feed-post-store' );
 
 const GUESSED_POST_HEIGHT = 600,
 	HEADER_OFFSET_TOP = 46;
@@ -162,6 +163,8 @@ module.exports = React.createClass( {
 		if ( 'scrollRestoration' in history ) {
 			history.scrollRestoration = 'auto';
 		}
+
+		FeedPostStore.removePostsMarkedForRemoval();
 	},
 
 	componentWillReceiveProps: function( nextProps ) {

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -367,13 +367,12 @@ module.exports = React.createClass( {
 		}
 
 		post = PostStore.get( postKey );
-		postState = post._state;
-		itemKey = this.getPostRef( postKey );
-
-		if ( ! post || postState === 'minimal' ) {
+		if ( ! post || post._state === 'minimal' ) {
 			FeedPostStoreActions.fetchPost( postKey );
 			postState = 'pending';
 		}
+
+		itemKey = this.getPostRef( postKey );
 
 		switch ( postState ) {
 			case 'pending':


### PR DESCRIPTION
Currently, when you unfollow a feed, posts from that feed do not disappear until you refresh the page.

This PR marks the posts that should be removed after the unfollow, and then clears them up on unmount. (Removing them immediately could be a jarring user experience.)

Fixes #3648.