### PR TITLE
Support User: Improve labels on login dialog

### DIFF
--- a/client/support/support-user/login-dialog.jsx
+++ b/client/support/support-user/login-dialog.jsx
@@ -70,14 +70,16 @@ const SupportUserLoginDialog = React.createClass( {
 						<FormTextInput
 							name="supportUser"
 							id="supportUser"
+							placeholder="Username"
 							valueLink={ this.linkState( 'supportUser' ) } />
 					</FormLabel>
 
 					<FormLabel>
-						<span>User support password</span>
+						<span>Support user password</span>
 						<FormPasswordInput
 							name="supportPassword"
 							id="supportPassword"
+							placeholder="Password"
 							valueLink={ this.linkState( 'supportPassword' ) } />
 					</FormLabel>
 				</FormFieldset>


### PR DESCRIPTION
Minor change to the labels on the support user login dialog

- "User support password" is now "Support user password" to match other documentation
- Addition of placeholders to the text fields.