### PR TITLE
Framework: Re-add source-map dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9211,6 +9211,14 @@
           "version": "1.1.0"
         }
       }
+    },
+    "source-map": {
+      "version": "0.1.39",
+      "dependencies": {
+        "amdefine": {
+          "version": "1.0.0"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "redux-thunk": "1.0.0",
     "rtlcss": "1.6.1",
     "sanitize-html": "1.11.1",
+    "source-map": "0.1.39",
     "source-map-support": "0.3.2",
     "srcset": "1.0.0",
     "store": "1.3.16",


### PR DESCRIPTION
Fixes #3948 

Adds `source-map` as a dependency, previously removed in #3849 as an unused dependency.

Without `source-map`, the editor bundle fails to build when running npm 2.x.

__Testing instructions:__

Verify that the editor bundle successfully builds in your current version of npm, and under npm 2.14.12 (the version associated with our production LTS Node release).

/cc @retrofox 