### PR TITLE
Signup: set Headstart themes as step prop

### DIFF
--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -20,6 +20,17 @@ module.exports = {
 		stepName: 'themes-headstart',
 		props: {
 			useHeadstart: true,
+			themes: [
+				{ name: 'Boardwalk', slug: 'boardwalk' },
+				{ name: 'Cubic', slug: 'cubic' },
+				{ name: 'Edin', slug: 'edin' },
+				{ name: 'Cols', slug: 'cols' },
+				{ name: 'Minnow', slug: 'minnow' },
+				{ name: 'Sequential', slug: 'sequential' },
+				{ name: 'Penscratch', slug: 'penscratch' },
+				{ name: 'Intergalactic', slug: 'intergalactic' },
+				{ name: 'Eighties', slug: 'eighties' },
+			],
 		},
 		dependencies: [ 'siteSlug' ],
 		providesDependencies: [ 'theme' ]


### PR DESCRIPTION
Pass Headstart-able themes as prop to theme step in Headstart flow. Prevents changes to default themes in themes step from breaking Headstart.