### PR TITLE
Plans: Fix multiple plans requests

### DIFF
--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -22,6 +22,10 @@ import {
 	getBySite,
 	isLoaded
 } from 'state/google-apps-users/selectors';
+import { shouldFetchSitePlans } from 'lib/plans';
+import { fetchSitePlans } from 'state/sites/plans/actions';
+import { getPlansBySite } from 'state/sites/plans/selectors';
+
 const user = userFactory();
 
 var stores = [
@@ -37,6 +41,7 @@ function getStateFromStores( props ) {
 		products: props.products,
 		selectedDomainName: props.selectedDomainName,
 		selectedSite: props.selectedSite,
+		sitePlans: props.sitePlans,
 		user: user.get(),
 		googleAppsUsers: props.googleAppsUsers,
 		googleAppsUsersLoaded: props.googleAppsUsersLoaded
@@ -51,6 +56,7 @@ const EmailData = React.createClass( {
 		context: React.PropTypes.object.isRequired,
 		productsList: React.PropTypes.object.isRequired,
 		selectedDomainName: React.PropTypes.string,
+		sitePlans: React.PropTypes.object.isRequired,
 		sites: React.PropTypes.object.isRequired,
 		googleAppsUsers: React.PropTypes.array.isRequired,
 		googleAppsUsersLoaded: React.PropTypes.bool.isRequired
@@ -59,19 +65,20 @@ const EmailData = React.createClass( {
 	mixins: [ observe( 'productsList' ) ],
 
 	componentWillMount() {
-		this.loadDomains();
+		this.loadDomainsAndSitePlans();
 		this.props.fetch();
 	},
 
 	componentWillUpdate() {
-		this.loadDomains();
+		this.loadDomainsAndSitePlans();
 	},
 
-	loadDomains() {
+	loadDomainsAndSitePlans() {
 		const selectedSite = this.props.sites.getSelectedSite();
 
 		if ( this.prevSelectedSite !== selectedSite ) {
 			fetchDomains( selectedSite.ID );
+			this.props.fetchSitePlans( this.props.sitePlans, this.props.sites.getSelectedSite() );
 
 			this.prevSelectedSite = selectedSite;
 		}
@@ -89,6 +96,7 @@ const EmailData = React.createClass( {
 				products={ this.props.productsList.get() }
 				selectedDomainName={ this.props.selectedDomainName }
 				selectedSite={ this.props.sites.getSelectedSite() }
+				sitePlans={ this.props.sitePlans }
 				context={ this.props.context } />
 		);
 	}
@@ -102,7 +110,8 @@ export default connect(
 
 		return {
 			googleAppsUsers,
-			googleAppsUsersLoaded: isLoaded( state )
+			googleAppsUsersLoaded: isLoaded( state ),
+			sitePlans: getPlansBySite( state, sites.getSelectedSite() )
 		}
 	},
 	( dispatch, { selectedDomainName, sites } ) => {
@@ -111,7 +120,12 @@ export default connect(
 			: () => fetchBySiteId( sites.getSelectedSite().ID );
 
 		return {
-			fetch: () => dispatch( fetcher() )
+			fetch: () => dispatch( fetcher() ),
+			fetchSitePlans: ( sitePlans, site ) => {
+				if ( shouldFetchSitePlans( sitePlans, site ) ) {
+					dispatch( fetchSitePlans( site.ID ) );
+				}
+			}
 		}
 	}
 )( EmailData );

--- a/client/components/data/domain-management/email/index.jsx
+++ b/client/components/data/domain-management/email/index.jsx
@@ -66,7 +66,7 @@ const EmailData = React.createClass( {
 
 	componentWillMount() {
 		this.loadDomainsAndSitePlans();
-		this.props.fetch();
+		this.props.fetchGoogleAppsUsers();
 	},
 
 	componentWillUpdate() {
@@ -115,12 +115,12 @@ export default connect(
 		}
 	},
 	( dispatch, { selectedDomainName, sites } ) => {
-		const fetcher = selectedDomainName
+		const googleAppsUsersFetcher = selectedDomainName
 			? () => fetchByDomain( selectedDomainName )
 			: () => fetchBySiteId( sites.getSelectedSite().ID );
 
 		return {
-			fetch: () => dispatch( fetcher() ),
+			fetchGoogleAppsUsers: () => dispatch( googleAppsUsersFetcher() ),
 			fetchSitePlans: ( sitePlans, site ) => {
 				if ( shouldFetchSitePlans( sitePlans, site ) ) {
 					dispatch( fetchSitePlans( site.ID ) );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -167,6 +167,7 @@ var Plans = React.createClass( {
 
 					<div id="plans" className="plans has-sidebar">
 						<UpgradesNavigation
+							sitePlans={ this.props.sitePlans }
 							path={ this.props.context.path }
 							cart={ this.props.cart }
 							selectedSite={ selectedSite } />

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -40,16 +40,16 @@ var Plans = React.createClass( {
 	},
 
 	componentDidMount: function() {
-		this.updateSitePlans();
+		this.updateSitePlans( this.props.sitePlans );
 	},
 
-	componentWillReceiveProps: function() {
-		this.updateSitePlans();
+	componentWillReceiveProps: function( nextProps ) {
+		this.updateSitePlans( nextProps.sitePlans );
 	},
 
-	updateSitePlans: function() {
+	updateSitePlans: function( sitePlans ) {
 		var selectedSite = this.props.sites.getSelectedSite();
-		this.props.fetchSitePlans( this.props.sitePlans, selectedSite );
+		this.props.fetchSitePlans( sitePlans, selectedSite );
 	},
 
 	openPlan: function( planId ) {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -150,6 +150,7 @@ var Plans = React.createClass( {
 		if ( this.props.sitePlans.hasLoadedFromServer && currentPlan.freeTrial ) {
 			return (
 				<PlanOverview
+					sitePlans={ this.props.sitePlans }
 					path={ this.props.context.path }
 					cart={ this.props.cart }
 					destinationType={ this.props.context.params.destinationType }

--- a/client/my-sites/plans/plan-overview/index.jsx
+++ b/client/my-sites/plans/plan-overview/index.jsx
@@ -25,7 +25,8 @@ const PlanOverview = React.createClass( {
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.bool
-		] ).isRequired
+		] ).isRequired,
+		sitePlans: React.PropTypes.object.isRequired
 	},
 
 	redirectToDefault() {
@@ -55,6 +56,7 @@ const PlanOverview = React.createClass( {
 					<SidebarNavigation />
 
 					<UpgradesNavigation
+						sitePlans={ this.props.sitePlans }
 						cart={ this.props.cart }
 						path={ this.props.path }
 						selectedSite={ this.props.selectedSite } />

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	connect = require( 'react-redux' ).connect,
 	reject = require( 'lodash/reject' ),
 	classNames = require( 'classnames' );
 
@@ -17,10 +16,7 @@ var CartBody = require( './cart-body' ),
 	CartPlanAd = require( './cart-plan-ad' ),
 	CartTrialAd = require( './cart-trial-ad' ),
 	isCredits = require( 'lib/products-values' ).isCredits,
-	Gridicon = require( 'components/gridicon' ),
-	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
-	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
-	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans;
+	Gridicon = require( 'components/gridicon' );
 
 var PopoverCart = React.createClass( {
 	propTypes: {
@@ -29,16 +25,13 @@ var PopoverCart = React.createClass( {
 			React.PropTypes.object,
 			React.PropTypes.bool
 		] ).isRequired,
+		sitePlans: React.PropTypes.object.isRequired,
 		onToggle: React.PropTypes.func.isRequired,
 		closeSectionNavMobilePanel: React.PropTypes.func,
 		visible: React.PropTypes.bool.isRequired,
 		pinned: React.PropTypes.bool.isRequired,
 		showKeepSearching: React.PropTypes.bool.isRequired,
 		onKeepSearchingClick: React.PropTypes.func.isRequired
-	},
-
-	componentDidMount: function() {
-		this.props.fetchSitePlans( this.props.sitePlans, this.props.selectedSite );
 	},
 
 	itemCount: function() {
@@ -156,17 +149,4 @@ var PopoverCart = React.createClass( {
 	}
 } );
 
-module.exports = connect(
-	function( state, props ) {
-		return { sitePlans: getPlansBySite( state, props.selectedSite ) };
-	},
-	function( dispatch ) {
-		return {
-			fetchSitePlans( sitePlans, site ) {
-				if ( shouldFetchSitePlans( sitePlans, site ) ) {
-					dispatch( fetchSitePlans( site.ID ) );
-				}
-			}
-		};
-	}
-)( PopoverCart );
+module.exports = PopoverCart;

--- a/client/my-sites/upgrades/domain-management/email/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email/index.jsx
@@ -34,6 +34,7 @@ const Email = React.createClass( {
 			React.PropTypes.object,
 			React.PropTypes.bool
 		] ).isRequired,
+		sitePlans: React.PropTypes.object.isRequired,
 		user: React.PropTypes.object.isRequired,
 		googleAppsUsers: React.PropTypes.array.isRequired,
 		googleAppsUsersLoaded: React.PropTypes.bool.isRequired
@@ -63,7 +64,8 @@ const Email = React.createClass( {
 			<UpgradesNavigation
 				path={ this.props.context.path }
 				cart={ this.props.cart }
-				selectedSite={ this.props.selectedSite }/>
+				selectedSite={ this.props.selectedSite }
+				sitePlans={ this.props.sitePlans } />
 		);
 	},
 

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -45,7 +45,8 @@ const List = React.createClass( {
 				<UpgradesNavigation
 					path={ this.props.context.path }
 					cart={ this.props.cart }
-					selectedSite={ this.props.selectedSite } />
+					selectedSite={ this.props.selectedSite }
+					sitePlans={ this.props.sitePlans } />
 
 				{ this.domainWarnings() }
 

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -46,8 +46,10 @@ var DomainSearch = React.createClass( {
 	},
 
 	componentWillReceiveProps: function() {
-		if ( this.previousSelectedSite !== this.props.sites.getSelectedSite() ) {
-			this.props.fetchSitePlans( this.props.sitePlans, this.props.sites.getSelectedSite() );
+		var selectedSite = this.props.sites.getSelectedSite();
+		if ( this.previousSelectedSite !== selectedSite ) {
+			this.props.fetchSitePlans( this.props.sitePlans, selectedSite );
+			this.previousSelectedSite = selectedSite;
 		}
 	},
 

--- a/client/my-sites/upgrades/domain-search/domain-search.jsx
+++ b/client/my-sites/upgrades/domain-search/domain-search.jsx
@@ -41,10 +41,14 @@ var DomainSearch = React.createClass( {
 	componentDidMount: function() {
 		this.props.sites.on( 'change', this.checkSiteIsUpgradeable );
 		this.props.fetchSitePlans( this.props.sitePlans, this.props.sites.getSelectedSite() );
+
+		this.previousSelectedSite = this.props.sites.getSelectedSite();
 	},
 
 	componentWillReceiveProps: function() {
-		this.props.fetchSitePlans( this.props.sitePlans, this.props.sites.getSelectedSite() );
+		if ( this.previousSelectedSite !== this.props.sites.getSelectedSite() ) {
+			this.props.fetchSitePlans( this.props.sitePlans, this.props.sites.getSelectedSite() );
+		}
 	},
 
 	componentWillUnmount: function() {
@@ -91,7 +95,8 @@ var DomainSearch = React.createClass( {
 						<UpgradesNavigation
 							path={ this.props.context.path }
 							cart={ this.props.cart }
-							selectedSite={ selectedSite } />
+							selectedSite={ selectedSite }
+							sitePlans={ this.props.sitePlans } />
 
 						<RegisterDomainStep
 							path={ this.props.context.path }

--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -67,11 +67,12 @@ var NAV_ITEMS = {
 var UpgradesNavigation = React.createClass( {
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
-
+		path: React.PropTypes.string.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.bool
-		] ).isRequired
+		] ).isRequired,
+		sitePlans: React.PropTypes.object.isRequired
 	},
 
 	getInitialState: function() {
@@ -184,6 +185,7 @@ var UpgradesNavigation = React.createClass( {
 
 		return (
 			<PopoverCart
+				sitePlans={ this.props.sitePlans }
 				cart={ this.props.cart }
 				selectedSite={ this.props.selectedSite }
 				onToggle={ this.toggleCartVisibility }


### PR DESCRIPTION
Fixes #3888 

When `Plans` and `PopoverCart` (a child of `Plans`) mount, they each trigger a request to the site-specific plans endpoint. Instead of having each of these components request data independently, we should trigger the request in the former and have it pass data down through props to the latter.

`PopoverCart` is mounted in `UpgradesNavigation`, which is mounted in four other components besides `Plans`. Two of those already had `sitePlans`, but data components needed to be updated for two others to pass `sitePlans` down from the top of the render tree.

**Testing**
Visit the following routes and assert in the developer tools that we do not make multiple requests to `/sites/%s/plans`. You can filter for this endpoint by entering `sites plans` in the filter input in the network pane in Chrome.
- `/plans/:site` for a site with a free trial and a site without a free trial
- `/domains/manage/:site`
- `/domains/manage/email/:site`
- `/domains/add/:site`

- [x] Code review
- [x] Product review