### PR TITLE
Checkout: Add nudge for Premium free trial on Thank You page

### DIFF
--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -17,6 +17,7 @@ const PurchaseDetail = ( {
 	icon,
 	isPlaceholder,
 	isRequired,
+	isSubmitting,
 	onClick,
 	requiredText,
 	target,
@@ -32,6 +33,7 @@ const PurchaseDetail = ( {
 		buttonElement = (
 			<Button
 				className="purchase-detail__button"
+				disabled={ isSubmitting }
 				href={ href }
 				onClick={ onClick }
 				target={ target }
@@ -78,6 +80,7 @@ PurchaseDetail.propTypes = {
 	icon: React.PropTypes.string,
 	isPlaceholder: React.PropTypes.bool,
 	isRequired: React.PropTypes.bool,
+	isSubmitting: React.PropTypes.bool,
 	onClick: React.PropTypes.func,
 	requiredText: React.PropTypes.string,
 	target: React.PropTypes.string,

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -17,6 +17,7 @@ const PurchaseDetail = ( {
 	icon,
 	isPlaceholder,
 	isRequired,
+	onClick,
 	requiredText,
 	target,
 	title
@@ -32,6 +33,7 @@ const PurchaseDetail = ( {
 			<Button
 				className="purchase-detail__button"
 				href={ href }
+				onClick={ onClick }
 				target={ target }
 				primary>
 				{ buttonText }
@@ -76,6 +78,7 @@ PurchaseDetail.propTypes = {
 	icon: React.PropTypes.string,
 	isPlaceholder: React.PropTypes.bool,
 	isRequired: React.PropTypes.bool,
+	onClick: React.PropTypes.func,
 	requiredText: React.PropTypes.string,
 	target: React.PropTypes.string,
 	title: React.PropTypes.string

--- a/client/lib/features-list/index.js
+++ b/client/lib/features-list/index.js
@@ -93,10 +93,8 @@ FeaturesList.prototype.initialize = function( features ) {
  * @return {array} features
  **/
 FeaturesList.prototype.parse = function( data ) {
-	/**
-	 * Remove the _headers
-	 */
 	delete data._headers;
+
 	return data;
 };
 

--- a/client/lib/plans-list/index.js
+++ b/client/lib/plans-list/index.js
@@ -102,10 +102,8 @@ PlansList.prototype.initialize = function( plans ) {
  * @return {array} plans
  **/
 PlansList.prototype.parse = function( data ) {
-	/**
-	 * Remove the _headers
-	 */
 	delete data._headers;
+
 	return data;
 };
 

--- a/client/lib/products-list/index.js
+++ b/client/lib/products-list/index.js
@@ -106,9 +106,6 @@ ProductsList.prototype.initialize = function( productsList ) {
  * @return {array}
  **/
 ProductsList.prototype.parse = function( data ) {
-	/**
-	 * Remove the _headers
-	 */
 	delete data._headers;
 
 	return data;

--- a/client/lib/stored-cards/index.js
+++ b/client/lib/stored-cards/index.js
@@ -93,10 +93,8 @@ StoredCards.prototype.initialize = function( storedCards ) {
  * @return {array} stored cards
  **/
 StoredCards.prototype.parse = function( data ) {
-	/**
-	 * Remove the _headers
-	 */
 	delete data._headers;
+
 	return data;
 };
 

--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -46,7 +46,10 @@ const BusinessPlanDetails = ( { selectedSite } ) => {
 };
 
 BusinessPlanDetails.propTypes = {
-	selectedSite: React.PropTypes.object.isRequired
+	selectedSite: React.PropTypes.oneOfType( [
+		React.PropTypes.bool,
+		React.PropTypes.object
+	] ).isRequired
 };
 
 export default BusinessPlanDetails;

--- a/client/my-sites/upgrades/checkout-thank-you/chargeback-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/chargeback-details.jsx
@@ -22,7 +22,10 @@ const ChargebackDetails = ( { selectedSite } ) => {
 };
 
 ChargebackDetails.propTypes = {
-	selectedSite: React.PropTypes.object.isRequired
+	selectedSite: React.PropTypes.oneOfType( [
+		React.PropTypes.bool,
+		React.PropTypes.object
+	] ).isRequired
 };
 
 export default ChargebackDetails;

--- a/client/my-sites/upgrades/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/domain-registration-details.jsx
@@ -66,9 +66,12 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 };
 
 DomainRegistrationDetails.propTypes = {
+	domain: React.PropTypes.string.isRequired,
 	purchases: React.PropTypes.array.isRequired,
-	selectedSite: React.PropTypes.object.isRequired,
-	domain: React.PropTypes.string.isRequired
+	selectedSite: React.PropTypes.oneOfType( [
+		React.PropTypes.bool,
+		React.PropTypes.object
+	] ).isRequired
 };
 
 export default DomainRegistrationDetails;

--- a/client/my-sites/upgrades/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/domain-registration-details.jsx
@@ -16,7 +16,7 @@ import supportUrls from 'lib/url/support';
 const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 	const googleAppsWasPurchased = purchases.some( isGoogleApps ),
 		domainContactEmailVerified = purchases.some( purchase => purchase.isEmailVerified ),
-		hasOtherPrimaryDomain = selectedSite.options.is_mapped_domain && selectedSite.domain !== domain;
+		hasOtherPrimaryDomain = selectedSite.options && selectedSite.options.is_mapped_domain && selectedSite.domain !== domain;
 
 	return (
 		<div>

--- a/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
@@ -34,11 +34,21 @@ const FreeTrialNudge = React.createClass( {
 		sitePlans: React.PropTypes.object.isRequired
 	},
 
+	getInitialState() {
+		return {
+			isSubmitting: false
+		};
+	},
+
 	startFreeTrial() {
 		upgradesNotices.clear();
 
+		this.setState( { isSubmitting: true } );
+
 		startFreeTrial( this.props.selectedSite.ID, cartItems.planItem( 'value_bundle' ), ( error ) => {
 			if ( error ) {
+				this.setState( { isSubmitting: false } );
+
 				upgradesNotices.displayError( error );
 			} else {
 				this.props.refreshSitePlans( this.props.selectedSite.ID );
@@ -77,7 +87,8 @@ const FreeTrialNudge = React.createClass( {
 				title={ this.translate( 'Try WordPress.com Premium free for 14 days' ) }
 				description={ this.translate( 'Go beyond basic with a supercharged WordPress.com website. The same easy-to-use platform, now with more features and more customization.' ) }
 				buttonText={ this.translate( 'Try Premium for Free' ) }
-				onClick={ this.startFreeTrial } />
+				onClick={ this.startFreeTrial }
+				isSubmitting={ this.state.isSubmitting } />
 		);
 	}
 } );

--- a/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { getABTestVariation } from 'lib/abtest';
 import {
 	isBusiness,
 	isDomainMapping,
@@ -26,6 +27,10 @@ const FreeTrialNudge = React.createClass( {
 	},
 
 	render() {
+		if ( getABTestVariation( 'freeTrials' ) !== 'offered' ) {
+			return null;
+		}
+
 		if ( ! this.props.purchases.some( isDomainMapping ) && ! this.props.purchases.some( isDomainRegistration ) ) {
 			return null;
 		}

--- a/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import find from 'lodash/find';
 import React from 'react';
 
@@ -8,6 +9,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { getABTestVariation } from 'lib/abtest';
+import { getPlansBySite } from 'state/sites/plans/selectors';
 import {
 	isBusiness,
 	isDomainMapping,
@@ -60,4 +62,10 @@ const FreeTrialNudge = React.createClass( {
 	}
 } );
 
-export default FreeTrialNudge;
+export default connect(
+	( state, props ) => {
+		return {
+			sitePlans: getPlansBySite( state, props.selectedSite )
+		};
+	}
+)( FreeTrialNudge );

--- a/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import find from 'lodash/find';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isBusiness,
+	isDomainMapping,
+	isDomainRegistration,
+	isPremium
+} from 'lib/products-values';
+import PurchaseDetail from 'components/purchase-detail';
+
+const FreeTrialNudge = React.createClass( {
+	propTypes: {
+		purchases: React.PropTypes.array.isRequired,
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.object
+		] ).isRequired,
+		sitePlans: React.PropTypes.object.isRequired
+	},
+
+	render() {
+		if ( ! this.props.purchases.some( isDomainMapping ) && ! this.props.purchases.some( isDomainRegistration ) ) {
+			return null;
+		}
+
+		if ( isBusiness( this.props.selectedSite.plan ) || isPremium( this.props.selectedSite.plan ) ) {
+			return null;
+		}
+
+		if ( ! this.props.sitePlans.hasLoadedFromServer ) {
+			return null;
+		}
+
+		const premiumPlan = find( this.props.sitePlans.data, isPremium );
+
+		if ( ! premiumPlan.canStartTrial ) {
+			return null;
+		}
+
+		return (
+			<PurchaseDetail
+				icon="clipboard"
+				title={ this.translate( 'Try WordPress.com Premium free for 14 days' ) }
+				description={ this.translate( 'Go beyond basic with a supercharged WordPress.com website. The same easy-to-use platform, now with more features and more customization.' ) }
+				buttonText={ this.translate( 'Try Premium for Free' ) }
+				href={ '#' } />
+		);
+	}
+} );
+
+export default FreeTrialNudge;

--- a/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
@@ -20,7 +20,11 @@ import {
 } from 'lib/products-values';
 import paths from 'my-sites/plans/paths';
 import PurchaseDetail from 'components/purchase-detail';
-import { refreshSitePlans } from 'state/sites/plans/actions';
+import {
+	fetchSitePlans,
+	refreshSitePlans
+} from 'state/sites/plans/actions';
+import { shouldFetchSitePlans } from 'lib/plans';
 import { startFreeTrial } from 'lib/upgrades/actions';
 import * as upgradesNotices from 'lib/upgrades/notices';
 
@@ -32,6 +36,10 @@ const FreeTrialNudge = React.createClass( {
 			React.PropTypes.object
 		] ).isRequired,
 		sitePlans: React.PropTypes.object.isRequired
+	},
+
+	componentWillMount() {
+		this.props.fetchSitePlans( this.props.sitePlans, this.props.selectedSite );
 	},
 
 	getInitialState() {
@@ -64,6 +72,10 @@ const FreeTrialNudge = React.createClass( {
 		}
 
 		if ( ! this.props.purchases.some( isDomainMapping ) && ! this.props.purchases.some( isDomainRegistration ) ) {
+			return null;
+		}
+
+		if ( ! this.props.selectedSite ) {
 			return null;
 		}
 
@@ -101,6 +113,11 @@ export default connect(
 	},
 	( dispatch ) => {
 		return {
+			fetchSitePlans( sitePlans, site ) {
+				if ( shouldFetchSitePlans( sitePlans, site ) ) {
+					dispatch( fetchSitePlans( site.ID ) );
+				}
+			},
 			refreshSitePlans: ( siteId ) => {
 				dispatch( refreshSitePlans( siteId ) );
 			}

--- a/client/my-sites/upgrades/checkout-thank-you/header.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/header.jsx
@@ -20,11 +20,7 @@ import Gridicon from 'components/gridicon';
 const CheckoutThankYouHeader = React.createClass( {
 	propTypes: {
 		isDataLoaded: React.PropTypes.bool.isRequired,
-		primaryPurchase: React.PropTypes.object,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
-		] )
+		primaryPurchase: React.PropTypes.object
 	},
 
 	getHeading() {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -200,9 +200,10 @@ const CheckoutThankYou = React.createClass( {
 				<div>
 					<CheckoutThankYouHeader
 						isDataLoaded={ false }
-						selectedSite={ this.props.selectedSite } />
+						selectedSite={ selectedSite } />
 
-					<CheckoutThankYouFeaturesHeader isDataLoaded={ false } />
+					<CheckoutThankYouFeaturesHeader
+						isDataLoaded={ false } />
 
 					<div className="checkout-thank-you__purchase-details-list">
 						<PurchaseDetail isPlaceholder />
@@ -224,12 +225,12 @@ const CheckoutThankYou = React.createClass( {
 				<CheckoutThankYouHeader
 					isDataLoaded={ this.isDataLoaded() }
 					primaryPurchase={ primaryPurchase }
-					selectedSite={ this.props.selectedSite } />
+					selectedSite={ selectedSite } />
 
 				<CheckoutThankYouFeaturesHeader
 					isDataLoaded={ this.isDataLoaded() }
 					isGenericReceipt={ this.isGenericReceipt() }
-					purchases={ this.isGenericReceipt() ? false : getPurchases( this.props ) } />
+					purchases={ purchases } />
 
 				{ ComponentClass && (
 					<div className="checkout-thank-you__purchase-details-list">

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -235,10 +235,10 @@ const CheckoutThankYou = React.createClass( {
 				{ ComponentClass && (
 					<div className="checkout-thank-you__purchase-details-list">
 						<ComponentClass
+							domain={ domain }
 							purchases={ purchases }
 							registrarSupportUrl={ this.isGenericReceipt() ? null : primaryPurchase.registrarSupportUrl }
-							selectedSite={ selectedSite }
-							domain={ domain } />
+							selectedSite={ selectedSite } />
 					</div>
 				) }
 			</div>
@@ -254,8 +254,8 @@ export default connect(
 	},
 	( dispatch ) => {
 		return {
-			activatedTheme: ( meta, selectedSite ) => {
-				dispatch( activated( meta, selectedSite, 'calypstore', true ) );
+			activatedTheme: ( meta, site ) => {
+				dispatch( activated( meta, site, 'calypstore', true ) );
 			},
 			fetchReceipt: ( receiptId ) => {
 				dispatch( fetchReceipt( receiptId ) );

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -59,6 +59,15 @@ function findPurchaseAndDomain( purchases, predicate ) {
 }
 
 const CheckoutThankYou = React.createClass( {
+	propTypes: {
+		productsList: React.PropTypes.object.isRequired,
+		receiptId: React.PropTypes.number,
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.object
+		] ).isRequired
+	},
+
 	componentDidMount() {
 		this.redirectIfThemePurchased();
 		this.refreshSitesAndSitePlansIfPlanPurchased();

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -251,8 +251,7 @@ const CheckoutThankYou = React.createClass( {
 
 						<FreeTrialNudge
 							purchases={ purchases }
-							selectedSite={ selectedSite }
-							sitePlans={ this.props.sitePlans } />
+							selectedSite={ selectedSite } />
 					</div>
 				) }
 			</div>

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -46,11 +46,7 @@ import Main from 'components/main';
 import plansPaths from 'my-sites/plans/paths';
 import PremiumPlanDetails from './premium-plan-details';
 import PurchaseDetail from 'components/purchase-detail';
-import {
-	fetchSitePlans,
-	refreshSitePlans
-} from 'state/sites/plans/actions';
-import { shouldFetchSitePlans } from 'lib/plans';
+import { refreshSitePlans } from 'state/sites/plans/actions';
 import SiteRedirectDetails from './site-redirect-details';
 import upgradesPaths from 'my-sites/upgrades/paths';
 
@@ -90,9 +86,6 @@ const CheckoutThankYou = React.createClass( {
 	componentWillReceiveProps() {
 		this.redirectIfThemePurchased();
 		this.refreshSitesAndSitePlansIfPlanPurchased();
-
-		// Fetches site plans only if they weren't refreshed or if they have not been loaded yet
-		this.props.fetchSitePlans( this.props.sitePlans, this.props.selectedSite );
 	},
 
 	refreshSitesAndSitePlansIfPlanPurchased() {
@@ -201,7 +194,7 @@ const CheckoutThankYou = React.createClass( {
 	},
 
 	productRelatedMessages() {
-		const selectedSite = this.props.selectedSite,
+		const { selectedSite } = this.props,
 			[ ComponentClass, primaryPurchase, domain ] = this.getComponentAndPrimaryPurchaseAndDomain();
 
 		if ( ! this.isDataLoaded() ) {
@@ -262,8 +255,7 @@ const CheckoutThankYou = React.createClass( {
 export default connect(
 	( state, props ) => {
 		return {
-			receipt: getReceiptById( state, props.receiptId ),
-			sitePlans: getPlansBySite( state, props.selectedSite )
+			receipt: getReceiptById( state, props.receiptId )
 		};
 	},
 	( dispatch ) => {
@@ -273,11 +265,6 @@ export default connect(
 			},
 			fetchReceipt: ( receiptId ) => {
 				dispatch( fetchReceipt( receiptId ) );
-			},
-			fetchSitePlans( sitePlans, site ) {
-				if ( shouldFetchSitePlans( sitePlans, site ) ) {
-					dispatch( fetchSitePlans( site.ID ) );
-				}
 			},
 			refreshSitePlans: ( siteId ) => {
 				dispatch( refreshSitePlans( siteId ) );

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -63,7 +63,10 @@ const PremiumPlanDetails = ( { selectedSite } ) => {
 };
 
 PremiumPlanDetails.propTypes = {
-	selectedSite: React.PropTypes.object.isRequired
+	selectedSite: React.PropTypes.oneOfType( [
+		React.PropTypes.bool,
+		React.PropTypes.object
+	] ).isRequired
 };
 
 export default PremiumPlanDetails;

--- a/client/my-sites/upgrades/checkout-thank-you/site-redirect-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/site-redirect-details.jsx
@@ -40,8 +40,11 @@ const SiteRedirectDetails = ( { selectedSite, domain } ) => {
 };
 
 SiteRedirectDetails.propTypes = {
-	selectedSite: React.PropTypes.object.isRequired,
-	domain: React.PropTypes.string.isRequired
+	domain: React.PropTypes.string.isRequired,
+	selectedSite: React.PropTypes.oneOfType( [
+		React.PropTypes.bool,
+		React.PropTypes.object
+	] ).isRequired
 };
 
 export default SiteRedirectDetails;

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -3,7 +3,6 @@
  */
 import debugFactory from 'debug';
 import map from 'lodash/map';
-import reject from 'lodash/reject';
 
 const debug = debugFactory( 'calypso:site-plans:actions' );
 
@@ -122,7 +121,7 @@ export function fetchSitePlans( siteId ) {
  * @returns {Object} the corresponding action object
  */
 export function fetchSitePlansCompleted( siteId, data ) {
-	data = reject( data, '_headers' );
+	delete data._headers;
 
 	return {
 		type: SITE_PLANS_FETCH_COMPLETED,

--- a/client/state/sites/plans/test/actions.js
+++ b/client/state/sites/plans/test/actions.js
@@ -13,7 +13,7 @@ describe( 'actions', () => {
 	describe( '#fetchSitePlansCompleted()', () => {
 		it( 'should return an action object with an array of plans', () => {
 			const siteId = 2916284,
-				action = fetchSitePlansCompleted( siteId );
+				action = fetchSitePlansCompleted( siteId, {} );
 
 			expect( action ).to.eql( {
 				type: SITE_PLANS_FETCH_COMPLETED,


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/3597 by adding a new section at the bottom of the `Thank You` page that promotes free trial for Premium plan. This nudge is only displayed after domain registration and domain mapping purchases, and if the Premium plan is eligible for free trial. If users click the button in this section they are redirected to the `Plan Overview` page (also known as trial hub):

![screenshot](https://cloud.githubusercontent.com/assets/594356/13603196/bbd62e5a-e53b-11e5-93d6-8a595660e847.png)

#### Testing instructions
 
1. Run `git checkout add/free-trial-nudge` and start your server
2. Sandbox the API and apply patch D1286-code
3. Execute `localStorage.setItem( 'ABTests', '{"freeTrials_20160120":"offered"}' )` in your browser's console
4. Purchase any type of product
5. Check that the nudge is only displayed when purchasing domain registrations or mappings
6. Check that the nudge is not displayed when the site is already on Business or Premium
7. Check that the nudge is not displayed when the user already subscribed to a free trial for Premium 
8. Check that you are directed on the `Plan Overview` page with your free trial enabled

#### Reviews
 
- [x] Code
- [x] Product