### PR TITLE
Framework: do not enable redux persistence if we switch users

### DIFF
--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -36,11 +36,11 @@ const reduxStoreReady = new Promise( ( resolve ) => {
 } );
 export const setReduxStore = _setReduxStore;
 
-/**
- * Check if there's a support user to be activated on boot
- * @return {bool} true if a support user token is waiting to be injected on boot, false otherwise
- */
-export const shouldBoot = () => {
+// Evaluate isSupportUserSession at module startup time, then freeze it
+// for the remainder of the session. This is needed because the User
+// module clears the store on change; it could return false if called
+// after boot.
+const _isSupportUserSession = () => {
 	if ( ! isEnabled() ) {
 		return false;
 	}
@@ -51,7 +51,9 @@ export const shouldBoot = () => {
 	}
 
 	return false;
-};
+}();
+
+export const isSupportUserSession = () => _isSupportUserSession;
 
 /**
  * Reboot normally as the main user

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -40,7 +40,7 @@ export const setReduxStore = _setReduxStore;
 // for the remainder of the session. This is needed because the User
 // module clears the store on change; it could return false if called
 // after boot.
-const _isSupportUserSession = () => {
+const _isSupportUserSession = ( () => {
 	if ( ! isEnabled() ) {
 		return false;
 	}
@@ -51,7 +51,7 @@ const _isSupportUserSession = () => {
 	}
 
 	return false;
-}();
+} )();
 
 export const isSupportUserSession = () => _isSupportUserSession;
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { shouldBoot as shouldBootToSupportUser, boot as supportUserBoot } from 'lib/user/support-user-interop';
+import { isSupportUserSession, boot as supportUserBoot } from 'lib/user/support-user-interop';
 
 /**
  * External dependencies
@@ -50,7 +50,7 @@ User.prototype.initialize = function() {
 	this.fetching = false;
 	this.initialized = false;
 
-	if ( shouldBootToSupportUser() ) {
+	if ( isSupportUserSession() ) {
 		supportUserBoot();
 		this.fetch();
 

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -25,7 +25,7 @@ export const MAX_AGE = 7 * DAY_IN_HOURS * HOUR_IN_MS;
 
 function getInitialServerState() {
 	// Bootstrapped state from a server-render
-	if ( typeof window === 'object' && window.initialReduxState ) {
+	if ( typeof window === 'object' && window.initialReduxState && ! isSupportUserSession() ) {
 		const serverState = reducer( window.initialReduxState, { type: SERVER_DESERIALIZE } );
 		return pick( serverState, Object.keys( window.initialReduxState ) );
 	}

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -10,7 +10,7 @@ import pick from 'lodash/pick';
 import { createReduxStore, reducer } from 'state';
 import { SERIALIZE, DESERIALIZE, SERVER_DESERIALIZE } from 'state/action-types'
 import { getLocalForage } from 'lib/localforage';
-import { shouldBoot } from 'lib/user/support-user-interop';
+import { isSupportUserSession } from 'lib/user/support-user-interop';
 import config from 'config';
 
 /**
@@ -74,7 +74,7 @@ function persistOnChange( reduxStore ) {
 }
 
 export default function createReduxStoreFromPersistedInitialState( reduxStoreReady ) {
-	if ( config.isEnabled( 'persist-redux' ) && ! shouldBoot() ) {
+	if ( config.isEnabled( 'persist-redux' ) && ! isSupportUserSession() ) {
 		localforage.getItem( 'redux-state' )
 			.then( loadInitialState )
 			.catch( loadInitialStateFailed )

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -10,6 +10,7 @@ import pick from 'lodash/pick';
 import { createReduxStore, reducer } from 'state';
 import { SERIALIZE, DESERIALIZE, SERVER_DESERIALIZE } from 'state/action-types'
 import { getLocalForage } from 'lib/localforage';
+import { shouldBoot } from 'lib/user/support-user-interop';
 import config from 'config';
 
 /**
@@ -73,7 +74,7 @@ function persistOnChange( reduxStore ) {
 }
 
 export default function createReduxStoreFromPersistedInitialState( reduxStoreReady ) {
-	if ( config.isEnabled( 'persist-redux' ) ) {
+	if ( config.isEnabled( 'persist-redux' ) && ! shouldBoot() ) {
 		localforage.getItem( 'redux-state' )
 			.then( loadInitialState )
 			.catch( loadInitialStateFailed )

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -8,42 +8,39 @@ import mockery from 'mockery';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import useMockery from 'test/helpers/use-mockery';
 import useFakeDom from 'test/helpers/use-fake-dom';
 
 describe( 'initial-state', () => {
 	let localforage, createReduxStoreFromPersistedInitialState, MAX_AGE,
 		isSwitchedUser = false,
+		isReduxEnabled = false,
+		isEnabled = () => isReduxEnabled,
 		isSupportUserSession = () => isSwitchedUser;
 
 	useFakeDom();
 
-	before( () => {
+	useMockery( () => {
+		const configMock = function() {
+			return 'development'; //needed to mock out lib/warn
+		};
+		configMock.isEnabled = isEnabled;
 		mockery.registerMock( 'lib/user/support-user-interop', { isSupportUserSession: isSupportUserSession } );
-		mockery.enable( { warnOnUnregistered: false } );
+		mockery.registerMock( 'config', configMock );
 		localforage = require( 'localforage' );
-		const initialState = require( '../initial-state' );
+		const initialState = require( 'state/initial-state' );
 		createReduxStoreFromPersistedInitialState = initialState.default;
 		MAX_AGE = initialState.MAX_AGE;
-	} );
-
-	after( () => {
-		mockery.deregisterAll();
-		mockery.disable();
-	} );
+	}, null );
 
 	describe( 'createReduxStoreFromPersistedInitialState', () => {
 		describe( 'persist-redux disabled', () => {
 			describe( 'with recently persisted data and initial server data', () => {
-				var configStub,
-					consoleSpy,
-					state,
+				var state,
 					serverState = { currentUser: { id: 123456789 } };
 				before( ( done ) => {
 					window.initialReduxState = serverState;
-					configStub = sinon.stub( config, 'isEnabled' );
-					configStub.withArgs( 'persist-redux' ).returns( false );
-					consoleSpy = sinon.spy( console, 'error' );
+					sinon.spy( console, 'error' );
 					const reduxReady = function( reduxStore ) {
 						state = reduxStore.getState();
 						done();
@@ -51,12 +48,11 @@ describe( 'initial-state', () => {
 					createReduxStoreFromPersistedInitialState( reduxReady );
 				} );
 				after( () => {
+					console.error.restore();
 					window.initialReduxState = null;
-					configStub.restore();
-					consoleSpy.restore();
 				} );
 				it( 'builds store without errors', () => {
-					expect( consoleSpy.called ).to.equal( false );
+					expect( console.error.called ).to.equal( false );
 				} );
 				it( 'does not add timestamp to store', () => {
 					expect( state._timestamp ).to.equal( undefined );
@@ -82,9 +78,9 @@ describe( 'initial-state', () => {
 							_timestamp: Date.now()
 						};
 					before( ( done ) => {
+						isReduxEnabled = true;
 						isSwitchedUser = true;
 						window.initialReduxState = { currentUser: { id: 123456789 } };
-						sinon.stub( config, 'isEnabled' ).withArgs( 'persist-redux' ).returns( true );
 						sinon.spy( console, 'error' );
 						sinon.stub( localforage, 'getItem' )
 							.returns(
@@ -99,9 +95,9 @@ describe( 'initial-state', () => {
 						createReduxStoreFromPersistedInitialState( reduxReady );
 					} );
 					after( () => {
+						isReduxEnabled = false;
 						isSwitchedUser = false;
 						window.initialReduxState = null;
-						config.isEnabled.restore();
 						console.error.restore();
 						localforage.getItem.restore();
 					} );
@@ -114,16 +110,13 @@ describe( 'initial-state', () => {
 					it( 'does not add timestamp to store', () => {
 						expect( state._timestamp ).to.equal( undefined );
 					} );
-					it( 'builds state using server state', () => {
-						expect( state.currentUser.id ).to.equal( 123456789 );
+					it( 'does not build state using server state', () => {
+						expect( state.currentUser.id ).to.equal( null );
 					} );
 				} );
 			} );
 			describe( 'with recently persisted data and initial server data', () => {
-				var configStub,
-					consoleSpy,
-					localforageGetItemStub,
-					state,
+				var state,
 					savedState = {
 						currentUser: { id: 123456789 },
 						postTypes: {
@@ -147,10 +140,9 @@ describe( 'initial-state', () => {
 					};
 				before( ( done ) => {
 					window.initialReduxState = serverState;
-					configStub = sinon.stub( config, 'isEnabled' );
-					configStub.withArgs( 'persist-redux' ).returns( true );
-					consoleSpy = sinon.spy( console, 'error' );
-					localforageGetItemStub = sinon.stub( localforage, 'getItem' )
+					isReduxEnabled = true;
+					sinon.spy( console, 'error' );
+					sinon.stub( localforage, 'getItem' )
 						.returns(
 						new Promise( function( resolve ) {
 							resolve( savedState );
@@ -164,12 +156,12 @@ describe( 'initial-state', () => {
 				} );
 				after( () => {
 					window.initialReduxState = null;
-					configStub.restore();
-					consoleSpy.restore();
-					localforageGetItemStub.restore();
+					isReduxEnabled = false;
+					console.error.restore();
+					localforage.getItem.restore();
 				} );
 				it( 'builds store without errors', () => {
-					expect( consoleSpy.called ).to.equal( false );
+					expect( console.error.called ).to.equal( false );
 				} );
 				it( 'builds state using local forage state', () => {
 					expect( state.currentUser.id ).to.equal( 123456789 );
@@ -182,10 +174,7 @@ describe( 'initial-state', () => {
 				} );
 			} );
 			describe( 'with stale persisted data and initial server data', () => {
-				var configStub,
-					consoleSpy,
-					localforageGetItemStub,
-					state,
+				var state,
 					serverState = {
 						postTypes: {
 							items: {
@@ -197,10 +186,9 @@ describe( 'initial-state', () => {
 					};
 				before( ( done ) => {
 					window.initialReduxState = serverState;
-					configStub = sinon.stub( config, 'isEnabled' );
-					configStub.withArgs( 'persist-redux' ).returns( true );
-					consoleSpy = sinon.spy( console, 'error' );
-					localforageGetItemStub = sinon.stub( localforage, 'getItem' )
+					isReduxEnabled = true;
+					sinon.spy( console, 'error' );
+					sinon.stub( localforage, 'getItem' )
 						.returns(
 						new Promise( function( resolve ) {
 							resolve( {
@@ -225,12 +213,12 @@ describe( 'initial-state', () => {
 				} );
 				after( () => {
 					window.initialReduxState = null;
-					configStub.restore();
-					consoleSpy.restore();
-					localforageGetItemStub.restore();
+					isReduxEnabled = false;
+					console.error.restore();
+					localforage.getItem.restore();
 				} );
 				it( 'builds store without errors', () => {
-					expect( consoleSpy.called ).to.equal( false );
+					expect( console.error.called ).to.equal( false );
 				} );
 				it( 'builds using server state', () => {
 					expect( state.postTypes.items ).to.equal( serverState.postTypes.items );
@@ -243,10 +231,7 @@ describe( 'initial-state', () => {
 				} );
 			} );
 			describe( 'with recently persisted data and no initial server data', () => {
-				var configStub,
-					consoleSpy,
-					localforageGetItemStub,
-					state,
+				var state,
 					savedState = {
 						currentUser: { id: 123456789 },
 						postTypes: {
@@ -262,10 +247,9 @@ describe( 'initial-state', () => {
 					serverState = {};
 				before( ( done ) => {
 					window.initialReduxState = serverState;
-					configStub = sinon.stub( config, 'isEnabled' );
-					configStub.withArgs( 'persist-redux' ).returns( true );
-					consoleSpy = sinon.spy( console, 'error' );
-					localforageGetItemStub = sinon.stub( localforage, 'getItem' )
+					isReduxEnabled = true;
+					sinon.spy( console, 'error' );
+					sinon.stub( localforage, 'getItem' )
 						.returns(
 						new Promise( function( resolve ) {
 							resolve( savedState );
@@ -279,12 +263,12 @@ describe( 'initial-state', () => {
 				} );
 				after( () => {
 					window.initialReduxState = null;
-					configStub.restore();
-					consoleSpy.restore();
-					localforageGetItemStub.restore();
+					isReduxEnabled = false;
+					console.error.restore();
+					localforage.getItem.restore();
 				} );
 				it( 'builds store without errors', () => {
-					expect( consoleSpy.called ).to.equal( false );
+					expect( console.error.called ).to.equal( false );
 				} );
 				it( 'builds state using local forage state', () => {
 					expect( state.currentUser.id ).to.equal( 123456789 );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -14,12 +14,12 @@ import useFakeDom from 'test/helpers/use-fake-dom';
 describe( 'initial-state', () => {
 	let localforage, createReduxStoreFromPersistedInitialState, MAX_AGE,
 		isSwitchedUser = false,
-		shouldBoot = () => isSwitchedUser;
+		isSupportUserSession = () => isSwitchedUser;
 
 	useFakeDom();
 
 	before( () => {
-		mockery.registerMock( 'lib/user/support-user-interop', { shouldBoot: shouldBoot } );
+		mockery.registerMock( 'lib/user/support-user-interop', { isSupportUserSession: isSupportUserSession } );
 		mockery.enable( { warnOnUnregistered: false } );
 		localforage = require( 'localforage' );
 		const initialState = require( '../initial-state' );

--- a/client/tests.json
+++ b/client/tests.json
@@ -120,6 +120,6 @@
 		"users": {
 			"test": [ "actions", "reducer", "selectors" ]
 		},
-		"test": [ "index" ]
+		"test": [ "index", "initial-state" ]
 	}
 }


### PR DESCRIPTION
This PR attempts to disable redux persistence if we are switched as another user. ~~The building blocks are here but @jordwest I'm not sure if the timing is correct for `shouldBoot` to return the correct value.~~ Thanks for fixing that @jordwest  

~~@blowery it looks like initial-state tests were accidentally turned off during the test runner conversion. We may want to consider scanning test directories so we don't need to specify every file in a config.~~

## Testing Instructions
* Start Calypso
* Set console debug to 'calypso:state';
* Refresh the page, and make sure Redux is initialized from browser storage.
* Follow switch user instructions here: (ref: p4TIVU-2OW-p2)
* When switched, redux persistence is disabled. You should see a debug message with the following:
```text
'persist-redux is not enabled, building state from scratch'
```

cc @jordwest @dllh @retrofox @aduth 