### PR TITLE
TokenField: Remove tooltip from errored token example

### DIFF
--- a/client/components/token-field/docs/example.jsx
+++ b/client/components/token-field/docs/example.jsx
@@ -80,12 +80,6 @@ var TokenFields = React.createClass( {
 			let returnToken;
 			switch ( token ) {
 				case 'error':
-					returnToken = {
-						value: token,
-						status: token,
-						tooltip: 'This token is errored'
-					};
-					break;
 				case 'validating':
 				case 'success':
 					returnToken = {


### PR DESCRIPTION
@apeatling reported that going to `/devdocs/design/token-fields` and then clicking the "UI Component" link in the sidebar caused the tooltip to not update.

This seems to be due to how we render all of our design components. If I grok the code correctly, we render the components once and then send them into a collection. That collection then hides or shows the component based on what the `component` prop is.

I was able to confirm that going between  `/devdocs/design/token-fields` and  `/devdocs/design` doesn't cause an update of the token fields example.

I was able to get the components to re-render by adding a `key` to the `Collection` component. But, this made switching between `/devdocs/design` and `/devdocs/design/$component` noticeably longer.

Based on all of this, I'd like to propose that we remove the tooltip from the `TokenField` example for now.

To test:
- Go to `/devdocs/design/token-fields`
- Click "UI Components" navigation
- You should not see an out of place tooltip

cc @apeatling @lezama for review