### PR TITLE
Editor: Images can now be uploaded from URLs with query-string parameters.

### DIFF
--- a/client/lib/media/Makefile
+++ b/client/lib/media/Makefile
@@ -2,7 +2,7 @@ REPORTER ?= spec
 NODE_BIN := $(shell npm bin)
 MOCHA ?= $(NODE_BIN)/mocha
 BASE_DIR := $(NODE_BIN)/../..
-NODE_PATH := $(BASE_DIR)/client
+NODE_PATH := $(BASE_DIR)/client:$(BASE_DIR)/test
 
 test:
 	@NODE_ENV=test NODE_PATH=$(NODE_PATH) $(MOCHA) --compilers js:babel/register --reporter $(REPORTER)

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -120,7 +120,7 @@ MediaActions.add = function( siteId, files ) {
 			// Generate from string
 			assign( transientMedia, {
 				file: file,
-				extension: path.extname( file ).slice( 1 ),
+				extension: MediaUtils.getFileExtension( file ),
 				mime_type: MediaUtils.getMimeType( file ),
 				title: path.basename( file )
 			} );
@@ -131,7 +131,7 @@ MediaActions.add = function( siteId, files ) {
 				URL: fileUrl,
 				guid: fileUrl,
 				file: file.name,
-				extension: path.extname( file.name ).slice( 1 ),
+				extension: MediaUtils.getFileExtension( file.name ),
 				mime_type: MediaUtils.getMimeType( file.name ),
 				title: path.basename( file.name ),
 				// Size is not an API media property, though can be useful for

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 var expect = require( 'chai' ).expect,
-	map = require( 'lodash/map' );
+	map = require( 'lodash/map' ),
+	useFakeDom = require( 'test/helpers/use-fake-dom' );
 
 /**
  * Internal dependencies
@@ -11,6 +12,8 @@ var JetpackSite = require( 'lib/site/jetpack' ),
 	MediaUtils = require( '../utils' );
 
 describe( 'MediaUtils', function() {
+	useFakeDom();
+
 	describe( '#url()', function() {
 		var media;
 

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -84,6 +84,40 @@ describe( 'MediaUtils', function() {
 		} );
 	} );
 
+	describe( '#getFileExtension()', function() {
+		it( 'should return undefined for a falsey media value', function() {
+			expect( MediaUtils.getFileExtension() ).to.be.undefined;
+		} );
+
+		it( 'should detect extension from file name', function() {
+			expect( MediaUtils.getFileExtension( 'example.gif' ) ).to.equal( 'gif' );
+		} );
+
+		it( 'should ignore querystring parameters', function() {
+			expect( MediaUtils.getFileExtension( 'example.gif?w=100' ) ).to.equal( 'gif' );
+		} );
+
+		it( 'should detect extension from HTML5 File object', function() {
+			expect( MediaUtils.getFileExtension( new window.File( [''], 'example.gif' ) ) ).to.equal( 'gif' );
+		} );
+
+		it( 'should detect extension from object file property', function() {
+			expect( MediaUtils.getFileExtension( { file: 'example.gif' } ) ).to.equal( 'gif' );
+		} );
+
+		it( 'should detect extension from already computed extension property', function() {
+			expect( MediaUtils.getFileExtension( { extension: 'gif' } ) ).to.equal( 'gif' );
+		} );
+
+		it( 'should detect extension from object URL property', function() {
+			expect( MediaUtils.getFileExtension( { URL: 'example.gif' } ) ).to.equal( 'gif' );
+		} );
+
+		it( 'should detect extension from object guid property', function() {
+			expect( MediaUtils.getFileExtension( { guid: 'example.gif' } ) ).to.equal( 'gif' );
+		} );
+	} );
+
 	describe( '#getMimePrefix()', function() {
 		it( 'should return undefined if a mime type can\'t be determined', function() {
 			expect( MediaUtils.getMimePrefix() ).to.be.undefined;
@@ -109,6 +143,10 @@ describe( 'MediaUtils', function() {
 
 		it( 'should detect mime type from string extension', function() {
 			expect( MediaUtils.getMimeType( 'example.gif' ) ).to.equal( 'image/gif' );
+		} );
+
+		it( 'should ignore querystring parameters', function() {
+			expect( MediaUtils.getMimeType( 'example.gif?w=100' ) ).to.equal( 'image/gif' );
 		} );
 
 		it( 'should detect mime type from object file property', function() {

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -63,6 +63,41 @@ var MediaUtils = {
 	},
 
 	/**
+	 * Given a media string, File, or object, returns the file extension.
+	 *
+	 * @example
+	 * getFileExtension( 'example.gif' );
+	 * getFileExtension( { URL: 'https://wordpress.com/example.gif' } );
+	 * getFileExtension( new window.File( [''], 'example.gif' ) );
+	 * // All examples return 'gif'
+	 *
+	 * @param  {(string|File|Object)} media Media object or string
+	 * @return {string}                     File extension
+	 */
+	getFileExtension: function( media ) {
+		let extension;
+
+		if ( ! media ) {
+			return;
+		}
+
+		const isUrl = 'string' === typeof media;
+		const isFileObject = 'File' in window && media instanceof window.File;
+		if ( isUrl ) {
+			const filePath = url.parse( media ).pathname;
+			extension = path.extname( filePath ).slice( 1 );
+		} else if ( isFileObject ) {
+			extension = path.extname( media.name ).slice( 1 );
+		} else if ( media.extension ) {
+			extension = media.extension;
+		} else {
+			extension = path.extname( url.parse( media.URL || media.file || media.guid || '' ).pathname ).slice( 1 );
+		}
+
+		return extension;
+	},
+
+	/**
 	 * Given a media string or object, returns the MIME type prefix.
 	 *
 	 * @example
@@ -103,8 +138,6 @@ var MediaUtils = {
 	 * @return {string}                     Mime type of the media, if known
 	 */
 	getMimeType: function( media ) {
-		var extension;
-
 		if ( ! media ) {
 			return;
 		}
@@ -115,13 +148,7 @@ var MediaUtils = {
 			return media.type;
 		}
 
-		if ( 'string' === typeof media ) {
-			extension = path.extname( media ).slice( 1 );
-		} else if ( media.extension ) {
-			extension = media.extension;
-		} else {
-			extension = path.extname( url.parse( media.URL || media.file || media.guid || '' ).pathname ).slice( 1 );
-		}
+		let extension = MediaUtils.getFileExtension( media );
 
 		if ( ! extension ) {
 			return;


### PR DESCRIPTION
Fixes #3817 

Current (production) situation: URL validation when uploading a media file from an URL is performed as if were a file path.

First example:
- URL: `http://foo.bar/something?f=path/to/imageName.png`
- Detected file name: `imageName.png`
- Detected extension: `png`
- Detected MIME type: `image/png`

Second example:
- URL: `http://foo.bar/path/to/imageName.png?12345`
- Detected file name: `imageName.png?12345`
- Detected extension: `png?12345`
- Detected MIME type: `undefined`

Therefore, the first URL is detected as valid, and the second as invalid, since `png?12345` is not a whitelisted extension in the WordPress configuration.

I've changed the logic so that the query-string (and hash, if any) are stripped before parsing the URL as if it were a file path. This would have the "opposite" result, allowing URLs like the second example, but rejecting URLs like the first example. We know that `imgur` uses the second format, so allowing it is a big win. Does anyone know any image hosting site that uses the first format (put the file name in the query-string)?

The perfect solution would be validating server-side, the same as we are throwing an error if the URL gives a 404. After all, `http://foo.bar/somethingWithoutExtension` can perfectly be a valid image file, but the only way of knowing it is to make a HEAD request to get the MIME-type, and that's not possible client-side due to the same-origin limitation.

What do you think? Good enough as it is, or should we implement server-side validation?