### PR TITLE
Automat(t)ic Domain Diagnostics 

### DIFF
--- a/client/components/domain-diagnostic/index.jsx
+++ b/client/components/domain-diagnostic/index.jsx
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import React from 'react';
-
+/**
+ * Internal dependencies
+ */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 

--- a/client/components/domain-diagnostic/index.jsx
+++ b/client/components/domain-diagnostic/index.jsx
@@ -32,7 +32,7 @@ export default React.createClass( {
 		if ( this.state.domainDidFail ) {
 			return (
 				<Notice status={ 'is-warning' } showDismiss={ false } text={ 'There seems to be a problem with your "' + this.props.domain + '" domain. Do not panic! Our Domain Helper tool awaits!' }>
-					<NoticeAction external={ true } href={ 'https://en.support.wordpress.com/domain-helper/' } />
+					<NoticeAction external={ true } href={ 'https://en.support.wordpress.com/domain-helper/?host=' + this.props.domain } />
 				</Notice>
 			);
 		} else {

--- a/client/components/domain-diagnostic/index.jsx
+++ b/client/components/domain-diagnostic/index.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+
+export default React.createClass( {
+
+	displayName: 'DomainDiagnostic',
+
+	propTypes: {
+		domain: React.PropTypes.string.isRequired,
+	},
+	getInitialState: function() {
+		return {
+			domainDidFail: false
+		};
+	},
+
+	componentDidMount() {
+		const self = this;
+		const imageChecker = new Image();
+		imageChecker.onerror = function() {
+			self.setState( { domainDidFail: true } );
+		}
+		imageChecker.src = 'http://' + this.props.domain + '/w32.gif';
+	},
+
+	render() {
+		if ( this.state.domainDidFail ) {
+			return (
+				<Notice status={ 'is-warning' } showDismiss={ false } text={ 'There seems to be a problem with your "' + this.props.domain + '" domain. Do not panic! Our Domain Helper tool awaits!' }>
+					<NoticeAction external={ true } href={ 'https://en.support.wordpress.com/domain-helper/' } />
+				</Notice>
+			);
+		} else {
+			return null;
+		}
+	}
+} );

--- a/client/components/domain-diagnostic/index.jsx
+++ b/client/components/domain-diagnostic/index.jsx
@@ -10,6 +10,8 @@ import NoticeAction from 'components/notice/notice-action';
 
 export default React.createClass( {
 
+	imageChecker: null,
+
 	displayName: 'DomainDiagnostic',
 
 	propTypes: {
@@ -23,11 +25,17 @@ export default React.createClass( {
 
 	componentDidMount() {
 		const self = this;
-		const imageChecker = new Image();
-		imageChecker.onerror = function() {
-			self.setState( { domainDidFail: true } );
+		this.imageChecker = new Image();
+		this.imageChecker.onerror = function() {
+			if ( self.isMounted() ) {
+				self.setState( { domainDidFail: true } );
+			}
 		}
-		imageChecker.src = 'http://' + this.props.domain + '/w32.gif';
+		this.imageChecker.src = 'http://' + this.props.domain + '/w32.gif';
+	},
+
+	componentWillUnmount() {
+		this.imageChecker = null;
 	},
 
 	render() {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -33,6 +33,7 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 
 import { isOffline } from 'state/application/selectors';
 
+import DomainDiagnostic from 'components/domain-diagnostic';
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
 }
@@ -161,6 +162,10 @@ Layout = React.createClass( {
 					{ this.renderWelcome() }
 					{ this.renderEmailVerificationNotice() }
 					<GlobalNotices id="notices" notices={ notices.list } forcePinned={ 'post' === this.props.section } />
+					<DomainDiagnostic domain='donaldjdrumpf.com' />
+					<DomainDiagnostic domain='wordpress.com' />
+					<DomainDiagnostic domain='baconipsum.com' />
+					<DomainDiagnostic domain='arturpiszek.wordpress.com' />
 					<div id="primary" className="wp-primary wp-section" />
 					<div id="secondary" className="wp-secondary" />
 				</div>


### PR DESCRIPTION
## Problem

Last week me and other members of **House Stark** and **House Lannister** were on support rotation.
What did we do?
Domains.

It turned out, most of the problems were falling into common categories. One of them were users having proper mapping, but domain bought elsewhere and not pointing to our name servers.

There is no indication about it, the support docs dont help much if you dont really know what to do and the site does not work.

It only gets users angry or unhappy and wastes the time of Happiness Engineers (a lot of time of HEs).

# Enough!

![](https://cldup.com/nZ20SwrbVX.png)

This is the domain helper the link opens: https://en.support.wordpress.com/domain-helper/

## Approach

Instead of dig, A record, validation etc, I am just checking if certain static content is in fact being served from the domain. Given we are operating a multisite I actually know what should be there.

#### What about CORS ?

Well, thats why I chose `Image` :)

### Really? Dont we have an API for this?

There are a lot of more elegant approaches to this, all of them include a need for additional endpoint doing `dig` requests (right now DA does this during page load), which would get us rate-limited. There were previous attempts to do this (search `get_blog_by_url_and_verify_we_host_it` ), but all of them have hit a wall.
I would argue, this is one of the only sure-fire ways to actually check if domain is set properly. Of course, choice of `w32.gif` can be debated and we can choose some other (more unique) static file in `wp.com`.
This offloads actual checking to the client and I am quite happy with this.

One point: `w32.gif` has been there for 10 years now. It does not look very fragile.

#### Y no https?

I am doing request to user mapped domain. I don't expect that user mapped domain will have a proper certificate. I own domains that DO NOT work over https:
- piszek.com
- humanized.technology

## Further work

Obviously, I dont want this in `/layot`, thats just an example.

- What do you think about this approach?
- Are global notices good for this? Should I use component that renders nothing, but just dispatches a global notice? Should I try to do all of it in some middleware?
- Should I wrap it in some bigger "Diagnostics" component ?
- Of course first I need to download user domain list from API
- When should we run this? (/sites ?)
- ~~it would be cool to automatically pass domain to domain helper tool (@dllh, how much work would it require?)~~ found it and done :)

CC @gwwar @rralian @mtias @adambbecker @gziolo @westi @dllh 