### PR TITLE
Accessibility: Make edit permalink feature keyboard-accessible.

### DIFF
--- a/client/post-editor/editor-permalink/index.jsx
+++ b/client/post-editor/editor-permalink/index.jsx
@@ -125,7 +125,12 @@ class EditorPermalink extends Component {
 		}
 
 		return (
-			<div className="editor-permalink" onMouseEnter={ this.showTooltip } onMouseLeave={ this.hideTooltip }>
+			<button
+				className="editor-permalink"
+				onMouseEnter={ this.showTooltip }
+				onMouseLeave={ this.hideTooltip }
+				onClick={ this.showPopover }
+			>
 				<Gridicon
 					className="editor-permalink__toggle"
 					icon="link"
@@ -143,6 +148,7 @@ class EditorPermalink extends Component {
 						{ ...pick( this.props, 'path', 'isEditable' ) }
 						onEscEnter={ this.closePopover }
 						instanceName="post-popover"
+						isVisible= { this.state.popoverVisible }
 					/>
 					{ this.renderCopyButton() }
 				</Popover>
@@ -153,7 +159,7 @@ class EditorPermalink extends Component {
 				>
 					{ tooltipMessage }
 				</Tooltip>
-			</div>
+			</button>
 		);
 	}
 }

--- a/client/post-editor/editor-slug/index.jsx
+++ b/client/post-editor/editor-slug/index.jsx
@@ -6,6 +6,7 @@ import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import defer from 'lodash/defer';
 
 /**
  * Internal Dependencies
@@ -28,7 +29,8 @@ class PostEditorSlug extends Component {
 		instanceName: PropTypes.string,
 		translate: PropTypes.func,
 		siteId: PropTypes.number,
-		postId: PropTypes.number
+		postId: PropTypes.number,
+		isVisible: PropTypes.bool
 	};
 
 	static defaultProps = {
@@ -81,6 +83,14 @@ class PostEditorSlug extends Component {
 	focusSlug() {
 		if ( this.props.isEditable ) {
 			ReactDom.findDOMNode( this.refs.slugField ).focus();
+		}
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.isVisible ) {
+			defer( () => {
+				this.focusSlug();
+			} );
 		}
 	}
 

--- a/client/post-editor/editor-title/style.scss
+++ b/client/post-editor/editor-title/style.scss
@@ -27,6 +27,10 @@
 		top: 18px;
 	display: none;
 
+	&:focus {
+		outline: thin dotted;
+	}
+
 	@include breakpoint( ">660px" ) {
 		display: block;
 	}


### PR DESCRIPTION
This PR attempts to make the edit permalink feature in post/page editing screen keyboard-accessible. Refer to issue #1995.

Here's a reference on why the `div` element is changed to `button` https://www.nczonline.net/blog/2013/01/29/you-cant-create-a-button/

**To test:**
1. Make a new post, give it a title and keep the post content empty (this is to make tabbing easier). Publish it.
2. The Edit Permalink button will show up to the left of the post title after it is published.
3. Put cursor on (the empty) post body, then press tab repeatedly until it eventually reaches the Edit Permalink icon.
4. The icon should now be in focus, and displaying a thin dotted outline. 
   ![screen shot 2016-03-06 at 1 02 21 pm](https://cloud.githubusercontent.com/assets/266376/13552592/ed31a58e-e39b-11e5-9fb7-10777a232279.png)
5. Press `enter` while the icon is in focus, and it will open the Popover containing the actual permalink field.

**Still being worked on:**
Currently, pressing `tab` after step 5 above moves the focus to the "Visual" tab on the editor, skipping the actual permalink field. This means currently it's possible to see the permalink, but not edit it, using keyboard-only.

Pressing tab should move the focus to the input field containing the slug, another `tab` should move to the "Copy" button, and _then_ the next `tab` should go to the title field.

Still can't figure out how to do that as the Popover element is located way at the end of the DOM tree instead of inside the form, so any help is appreciated!
