### PR TITLE
Editor: Fix lost focus when editing a post on a site with autofocus fields

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -126,7 +126,7 @@ const WebPreview = React.createClass( {
 	shouldRenderIframe() {
 		// Don't preload iframe on mobile devices as bandwidth is typically more limited and
 		// the preview causes weird issues
-		return ! this._isMobile || this.props.showPreview;
+		return ! this._isMobile && this.props.showPreview;
 	},
 
 	setDeviceViewport( device = 'computer' ) {


### PR DESCRIPTION
When using the editor on a site that has an element that requests focus upon load (for example an `<input autofocus />` then this steals the focus from the editor (most annoyingly while typing).

This PR changes the behavior so that the iframe is actually only rendered when it is being displayed, hence it is not a problem when the focus is being lost.

Steps to reproduce:
1. add a site to your account that utilizes an input form with autofocus
2. open or create a new post on that site in the editor
3. type something, wait for autosave and preview to kick in
4. a) without patch: lost focus because iframe is rendered in the background
4. b) with patch: focus not lost becaues no preview is rendered in the background