### PR TITLE
Offline: adds defensive check against a missing serverResponse

### DIFF
--- a/client/lib/wp/sync-handler/index.js
+++ b/client/lib/wp/sync-handler/index.js
@@ -186,6 +186,11 @@ export class SyncHandler {
 			 * @returns {Object} - combinedResponse object
 			 */
 			const cacheResponse = combinedResponse => {
+				debug( 'cacheResponse()', combinedResponse );
+				if ( ! combinedResponse || ! combinedResponse.serverResponse ) {
+					return;
+				}
+
 				const { serverResponse } = combinedResponse;
 				// get response object without _headers property
 				let responseWithoutHeaders = Object.assign( {}, serverResponse );


### PR DESCRIPTION
@aduth pinged me about an error where he was seeing:
```
Uncaught (in promise) TypeError: Cannot read property 'serverResponse' of undefined(…)
```
Looks to me like the server request had failed for a request he was making, but we weren't handling the server failure correctly. Adding this check means we won't try to cache a failed server response.

/cc @retrofox 