### PR TITLE
Signup: Remove extraneous lines from StepWrapper

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -8,7 +8,6 @@ import React from 'react';
  */
 import StepHeader from 'signup/step-header';
 import NavigationLink from 'signup/navigation-link';
-import Button from 'components/button';
 import config from 'config';
 
 export default React.createClass( {
@@ -53,7 +52,6 @@ export default React.createClass( {
 	},
 
 	render: function() {
-		console.log( config.isEnabled( 'jetpack/calypso-first-signup-flow' ) );
 		return (
 			<div className="step-wrapper">
 				<StepHeader
@@ -61,7 +59,7 @@ export default React.createClass( {
 					subHeaderText={ this.subHeaderText() }>
 					{ config.isEnabled( 'jetpack/calypso-first-signup-flow' )
 						? ( this.props.headerButton )
-					 	: null }
+						: null }
 				</StepHeader>
 				<div className="is-animated-content">
 					{ this.props.stepContent }


### PR DESCRIPTION
As @drewblaisdell commented in #3375, there were a couple of extra unnecessary lines of code in `StepWrapper`:

- A `console.log`call
- `Button` was imported but never used.

This PR removes these lines.