### PR TITLE
Domains: Google Apps: Add loading placeholder

### DIFF
--- a/client/my-sites/upgrades/domain-management/email/google-apps-user-item.jsx
+++ b/client/my-sites/upgrades/domain-management/email/google-apps-user-item.jsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
+
+const GoogleAppsUserItem = React.createClass( {
+	propTypes: {
+		user: React.PropTypes.object.isRequired,
+		onClick: React.PropTypes.func
+	},
+
+	shouldComponentUpdate( nextProps ) {
+		return this.props.user !== nextProps.user || this.props.onClick !== nextProps.onClick;
+	},
+
+	render() {
+		return (
+			<li>
+				<span className="google-apps-user-item__email">
+					{ this.props.user.email }
+				</span>
+
+				<ExternalLink
+					icon
+					className="google-apps-user-item__manage-link"
+					href={ `https://admin.google.com/a/${ this.props.user.domain }` }
+					target="_blank">
+					{ this.translate( 'Manage', { context: 'Google Apps user item' } ) }
+				</ExternalLink>
+			</li>
+		);
+	}
+} );
+
+export default GoogleAppsUserItem;

--- a/client/my-sites/upgrades/domain-management/email/google-apps-users-card.jsx
+++ b/client/my-sites/upgrades/domain-management/email/google-apps-users-card.jsx
@@ -8,10 +8,9 @@ import React from 'react';
  */
 import CompactCard from 'components/card/compact';
 import paths from 'my-sites/upgrades/paths';
-import ExternalLink from 'components/external-link';
 import analyticsMixin from 'lib/mixins/analytics';
 import SectionHeader from 'components/section-header';
-import i18n from 'lib/mixins/i18n';
+import GoogleAppsUserItem from './google-apps-user-item';
 import { getSelectedDomain } from 'lib/domains';
 
 const GoogleAppsUsers = React.createClass( {
@@ -76,35 +75,6 @@ const GoogleAppsUsers = React.createClass( {
 					</ul>
 				</CompactCard>
 			</div>
-		);
-	}
-} );
-
-const GoogleAppsUserItem = React.createClass( {
-	propTypes: {
-		user: React.PropTypes.object.isRequired,
-		onClick: React.PropTypes.func
-	},
-
-	shouldComponentUpdate( nextProps ) {
-		return this.props.user !== nextProps.user || this.props.onClick !== nextProps.onClick;
-	},
-
-	render() {
-		return (
-			<li>
-				<span className="google-apps-users-card__user-email">
-					{ this.props.user.email }
-				</span>
-
-				<ExternalLink
-					icon
-					className="google-apps-users-card__user-manage-link"
-					href={ `https://admin.google.com/a/${ this.props.user.domain }` }
-					target="_blank">
-					{ i18n.translate( 'Manage', { context: 'Google Apps user item' } ) }
-				</ExternalLink>
-			</li>
 		);
 	}
 } );

--- a/client/my-sites/upgrades/domain-management/email/index.jsx
+++ b/client/my-sites/upgrades/domain-management/email/index.jsx
@@ -12,6 +12,7 @@ import Header from 'my-sites/upgrades/domain-management/components/header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import AddGoogleAppsCard from './add-google-apps-card';
 import GoogleAppsUsersCard from './google-apps-users-card';
+import Placeholder from './placeholder';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
@@ -68,7 +69,7 @@ const Email = React.createClass( {
 
 	content() {
 		if ( ! ( this.props.domains.hasLoadedFromServer && this.props.googleAppsUsersLoaded ) ) {
-			return this.translate( 'Loading…' );
+			return <Placeholder />;
 		}
 
 		let domainList = this.props.selectedDomainName

--- a/client/my-sites/upgrades/domain-management/email/placeholder.jsx
+++ b/client/my-sites/upgrades/domain-management/email/placeholder.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CompactCard from 'components/card/compact';
+import SectionHeader from 'components/section-header';
+import GoogleAppsUserItem from './google-apps-user-item';
+
+const Placeholder = () =>
+	<div className="is-placeholder">
+		<SectionHeader
+			label={ 'Google Apps Users' } />
+		<CompactCard className="google-apps-users-card">
+			<ul className="google-apps-users-card__user-list">
+				<GoogleAppsUserItem user={ { email: 'mail@example.com', domain: 'example.com' } } />
+			</ul>
+		</CompactCard>
+	</div>
+;
+
+export default Placeholder;

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -949,6 +949,23 @@ ul.dns__list {
 	}
 }
 
+.domain-management-email {
+	.is-placeholder {
+		.section-header__label {
+			@include placeholder();
+
+			&::before {
+				display: none;
+			}
+		}
+
+		.google-apps-user-item__email,
+		.google-apps-user-item__manage-link {
+			@include placeholder();
+		}
+	}
+}
+
 .google-apps-users-card.card {
 	padding: 0;
 	@include clear-fix;

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -997,11 +997,11 @@ ul.dns__list {
 	}
 }
 
-.google-apps-users-card__user-email {
+.google-apps-user-item__email {
 	float: left;
 }
 
-.google-apps-users-card__user-manage-link {
+.google-apps-user-item__manage-link {
 	float: right;
 	font-size: 13px;
 }


### PR DESCRIPTION
Adds a loading placeholder in Email management page (`/domains/manage/email/example.com`).

Before:
<img width="742" alt="screen shot 2016-03-10 at 02 47 18" src="https://cloud.githubusercontent.com/assets/3392497/13656801/6f9c0322-e66a-11e5-9480-0ca13134bcf5.png">


After:
<img width="749" alt="screen shot 2016-03-10 at 02 44 52" src="https://cloud.githubusercontent.com/assets/3392497/13656762/21ffa27c-e66a-11e5-928a-c748e3e5ae0a.png">


/cc @aidvu @umurkontaci 