### PR TITLE
Reader: add empty state to Manage Following

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -89,6 +89,10 @@ const Search = React.createClass( {
 				? debounce( this.props.onSearch, this.props.delayTimeout )
 				: this.props.onSearch;
 		}
+
+		if ( nextProps.isOpen ) {
+			this.setState( { isOpen: nextProps.isOpen } );
+		}
 	},
 
 	componentDidUpdate: function( prevProps, prevState ) {

--- a/client/reader/following-edit/empty.jsx
+++ b/client/reader/following-edit/empty.jsx
@@ -8,17 +8,23 @@ import React from 'react';
  */
 import EmptyContent from 'components/empty-content';
 import i18n from 'lib/mixins/i18n';
-import { recordAction, recordGaEvent } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 const FollowingEditEmptyContent = React.createClass( {
+	componentDidMount() {
+		recordTrack( 'calypso_reader_empty_manage_following_loaded' );
+	},
+
 	recordAction() {
-		recordAction( 'clicked_discover_on_empty' );
-		recordGaEvent( 'Clicked Discover on EmptyContent' );
+		recordAction( 'clicked_discover_on_empty_manage_following' );
+		recordGaEvent( 'Clicked Discover on EmptyContent in Manage Following' );
+		recordTrack( 'calypso_reader_discover_on_empty_manage_following_clicked' );
 	},
 
 	recordSecondaryAction() {
-		recordAction( 'clicked_recommendations_on_empty' );
-		recordGaEvent( 'Clicked Recommendations on EmptyContent' );
+		recordAction( 'clicked_recommendations_on_empty_manage_following' );
+		recordGaEvent( 'Clicked Recommendations on EmptyContent in Manage Following' );
+		recordTrack( 'calypso_reader_recommendations_on_empty_manage_following_clicked' );
 	},
 
 	render() {

--- a/client/reader/following-edit/empty.jsx
+++ b/client/reader/following-edit/empty.jsx
@@ -1,0 +1,46 @@
+var React = require( 'react' );
+
+var EmptyContent = require( 'components/empty-content' ),
+	stats = require( 'reader/stats' ),
+	discoverHelper = require( 'reader/discover/helper' );
+
+var FollowingEmptyContent = React.createClass( {
+	shouldComponentUpdate: function() {
+		return false;
+	},
+
+	recordAction: function() {
+		stats.recordAction( 'clicked_discover_on_empty' );
+		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
+	},
+
+	recordSecondaryAction: function() {
+		stats.recordAction( 'clicked_recommendations_on_empty' );
+		stats.recordGaEvent( 'Clicked Recommendations on EmptyContent' );
+	},
+
+	render: function() {
+		var action = discoverHelper.isEnabled()
+		? (
+			<a
+				className="empty-content__action button is-primary"
+				onClick={ this.recordAction }
+				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null,
+			secondaryAction = (
+				<a
+					className="empty-content__action button"
+					onClick={ this.recordSecondaryAction }
+					href="/recommendations">{ this.translate( 'Get recommendations on who to follow' ) }</a> );
+
+		return ( <EmptyContent
+			title={ this.translate( 'You haven\t added sites to follow' ) }
+			line={ this.translate( 'Search for a site above or get recommendations.' ) }
+			action={ action }
+			secondaryAction={ secondaryAction }
+			illustration={ '/calypso/images/drake/drake-all-done.svg' }
+			illustrationWidth={ 500 }
+			/> );
+	}
+} );
+
+module.exports = FollowingEmptyContent;

--- a/client/reader/following-edit/empty.jsx
+++ b/client/reader/following-edit/empty.jsx
@@ -6,8 +6,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import EmptyContent from 'components/empty-content';
 import i18n from 'lib/mixins/i18n';
 import { recordAction, recordGaEvent } from 'reader/stats';
@@ -36,7 +34,8 @@ const FollowingEditEmptyContent = React.createClass( {
 			<EmptyContent
 				action={ action }
 				secondaryAction={ secondaryAction }
-				title={ i18n.translate( 'Sorry, we can\'t find that stream.' ) }
+				title={ i18n.translate( 'You haven\'t followed any sites yet' ) }
+				line={ i18n.translate( 'Search for a site above or get recommendations.' ) }
 				illustration={ '/calypso/images/drake/drake-404.svg' }
 				illustrationWidth={ 500 }
 			/>

--- a/client/reader/following-edit/empty.jsx
+++ b/client/reader/following-edit/empty.jsx
@@ -1,46 +1,47 @@
-var React = require( 'react' );
+/**
+ * External dependencies
+ */
+import React from 'react';
 
-var EmptyContent = require( 'components/empty-content' ),
-	stats = require( 'reader/stats' ),
-	discoverHelper = require( 'reader/discover/helper' );
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
+import EmptyContent from 'components/empty-content';
+import i18n from 'lib/mixins/i18n';
+import { recordAction, recordGaEvent } from 'reader/stats';
 
-var FollowingEmptyContent = React.createClass( {
-	shouldComponentUpdate: function() {
-		return false;
+const FollowingEditEmptyContent = React.createClass( {
+	recordAction() {
+		recordAction( 'clicked_discover_on_empty' );
+		recordGaEvent( 'Clicked Discover on EmptyContent' );
 	},
 
-	recordAction: function() {
-		stats.recordAction( 'clicked_discover_on_empty' );
-		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
+	recordSecondaryAction() {
+		recordAction( 'clicked_recommendations_on_empty' );
+		recordGaEvent( 'Clicked Recommendations on EmptyContent' );
 	},
 
-	recordSecondaryAction: function() {
-		stats.recordAction( 'clicked_recommendations_on_empty' );
-		stats.recordGaEvent( 'Clicked Recommendations on EmptyContent' );
-	},
-
-	render: function() {
-		var action = discoverHelper.isEnabled()
-		? (
-			<a
-				className="empty-content__action button is-primary"
+	render() {
+		const action = ( <a className="empty-content__action button is-primary"
 				onClick={ this.recordAction }
-				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null,
+				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ),
 			secondaryAction = (
-				<a
-					className="empty-content__action button"
+				<a className="empty-content__action button"
 					onClick={ this.recordSecondaryAction }
 					href="/recommendations">{ this.translate( 'Get recommendations on who to follow' ) }</a> );
 
-		return ( <EmptyContent
-			title={ this.translate( 'You haven\t added sites to follow' ) }
-			line={ this.translate( 'Search for a site above or get recommendations.' ) }
-			action={ action }
-			secondaryAction={ secondaryAction }
-			illustration={ '/calypso/images/drake/drake-all-done.svg' }
-			illustrationWidth={ 500 }
-			/> );
+		return (
+			<EmptyContent
+				action={ action }
+				secondaryAction={ secondaryAction }
+				title={ i18n.translate( 'Sorry, we can\'t find that stream.' ) }
+				illustration={ '/calypso/images/drake/drake-404.svg' }
+				illustrationWidth={ 500 }
+			/>
+		);
 	}
 } );
 
-module.exports = FollowingEmptyContent;
+export default FollowingEditEmptyContent;

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -12,7 +12,7 @@ import FeedSubscriptionStore from 'lib/reader-feed-subscriptions';
 import SiteStore from 'lib/reader-site-store';
 import FeedStore from 'lib/feed-store';
 import FeedSubscriptionActions from 'lib/reader-feed-subscriptions/actions';
-import EmptyContent from 'components/empty-content';
+import EmptyContent from './empty';
 import NoResults from 'my-sites/no-results';
 import InfiniteList from 'components/infinite-list';
 import SubscriptionPlaceholder from './placeholder';
@@ -322,7 +322,8 @@ const FollowingEdit = React.createClass( {
 	render: function() {
 		let subscriptions = this.state.subscriptions,
 			subscriptionsToDisplay = [],
-			searchPlaceholder = '';
+			searchPlaceholder = '',
+			hasNoSubscriptions = false;
 
 		// We're only interested in showing subscriptions with an ID (i.e. those that came from the API)
 		// At this point we may have some kicking around that just have a URL, such as those added when
@@ -333,11 +334,8 @@ const FollowingEdit = React.createClass( {
 			} ).toArray();
 		}
 
-		if ( ! subscriptionsToDisplay || subscriptionsToDisplay.length < initialLoadFeedCount ) {
-			// If we don't have any data after a fetch has happened, show EmptyContent
-			if ( this.props.isLastPage ) {
-				return ( <EmptyContent title={ this.translate( 'No subscribed feeds found.' ) } /> );
-			}
+		if ( subscriptionsToDisplay.length === 0 && this.state.isLastPage ) {
+			hasNoSubscriptions = true;
 		}
 
 		if ( this.state.windowWidth && this.state.windowWidth > 960 ) {
@@ -359,7 +357,7 @@ const FollowingEdit = React.createClass( {
 				{ this.renderUnfollowError() }
 
 				<SectionHeader className="following-edit__header" label={ this.translate( 'Sites' ) } count={ this.state.totalSubscriptions }>
-					<FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
+					{ ! hasNoSubscriptions ? <FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } /> : null }
 
 					<Button compact primary onClick={ this.toggleAddSite }>
 						{ this.translate( 'Follow Site' ) }
@@ -373,7 +371,7 @@ const FollowingEdit = React.createClass( {
 					initialSearchString={ this.props.initialFollowUrl }
 					ref="feed-search" />
 
-				<SearchCard
+				{ ! hasNoSubscriptions ? <SearchCard
 					key="existingFeedSearch"
 					autoFocus={ true }
 					additionalClasses="following-edit__existing-feed-search"
@@ -381,7 +379,7 @@ const FollowingEdit = React.createClass( {
 					onSearch={ this.doSearch }
 					initialValue={ this.props.search }
 					delaySearch={ true }
-					ref="url-search" />
+					ref="url-search" /> : null }
 				{ this.state.isAttemptingFollow && ! this.state.lastError ? <SubscriptionPlaceholder key={ 'placeholder-add-feed' } /> : null }
 				{ subscriptionsToDisplay.length === 0 && this.props.search && ! this.state.isLoading ?
 					<NoResults text={ this.translate( 'No subscriptions match that search.' ) } /> :
@@ -396,6 +394,8 @@ const FollowingEdit = React.createClass( {
 					renderItem={ this.renderSubscription }
 					renderLoadingPlaceholders={ this.renderLoadingPlaceholders } />
 				}
+
+				{ hasNoSubscriptions ? <EmptyContent /> : null }
 			</Main>
 		);
 	}

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -135,7 +135,8 @@ const FollowingEdit = React.createClass( {
 
 	handleAdd: function( newSubscription ) {
 		let newState = {
-			isAttemptingFollow: false
+			isAttemptingFollow: false,
+			isAddingOpen: false
 		};
 
 		// If it's a brand new subscription, re-sort by date followed so
@@ -369,7 +370,7 @@ const FollowingEdit = React.createClass( {
 					onSearchClose={ this.handleNewSubscriptionSearchClose }
 					onFollow={ this.handleFollow }
 					initialSearchString={ this.props.initialFollowUrl }
-					isSearchOpen={ ! hasNoSubscriptions }
+					isSearchOpen={ this.state.isAddingOpen }
 					ref="feed-search" />
 
 				{ ! hasNoSubscriptions ? <SearchCard

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -346,7 +346,7 @@ const FollowingEdit = React.createClass( {
 		}
 
 		const containerClasses = classnames( {
-			'is-adding': this.state.isAddingOpen || hasNoSubscriptions,
+			'is-adding': this.state.isAddingOpen,
 			'has-no-subscriptions': hasNoSubscriptions
 		}, 'following-edit' );
 
@@ -359,7 +359,7 @@ const FollowingEdit = React.createClass( {
 				{ this.renderUnfollowError() }
 
 				<SectionHeader className="following-edit__header" label={ this.translate( 'Sites' ) } count={ this.state.totalSubscriptions }>
-					<FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
+					{ ! hasNoSubscriptions ? <FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } /> : null }
 					<Button compact primary onClick={ this.toggleAddSite }>
 						{ this.translate( 'Follow Site' ) }
 					</Button>

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -382,6 +382,7 @@ const FollowingEdit = React.createClass( {
 					initialValue={ this.props.search }
 					delaySearch={ true }
 					ref="url-search" /> : null }
+
 				{ this.state.isAttemptingFollow && ! this.state.lastError ? <SubscriptionPlaceholder key={ 'placeholder-add-feed' } /> : null }
 				{ subscriptionsToDisplay.length === 0 && this.props.search && ! this.state.isLoading
 					? <NoResults text={ this.translate( 'No subscriptions match that search.' ) } />

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -334,7 +334,7 @@ const FollowingEdit = React.createClass( {
 			} ).toArray();
 		}
 
-		if ( subscriptionsToDisplay.length === 0 && this.state.isLastPage ) {
+		if ( subscriptionsToDisplay.length === 0 && this.state.isLastPage && ! this.props.search ) {
 			hasNoSubscriptions = true;
 		}
 
@@ -345,7 +345,8 @@ const FollowingEdit = React.createClass( {
 		}
 
 		const containerClasses = classnames( {
-			'is-adding': this.state.isAddingOpen
+			'is-adding': this.state.isAddingOpen || hasNoSubscriptions,
+			'has-no-subscriptions': hasNoSubscriptions
 		}, 'following-edit' );
 
 		return (
@@ -357,8 +358,7 @@ const FollowingEdit = React.createClass( {
 				{ this.renderUnfollowError() }
 
 				<SectionHeader className="following-edit__header" label={ this.translate( 'Sites' ) } count={ this.state.totalSubscriptions }>
-					{ ! hasNoSubscriptions ? <FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } /> : null }
-
+					<FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
 					<Button compact primary onClick={ this.toggleAddSite }>
 						{ this.translate( 'Follow Site' ) }
 					</Button>
@@ -369,6 +369,7 @@ const FollowingEdit = React.createClass( {
 					onSearchClose={ this.handleNewSubscriptionSearchClose }
 					onFollow={ this.handleFollow }
 					initialSearchString={ this.props.initialFollowUrl }
+					isSearchOpen={ ! hasNoSubscriptions }
 					ref="feed-search" />
 
 				{ ! hasNoSubscriptions ? <SearchCard
@@ -381,18 +382,17 @@ const FollowingEdit = React.createClass( {
 					delaySearch={ true }
 					ref="url-search" /> : null }
 				{ this.state.isAttemptingFollow && ! this.state.lastError ? <SubscriptionPlaceholder key={ 'placeholder-add-feed' } /> : null }
-				{ subscriptionsToDisplay.length === 0 && this.props.search && ! this.state.isLoading ?
-					<NoResults text={ this.translate( 'No subscriptions match that search.' ) } /> :
-
-				<InfiniteList className="following-edit__sites"
-					items={ subscriptionsToDisplay }
-					lastPage={ this.state.isLastPage }
-					fetchingNextPage={ this.state.isLoading }
-					guessedItemHeight={ 75 }
-					fetchNextPage={ this.fetchNextPage }
-					getItemRef= { this.getSubscriptionRef }
-					renderItem={ this.renderSubscription }
-					renderLoadingPlaceholders={ this.renderLoadingPlaceholders } />
+				{ subscriptionsToDisplay.length === 0 && this.props.search && ! this.state.isLoading
+					? <NoResults text={ this.translate( 'No subscriptions match that search.' ) } />
+					: <InfiniteList className="following-edit__sites"
+						items={ subscriptionsToDisplay }
+						lastPage={ this.state.isLastPage }
+						fetchingNextPage={ this.state.isLoading }
+						guessedItemHeight={ 75 }
+						fetchNextPage={ this.fetchNextPage }
+						getItemRef= { this.getSubscriptionRef }
+						renderItem={ this.renderSubscription }
+						renderLoadingPlaceholders={ this.renderLoadingPlaceholders } />
 				}
 
 				{ hasNoSubscriptions ? <EmptyContent /> : null }

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -391,6 +391,12 @@
 	}
 }
 
+.following-edit.is-adding.has-no-subscriptions {
+	.following-edit__subscribe-form-blank {
+		display: none;
+	}
+}
+
 .is-section-reader .main.following-edit .empty-content {
 	margin-top: -70px;
 }

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -296,16 +296,16 @@
 
 	&.is-placeholder {
 		.reader-list-item__icon {
-			left: 16px;
-
-			@include breakpoint( ">480px" ) {
-				left: 23px;
-			}
+			left: 17px;
 		}
 
 		.reader-list-item__title,
 		.reader-list-item__description {
-			margin-left: 66px;
+			margin-left: 68px;
+
+			@include breakpoint( ">480px" ) {
+				margin-left: 55px;
+			}
 		}
 	}
 }

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -390,3 +390,7 @@
 		}
 	}
 }
+
+.is-section-reader .main.following-edit .empty-content {
+	margin-top: -70px;
+}

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -292,6 +292,24 @@
 	}
 }
 
+.following-edit.has-no-subscriptions .reader-list-item__card {
+
+	&.is-placeholder {
+		.reader-list-item__icon {
+			left: 16px;
+
+			@include breakpoint( ">480px" ) {
+				left: 23px;
+			}
+		}
+
+		.reader-list-item__title,
+		.reader-list-item__description {
+			margin-left: 66px;
+		}
+	}
+}
+
 .following-edit-navigation {
 	min-height: 25px;
 	margin-bottom: 0.5em;

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -391,12 +391,6 @@
 	}
 }
 
-.following-edit.is-adding.has-no-subscriptions {
-	.following-edit__subscribe-form-blank {
-		display: none;
-	}
-}
-
 .is-section-reader .main.following-edit .empty-content {
-	margin-top: -70px;
+	margin-top: -40px;
 }

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -18,7 +18,8 @@ var FollowingEditSubscribeForm = React.createClass( {
 		onSearch: React.PropTypes.func,
 		onSearchClose: React.PropTypes.func,
 		onFollow: React.PropTypes.func,
-		initialSearchString: React.PropTypes.string
+		initialSearchString: React.PropTypes.string,
+		isSearchOpen: React.PropTypes.bool
 	},
 
 	getDefaultProps: function() {
@@ -26,7 +27,8 @@ var FollowingEditSubscribeForm = React.createClass( {
 			onSearch: noop,
 			onSearchClose: noop,
 			onFollow: noop,
-			initialSearchString: ''
+			initialSearchString: '',
+			isSearchOpen: true
 		}
 	},
 
@@ -143,7 +145,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 		return (
 			<div className="following-edit__subscribe-form">
 				<Search
-					isOpen={ true }
+					isOpen={ this.props.isSearchOpen }
 					key="newSubscriptionSearch"
 					onSearch={ this.handleSearch }
 					onSearchClose={ this.handleSearchClose }

--- a/client/reader/following-edit/subscribe-form.jsx
+++ b/client/reader/following-edit/subscribe-form.jsx
@@ -1,5 +1,3 @@
-//const debug = require( 'debug' )( 'calypso:reader:following:edit' );
-
 // External dependencies
 const React = require( 'react' ),
 	url = require( 'url' ),
@@ -28,7 +26,7 @@ var FollowingEditSubscribeForm = React.createClass( {
 			onSearchClose: noop,
 			onFollow: noop,
 			initialSearchString: '',
-			isSearchOpen: true
+			isSearchOpen: false
 		}
 	},
 


### PR DESCRIPTION
Currently, a user with no feeds sees a pretty confusing initial screen, including a redundant search bar:

<img width="761" alt="screen shot 2016-03-10 at 11 42 26" src="https://cloud.githubusercontent.com/assets/17325/13653217/36d28796-e6b5-11e5-89c2-19d42a7c2930.png">

This PR improves the UI for those with no subscribed feeds. The feed search is immediately visible, and we point them towards Recommendations and Discover to find feeds to follow:

<img width="747" alt="screen shot 2016-03-10 at 11 44 30" src="https://cloud.githubusercontent.com/assets/17325/13653265/7c7b0c78-e6b5-11e5-8437-e133b89fa70d.png">

Fixes https://github.com/Automattic/wp-calypso/issues/3785.