### PR TITLE
Framework: fix case where you may fall in the abyss of 12 sites.

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -178,7 +178,7 @@ export default React.createClass( {
 		if ( this.shouldShowGroups() && ! this.state.search ) {
 			return (
 				<div>
-					{ user.get().visible_site_count > 12 && this.renderRecentSites() }
+					{ user.get().visible_site_count > 11 && this.renderRecentSites() }
 					{ siteElements }
 				</div>
 			);


### PR DESCRIPTION
We filter out recent sites from main list if user has _12 or more sites_, but we were only rendering recent sites if the user had _more than 12 sites_.