### PR TITLE
Customizer: hide masterbar at mobile width

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -32,7 +32,8 @@ var Customize = React.createClass( {
 		domain: React.PropTypes.string.isRequired,
 		sites: React.PropTypes.object.isRequired,
 		prevPath: React.PropTypes.string,
-		themeActivated: React.PropTypes.func.isRequired
+		query: React.PropTypes.object,
+		themeActivated: React.PropTypes.func.isRequired,
 	},
 
 	getDefaultProps: function() {

--- a/client/my-sites/customize/style.scss
+++ b/client/my-sites/customize/style.scss
@@ -5,20 +5,13 @@
 	padding: 0;
 	z-index: z-index( 'root', '.main.customize.is-iframe' );
 	-webkit-overflow-scrolling: touch;
-
-	@include breakpoint( "<660px" ) {
-		height: 100vh;
-		position: relative;
-	}
-	@include breakpoint( ">660px" ) {
-		min-height: 0;
-		position: fixed;
-			bottom: 0;
-			left: 0;
-			right: 0;
-			top: 0;
-		width: auto;
-	}
+	min-height: 0;
+	position: fixed;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		top: 0;
+	width: auto;
 
 	iframe {
 		height: 100%;


### PR DESCRIPTION
Fixes #3763 

Tested in mobile Safari in iOS 9.2.1 without any noticeable regressions.

Testing instructions:

1. Load WordPress.com on Mobile Safari
2. Navigate to the Customizer

You should not see the masterbar appear.