### PR TITLE
Editor: use "cog" icon instead of chevron for editing posts status options

### DIFF
--- a/client/post-editor/status-label.jsx
+++ b/client/post-editor/status-label.jsx
@@ -80,11 +80,7 @@ var StatusLabel = React.createClass( {
 				aria-label={ this.translate( 'Show advanced status details' ) }
 				aria-pressed={ !! this.props.advancedStatus }
 			>
-				<Gridicon
-					icon={ this.props.advancedStatus
-						? 'chevron-up'
-						: 'chevron-down' }
-					size={ 16 } />
+				<Gridicon icon="cog" size={ 16 } />
 				{ this.renderLabel() }
 			</button>
 		);


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/548849/13701370/b703f8dc-e787-11e5-8eaa-22ce1b48b26e.png)

See #3895.