### PR TITLE
Reader: fix position of placeholder skeleton

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -14,7 +14,8 @@
 		margin-bottom: 13px;
 	}
 
-	.foldable-card.card, .foldable-card.card.is-expanded {
+	.foldable-card.card,
+	.foldable-card.card.is-expanded {
 		margin-bottom: 0;
 	}
 
@@ -237,7 +238,11 @@
 	&.is-placeholder {
 		.reader-list-item__title,
 		.reader-list-item__description {
-			margin-left: 92px;
+			margin-left: 91px;
+
+			@include breakpoint( ">480px" ) {
+				margin-left: 83px;
+			}
 		}
 
 		.following-edit__list-title {
@@ -247,6 +252,10 @@
 		.following-edit__list-url {
 			margin-top: 4px;
 			width: 25%;
+		}
+
+		.reader-list-item__icon {
+			left: 42px;
 		}
 	}
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -236,6 +236,7 @@
 .following-edit .reader-list-item__card {
 
 	&.is-placeholder {
+
 		.reader-list-item__title,
 		.reader-list-item__description {
 			margin-left: 91px;

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -237,9 +237,11 @@
 
 	&.is-placeholder {
 
+		height: 74px;
+
 		.reader-list-item__title,
 		.reader-list-item__description {
-			margin-left: 91px;
+			margin: 1px 0 0 91px;
 
 			@include breakpoint( ">480px" ) {
 				margin-left: 83px;
@@ -357,7 +359,7 @@
 }
 
 .following-edit__notification-settings-error {
-	margin-top: 12px;
+	margin-top: 14px;
 }
 
 @include breakpoint( ">660px" ) {
@@ -369,6 +371,7 @@
 		.reader-list-item__title,
 		.reader-list-item__description {
 			margin-right: 100px;
+			padding-left: 3px;
 		}
 	}
 }


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/3776

Placeholder icon and site title/description now line up with the actual icon and title/description.

**Before:**

When a site is waiting to be added:
![screenshot 2016-03-04 10 46 27](https://cloud.githubusercontent.com/assets/4924246/13536747/62270dcc-e1f6-11e5-9714-3ea6549f41c7.png)

When followed sites are loading:
![screenshot 2016-03-04 10 06 32](https://cloud.githubusercontent.com/assets/4924246/13536653/00bc4ebc-e1f6-11e5-9461-134e0a653516.png)

**After:**

When a site is waiting to be added:
![screenshot-2016-03-05-09 19 16](https://cloud.githubusercontent.com/assets/4924246/13549089/833cc34a-e2b3-11e5-890d-35a5769beb82.jpg)

When followed sites are loading:
![screenshot 2016-03-05 09 19 00](https://cloud.githubusercontent.com/assets/4924246/13549082/66cca234-e2b3-11e5-8cbc-65d2d1f1d9fd.png)
