### PR TITLE
Search component: fix logic for disableAutocorrect prop

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -239,10 +239,9 @@ const Search = React.createClass( {
 				! this.props.pinned ||
 				this.props.initialValue;
 
-		const autocorrect = ! this.props.disableAutocorrect && {
+		const autocorrect = this.props.disableAutocorrect && {
 			autoComplete: 'off',
 			autoCorrect: 'off',
-			autoCapitalize: 'off',
 			spellCheck: 'false'
 		};
 


### PR DESCRIPTION
At the moment, specifying `disableAutocorrect={ true }` on the Search component will omit the autoComplete, autoCorrect and spellCheck attributes from the `<input>`, which is the exact opposite of what it's supposed to do.

I've also removed `autoCapitalize` from the the attributes added when `disableAutocorrect={ true }`, because we now always set `autoCapitalize="none"` on the input.

Fixes #3805.