### PR TITLE
Reader: add default padding to tables

### DIFF
--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -7,7 +7,8 @@
 		}
 	}
 
-	img.emoji, img.wp-smiley {
+	img.emoji,
+	img.wp-smiley {
 		display: inline;
 		height: 1em;
 		width: 1em;
@@ -30,6 +31,14 @@
 
 	sub {
 		bottom: -0.5em;
+	}
+}
+
+.reader__full-post-content {
+
+	table th,
+	table td {
+		padding: 10px;
 	}
 }
 
@@ -336,7 +345,7 @@
 	}
 
 	.foldable-card__expand .gridicon {
-		transform: rotate(-90deg);
+		transform: rotate( -90deg );
 	    position: absolute;
 	    	top: 24px;
 	    	left: 0;
@@ -344,6 +353,5 @@
 }
 // Make sure it rotates in the right direction
 .following-edit .foldable-card.is-expanded .gridicon {
-	transform: rotate(0deg);
+	transform: rotate( 0deg );
 }
-


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/3526

**Before:**
![screenshot 2016-03-03 14 02 13](https://cloud.githubusercontent.com/assets/4924246/13511411/2084b664-e14a-11e5-8303-c96c481e3275.png)

**After:**
![screenshot 2016-03-03 14 11 27](https://cloud.githubusercontent.com/assets/4924246/13511412/24958ea4-e14a-11e5-8abd-c02b8ae116aa.png)

