### PR TITLE
Support User: Bypass localForage while active to avoid conflicts across sessions

### DIFF
--- a/client/lib/localforage/index.js
+++ b/client/lib/localforage/index.js
@@ -8,7 +8,6 @@ import reduce from 'lodash/reduce';
  * Internal dependencies
  */
 import localforageBypass from './localforage-bypass';
-import { isSupportUserSession } from 'lib/user/support-user-interop';
 
 const config = {
 	name: 'calypso',
@@ -22,15 +21,12 @@ const config = {
 	]
 };
 
-if ( isSupportUserSession() ) {
-	// Only use the bypass driver
-	config.driver = [ localforageBypass._driver ];
-}
-
+let _ready = false;
 // Promise that resolves when our localforage configuration has been applied
 const localForagePromise = localforage.defineDriver( localforageBypass )
 	.then( () => {
 		localforage.config( config );
+		_ready = true;
 		return localforage;
 	} )
 	.catch( ( error ) => console.error( 'Configuring localforage: %s', error ) );
@@ -59,5 +55,13 @@ const localForageProxy = reduce(
 		},
 		{}
 );
+
+localForageProxy.bypass = () => {
+	if ( _ready ) {
+		console.error( 'Cannot bypass localforage after initialization' );
+	} else {
+		config.driver = [ localforageBypass._driver ];
+	}
+}
 
 export default Object.assign( {}, localforage, localForageProxy );

--- a/client/lib/localforage/localforage-bypass.js
+++ b/client/lib/localforage/localforage-bypass.js
@@ -1,0 +1,230 @@
+/**
+ * External dependencies
+ */
+import debugModule from 'debug';
+
+const debug = debugModule( 'calypso:support-user' );
+
+// This module defines a custom localForage driver which bypasses all persistent
+// storage. Any calls to read/write data using localForage instead access a temporary
+// in-memory store which is lost on page reload. This driver is used to sandbox
+// a user's data while support-user is active, ensuring it does not contaminate the
+// original user/vice versa.
+// Copied with modifications from localForage source: localforage/test/dummyStorageDriver.js
+
+const dummyStorage = {};
+
+// Config the localStorage backend, using options set in the config.
+function _initStorage( options ) {
+	const dbInfo = {};
+	if ( options ) {
+		for ( let i in options ) {
+			dbInfo[ i ] = options[ i ];
+		};
+	}
+
+	dbInfo.db = {};
+	dummyStorage[ dbInfo.name ] = dbInfo.db;
+
+	this._dbInfo = dbInfo;
+	return Promise.resolve();
+}
+
+function clear( callback ) {
+	debug( 'localForage bypass', 'clear' );
+
+	const promise = new Promise( ( resolve, reject ) => {
+		this.ready().then( () => {
+			const db = this._dbInfo.db;
+
+			for ( let key in db ) {
+				if ( db.hasOwnProperty( key ) ) {
+					delete db[ key ];
+				}
+			}
+
+			resolve();
+		} ).catch( reject );
+	} );
+
+	executeCallback( promise, callback );
+	return promise;
+}
+
+function getItem( key, callback ) {
+	debug( 'localForage bypass', 'getItem', key );
+
+	// Cast the key to a string, as that's all we can set as a key.
+	if ( typeof key !== 'string' ) {
+		key = String( key );
+	}
+
+	const promise = new Promise( ( resolve, reject ) => {
+		this.ready().then( () => {
+			try {
+				const db = this._dbInfo.db;
+				const result = db[ key ];
+
+				resolve( result );
+			} catch ( e ) {
+				reject( e );
+			}
+		} ).catch( reject );
+	} );
+
+	executeCallback( promise, callback );
+	return promise;
+}
+
+function iterate( callback ) {
+	const promise = new Promise( ( resolve, reject ) => {
+		this.ready().then( () => {
+			try {
+				const db = this._dbInfo.db;
+
+				for ( let key in db ) {
+					const result = db[ key ];
+
+					callback( result, key );
+				}
+
+				resolve();
+			} catch ( e ) {
+				reject( e );
+			}
+		} ).catch( reject );
+	} );
+
+	executeCallback( promise, callback );
+	return promise;
+}
+
+function _key( n, callback ) {
+	const promise = new Promise( ( resolve, reject ) => {
+		this.ready().then( () => {
+			const db = this._dbInfo.db;
+			let result = null;
+			let index = 0;
+
+			for ( let key in db ) {
+				if ( db.hasOwnProperty( key ) && db[ key ] !== undefined ) {
+					if ( n === index ) {
+						result = key;
+						break;
+					}
+					index++;
+				}
+			}
+
+			resolve( result );
+		} ).catch( reject );
+	} );
+
+	executeCallback( promise, callback );
+	return promise;
+}
+
+function _keys( callback ) {
+	const promise = new Promise( ( resolve, reject ) => {
+		this.ready().then( () => {
+			const db = this._dbInfo.db;
+			const keys = [ ];
+
+			for ( let key in db ) {
+				if ( db.hasOwnProperty( key ) ) {
+					keys.push( key );
+				}
+			}
+
+			resolve( keys );
+		} ).catch( reject );
+	} );
+
+	executeCallback( promise, callback );
+	return promise;
+}
+
+function length( callback ) {
+	const promise = new Promise( ( resolve, reject ) => {
+		this.keys().then( ( keys ) => {
+			resolve( keys.length );
+		} ).catch( reject );
+	} );
+
+	executeCallback( promise, callback );
+	return promise;
+}
+
+function removeItem( key, callback ) {
+	debug( 'localForage bypass', 'removeItem', key );
+
+	const promise = new Promise( ( resolve, reject ) => {
+		if ( typeof key !== 'string' ) {
+			return reject();
+		}
+
+		this.ready().then( () => {
+			const db = this._dbInfo.db;
+			if ( db.hasOwnProperty( key ) ) {
+				delete db[ key ];
+			}
+
+			resolve();
+		} ).catch( reject );
+	} );
+
+	executeCallback( promise, callback );
+	return promise;
+}
+
+function setItem( key, value, callback ) {
+	debug( 'localForage bypass', 'setItem', key );
+
+	const promise = new Promise( ( resolve, reject ) => {
+		if ( typeof key !== 'string' ) {
+			return reject();
+		}
+
+		this.ready().then( () => {
+			// Convert undefined values to null.
+			// https://github.com/mozilla/localForage/pull/42
+			if ( value === undefined ) {
+				value = null;
+			}
+
+			// Save the original value to pass to the callback.
+			const originalValue = value;
+
+			let db = this._dbInfo.db;
+			db[ key ] = value;
+			resolve( originalValue );
+		} ).catch( reject );
+	} );
+
+	executeCallback( promise, callback );
+	return promise;
+}
+
+function executeCallback( promise, callback ) {
+	if ( callback ) {
+		promise.then( ( result ) => {
+			callback( null, result );
+		}, ( error ) => {
+			callback( error );
+		} );
+	}
+}
+
+export default {
+	_driver: 'localForageBypass',
+	_initStorage: _initStorage,
+	// _supports: function() { return true; }
+	iterate: iterate,
+	getItem: getItem,
+	setItem: setItem,
+	removeItem: removeItem,
+	clear: clear,
+	length: length,
+	key: _key,
+	keys: _keys
+};

--- a/client/lib/localforage/test/localforage-bypass.js
+++ b/client/lib/localforage/test/localforage-bypass.js
@@ -1,0 +1,155 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import localForageBypass from '../localforage-bypass';
+
+describe( 'localforage-bypass', () => {
+	const localForage = localForageBypass;
+	let db = null;
+
+	beforeEach( () => {
+		localForage.ready = () => Promise.resolve();
+		return localForage._initStorage( {} )
+			.then( () => {
+				db = localForage._dbInfo.db;
+			} );
+	} );
+
+	describe( 'keys', () => {
+		it( 'should list all keys', () => {
+			db.one = 1;
+			db.two = 2;
+			return localForage.keys()
+				.then( ( keys ) => {
+					expect( keys ).to.have.length( 2 );
+					expect( keys ).to.deep.equal( [ 'one', 'two' ] );
+				} );
+		} );
+
+		it( 'should be empty when initialized', () => {
+			return localForage.keys()
+				.then( ( keys ) => {
+					expect( keys ).to.have.length( 0 );
+				} );
+		} );
+	} );
+
+	describe( 'length', () => {
+		const length = () => localForage.length();
+		const expectLength = ( expected ) => {
+			return () => {
+				return length()
+					.then( ( l ) => expect( l ).to.equal( expected ) );
+			}
+		};
+		const addItem = ( key, value ) => {
+			return () => localForage.setItem( key, value )
+		};
+
+		it( 'should be zero when initialized', () => {
+			return expectLength( 0 )();
+		} )
+
+		it( 'should match number of items', () => {
+			db.one = 1;
+			db.two = 2;
+			return expectLength( 2 )();
+		} )
+
+		it( 'should increment after setItem', () => {
+			db.one = 1;
+			db.two = 2;
+
+			return expectLength( 2 )()
+				.then( addItem( 'eight', 8 ) )
+				.then( expectLength( 3 ) );
+		} )
+
+		it( 'should not increment after setItem where key already exists', () => {
+			db.one = 1;
+			db.two = 2;
+
+			return expectLength( 2 )()
+				.then( addItem( 'two', 9 ) )
+				.then( length )
+				.then( expectLength( 2 ) );
+		} )
+	} );
+
+	describe( 'clear', () => {
+		it( 'should remove all keys', () => {
+			db.one = 1;
+			db.two = 2;
+			return localForage.clear()
+				.then( () => {
+					expect( db ).to.be.empty;
+				} );
+		} )
+	} );
+
+	describe( 'getItem', () => {
+		it( 'should get an item that exists', () => {
+			db.one = 1;
+			return localForage.getItem( 'one' )
+				.then( ( value ) => {
+					expect( value ).to.equal( 1 );
+				} );
+		} );
+
+		it( 'should return undefined for an item that doesn\'t exist', () => {
+			db.one = 1;
+			localForage.getItem( 'two' )
+				.then( ( value ) => {
+					expect( value ).to.be.undefined;
+				} );
+		} );
+	} );
+
+	describe( 'setItem', () => {
+		it( 'should set an item', () => {
+			localForage.setItem( 'abc', 123 )
+				.then( () => {
+					expect( db.abc ).to.equal( 123 );
+				} );
+		} );
+
+		it( 'should overwrite an item', () => {
+			db.abc = 'not a number';
+			localForage.setItem( 'abc', 123 )
+				.then( () => {
+					expect( db.abc ).to.equal( 123 );
+				} );
+		} );
+	} );
+
+	describe( 'removeItem', () => {
+		it( 'should remove an item', () => {
+			db.one = 1;
+			db.two = 2;
+			db.three = 3;
+			localForage.removeItem( 'two' )
+				.then( () => {
+					expect( db ).to.deep.equal( { one: 1, three: 3 } );
+				} );
+		} );
+
+		it( 'should silently fail to remove item that doesn\'t exist', () => {
+			db.one = 1;
+			db.two = 2;
+			db.three = 3;
+			localForage.removeItem( 'four' )
+				.then( () => {
+					expect( db ).to.deep.equal( {
+						one: 1,
+						two: 2,
+						three: 3
+					} );
+				} );
+		} );
+	} );
+} );

--- a/client/lib/user/support-user-interop.js
+++ b/client/lib/user/support-user-interop.js
@@ -10,6 +10,7 @@ import noop from 'lodash/noop';
 import wpcom from 'lib/wp';
 import config from 'config';
 import store from 'store';
+import localforage from 'lib/localforage';
 import { supportUserTokenFetch, supportUserActivate, supportUserError } from 'state/support/actions';
 
 /**
@@ -98,6 +99,8 @@ export const boot = () => {
 	if ( ! isEnabled() ) {
 		return;
 	}
+
+	localforage.bypass();
 
 	const { user, token } = store.get( STORAGE_KEY );
 	debug( 'Booting Calypso with support user', user );

--- a/client/lib/wp/sync-handler/test/localforage-mock.js
+++ b/client/lib/wp/sync-handler/test/localforage-mock.js
@@ -7,6 +7,7 @@ const debug = debugFactory( 'calypso:sync-handler:localforage-mock' );
 let localData = {};
 
 export default {
+	defineDriver() { return Promise.resolve() },
 	setItem( key, data ) {
 		return new Promise( resolve => {
 			debug( 'setItem: %o, (%o)', key, data );

--- a/client/tests.json
+++ b/client/tests.json
@@ -91,6 +91,9 @@
 		"i18n-utils" : {
 			"test": [ "utils" ]
 		},
+		"localforage": {
+			"test": [ "localforage-bypass" ]
+		},
 		"menu-data" : {
 			"test" : [ "menu-data" ]
 		},


### PR DESCRIPTION
Bypasses localForage while support user is active. This allows sync-handler and other persistent data stores using localForage to use a 'sandboxed' temporary in-memory store while support user is active, avoiding conflicts with the original user's persisted data. This doesn't cover instances of direct localStorage usage - see #3941 which covers that.

The goal is to eventually move all direct localStorage usage to localForage.

-----

This still needs some more testing, but overall it's working.

`localforage-bypass.js` was copied and modified from a [localForage testing module](https://github.com/mozilla/localForage/blob/master/test/dummyStorageDriver.js); ~~we can likely cut quite a bit of cruft out of it as a lot of the logic relates to test facilitation.~~ (cruft removed in 4c39e79)

Things to test:
 - [x] With `support-user` feature flag disabled
 - [x] With `wpcom_user_bootstrap` enabled
 - [x] Running in non-`development` environment
 - [x] Running in `development`
 - [x] Chrome 49
 - [x] Firefox
 - [x] Safari
 - [x] IE


cc @retrofox @gwwar 