### PR TITLE
My Sites: Do not force full refresh for People "Add" button for WP.com sites

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -390,7 +390,7 @@ module.exports = React.createClass( {
 		var site = this.getSelectedSite(),
 			usersLink = '/people/team' + this.siteSuffix(),
 			addPeopleLink = '/people/new' + this.siteSuffix(),
-			addPeopleTarget = '_self',
+			addPeopleTarget = null,
 			addPeopleButton;
 
 		if ( ! site.capabilities ) {


### PR DESCRIPTION
It was reported by @beaulebens that clicking the "Add" button in the My Sites sidebar always resulted in a full reload of the page, even the new `/people/new/$site` route that is currently launched in `wpcalypso`.

The issue seems to be setting a target by default. I would've expected that setting `_self` would not have caused a full refresh, but perhaps I am wrong or we have some routing code that looks for a target being set.

To test:
- Checkout `update/my-sites-sidebar-people` branch
- Go to `/stats/$site` where `$site` is a Jetpack site
- Click People "Add" button
- You should land in the wp-admin of your site, in a new tab
- Go to `/stats/$site` where `$site` is a WP.com site
- Click People "Add" button
- You should land on `/people/new/$site` without a full load
