### PR TITLE
Checkout: Show the "Email Verification" at the Thank You page only if email is unverified

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/domain-registration-details.jsx
@@ -15,20 +15,23 @@ import supportUrls from 'lib/url/support';
 
 const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 	const googleAppsWasPurchased = purchases.some( isGoogleApps ),
+		domainContactEmailVerified = purchases.some( purchase => purchase.isEmailVerified ),
 		hasOtherPrimaryDomain = selectedSite.options.is_mapped_domain && selectedSite.domain !== domain;
 
 	return (
 		<div>
 			<div className="checkout-thank-you__domain-registration-details-compact">
-				<PurchaseDetail
-					icon="mail"
-					title={ i18n.translate( 'Verify your email address' ) }
-					description={ i18n.translate( 'We sent you an email with a request to verify your new domain. Unverified domains may be suspended.' ) }
-					buttonText={ i18n.translate( 'Learn more about verifying your domain' ) }
-					href={ supportUrls.EMAIL_VALIDATION_AND_VERIFICATION }
-					target="_blank"
-					requiredText={ i18n.translate( 'Important! Your action is required.' ) }
-					isRequired />
+				{ ! domainContactEmailVerified && (
+					<PurchaseDetail
+						icon="mail"
+						title={ i18n.translate( 'Verify your email address' ) }
+						description={ i18n.translate( 'We sent you an email with a request to verify your new domain. Unverified domains may be suspended.' ) }
+						buttonText={ i18n.translate( 'Learn more about verifying your domain' ) }
+						href={ supportUrls.EMAIL_VALIDATION_AND_VERIFICATION }
+						target="_blank"
+						requiredText={ i18n.translate( 'Important! Your action is required.' ) }
+						isRequired />
+				) }
 
 				{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
 			</div>

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -11,8 +11,9 @@ export function createReceiptObject( data ) {
 				productType: purchase.product_type,
 				productName: purchase.product_name,
 				productNameShort: purchase.product_name_short,
-				registrarSupportUrl: purchase.registrar_support_url
+				registrarSupportUrl: purchase.registrar_support_url,
+				isEmailVerified: Boolean( purchase.is_email_verified )
 			};
 		} )
 	};
-};
+}


### PR DESCRIPTION
**What:**
Show "Verify Email" text only to users that should verify it

**Why:**
Verify Email text was shown even if the email used was verified telling the user to check
their email account, but the email wasn't sent, as it's already verified.

**Test:**
* Email verified
 * Register a domain with an email you have already verified.
 * On the Thank you page you shouldn't see the "Verify Domain" text

* Email unverified
 * Register a domain with an email you haven't used yet
 * Make sure the Thank you page show you the "Verify Domain" text

Merge D1294-code for this to work.