### PR TITLE
Framework: Add in a sinon sandbox helper

### DIFF
--- a/test/test/helpers/use-sinon/README.md
+++ b/test/test/helpers/use-sinon/README.md
@@ -1,5 +1,5 @@
 # Sinon Test Helpers
-A set of helpers for folks using sinon to fake, mock, spy and bend time
+A set of helpers for folks using sinon to fake, mock, spy and bend time.
 
 ## Usage
 
@@ -34,9 +34,10 @@ describe( 'my tests that use a sandbox and arrow functions', function() {
 ```js
 import { useFakeTimers } from 'test/helpers/use-sinon';
 
-describe( 'my time dependent test' function() {
+describe( 'my time dependent test', function() {
 	const aLongTimeAgo = Date.parse( '1976-09-15T010:00:00Z' ).valueOf(),
 		yearInMillis = 1000 * 60 * 60 * 24 * 365;
+
 	useFakeTimers( aLongTimeAgo );
 
 	it( 'can access the fake clock via this', function() {
@@ -44,16 +45,17 @@ describe( 'my time dependent test' function() {
 		this.clock.tick( yearInMillis );
 		assert.equals( Date.now(), aLongTimeAgo + yearInMillis );
 	} );
+} );
 
-	context( 'if I want to use arrow functions', () => {
-		let clock;
-		useFakeTimers( Date.now() ) newClock => {
-			clock = newClock;
-		} );
+describe( 'my time dependent test that use a sandbox and arrow functions', () => {
+	let clock;
+	
+	useFakeTimers( Date.now() ) newClock => {
+		clock = newClock;
+	} );
 
-		it( 'can use the clock via closure', () => {
-			clock.tick( -5 );
-		} );
+	it( 'can use the clock via closure', () => {
+		clock.tick( -5 );
 	} );
 } )
 

--- a/test/test/helpers/use-sinon/README.md
+++ b/test/test/helpers/use-sinon/README.md
@@ -3,11 +3,38 @@ A set of helpers for folks using sinon to fake, mock, spy and bend time
 
 ## Usage
 
+### Full sandbox
+```js
+import { useSandbox } from 'test/helpers/use-sinon';
+
+describe( 'my tests that use a sandbox', function() {
+	useSandbox();
+
+	it( 'should have a full suite of sandbox things available', function() {
+		// this will get torn down automatically by the sandbox
+		const onWindowClick = this.sandbox.stub( global.window, 'onclick' );
+	} );
+} );
+
+describe( 'my tests that use a sandbox and arrow functions', function() {
+	let sandbox = null;
+
+	useSandbox( newSandbox => {
+		sandbox = newSandbox;
+	});
+
+	it( 'should have a full suite of sandbox things available', () => {
+		// this will get torn down automatically by the sandbox
+		const onWindowClick = sandbox.stub( global.window, 'onclick' );
+	} );
+} );
+```
+
 ### Fake Clock
 ```js
 import { useFakeTimers } from 'test/helpers/use-sinon';
 
-describe( function() {
+describe( 'my time dependent test' function() {
 	const aLongTimeAgo = Date.parse( '1976-09-15T010:00:00Z' ).valueOf(),
 		yearInMillis = 1000 * 60 * 60 * 24 * 365;
 	useFakeTimers( aLongTimeAgo );

--- a/test/test/helpers/use-sinon/README.md
+++ b/test/test/helpers/use-sinon/README.md
@@ -49,8 +49,8 @@ describe( 'my time dependent test', function() {
 
 describe( 'my time dependent test that use a sandbox and arrow functions', () => {
 	let clock;
-	
-	useFakeTimers( Date.now() ) newClock => {
+
+	useFakeTimers( Date.now(), newClock => {
 		clock = newClock;
 	} );
 

--- a/test/test/helpers/use-sinon/index.js
+++ b/test/test/helpers/use-sinon/index.js
@@ -35,3 +35,30 @@ export function useFakeTimers( now = 0, clockCallback = noop ) {
 		}
 	} );
 }
+
+/**
+ * Use a full sinon sandbox for this test block
+ *
+ * See http://sinonjs.org/docs/#sandbox
+ *
+ * @param  {Object|Function} config The configuration to use, or a callback that is invoked with the sandbox instance
+ * @param  {Function} sandboxCallback A callback function that is invoked with the sandbox instance
+ */
+export function useSandbox( config, sandboxCallback = noop ) {
+	if ( isFunction( config ) && sandboxCallback === noop ) {
+		sandboxCallback = config;
+		config = undefined;
+	}
+
+	before( function() {
+		this.sandbox = sinon.sandbox.create( config );
+		sandboxCallback( this.sandbox );
+	} );
+
+	after( function() {
+		if ( this.sandbox ) {
+			this.sandbox.restore();
+			this.sandbox = null;
+		}
+	} );
+}


### PR DESCRIPTION
A little helper for folks that want to use a full sinon sandbox and tear it down at the end of a test run.