### PR TITLE
State: Global test runner cleanup

### DIFF
--- a/client/state/test/index.js
+++ b/client/state/test/index.js
@@ -174,9 +174,9 @@ describe( 'state', () => {
 	} );
 
 	describe( 'ui', () => {
-		require( '../users/test/actions' );
-		require( '../users/test/reducer' );
-		require( '../users/test/selectors' );
+		require( '../ui/test/actions' );
+		require( '../ui/test/reducer' );
+		require( '../ui/test/selectors' );
 
 		describe( 'editor', () => {
 			describe( 'contact-form', () => {

--- a/client/state/test/index.js
+++ b/client/state/test/index.js
@@ -30,6 +30,7 @@ describe( 'state', () => {
 			expect( reduxStoreNoArgs ).to.be.an( 'object' );
 			expect( reduxStoreWithEmptyState ).to.eql( reduxStoreNoArgs );
 		} );
+
 		it( 'is instantiated with initialState', () => {
 			const user = { ID: 1234, display_name: 'test user', username: 'testuser' };
 			const initialState = {
@@ -41,20 +42,22 @@ describe( 'state', () => {
 			expect( Object.keys( reduxStoreWithCurrentUser.users.items ).length ).to.eql( 1 );
 			expect( reduxStoreWithCurrentUser.users.items[ 1234 ] ).to.eql( user );
 		} );
+
 		describe( 'invalid data', () => {
-			var consoleStub;
 			before( () => {
-				consoleStub = sinon.stub( console, 'error' );
+				sinon.stub( console, 'error' );
 			} );
+
 			after( () => {
-				consoleStub.restore();
+				console.error.restore();
 			} );
+
 			it( 'ignores non-existent keys', () => {
-				expect( consoleStub.calledOnce ).to.eql( false );
+				expect( console.error.calledOnce ).to.eql( false );
 				const reduxStoreNoArgs = createReduxStore().getState();
 				const reduxStoreBadData = createReduxStore( { some: { bad: { stuff: true } } } ).getState();
 				expect( reduxStoreBadData ).to.eql( reduxStoreNoArgs );
-				expect( consoleStub.calledOnce ).to.eql( true );
+				expect( console.error.calledOnce ).to.eql( true );
 			} );
 		} );
 	} );

--- a/client/state/test/index.js
+++ b/client/state/test/index.js
@@ -9,7 +9,7 @@ import nock from 'nock';
 /**
  * Internal dependencies
  */
-import domEnvSetup from 'lib/react-test-env-setup';
+import { createReduxStore } from '../';
 
 describe( 'state', () => {
 	before( () => {
@@ -24,17 +24,6 @@ describe( 'state', () => {
 	} );
 
 	describe( 'createReduxStore', () => {
-		let createReduxStore;
-
-		before( () => {
-			domEnvSetup();
-			createReduxStore = require( '../' ).createReduxStore;
-		} );
-
-		after( () => {
-			domEnvSetup.cleanup();
-		} );
-
 		it( 'can be called without specifying initialState', () => {
 			const reduxStoreNoArgs = createReduxStore().getState();
 			const reduxStoreWithEmptyState = createReduxStore( {} ).getState();


### PR DESCRIPTION
Follow-up to #3773 

This pull request seeks to:
- Fix an incorrect test import (`ui` accidentally importing `users`)
- Remove unnecessary DOM environment setup and teardown in `createReduxStore` tests
 - /cc @gwwar : Do you recall why this was necessary? Tests seem to run fine without it.
- Apply stub to `console.error` directly in `createReduxStore` tests

__Testing instructions:__

Ensure tests pass by running `make test`