### PR TITLE
Signup: Fix unnecessary requests to /me endpoints

### DIFF
--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -67,8 +67,8 @@ const olark = {
 	},
 
 	handleError: function( error ) {
-		// error.error === 'authorization_required' when the user is logged out
-		// when https://github.com/Automattic/wp-calypso/issues/289 is fixed then we can remove this condition
+		// Hides notices for authorization errors as they should be legitimate (e.g. we use this error code to check
+		// whether the user is logged in when fetching the user profile)
 		if ( error && error.message && error.error !== 'authorization_required' ) {
 			notices.error( error.message );
 		}

--- a/client/lib/preferences/actions.js
+++ b/client/lib/preferences/actions.js
@@ -9,7 +9,8 @@ var store = require( 'store' ),
  * Internal dependencies
  */
 var Dispatcher = require( 'dispatcher' ),
-	PreferencesConstants = require( './constants' );
+	PreferencesConstants = require( './constants' ),
+	user = require( 'lib/user' )();
 
 /**
  * Module variables
@@ -36,7 +37,12 @@ function mergePreferencesToLocalStorage( preferences ) {
 }
 
 PreferencesActions.fetch = function() {
-	var localStorage = getLocalStorage();
+	var localStorage = getLocalStorage(),
+		userIsLoggedIn = Boolean( user.data );
+
+	if ( ! userIsLoggedIn ) {
+		return;
+	}
 
 	Dispatcher.handleViewAction( {
 		type: 'FETCH_ME_SETTINGS'

--- a/client/lib/preferences/actions.js
+++ b/client/lib/preferences/actions.js
@@ -10,8 +10,7 @@ var store = require( 'store' ),
  */
 var Dispatcher = require( 'dispatcher' ),
 	PreferencesConstants = require( './constants' ),
-	user = require( 'lib/user' )();
-
+	userUtils = require( 'lib/user/utils' );
 /**
  * Module variables
  */
@@ -37,10 +36,9 @@ function mergePreferencesToLocalStorage( preferences ) {
 }
 
 PreferencesActions.fetch = function() {
-	var localStorage = getLocalStorage(),
-		userIsLoggedIn = Boolean( user.data );
+	var localStorage = getLocalStorage();
 
-	if ( ! userIsLoggedIn ) {
+	if ( ! userUtils.isLoggedIn() ) {
 		return;
 	}
 

--- a/client/lib/preferences/test/actions.js
+++ b/client/lib/preferences/test/actions.js
@@ -37,6 +37,13 @@ describe( 'PreferencesActions', function() {
 		sandbox.stub( Dispatcher, 'handleServerAction' );
 
 		mockery.enable( { warnOnReplace: false, warnOnUnregistered: false } );
+
+		mockery.registerMock( 'lib/user', function() {
+			return {
+				data: {}
+			}
+		} );
+
 		mockery.registerMock( 'lib/wp', {
 			undocumented: function() {
 				return {

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -72,18 +72,24 @@ SitesList.prototype.get = function() {
  * @api public
  */
 SitesList.prototype.fetch = function() {
-	if ( this.fetching ) {
+	var userIsLoggedIn = Boolean( user.data );
+
+	if ( ! userIsLoggedIn || this.fetching ) {
 		return;
 	}
 
 	this.fetching = true;
+
 	debug( 'getting SitesList from api' );
+
 	wpcom.me().sites( { site_visibility: 'all' }, function( error, data ) {
 		if ( error ) {
 			debug( 'error fetching SitesList from api', error );
 			this.fetching = false;
+
 			return;
 		}
+
 		this.sync( data );
 		this.fetching = false;
 	}.bind( this ) );

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -19,7 +19,8 @@ var wpcom = require( 'lib/wp' ),
 	isPlan = require( 'lib/products-values' ).isPlan,
 	PreferencesActions = require( 'lib/preferences/actions' ),
 	PreferencesStore = require( 'lib/preferences/store' ),
-	user = require( 'lib/user' )();
+	user = require( 'lib/user' )(),
+	userUtils = require( 'lib/user/utils' );
 
 /**
  * SitesList component
@@ -72,9 +73,7 @@ SitesList.prototype.get = function() {
  * @api public
  */
 SitesList.prototype.fetch = function() {
-	var userIsLoggedIn = Boolean( user.data );
-
-	if ( ! userIsLoggedIn || this.fetching ) {
+	if ( ! userUtils.isLoggedIn() || this.fetching ) {
 		return;
 	}
 

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -73,12 +73,16 @@ UserSettings.prototype.getSettings = function() {
  * Fetch user settings from WordPress.com API and store them in UserSettings instance
  */
 UserSettings.prototype.fetchSettings = function() {
-	if ( this.fetchingSettings ) {
+	var userIsLoggedIn = Boolean( user.data );
+
+	if ( ! userIsLoggedIn || this.fetchingSettings ) {
 		return;
 	}
 
 	this.fetchingSettings = true;
+
 	debug( 'Fetching user settings' );
+
 	wpcom.me().settings().get( function( error, data ) {
 		if ( ! error ) {
 			this.settings = decodeUserSettingsEntities( data );

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -13,8 +13,8 @@ var debug = require( 'debug' )( 'calypso:user:settings' ),
  */
 var emitterClass = require( 'lib/mixins/emitter' ),
 	wpcom = require( 'lib/wp' ).undocumented(),
-	user = require( 'lib/user' )();
-
+	user = require( 'lib/user' )(),
+	userUtils = require( 'lib/user/utils' );
 /*
  * Decodes entities in those specific user settings properties
  * that the REST API returns already HTML-encoded
@@ -73,9 +73,7 @@ UserSettings.prototype.getSettings = function() {
  * Fetch user settings from WordPress.com API and store them in UserSettings instance
  */
 UserSettings.prototype.fetchSettings = function() {
-	var userIsLoggedIn = Boolean( user.data );
-
-	if ( ! userIsLoggedIn || this.fetchingSettings ) {
+	if ( ! userUtils.isLoggedIn() || this.fetchingSettings ) {
 		return;
 	}
 

--- a/client/lib/user-settings/test/index.js
+++ b/client/lib/user-settings/test/index.js
@@ -14,17 +14,18 @@ describe( 'User Settings', function() {
 	} );
 
 	it( 'should consider overridden settings as saved', function( done ) {
-		userSettings.updateSetting( 'test', true );
-		userSettings.updateSetting( 'lang_id', true );
-		assert.equal( true, userSettings.unsavedSettings.test );
-		assert.equal( true, userSettings.unsavedSettings.lang_id );
+		assert.isTrue( userSettings.updateSetting( 'test', true ) );
+		assert.isTrue( userSettings.updateSetting( 'lang_id', true ) );
 
-		userSettings.saveSettings( assertCorrectSettingIsRemoved,
-			{ test: true } );
+		assert.isTrue( userSettings.unsavedSettings.test );
+		assert.isTrue( userSettings.unsavedSettings.lang_id );
+
+		userSettings.saveSettings( assertCorrectSettingIsRemoved, { test: true } );
 
 		function assertCorrectSettingIsRemoved() {
 			assert.isUndefined( userSettings.unsavedSettings.test );
-			assert.equal( true, userSettings.unsavedSettings.lang_id );
+			assert.isTrue( userSettings.unsavedSettings.lang_id );
+
 			done();
 		}
 	} );

--- a/client/lib/user-settings/test/lib/user.js
+++ b/client/lib/user-settings/test/lib/user.js
@@ -1,5 +1,6 @@
 module.exports = function() {
 	return {
+		data: {},
 		fetch: function() {}
 	};
 };

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -52,6 +52,10 @@ var userUtils = {
 
 	getLocaleSlug: function() {
 		return user.get().localeSlug;
+	},
+
+	isLoggedIn: function() {
+		return Boolean( user.data );
 	}
 };
 

--- a/client/signup/step-header/index.jsx
+++ b/client/signup/step-header/index.jsx
@@ -13,7 +13,10 @@ module.exports = React.createClass( {
 
 	propTypes: {
 		headerText: PropTypes.string,
-		subHeaderText: PropTypes.string,
+		subHeaderText: React.PropTypes.oneOfType( [
+			PropTypes.array,
+			PropTypes.string
+		] )
 	},
 
 	render: function() {


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/289 by making sure we don't call the following endpoints during signup:

* `/me/sites`
* `/me/settings`

These endpoints indeed return a `403` error code when the user is not logged in so there really is no point in trying to fetch data in that case - especially as we poll the list of sites every 30 seconds:
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/13708021/bbbcded2-e7ac-11e5-8ba8-26261e9978ca.png)
  
#### Testing instructions
 
1. Run `git checkout fix/unnecessary-signup-requests` and start your server
2. Open the [`Signup` page](http://calypso.localhost:3000/start/) in incognito mode
3. Check that no call is made to the endpoints mentioned above
4. Check that you can still create a new user and site
5. Open any page from the `My Site` section
6. Click on the `ADD NEW WORDPRESS` link at the top of the sidebar
7. Check that you can create a new site
8. Check that you can still access any page of Calypso as usual

#### Additional notes

I couldn't remove the call to `/me` since this is actually used to determine in development [whether the user is logged in](https://github.com/Automattic/wp-calypso/blob/efea79bb0131ec7485585814966b48679592d13b/client/lib/user/user.js#L130). It also looks like we don't call `/me/upgrades` (nor `/me/purchases`) during signup any longer. Both endpoints were mentioned in https://github.com/Automattic/wp-calypso/issues/289.
 
#### Reviews
 
- [x] Code
- [x] Product