### PR TITLE
Components: allow number for Version `version` prop

### DIFF
--- a/client/components/version/README.md
+++ b/client/components/version/README.md
@@ -24,7 +24,7 @@ The following props can be passed to the Version component:
 ### `version`
 
 <table>
-	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Type</td><td>String or Number</td></tr>
 	<tr><td>Required</td><td>Yes</td></tr>
 </table>
 

--- a/client/components/version/index.jsx
+++ b/client/components/version/index.jsx
@@ -13,7 +13,10 @@ export default React.createClass( {
 	displayName: 'Version',
 
 	propTypes: {
-		version: React.PropTypes.string.isRequired,
+		version: React.PropTypes.oneOfType( [
+			React.PropTypes.string,
+			React.PropTypes.number,
+		] ).isRequired,
 		icon: React.PropTypes.string
 	},
 


### PR DESCRIPTION
Before only a "string" type was allowed, despite the fact that
[a number was being used in the devdocs examples](https://github.com/Automattic/wp-calypso/blob/c3bbea51e99e5071c54ea83877f842299c89a343/client/components/version/docs/example.jsx#L24-L25). Allowing a string
or number to be passed in for `version` seems reasonable, and
fixes the warning:

<img width="781" alt="screen shot 2016-03-10 at 5 03 22 pm" src="https://cloud.githubusercontent.com/assets/71256/13690114/c1a2451e-e6e2-11e5-8849-d162c591c500.png">

/cc @enejb because of 32ca3c67b4552a5e18662b6b7e1146dfb7d0a400.