### PR TITLE
Updates: Prevent requesting the updates endpoint.

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -60,7 +60,9 @@ JetpackSite.prototype.canManage = function() {
 };
 
 JetpackSite.prototype.fetchAvailableUpdates = function() {
-	if ( ! this.hasMinimumJetpackVersion || ! this.capabilities.manage_options ) {
+	if ( ! this.hasMinimumJetpackVersion ||
+		! this.capabilities.manage_options ||
+		! this.canUpdateFiles ) {
 		return;
 	}
 	wpcom.undocumented().getAvailableUpdates( this.ID, function( error, data ) {


### PR DESCRIPTION
We currently request the update api endpoint for every jetpack site. 

This can be a problem for secondary network sites since we would be hitting the network for each site on the network. And since the requests all happen on load we could be bringing down the network. 

This PR fixed that by removing calls to sites that don't have the ability to updateFiles which are all secondary network sites. 

Before:
<img width="287" alt="screen_shot_2016-03-10_at_14_51_12" src="https://cloud.githubusercontent.com/assets/115071/13687374/b70f1978-e6cf-11e5-95d5-905f8fdd72f3.png">

After:
<img width="350" alt="screen_shot_2016-03-10_at_14_50_45" src="https://cloud.githubusercontent.com/assets/115071/13687385/ca5cc386-e6cf-11e5-8ede-30cc8ee7f2b3.png">


