### PR TITLE
Offline: adds cache-list invalidation and unit tests for sync-handler in general

### DIFF
--- a/client/lib/wp/sync-handler/constants.js
+++ b/client/lib/wp/sync-handler/constants.js
@@ -1,0 +1,5 @@
+module.exports = {
+	RECORDS_LIST_KEY: 'records-list',
+	SYNC_RECORD_NAMESPACE: 'sync-record-',
+	LIFETIME: '2 days',
+};

--- a/client/lib/wp/sync-handler/index.js
+++ b/client/lib/wp/sync-handler/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import config from 'config';
-import Hashes from 'jshashes';
 import debugFactory from 'debug';
 
 /**
@@ -12,6 +11,7 @@ import warn from 'lib/warn';
 import { getLocalForage } from 'lib/localforage';
 import { isWhitelisted } from './whitelist-handler';
 import { cacheIndex } from './cache-index';
+import { generateKey, generatePageSeriesKey } from './utils';
 
 /**
  * Module variables
@@ -20,40 +20,19 @@ const localforage = getLocalForage();
 const debug = debugFactory( 'calypso:sync-handler' );
 
 /**
- * Generate a key from the given param object
- *
- * @param {Object} params - request parameters
- * @param {Boolean} applyHash - codificate key when it's true
- * @return {String} request key
- */
-export const generateKey = ( params, applyHash = true ) => {
-	var key = `${params.apiVersion || ''}-${params.method}-${params.path}`;
-
-	if ( params.query ) {
-		key += '-' + params.query;
-	}
-
-	if ( applyHash ) {
-		key = new Hashes.SHA1().hex( key );
-	}
-
-	key = 'sync-record-' + key;
-
-	debug( 'key: %o', key );
-	return key;
-}
-
-/**
  * Detect pagination changes in local vs request response bodies
- * @param  {Object} res - response object as passed from promise
+ * @param  {Object} serverResponseBody - response object as passed from promise
  * @param  {Object} localResponseBody - local response body
  * @return {Boolean} returns whether pagination has changed
  */
-export const hasPaginationChanged = ( res, localResponseBody ) => {
-	if ( ! res || ! res.meta || ! res.meta.next_page ) {
+export const hasPaginationChanged = ( serverResponseBody, localResponseBody ) => {
+	if ( ! serverResponseBody || ! serverResponseBody.meta || ! serverResponseBody.meta.next_page ) {
 		return false;
 	}
-	if ( localResponseBody && localResponseBody.meta && localResponseBody.meta.next_page === res.meta.next_page ) {
+	if ( ! localResponseBody ) {
+		return false;
+	}
+	if ( localResponseBody && localResponseBody.meta && localResponseBody.meta.next_page === serverResponseBody.meta.next_page ) {
 		return false;
 	}
 	return true;
@@ -94,7 +73,6 @@ export class SyncHandler {
 
 			// whitelist barrier
 			if ( ! isWhitelisted( params ) ) {
-				debug( 'not whitelisted: skip %o request', path );
 				return handler( params, callback );
 			}
 
@@ -108,9 +86,11 @@ export class SyncHandler {
 			 * getting the data locally (localforage)
 			 *
 			 * @param {Object} localRecord - response stored locally
+			 * @returns {Object} localRecord object
 			 */
 			const localResponseHandler = localRecord => {
 				// let's be optimistic
+				debug( 'localResponseHandler()', localRecord );
 				if ( localRecord ) {
 					debug( 'local callback run => %o, params (%o), response (%o)', path, reqParams, localRecord );
 					// try/catch in case cached record does not match expected schema
@@ -123,6 +103,7 @@ export class SyncHandler {
 				} else {
 					debug( 'No data for [%s] %o - %o', reqParams.method, path, reqParams );
 				}
+				return localRecord;
 			};
 
 			/**
@@ -161,10 +142,48 @@ export class SyncHandler {
 			};
 
 			/**
+			 * clear pageSeries if pagination out of alignment
+			 *
+			 * @param {Object} combinedResponse - object with local and server responses
+			 * @returns {Object} - combinedResponse object
+			 */
+			const adjustPagination = combinedResponse => {
+				debug( 'adjustPagination()', combinedResponse );
+				if ( ! combinedResponse ) {
+					return;
+				}
+				const { serverResponse, localResponse } = combinedResponse;
+				const localResponseBody = localResponse ? localResponse.body : null;
+				if ( hasPaginationChanged( serverResponse, localResponseBody ) ) {
+					debug( 'run clearPageSeries()' );
+					cacheIndex.clearPageSeries( reqParams );
+				} else {
+					debug( 'do not clearPageSeries()' );
+				}
+				return combinedResponse;
+			};
+
+			/**
+			 * Handle response gotten form the
+			 * server-side response
+			 *AzSX
+			 * @param {Error} err - error object
+			 */
+			const networkErrorHandler = err => {
+				if ( err ) {
+					// @TODO improve error handling here
+					warn( err );
+					warn( 'request params: %o', reqParams );
+					callback( err );
+				}
+			};
+
+			/**
 			 * Add/Override the data gotten from the
 			 * WP.com server-side response.
 			 *
 			 * @param {Object} combinedResponse - object with local and server responses
+			 * @returns {Object} - combinedResponse object
 			 */
 			const cacheResponse = combinedResponse => {
 				const { serverResponse } = combinedResponse;
@@ -187,39 +206,16 @@ export class SyncHandler {
 					// @TODO error handling
 					warn( err );
 				} );
+
+				return combinedResponse;
 			};
 
-			/**
-			 * Handle response gotten form the
-			 * server-side response
-			 *
-			 * @param {Error} err - error object
-			 */
-			const networkErrorHandler = err => {
-				if ( err ) {
-					// @TODO improve error handling here
-					warn( err );
-					warn( 'request params: %o', reqParams );
-					callback( err );
-				}
-			};
-
-			const checkPagination = combinedResponse => {
-				if ( ! combinedResponse ) {
-					return;
-				}
-				const { serverResponse, localResponse } = combinedResponse;
-				if ( hasPaginationChanged( serverResponse, localResponse.body ) ) {
-					// clearPageResultsForSite( reqParams )
-				}
-				return serverResponse;
-			};
 			// request/response workflow
-			this.retrieveRecord( key )
-				.then( localResponseHandler, recordErrorHandler )
-				.then( networkFetch )
-				.then( cacheResponse, networkErrorHandler )
-				.then( checkPagination );
+			this.retrieveRecord( key ) // => localforage record
+				.then( localResponseHandler, recordErrorHandler ) // => localforage record
+				.then( networkFetch ) // => combinedResponse { localResponse, serverResponse }
+				.then( adjustPagination, networkErrorHandler ) // => combinedResponse { localResponse, serverResponse }
+				.then( cacheResponse ); // => combinedResponse { localResponse, serverResponse }
 		};
 	}
 
@@ -237,18 +233,22 @@ export class SyncHandler {
 	 */
 	storeRecord( key, data ) {
 		debug( 'storing data in %o key\n', key );
+		let pageSeriesKey;
+		if ( data && data.body && data.body.meta && data.body.meta.next_page ) {
+			pageSeriesKey = generatePageSeriesKey( data.params );
+		}
 
 		// add this record to history
 		return cacheIndex
-			.addItem( key )
-			.then( localforage.setItem( key, data ) );
+			.addItem( key, pageSeriesKey )
+				.then( localforage.setItem( key, data ) );
 	}
 
 	removeRecord( key ) {
 		debug( 'removing %o key\n', key );
 		return localforage
 			.removeItem( key )
-			.then( cacheIndex.removeItem( key ) );
+				.then( cacheIndex.removeItem( key ) );
 	}
 }
 

--- a/client/lib/wp/sync-handler/test/cache-index.js
+++ b/client/lib/wp/sync-handler/test/cache-index.js
@@ -1,0 +1,212 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import mockery from 'mockery';
+import ms from 'ms';
+
+/**
+ * Internal dependencies
+ */
+import { RECORDS_LIST_KEY } from '../constants';
+import * as testData from './data';
+import localforageMock from './localforage-mock';
+
+let cacheIndex;
+
+const localData = () => localforageMock.getLocalData();
+const setLocalData = data => localforageMock.setLocalData( data );
+const clearLocal = () => setLocalData( {} );
+
+describe( 'cache-index', () => {
+	before( () => {
+		mockery.enable( {
+			warnOnReplace: false,
+			warnOnUnregistered: false
+		} );
+		mockery.registerSubstitute( 'localforage', 'lib/wp/sync-handler/test/localforage-mock' );
+		( { cacheIndex } = require( '../cache-index' ) );
+	} );
+
+	after( function() {
+		mockery.disable();
+		mockery.deregisterSubstitute( 'localforage' );
+	} );
+
+	beforeEach( clearLocal ); // also do inside nested blocks with >1 test
+
+	describe( '#getAll', () => {
+		beforeEach( clearLocal );
+
+		it( 'should return undefined for empty localforage', ( done ) => {
+			return cacheIndex.getAll()
+				.then( res => {
+					try {
+						expect( res ).to.equal( undefined );
+						done();
+					} catch ( err ) {
+						done( err );
+					}
+				}, ( err ) => done( err ) );
+		} );
+		it( 'should return index from localforage and nothing else', ( done ) => {
+			const { recordsList } = testData;
+			setLocalData( {
+				someStoredRecord: 1,
+				someOtherRecord: 2,
+				[ RECORDS_LIST_KEY ]: recordsList
+			} );
+			return cacheIndex.getAll()
+				.then( res => {
+					try {
+						expect( res ).to.equal( recordsList );
+						done();
+					} catch ( err ) {
+						done( err );
+					}
+				}, ( err ) => done( err ) );
+		} );
+	} );
+
+	describe( '#addItem', () => {
+		beforeEach( clearLocal ); // also do inside nested blocks with >1 test
+
+		it( 'should add item to empty index', ( done ) => {
+			const key = 'unique-key';
+			return cacheIndex.addItem( key )
+				.then( () => {
+					try {
+						const currentIndex = localforageMock.getLocalData()[ RECORDS_LIST_KEY ];
+						expect( currentIndex ).to.be.an( 'array' );
+						expect( currentIndex[0] ).to.have.property( 'key', key );
+						expect( currentIndex[0] ).to.have.property( 'timestamp' );
+						done();
+					} catch ( err ) {
+						done( err );
+					}
+				}, ( err ) => done( err ) );
+		} );
+		it( 'should store a pageSeriesKey when passed as second parameter', ( done ) => {
+			const { postListKey, postListPageSeriesKey } = testData;
+			return cacheIndex.addItem( postListKey, postListPageSeriesKey )
+				.then( () => {
+					try {
+						const currentIndex = localforageMock.getLocalData()[ RECORDS_LIST_KEY ];
+						expect( currentIndex ).to.be.an( 'array' );
+						expect( currentIndex[0] ).to.have.property( 'key', postListKey );
+						expect( currentIndex[0] ).to.have.property( 'pageSeriesKey', postListPageSeriesKey );
+						expect( currentIndex[0] ).to.have.property( 'timestamp' );
+						done();
+					} catch ( err ) {
+						done( err );
+					}
+				}, ( err ) => done( err ) );
+		} );
+	} );
+
+	describe( '#removeItem', () => {
+		it( 'should remove item from a populated index', ( done ) => {
+			const { postListKey, localDataFull } = testData;
+			setLocalData( localDataFull );
+			return cacheIndex.removeItem( postListKey )
+				.then( () => {
+					try {
+						const currentIndex = localData()[ RECORDS_LIST_KEY ];
+						expect( currentIndex.length ).to.eql( 2 );
+						done();
+					} catch ( err ) {
+						done( err );
+					}
+				}, ( err ) => done( err ) );
+		} );
+	} );
+
+	describe( '#pruneRecordsFrom', () => {
+		it( 'should prune old records', ( done ) => {
+			const {
+				postListKey,
+				postListDifferentKey,
+				postListLocalRecord,
+				postListLocalRecordDifferent,
+			} = testData;
+			const now = Date.now();
+			const yesterday = now - ms( '1 day' );
+			setLocalData( {
+				[ postListKey ]: postListLocalRecord,
+				[ postListDifferentKey ]: postListLocalRecordDifferent,
+				[ RECORDS_LIST_KEY ]: [
+					{ key: postListKey, timestamp: now },
+					{ key: postListDifferentKey, timestamp: yesterday },
+				]
+			} );
+			return cacheIndex.pruneRecordsFrom( '1 hour' )
+				.then( () => {
+					try {
+						const freshData = localData();
+						const currentIndex = freshData[ RECORDS_LIST_KEY ];
+						expect( currentIndex ).to.eql( [ { key: postListKey, timestamp: now } ] );
+						expect( freshData ).to.have.property( postListKey, postListLocalRecord );
+						expect( freshData ).to.have.property( RECORDS_LIST_KEY );
+						expect( freshData ).to.not.have.property( postListDifferentKey );
+						done();
+					} catch ( err ) {
+						done( err );
+					}
+				}, ( err ) => done( err ) );
+		} );
+	} );
+
+	describe( '#clearAll', () => {
+		it( 'should clear all sync records and nothing else', ( done ) => {
+			const { localDataFull } = testData;
+			setLocalData( Object.assign( { someRecord: 1 }, localDataFull ) );
+			return cacheIndex.clearAll()
+				.then( () => {
+					try {
+						const freshData = localData();
+						expect( freshData ).to.eql( { someRecord: 1 } );
+						done();
+					} catch ( err ) {
+						done( err );
+					}
+				}, ( err ) => done( err ) );
+		} );
+	} );
+
+	describe( '#clearPageSeries', () => {
+		it( 'should clear records with matching pageSeriesKey and leave other records intact', ( done ) => {
+			const {
+				postListKey,
+				postListNextPageKey,
+				postListDifferentKey,
+				postListPageSeriesKey,
+				postListPageSeriesKeyDifferent,
+				postListLocalRecord,
+				postListParamsNextPage,
+				postListLocalRecordNextPage,
+			} = testData;
+			const now = Date.now();
+			setLocalData( {
+				someOtherRecord: 1,
+				[ postListKey ]: postListLocalRecord,
+				[ postListNextPageKey ]: postListLocalRecordNextPage,
+				[ postListDifferentKey ]: Object.assign( {}, postListLocalRecord ),
+				[ RECORDS_LIST_KEY ]: [
+					{ key: postListKey, pageSeriesKey: postListPageSeriesKey, timestamp: now },
+					{ key: postListNextPageKey, pageSeriesKey: postListPageSeriesKey, timestamp: now },
+					{ key: postListDifferentKey, pageSerieKey: postListPageSeriesKeyDifferent, timestamp: now },
+				]
+			} );
+			return cacheIndex.clearPageSeries( postListParamsNextPage )
+				.then( () => {
+					try {
+						const freshData = localData();
+						expect( freshData ).to.eql( { someOtherRecord: 1, [ postListDifferentKey ]: postListLocalRecord, [ RECORDS_LIST_KEY ]: [ { key: postListDifferentKey, pageSerieKey: postListPageSeriesKeyDifferent, timestamp: now } ] } );
+						done();
+					} catch ( err ) {
+						done( err );
+					}
+				}, ( err ) => done( err ) );
+		} );
+	} );
+} );

--- a/client/lib/wp/sync-handler/test/data.js
+++ b/client/lib/wp/sync-handler/test/data.js
@@ -1,0 +1,166 @@
+/**
+ * Internal dependencies
+ */
+import { RECORDS_LIST_KEY } from '../constants';
+
+/**
+ * Keys
+ */
+export const postListKey = 'sync-record-c8234aa4facc43d9bf2a2ef4037c595200f282f2';
+export const postListNextPageKey = 'sync-record-e1e623dc2933ed96ead4b0508b053660cd4542c3';
+export const postListDifferentKey = 'sync-record-5c73482c2934a7f40601935c92e734748026fe70';
+
+export const postListPageSeriesKey = 'sync-record-c8234aa4facc43d9bf2a2ef4037c595200f282f2';
+export const postListPageSeriesKeyDifferent = 'sync-record-5c73482c2934a7f40601935c92e734748026fe70';
+
+/*
+ * Request Parameters
+ */
+
+export const postListParams = {
+	apiVersion: '1.1',
+	method: 'GET',
+	path: '/sites/bobinprogress.wordpress.com/posts',
+	query: 'status=publish%2Cprivate&order_by=date&order=DESC&author=6617482&type=post&site_visibility=visible&meta=counts',
+};
+
+export const postListParamsDifferentOrder = {
+	apiVersion: '1.1',
+	method: 'GET',
+	path: '/sites/bobinprogress.wordpress.com/posts',
+	query: 'order_by=date&order=DESC&author=6617482&type=post&site_visibility=visible&meta=counts&status=publish%2Cprivate',
+};
+
+export const postListParamsNextPage = {
+	apiVersion: '1.1',
+	method: 'GET',
+	path: '/sites/bobinprogress.wordpress.com/posts',
+	query: 'status=publish%2Cprivate&order_by=date&order=DESC&author=6617482&type=post&site_visibility=visible&meta=counts&page_handle=2014-11-24T13%3A39%3A39-08%3A00%26id=1307',
+};
+
+export const postListParamsDifferent = Object.assign( {}, postListParams, { query: 'filter=test' } );
+
+export const nonWhiteListedRequest = {
+	apiVersion: '1.1',
+	method: 'GET',
+	path: '/not-whitelisted',
+};
+
+/*
+ * Response Bodies
+ */
+
+export const postListResponseBody = {
+	found: 2,
+	meta: {
+		data: {},
+		links: {},
+		next_page: 'value=2014-11-24T13%3A39%3A39-08%3A00&id=9900',
+	},
+	posts: [
+		{ ID: 9900 },
+		{ ID: 9901 },
+	],
+};
+
+export const postListResponseBodyNextPage = {
+	found: 3,
+	meta: {
+		data: {},
+		links: {},
+		next_page: 'value=2014-10-24T13%3A39%3A39-08%3A00&id=9897',
+	},
+	posts: [
+		{ ID: 9897 },
+		{ ID: 9898 },
+		{ ID: 9899}
+	],
+};
+
+export const postListResponseBodyDifferent = {
+	found: 2,
+	meta: {
+		data: {},
+		links: {},
+		next_page: 'value=2015-11-24T13%3A39%3A39-08%3A00&id=2000',
+	},
+	posts: [
+		{ ID: 2000 },
+		{ ID: 2001 },
+	],
+};
+
+export const postListResponseBodyFresh = {
+	found: 3,
+	meta: {
+		data: {},
+		links: {},
+		next_page: 'value=2014-11-26T13%3A39%3A39-08%3A00&id=9899',
+	},
+	posts: [
+		{ ID: 9899 },
+		{ ID: 9900 },
+		{ ID: 9901 },
+	]
+}
+
+export const postListResponseBodyNoHandle = Object.assign( {}, postListResponseBody, { meta: {} } );
+
+/*
+ * Local Data
+ */
+
+export const postListLocalRecord = {
+	__sync: {
+		key: postListKey,
+		synced: 1457329263679,
+		syncing: false,
+	},
+	body: postListResponseBody,
+	params: Object.assign( {}, postListParams ),
+};
+
+export const postListLocalRecordNextPage = {
+	__sync: {
+		key: postListNextPageKey,
+		synced: 1457329263679,
+		syncing: false,
+	},
+	body: postListResponseBodyNextPage,
+	params: Object.assign( {}, postListParamsNextPage ),
+};
+
+export const postListLocalRecordDifferent = {
+	__sync: {
+		key: postListDifferentKey,
+		synced: 1457329263679,
+		syncing: false,
+	},
+	body: postListResponseBodyDifferent,
+	params: Object.assign( {}, postListParamsDifferent ),
+};
+
+export const recordsList = [
+	{
+		key: postListKey,
+		pageSeriesKey: postListPageSeriesKey,
+		timestamp: 1457329204357,
+	},
+	{
+		key: postListNextPageKey,
+		pageSeriesKey: postListPageSeriesKey,
+		timestamp: 1457329263835,
+	},
+	{
+		key: postListDifferentKey,
+		pageSeriesKey: postListPageSeriesKeyDifferent,
+		timestamp: 1457329442428,
+	},
+];
+
+export const localDataFull = {
+	[ postListKey ]: postListLocalRecord,
+	[ postListNextPageKey ]: postListLocalRecordNextPage,
+	[ postListDifferentKey ]: postListLocalRecordDifferent,
+	[ RECORDS_LIST_KEY ]: recordsList,
+}

--- a/client/lib/wp/sync-handler/test/index.js
+++ b/client/lib/wp/sync-handler/test/index.js
@@ -5,50 +5,17 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import mockery from 'mockery';
 
-let wpcom, SyncHandler, generateKey, hasPaginationChanged, localData, responseData;
+/**
+ * Internal dependencies
+ */
+import { generateKey } from '../utils';
+import * as testData from './data';
+import localforageMock from './localforage-mock';
+import { RECORDS_LIST_KEY } from '../constants';
 
-const localforageMock = {
-	getLocalForage() {
-		return {
-			setItem: function( key, data ) {
-				return new Promise( resolve => {
-					localData[ key ] = data;
-					resolve();
-				} )
-			},
-			getItem: function( key ) {
-				return new Promise( resolve => {
-					resolve( localData[ key ] );
-				} );
-			},
-		}
-	}
-};
+let wpcom, SyncHandler, hasPaginationChanged, responseData, cacheIndex;
 
-const testRequestData = {
-	simpleRequest: {
-		method: 'GET',
-		path: '/test'
-	},
-	postRequest: {
-		method: 'GET',
-		path: '/sites/example.wordpress.com/posts',
-	},
-}
-
-const testResponseData = {
-	postResponseWithNoHandle: {},
-	postResponseWithHandle: {
-		meta: {
-			next_page: 'test'
-		}
-	},
-	postResponseNewHandle: {
-		meta: {
-			next_page: 'test2'
-		}
-	}
-}
+const setLocalData = data => localforageMock.setLocalData( data );
 
 describe( 'sync-handler', () => {
 	before( () => {
@@ -56,110 +23,175 @@ describe( 'sync-handler', () => {
 			warnOnReplace: false,
 			warnOnUnregistered: false
 		} );
-		mockery.registerMock( 'lib/localforage', localforageMock );
+		mockery.registerSubstitute( 'localforage', 'lib/wp/sync-handler/test/localforage-mock' );
+		( { cacheIndex } = require( '../cache-index' ) );
 		const handlerMock = ( params, callback ) => {
 			const key = generateKey( params );
 			callback( null, responseData[ key ] );
 			return responseData[ key ];
 		};
-
-		( { SyncHandler, generateKey, hasPaginationChanged } = require( '../' ) );
+		( { SyncHandler, hasPaginationChanged } = require( '../' ) );
 		wpcom = new SyncHandler( handlerMock );
 	} );
-
 	beforeEach( () => {
 		responseData = {};
-		localData = {};
+		setLocalData( {} );
 	} );
-
 	after( function() {
 		mockery.disable();
+		mockery.deregisterSubstitute( 'localforage' );
 	} );
-
 	it( 'should call callback with local response', () => {
-		const { postRequest } = testRequestData;
-		const key = generateKey( postRequest );
+		const {
+			postListKey,
+			postListParams,
+			postListLocalRecord,
+			postListResponseBody
+		} = testData;
 		const callback = sinon.spy();
-		localData[ key ] = { body: 'test' };
-		wpcom( postRequest, callback );
-		expect( callback.calledWith( null, 'test' ) );
+		setLocalData( {
+			[ postListKey ]: postListLocalRecord
+		} );
+		wpcom( postListParams, callback );
+		expect( callback.calledWith( null, postListResponseBody ) );
 	} );
-
 	it( 'should call callback with request response', () => {
-		const { postRequest } = testRequestData;
-		const key = generateKey( postRequest );
+		const {
+			postListKey,
+			postListParams,
+			postListResponseBody
+		} = testData;
 		const callback = sinon.spy();
-		responseData[ key ] = { body: 'test' };
-		wpcom( postRequest, callback );
+		responseData[ postListKey ] = postListResponseBody;
+		wpcom( postListParams, callback );
 		expect( callback ).to.have.been.calledOnce;
-		expect( callback.calledWith( null, 'test' ) );
+		expect( callback.calledWith( null, postListResponseBody ) );
 	} );
-
 	it( 'should call callback twice with local and request responses', () => {
-		const { postRequest } = testRequestData;
-		const key = generateKey( postRequest );
+		const {
+			postListKey,
+			postListParams,
+			postListLocalRecord,
+			postListResponseBody,
+			postListResponseBodyFresh
+		} = testData;
 		const callback = sinon.spy();
-		localData[ key ] = { body: 'test1' };
-		responseData[ key ] = ( null, { body: 'test2' } );
-		wpcom( postRequest, callback );
+		setLocalData( {
+			[ postListKey ]: postListLocalRecord
+		} );
+		responseData[ postListKey ] = postListResponseBodyFresh;
+		wpcom( postListParams, callback );
 		expect( callback ).to.have.been.calledTwice;
-		expect( callback.calledWith( null, 'test1' ) );
-		expect( callback.calledWith( null, 'test2' ) );
+		expect( callback.calledWith( null, postListResponseBody ) );
+		expect( callback.calledWith( null, postListResponseBodyFresh ) );
+	} );
+	it( 'should store cacheIndex records with matching pageSeriesKey for paginated responses', ( done ) => {
+		const {
+			postListKey,
+			postListNextPageKey,
+			postListParams,
+			postListParamsNextPage,
+			postListResponseBody,
+			postListResponseBodyNextPage,
+		} = testData;
+		responseData = {
+			[ postListKey ]: postListResponseBody,
+			[ postListNextPageKey ]: postListResponseBodyNextPage,
+		};
+		wpcom( postListParams, () => {} );
+		setTimeout( () => {
+			try {
+				wpcom( postListParamsNextPage, () => {} );
+				setTimeout( () => {
+					try {
+						const freshData = localforageMock.getLocalData();
+						const firstRecord = freshData[ RECORDS_LIST_KEY ][ 0 ];
+						const secondRecord = freshData[ RECORDS_LIST_KEY ][ 1 ];
+						expect( firstRecord.key ).to.not.equal( secondRecord.key );
+						expect( firstRecord.pageSeriesKey ).to.equal( secondRecord.pageSeriesKey );
+						done();
+					} catch ( err ) {
+						done( err );
+					}
+				}, 0 );
+			} catch ( err ) {
+				done( err );
+			}
+		}, 0 );
+	} );
+	it( 'should call clearPageSeries when getting a response with an updated page_handle', ( done ) => {
+		const {
+			postListParams,
+			postListLocalRecord,
+			postListResponseBodyFresh,
+			postListKey,
+		} = testData;
+		setLocalData( { [ postListKey ]: postListLocalRecord } );
+		responseData[ postListKey ] = postListResponseBodyFresh;
+		sinon.spy( cacheIndex, 'clearPageSeries' );
+		wpcom( postListParams, () => {} );
+		setTimeout( () => {
+			try {
+				expect( cacheIndex.clearPageSeries.called ).to.be.true;
+				cacheIndex.clearPageSeries.restore();
+				done();
+			} catch ( err ) {
+				done( err );
+			}
+		}, 0 );
 	} );
 
 	describe( 'generateKey', () => {
+		beforeEach( () => {
+			responseData = {};
+			setLocalData( {} );
+		} );
 		it( 'should return the same key for identical request', () => {
-			const { simpleRequest } = testRequestData;
-			const secondRequest = Object.assign( {}, simpleRequest );
-			const key1 = generateKey( simpleRequest );
+			const { postListParams } = testData;
+			const secondRequest = Object.assign( {}, postListParams );
+			const key1 = generateKey( postListParams );
 			const key2 = generateKey( secondRequest );
 			expect( typeof key1 ).to.equal( 'string' );
 			expect( key1 ).to.equal( key2 );
 		} );
 		it( 'should return unique keys for different requests', () => {
-			const { simpleRequest } = testRequestData;
-			const secondRequest = Object.assign( { query: '?filter=test' }, simpleRequest );
-			const key1 = generateKey( simpleRequest );
+			const { postListParams } = testData;
+			const secondRequest = Object.assign( {}, postListParams, { query: '?filter=test' } );
+			const key1 = generateKey( postListParams );
 			const key2 = generateKey( secondRequest );
 			expect( typeof key1 ).to.equal( 'string' );
 			expect( key1 ).to.not.equal( key2 );
 		} );
+		it( 'should return the same key if parameters are in different order', () => {
+			const { postListParams, postListParamsDifferentOrder } = testData;
+			const key1 = generateKey( postListParams );
+			const key2 = generateKey( postListParamsDifferentOrder );
+			expect( typeof key1 ).to.equal( 'string' );
+			expect( key1 ).to.equal( key2 );
+		} );
 	} );
 
 	describe( 'hasPaginationChanged', () => {
-		before( () => {
-			sinon.spy( hasPaginationChanged );
-		} );
-		it( 'should not call hasPaginationChanged for non-whitelisted requests', () => {
-			const { simpleRequest } = testRequestData;
-			wpcom( simpleRequest, () => {} );
-			expect( hasPaginationChanged ).not.to.have.been.called;
-		} );
-		it( 'should call hasPaginationChanged once for whitelisted request', () => {
-			const { postRequest } = testRequestData;
-			wpcom( postRequest, () => {} );
-			expect( hasPaginationChanged ).to.have.been.calledOnce;
-		} );
 		it( 'should return false if requestResponse has no page handle', () => {
-			const { postResponseWithNoHandle } = testResponseData;
-			const result = hasPaginationChanged( postResponseWithNoHandle, null );
+			const { postListResponseBodyNoHandle } = testData;
+			const result = hasPaginationChanged( postListResponseBodyNoHandle, null );
 			expect( result ).to.equal( false );
 		} );
 		it( 'should return false for call with identical response', () => {
-			const { postResponseWithHandle } = testResponseData;
-			const localResponse = Object.assign( {}, postResponseWithHandle );
-			const result = hasPaginationChanged( postResponseWithHandle, localResponse );
+			const { postListResponseBody } = testData;
+			const identicalResponse = Object.assign( {}, postListResponseBody );
+			const result = hasPaginationChanged( postListResponseBody, identicalResponse );
 			expect( result ).to.equal( false );
 		} );
 		it( 'should return true if page handle is different', () => {
-			const { postResponseWithHandle, postResponseNewHandle } = testResponseData;
-			const result = hasPaginationChanged( postResponseWithHandle, postResponseNewHandle );
+			const { postListResponseBody, postListResponseBodyFresh } = testData;
+			const result = hasPaginationChanged( postListResponseBody, postListResponseBodyFresh );
 			expect( result ).to.equal( true );
-		} )
-		it( 'should return true call with empty local response', () => {
-			const { postResponseWithHandle } = testResponseData;
-			const result = hasPaginationChanged( postResponseWithHandle, null );
-			expect( result ).to.equal( true );
-		} )
+		} );
+		it( 'should return false with empty local response', () => {
+			const { postListResponseBody } = testData;
+			const result = hasPaginationChanged( postListResponseBody, null );
+			expect( result ).to.equal( false );
+		} );
 	} );
 } );

--- a/client/lib/wp/sync-handler/test/localforage-mock.js
+++ b/client/lib/wp/sync-handler/test/localforage-mock.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:sync-handler:localforage-mock' );
+let localData = {};
+
+export default {
+	setItem( key, data ) {
+		return new Promise( resolve => {
+			debug( 'setItem: %o, (%o)', key, data );
+			localData[ key ] = data;
+			resolve();
+		} )
+	},
+	getItem( key ) {
+		return new Promise( resolve => {
+			debug( 'getItem: %o', key );
+			resolve( localData[ key ] );
+		} );
+	},
+	removeItem( key ) {
+		return new Promise( resolve => {
+			debug( 'removeItem: %o', key );
+			delete localData[ key ];
+			resolve();
+		} );
+	},
+	keys() {
+		return new Promise( resolve => {
+			const keys = Object.keys( localData );
+			debug( 'keys: %o', keys );
+			resolve( keys );
+		} )
+	},
+	getLocalData() {
+		return localData;
+	},
+	setLocalData( newData ) {
+		localData = newData;
+	},
+	config() {},
+};

--- a/client/lib/wp/sync-handler/utils.js
+++ b/client/lib/wp/sync-handler/utils.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import Hashes from 'jshashes';
+import qs from 'querystring';
+import deterministicStringify from 'lib/deterministic-stringify';
+
+/**
+ * Internal dependencies
+ */
+import { SYNC_RECORD_NAMESPACE } from './constants';
+
+/**
+ * Generate a key from the given param object
+ *
+ * @param {Object} params - request parameters
+ * @param {Boolean} applyHash - codificate key when it's true
+ * @return {String} request key
+ */
+export const generateKey = ( params, applyHash = true ) => {
+	var key = `${params.apiVersion || ''}-${params.method}-${params.path}`;
+
+	if ( params.query ) {
+		// sort parameters alphabetically
+		key += '-' + deterministicStringify( qs.parse( params.query ) );
+	}
+
+	if ( applyHash ) {
+		key = new Hashes.SHA1().hex( key );
+	}
+
+	key = SYNC_RECORD_NAMESPACE + key;
+	return key;
+}
+
+/**
+ * Generate pageSeriesKey from request parameters
+ * @param  {Object} reqParams - request parameters
+ * @return {String}        - pageSeriesKey string
+ */
+export const generatePageSeriesKey = ( reqParams ) => {
+	const queryParams = qs.parse( reqParams.query );
+	delete queryParams.page_handle;
+	const paramsWithoutPage = Object.assign( {}, reqParams, { query: qs.stringify( queryParams ) } );
+	return generateKey( paramsWithoutPage );
+}


### PR DESCRIPTION
This is a re-do of #3682. After merging that PR and testing in wpcalypso/staging, I noticed a quirk on the `/pages/:site` page where pages would show up empty. I quickly reverted the PR (#3917). I did a little more testing and could no longer recreate the bug after restarting my browser. @gwwar tried testing as well and was also unable to reproduce the issue. So I'm creating a new PR to re-submit this. I'm going to push it straight through, as it's unmodified from the already-reviewed-and-approved PR.