### PR TITLE
People: Enables invite form in wpcalypso

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -20,6 +20,7 @@
 		"help": true,
 		"login": false,
 		"mailing-lists/unsubscribe": true,
+		"manage/add-people": false,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,6 +21,7 @@
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"login": false,
+		"manage/add-people": false,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,

--- a/config/production.json
+++ b/config/production.json
@@ -17,6 +17,7 @@
 		"desktop-promo": true,
 		"help": true,
 		"mailing-lists/unsubscribe": true,
+		"manage/add-people": false,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -20,6 +20,7 @@
 		"help": true,
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,
+		"manage/add-people": false,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,6 +24,7 @@
 		"keyboard-shortcuts": true,
 		"login": false,
 		"mailing-lists/unsubscribe": true,
+		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,


### PR DESCRIPTION
Enables the ability to send invites from Calypso in `wpcalypso`. Also, ensures that `manage/add-people` is added to other development environments so that deploying to other environments will be less prone to error.

To test:
- Checkout `update/people-invites-to-wpcalypso` branch
- In terminal, `CALYPSO_ENV=wpcalpso make run`
- Go to `/people/new/$site`
- Attempt to send invites

cc @lezama for review