### PR TITLE
Sites/CPT: Refactor PublishMenu to accommodate custom post types

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -4,6 +4,7 @@
 var page = require( 'page' ),
 	ReactDom = require( 'react-dom' ),
 	React = require( 'react' );
+import { Provider as ReduxProvider } from 'react-redux';
 
 /**
  * Internal Dependencies
@@ -30,14 +31,16 @@ var user = require( 'lib/user' )(),
 function renderNavigation( context, allSitesPath, siteBasePath ) {
 	// Render the My Sites navigation in #secondary
 	ReactDom.render(
-		React.createElement( NavigationComponent, {
-			layoutFocus: layoutFocus,
-			path: context.path,
-			allSitesPath: allSitesPath,
-			siteBasePath: siteBasePath,
-			user: user,
-			sites: sites
-		} ),
+		React.createElement( ReduxProvider, { store: context.store },
+			React.createElement( NavigationComponent, {
+				layoutFocus: layoutFocus,
+				path: context.path,
+				allSitesPath: allSitesPath,
+				siteBasePath: siteBasePath,
+				user: user,
+				sites: sites
+			} )
+		),
 		document.getElementById( 'secondary' )
 	);
 }

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -23,7 +23,6 @@ const PublishMenu = React.createClass( {
 			React.PropTypes.object,
 			React.PropTypes.bool
 		] ),
-		siteId: React.PropTypes.number,
 		sites: React.PropTypes.object.isRequired,
 		postTypes: React.PropTypes.object,
 		siteSuffix: React.PropTypes.string,
@@ -170,7 +169,9 @@ const PublishMenu = React.createClass( {
 
 		return (
 			<ul>
-				<QueryPostTypes siteId={ this.props.siteId } />
+				{ this.props.site && (
+					<QueryPostTypes siteId={ this.props.site.ID } />
+				) }
 				{ menuItems.map( this.renderMenuItem ) }
 			</ul>
 		);
@@ -180,7 +181,6 @@ const PublishMenu = React.createClass( {
 export default connect( ( state ) => {
 	const siteId = get( getSelectedSite( state ), 'ID' );
 	return {
-		siteId,
 		postTypes: getPostTypes( state, siteId )
 	};
 }, null, null, { pure: false } )( PublishMenu );

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -143,17 +143,15 @@ const PublishMenu = React.createClass( {
 				name: postType.name,
 				label: get( postType.labels, 'menu_name', postType.label ),
 				className: postType.name,
+				config: 'manage/custom-post-types',
 
 				//If the API endpoint doesn't send the .capabilities property (e.g. because the site's Jetpack
 				//version isn't up-to-date), silently assume we don't have the capability to edit this CPT.
 				capability: get( postType.capabilities, 'edit_posts' ),
 
-				// Dummy - doesn't exist yet, so wpAdminLink will be used
-				config: 'manage/cpts',
-
 				// Required to build the menu item class name. Must be discernible from other
 				// items' paths in the same section for item highlighting to work properly.
-				link: '/' + postType.name,
+				link: '/types/' + postType.name,
 				buttonLink: '',
 				wpAdminLink: 'edit.php?post_type=' + postType.name,
 				showOnAllMySites: false

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -36,20 +36,22 @@ const PublishMenu = React.createClass( {
 	},
 
 	// We default to `/my` posts when appropriate
-	getMyParameter( selectedSite ) {
-		const sites = this.props.sites;
+	getMyParameter() {
+		const { sites, site } = this.props;
 		if ( ! sites.initialized ) {
 			return '';
 		}
 
-		if ( selectedSite ) {
-			return ( selectedSite.single_user_site || selectedSite.jetpack ) ? '' : '/my';
+		if ( site ) {
+			return ( site.single_user_site || site.jetpack ) ? '' : '/my';
 		}
 
 		return ( sites.allSingleSites ) ? '' : '/my';
 	},
 
 	getDefaultMenuItems() {
+		const { site } = this.props;
+
 		return [
 			{
 				name: 'post',
@@ -57,9 +59,9 @@ const PublishMenu = React.createClass( {
 				className: 'posts',
 				capability: 'edit_posts',
 				config: 'manage/posts',
-				link: '/posts' + this.getMyParameter( this.props.site ),
+				link: '/posts' + this.getMyParameter(),
 				paths: [ '/posts', '/posts/my' ],
-				buttonLink: this.props.site ? '/post/' + this.props.site.slug : '/post',
+				buttonLink: site ? '/post/' + site.slug : '/post',
 				wpAdminLink: 'edit.php',
 				showOnAllMySites: true,
 			},
@@ -70,7 +72,7 @@ const PublishMenu = React.createClass( {
 				capability: 'edit_pages',
 				config: 'manage/pages',
 				link: '/pages',
-				buttonLink: this.props.site ? '/page/' + this.props.site.slug : '/page',
+				buttonLink: site ? '/page/' + site.slug : '/page',
 				wpAdminLink: 'edit.php?post_type=page',
 				showOnAllMySites: true,
 			}
@@ -78,7 +80,8 @@ const PublishMenu = React.createClass( {
 	},
 
 	renderMenuItem( menuItem ) {
-		if ( this.props.site.capabilities && ! this.props.site.capabilities[ menuItem.capability ] ) {
+		const { site } = this.props;
+		if ( site.capabilities && ! site.capabilities[ menuItem.capability ] ) {
 			return null;
 		}
 
@@ -95,7 +98,7 @@ const PublishMenu = React.createClass( {
 		}
 
 		let link;
-		if ( ! isEnabled && this.props.site.options ) {
+		if ( ! isEnabled && site.options ) {
 			link = this.props.site.options.admin_url + menuItem.wpAdminLink;
 		} else {
 			link = menuItem.link + this.props.siteSuffix;

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -104,6 +104,8 @@ const PublishMenu = React.createClass( {
 		let preload;
 		if ( includes( [ 'post', 'page' ], menuItem.name ) ) {
 			preload = 'posts-pages';
+		} else {
+			preload = 'posts-custom';
 		}
 
 		let icon;

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -59,6 +59,7 @@ const PublishMenu = React.createClass( {
 				className: 'posts',
 				capability: 'edit_posts',
 				config: 'manage/posts',
+				queryable: true,
 				link: '/posts' + this.getMyParameter(),
 				paths: [ '/posts', '/posts/my' ],
 				buttonLink: site ? '/post/' + site.slug : '/post',
@@ -70,6 +71,7 @@ const PublishMenu = React.createClass( {
 				label: this.translate( 'Pages' ),
 				className: 'pages',
 				capability: 'edit_pages',
+				queryable: true,
 				config: 'manage/pages',
 				link: '/pages',
 				buttonLink: site ? '/page/' + site.slug : '/page',
@@ -106,7 +108,7 @@ const PublishMenu = React.createClass( {
 		}
 
 		let link;
-		if ( ! isEnabled && site.options ) {
+		if ( ( ! isEnabled || ! menuItem.queryable ) && site.options ) {
 			link = this.props.site.options.admin_url + menuItem.wpAdminLink;
 		} else {
 			link = menuItem.link + this.props.siteSuffix;
@@ -155,6 +157,7 @@ const PublishMenu = React.createClass( {
 				label: get( postType.labels, 'menu_name', postType.label ),
 				className: postType.name,
 				config: 'manage/custom-post-types',
+				queryable: postType.api_queryable,
 
 				//If the API endpoint doesn't send the .capabilities property (e.g. because the site's Jetpack
 				//version isn't up-to-date), silently assume we don't have the capability to edit this CPT.

--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -16,6 +16,7 @@ import config from 'config';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
+import analytics from 'analytics';
 
 const PublishMenu = React.createClass( {
 	propTypes: {
@@ -78,6 +79,14 @@ const PublishMenu = React.createClass( {
 		];
 	},
 
+	onNavigate( postType ) {
+		if ( ! includes( [ 'post', 'page' ], postType ) ) {
+			analytics.mc.bumpStat( 'calypso_publish_menu_click', postType );
+		}
+
+		this.props.onNavigate();
+	},
+
 	renderMenuItem( menuItem ) {
 		const { site } = this.props;
 		if ( site.capabilities && ! site.capabilities[ menuItem.capability ] ) {
@@ -131,7 +140,7 @@ const PublishMenu = React.createClass( {
 				className={ className }
 				link={ link }
 				buttonLink={ menuItem.buttonLink }
-				onNavigate={ this.props.onNavigate }
+				onNavigate={ this.onNavigate.bind( this, menuItem.name ) }
 				icon={ icon }
 				preloadSectionName={ preload }
 			/>


### PR DESCRIPTION
This pull request seeks to refactor the `<PublishMenu />` component to better accommodate for custom post types. Notably, it:

- Requests and retrieves post types from global Redux state
- Uses accurate route paths and feature config for navigation to occur in development
- Preloads the custom post types bundle
- Simplifies logic for rendering menu items (general refactoring, ES6-ification)

__Testing instructions:__

The only observable difference should be that links for custom post types are no longer external in development environments.

1. Click My Sites in the master bar
2. Note that custom post types are still shown if applicable for site
 - Types shown should match that of master / production
3. For each custom post type, note that the link is not external*
4. Click the custom post type
5. Note that you are directed to the work-in-progress custom post types page
 - Should be presented with "Custom post types listing" text in content area

_*_ An external link includes an arrow icon: ![arrow](https://cloud.githubusercontent.com/assets/1779930/13652016/fb52a6a8-e617-11e5-9891-679c472cbb21.png)
