### PR TITLE
Support User: Ensure token persists across further reloads

### DIFF
--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -53,6 +53,16 @@ export const shouldBoot = () => {
 	return false;
 };
 
+const checkIfTokenChanged = ( event ) => {
+	if ( event.key === STORAGE_KEY && event.oldValue !== event.newValue ) {
+		window.location.reload();
+	}
+}
+
+if ( isEnabled() && window ) {
+	window.addEventListener( 'storage', checkIfTokenChanged );
+}
+
 /**
  * Ensure the current support token is persisted for the next time Calypso boots
  * @param {Object} tokenObject The token data that should be persisted
@@ -72,6 +82,11 @@ export const rebootNormally = () => {
 	debug( 'Rebooting Calypso normally' );
 
 	store.clear();
+
+	// We need to store a blank key to trigger a 'storage' event on other tabs
+	// so they invalidate their sessions
+	store.set( STORAGE_KEY, {} );
+
 	window.location.reload();
 };
 

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -54,6 +54,14 @@ export const shouldBoot = () => {
 };
 
 /**
+ * Ensure the current support token is persisted for the next time Calypso boots
+ * @param {Object} tokenObject The token data that should be persisted
+ */
+export const persistToken = ( tokenObject ) => {
+	store.set( STORAGE_KEY, tokenObject );
+}
+
+/**
  * Reboot normally as the main user
  */
 export const rebootNormally = () => {
@@ -79,7 +87,7 @@ export const rebootWithToken = ( user, token ) => {
 
 	debug( 'Rebooting Calypso with support user' );
 
-	store.set( STORAGE_KEY, { user, token } );
+	persistToken( { user, token } );
 	window.location.reload();
 };
 
@@ -91,6 +99,7 @@ const onTokenError = ( error ) => {
 
 /**
  * Inject the support user token into all following API calls
+ * @return {Object}      The token information
  */
 export const boot = () => {
 	if ( ! isEnabled() ) {
@@ -109,6 +118,8 @@ export const boot = () => {
 	reduxStoreReady.then( ( reduxStore ) => {
 		reduxStore.dispatch( supportUserActivate() );
 	} );
+
+	return { user, token };
 };
 
 export const fetchToken = ( user, password ) => {

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { shouldBoot as shouldBootToSupportUser, boot as supportUserBoot } from 'lib/user/support-user-interop';
+import {
+	boot as supportUserBoot,
+	persistToken as supportUserPersistToken,
+	shouldBoot as shouldBootToSupportUser,
+} from 'lib/user/support-user-interop';
 
 /**
  * External dependencies
@@ -51,8 +55,15 @@ User.prototype.initialize = function() {
 	this.initialized = false;
 
 	if ( shouldBootToSupportUser() ) {
-		supportUserBoot();
+		const token = supportUserBoot();
+
 		this.fetch();
+
+		// The store is cleared when the user changes, so we need to persist the token
+		// again for future reloads
+		this.once( 'change', () => {
+			supportUserPersistToken( token );
+		} );
 
 		// We're booting into support user mode, skip initialization of the main user.
 		return;


### PR DESCRIPTION
This change ensures a support user token is not lost when reloading the page or opening duplicate tabs. 

The support user token will be kept until it is known to be invalid/expired. In such a case, the token will be cleared and Calypso will reload. In a future PR, we can clear the support token proactively to avoid the double-boot if the client knows the token's expiry time.

Fixes #3750 

cc @dllh @alisterscott 