### PR TITLE
Components: Set <WebPreview /> frame URL using location replace

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -48,13 +48,13 @@ const WebPreview = React.createClass( {
 		return {
 			showExternal: true,
 			showDeviceSwitcher: true,
-			previewUrl: 'about:blank'
+			previewUrl: null
 		}
 	},
 
 	getInitialState() {
 		return {
-			iframeUrl: 'about:blank',
+			iframeUrl: null,
 			device: this.props.defaultViewportDevice || 'computer',
 			loaded: false
 		};
@@ -67,7 +67,7 @@ const WebPreview = React.createClass( {
 	},
 
 	componentDidMount() {
-		if ( this.props.previewUrl !== 'about:blank' ) {
+		if ( this.props.previewUrl ) {
 			this.setIframeUrl( this.props.previewUrl );
 		}
 	},
@@ -79,7 +79,7 @@ const WebPreview = React.createClass( {
 
 		if ( ! this.shouldRenderIframe() ) {
 			this.setState( {
-				iframeUrl: 'about:blank',
+				iframeUrl: null,
 				loaded: false,
 			} );
 		}
@@ -136,7 +136,7 @@ const WebPreview = React.createClass( {
 	},
 
 	setLoaded() {
-		if ( this.state.iframeUrl === 'about:blank' ) {
+		if ( ! this.state.iframeUrl ) {
 			return;
 		}
 		debug( 'preview loaded:', this.state.iframeUrl );

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -116,7 +116,9 @@ const WebPreview = React.createClass( {
 		if ( iframeUrl === this.state.iframeUrl ) {
 			return;
 		}
+
 		debug( 'setIframeUrl', iframeUrl );
+		this.refs.iframe.contentWindow.location.replace( iframeUrl );
 		this.setState( {
 			loaded: false,
 			iframeUrl: iframeUrl,
@@ -173,8 +175,9 @@ const WebPreview = React.createClass( {
 						}
 						{ this.shouldRenderIframe() &&
 							<iframe
+								ref="iframe"
 								className="web-preview__frame"
-								src={ this.state.iframeUrl }
+								src="about:blank"
 								onLoad={ this.setLoaded }
 								title={ this.props.iframeTitle || this.translate( 'Preview' ) }
 							/>


### PR DESCRIPTION
This pull request seeks to resolve an issue where a browser history entry is added for every save which occurs in desktop browsers in the post editor.

__Implementation notes:__

Rather than assigning the frame URL using the `src` attribute, which incurs a new history entry for every change, set it via the `frame.contentWindow.location.replace` function.

__Testing instructions:__

Verify that post previews continue to load correctly for a new and existing post, for desktop and mobile viewports (mobile viewports do not include background preview loading). Also ensure that no regressions occur in theme previews.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Enter content
4. Press Preview
5. Note that the preview contains your contain
6. Dismiss the preview
7. Change the content
8. Press Preview
9. Note that the preview updates to reflect the new content