### PR TITLE
Editor: Allow pasting text to image caption

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -608,30 +608,6 @@ function mediaButton( editor ) {
 		}
 	}
 
-	function fixCaptionPaste( event ) {
-		// Limit effect to captions, though reasonably this behavior could
-		// probably be applied generally to fix any inline paste.
-		const target = editor.selection.getStart( true );
-		if ( ! editor.dom.hasClass( target, 'wp-caption-dd' ) ) {
-			return;
-		}
-
-		// If the entire caption is selected (e.g. on double-click select), a
-		// paste may remove the caption inadvertedly. If this is the case,
-		// change selection to the contents of the caption.
-		const startContainer = editor.selection.getRng().startContainer;
-		if ( editor.dom.hasClass( startContainer, 'wp-caption' ) ) {
-			editor.selection.select( target, true );
-		}
-
-		// By default, TinyMCE inserts paste using `editor.insertContent`. We
-		// substitute this with `selection.setContent` and prevent the default.
-		//
-		// See: https://github.com/tinymce/tinymce/blob/e35d1de/js/tinymce/plugins/paste/classes/Clipboard.js#L69-L71
-		editor.selection.setContent( event.node.innerHTML );
-		event.preventDefault();
-	}
-
 	function removeEmptyCaptions( focussed ) {
 		if ( focussed ) {
 			return;
@@ -675,8 +651,6 @@ function mediaButton( editor ) {
 	editor.on( 'click', preventCaptionTripleClick );
 
 	editor.on( 'keydown', preventCaptionBackspaceRemove );
-
-	editor.on( 'PastePostProcess', fixCaptionPaste );
 
 	editor.on( 'touchstart touchmove touchend', selectImageOnTap() );
 

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -608,6 +608,22 @@ function mediaButton( editor ) {
 		}
 	}
 
+	function fixCaptionPaste( event ) {
+		// Limit effect to captions, though reasonably this behavior could
+		// probably be applied generally to fix any inline paste.
+		const target = editor.selection.getStart( true );
+		if ( ! editor.dom.hasClass( target, 'wp-caption-dd' ) ) {
+			return;
+		}
+
+		// By default, TinyMCE inserts paste using `editor.insertContent`. We
+		// substitute this with `selection.setContent` and prevent the default.
+		//
+		// See: https://github.com/tinymce/tinymce/blob/e35d1de/js/tinymce/plugins/paste/classes/Clipboard.js#L69-L71
+		editor.selection.setContent( event.node.innerHTML );
+		event.preventDefault();
+	}
+
 	function removeEmptyCaptions( focussed ) {
 		if ( focussed ) {
 			return;
@@ -651,6 +667,8 @@ function mediaButton( editor ) {
 	editor.on( 'click', preventCaptionTripleClick );
 
 	editor.on( 'keydown', preventCaptionBackspaceRemove );
+
+	editor.on( 'PastePostProcess', fixCaptionPaste );
 
 	editor.on( 'touchstart touchmove touchend', selectImageOnTap() );
 

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -616,6 +616,14 @@ function mediaButton( editor ) {
 			return;
 		}
 
+		// If the entire caption is selected (e.g. on double-click select), a
+		// paste may remove the caption inadvertedly. If this is the case,
+		// change selection to the contents of the caption.
+		const startContainer = editor.selection.getRng().startContainer;
+		if ( editor.dom.hasClass( startContainer, 'wp-caption' ) ) {
+			editor.selection.select( target, true );
+		}
+
 		// By default, TinyMCE inserts paste using `editor.insertContent`. We
 		// substitute this with `selection.setContent` and prevent the default.
 		//

--- a/client/components/tinymce/plugins/wpeditimage/plugin.js
+++ b/client/components/tinymce/plugins/wpeditimage/plugin.js
@@ -563,7 +563,7 @@ function wpEditImage( editor ) {
 			if ( 'getComputedStyle' in window ) {
 				computedStyle = window.getComputedStyle( child );
 			} else {
-				computedStyle = child.currenStyle;
+				computedStyle = child.currentStyle;
 			}
 
 			if ( 'block' === computedStyle.display ) {

--- a/client/components/tinymce/plugins/wpeditimage/plugin.js
+++ b/client/components/tinymce/plugins/wpeditimage/plugin.js
@@ -548,17 +548,62 @@ function wpEditImage( editor ) {
 		}
 	} );
 
+	editor.on( 'PastePostProcess', function( event ) {
+		var selectedNode = editor.selection.getNode(),
+			c, cl, child, computedStyle;
+
+		// Test paste within caption
+		if ( ! editor.dom.getParent( selectedNode, 'div.mceTemp' ) ) {
+			return;
+		}
+
+		// Avoid paste in new paragraph behavior for inline node types
+		for ( c = 0, cl = event.node.children.length; c < cl; c++ ) {
+			child = event.node.children[ c ];
+			if ( 'getComputedStyle' in window ) {
+				computedStyle = window.getComputedStyle( child );
+			} else {
+				computedStyle = child.currenStyle;
+			}
+
+			if ( 'block' === computedStyle.display ) {
+				return;
+			}
+		}
+
+		// If entire element selected, change selection to contents to avoid
+		// accidental removal
+		const startContainer = editor.selection.getRng().startContainer;
+		if ( editor.dom.hasClass( startContainer, 'wp-caption' ) ) {
+			editor.selection.select( selectedNode, true );
+		}
+
+		// For inline text nodes, recreate default TinyMCE paste behavior with
+		// custom data value for detection in `mceInsertContent` handler
+		//
+		// See: https://github.com/tinymce/tinymce/blob/e35d1de/js/tinymce/plugins/paste/classes/Clipboard.js#L69-L71
+		event.preventDefault();
+		editor.insertContent( event.node.innerHTML, {
+			merge: editor.settings.paste_merge_formats !== false,
+			data: {
+				inline: true,
+				paste: true
+			}
+		} );
+	} );
+
 	editor.on( 'BeforeExecCommand', function( event ) {
-		var node, p, DL, align, replacement,
+		var node, p, DL, align, replacement, caption,
 			cmd = event.command,
 			dom = editor.dom;
 
 		if ( cmd === 'mceInsertContent' ) {
 			// When inserting content, if the caret is inside a caption create new paragraph under
 			// and move the caret there
-			if ( node = dom.getParent( editor.selection.getNode(), 'div.mceTemp' ) ) { //eslint-disable-line no-cond-assign
+			caption = dom.getParent( editor.selection.getNode(), 'div.mceTemp' );
+			if ( caption && ! ( event.value && event.value.data && event.value.data.inline ) ) {
 				p = dom.create( 'p' );
-				dom.insertAfter( p, node );
+				dom.insertAfter( p, caption );
 				editor.selection.setCursorLocation( p, 0 );
 				editor.nodeChanged();
 			}


### PR DESCRIPTION
Fixes #1658 

This pull request seeks to resolve an issue where pasting while the current selection is within an image caption would cause the caption to be added to the paragraph following the image, not the image caption itself.

__Testing instructions:__

Verify that you can paste text into a caption, including when selecting the entire caption via double- or triple-click.

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Insert an image to post contents
4. If not captioned already, select the image, and click Add Caption in the inline image toolbar
5. Place cursor within or select caption contents
6. Paste text
7. Note that clipboard contents are inserted within the caption itself

__Follow-up tasks:__

We should pursue one of the following:

- Propose change to TinyMCE `paste` plugin to use `editor.selection.setContent` when pasting, in place of [`editor.insertContent`](https://github.com/tinymce/tinymce/blob/e35d1deba514c006e803e57407312345f4f2047c/js/tinymce/plugins/paste/classes/Clipboard.js#L69-L71)
- Submit patch to WordPress core Trac with equivalent changes as implemented here