### PR TITLE
Notices: Fix global notices with a small amount of text

### DIFF
--- a/client/components/global-notices/docs/example.jsx
+++ b/client/components/global-notices/docs/example.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
+import notices from 'notices';
+
+function showSuccessNotice() {
+	notices.success( 'This is a global success notice' );
+}
+
+function showErrorNotice() {
+	notices.error( 'This is a global error notice' );
+}
+
+function showInfoNotice() {
+	notices.info( 'This is a global info notice' );
+}
+
+function showWarningNotice() {
+	notices.warning( 'This is a global warning notice' );
+}
+
+const GlobalNotices = () => (
+	<div>
+		<h2>Global Notices</h2>
+		<ButtonGroup>
+			<Button onClick={ showSuccessNotice }>Show success notice</Button>
+			<Button onClick={ showErrorNotice }>Show error notice</Button>
+			<Button onClick={ showInfoNotice }>Show info notice</Button>
+			<Button onClick={ showWarningNotice }>Show warning notice</Button>
+		</ButtonGroup>
+	</div>
+);
+
+module.exports = GlobalNotices;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -1,6 +1,5 @@
 .notice {
 	display: flex;
-		flex-wrap: wrap;
 	position: relative;
 	margin-bottom: 24px;
 	border-radius: 1px;
@@ -44,7 +43,6 @@
 
 .notice__text {
 	flex-grow: 1;
-	flex-basis: 100px;
 	font-size: 15px;
 	padding: 11px 24px;
 

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -12,6 +12,7 @@ import trim from 'lodash/trim';
 import SearchCard from 'components/search-card';
 import SearchDemo from 'components/search/docs/example';
 import Notices from 'components/notice/docs/example';
+import GlobalNotices from 'components/global-notices/docs/example';
 import Buttons from 'components/button/docs/example';
 import ButtonGroups from 'components/button-group/docs/example';
 import Gridicons from 'components/gridicon/docs/example';
@@ -96,6 +97,7 @@ export default React.createClass( {
 					<FoldableCard />
 					<FormFields searchKeywords="input textbox textarea radio"/>
 					<Gauge />
+					<GlobalNotices />
 					<Gridicons />
 					<Headers />
 					<InfoPopover />


### PR DESCRIPTION
As reported in #3593, notices with only a little text have a broken layout.

This PR fixes that by removing the `flex-basis` property and the flex-wrap property that it depends on:

Before:
<img width="238" alt="screen shot 2016-03-10 at 20 35 57" src="https://cloud.githubusercontent.com/assets/275961/13683677/ebd02320-e6ff-11e5-8dd6-ae65dba16b25.png">

After:
<img width="228" alt="screen shot 2016-03-10 at 20 37 05" src="https://cloud.githubusercontent.com/assets/275961/13683686/f187fdd8-e6ff-11e5-911c-f7ed1842fde6.png">

It also introduces the Global Notices into devdocs:
<img width="999" alt="screen shot 2016-03-10 at 20 34 11" src="https://cloud.githubusercontent.com/assets/275961/13683696/f77274ee-e6ff-11e5-8fe6-2bac59c2bd63.png">
 
#### Testing instructions

1. Run `git checkout fix/global-notices` and start your server
2. Open the [`DevDocs` page](http://calypso.localhost:3000/devdocs/design)
3. Check that the notices look ok at different screen sizes
4. Find other cases of notices (particularly with buttons) and check that they still look ok at different screen sizes.

#### Reviews

- [x] Code
- [x] Product