### PR TITLE
Editor: Fix delay which occurs when switching tabs

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -252,12 +252,12 @@ const EditPostStatus = React.createClass( {
 	}
 } );
 
-
-
 export default connect(
 	null,
 	dispatch => bindActionCreators( {
 		toggleStickyStatus,
 		togglePendingStatus
-	}, dispatch )
+	}, dispatch ),
+	null,
+	{ pure: false }
 )( EditPostStatus );

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -90,5 +90,7 @@ const EditorAuthor = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { setAuthor }, dispatch )
+	dispatch => bindActionCreators( { setAuthor }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorAuthor );

--- a/client/post-editor/editor-author/index.jsx
+++ b/client/post-editor/editor-author/index.jsx
@@ -19,13 +19,17 @@ import { setAuthor } from 'state/ui/editor/post/actions';
 
 const EditorAuthor = React.createClass( {
 	propTypes: {
+		post: React.PropTypes.object,
+		isNew: React.PropTypes.bool,
 		setAuthor: React.PropTypes.func,
 	},
+
 	getDefaultProps: function() {
 		return {
 			setAuthor: () => {}
 		};
 	},
+
 	render: function() {
 		// if it's not a new post and we are still loading
 		// show a placeholder component

--- a/client/post-editor/editor-categories/index.jsx
+++ b/client/post-editor/editor-categories/index.jsx
@@ -128,5 +128,7 @@ const EditorCategories = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { setCategories }, dispatch )
+	dispatch => bindActionCreators( { setCategories }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorCategories );

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -110,5 +110,7 @@ const EditorDeletePost = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { trashPost }, dispatch )
+	dispatch => bindActionCreators( { trashPost }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorDeletePost );

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -117,5 +117,7 @@ const EditorDiscussion = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { setDiscussionSettings }, dispatch )
+	dispatch => bindActionCreators( { setDiscussionSettings }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorDiscussion );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -310,5 +310,7 @@ export default connect(
 			postTypes: getPostTypes( state, site.ID )
 		};
 	},
-	dispatch => bindActionCreators( { setExcerpt }, dispatch )
+	dispatch => bindActionCreators( { setExcerpt }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorDrawer );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -44,7 +44,8 @@ const EditorDrawer = React.createClass( {
 		post: React.PropTypes.object,
 		postTypes: React.PropTypes.object,
 		isNew: React.PropTypes.bool,
-		setExcerpt: React.PropTypes.func
+		setExcerpt: React.PropTypes.func,
+		type: React.PropTypes.string
 	},
 
 	getDefaultProps: function() {

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -150,5 +150,7 @@ const EditorFeaturedImage = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { setFeaturedImage, removeFeaturedImage }, dispatch )
+	dispatch => bindActionCreators( { setFeaturedImage, removeFeaturedImage }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorFeaturedImage );

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -410,5 +410,7 @@ const EditorGroundControl = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { setDate }, dispatch )
+	dispatch => bindActionCreators( { setDate }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorGroundControl );

--- a/client/post-editor/editor-page-templates/index.jsx
+++ b/client/post-editor/editor-page-templates/index.jsx
@@ -93,5 +93,7 @@ const EditorPageTemplates = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { setPageTemplate }, dispatch )
+	dispatch => bindActionCreators( { setPageTemplate }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorPageTemplates );

--- a/client/post-editor/editor-post-formats/index.jsx
+++ b/client/post-editor/editor-post-formats/index.jsx
@@ -111,5 +111,7 @@ const EditorPostFormats = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { setPostFormat }, dispatch )
+	dispatch => bindActionCreators( { setPostFormat }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorPostFormats );

--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -120,5 +120,7 @@ const EditorSharingPublicizeConnection = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { addPublicizeConnectionKey, removePublicizeConnectionKey }, dispatch )
+	dispatch => bindActionCreators( { addPublicizeConnectionKey, removePublicizeConnectionKey }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorSharingPublicizeConnection );

--- a/client/post-editor/editor-sharing/sharing-like-options.jsx
+++ b/client/post-editor/editor-sharing/sharing-like-options.jsx
@@ -125,5 +125,7 @@ const SharingLikeOptions = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { setSharingLikeOption }, dispatch )
+	dispatch => bindActionCreators( { setSharingLikeOption }, dispatch ),
+	null,
+	{ pure: false }
 )( SharingLikeOptions );

--- a/client/post-editor/editor-tags/index.jsx
+++ b/client/post-editor/editor-tags/index.jsx
@@ -103,5 +103,7 @@ const EditorTags = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { setTags }, dispatch )
+	dispatch => bindActionCreators( { setTags }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorTags );

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -137,5 +137,7 @@ const EditorTitle = React.createClass( {
 
 export default connect(
 	null,
-	dispatch => bindActionCreators( { setTitle }, dispatch )
+	dispatch => bindActionCreators( { setTitle }, dispatch ),
+	null,
+	{ pure: false }
 )( EditorTitle );

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -935,5 +935,7 @@ export default connect(
 		setPostPrivate,
 		setPostPublished,
 		resetRawContent
-	}, dispatch )
+	}, dispatch ),
+	null,
+	{ pure: false }
 )( PostEditor );


### PR DESCRIPTION
Fixes #3709 
Regression introduced in #3025, #3202

This pull request seeks to resolve an issue where the editor can hang when changing tabs, particularly while an autosave is pending.

The root cause of the issue was the introduction of `react-redux` `connect`, which [defaults connected components to being pure](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options). Since many editor components are not pure, rerenders were being skipped which should not have been.

This pull request changes all `connect` calls in `client/post-editor` to specify `{ pure: false }`, unless the component is obviously pure or has been tested to operate well as a pure component.

__Testing instructions:__

Repeat steps to reproduce at #3709, noting that no delay occurs when switching between editing modes.

/cc @artpi , @gwwar , @codebykat 