### PR TITLE
Domains: Move transfer_prohibited field to wapi-domain-info store

### DIFF
--- a/client/lib/domains/assembler.js
+++ b/client/lib/domains/assembler.js
@@ -36,7 +36,6 @@ function createDomainObjects( dataTransferObject ) {
 			privateDomain: domain.private_domain,
 			registrationDate: domain.registration_date,
 			registrationMoment: domain.registration_date && i18n.moment( domain.registration_date, 'MMMM D, YYYY', 'en' ).locale( false ),
-			transferProhibited: domain.transfer_prohibited,
 			type: getDomainType( domain )
 		};
 	} );

--- a/client/lib/domains/test/assembler.js
+++ b/client/lib/domains/test/assembler.js
@@ -47,7 +47,6 @@ describe( 'assembler', () => {
 			privateDomain: undefined,
 			registrationDate: undefined,
 			registrationMoment: undefined,
-			transferProhibited: undefined,
 			type: domainTypes.SITE_REDIRECT
 		},
 		mappedDomainObject = assign( {}, redirectDomainObject, {

--- a/client/lib/domains/wapi-domain-info/assembler.js
+++ b/client/lib/domains/wapi-domain-info/assembler.js
@@ -1,7 +1,8 @@
 function createDomainObject( status ) {
 	return {
 		locked: status.locked,
-		pendingTransfer: status.pending_transfer
+		pendingTransfer: status.pending_transfer,
+		transferProhibited: status.transfer_prohibited
 	};
 }
 

--- a/client/my-sites/upgrades/domain-management/transfer/index.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/index.jsx
@@ -30,8 +30,8 @@ const Transfer = React.createClass( {
 	},
 
 	renderSection() {
-		const { locked } = this.props.wapiDomainInfo.data,
-			{ isPendingIcannVerification, transferProhibited } = getSelectedDomain( this.props );
+		const { locked, transferProhibited } = this.props.wapiDomainInfo.data,
+			{ isPendingIcannVerification } = getSelectedDomain( this.props );
 		let section = null;
 
 		if ( transferProhibited ) {


### PR DESCRIPTION
**What:**
Move `transfer_prohibited` field from `domains` store to `wapi-domain-info` store.

**Why:**
The field is only needed when users try to transfer a domain. Removing the field from `/domains` endpoint will get us a speedup of almost 50%.

**Test:**
1. Calypso -> Domains
2. Domains loaded
3. Click on a domain
4. Click on Transfer Domain
5. You should see a message if domain is not older than 60 days, or the usual transfer flow

See D1265-code for back-end changes.