### PR TITLE
Sites: lift sites limit threshold.

### DIFF
--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -72,21 +72,13 @@ SitesList.prototype.get = function() {
  * @api public
  */
 SitesList.prototype.fetch = function() {
-	var currentUser = user.get(),
-		siteVisiblity = 'all';
-
 	if ( this.fetching ) {
 		return;
 	}
 
-	// If the user has too many sites the endpoint fails to resolve
-	if ( currentUser && currentUser.site_count > 300 ) {
-		siteVisiblity = 'visible';
-	}
-
 	this.fetching = true;
 	debug( 'getting SitesList from api' );
-	wpcom.me().sites( { site_visibility: siteVisiblity }, function( error, data ) {
+	wpcom.me().sites( { site_visibility: 'all' }, function( error, data ) {
 		if ( error ) {
 			debug( 'error fetching SitesList from api', error );
 			this.fetching = false;


### PR DESCRIPTION
This removes the artificial limit we had on how many sites to retrieve after a round of performance improvements done on the API endpoint.