### PR TITLE
People: Adds anayltics to invite form

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -30,6 +30,7 @@ var TokenField = React.createClass( {
 		tokenStatus: React.PropTypes.func,
 		isBorderless: React.PropTypes.bool,
 		maxLength: React.PropTypes.number,
+		onFocus: React.PropTypes.func,
 		value: function( props ) {
 			const value = props.value;
 			if ( ! Array.isArray( value ) ) {
@@ -160,7 +161,7 @@ var TokenField = React.createClass( {
 		);
 	},
 
-	_onFocus: function() {
+	_onFocus: function( event ) {
 		if ( this._blurTimeoutID ) {
 			this._clearBlurTimeout();
 			return;
@@ -169,6 +170,9 @@ var TokenField = React.createClass( {
 		}
 
 		this.setState( { isActive: true } );
+		if ( 'function' === typeof this.props.onFocus ) {
+			this.props.onFocus( event );
+		}
 	},
 
 	_onBlur: function( event ) {

--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -85,6 +85,7 @@ function renderInvitePeople( context ) {
 	if ( isJetpack ) {
 		layoutFocus.setNext( layoutFocus.getCurrent() );
 		page.redirect( '/people/team/' + site.slug );
+		analytics.tracks.recordEvent( 'calypso_invite_people_controller_redirect_to_team' );
 	}
 
 	titleActions.setTitle( i18n.translate( 'Invite People', { textOnly: true } ), { siteID: route.getSiteFragment( context.path ) } );


### PR DESCRIPTION
Closes #2861 by adding analytics throughout the invitation process.

To test:
- Checkout `update/people-invites-analytics` branch
- In console, `localStorage.setItem('debug','calypso:analytics')
- Go to `/people/new$site`
- Do all of the things and test that analytics are being recorded

cc @lezama for code review.