### PR TITLE
TokenField: People: Add ability to tokenize value when pressing space

### DIFF
--- a/client/components/token-field/README.md
+++ b/client/components/token-field/README.md
@@ -34,6 +34,7 @@ The `value` property is handled in a manner similar to controlled form component
 - `suggestions` - An array of strings to present to the user as suggested
   tokens.
 - `maxSuggestions` - The maximum number of suggestions to display at a time.
+- `tokenizeOnSpace` - If true, will add a token when `TokenField` is focused and `space` is pressed.
 
 ### Example
 

--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -32,6 +32,7 @@ var TokenField = React.createClass( {
 		maxLength: React.PropTypes.number,
 		onFocus: React.PropTypes.func,
 		disabled: React.PropTypes.bool,
+		tokenizeOnSpace: React.PropTypes.bool,
 		value: function( props ) {
 			const value = props.value;
 			if ( ! Array.isArray( value ) ) {
@@ -62,7 +63,8 @@ var TokenField = React.createClass( {
 			onChange: function() {},
 			tokenStatus: function() {},
 			isBorderless: false,
-			disabled: false
+			disabled: false,
+			tokenizeOnSpace: false
 		};
 	},
 
@@ -316,6 +318,11 @@ var TokenField = React.createClass( {
 				break;
 			case 46: // delete (to right)
 				preventDefault = this._handleDeleteKey( this._deleteTokenAfterInput );
+				break;
+			case 32: // space
+				if ( this.props.tokenizeOnSpace ) {
+					preventDefault = this._addCurrentToken();
+				}
 				break;
 			default:
 				break;

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -278,6 +278,7 @@ const InvitePeople = React.createClass( {
 							<FormLabel>{ this.translate( 'Usernames or Emails' ) }</FormLabel>
 							<TokenField
 								isBorderless
+								tokenizeOnSpace
 								maxLength={ 10 }
 								value={ this.getTokensWithStatus() }
 								onChange={ this.onTokensChange }


### PR DESCRIPTION
Closes #3864

The original version of `TokenField` does not tokenize when a user presses space. While this makes sense in the context of the post editor, for our purposes in the invite people form, we'd like to tokenize username and email addresses when a user hits space. 

To support both, we add a `tokenizeOnSpace` prop that will allow us to add the functionality while not breaking multi word tokens in the editor.

To test:
- Checkout `update/invites-tokenize-on-space` branch
- Go to `/people/new/$site`
- Add tokens. Ensure that hitting `space` adds a new token
- Go to `/post/$site`
- Add post tags. Ensure that hitting `space` does not add a tag

cc @lezama for a review.