### PR TITLE
Plugin: Update plugins list rendering performance 

### DIFF
--- a/client/lib/mixins/render-visualizer/index.js
+++ b/client/lib/mixins/render-visualizer/index.js
@@ -83,7 +83,7 @@ var RenderVisualizerMixin = {
 
 		resetRenderLog: function() {
 			this.renderLog = [];
-			this.renderCount = 1;
+			this.renderCountLog = 1;
 		},
 
 		applyCssStyling: function( node, styles ) {
@@ -161,7 +161,7 @@ var RenderVisualizerMixin = {
 			var logFragment = document.createDocumentFragment();
 
 			if ( this.renderLogRenderCount ) {
-				this.renderLogRenderCount.innerText = ( this.renderCount - 1 );
+				this.renderLogRenderCount.innerText = ( this.renderCountLog - 1 );
 			}
 
 			if ( this.renderLogDetail ) {
@@ -183,8 +183,8 @@ var RenderVisualizerMixin = {
 		},
 
 		addToRenderLog: function( message ) {
-			this.renderLog.unshift( this.renderCount + ') ' + message );
-			this.renderCount++;
+			this.renderLog.unshift( this.renderCountLog + ') ' + message );
+			this.renderCountLog++;
 
 			this.renderLog.splice( this.MAX_LOG_LENGTH, 1 );
 		},

--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -19,7 +19,7 @@ const debug = debugFactory( 'calypso:my-sites:plugins:actions' );
 let _actionsQueueBySite = {};
 
 const queueSitePluginAction = ( action, siteId, pluginId, callback ) => {
-	let next = ( nextCallback, error, data ) => {
+	const next = ( nextCallback, error, data ) => {
 		let nextAction;
 
 		if ( nextCallback ) {
@@ -49,7 +49,7 @@ const queueSitePluginAction = ( action, siteId, pluginId, callback ) => {
 };
 
 const queueSitePluginActionAsPromise = ( action, siteId, pluginId, callback ) => {
-	var promise = new Promise( ( resolve, reject ) => {
+	return new Promise( ( resolve, reject ) => {
 		queueSitePluginAction( action, siteId, pluginId, ( error, data ) => {
 			if ( callback ) {
 				callback( error, data );
@@ -60,8 +60,6 @@ const queueSitePluginActionAsPromise = ( action, siteId, pluginId, callback ) =>
 			resolve( data );
 		} );
 	} );
-
-	return promise;
 };
 
 const getSolvedPromise = ( dataToPass ) => {
@@ -147,7 +145,7 @@ const autoupdatePlugin = ( site, plugin ) => {
 
 	analytics.mc.bumpStat( 'calypso_plugin_update_automatic' );
 
-	const boundEnableAU = getPluginBoundMethod( site, plugin.id, 'enableAutoupdate' );
+	const boundEnableAU = getPluginBoundMethod( site, plugin.id, 'updateVersion' );
 	queueSitePluginAction( boundEnableAU, site.ID, plugin.id, ( error, data ) => {
 		Dispatcher.handleServerAction( {
 			type: 'RECEIVE_AUTOUPDATE_PLUGIN',
@@ -283,7 +281,7 @@ const PluginsActions = {
 		};
 
 		const dispatchMessage = ( type, responseData, error ) => {
-			var message = {
+			const message = {
 				type: type,
 				action: 'INSTALL_PLUGIN',
 				site: site,

--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -43,6 +43,18 @@ function getTranslateArg( logs, sampleLog, typeFilter ) {
 }
 
 module.exports = {
+	shouldComponentUpdateNotices: function( currentNotices, nextNotices ) {
+		if ( currentNotices.errors && currentNotices.errors.length !== nextNotices.errors.length ) {
+			return true;
+		}
+		if ( currentNotices.inProgress && currentNotices.inProgress.length !== nextNotices.inProgress.length ) {
+			return true;
+		}
+		if ( currentNotices.completed && currentNotices.completed.length !== nextNotices.completed.length ) {
+			return true;
+		}
+		return false;
+	},
 	getInitialState: function() {
 		return { notices: this.refreshPluginNotices() };
 	},

--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -1,34 +1,32 @@
 /**
  * External dependencies
  */
-var groupBy = require( 'lodash/groupBy' ),
-	i18n = require( 'i18n-calypso' );
+import groupBy from 'lodash/groupBy';
+import i18n from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-var notices = require( 'notices' ),
-	PluginsLog = require( 'lib/plugins/log-store' ),
-	PluginsActions = require( 'lib/plugins/actions' ),
-	PluginsUtil = require( 'lib/plugins/utils' ),
-	versionCompare = require( 'lib/version-compare' );
+import notices from 'notices';
+import PluginsLog from 'lib/plugins/log-store';
+import PluginsActions from 'lib/plugins/actions';
+import PluginsUtil from 'lib/plugins/utils';
+import versionCompare from 'lib/version-compare';
 
 function getCombination( translateArg ) {
 	return ( translateArg.numberOfSites > 1 ? 'n sites' : '1 site' ) + ' ' + ( translateArg.numberOfPlugins > 1 ? 'n plugins' : '1 plugin' );
 }
 
 function getTranslateArg( logs, sampleLog, typeFilter ) {
-	var groupedBySite,
-		groupedByPlugin,
-		filteredLogs = logs.filter( ( log ) => {
-			return log.status === typeFilter ? typeFilter : sampleLog.type;
-		} );
+	const filteredLogs = logs.filter( ( log ) => {
+		return log.status === typeFilter ? typeFilter : sampleLog.type;
+	} );
 
-	groupedBySite = groupBy( filteredLogs, function( log ) {
+	const groupedBySite = groupBy( filteredLogs, ( log ) => {
 		return log.site.ID;
 	} );
 
-	groupedByPlugin = groupBy( filteredLogs, function( log ) {
+	const groupedByPlugin = groupBy( filteredLogs, ( log ) => {
 		return log.plugin.slug;
 	} );
 
@@ -43,7 +41,7 @@ function getTranslateArg( logs, sampleLog, typeFilter ) {
 }
 
 module.exports = {
-	shouldComponentUpdateNotices: function( currentNotices, nextNotices ) {
+	shouldComponentUpdateNotices( currentNotices, nextNotices ) {
 		if ( currentNotices.errors && currentNotices.errors.length !== nextNotices.errors.length ) {
 			return true;
 		}
@@ -55,19 +53,21 @@ module.exports = {
 		}
 		return false;
 	},
-	getInitialState: function() {
+
+	getInitialState() {
 		return { notices: this.refreshPluginNotices() };
 	},
-	componentDidMount: function() {
+
+	componentDidMount() {
 		PluginsLog.on( 'change', this.showNotification );
 	},
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		PluginsLog.removeListener( 'change', this.showNotification );
 	},
 
-	refreshPluginNotices: function() {
-		var site = this.props.sites.getSelectedSite();
+	refreshPluginNotices() {
+		const site = this.props.sites.getSelectedSite();
 		return {
 			errors: PluginsUtil.filterNotices( PluginsLog.getErrors(), site, this.props.pluginSlug ),
 			inProgress: PluginsUtil.filterNotices( PluginsLog.getInProgress(), site, this.props.pluginSlug ),
@@ -75,8 +75,8 @@ module.exports = {
 		};
 	},
 
-	showNotification: function() {
-		var logNotices = this.refreshPluginNotices();
+	showNotification() {
+		const logNotices = this.refreshPluginNotices();
 		this.setState( { notices: logNotices } );
 		if ( logNotices.inProgress.length > 0 ) {
 			notices.info( this.getMessage( logNotices.inProgress, this.inProgressMessage, 'inProgress' ) );
@@ -109,15 +109,14 @@ module.exports = {
 		}
 	},
 
-	getMessage: function( logs, messageFunction, typeFilter ) {
-		var sampleLog, combination, translateArg;
-		sampleLog = ( logs[ 0 ].status === 'inProgress' ? logs[ 0 ] : logs[ logs.length - 1 ] );
-		translateArg = getTranslateArg( logs, sampleLog, typeFilter );
-		combination = getCombination( translateArg );
+	getMessage( logs, messageFunction, typeFilter ) {
+		const sampleLog = ( logs[ 0 ].status === 'inProgress' ? logs[ 0 ] : logs[ logs.length - 1 ] ),
+			translateArg = getTranslateArg( logs, sampleLog, typeFilter ),
+			combination = getCombination( translateArg );
 		return messageFunction( sampleLog.action, combination, translateArg, sampleLog );
 	},
 
-	successMessage: function( action, combination, translateArg ) {
+	successMessage( action, combination, translateArg ) {
 		switch ( action ) {
 			case 'INSTALL_PLUGIN':
 				if ( translateArg.isMultiSite ) {
@@ -273,7 +272,7 @@ module.exports = {
 		}
 	},
 
-	inProgressMessage: function( action, combination, translateArg ) {
+	inProgressMessage( action, combination, translateArg ) {
 		switch ( action ) {
 			case 'INSTALL_PLUGIN':
 				switch ( combination ) {
@@ -436,13 +435,13 @@ module.exports = {
 		}
 	},
 
-	erroredAndCompletedMessage: function( logNotices ) {
-		var completedMessage = this.getMessage( logNotices.completed, this.successMessage, 'completed' ),
+	erroredAndCompletedMessage( logNotices ) {
+		const completedMessage = this.getMessage( logNotices.completed, this.successMessage, 'completed' ),
 			errorMessage = this.getMessage( logNotices.errors, this.errorMessage, 'errors' );
 		return ' ' + completedMessage + ' ' + errorMessage;
 	},
 
-	errorMessage: function( action, combination, translateArg, sampleLog ) {
+	errorMessage( action, combination, translateArg, sampleLog ) {
 		if ( combination === '1 site 1 plugin' ) {
 			return this.singleErrorMessage( action, translateArg, sampleLog );
 		}
@@ -562,7 +561,7 @@ module.exports = {
 		}
 	},
 
-	additionalExplanation: function( error_code ) {
+	additionalExplanation( error_code ) {
 		switch ( error_code ) {
 			case 'no_package':
 				return i18n.translate( 'Plugin doesn\'t exist in the plugin repo.' );
@@ -637,7 +636,7 @@ module.exports = {
 		return null;
 	},
 
-	singleErrorMessage: function( action, translateArg, sampleLog ) {
+	singleErrorMessage( action, translateArg, sampleLog ) {
 		const additionalExplanation = this.additionalExplanation( sampleLog.error.error );
 		switch ( action ) {
 			case 'INSTALL_PLUGIN':
@@ -737,7 +736,7 @@ module.exports = {
 		}
 	},
 
-	getErrorButton: function( log ) {
+	getErrorButton( log ) {
 		if ( log.length > 1 ) {
 			return null;
 		}
@@ -748,8 +747,7 @@ module.exports = {
 		return null;
 	},
 
-	getErrorHref: function( log ) {
-		var remoteManagementUrl;
+	getErrorHref( log ) {
 		if ( log.length > 1 ) {
 			return null;
 		}
@@ -757,14 +755,14 @@ module.exports = {
 		if ( log.error.error !== 'unauthorized_full_access' ) {
 			return null;
 		}
-		remoteManagementUrl = log.site.options.admin_url + 'admin.php?page=jetpack&configure=json-api';
+		let remoteManagementUrl = log.site.options.admin_url + 'admin.php?page=jetpack&configure=json-api';
 		if ( versionCompare( log.site.options.jetpack_version, 3.4 ) >= 0 ) {
 			remoteManagementUrl = log.site.options.admin_url + 'admin.php?page=jetpack&configure=manage';
 		}
 		return remoteManagementUrl;
 	},
 
-	getSuccessButton: function( log ) {
+	getSuccessButton( log ) {
 		if ( log.length > 1 ) {
 			return null;
 		}
@@ -778,7 +776,7 @@ module.exports = {
 		return i18n.translate( 'Setup' );
 	},
 
-	getSuccessHref: function( log ) {
+	getSuccessHref( log ) {
 		if ( log.length > 1 ) {
 			return null;
 		}

--- a/client/my-sites/all-sites/index.jsx
+++ b/client/my-sites/all-sites/index.jsx
@@ -41,7 +41,7 @@ export default React.createClass( {
 		this.props.onSelect( event );
 	},
 
-	renderCount() {
+	renderSiteCount() {
 		const count = this.props.count || user.get().visible_site_count;
 		return <Count count={ count } />;
 	},
@@ -57,7 +57,7 @@ export default React.createClass( {
 		return (
 			<div className={ allSitesClass }>
 				<a className="site__content" href={ this.props.href } onTouchTap={ this.onSelect }>
-					{ this.props.showCount && this.renderCount() }
+					{ this.props.showCount && this.renderSiteCount() }
 					<div className="site__info">
 						<span className="site__title">{ title }</span>
 						{ this.props.domain && <span className="site__domain">{ this.props.domain }</span> }

--- a/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
+++ b/client/my-sites/plugins/plugin-icon/plugin-icon.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React from 'react'
-import classNames from 'classnames'
-import Gridicon from 'components/gridicon'
+import React from 'react';
+import classNames from 'classnames';
+import Gridicon from 'components/gridicon';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 export default React.createClass( {
 
@@ -13,6 +14,8 @@ export default React.createClass( {
 		image: React.PropTypes.string,
 		isPlaceholder: React.PropTypes.bool
 	},
+
+	mixins: [ PureRenderMixin ],
 
 	render() {
 		const className = classNames( {

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -1,30 +1,30 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	uniqBy = require( 'lodash/uniqBy' ),
-	i18n = require( 'i18n-calypso' ),
-	isEqual = require( 'lodash/isEqual' );
+import React from 'react';
+import classNames from 'classnames';
+import uniqBy from 'lodash/uniqBy';
+import i18n from 'i18n-calypso';
+import isEqual from 'lodash/isEqual';
 
 /**
  * Internal dependencies
  */
-var CompactCard = require( 'components/card/compact' ),
-	PluginIcon = require( 'my-sites/plugins/plugin-icon/plugin-icon' ),
-	PluginsActions = require( 'lib/plugins/actions' ),
-	PluginActivateToggle = require( 'my-sites/plugins/plugin-activate-toggle' ),
-	PluginAutoupdateToggle = require( 'my-sites/plugins/plugin-autoupdate-toggle' ),
-	Count = require( 'components/count' ),
-	Notice = require( 'components/notice' ),
-	PluginNotices = require( 'lib/plugins/notices' ),
-	analytics = require( 'lib/analytics' );
+import CompactCard from 'components/card/compact';
+import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
+import PluginsActions from 'lib/plugins/actions';
+import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
+import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
+import Count from 'components/count';
+import Notice from 'components/notice';
+import PluginNotices from 'lib/plugins/notices';
+import analytics from 'lib/analytics';
 
 function checkPropsChange( nextProps, propArr ) {
-	var i, prop;
+	let i;
 
 	for ( i = 0; i < propArr.length; i++ ) {
-		prop = propArr[ i ];
+		const prop = propArr[ i ];
 
 		if ( ! isEqual( nextProps[ prop ], this.props[ prop ] ) ) {
 			return true;
@@ -37,8 +37,8 @@ module.exports = React.createClass( {
 
 	displayName: 'PluginItem',
 
-	shouldComponentUpdate: function( nextProps, nextState ) {
-		var propsToCheck = [ 'plugin', 'sites', 'selectedSite', 'isMock', 'isSelectable', 'isSelected' ];
+	shouldComponentUpdate( nextProps, nextState ) {
+		const propsToCheck = [ 'plugin', 'sites', 'selectedSite', 'isMock', 'isSelectable', 'isSelected' ];
 		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
 			return true;
 		}
@@ -57,28 +57,27 @@ module.exports = React.createClass( {
 		return false;
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return { clicked: false };
 	},
 
-	recordEvent: function( eventAction ) {
+	recordEvent( eventAction ) {
 		analytics.ga.recordEvent( 'Plugins', eventAction, 'Plugin Name', this.props.plugin.slug );
 	},
 
-	ago: function( date ) {
+	ago( date ) {
 		return i18n.moment.utc( date, 'YYYY-MM-DD hh:mma' ).fromNow();
 	},
 
-	hasUpdate: function() {
+	hasUpdate() {
 		return this.props.sites.some( function( site ) {
 			return site.plugin && site.plugin.update && site.canUpdateFiles;
 		} );
 	},
 
-	doing: function() {
-		var progress = this.props.progress ? this.props.progress : [],
+	doing() {
+		const progress = this.props.progress ? this.props.progress : [],
 			log = progress[ 0 ],
-			message,
 			uniqLogs = uniqBy( progress, function( uniqLog ) {
 				return uniqLog.site.ID;
 			} ),
@@ -87,8 +86,8 @@ module.exports = React.createClass( {
 				count: uniqLogs.length
 			};
 
+		let message;
 		switch ( log && log.action ) {
-
 			case 'UPDATE_PLUGIN':
 				message = ( this.props.selectedSite
 					? i18n.translate( 'Updating', { context: 'plugin' } )
@@ -127,7 +126,7 @@ module.exports = React.createClass( {
 		return message;
 	},
 
-	renderUpdateFlag: function() {
+	renderUpdateFlag() {
 		const recentlyUpdated = this.props.sites.some( function( site ) {
 			return site.plugin &&
 				site.plugin.update &&
@@ -152,7 +151,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	pluginMeta: function( pluginData ) {
+	pluginMeta( pluginData ) {
 		if ( this.props.progress.length ) {
 			return (
 				<Notice isCompact status="is-info" text={ this.doing() } inline={ true }/>
@@ -173,17 +172,17 @@ module.exports = React.createClass( {
 		return null;
 	},
 
-	clickNoManageItem: function() {
+	clickNoManageItem() {
 		this.setState( { clicked: true } );
 	},
 
-	getNoManageWarning: function() {
+	getNoManageWarning() {
 		return <Notice text={ i18n.translate( 'Jetpack Manage is disabled for all the sites where this plugin is installed' ) }
 			status="is-error"
 			showDismiss={ false } />;
 	},
 
-	renderActions: function() {
+	renderActions() {
 		return (
 			<div className="plugin-item__actions">
 				<PluginActivateToggle
@@ -203,7 +202,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	renderSiteCount: function() {
+	renderSiteCount() {
 		return (
 			<div className="plugin-item__count">{ this.translate( 'Sites {{count/}}',
 				{
@@ -215,7 +214,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	renderPlaceholder: function() {
+	renderPlaceholder() {
 		return (
 			<CompactCard className="plugin-item is-placeholder ">
 				<PluginIcon isPlaceholder={ true } />
@@ -225,39 +224,38 @@ module.exports = React.createClass( {
 		);
 	},
 
-	onItemClick: function( event ) {
+	onItemClick( event ) {
 		if ( this.props.isSelectable ) {
 			event.preventDefault();
 			this.props.onClick( this );
 		}
 	},
 
-	render: function() {
-		var pluginTitle,
-			plugin = this.props.plugin,
-			errors = this.props.errors ? this.props.errors : [],
-			numberOfWarningIcons = 0,
-			errorNotices = [],
-			errorCounter = 0;
+	render() {
+		const plugin = this.props.plugin;
+		const errors = this.props.errors ? this.props.errors : [];
 
-		if ( ! this.props.plugin ) {
+		if ( ! plugin ) {
 			return this.renderPlaceholder();
 		}
 
-		errors.forEach( function( error ) {
-			errorNotices.push(
+		let numberOfWarningIcons = 0;
+		const errorNotices = errors.map( ( error, index ) => {
+			const dismissErrorNotice = function() {
+				PluginsActions.removePluginsNotices( [ error ] );
+			};
+			return (
 				<Notice
 					type="message"
 					status="is-error"
 					text={ PluginNotices.getMessage( [ error ], PluginNotices.errorMessage.bind( PluginNotices ) ) }
 					button={ PluginNotices.getErrorButton( error ) }
 					href={ PluginNotices.getErrorHref( error ) }
-					raw={ { onRemoveCallback: PluginsActions.removePluginsNotices.bind( this, [ error ] ) } }
 					inline={ true }
-					key={ 'notice-' + errorCounter } />
+					onDismissClick={ dismissErrorNotice }
+					key={ 'notice-' + index } />
 			);
-			errorCounter++;
-		}, this );
+		} );
 
 		if ( this.props.hasNoManageSite ) {
 			numberOfWarningIcons++;
@@ -267,7 +265,7 @@ module.exports = React.createClass( {
 			numberOfWarningIcons++;
 		}
 
-		pluginTitle = (
+		const pluginTitle = (
 			<div className="plugin-item__title" data-warnings={ numberOfWarningIcons }>
 				{ plugin.name }
 			</div>

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -47,7 +47,7 @@ module.exports = React.createClass( {
 			return true;
 		}
 
-		if ( PluginNotices.shouldComponentUpdateNotices( this.props.notices, nextProps.notices ) ) {
+		if ( this.props.notices && PluginNotices.shouldComponentUpdateNotices( this.props.notices, nextProps.notices ) ) {
 			return true;
 		}
 

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -4,7 +4,8 @@
 var React = require( 'react' ),
 	classNames = require( 'classnames' ),
 	uniqBy = require( 'lodash/uniqBy' ),
-	i18n = require( 'i18n-calypso' );
+	i18n = require( 'i18n-calypso' ),
+	isEqual = require( 'lodash/isEqual' );
 
 /**
  * Internal dependencies
@@ -19,9 +20,42 @@ var CompactCard = require( 'components/card/compact' ),
 	PluginNotices = require( 'lib/plugins/notices' ),
 	analytics = require( 'lib/analytics' );
 
+function checkPropsChange( nextProps, propArr ) {
+	var i, prop;
+
+	for ( i = 0; i < propArr.length; i++ ) {
+		prop = propArr[ i ];
+
+		if ( ! isEqual( nextProps[ prop ], this.props[ prop ] ) ) {
+			return true;
+		}
+	}
+	return false;
+}
+
 module.exports = React.createClass( {
 
 	displayName: 'PluginItem',
+
+	shouldComponentUpdate: function( nextProps, nextState ) {
+		var propsToCheck = [ 'plugin', 'sites', 'selectedSite', 'isMock', 'isSelectable', 'isSelected' ];
+		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
+			return true;
+		}
+
+		if ( this.props.hasAllNoManageSites !== nextProps.hasAllNoManageSites ) {
+			return true;
+		}
+
+		if ( PluginNotices.shouldComponentUpdateNotices( this.props.notices, nextProps.notices ) ) {
+			return true;
+		}
+
+		if ( this.state.clicked !== nextState.clicked ) {
+			return true;
+		}
+		return false;
+	},
 
 	getInitialState: function() {
 		return { clicked: false };
@@ -169,7 +203,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	renderCount: function() {
+	renderSiteCount: function() {
 		return (
 			<div className="plugin-item__count">{ this.translate( 'Sites {{count/}}',
 				{
@@ -252,7 +286,7 @@ module.exports = React.createClass( {
 							{ pluginTitle }
 							{ this.pluginMeta( plugin ) }
 						</span>
-						{ this.props.selectedSite ? null : this.renderCount() }
+						{ this.props.selectedSite ? null : this.renderSiteCount() }
 					</CompactCard>
 					<div>
 					{ this.state.clicked ? this.getNoManageWarning() : null }
@@ -277,7 +311,7 @@ module.exports = React.createClass( {
 						{ pluginTitle }
 						{ this.pluginMeta( plugin ) }
 					</a>
-					{ this.props.selectedSite ? this.renderActions() : this.renderCount() }
+					{ this.props.selectedSite ? this.renderActions() : this.renderSiteCount() }
 				</CompactCard>
 				{ errorNotices }
 			</div>

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -21,17 +21,15 @@ import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
 import Tooltip from 'components/tooltip';
 
-let _actionBarVisible = true;
+const _actionBarVisible = true;
 
 // If the Action
 const MAX_ACTIONBAR_HEIGHT = 50;
 const MIN_ACTIONBAR_WIDTH = 600;
 
 function checkPropsChange( nextProps, propArr ) {
-	var i, prop;
-
-	for ( i = 0; i < propArr.length; i++ ) {
-		prop = propArr[ i ];
+	for ( let i = 0; i < propArr.length; i++ ) {
+		const prop = propArr[ i ];
 
 		if ( nextProps[ prop ] !== this.props[ prop ] ) {
 			return true;
@@ -67,12 +65,12 @@ export default React.createClass( {
 	},
 
 	shouldComponentUpdate( nextProps, nextState ) {
-		var propsToCheck = [ 'label', 'isBulkManagementActive', 'haveUpdatesSelected', 'pluginUpdateCount', 'haveActiveSelected', 'haveInactiveSelected', 'bulkManagement' ];
+		const propsToCheck = [ 'label', 'isBulkManagementActive', 'haveUpdatesSelected', 'pluginUpdateCount', 'haveActiveSelected', 'haveInactiveSelected', 'bulkManagement' ];
 		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
 			return true;
 		}
 
-		if ( this.props.plugins.length !== nextProps.plugins.length ){
+		if ( this.props.plugins.length !== nextProps.plugins.length ) {
 			return true;
 		}
 
@@ -130,11 +128,11 @@ export default React.createClass( {
 	},
 
 	showPluginTooltip() {
-		this.setState( { addPluginTooltip: true } )
+		this.setState( { addPluginTooltip: true } );
 	},
 
 	hidePluginTooltip() {
-		this.setState( { addPluginTooltip: false } )
+		this.setState( { addPluginTooltip: false } );
 	},
 
 	toggleBulkManagement() {
@@ -193,7 +191,7 @@ export default React.createClass( {
 						onClick={ this.onBrowserLinkClick }
 						className="plugin-list-header__browser-button"
 						onMouseEnter={ this.showPluginTooltip }
-						onMouseEnter={ this.hidePluginTooltip }
+						onMouseLeave={ this.hidePluginTooltip }
 						ref="addPluginButton"
 						aria-label={ this.translate( 'Browse all plugins', { context: 'button label' } ) }>
 						<Gridicon key="plus-icon" icon="plus-small" size={ 18 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } />
@@ -240,7 +238,7 @@ export default React.createClass( {
 						{ this.translate( 'Deactivate' ) }
 					</Button>
 				);
-			activateButtons.push( deactivateButton )
+			activateButtons.push( deactivateButton );
 			leftSideButtons.push( <ButtonGroup key="plugin-list-header__buttons-activate-buttons">{ activateButtons }</ButtonGroup> );
 
 			autoupdateButtons.push(

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -6,6 +6,7 @@ import debounce from 'lodash/debounce';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
 import analytics from 'lib/analytics';
+import isEqual from 'lodash/isEqual';
 
 /**
  * Internal dependencies
@@ -25,6 +26,19 @@ let _actionBarVisible = true;
 // If the Action
 const MAX_ACTIONBAR_HEIGHT = 50;
 const MIN_ACTIONBAR_WIDTH = 600;
+
+function checkPropsChange( nextProps, propArr ) {
+	var i, prop;
+
+	for ( i = 0; i < propArr.length; i++ ) {
+		prop = propArr[ i ];
+
+		if ( nextProps[ prop ] !== this.props[ prop ] ) {
+			return true;
+		}
+	}
+	return false;
+}
 
 export default React.createClass( {
 	displayName: 'Plugins-list-header',
@@ -47,9 +61,38 @@ export default React.createClass( {
 		haveActiveSelected: React.PropTypes.bool,
 		haveInactiveSelected: React.PropTypes.bool,
 		bulkManagement: React.PropTypes.bool,
-		sites: React.PropTypes.object.isRequired,
+		selectedSiteSlug: React.PropTypes.string,
 		plugins: React.PropTypes.array.isRequired,
 		selected: React.PropTypes.array.isRequired
+	},
+
+	shouldComponentUpdate( nextProps, nextState ) {
+		var propsToCheck = [ 'label', 'isBulkManagementActive', 'haveUpdatesSelected', 'pluginUpdateCount', 'haveActiveSelected', 'haveInactiveSelected', 'bulkManagement' ];
+		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
+			return true;
+		}
+
+		if ( this.props.plugins.length !== nextProps.plugins.length ){
+			return true;
+		}
+
+		if ( ! isEqual( this.props.sites, nextProps.sites ) ) {
+			return true;
+		}
+
+		if ( this.props.selected.length !== nextProps.selected.length ) {
+			return true;
+		}
+
+		if ( this.state.actionBarVisible !== nextState.actionBarVisible ) {
+			return true;
+		}
+
+		if ( this.state.addPluginTooltip !== nextState.addPluginTooltip ) {
+			return true;
+		}
+
+		return false;
 	},
 
 	getInitialState() {
@@ -84,6 +127,14 @@ export default React.createClass( {
 			const actionBarVisible = actionBarDomElement.offsetHeight <= MAX_ACTIONBAR_HEIGHT;
 			this.setState( { actionBarVisible } );
 		}, 1 );
+	},
+
+	showPluginTooltip() {
+		this.setState( { addPluginTooltip: true } )
+	},
+
+	hidePluginTooltip() {
+		this.setState( { addPluginTooltip: false } )
 	},
 
 	toggleBulkManagement() {
@@ -132,8 +183,7 @@ export default React.createClass( {
 					</Button>
 				</ButtonGroup>
 			);
-			const selectedSite = this.props.sites.getSelectedSite();
-			const browserUrl = '/plugins/browse' + ( selectedSite ? '/' + selectedSite.slug : '' );
+			const browserUrl = '/plugins/browse' + ( this.props.selectedSiteSlug ? '/' + this.props.selectedSiteSlug : '' );
 
 			rightSideButtons.push(
 				<ButtonGroup key="plugin-list-header__buttons-browser">
@@ -142,8 +192,8 @@ export default React.createClass( {
 						href={ browserUrl }
 						onClick={ this.onBrowserLinkClick }
 						className="plugin-list-header__browser-button"
-						onMouseEnter={ () => this.setState( { addPluginTooltip: true } ) }
-						onMouseLeave={ () => this.setState( { addPluginTooltip: false } ) }
+						onMouseEnter={ this.showPluginTooltip }
+						onMouseEnter={ this.hidePluginTooltip }
 						ref="addPluginButton"
 						aria-label={ this.translate( 'Browse all plugins', { context: 'button label' } ) }>
 						<Gridicon key="plus-icon" icon="plus-small" size={ 18 } /><Gridicon key="plugins-icon" icon="plugins" size={ 18 } />

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -8,6 +8,8 @@ import find from 'lodash/find';
 import includes from 'lodash/includes';
 import negate from 'lodash/negate';
 import range from 'lodash/range';
+import isEqual from 'lodash/isEqual';
+import map from 'lodash/map';
 
 /**
  * Internal dependencies
@@ -21,6 +23,19 @@ import PluginsListHeader from 'my-sites/plugins/plugin-list-header';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginNotices from 'lib/plugins/notices';
 import SectionHeader from 'components/section-header';
+
+function checkPropsChange( nextProps, propArr ) {
+	var i, prop;
+
+	for ( i = 0; i < propArr.length; i++ ) {
+		prop = propArr[ i ];
+
+		if ( ! isEqual( nextProps[ prop ], this.props[ prop ] ) ) {
+			return true;
+		}
+	}
+	return false;
+}
 
 export default React.createClass( {
 	displayName: 'PluginsList',
@@ -38,6 +53,34 @@ export default React.createClass( {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
 		pluginUpdateCount: PropTypes.number,
 		isPlaceholder: PropTypes.bool.isRequired,
+	},
+
+	shouldComponentUpdate( nextProps, nextState ) {
+		var propsToCheck = [ 'plugins', 'sites', 'selectedSite', 'pluginUpdateCount', '' ];
+		if ( checkPropsChange.call( this, nextProps, propsToCheck ) ) {
+			return true;
+		}
+
+		if ( this.props.isPlaceholder !== nextProps.isPlaceholder ) {
+			return true;
+		}
+
+		if ( this.state.bulkManagement !== nextState.bulkManagement ) {
+			return true;
+		}
+
+		if ( this.state.disconnectJetpackDialog !== nextState.disconnectJetpackDialog ) {
+			return true;
+		}
+
+		if ( ! isEqual( this.state.selectedPlugins, nextState.selectedPlugins ) ) {
+			return true;
+		}
+		if ( this.shouldComponentUpdateNotices( this.state.notices, nextState.notices) ) {
+			return true;
+		}
+
+		return false;
 	},
 
 	getInitialState() {
@@ -322,6 +365,8 @@ export default React.createClass( {
 			'is-bulk-editing': this.state.bulkManagementActive
 		} );
 
+		const selectedSiteSlug = this.props.sites.getSelectedSite() ? this.props.sites.getSelectedSite().slug : '';
+
 		if ( this.props.isPlaceholder ) {
 			return (
 				<div className="plugins-list">
@@ -339,7 +384,7 @@ export default React.createClass( {
 			<div className="plugins-list" >
 				<PluginsListHeader label={ this.props.header }
 					isBulkManagementActive={ this.state.bulkManagementActive }
-					sites={ this.props.sites }
+					selectedSiteSlug={ selectedSiteSlug }
 					plugins={ this.props.plugins }
 					selected={ this.getSelected() }
 					toggleBulkManagement={ this.toggleBulkManagement }


### PR DESCRIPTION
Current on the plugin list view we don't do any kind of rendering optimisations. 
This PR tried to fix this by putting should component update in place. 

Before:
![screen shot 2016-03-04 at 10 10 34](https://cloud.githubusercontent.com/assets/115071/13541913/180dbbc8-e214-11e5-8120-a12ccf7db41d.png)

After:
![screen shot 2016-03-04 at 12 53 39](https://cloud.githubusercontent.com/assets/115071/13541903/0f2dccf0-e214-11e5-8c23-672825ce44da.png)

**To test**:
Run calypso development with render-visiualizer enabled.
`ENABLE_FEATURES=render-visualizer make run`
Notice the significant reduction in re-renders.

Run in regular mode and make sure that the view updates as expected.

cc: @johnHackworth, @lezama, @rralian 
