### PR TITLE
Editor: Fixed 'buggy' UI in the Post Visibility component.

### DIFF
--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -191,6 +191,7 @@ const EditorVisibility = React.createClass( {
 
 			case 'password':
 				postEdits.password = this.props.savedPassword || ' ';
+				this.setState( { passwordIsValid: true } );
 				this.props.setPostPasswordProtected( postEdits.password );
 				break;
 		}
@@ -205,18 +206,9 @@ const EditorVisibility = React.createClass( {
 	},
 
 	onKey( event ) {
-		var password;
-
-		password = ReactDom.findDOMNode( this.refs.postPassword ).value.trim();
-
-		if ( event.key === 'Backspace' &&
-			! password.length ) {
-			this.setState( { passwordIsValid: false } );
-		}
 		if ( includes( [ 'Enter', 'Escape' ], event.key ) ) {
 			this.closePopover();
 		}
-		return;
 	},
 
 	setPostToPrivate() {
@@ -267,12 +259,17 @@ const EditorVisibility = React.createClass( {
 	},
 
 	onPasswordChange( event ) {
-		var newPassword = event.target.value.trim();
+		let newPassword = event.target.value.trim();
+		const passwordIsValid = newPassword.length > 0;
+
+		this.setState( { passwordIsValid } );
+
+		if ( ! passwordIsValid ) {
+			newPassword = ' ';
+		}
 
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		postActions.edit( { password: newPassword } );
-
-		this.setState( { passwordIsValid: newPassword.length > 0 } );
 
 		this.props.setPostPassword( newPassword );
 	},


### PR DESCRIPTION
The main problem with the EditorVisibility logic is that these properties affect a post visibility:
* Nothing special: public
* Non-empty password property: password-protected
* 'private' status: private

So, when the user clicks in the "Password Protected" radio button and the password is blank, strictly speaking the post object has an invalid password, so it's public. There were a few hacks to prevent the UI from reverting to the "Public" state, and I added some more (it's the most that can be done without adding a field to the "post" object or doing a deep refactor of the EditorVisibility component).

Fixes #3673 