### PR TITLE
Editor: track sidebar clicks to gauge usage of CPT links.

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -10,6 +10,7 @@ import classnames from 'classnames';
 import { isExternal } from 'lib/url';
 import Gridicon from 'components/gridicon';
 import sections from 'sections';
+import analytics from 'analytics';
 
 export default React.createClass( {
 	displayName: 'SidebarItem',
@@ -27,6 +28,11 @@ export default React.createClass( {
 	},
 
 	_preloaded: false,
+
+	onLinkClick() {
+		analytics.mc.bumpStat( 'calypso_sidebar_navigation_click', this.props.className );
+		this.props.onNavigate();
+	},
 
 	renderButton( link ) {
 		if ( ! link ) {
@@ -59,7 +65,7 @@ export default React.createClass( {
 		return (
 			<li className={ classes }>
 				<a
-					onClick={ this.props.onNavigate }
+					onClick={ this.onLinkClick }
 					href={ this.props.link }
 					target={ isExternalLink ? '_blank' : null }
 					onMouseEnter={ this.preload }

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -10,7 +10,6 @@ import classnames from 'classnames';
 import { isExternal } from 'lib/url';
 import Gridicon from 'components/gridicon';
 import sections from 'sections';
-import analytics from 'analytics';
 
 export default React.createClass( {
 	displayName: 'SidebarItem',
@@ -29,9 +28,14 @@ export default React.createClass( {
 
 	_preloaded: false,
 
+	getDefaultProps() {
+		return {
+			onNavigate: () => {}
+		};
+	},
+
 	onLinkClick() {
-		analytics.mc.bumpStat( 'calypso_sidebar_navigation_click', this.props.className );
-		this.props.onNavigate();
+		this.props.onNavigate( this.props.className );
 	},
 
 	renderButton( link ) {

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -9,7 +9,8 @@ var React = require( 'react' ),
  */
 var SidebarItem = require( 'layout/sidebar/item' ),
 	config = require( 'config' ),
-	postTypesList = require( 'lib/post-types-list' )();
+	postTypesList = require( 'lib/post-types-list' )(),
+	analytics = require( 'analytics' );
 
 var PublishMenu = React.createClass( {
 
@@ -104,6 +105,15 @@ var PublishMenu = React.createClass( {
 		this.setState( this.getPostTypes( this.props.site ) );
 	},
 
+	maybeRecordPostTypeStats: function( className ) {
+		var excludeFromStats = [ 'posts', 'pages' ];
+
+		if ( excludeFromStats.indexOf( className ) === -1 ) {
+			analytics.mc.bumpStat( 'calypso_publish_menu_click', className );
+		}
+		this.props.onNavigate();
+	},
+
 	renderMenuItem: function( menuItem ) {
 		var className = this.props.itemLinkClass(
 				menuItem.paths ? menuItem.paths : menuItem.link,
@@ -156,7 +166,7 @@ var PublishMenu = React.createClass( {
 				className={ className }
 				link={ link }
 				buttonLink={ menuItem.buttonLink }
-				onNavigate={ this.props.onNavigate }
+				onNavigate={ this.maybeRecordPostTypeStats }
 				icon={ icon }
 				preloadSectionName={ preload }
 			/>


### PR DESCRIPTION
With discussion around CPT support and Jetpack, as well as forthcoming better support for CPT's in Calypso, this branch adds in some simple tracking to clicks on sidebar navigation items.

__To Test__
- set your debug to `calypso:analytics`
- click on any of the links in the sidebar, 'Posts' / 'Pages' etc, validate a stat in the `calypso_sidebar_navigation_click` is bumped
- Specifically click on something like `Portfolio` - a CPT - which is an external link in the sidebar and verify the stat is recorded

/cc @codebykat 