### PR TITLE
Build: use shonkwrap to generate npm-shrinkwrap.json and update docs

### DIFF
--- a/docs/shrinkwrap.md
+++ b/docs/shrinkwrap.md
@@ -9,7 +9,7 @@ See: [shrinkwrap docs](https://docs.npmjs.com/cli/shrinkwrap)
 
 We use clingwrap to avoid creating huge diffs in npm-shrinkwrap.json. clingwrap also removes
 `from` and `resolved` fields which is expected. If you need to update a package that is not published with npm, 
-you will need to update the npm-shrinkwrap.json by hand.
+use the `Bumping Sub-Dependencies in all Packages` instructions instead.
 
 - Install [clingwrap](https://github.com/goodeggs/clingwrap) globally: `npm install -g clingwrap`
 - Update your desired package, e.g. `npm install lodash@4.0.0 --save`
@@ -34,11 +34,13 @@ We may also choose to update all package sub-dependencies. This will result in a
 so testing instructions should ensure that a clean install works and Calypso runs and tests correctly. It's very 
 important that your node_modules is deleted before you do this to be sure to pick up the latest versions.
 
+- Install [shonkwrap](https://github.com/skybet/shonkwrap) globally: `npm install -g shonkwrap`. This package attempts
+to remove the from/resolved fields if possible.
 - Run `make distclean` to delete local node_modules
 - Delete your local copy of npm-shrinkwrap.json.
 - Run `npm install`
 - Verify that Calypso works as expected and that tests pass.
-- Run `npm shrinkwrap --dev`
+- Run `shonkwrap --dev`
 - Commit the new npm-shrinkwrap.json
 
 ## Testing

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3,351 +3,187 @@
   "version": "0.17.0",
   "dependencies": {
     "async": {
-      "version": "0.9.0",
-      "from": "async@0.9.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+      "version": "0.9.0"
     },
     "atob": {
-      "version": "1.1.2",
-      "from": "atob@1.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.2.tgz"
+      "version": "1.1.2"
     },
     "autoprefixer": {
       "version": "4.0.0",
-      "from": "autoprefixer@4.0.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-4.0.0.tgz",
       "dependencies": {
         "autoprefixer-core": {
           "version": "4.0.2",
-          "from": "autoprefixer-core@>=4.0.0 <4.1.0",
-          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-4.0.2.tgz",
           "dependencies": {
             "caniuse-db": {
-              "version": "1.0.30000409",
-              "from": "caniuse-db@>=1.0.30000030 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000409.tgz"
+              "version": "1.0.30000428"
             }
           }
         },
         "fs-extra": {
           "version": "0.11.1",
-          "from": "fs-extra@>=0.11.1 <0.12.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.11.1.tgz",
           "dependencies": {
             "ncp": {
-              "version": "0.6.0",
-              "from": "ncp@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.6.0.tgz"
+              "version": "0.6.0"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "version": "0.0.8"
                 }
               }
             },
             "jsonfile": {
-              "version": "2.2.3",
-              "from": "jsonfile@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+              "version": "2.2.3"
             },
             "rimraf": {
-              "version": "2.5.2",
-              "from": "rimraf@>=2.2.8 <3.0.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
-              "dependencies": {
-                "glob": {
-                  "version": "7.0.0",
-                  "from": "glob@>=7.0.0 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
+              "version": "2.5.2"
             }
           }
         },
         "postcss": {
           "version": "3.0.7",
-          "from": "postcss@>=3.0.1 <3.1.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-3.0.7.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.43",
-              "from": "source-map@>=0.1.40 <0.2.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.5 <2.2.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+              "version": "2.1.9"
             }
           }
         }
       }
     },
     "autosize": {
-      "version": "3.0.7",
-      "from": "autosize@3.0.7",
-      "resolved": "https://registry.npmjs.org/autosize/-/autosize-3.0.7.tgz"
+      "version": "3.0.7"
     },
     "babel": {
       "version": "5.8.12",
-      "from": "babel@5.8.12",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.12.tgz",
       "dependencies": {
         "chokidar": {
-          "version": "1.4.2",
-          "from": "chokidar@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
+          "version": "1.4.3",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "arrify": {
-                  "version": "1.0.1",
-                  "from": "arrify@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "micromatch": {
                   "version": "2.3.7",
-                  "from": "micromatch@>=2.1.5 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "2.0.0",
-                      "from": "arr-diff@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "dependencies": {
                         "arr-flatten": {
-                          "version": "1.0.1",
-                          "from": "arr-flatten@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "array-unique": {
-                      "version": "0.2.1",
-                      "from": "array-unique@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                      "version": "0.2.1"
                     },
                     "braces": {
                       "version": "1.8.3",
-                      "from": "braces@>=1.8.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.3",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "dependencies": {
                                 "is-number": {
-                                  "version": "2.1.0",
-                                  "from": "is-number@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                  "version": "2.1.0"
                                 },
                                 "isobject": {
                                   "version": "2.0.0",
-                                  "from": "isobject@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                                   "dependencies": {
                                     "isarray": {
-                                      "version": "0.0.1",
-                                      "from": "isarray@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                      "version": "0.0.1"
                                     }
                                   }
                                 },
                                 "randomatic": {
-                                  "version": "1.1.5",
-                                  "from": "randomatic@>=1.1.3 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                  "version": "1.1.5"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "version": "1.5.4"
                                 }
                               }
                             }
                           }
                         },
                         "preserve": {
-                          "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                          "version": "0.2.0"
                         },
                         "repeat-element": {
-                          "version": "1.1.2",
-                          "from": "repeat-element@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                          "version": "1.1.2"
                         }
                       }
                     },
                     "expand-brackets": {
-                      "version": "0.1.4",
-                      "from": "expand-brackets@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                      "version": "0.1.4"
                     },
                     "extglob": {
-                      "version": "0.3.2",
-                      "from": "extglob@>=0.3.1 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                      "version": "0.3.2"
                     },
                     "filename-regex": {
-                      "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "kind-of": {
                       "version": "3.0.2",
-                      "from": "kind-of@>=3.0.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "dependencies": {
                         "is-buffer": {
-                          "version": "1.1.2",
-                          "from": "is-buffer@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                          "version": "1.1.3"
                         }
                       }
                     },
                     "normalize-path": {
-                      "version": "2.0.1",
-                      "from": "normalize-path@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                      "version": "2.0.1"
                     },
                     "object.omit": {
                       "version": "2.0.0",
-                      "from": "object.omit@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.3",
-                          "from": "for-own@>=0.1.3 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                           "dependencies": {
                             "for-in": {
-                              "version": "0.1.4",
-                              "from": "for-in@>=0.1.4 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                              "version": "0.1.4"
                             }
                           }
                         },
                         "is-extendable": {
-                          "version": "0.1.1",
-                          "from": "is-extendable@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                          "version": "0.1.1"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.4",
-                      "from": "parse-glob@>=3.0.4 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "dependencies": {
                         "glob-base": {
-                          "version": "0.3.0",
-                          "from": "glob-base@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                          "version": "0.3.0"
                         },
                         "is-dotfile": {
-                          "version": "1.0.2",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                          "version": "1.0.2"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.2",
-                      "from": "regex-cache@>=0.4.2 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
-                          "version": "0.1.3",
-                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                          "version": "0.1.3"
                         },
                         "is-primitive": {
-                          "version": "2.0.0",
-                          "from": "is-primitive@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                          "version": "2.0.0"
                         }
                       }
                     }
@@ -356,68 +192,44 @@
               }
             },
             "async-each": {
-              "version": "0.1.6",
-              "from": "async-each@>=0.1.6 <0.2.0",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+              "version": "1.0.0"
             },
             "glob-parent": {
-              "version": "2.0.0",
-              "from": "glob-parent@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+              "version": "2.0.0"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
-                  "version": "1.4.0",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                  "version": "1.4.0"
                 }
               }
             },
             "is-glob": {
               "version": "2.0.1",
-              "from": "is-glob@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "dependencies": {
                 "is-extglob": {
-                  "version": "1.0.0",
-                  "from": "is-extglob@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "readdirp": {
               "version": "2.0.0",
-              "from": "readdirp@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "4.1.3",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                  "version": "4.1.3"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.10 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "version": "0.3.0"
                         },
                         "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "version": "0.0.1"
                         }
                       }
                     }
@@ -425,555 +237,354 @@
                 },
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "version": "1.0.6"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "version": "0.10.31"
                     },
                     "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "version": "1.0.2"
                     }
                   }
                 }
               }
             },
             "fsevents": {
-              "version": "1.0.7",
-              "from": "fsevents@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.7.tgz",
+              "version": "1.0.8",
               "dependencies": {
                 "nan": {
-                  "version": "2.2.0",
-                  "from": "nan@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+                  "version": "2.2.0"
                 },
                 "node-pre-gyp": {
-                  "version": "0.6.19",
-                  "from": "node-pre-gyp@>=0.6.17 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.19.tgz",
+                  "version": "0.6.21",
                   "dependencies": {
                     "nopt": {
                       "version": "3.0.6",
-                      "from": "nopt@~3.0.1",
-                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                       "dependencies": {
                         "abbrev": {
-                          "version": "1.0.7",
-                          "from": "abbrev@1",
-                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                          "version": "1.0.7"
                         }
                       }
                     }
                   }
                 },
                 "ansi": {
-                  "version": "0.3.0",
-                  "from": "ansi@~0.3.0",
-                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                  "version": "0.3.1"
                 },
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "2.0.0"
                 },
                 "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                  "version": "2.1.0"
                 },
                 "are-we-there-yet": {
-                  "version": "1.0.5",
-                  "from": "are-we-there-yet@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz"
+                  "version": "1.0.6"
                 },
                 "asn1": {
-                  "version": "0.2.3",
-                  "from": "asn1@>=0.2.3 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                },
-                "assert-plus": {
-                  "version": "0.1.5",
-                  "from": "assert-plus@^0.1.5",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                  "version": "0.2.3"
                 },
                 "async": {
-                  "version": "1.5.1",
-                  "from": "async@^1.4.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
+                  "version": "1.5.2"
+                },
+                "assert-plus": {
+                  "version": "0.2.0"
                 },
                 "aws-sign2": {
-                  "version": "0.6.0",
-                  "from": "aws-sign2@~0.6.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                  "version": "0.6.0"
                 },
                 "bl": {
-                  "version": "1.0.0",
-                  "from": "bl@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                  "version": "1.0.2"
                 },
                 "block-stream": {
-                  "version": "0.0.8",
-                  "from": "block-stream@*",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                  "version": "0.0.8"
                 },
                 "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@2.x.x",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                  "version": "2.10.1"
                 },
                 "caseless": {
-                  "version": "0.11.0",
-                  "from": "caseless@~0.11.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                  "version": "0.11.0"
                 },
                 "chalk": {
-                  "version": "1.1.1",
-                  "from": "chalk@^1.1.1",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-                },
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "version": "1.1.1"
                 },
                 "combined-stream": {
-                  "version": "1.0.5",
-                  "from": "combined-stream@~1.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                  "version": "1.0.5"
                 },
                 "commander": {
-                  "version": "2.9.0",
-                  "from": "commander@^2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                  "version": "2.9.0"
+                },
+                "core-util-is": {
+                  "version": "1.0.2"
                 },
                 "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@2.x.x",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                  "version": "2.0.5"
                 },
                 "dashdash": {
-                  "version": "1.11.0",
-                  "from": "dashdash@>=1.10.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.11.0.tgz"
+                  "version": "1.12.2"
                 },
                 "debug": {
-                  "version": "0.7.4",
-                  "from": "debug@~0.7.2",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                  "version": "2.2.0"
                 },
                 "deep-extend": {
-                  "version": "0.4.0",
-                  "from": "deep-extend@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                  "version": "0.4.1"
                 },
                 "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "delayed-stream@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "delegates": {
-                  "version": "0.1.0",
-                  "from": "delegates@^0.1.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                  "version": "1.0.0"
                 },
                 "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                  "version": "0.1.1"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.4",
-                  "from": "escape-string-regexp@^1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                },
-                "extend": {
-                  "version": "3.0.0",
-                  "from": "extend@~3.0.0",
-                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                },
-                "forever-agent": {
-                  "version": "0.6.1",
-                  "from": "forever-agent@~0.6.1",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                  "version": "1.0.4"
                 },
                 "extsprintf": {
-                  "version": "1.0.2",
-                  "from": "extsprintf@1.0.2",
-                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                  "version": "1.0.2"
                 },
-                "form-data": {
-                  "version": "1.0.0-rc3",
-                  "from": "form-data@~1.0.0-rc3",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                "extend": {
+                  "version": "3.0.0"
+                },
+                "forever-agent": {
+                  "version": "0.6.1"
                 },
                 "fstream": {
-                  "version": "1.0.8",
-                  "from": "fstream@^1.0.2",
-                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                  "version": "1.0.8"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3"
                 },
                 "gauge": {
-                  "version": "1.2.2",
-                  "from": "gauge@~1.2.0",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "from": "generate-object-property@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                  "version": "1.2.5"
                 },
                 "generate-function": {
-                  "version": "2.0.0",
-                  "from": "generate-function@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                  "version": "2.0.0"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0"
                 },
                 "graceful-fs": {
-                  "version": "4.1.2",
-                  "from": "graceful-fs@^4.1.2",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                  "version": "4.1.3"
                 },
                 "graceful-readlink": {
-                  "version": "1.0.1",
-                  "from": "graceful-readlink@>= 1.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "har-validator": {
-                  "version": "2.0.3",
-                  "from": "har-validator@~2.0.2",
-                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                  "version": "2.0.6"
                 },
                 "has-unicode": {
-                  "version": "1.0.1",
-                  "from": "has-unicode@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                  "version": "2.0.0"
+                },
+                "has-ansi": {
+                  "version": "2.0.0"
                 },
                 "hawk": {
-                  "version": "3.1.2",
-                  "from": "hawk@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+                  "version": "3.1.3"
                 },
                 "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@2.x.x",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                  "version": "2.16.3"
                 },
                 "http-signature": {
-                  "version": "1.1.0",
-                  "from": "http-signature@~1.1.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@*",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "1.1.1"
                 },
                 "ini": {
-                  "version": "1.3.4",
-                  "from": "ini@~1.3.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                  "version": "1.3.4"
+                },
+                "inherits": {
+                  "version": "2.0.1"
                 },
                 "is-my-json-valid": {
-                  "version": "2.12.3",
-                  "from": "is-my-json-valid@^2.12.3",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+                  "version": "2.12.4"
                 },
                 "is-property": {
-                  "version": "1.0.2",
-                  "from": "is-property@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                  "version": "1.0.2"
                 },
                 "is-typedarray": {
-                  "version": "1.0.0",
-                  "from": "is-typedarray@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "0.0.1"
                 },
                 "isstream": {
-                  "version": "0.1.2",
-                  "from": "isstream@~0.1.2",
-                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                },
-                "jodid25519": {
-                  "version": "1.0.2",
-                  "from": "jodid25519@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                  "version": "0.1.2"
                 },
                 "jsbn": {
-                  "version": "0.1.0",
-                  "from": "jsbn@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                  "version": "0.1.0"
+                },
+                "jodid25519": {
+                  "version": "1.0.2"
                 },
                 "json-schema": {
-                  "version": "0.2.2",
-                  "from": "json-schema@0.2.2",
-                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                  "version": "0.2.2"
                 },
                 "json-stringify-safe": {
-                  "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.1",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                  "version": "5.0.1"
                 },
                 "jsonpointer": {
-                  "version": "2.0.0",
-                  "from": "jsonpointer@2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "from": "jsprim@^1.2.2",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                  "version": "2.0.0"
                 },
                 "lodash._basetostring": {
-                  "version": "3.0.1",
-                  "from": "lodash._basetostring@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                  "version": "3.0.1"
+                },
+                "jsprim": {
+                  "version": "1.2.2"
                 },
                 "lodash._createpadding": {
-                  "version": "3.6.1",
-                  "from": "lodash._createpadding@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+                  "version": "3.6.1"
+                },
+                "lodash._root": {
+                  "version": "3.0.0"
                 },
                 "lodash.pad": {
-                  "version": "3.1.1",
-                  "from": "lodash.pad@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+                  "version": "3.3.0"
                 },
                 "lodash.padleft": {
-                  "version": "3.1.1",
-                  "from": "lodash.padleft@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                  "version": "3.1.1"
                 },
                 "lodash.padright": {
-                  "version": "3.1.1",
-                  "from": "lodash.padright@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                  "version": "3.1.1"
                 },
                 "lodash.repeat": {
-                  "version": "3.0.1",
-                  "from": "lodash.repeat@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                  "version": "3.2.0"
                 },
                 "mime-db": {
-                  "version": "1.21.0",
-                  "from": "mime-db@~1.21.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                  "version": "1.21.0"
                 },
                 "mime-types": {
-                  "version": "2.1.9",
-                  "from": "mime-types@~2.1.7",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
-                },
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "version": "2.1.9"
                 },
                 "mkdirp": {
-                  "version": "0.5.1",
-                  "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                  "version": "0.5.1"
+                },
+                "minimist": {
+                  "version": "0.0.8"
+                },
+                "ms": {
+                  "version": "0.7.1"
                 },
                 "node-uuid": {
-                  "version": "1.4.7",
-                  "from": "node-uuid@~1.4.7",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                  "version": "1.4.7"
                 },
                 "npmlog": {
-                  "version": "2.0.0",
-                  "from": "npmlog@~2.0.0",
-                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
+                  "version": "2.0.2"
                 },
                 "oauth-sign": {
-                  "version": "0.8.0",
-                  "from": "oauth-sign@~0.8.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                  "version": "0.8.1"
                 },
                 "once": {
-                  "version": "1.1.1",
-                  "from": "once@~1.1.1",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                  "version": "1.3.3"
                 },
                 "pinkie": {
-                  "version": "2.0.1",
-                  "from": "pinkie@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                },
-                "pinkie-promise": {
-                  "version": "2.0.0",
-                  "from": "pinkie-promise@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                  "version": "2.0.4"
                 },
                 "process-nextick-args": {
-                  "version": "1.0.6",
-                  "from": "process-nextick-args@~1.0.6",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                  "version": "1.0.6"
+                },
+                "pinkie-promise": {
+                  "version": "2.0.0"
                 },
                 "qs": {
-                  "version": "5.2.0",
-                  "from": "qs@~5.2.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-                },
-                "request": {
-                  "version": "2.67.0",
-                  "from": "request@2.x",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+                  "version": "6.0.2"
                 },
                 "readable-stream": {
-                  "version": "2.0.5",
-                  "from": "readable-stream@^2.0.0 || ^1.1.13",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                  "version": "2.0.5"
                 },
-                "semver": {
-                  "version": "5.1.0",
-                  "from": "semver@~5.1.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                "request": {
+                  "version": "2.69.0"
                 },
                 "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@1.x.x",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                  "version": "1.0.9"
+                },
+                "sshpk": {
+                  "version": "1.7.3"
+                },
+                "semver": {
+                  "version": "5.1.0"
                 },
                 "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "version": "0.10.31"
                 },
                 "stringstream": {
-                  "version": "0.0.5",
-                  "from": "stringstream@~0.0.4",
-                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                  "version": "0.0.5"
                 },
                 "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                  "version": "3.0.0"
                 },
                 "strip-json-comments": {
-                  "version": "1.0.4",
-                  "from": "strip-json-comments@~1.0.4",
-                  "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                  "version": "1.0.4"
                 },
                 "tar": {
-                  "version": "2.2.1",
-                  "from": "tar@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                  "version": "2.2.1"
                 },
-                "tough-cookie": {
-                  "version": "2.2.1",
-                  "from": "tough-cookie@~2.2.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                "supports-color": {
+                  "version": "2.0.0"
+                },
+                "tar-pack": {
+                  "version": "3.1.3"
                 },
                 "tunnel-agent": {
-                  "version": "0.4.2",
-                  "from": "tunnel-agent@~0.4.1",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                  "version": "0.4.2"
+                },
+                "tough-cookie": {
+                  "version": "2.2.1"
                 },
                 "tweetnacl": {
-                  "version": "0.13.2",
-                  "from": "tweetnacl@>=0.13.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
-                },
-                "uid-number": {
-                  "version": "0.0.3",
-                  "from": "uid-number@0.0.3",
-                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                  "version": "0.13.3"
                 },
                 "verror": {
-                  "version": "1.3.6",
-                  "from": "verror@1.3.6",
-                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                  "version": "1.3.6"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2"
+                },
+                "uid-number": {
+                  "version": "0.0.6"
                 },
                 "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@^4.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                  "version": "4.0.1"
                 },
-                "rc": {
-                  "version": "1.1.6",
-                  "from": "rc@~1.1.0",
-                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+                "wrappy": {
+                  "version": "1.0.1"
+                },
+                "aws4": {
+                  "version": "1.2.1",
                   "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0",
-                      "from": "minimist@^1.2.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    "lru-cache": {
+                      "version": "2.7.3"
                     }
                   }
                 },
-                "sshpk": {
-                  "version": "1.7.2",
-                  "from": "sshpk@^1.7.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.2.tgz",
+                "rc": {
+                  "version": "1.1.6",
                   "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "from": "assert-plus@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                    "minimist": {
+                      "version": "1.2.0"
                     }
                   }
                 },
                 "fstream-ignore": {
                   "version": "1.0.3",
-                  "from": "fstream-ignore@~1.0.3",
-                  "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.2",
-                          "from": "brace-expansion@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "balanced-match@^0.3.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "version": "0.3.0"
                             },
                             "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "version": "0.0.1"
                             }
                           }
                         }
@@ -982,51 +593,33 @@
                   }
                 },
                 "rimraf": {
-                  "version": "2.5.0",
-                  "from": "rimraf@~2.5.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
+                  "version": "2.5.1",
                   "dependencies": {
                     "glob": {
-                      "version": "6.0.3",
-                      "from": "glob@^6.0.1",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+                      "version": "6.0.4",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "inflight@^1.0.4",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@1",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.1"
                             }
                           }
                         },
                         "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                          "version": "2.0.1"
                         },
                         "minimatch": {
                           "version": "3.0.0",
-                          "from": "minimatch@2 || 3",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.2",
-                              "from": "brace-expansion@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                               "dependencies": {
                                 "balanced-match": {
-                                  "version": "0.3.0",
-                                  "from": "balanced-match@^0.3.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                  "version": "0.3.0"
                                 },
                                 "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                  "version": "0.0.1"
                                 }
                               }
                             }
@@ -1034,99 +627,14 @@
                         },
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@^1.3.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@1",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.1"
                             }
                           }
                         },
                         "path-is-absolute": {
-                          "version": "1.0.0",
-                          "from": "path-is-absolute@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "tar-pack": {
-                  "version": "3.1.2",
-                  "from": "tar-pack@~3.1.0",
-                  "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.2.tgz",
-                  "dependencies": {
-                    "rimraf": {
-                      "version": "2.4.5",
-                      "from": "rimraf@~2.4.4",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-                      "dependencies": {
-                        "glob": {
-                          "version": "6.0.3",
-                          "from": "glob@^6.0.1",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "from": "inflight@^1.0.4",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@1",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@2",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "from": "minimatch@2 || 3",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.2",
-                                  "from": "brace-expansion@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.3.0",
-                                      "from": "balanced-match@^0.3.0",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1",
-                                      "from": "concat-map@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "from": "once@^1.3.0",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@1",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.0",
-                              "from": "path-is-absolute@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                            }
-                          }
+                          "version": "1.0.0"
                         }
                       }
                     }
@@ -1138,62 +646,40 @@
         },
         "commander": {
           "version": "2.9.0",
-          "from": "commander@>=2.6.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dependencies": {
             "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         },
         "convert-source-map": {
-          "version": "1.1.3",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+          "version": "1.2.0"
         },
         "fs-readdir-recursive": {
-          "version": "0.1.2",
-          "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+          "version": "0.1.2"
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.5 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                      "version": "0.3.0"
                     },
                     "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      "version": "0.0.1"
                     }
                   }
                 }
@@ -1201,292 +687,186 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             }
           }
         },
         "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.2.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+          "version": "3.10.1"
         },
         "output-file-sync": {
           "version": "1.1.1",
-          "from": "output-file-sync@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "version": "0.0.8"
                 }
               }
             },
             "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "version": "4.0.1"
             }
           }
         },
         "path-exists": {
-          "version": "1.0.0",
-          "from": "path-exists@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "slash": {
-          "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+          "version": "1.0.0"
         }
       }
     },
     "babel-core": {
       "version": "5.8.12",
-      "from": "babel-core@5.8.12",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.12.tgz",
       "dependencies": {
         "babel-plugin-constant-folding": {
-          "version": "1.0.1",
-          "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "babel-plugin-dead-code-elimination": {
-          "version": "1.0.2",
-          "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+          "version": "1.0.2"
         },
         "babel-plugin-eval": {
-          "version": "1.0.1",
-          "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "babel-plugin-inline-environment-variables": {
-          "version": "1.0.1",
-          "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "babel-plugin-jscript": {
-          "version": "1.0.4",
-          "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+          "version": "1.0.4"
         },
         "babel-plugin-member-expression-literals": {
-          "version": "1.0.1",
-          "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "babel-plugin-property-literals": {
-          "version": "1.0.1",
-          "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "babel-plugin-proto-to-assign": {
-          "version": "1.0.4",
-          "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+          "version": "1.0.4"
         },
         "babel-plugin-react-constant-elements": {
-          "version": "1.0.3",
-          "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+          "version": "1.0.3"
         },
         "babel-plugin-react-display-name": {
-          "version": "1.0.3",
-          "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+          "version": "1.0.3"
         },
         "babel-plugin-remove-console": {
-          "version": "1.0.1",
-          "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "babel-plugin-remove-debugger": {
-          "version": "1.0.1",
-          "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "babel-plugin-runtime": {
-          "version": "1.0.7",
-          "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+          "version": "1.0.7"
         },
         "babel-plugin-undeclared-variables-check": {
           "version": "1.0.2",
-          "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
           "dependencies": {
             "leven": {
-              "version": "1.0.2",
-              "from": "leven@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+              "version": "1.0.2"
             }
           }
         },
         "babel-plugin-undefined-to-void": {
-          "version": "1.1.6",
-          "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+          "version": "1.1.6"
         },
         "babylon": {
-          "version": "5.8.35",
-          "from": "babylon@>=5.8.12 <6.0.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.35.tgz"
+          "version": "5.8.35"
         },
         "bluebird": {
-          "version": "2.10.2",
-          "from": "bluebird@>=2.9.33 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+          "version": "2.10.2"
         },
         "convert-source-map": {
-          "version": "1.1.3",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+          "version": "1.2.0"
         },
         "core-js": {
-          "version": "0.9.18",
-          "from": "core-js@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.9.18.tgz"
+          "version": "0.9.18"
         },
         "detect-indent": {
           "version": "3.0.1",
-          "from": "detect-indent@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "dependencies": {
             "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "version": "4.0.1"
             },
             "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+              "version": "1.2.0"
             }
           }
         },
         "esutils": {
-          "version": "2.0.2",
-          "from": "esutils@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+          "version": "2.0.2"
         },
         "fs-readdir-recursive": {
-          "version": "0.1.2",
-          "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+          "version": "0.1.2"
         },
         "globals": {
-          "version": "6.4.1",
-          "from": "globals@>=6.4.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+          "version": "6.4.1"
         },
         "home-or-tmp": {
           "version": "1.0.0",
-          "from": "home-or-tmp@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "dependencies": {
             "os-tmpdir": {
-              "version": "1.0.1",
-              "from": "os-tmpdir@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "user-home": {
-              "version": "1.1.1",
-              "from": "user-home@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+              "version": "1.1.1"
             }
           }
         },
         "is-integer": {
           "version": "1.0.6",
-          "from": "is-integer@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
           "dependencies": {
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "dependencies": {
                 "number-is-nan": {
-                  "version": "1.0.0",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             }
           }
         },
         "js-tokens": {
-          "version": "1.0.1",
-          "from": "js-tokens@1.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "line-numbers": {
           "version": "0.2.0",
-          "from": "line-numbers@0.2.0",
-          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
           "dependencies": {
             "left-pad": {
-              "version": "0.0.3",
-              "from": "left-pad@0.0.3",
-              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+              "version": "0.0.3"
             }
           }
         },
         "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@>=3.10.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+          "version": "3.10.1"
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.3",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
               "dependencies": {
                 "balanced-match": {
-                  "version": "0.3.0",
-                  "from": "balanced-match@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                  "version": "0.3.0"
                 },
                 "concat-map": {
-                  "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                  "version": "0.0.1"
                 }
               }
             }
@@ -1494,423 +874,270 @@
         },
         "output-file-sync": {
           "version": "1.1.1",
-          "from": "output-file-sync@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "version": "0.0.8"
                 }
               }
             },
             "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+              "version": "4.0.1"
             }
           }
         },
         "path-exists": {
-          "version": "1.0.0",
-          "from": "path-exists@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "private": {
-          "version": "0.1.6",
-          "from": "private@>=0.1.6 <0.2.0",
-          "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+          "version": "0.1.6"
         },
         "regenerator": {
           "version": "0.8.34",
-          "from": "regenerator@0.8.34",
-          "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.34.tgz",
           "dependencies": {
             "commoner": {
               "version": "0.10.4",
-              "from": "commoner@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.5.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "detective": {
                   "version": "4.3.1",
-                  "from": "detective@>=4.3.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                   "dependencies": {
                     "acorn": {
-                      "version": "1.2.2",
-                      "from": "acorn@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                      "version": "1.2.2"
                     },
                     "defined": {
-                      "version": "1.0.0",
-                      "from": "defined@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.15 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     }
                   }
                 },
                 "graceful-fs": {
-                  "version": "4.1.3",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                  "version": "4.1.3"
                 },
                 "iconv-lite": {
-                  "version": "0.4.13",
-                  "from": "iconv-lite@>=0.4.5 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                  "version": "0.4.13"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                      "version": "0.0.8"
                     }
                   }
                 },
                 "q": {
-                  "version": "1.4.1",
-                  "from": "q@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                  "version": "1.4.1"
                 }
               }
             },
             "defs": {
               "version": "1.1.1",
-              "from": "defs@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
               "dependencies": {
                 "alter": {
                   "version": "0.2.0",
-                  "from": "alter@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                   "dependencies": {
                     "stable": {
-                      "version": "0.1.5",
-                      "from": "stable@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                      "version": "0.1.5"
                     }
                   }
                 },
                 "ast-traverse": {
-                  "version": "0.1.1",
-                  "from": "ast-traverse@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                  "version": "0.1.1"
                 },
                 "breakable": {
-                  "version": "1.0.0",
-                  "from": "breakable@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                  "version": "15001.1001.0-dev-harmony-fb"
                 },
                 "simple-fmt": {
-                  "version": "0.1.0",
-                  "from": "simple-fmt@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                  "version": "0.1.0"
                 },
                 "simple-is": {
-                  "version": "0.2.0",
-                  "from": "simple-is@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                  "version": "0.2.0"
                 },
                 "stringmap": {
-                  "version": "0.2.2",
-                  "from": "stringmap@>=0.2.2 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                  "version": "0.2.2"
                 },
                 "stringset": {
-                  "version": "0.2.1",
-                  "from": "stringset@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                  "version": "0.2.1"
                 },
                 "tryor": {
-                  "version": "0.1.2",
-                  "from": "tryor@>=0.1.2 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                  "version": "0.1.2"
                 },
                 "yargs": {
                   "version": "3.27.0",
-                  "from": "yargs@>=3.27.0 <3.28.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
                   "dependencies": {
                     "camelcase": {
-                      "version": "1.2.1",
-                      "from": "camelcase@>=1.2.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                      "version": "1.2.1"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.3",
-                          "from": "center-align@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "align-text@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.0.2",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "dependencies": {
                                     "is-buffer": {
-                                      "version": "1.1.2",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                      "version": "1.1.3"
                                     }
                                   }
                                 },
                                 "longest": {
-                                  "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                  "version": "1.0.1"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "version": "1.5.4"
                                 }
                               }
                             },
                             "lazy-cache": {
-                              "version": "1.0.3",
-                              "from": "lazy-cache@>=1.0.3 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                              "version": "1.0.3"
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "align-text@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.0.2",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "dependencies": {
                                     "is-buffer": {
-                                      "version": "1.1.2",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                      "version": "1.1.3"
                                     }
                                   }
                                 },
                                 "longest": {
-                                  "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                  "version": "1.0.1"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                  "version": "1.5.4"
                                 }
                               }
                             }
                           }
                         },
                         "wordwrap": {
-                          "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                          "version": "0.0.2"
                         }
                       }
                     },
                     "decamelize": {
-                      "version": "1.1.2",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                      "dependencies": {
-                        "escape-string-regexp": {
-                          "version": "1.0.4",
-                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                        }
-                      }
+                      "version": "1.2.0"
                     },
                     "os-locale": {
                       "version": "1.4.0",
-                      "from": "os-locale@>=1.4.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                       "dependencies": {
                         "lcid": {
                           "version": "1.0.0",
-                          "from": "lcid@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                           "dependencies": {
                             "invert-kv": {
-                              "version": "1.0.0",
-                              "from": "invert-kv@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                              "version": "1.0.0"
                             }
                           }
                         }
                       }
                     },
                     "window-size": {
-                      "version": "0.1.4",
-                      "from": "window-size@>=0.1.2 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                      "version": "0.1.4"
                     },
                     "y18n": {
-                      "version": "3.2.0",
-                      "from": "y18n@>=3.2.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                      "version": "3.2.0"
                     }
                   }
                 }
               }
             },
             "esprima-fb": {
-              "version": "13001.1.0-dev-harmony-fb",
-              "from": "esprima-fb@>=13001.1.0-dev-harmony-fb <13001.2.0",
-              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1.0-dev-harmony-fb.tgz"
+              "version": "13001.1.0-dev-harmony-fb"
             },
             "recast": {
               "version": "0.10.18",
-              "from": "recast@0.10.18",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.18.tgz",
               "dependencies": {
                 "esprima-fb": {
-                  "version": "14001.1.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=14001.1.0-dev-harmony-fb <14001.2.0",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-14001.1.0-dev-harmony-fb.tgz"
+                  "version": "14001.1.0-dev-harmony-fb"
                 },
                 "ast-types": {
-                  "version": "0.8.2",
-                  "from": "ast-types@0.8.2",
-                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.2.tgz"
+                  "version": "0.8.2"
                 }
               }
             },
             "through": {
-              "version": "2.3.8",
-              "from": "through@>=2.3.6 <2.4.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+              "version": "2.3.8"
             }
           }
         },
         "regexpu": {
           "version": "1.3.0",
-          "from": "regexpu@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
           "dependencies": {
             "esprima": {
-              "version": "2.7.2",
-              "from": "esprima@>=2.6.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+              "version": "2.7.2"
             },
             "recast": {
               "version": "0.10.43",
-              "from": "recast@>=0.10.10 <0.11.0",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
               "dependencies": {
                 "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                  "version": "15001.1001.0-dev-harmony-fb"
                 },
                 "source-map": {
-                  "version": "0.5.3",
-                  "from": "source-map@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                  "version": "0.5.3"
                 },
                 "ast-types": {
-                  "version": "0.8.15",
-                  "from": "ast-types@0.8.15",
-                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
+                  "version": "0.8.15"
                 }
               }
             },
             "regenerate": {
-              "version": "1.2.1",
-              "from": "regenerate@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+              "version": "1.2.1"
             },
             "regjsgen": {
-              "version": "0.2.0",
-              "from": "regjsgen@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+              "version": "0.2.0"
             },
             "regjsparser": {
               "version": "0.1.5",
-              "from": "regjsparser@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
               "dependencies": {
                 "jsesc": {
-                  "version": "0.5.0",
-                  "from": "jsesc@>=0.5.0 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                  "version": "0.5.0"
                 }
               }
             }
@@ -1918,317 +1145,201 @@
         },
         "repeating": {
           "version": "1.1.3",
-          "from": "repeating@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "dependencies": {
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "dependencies": {
                 "number-is-nan": {
-                  "version": "1.0.0",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             }
           }
         },
         "resolve": {
-          "version": "1.1.7",
-          "from": "resolve@>=1.1.6 <2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+          "version": "1.1.7"
         },
         "shebang-regex": {
-          "version": "1.0.0",
-          "from": "shebang-regex@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "slash": {
-          "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "source-map-support": {
           "version": "0.2.10",
-          "from": "source-map-support@>=0.2.10 <0.3.0",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             }
           }
         },
         "strip-json-comments": {
-          "version": "1.0.4",
-          "from": "strip-json-comments@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+          "version": "1.0.4"
         },
         "to-fast-properties": {
-          "version": "1.0.1",
-          "from": "to-fast-properties@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "trim-right": {
-          "version": "1.0.1",
-          "from": "trim-right@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "try-resolve": {
-          "version": "1.0.1",
-          "from": "try-resolve@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+          "version": "1.0.1"
         }
       }
     },
     "babel-eslint": {
       "version": "4.1.8",
-      "from": "babel-eslint@4.1.8",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-4.1.8.tgz",
       "dependencies": {
         "babel-core": {
           "version": "5.8.35",
-          "from": "babel-core@>=5.8.33 <6.0.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.35.tgz",
           "dependencies": {
             "babel-plugin-constant-folding": {
-              "version": "1.0.1",
-              "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-dead-code-elimination": {
-              "version": "1.0.2",
-              "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+              "version": "1.0.2"
             },
             "babel-plugin-eval": {
-              "version": "1.0.1",
-              "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-inline-environment-variables": {
-              "version": "1.0.1",
-              "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-jscript": {
-              "version": "1.0.4",
-              "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+              "version": "1.0.4"
             },
             "babel-plugin-member-expression-literals": {
-              "version": "1.0.1",
-              "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-property-literals": {
-              "version": "1.0.1",
-              "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-proto-to-assign": {
-              "version": "1.0.4",
-              "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+              "version": "1.0.4"
             },
             "babel-plugin-react-constant-elements": {
-              "version": "1.0.3",
-              "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "babel-plugin-react-display-name": {
-              "version": "1.0.3",
-              "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "babel-plugin-remove-console": {
-              "version": "1.0.1",
-              "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-remove-debugger": {
-              "version": "1.0.1",
-              "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "babel-plugin-runtime": {
-              "version": "1.0.7",
-              "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+              "version": "1.0.7"
             },
             "babel-plugin-undeclared-variables-check": {
               "version": "1.0.2",
-              "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
               "dependencies": {
                 "leven": {
-                  "version": "1.0.2",
-                  "from": "leven@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                  "version": "1.0.2"
                 }
               }
             },
             "babel-plugin-undefined-to-void": {
-              "version": "1.1.6",
-              "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+              "version": "1.1.6"
             },
             "babylon": {
-              "version": "5.8.35",
-              "from": "babylon@>=5.8.35 <6.0.0",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.35.tgz"
+              "version": "5.8.35"
             },
             "bluebird": {
-              "version": "2.10.2",
-              "from": "bluebird@>=2.9.33 <3.0.0",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+              "version": "2.10.2"
             },
             "convert-source-map": {
-              "version": "1.1.3",
-              "from": "convert-source-map@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+              "version": "1.2.0"
             },
             "core-js": {
-              "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+              "version": "1.2.6"
             },
             "detect-indent": {
               "version": "3.0.1",
-              "from": "detect-indent@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
               "dependencies": {
                 "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                  "version": "4.0.1"
                 },
                 "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                  "version": "1.2.0"
                 }
               }
             },
             "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+              "version": "2.0.2"
             },
             "fs-readdir-recursive": {
-              "version": "0.1.2",
-              "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+              "version": "0.1.2"
             },
             "globals": {
-              "version": "6.4.1",
-              "from": "globals@>=6.4.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+              "version": "6.4.1"
             },
             "home-or-tmp": {
               "version": "1.0.0",
-              "from": "home-or-tmp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
               "dependencies": {
                 "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "user-home": {
-                  "version": "1.1.1",
-                  "from": "user-home@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                  "version": "1.1.1"
                 }
               }
             },
             "is-integer": {
               "version": "1.0.6",
-              "from": "is-integer@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
               }
             },
             "js-tokens": {
-              "version": "1.0.1",
-              "from": "js-tokens@1.0.1",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "json5": {
-              "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "version": "0.4.0"
             },
             "line-numbers": {
               "version": "0.2.0",
-              "from": "line-numbers@0.2.0",
-              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
               "dependencies": {
                 "left-pad": {
-                  "version": "0.0.3",
-                  "from": "left-pad@0.0.3",
-                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                  "version": "0.0.3"
                 }
               }
             },
             "lodash": {
-              "version": "3.10.1",
-              "from": "lodash@>=3.10.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+              "version": "3.10.1"
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.3 <3.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                      "version": "0.3.0"
                     },
                     "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      "version": "0.0.1"
                     }
                   }
                 }
@@ -2236,408 +1347,261 @@
             },
             "output-file-sync": {
               "version": "1.1.1",
-              "from": "output-file-sync@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                      "version": "0.0.8"
                     }
                   }
                 },
                 "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                  "version": "4.0.1"
                 }
               }
             },
             "path-exists": {
-              "version": "1.0.0",
-              "from": "path-exists@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "private": {
-              "version": "0.1.6",
-              "from": "private@>=0.1.6 <0.2.0",
-              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+              "version": "0.1.6"
             },
             "regenerator": {
               "version": "0.8.40",
-              "from": "regenerator@0.8.40",
-              "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
               "dependencies": {
                 "commoner": {
                   "version": "0.10.4",
-                  "from": "commoner@>=0.10.3 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
                   "dependencies": {
                     "commander": {
                       "version": "2.9.0",
-                      "from": "commander@>=2.5.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                       "dependencies": {
                         "graceful-readlink": {
-                          "version": "1.0.1",
-                          "from": "graceful-readlink@>=1.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "detective": {
                       "version": "4.3.1",
-                      "from": "detective@>=4.3.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                       "dependencies": {
                         "acorn": {
-                          "version": "1.2.2",
-                          "from": "acorn@>=1.0.3 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                          "version": "1.2.2"
                         },
                         "defined": {
-                          "version": "1.0.0",
-                          "from": "defined@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     },
                     "glob": {
                       "version": "5.0.15",
-                      "from": "glob@>=5.0.15 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
-                          "from": "inflight@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.1"
                             }
                           }
                         },
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                              "version": "1.0.1"
                             }
                           }
                         }
                       }
                     },
                     "graceful-fs": {
-                      "version": "4.1.3",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                      "version": "4.1.3"
                     },
                     "iconv-lite": {
-                      "version": "0.4.13",
-                      "from": "iconv-lite@>=0.4.5 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                      "version": "0.4.13"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                          "version": "0.0.8"
                         }
                       }
                     },
                     "q": {
-                      "version": "1.4.1",
-                      "from": "q@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                      "version": "1.4.1"
                     }
                   }
                 },
                 "defs": {
                   "version": "1.1.1",
-                  "from": "defs@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
                   "dependencies": {
                     "alter": {
                       "version": "0.2.0",
-                      "from": "alter@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                       "dependencies": {
                         "stable": {
-                          "version": "0.1.5",
-                          "from": "stable@>=0.1.3 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                          "version": "0.1.5"
                         }
                       }
                     },
                     "ast-traverse": {
-                      "version": "0.1.1",
-                      "from": "ast-traverse@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
+                      "version": "0.1.1"
                     },
                     "breakable": {
-                      "version": "1.0.0",
-                      "from": "breakable@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "simple-fmt": {
-                      "version": "0.1.0",
-                      "from": "simple-fmt@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+                      "version": "0.1.0"
                     },
                     "simple-is": {
-                      "version": "0.2.0",
-                      "from": "simple-is@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+                      "version": "0.2.0"
                     },
                     "stringmap": {
-                      "version": "0.2.2",
-                      "from": "stringmap@>=0.2.2 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+                      "version": "0.2.2"
                     },
                     "stringset": {
-                      "version": "0.2.1",
-                      "from": "stringset@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+                      "version": "0.2.1"
                     },
                     "tryor": {
-                      "version": "0.1.2",
-                      "from": "tryor@>=0.1.2 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+                      "version": "0.1.2"
                     },
                     "yargs": {
                       "version": "3.27.0",
-                      "from": "yargs@>=3.27.0 <3.28.0",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.2.1",
-                          "from": "camelcase@>=1.2.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                          "version": "1.2.1"
                         },
                         "cliui": {
                           "version": "2.1.0",
-                          "from": "cliui@>=2.1.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                           "dependencies": {
                             "center-align": {
                               "version": "0.1.3",
-                              "from": "center-align@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "align-text@>=0.1.1 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.2",
-                                      "from": "kind-of@>=3.0.2 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "dependencies": {
                                         "is-buffer": {
-                                          "version": "1.1.2",
-                                          "from": "is-buffer@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                          "version": "1.1.3"
                                         }
                                       }
                                     },
                                     "longest": {
-                                      "version": "1.0.1",
-                                      "from": "longest@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                      "version": "1.0.1"
                                     },
                                     "repeat-string": {
-                                      "version": "1.5.2",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                      "version": "1.5.4"
                                     }
                                   }
                                 },
                                 "lazy-cache": {
-                                  "version": "1.0.3",
-                                  "from": "lazy-cache@>=1.0.3 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                                  "version": "1.0.3"
                                 }
                               }
                             },
                             "right-align": {
                               "version": "0.1.3",
-                              "from": "right-align@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                               "dependencies": {
                                 "align-text": {
                                   "version": "0.1.4",
-                                  "from": "align-text@>=0.1.1 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                   "dependencies": {
                                     "kind-of": {
                                       "version": "3.0.2",
-                                      "from": "kind-of@>=3.0.2 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                       "dependencies": {
                                         "is-buffer": {
-                                          "version": "1.1.2",
-                                          "from": "is-buffer@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                                          "version": "1.1.3"
                                         }
                                       }
                                     },
                                     "longest": {
-                                      "version": "1.0.1",
-                                      "from": "longest@>=1.0.1 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                      "version": "1.0.1"
                                     },
                                     "repeat-string": {
-                                      "version": "1.5.2",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                      "version": "1.5.4"
                                     }
                                   }
                                 }
                               }
                             },
                             "wordwrap": {
-                              "version": "0.0.2",
-                              "from": "wordwrap@0.0.2",
-                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                              "version": "0.0.2"
                             }
                           }
                         },
                         "decamelize": {
-                          "version": "1.1.2",
-                          "from": "decamelize@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                          "dependencies": {
-                            "escape-string-regexp": {
-                              "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                            }
-                          }
+                          "version": "1.2.0"
                         },
                         "os-locale": {
                           "version": "1.4.0",
-                          "from": "os-locale@>=1.4.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                           "dependencies": {
                             "lcid": {
                               "version": "1.0.0",
-                              "from": "lcid@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                               "dependencies": {
                                 "invert-kv": {
-                                  "version": "1.0.0",
-                                  "from": "invert-kv@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                  "version": "1.0.0"
                                 }
                               }
                             }
                           }
                         },
                         "window-size": {
-                          "version": "0.1.4",
-                          "from": "window-size@>=0.1.2 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                          "version": "0.1.4"
                         },
                         "y18n": {
-                          "version": "3.2.0",
-                          "from": "y18n@>=3.2.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                          "version": "3.2.0"
                         }
                       }
                     }
                   }
                 },
                 "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                  "version": "15001.1001.0-dev-harmony-fb"
                 },
                 "recast": {
                   "version": "0.10.33",
-                  "from": "recast@0.10.33",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
                   "dependencies": {
                     "ast-types": {
-                      "version": "0.8.12",
-                      "from": "ast-types@0.8.12",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                      "version": "0.8.12"
                     }
                   }
                 },
                 "through": {
-                  "version": "2.3.8",
-                  "from": "through@>=2.3.8 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                  "version": "2.3.8"
                 }
               }
             },
             "regexpu": {
               "version": "1.3.0",
-              "from": "regexpu@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
               "dependencies": {
                 "esprima": {
-                  "version": "2.7.2",
-                  "from": "esprima@>=2.6.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                  "version": "2.7.2"
                 },
                 "recast": {
                   "version": "0.10.43",
-                  "from": "recast@>=0.10.10 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
                   "dependencies": {
                     "esprima-fb": {
-                      "version": "15001.1001.0-dev-harmony-fb",
-                      "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                      "version": "15001.1001.0-dev-harmony-fb"
                     },
                     "ast-types": {
-                      "version": "0.8.15",
-                      "from": "ast-types@0.8.15",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
+                      "version": "0.8.15"
                     }
                   }
                 },
                 "regenerate": {
-                  "version": "1.2.1",
-                  "from": "regenerate@>=1.2.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                  "version": "1.2.1"
                 },
                 "regjsgen": {
-                  "version": "0.2.0",
-                  "from": "regjsgen@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                  "version": "0.2.0"
                 },
                 "regjsparser": {
                   "version": "0.1.5",
-                  "from": "regjsparser@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "dependencies": {
                     "jsesc": {
-                      "version": "0.5.0",
-                      "from": "jsesc@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                      "version": "0.5.0"
                     }
                   }
                 }
@@ -2645,137 +1609,89 @@
             },
             "repeating": {
               "version": "1.1.3",
-              "from": "repeating@>=1.1.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.1",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                   "dependencies": {
                     "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
               }
             },
             "resolve": {
-              "version": "1.1.7",
-              "from": "resolve@>=1.1.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+              "version": "1.1.7"
             },
             "shebang-regex": {
-              "version": "1.0.0",
-              "from": "shebang-regex@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "slash": {
-              "version": "1.0.0",
-              "from": "slash@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "source-map": {
-              "version": "0.5.3",
-              "from": "source-map@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+              "version": "0.5.3"
             },
             "source-map-support": {
               "version": "0.2.10",
-              "from": "source-map-support@>=0.2.10 <0.3.0",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
               "dependencies": {
                 "source-map": {
                   "version": "0.1.32",
-                  "from": "source-map@0.1.32",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
               }
             },
             "to-fast-properties": {
-              "version": "1.0.1",
-              "from": "to-fast-properties@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "trim-right": {
-              "version": "1.0.1",
-              "from": "trim-right@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "try-resolve": {
-              "version": "1.0.1",
-              "from": "try-resolve@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+              "version": "1.0.1"
             }
           }
         },
         "lodash.assign": {
           "version": "3.2.0",
-          "from": "lodash.assign@>=3.2.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
           "dependencies": {
             "lodash._baseassign": {
               "version": "3.2.0",
-              "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
               "dependencies": {
                 "lodash._basecopy": {
-                  "version": "3.0.1",
-                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                  "version": "3.0.1"
                 }
               }
             },
             "lodash._createassigner": {
               "version": "3.1.1",
-              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
               "dependencies": {
                 "lodash._bindcallback": {
-                  "version": "3.0.1",
-                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                  "version": "3.0.1"
                 },
                 "lodash._isiterateecall": {
-                  "version": "3.0.9",
-                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                  "version": "3.0.9"
                 },
                 "lodash.restparam": {
-                  "version": "3.6.1",
-                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                  "version": "3.6.1"
                 }
               }
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "dependencies": {
                 "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                  "version": "3.9.1"
                 },
                 "lodash.isarguments": {
-                  "version": "3.0.7",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                  "version": "3.0.8"
                 },
                 "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                  "version": "3.0.4"
                 }
               }
             }
@@ -2783,205 +1699,163 @@
         },
         "lodash.pick": {
           "version": "3.1.0",
-          "from": "lodash.pick@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz",
           "dependencies": {
             "lodash._baseflatten": {
               "version": "3.1.4",
-              "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
               "dependencies": {
                 "lodash.isarguments": {
-                  "version": "3.0.7",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                  "version": "3.0.8"
                 },
                 "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                  "version": "3.0.4"
                 }
               }
             },
             "lodash._bindcallback": {
-              "version": "3.0.1",
-              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+              "version": "3.0.1"
             },
             "lodash._pickbyarray": {
-              "version": "3.0.2",
-              "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+              "version": "3.0.2"
             },
             "lodash._pickbycallback": {
               "version": "3.0.0",
-              "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
-                  "version": "3.0.3",
-                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+                  "version": "3.0.3"
                 },
                 "lodash.keysin": {
                   "version": "3.0.8",
-                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
                   "dependencies": {
                     "lodash.isarguments": {
-                      "version": "3.0.7",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                      "version": "3.0.8"
                     },
                     "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                      "version": "3.0.4"
                     }
                   }
                 }
               }
             },
             "lodash.restparam": {
-              "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+              "version": "3.6.1"
             }
           }
         },
         "acorn-to-esprima": {
-          "version": "1.0.7",
-          "from": "acorn-to-esprima@>=1.0.5 <2.0.0",
-          "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-1.0.7.tgz"
+          "version": "1.0.7"
         }
       }
     },
     "babel-loader": {
       "version": "5.3.2",
-      "from": "babel-loader@5.3.2",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.3.2.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.9 <0.3.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "version": "3.1.3"
             },
             "json5": {
-              "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "version": "0.4.0"
             }
           }
         },
         "object-assign": {
-          "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+          "version": "3.0.0"
         }
       }
     },
     "babel-runtime": {
       "version": "5.8.12",
-      "from": "babel-runtime@5.8.12",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.12.tgz",
       "dependencies": {
         "core-js": {
-          "version": "0.9.18",
-          "from": "core-js@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.9.18.tgz"
+          "version": "0.9.18"
+        }
+      }
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "dependencies": {
+        "callsite": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "blanket": {
+      "version": "1.1.6",
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.4"
+        },
+        "falafel": {
+          "version": "0.1.6"
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "dependencies": {
+            "object-keys": {
+              "version": "0.4.0"
+            }
+          }
         }
       }
     },
     "body-parser": {
       "version": "1.15.0",
-      "from": "body-parser@>=1.13.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
       "dependencies": {
         "bytes": {
-          "version": "2.2.0",
-          "from": "bytes@2.2.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+          "version": "2.2.0"
         },
         "content-type": {
-          "version": "1.0.1",
-          "from": "content-type@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "depd": {
-          "version": "1.1.0",
-          "from": "depd@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+          "version": "1.1.0"
         },
         "http-errors": {
           "version": "1.4.0",
-          "from": "http-errors@>=1.4.0 <1.5.0",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
           "dependencies": {
             "statuses": {
-              "version": "1.2.1",
-              "from": "statuses@>=1.2.1 <1.3.0",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+              "version": "1.2.1"
             }
           }
         },
         "iconv-lite": {
-          "version": "0.4.13",
-          "from": "iconv-lite@0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+          "version": "0.4.13"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "on-finished@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
-              "version": "1.1.1",
-              "from": "ee-first@1.1.1",
-              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+              "version": "1.1.1"
             }
           }
         },
         "qs": {
-          "version": "6.1.0",
-          "from": "qs@6.1.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
+          "version": "6.1.0"
         },
         "raw-body": {
-          "version": "2.1.5",
-          "from": "raw-body@>=2.1.5 <2.2.0",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz",
+          "version": "2.1.6",
           "dependencies": {
+            "bytes": {
+              "version": "2.3.0"
+            },
             "unpipe": {
-              "version": "1.0.0",
-              "from": "unpipe@1.0.0",
-              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "type-is": {
-          "version": "1.6.11",
-          "from": "type-is@>=1.6.11 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
+          "version": "1.6.12",
           "dependencies": {
             "media-typer": {
-              "version": "0.3.0",
-              "from": "media-typer@0.3.0",
-              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+              "version": "0.3.0"
             },
             "mime-types": {
               "version": "2.1.10",
-              "from": "mime-types@>=2.1.6 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.22.0",
-                  "from": "mime-db@>=1.22.0 <1.23.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                  "version": "1.22.0"
                 }
               }
             }
@@ -2990,124 +1864,101 @@
       }
     },
     "browser-filesaver": {
-      "version": "1.1.0",
-      "from": "browser-filesaver@1.1.0",
-      "resolved": "https://registry.npmjs.org/browser-filesaver/-/browser-filesaver-1.1.0.tgz"
+      "version": "1.1.0"
+    },
+    "chai": {
+      "version": "2.0.0",
+      "dependencies": {
+        "assertion-error": {
+          "version": "1.0.0"
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1"
+            }
+          }
+        }
+      }
     },
     "chalk": {
       "version": "1.0.0",
-      "from": "chalk@1.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
       "dependencies": {
         "ansi-styles": {
-          "version": "2.1.0",
-          "from": "ansi-styles@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+          "version": "2.2.0",
+          "dependencies": {
+            "color-convert": {
+              "version": "1.0.0"
+            }
+          }
         },
         "has-ansi": {
           "version": "1.0.3",
-          "from": "has-ansi@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "1.1.1",
-              "from": "ansi-regex@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+              "version": "1.1.1"
             },
             "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "version": "4.0.1"
             }
           }
         },
         "strip-ansi": {
           "version": "2.0.1",
-          "from": "strip-ansi@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "dependencies": {
             "ansi-regex": {
-              "version": "1.1.1",
-              "from": "ansi-regex@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+              "version": "1.1.1"
             }
           }
         },
         "supports-color": {
-          "version": "1.3.1",
-          "from": "supports-color@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+          "version": "1.3.1"
         }
       }
     },
     "char-spinner": {
-      "version": "1.0.1",
-      "from": "char-spinner@1.0.1",
-      "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "chrono-node": {
-      "version": "1.1.2",
-      "from": "chrono-node@>=1.0.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-1.1.2.tgz"
+      "version": "1.1.3"
     },
     "classnames": {
-      "version": "1.1.1",
-      "from": "classnames@1.1.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-1.1.1.tgz"
+      "version": "1.1.1"
     },
     "click-outside": {
       "version": "1.0.4",
-      "from": "click-outside@1.0.4",
-      "resolved": "https://registry.npmjs.org/click-outside/-/click-outside-1.0.4.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "4.7.4",
-          "from": "babel-runtime@4.7.4",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-4.7.4.tgz",
           "dependencies": {
             "core-js": {
-              "version": "0.6.1",
-              "from": "core-js@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.6.1.tgz"
+              "version": "0.6.1"
             }
           }
         },
         "component-event": {
-          "version": "0.1.4",
-          "from": "component-event@0.1.4",
-          "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz"
+          "version": "0.1.4"
         },
         "node-contains": {
-          "version": "1.0.0",
-          "from": "node-contains@1.0.0",
-          "resolved": "https://registry.npmjs.org/node-contains/-/node-contains-1.0.0.tgz"
+          "version": "1.0.0"
         }
       }
     },
     "clipboard": {
       "version": "1.5.3",
-      "from": "clipboard@1.5.3",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.5.3.tgz",
       "dependencies": {
         "good-listener": {
           "version": "1.1.7",
-          "from": "good-listener@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.1.7.tgz",
           "dependencies": {
             "delegate": {
               "version": "3.0.1",
-              "from": "delegate@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.0.1.tgz",
               "dependencies": {
                 "closest": {
                   "version": "0.0.1",
-                  "from": "closest@0.0.1",
-                  "resolved": "https://registry.npmjs.org/closest/-/closest-0.0.1.tgz",
                   "dependencies": {
                     "matches-selector": {
-                      "version": "0.0.1",
-                      "from": "matches-selector@0.0.1",
-                      "resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-0.0.1.tgz"
+                      "version": "0.0.1"
                     }
                   }
                 }
@@ -3116,48 +1967,32 @@
           }
         },
         "select": {
-          "version": "1.0.6",
-          "from": "select@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/select/-/select-1.0.6.tgz"
+          "version": "1.0.6"
         },
         "tiny-emitter": {
-          "version": "1.0.2",
-          "from": "tiny-emitter@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.0.2.tgz"
+          "version": "1.0.2"
         }
       }
     },
     "commander": {
-      "version": "2.3.0",
-      "from": "commander@2.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+      "version": "2.3.0"
     },
     "component-classes": {
       "version": "1.2.1",
-      "from": "component-classes@1.2.1",
-      "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.1.tgz",
       "dependencies": {
         "component-indexof": {
-          "version": "0.0.3",
-          "from": "component-indexof@*",
-          "resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz"
+          "version": "0.0.3"
         }
       }
     },
     "component-closest": {
       "version": "0.1.4",
-      "from": "component-closest@0.1.4",
-      "resolved": "https://registry.npmjs.org/component-closest/-/component-closest-0.1.4.tgz",
       "dependencies": {
         "component-matches-selector": {
           "version": "0.1.5",
-          "from": "component-matches-selector@>=0.1.5 <0.2.0",
-          "resolved": "https://registry.npmjs.org/component-matches-selector/-/component-matches-selector-0.1.5.tgz",
           "dependencies": {
             "component-query": {
-              "version": "0.0.3",
-              "from": "component-query@*",
-              "resolved": "https://registry.npmjs.org/component-query/-/component-query-0.0.3.tgz"
+              "version": "0.0.3"
             }
           }
         }
@@ -3165,50 +2000,32 @@
     },
     "component-tip": {
       "version": "2.5.0",
-      "from": "component-tip@2.5.0",
-      "resolved": "https://registry.npmjs.org/component-tip/-/component-tip-2.5.0.tgz",
       "dependencies": {
         "bounding-client-rect": {
           "version": "1.0.5",
-          "from": "bounding-client-rect@1.0.5",
-          "resolved": "https://registry.npmjs.org/bounding-client-rect/-/bounding-client-rect-1.0.5.tgz",
           "dependencies": {
             "get-document": {
-              "version": "1.0.0",
-              "from": "get-document@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/get-document/-/get-document-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "component-bind": {
-          "version": "1.0.0",
-          "from": "component-bind@*",
-          "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "component-css": {
           "version": "0.0.6",
-          "from": "component-css@0.0.6",
-          "resolved": "https://registry.npmjs.org/component-css/-/component-css-0.0.6.tgz",
           "dependencies": {
             "within-document": {
-              "version": "0.0.1",
-              "from": "within-document@0.0.1",
-              "resolved": "https://registry.npmjs.org/within-document/-/within-document-0.0.1.tgz"
+              "version": "0.0.1"
             },
             "to-camel-case": {
               "version": "0.2.1",
-              "from": "to-camel-case@0.2.1",
-              "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-0.2.1.tgz",
               "dependencies": {
                 "to-space-case": {
                   "version": "0.1.2",
-                  "from": "to-space-case@0.1.2",
-                  "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-0.1.2.tgz",
                   "dependencies": {
                     "to-no-case": {
-                      "version": "0.1.1",
-                      "from": "to-no-case@0.1.1",
-                      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-0.1.1.tgz"
+                      "version": "0.1.1"
                     }
                   }
                 }
@@ -3216,23 +2033,15 @@
             },
             "component-each": {
               "version": "0.2.6",
-              "from": "component-each@>=0.2.2 <0.3.0",
-              "resolved": "https://registry.npmjs.org/component-each/-/component-each-0.2.6.tgz",
               "dependencies": {
                 "component-type": {
-                  "version": "1.0.0",
-                  "from": "component-type@1.0.0",
-                  "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "to-function": {
                   "version": "2.0.6",
-                  "from": "to-function@2.0.6",
-                  "resolved": "https://registry.npmjs.org/to-function/-/to-function-2.0.6.tgz",
                   "dependencies": {
                     "component-props": {
-                      "version": "1.1.1",
-                      "from": "component-props@*",
-                      "resolved": "https://registry.npmjs.org/component-props/-/component-props-1.1.1.tgz"
+                      "version": "1.1.1"
                     }
                   }
                 }
@@ -3241,153 +2050,1508 @@
           }
         },
         "component-emitter": {
-          "version": "1.1.3",
-          "from": "component-emitter@1.1.3",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.3.tgz"
+          "version": "1.1.3"
         },
         "component-events": {
           "version": "1.0.9",
-          "from": "component-events@1.0.9",
-          "resolved": "https://registry.npmjs.org/component-events/-/component-events-1.0.9.tgz",
           "dependencies": {
             "component-event": {
-              "version": "0.1.4",
-              "from": "component-event@0.1.4",
-              "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz"
+              "version": "0.1.4"
             },
             "component-delegate": {
-              "version": "0.2.3",
-              "from": "component-delegate@0.2.3",
-              "resolved": "https://registry.npmjs.org/component-delegate/-/component-delegate-0.2.3.tgz"
+              "version": "0.2.3"
             }
           }
         },
         "component-query": {
-          "version": "0.0.3",
-          "from": "component-query@0.0.3",
-          "resolved": "https://registry.npmjs.org/component-query/-/component-query-0.0.3.tgz"
+          "version": "0.0.3"
         },
         "domify": {
-          "version": "1.3.0",
-          "from": "domify@1.3.0",
-          "resolved": "https://registry.npmjs.org/domify/-/domify-1.3.0.tgz"
+          "version": "1.3.0"
         },
         "html-browserify": {
           "version": "0.0.4",
-          "from": "html-browserify@0.0.4",
-          "resolved": "https://registry.npmjs.org/html-browserify/-/html-browserify-0.0.4.tgz",
           "dependencies": {
             "through": {
-              "version": "2.3.8",
-              "from": "through@>=2.3.4 <2.4.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+              "version": "2.3.8"
             }
           }
         }
       }
     },
     "component-uid": {
-      "version": "0.0.2",
-      "from": "component-uid@0.0.2",
-      "resolved": "https://registry.npmjs.org/component-uid/-/component-uid-0.0.2.tgz"
+      "version": "0.0.2"
     },
     "cookie": {
-      "version": "0.1.2",
-      "from": "cookie@0.1.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+      "version": "0.1.2"
     },
     "cookie-parser": {
       "version": "1.3.2",
-      "from": "cookie-parser@1.3.2",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.2.tgz",
       "dependencies": {
         "cookie-signature": {
-          "version": "1.0.4",
-          "from": "cookie-signature@1.0.4",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
+          "version": "1.0.4"
         }
       }
     },
     "creditcards": {
       "version": "1.1.1",
-      "from": "creditcards@1.1.1",
-      "resolved": "https://registry.npmjs.org/creditcards/-/creditcards-1.1.1.tgz",
       "dependencies": {
         "camel-case": {
           "version": "0.1.0",
-          "from": "camel-case@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-0.1.0.tgz",
           "dependencies": {
             "sentence-case": {
-              "version": "0.1.2",
-              "from": "sentence-case@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-0.1.2.tgz"
+              "version": "0.1.2"
             }
           }
         }
       }
     },
     "debug": {
-      "version": "2.2.0",
-      "from": "debug@2.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "version": "2.2.0"
+    },
+    "deep-freeze": {
+      "version": "0.0.1"
+    },
+    "dom-scroll-into-view": {
+      "version": "1.0.1"
+    },
+    "email-validator": {
+      "version": "1.0.1"
+    },
+    "emitter-component": {
+      "version": "1.1.1"
+    },
+    "enzyme": {
+      "version": "1.1.0",
       "dependencies": {
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+        "cheerio": {
+          "version": "0.19.0",
+          "dependencies": {
+            "css-select": {
+              "version": "1.0.0",
+              "dependencies": {
+                "css-what": {
+                  "version": "1.0.0"
+                },
+                "domutils": {
+                  "version": "1.4.3",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0"
+                    }
+                  }
+                },
+                "boolbase": {
+                  "version": "1.0.0"
+                },
+                "nth-check": {
+                  "version": "1.0.1"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.1.1"
+            },
+            "htmlparser2": {
+              "version": "3.8.3",
+              "dependencies": {
+                "domhandler": {
+                  "version": "2.3.0"
+                },
+                "domutils": {
+                  "version": "1.5.1"
+                },
+                "domelementtype": {
+                  "version": "1.3.0"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2"
+                    },
+                    "isarray": {
+                      "version": "0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "dom-serializer": {
+              "version": "0.1.0",
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.1.3"
+                }
+              }
+            },
+            "lodash": {
+              "version": "3.10.1"
+            }
+          }
+        },
+        "sinon": {
+          "version": "1.17.3",
+          "dependencies": {
+            "formatio": {
+              "version": "1.1.1"
+            },
+            "util": {
+              "version": "0.10.3"
+            },
+            "lolex": {
+              "version": "1.3.2"
+            },
+            "samsam": {
+              "version": "1.1.2"
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.8.3"
+        },
+        "jsdom": {
+          "version": "6.5.1",
+          "dependencies": {
+            "acorn": {
+              "version": "2.7.0"
+            },
+            "acorn-globals": {
+              "version": "1.0.9"
+            },
+            "browser-request": {
+              "version": "0.3.3"
+            },
+            "cssom": {
+              "version": "0.3.1"
+            },
+            "cssstyle": {
+              "version": "0.2.34"
+            },
+            "escodegen": {
+              "version": "1.8.0",
+              "dependencies": {
+                "estraverse": {
+                  "version": "1.9.3"
+                },
+                "esutils": {
+                  "version": "2.0.2"
+                },
+                "esprima": {
+                  "version": "2.7.2"
+                },
+                "optionator": {
+                  "version": "0.8.1",
+                  "dependencies": {
+                    "prelude-ls": {
+                      "version": "1.1.2"
+                    },
+                    "deep-is": {
+                      "version": "0.1.3"
+                    },
+                    "wordwrap": {
+                      "version": "1.0.0"
+                    },
+                    "type-check": {
+                      "version": "0.3.2"
+                    },
+                    "levn": {
+                      "version": "0.3.0"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.1.3"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.2.0",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "htmlparser2": {
+              "version": "3.9.0",
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.3.0"
+                },
+                "domhandler": {
+                  "version": "2.3.0"
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3"
+                        }
+                      }
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.1.1"
+                },
+                "readable-stream": {
+                  "version": "2.0.5",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2"
+                    },
+                    "isarray": {
+                      "version": "0.0.1"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "nwmatcher": {
+              "version": "1.3.7"
+            },
+            "parse5": {
+              "version": "1.5.1"
+            },
+            "request": {
+              "version": "2.69.0",
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0"
+                },
+                "aws4": {
+                  "version": "1.3.2"
+                },
+                "bl": {
+                  "version": "1.0.3",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2"
+                        },
+                        "isarray": {
+                          "version": "0.0.1"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.11.0"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0"
+                },
+                "forever-agent": {
+                  "version": "0.6.1"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.5.2"
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.1",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.0",
+                          "dependencies": {
+                            "color-convert": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.13.1",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4"
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.16.3"
+                    },
+                    "boom": {
+                      "version": "2.10.1"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5"
+                    },
+                    "sntp": {
+                      "version": "1.0.9"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0"
+                    },
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2"
+                        },
+                        "json-schema": {
+                          "version": "0.2.2"
+                        },
+                        "verror": {
+                          "version": "1.3.6"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.7.4",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3"
+                        },
+                        "dashdash": {
+                          "version": "1.13.0",
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        },
+                        "jsbn": {
+                          "version": "0.1.0"
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.1"
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0"
+                },
+                "isstream": {
+                  "version": "0.1.2"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1"
+                },
+                "mime-types": {
+                  "version": "2.1.10",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.22.0"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.7"
+                },
+                "oauth-sign": {
+                  "version": "0.8.1"
+                },
+                "qs": {
+                  "version": "6.0.2"
+                },
+                "stringstream": {
+                  "version": "0.0.5"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2"
+                }
+              }
+            },
+            "symbol-tree": {
+              "version": "3.1.4"
+            },
+            "tough-cookie": {
+              "version": "2.2.2"
+            },
+            "whatwg-url-compat": {
+              "version": "0.6.5",
+              "dependencies": {
+                "tr46": {
+                  "version": "0.0.3"
+                }
+              }
+            },
+            "xml-name-validator": {
+              "version": "2.0.1"
+            },
+            "xmlhttprequest": {
+              "version": "1.8.0"
+            },
+            "xtend": {
+              "version": "4.0.1"
+            }
+          }
+        },
+        "mocha-jsdom": {
+          "version": "1.1.0"
         }
       }
     },
-    "dom-scroll-into-view": {
-      "version": "1.0.1",
-      "from": "dom-scroll-into-view@1.0.1",
-      "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.0.1.tgz"
-    },
-    "email-validator": {
-      "version": "1.0.1",
-      "from": "email-validator@1.0.1",
-      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-1.0.1.tgz"
-    },
-    "emitter-component": {
-      "version": "1.1.1",
-      "from": "emitter-component@1.1.1",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz"
-    },
     "escape-regexp": {
-      "version": "0.0.1",
-      "from": "escape-regexp@0.0.1",
-      "resolved": "https://registry.npmjs.org/escape-regexp/-/escape-regexp-0.0.1.tgz"
+      "version": "0.0.1"
     },
     "escape-string-regexp": {
-      "version": "1.0.3",
-      "from": "escape-string-regexp@1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+      "version": "1.0.3"
+    },
+    "esformatter": {
+      "version": "0.7.3",
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4"
+        },
+        "disparity": {
+          "version": "2.0.0",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.0",
+              "dependencies": {
+                "color-convert": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "diff": {
+              "version": "1.4.0"
+            }
+          }
+        },
+        "espree": {
+          "version": "1.12.3"
+        },
+        "glob": {
+          "version": "5.0.15",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0"
+        },
+        "mout": {
+          "version": "0.12.0"
+        },
+        "npm-run": {
+          "version": "1.1.1",
+          "dependencies": {
+            "npm-path": {
+              "version": "1.1.0",
+              "dependencies": {
+                "which": {
+                  "version": "1.2.4",
+                  "dependencies": {
+                    "is-absolute": {
+                      "version": "0.1.7",
+                      "dependencies": {
+                        "is-relative": {
+                          "version": "0.1.3"
+                        }
+                      }
+                    },
+                    "isexe": {
+                      "version": "1.1.2"
+                    }
+                  }
+                }
+              }
+            },
+            "serializerr": {
+              "version": "1.0.2",
+              "dependencies": {
+                "protochain": {
+                  "version": "1.0.3"
+                }
+              }
+            },
+            "sync-exec": {
+              "version": "0.5.0"
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7"
+        },
+        "rocambole": {
+          "version": "0.7.0",
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.2"
+            }
+          }
+        },
+        "rocambole-indent": {
+          "version": "2.0.4",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0"
+            },
+            "mout": {
+              "version": "0.11.1"
+            }
+          }
+        },
+        "rocambole-linebreak": {
+          "version": "1.0.1",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0"
+            },
+            "semver": {
+              "version": "4.3.6"
+            }
+          }
+        },
+        "rocambole-node": {
+          "version": "1.0.0"
+        },
+        "rocambole-token": {
+          "version": "1.2.1"
+        },
+        "rocambole-whitespace": {
+          "version": "1.0.0",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0"
+            },
+            "repeat-string": {
+              "version": "1.5.4"
+            }
+          }
+        },
+        "semver": {
+          "version": "2.2.1"
+        },
+        "stdin": {
+          "version": "0.0.1"
+        },
+        "strip-json-comments": {
+          "version": "0.1.3"
+        },
+        "supports-color": {
+          "version": "1.3.1"
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.1"
+            }
+          }
+        }
+      }
+    },
+    "esformatter-braces": {
+      "version": "1.2.1",
+      "dependencies": {
+        "rocambole-token": {
+          "version": "1.2.1"
+        }
+      }
+    },
+    "esformatter-collapse-objects-a8c": {
+      "version": "0.1.0",
+      "dependencies": {
+        "defaults-deep": {
+          "version": "0.2.3",
+          "dependencies": {
+            "for-own": {
+              "version": "0.1.3",
+              "dependencies": {
+                "for-in": {
+                  "version": "0.1.4"
+                }
+              }
+            },
+            "is-extendable": {
+              "version": "0.1.1"
+            },
+            "lazy-cache": {
+              "version": "0.2.7"
+            }
+          }
+        },
+        "rocambole": {
+          "version": "0.5.1",
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.2"
+            }
+          }
+        },
+        "rocambole-token": {
+          "version": "1.2.1"
+        }
+      }
+    },
+    "esformatter-dot-notation": {
+      "version": "1.3.1",
+      "dependencies": {
+        "rocambole": {
+          "version": "0.6.0",
+          "dependencies": {
+            "esprima": {
+              "version": "2.7.2"
+            }
+          }
+        },
+        "rocambole-token": {
+          "version": "1.2.1"
+        },
+        "unquoted-property-validator": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "esformatter-quotes": {
+      "version": "1.0.3"
+    },
+    "esformatter-semicolons": {
+      "version": "1.1.1"
+    },
+    "esformatter-special-bangs": {
+      "version": "1.0.1",
+      "dependencies": {
+        "rocambole-token": {
+          "version": "1.2.1"
+        }
+      }
+    },
+    "eslint": {
+      "version": "1.10.3",
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.5.1",
+          "dependencies": {
+            "typedarray": {
+              "version": "0.0.6"
+            },
+            "readable-stream": {
+              "version": "2.0.5",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2"
+                },
+                "isarray": {
+                  "version": "0.0.1"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6"
+                },
+                "string_decoder": {
+                  "version": "0.10.31"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2"
+                }
+              }
+            }
+          }
+        },
+        "doctrine": {
+          "version": "0.7.2",
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6"
+            },
+            "isarray": {
+              "version": "0.0.1"
+            }
+          }
+        },
+        "escope": {
+          "version": "3.6.0",
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.3",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1"
+                },
+                "es5-ext": {
+                  "version": "0.10.11"
+                },
+                "es6-iterator": {
+                  "version": "2.0.0"
+                },
+                "es6-set": {
+                  "version": "0.1.4"
+                },
+                "es6-symbol": {
+                  "version": "3.0.2"
+                },
+                "event-emitter": {
+                  "version": "0.3.4"
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "2.0.1",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1"
+                },
+                "es5-ext": {
+                  "version": "0.10.11"
+                },
+                "es6-iterator": {
+                  "version": "2.0.0"
+                },
+                "es6-symbol": {
+                  "version": "3.0.2"
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "4.1.0",
+              "dependencies": {
+                "estraverse": {
+                  "version": "4.1.1"
+                }
+              }
+            }
+          }
+        },
+        "espree": {
+          "version": "2.2.5"
+        },
+        "estraverse": {
+          "version": "4.2.0"
+        },
+        "estraverse-fb": {
+          "version": "1.3.1"
+        },
+        "esutils": {
+          "version": "2.0.2"
+        },
+        "file-entry-cache": {
+          "version": "1.2.4",
+          "dependencies": {
+            "flat-cache": {
+              "version": "1.0.10",
+              "dependencies": {
+                "del": {
+                  "version": "2.2.0",
+                  "dependencies": {
+                    "globby": {
+                      "version": "4.0.0",
+                      "dependencies": {
+                        "array-union": {
+                          "version": "1.0.1",
+                          "dependencies": {
+                            "array-uniq": {
+                              "version": "1.0.2"
+                            }
+                          }
+                        },
+                        "arrify": {
+                          "version": "1.0.1"
+                        },
+                        "glob": {
+                          "version": "6.0.4",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1"
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-path-cwd": {
+                      "version": "1.0.0"
+                    },
+                    "is-path-in-cwd": {
+                      "version": "1.0.0",
+                      "dependencies": {
+                        "is-path-inside": {
+                          "version": "1.0.0"
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.5.2",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.0.3",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1"
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.3"
+                },
+                "read-json-sync": {
+                  "version": "1.1.1"
+                },
+                "write": {
+                  "version": "0.2.1"
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1"
+                }
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "8.18.0"
+        },
+        "handlebars": {
+          "version": "4.0.5",
+          "dependencies": {
+            "async": {
+              "version": "1.5.2"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3"
+                },
+                "minimist": {
+                  "version": "0.0.10"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.11.4",
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.3.0"
+            },
+            "ansi-regex": {
+              "version": "2.0.0"
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "dependencies": {
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "dependencies": {
+                    "exit-hook": {
+                      "version": "1.1.1"
+                    },
+                    "onetime": {
+                      "version": "1.1.0"
+                    }
+                  }
+                }
+              }
+            },
+            "cli-width": {
+              "version": "1.1.1"
+            },
+            "figures": {
+              "version": "1.4.0"
+            },
+            "lodash": {
+              "version": "3.10.1"
+            },
+            "readline2": {
+              "version": "1.0.1",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "mute-stream": {
+                  "version": "0.0.5"
+                }
+              }
+            },
+            "run-async": {
+              "version": "0.1.0",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.3",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "rx-lite": {
+              "version": "3.1.2"
+            },
+            "string-width": {
+              "version": "1.0.1",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1"
+            },
+            "through": {
+              "version": "2.3.8"
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.13.1",
+          "dependencies": {
+            "generate-function": {
+              "version": "2.0.0"
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "dependencies": {
+                "is-property": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "jsonpointer": {
+              "version": "2.0.0"
+            },
+            "xtend": {
+              "version": "4.0.1"
+            }
+          }
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "dependencies": {
+            "tryit": {
+              "version": "1.0.2"
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.4.5",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.6",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.2"
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0"
+            }
+          }
+        },
+        "lodash.clonedeep": {
+          "version": "3.0.2",
+          "dependencies": {
+            "lodash._baseclone": {
+              "version": "3.3.0",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0"
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0"
+                },
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1"
+                    }
+                  }
+                },
+                "lodash._basefor": {
+                  "version": "3.0.3"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.8"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1"
+            }
+          }
+        },
+        "lodash.merge": {
+          "version": "3.3.2",
+          "dependencies": {
+            "lodash._arraycopy": {
+              "version": "3.0.0"
+            },
+            "lodash._arrayeach": {
+              "version": "3.0.0"
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9"
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1"
+                }
+              }
+            },
+            "lodash._getnative": {
+              "version": "3.9.1"
+            },
+            "lodash.isarguments": {
+              "version": "3.0.8"
+            },
+            "lodash.isarray": {
+              "version": "3.0.4"
+            },
+            "lodash.isplainobject": {
+              "version": "3.2.0",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.3"
+                }
+              }
+            },
+            "lodash.istypedarray": {
+              "version": "3.0.5"
+            },
+            "lodash.keys": {
+              "version": "3.1.2"
+            },
+            "lodash.keysin": {
+              "version": "3.0.8"
+            },
+            "lodash.toplainobject": {
+              "version": "3.0.0",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1"
+                }
+              }
+            }
+          }
+        },
+        "lodash.omit": {
+          "version": "3.1.0",
+          "dependencies": {
+            "lodash._arraymap": {
+              "version": "3.0.0"
+            },
+            "lodash._basedifference": {
+              "version": "3.0.3",
+              "dependencies": {
+                "lodash._baseindexof": {
+                  "version": "3.1.0"
+                },
+                "lodash._cacheindexof": {
+                  "version": "3.0.2"
+                },
+                "lodash._createcache": {
+                  "version": "3.1.2",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._baseflatten": {
+              "version": "3.1.4",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.8"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4"
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1"
+            },
+            "lodash._pickbyarray": {
+              "version": "3.0.2"
+            },
+            "lodash._pickbycallback": {
+              "version": "3.0.0",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.3"
+                }
+              }
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.8"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.0",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.3",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.3.0"
+                },
+                "concat-map": {
+                  "version": "0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.0.1"
+        },
+        "optionator": {
+          "version": "0.6.0",
+          "dependencies": {
+            "prelude-ls": {
+              "version": "1.1.2"
+            },
+            "deep-is": {
+              "version": "0.1.3"
+            },
+            "wordwrap": {
+              "version": "0.0.3"
+            },
+            "type-check": {
+              "version": "0.3.2"
+            },
+            "levn": {
+              "version": "0.2.5"
+            },
+            "fast-levenshtein": {
+              "version": "1.0.7"
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0"
+        },
+        "path-is-inside": {
+          "version": "1.0.1"
+        },
+        "shelljs": {
+          "version": "0.5.3"
+        },
+        "strip-json-comments": {
+          "version": "1.0.4"
+        },
+        "text-table": {
+          "version": "0.2.0"
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.1"
+            }
+          }
+        },
+        "xml-escape": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "3.11.3"
+    },
+    "eslint-plugin-wpcalypso": {
+      "version": "1.1.3",
+      "dependencies": {
+        "requireindex": {
+          "version": "1.1.0"
+        }
+      }
     },
     "events": {
-      "version": "1.0.2",
-      "from": "events@1.0.2",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "exports-loader": {
       "version": "0.6.2",
-      "from": "exports-loader@0.6.2",
-      "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.2.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "version": "3.1.3"
             },
             "json5": {
-              "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "version": "0.4.0"
             }
           }
         }
@@ -3395,386 +3559,242 @@
     },
     "express": {
       "version": "4.13.3",
-      "from": "express@4.13.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.13.3.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.2.13",
-          "from": "accepts@>=1.2.12 <1.3.0",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.1.10",
-              "from": "mime-types@>=2.1.6 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.22.0",
-                  "from": "mime-db@>=1.22.0 <1.23.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                  "version": "1.22.0"
                 }
               }
             },
             "negotiator": {
-              "version": "0.5.3",
-              "from": "negotiator@0.5.3",
-              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+              "version": "0.5.3"
             }
           }
         },
         "array-flatten": {
-          "version": "1.1.1",
-          "from": "array-flatten@1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+          "version": "1.1.1"
         },
         "content-disposition": {
-          "version": "0.5.0",
-          "from": "content-disposition@0.5.0",
-          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
+          "version": "0.5.0"
         },
         "content-type": {
-          "version": "1.0.1",
-          "from": "content-type@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "cookie": {
-          "version": "0.1.3",
-          "from": "cookie@0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+          "version": "0.1.3"
         },
         "cookie-signature": {
-          "version": "1.0.6",
-          "from": "cookie-signature@1.0.6",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+          "version": "1.0.6"
         },
         "depd": {
-          "version": "1.0.1",
-          "from": "depd@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "escape-html": {
-          "version": "1.0.2",
-          "from": "escape-html@1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+          "version": "1.0.2"
         },
         "etag": {
-          "version": "1.7.0",
-          "from": "etag@>=1.7.0 <1.8.0",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+          "version": "1.7.0"
         },
         "finalhandler": {
           "version": "0.4.0",
-          "from": "finalhandler@0.4.0",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
           "dependencies": {
             "unpipe": {
-              "version": "1.0.0",
-              "from": "unpipe@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "fresh": {
-          "version": "0.3.0",
-          "from": "fresh@0.3.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+          "version": "0.3.0"
         },
         "merge-descriptors": {
-          "version": "1.0.0",
-          "from": "merge-descriptors@1.0.0",
-          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "methods": {
-          "version": "1.1.2",
-          "from": "methods@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+          "version": "1.1.2"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "on-finished@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
-              "version": "1.1.1",
-              "from": "ee-first@1.1.1",
-              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+              "version": "1.1.1"
             }
           }
         },
         "parseurl": {
-          "version": "1.3.1",
-          "from": "parseurl@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+          "version": "1.3.1"
         },
         "path-to-regexp": {
-          "version": "0.1.7",
-          "from": "path-to-regexp@0.1.7",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+          "version": "0.1.7"
         },
         "proxy-addr": {
           "version": "1.0.10",
-          "from": "proxy-addr@>=1.0.8 <1.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
           "dependencies": {
             "forwarded": {
-              "version": "0.1.0",
-              "from": "forwarded@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+              "version": "0.1.0"
             },
             "ipaddr.js": {
-              "version": "1.0.5",
-              "from": "ipaddr.js@1.0.5",
-              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
+              "version": "1.0.5"
             }
           }
         },
         "range-parser": {
-          "version": "1.0.3",
-          "from": "range-parser@>=1.0.2 <1.1.0",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+          "version": "1.0.3"
         },
         "send": {
           "version": "0.13.0",
-          "from": "send@0.13.0",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
           "dependencies": {
             "destroy": {
-              "version": "1.0.3",
-              "from": "destroy@1.0.3",
-              "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "http-errors": {
-              "version": "1.3.1",
-              "from": "http-errors@>=1.3.1 <1.4.0",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+              "version": "1.3.1"
             },
             "mime": {
-              "version": "1.3.4",
-              "from": "mime@1.3.4",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-            },
-            "ms": {
-              "version": "0.7.1",
-              "from": "ms@0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+              "version": "1.3.4"
             },
             "statuses": {
-              "version": "1.2.1",
-              "from": "statuses@>=1.2.1 <1.3.0",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+              "version": "1.2.1"
             }
           }
         },
         "serve-static": {
           "version": "1.10.2",
-          "from": "serve-static@>=1.10.0 <1.11.0",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz",
           "dependencies": {
             "escape-html": {
-              "version": "1.0.3",
-              "from": "escape-html@>=1.0.3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+              "version": "1.0.3"
             },
             "send": {
               "version": "0.13.1",
-              "from": "send@0.13.1",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
               "dependencies": {
                 "depd": {
-                  "version": "1.1.0",
-                  "from": "depd@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+                  "version": "1.1.0"
                 },
                 "destroy": {
-                  "version": "1.0.4",
-                  "from": "destroy@>=1.0.4 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                  "version": "1.0.4"
                 },
                 "http-errors": {
-                  "version": "1.3.1",
-                  "from": "http-errors@>=1.3.1 <1.4.0",
-                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+                  "version": "1.3.1"
                 },
                 "mime": {
-                  "version": "1.3.4",
-                  "from": "mime@1.3.4",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-                },
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                  "version": "1.3.4"
                 },
                 "statuses": {
-                  "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                  "version": "1.2.1"
                 }
               }
             }
           }
         },
         "type-is": {
-          "version": "1.6.11",
-          "from": "type-is@>=1.6.6 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz",
+          "version": "1.6.12",
           "dependencies": {
             "media-typer": {
-              "version": "0.3.0",
-              "from": "media-typer@0.3.0",
-              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+              "version": "0.3.0"
             },
             "mime-types": {
               "version": "2.1.10",
-              "from": "mime-types@>=2.1.6 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.22.0",
-                  "from": "mime-db@>=1.22.0 <1.23.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                  "version": "1.22.0"
                 }
               }
             }
           }
         },
         "utils-merge": {
-          "version": "1.0.0",
-          "from": "utils-merge@1.0.0",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "vary": {
-          "version": "1.0.1",
-          "from": "vary@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+          "version": "1.0.1"
         }
       }
     },
     "fbjs": {
       "version": "0.5.0",
-      "from": "fbjs@0.5.0",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.5.0.tgz",
       "dependencies": {
         "core-js": {
-          "version": "1.2.6",
-          "from": "core-js@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+          "version": "1.2.6"
         },
         "loose-envify": {
           "version": "1.1.0",
-          "from": "loose-envify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
           "dependencies": {
             "js-tokens": {
-              "version": "1.0.2",
-              "from": "js-tokens@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+              "version": "1.0.2"
             }
           }
         },
         "promise": {
           "version": "7.1.1",
-          "from": "promise@>=7.0.3 <8.0.0",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
           "dependencies": {
             "asap": {
-              "version": "2.0.3",
-              "from": "asap@>=2.0.3 <2.1.0",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+              "version": "2.0.3"
             }
           }
         },
         "ua-parser-js": {
-          "version": "0.7.10",
-          "from": "ua-parser-js@>=0.7.9 <0.8.0",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
+          "version": "0.7.10"
         },
         "whatwg-fetch": {
-          "version": "0.9.0",
-          "from": "whatwg-fetch@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+          "version": "0.9.0"
         }
       }
     },
     "flux": {
       "version": "2.1.1",
-      "from": "flux@2.1.1",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-2.1.1.tgz",
       "dependencies": {
         "fbemitter": {
           "version": "2.0.2",
-          "from": "fbemitter@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.0.2.tgz",
           "dependencies": {
             "fbjs": {
               "version": "0.7.2",
-              "from": "fbjs@>=0.6.0 <0.7.0||>=0.7.1 <0.8.0",
-              "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.7.2.tgz",
               "dependencies": {
                 "core-js": {
-                  "version": "1.2.6",
-                  "from": "core-js@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                  "version": "1.2.6"
                 },
                 "loose-envify": {
                   "version": "1.1.0",
-                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
                   "dependencies": {
                     "js-tokens": {
-                      "version": "1.0.2",
-                      "from": "js-tokens@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                      "version": "1.0.2"
                     }
                   }
                 },
                 "isomorphic-fetch": {
                   "version": "2.2.1",
-                  "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
                   "dependencies": {
                     "node-fetch": {
                       "version": "1.3.3",
-                      "from": "node-fetch@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.3.3.tgz",
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
-                          "from": "encoding@>=0.1.11 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
                           "dependencies": {
                             "iconv-lite": {
-                              "version": "0.4.13",
-                              "from": "iconv-lite@>=0.4.13 <0.5.0",
-                              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                              "version": "0.4.13"
                             }
                           }
                         }
                       }
                     },
                     "whatwg-fetch": {
-                      "version": "0.11.0",
-                      "from": "whatwg-fetch@>=0.10.0",
-                      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.11.0.tgz"
+                      "version": "0.11.0"
                     }
                   }
                 },
                 "promise": {
                   "version": "7.1.1",
-                  "from": "promise@>=7.1.1 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
                   "dependencies": {
                     "asap": {
-                      "version": "2.0.3",
-                      "from": "asap@>=2.0.3 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                      "version": "2.0.3"
                     }
                   }
                 },
                 "ua-parser-js": {
-                  "version": "0.7.10",
-                  "from": "ua-parser-js@>=0.7.9 <0.8.0",
-                  "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
+                  "version": "0.7.10"
                 }
               }
             }
@@ -3782,260 +3802,206 @@
         },
         "fbjs": {
           "version": "0.1.0-alpha.7",
-          "from": "fbjs@0.1.0-alpha.7",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
           "dependencies": {
             "core-js": {
-              "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+              "version": "1.2.6"
             },
             "promise": {
               "version": "7.1.1",
-              "from": "promise@>=7.0.3 <8.0.0",
-              "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
               "dependencies": {
                 "asap": {
-                  "version": "2.0.3",
-                  "from": "asap@>=2.0.3 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                  "version": "2.0.3"
                 }
               }
             },
             "whatwg-fetch": {
-              "version": "0.9.0",
-              "from": "whatwg-fetch@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+              "version": "0.9.0"
             }
           }
         }
       }
     },
+    "glob": {
+      "version": "7.0.3",
+      "dependencies": {
+        "inflight": {
+          "version": "1.0.4",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.0",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.3",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.3.0"
+                },
+                "concat-map": {
+                  "version": "0.0.1"
+                }
+              }
+            }
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1"
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0"
+        }
+      }
+    },
     "he": {
-      "version": "0.5.0",
-      "from": "he@0.5.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz"
+      "version": "0.5.0"
     },
     "html-loader": {
       "version": "0.4.0",
-      "from": "html-loader@0.4.0",
-      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.4.0.tgz",
       "dependencies": {
         "es6-templates": {
           "version": "0.2.2",
-          "from": "es6-templates@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.2.tgz",
           "dependencies": {
             "recast": {
               "version": "0.9.18",
-              "from": "recast@>=0.9.11 <0.10.0",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
               "dependencies": {
                 "esprima-fb": {
-                  "version": "10001.1.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=10001.1.0-dev-harmony-fb <10001.2.0",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz"
+                  "version": "10001.1.0-dev-harmony-fb"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.40 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "private": {
-                  "version": "0.1.6",
-                  "from": "private@>=0.1.5 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                  "version": "0.1.6"
                 },
                 "ast-types": {
-                  "version": "0.6.16",
-                  "from": "ast-types@>=0.6.1 <0.7.0",
-                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz"
+                  "version": "0.6.16"
                 }
               }
             },
             "through": {
-              "version": "2.3.8",
-              "from": "through@>=2.3.6 <2.4.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+              "version": "2.3.8"
             }
           }
         },
         "fastparse": {
-          "version": "1.1.1",
-          "from": "fastparse@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+          "version": "1.1.1"
         },
         "html-minifier": {
-          "version": "1.1.1",
-          "from": "html-minifier@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-1.1.1.tgz",
+          "version": "1.2.0",
           "dependencies": {
             "change-case": {
               "version": "2.3.1",
-              "from": "change-case@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
               "dependencies": {
                 "camel-case": {
-                  "version": "1.2.2",
-                  "from": "camel-case@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz"
+                  "version": "1.2.2"
                 },
                 "constant-case": {
-                  "version": "1.1.2",
-                  "from": "constant-case@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "dot-case": {
-                  "version": "1.1.2",
-                  "from": "dot-case@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "is-lower-case": {
-                  "version": "1.1.3",
-                  "from": "is-lower-case@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
+                  "version": "1.1.3"
                 },
                 "is-upper-case": {
-                  "version": "1.1.2",
-                  "from": "is-upper-case@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "lower-case": {
-                  "version": "1.1.3",
-                  "from": "lower-case@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
+                  "version": "1.1.3"
                 },
                 "lower-case-first": {
-                  "version": "1.0.2",
-                  "from": "lower-case-first@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
+                  "version": "1.0.2"
                 },
                 "param-case": {
-                  "version": "1.1.2",
-                  "from": "param-case@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "pascal-case": {
-                  "version": "1.1.2",
-                  "from": "pascal-case@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "path-case": {
-                  "version": "1.1.2",
-                  "from": "path-case@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "sentence-case": {
-                  "version": "1.1.3",
-                  "from": "sentence-case@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz"
+                  "version": "1.1.3"
                 },
                 "snake-case": {
-                  "version": "1.1.2",
-                  "from": "snake-case@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "swap-case": {
-                  "version": "1.1.2",
-                  "from": "swap-case@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "title-case": {
-                  "version": "1.1.2",
-                  "from": "title-case@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz"
+                  "version": "1.1.2"
                 },
                 "upper-case": {
-                  "version": "1.1.3",
-                  "from": "upper-case@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+                  "version": "1.1.3"
                 },
                 "upper-case-first": {
-                  "version": "1.1.2",
-                  "from": "upper-case-first@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
+                  "version": "1.1.2"
                 }
               }
             },
             "clean-css": {
-              "version": "3.4.9",
-              "from": "clean-css@>=3.4.0 <3.5.0",
-              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.9.tgz",
+              "version": "3.4.10",
               "dependencies": {
                 "commander": {
                   "version": "2.8.1",
-                  "from": "commander@>=2.8.0 <2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "from": "source-map@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
               }
             },
             "cli": {
-              "version": "0.11.1",
-              "from": "cli@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.11.1.tgz",
+              "version": "0.11.2",
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
-                  "from": "glob@>=5.0.10 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "version": "0.3.0"
                             },
                             "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "version": "0.0.1"
                             }
                           }
                         }
@@ -4043,143 +4009,95 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "exit": {
-                  "version": "0.1.2",
-                  "from": "exit@0.1.2",
-                  "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+                  "version": "0.1.2"
                 }
               }
             },
             "concat-stream": {
               "version": "1.5.1",
-              "from": "concat-stream@>=1.5.0 <1.6.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
               "dependencies": {
                 "typedarray": {
-                  "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                  "version": "0.0.6"
                 },
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "version": "1.0.6"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "version": "0.10.31"
                     },
                     "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "version": "1.0.2"
                     }
                   }
                 }
               }
             },
             "relateurl": {
-              "version": "0.2.6",
-              "from": "relateurl@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.6.tgz"
+              "version": "0.2.6"
             }
           }
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "version": "3.1.3"
             },
             "json5": {
-              "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "version": "0.4.0"
             }
           }
         },
         "object-assign": {
-          "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+          "version": "4.0.1"
         },
         "source-map": {
-          "version": "0.5.3",
-          "from": "source-map@>=0.5.3 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+          "version": "0.5.3"
         }
       }
     },
     "immutable": {
-      "version": "3.7.5",
-      "from": "immutable@3.7.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.5.tgz"
+      "version": "3.7.5"
     },
     "imports-loader": {
       "version": "0.6.5",
-      "from": "imports-loader@0.6.5",
-      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.2 <0.3.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "version": "3.1.3"
             },
             "json5": {
-              "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "version": "0.4.0"
             }
           }
         }
       }
     },
     "inherits": {
-      "version": "2.0.1",
-      "from": "inherits@2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+      "version": "2.0.1"
     },
     "jade": {
       "version": "1.11.0",
@@ -4188,65 +4106,41 @@
       "dependencies": {
         "jade-code-gen": {
           "version": "0.0.4",
-          "from": "jade-code-gen@0.0.4",
-          "resolved": "https://registry.npmjs.org/jade-code-gen/-/jade-code-gen-0.0.4.tgz",
           "dependencies": {
             "constantinople": {
               "version": "3.0.2",
-              "from": "constantinople@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "2.7.0",
-                  "from": "acorn@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+                  "version": "2.7.0"
                 }
               }
             },
             "doctypes": {
-              "version": "1.0.0",
-              "from": "doctypes@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "jade-attrs": {
-              "version": "2.0.0",
-              "from": "jade-attrs@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/jade-attrs/-/jade-attrs-2.0.0.tgz"
+              "version": "2.0.0"
             },
             "jade-runtime": {
-              "version": "1.1.0",
-              "from": "jade-runtime@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jade-runtime/-/jade-runtime-1.1.0.tgz"
+              "version": "1.1.0"
             },
             "js-stringify": {
-              "version": "1.0.2",
-              "from": "js-stringify@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz"
+              "version": "1.0.2"
             },
             "void-elements": {
-              "version": "2.0.1",
-              "from": "void-elements@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
+              "version": "2.0.1"
             },
             "with": {
               "version": "5.0.0",
-              "from": "with@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/with/-/with-5.0.0.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "1.2.2",
-                  "from": "acorn@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                  "version": "1.2.2"
                 },
                 "acorn-globals": {
                   "version": "1.0.9",
-                  "from": "acorn-globals@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
                   "dependencies": {
                     "acorn": {
-                      "version": "2.7.0",
-                      "from": "acorn@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+                      "version": "2.7.0"
                     }
                   }
                 }
@@ -4256,35 +4150,23 @@
         },
         "jade-filters": {
           "version": "1.1.0",
-          "from": "jade-filters@1.1.0",
-          "resolved": "https://registry.npmjs.org/jade-filters/-/jade-filters-1.1.0.tgz",
           "dependencies": {
             "clean-css": {
-              "version": "3.4.9",
-              "from": "clean-css@>=3.3.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.9.tgz",
+              "version": "3.4.10",
               "dependencies": {
                 "commander": {
                   "version": "2.8.1",
-                  "from": "commander@>=2.8.0 <2.9.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "from": "source-map@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
@@ -4292,370 +4174,682 @@
             },
             "constantinople": {
               "version": "3.0.2",
-              "from": "constantinople@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "2.7.0",
-                  "from": "acorn@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+                  "version": "2.7.0"
                 }
               }
             },
             "jade-error": {
-              "version": "1.2.0",
-              "from": "jade-error@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jade-error/-/jade-error-1.2.0.tgz"
+              "version": "1.2.0"
             },
             "jade-walk": {
-              "version": "0.0.3",
-              "from": "jade-walk@>=0.0.3 <0.0.4",
-              "resolved": "https://registry.npmjs.org/jade-walk/-/jade-walk-0.0.3.tgz"
+              "version": "0.0.3"
             },
             "jstransformer": {
               "version": "0.0.3",
-              "from": "jstransformer@0.0.3",
-              "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.3.tgz",
               "dependencies": {
                 "is-promise": {
-                  "version": "2.1.0",
-                  "from": "is-promise@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
+                  "version": "2.1.0"
                 },
                 "promise": {
                   "version": "7.1.1",
-                  "from": "promise@>=7.0.1 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
                   "dependencies": {
                     "asap": {
-                      "version": "2.0.3",
-                      "from": "asap@>=2.0.3 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                      "version": "2.0.3"
                     }
                   }
                 }
               }
             },
             "resolve": {
-              "version": "1.1.7",
-              "from": "resolve@>=1.1.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+              "version": "1.1.7"
             }
           }
         },
         "jade-lexer": {
           "version": "0.0.9",
-          "from": "jade-lexer@0.0.9",
-          "resolved": "https://registry.npmjs.org/jade-lexer/-/jade-lexer-0.0.9.tgz",
           "dependencies": {
             "character-parser": {
               "version": "2.2.0",
-              "from": "character-parser@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
               "dependencies": {
                 "is-regex": {
-                  "version": "1.0.3",
-                  "from": "is-regex@>=1.0.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
+                  "version": "1.0.3"
                 }
               }
             },
             "is-expression": {
               "version": "1.0.2",
-              "from": "is-expression@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-1.0.2.tgz",
               "dependencies": {
                 "acorn": {
-                  "version": "2.7.0",
-                  "from": "acorn@>=2.7.0 <2.8.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+                  "version": "2.7.0"
                 },
                 "object-assign": {
-                  "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                  "version": "4.0.1"
                 }
               }
             },
             "jade-error": {
-              "version": "1.2.0",
-              "from": "jade-error@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jade-error/-/jade-error-1.2.0.tgz"
+              "version": "1.2.0"
             }
           }
         },
         "jade-linker": {
           "version": "0.0.3",
-          "from": "jade-linker@0.0.3",
-          "resolved": "https://registry.npmjs.org/jade-linker/-/jade-linker-0.0.3.tgz",
           "dependencies": {
             "jade-error": {
-              "version": "1.2.0",
-              "from": "jade-error@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jade-error/-/jade-error-1.2.0.tgz"
+              "version": "1.2.0"
             },
             "jade-walk": {
-              "version": "0.0.3",
-              "from": "jade-walk@>=0.0.3 <0.0.4",
-              "resolved": "https://registry.npmjs.org/jade-walk/-/jade-walk-0.0.3.tgz"
+              "version": "0.0.3"
             }
           }
         },
         "jade-load": {
           "version": "0.0.4",
-          "from": "jade-load@0.0.4",
-          "resolved": "https://registry.npmjs.org/jade-load/-/jade-load-0.0.4.tgz",
           "dependencies": {
             "jade-walk": {
-              "version": "0.0.3",
-              "from": "jade-walk@>=0.0.3 <0.0.4",
-              "resolved": "https://registry.npmjs.org/jade-walk/-/jade-walk-0.0.3.tgz"
+              "version": "0.0.3"
             }
           }
         },
         "jade-parser": {
           "version": "0.0.9",
-          "from": "jade-parser@0.0.9",
-          "resolved": "https://registry.npmjs.org/jade-parser/-/jade-parser-0.0.9.tgz",
           "dependencies": {
             "jade-error": {
-              "version": "1.2.0",
-              "from": "jade-error@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jade-error/-/jade-error-1.2.0.tgz"
+              "version": "1.2.0"
             },
             "token-stream": {
-              "version": "0.0.1",
-              "from": "token-stream@0.0.1",
-              "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz"
+              "version": "0.0.1"
             }
           }
         },
         "jade-runtime": {
-          "version": "2.0.0",
-          "from": "jade-runtime@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/jade-runtime/-/jade-runtime-2.0.0.tgz"
+          "version": "2.0.0"
         },
         "jade-strip-comments": {
           "version": "1.0.0",
-          "from": "jade-strip-comments@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jade-strip-comments/-/jade-strip-comments-1.0.0.tgz",
           "dependencies": {
             "jade-error": {
-              "version": "1.2.0",
-              "from": "jade-error@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jade-error/-/jade-error-1.2.0.tgz"
+              "version": "1.2.0"
             }
           }
         }
       }
     },
     "jed": {
-      "version": "1.0.2",
-      "from": "jed@1.0.2",
-      "resolved": "https://registry.npmjs.org/jed/-/jed-1.0.2.tgz"
+      "version": "1.0.2"
+    },
+    "jquery": {
+      "version": "1.11.3"
+    },
+    "jsdom": {
+      "version": "7.2.0",
+      "dependencies": {
+        "abab": {
+          "version": "1.0.3"
+        },
+        "acorn": {
+          "version": "2.7.0"
+        },
+        "acorn-globals": {
+          "version": "1.0.9"
+        },
+        "cssom": {
+          "version": "0.3.1"
+        },
+        "cssstyle": {
+          "version": "0.2.34"
+        },
+        "escodegen": {
+          "version": "1.8.0",
+          "dependencies": {
+            "estraverse": {
+              "version": "1.9.3"
+            },
+            "esutils": {
+              "version": "2.0.2"
+            },
+            "esprima": {
+              "version": "2.7.2"
+            },
+            "optionator": {
+              "version": "0.8.1",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2"
+                },
+                "deep-is": {
+                  "version": "0.1.3"
+                },
+                "wordwrap": {
+                  "version": "1.0.0"
+                },
+                "type-check": {
+                  "version": "0.3.2"
+                },
+                "levn": {
+                  "version": "0.3.0"
+                },
+                "fast-levenshtein": {
+                  "version": "1.1.3"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.2.0",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "nwmatcher": {
+          "version": "1.3.7"
+        },
+        "parse5": {
+          "version": "1.5.1"
+        },
+        "request": {
+          "version": "2.69.0",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0"
+            },
+            "aws4": {
+              "version": "1.3.2"
+            },
+            "bl": {
+              "version": "1.0.3",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.5",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2"
+                    },
+                    "isarray": {
+                      "version": "0.0.1"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0"
+            },
+            "forever-agent": {
+              "version": "0.6.1"
+            },
+            "form-data": {
+              "version": "1.0.0-rc3",
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.1",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.0",
+                      "dependencies": {
+                        "color-convert": {
+                          "version": "1.0.0"
+                        }
+                      }
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.13.1",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0"
+                    },
+                    "xtend": {
+                      "version": "4.0.1"
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.0",
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3"
+                },
+                "boom": {
+                  "version": "2.10.1"
+                },
+                "cryptiles": {
+                  "version": "2.0.5"
+                },
+                "sntp": {
+                  "version": "1.0.9"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0"
+                },
+                "jsprim": {
+                  "version": "1.2.2",
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2"
+                    },
+                    "json-schema": {
+                      "version": "0.2.2"
+                    },
+                    "verror": {
+                      "version": "1.3.6"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.7.4",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3"
+                    },
+                    "dashdash": {
+                      "version": "1.13.0",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0"
+                        }
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.0"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.1"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1"
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0"
+            },
+            "isstream": {
+              "version": "0.1.2"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1"
+            },
+            "mime-types": {
+              "version": "2.1.10",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.22.0"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7"
+            },
+            "oauth-sign": {
+              "version": "0.8.1"
+            },
+            "qs": {
+              "version": "6.0.2"
+            },
+            "stringstream": {
+              "version": "0.0.5"
+            },
+            "tunnel-agent": {
+              "version": "0.4.2"
+            }
+          }
+        },
+        "sax": {
+          "version": "1.1.6"
+        },
+        "symbol-tree": {
+          "version": "3.1.4"
+        },
+        "tough-cookie": {
+          "version": "2.2.2"
+        },
+        "webidl-conversions": {
+          "version": "2.0.1"
+        },
+        "whatwg-url-compat": {
+          "version": "0.6.5",
+          "dependencies": {
+            "tr46": {
+              "version": "0.0.3"
+            }
+          }
+        },
+        "xml-name-validator": {
+          "version": "2.0.1"
+        }
+      }
     },
     "jshashes": {
-      "version": "1.0.5",
-      "from": "jshashes@1.0.5",
-      "resolved": "https://registry.npmjs.org/jshashes/-/jshashes-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "json-loader": {
-      "version": "0.5.4",
-      "from": "json-loader@0.5.4",
-      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz"
+      "version": "0.5.4"
     },
     "jstimezonedetect": {
-      "version": "1.0.5",
-      "from": "jstimezonedetect@1.0.5",
-      "resolved": "https://registry.npmjs.org/jstimezonedetect/-/jstimezonedetect-1.0.5.tgz"
+      "version": "1.0.5"
     },
     "key-mirror": {
-      "version": "1.0.1",
-      "from": "key-mirror@1.0.1",
-      "resolved": "https://registry.npmjs.org/key-mirror/-/key-mirror-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "keymaster": {
-      "version": "1.6.2",
-      "from": "keymaster@1.6.2",
-      "resolved": "https://registry.npmjs.org/keymaster/-/keymaster-1.6.2.tgz"
+      "version": "1.6.2"
+    },
+    "localStorage": {
+      "version": "1.0.2"
     },
     "localforage": {
       "version": "1.3.3",
-      "from": "localforage@1.3.3",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.3.3.tgz",
       "dependencies": {
         "promise": {
           "version": "5.0.0",
-          "from": "promise@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-5.0.0.tgz",
           "dependencies": {
             "asap": {
-              "version": "1.0.0",
-              "from": "asap@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         }
       }
     },
     "lodash": {
-      "version": "4.5.0",
-      "from": "lodash@4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.5.0.tgz"
+      "version": "4.5.0"
+    },
+    "lodash-deep": {
+      "version": "1.5.3"
     },
     "lru-cache": {
       "version": "4.0.0",
-      "from": "lru-cache@4.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
       "dependencies": {
         "pseudomap": {
-          "version": "1.0.2",
-          "from": "pseudomap@>=1.0.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+          "version": "1.0.2"
         },
         "yallist": {
-          "version": "2.0.0",
-          "from": "yallist@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+          "version": "2.0.0"
         }
       }
     },
     "lunr": {
-      "version": "0.5.7",
-      "from": "lunr@0.5.7",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-0.5.7.tgz"
+      "version": "0.5.7"
     },
     "marked": {
-      "version": "0.3.5",
-      "from": "marked@0.3.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
+      "version": "0.3.5"
+    },
+    "mixedindentlint": {
+      "version": "1.1.1",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0"
+        }
+      }
+    },
+    "mocha": {
+      "version": "2.3.4",
+      "dependencies": {
+        "diff": {
+          "version": "1.4.0"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2"
+        },
+        "glob": {
+          "version": "3.2.3",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.3"
+                },
+                "sigmund": {
+                  "version": "1.0.1"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "2.0.3"
+            }
+          }
+        },
+        "growl": {
+          "version": "1.8.1"
+        },
+        "jade": {
+          "version": "0.26.3",
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1"
+            },
+            "mkdirp": {
+              "version": "0.3.0"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "1.2.0"
+        }
+      }
+    },
+    "mockery": {
+      "version": "1.4.0"
     },
     "moment": {
-      "version": "2.10.6",
-      "from": "moment@2.10.6",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+      "version": "2.10.6"
     },
     "moment-timezone": {
-      "version": "0.4.1",
-      "from": "moment-timezone@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz"
+      "version": "0.4.1"
     },
     "morgan": {
       "version": "1.2.0",
-      "from": "morgan@1.2.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.2.0.tgz",
       "dependencies": {
         "basic-auth": {
-          "version": "1.0.0",
-          "from": "basic-auth@1.0.0",
-          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "bytes": {
-          "version": "1.0.0",
-          "from": "bytes@1.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "depd": {
-          "version": "0.4.2",
-          "from": "depd@0.4.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.2.tgz"
+          "version": "0.4.2"
         },
         "finished": {
           "version": "1.2.2",
-          "from": "finished@>=1.2.2 <1.3.0",
-          "resolved": "https://registry.npmjs.org/finished/-/finished-1.2.2.tgz",
           "dependencies": {
             "ee-first": {
-              "version": "1.0.3",
-              "from": "ee-first@1.0.3",
-              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
+              "version": "1.0.3"
             }
           }
+        }
+      }
+    },
+    "ms": {
+      "version": "0.7.1"
+    },
+    "nock": {
+      "version": "2.17.0",
+      "dependencies": {
+        "debug": {
+          "version": "1.0.4",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2"
+            }
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1"
+        },
+        "lodash": {
+          "version": "2.4.1"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8"
+            }
+          }
+        },
+        "propagate": {
+          "version": "0.3.1"
         }
       }
     },
     "node-sass": {
       "version": "3.4.2",
-      "from": "node-sass@3.4.2",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.4.2.tgz",
       "dependencies": {
         "async-foreach": {
-          "version": "0.1.3",
-          "from": "async-foreach@>=0.1.3 <0.2.0",
-          "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
+          "version": "0.1.3"
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
-              "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+              "version": "2.2.0",
+              "dependencies": {
+                "color-convert": {
+                  "version": "1.0.0"
+                }
+              }
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "strip-ansi": {
-              "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "version": "3.0.1",
               "dependencies": {
                 "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                  "version": "2.0.0"
                 }
               }
             },
             "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+              "version": "2.0.0"
             }
           }
         },
         "cross-spawn": {
           "version": "2.1.5",
-          "from": "cross-spawn@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.1.5.tgz",
           "dependencies": {
             "cross-spawn-async": {
-              "version": "2.1.8",
-              "from": "cross-spawn-async@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.1.8.tgz",
+              "version": "2.1.9",
               "dependencies": {
                 "which": {
                   "version": "1.2.4",
-                  "from": "which@>=1.2.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
                   "dependencies": {
                     "is-absolute": {
                       "version": "0.1.7",
-                      "from": "is-absolute@>=0.1.7 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                       "dependencies": {
                         "is-relative": {
-                          "version": "0.1.3",
-                          "from": "is-relative@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                          "version": "0.1.3"
                         }
                       }
                     },
                     "isexe": {
-                      "version": "1.1.2",
-                      "from": "isexe@>=1.1.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+                      "version": "1.1.2"
                     }
                   }
                 }
@@ -4663,57 +4857,37 @@
             },
             "spawn-sync": {
               "version": "1.0.15",
-              "from": "spawn-sync@>=1.0.15 <2.0.0",
-              "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
               "dependencies": {
                 "concat-stream": {
                   "version": "1.5.1",
-                  "from": "concat-stream@>=1.4.7 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
                   "dependencies": {
                     "typedarray": {
-                      "version": "0.0.6",
-                      "from": "typedarray@>=0.0.5 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                      "version": "0.0.6"
                     },
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "version": "1.0.2"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "version": "1.0.6"
                         },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "0.10.31"
                         },
                         "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                          "version": "1.0.2"
                         }
                       }
                     }
                   }
                 },
                 "os-shim": {
-                  "version": "0.1.3",
-                  "from": "os-shim@>=0.1.2 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
+                  "version": "0.1.3"
                 }
               }
             }
@@ -4721,50 +4895,32 @@
         },
         "gaze": {
           "version": "0.5.2",
-          "from": "gaze@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
           "dependencies": {
             "globule": {
               "version": "0.1.0",
-              "from": "globule@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
               "dependencies": {
                 "lodash": {
-                  "version": "1.0.2",
-                  "from": "lodash@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                  "version": "1.0.2"
                 },
                 "glob": {
                   "version": "3.1.21",
-                  "from": "glob@>=3.1.21 <3.2.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                   "dependencies": {
                     "graceful-fs": {
-                      "version": "1.2.3",
-                      "from": "graceful-fs@>=1.2.0 <1.3.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                      "version": "1.2.3"
                     },
                     "inherits": {
-                      "version": "1.0.2",
-                      "from": "inherits@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                      "version": "1.0.2"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.11 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                      "version": "2.7.3"
                     },
                     "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
@@ -4773,46 +4929,30 @@
           }
         },
         "get-stdin": {
-          "version": "4.0.1",
-          "from": "get-stdin@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+          "version": "4.0.1"
         },
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.14 <6.0.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dependencies": {
             "inflight": {
               "version": "1.0.4",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.3",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                      "version": "0.3.0"
                     },
                     "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                      "version": "0.0.1"
                     }
                   }
                 }
@@ -4820,137 +4960,84 @@
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "meow": {
           "version": "3.7.0",
-          "from": "meow@>=3.3.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "dependencies": {
             "camelcase-keys": {
               "version": "2.0.0",
-              "from": "camelcase-keys@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
               "dependencies": {
                 "camelcase": {
-                  "version": "2.1.0",
-                  "from": "camelcase@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                  "version": "2.1.0"
                 }
               }
             },
             "decamelize": {
-              "version": "1.1.2",
-              "from": "decamelize@>=1.1.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                }
-              }
+              "version": "1.2.0"
             },
             "loud-rejection": {
-              "version": "1.2.1",
-              "from": "loud-rejection@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
+              "version": "1.3.0",
               "dependencies": {
                 "array-find-index": {
-                  "version": "1.0.1",
-                  "from": "array-find-index@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "signal-exit": {
-                  "version": "2.1.2",
-                  "from": "signal-exit@>=2.1.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                  "version": "2.1.2"
                 }
               }
             },
             "map-obj": {
-              "version": "1.0.1",
-              "from": "map-obj@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+              "version": "1.0.1"
             },
             "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.1.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+              "version": "1.2.0"
             },
             "normalize-package-data": {
               "version": "2.3.5",
-              "from": "normalize-package-data@>=2.3.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
               "dependencies": {
                 "hosted-git-info": {
-                  "version": "2.1.4",
-                  "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                  "version": "2.1.4"
                 },
                 "is-builtin-module": {
                   "version": "1.0.0",
-                  "from": "is-builtin-module@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                   "dependencies": {
                     "builtin-modules": {
-                      "version": "1.1.1",
-                      "from": "builtin-modules@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                      "version": "1.1.1"
                     }
                   }
                 },
                 "semver": {
-                  "version": "5.1.0",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                  "version": "5.1.0"
                 },
                 "validate-npm-package-license": {
                   "version": "3.0.1",
-                  "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                   "dependencies": {
                     "spdx-correct": {
                       "version": "1.0.2",
-                      "from": "spdx-correct@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                       "dependencies": {
                         "spdx-license-ids": {
-                          "version": "1.2.0",
-                          "from": "spdx-license-ids@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                          "version": "1.2.0"
                         }
                       }
                     },
                     "spdx-expression-parse": {
                       "version": "1.0.2",
-                      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                       "dependencies": {
                         "spdx-exceptions": {
-                          "version": "1.0.4",
-                          "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                          "version": "1.0.4"
                         },
                         "spdx-license-ids": {
-                          "version": "1.2.0",
-                          "from": "spdx-license-ids@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                          "version": "1.2.0"
                         }
                       }
                     }
@@ -4959,34 +5046,22 @@
               }
             },
             "object-assign": {
-              "version": "4.0.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+              "version": "4.0.1"
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "from": "read-pkg-up@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
               "dependencies": {
                 "find-up": {
-                  "version": "1.1.0",
-                  "from": "find-up@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                  "version": "1.1.2",
                   "dependencies": {
                     "path-exists": {
-                      "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                      "version": "2.1.0"
                     },
                     "pinkie-promise": {
                       "version": "2.0.0",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                       "dependencies": {
                         "pinkie": {
-                          "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                          "version": "2.0.4"
                         }
                       }
                     }
@@ -4994,64 +5069,42 @@
                 },
                 "read-pkg": {
                   "version": "1.1.0",
-                  "from": "read-pkg@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
-                      "from": "load-json-file@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
-                          "version": "4.1.3",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                          "version": "4.1.3"
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "from": "parse-json@>=2.2.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.0",
-                              "from": "error-ex@>=1.2.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                               "dependencies": {
                                 "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                  "version": "0.2.1"
                                 }
                               }
                             }
                           }
                         },
                         "pify": {
-                          "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                          "version": "2.3.0"
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
-                              "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                              "version": "2.0.4"
                             }
                           }
                         },
                         "strip-bom": {
                           "version": "2.0.0",
-                          "from": "strip-bom@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                           "dependencies": {
                             "is-utf8": {
-                              "version": "0.2.1",
-                              "from": "is-utf8@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                              "version": "0.2.1"
                             }
                           }
                         }
@@ -5059,28 +5112,18 @@
                     },
                     "path-type": {
                       "version": "1.1.0",
-                      "from": "path-type@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
-                          "version": "4.1.3",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+                          "version": "4.1.3"
                         },
                         "pify": {
-                          "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                          "version": "2.3.0"
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
-                              "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                              "version": "2.0.4"
                             }
                           }
                         }
@@ -5092,28 +5135,18 @@
             },
             "redent": {
               "version": "1.0.0",
-              "from": "redent@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
               "dependencies": {
                 "indent-string": {
                   "version": "2.1.0",
-                  "from": "indent-string@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                   "dependencies": {
                     "repeating": {
                       "version": "2.0.0",
-                      "from": "repeating@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                       "dependencies": {
                         "is-finite": {
                           "version": "1.0.1",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                           "dependencies": {
                             "number-is-nan": {
-                              "version": "1.0.0",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                              "version": "1.0.0"
                             }
                           }
                         }
@@ -5122,157 +5155,103 @@
                   }
                 },
                 "strip-indent": {
-                  "version": "1.0.1",
-                  "from": "strip-indent@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "trim-newlines": {
-              "version": "1.0.0",
-              "from": "trim-newlines@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "version": "0.0.8"
             }
           }
         },
         "nan": {
-          "version": "2.2.0",
-          "from": "nan@>=2.0.8 <3.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+          "version": "2.2.0"
         },
         "npmconf": {
           "version": "2.1.2",
-          "from": "npmconf@>=2.1.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
           "dependencies": {
             "config-chain": {
               "version": "1.1.10",
-              "from": "config-chain@>=1.1.8 <1.2.0",
-              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
               "dependencies": {
                 "proto-list": {
-                  "version": "1.2.4",
-                  "from": "proto-list@>=1.2.1 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                  "version": "1.2.4"
                 }
               }
             },
             "ini": {
-              "version": "1.3.4",
-              "from": "ini@>=1.2.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+              "version": "1.3.4"
             },
             "nopt": {
               "version": "3.0.6",
-              "from": "nopt@>=3.0.1 <3.1.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                  "version": "1.0.7"
                 }
               }
             },
             "once": {
               "version": "1.3.3",
-              "from": "once@>=1.3.0 <1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
               "dependencies": {
                 "wrappy": {
-                  "version": "1.0.1",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "osenv@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "semver": {
-              "version": "4.3.6",
-              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+              "version": "4.3.6"
             },
             "uid-number": {
-              "version": "0.0.5",
-              "from": "uid-number@0.0.5",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+              "version": "0.0.5"
             }
           }
         },
         "node-gyp": {
-          "version": "3.3.0",
-          "from": "node-gyp@>=3.0.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.3.0.tgz",
+          "version": "3.3.1",
           "dependencies": {
             "fstream": {
-              "version": "1.0.8",
-              "from": "fstream@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+              "version": "1.0.8"
             },
             "glob": {
               "version": "4.5.3",
-              "from": "glob@>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "version": "0.3.0"
                         },
                         "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "version": "0.0.1"
                         }
                       }
                     }
@@ -5280,192 +5259,106 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 }
               }
             },
             "graceful-fs": {
-              "version": "4.1.3",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+              "version": "4.1.3"
             },
             "minimatch": {
               "version": "1.0.0",
-              "from": "minimatch@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
               "dependencies": {
                 "lru-cache": {
-                  "version": "2.7.3",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                  "version": "2.7.3"
                 },
                 "sigmund": {
-                  "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "nopt": {
               "version": "3.0.6",
-              "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
               "dependencies": {
                 "abbrev": {
-                  "version": "1.0.7",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                  "version": "1.0.7"
                 }
               }
             },
             "npmlog": {
               "version": "2.0.2",
-              "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.2.tgz",
               "dependencies": {
                 "ansi": {
-                  "version": "0.3.1",
-                  "from": "ansi@>=0.3.1 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
+                  "version": "0.3.1"
                 },
                 "are-we-there-yet": {
                   "version": "1.0.6",
-                  "from": "are-we-there-yet@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
                   "dependencies": {
                     "delegates": {
-                      "version": "1.0.0",
-                      "from": "delegates@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "version": "1.0.2"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "version": "1.0.6"
                         },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "0.10.31"
                         },
                         "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                          "version": "1.0.2"
                         }
                       }
                     }
                   }
                 },
                 "gauge": {
-                  "version": "1.2.5",
-                  "from": "gauge@>=1.2.5 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.5.tgz",
+                  "version": "1.2.7",
                   "dependencies": {
                     "has-unicode": {
-                      "version": "2.0.0",
-                      "from": "has-unicode@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "lodash.pad": {
-                      "version": "3.3.0",
-                      "from": "lodash.pad@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.3.0.tgz",
+                      "version": "4.1.0",
                       "dependencies": {
-                        "lodash._root": {
-                          "version": "3.0.1",
-                          "from": "lodash._root@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-                        },
                         "lodash.repeat": {
-                          "version": "3.2.0",
-                          "from": "lodash.repeat@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.2.0.tgz"
+                          "version": "4.0.0"
+                        },
+                        "lodash.tostring": {
+                          "version": "4.1.2"
                         }
                       }
                     },
-                    "lodash.padleft": {
-                      "version": "3.1.1",
-                      "from": "lodash.padleft@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz",
+                    "lodash.padend": {
+                      "version": "4.2.0",
                       "dependencies": {
-                        "lodash._basetostring": {
-                          "version": "3.0.1",
-                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                        "lodash.repeat": {
+                          "version": "4.0.0"
                         },
-                        "lodash._createpadding": {
-                          "version": "3.6.1",
-                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "dependencies": {
-                            "lodash.repeat": {
-                              "version": "3.2.0",
-                              "from": "lodash.repeat@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.2.0.tgz",
-                              "dependencies": {
-                                "lodash._root": {
-                                  "version": "3.0.1",
-                                  "from": "lodash._root@>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
+                        "lodash.tostring": {
+                          "version": "4.1.2"
                         }
                       }
                     },
-                    "lodash.padright": {
-                      "version": "3.1.1",
-                      "from": "lodash.padright@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz",
+                    "lodash.padstart": {
+                      "version": "4.2.0",
                       "dependencies": {
-                        "lodash._basetostring": {
-                          "version": "3.0.1",
-                          "from": "lodash._basetostring@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                        "lodash.repeat": {
+                          "version": "4.0.0"
                         },
-                        "lodash._createpadding": {
-                          "version": "3.6.1",
-                          "from": "lodash._createpadding@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz",
-                          "dependencies": {
-                            "lodash.repeat": {
-                              "version": "3.2.0",
-                              "from": "lodash.repeat@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.2.0.tgz",
-                              "dependencies": {
-                                "lodash._root": {
-                                  "version": "3.0.1",
-                                  "from": "lodash._root@>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
+                        "lodash.tostring": {
+                          "version": "4.1.2"
                         }
                       }
                     }
@@ -5475,50 +5368,32 @@
             },
             "osenv": {
               "version": "0.1.3",
-              "from": "osenv@>=0.0.0 <1.0.0",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
               "dependencies": {
                 "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+                  "version": "1.0.1"
                 },
                 "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                  "version": "1.0.1"
                 }
               }
             },
             "path-array": {
               "version": "1.0.1",
-              "from": "path-array@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
               "dependencies": {
                 "array-index": {
                   "version": "1.0.0",
-                  "from": "array-index@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
                   "dependencies": {
                     "es6-symbol": {
                       "version": "3.0.2",
-                      "from": "es6-symbol@>=3.0.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
                       "dependencies": {
                         "d": {
-                          "version": "0.1.1",
-                          "from": "d@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                          "version": "0.1.1"
                         },
                         "es5-ext": {
                           "version": "0.10.11",
-                          "from": "es5-ext@>=0.10.10 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
                           "dependencies": {
                             "es6-iterator": {
-                              "version": "2.0.0",
-                              "from": "es6-iterator@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                              "version": "2.0.0"
                             }
                           }
                         }
@@ -5530,45 +5405,29 @@
             },
             "rimraf": {
               "version": "2.5.2",
-              "from": "rimraf@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
               "dependencies": {
                 "glob": {
-                  "version": "7.0.0",
-                  "from": "glob@>=7.0.0 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
+                  "version": "7.0.3",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "minimatch": {
                       "version": "3.0.0",
-                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "version": "0.3.0"
                             },
                             "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "version": "0.0.1"
                             }
                           }
                         }
@@ -5576,63 +5435,43 @@
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                          "version": "1.0.1"
                         }
                       }
                     },
                     "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
               }
             },
             "semver": {
-              "version": "5.1.0",
-              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+              "version": "5.1.0"
             },
             "tar": {
               "version": "2.2.1",
-              "from": "tar@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
               "dependencies": {
                 "block-stream": {
-                  "version": "0.0.8",
-                  "from": "block-stream@*",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                  "version": "0.0.8"
                 }
               }
             },
             "which": {
               "version": "1.2.4",
-              "from": "which@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
               "dependencies": {
                 "is-absolute": {
                   "version": "0.1.7",
-                  "from": "is-absolute@>=0.1.7 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                   "dependencies": {
                     "is-relative": {
-                      "version": "0.1.3",
-                      "from": "is-relative@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                      "version": "0.1.3"
                     }
                   }
                 },
                 "isexe": {
-                  "version": "1.1.2",
-                  "from": "isexe@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+                  "version": "1.1.2"
                 }
               }
             }
@@ -5640,164 +5479,101 @@
         },
         "request": {
           "version": "2.69.0",
-          "from": "request@>=2.61.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
           "dependencies": {
             "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+              "version": "0.6.0"
             },
             "aws4": {
-              "version": "1.2.1",
-              "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3",
-                  "from": "lru-cache@>=2.6.5 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                }
-              }
+              "version": "1.3.2"
             },
             "bl": {
               "version": "1.0.3",
-              "from": "bl@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "version": "1.0.6"
                     },
                     "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                      "version": "0.10.31"
                     },
                     "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "version": "1.0.2"
                     }
                   }
                 }
               }
             },
             "caseless": {
-              "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+              "version": "0.11.0"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "extend": {
-              "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+              "version": "3.0.0"
             },
             "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+              "version": "0.6.1"
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
-                  "version": "1.5.2",
-                  "from": "async@>=1.4.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                  "version": "1.5.2"
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "is-my-json-valid": {
-                  "version": "2.12.4",
-                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
+                  "version": "2.13.1",
                   "dependencies": {
                     "generate-function": {
-                      "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
-                          "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                          "version": "1.0.2"
                         }
                       }
                     },
                     "jsonpointer": {
-                      "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                      "version": "4.0.1"
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.0",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                   "dependencies": {
                     "pinkie": {
-                      "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                      "version": "2.0.4"
                     }
                   }
                 }
@@ -5805,209 +5581,133 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "hawk@>=3.1.0 <3.2.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
                 "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                  "version": "2.16.3"
                 },
                 "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                  "version": "2.10.1"
                 },
                 "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                  "version": "2.0.5"
                 },
                 "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                  "version": "1.0.9"
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "dependencies": {
                 "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                  "version": "0.2.0"
                 },
                 "jsprim": {
                   "version": "1.2.2",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                   "dependencies": {
                     "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "json-schema": {
-                      "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                      "version": "0.2.2"
                     },
                     "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                      "version": "1.3.6"
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.7.4",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.4.tgz",
                   "dependencies": {
                     "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                      "version": "0.2.3"
                     },
                     "dashdash": {
                       "version": "1.13.0",
-                      "from": "dashdash@>=1.10.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.13.0.tgz",
                       "dependencies": {
                         "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     },
                     "jsbn": {
-                      "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                      "version": "0.1.0"
                     },
                     "tweetnacl": {
-                      "version": "0.13.3",
-                      "from": "tweetnacl@>=0.13.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                      "version": "0.14.1"
                     },
                     "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                      "version": "0.1.1"
                     }
                   }
                 }
               }
             },
             "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+              "version": "0.1.2"
             },
             "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+              "version": "5.0.1"
             },
             "mime-types": {
               "version": "2.1.10",
-              "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.10.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.22.0",
-                  "from": "mime-db@>=1.22.0 <1.23.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.22.0.tgz"
+                  "version": "1.22.0"
                 }
               }
             },
             "node-uuid": {
-              "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "version": "1.4.7"
             },
             "oauth-sign": {
-              "version": "0.8.1",
-              "from": "oauth-sign@>=0.8.0 <0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
+              "version": "0.8.1"
             },
             "qs": {
-              "version": "6.0.2",
-              "from": "qs@>=6.0.2 <6.1.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
+              "version": "6.0.2"
             },
             "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+              "version": "0.0.5"
             },
             "tough-cookie": {
-              "version": "2.2.1",
-              "from": "tough-cookie@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+              "version": "2.2.2"
             },
             "tunnel-agent": {
-              "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+              "version": "0.4.2"
             }
           }
         },
         "sass-graph": {
           "version": "2.1.1",
-          "from": "sass-graph@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.1.tgz",
           "dependencies": {
             "glob": {
               "version": "6.0.4",
-              "from": "glob@>=6.0.4 <7.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "minimatch": {
                   "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                          "version": "0.3.0"
                         },
                         "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "version": "0.0.1"
                         }
                       }
                     }
@@ -6015,83 +5715,50 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.1"
                     }
                   }
                 },
                 "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "yargs": {
               "version": "3.32.0",
-              "from": "yargs@>=3.8.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
               "dependencies": {
                 "camelcase": {
-                  "version": "2.1.0",
-                  "from": "camelcase@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                  "version": "2.1.0"
                 },
                 "cliui": {
                   "version": "3.1.0",
-                  "from": "cliui@>=3.0.3 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.1.0.tgz",
                   "dependencies": {
                     "strip-ansi": {
-                      "version": "3.0.0",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "version": "3.0.1",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                          "version": "2.0.0"
                         }
                       }
                     },
                     "wrap-ansi": {
-                      "version": "1.0.0",
-                      "from": "wrap-ansi@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "decamelize": {
-                  "version": "1.1.2",
-                  "from": "decamelize@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.4",
-                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                    }
-                  }
+                  "version": "1.2.0"
                 },
                 "os-locale": {
                   "version": "1.4.0",
-                  "from": "os-locale@>=1.4.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                   "dependencies": {
                     "lcid": {
                       "version": "1.0.0",
-                      "from": "lcid@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                       "dependencies": {
                         "invert-kv": {
-                          "version": "1.0.0",
-                          "from": "invert-kv@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     }
@@ -6099,56 +5766,38 @@
                 },
                 "string-width": {
                   "version": "1.0.1",
-                  "from": "string-width@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.0.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
                       "dependencies": {
                         "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "dependencies": {
                         "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                          "version": "1.0.0"
                         }
                       }
                     },
                     "strip-ansi": {
-                      "version": "3.0.0",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "version": "3.0.1",
                       "dependencies": {
                         "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                          "version": "2.0.0"
                         }
                       }
                     }
                   }
                 },
                 "window-size": {
-                  "version": "0.1.4",
-                  "from": "window-size@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                  "version": "0.1.4"
                 },
                 "y18n": {
-                  "version": "3.2.0",
-                  "from": "y18n@>=3.2.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                  "version": "3.2.0"
                 }
               }
             }
@@ -6158,122 +5807,81 @@
     },
     "page": {
       "version": "1.6.4",
-      "from": "page@1.6.4",
-      "resolved": "https://registry.npmjs.org/page/-/page-1.6.4.tgz",
       "dependencies": {
         "path-to-regexp": {
           "version": "1.2.1",
-          "from": "path-to-regexp@>=1.2.1 <1.3.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz",
           "dependencies": {
             "isarray": {
-              "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              "version": "0.0.1"
             }
           }
         }
       }
     },
     "path-parser": {
-      "version": "1.0.2",
-      "from": "path-parser@1.0.2",
-      "resolved": "https://registry.npmjs.org/path-parser/-/path-parser-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "phone": {
-      "version": "1.0.4-9",
-      "resolved": "git+https://github.com/Automattic/node-phone.git#1.0.4-9"
+      "version": "1.0.4-3",
+      "from": "git+https://github.com/Automattic/node-phone.git#8f012b153e968038c2ce758b7f34e5b8d792eb20",
+      "resolved": "git+https://github.com/Automattic/node-phone.git#8f012b153e968038c2ce758b7f34e5b8d792eb20"
     },
     "photon": {
       "version": "2.0.0",
-      "from": "photon@2.0.0",
-      "resolved": "https://registry.npmjs.org/photon/-/photon-2.0.0.tgz",
       "dependencies": {
         "crc32": {
-          "version": "0.2.2",
-          "from": "crc32@0.2.2",
-          "resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz"
+          "version": "0.2.2"
         },
         "seed-random": {
-          "version": "2.2.0",
-          "from": "seed-random@2.2.0",
-          "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz"
+          "version": "2.2.0"
         }
       }
     },
     "q": {
-      "version": "1.0.1",
-      "from": "q@1.0.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+      "version": "1.0.1"
     },
     "qrcode.react": {
       "version": "0.5.2",
-      "from": "qrcode.react@0.5.2",
-      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-0.5.2.tgz",
       "dependencies": {
         "qr.js": {
-          "version": "0.0.0",
-          "from": "qr.js@0.0.0",
-          "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz"
+          "version": "0.0.0"
         }
       }
     },
     "qs": {
-      "version": "4.0.0",
-      "from": "qs@4.0.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+      "version": "4.0.0"
     },
     "raf": {
       "version": "2.0.4",
-      "from": "raf@2.0.4",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-2.0.4.tgz",
       "dependencies": {
         "performance-now": {
-          "version": "0.1.4",
-          "from": "performance-now@>=0.1.3 <0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.1.4.tgz"
+          "version": "0.1.4"
         }
       }
     },
     "react": {
       "version": "0.14.3",
-      "from": "react@0.14.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.14.3.tgz",
       "dependencies": {
         "envify": {
           "version": "3.4.0",
-          "from": "envify@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
           "dependencies": {
             "through": {
-              "version": "2.3.8",
-              "from": "through@>=2.3.4 <2.4.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+              "version": "2.3.8"
             },
             "jstransform": {
               "version": "10.1.0",
-              "from": "jstransform@>=10.0.1 <11.0.0",
-              "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
               "dependencies": {
                 "base62": {
-                  "version": "0.1.1",
-                  "from": "base62@0.1.1",
-                  "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
+                  "version": "0.1.1"
                 },
                 "esprima-fb": {
-                  "version": "13001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+                  "version": "13001.1001.0-dev-harmony-fb"
                 },
                 "source-map": {
                   "version": "0.1.31",
-                  "from": "source-map@0.1.31",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 }
@@ -6283,116 +5891,77 @@
         },
         "fbjs": {
           "version": "0.3.2",
-          "from": "fbjs@>=0.3.1 <0.4.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.3.2.tgz",
           "dependencies": {
             "core-js": {
-              "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+              "version": "1.2.6"
             },
             "loose-envify": {
               "version": "1.1.0",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "dependencies": {
                 "js-tokens": {
-                  "version": "1.0.2",
-                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                  "version": "1.0.2"
                 }
               }
             },
             "promise": {
               "version": "7.1.1",
-              "from": "promise@>=7.0.3 <8.0.0",
-              "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
               "dependencies": {
                 "asap": {
-                  "version": "2.0.3",
-                  "from": "asap@>=2.0.3 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                  "version": "2.0.3"
                 }
               }
             },
             "ua-parser-js": {
-              "version": "0.7.10",
-              "from": "ua-parser-js@>=0.7.9 <0.8.0",
-              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
+              "version": "0.7.10"
             },
             "whatwg-fetch": {
-              "version": "0.9.0",
-              "from": "whatwg-fetch@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+              "version": "0.9.0"
             }
           }
         }
       }
     },
     "react-addons-create-fragment": {
-      "version": "0.14.3",
-      "from": "react-addons-create-fragment@0.14.3",
-      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-0.14.3.tgz"
+      "version": "0.14.3"
     },
     "react-addons-css-transition-group": {
-      "version": "0.14.3",
-      "from": "react-addons-css-transition-group@0.14.3",
-      "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-0.14.3.tgz"
+      "version": "0.14.3"
     },
     "react-addons-linked-state-mixin": {
-      "version": "0.14.3",
-      "from": "react-addons-linked-state-mixin@0.14.3",
-      "resolved": "https://registry.npmjs.org/react-addons-linked-state-mixin/-/react-addons-linked-state-mixin-0.14.3.tgz"
+      "version": "0.14.3"
+    },
+    "react-addons-test-utils": {
+      "version": "0.14.3"
     },
     "react-addons-update": {
-      "version": "0.14.3",
-      "from": "react-addons-update@0.14.3",
-      "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-0.14.3.tgz"
+      "version": "0.14.3"
     },
     "react-click-outside": {
-      "version": "2.1.0",
-      "from": "react-click-outside@2.1.0",
-      "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-2.1.0.tgz"
+      "version": "2.1.0"
     },
     "react-day-picker": {
-      "version": "1.1.0",
-      "from": "react-day-picker@1.1.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-1.1.0.tgz"
+      "version": "1.1.0"
     },
     "react-dom": {
-      "version": "0.14.3",
-      "from": "react-dom@0.14.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.3.tgz"
+      "version": "0.14.3"
     },
     "react-helmet": {
       "version": "2.2.0",
-      "from": "react-helmet@2.2.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-2.2.0.tgz",
       "dependencies": {
         "core-js": {
-          "version": "1.2.6",
-          "from": "core-js@1.2.6",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+          "version": "1.2.6"
         },
         "deep-equal": {
-          "version": "1.0.1",
-          "from": "deep-equal@1.0.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "invariant": {
           "version": "2.1.2",
-          "from": "invariant@2.1.2",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.1.2.tgz",
           "dependencies": {
             "loose-envify": {
               "version": "1.1.0",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "dependencies": {
                 "js-tokens": {
-                  "version": "1.0.2",
-                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                  "version": "1.0.2"
                 }
               }
             }
@@ -6400,30 +5969,20 @@
         },
         "react-side-effect": {
           "version": "1.0.2",
-          "from": "react-side-effect@1.0.2",
-          "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.0.2.tgz",
           "dependencies": {
             "fbjs": {
               "version": "0.1.0-alpha.10",
-              "from": "fbjs@0.1.0-alpha.10",
-              "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.10.tgz",
               "dependencies": {
                 "promise": {
                   "version": "7.1.1",
-                  "from": "promise@>=7.0.3 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
                   "dependencies": {
                     "asap": {
-                      "version": "2.0.3",
-                      "from": "asap@>=2.0.3 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                      "version": "2.0.3"
                     }
                   }
                 },
                 "whatwg-fetch": {
-                  "version": "0.9.0",
-                  "from": "whatwg-fetch@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+                  "version": "0.9.0"
                 }
               }
             }
@@ -6431,28 +5990,18 @@
         },
         "shallowequal": {
           "version": "0.2.2",
-          "from": "shallowequal@0.2.2",
-          "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
           "dependencies": {
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "dependencies": {
                 "lodash._getnative": {
-                  "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                  "version": "3.9.1"
                 },
                 "lodash.isarguments": {
-                  "version": "3.0.7",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                  "version": "3.0.8"
                 },
                 "lodash.isarray": {
-                  "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                  "version": "3.0.4"
                 }
               }
             }
@@ -6460,18 +6009,12 @@
         },
         "warning": {
           "version": "2.1.0",
-          "from": "warning@2.1.0",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
           "dependencies": {
             "loose-envify": {
               "version": "1.1.0",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "dependencies": {
                 "js-tokens": {
-                  "version": "1.0.2",
-                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                  "version": "1.0.2"
                 }
               }
             }
@@ -6479,35 +6022,39 @@
         }
       }
     },
+    "react-hot-loader": {
+      "version": "1.3.0",
+      "dependencies": {
+        "react-hot-api": {
+          "version": "0.4.7"
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.0"
+            }
+          }
+        }
+      }
+    },
     "react-pure-render": {
-      "version": "1.0.2",
-      "from": "react-pure-render@1.0.2",
-      "resolved": "https://registry.npmjs.org/react-pure-render/-/react-pure-render-1.0.2.tgz"
+      "version": "1.0.2"
     },
     "react-redux": {
       "version": "4.0.1",
-      "from": "react-redux@4.0.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.0.1.tgz",
       "dependencies": {
         "hoist-non-react-statics": {
-          "version": "1.0.5",
-          "from": "hoist-non-react-statics@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.0.5.tgz"
+          "version": "1.0.5"
         },
         "invariant": {
-          "version": "2.2.0",
-          "from": "invariant@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+          "version": "2.2.1",
           "dependencies": {
             "loose-envify": {
               "version": "1.1.0",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
               "dependencies": {
                 "js-tokens": {
-                  "version": "1.0.2",
-                  "from": "js-tokens@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                  "version": "1.0.2"
                 }
               }
             }
@@ -6517,79 +6064,51 @@
     },
     "react-tap-event-plugin": {
       "version": "0.2.1",
-      "from": "react-tap-event-plugin@0.2.1",
-      "resolved": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-0.2.1.tgz",
       "dependencies": {
         "fbjs": {
           "version": "0.2.1",
-          "from": "fbjs@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.2.1.tgz",
           "dependencies": {
             "core-js": {
-              "version": "1.2.6",
-              "from": "core-js@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+              "version": "1.2.6"
             },
             "promise": {
               "version": "7.1.1",
-              "from": "promise@>=7.0.3 <8.0.0",
-              "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
               "dependencies": {
                 "asap": {
-                  "version": "2.0.3",
-                  "from": "asap@>=2.0.3 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                  "version": "2.0.3"
                 }
               }
             },
             "whatwg-fetch": {
-              "version": "0.9.0",
-              "from": "whatwg-fetch@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+              "version": "0.9.0"
             }
           }
         }
       }
     },
     "redux": {
-      "version": "3.0.4",
-      "from": "redux@3.0.4",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.0.4.tgz"
+      "version": "3.0.4"
     },
     "redux-analytics": {
       "version": "0.3.0",
-      "from": "redux-analytics@0.3.0",
-      "resolved": "https://registry.npmjs.org/redux-analytics/-/redux-analytics-0.3.0.tgz",
       "dependencies": {
         "flux-standard-action": {
           "version": "0.6.1",
-          "from": "flux-standard-action@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.1.tgz",
           "dependencies": {
             "lodash.isplainobject": {
               "version": "3.2.0",
-              "from": "lodash.isplainobject@>=3.2.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
-                  "version": "3.0.3",
-                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+                  "version": "3.0.3"
                 },
                 "lodash.isarguments": {
-                  "version": "3.0.7",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.7.tgz"
+                  "version": "3.0.8"
                 },
                 "lodash.keysin": {
                   "version": "3.0.8",
-                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
                   "dependencies": {
                     "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                      "version": "3.0.4"
                     }
                   }
                 }
@@ -6600,75 +6119,52 @@
       }
     },
     "redux-thunk": {
-      "version": "1.0.0",
-      "from": "redux-thunk@1.0.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.0.tgz"
+      "version": "1.0.0"
+    },
+    "rewire": {
+      "version": "2.3.3"
     },
     "rtlcss": {
       "version": "1.6.1",
-      "from": "rtlcss@1.6.1",
-      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-1.6.1.tgz",
       "dependencies": {
         "postcss": {
           "version": "4.1.16",
-          "from": "postcss@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
           "dependencies": {
             "es6-promise": {
-              "version": "2.3.0",
-              "from": "es6-promise@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz"
+              "version": "2.3.0"
             },
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.2 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.8 <2.2.0",
-              "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+              "version": "2.1.9"
             }
           }
         },
         "findup": {
           "version": "0.1.5",
-          "from": "findup@0.1.5",
-          "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
           "dependencies": {
             "colors": {
-              "version": "0.6.2",
-              "from": "colors@>=0.6.0-1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+              "version": "0.6.2"
             },
             "commander": {
-              "version": "2.1.0",
-              "from": "commander@>=2.1.0 <2.2.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+              "version": "2.1.0"
             }
           }
         },
         "strip-json-comments": {
-          "version": "1.0.4",
-          "from": "strip-json-comments@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+          "version": "1.0.4"
         },
         "mkdirp": {
           "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "version": "0.0.8"
             }
           }
         }
@@ -6676,103 +6172,379 @@
     },
     "sanitize-html": {
       "version": "1.11.1",
-      "from": "sanitize-html@1.11.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.11.1.tgz",
       "dependencies": {
         "htmlparser2": {
           "version": "3.8.3",
-          "from": "htmlparser2@>=3.8.0 <3.9.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "dependencies": {
             "domhandler": {
-              "version": "2.3.0",
-              "from": "domhandler@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+              "version": "2.3.0"
             },
             "domutils": {
               "version": "1.5.1",
-              "from": "domutils@>=1.5.0 <1.6.0",
-              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
               "dependencies": {
                 "dom-serializer": {
                   "version": "0.1.0",
-                  "from": "dom-serializer@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
                   "dependencies": {
                     "domelementtype": {
-                      "version": "1.1.3",
-                      "from": "domelementtype@>=1.1.1 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                      "version": "1.1.3"
                     },
                     "entities": {
-                      "version": "1.1.1",
-                      "from": "entities@>=1.1.1 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                      "version": "1.1.1"
                     }
                   }
                 }
               }
             },
             "domelementtype": {
-              "version": "1.3.0",
-              "from": "domelementtype@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+              "version": "1.3.0"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "version": "1.0.2"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "0.0.1"
                 },
                 "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "version": "0.10.31"
                 }
               }
             },
             "entities": {
-              "version": "1.0.0",
-              "from": "entities@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "regexp-quote": {
-          "version": "0.0.0",
-          "from": "regexp-quote@0.0.0",
-          "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz"
+          "version": "0.0.0"
         },
         "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+          "version": "4.0.1"
+        }
+      }
+    },
+    "sinon": {
+      "version": "1.12.2",
+      "dependencies": {
+        "formatio": {
+          "version": "1.1.1",
+          "dependencies": {
+            "samsam": {
+              "version": "1.1.3"
+            }
+          }
+        },
+        "util": {
+          "version": "0.10.3"
+        },
+        "lolex": {
+          "version": "1.1.0"
+        }
+      }
+    },
+    "sinon-chai": {
+      "version": "2.7.0"
+    },
+    "socket.io": {
+      "version": "1.3.7",
+      "dependencies": {
+        "engine.io": {
+          "version": "1.5.4",
+          "dependencies": {
+            "base64id": {
+              "version": "0.1.0"
+            },
+            "debug": {
+              "version": "1.0.3",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2"
+                }
+              }
+            },
+            "engine.io-parser": {
+              "version": "1.2.2",
+              "dependencies": {
+                "after": {
+                  "version": "0.8.1"
+                },
+                "arraybuffer.slice": {
+                  "version": "0.0.6"
+                },
+                "base64-arraybuffer": {
+                  "version": "0.1.2"
+                },
+                "blob": {
+                  "version": "0.0.4"
+                },
+                "has-binary": {
+                  "version": "0.1.6",
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1"
+                    }
+                  }
+                },
+                "utf8": {
+                  "version": "2.1.0"
+                }
+              }
+            },
+            "ws": {
+              "version": "0.8.0",
+              "dependencies": {
+                "options": {
+                  "version": "0.0.6"
+                },
+                "ultron": {
+                  "version": "1.0.2"
+                },
+                "bufferutil": {
+                  "version": "1.2.1",
+                  "dependencies": {
+                    "bindings": {
+                      "version": "1.2.1"
+                    },
+                    "nan": {
+                      "version": "2.2.0"
+                    }
+                  }
+                },
+                "utf-8-validate": {
+                  "version": "1.2.1",
+                  "dependencies": {
+                    "bindings": {
+                      "version": "1.2.1"
+                    },
+                    "nan": {
+                      "version": "2.2.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "socket.io-parser": {
+          "version": "2.2.4",
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4"
+            },
+            "json3": {
+              "version": "3.2.6"
+            },
+            "component-emitter": {
+              "version": "1.1.2"
+            },
+            "isarray": {
+              "version": "0.0.1"
+            },
+            "benchmark": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "socket.io-client": {
+          "version": "1.3.7",
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4"
+            },
+            "engine.io-client": {
+              "version": "1.5.4",
+              "dependencies": {
+                "component-inherit": {
+                  "version": "0.0.3"
+                },
+                "debug": {
+                  "version": "1.0.4",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2"
+                    }
+                  }
+                },
+                "engine.io-parser": {
+                  "version": "1.2.2",
+                  "dependencies": {
+                    "after": {
+                      "version": "0.8.1"
+                    },
+                    "arraybuffer.slice": {
+                      "version": "0.0.6"
+                    },
+                    "base64-arraybuffer": {
+                      "version": "0.1.2"
+                    },
+                    "blob": {
+                      "version": "0.0.4"
+                    },
+                    "utf8": {
+                      "version": "2.1.0"
+                    }
+                  }
+                },
+                "has-cors": {
+                  "version": "1.0.3",
+                  "dependencies": {
+                    "global": {
+                      "version": "2.0.1",
+                      "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+                    }
+                  }
+                },
+                "parsejson": {
+                  "version": "0.0.1"
+                },
+                "parseqs": {
+                  "version": "0.0.2"
+                },
+                "parseuri": {
+                  "version": "0.0.4"
+                },
+                "ws": {
+                  "version": "0.8.0",
+                  "dependencies": {
+                    "options": {
+                      "version": "0.0.6"
+                    },
+                    "ultron": {
+                      "version": "1.0.2"
+                    },
+                    "bufferutil": {
+                      "version": "1.2.1",
+                      "dependencies": {
+                        "bindings": {
+                          "version": "1.2.1"
+                        },
+                        "nan": {
+                          "version": "2.2.0"
+                        }
+                      }
+                    },
+                    "utf-8-validate": {
+                      "version": "1.2.1",
+                      "dependencies": {
+                        "bindings": {
+                          "version": "1.2.1"
+                        },
+                        "nan": {
+                          "version": "2.2.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "xmlhttprequest": {
+                  "version": "1.5.0",
+                  "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
+                }
+              }
+            },
+            "component-bind": {
+              "version": "1.0.0"
+            },
+            "component-emitter": {
+              "version": "1.1.2"
+            },
+            "object-component": {
+              "version": "0.0.3"
+            },
+            "has-binary": {
+              "version": "0.1.6",
+              "dependencies": {
+                "isarray": {
+                  "version": "0.0.1"
+                }
+              }
+            },
+            "indexof": {
+              "version": "0.0.1"
+            },
+            "parseuri": {
+              "version": "0.0.2"
+            },
+            "to-array": {
+              "version": "0.1.3"
+            },
+            "backo2": {
+              "version": "1.0.2"
+            }
+          }
+        },
+        "socket.io-adapter": {
+          "version": "0.3.1",
+          "dependencies": {
+            "debug": {
+              "version": "1.0.2",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2"
+                }
+              }
+            },
+            "socket.io-parser": {
+              "version": "2.2.2",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4"
+                },
+                "json3": {
+                  "version": "3.2.6"
+                },
+                "component-emitter": {
+                  "version": "1.1.2"
+                },
+                "isarray": {
+                  "version": "0.0.1"
+                },
+                "benchmark": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "object-keys": {
+              "version": "1.0.1"
+            }
+          }
+        },
+        "has-binary-data": {
+          "version": "0.1.3",
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.1.0",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2"
+            }
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.1.39",
+      "dependencies": {
+        "amdefine": {
+          "version": "1.0.0"
         }
       }
     },
     "source-map-support": {
       "version": "0.3.2",
-      "from": "source-map-support@0.3.2",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.2.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
-          "from": "source-map@0.1.32",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "dependencies": {
             "amdefine": {
-              "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         }
@@ -6780,102 +6552,64 @@
     },
     "srcset": {
       "version": "1.0.0",
-      "from": "srcset@1.0.0",
-      "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
       "dependencies": {
         "array-uniq": {
-          "version": "1.0.2",
-          "from": "array-uniq@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+          "version": "1.0.2"
         },
         "number-is-nan": {
-          "version": "1.0.0",
-          "from": "number-is-nan@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+          "version": "1.0.0"
         }
       }
     },
     "store": {
-      "version": "1.3.16",
-      "from": "store@1.3.16",
-      "resolved": "https://registry.npmjs.org/store/-/store-1.3.16.tgz"
+      "version": "1.3.16"
     },
     "striptags": {
-      "version": "2.1.1",
-      "from": "striptags@2.1.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.1.1.tgz"
+      "version": "2.1.1"
     },
     "superagent": {
       "version": "1.2.0",
-      "from": "superagent@1.2.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.2.0.tgz",
       "dependencies": {
         "qs": {
-          "version": "2.3.3",
-          "from": "qs@2.3.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+          "version": "2.3.3"
         },
         "formidable": {
-          "version": "1.0.14",
-          "from": "formidable@1.0.14",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+          "version": "1.0.14"
         },
         "mime": {
-          "version": "1.3.4",
-          "from": "mime@1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+          "version": "1.3.4"
         },
         "component-emitter": {
-          "version": "1.1.2",
-          "from": "component-emitter@1.1.2",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+          "version": "1.1.2"
         },
         "methods": {
-          "version": "1.0.1",
-          "from": "methods@1.0.1",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "cookiejar": {
-          "version": "2.0.1",
-          "from": "cookiejar@2.0.1",
-          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz"
+          "version": "2.0.1"
         },
         "reduce-component": {
-          "version": "1.0.1",
-          "from": "reduce-component@1.0.1",
-          "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz"
+          "version": "1.0.1"
         },
         "extend": {
-          "version": "1.2.1",
-          "from": "extend@1.2.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz"
+          "version": "1.2.1"
         },
         "form-data": {
           "version": "0.2.0",
-          "from": "form-data@0.2.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.7",
-              "from": "combined-stream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "dependencies": {
                 "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "version": "0.0.5"
                 }
               }
             },
             "mime-types": {
               "version": "2.0.14",
-              "from": "mime-types@>=2.0.3 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.12.0",
-                  "from": "mime-db@>=1.12.0 <1.13.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                  "version": "1.12.0"
                 }
               }
             }
@@ -6883,212 +6617,205 @@
         },
         "readable-stream": {
           "version": "1.0.27-1",
-          "from": "readable-stream@1.0.27-1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
           "dependencies": {
             "core-util-is": {
-              "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+              "version": "1.0.2"
             },
             "isarray": {
-              "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              "version": "0.0.1"
             },
             "string_decoder": {
-              "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              "version": "0.10.31"
             }
           }
         }
       }
     },
+    "supertest": {
+      "version": "1.2.0",
+      "dependencies": {
+        "superagent": {
+          "version": "1.8.0",
+          "dependencies": {
+            "qs": {
+              "version": "2.3.3"
+            },
+            "formidable": {
+              "version": "1.0.17"
+            },
+            "mime": {
+              "version": "1.3.4"
+            },
+            "component-emitter": {
+              "version": "1.2.0"
+            },
+            "cookiejar": {
+              "version": "2.0.6"
+            },
+            "reduce-component": {
+              "version": "1.0.1"
+            },
+            "extend": {
+              "version": "3.0.0"
+            },
+            "form-data": {
+              "version": "1.0.0-rc3",
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "mime-types": {
+                  "version": "2.1.10",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.22.0"
+                    }
+                  }
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "1.0.27-1",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2"
+                },
+                "isarray": {
+                  "version": "0.0.1"
+                },
+                "string_decoder": {
+                  "version": "0.10.31"
+                }
+              }
+            }
+          }
+        },
+        "methods": {
+          "version": "1.1.2"
+        }
+      }
+    },
     "tinymce": {
-      "version": "4.2.8",
-      "from": "tinymce@4.2.8",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-4.2.8.tgz"
+      "version": "4.2.8"
     },
     "to-title-case": {
       "version": "0.1.5",
-      "from": "to-title-case@0.1.5",
-      "resolved": "https://registry.npmjs.org/to-title-case/-/to-title-case-0.1.5.tgz",
       "dependencies": {
         "escape-regexp-component": {
-          "version": "1.0.2",
-          "from": "escape-regexp-component@1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
+          "version": "1.0.2"
         },
         "title-case-minors": {
-          "version": "0.0.2",
-          "from": "title-case-minors@0.0.2",
-          "resolved": "https://registry.npmjs.org/title-case-minors/-/title-case-minors-0.0.2.tgz"
+          "version": "0.0.2"
         },
         "to-capital-case": {
           "version": "0.1.1",
-          "from": "to-capital-case@0.1.1",
-          "resolved": "https://registry.npmjs.org/to-capital-case/-/to-capital-case-0.1.1.tgz",
           "dependencies": {
             "to-no-case": {
-              "version": "0.1.1",
-              "from": "to-no-case@0.1.1",
-              "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-0.1.1.tgz"
+              "version": "0.1.1"
             }
           }
         }
       }
     },
     "tv4": {
-      "version": "1.2.7",
-      "from": "tv4@1.2.7",
-      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz"
+      "version": "1.2.7"
     },
     "tween.js": {
-      "version": "16.3.1",
-      "from": "tween.js@16.3.1",
-      "resolved": "https://registry.npmjs.org/tween.js/-/tween.js-16.3.1.tgz"
+      "version": "16.3.1"
     },
     "twemoji": {
-      "version": "1.3.2",
-      "from": "twemoji@1.3.2",
-      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-1.3.2.tgz"
+      "version": "1.3.2"
     },
     "uglify-js": {
       "version": "2.6.1",
-      "from": "uglify-js@2.6.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "from": "async@>=0.2.6 <0.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+          "version": "0.2.10"
         },
         "source-map": {
-          "version": "0.5.3",
-          "from": "source-map@>=0.5.1 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+          "version": "0.5.3"
         },
         "uglify-to-browserify": {
-          "version": "1.0.2",
-          "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+          "version": "1.0.2"
         },
         "yargs": {
           "version": "3.10.0",
-          "from": "yargs@>=3.10.0 <3.11.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "dependencies": {
             "camelcase": {
-              "version": "1.2.1",
-              "from": "camelcase@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+              "version": "1.2.1"
             },
             "cliui": {
               "version": "2.1.0",
-              "from": "cliui@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
               "dependencies": {
                 "center-align": {
                   "version": "0.1.3",
-                  "from": "center-align@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                   "dependencies": {
                     "align-text": {
                       "version": "0.1.4",
-                      "from": "align-text@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                       "dependencies": {
                         "kind-of": {
                           "version": "3.0.2",
-                          "from": "kind-of@>=3.0.2 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                           "dependencies": {
                             "is-buffer": {
-                              "version": "1.1.2",
-                              "from": "is-buffer@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                              "version": "1.1.3"
                             }
                           }
                         },
                         "longest": {
-                          "version": "1.0.1",
-                          "from": "longest@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "repeat-string": {
-                          "version": "1.5.2",
-                          "from": "repeat-string@>=1.5.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                          "version": "1.5.4"
                         }
                       }
                     },
                     "lazy-cache": {
-                      "version": "1.0.3",
-                      "from": "lazy-cache@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
+                      "version": "1.0.3"
                     }
                   }
                 },
                 "right-align": {
                   "version": "0.1.3",
-                  "from": "right-align@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                   "dependencies": {
                     "align-text": {
                       "version": "0.1.4",
-                      "from": "align-text@>=0.1.3 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                       "dependencies": {
                         "kind-of": {
                           "version": "3.0.2",
-                          "from": "kind-of@>=3.0.2 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                           "dependencies": {
                             "is-buffer": {
-                              "version": "1.1.2",
-                              "from": "is-buffer@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                              "version": "1.1.3"
                             }
                           }
                         },
                         "longest": {
-                          "version": "1.0.1",
-                          "from": "longest@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                          "version": "1.0.1"
                         },
                         "repeat-string": {
-                          "version": "1.5.2",
-                          "from": "repeat-string@>=1.5.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                          "version": "1.5.4"
                         }
                       }
                     }
                   }
                 },
                 "wordwrap": {
-                  "version": "0.0.2",
-                  "from": "wordwrap@0.0.2",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                  "version": "0.0.2"
                 }
               }
             },
             "decamelize": {
-              "version": "1.1.2",
-              "from": "decamelize@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                }
-              }
+              "version": "1.2.0"
             },
             "window-size": {
-              "version": "0.1.0",
-              "from": "window-size@0.1.0",
-              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+              "version": "0.1.0"
             }
           }
         }
@@ -7096,285 +6823,181 @@
     },
     "walk": {
       "version": "2.3.4",
-      "from": "walk@2.3.4",
-      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.4.tgz",
       "dependencies": {
         "foreachasync": {
-          "version": "3.0.0",
-          "from": "foreachasync@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
+          "version": "3.0.0"
         }
       }
     },
     "webpack": {
       "version": "1.12.6",
-      "from": "webpack@1.12.6",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.6.tgz",
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+          "version": "1.5.2"
         },
         "clone": {
-          "version": "1.0.2",
-          "from": "clone@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+          "version": "1.0.2"
         },
         "enhanced-resolve": {
           "version": "0.9.1",
-          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "dependencies": {
             "graceful-fs": {
-              "version": "4.1.3",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+              "version": "4.1.3"
             }
           }
         },
         "esprima": {
-          "version": "2.7.2",
-          "from": "esprima@>=2.5.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+          "version": "2.7.2"
         },
         "interpret": {
-          "version": "0.6.6",
-          "from": "interpret@>=0.6.4 <0.7.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+          "version": "0.6.6"
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+              "version": "3.1.3"
             },
             "json5": {
-              "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+              "version": "0.4.0"
             }
           }
         },
         "memory-fs": {
-          "version": "0.2.0",
-          "from": "memory-fs@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+          "version": "0.2.0"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+              "version": "0.0.8"
             }
           }
         },
         "node-libs-browser": {
           "version": "0.5.3",
-          "from": "node-libs-browser@>=0.4.0 <=0.6.0",
-          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
           "dependencies": {
             "assert": {
-              "version": "1.3.0",
-              "from": "assert@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+              "version": "1.3.0"
             },
             "browserify-zlib": {
               "version": "0.1.4",
-              "from": "browserify-zlib@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "dependencies": {
                 "pako": {
-                  "version": "0.2.8",
-                  "from": "pako@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+                  "version": "0.2.8"
                 }
               }
             },
             "buffer": {
               "version": "3.6.0",
-              "from": "buffer@>=3.0.3 <4.0.0",
-              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
               "dependencies": {
                 "base64-js": {
-                  "version": "0.0.8",
-                  "from": "base64-js@0.0.8",
-                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+                  "version": "0.0.8"
                 },
                 "ieee754": {
-                  "version": "1.1.6",
-                  "from": "ieee754@>=1.1.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+                  "version": "1.1.6"
                 },
                 "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
-                  "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                  "version": "0.1.4"
                 }
               }
             },
             "constants-browserify": {
-              "version": "0.0.1",
-              "from": "constants-browserify@0.0.1",
-              "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+              "version": "0.0.1"
             },
             "crypto-browserify": {
               "version": "3.2.8",
-              "from": "crypto-browserify@>=3.2.6 <3.3.0",
-              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
               "dependencies": {
                 "pbkdf2-compat": {
-                  "version": "2.0.1",
-                  "from": "pbkdf2-compat@2.0.1",
-                  "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                  "version": "2.0.1"
                 },
                 "ripemd160": {
-                  "version": "0.2.0",
-                  "from": "ripemd160@0.2.0",
-                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                  "version": "0.2.0"
                 },
                 "sha.js": {
-                  "version": "2.2.6",
-                  "from": "sha.js@2.2.6",
-                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+                  "version": "2.2.6"
                 }
               }
             },
             "domain-browser": {
-              "version": "1.1.7",
-              "from": "domain-browser@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+              "version": "1.1.7"
             },
             "http-browserify": {
               "version": "1.7.0",
-              "from": "http-browserify@>=1.3.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
               "dependencies": {
                 "Base64": {
-                  "version": "0.2.1",
-                  "from": "Base64@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                  "version": "0.2.1"
                 }
               }
             },
             "https-browserify": {
-              "version": "0.0.0",
-              "from": "https-browserify@0.0.0",
-              "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+              "version": "0.0.0"
             },
             "os-browserify": {
-              "version": "0.1.2",
-              "from": "os-browserify@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+              "version": "0.1.2"
             },
             "path-browserify": {
-              "version": "0.0.0",
-              "from": "path-browserify@0.0.0",
-              "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+              "version": "0.0.0"
             },
             "process": {
-              "version": "0.11.2",
-              "from": "process@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+              "version": "0.11.2"
             },
             "punycode": {
-              "version": "1.4.0",
-              "from": "punycode@>=1.2.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
+              "version": "1.4.0"
             },
             "querystring-es3": {
-              "version": "0.2.1",
-              "from": "querystring-es3@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+              "version": "0.2.1"
             },
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.13 <2.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "version": "1.0.2"
                 },
                 "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "version": "0.0.1"
                 }
               }
             },
             "stream-browserify": {
-              "version": "1.0.0",
-              "from": "stream-browserify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+              "version": "1.0.0"
             },
             "string_decoder": {
-              "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              "version": "0.10.31"
             },
             "timers-browserify": {
-              "version": "1.4.2",
-              "from": "timers-browserify@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+              "version": "1.4.2"
             },
             "tty-browserify": {
-              "version": "0.0.0",
-              "from": "tty-browserify@0.0.0",
-              "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+              "version": "0.0.0"
             },
             "url": {
               "version": "0.10.3",
-              "from": "url@>=0.10.1 <0.11.0",
-              "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
               "dependencies": {
                 "punycode": {
-                  "version": "1.3.2",
-                  "from": "punycode@1.3.2",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                  "version": "1.3.2"
                 },
                 "querystring": {
-                  "version": "0.2.0",
-                  "from": "querystring@0.2.0",
-                  "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                  "version": "0.2.0"
                 }
               }
             },
             "util": {
-              "version": "0.10.3",
-              "from": "util@>=0.10.3 <0.11.0",
-              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+              "version": "0.10.3"
             },
             "vm-browserify": {
               "version": "0.0.4",
-              "from": "vm-browserify@0.0.4",
-              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "dependencies": {
                 "indexof": {
-                  "version": "0.0.1",
-                  "from": "indexof@0.0.1",
-                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                  "version": "0.0.1"
                 }
               }
             }
@@ -7382,235 +7005,151 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
-              "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+              "version": "0.0.3"
             },
             "minimist": {
-              "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+              "version": "0.0.10"
             }
           }
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "dependencies": {
             "has-flag": {
-              "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+              "version": "1.0.0"
             }
           }
         },
         "tapable": {
-          "version": "0.1.10",
-          "from": "tapable@>=0.1.8 <0.2.0",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+          "version": "0.1.10"
         },
         "watchpack": {
           "version": "0.2.9",
-          "from": "watchpack@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
           "dependencies": {
             "async": {
-              "version": "0.9.2",
-              "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+              "version": "0.9.2"
             },
             "chokidar": {
-              "version": "1.4.2",
-              "from": "chokidar@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.2.tgz",
+              "version": "1.4.3",
               "dependencies": {
                 "anymatch": {
                   "version": "1.3.0",
-                  "from": "anymatch@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "dependencies": {
                     "arrify": {
-                      "version": "1.0.1",
-                      "from": "arrify@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                      "version": "1.0.1"
                     },
                     "micromatch": {
                       "version": "2.3.7",
-                      "from": "micromatch@>=2.1.5 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
                       "dependencies": {
                         "arr-diff": {
                           "version": "2.0.0",
-                          "from": "arr-diff@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                           "dependencies": {
                             "arr-flatten": {
-                              "version": "1.0.1",
-                              "from": "arr-flatten@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                              "version": "1.0.1"
                             }
                           }
                         },
                         "array-unique": {
-                          "version": "0.2.1",
-                          "from": "array-unique@>=0.2.1 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                          "version": "0.2.1"
                         },
                         "braces": {
                           "version": "1.8.3",
-                          "from": "braces@>=1.8.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
                           "dependencies": {
                             "expand-range": {
                               "version": "1.8.1",
-                              "from": "expand-range@>=1.8.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                               "dependencies": {
                                 "fill-range": {
                                   "version": "2.2.3",
-                                  "from": "fill-range@>=2.1.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                                   "dependencies": {
                                     "is-number": {
-                                      "version": "2.1.0",
-                                      "from": "is-number@>=2.1.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                      "version": "2.1.0"
                                     },
                                     "isobject": {
                                       "version": "2.0.0",
-                                      "from": "isobject@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                                       "dependencies": {
                                         "isarray": {
-                                          "version": "0.0.1",
-                                          "from": "isarray@0.0.1",
-                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                          "version": "0.0.1"
                                         }
                                       }
                                     },
                                     "randomatic": {
-                                      "version": "1.1.5",
-                                      "from": "randomatic@>=1.1.3 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                      "version": "1.1.5"
                                     },
                                     "repeat-string": {
-                                      "version": "1.5.2",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                      "version": "1.5.4"
                                     }
                                   }
                                 }
                               }
                             },
                             "preserve": {
-                              "version": "0.2.0",
-                              "from": "preserve@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                              "version": "0.2.0"
                             },
                             "repeat-element": {
-                              "version": "1.1.2",
-                              "from": "repeat-element@>=1.1.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                              "version": "1.1.2"
                             }
                           }
                         },
                         "expand-brackets": {
-                          "version": "0.1.4",
-                          "from": "expand-brackets@>=0.1.4 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                          "version": "0.1.4"
                         },
                         "extglob": {
-                          "version": "0.3.2",
-                          "from": "extglob@>=0.3.1 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                          "version": "0.3.2"
                         },
                         "filename-regex": {
-                          "version": "2.0.0",
-                          "from": "filename-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                          "version": "2.0.0"
                         },
                         "is-extglob": {
-                          "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                          "version": "1.0.0"
                         },
                         "kind-of": {
                           "version": "3.0.2",
-                          "from": "kind-of@>=3.0.2 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                           "dependencies": {
                             "is-buffer": {
-                              "version": "1.1.2",
-                              "from": "is-buffer@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                              "version": "1.1.3"
                             }
                           }
                         },
                         "normalize-path": {
-                          "version": "2.0.1",
-                          "from": "normalize-path@>=2.0.1 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                          "version": "2.0.1"
                         },
                         "object.omit": {
                           "version": "2.0.0",
-                          "from": "object.omit@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                           "dependencies": {
                             "for-own": {
                               "version": "0.1.3",
-                              "from": "for-own@>=0.1.3 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                               "dependencies": {
                                 "for-in": {
-                                  "version": "0.1.4",
-                                  "from": "for-in@>=0.1.4 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                  "version": "0.1.4"
                                 }
                               }
                             },
                             "is-extendable": {
-                              "version": "0.1.1",
-                              "from": "is-extendable@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                              "version": "0.1.1"
                             }
                           }
                         },
                         "parse-glob": {
                           "version": "3.0.4",
-                          "from": "parse-glob@>=3.0.4 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                           "dependencies": {
                             "glob-base": {
-                              "version": "0.3.0",
-                              "from": "glob-base@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                              "version": "0.3.0"
                             },
                             "is-dotfile": {
-                              "version": "1.0.2",
-                              "from": "is-dotfile@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                              "version": "1.0.2"
                             }
                           }
                         },
                         "regex-cache": {
                           "version": "0.4.2",
-                          "from": "regex-cache@>=0.4.2 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                           "dependencies": {
                             "is-equal-shallow": {
-                              "version": "0.1.3",
-                              "from": "is-equal-shallow@>=0.1.1 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                              "version": "0.1.3"
                             },
                             "is-primitive": {
-                              "version": "2.0.0",
-                              "from": "is-primitive@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                              "version": "2.0.0"
                             }
                           }
                         }
@@ -7619,68 +7158,44 @@
                   }
                 },
                 "async-each": {
-                  "version": "0.1.6",
-                  "from": "async-each@>=0.1.6 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                  "version": "1.0.0"
                 },
                 "glob-parent": {
-                  "version": "2.0.0",
-                  "from": "glob-parent@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                  "version": "2.0.0"
                 },
                 "is-binary-path": {
                   "version": "1.0.1",
-                  "from": "is-binary-path@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "dependencies": {
                     "binary-extensions": {
-                      "version": "1.4.0",
-                      "from": "binary-extensions@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                      "version": "1.4.0"
                     }
                   }
                 },
                 "is-glob": {
                   "version": "2.0.1",
-                  "from": "is-glob@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                   "dependencies": {
                     "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                      "version": "1.0.0"
                     }
                   }
                 },
                 "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                  "version": "1.0.0"
                 },
                 "readdirp": {
                   "version": "2.0.0",
-                  "from": "readdirp@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
                   "dependencies": {
                     "minimatch": {
                       "version": "2.0.10",
-                      "from": "minimatch@>=2.0.10 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.3",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.3.tgz",
                           "dependencies": {
                             "balanced-match": {
-                              "version": "0.3.0",
-                              "from": "balanced-match@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                              "version": "0.3.0"
                             },
                             "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "version": "0.0.1"
                             }
                           }
                         }
@@ -7688,555 +7203,354 @@
                     },
                     "readable-stream": {
                       "version": "2.0.5",
-                      "from": "readable-stream@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "dependencies": {
                         "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                          "version": "1.0.2"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "0.0.1"
                         },
                         "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                          "version": "1.0.6"
                         },
                         "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                          "version": "0.10.31"
                         },
                         "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                          "version": "1.0.2"
                         }
                       }
                     }
                   }
                 },
                 "fsevents": {
-                  "version": "1.0.7",
-                  "from": "fsevents@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.7.tgz",
+                  "version": "1.0.8",
                   "dependencies": {
                     "nan": {
-                      "version": "2.2.0",
-                      "from": "nan@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+                      "version": "2.2.0"
                     },
                     "node-pre-gyp": {
-                      "version": "0.6.19",
-                      "from": "node-pre-gyp@>=0.6.17 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.19.tgz",
+                      "version": "0.6.21",
                       "dependencies": {
                         "nopt": {
                           "version": "3.0.6",
-                          "from": "nopt@~3.0.1",
-                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                           "dependencies": {
                             "abbrev": {
-                              "version": "1.0.7",
-                              "from": "abbrev@1",
-                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                              "version": "1.0.7"
                             }
                           }
                         }
                       }
                     },
                     "ansi": {
-                      "version": "0.3.0",
-                      "from": "ansi@~0.3.0",
-                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-                    },
-                    "ansi-styles": {
-                      "version": "2.1.0",
-                      "from": "ansi-styles@^2.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                      "version": "0.3.1"
                     },
                     "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                      "version": "2.0.0"
+                    },
+                    "ansi-styles": {
+                      "version": "2.1.0"
                     },
                     "are-we-there-yet": {
-                      "version": "1.0.5",
-                      "from": "are-we-there-yet@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.5.tgz"
+                      "version": "1.0.6"
                     },
                     "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                      "version": "0.2.3"
                     },
                     "async": {
-                      "version": "1.5.1",
-                      "from": "async@^1.4.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.1.tgz"
+                      "version": "1.5.2"
+                    },
+                    "assert-plus": {
+                      "version": "0.2.0"
                     },
                     "aws-sign2": {
-                      "version": "0.6.0",
-                      "from": "aws-sign2@~0.6.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                      "version": "0.6.0"
                     },
                     "bl": {
-                      "version": "1.0.0",
-                      "from": "bl@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                      "version": "1.0.2"
                     },
                     "block-stream": {
-                      "version": "0.0.8",
-                      "from": "block-stream@*",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                      "version": "0.0.8"
                     },
                     "boom": {
-                      "version": "2.10.1",
-                      "from": "boom@2.x.x",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                    },
-                    "caseless": {
-                      "version": "0.11.0",
-                      "from": "caseless@~0.11.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                      "version": "2.10.1"
                     },
                     "chalk": {
-                      "version": "1.1.1",
-                      "from": "chalk@^1.1.1",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                      "version": "1.1.1"
                     },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "from": "combined-stream@~1.0.5",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                    "caseless": {
+                      "version": "0.11.0"
                     },
                     "commander": {
-                      "version": "2.9.0",
-                      "from": "commander@^2.9.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                      "version": "2.9.0"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5"
                     },
                     "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@2.x.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                      "version": "2.0.5"
                     },
                     "dashdash": {
-                      "version": "1.11.0",
-                      "from": "dashdash@>=1.10.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.11.0.tgz"
+                      "version": "1.12.2"
                     },
                     "debug": {
-                      "version": "0.7.4",
-                      "from": "debug@~0.7.2",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                      "version": "2.2.0"
                     },
                     "deep-extend": {
-                      "version": "0.4.0",
-                      "from": "deep-extend@~0.4.0",
-                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                      "version": "0.4.1"
                     },
                     "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "delayed-stream@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                    },
-                    "delegates": {
-                      "version": "0.1.0",
-                      "from": "delegates@^0.1.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                      "version": "1.0.0"
                     },
                     "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                      "version": "0.1.1"
                     },
                     "escape-string-regexp": {
-                      "version": "1.0.4",
-                      "from": "escape-string-regexp@^1.0.2",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                      "version": "1.0.4"
                     },
-                    "extend": {
-                      "version": "3.0.0",
-                      "from": "extend@~3.0.0",
-                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    "delegates": {
+                      "version": "1.0.0"
                     },
                     "forever-agent": {
-                      "version": "0.6.1",
-                      "from": "forever-agent@~0.6.1",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                      "version": "0.6.1"
                     },
-                    "form-data": {
-                      "version": "1.0.0-rc3",
-                      "from": "form-data@~1.0.0-rc3",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                    "extend": {
+                      "version": "3.0.0"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2"
                     },
                     "fstream": {
-                      "version": "1.0.8",
-                      "from": "fstream@^1.0.2",
-                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                      "version": "1.0.8"
                     },
-                    "gauge": {
-                      "version": "1.2.2",
-                      "from": "gauge@~1.2.0",
-                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+                    "form-data": {
+                      "version": "1.0.0-rc3"
                     },
                     "generate-function": {
-                      "version": "2.0.0",
-                      "from": "generate-function@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                      "version": "2.0.0"
+                    },
+                    "gauge": {
+                      "version": "1.2.5"
                     },
                     "generate-object-property": {
-                      "version": "1.2.0",
-                      "from": "generate-object-property@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                      "version": "1.2.0"
                     },
                     "graceful-fs": {
-                      "version": "4.1.2",
-                      "from": "graceful-fs@^4.1.2",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                      "version": "4.1.3"
                     },
                     "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>= 1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    },
-                    "har-validator": {
-                      "version": "2.0.3",
-                      "from": "har-validator@~2.0.2",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
+                      "version": "1.0.1"
                     },
                     "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "has-ansi@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
-                    "has-unicode": {
-                      "version": "1.0.1",
-                      "from": "has-unicode@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                    "har-validator": {
+                      "version": "2.0.6"
                     },
                     "hawk": {
-                      "version": "3.1.2",
-                      "from": "hawk@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+                      "version": "3.1.3"
+                    },
+                    "has-unicode": {
+                      "version": "2.0.0"
                     },
                     "hoek": {
-                      "version": "2.16.3",
-                      "from": "hoek@2.x.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
-                    "http-signature": {
-                      "version": "1.1.0",
-                      "from": "http-signature@~1.1.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+                      "version": "2.16.3"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@*",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.1"
                     },
-                    "ini": {
-                      "version": "1.3.4",
-                      "from": "ini@~1.3.0",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.12.3",
-                      "from": "is-my-json-valid@^2.12.3",
-                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+                    "http-signature": {
+                      "version": "1.1.1"
                     },
                     "is-property": {
-                      "version": "1.0.2",
-                      "from": "is-property@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                      "version": "1.0.2"
+                    },
+                    "ini": {
+                      "version": "1.3.4"
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.4"
                     },
                     "is-typedarray": {
-                      "version": "1.0.0",
-                      "from": "is-typedarray@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                      "version": "1.0.0"
                     },
                     "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "version": "0.0.1"
                     },
                     "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@~0.1.2",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                      "version": "0.1.2"
                     },
                     "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "jsbn": {
-                      "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                      "version": "0.1.0"
                     },
                     "json-schema": {
-                      "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                      "version": "0.2.2"
                     },
                     "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@~5.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                      "version": "5.0.1"
                     },
                     "jsprim": {
-                      "version": "1.2.2",
-                      "from": "jsprim@^1.2.2",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                      "version": "1.2.2"
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0"
                     },
                     "lodash._basetostring": {
-                      "version": "3.0.1",
-                      "from": "lodash._basetostring@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                      "version": "3.0.1"
+                    },
+                    "lodash._root": {
+                      "version": "3.0.0"
                     },
                     "lodash._createpadding": {
-                      "version": "3.6.1",
-                      "from": "lodash._createpadding@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-                    },
-                    "lodash.pad": {
-                      "version": "3.1.1",
-                      "from": "lodash.pad@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+                      "version": "3.6.1"
                     },
                     "lodash.padleft": {
-                      "version": "3.1.1",
-                      "from": "lodash.padleft@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                      "version": "3.1.1"
+                    },
+                    "lodash.pad": {
+                      "version": "3.3.0"
                     },
                     "lodash.padright": {
-                      "version": "3.1.1",
-                      "from": "lodash.padright@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                      "version": "3.1.1"
                     },
                     "lodash.repeat": {
-                      "version": "3.0.1",
-                      "from": "lodash.repeat@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                      "version": "3.2.0"
                     },
                     "mime-db": {
-                      "version": "1.21.0",
-                      "from": "mime-db@~1.21.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.1.9",
-                      "from": "mime-types@~2.1.7",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
+                      "version": "1.21.0"
                     },
                     "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                      "version": "0.0.8"
+                    },
+                    "mime-types": {
+                      "version": "2.1.9"
                     },
                     "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                      "version": "0.5.1"
+                    },
+                    "ms": {
+                      "version": "0.7.1"
                     },
                     "node-uuid": {
-                      "version": "1.4.7",
-                      "from": "node-uuid@~1.4.7",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                      "version": "1.4.7"
                     },
                     "npmlog": {
-                      "version": "2.0.0",
-                      "from": "npmlog@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
+                      "version": "2.0.2"
                     },
                     "oauth-sign": {
-                      "version": "0.8.0",
-                      "from": "oauth-sign@~0.8.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                      "version": "0.8.1"
                     },
                     "once": {
-                      "version": "1.1.1",
-                      "from": "once@~1.1.1",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                      "version": "1.3.3"
                     },
                     "pinkie": {
-                      "version": "2.0.1",
-                      "from": "pinkie@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                      "version": "2.0.4"
                     },
                     "pinkie-promise": {
-                      "version": "2.0.0",
-                      "from": "pinkie-promise@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "process-nextick-args": {
-                      "version": "1.0.6",
-                      "from": "process-nextick-args@~1.0.6",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                      "version": "1.0.6"
                     },
                     "qs": {
-                      "version": "5.2.0",
-                      "from": "qs@~5.2.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                      "version": "6.0.2"
                     },
                     "readable-stream": {
-                      "version": "2.0.5",
-                      "from": "readable-stream@^2.0.0 || ^1.1.13",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz"
+                      "version": "2.0.5"
                     },
                     "request": {
-                      "version": "2.67.0",
-                      "from": "request@2.x",
-                      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+                      "version": "2.69.0"
                     },
                     "semver": {
-                      "version": "5.1.0",
-                      "from": "semver@~5.1.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                      "version": "5.1.0"
                     },
                     "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@1.x.x",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                      "version": "1.0.9"
                     },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    "sshpk": {
+                      "version": "1.7.3"
                     },
                     "stringstream": {
-                      "version": "0.0.5",
-                      "from": "stringstream@~0.0.4",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                      "version": "0.0.5"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
                     },
                     "strip-ansi": {
-                      "version": "3.0.0",
-                      "from": "strip-ansi@^3.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                      "version": "3.0.0"
                     },
                     "strip-json-comments": {
-                      "version": "1.0.4",
-                      "from": "strip-json-comments@~1.0.4",
-                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                      "version": "1.0.4"
                     },
                     "supports-color": {
-                      "version": "2.0.0",
-                      "from": "supports-color@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                      "version": "2.0.0"
                     },
                     "tar": {
-                      "version": "2.2.1",
-                      "from": "tar@~2.2.0",
-                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                      "version": "2.2.1"
                     },
                     "tough-cookie": {
-                      "version": "2.2.1",
-                      "from": "tough-cookie@~2.2.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                      "version": "2.2.1"
                     },
                     "tunnel-agent": {
-                      "version": "0.4.2",
-                      "from": "tunnel-agent@~0.4.1",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                      "version": "0.4.2"
+                    },
+                    "tar-pack": {
+                      "version": "3.1.3"
                     },
                     "tweetnacl": {
-                      "version": "0.13.2",
-                      "from": "tweetnacl@>=0.13.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                      "version": "0.13.3"
                     },
                     "uid-number": {
-                      "version": "0.0.3",
-                      "from": "uid-number@0.0.3",
-                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                      "version": "0.0.6"
                     },
                     "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@~1.0.1",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "version": "1.0.2"
                     },
                     "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                      "version": "1.3.6"
                     },
                     "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@^4.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                      "version": "4.0.1"
                     },
-                    "rc": {
-                      "version": "1.1.6",
-                      "from": "rc@~1.1.0",
-                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+                    "wrappy": {
+                      "version": "1.0.1"
+                    },
+                    "aws4": {
+                      "version": "1.2.1",
                       "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@^1.2.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        "lru-cache": {
+                          "version": "2.7.3"
                         }
                       }
                     },
-                    "sshpk": {
-                      "version": "1.7.2",
-                      "from": "sshpk@^1.7.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.2.tgz",
+                    "rc": {
+                      "version": "1.1.6",
                       "dependencies": {
-                        "assert-plus": {
-                          "version": "0.2.0",
-                          "from": "assert-plus@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                        "minimist": {
+                          "version": "1.2.0"
                         }
                       }
                     },
                     "fstream-ignore": {
                       "version": "1.0.3",
-                      "from": "fstream-ignore@~1.0.3",
-                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
                       "dependencies": {
                         "minimatch": {
                           "version": "3.0.0",
-                          "from": "minimatch@^3.0.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.2",
-                              "from": "brace-expansion@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                               "dependencies": {
                                 "balanced-match": {
-                                  "version": "0.3.0",
-                                  "from": "balanced-match@^0.3.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                  "version": "0.3.0"
                                 },
                                 "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                  "version": "0.0.1"
                                 }
                               }
                             }
@@ -8245,51 +7559,33 @@
                       }
                     },
                     "rimraf": {
-                      "version": "2.5.0",
-                      "from": "rimraf@~2.5.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.0.tgz",
+                      "version": "2.5.1",
                       "dependencies": {
                         "glob": {
-                          "version": "6.0.3",
-                          "from": "glob@^6.0.1",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
+                          "version": "6.0.4",
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.4",
-                              "from": "inflight@^1.0.4",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                               "dependencies": {
                                 "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@1",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                  "version": "1.0.1"
                                 }
                               }
                             },
                             "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@~2.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "version": "2.0.1"
                             },
                             "minimatch": {
                               "version": "3.0.0",
-                              "from": "minimatch@2 || 3",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.2",
-                                  "from": "brace-expansion@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                                   "dependencies": {
                                     "balanced-match": {
-                                      "version": "0.3.0",
-                                      "from": "balanced-match@^0.3.0",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                      "version": "0.3.0"
                                     },
                                     "concat-map": {
-                                      "version": "0.0.1",
-                                      "from": "concat-map@0.0.1",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                      "version": "0.0.1"
                                     }
                                   }
                                 }
@@ -8297,99 +7593,14 @@
                             },
                             "once": {
                               "version": "1.3.3",
-                              "from": "once@^1.3.0",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                               "dependencies": {
                                 "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@1",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                  "version": "1.0.1"
                                 }
                               }
                             },
                             "path-is-absolute": {
-                              "version": "1.0.0",
-                              "from": "path-is-absolute@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "tar-pack": {
-                      "version": "3.1.2",
-                      "from": "tar-pack@~3.1.0",
-                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.2.tgz",
-                      "dependencies": {
-                        "rimraf": {
-                          "version": "2.4.5",
-                          "from": "rimraf@~2.4.4",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-                          "dependencies": {
-                            "glob": {
-                              "version": "6.0.3",
-                              "from": "glob@^6.0.1",
-                              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.3.tgz",
-                              "dependencies": {
-                                "inflight": {
-                                  "version": "1.0.4",
-                                  "from": "inflight@^1.0.4",
-                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.1",
-                                      "from": "wrappy@1",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                    }
-                                  }
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@2",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "minimatch": {
-                                  "version": "3.0.0",
-                                  "from": "minimatch@2 || 3",
-                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                                  "dependencies": {
-                                    "brace-expansion": {
-                                      "version": "1.1.2",
-                                      "from": "brace-expansion@^1.0.0",
-                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
-                                      "dependencies": {
-                                        "balanced-match": {
-                                          "version": "0.3.0",
-                                          "from": "balanced-match@^0.3.0",
-                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
-                                        },
-                                        "concat-map": {
-                                          "version": "0.0.1",
-                                          "from": "concat-map@0.0.1",
-                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "once": {
-                                  "version": "1.3.3",
-                                  "from": "once@^1.3.0",
-                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.1",
-                                      "from": "wrappy@1",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                    }
-                                  }
-                                },
-                                "path-is-absolute": {
-                                  "version": "1.0.0",
-                                  "from": "path-is-absolute@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                                }
-                              }
+                              "version": "1.0.0"
                             }
                           }
                         }
@@ -8400,33 +7611,23 @@
               }
             },
             "graceful-fs": {
-              "version": "4.1.3",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
+              "version": "4.1.3"
             }
           }
         },
         "webpack-core": {
           "version": "0.6.8",
-          "from": "webpack-core@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
-                  "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                  "version": "1.0.0"
                 }
               }
             },
             "source-list-map": {
-              "version": "0.1.5",
-              "from": "source-list-map@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+              "version": "0.1.5"
             }
           }
         }
@@ -8434,40 +7635,229 @@
     },
     "webpack-dev-middleware": {
       "version": "1.2.0",
-      "from": "webpack-dev-middleware@1.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.2.0.tgz",
       "dependencies": {
         "memory-fs": {
-          "version": "0.2.0",
-          "from": "memory-fs@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+          "version": "0.2.0"
         },
         "mime": {
-          "version": "1.3.4",
-          "from": "mime@>=1.3.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+          "version": "1.3.4"
+        }
+      }
+    },
+    "webpack-dev-server": {
+      "version": "1.11.0",
+      "dependencies": {
+        "connect-history-api-fallback": {
+          "version": "1.1.0"
+        },
+        "http-proxy": {
+          "version": "1.13.2",
+          "dependencies": {
+            "eventemitter3": {
+              "version": "1.1.1"
+            },
+            "requires-port": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3"
+            },
+            "minimist": {
+              "version": "0.0.10"
+            }
+          }
+        },
+        "serve-index": {
+          "version": "1.7.3",
+          "dependencies": {
+            "accepts": {
+              "version": "1.2.13",
+              "dependencies": {
+                "negotiator": {
+                  "version": "0.5.3"
+                }
+              }
+            },
+            "batch": {
+              "version": "0.5.3"
+            },
+            "escape-html": {
+              "version": "1.0.3"
+            },
+            "http-errors": {
+              "version": "1.3.1",
+              "dependencies": {
+                "statuses": {
+                  "version": "1.2.1"
+                }
+              }
+            },
+            "mime-types": {
+              "version": "2.1.10",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.22.0"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.1"
+            }
+          }
+        },
+        "socket.io-client": {
+          "version": "1.4.5",
+          "dependencies": {
+            "engine.io-client": {
+              "version": "1.6.8",
+              "dependencies": {
+                "has-cors": {
+                  "version": "1.1.0"
+                },
+                "ws": {
+                  "version": "1.0.1",
+                  "dependencies": {
+                    "options": {
+                      "version": "0.0.6"
+                    },
+                    "ultron": {
+                      "version": "1.0.2"
+                    }
+                  }
+                },
+                "xmlhttprequest-ssl": {
+                  "version": "1.5.1"
+                },
+                "component-emitter": {
+                  "version": "1.1.2"
+                },
+                "engine.io-parser": {
+                  "version": "1.2.4",
+                  "dependencies": {
+                    "after": {
+                      "version": "0.8.1"
+                    },
+                    "arraybuffer.slice": {
+                      "version": "0.0.6"
+                    },
+                    "base64-arraybuffer": {
+                      "version": "0.1.2"
+                    },
+                    "blob": {
+                      "version": "0.0.4"
+                    },
+                    "has-binary": {
+                      "version": "0.1.6",
+                      "dependencies": {
+                        "isarray": {
+                          "version": "0.0.1"
+                        }
+                      }
+                    },
+                    "utf8": {
+                      "version": "2.1.0"
+                    }
+                  }
+                },
+                "parsejson": {
+                  "version": "0.0.1"
+                },
+                "parseqs": {
+                  "version": "0.0.2"
+                },
+                "component-inherit": {
+                  "version": "0.0.3"
+                },
+                "yeast": {
+                  "version": "0.1.2"
+                }
+              }
+            },
+            "component-bind": {
+              "version": "1.0.0"
+            },
+            "component-emitter": {
+              "version": "1.2.0"
+            },
+            "object-component": {
+              "version": "0.0.3"
+            },
+            "socket.io-parser": {
+              "version": "2.2.6",
+              "dependencies": {
+                "json3": {
+                  "version": "3.3.2"
+                },
+                "component-emitter": {
+                  "version": "1.1.2"
+                },
+                "isarray": {
+                  "version": "0.0.1"
+                },
+                "benchmark": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "has-binary": {
+              "version": "0.1.7",
+              "dependencies": {
+                "isarray": {
+                  "version": "0.0.1"
+                }
+              }
+            },
+            "indexof": {
+              "version": "0.0.1"
+            },
+            "parseuri": {
+              "version": "0.0.4"
+            },
+            "to-array": {
+              "version": "0.1.4"
+            },
+            "backo2": {
+              "version": "1.0.2"
+            }
+          }
+        },
+        "stream-cache": {
+          "version": "0.0.2"
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.0.0"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0"
+            }
+          }
         }
       }
     },
     "wpcom-proxy-request": {
       "version": "1.0.5",
-      "from": "wpcom-proxy-request@1.0.5",
-      "resolved": "https://registry.npmjs.org/wpcom-proxy-request/-/wpcom-proxy-request-1.0.5.tgz",
       "dependencies": {
         "component-event": {
-          "version": "0.1.4",
-          "from": "component-event@0.1.4",
-          "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz"
+          "version": "0.1.4"
         },
         "progress-event": {
-          "version": "1.0.0",
-          "from": "progress-event@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/progress-event/-/progress-event-1.0.0.tgz"
+          "version": "1.0.0"
         },
         "uid": {
-          "version": "0.0.2",
-          "from": "uid@0.0.2",
-          "resolved": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz"
+          "version": "0.0.2"
         }
       }
     },
@@ -8481,7 +7871,7 @@
               "version": "5.8.35",
               "dependencies": {
                 "chokidar": {
-                  "version": "1.4.2",
+                  "version": "1.4.3",
                   "dependencies": {
                     "anymatch": {
                       "version": "1.3.0",
@@ -8527,7 +7917,7 @@
                                           "version": "1.1.5"
                                         },
                                         "repeat-string": {
-                                          "version": "1.5.2"
+                                          "version": "1.5.4"
                                         }
                                       }
                                     }
@@ -8557,7 +7947,7 @@
                               "version": "3.0.2",
                               "dependencies": {
                                 "is-buffer": {
-                                  "version": "1.1.2"
+                                  "version": "1.1.3"
                                 }
                               }
                             },
@@ -8607,7 +7997,7 @@
                       }
                     },
                     "async-each": {
-                      "version": "0.1.6"
+                      "version": "1.0.0"
                     },
                     "glob-parent": {
                       "version": "2.0.0"
@@ -8697,23 +8087,23 @@
                         "ansi": {
                           "version": "0.3.1"
                         },
-                        "ansi-styles": {
-                          "version": "2.1.0"
-                        },
                         "are-we-there-yet": {
                           "version": "1.0.6"
                         },
-                        "asn1": {
-                          "version": "0.2.3"
+                        "ansi-styles": {
+                          "version": "2.1.0"
                         },
                         "assert-plus": {
                           "version": "0.2.0"
                         },
-                        "async": {
-                          "version": "1.5.2"
+                        "asn1": {
+                          "version": "0.2.3"
                         },
                         "aws-sign2": {
                           "version": "0.6.0"
+                        },
+                        "async": {
+                          "version": "1.5.2"
                         },
                         "bl": {
                           "version": "1.0.2"
@@ -8724,14 +8114,14 @@
                         "boom": {
                           "version": "2.10.1"
                         },
-                        "chalk": {
-                          "version": "1.1.1"
+                        "combined-stream": {
+                          "version": "1.0.5"
                         },
                         "caseless": {
                           "version": "0.11.0"
                         },
-                        "combined-stream": {
-                          "version": "1.0.5"
+                        "chalk": {
+                          "version": "1.1.1"
                         },
                         "commander": {
                           "version": "2.9.0"
@@ -8739,20 +8129,20 @@
                         "core-util-is": {
                           "version": "1.0.2"
                         },
+                        "dashdash": {
+                          "version": "1.12.2"
+                        },
                         "cryptiles": {
                           "version": "2.0.5"
+                        },
+                        "delayed-stream": {
+                          "version": "1.0.0"
                         },
                         "debug": {
                           "version": "2.2.0"
                         },
-                        "dashdash": {
-                          "version": "1.12.2"
-                        },
                         "deep-extend": {
                           "version": "0.4.1"
-                        },
-                        "delayed-stream": {
-                          "version": "1.0.0"
                         },
                         "delegates": {
                           "version": "1.0.0"
@@ -8763,11 +8153,11 @@
                         "escape-string-regexp": {
                           "version": "1.0.4"
                         },
-                        "extend": {
-                          "version": "3.0.0"
-                        },
                         "forever-agent": {
                           "version": "0.6.1"
+                        },
+                        "extend": {
+                          "version": "3.0.0"
                         },
                         "extsprintf": {
                           "version": "1.0.2"
@@ -8775,23 +8165,23 @@
                         "form-data": {
                           "version": "1.0.0-rc3"
                         },
-                        "generate-function": {
-                          "version": "2.0.0"
-                        },
                         "fstream": {
                           "version": "1.0.8"
                         },
-                        "generate-object-property": {
-                          "version": "1.2.0"
+                        "generate-function": {
+                          "version": "2.0.0"
                         },
                         "gauge": {
                           "version": "1.2.5"
                         },
-                        "graceful-fs": {
-                          "version": "4.1.3"
+                        "generate-object-property": {
+                          "version": "1.2.0"
                         },
                         "graceful-readlink": {
                           "version": "1.0.1"
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.3"
                         },
                         "har-validator": {
                           "version": "2.0.6"
@@ -8802,68 +8192,68 @@
                         "has-unicode": {
                           "version": "2.0.0"
                         },
-                        "hawk": {
-                          "version": "3.1.3"
-                        },
                         "hoek": {
                           "version": "2.16.3"
+                        },
+                        "hawk": {
+                          "version": "3.1.3"
                         },
                         "http-signature": {
                           "version": "1.1.1"
                         },
-                        "inherits": {
-                          "version": "2.0.1"
-                        },
                         "ini": {
                           "version": "1.3.4"
                         },
-                        "is-my-json-valid": {
-                          "version": "2.12.4"
+                        "inherits": {
+                          "version": "2.0.1"
                         },
                         "is-property": {
                           "version": "1.0.2"
                         },
+                        "is-my-json-valid": {
+                          "version": "2.12.4"
+                        },
                         "is-typedarray": {
                           "version": "1.0.0"
-                        },
-                        "isstream": {
-                          "version": "0.1.2"
                         },
                         "isarray": {
                           "version": "0.0.1"
                         },
-                        "jsbn": {
-                          "version": "0.1.0"
-                        },
                         "jodid25519": {
                           "version": "1.0.2"
                         },
-                        "json-stringify-safe": {
-                          "version": "5.0.1"
+                        "isstream": {
+                          "version": "0.1.2"
                         },
                         "json-schema": {
                           "version": "0.2.2"
                         },
-                        "jsonpointer": {
-                          "version": "2.0.0"
+                        "jsbn": {
+                          "version": "0.1.0"
+                        },
+                        "json-stringify-safe": {
+                          "version": "5.0.1"
                         },
                         "jsprim": {
                           "version": "1.2.2"
                         },
+                        "jsonpointer": {
+                          "version": "2.0.0"
+                        },
                         "lodash._basetostring": {
                           "version": "3.0.1"
-                        },
-                        "lodash._createpadding": {
-                          "version": "3.6.1"
                         },
                         "lodash._root": {
                           "version": "3.0.0"
                         },
+                        "lodash.pad": {
+                          "version": "3.3.0"
+                        },
                         "lodash.padleft": {
                           "version": "3.1.1"
                         },
-                        "lodash.pad": {
-                          "version": "3.3.0"
+                        "lodash._createpadding": {
+                          "version": "3.6.1"
                         },
                         "lodash.padright": {
                           "version": "3.1.1"
@@ -8889,14 +8279,14 @@
                         "node-uuid": {
                           "version": "1.4.7"
                         },
-                        "npmlog": {
-                          "version": "2.0.2"
-                        },
                         "oauth-sign": {
                           "version": "0.8.1"
                         },
                         "once": {
                           "version": "1.3.3"
+                        },
+                        "npmlog": {
+                          "version": "2.0.2"
                         },
                         "pinkie-promise": {
                           "version": "2.0.0"
@@ -8904,11 +8294,11 @@
                         "pinkie": {
                           "version": "2.0.4"
                         },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
                         "qs": {
                           "version": "6.0.2"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6"
                         },
                         "readable-stream": {
                           "version": "2.0.5"
@@ -8925,38 +8315,38 @@
                         "sshpk": {
                           "version": "1.7.3"
                         },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
                         "stringstream": {
                           "version": "0.0.5"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31"
                         },
                         "strip-ansi": {
                           "version": "3.0.0"
                         },
-                        "strip-json-comments": {
-                          "version": "1.0.4"
-                        },
                         "supports-color": {
                           "version": "2.0.0"
                         },
-                        "tar-pack": {
-                          "version": "3.1.3"
+                        "strip-json-comments": {
+                          "version": "1.0.4"
                         },
                         "tar": {
                           "version": "2.2.1"
                         },
-                        "tough-cookie": {
-                          "version": "2.2.1"
-                        },
-                        "tweetnacl": {
-                          "version": "0.13.3"
+                        "tar-pack": {
+                          "version": "3.1.3"
                         },
                         "tunnel-agent": {
                           "version": "0.4.2"
                         },
+                        "tough-cookie": {
+                          "version": "2.2.1"
+                        },
                         "uid-number": {
                           "version": "0.0.6"
+                        },
+                        "tweetnacl": {
+                          "version": "0.13.3"
                         },
                         "util-deprecate": {
                           "version": "1.0.2"
@@ -9068,7 +8458,7 @@
                   }
                 },
                 "convert-source-map": {
-                  "version": "1.1.3"
+                  "version": "1.2.0"
                 },
                 "fs-readdir-recursive": {
                   "version": "0.1.2"
@@ -9158,65 +8548,6 @@
         },
         "lodash": {
           "version": "2.4.2"
-        }
-      }
-    },
-    "ms": {
-      "version": "0.7.1"
-    },
-    "glob": {
-      "version": "7.0.3",
-      "dependencies": {
-        "inflight": {
-          "version": "1.0.4",
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "minimatch": {
-          "version": "3.0.0",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.3",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0"
-                },
-                "concat-map": {
-                  "version": "0.0.1"
-                }
-              }
-            }
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.0"
-        }
-      }
-    },
-    "eslint-plugin-wpcalypso": {
-      "version": "1.1.3",
-      "dependencies": {
-        "requireindex": {
-          "version": "1.1.0"
-        }
-      }
-    },
-    "source-map": {
-      "version": "0.1.39",
-      "dependencies": {
-        "amdefine": {
-          "version": "1.0.0"
         }
       }
     }


### PR DESCRIPTION
This PR adds a newly generated npm-shrinkwrap.json from [shronkwrap](https://github.com/skybet/shonkwrap). The resolved/from fields have been removed where possible to allow us to use local repository settings.

## Testing Instructions 
- Run `make distclean` to delete local node_modules
- Run `npm install`
- Verify that Calypso works as expected and that tests pass.

cc @rralian @aduth @blowery 