### PR TITLE
Reader site stream: show a 'stream not found' message if the blog ID is not recognised

### DIFF
--- a/client/components/empty-content/empty-content.jsx
+++ b/client/components/empty-content/empty-content.jsx
@@ -102,7 +102,7 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<div className={ classNames( 'empty-content', this.props.className, { 'is-compact': this.props.isCompact } ) }>
+			<div className={ classNames( 'empty-content', this.props.className, { 'is-compact': this.props.isCompact, 'has-title-only': this.props.title && ! this.props.line } ) }>
 				{ illustration }
 
 				{

--- a/client/components/empty-content/style.scss
+++ b/client/components/empty-content/style.scss
@@ -10,6 +10,12 @@
 		margin-left: 15px;
 		margin-right: 15px;
 	}
+
+	&.has-title-only {
+		.empty-content__title {
+			margin-bottom: 40px;
+		}
+	}
 }
 
 .empty-content__title {

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -10,21 +10,45 @@ import Main from 'components/main';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import EmptyContent from 'components/empty-content';
 import i18n from 'lib/mixins/i18n';
+import { recordAction, recordGaEvent } from 'reader/stats';
 
-const FeedError = ( { sidebarTitle } ) => (
-	<Main>
-		<MobileBackToSidebar>
-			<h1>{ sidebarTitle }</h1>
-		</MobileBackToSidebar>
+const FeedError = React.createClass( {
+	recordAction() {
+		recordAction( 'clicked_discover_on_empty' );
+		recordGaEvent( 'Clicked Discover on EmptyContent' );
+	},
 
-		<EmptyContent
-			title={ i18n.translate( 'Sorry. We can\'t find that stream.' ) }
-			illustration={ '/calypso/images/drake/drake-404.svg' }
-			illustrationWidth={ 500 }
-		/>
+	recordSecondaryAction() {
+		recordAction( 'clicked_recommendations_on_empty' );
+		recordGaEvent( 'Clicked Recommendations on EmptyContent' );
+	},
 
-	</Main>
-);
+	render() {
+		const action = ( <a className="empty-content__action button is-primary"
+				onClick={ this.recordAction }
+				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ),
+			secondaryAction = (
+				<a className="empty-content__action button"
+					onClick={ this.recordSecondaryAction }
+					href="/recommendations">{ this.translate( 'Get recommendations on who to follow' ) }</a> );
+
+		return (
+			<Main>
+				<MobileBackToSidebar>
+					<h1>{ this.props.sidebarTitle }</h1>
+				</MobileBackToSidebar>
+
+				<EmptyContent
+					action={ action }
+					secondaryAction={ secondaryAction }
+					title={ i18n.translate( 'Sorry. We can\'t find that stream.' ) }
+					illustration={ '/calypso/images/drake/drake-404.svg' }
+					illustrationWidth={ 500 }
+				/>
+			</Main>
+		);
+	}
+} );
 
 FeedError.propTypes = {
 	sidebarTitle: React.PropTypes.string

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -1,30 +1,33 @@
-// External dependencies
-var React = require( 'react' );
+/**
+ * External dependencies
+ */
+import React from 'react';
 
-// Internal dependencies
-var Main = require( 'components/main' ),
-	MobileBackToSidebar = require( 'components/mobile-back-to-sidebar' ),
-	EmptyContent = require( 'components/empty-content' );
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
+import EmptyContent from 'components/empty-content';
+import i18n from 'lib/mixins/i18n';
 
-var FeedError = React.createClass( {
+const FeedError = ( { sidebarTitle } ) => (
+	<Main>
+		<MobileBackToSidebar>
+			<h1>{ sidebarTitle }</h1>
+		</MobileBackToSidebar>
 
-	render: function() {
-		return (
-			<Main>
-				<MobileBackToSidebar>
-					<h1>{ this.props.listName }</h1>
-				</MobileBackToSidebar>
+		<EmptyContent
+			title={ i18n.translate( 'Sorry. We can\'t find that stream.' ) }
+			illustration={ '/calypso/images/drake/drake-404.svg' }
+			illustrationWidth={ 500 }
+		/>
 
-				<EmptyContent
-					title={ this.translate( 'Sorry. We can\'t find that stream.' ) }
-					illustration={ '/calypso/images/drake/drake-404.svg' }
-					illustrationWidth={ 500 }
-				/>
+	</Main>
+);
 
-			</Main>
-		);
-	}
+FeedError.propTypes = {
+	sidebarTitle: React.PropTypes.string
+};
 
-} );
-
-module.exports = FeedError;
+export default FeedError;

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -41,7 +41,7 @@ const FeedError = React.createClass( {
 				<EmptyContent
 					action={ action }
 					secondaryAction={ secondaryAction }
-					title={ i18n.translate( 'Sorry. We can\'t find that stream.' ) }
+					title={ i18n.translate( 'Sorry, we can\'t find that stream.' ) }
 					illustration={ '/calypso/images/drake/drake-404.svg' }
 					illustrationWidth={ 500 }
 				/>

--- a/client/reader/feed-stream/index.jsx
+++ b/client/reader/feed-stream/index.jsx
@@ -140,7 +140,7 @@ var FeedStream = React.createClass( {
 		}
 
 		if ( feed && feed.state === FeedStoreState.ERROR ) {
-			return <FeedError listName={ this.state.title } />;
+			return <FeedError sidebarTitle={ this.state.title } />;
 		}
 
 		return (

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -132,7 +132,7 @@ const SiteStream = React.createClass( {
 		}
 
 		if ( site && site.get( 'state' ) === SiteState.ERROR ) {
-			return <FeedError listName={ title } />;
+			return <FeedError sidebarTitle={ title } />;
 		}
 
 		if ( site && site.get( 'has_featured' ) ) {

--- a/client/reader/site-stream/index.jsx
+++ b/client/reader/site-stream/index.jsx
@@ -1,5 +1,6 @@
 var React = require( 'react' ),
-	page = require( 'page' );
+	page = require( 'page' ),
+	includes = require( 'lodash/includes' );
 
 var FeedHeader = require( 'reader/feed-header' ),
 	FeedFeatured = require( './featured' ),
@@ -80,11 +81,11 @@ const SiteStream = React.createClass( {
 			SiteStoreActions.fetch( siteId );
 		}
 
-		if ( site && site.get( 'state' ) !== SiteState.COMPLETE ) {
-			site = null; // don't accept an incomplete or error site
+		if ( site && ! includes( [ SiteState.COMPLETE, SiteState.ERROR ], site.get( 'state' ) ) ) {
+			site = null; // don't accept an incomplete site
 		}
 
-		if ( site && site.get( 'feed_ID' ) ) {
+		if ( site && site.get( 'state' ) === SiteState.COMPLETE && site.get( 'feed_ID' ) ) {
 			feed = FeedStore.get( site.get( 'feed_ID' ) );
 			if ( ! feed ) {
 				setTimeout( () => {


### PR DESCRIPTION
Fix a regression in the site stream (/read/sites/:site_id) that prevents the 'stream not found message' from being displayed.

Before: 

![screen shot 2016-03-07 at 13 02 43](https://cloud.githubusercontent.com/assets/17325/13558255/ebb07108-e464-11e5-9449-7ab7fc055178.png)

After:

![screen shot 2016-03-07 at 13 02 31](https://cloud.githubusercontent.com/assets/17325/13558257/f0872514-e464-11e5-9f70-713f663d2d46.png)

Example streams:
- exists http://calypso.localhost:3000/read/feeds/44852367
- does not exist http://calypso.localhost:3000/read/feeds/4485236712345673456

Fixes https://github.com/Automattic/wp-calypso/issues/3680.