### PR TITLE
Reader: Pull margins off of p tags in excerpts

### DIFF
--- a/client/components/post-excerpt/style.scss
+++ b/client/components/post-excerpt/style.scss
@@ -16,6 +16,14 @@
 			max-height: 22px * 3;
 		}
 
+		p {
+			margin: 0;
+		}
+
+		p[align] {
+			text-align: inherit;
+		}
+
 		&.is-long {
 			&:after {
 				content: '';


### PR DESCRIPTION
And remove align via attributes.

Fixes styling of post cards where the generated summary contains multiple p tags.