### PR TITLE
Stats: Change the threshold at which we display the insights nux

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -188,7 +188,7 @@ module.exports = {
 
 		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
 
-		if ( site.post_count <= 2 &&
+		if ( site.post_count <= 1 &&
 				twoWeeksAgo.isBefore( siteCreated ) &&
 				( ! site.jetpack ) ) {
 			isNux = true;
@@ -473,7 +473,7 @@ module.exports = {
 				siteCreated = i18n.moment( currentSite.options.created_at );
 			}
 
-			if ( currentSite.post_count <= 2 &&
+			if ( currentSite.post_count <= 1 &&
 					twoWeeksAgo.isBefore( siteCreated ) &&
 					( ! currentSite.jetpack ) ) {
 				isNux = true;


### PR DESCRIPTION
The post_count returned for sites currently erroneously also counts pages, this code assumes that you will start with a count of 1 and a count of more than 2 means you have published a couple of posts now.

Fixing the API is going to reduce all these numbers by 1 so I want to reflect that change here first.

cc @timmyc as you introduced this feature from what I can tell.