### PR TITLE
Editor: improve tooltips for mode switches

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -358,10 +358,16 @@ const PostEditor = React.createClass( {
 									null
 								}
 								<SegmentedControl className="editor__switch-mode" compact={ true }>
-									<SegmentedControlItem selected={ mode === 'tinymce' } onClick={ this.switchEditorMode.bind( this, 'tinymce' ) }>
+									<SegmentedControlItem
+										selected={ mode === 'tinymce' }
+										onClick={ this.switchEditorMode.bind( this, 'tinymce' ) }
+										title={ this.translate( 'Edit with a visual editor' ) }>
 										{ this.translate( 'Visual', { context: 'Editor writing mode' } ) }
 									</SegmentedControlItem>
-									<SegmentedControlItem selected={ mode === 'html' } onClick={ this.switchEditorMode.bind( this, 'html' ) }>
+									<SegmentedControlItem
+										selected={ mode === 'html' }
+										onClick={ this.switchEditorMode.bind( this, 'html' ) }
+										title={ this.translate( 'Edit the raw HTML code' ) }>
 										HTML
 									</SegmentedControlItem>
 								</SegmentedControl>


### PR DESCRIPTION
Addresses #1560.

I did not see any shortcuts for changing the editing mode, so they are not included in the tooltips. I don't know if authors switch between the visual and HTML mode frequently -- if so, I can add the shortcuts along this change.