### PR TITLE
Editor: Fix issue where embed is unloaded if multiple embeds visible

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-view/plugin.js
@@ -249,11 +249,7 @@ function wpview( editor ) {
 			return;
 		}
 
-		content = editor.getContent( {
-			format: 'raw',
-			withMarkers: true
-		} );
-
+		content = editor.getContent( { format: 'raw' } );
 		processedContent = views.setMarkers( content );
 
 		if ( content !== processedContent ) {
@@ -488,7 +484,7 @@ function wpview( editor ) {
 	});
 
 	editor.on( 'GetContent', function( event ) {
-		if ( event.format === 'raw' && event.content && ! event.selection && ! event.withMarkers ) {
+		if ( event.format === 'raw' && event.content && ! event.selection ) {
 			event.content = resetViews( event.content );
 		}
 	} );


### PR DESCRIPTION
This pull request seeks to resolve an issue where an embed may be removed from the editor if more than one embed exists in the content.

__Implementation notes:__

The cause of the issue was related to views being unmounted [during the `BeforeSetContent` handler](https://github.com/Automattic/wp-calypso/blob/27ca11e1a28f1c1855127b3fd91acc7d3f046dfd/client/components/tinymce/plugins/wpcom-view/plugin.js#L282-L284) in the `wpcom-view` plugin. When a subsequent embed was rendered to content, the previous embeds were unmounted from the content.

The `SetContent` event handler is responsible for rendering the views (in `renderViews`), but [has a check](https://github.com/Automattic/wp-calypso/blob/27ca11e1a28f1c1855127b3fd91acc7d3f046dfd/client/components/tinymce/plugins/wpcom-view/plugin.js#L86) to prevent rendering of views it already considers to be rendered (including the view unmounted during the `BeforeSetContent` step).

To work around this, we first reset the content to its original state when setting markers, such that when `SetContent` is reached, the `data-wpview-rendered` attribute is not set.

__Testing instructions:__

Verify that if multiple embeds are present in a post, they are always rendered, including upon refresh of the saved post.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Insert a few oEmbed URLs in the post content (e.g. YouTube video, Tweet, SlideShare, etc)
4. Note that the oEmbed URLs are replaced with a preview
5. Save the post
6. Refresh the page
7. Note that the oEmbed URLs are replaced with a preview