### PR TITLE
Reader: update Manage Following search Follow button

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -40,6 +40,7 @@
 	}
 }
 
+
 .section-header.following-edit__header {
 	margin-bottom: 24px;
 
@@ -151,6 +152,10 @@
 		.follow-button {
 			cursor: default;
 
+			@include breakpoint( "<480px" ) {
+				margin-top: 7px;
+			}
+
 			.gridicon {
 				cursor: default;
 				fill: lighten( $gray, 20% );
@@ -158,6 +163,7 @@
 
 			.follow-button__label {
 				color: lighten( $gray, 20% );
+				display: inline-block;
 			}
 		}
 

--- a/client/reader/following-edit/subscribe-form-result.jsx
+++ b/client/reader/following-edit/subscribe-form-result.jsx
@@ -24,7 +24,7 @@ var FollowingEditSubscribeFormResult = React.createClass( {
 	render: function() {
 		const message = ! this.props.isValid ?
 			this.translate( 'Not a valid URL' ) :
-			this.translate( 'Click Follow to follow this URL' );
+			this.translate( 'Follow this site' );
 		const classes = classNames( 'is-search-result', { 'is-valid': this.props.isValid } );
 
 		return (

--- a/client/reader/following-edit/subscribe-form-result.jsx
+++ b/client/reader/following-edit/subscribe-form-result.jsx
@@ -22,9 +22,9 @@ var FollowingEditSubscribeFormResult = React.createClass( {
 	},
 
 	render: function() {
-		const message = ! this.props.isValid ?
-			this.translate( 'Not a valid URL' ) :
-			this.translate( 'Follow this site' );
+		const message = ! this.props.isValid
+			? this.translate( 'Not a valid URL' )
+			: this.translate( 'Follow this site' );
 		const classes = classNames( 'is-search-result', { 'is-valid': this.props.isValid } );
 
 		return (


### PR DESCRIPTION
This fixes: https://github.com/Automattic/wp-calypso/issues/3806

**Before:**
![screenshot 2016-03-08 10 58 38](https://cloud.githubusercontent.com/assets/4924246/13612676/85fa6486-e51d-11e5-805c-d2af1d7ad517.png)

**After:**
![screenshot 2016-03-08 11 04 57](https://cloud.githubusercontent.com/assets/4924246/13612688/9d1b9fe0-e51d-11e5-8acf-9f9c29adf24a.png)

I think "Click" is universal, but I also think the Follow icon paired with text is self-explanatory and there's already 2 separate instructions we provide before users type in a URL. I'm not opposed to dropping this description text either, although it'd be good to make Follow look like an actual button, but that's for a separate PR since we'd have to change that everywhere else.