### PR TITLE
Signup: Call setState() on the RegisterDomain and Site signup steps only if mounted

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -218,7 +218,9 @@ var RegisterDomainStep = React.createClass( {
 		var suggestions = [],
 			domain = getFixedDomainSearch( searchQuery );
 
-		this.setState( { lastQuery: searchQuery }, this.save );
+		if ( this.isMounted() ) {
+			this.setState( { lastQuery: searchQuery }, this.save );
+		}
 
 		if ( ! domain || ! this.state.loadingResults ) {
 			// the search was cleared or the domain contained only spaces
@@ -227,11 +229,13 @@ var RegisterDomainStep = React.createClass( {
 
 		this.recordEvent( 'searchFormSubmit', searchQuery, this.props.analyticsSection );
 
-		this.setState( {
-			lastDomainSearched: domain,
-			searchResults: [],
-			lastDomainError: null
-		} );
+		if ( this.isMounted() ) {
+			this.setState( {
+				lastDomainSearched: domain,
+				searchResults: [],
+				lastDomainError: null
+			} );
+		}
 
 		async.parallel(
 			[
@@ -293,10 +297,12 @@ var RegisterDomainStep = React.createClass( {
 					return suggestion.domain_name;
 				} );
 
-				this.setState( {
-					searchResults: suggestions,
-					loadingResults: false
-				}, this.save );
+				if ( this.isMounted() ) {
+					this.setState( {
+						searchResults: suggestions,
+						loadingResults: false
+					}, this.save );
+				}
 			}
 		);
 	},

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -119,7 +119,9 @@ module.exports = React.createClass( {
 	},
 
 	setFormState: function( state ) {
-		this.setState( { form: state } );
+		if ( this.isMounted() ) {
+			this.setState( { form: state } );
+		}
 	},
 
 	resetAnalyticsData: function() {


### PR DESCRIPTION
The RegisterDomainStep and Site components make an async call to check for domain suggestions and call `setState()` when the response arrives. If the user went a step back in the signup flow, then when the response arrives, the call to `setState()` is done on the unmounted components as we're now on a previous flow step.

This `setSate()` call was logging warnings on the console about the components trying to set their state when they were unmounted after the user went a step back in the respective signup flow

The warning reads ``Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the RegisterDomainStep component`.

## Testing instructions

_The testing instructions also apply for being able to see the warnings before this PR_.

While being logged in and with the console opened:

### For the RegisterDomainStep component fix

* Go to `/start`
* Pick a theme
* Then, on the domain selection step, enter some domain and, quickly if you can, click the "Back" link at the bottom.
* Now, on the Theme Selection step, you should not see the warning.

### For the Site component fix

* Go to `/start/free-trial`
* Pick a theme
* Then, on the domain selection step, enter some domain and, quickly if you can, click the "Back" link at the bottom.
* Now, on the Theme Selection step, you should not see the warning.

