### PR TITLE
Jetpack-connect: Redirect to jetpack auth endpoint

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * internal dependencies
+ */
 import Card from 'components/card';
 import ConnectHeader from './connect-header';
 import Dialog from 'components/dialog';
@@ -9,6 +15,9 @@ import Main from 'components/main';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
 
+/**
+ * Constants
+ */
 const pluginURL = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 const authURL = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true'
 
@@ -31,31 +40,38 @@ export default React.createClass( {
 	},
 
 	goToPluginInstall() {
-		window.location = 'http://' + this.refs.siteUrlInputRef.state.value + pluginURL;
+		window.location = this.getCurrentUrl() + pluginURL;
 	},
 
 	goToRemoteAuth() {
-		window.location = this.refs.siteUrlInputRef.state.value + authURL;
+		window.location = this.getCurrentUrl() + authURL;
+	},
+
+	showNotExistsError() {
+		this.setState( { siteStatus: 'notExist' } );
+	},
+
+	checkIfUrlIsReadyForJetpack( url ) {
+		var promise = new Promise( function( resolve, reject ) {
+			// we need to develop the backend endpoint for this check. Meanwhile, it always succeed
+			resolve();
+		} );
+
+		return promise;
+	},
+
+	getCurrentUrl() {
+		let url = this.refs.siteUrlInputRef.state.value;
+		if ( url.substr( 0, 4 ) !== 'http' ) {
+			url = 'http://' + url;
+		}
+		return url;
 	},
 
 	onURLEnter() {
-		this.goToRemoteAuth();
-/*		const stepToShow = Math.floor( ( Math.random() * 5 ) + 1 );
-
-		if ( stepToShow === 1 ) {
-			this.setState( { siteStatus: 'notExist' } );
-		} else if ( stepToShow === 2 ) {
-			this.setState( {
-				siteStatus: 'jetpackNotInstalled',
-				showDialog: true
-			} );
-		} else if ( stepToShow === 3 ) {
-			this.setState( { siteStatus: 'jetpackIsDeactivated' } );
-		} else if ( stepToShow === 4 ) {
-			this.setState( { siteStatus: 'jetpackIsDisconnected' } );
-		} else if ( stepToShow === 5 ) {
-			this.setState( { siteStatus: 'jetpackIsValid' } );
-		}*/
+		this.checkIfUrlIsReadyForJetpack( this.getCurrentUrl() )
+			.then( this.goToRemoteAuth )
+			.catch( this.showNotExistsError )
 	},
 
 	onDismissClick() {

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -52,12 +52,10 @@ export default React.createClass( {
 	},
 
 	checkIfUrlIsReadyForJetpack( url ) {
-		var promise = new Promise( function( resolve, reject ) {
+		return new Promise( function( resolve, reject ) {
 			// we need to develop the backend endpoint for this check. Meanwhile, it always succeed
 			resolve();
 		} );
-
-		return promise;
 	},
 
 	getCurrentUrl() {


### PR DESCRIPTION
This PR modifies the dummy jetpack connect url input box to really redirect to the self-host server endpoint that would start the remote auth request.

Depends on https://github.com/Automattic/wp-calypso/pull/3854 being merged to work

![image](https://cloud.githubusercontent.com/assets/1554855/13632190/bdbdbb54-e5e8-11e5-80d3-47adc7eec649.png)

This is how it works for a user that is logged in their own server:
https://cloudup.com/cvcLj7bgZ0T

And this how it looks when they need to log there before continuing:
https://cloudup.com/cga6KSG4hw0

Testing:
========
1. You need your site to be running this branch of jetpack: https://github.com/Automattic/jetpack/pull/3364
2. Go to http://calypso.dev:3000/jetpack/connect, enter the url of your site, and ~watch the magic happen :) ~ Not yet! We need to merge https://github.com/Automattic/wp-calypso/pull/2974 to make this work as in the videos ... right now this would redirect you to your wp-admin, which would redirect you to an url that calypso doesn't know how to handle... so it would take you to the theme selector, for some reason. But the main purpose of this PR was to add that calypso => wp-admin redirection, so it works :D

ping @roccotripaldi @oskosk @alternatekev 