### PR TITLE
Reader: center "no match" message on narrow viewports

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -219,6 +219,12 @@
 	transition: all 0.2s ease-in-out;
 }
 
+.following-edit .no-results {
+	@include breakpoint( "<660px" ) {
+		text-align: center;
+	}
+}
+
 .is-adding .following-edit__sites,
 .following-edit.is-adding .search-card {
 	opacity: 0.3;


### PR DESCRIPTION
Small nitpicky fix.

On Manage Following, "No subscriptions match that search." could use some padding on viewports `<660px`.

**Before:**
![img_7689](https://cloud.githubusercontent.com/assets/4924246/13543252/49fc6486-e21e-11e5-9ec6-084e3e43f31f.jpg)

**After:**
![img_7690](https://cloud.githubusercontent.com/assets/4924246/13543254/4ca7a11e-e21e-11e5-9db3-f4aceb123f1e.jpg)
