### PR TITLE
Framework: enable redux persistence on stage and wpcalypso

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -61,7 +61,7 @@
 		"olark": true,
 		"olark_use_wpcom_configuration": true,
 		"perfmon": true,
-		"persist-redux": false,
+		"persist-redux": true,
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -68,7 +68,7 @@
 		"olark": true,
 		"olark_use_wpcom_configuration": true,
 		"perfmon": true,
-		"persist-redux": false,
+		"persist-redux": true,
 		"phone_signup": true,
 		"post-editor/live-image-updates": true,
 		"press-this": true,


### PR DESCRIPTION
As a follow up to #3483 this PR turns on redux-persistence for stage and wpcalypso environments.

## Testing Instructions
- Set debug to 'calypso:state'
- Calypso behaves normally, and initial state is loaded from browser storage on refresh.

cc @rralian @mtias 