### PR TITLE
Testing: Move test run spec to circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,17 @@
 machine:
   node:
     version: 4.3.0
-
+  environment:
+    NODE_ENV: development
+test:
+  pre:
+    - make build
+  override:
+    - ./node_modules/.bin/eslint --quiet:
+        parallel: true
+        files:
+          - client/**/*.js
+          - client/**/*.jsx
+          - server/**/*.js
+          - server/**/*.jsx
+    - make test


### PR DESCRIPTION
Right now we spec this in the web settings on the circle ci site, which makes it hard to test changes to how we run tests. This information should really live in the circle config.