### PR TITLE
Manage Following: don't accept hostnames with less than two parts separated by a dot (e.g. ".co")

### DIFF
--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -106,6 +106,12 @@ var FollowingEditSubscribeForm = React.createClass( {
 			return false;
 		}
 
+		// Make sure the hostname has at least two parts separated by a dot
+		const hostnameParts = parsedUrl.hostname.split( '.' ).filter( Boolean );
+		if ( hostnameParts.length < 2 ) {
+			return false;
+		}
+
 		return true;
 	},
 


### PR DESCRIPTION
@jancavan noticed that, on http://calypso.localhost:3000/following/edit when adding a new site, ".co" was accepted as a valid URL.

This PR checks that the hostname has at least parts separated by a dot, so ".co" is no longer valid, but "t.co" correctly is.

<img width="773" alt="screen shot 2016-03-03 at 17 29 53" src="https://cloud.githubusercontent.com/assets/17325/13484768/9413262c-e165-11e5-9ce6-3d54a3634a7d.png">

Fixes #3744.