### PR TITLE
Framework: Be explicit about which cache we use for babel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ env-config.sh
 /calypso-strings.php
 cover.html
 .test.log
+
+.caches/

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ CALYPSO_ENV ?= $(NODE_ENV)
 export NODE_ENV := $(NODE_ENV)
 export CALYPSO_ENV := $(CALYPSO_ENV)
 export NODE_PATH := server$(SEPARATOR)client$(SEPARATOR).
+export BABEL_CACHE_PATH := $(THIS_DIR)/.caches/babel.json
 
 # We use `semver` to check the version of Node.js before installing npm
 # packages or running scripts.  Since this is before npm runs, we need to grab
@@ -159,7 +160,7 @@ server/devdocs/search-index.js: $(MD_FILES) $(ALL_DEVDOCS_JS)
 	@$(ALL_DEVDOCS_JS) $(MD_FILES)
 
 build-server: install
-	@mkdir -p build
+	@mkdir -p build .caches
 	@CALYPSO_ENV=$(CALYPSO_ENV) $(NODE_BIN)/webpack --display-error-details --config webpack.config.node.js
 
 build: install build-$(CALYPSO_ENV)
@@ -177,7 +178,7 @@ build-desktop build-desktop-mac-app-store build-horizon build-stage build-produc
 # the `clean` rule deletes all the files created from `make build`, but not
 # those created by `make install`
 clean:
-	@rm -rf public/style*.css public/style-debug.css.map public/*.js $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js public/editor.css build/* server/bundler/*.json
+	@rm -rf public/style*.css public/style-debug.css.map public/*.js $(CLIENT_CONFIG_FILE) server/devdocs/search-index.js public/editor.css build/* .caches/* server/bundler/*.json
 
 # the `distclean` rule deletes all the files created from `make install`
 distclean:

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,3 @@
 machine:
   node:
     version: 4.3.0
-

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,7 +98,7 @@ const babelCache = path.join( __dirname, '.caches' );
 jsLoader = {
 	test: /\.jsx?$/,
 	exclude: /node_modules/,
-	loaders: [ 'babel-loader?cacheDirectory=' + babelCache + '&optional[]=runtime' ]
+	loaders: [ 'babel-loader?cacheDirectory=' + encodeURIComponent( babelCache ) + '&optional[]=runtime' ]
 };
 
 if ( CALYPSO_ENV === 'development' ) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,10 +93,12 @@ if ( CALYPSO_ENV === 'desktop' || CALYPSO_ENV === 'desktop-mac-app-store' ) {
 	webpackConfig.externals.push( 'jquery' );
 }
 
+const babelCache = path.join( __dirname, '.caches' );
+
 jsLoader = {
 	test: /\.jsx?$/,
 	exclude: /node_modules/,
-	loaders: [ 'babel-loader?cacheDirectory&optional[]=runtime' ]
+	loaders: [ 'babel-loader?cacheDirectory=' + babelCache + '&optional[]=runtime' ]
 };
 
 if ( CALYPSO_ENV === 'development' ) {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -55,7 +55,7 @@ module.exports = {
 			{
 				test: /\.jsx?$/,
 				exclude: /(node_modules|devdocs\/search-index)/,
-				loader: 'babel-loader?optional[]=runtime&cacheDirectory=' + babelCache
+				loader: 'babel-loader?optional[]=runtime&cacheDirectory=' + encodeURIComponent( babelCache )
 			},
 			{
 				test: /\.json$/,

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -40,6 +40,8 @@ function getExternals() {
 	return externals;
 }
 
+const babelCache = path.join( __dirname, '.caches' );
+
 module.exports = {
 	devtool: 'source-map',
 	entry: 'index.js',
@@ -53,7 +55,7 @@ module.exports = {
 			{
 				test: /\.jsx?$/,
 				exclude: /(node_modules|devdocs\/search-index)/,
-				loader: 'babel-loader?optional[]=runtime'
+				loader: 'babel-loader?optional[]=runtime&cacheDirectory=' + babelCache
 			},
 			{
 				test: /\.json$/,
@@ -80,4 +82,3 @@ module.exports = {
 	],
 	externals: getExternals()
 };
-


### PR DESCRIPTION
And teach CircleCI about the cache location.

We found that using an explicit cache location in dev cut test run times by about 1/3. Curious to see if this holds up in CircleCI.