### PR TITLE
Support User: Add checkbox for switching to user's locale

### DIFF
--- a/client/support/support-user/active-dialog.jsx
+++ b/client/support/support-user/active-dialog.jsx
@@ -1,0 +1,69 @@
+/**
+ * External Dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal Dependencies
+ */
+import Dialog from 'components/dialog';
+import FormButton from 'components/forms/form-button';
+import FormLabel from 'components/forms/form-label';
+import EnableLocaleCheckbox from './enable-locale-checkbox';
+import config from 'config';
+import { getCurrentUser } from 'state/current-user/selectors';
+import i18n from 'lib/mixins/i18n'
+
+class SupportUserActiveDialog extends Component {
+
+	render() {
+		const { isVisible, onCloseDialog, onRestoreUser } = this.props;
+
+		const { defaultLocaleSlug, userLocaleSlug } = this.props;
+
+		const buttons = [
+			<FormButton
+				key="close"
+				isPrimary={ false }
+				onClick={ onCloseDialog }>
+					Close
+			</FormButton>,
+			<FormButton
+				key="restoreuser"
+				isPrimary={ false }
+				onClick={ onRestoreUser }>
+					Restore User
+			</FormButton>
+		];
+
+		return (
+			<Dialog
+				isVisible={ isVisible }
+				onClose={ onCloseDialog }
+				buttons={ buttons }>
+				<h2 className="support-user__heading">Support user</h2>
+				{ defaultLocaleSlug !== userLocaleSlug &&
+					<FormLabel>
+						<EnableLocaleCheckbox
+							defaultLocaleSlug={ defaultLocaleSlug }
+							userLocaleSlug={ userLocaleSlug } />
+						{ i18n.translate( 'Display Calypso in user locale' ) }
+					</FormLabel>
+				}
+			</Dialog>
+		);
+	}
+}
+
+SupportUserActiveDialog.defaultProps = {
+	defaultLocaleSlug: config( 'i18n_default_locale_slug' )
+}
+
+const mapStateToProps = ( state ) => {
+	return {
+		userLocaleSlug: getCurrentUser( state ).localeSlug,
+	}
+}
+
+export default connect( mapStateToProps )( SupportUserActiveDialog );

--- a/client/support/support-user/enable-locale-checkbox.js
+++ b/client/support/support-user/enable-locale-checkbox.js
@@ -1,0 +1,60 @@
+/**
+ * External Dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import FormCheckbox from 'components/forms/form-checkbox';
+import i18n from 'lib/mixins/i18n'
+
+class EnableLocaleCheckbox extends Component {
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			checked: false
+		};
+	}
+
+	componentDidMount() {
+		const checkCurrentLocale = this.checkCurrentLocale.bind( this );
+
+		i18n.on( 'change', checkCurrentLocale );
+
+		// Tidy up the event when done
+		this.componentWillUnmount = () => i18n.off( 'change', checkCurrentLocale );
+
+		checkCurrentLocale();
+	}
+
+	onClick() {
+		if ( this.state.checked ) {
+			i18n.setLocaleSlug( this.props.defaultLocaleSlug );
+		} else {
+			i18n.setLocaleSlug( this.props.userLocaleSlug );
+		}
+	}
+
+	checkCurrentLocale() {
+		this.setState( {
+			checked: ( i18n.getLocaleSlug() === this.props.userLocaleSlug )
+		} );
+	}
+
+	render() {
+		const onClick = this.onClick.bind( this );
+
+		return (
+			<FormCheckbox checked={ this.state.checked } onClick={ onClick } />
+		);
+	}
+}
+EnableLocaleCheckbox.defaultProps = {
+	defaultLocaleSlug: 'en',
+	userLocaleSlug: 'en'
+}
+
+export default EnableLocaleCheckbox;

--- a/client/support/support-user/index.jsx
+++ b/client/support/support-user/index.jsx
@@ -10,6 +10,7 @@ import flowRight from 'lodash/flowRight';
  */
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import SupportUserLoginDialog from './login-dialog';
+import SupportUserActiveDialog from './active-dialog';
 import { fetchToken, rebootNormally } from 'lib/user/support-user-interop';
 
 import { supportUserToggleDialog } from 'state/support/actions';
@@ -30,14 +31,19 @@ const SupportUser = React.createClass( {
 		// the shortcut key being entered into the field
 		e.preventDefault();
 
-		if ( this.props.isSupportUser ) {
-			this.props.supportUserRestore();
-		} else {
-			this.props.supportUserToggleDialog();
-		}
+		this.props.supportUserToggleDialog();
 	},
 
 	render: function() {
+		if ( this.props.isSupportUser ) {
+			return (
+				<SupportUserActiveDialog
+					isVisible={ this.props.showDialog }
+					onCloseDialog={ this.props.supportUserToggleDialog }
+					onRestoreUser={ this.props.supportUserRestore } />
+			);
+		}
+
 		return (
 			<SupportUserLoginDialog
 				isVisible={ this.props.showDialog }


### PR DESCRIPTION
This effectively fixes #3643 (i18n not switching) by allowing the user to control which locale is displayed.

Pressing the keyboard shortcut while support user mode is active will toggle the following dialog:

![xjhsp3ftki](https://cloud.githubusercontent.com/assets/416133/13523081/0bf439ea-e23f-11e5-8b10-a21a5afc7312.gif)
