### PR TITLE
Themes SSR: Rely on Redux store for caching themeDetails API object

### DIFF
--- a/client/my-sites/themes/controller/index.node.js
+++ b/client/my-sites/themes/controller/index.node.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import omit from 'lodash/omit';
+import debugFactory from 'debug';
 
 /**
  * Internal Dependencies
@@ -17,6 +18,8 @@ import ClientSideEffects from 'components/client-side-effects';
 import { fetchThemeDetails } from 'state/themes/actions';
 import config from 'config';
 import { decodeEntities } from 'lib/formatting';
+
+const debug = debugFactory( 'calypso:themes' );
 
 export function makeElement( ThemesComponent, Head, store, props ) {
 	return(
@@ -37,8 +40,14 @@ export function fetchThemeDetailsData( context, next ) {
 	}
 
 	const themeSlug = context.params.slug;
+	const theme = getThemeDetails( context.store.getState(), themeSlug );
 
-	themeSlug && context.store.dispatch( fetchThemeDetails( themeSlug, next ) );
+	if ( theme ) {
+		debug( 'found theme!', theme.id );
+		next();
+	} else {
+		themeSlug && context.store.dispatch( fetchThemeDetails( themeSlug, next ) );
+	}
 } // TODO(ehg): We don't want to hit the endpoint for every req. Debounce based on theme arg?
 
 export function details( context, next ) {

--- a/client/my-sites/themes/controller/index.node.js
+++ b/client/my-sites/themes/controller/index.node.js
@@ -42,11 +42,11 @@ export function fetchThemeDetailsData( context, next ) {
 	const themeSlug = context.params.slug;
 	const theme = getThemeDetails( context.store.getState(), themeSlug );
 
-	if ( theme ) {
+	if ( Object.keys( theme ).length ) {
 		debug( 'found theme!', theme.id );
 		next();
-	} else {
-		themeSlug && context.store.dispatch( fetchThemeDetails( themeSlug, next ) );
+	} else if ( themeSlug ) {
+		context.store.dispatch( fetchThemeDetails( themeSlug, next ) );
 	}
 } // TODO(ehg): We don't want to hit the endpoint for every req. Debounce based on theme arg?
 

--- a/client/my-sites/themes/controller/index.node.js
+++ b/client/my-sites/themes/controller/index.node.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import omit from 'lodash/omit';
-import debugFactory from 'debug';
 
 /**
  * Internal Dependencies
@@ -15,12 +14,9 @@ import i18n from 'lib/mixins/i18n';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getThemeDetails } from 'state/themes/theme-details/selectors';
 import ClientSideEffects from 'components/client-side-effects';
-import { receiveThemeDetails } from 'state/themes/actions';
-import wpcom from 'lib/wp';
+import { fetchThemeDetails } from 'state/themes/actions';
 import config from 'config';
 import { decodeEntities } from 'lib/formatting';
-
-const debug = debugFactory( 'calypso:themes' );
 
 export function makeElement( ThemesComponent, Head, store, props ) {
 	return(
@@ -42,14 +38,7 @@ export function fetchThemeDetailsData( context, next ) {
 
 	const themeSlug = context.params.slug;
 
-	themeSlug && wpcom.undocumented().themeDetails( themeSlug, ( error, data ) => {
-		if ( error ) {
-			debug( `Error fetching theme ${ themeSlug } details: `, error.message || error );
-			return;
-		}
-		context.store.dispatch( receiveThemeDetails( data ) );
-		next();
-	} );
+	themeSlug && context.store.dispatch( fetchThemeDetails( themeSlug, next ) );
 } // TODO(ehg): We don't want to hit the endpoint for every req. Debounce based on theme arg?
 
 export function details( context, next ) {

--- a/client/my-sites/themes/controller/index.node.js
+++ b/client/my-sites/themes/controller/index.node.js
@@ -21,7 +21,6 @@ import config from 'config';
 import { decodeEntities } from 'lib/formatting';
 
 const debug = debugFactory( 'calypso:themes' );
-let themeDetailsCache = new Map();
 
 export function makeElement( ThemesComponent, Head, store, props ) {
 	return(
@@ -42,26 +41,14 @@ export function fetchThemeDetailsData( context, next ) {
 	}
 
 	const themeSlug = context.params.slug;
-	const theme = themeDetailsCache.get( themeSlug );
-
-	if ( theme ) {
-		debug( 'found theme!', theme.id );
-		context.store.dispatch( receiveThemeDetails( theme ) );
-		next();
-	}
 
 	themeSlug && wpcom.undocumented().themeDetails( themeSlug, ( error, data ) => {
 		if ( error ) {
 			debug( `Error fetching theme ${ themeSlug } details: `, error.message || error );
 			return;
 		}
-		const themeData = themeDetailsCache.get( themeSlug );
-		if ( ! themeData || ( Date( data.date_updated ) > Date( themeData.date_updated ) ) ) {
-			debug( 'caching', themeSlug );
-			themeDetailsCache.set( themeSlug, data );
-			context.store.dispatch( receiveThemeDetails( data ) );
-			next();
-		}
+		context.store.dispatch( receiveThemeDetails( data ) );
+		next();
 	} );
 } // TODO(ehg): We don't want to hit the endpoint for every req. Debounce based on theme arg?
 

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -88,14 +88,16 @@ export function fetchCurrentTheme( site ) {
 	};
 }
 
-export function fetchThemeDetails( id ) {
+export function fetchThemeDetails( id, callback = function() {} ) {
 	return dispatch => {
 		wpcom.undocumented().themeDetails( id )
 			.then( themeDetails => {
 				debug( 'Received theme details', themeDetails );
 				dispatch( receiveThemeDetails( themeDetails ) )
+				callback();
 			} )
 			.catch( error => {
+				debug( `Error fetching theme ${ id } details: `, error.message || error );
 				dispatch( receiveServerError( error ) )
 			} );
 	}


### PR DESCRIPTION
Simplify the caching logic by relying on the `themeDetails` Redux subtree to cache theme details API data.

Since the theme object is part of `initialState` which is used to compute the
markup caching key, an updated theme should still cause a markup cache miss and
hence a freshly rendered page. This way, the functionality provided by the API
data cache is retained.

Also, markup is now returned on first hit (when cache is empty), mostly for
better DevX.

To test -- verify that everyting still works as before, except for theme details pages being SSR'ed on first hit already.