### PR TITLE
Editor: Restore active element after preview frame loads

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -39,7 +39,11 @@ const WebPreview = React.createClass( {
 		// Optional loading message to display during loading
 		loadingMessage: React.PropTypes.string,
 		// The iframe's title element, used for accessibility purposes
-		iframeTitle: React.PropTypes.string
+		iframeTitle: React.PropTypes.string,
+		// Function handler to call when IFrame URL changes
+		onFrameUrlChange: React.PropTypes.func,
+		// Function handler to call when IFrame contents load
+		onFrameLoad: React.PropTypes.func
 	},
 
 	mixins: [ PureRenderMixin ],
@@ -48,7 +52,9 @@ const WebPreview = React.createClass( {
 		return {
 			showExternal: true,
 			showDeviceSwitcher: true,
-			previewUrl: 'about:blank'
+			previewUrl: 'about:blank',
+			onFrameUrlChange: () => {},
+			onFrameLoad: () => {}
 		}
 	},
 
@@ -121,6 +127,8 @@ const WebPreview = React.createClass( {
 			loaded: false,
 			iframeUrl: iframeUrl,
 		} );
+
+		this.props.onFrameUrlChange( iframeUrl );
 	},
 
 	shouldRenderIframe() {
@@ -139,6 +147,7 @@ const WebPreview = React.createClass( {
 		}
 		debug( 'preview loaded:', this.state.iframeUrl );
 		this.setState( { loaded: true } );
+		this.props.onFrameLoad();
 	},
 
 	render() {

--- a/client/post-editor/editor-preview/index.jsx
+++ b/client/post-editor/editor-preview/index.jsx
@@ -1,13 +1,15 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	url = require( 'url' );
+import React from 'react';
+import ReactDom from 'react-dom';
+import url from 'url';
+import defer from 'lodash/defer';
 
 /**
  * Internal dependencies
  */
-const WebPreview = require( 'components/web-preview' );
+import WebPreview from 'components/web-preview';
 
 const EditorPreview = React.createClass( {
 
@@ -79,12 +81,38 @@ const EditorPreview = React.createClass( {
 		return url.format( parsed );
 	},
 
+	detectFocusLoss() {
+		this.activeElement = document.activeElement;
+		while ( this.activeElement && this.activeElement.contentWindow ) {
+			try {
+				this.activeElement = this.activeElement.contentDocument.activeElement;
+			} catch ( e ) {
+				break;
+			}
+		}
+	},
+
+	verifyFocusLoss() {
+		defer( () => {
+			if ( this.activeElement && document.activeElement &&
+					document.activeElement !== this.activeElement &&
+					ReactDom.findDOMNode( this.refs.preview ).contains( document.activeElement ) ) {
+				this.activeElement.focus();
+			}
+
+			delete this.activeElement;
+		} );
+	},
+
 	render() {
 		return (
 			<WebPreview
+				ref="preview"
 				showPreview={ this.props.showPreview }
 				defaultViewportDevice="tablet"
 				onClose={ this.props.onClose }
+				onFrameUrlChange={ this.detectFocusLoss }
+				onFrameLoad={ this.verifyFocusLoss }
 				previewUrl={ this.state.iframeUrl }
 				loadingMessage="Beep beep boop…"
 			/>


### PR DESCRIPTION
Related: #3756

This pull request seeks to resolve an issue where if a theme triggers a focus on an element when rendering a post preview, focus will be moved away from the editor after each autosave occurs, since the `<EditorPreview />` component is always rendered in the background of the page (a feature to improve perceived performance of preview load times).

__Implementation notes:__

This is a hacky and imperfect solution. Particularly, it may not work well in scenarios where focus changes between the time that the preview frame begins to load and finishes, and the restoration of the focus is not always quick enough such that if the user were in the midst of typing, one or more character may be omitted in the time that focus was removed.

__Alternative solutions:__

- Update themes to either not apply an autofocus, or detect the presence of being rendered in an iframe
- Remove editor preview background preloading
- Other mechanism for preventing frame from stealing focus...?

__Testing instructions:__

1. Navigate to the [Calypso editor](http://calypso.localhost:3000/post)
2. Select a site whose theme will focus an element on post template page load
3. Enter some content
4. Note that after autosave occurs, focus is no longer stolen from the editor