### PR TITLE
Checkout: Thank You: Scroll to the top of the page when mounting

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -68,6 +68,8 @@ const CheckoutThankYou = React.createClass( {
 		}
 
 		analytics.tracks.recordEvent( 'calypso_checkout_thank_you_view' );
+
+		window.scrollTo( 0, 0 );
 	},
 
 	componentWillReceiveProps() {


### PR DESCRIPTION
Fixes #3653 by scrolling to the top the page when `CheckoutThankYou` is mounted.

**Testing**

- Visit `/plans/:site`.
- Select a plan and proceed to checkout.
- On the payment page, make sure that your viewport is small enough that a scrollbar appears, and scroll to the bottom of the page.
- Proceed to the thank you page.
- Assert that the page is scrolled to the top.

- [x] Code review
- [x] Product review