### PR TITLE
Domains: refactor fetchDomains to use isFetching/hasLoadedFromServer

### DIFF
--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -117,7 +117,6 @@ function deleteEmailForwarding( domainName, mailbox, onComplete ) {
 	} );
 }
 
-let _activefetchDomainsForSite = {};
 function fetchDomains( siteId ) {
 	if ( ! isDomainInitialized( DomainsStore.get(), siteId ) ) {
 		Dispatcher.handleViewAction( {
@@ -126,17 +125,17 @@ function fetchDomains( siteId ) {
 		} );
 	}
 
+	const domains = DomainsStore.getBySite( siteId );
+	if ( domains.isFetching ) {
+		return;
+	}
+
 	Dispatcher.handleViewAction( {
 		type: ActionTypes.DOMAINS_FETCH,
 		siteId
 	} );
 
-	if ( _activefetchDomainsForSite[ siteId ] ) {
-		return;
-	}
-	_activefetchDomainsForSite[ siteId ] = true;
 	wpcom.site( siteId ).domains( function( error, data ) {
-		delete _activefetchDomainsForSite[ siteId ];
 		if ( error ) {
 			Dispatcher.handleServerAction( {
 				type: ActionTypes.DOMAINS_FETCH_FAILED,


### PR DESCRIPTION
Replace the old fix for enforcing a single request to the /domains endpoint, with one that uses store variables

Test:
Make sure there is only one `/domains` call, and everything works fine. Calypso -> Domains