### PR TITLE
Jetpack Connect: new wpcom endpoints

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -275,6 +275,26 @@ Undocumented.prototype.testConnectionJetpack = function( siteId, fn ) {
 	this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/test-connection' }, fn );
 };
 
+Undocumented.prototype.jetpackLogin = function( queryObject, fn ) {
+	debug( '/jetpack-blogs/:site_id:/jetpack-login query' );
+	this.wpcom.req.get( { path: '/jetpack-blogs/' + queryObject.client_id + '/jetpack-login' }, {
+		_wp_nonce: queryObject._wp_nonce,
+		redirect_uri: queryObject.redirect_uri,
+		scope: queryObject.scope,
+		state: queryObject.state
+	}, fn );
+};
+
+Undocumented.prototype.jetpackAuthorize = function( siteId, code, state, redirect, secret, fn ) {
+	debug( '/jetpack-blogs/:site_id:/authorize query' );
+	this.wpcom.req.post( { path: '/jetpack-blogs/' + siteId + '/authorize' }, {}, {
+		code: code,
+		state: state,
+		redirect_uri: redirect,
+		secret: secret
+	}, fn );
+};
+
 Undocumented.prototype.invitesList = function( siteId, number, offset, fn ) {
 	debug( '/sites/:site_id:/invites query' );
 	this.wpcom.req.get( '/sites/' + siteId + '/invites', {


### PR DESCRIPTION
Adding two methods that will be used for connecting a Jetpack site.

No testing is necessary, as we are just adding new WPCOM API methods. See #2974 for more information on how we plan to use these methods.

cc: @johnHackworth @oskosk 