### PR TITLE
Editor: Support VideoPress post-editor preview (via Shortcode component)

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -14,6 +14,7 @@ var tinymce = require( 'tinymce/tinymce' ),
 	debounce = require( 'lodash/debounce' ),
 	ReactDom = require( 'react-dom' ),
 	React = require( 'react' );
+import { Provider as ReduxProvider } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -90,11 +91,13 @@ function wpview( editor ) {
 			type = $view.attr( 'data-wpview-type' );
 
 			ReactDom.render(
-				React.createElement( views.components[ type ], {
-					content: getText( view ),
-					siteId: sites.getSelectedSite() ? sites.getSelectedSite().ID : null,
-					onResize: debounce( triggerNodeChanged, 500 )
-				} ),
+				React.createElement( ReduxProvider, { store: editor.getParam( 'redux_store' ) },
+					React.createElement( views.components[ type ], {
+						content: getText( view ),
+						siteId: sites.getSelectedSite() ? sites.getSelectedSite().ID : null,
+						onResize: debounce( triggerNodeChanged, 500 )
+					} )
+				),
 				$view.find( '.wpview-body' )[0]
 			);
 

--- a/client/components/tinymce/plugins/wpcom-view/resizable-view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/resizable-view.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import PureComponent from 'react-pure-render/component';
+
+export default class ResizableView extends PureComponent {
+	constructor( props ) {
+		super( props );
+
+		this.boundSetWrapperState = this.setWrapperState.bind( this );
+		this.state = {
+			wrapper: null
+		};
+	}
+
+	setWrapperState( wrapper ) {
+		if ( ! wrapper ) {
+			return;
+		}
+
+		this.setState( { wrapper } );
+		this.disconnectObserver();
+		this.observer = new MutationObserver( this.props.onResize );
+		this.observer.observe( wrapper, {
+			attributes: true,
+			childList: true,
+			subtree: true
+		} );
+	}
+
+	componentWillUnmount() {
+		this.disconnectObserver();
+	}
+
+	disconnectObserver() {
+		if ( this.observer ) {
+			this.observer.disconnect();
+		}
+	}
+
+	render() {
+		let children;
+		if ( this.state.wrapper ) {
+			children = React.cloneElement( this.props.children, {
+				width: this.state.wrapper.clientWidth
+			} );
+		}
+
+		return (
+			<div ref={ this.boundSetWrapperState } { ...this.props }>
+				{ children }
+			</div>
+		);
+	}
+}
+
+ResizableView.propTypes = {
+	onResize: PropTypes.func
+};
+
+ResizableView.defaultProps = {
+	onResize: () => {}
+};

--- a/client/components/tinymce/plugins/wpcom-view/views.js
+++ b/client/components/tinymce/plugins/wpcom-view/views.js
@@ -13,6 +13,7 @@ import values from 'lodash/values';
 import config from 'config';
 import GalleryView from './gallery-view';
 import EmbedViewManager from './views/embed';
+import * as VideoView from './views/video';
 import ContactFormView from './contact-form-view';
 
 /**
@@ -20,7 +21,8 @@ import ContactFormView from './contact-form-view';
  */
 let views = {
 	gallery: GalleryView,
-	embed: new EmbedViewManager()
+	embed: new EmbedViewManager(),
+	video: VideoView
 };
 
 if ( config.isEnabled( 'post-editor/contact-form' ) ) {

--- a/client/components/tinymce/plugins/wpcom-view/views/video/index.js
+++ b/client/components/tinymce/plugins/wpcom-view/views/video/index.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import ShortcodeUtils from 'lib/shortcode';
+import VideoView from './view';
+
+export function match( content ) {
+	const nextMatch = ShortcodeUtils.next( 'wpvideo', content );
+
+	if ( nextMatch ) {
+		return {
+			index: nextMatch.index,
+			content: nextMatch.content,
+			options: {
+				shortcode: nextMatch.shortcode
+			}
+		};
+	}
+}
+
+export function serialize( content ) {
+	return encodeURIComponent( content );
+}
+
+export function getComponent() {
+	return VideoView;
+}

--- a/client/components/tinymce/plugins/wpcom-view/views/video/view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/video/view.jsx
@@ -57,4 +57,4 @@ export default connect( ( state ) => {
 	return {
 		siteId: get( getSelectedSite( state ), 'ID' )
 	};
-}, null, null, { pure: false } )( VideoView )
+} )( VideoView )

--- a/client/components/tinymce/plugins/wpcom-view/views/video/view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/video/view.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import get from 'lodash/get';
+import merge from 'lodash/merge';
+
+/**
+ * Internal dependecies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+import ResizableView from '../../resizable-view';
+import ShortcodeUtils from 'lib/shortcode';
+import Shortcode from 'components/shortcode';
+
+function VideoView( props ) {
+	return (
+		<ResizableView className="wpview-content wpview-type-video">
+			{ props.siteId && ( <VideoShortcode { ...props } /> ) }
+		</ResizableView>
+	);
+}
+
+VideoView.propTypes = {
+	siteId: PropTypes.number,
+	content: PropTypes.string
+};
+
+function VideoShortcode( { siteId, content, width } ) {
+	if ( ! width ) {
+		return <div />;
+	}
+
+	const shortcode = ShortcodeUtils.stringify( merge( {
+		attrs: {
+			named: {
+				w: width
+			}
+		}
+	}, ShortcodeUtils.parse( content ) ) );
+
+	return (
+		<Shortcode
+			siteId={ siteId }
+			width={ width }>
+			{ shortcode }
+		</Shortcode>
+	);
+}
+
+VideoShortcode.propTypes = Object.assign( {}, VideoView.propTypes, {
+	width: PropTypes.number
+} );
+
+export default connect( ( state ) => {
+	return {
+		siteId: get( getSelectedSite( state ), 'ID' )
+	};
+}, null, null, { pure: false } )( VideoView )


### PR DESCRIPTION
Related: #2267

This pull request is a proposed alternative to #2267, leveraging the existing [`<Shortcode />` component](https://github.com/Automattic/wp-calypso/tree/master/client/components/shortcode) in the rendering of VideoPress shortcodes.

__Testing instructions:__

Repeat testing instructions from #2267.

/cc @mjuhasz 