### PR TITLE
TokenField: Fix extra padding regression

### DIFF
--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -58,7 +58,6 @@ input[type="text"].token-field__input {
 	font-size: 14px;
 	display: flex;
 	margin: 2px 0 2px 8px;
-	padding: 0 16px 0 0;
 	color: $white;
 	overflow: hidden;
 
@@ -85,6 +84,7 @@ input[type="text"].token-field__input {
 
 	&.is-borderless {
 		position: relative;
+		padding: 0 16px 0 0;
 
 		.token-field__token-text {
 			background: transparent;


### PR DESCRIPTION
When updating the borderless token field, I accidentally introduced extra space for the non-borderless fields:

<img width="781" alt="screen shot 2016-03-10 at 12 59 50 pm" src="https://cloud.githubusercontent.com/assets/1084656/13682700/36b8961e-e6c0-11e5-87e0-34745bbcab4c.png">

This PR fixes things so that tokens look like this when lined up:

<img width="779" alt="screen shot 2016-03-10 at 1 00 00 pm" src="https://cloud.githubusercontent.com/assets/1084656/13682713/4144519a-e6c0-11e5-9f5d-12a782ad17d1.png">

This is testable by going to the devdocs and looking at the token field examples.
