### PR TITLE
WebPreview: prevent scrolling when web preview is open.

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -70,6 +70,10 @@ const WebPreview = React.createClass( {
 		if ( this.props.previewUrl !== 'about:blank' ) {
 			this.setIframeUrl( this.props.previewUrl );
 		}
+
+		if ( this.props.showPreview ) {
+			document.documentElement.classList.add( 'no-scroll' );
+		}
 	},
 
 	componentDidUpdate( prevProps ) {
@@ -90,13 +94,16 @@ const WebPreview = React.createClass( {
 		}
 		if ( showPreview ) {
 			window.addEventListener( 'keydown', this.keyDown );
+			document.documentElement.classList.add( 'no-scroll' );
 		} else {
 			window.removeEventListener( 'keydown', this.keyDown );
+			document.documentElement.classList.remove( 'no-scroll' );
 		}
 	},
 
 	componentWillUnmount() {
 		window.removeEventListener( 'keydown', this.keyDown );
+		document.documentElement.classList.remove( 'no-scroll' );
 	},
 
 	keyDown( event ) {


### PR DESCRIPTION
Also removes extra scrollbars from body. See #3901.

Fixes #316 