### PR TITLE
Support User: Bypass localStorage when active

### DIFF
--- a/client/lib/support/support-user/localstorage-bypass.js
+++ b/client/lib/support/support-user/localstorage-bypass.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import debugModule from 'debug';
+
+const debug = debugModule( 'calypso:support-user' );
+
+export const length = ( memoryStore ) => {
+	return () => {
+		debug( 'Bypassing localStorage', 'length property' );
+		return Object.keys( memoryStore ).length;
+	}
+}
+
+export const key = ( memoryStore ) => {
+	return ( index ) => {
+		debug( 'Bypassing localStorage', 'key' );
+		if ( index >= Object.keys( memoryStore ).length ) {
+			return null;
+		}
+
+		return Object.keys( memoryStore )[ index ];
+	}
+}
+
+export const setItem = ( memoryStore, allowedKeys, original ) => {
+	return ( _key, value ) => {
+		if ( allowedKeys.indexOf( _key ) > -1 ) {
+			original( _key, value );
+			return;
+		}
+
+		debug( 'Bypassing localStorage', 'setItem', _key );
+		memoryStore[ _key ] = value;
+	}
+}
+
+export const getItem = ( memoryStore, allowedKeys, original ) => {
+	return ( _key ) => {
+		if ( allowedKeys.indexOf( _key ) > -1 ) {
+			return original( _key );
+		}
+
+		debug( 'Bypassing localStorage', 'getItem', _key );
+		return memoryStore[ _key ] || null;
+	}
+}
+
+export const removeItem = ( memoryStore, allowedKeys, original ) => {
+	return ( _key ) => {
+		if ( allowedKeys.indexOf( _key ) > -1 ) {
+			original( _key );
+			return;
+		}
+
+		debug( 'Bypassing localStorage', 'removeItem', _key );
+		delete memoryStore[ _key ];
+	};
+};
+
+export const clear = ( memoryStore ) => {
+	return () => {
+		debug( 'Bypassing localStorage', 'clear' );
+
+		for ( let _key in memoryStore ) {
+			delete memoryStore[ _key ];
+		}
+	};
+};
+
+/**
+ * Overrides localStorage, using an in-memory store instead of the real localStorage.
+ * This avoids conflicts caused by shared localStorage across multiple support user sessions.
+ * @param  {string[]} allowedKeys An array of localStorage keys that are proxied to the real localStorage
+ */
+export default function( allowedKeys ) {
+	if ( window && window.localStorage && window.Storage && window.Storage.prototype ) {
+		debug( 'Bypassing localStorage' );
+		const memoryStore = {};
+		const _setItem = window.Storage.prototype.setItem.bind( window.localStorage );
+		const _getItem = window.Storage.prototype.getItem.bind( window.localStorage );
+		const _removeItem = window.Storage.prototype.removeItem.bind( window.localStorage );
+
+		Object.defineProperty( Storage.prototype, 'length', {
+			get: length( memoryStore ),
+		} );
+
+		Object.assign( Storage.prototype, {
+			setItem: setItem( memoryStore, allowedKeys, _setItem ),
+			getItem: getItem( memoryStore, allowedKeys, _getItem ),
+			removeItem: removeItem( memoryStore, allowedKeys, _removeItem ),
+			key: key( memoryStore ),
+			clear: clear( memoryStore ),
+		} );
+	}
+}

--- a/client/lib/support/support-user/test/localstorage-bypass.js
+++ b/client/lib/support/support-user/test/localstorage-bypass.js
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { spy } from 'sinon';
+
+/**
+ * Internal dependencies
+ */
+import {
+	key,
+	clear,
+	setItem,
+	getItem,
+	removeItem,
+	length,
+} from '../localstorage-bypass';
+
+describe( 'localstorage-bypass', () => {
+	// Spy on the original localStorage functions
+	const _setItem = spy();
+	const _getItem = spy( ( x ) => x );
+	const _removeItem = spy();
+	let db = {};
+
+	beforeEach( () => {
+		_setItem.reset();
+		_getItem.reset();
+		_removeItem.reset();
+		db = {};
+	} );
+
+	describe( 'length', () => {
+		it( 'returns the number of keys in dummy storage', () => {
+			db.one = 'a';
+			db.two = 'b';
+			expect( length( db )() ).to.equal( 2 );
+			db.three = 'c';
+			expect( length( db )() ).to.equal( 3 );
+		} );
+	} );
+
+	describe( 'clear', () => {
+		it( 'clears all keys', () => {
+			db.one = 1;
+			db.two = 2;
+			clear( db )();
+			expect( db ).to.be.empty;
+		} );
+	} );
+
+	describe( 'key', () => {
+		it( 'returns a specific key', () => {
+			db.first = 'a';
+			db.second = 'b';
+
+			expect( key( db )( 0 ) ).to.equal( 'first' );
+			expect( key( db )( 1 ) ).to.equal( 'second' );
+		} );
+
+		it( 'returns null for a key that doesn\'t exist', () => {
+			expect( key( db )( 2 ) ).to.be.null;
+		} );
+	} );
+
+	describe( 'setItem', () => {
+		it( 'sets an item in memory store', () => {
+			setItem( db, [], _setItem )( 'key', 'value' );
+			expect( db.key ).to.equal( 'value' );
+		} );
+
+		it( 'calls the original setItem function for an allowed key', () => {
+			setItem( db, [ 'key' ], _setItem )( 'key', 'value' );
+			expect( db.key ).to.be.undefined;
+			expect( _setItem ).to.have.been.calledWith( 'key', 'value' );
+		} );
+
+		it( 'overrides an existing value', () => {
+			db.existing = 'abc';
+			setItem( db, [], _setItem )( 'existing', 'def' );
+			expect( db ).to.deep.equal( { existing: 'def' } );
+		} );
+	} );
+
+	describe( 'getItem', () => {
+		beforeEach( () => {
+			db.first = 'abc';
+			db.second = 'def';
+		} );
+
+		it( 'gets an item in memory store', () => {
+			expect( getItem( db, [], _getItem )( 'first' ) ).to.equal( 'abc' );
+		} );
+
+		it( 'calls the original getItem function for an allowed key', () => {
+			expect( getItem( db, [ 'first' ], _getItem )( 'first' ) ).to.equal( 'first' );
+			expect( _getItem ).to.have.been.calledWith( 'first' );
+		} );
+
+		it( 'returns null for a key that doesn\'t exist', () => {
+			expect( getItem( db, [], _getItem )( 'missing' ) ).to.be.null;
+		} );
+	} );
+
+	describe( 'removeItem', () => {
+		beforeEach( () => {
+			db.first = 'abc';
+			db.second = 'def';
+		} );
+
+		it( 'removes an item in memory store', () => {
+			removeItem( db, [], _removeItem )( 'first' );
+			expect( db.first ).to.be.undefined;
+		} );
+
+		it( 'calls the original removeItem function for an allowed key', () => {
+			removeItem( db, [ 'first' ], _removeItem )( 'first' );
+			expect( db.first ).to.equal( 'abc' );
+			expect( _removeItem ).to.have.been.calledWith( 'first' );
+		} );
+
+		it( 'has no effect when a key doesn\'t already exist', () => {
+			removeItem( db, [], _removeItem )( 'missing' );
+			expect( db ).to.deep.equal( { first: 'abc', second: 'def' } );
+		} )
+	} );
+
+	it( 'should add a key, read it, then remove it', () => {
+		setItem( db, [], _setItem )( 'test', 'value' );
+		expect( getItem( db, [], _getItem )( 'test' ) ).to.equal( 'value' );
+		removeItem( db, [], _removeItem )( 'test' );
+		expect( getItem( db, [], _getItem )( 'test' ) ).to.be.null;
+	} );
+} );

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -12,6 +12,7 @@ import config from 'config';
 import store from 'store';
 import localforage from 'lib/localforage';
 import { supportUserTokenFetch, supportUserActivate, supportUserError } from 'state/support/actions';
+import localStorageBypass from 'lib/support/support-user/localstorage-bypass';
 
 /**
  * Connects the Redux store and the low-level support user functions
@@ -66,7 +67,7 @@ export const rebootNormally = () => {
 
 	debug( 'Rebooting Calypso normally' );
 
-	store.clear();
+	store.remove( STORAGE_KEY );
 	window.location.reload();
 };
 
@@ -104,6 +105,12 @@ export const boot = () => {
 
 	const { user, token } = store.get( STORAGE_KEY );
 	debug( 'Booting Calypso with support user', user );
+	store.remove( STORAGE_KEY );
+
+	// The following keys will not be bypassed as
+	// they are safe to share across user sessions.
+	const allowedKeys = [ STORAGE_KEY, 'debug' ];
+	localStorageBypass( allowedKeys );
 
 	const errorHandler = ( error ) => onTokenError( error );
 

--- a/client/tests.json
+++ b/client/tests.json
@@ -191,6 +191,11 @@
 		"store": {
 			"test": [ "index" ]
 		},
+		"support": {
+			"support-user": {
+				"test": [ "localstorage-bypass" ]
+			}
+		},
 		"terms": {
 			"test": [ "actions", "category-store", "store", "tag-store" ]
 		},


### PR DESCRIPTION
This change keeps all localStorage data from a support user session isolated from the main user session.

To achieve this, `localStorage` is bypassed and replaced with an in-memory store - only while support user is active. This in combination with #3879 will mean we can avoid having to refresh all open sessions, closing #3819.

-------

### How to test

1. Set `localStorage.setItem( 'debug', 'calypso:support-user' )`
2. Log in to support user (ref p4TIVU-2OW-p2)
3. When login is successful and Calypso reboots, messages in the console should indicate `localStorage` bypass.
4. Check that the actual stored localStorage values (using the browser dev tools) relate to the original user, not the support user. Specifically, you can check that `wpcom_user` shows the display name of the original user.
5. Using the browser console, run the following command:
```js
JSON.parse( localStorage.getItem( 'wpcom_user' ) );
```
The console should show the support user's data.

Tested in:
 - [x] Chrome 48
 - [x] Firefox 44
 - [x] Safari 9
 - [x] IE/Edge
 - [x] With `support-user` feature flag disabled
 - [x] In local `production` environment