### PR TITLE
People: Update invalid invite wording to use "Site"

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -167,10 +167,10 @@ let InviteAccept = React.createClass( {
 			};
 			switch ( this.state.error.error ) {
 				case 'already_member':
-					return ( <EmptyContent { ... props } title={ this.translate( 'You are already a member of this blog.' ) } /> );
+					return ( <EmptyContent { ... props } title={ this.translate( 'You are already a member of this site.' ) } /> );
 					break;
 				case 'already_subscribed':
-					return ( <EmptyContent { ... props } title={ this.translate( 'You are already a follower on this blog.' ) } /> );
+					return ( <EmptyContent { ... props } title={ this.translate( 'You are already a follower on this site.' ) } /> );
 					break;
 			}
 		}


### PR DESCRIPTION
Previously, we were using "Blog" in wording for the "already_member" and "already_following" errors.

In Slack today, @rickybanister suggested that we update that wording.

![screen shot 2016-03-09 at 5 45 51 pm](https://cloud.githubusercontent.com/assets/1126811/13654611/f7d20c88-e61e-11e5-86cd-8f5ef7a4e933.png)
