### PR TITLE
Support User: Ensure keys to activate can only be typed in sequence

### DIFF
--- a/client/lib/keyboard-shortcuts/key-bindings.js
+++ b/client/lib/keyboard-shortcuts/key-bindings.js
@@ -130,6 +130,7 @@ KeyBindings.prototype.get = function() {
 			{
 				eventName: 'open-support-user',
 				keys: [ 's', 'u' ],
+				type: 'sequence',
 				description: {
 					keys: [],
 					text: '',


### PR DESCRIPTION
This change fixes #3753, requiring that the support user shortcut keys are **both** pressed in sequence. Prior to this change, pressing only `u` was sufficient to activate the feature.