### PR TITLE
Reader: make comment button label consistent with like button

### DIFF
--- a/client/components/comment-button/README.md
+++ b/client/components/comment-button/README.md
@@ -1,16 +1,16 @@
 Comment Button
 =========
 
-This component is used to display a button with an embedded number indicator
+This component is used to display a button with an embedded number indicator.
 
 #### How to use:
 
 ```js
-const  CommentButton = require( 'components/comment-button' );
+import CommentButton from 'components/comment-button';
 
-render: function() {
+render() {
 	return (
-		<CommentButton />
+		<CommentButton commentCount={ 123 } />
 	);
 }
 ```

--- a/client/components/comment-button/docs/example.jsx
+++ b/client/components/comment-button/docs/example.jsx
@@ -1,26 +1,28 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var CommentButton = require( 'components/comment-button' );
+import CommentButton from 'components/comment-button';
+import Card from 'components/card';
 
-var AddNewButtons = React.createClass( {
-	displayName: 'CommentButton',
+const CommentButtonExample = () => (
+	<div className="design-assets__group">
+		<h2>
+			<a href="/devdocs/app-components/comment-button">Comment Buttons</a>
+		</h2>
+		<Card>
+			<span>No comments:</span>
+			<CommentButton commentCount={ 0 } />
+		</Card>
+		<Card>
+			<span>With comments:</span>
+			<CommentButton commentCount={ 42 } />
+		</Card>
+	</div>
+);
 
-	render: function() {
-		return (
-			<div className="design-assets__group">
-				<h2>
-					<a href="/devdocs/app-components/comment-button">Comment Buttons</a>
-				</h2>
-				<CommentButton commentCount={ 10 } />
-			</div>
-		);
-	}
-} );
-
-module.exports = AddNewButtons;
+export default CommentButtonExample;

--- a/client/components/comment-button/index.jsx
+++ b/client/components/comment-button/index.jsx
@@ -1,14 +1,15 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	noop = require( 'lodash/noop' );
+import React from 'react';
+import noop from 'lodash/noop';
+
 /**
  * Internal dependencies
  */
-var Gridicon = require( 'components/gridicon' );
+import Gridicon from 'components/gridicon';
 
-var CommentButton = React.createClass( {
+const CommentButton = React.createClass( {
 
 	propTypes: {
 		onClick: React.PropTypes.func,
@@ -16,7 +17,7 @@ var CommentButton = React.createClass( {
 		commentCount: React.PropTypes.number.isRequired
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			onClick: noop,
 			tagName: 'li',
@@ -24,18 +25,34 @@ var CommentButton = React.createClass( {
 		};
 	},
 
-	onClick: function( event ) {
+	onClick( event ) {
 		event.preventDefault();
 	},
 
-	onTap: function() {
+	onTap() {
 		this.props.onClick();
 	},
 
-	render: function() {
-		var containerTag = this.props.tagName;
+	render() {
+		let label;
+		const containerTag = this.props.tagName,
+			commentCount = this.props.commentCount;
 
-		var labelElement = ( <span className="comment-button__label">{ this.props.commentCount }</span> );
+		if ( commentCount === 0 ) {
+			label = this.translate( 'Comment' );
+		} else {
+			label = this.translate(
+				'comment',
+				'comments', {
+					count: commentCount,
+				}
+			);
+		}
+
+		const labelElement = ( <span className="comment-button__label">
+			{ commentCount > 0 ? <span className="comment-button__label-count">{ commentCount }</span> : null }
+			<span className="comment-button__label-status">{ label }</span>
+		</span> );
 
 		return React.createElement(
 			containerTag, {
@@ -48,4 +65,4 @@ var CommentButton = React.createClass( {
 	}
 } );
 
-module.exports = CommentButton;
+export default CommentButton;

--- a/client/components/comment-button/index.jsx
+++ b/client/components/comment-button/index.jsx
@@ -42,8 +42,8 @@ const CommentButton = React.createClass( {
 			label = this.translate( 'Comment' );
 		} else {
 			label = this.translate(
-				'comment',
-				'comments', {
+				'Comment',
+				'Comments', {
 					count: commentCount,
 				}
 			);

--- a/client/components/comment-button/style.scss
+++ b/client/components/comment-button/style.scss
@@ -3,11 +3,20 @@
 	list-style-type: none;
 	padding: 4px 4px 4px 27px;
 	position: relative;
-	text-transform: uppercase;
 
 	&:hover {
 		color: $blue-light;
 		cursor: pointer;
+	}
+
+	.comment-button__label-count {
+		margin-right: 4px;
+	}
+
+	@include breakpoint( "<480px" ) {
+		.comment-button__label-status {
+			display: none;
+		}
 	}
 }
 

--- a/client/components/comment-button/style.scss
+++ b/client/components/comment-button/style.scss
@@ -22,7 +22,7 @@
 }
 
 .comment-button__icon {
-	fill: lighten( $gray, 10 );
+	fill: lighten( $gray, 10% );
 	position: absolute;
 		left: 0;
 		top: 3px;

--- a/client/components/comment-button/style.scss
+++ b/client/components/comment-button/style.scss
@@ -13,8 +13,9 @@
 		margin-right: 4px;
 	}
 
-	@include breakpoint( "<480px" ) {
-		.comment-button__label-status {
+	.comment-button__label-status {
+
+		@include breakpoint( "<480px" ) {
 			display: none;
 		}
 	}
@@ -24,7 +25,7 @@
 	fill: lighten( $gray, 10 );
 	position: absolute;
 		left: 0;
-		top: 2px;
+		top: 3px;
 
 	&:hover {
 		fill: $blue-light;

--- a/client/components/like-button/button.jsx
+++ b/client/components/like-button/button.jsx
@@ -69,7 +69,7 @@ var LikeButton = React.createClass( {
 
 		// Override the label with a counter
 		if ( likeCount > 0 || this.props.showCount ) {
-			likeLabel = this.translate( 'like', 'likes', {
+			likeLabel = this.translate( 'Like', 'Likes', {
 				count: likeCount,
 				comment: 'Displayed when a person "likes" a post.'
 			} );

--- a/client/components/like-button/button.jsx
+++ b/client/components/like-button/button.jsx
@@ -69,7 +69,7 @@ var LikeButton = React.createClass( {
 
 		// Override the label with a counter
 		if ( likeCount > 0 || this.props.showCount ) {
-			likeLabel = this.translate( 'Like', 'Likes', {
+			likeLabel = this.translate( 'like', 'likes', {
 				count: likeCount,
 				comment: 'Displayed when a person "likes" a post.'
 			} );

--- a/client/components/like-button/docs/example.jsx
+++ b/client/components/like-button/docs/example.jsx
@@ -26,7 +26,7 @@ var SimpleLikeButtonContainer = React.createClass( {
 			<LikeButton { ...this.props }
 				onLikeToggle={ this.handleLikeToggle }
 				likeCount={ this.state.count }
-				liked={this.state.liked }
+				liked={ this.state.liked }
 			/> );
 	},
 
@@ -52,10 +52,6 @@ var LikeButtons = React.createClass( {
 				<Card>
 					<span>Default:</span>
 					<SimpleLikeButtonContainer tagName="button" likeCount={ 12 } />
-				</Card>
-				<Card>
-					<span>Counter shown by default:</span>
-					<SimpleLikeButtonContainer tagName="button" likeCount={ 12 } showCount={ true } />
 				</Card>
 				<Card>
 					<span>Liked button:</span>

--- a/client/components/like-button/docs/example.jsx
+++ b/client/components/like-button/docs/example.jsx
@@ -50,11 +50,15 @@ var LikeButtons = React.createClass( {
 					<a href="/devdocs/app-components/like-button">Like button</a>
 				</h2>
 				<Card>
-					<span>Default:</span>
+					<span>No likes:</span>
+					<SimpleLikeButtonContainer tagName="button" likeCount={ 0 } />
+				</Card>
+				<Card>
+					<span>Has likes, not liked:</span>
 					<SimpleLikeButtonContainer tagName="button" likeCount={ 12 } />
 				</Card>
 				<Card>
-					<span>Liked button:</span>
+					<span>Liked:</span>
 					<SimpleLikeButtonContainer tagName="button" likeCount={ 12 } liked={ true } />
 				</Card>
 			</div>


### PR DESCRIPTION
@jancavan noticed during her design audit that we always display a "like" label for the Like button, but never for the comment button. 

This PR changes the behaviour of the comment button to match the like button.

Before:
<img width="250" alt="screen shot 2016-03-07 at 15 47 46" src="https://cloud.githubusercontent.com/assets/17325/13559714/0c238742-e47c-11e5-9e7b-695d126e62d7.png">
<img width="245" alt="screen shot 2016-03-07 at 15 47 39" src="https://cloud.githubusercontent.com/assets/17325/13559715/0c5514ec-e47c-11e5-955d-9db43e9e82af.png">

After:

<img width="313" alt="screen shot 2016-03-07 at 15 48 05" src="https://cloud.githubusercontent.com/assets/17325/13559724/1536bfca-e47c-11e5-8e49-54d55a98ceac.png">
<img width="285" alt="screen shot 2016-03-07 at 15 48 01" src="https://cloud.githubusercontent.com/assets/17325/13559725/1539b3ce-e47c-11e5-8ba0-631e3262ff5e.png">

As with the Like button, we collapse the label on smaller viewports:

<img width="432" alt="screen shot 2016-03-07 at 15 51 56" src="https://cloud.githubusercontent.com/assets/17325/13559774/8c14a684-e47c-11e5-9b00-1d72a3f37bef.png">

Fixes #3646.