### PR TITLE
Reader: fix one liner posts in main feed

### DIFF
--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -185,11 +185,7 @@
 
 			padding: 16px 24px 54px;
 
-			.reader__post-title {
-				position: absolute;
-					left: 25px;
-			}
-
+			.reader__post-title,
 			.reader-post-byline {
 				position: absolute;
 					left: 25px;

--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -134,7 +134,7 @@
 	&.tag-afk {
 		background: transparent;
 		box-shadow: none;
-		padding: 16px 24px 54px 24px;
+		padding: 16px 24px;
 
 		&:hover {
 			cursor: pointer;
@@ -162,7 +162,7 @@
 			margin: 0;
 			position: absolute;
 				top: 14px;
-				left: 25px;
+				left: 66px;
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
@@ -174,11 +174,26 @@
 			font-size: 13px;
 			position: absolute;
 				top: 34px;
-				left: 25px;
+				left: 44px;
 		}
 
 		.follow-button {
 			display: none;
+		}
+
+		&.is-headerless {
+
+			padding: 16px 24px 54px;
+
+			.reader__post-title {
+				position: absolute;
+					left: 25px;
+			}
+
+			.reader-post-byline {
+				position: absolute;
+					left: 25px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR fixed single-liner posts on the individual blog feeds, https://github.com/Automattic/wp-calypso/pull/3764. However, it broke it on the main feed.

What's causing it was the main blog feed was using a different layout - gravatar is overlaid on top of the blavatar while on the individual blog feed, only the gravatars are shown.

This fixes them on both main and individual blog feeds.

/cc @blowery 