### PR TITLE
SyncHandler: add --grep parameter to test rule

### DIFF
--- a/client/lib/wp/sync-handler/Makefile
+++ b/client/lib/wp/sync-handler/Makefile
@@ -5,6 +5,10 @@ BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := $(BASE_DIR)/client
 
 test:
-	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers jsx:babel/register,js:babel/register --reporter $(REPORTER)
+	@NODE_ENV=test \
+		NODE_PATH=$(NODE_PATH) $(MOCHA) \
+		--compilers jsx:babel/register,js:babel/register \
+		--grep "$(filter-out $@,$(MAKECMDGOALS))" \
+		--reporter $(REPORTER)
 
 .PHONY: test


### PR DESCRIPTION
This PR allow us filter SyncHandler. So you can pass a <pattern> parameter to filter those tests that match with the given pattern.

```cli
> make test cacheIndex
```

Only tests that contain `cacheIndex` in their title will be executed.