### PR TITLE
Reader: handle full-post 404s more gracefully

### DIFF
--- a/client/lib/feed-post-store/actions.js
+++ b/client/lib/feed-post-store/actions.js
@@ -15,7 +15,7 @@ feedPostBatcher = new PostBatcher( {
 	buildUrl: function( postKey ) {
 		return '/read/feed/' + encodeURIComponent( postKey.feedId ) + '/posts/' + encodeURIComponent( postKey.postId );
 	},
-	resultKeyRegex: /\/read\/feed\/(\d+)\/posts\/(\d+)/,
+	resultKeyRegex: /\/read\/feed\/(\w+)\/posts\/(\w+)/,
 	onFetch: function( postKey ) {
 		Dispatcher.handleViewAction( {
 			type: ACTION.FETCH_FEED_POST,
@@ -43,7 +43,7 @@ blogPostBatcher = new PostBatcher( {
 	buildUrl: function( postKey ) {
 		return '/read/sites/' + encodeURIComponent( postKey.blogId ) + '/posts/' + encodeURIComponent( postKey.postId );
 	},
-	resultKeyRegex: /\/read\/sites\/(\d+)\/posts\/(\d+)/,
+	resultKeyRegex: /\/read\/sites\/(\w+)\/posts\/(\w+)/,
 	onFetch: function( postKey ) {
 		Dispatcher.handleViewAction( {
 			type: ACTION.FETCH_FEED_POST,

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -203,6 +203,10 @@ function receivePostFromPage( newPost ) {
 }
 
 function receivePost( feedId, postId, post ) {
+	if ( ! post ) {
+		return;
+	}
+
 	if ( post.errors || post.status_code === 404 ) {
 		receiveError( feedId, postId, post );
 	} else {
@@ -211,6 +215,10 @@ function receivePost( feedId, postId, post ) {
 }
 
 function receiveBlogPost( blogId, postId, post ) {
+	if ( ! post ) {
+		return;
+	}
+
 	if ( post.errors || post.status_code === 404 ) {
 		post.site_ID = blogId;
 		post.ID = postId;

--- a/client/lib/feed-post-store/index.js
+++ b/client/lib/feed-post-store/index.js
@@ -203,7 +203,7 @@ function receivePostFromPage( newPost ) {
 }
 
 function receivePost( feedId, postId, post ) {
-	if ( post.errors ) {
+	if ( post.errors || post.status_code === 404 ) {
 		receiveError( feedId, postId, post );
 	} else {
 		normalizePost( feedId, postId, post );
@@ -211,7 +211,7 @@ function receivePost( feedId, postId, post ) {
 }
 
 function receiveBlogPost( blogId, postId, post ) {
-	if ( post.errors ) {
+	if ( post.errors || post.status_code === 404 ) {
 		post.site_ID = blogId;
 		post.ID = postId;
 		post.is_external = false;
@@ -225,8 +225,11 @@ function receiveError( feedId, postId, error ) {
 	var statusCode, errorCode, message;
 	if ( error.status_code ) {
 		statusCode = error.status_code;
-		errorCode = error.errors.error;
-		message = error.errors.message;
+
+		if ( error.errors ) {
+			errorCode = error.errors.error;
+			message = error.errors.message;
+		}
 	} else {
 		// find the key in the Error
 		errorCode = Object.keys( error.errors )[ 0 ];

--- a/client/lib/feed-post-store/post-batch-fetcher.js
+++ b/client/lib/feed-post-store/post-batch-fetcher.js
@@ -88,8 +88,8 @@ assign( PostBatchFetcher.prototype, {
 					return;
 				}
 
-				containerId = +match[ 1 ];
-				postId = +match[ 2 ];
+				containerId = match[ 1 ];
+				postId = match[ 2 ];
 
 				if ( ! ( containerId && postId ) ) {
 					return;

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -55,7 +55,7 @@ function renderPostNotFound() {
 	setPageTitle( sidebarAndPageTitle );
 
 	ReactDom.render(
-		<FeedError sidebarTitle={ sidebarAndPageTitle } />,
+		<FeedError sidebarTitle={ sidebarAndPageTitle } message={ i18n.translate( 'Post Not Found' ) } />,
 		document.getElementById( 'primary' )
 	);
 }
@@ -65,8 +65,6 @@ function userHasHistory( context ) {
 }
 
 function renderFeedError() {
-	var FeedError = require( 'reader/feed-error' );
-
 	ReactDom.render(
 		React.createElement( FeedError ),
 		document.getElementById( 'primary' )

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -50,8 +50,12 @@ function removeFullPostDialog() {
 }
 
 function renderPostNotFound() {
+	var sidebarAndPageTitle = i18n.translate( 'Post not found' );
+
+	setPageTitle( sidebarAndPageTitle );
+
 	ReactDom.render(
-		<FeedError />,
+		<FeedError sidebarTitle={ sidebarAndPageTitle } />,
 		document.getElementById( 'primary' )
 	);
 }

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -24,6 +24,7 @@ import {
 	getPrettySiteUrl
 } from 'reader/route';
 import { recordTrack } from 'reader/stats';
+import FeedError from 'reader/feed-error';
 
 const analyticsPageTitle = 'Reader';
 
@@ -46,6 +47,13 @@ pageNotifier( function removeFullPostOnLeave( newContext, oldContext ) {
 
 function removeFullPostDialog() {
 	ReactDom.unmountComponentAtNode( document.getElementById( 'tertiary' ) );
+}
+
+function renderPostNotFound() {
+	ReactDom.render(
+		<FeedError />,
+		document.getElementById( 'primary' )
+	);
 }
 
 function userHasHistory( context ) {
@@ -292,7 +300,8 @@ module.exports = {
 					onClose: function() {
 						page.back( context.lastRoute || '/' );
 					},
-					onClosed: removeFullPostDialog
+					onClosed: removeFullPostDialog,
+					onPostNotFound: renderPostNotFound
 				} )
 			),
 			document.getElementById( 'tertiary' )
@@ -330,7 +339,8 @@ module.exports = {
 					onClose: function() {
 						page.back( context.lastRoute || '/' );
 					},
-					onClosed: removeFullPostDialog
+					onClosed: removeFullPostDialog,
+					onPostNotFound: renderPostNotFound
 				} )
 			),
 			document.getElementById( 'tertiary' )

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -13,6 +13,12 @@ import i18n from 'lib/mixins/i18n';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 const FeedError = React.createClass( {
+	getDefaultProps() {
+		return {
+			message: i18n.translate( 'Sorry, we can\'t find that stream.' )
+		};
+	},
+
 	recordAction() {
 		recordAction( 'clicked_discover_on_404' );
 		recordGaEvent( 'Clicked Discover on 404' );
@@ -43,7 +49,7 @@ const FeedError = React.createClass( {
 				<EmptyContent
 					action={ action }
 					secondaryAction={ secondaryAction }
-					title={ i18n.translate( 'Sorry, we can\'t find that stream.' ) }
+					title={ this.props.message }
 					illustration={ '/calypso/images/drake/drake-404.svg' }
 					illustrationWidth={ 500 }
 				/>

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -488,6 +488,10 @@ FullPostContainer = React.createClass( {
 		PostStore.off( 'change', this._onChange );
 		SiteStore.off( 'change', this._onChange );
 		FeedStore.off( 'change', this._onChange );
+		
+		if ( utils.isPostNotFound( this.state.post ) ) {
+			this.props.onPostNotFound();
+		}
 	},
 
 	_onChange: function() {
@@ -498,7 +502,8 @@ FullPostContainer = React.createClass( {
 	},
 
 	render: function() {
-		var passedProps = omit( this.props, [ 'postId', 'feedId' ] );
+		var passedProps = omit( this.props, [ 'postId', 'feedId' ] ),
+			post = this.state.post;
 
 		if ( this.props.setPageTitle && this.props.isVisible ) { // only set the title if we're visible
 			this.props.setPageTitle( this.state.title );
@@ -507,8 +512,8 @@ FullPostContainer = React.createClass( {
 		return (
 
 			<FullPostDialog {...passedProps }
-				isVisible={ this.props.isVisible }
-				post={ this.state.post }
+				isVisible={ utils.isPostNotFound( post ) ? false : this.props.isVisible }
+				post={ post }
 				site={ this.state.site }
 				feed={ this.state.feed }/>
 		);

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -36,7 +36,7 @@ module.exports = function() {
 
 		// Feed full post
 		page( '/read/post/feed/:feed_id/:post_id', controller.legacyRedirects );
-		page( '/read/feeds/:feed/posts/:post', controller.updateLastRoute, controller.feedPost );
+		page( '/read/feeds/:feed/posts/:post', controller.updateLastRoute, controller.sidebar, controller.feedPost );
 		page.exit( '/read/feeds/:feed/posts/:post', controller.resetTitle );
 
 		// Blog stream
@@ -46,7 +46,7 @@ module.exports = function() {
 
 		// Blog full post
 		page( '/read/post/id/:blog_id/:post_id', controller.legacyRedirects );
-		page( '/read/blogs/:blog/posts/:post', controller.updateLastRoute, controller.blogPost );
+		page( '/read/blogs/:blog/posts/:post', controller.updateLastRoute, controller.sidebar, controller.blogPost );
 		page.exit( '/read/blogs/:blog/posts/:post', controller.resetTitle );
 	}
 

--- a/client/reader/utils.js
+++ b/client/reader/utils.js
@@ -54,8 +54,17 @@ function isSpecialClick( event ) {
 	return event.button > 0 || event.metaKey || event.controlKey || event.shiftKey || event.altKey;
 }
 
+function isPostNotFound( post ) {
+	if ( post === undefined ) {
+		return false;
+	}
+
+	return post.statusCode === 404;
+}
+
 module.exports = {
 	siteNameFromSiteAndPost,
 	siteishFromSiteAndPost,
-	isSpecialClick
+	isSpecialClick,
+	isPostNotFound
 };


### PR DESCRIPTION
Fixes #3860.

## Testing

Visit a non-existent full post link; examples:
- http://calypso.localhost:3000/read/feeds/41325786/posts/121321321
- http://calypso.localhost:3000/read/feeds/41325786/posts/somel3tt3rs

You should see this:
![](https://i.imgur.com/IM5Jwae.png)

instead of this:
![screenshot 2016-03-08 11 44 11](https://cloud.githubusercontent.com/assets/4924246/13613962/1a72f33a-e523-11e5-84ff-a592053fbc3b.png)

## Todo:

- [ ] Code review.
- [x] Fix `Uncaught TypeError: Cannot read property 'componentDidLeave' of undefined` when closing the full post dialog with the back arrow.
- [x] Apply this 404 handler to other reader screens (e.g.: `blogPost`)

/cc @jancavan 
