### PR TITLE
Plans: Set plugin registration keys automatically

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -197,7 +197,7 @@ PluginsActions = {
 	},
 
 	installPlugin: function( site, plugin ) {
-		var install, activate, autoupdate, dispatchMessage, manageError, manageSuccess;
+		var install, update, activate, autoupdate, dispatchMessage, manageError, manageSuccess;
 
 		if ( ! site.canUpdateFiles ) {
 			return getRejectedPromise( 'Error: Can\'t update files on the site' )
@@ -209,6 +209,10 @@ PluginsActions = {
 
 		install = function() {
 			return queueSitePluginActionAsPromise( wpcom.pluginsInstall.bind( wpcom ), site.ID, plugin.slug );
+		};
+
+		update = function( pluginData ) {
+			return queueSitePluginActionAsPromise( wpcom.pluginsUpdate.bind( wpcom ), site.ID, pluginData.id );
 		};
 
 		activate = function( pluginData ) {
@@ -244,17 +248,21 @@ PluginsActions = {
 		manageError = function( error ) {
 			if ( error.name === 'PluginAlreadyInstalledError' ) {
 				if ( site.isMainNetworkSite() ) {
-					return autoupdate( plugin )
+					return update( plugin )
+						.then( autoupdate )
 						.then( manageSuccess )
 						.catch( manageError );
 				}
-				return activate( plugin )
+
+				return update( plugin )
+					.then( activate )
 					.then( autoupdate )
 					.then( manageSuccess )
 					.catch( manageError );
 			}
 			if ( error.name === 'ActivationErrorError' ) {
-				return autoupdate( plugin )
+				return update( plugin )
+					.then( autoupdate )
 					.then( manageSuccess )
 					.catch( manageError );
 			}

--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -276,13 +276,13 @@ PluginsActions = {
 		if ( site.isMainNetworkSite() ) {
 			return install()
 				.then( autoupdate )
-				.then( responseData => dispatchMessage( 'RECEIVE_INSTALLED_PLUGIN', responseData ) )
+				.then( manageSuccess )
 				.catch( manageError );
 		}
 		return install()
 			.then( activate )
 			.then( autoupdate )
-			.then( responseData => dispatchMessage( 'RECEIVE_INSTALLED_PLUGIN', responseData ) )
+			.then( manageSuccess )
 			.catch( manageError );
 	},
 

--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -395,4 +395,13 @@ JetpackSite.prototype.setOption = function( query, callback ) {
 	this.emit( 'change' );
 };
 
+JetpackSite.prototype.fetchJetpackKeys = function( callback ) {
+	wpcom.undocumented().fetchJetpackKeys( this.ID, function( error, data ) {
+		if ( error ) {
+			debug( 'error getting Jetpack registration keys', error );
+		}
+		callback && callback( error, data );
+	}.bind( this ) );
+};
+
 module.exports = JetpackSite;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -265,6 +265,18 @@ Undocumented.prototype.disconnectJetpack = function( siteId, fn ) {
 };
 
 /**
+ * Fetches plugin registration keys for WordPress.org sites with paid services
+ *
+ * @param {int} [siteId] The site ID
+ * @param {Function} fn The callback function
+ * @api public
+ */
+Undocumented.prototype.fetchJetpackKeys = function( siteId, fn ) {
+	debug( '/jetpack-blogs/:site_id:/keys query' );
+	this.wpcom.req.get( { path: '/jetpack-blogs/' + siteId + '/keys' }, fn );
+};
+
+/**
  * Test if a Jetpack Site is connected to .com
  *
  * @param {int} [siteId] The site ID

--- a/client/my-sites/plugins/plan-setup/index.jsx
+++ b/client/my-sites/plugins/plan-setup/index.jsx
@@ -42,6 +42,9 @@ module.exports = React.createClass( {
 	},
 
 	componentDidMount() {
+		if ( ! this.props.selectedSite || ! this.props.selectedSite.jetpack || ! this.props.selectedSite.canManage() ) {
+			return;
+		}
 		this.runInstall();
 	},
 

--- a/client/my-sites/plugins/plan-setup/index.jsx
+++ b/client/my-sites/plugins/plan-setup/index.jsx
@@ -51,7 +51,6 @@ module.exports = React.createClass( {
 	runInstall() {
 		let steps = PluginInstallation.start( {
 			site: this.props.selectedSite,
-			plugins: [ 'akismet', 'vaultpress' ]
 		} );
 
 		steps.on( 'data', ( step ) => {

--- a/client/my-sites/plugins/plan-setup/installation.js
+++ b/client/my-sites/plugins/plan-setup/installation.js
@@ -92,7 +92,11 @@ InstallationFlow.prototype.install = function( slug, next ) {
 	installer.then( ( response ) => {
 		if ( 'undefined' !== typeof response.error ) {
 			// @todo Handle failed installs
-			console.warn( response.error );
+			if ( response.error.name === 'UpdateFailError' ) {
+				console.warn( 'Plugin not up-to-date, cannot continue.' );
+			} else {
+				console.warn( response.error );
+			}
 			return;
 		}
 		this._pushStep( { name: 'configure-plugin', plugin: slug } );

--- a/client/my-sites/plugins/plan-setup/installation.js
+++ b/client/my-sites/plugins/plan-setup/installation.js
@@ -92,9 +92,39 @@ InstallationFlow.prototype.install = function( slug, next ) {
 	installer.then( ( response ) => {
 		if ( 'undefined' !== typeof response.error ) {
 			// @todo Handle failed installs
+			console.warn( response.error );
+			return;
 		}
-		// @todo Registration keys will be set here.
-		next();
+		this._pushStep( { name: 'configure-plugin', plugin: slug } );
+		// Configure the plugin (process depends on which plugin)
+		configureOption( site, plugin, next );
+	} );
+}
+
+// Configure the relevant option for each plugin
+function configureOption( site, plugin, callback ) {
+	let option = false;
+	let key = site.options[ plugin.slug ];
+	switch ( plugin.slug ) {
+		case 'vaultpress':
+			option = 'vaultpress_auto_register';
+			break;
+		case 'akismet':
+			option = 'wordpress_api_key';
+			break;
+		case 'polldaddy':
+			option = 'polldaddy_api_key';
+			break;
+	}
+	if ( ! option ) {
+		callback();
+		return;
+	}
+	site.setOption( { option_name: option, option_value: key }, ( error ) => {
+		if ( error ) {
+			console.warn( error );
+		}
+		callback();
 	} );
 }
 

--- a/client/my-sites/plugins/plan-setup/installation.js
+++ b/client/my-sites/plugins/plan-setup/installation.js
@@ -100,8 +100,9 @@ InstallationFlow.prototype.install = function( slug, key, next ) {
 	installer.then( ( response ) => {
 		if ( 'undefined' !== typeof response.error ) {
 			// @todo Handle failed installs
-			if ( response.error.name === 'UpdateFailError' ) {
+			if ( response.error === 'update_fail' ) {
 				console.warn( 'Plugin not up-to-date, cannot continue.' );
+				next();
 			} else {
 				console.warn( response.error );
 			}


### PR DESCRIPTION
Following up on #2944, after installing a set of plugins, we want to set registration keys to save the user some (confusing) steps. This PR also fixes some issues in the auto-install flow: updating existing plugins on the site, and not running the install if it won't work.

This PR is done, but dependent on these keys being added to the sites endpoint on wp.com, so I'm considering it "in progress"/on hold until then.