### PR TITLE
People: Adds polling to followers lists

### DIFF
--- a/client/components/data/email-followers-data/index.jsx
+++ b/client/components/data/email-followers-data/index.jsx
@@ -11,6 +11,7 @@ import debugModule from 'debug';
 import EmailFollowersStore from 'lib/email-followers/store';
 import EmailFollowersActions from 'lib/email-followers/actions';
 import passToChildren from 'lib/react-pass-to-children';
+import pollers from 'lib/data-poller';
 
 /**
  * Module variables
@@ -36,6 +37,11 @@ export default React.createClass( {
 	componentDidMount() {
 		EmailFollowersStore.on( 'change', this.refreshFollowers );
 		this.fetchIfEmpty( this.props.fetchOptions );
+		this._poller = pollers.add(
+			EmailFollowersStore,
+			EmailFollowersActions.fetchFollowers.bind( EmailFollowersActions, this.props.fetchOptions, true ),
+			{ leading: false }
+		);
 	},
 
 	componentWillReceiveProps( nextProps ) {
@@ -45,6 +51,12 @@ export default React.createClass( {
 		if ( ! isEqual( this.props.fetchOptions, nextProps.fetchOptions ) ) {
 			this.setState( this.getInitialState() );
 			this.fetchIfEmpty( nextProps.fetchOptions );
+			pollers.remove( this._poller );
+			this._poller = pollers.add(
+				EmailFollowersStore,
+				EmailFollowersActions.fetchFollowers.bind( EmailFollowersActions, this.props.fetchOptions, true ),
+				{ leading: false }
+			);
 		}
 	},
 

--- a/client/components/data/followers-data/index.jsx
+++ b/client/components/data/followers-data/index.jsx
@@ -11,6 +11,7 @@ import debugModule from 'debug';
 import FollowersStore from 'lib/followers/store';
 import FollowersActions from 'lib/followers/actions';
 import passToChildren from 'lib/react-pass-to-children';
+import pollers from 'lib/data-poller';
 
 /**
  * Module variables
@@ -36,6 +37,11 @@ export default React.createClass( {
 	componentDidMount() {
 		FollowersStore.on( 'change', this.refreshFollowers );
 		this.fetchIfEmpty( this.props.fetchOptions );
+		this._poller = pollers.add(
+			FollowersStore,
+			FollowersActions.fetchFollowers.bind( FollowersActions, this.props.fetchOptions, true ),
+			{ leading: false }
+		);
 	},
 
 	componentWillReceiveProps( nextProps ) {
@@ -45,6 +51,12 @@ export default React.createClass( {
 		if ( ! isEqual( this.props.fetchOptions, nextProps.fetchOptions ) ) {
 			this.setState( this.getInitialState() );
 			this.fetchIfEmpty( nextProps.fetchOptions );
+			pollers.remove( this._poller );
+			this._poller = pollers.add(
+				FollowersStore,
+				FollowersActions.fetchFollowers.bind( FollowersActions, this.props.fetchOptions, true ),
+				{ leading: false }
+			);
 		}
 	},
 

--- a/client/lib/email-followers/actions.js
+++ b/client/lib/email-followers/actions.js
@@ -11,17 +11,19 @@ var Dispatcher = require( 'dispatcher' ),
 	EmailFollowersStore = require( 'lib/email-followers/store' );
 
 var EmailFollowersActions = {
-	fetchFollowers: fetchOptions => {
+	fetchFollowers: ( fetchOptions, silentUpdate = false ) => {
 		Object.assign( fetchOptions, { type: 'email' } );
 		const paginationData = EmailFollowersStore.getPaginationData( fetchOptions );
 		if ( paginationData.fetchingUsers ) {
 			return;
 		}
 		debug( 'fetchFollowers', fetchOptions );
-		Dispatcher.handleViewAction( {
-			type: 'FETCHING_EMAIL_FOLLOWERS',
-			fetchOptions: fetchOptions
-		} );
+		if ( ! silentUpdate ) {
+			Dispatcher.handleViewAction( {
+				type: 'FETCHING_EMAIL_FOLLOWERS',
+				fetchOptions: fetchOptions
+			} );
+		}
 		wpcom.site( fetchOptions.siteId ).statsFollowers( fetchOptions, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_EMAIL_FOLLOWERS',

--- a/client/lib/followers/actions.js
+++ b/client/lib/followers/actions.js
@@ -11,16 +11,18 @@ var Dispatcher = require( 'dispatcher' ),
 	FollowersStore = require( 'lib/followers/store' );
 
 var FollowersActions = {
-	fetchFollowers: fetchOptions => {
+	fetchFollowers: ( fetchOptions, silentUpdate = false ) => {
 		const paginationData = FollowersStore.getPaginationData( fetchOptions );
 		if ( paginationData.fetchingUsers ) {
 			return;
 		}
 		debug( 'fetchFollowers', fetchOptions );
-		Dispatcher.handleViewAction( {
-			type: 'FETCHING_FOLLOWERS',
-			fetchOptions: fetchOptions
-		} );
+		if ( ! silentUpdate ) {
+			Dispatcher.handleViewAction( {
+				type: 'FETCHING_FOLLOWERS',
+				fetchOptions: fetchOptions
+			} );
+		}
 		wpcom.site( fetchOptions.siteId ).statsFollowers( fetchOptions, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_FOLLOWERS',


### PR DESCRIPTION
Related to #3936 and #3962.

Previously, we did not have polling for the followers lists, which causes issues for our Desktop apps. This PR adds polling to the `/people/followers/$site` and `/people/email-followers/$site` routes.

To test:
- Checkout `update/people-followers-poll` branch
- Go to `/people/followers/$site`
- In another browser, go to `/people/followers/$site`
  - Remove a follower
- Wait up to 30 seconds. Does follower get removed from 1st browser?
- Repeat process for email followers
- Repeat process by adding a follower and email follower

cc @apeatling @lezama for review and testing