### PR TITLE
TokenField: Update documentation after invite modifications

### DIFF
--- a/client/components/token-field/README.md
+++ b/client/components/token-field/README.md
@@ -18,7 +18,17 @@ The `value` property is handled in a manner similar to controlled form component
 
 ### Properties
 
-- `value` - An array of strings or objects to display as tokens in the field. If objects are present in the array, they **must** have a property of `value`. For an example of supported properties, see the `_renderToken` method in `./index.jsx`.
+- `value` - An array of strings or objects to display as tokens in the field. If objects are present in the array, they **must** have a property of `value`. Here is an example object that could be passed in as a value:
+
+	  ```javascript
+	  {
+	    value: '(string) The value of the token.',
+	    status: "(string) One of 'error', 'validating', or 'success'. Applies styles to token."
+	    tooltip: '(string) If not falsey, will add a tooltip to the token.',
+	    onMouserEnter: '(function) Function to call when onMouseEnter event triggered on token.'
+	    onMouseLeave: '(function) Function to call when onMouseLeave is triggered on token.'
+	  }
+	  ```
 - `displayTransform` - Function to call to transform tokens for display.  (In
   the editor, this is needed to decode HTML entities embedded in tags -
   otherwise entities like `&` in tag names are double-encoded like `&amp;`,

--- a/client/components/token-field/README.md
+++ b/client/components/token-field/README.md
@@ -18,7 +18,7 @@ The `value` property is handled in a manner similar to controlled form component
 
 ### Properties
 
-- `value` - An array of strings to display as tokens in the field.
+- `value` - An array of strings or objects to display as tokens in the field. If objects are present in the array, they **must** have a property of `value`. For an example of supported properties, see the `_renderToken` method in `./index.jsx`.
 - `displayTransform` - Function to call to transform tokens for display.  (In
   the editor, this is needed to decode HTML entities embedded in tags -
   otherwise entities like `&` in tag names are double-encoded like `&amp;`,
@@ -31,10 +31,14 @@ The `value` property is handled in a manner similar to controlled form component
   Otherwise the REST API won't save them.)
 - `onChange` - Function to call when the tokens have changed. An array of new
   tokens is passed to the callback.
+- `onFocus` - Function to call when the TokenField has been focused on. The event is passed to the callback. Useful for analytics.
 - `suggestions` - An array of strings to present to the user as suggested
   tokens.
 - `maxSuggestions` - The maximum number of suggestions to display at a time.
 - `tokenizeOnSpace` - If true, will add a token when `TokenField` is focused and `space` is pressed.
+- `isBorderless` - When true, renders tokens as without a background.
+- `maxLength` - If passed, `TokenField` will disable ability to add new tokens once number of tokens is greater than or equal to `maxLength`.
+- `disabled` - When true, tokens are not able to be added or removed.
 
 ### Example
 

--- a/client/components/token-field/docs/example.jsx
+++ b/client/components/token-field/docs/example.jsx
@@ -7,7 +7,8 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var TokenField = require( 'components/token-field' );
+var TokenField = require( 'components/token-field' ),
+	Card = require( 'components/card' );
 
 /**
  * Module variables
@@ -27,7 +28,9 @@ var TokenFields = React.createClass( {
 	getInitialState: function() {
 		return {
 			tokenSuggestions: suggestions,
-			tokens: Object.freeze( [ 'foo', 'bar' ] )
+			tokens: Object.freeze( [ 'foo', 'bar' ] ),
+			disabledTokens: [ 'foo', 'bar' ],
+			statusTokens: Object.freeze( [ 'success', 'error', 'validating', 'none' ] )
 		};
 	},
 
@@ -37,12 +40,77 @@ var TokenFields = React.createClass( {
 				<h2>
 					<a href="/devdocs/design/token-fields">Token Field</a>
 				</h2>
-				<TokenField
-					suggestions={ this.state.tokenSuggestions }
-					value={ this.state.tokens }
-					onChange={ this._onTokensChange } />
+
+				<p>
+					The <code>TokenField</code> is a field similar to the tags and categories
+					fields in the interim editor chrome, or the "to" field in Mail on OS X.
+					Tokens can be entered by typing them or selecting them from a list of suggested tokens.
+				</p>
+
+				<Card>
+					<h3>Default TokenField with Suggestions</h3>
+					<TokenField
+						isBorderless={ this.state.isBorderless }
+						suggestions={ this.state.tokenSuggestions }
+						value={ this.state.tokens }
+						onChange={ this._onTokensChange } />
+				</Card>
+
+				<Card>
+					<h3>Borderless Tokens with Statuses</h3>
+					<TokenField
+						isBorderless
+						value={ this._getStatusTokens() }
+						onChange={ this._onStatusTokensChange } />
+				</Card>
+
+				<Card>
+					<h3>Borderless and Disabled TokenField</h3>
+					<TokenField
+						disabled
+						isBorderless
+						value={ this.state.disabledTokens } />
+				</Card>
 			</div>
 		);
+	},
+
+	_getStatusTokens() {
+		return this.state.statusTokens.map( ( token ) => {
+			let returnToken;
+			switch ( token ) {
+				case 'error':
+					returnToken = {
+						value: token,
+						status: token,
+						tooltip: 'This token is errored'
+					};
+					break;
+				case 'validating':
+				case 'success':
+					returnToken = {
+						value: token,
+						status: token
+					};
+					break;
+				default:
+					returnToken = token;
+					break;
+			}
+
+			return returnToken;
+		} );
+	},
+
+	_onStatusTokensChange( value ) {
+		const filteredTokens = value.map( ( token ) => {
+			if ( 'object' === typeof token ) {
+				return token.value;
+			}
+			return token;
+		} );
+
+		this.setState( { statusTokens: filteredTokens } );
 	},
 
 	_onTokensChange: function( value ) {

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -27,7 +27,6 @@ var TokenField = React.createClass( {
 		displayTransform: React.PropTypes.func,
 		saveTransform: React.PropTypes.func,
 		onChange: React.PropTypes.func,
-		tokenStatus: React.PropTypes.func,
 		isBorderless: React.PropTypes.bool,
 		maxLength: React.PropTypes.number,
 		onFocus: React.PropTypes.func,
@@ -61,7 +60,6 @@ var TokenField = React.createClass( {
 				return token.trim();
 			},
 			onChange: function() {},
-			tokenStatus: function() {},
 			isBorderless: false,
 			disabled: false,
 			tokenizeOnSpace: false


### PR DESCRIPTION
Closes #3196.

After modifying `TokenField` quite a bit to fit our needs for invites, it is time that we update the docs to reflect that.

To test:
- Read over [TokenField README](https://github.com/Automattic/wp-calypso/blob/update/token-field-readme-invites/client/components/token-field/README.md) and make sure it is correct
- Checkout `update/token-field-readme-invites` branch
- Go to http://calypso.localhost:3000/devdocs/design/token-fields and ensure that example works properly

cc @lezama for a review

Screenshot of updates devDoc example:

<img width="636" alt="screen shot 2016-03-08 at 3 34 30 pm" src="https://cloud.githubusercontent.com/assets/1126811/13617339/de8c283e-e543-11e5-972f-8d8cd6b94474.png">
