### PR TITLE
Signup: Headstart: Disable the Headstart flow in production.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -228,6 +228,9 @@ function removeUserStepFromFlow( flow ) {
 }
 
 function filterFlowName( flowName ) {
+	if ( 'headstart' === flowName && 'production' === config( 'env' ) ) {
+		return 'main';
+	}
 	return flowName;
 }
 


### PR DESCRIPTION
This is temporary while preparing for its launch this week.