### PR TITLE
Users: Improves polling for SiteUserFetcher component

### DIFF
--- a/client/components/site-users-fetcher/index.jsx
+++ b/client/components/site-users-fetcher/index.jsx
@@ -44,7 +44,7 @@ module.exports = React.createClass( {
 		this._fetchIfEmpty();
 		this._poller = pollers.add(
 			UsersStore,
-			UsersActions.fetchUsers.bind( UsersActions, this.props.fetchOptions, true ),
+			UsersActions.fetchUpdated.bind( UsersActions, this.props.fetchOptions, true ),
 			{ leading: false }
 		);
 	},
@@ -64,7 +64,7 @@ module.exports = React.createClass( {
 			pollers.remove( this._poller );
 			this._poller = pollers.add(
 				UsersStore,
-				UsersActions.fetchUsers.bind( UsersActions, nextProps.fetchOptions, true ),
+				UsersActions.fetchUpdated.bind( UsersActions, nextProps.fetchOptions, true ),
 				{ leading: false }
 			);
 		}

--- a/client/lib/users/actions.js
+++ b/client/lib/users/actions.js
@@ -11,22 +11,44 @@ const Dispatcher = require( 'dispatcher' ),
 	UsersStore = require( 'lib/users/store' );
 
 const UsersActions = {
-	fetchUsers: ( fetchOptions, silentUpdate = false ) => {
+	fetchUsers: fetchOptions => {
 		const paginationData = UsersStore.getPaginationData( fetchOptions );
 		if ( paginationData.fetchingUsers ) {
 			return;
 		}
 		debug( 'fetchUsers', fetchOptions );
-		if ( ! silentUpdate ) {
-			Dispatcher.handleViewAction( {
-				type: 'FETCHING_USERS',
-				fetchOptions: fetchOptions
-			} );
-		}
+		Dispatcher.handleViewAction( {
+			type: 'FETCHING_USERS',
+			fetchOptions: fetchOptions
+		} );
 
 		wpcom.site( fetchOptions.siteId ).usersList( fetchOptions, ( error, data ) => {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_USERS',
+				fetchOptions: fetchOptions,
+				data: data,
+				error: error
+			} );
+		} );
+	},
+
+	fetchUpdated: fetchOptions => {
+		const paginationData = UsersStore.getPaginationData( fetchOptions );
+		if ( paginationData.fetchingUsers ) {
+			return;
+		}
+
+		Dispatcher.handleViewAction( {
+			type: 'FETCHING_UPDATED_USERS',
+			fetchOptions: fetchOptions
+		} );
+
+		const updatedFetchOptions = UsersStore.getUpdatedParams( fetchOptions );
+		debug( 'Updated fetchOptions: ' + JSON.stringify( updatedFetchOptions ) );
+
+		wpcom.site( fetchOptions.siteId ).usersList( updatedFetchOptions, ( error, data ) => {
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_UPDATED_USERS',
 				fetchOptions: fetchOptions,
 				data: data,
 				error: error

--- a/client/lib/users/store.js
+++ b/client/lib/users/store.js
@@ -13,12 +13,13 @@ var Dispatcher = require( 'dispatcher' ),
 	emitter = require( 'lib/mixins/emitter' ),
 	deterministicStringify = require( 'lib/deterministic-stringify' );
 
-var _fetchingUsersByNamespace = {}, // store fetching state (boolean)
-	_usersBySite = {}, // store user objects
-	_totalUsersByNamespace = {}, // store total found for params
-	_usersFetchedByNamespace = {}, // store fetch progress
-	_offsetByNamespace = {}, // store fetch progress
-	_userIDsByNamespace = {}; // store user order
+var _fetchingUsersByNamespace = {},        // store fetching state (boolean)
+	_fetchingUpdatedUsersByNamespace = {}, // store fetching state (boolean)
+	_usersBySite = {},                     // store user objects
+	_totalUsersByNamespace = {},           // store total found for params
+	_usersFetchedByNamespace = {},         // store fetch progress
+	_offsetByNamespace = {},               // store fetch progress
+	_userIDsByNamespace = {};              // store user order
 
 var UsersStore = {
 	// This data can help manage infinite scroll
@@ -66,6 +67,16 @@ var UsersStore = {
 	getUserByLogin: function( siteId, login ) {
 		return find( _usersBySite[ siteId ], function( user ) {
 			return user.login === login;
+		} );
+	},
+
+	getUpdatedParams( fetchOptions ) {
+		const namespace = getNamespace( fetchOptions );
+		const requestNumber = _usersFetchedByNamespace[ namespace ] || fetchOptions.number;
+
+		return Object.assign( {}, fetchOptions, {
+			offset: 0,
+			number: Math.min( requestNumber, 1000 )
 		} );
 	},
 
@@ -168,6 +179,15 @@ UsersStore.dispatchToken = Dispatcher.register( function( payload ) {
 			}
 
 			break;
+		case 'RECEIVE_UPDATED_USERS':
+			namespace = getNamespace( action.fetchOptions );
+			_fetchingUpdatedUsersByNamespace[ namespace ] = false;
+
+			if ( ! action.error ) {
+				updateUsers( action.fetchOptions, action.data.users, action.data.found );
+				UsersStore.emitChange();
+			}
+			break;
 		case 'UPDATE_SITE_USER':
 			updateUser( action.siteId, action.user.ID, action.user );
 			UsersStore.emitChange();
@@ -192,6 +212,11 @@ UsersStore.dispatchToken = Dispatcher.register( function( payload ) {
 		case 'FETCHING_USERS':
 			namespace = getNamespace( action.fetchOptions );
 			_fetchingUsersByNamespace[ namespace ] = true;
+			UsersStore.emitChange();
+			break;
+		case 'FETCHING_UPDATED_USERS':
+			namespace = getNamespace( action.fetchOptions );
+			_fetchingUpdatedUsersByNamespace[ namespace ] = true;
 			UsersStore.emitChange();
 			break;
 		case 'RECEIVE_SINGLE_USER':

--- a/client/lib/users/test/lib/mock-actions.js
+++ b/client/lib/users/test/lib/mock-actions.js
@@ -3,7 +3,8 @@ var site = require( './mock-site' ),
 	moreUsersData = require( './mock-more-users-data' ),
 	deletedUserData = require( './mock-deleted-user-data' ),
 	updatedUserData = require( './mock-updated-single-user' ),
-	singleUserData = require( './mock-single-user' );
+	singleUserData = require( './mock-single-user' ),
+	pollingUsersData = require( './mock-polling-users-data' );
 
 module.exports = {
 	fetched: {
@@ -79,6 +80,17 @@ module.exports = {
 			siteId: site.ID
 		},
 		user: singleUserData,
+		error: null
+	},
+
+	receiveUpdatedUsers: {
+		type: 'RECEIVE_UDPATED_USERS',
+		fetchOptions: {
+			siteId: site.ID,
+			offset: 0,
+			number: 7
+		},
+		data: pollingUsersData,
 		error: null
 	}
 };

--- a/client/lib/users/test/lib/mock-polling-users-data.js
+++ b/client/lib/users/test/lib/mock-polling-users-data.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import cloneDeep from 'lodash/cloneDeep';
+
+/**
+ * Internal dependencies
+ */
+import usersData from './mock-users-data';
+import moreUsersData from './mock-more-users-data';
+
+const clonedMoreUsers = cloneDeep( moreUsersData.users );
+const updatedUsers = clonedMoreUsers.map( ( user ) => {
+	return Object.assign( {}, user, { roles: [ 'contributor' ] } );
+} );
+
+export default {
+	found: 7,
+	users: Array.concat( usersData.users, updatedUsers )
+};

--- a/client/lib/users/test/test-store.js
+++ b/client/lib/users/test/test-store.js
@@ -106,6 +106,30 @@ describe( 'Users Store', function() {
 		} );
 	} );
 
+	describe( 'Polling updated users', function() {
+		beforeEach( function() {
+			Dispatcher.handleServerAction( actions.fetched );
+			Dispatcher.handleServerAction( actions.fetchMoreUsers );
+			Dispatcher.handleServerAction( actions.receiveUpdatedUsers );
+		} );
+
+		it( 'getUpdatedParams returns correct params', function() {
+			var updatedParams = UsersStore.getUpdatedParams( options );
+			assert.equal( updatedParams.offset, 0 );
+			assert.equal( updatedParams.number, usersData.found )
+		} );
+
+		it( 'Polling updates expected users', function() {
+			var updatedUsers = UsersStore.getUsers( options );
+			assert.equal( updatedUsers.length, usersData.found );
+
+			// The last two users should have a 'contributor' role
+			updatedUsers.slice( -2, 2 ).forEach( function( user ) {
+				assert.equal( user.roles[0], 'contributor' );
+			} );
+		} );
+	} );
+
 	describe( 'Update a user', function() {
 		beforeEach( function() {
 			Dispatcher.handleServerAction( actions.fetched );


### PR DESCRIPTION
Previously, we added polling to the SiteUserFetcher component in #3962, but that polling didn't update the entire team list. Also, with longer lists, there was some noticeable jank.

To test:
- Test existence of bug on `wpcalypso.wordpress.com/people/team/$site`
  - On a site with more than 100 users
  - Scroll to second page of results
  - In new browser, update one of the users in the second list
  - Wait for polling. Notice jank and/or that user doesn't update. :scream: 
- Checkout `update/people-polling-improvements` branch
- Check the same as above and notice lack of jank and that the user gets updated

cc @lezama for review