### PR TITLE
Themes: Loading placeholders for theme sheets

### DIFF
--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -76,7 +76,7 @@ export const ThemeSheet = React.createClass( {
 	renderBar() {
 		const placeholder = <span className="themes__sheet-placeholder">loading.....</span>;
 		const title = this.props.name || placeholder;
-		const tag = this.props.author ? 'by ' + this.props.author : placeholder;
+		const tag = this.props.author ? i18n.translate( 'by ' ) + this.props.author : placeholder;
 
 		return (
 			<div className="themes__sheet-bar">

--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -89,13 +89,9 @@ export const ThemeSheet = React.createClass( {
 	},
 
 	renderScreenshot() {
-		const classes = classNames(
-			'themes__sheet-screenshot',
-			{ 'is-placeholder': ! this.props.screenshot }
-		);
 		const img = <img className="themes__sheet-img" src={ this.props.screenshot + '?=w680' } />;
 		return (
-			<div className={ classes }>
+			<div className="themes__sheet-screenshot">
 				{ this.props.screenshot && img }
 			</div>
 		);

--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -75,6 +75,19 @@ export const ThemeSheet = React.createClass( {
 		return { priceElement, themeContentElement };
 	},
 
+	renderBar() {
+		const placeholder = <span className="themes__sheet-placeholder">loading.....</span>;
+		const title = this.props.name || placeholder;
+		const tag = this.props.author ? 'by ' + this.props.author : placeholder;
+
+		return (
+			<div className="themes__sheet-bar">
+				<span className="themes__sheet-bar-title">{ title }</span>
+				<span className="themes__sheet-bar-tag">{ tag }</span>
+			</div>
+		)
+	},
+
 	renderScreenshot() {
 		const classes = classNames(
 			'themes__sheet-screenshot',
@@ -111,10 +124,7 @@ export const ThemeSheet = React.createClass( {
 
 		return (
 			<Main className="themes__sheet">
-				<div className="themes__sheet-bar">
-					<span className="themes__sheet-bar-title">{ this.props.name }</span>
-					<span className="themes__sheet-bar-tag">by { this.props.author }</span>
-				</div>
+				{ this.renderBar() }
 				<div className="themes__sheet-columns">
 					<div className="themes__sheet-column-left">
 						<HeaderCake className="themes__sheet-action-bar" onClick={ this.onBackClick }>

--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -95,6 +95,28 @@ export const ThemeSheet = React.createClass( {
 		);
 	},
 
+	renderSectionNav( section ) {
+		const filterStrings = {
+			details: i18n.translate( 'Details', { context: 'Filter label for theme content' } ),
+			documentation: i18n.translate( 'Documentation', { context: 'Filter label for theme content' } ),
+			support: i18n.translate( 'Support', { context: 'Filter label for theme content' } ),
+		};
+
+		const nav = (
+			<NavTabs label="Details" >
+				<NavItem path={ `/theme/${ this.props.id }/details` } selected={ section === 'details' } >{ i18n.translate( 'Details' ) }</NavItem>
+				<NavItem path={ `/theme/${ this.props.id }/documentation` } selected={ section === 'documentation' } >{ i18n.translate( 'Documentation' ) }</NavItem>
+				<NavItem path={ `/theme/${ this.props.id }/support` } selected={ section === 'support' } >{ i18n.translate( 'Support' ) }</NavItem>
+			</NavTabs>
+		);
+
+		return (
+			<SectionNav className="themes__sheet-section-nav" selectedText={ filterStrings[section] }>
+				{ this.props.name && nav }
+			</SectionNav>
+		);
+	},
+
 	render() {
 		let actionTitle = <span className="themes__sheet-button-placeholder">loading......</span>;
 		if ( this.props.isLoggedIn && this.props.active ) { //FIXME: active ENOENT
@@ -104,12 +126,6 @@ export const ThemeSheet = React.createClass( {
 		}
 
 		const section = this.props.section || 'details';
-		const filterStrings = {
-			details: i18n.translate( 'Details', { context: 'Filter label for theme content' } ),
-			documentation: i18n.translate( 'Documentation', { context: 'Filter label for theme content' } ),
-			support: i18n.translate( 'Support', { context: 'Filter label for theme content' } ),
-		};
-
 		const { themeContentElement, priceElement } = this.getDangerousElements( section );
 
 		return (
@@ -126,13 +142,7 @@ export const ThemeSheet = React.createClass( {
 							</div>
 						</HeaderCake>
 						<div className="themes__sheet-content">
-							<SectionNav className="themes__sheet-section-nav" selectedText={ filterStrings[section] }>
-								<NavTabs label="Details" >
-									<NavItem path={ `/theme/${ this.props.id }/details` } selected={ section === 'details' } >{ i18n.translate( 'Details' ) }</NavItem>
-									<NavItem path={ `/theme/${ this.props.id }/documentation` } selected={ section === 'documentation' } >{ i18n.translate( 'Documentation' ) }</NavItem>
-									<NavItem path={ `/theme/${ this.props.id }/support` } selected={ section === 'support' } >{ i18n.translate( 'Support' ) }</NavItem>
-								</NavTabs>
-							</SectionNav>
+							{ this.renderSectionNav( section ) }
 							<Card className="themes__sheet-content">{ themeContentElement }</Card>
 						</div>
 					</div>

--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -14,7 +14,6 @@ import page from 'page';
  * Internal dependencies
  */
 import Main from 'components/main';
-import Gridicon from 'components/gridicon';
 import HeaderCake from 'components/header-cake';
 import Button from 'components/button';
 import SectionNav from 'components/section-nav';
@@ -25,7 +24,6 @@ import { purchase, customize, activate, signup } from 'state/themes/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import ThemeHelpers from 'my-sites/themes/helpers';
 import i18n from 'lib/mixins/i18n';
-import classNames from 'classnames';
 
 export const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
@@ -98,15 +96,11 @@ export const ThemeSheet = React.createClass( {
 	},
 
 	render() {
-		let actionTitle;
+		let actionTitle = <span className="themes__sheet-button-placeholder">loading......</span>;
 		if ( this.props.isLoggedIn && this.props.active ) { //FIXME: active ENOENT
 			actionTitle = i18n.translate( 'Customize' );
-		} else if ( this.props.isLoggedIn ) {
-			actionTitle = ThemeHelpers.isPremium( this.props ) && ! this.props.purchased //FIXME: purchased ENOENT
-				? i18n.translate( 'Purchase & Activate' )
-				: i18n.translate( 'Activate' );
-		} else {
-			actionTitle = i18n.translate( 'Start with this design' );
+		} else if ( this.props.name ) {
+			actionTitle = i18n.translate( 'Pick this design' );
 		}
 
 		const section = this.props.section || 'details';
@@ -125,9 +119,10 @@ export const ThemeSheet = React.createClass( {
 					<div className="themes__sheet-column-left">
 						<HeaderCake className="themes__sheet-action-bar" onClick={ this.onBackClick }>
 							<div className="themes__sheet-action-bar-container">
-								{ priceElement }
-								<Button secondary >{ i18n.translate( 'Download' ) }</Button>
-								<Button primary icon onClick={ this.onPrimaryClick }><Gridicon icon="checkmark"/>{ actionTitle }</Button>
+								<Button onClick={ this.onPrimaryClick }>
+									{ actionTitle }
+									{ priceElement }
+								</Button>
 							</div>
 						</HeaderCake>
 						<div className="themes__sheet-content">

--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -25,6 +25,7 @@ import { purchase, customize, activate, signup } from 'state/themes/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import ThemeHelpers from 'my-sites/themes/helpers';
 import i18n from 'lib/mixins/i18n';
+import classNames from 'classnames';
 
 export const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
@@ -72,6 +73,19 @@ export const ThemeSheet = React.createClass( {
 		const priceElement = <span className="themes__sheet-action-bar-cost" dangerouslySetInnerHTML={ { __html: this.props.price } } />;
 		const themeContentElement = this.getContentElement( section );
 		return { priceElement, themeContentElement };
+	},
+
+	renderScreenshot() {
+		const classes = classNames(
+			'themes__sheet-screenshot',
+			{ 'is-placeholder': ! this.props.screenshot }
+		);
+		const img = <img className="themes__sheet-img" src={ this.props.screenshot + '?=w680' } />;
+		return (
+			<div className={ classes }>
+				{ this.props.screenshot && img }
+			</div>
+		);
 	},
 
 	render() {
@@ -123,9 +137,7 @@ export const ThemeSheet = React.createClass( {
 					</div>
 					<div className="themes__sheet-column-right">
 						<Card className="themes_sheet-action-bar-spacer"/>
-						<div className="themes__sheet-screenshot">
-							<img className="themes__sheet-img" src={ this.props.screenshot + '?=w680' } />
-						</div>
+						{ this.renderScreenshot() }
 					</div>
 				</div>
 			</Main>

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -96,7 +96,7 @@
 	font-size: 16px;
 	font-weight: 200;
 	padding-top: 5px;
-	padding-left: 25px
+	padding-left: 25px;
 }
 
 .themes__sheet-columns {
@@ -116,7 +116,6 @@
 	width: 50%;
 	flex-direction: column;
 }
-
 
 .themes__sheet-action-bar {
 	height: 50px;
@@ -180,6 +179,12 @@
 	padding: 20px;
 	// whilst loading
 	min-height: 600px;
+}
+
+.themes__sheet-placeholder {
+	color: transparent;
+	background-color: white;
+	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
 @include breakpoint( "<660px" ) {

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -132,10 +132,14 @@
 	margin: 2px;
 }
 
+.themes__sheet-button-placeholder {
+	color: transparent;
+}
+
 .themes__sheet-action-bar-cost {
 	font-weight: 600;
 	color: #4AB866;
-	margin-right: 10px;
+	margin-left: 10px;
 	display: inline-block;
 	max-width: 50%;
 }

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -218,4 +218,12 @@
 	.themes_sheet-action-bar-spacer {
 		display: none;
 	}
+
+	.themes__sheet-screenshot {
+		box-shadow: none;
+	}
+
+	.themes__sheet-screenshot:before {
+		background: linear-gradient( to bottom, transparentize( white, 0.5 ), transparent );
+	}
 }

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -156,19 +156,30 @@
 	width: 0;
 }
 
-.themes__sheet-img {
+.themes__sheet-screenshot {
 	display: block;
-	max-width: 49%;
 	position: absolute;
 	top: 90px;
-	height: auto;
-	width: auto;
+	width: 49%;
+
+	&.is-placeholder {
+		// 4:3 screenshot ratio (based on 50% width)
+		padding-top: 37.5%;
+		background-color: lighten( $gray, 20% );
+		animation: loading-fade 1.6s ease-in-out infinite;
+		border: none;
+	}
+}
+
+.themes__sheet-img {
 	border: 1px solid $gray;
 	box-shadow: 0px 2px 8px 0px rgba(46,68,83,0.45);
 }
 
 .themes__sheet-content {
 	padding: 20px;
+	// whilst loading
+	min-height: 600px;
 }
 
 @include breakpoint( "<660px" ) {
@@ -184,11 +195,15 @@
 		width: 100%;
 	}
 
-	.themes__sheet-img {
+	.themes__sheet-screenshot {
 		position: relative;
 		top: 0;
-		max-width: 100%;
+		width: 100%;
 
+		&.is-placeholder {
+			// 4:3 screenshot ratio
+			padding-top: 75%;
+		}
 	}
 
 	.themes_sheet-action-bar-spacer {

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -160,25 +160,30 @@
 	position: absolute;
 	top: 90px;
 	width: 49%;
+	box-shadow: 0px 2px 8px 0px rgba(46,68,83,0.45);
+}
 
-	&.is-placeholder {
-		// 4:3 screenshot ratio (based on 50% width)
-		padding-top: 37.5%;
-		background-color: lighten( $gray, 20% );
-		animation: loading-fade 1.6s ease-in-out infinite;
-		border: none;
-	}
+.themes__sheet-screenshot:before {
+	content: "";
+	display: block;
+	// 4:3 screenshot ratio
+	padding-top: 75%;
+	background-color: transparentize( white, 0.5 );
 }
 
 .themes__sheet-img {
+	position: absolute;
+		top: 0;
+		left: 0;
+	width: 100%;
+	height: 100%;
 	border: 1px solid $gray;
-	box-shadow: 0px 2px 8px 0px rgba(46,68,83,0.45);
 }
 
 .themes__sheet-content {
 	padding: 20px;
 	// whilst loading
-	min-height: 600px;
+	min-height: 900px;
 }
 
 .themes__sheet-placeholder {
@@ -204,11 +209,6 @@
 		position: relative;
 		top: 0;
 		width: 100%;
-
-		&.is-placeholder {
-			// 4:3 screenshot ratio
-			padding-top: 75%;
-		}
 	}
 
 	.themes_sheet-action-bar-spacer {

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -192,7 +192,7 @@
 
 .themes__sheet-placeholder {
 	color: transparent;
-	background-color: white;
+	background-color: rgba(255, 255, 255, 0.4);
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
 


### PR DESCRIPTION
Loading placeholders for Theme sheets.

<img width="300" alt="screen shot 2016-03-15 at 13 30 53" src="https://cloud.githubusercontent.com/assets/7767559/13779320/4c0c2260-eab2-11e5-9dee-6da5e011f5eb.png">

<img width="963" alt="screen shot 2016-03-15 at 13 29 37" src="https://cloud.githubusercontent.com/assets/7767559/13779326/50f03bb8-eab2-11e5-8432-a685dde603c9.png">



**To Test**
* Go to http://calypso.localhost:3000/design, and select _Details_ from the ... button for a theme
* Try at different viewport widths
