### PR TITLE
Framework: Add fn to create a middleware which removes sidebar

### DIFF
--- a/client/lib/react-helpers/index.js
+++ b/client/lib/react-helpers/index.js
@@ -5,6 +5,11 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
+/**
+ * Internal dependencies
+ */
+import { setSection } from 'state/ui/actions';
+
 export default {
 	renderWithReduxStore( reactElement, domContainer, reduxStore ) {
 		const domContainerNode = ( 'string' === typeof domContainer )
@@ -15,5 +20,14 @@ export default {
 			React.createElement( ReduxProvider, { store: reduxStore }, reactElement ),
 			domContainerNode
 		);
+	},
+
+	dispatchSetSectionMiddlewareFactory( options = {} ) {
+		return ( context, next ) => {
+			context.store.dispatch( setSection( options ) );
+
+			next();
+		}
 	}
 };
+

--- a/client/my-sites/themes/controller/index.node.js
+++ b/client/my-sites/themes/controller/index.node.js
@@ -14,7 +14,6 @@ import ThemeDetailsComponent from 'components/data/theme-details';
 import i18n from 'lib/mixins/i18n';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getThemeDetails } from 'state/themes/theme-details/selectors';
-import { setSection } from 'state/ui/actions';
 import ClientSideEffects from 'components/client-side-effects';
 import { receiveThemeDetails } from 'state/themes/actions';
 import wpcom from 'lib/wp';
@@ -84,12 +83,6 @@ export function details( context, next ) {
 		title: decodeEntities( title ) + ' — WordPress.com', // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
 		isLoggedIn: !! user
 	};
-
-	context.store.dispatch( setSection( {
-		name: 'theme',
-		group: 'sites',
-		secondary: false,
-	} ) );
 
 	const ConnectedComponent = ( { themeSlug, contentSection } ) => (
 		<ThemeDetailsComponent id={ themeSlug } section={ contentSection } >

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -4,16 +4,19 @@
 import config from 'config';
 import { makeLoggedOutLayout } from 'controller';
 import { details, fetchThemeDetailsData } from './controller';
-import { setSection } from 'state/ui/actions';
+import { dispatchSetSectionMiddlewareFactory } from 'lib/react-helpers';
 
-function dispatchSetSection( context, next ) {
-	context.store.dispatch( setSection( {
-		name: 'themes',
-		group: 'sites',
-		secondary: true,
-	} ) );
-	next();
-}
+const dispatchThemesWithSidebar = dispatchSetSectionMiddlewareFactory( {
+	name: 'themes',
+	group: 'sites',
+	secondary: true
+} );
+
+const dispatchThemeNoSidebar = dispatchSetSectionMiddlewareFactory( {
+	name: 'theme',
+	group: 'sites',
+	secondary: false
+} );
 
 // FIXME: These routes will SSR the logged-out Layout even if logged-in.
 // While subsequently replaced by the logged-in Layout on the client-side,
@@ -23,12 +26,12 @@ function dispatchSetSection( context, next ) {
 // the layout.
 // FIXME: Also create loggedOut/multiSite/singleSite elements, depending on route.
 const designRoutes = {
-	'/design': [ dispatchSetSection, makeLoggedOutLayout ],
-	'/design/type/:tier': [ dispatchSetSection, makeLoggedOutLayout ]
+	'/design': [ dispatchThemesWithSidebar, makeLoggedOutLayout ],
+	'/design/type/:tier': [ dispatchThemesWithSidebar, makeLoggedOutLayout ]
 };
 
 const themesRoutes = {
-	'/theme/:slug/:section?/:site_id?': [ fetchThemeDetailsData, details, makeLoggedOutLayout ]
+	'/theme/:slug/:section?/:site_id?': [ dispatchThemeNoSidebar, fetchThemeDetailsData, details, makeLoggedOutLayout ]
 };
 
 const routes = Object.assign( {},


### PR DESCRIPTION
@nb raised an issue with dispatching actions in non-layout/non-library code (as is done [here](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/themes/controller.js#L144) for example). @ockham suggested in [3513](https://github.com/Automattic/wp-calypso/pull/3513) to create a middleware for this:

> We could wrap it in a middleware, or actually, a generic factory to produce one, i.e. something akin to this idea: https://github.com/Automattic/wp-calypso/pull/3425/files?diff=unified#diff-85f90b61d9c36634c5464a3180470726R108

I went ahead and wrote a simple `removeSidebarMiddleware` as a factory returning router's middleware which removes the sidebar. It works fine but here's the problem: some code doesn't remove the sidebar (doesn't call `context.secondary = null`), only dispatches an action. E.g.:
- [here](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/themes/controller.js#L121)
- [here](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/themes/controller.js#L108)
- [here](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/themes/controller.js#L95)

Is it a valid code? Do we really need to dispatch that actions when we are not setting `context.secondary = null`? If yes, what's the best way to tackle this? I could write a very generic factory which would return a middleware that dispatches actions and/or removes sidebar. But as @mcsf said in [3425](https://github.com/Automattic/wp-calypso/pull/3425):
> [...] My doubts stem from the idea that it might be early for us to define more interfaces than needed, as these are likely to change at such an early stage. [...]

I think it would be too generic. Feedback appreciated very much.