### PR TITLE
TokenField: Fixes a usability/accessibility issue with maxLength

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -172,14 +172,22 @@ var TokenField = React.createClass( {
 
 	_renderInput: function() {
 		const { maxLength, value } = this.props;
+
+		let props = {
+			ref: 'input',
+			key: 'input',
+			disabled: this.props.disabled,
+			value: this.state.incompleteTokenValue
+		};
+
+		if ( ! ( maxLength && value.length >= maxLength ) ) {
+			Object.assign( props, {
+				onChange: this._onInputChange
+			} );
+		}
+
 		return (
-			<TokenInput
-				ref="input"
-				key="input"
-				disabled={ maxLength && value.length >= maxLength || this.props.disabled }
-				value={ this.state.incompleteTokenValue }
-				onChange={ this._onInputChange }
-			/>
+			<TokenInput { ...props } />
 		);
 	},
 


### PR DESCRIPTION
Fixes #3951

Previously, when we disabled the TokenInput, we used the default "disabled" prop. But, this broke the ability to use keyboard shortcuts to move the input and remove tokens.

This PR suggests disabling the ability to add a token by removing the onChange event from TokenInput when maxLength has been reached. This allows us to still use the keyboard to remove tokens even after hitting maxLength.

To test:
- Checkout `update/token-field-input-disabled`
- Go to `/people/new/$site`
- Add 10 tokens (does not matter if they error or not)
- After the 10th token, you should not be able to add another one, *but* you should be able to use the left/right arrow keys to navigate between tokens and then hit `delete` to remove a token

cc @aduth and @lezama for review