### PR TITLE
Checkout: Thank You: Move URLs to `lib/url/support`

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -1,4 +1,5 @@
-const root = 'https://support.wordpress.com';
+const root = 'https://support.wordpress.com',
+	jetpackRoot = 'https://jetpack.me';
 
 export default {
 	ADDING_GOOGLE_APPS_TO_YOUR_SITE: `${root}/add-email/adding-google-apps-to-your-site`,
@@ -15,6 +16,7 @@ export default {
 	CUSTOM_DNS: `${root}/domains/custom-dns`,
 	DOMAINS: `${root}/domains`,
 	EMAIL_FORWARDING: `${root}/email-forwarding`,
+	EMAIL_VALIDATION_AND_VERIFICATION: `${root}/domains/register-domain/#email-validation-and-verification`,
 	ENABLE_DISABLE_COMMENTS: `${root}/enable-disable-comments`,
 	EVENTBRITE: `${root}/eventbrite`,
 	EVENTBRITE_EVENT_CALENDARLISTING_WIDGET: `${root}/widgets/eventbrite-event-calendarlisting-widget`,
@@ -24,10 +26,13 @@ export default {
 	FOLLOWERS: `${root}/followers`,
 	GETTING_MORE_VIEWS_AND_TRAFFIC: `${root}/getting-more-views-and-traffic`,
 	GOOGLE_ANALYTICS: `${root}/google-analytics`,
+	GOOGLE_APPS_LEARNING_CENTER: 'https://apps.google.com/learning-center/',
 	GOOGLE_PLUS_EMBEDS: `${root}/google-plus-embeds`,
 	GRAVATAR_HOVERCARDS: `${root}/gravatar-hovercards`,
 	IMPORT: `${root}/import`,
 	INSTAGRAM_WIDGET: `${root}/instagram/instagram-widget`,
+	JETPACK_SUPPORT: `${jetpackRoot}/support/`,
+	JETPACK_CONTACT_SUPPORT: `${jetpackRoot}/contact-support/`,
 	LIVE_CHAT: `${root}/live-chat`,
 	MANAGE_PURCHASES: `${root}/manage-purchases`,
 	MAP_EXISTING_DOMAIN: `${root}/domains/map-existing-domain`,
@@ -36,6 +41,7 @@ export default {
 	PUBLICIZE: `${root}/publicize`,
 	PUBLIC_VS_PRIVATE: `${root}/domains/register-domain/#public-versus-private`,
 	REFUNDS: `${root}/refunds`,
+	REGISTER_DOMAIN: `${root}/domains/register-domain/`,
 	SEO_TAGS: `${root}/getting-more-views-and-traffic/#use-appropriate-tags`,
 	SETTING_PRIMARY_DOMAIN: `${root}/domains/#setting-the-primary-domain`,
 	SETTING_UP_PREMIUM_SERVICES: `${root}/setting-up-premium-services`,

--- a/client/my-sites/upgrades/checkout-thank-you/chargeback-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/chargeback-details.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import i18n from 'lib/mixins/i18n';
+import paths from 'lib/paths';
 import PurchaseDetail from 'components/purchase-detail';
 
 const ChargebackDetails = ( { selectedSite } ) => {
@@ -16,7 +17,7 @@ const ChargebackDetails = ( { selectedSite } ) => {
 			title={ i18n.translate( 'Get back to posting' ) }
 			description={ i18n.translate( 'You can now use the full features of your site, without limits.' ) }
 			buttonText={ i18n.translate( 'Write a Post' ) }
-			href={ '/post/' + selectedSite.slug } />
+			href={ paths.newPost( selectedSite ) } />
 	);
 };
 

--- a/client/my-sites/upgrades/checkout-thank-you/domain-mapping-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/domain-mapping-details.jsx
@@ -8,6 +8,7 @@ import React from 'react';
  */
 import i18n from 'lib/mixins/i18n';
 import PurchaseDetail from 'components/purchase-detail';
+import supportUrls from 'lib/url/support';
 
 const DomainMappingDetails = ( { domain, registrarSupportUrl } ) => {
 	const registrarSupportLink = registrarSupportUrl ? <a target="_blank" href={ registrarSupportUrl } /> : <span />;
@@ -50,7 +51,7 @@ const DomainMappingDetails = ( { domain, registrarSupportUrl } ) => {
 				title={ i18n.translate( 'Finish setting up your domain' ) }
 				description={ description }
 				buttonText={ i18n.translate( 'Learn more' ) }
-				href="//support.wordpress.com/map-existing-domain/"
+				href={ supportUrls.MAP_EXISTING_DOMAIN }
 				target="_blank"
 				requiredText={ i18n.translate( 'Almost done! One step remaining…' ) }
 				isRequired />

--- a/client/my-sites/upgrades/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/domain-registration-details.jsx
@@ -11,6 +11,7 @@ import GoogleAppsDetails from './google-apps-details';
 import { isGoogleApps } from 'lib/products-values';
 import i18n from 'lib/mixins/i18n';
 import PurchaseDetail from 'components/purchase-detail';
+import supportUrls from 'lib/url/support';
 
 const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 	const googleAppsWasPurchased = purchases.some( isGoogleApps ),
@@ -24,7 +25,7 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 					title={ i18n.translate( 'Verify your email address' ) }
 					description={ i18n.translate( 'We sent you an email with a request to verify your new domain. Unverified domains may be suspended.' ) }
 					buttonText={ i18n.translate( 'Learn more about verifying your domain' ) }
-					href="//support.wordpress.com/domains/register-domain/#email-validation-and-verification"
+					href={ supportUrls.EMAIL_VALIDATION_AND_VERIFICATION }
 					target="_blank"
 					requiredText={ i18n.translate( 'Important! Your action is required.' ) }
 					isRequired />
@@ -37,7 +38,7 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 				title={ i18n.translate( 'When will it be ready?' ) }
 				description={ i18n.translate( 'Your domain should start working immediately, but may be unreliable during the first 72 hours.' ) }
 				buttonText={ i18n.translate( 'Learn more about your domain' ) }
-				href="//support.wordpress.com/domains/register-domain/"
+				href={ supportUrls.REGISTER_DOMAIN }
 				target="_blank" />
 
 			{ hasOtherPrimaryDomain && (

--- a/client/my-sites/upgrades/checkout-thank-you/footer.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/footer.jsx
@@ -8,6 +8,7 @@ import React from 'react';
  */
 import Card from 'components/card';
 import { isJetpackPlan } from 'lib/products-values';
+import supportUrls from 'lib/url/support';
 
 const CheckoutThankYouFooter = React.createClass( {
 	propTypes: {
@@ -26,8 +27,8 @@ const CheckoutThankYouFooter = React.createClass( {
 				'or {{contactLink}}contact us{{/contactLink}}.',
 				{
 					components: {
-						supportDocsLink: <a href={ 'http://jetpack.me/support/' } target="_blank" />,
-						contactLink: <a href={ 'http://jetpack.me/contact-support/' } target="_blank" />
+						supportDocsLink: <a href={ supportUrls.JETPACK_SUPPORT } target="_blank" />,
+						contactLink: <a href={ supportUrls.JETPACK_CONTACT_SUPPORT } target="_blank" />
 					}
 				}
 			);
@@ -39,7 +40,7 @@ const CheckoutThankYouFooter = React.createClass( {
 			'or {{contactLink}}contact us{{/contactLink}}.',
 			{
 				components: {
-					supportDocsLink: <a href="http://support.wordpress.com" target="_blank" />,
+					supportDocsLink: <a href={ supportUrls.SUPPORT_ROOT } target="_blank" />,
 					forumLink: <a href="http://forums.wordpress.com" target="_blank" />,
 					contactLink: <a href={ '/help/contact' } />
 				}

--- a/client/my-sites/upgrades/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/google-apps-details.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import i18n from 'lib/mixins/i18n';
+import supportUrls from 'lib/url/support';
 import PurchaseDetail from 'components/purchase-detail';
 import userFactory from 'lib/user';
 
@@ -24,7 +25,7 @@ const GoogleAppsDetails = () => {
 				)
 			}
 			buttonText={ i18n.translate( 'Learn more about Google Apps' ) }
-			href="https://apps.google.com/learning-center/"
+			href={ supportUrls.GOOGLE_APPS_LEARNING_CENTER }
 			target="_blank"
 			requiredText={ i18n.translate( 'Almost done! One step remaining…' ) }
 			isRequired />

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -8,6 +8,7 @@ import React from 'react';
  */
 import config from 'config';
 import i18n from 'lib/mixins/i18n';
+import paths from 'lib/paths';
 import PurchaseDetail from 'components/purchase-detail';
 
 const PremiumPlanDetails = ( { selectedSite } ) => {
@@ -55,7 +56,7 @@ const PremiumPlanDetails = ( { selectedSite } ) => {
 					)
 				}
 				buttonText={ i18n.translate( 'Start a new post' ) }
-				href={ '/post/' + selectedSite.slug } />
+				href={ paths.newPost( selectedSite ) } />
 
 		</div>
 	);


### PR DESCRIPTION
Mentioned by @stephanethomas elsewhere:

> We should use the same format for any url displayed in the Thank You page (e.g. protocole relative urls with //). As mentioned by @tugdualdekerviler2, we can for example use the client/lib/url/support.js for links to support pages.

I didn't use protocol-relative URLs, instead following the pattern in `lib/url/support`, but we should talk about whether that needs to change. I don't see a benefit to linking to `http://jetpack.me` when we're running Calypso locally, as it seems that `https://jetpack.me` should be preferred regardless of the local protocol, but I may be missing something.

**Testing**
We should assert that all of the links from the buttons on the thank you pages of the following products work as expected:

- Domain mapping
- Domain registration
- Google Apps
- Premium plan
- Chargeback item (which we can test by updating [this line](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/upgrades/checkout-thank-you/index.jsx#L174) to `return [ ChargebackDetails ];`

We should also assert that the links in the footer work when checking out with a Jetpack plan and any product that is not a Jetpack plan.

- [x] Code review
- [x] Product review