### PR TITLE
Build: Remove quasi-dependency on semver package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,19 +64,6 @@ export NODE_ENV := $(NODE_ENV)
 export CALYPSO_ENV := $(CALYPSO_ENV)
 export NODE_PATH := server$(SEPARATOR)client$(SEPARATOR).
 
-# We use `semver` to check the version of Node.js before installing npm
-# packages or running scripts.  Since this is before npm runs, we need to grab
-# the version of `semver` installed with the npm executable.
-ifeq ($(OS),Windows_NT)
-# On Windows, the npm global install path is under AppData:
-# http://stackoverflow.com/a/26894197
-# `semver` is in the base `node_modules` folder for the `node` installation.
-export SEMVER_GLOBAL_PATH := $(dir $(shell which $(NODE)))/node_modules/npm/node_modules/semver
-else
-# On OS X and Linux, npm is just a globally installed npm package.
-export SEMVER_GLOBAL_PATH := $(shell $(NPM) -g root)/npm/node_modules/semver
-endif
-
 .DEFAULT_GOAL := install
 
 welcome:

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -1,0 +1,9 @@
+REPORTER ?= spec
+NODE_BIN := $(shell npm bin)
+MOCHA ?= $(NODE_BIN)/mocha
+BASE_DIR := $(NODE_BIN)/../..
+
+test:
+	@NODE_ENV=test $(MOCHA) --reporter $(REPORTER)
+
+.PHONY: test

--- a/bin/check-node-version
+++ b/bin/check-node-version
@@ -1,8 +1,61 @@
 #!/usr/bin/env node
-const requiredVersion = require( '../package' ).engines.node,
-	semver = require( process.env.SEMVER_GLOBAL_PATH );
 
-if ( ! semver.satisfies( process.version, requiredVersion ) ) {
-	console.error( 'wp-calypso requires node ' + requiredVersion + '. Please upgrade! See https://nodejs.org for instructions.' );
-	process.exit( 1 );
+function decomposeVersion( v ) {
+	return v.replace( /^[^0-9.]+/, '' )
+		.split( '.' )
+		.map( component => +component );
+}
+
+function versionIsAtLeast( requiredVersion, currentVersion ) {
+	const requiredArray = decomposeVersion( requiredVersion );
+	const currentArray = decomposeVersion( currentVersion);
+
+	if ( currentArray[0] < requiredArray[0] ) {
+		// Major version does not meet requirements
+		return false;
+	} else if ( currentArray[0] > requiredArray[0] ) {
+		// Major version satisfies the requirements by itself
+		return true;
+	}
+
+	if ( currentArray[1] < requiredArray[1] ) {
+		// Minor version does not meet requirements
+		return false;
+	} else if ( currentArray[1] > requiredArray[1] ) {
+		// Major + minor version satisfy the requirements
+		return true;
+	}
+
+	if ( requiredArray.length > 2 && currentArray.length <= 2 ) {
+		// Required version has a patch number but current version doesn't
+		// (not sure if this can ever happen)
+		return false;
+	} else if ( requiredArray.length > 2 && currentArray[2] < requiredArray[2] ) {
+		// Patch version does not meet requirements
+		return false;
+	}
+
+	// If we got here, everything looks OK
+	return true;
+}
+
+if ( global.TEST_VERSION_COMPARE ) {
+	// Export our version compare function for testing
+	module.exports = {
+		versionIsAtLeast: versionIsAtLeast
+	};
+
+} else {
+	// Run the version check normally
+	const requiredVersion = require( '../package' ).engines.node;
+	const currentVersion = process.version;
+
+	if ( ! versionIsAtLeast( requiredVersion, currentVersion ) ) {
+		console.error(
+			'wp-calypso requires node %s (found %s). Please upgrade! See https://nodejs.org for instructions.',
+			requiredVersion,
+			currentVersion
+		);
+		process.exit( 1 );
+	}
 }

--- a/bin/run-all-tests
+++ b/bin/run-all-tests
@@ -84,4 +84,4 @@ __cleanup() {
 trap __cleanup SIGINT SIGTERM
 
 # Run all tests
-find {$BASEDIR/../client,$BASEDIR/../server} -name Makefile | run_test_fast
+find {$BASEDIR/../client,$BASEDIR/../server,$BASEDIR} -name Makefile | run_test_fast

--- a/bin/test/check-node-version.js
+++ b/bin/test/check-node-version.js
@@ -1,0 +1,43 @@
+global.TEST_VERSION_COMPARE = true;
+
+/**
+ * External dependencies
+ */
+const expect = require( 'chai' ).expect;
+
+/**
+ * Internal dependencies
+ */
+const versionIsAtLeast = require( '../check-node-version' ).versionIsAtLeast;
+
+describe( 'check-node-version versionIsAtLeast', () => {
+	it( 'should fail if major version mismatches', () => {
+		expect( versionIsAtLeast( '4.3.0', '3.5.5' ) ).to.eql( false );
+	} );
+
+	it( 'should fail if minor version mismatches', () => {
+		expect( versionIsAtLeast( '4.3.0', '4.2.5' ) ).to.eql( false );
+	} );
+
+	it( 'should fail if patch version mismatches', () => {
+		expect( versionIsAtLeast( '4.3.1', '4.3.0' ) ).to.eql( false );
+	} );
+
+	it( 'should succeed if everything looks OK', () => {
+		expect( versionIsAtLeast( '4.3.0', '4.3.0' ) ).to.eql( true );
+		expect( versionIsAtLeast( '4.3.0', '4.3.1' ) ).to.eql( true );
+		expect( versionIsAtLeast( '4.3.0', '4.4.1' ) ).to.eql( true );
+		expect( versionIsAtLeast( '4.3.2', '5.0.0' ) ).to.eql( true );
+	} );
+
+	it( 'should fail if patch version required but none present', () => {
+		expect( versionIsAtLeast( '4.3.1', '4.3' ) ).to.eql( false );
+	} );
+
+	it( 'should succeed if patch version not required', () => {
+		expect( versionIsAtLeast( '4.3', '4.3' ) ).to.eql( true );
+		expect( versionIsAtLeast( '4.3', '4.3.1' ) ).to.eql( true );
+		expect( versionIsAtLeast( '4.3', '4.4.1' ) ).to.eql( true );
+		expect( versionIsAtLeast( '4.3', '4.4' ) ).to.eql( true );
+	} );
+} );

--- a/circle.yml
+++ b/circle.yml
@@ -15,3 +15,4 @@ test:
         files:
           - client/**/Makefile
           - server/**/Makefile
+          - bin/Makefile


### PR DESCRIPTION
This code (the `make node-version` step that verifies the Node.js version) has been discussed a few times recently, for example https://github.com/Automattic/wp-calypso/pull/2124#discussion_r54125894 and #3877.

This PR intends to supersede #3877 by removing the makefile hacks around semver and adding a fairly simple version comparison routine in the script where it needs to be, along with some tests.

One of the goals of this check is to run very quickly before `npm install`, since installing all of our dependencies takes a while and we want to be able to give an early warning if installing all of that stuff would be a waste of time.  This is the reason for not adding semver to `devDependencies`.

We also discussed running `npm install semver` before the check-version script, but we were concerned that doing this additional install on the side would cause issues with the shrinkwrapping process.

Note that the `check-node-version` script cannot use babel features like ES6 imports, so it seemed wise to impose the same constraint on the test suite for the version compare code.

cc @TooTallNate @blowery @aduth @Pomax