### PR TITLE
Users: Adds polling to SiteUsersFetcher data component

### DIFF
--- a/client/components/site-users-fetcher/index.jsx
+++ b/client/components/site-users-fetcher/index.jsx
@@ -61,6 +61,7 @@ module.exports = React.createClass( {
 		if ( ! isEqual( this.props.fetchOptions, nextProps.fetchOptions ) ) {
 			this._updateSiteUsers( nextProps.fetchOptions );
 			this._fetchIfEmpty( nextProps.fetchOptions );
+			pollers.remove( this._poller );
 			this._poller = pollers.add(
 				UsersStore,
 				UsersActions.fetchUsers.bind( UsersActions, nextProps.fetchOptions, true ),

--- a/client/lib/users/actions.js
+++ b/client/lib/users/actions.js
@@ -11,16 +11,18 @@ const Dispatcher = require( 'dispatcher' ),
 	UsersStore = require( 'lib/users/store' );
 
 const UsersActions = {
-	fetchUsers: fetchOptions => {
+	fetchUsers: ( fetchOptions, silentUpdate = false ) => {
 		const paginationData = UsersStore.getPaginationData( fetchOptions );
 		if ( paginationData.fetchingUsers ) {
 			return;
 		}
 		debug( 'fetchUsers', fetchOptions );
-		Dispatcher.handleViewAction( {
-			type: 'FETCHING_USERS',
-			fetchOptions: fetchOptions
-		} );
+		if ( ! silentUpdate ) {
+			Dispatcher.handleViewAction( {
+				type: 'FETCHING_USERS',
+				fetchOptions: fetchOptions
+			} );
+		}
 
 		wpcom.site( fetchOptions.siteId ).usersList( fetchOptions, ( error, data ) => {
 			Dispatcher.handleServerAction( {

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -43,7 +43,7 @@ var Team = React.createClass( {
 		if ( this.props.fetchInitialized && ! this.props.users.length && this.props.fetchOptions.search && ! this.props.fetchingUsers ) {
 			return (
 				<NoResults
-					image='/calypso/images/people/mystery-person.svg'
+					image="/calypso/images/people/mystery-person.svg"
 					text={
 						this.translate( 'No results found for {{em}}%(searchTerm)s{{/em}}',
 							{
@@ -108,7 +108,7 @@ var Team = React.createClass( {
 			<PeopleListItem
 				key={ user.ID }
 				user={ user }
-				type='user'
+				type="user"
 				site={ this.props.site }
 				isSelectable={ this.state.bulkEditing } />
 		);


### PR DESCRIPTION
Fixes #3936.

Previously, we didn't employ polling for the team list at `/people/team/$site`. While this is fine for web, this present an issue for the desktop apps.

To test:
- Checkout `update/people-lists-poll` branch
- Go to `/people/team/$site` where `$site` is a Jetpack site (WP.com will work as well, but it's easier to add users to Jetpack sites)
- In another tab, go to `$site/wp-admin` and add a user
- Within 30 seconds, the user should be added to the team list
- Go to `/post/$site`
- Click on the author selector near the top left of the editor to drop down a list of authors for your site
- Delete the user we added before
- Within 30 seconds, the user should be removed from that list

cc @rralian and @lezama for review.