### PR TITLE
Jetpack-connect: remove dummy wait in jetpack-connect

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 /**
- * internal dependencies
+ * Internal dependencies
  */
 import Card from 'components/card';
 import ConnectHeader from './connect-header';
@@ -27,7 +27,8 @@ export default React.createClass( {
 	getInitialState() {
 		return {
 			showDialog: false,
-			siteStatus: false
+			siteStatus: false,
+			isFetching: false,
 		};
 	},
 
@@ -48,7 +49,7 @@ export default React.createClass( {
 	},
 
 	showNotExistsError() {
-		this.setState( { siteStatus: 'notExist' } );
+		this.setState( { siteStatus: 'notExist', isFetching: false } );
 	},
 
 	checkIfUrlIsReadyForJetpack( url ) {
@@ -67,6 +68,7 @@ export default React.createClass( {
 	},
 
 	onURLEnter() {
+		this.setState( { isFetching: true } );
 		this.checkIfUrlIsReadyForJetpack( this.getCurrentUrl() )
 			.then( this.goToRemoteAuth )
 			.catch( this.showNotExistsError )
@@ -131,7 +133,7 @@ export default React.createClass( {
 							onClick={ this.onURLEnter }
 							onDismissClick={ this.onDismissClick }
 							isError={ this.state.isError }
-							spinnerDuration={ 60000 } />
+							isFetching={ this.state.isFetching } />
 					</Card>
 
 					<LoggedOutFormLinks>

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -1,11 +1,16 @@
-import React from 'react';
+/**
+ * External dependencies
+ */
+ import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import Button from 'components/button';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
 import Spinner from 'components/spinner';
-
 
 export default React.createClass( {
 	displayName: 'JetpackConnectSiteURLInput',
@@ -19,6 +24,10 @@ export default React.createClass( {
 	},
 
 	handleChange( event ) {
+		if ( this.props.isFetching ) {
+			return;
+		}
+
 		this.setState( {
 			value: event.target.value
 		} );
@@ -30,40 +39,14 @@ export default React.createClass( {
 		}
 	},
 
-	spinny() {
-		this.props.onDismissClick();
-		this.setState( { isSpinning: true } );
-		setTimeout( this.spinnyStop, 3000 );
-	},
-
-	spinnyStop() {
-		this.setState( {
-			isSpinning: false
-		} )
-		this.props.onClick();
-	},
-
-	buttonLabel() {
-		if( !this.state.isSpinning ) {
+	renderButtonLabel() {
+		if ( ! this.props.isFetching ) {
 			return( this.translate( 'Connect Now' ) );
-		} else {
-			return( this.translate( 'Connecting…' ) )
 		}
+		return( this.translate( 'Connecting…' ) )
 	},
 
 	render() {
-		const dialogButtons = [ {
-				action: 'cancel',
-				label: this.translate( 'Cancel' )
-			},
-			{
-				action: 'install',
-				label: this.translate( 'Install Now' ),
-				onClick: this.goToPluginInstall,
-				isPrimary: true
-			}
-		];
-
 		return (
 			<div>
 				<FormLabel>{ this.translate( 'Site Address' ) }</FormLabel>
@@ -74,16 +57,15 @@ export default React.createClass( {
 					<FormTextInput
 						value={ this.state.value }
 						onChange={ this.handleChange }
-						disabled={ this.state.isSpinning }
+						disabled={ this.props.isFetching }
 						placeholder={ this.translate( 'http://www.yoursite.com' ) } />
-					{ this.state.isSpinning
+					{ this.props.isFetching
 						? ( <Spinner duration={ 30 } /> )
 						: null }
 				</div>
-				<Button
-					primary
-					disabled={ ( !Boolean( this.state.value ) || this.state.isSpinning ) }
-					onClick={ this.spinny }>{ this.buttonLabel() }</Button>
+				<Button primary
+					disabled={ ( !Boolean( this.state.value ) || this.props.isFetching ) }
+					onClick={ this.props.onClick }>{ this.renderButtonLabel() }</Button>
 			</div>
 		);
 	}


### PR DESCRIPTION
This PR changes the way the spinner in `site-url-input` works:
![image](https://cloud.githubusercontent.com/assets/1554855/13669777/f9740260-e6c5-11e5-971d-7e18812bd7d7.png)

Takes the logic about when it should show or not outside of the component and let the parent be the one who decides when to show it and when to hide it. This way, we can for example, show it until the user get redirected to their wp-admin to get logged:

https://cloudup.com/cQGRCZ-485c

How to test:
========
1. to go http://calypso.local:3000/jetpack/connect and enter one of your jetpack sites 
2. You should see the spinner and the connect button should be dissabled all the time until you get redirected somewhere else


ping @oskosk @alternatekev 