### PR TITLE
Signup: Allow i18n arrays for the subHeaderText step prop.

### DIFF
--- a/client/signup/step-header/index.jsx
+++ b/client/signup/step-header/index.jsx
@@ -13,7 +13,10 @@ module.exports = React.createClass( {
 
 	propTypes: {
 		headerText: PropTypes.string,
-		subHeaderText: PropTypes.string,
+		subHeaderText: PropTypes.oneOfType( [
+			PropTypes.string,
+			PropTypes.array
+		] )
 	},
 
 	render: function() {


### PR DESCRIPTION
The `i18n.translate()` method will return an array if markup is being mixed into the string, such as with the [Plans step](https://github.com/Automattic/wp-calypso/blob/05a4c8834817abec5a9b3326f53a3f3d193a728d/client/signup/steps/plans/index.jsx#L124). This fixes the console error `Warning: Failed propType: Invalid prop subHeaderText of type array supplied to StepHeader, expected string. Check the render method of StepWrapper`.

See: https://github.com/Automattic/wp-calypso/tree/master/client/lib/mixins/i18n#translate-method