### PR TITLE
Editor: use new WP-API post-counts endpoint for drafts drawer.

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -533,12 +533,19 @@ PostActions = {
 	},
 
 	fetchCounts: function( siteId, options ) {
+		var wpcomInterface = wpcom;
+
 		Dispatcher.handleViewAction( {
 			type: 'FETCH_POST_COUNTS',
 			siteId: siteId
 		} );
 
-		wpcom.undocumented().site( siteId ).postCounts( options, function( error, data ) {
+		// Only pass 20%ish of requests to WP-API for now.
+		if ( 0 === ( siteId % 5 ) ) {
+			wpcomInterface = wpcom.undocumented();
+		}
+
+		wpcomInterface.site( siteId ).postCounts( options, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_POST_COUNTS',
 				error: error,

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -538,7 +538,7 @@ PostActions = {
 			siteId: siteId
 		} );
 
-		wpcom.site( siteId ).postCounts( options, function( error, data ) {
+		wpcom.undocumented().site( siteId ).postCounts( options, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_POST_COUNTS',
 				error: error,

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 var debug = require( 'debug' )( 'calypso:wpcom-undocumented:site' );
+var merge = require( 'lodash/merge' );
 
 /**
  * Internal dependencies.
@@ -182,6 +183,20 @@ UndocumentedSite.prototype.setOption = function( query, callback ) {
 		callback
 	);
 }
+
+UndocumentedSite.prototype.postCounts = function( options, callback ) {
+	var type,
+		query = merge( {
+			type: 'post',
+			apiNamespace: 'wpcom/v2',
+			locale: i18n.getLocaleSlug()
+		}, options );
+
+	type = query.type;
+	delete query.type;
+
+	this.wpcom.req.get( '/sites/' + this._id + '/wpcom/v2/post-counts/' + type, query, callback );
+};
 
 /**
  * Create an `Export` instance

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -188,7 +188,7 @@ UndocumentedSite.prototype.postCounts = function( options, callback ) {
 	var type,
 		query = merge( {
 			type: 'post',
-			apiNamespace: 'wpcom/v2',
+			apiNamespace: 'wp', // This currently has no bearing on the route, wpcom-xhr-request needs to be updated to remove the namespace whitelist
 			locale: i18n.getLocaleSlug()
 		}, options );
 

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -2,7 +2,6 @@
  * External dependencies.
  */
 var debug = require( 'debug' )( 'calypso:wpcom-undocumented:site' );
-var merge = require( 'lodash/merge' );
 
 /**
  * Internal dependencies.
@@ -185,17 +184,15 @@ UndocumentedSite.prototype.setOption = function( query, callback ) {
 }
 
 UndocumentedSite.prototype.postCounts = function( options, callback ) {
-	var type,
-		query = merge( {
-			type: 'post',
-			apiNamespace: 'wp', // This currently has no bearing on the route, wpcom-xhr-request needs to be updated to remove the namespace whitelist
-			locale: i18n.getLocaleSlug()
-		}, options );
+	let query = Object.assign( {
+		type: 'post',
+		apiNamespace: 'wp' // This currently has no bearing on the route, wpcom-xhr-request needs to be updated to remove the namespace whitelist
+	}, options );
 
-	type = query.type;
+	const type = query.type;
 	delete query.type;
 
-	this.wpcom.req.get( '/sites/' + this._id + '/wpcom/v2/post-counts/' + type, query, callback );
+	return this.wpcom.req.get( '/sites/' + this._id + '/wpcom/v2/post-counts/' + type, query, callback );
 };
 
 /**


### PR DESCRIPTION
This branch creates a new `wpcom-undocumented` endpoint for the new WP-API based `post-counts` endpoint.  The new method is then utilized in the `post/actions#fetchCounts` action that powers the draft count in the editor:

<img width="312" alt="new_post_ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/13586227/87642b80-e474-11e5-8301-afdfb2bbd13a.png">

__To Test__
- Open up the post editor
- Ensure the draft drawer shows the same number as it does under the production or master branch 