### PR TITLE
Added handling for soundcloud embed

### DIFF
--- a/client/reader/embed-helper.jsx
+++ b/client/reader/embed-helper.jsx
@@ -27,6 +27,22 @@ var embedsConfig = {
 			};
 		},
 		urlRegex: /\/\/embed.spotify.com/
+	},
+	soundcloud: {
+		sizingFunction: function soundcloudEmbedSizingFunction( embed, availableWidth ) {
+			var aspectRatio = embed.aspectRatio || 1,
+				height = '100%';
+
+			if ( embed.iframe.indexOf( 'visual=true' ) > -1 ) {
+				height = Math.floor( availableWidth / aspectRatio ) + 'px';
+			}
+
+			return {
+				width: availableWidth + 'px',
+				height: height
+			};
+		},
+		urlRegex: /\/\/w\.soundcloud\.com\/player/
 	}
 };
 


### PR DESCRIPTION
It should be 100% height for the small ones and for one that has
visual=true, the large ones, it should be as usual apsectRatio

Could be checked with https://wordpress.com/read/feeds/116494