### PR TITLE
Global Notices: fixing the mobile width notices so they are block-level

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -31,13 +31,13 @@
 }
 
 .global-notices .notice {
-	display: inline-flex;
-		flex-wrap: nowrap;
+	flex-wrap: nowrap;
 	margin-bottom: 0;
 	text-align: left;
 	pointer-events: auto;
 
 	@include breakpoint( ">660px" ) {
+		display: inline-flex;
 		border-radius: 20px;
 		overflow: hidden;
 		margin-bottom: 24px;
@@ -55,9 +55,10 @@
 .global-notices .notice__text {
 	padding-left: 16px;
 	flex-basis: auto;
-	flex-grow: 0;
+	flex-grow: 1;
 
 	@include breakpoint( ">660px" ) {
+		flex-grow: 0;
 		padding: 9px 13px;
 	}
 }


### PR DESCRIPTION
@MichaelArestad's recent fix for IE caused the mobile display to become inline-flex instead of spanning the entire bottom of the screen.

**Before:**
<img width="401" alt="screen shot 2016-03-11 at 2 31 28 pm" src="https://cloud.githubusercontent.com/assets/437258/13713260/1b0d4708-e796-11e5-8727-2d29baae6f89.png">

**After:**
<img width="406" alt="screen shot 2016-03-11 at 2 30 43 pm" src="https://cloud.githubusercontent.com/assets/437258/13713254/161a14c4-e796-11e5-90d2-7f5b824a0329.png">
