### PR TITLE
Server: Remove the use of babel in Makefile

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -4,18 +4,11 @@ BASE_DIR := $(NODE_BIN)/../..
 NODE_PATH := $(BASE_DIR)/test:$(BASE_DIR)/server:$(BASE_DIR)/client
 BABEL := $(NODE_BIN)/babel
 
-test: i18n/test/out
+test:
 	@NODE_ENV=development NODE_PATH=$(NODE_PATH) $(BASE_DIR)/test/runner.js --reporter=$(REPORTER) $(addprefix --grep ,$(GREP))
 
-	@$(MAKE) clean
-
-test-%: i18n/test/out
+test-%:
 	@GREP="$*" make test
 
-i18n/test/out: i18n/test/examples
-	@$(BABEL) i18n/test/examples --out-dir i18n/test/out > /dev/null
-
-clean:
-	@rm -rf i18n/test/out
 
 .PHONY: test test-% clean


### PR DESCRIPTION
This PR removes the use of babel from Makefile and moves it into the test logic itself.

In `before` hook, we create the necessary output folder and parse the files with babel and write them into `out` folder, and start the test. Similarly `after` cleans up the files we've created.

This will make it easier to get rid of the Makefile in server when the time comes.

/cc: @blowery