### PR TITLE
Plans: Add free trials without going through checkout

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	classNames = require( 'classnames' );
+	classNames = require( 'classnames' ),
+	page = require( 'page' );
 
 /**
  * Internal dependencies
@@ -15,7 +16,8 @@ var abtest = require( 'lib/abtest' ).abtest,
 	isBusiness = productsValues.isBusiness,
 	isEnterprise = productsValues.isEnterprise,
 	cartItems = require( 'lib/cart-values' ).cartItems,
-	puchasesPaths = require( 'me/purchases/paths' );
+	puchasesPaths = require( 'me/purchases/paths' ),
+	upgradesActions = require( 'lib/upgrades/actions' );
 
 module.exports = React.createClass( {
 	displayName: 'PlanActions',
@@ -145,6 +147,10 @@ module.exports = React.createClass( {
 
 		if ( this.props.onSelectPlan ) {
 			this.props.onSelectPlan( cartItem );
+		} else {
+			upgradesActions.addItem( cartItem );
+
+			page( '/checkout/' + this.props.site.slug );
 		}
 	},
 

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -2,26 +2,23 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	page = require( 'page' );
+	classNames = require( 'classnames' );
 
 /**
  * Internal dependencies
  */
 var abtest = require( 'lib/abtest' ).abtest,
 	analytics = require( 'analytics' ),
+	cartValues = require( 'lib/cart-values' ),
+	cartItems = cartValues.cartItems,
 	config = require( 'config' ),
 	productsValues = require( 'lib/products-values' ),
 	isFreePlan = productsValues.isFreePlan,
 	isBusiness = productsValues.isBusiness,
 	isEnterprise = productsValues.isEnterprise,
-	cartItems = require( 'lib/cart-values' ).cartItems,
-	puchasesPaths = require( 'me/purchases/paths' ),
-	upgradesActions = require( 'lib/upgrades/actions' );
+	puchasesPaths = require( 'me/purchases/paths' );
 
-module.exports = React.createClass( {
-	displayName: 'PlanActions',
-
+var PlanActions = React.createClass( {
 	propTypes: { plan: React.PropTypes.object },
 
 	getButtons: function() {
@@ -145,13 +142,7 @@ module.exports = React.createClass( {
 			}
 		}
 
-		if ( this.props.onSelectPlan ) {
-			this.props.onSelectPlan( cartItem );
-		} else {
-			upgradesActions.addItem( cartItem );
-
-			page( '/checkout/' + this.props.site.slug );
-		}
+		this.props.onSelectPlan( cartItem );
 	},
 
 	canSelectPlan: function() {
@@ -314,3 +305,5 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+module.exports = PlanActions;

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -21,7 +21,8 @@ var abtest = require( 'lib/abtest' ).abtest,
 	plansPaths = require( 'my-sites/plans/paths' ),
 	puchasesPaths = require( 'me/purchases/paths' ),
 	refreshSitePlans = require( 'state/sites/plans/actions' ).refreshSitePlans,
-	upgradesActions = require( 'lib/upgrades/actions' );
+	upgradesActions = require( 'lib/upgrades/actions' ),
+	upgradesNotices = require( 'lib/upgrades/notices' );
 
 var PlanActions = React.createClass( {
 	propTypes: { plan: React.PropTypes.object },
@@ -155,14 +156,19 @@ var PlanActions = React.createClass( {
 
 		this.recordStartFreeTrialClick();
 
-		const plan = this.props.plan;
+		upgradesNotices.displaySubmitting( { isFreeCart: true } );
 
-		upgradesActions.startFreeTrial( this.props.site.ID, plan, function( error ) {
-			if ( ! error ) { // TODO: show notice on error
-				this.props.refreshSitePlans( this.props.site.ID );
-
-				page( plansPaths.plansDestination( this.props.site.slug, 'thank-you' ) );
+		upgradesActions.startFreeTrial( this.props.site.ID, this.props.plan, function( error ) {
+			if ( error ) {
+				upgradesNotices.displayError( error );
+				return;
 			}
+
+			upgradesNotices.clear();
+
+			this.props.refreshSitePlans( this.props.site.ID );
+
+			page( plansPaths.plansDestination( this.props.site.slug, 'thank-you' ) );
 		}.bind( this ) );
 	},
 

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -16,7 +16,6 @@ var abtest = require( 'lib/abtest' ).abtest,
 	config = require( 'config' ),
 	productsValues = require( 'lib/products-values' ),
 	isFreePlan = productsValues.isFreePlan,
-	isFreeTrial = productsValues.isFreeTrial,
 	isBusiness = productsValues.isBusiness,
 	isEnterprise = productsValues.isEnterprise,
 	plansPaths = require( 'my-sites/plans/paths' ),
@@ -73,7 +72,7 @@ var PlanActions = React.createClass( {
 			<div>
 				<button className="button is-primary plan-actions__upgrade-button"
 					disabled={ this.props.isSubmitting }
-					onClick={ this.handleAddToCart.bind( null, null, 'button' ) }>
+					onClick={ this.handleSelectPlan }>
 					{ this.translate( 'Select Free Plan' ) }
 				</button>
 			</div>
@@ -102,77 +101,69 @@ var PlanActions = React.createClass( {
 				<button
 					className="button is-primary plan-actions__upgrade-button"
 					disabled={ this.props.isSubmitting }
-					onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'button' ) }>
+					onClick={ this.handleSelectPlan }>
 					{ label }
 				</button>
 			</div>
 		);
 	},
 
-	recordStartFreeTrialClick: function( cartItem ) {
-		analytics.ga.recordEvent( 'Upgrades', 'Clicked Start Free Trial Button', 'Product ID', cartItem.product_id );
+	recordStartFreeTrialClick: function() {
+		analytics.ga.recordEvent( 'Upgrades', 'Clicked Start Free Trial Button', 'Product ID', this.props.plan.product_id );
 	},
 
-	recordUpgradeNowClick: function( cartItem ) {
-		analytics.ga.recordEvent( 'Upgrades', 'Clicked Upgrade Now Link', 'Product ID', cartItem.product_id );
+	recordUpgradeNowClick: function() {
+		analytics.ga.recordEvent( 'Upgrades', 'Clicked Upgrade Now Link', 'Product ID', this.props.plan.product_id );
 	},
 
-	recordUpgradeNowButton: function( cartItem ) {
-		analytics.ga.recordEvent( 'Upgrades', 'Clicked Upgrade Now Button', 'Product ID', cartItem.product_id );
+	recordUpgradeNowButton: function() {
+		analytics.ga.recordEvent( 'Upgrades', 'Clicked Upgrade Now Button', 'Product ID', this.props.plan.product_id );
 	},
 
-	recordUpgradeTrialNowClick: function( cartItem ) {
-		analytics.ga.recordEvent( 'Upgrades', 'Clicked Upgrade Now Link For Trial', 'Product ID', cartItem.product_id );
-	},
-
-	handleAddToCart: function( cartItem, actionType, event ) {
-		if ( event ) {
-			event.preventDefault();
-		}
+	handleSelectPlan: function( event ) {
+		event.preventDefault();
 
 		if ( this.props.isSubmitting ) {
 			return;
 		}
 
-		if ( cartItem && actionType ) {
-			if ( actionType === 'button' ) {
-				if ( cartItem.free_trial ) {
-					this.recordStartFreeTrialClick( cartItem );
-				}
-				if ( ! cartItem.free_trial ) {
-					this.recordUpgradeNowButton( cartItem );
-				}
-			}
+		const actionType = event.target.tagName === 'A' ? 'link' : 'button';
 
-			if ( actionType === 'link' ) {
-				if ( cartItem.free_trial ) {
-					this.recordUpgradeTrialNowClick( cartItem );
-				}
-				if ( ! cartItem.free_trial ) {
-					this.recordUpgradeNowClick( cartItem );
-				}
-			}
+		if ( 'link' === actionType ) {
+			this.recordUpgradeNowClick();
+		} else {
+			this.recordUpgradeNowButton();
 		}
+
+		const cartItem = cartItems.getItemForPlan( this.props.plan );
 
 		if ( this.props.onSelectPlan ) {
 			return this.props.onSelectPlan( cartItem );
 		}
 
-		if ( isFreeTrial( cartItem ) && ! this.props.isImageButton ) {
-			upgradesActions.submitFreeTransaction( this.props.site, cartItem, function( error ) {
-				if ( ! error ) {
-					this.props.refreshSitePlans( this.props.site.ID );
+		upgradesActions.addItem( cartItem );
 
-					page( plansPaths.plansDestination( this.props.site.slug, 'thank-you' ) );
-				}
-			}.bind( this ) );
+		page( '/checkout/' + this.props.site.slug );
+	},
+
+	handleClickStartTrial: function( event ) {
+		event.preventDefault();
+
+		if ( this.props.isSubmitting ) {
+			return;
 		}
 
-		if ( ! isFreeTrial( cartItem ) ) {
-			upgradesActions.addItem( cartItem );
+		this.recordStartFreeTrialClick();
 
-			page( '/checkout/' + this.props.site.slug );
-		}
+		const plan = this.props.plan;
+
+		upgradesActions.startFreeTrial( this.props.site.ID, plan, function( error ) {
+			if ( ! error ) { // TODO: show notice on error
+				this.props.refreshSitePlans( this.props.site.ID );
+
+				page( plansPaths.plansDestination( this.props.site.slug, 'thank-you' ) );
+			}
+		}.bind( this ) );
 	},
 
 	canSelectPlan: function() {
@@ -194,6 +185,11 @@ var PlanActions = React.createClass( {
 	},
 
 	shouldOfferFreeTrial: function() {
+		// do not offer free trial for the free plan
+		if ( isFreePlan( this.props.plan ) ) {
+			return false;
+		}
+
 		if ( ! this.props.enableFreeTrials ) {
 			return false;
 		}
@@ -216,14 +212,14 @@ var PlanActions = React.createClass( {
 			);
 		}
 
-		if ( isFreePlan( this.props.plan ) ) {
+		if ( this.shouldOfferFreeTrial() ) {
 			return (
-				<div onClick={ this.handleAddToCart.bind( null, null, 'button' ) } className={ classes } />
+				<div onClick={ this.handleClickStartTrial } className={ classes } />
 			);
 		}
 
 		return (
-			<div onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: this.shouldOfferFreeTrial() } ), 'button' ) } className={ classes } />
+			<div onClick={ this.handleSelectPlan } className={ classes } />
 		);
 	},
 
@@ -236,7 +232,7 @@ var PlanActions = React.createClass( {
 			<div>
 				<button className="button is-primary plan-actions__upgrade-button"
 					disabled={ this.props.isSubmitting }
-					onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: true } ), 'button' ) }>
+					onClick={ this.handleClickStartTrial }>
 						{ this.translate( 'Start Free Trial', { context: 'Store action' } ) }
 				</button>
 
@@ -245,8 +241,7 @@ var PlanActions = React.createClass( {
 						? this.translate( 'Try it free for 14 days, no credit card needed, or {{a}}upgrade now{{/a}}.', {
 							context: 'Store action',
 							components: {
-								a: <a href="#"
-									onClick={ this.handleAddToCart.bind( null, this.cartItem( { isFreeTrial: false } ), 'link' ) } />
+								a: <a href="#" onClick={ this.handleSelectPlan } />
 							}
 						} )
 						: this.translate( 'Try it free for 14 days, no credit card needed.' )
@@ -254,10 +249,6 @@ var PlanActions = React.createClass( {
 				</small>
 			</div>
 		);
-	},
-
-	cartItem: function( properties ) {
-		return cartItems.getItemForPlan( this.props.plan, properties );
 	},
 
 	downgradeMessage: function() {

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -121,6 +121,10 @@ var PlanActions = React.createClass( {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Upgrade Now Button', 'Product ID', this.props.plan.product_id );
 	},
 
+	getCartItem: function( properties ) {
+		return cartItems.getItemForPlan( this.props.plan, properties );
+	},
+
 	handleSelectPlan: function( event ) {
 		event.preventDefault();
 
@@ -136,7 +140,7 @@ var PlanActions = React.createClass( {
 			this.recordUpgradeNowButton();
 		}
 
-		const cartItem = cartItems.getItemForPlan( this.props.plan );
+		const cartItem = isFreePlan( this.props.plan ) ? null : this.getCartItem();
 
 		if ( this.props.onSelectPlan ) {
 			return this.props.onSelectPlan( cartItem );
@@ -155,6 +159,10 @@ var PlanActions = React.createClass( {
 		}
 
 		this.recordStartFreeTrialClick();
+
+		if ( this.props.onSelectPlan ) {
+			return this.props.onSelectPlan( this.getCartItem( { isFreeTrial: true } ) );
+		}
 
 		upgradesNotices.displaySubmitting( { isFreeCart: true } );
 
@@ -191,7 +199,6 @@ var PlanActions = React.createClass( {
 	},
 
 	shouldOfferFreeTrial: function() {
-		// do not offer free trial for the free plan
 		if ( isFreePlan( this.props.plan ) ) {
 			return false;
 		}

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -91,7 +91,8 @@ module.exports = React.createClass( {
 						onSelectPlan={ this.props.onSelectPlan }
 						site={ site }
 						enableFreeTrials={ this.props.enableFreeTrials }
-						cart={ this.props.cart } />
+						cart={ this.props.cart }
+						isSubmitting={ this.props.isSubmitting } />
 				);
 			}, this );
 		}

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -231,7 +231,8 @@ module.exports = React.createClass( {
 				site={ this.props.site }
 				cart={ this.props.cart }
 				enableFreeTrials={ this.props.enableFreeTrials }
-				isPlaceholder={ this.isPlaceholder() }/>
+				isPlaceholder={ this.isPlaceholder() }
+				isSubmitting={ this.props.isSubmitting } />
 		);
 	},
 
@@ -246,6 +247,7 @@ module.exports = React.createClass( {
 				cart={ this.props.cart }
 				enableFreeTrials={ this.props.enableFreeTrials }
 				isPlaceholder={ this.isPlaceholder() }
+				isSubmitting={ this.props.isSubmitting }
 				isImageButton />
 		);
 	},

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -32,7 +32,8 @@ var observe = require( 'lib/mixins/data-observe' ),
 	NavItem = require( 'components/section-nav/item' ),
 	NavTabs = require( 'components/section-nav/tabs' ),
 	SectionNav = require( 'components/section-nav' ),
-	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans;
+	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans,
+	transactionStepTypes = require( 'lib/store-transactions/step-types' );
 
 var PlansCompare = React.createClass( {
 	displayName: 'PlansCompare',
@@ -239,7 +240,7 @@ var PlansCompare = React.createClass( {
 								site={ this.props.selectedSite }
 								cart={ this.props.cart }
 								enableFreeTrials={ this.props.enableFreeTrials }
-								isSubmitting={ this.props.transaction.step.name === 'submitting-wpcom-request' }
+								isSubmitting={ this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST }
 								isImageButton />
 							<span className="plans-compare__plan-name">
 								{ plan.product_name_short }
@@ -358,7 +359,7 @@ var PlansCompare = React.createClass( {
 						plan={ plan }
 						site={ this.props.selectedSite }
 						sitePlan={ sitePlan }
-						isSubmitting={ this.props.transaction.step.name === 'submitting-wpcom-request' }
+						isSubmitting={ this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST }
 						cart={ this.props.cart } />
 				</td>
 			);

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -239,6 +239,7 @@ var PlansCompare = React.createClass( {
 								site={ this.props.selectedSite }
 								cart={ this.props.cart }
 								enableFreeTrials={ this.props.enableFreeTrials }
+								isSubmitting={ this.props.transaction.step.name === 'submitting-wpcom-request' }
 								isImageButton />
 							<span className="plans-compare__plan-name">
 								{ plan.product_name_short }
@@ -357,6 +358,7 @@ var PlansCompare = React.createClass( {
 						plan={ plan }
 						site={ this.props.selectedSite }
 						sitePlan={ sitePlan }
+						isSubmitting={ this.props.transaction.step.name === 'submitting-wpcom-request' }
 						cart={ this.props.cart } />
 				</td>
 			);

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -464,6 +464,8 @@ function spaceUpgradeItem( slug ) {
  * @returns {Object} the new item as `CartItemValue` object
  */
 function getItemForPlan( plan, properties ) {
+	properties = properties || {};
+
 	switch ( plan.product_slug ) {
 		case 'value_bundle':
 		case 'jetpack_premium':

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -13,8 +13,20 @@ var cartItems = require( './cart-items' ),
 	productsValues = require( 'lib/products-values' ),
 	{ abtest } = require( 'lib/abtest' );
 
-function emptyCart( siteID ) {
-	return { blog_id: siteID, products: [] };
+/**
+ * Create a new empty cart.
+ *
+ * A cart has at least a `blog_id` and an empty list of `products`
+ * We can give additional attributes and build new types of empty carts.
+ * For instance you may want to create a temporary this way:
+ * `emptyCart( 123456, { temporary: true } )`
+ *
+ * @param {int} [siteId] The Site Id the cart will be associated with
+ * @param {Object} [attributes] Additional attributes for the cart (optional)
+ * @returns {cart} [emptyCart] The new empty cart created
+ */
+function emptyCart( siteId, attributes ) {
+	return Object.assign( { blog_id: siteId, products: [] }, attributes );
 }
 
 function applyCoupon( coupon ) {

--- a/client/lib/store-transactions/step-types.js
+++ b/client/lib/store-transactions/step-types.js
@@ -1,0 +1,7 @@
+
+export const BEFORE_SUBMIT = 'before-submit';
+export const INPUT_VALIDATION = 'input-validation';
+export const RECEIVED_PAYMENT_KEY_RESPONSE = 'received-payment-key-response';
+export const RECEIVED_WPCOM_RESPONSE = 'received-wpcom-response';
+export const SUBMITTING_PAYMENT_KEY_REQUEST = 'submitting-payment-key-request';
+export const SUBMITTING_WPCOM_REQUEST = 'submitting-wpcom-request';

--- a/client/lib/transaction/store.js
+++ b/client/lib/transaction/store.js
@@ -14,6 +14,7 @@ var UpgradesActionTypes = require( 'lib/upgrades/constants' ).action,
 	CartStore = require( 'lib/cart/store' ),
 	Emitter = require( 'lib/mixins/emitter' ),
 	Dispatcher = require( 'dispatcher' ),
+	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
 	hasDomainDetails = require( 'lib/store-transactions' ).hasDomainDetails;
 
 var _transaction = createInitialTransaction();
@@ -35,7 +36,7 @@ function createInitialTransaction() {
 	return {
 		errors: {},
 		newCardFormFields: {},
-		step: { name: 'before-submit' },
+		step: { name: transactionStepTypes.BEFORE_SUBMIT },
 		domainDetails: null
 	};
 }

--- a/client/lib/upgrades/actions/checkout.js
+++ b/client/lib/upgrades/actions/checkout.js
@@ -7,7 +7,6 @@ import { cartItems } from 'lib/cart-values';
 import Dispatcher from 'dispatcher';
 import productsListFactory from 'lib/products-list';
 import storeTransactions from 'lib/store-transactions';
-import wpcom from 'lib/wp';
 
 const productsList = productsListFactory();
 
@@ -42,15 +41,17 @@ function submitFreeTransaction( site, cartItem, onComplete ) {
 
 	cart = cartValues.fillInAllCartItemAttributes( addFunction( cart ), productsList.get() );
 
-	wpcom.undocumented().transactions( 'POST', {
+	submitTransaction( {
 		cart,
-		payment: {
-			paymentMethod: 'WPCOM_Billing_WPCOM'
+		transaction: {
+			payment: {
+				paymentMethod: 'WPCOM_Billing_WPCOM'
+			}
 		}
 	}, onComplete );
 }
 
-function submitTransaction( { cart, transaction } ) {
+function submitTransaction( { cart, transaction }, onComplete ) {
 	const steps = storeTransactions.submit( {
 		cart: cart,
 		payment: transaction.payment,
@@ -62,6 +63,10 @@ function submitTransaction( { cart, transaction } ) {
 			type: ActionTypes.TRANSACTION_STEP_SET,
 			step
 		} );
+
+		if ( onComplete && step.name === 'received-wpcom-response' ) {
+			onComplete();
+		}
 	} );
 }
 

--- a/client/lib/upgrades/actions/checkout.js
+++ b/client/lib/upgrades/actions/checkout.js
@@ -2,8 +2,14 @@
  * Internal dependencies
  */
 import { action as ActionTypes } from '../constants';
+import cartValues from 'lib/cart-values';
+import { cartItems } from 'lib/cart-values';
 import Dispatcher from 'dispatcher';
+import productsListFactory from 'lib/products-list';
 import storeTransactions from 'lib/store-transactions';
+import wpcom from 'lib/wp';
+
+const productsList = productsListFactory();
 
 function setDomainDetails( domainDetails ) {
 	Dispatcher.handleViewAction( {
@@ -27,6 +33,21 @@ function setNewCreditCardDetails( options ) {
 		rawDetails,
 		maskedDetails
 	} );
+}
+
+function submitFreeTransaction( site, cartItem, onComplete ) {
+	const addFunction = cartItems.add( cartItem );
+
+	let cart = cartValues.emptyCart( site.ID );
+
+	cart = cartValues.fillInAllCartItemAttributes( addFunction( cart ), productsList.get() );
+
+	wpcom.undocumented().transactions( 'POST', {
+		cart,
+		payment: {
+			paymentMethod: 'WPCOM_Billing_WPCOM'
+		}
+	}, onComplete );
 }
 
 function submitTransaction( { cart, transaction } ) {
@@ -55,5 +76,6 @@ export {
 	setDomainDetails,
 	setNewCreditCardDetails,
 	setPayment,
+	submitFreeTransaction,
 	submitTransaction
 };

--- a/client/lib/upgrades/actions/checkout.js
+++ b/client/lib/upgrades/actions/checkout.js
@@ -2,13 +2,8 @@
  * Internal dependencies
  */
 import { action as ActionTypes } from '../constants';
-import cartValues from 'lib/cart-values';
-import { cartItems } from 'lib/cart-values';
 import Dispatcher from 'dispatcher';
-import productsListFactory from 'lib/products-list';
 import storeTransactions from 'lib/store-transactions';
-
-const productsList = productsListFactory();
 
 function setDomainDetails( domainDetails ) {
 	Dispatcher.handleViewAction( {
@@ -32,23 +27,6 @@ function setNewCreditCardDetails( options ) {
 		rawDetails,
 		maskedDetails
 	} );
-}
-
-function submitFreeTransaction( site, cartItem, onComplete ) {
-	const addFunction = cartItems.add( cartItem );
-
-	let cart = cartValues.emptyCart( site.ID );
-
-	cart = cartValues.fillInAllCartItemAttributes( addFunction( cart ), productsList.get() );
-
-	submitTransaction( {
-		cart,
-		transaction: {
-			payment: {
-				paymentMethod: 'WPCOM_Billing_WPCOM'
-			}
-		}
-	}, onComplete );
 }
 
 function submitTransaction( { cart, transaction }, onComplete ) {
@@ -81,6 +59,5 @@ export {
 	setDomainDetails,
 	setNewCreditCardDetails,
 	setPayment,
-	submitFreeTransaction,
 	submitTransaction
 };

--- a/client/lib/upgrades/actions/checkout.js
+++ b/client/lib/upgrades/actions/checkout.js
@@ -43,7 +43,7 @@ function submitTransaction( { cart, transaction }, onComplete ) {
 		} );
 
 		if ( onComplete && step.name === 'received-wpcom-response' ) {
-			onComplete();
+			onComplete( step.error );
 		}
 	} );
 }

--- a/client/lib/upgrades/actions/free-trials.js
+++ b/client/lib/upgrades/actions/free-trials.js
@@ -8,6 +8,16 @@ import { submitTransaction } from './checkout';
 
 const productsList = productsListFactory();
 
+/*
+ * Submit a free cart transaction
+ *
+ * This an helper method to be used for when we want to make a
+ * quick (free) transaction without a valid payment method.
+ * The default payment method for free carts is used here.
+ *
+ * {cart} [partialCart] - A cart-like object. We just need a valid `product_slug` property for cart items
+ * {function} [onComplete] Callback function called on completion
+ */
 function submitFreeTransaction( partialCart, onComplete ) {
 	const cart = fillInAllCartItemAttributes( partialCart, productsList.get() ),
 		transaction = {
@@ -17,6 +27,16 @@ function submitFreeTransaction( partialCart, onComplete ) {
 	submitTransaction( { cart, transaction }, onComplete );
 }
 
+/*
+ * Start a free trial for a given site and plan
+ *
+ * This method creates a free cart containing our plan as a cart item with the
+ * `isFreeTrial` option set to `true`. It uses `submitFreeTransaction` to make the request.
+ *
+ * {int} [siteId] - The ID of the site this free trial is for.
+ * {Object} [plan] - A plan-like object. We just need a valid `product_slug` property to make a cartItem out of it.
+ * {function} [onComplete] Callback function called on completion
+ */
 export function startFreeTrial( siteId, plan, onComplete ) {
 	let cart = emptyCart( siteId, { temporary: true } );
 	const planItem = cartItems.getItemForPlan( plan, { isFreeTrial: true } );

--- a/client/lib/upgrades/actions/free-trials.js
+++ b/client/lib/upgrades/actions/free-trials.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { cartItems, emptyCart, fillInAllCartItemAttributes } from 'lib/cart-values';
+import productsListFactory from 'lib/products-list';
+import { fullCreditsPayment } from 'lib/store-transactions';
+import { submitTransaction } from './checkout';
+
+const productsList = productsListFactory();
+
+function submitFreeTransaction( partialCart, onComplete ) {
+	const cart = fillInAllCartItemAttributes( partialCart, productsList.get() ),
+		transaction = {
+			payment: fullCreditsPayment()
+		};
+
+	submitTransaction( { cart, transaction }, onComplete );
+}
+
+export function startFreeTrial( siteId, plan, onComplete ) {
+	let cart = emptyCart( siteId, { temporary: true } );
+	const planItem = cartItems.getItemForPlan( plan, { isFreeTrial: true } );
+
+	cart = cartItems.add( planItem )( cart );
+
+	submitFreeTransaction( cart, onComplete );
+}

--- a/client/lib/upgrades/actions/index.js
+++ b/client/lib/upgrades/actions/index.js
@@ -1,5 +1,6 @@
 export * from './cart';
 export * from './checkout';
+export * from './free-trials';
 export * from './domain-management';
 export * from './domain-search';
 export * from './purchases';

--- a/client/lib/upgrades/notices.jsx
+++ b/client/lib/upgrades/notices.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ), // eslint-disable-line no-unused-vars
-	flatten = require( 'lodash/flatten' ),
-	values = require( 'lodash/values' );
+import React from 'react'; // eslint-disable-line no-unused-vars
+import flatten from 'lodash/flatten';
+import values from 'lodash/values';
 
 /**
  * Internal dependencies
  */
-var i18n = require( 'lib/mixins/i18n' ),
-	notices = require( 'notices' ),
-	ValidationErrorList = require( 'notices/validation-error-list' );
+import i18n from 'lib/mixins/i18n';
+import notices from 'notices'
+import ValidationErrorList from 'notices/validation-error-list';
 
 function getErrorFromApi( errorMessage ) {
 	if ( errorMessage ) {
@@ -33,7 +33,7 @@ function getErrorFromApi( errorMessage ) {
 	}
 
 	return i18n.translate( 'There was a problem completing the checkout. Please try again.' );
-};
+}
 
 export function displayError( error ) {
 	if ( typeof error.message === 'object' ) {
@@ -41,12 +41,12 @@ export function displayError( error ) {
 	} else {
 		notices.error( getErrorFromApi( error.message ) )
 	}
-};
+}
 
 export function displaySubmitting( { isFreeCart } ) {
 	notices.info( isFreeCart ? i18n.translate( 'Submitting' ) : i18n.translate( 'Submitting payment' ) );
-};
+}
 
 export function clear() {
 	notices.clearNotices( 'notices' );
-};
+}

--- a/client/lib/upgrades/notices.jsx
+++ b/client/lib/upgrades/notices.jsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+var React = require( 'react' ), // eslint-disable-line no-unused-vars
+	flatten = require( 'lodash/flatten' ),
+	values = require( 'lodash/values' );
+
+/**
+ * Internal dependencies
+ */
+var i18n = require( 'lib/mixins/i18n' ),
+	notices = require( 'notices' ),
+	ValidationErrorList = require( 'notices/validation-error-list' );
+
+function getErrorFromApi( errorMessage ) {
+	if ( errorMessage ) {
+		const errorArray = errorMessage.split( /<a href="(.+)">(.+)<\/a>/ );
+
+		if ( errorArray.length === 4 ) { // This assumes we have only one link
+			const errorText1 = errorArray[ 0 ],
+				errorUrl = errorArray[ 1 ],
+				errorLinkText = errorArray[ 2 ],
+				errorText2 = errorArray[ 3 ];
+
+			return (
+				<span>
+					{ errorText1 } <a href={ errorUrl }>{ errorLinkText }</a> { errorText2 }
+				</span>
+			);
+		}
+
+		return errorMessage;
+	}
+
+	return i18n.translate( 'There was a problem completing the checkout. Please try again.' );
+};
+
+export function displayError( error ) {
+	if ( typeof error.message === 'object' ) {
+		notices.error( <ValidationErrorList messages={ flatten( values( error.message ) ) } /> );
+	} else {
+		notices.error( getErrorFromApi( error.message ) )
+	}
+};
+
+export function displaySubmitting( { isFreeCart } ) {
+	notices.info( isFreeCart ? i18n.translate( 'Submitting' ) : i18n.translate( 'Submitting payment' ) );
+};
+
+export function clear() {
+	notices.clearNotices( 'notices' );
+};

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -22,7 +22,7 @@ module.exports = {
 
 	plans: function( context ) {
 		var Plans = require( 'my-sites/plans/main' ),
-			CartData = require( 'components/data/cart' ),
+			CheckoutData = require( 'components/data/checkout' ),
 			MainComponent = require( 'components/main' ),
 			EmptyContentComponent = require( 'components/empty-content' ),
 			site = sites.getSelectedSite(),
@@ -63,13 +63,13 @@ module.exports = {
 		analytics.pageView.record( analyticsBasePath, analyticsPageTitle );
 
 		renderWithReduxStore(
-			<CartData>
+			<CheckoutData>
 				<Plans
 					sites={ sites }
 					plans={ plans }
 					context={ context }
 					destinationType={ context.params.destinationType } />
-			</CartData>,
+			</CheckoutData>,
 			document.getElementById( 'primary' ),
 			context.store
 		);
@@ -78,7 +78,7 @@ module.exports = {
 	plansCompare: function( context ) {
 		var PlansCompare = require( 'components/plans/plans-compare' ),
 			Main = require( 'components/main' ),
-			CartData = require( 'components/data/cart' ),
+			CheckoutData = require( 'components/data/checkout' ),
 			features = require( 'lib/features-list' )(),
 			productsList = require( 'lib/products-list' )(),
 			analyticsPageTitle = 'Plans > Compare',
@@ -104,14 +104,14 @@ module.exports = {
 
 		renderWithReduxStore(
 			<Main className="plans has-sidebar">
-				<CartData>
+				<CheckoutData>
 					<PlansCompare
 						enableFreeTrials={ getABTestVariation( 'freeTrials' ) === 'offered' }
 						selectedSite={ site }
 						plans={ plans }
 						features={ features }
 						productsList={ productsList } />
-				</CartData>
+				</CheckoutData>
 			</Main>,
 			document.getElementById( 'primary' ),
 			context.store

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -3,8 +3,7 @@
  */
 var page = require( 'page' ),
 	ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	defer = require( 'lodash/defer' );
+	React = require( 'react' );
 
 /**
  * Internal Dependencies
@@ -17,18 +16,7 @@ var sites = require( 'lib/sites-list' )(),
 	plans = require( 'lib/plans-list' )(),
 	config = require( 'config' ),
 	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
-	upgradesActions = require( 'lib/upgrades/actions' ),
 	titleActions = require( 'lib/screen-title/actions' );
-
-function handlePlanSelect( cartItem ) {
-	upgradesActions.addItem( cartItem );
-
-	// FIXME: @rads: The `defer` is necessary here to prevent an error with
-	//   React when changing pages, but the root cause is currently unknown.
-	defer( function() {
-		page( '/checkout/' + sites.getSelectedSite().slug );
-	} );
-}
 
 module.exports = {
 
@@ -78,7 +66,6 @@ module.exports = {
 			<CartData>
 				<Plans
 					sites={ sites }
-					onSelectPlan={ handlePlanSelect }
 					plans={ plans }
 					context={ context }
 					destinationType={ context.params.destinationType } />
@@ -121,7 +108,6 @@ module.exports = {
 					<PlansCompare
 						enableFreeTrials={ getABTestVariation( 'freeTrials' ) === 'offered' }
 						selectedSite={ site }
-						onSelectPlan={ handlePlanSelect }
 						plans={ plans }
 						features={ features }
 						productsList={ productsList } />

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -27,7 +27,8 @@ var analytics = require( 'analytics' ),
 	PlanOverview = require( './plan-overview' ),
 	preventWidows = require( 'lib/formatting' ).preventWidows,
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	UpgradesNavigation = require( 'my-sites/upgrades/navigation' );
+	UpgradesNavigation = require( 'my-sites/upgrades/navigation' ),
+	transactionStepTypes = require( 'lib/store-transactions/step-types' );
 
 var Plans = React.createClass( {
 	displayName: 'Plans',
@@ -180,7 +181,7 @@ var Plans = React.createClass( {
 							onOpen={ this.openPlan }
 							onSelectPlan={ this.props.onSelectPlan }
 							cart={ this.props.cart }
-							isSubmitting={ this.props.transaction.step.name === 'submitting-wpcom-request' } />
+							isSubmitting={ this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST } />
 						{ ! hasJpphpBundle && this.comparePlansLink() }
 					</div>
 				</Main>

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -25,7 +25,8 @@ var analytics = require( 'analytics' ),
 	getExitCheckoutUrl = require( 'lib/checkout' ).getExitCheckoutUrl,
 	upgradesActions = require( 'lib/upgrades/actions' ),
 	{ setSection } = require( 'state/ui/actions' ),
-	{ abtest } = require( 'lib/abtest' );
+	{ abtest } = require( 'lib/abtest' ),
+	transactionStepTypes = require( 'lib/store-transactions/step-types' );
 
 const Checkout = React.createClass( {
 	mixins: [ observe( 'sites', 'cards', 'productsList' ) ],
@@ -113,7 +114,7 @@ const Checkout = React.createClass( {
 			return false;
 		}
 
-		if ( this.props.transaction.step.name === 'submitting-wpcom-request' ) {
+		if ( this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST ) {
 			return false;
 		}
 

--- a/client/my-sites/upgrades/checkout/pay-button.jsx
+++ b/client/my-sites/upgrades/checkout/pay-button.jsx
@@ -10,18 +10,19 @@ var cartValues = require( 'lib/cart-values' ),
 	cartItems = cartValues.cartItems,
 	hasFreeTrial = cartItems.hasFreeTrial,
 	isPaidForFullyInCredits = cartValues.isPaidForFullyInCredits,
-	SubscriptionText = require( './subscription-text' );
+	SubscriptionText = require( './subscription-text' ),
+	transactionStepTypes = require( 'lib/store-transactions/step-types' );
 
 var PayButton = React.createClass( {
 	buttonState: function() {
 		var state;
 
 		switch ( this.props.transactionStep.name ) {
-			case 'before-submit':
+			case transactionStepTypes.BEFORE_SUBMIT:
 				state = this.beforeSubmit();
 				break;
 
-			case 'input-validation':
+			case transactionStepTypes.INPUT_VALIDATION:
 				if ( this.props.transactionStep.error ) {
 					state = this.beforeSubmit();
 				} else {
@@ -29,16 +30,16 @@ var PayButton = React.createClass( {
 				}
 				break;
 
-			case 'submitting-payment-key-request':
-			case 'received-payment-key-response':
+			case transactionStepTypes.SUBMITTING_PAYMENT_KEY_REQUEST:
+			case transactionStepTypes.RECEIVED_PAYMENT_KEY_RESPONSE:
 				state = this.sending();
 				break;
 
-			case 'submitting-wpcom-request':
+			case transactionStepTypes.SUBMITTING_WPCOM_REQUEST:
 				state = this.completing();
 				break;
 
-			case 'received-wpcom-response':
+			case transactionStepTypes.RECEIVED_WPCOM_RESPONSE:
 				if ( this.props.transactionStep.error || ! this.props.transactionStep.data.success ) {
 					state = this.beforeSubmit();
 				} else {


### PR DESCRIPTION
This PR updates the components on `/plans` such that a free trial is added to the user's account when they click 'Start Free Trial' without going through checkout.

**Testing**
- [x] *Free trials on `/plans`*
- Run `localStorage.setItem( 'ABTests', '{ "freeTrials_20160120":"offered" }' );`
- Visit `/plans/:site` for a site that has not had a free trial before.
- Click 'Start Free Trial' under one of the plans.
- Assert that the buttons to select a plan are disabled.
- Assert that a 'Submitting' notice appears.
- Assert that you are redirected to `/plans/:site/thank-you`.

- [x] *Plans on `/plans` with free trials enabled*
- Run `localStorage.setItem( 'ABTests', '{ "freeTrials_20160120":"offered" }' );`
- Visit `/plans/:site` for a site that has not had a free trial before.
- Assert that you can add a full plan to your cart by clicking the 'upgrade now' link under the 'Start Free Trial' buttons.
- Assert that you can complete checkout with this plan successfully.

- [x] *Plans on `/plans` with free trials disabled*
- Run `localStorage.setItem( 'ABTests', '{ "freeTrials_20160120":"notOffered" }' );`
- Visit `/plans/:site`.
- Assert that you can complete checkout after adding a plan to your cart by clicking 'Upgrade Now'.

- [x] *Free plan in signup with free trials enabled*
- Run `localStorage.setItem( 'ABTests', '{ "freeTrials_20160120":"offered" }' );`
- Visit `/start`
- Proceed through signup, selecting the free plan.
- Assert that you are redirected to `[site].wordpress.com` after the signup is complete.

- [x] *Paid plans in signup with free trials enabled*
- Run `localStorage.setItem( 'ABTests', '{ "freeTrials_20160120":"offered" }' );`
- Visit `/start`
- Proceed through signup, selecting a paid plan.
- Assert that you are redirected to checkout after signup with the plan you selected in your cart.

- [x] *Free plan in signup with free trials disabled*
- Run `localStorage.setItem( 'ABTests', '{ "freeTrials_20160120":"notOffered" }' );`
- Visit `/start`
- Proceed through signup, selecting the free plan.
- Assert that you are redirected to `[site].wordpress.com` after the signup is complete.

- [x] *Paid plans in signup with free trials disabled*
- Run `localStorage.setItem( 'ABTests', '{ "freeTrials_20160120":"notOffered" }' );`
- Visit `/start`
- Proceed through signup, selecting a paid plan.
- Assert that you are redirected to checkout after signup with the plan you selected in your cart.

- [x] Product review
- [x] Code review