### PR TITLE
State: Omit posts from query selector where item unknown

### DIFF
--- a/client/state/posts/schema.js
+++ b/client/state/posts/schema.js
@@ -32,7 +32,7 @@ export const itemsSchema = {
 				is_reblogged: { type: 'boolean' },
 				is_following: { type: 'boolean' },
 				featured_image: { type: 'string' },
-				post_thumbnail: { type: [ 'string', 'null' ] },
+				post_thumbnail: { type: [ 'object', 'string', 'null' ] },
 				format: { type: 'string' },
 				geo: { type: 'boolean' },
 				menu_order: { type: 'integer' },

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -70,7 +70,7 @@ export function getSitePostsForQuery( state, siteId, query ) {
 
 	return state.posts.queries[ serializedQuery ].map( ( globalId ) => {
 		return getPost( state, globalId );
-	} );
+	} ).filter( Boolean );
 }
 
 /**

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -118,6 +118,19 @@ describe( 'selectors', () => {
 				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
 			] );
 		} );
+
+		it( 'should omit known query posts where post object is unknown', () => {
+			const sitePosts = getSitePostsForQuery( {
+				posts: {
+					items: {},
+					queries: {
+						'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
+					}
+				}
+			}, 2916284, { search: 'Hello' } );
+
+			expect( sitePosts ).to.eql( [] );
+		} );
 	} );
 
 	describe( '#isRequestingSitePostsForQuery()', () => {


### PR DESCRIPTION
This pull request seeks to resolve an issue where the `<PostSelector />` may not correctly render if state persistence deserialization causes a state where `posts.queries` is restored, but `posts.items` is not. Since `posts.queries` tracks an array of global IDs, if the item associated with that ID is not restored, it will result in an `undefined` value from `getPost`. The `<PostSelector />` would therefore receive an array of posts where some items in the array were `undefined`. We resolve this issue by filtering out non-truthy values from the return value of `getPostsForQuery` selector.

Further, the root cause of the non-restored `posts.items` state was not accounting for the object form of `post_thumbnail`, which has also been fixed here in the posts schema.

__Testing instructions:__

Ensure that Mocha tests pass by running `cd client && make test-"state posts"`

The schema validation case is a bit more difficult to test, since the underlying cause has been fixed as well. If you revert 1b71e44 locally, then save a post with a featured image, you should encounter a state validation error when visiting [DevDocs App Components](http://calypso.localhost:3000/devdocs/app-components), but the `<PostSelector />` example should still render correctly.

More importantly, simply ensure that `<PostSelector />` continues to render correctly :smile: 

/cc @gwwar 