### PR TITLE
Display any error message sent back from the API

### DIFF
--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -70,7 +70,11 @@ module.exports = {
 				debug( 'Error saving settings: ' + JSON.stringify( error ) );
 
 				// handle error case here
-				notices.error( error.message );
+				if ( error.message ) {
+					notices.error( error.message );
+				} else {
+					notices.error( this.translate( 'There was a problem saving your changes.' ) );
+				}
 			} else {
 				this.markSaved();
 

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -70,7 +70,7 @@ module.exports = {
 				debug( 'Error saving settings: ' + JSON.stringify( error ) );
 
 				// handle error case here
-				notices.error( 'There was a problem saving your changes.' );
+				notices.error( error.message );
 			} else {
 				this.markSaved();
 


### PR DESCRIPTION
In #1647, it's reported that error message handling under /me isn't optimal. For example, if you try to change your email address to an address that's already in our system, you get a generic "there was a problem saving your changes" error message rather than one telling you about the duplication.

This causes some support load because, rather than being able to see right away that they're trying to save an address that's already in the system, the user gets the generic message and contacts us to ask what it means.

This PR sends API error messages right back into the client to be displayed in the current error notice. #1647 proposes an overall improvement to the way the way we display error messages, and that's out of the scope of this PR. I'd love to get this landed to help our users out in the mean time.

My main concern is with whether the quality of the error messages we're sending back from the API is always very high. For example, for the use case in question, I was getting this back:

![screen shot 2016-03-08 at 9 05 52 am](https://cloud.githubusercontent.com/assets/2738252/13603697/03ec19ea-e50d-11e5-8b46-fbc6ba58ab6e.png)

Maybe a weird looking but more descriptive error message here and there is preferable to a vague one, though. At any rate, the error message formatting is very easy to fix up in the API if/as we find suboptimally formatted ones.

To test:

1. Go to http://calypso.localhost:3000/me/account
2. Try to save an email address that you know is already used in wordpress.com

Cc @ebinnion 