### PR TITLE
DevDocs: add titles and intro paragraphs, fixes #1162

### DIFF
--- a/assets/stylesheets/sections/_devdocs.scss
+++ b/assets/stylesheets/sections/_devdocs.scss
@@ -62,7 +62,8 @@
 	background-color: $white;
 }
 
-.devdocs__doc {
+.devdocs__doc,
+.design-assets {
 	h1, h2, h3, h4, h5, h6 {
 		font-family: Merriweather, Georgia, "Times New Roman", Times, serif;
 		font-weight: 700;

--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -56,7 +56,7 @@ export default React.createClass( {
 				</p>
 				<p>
 					<FoldableCard
-						header={ <div><div>This is a multiline foldable card</div><div><small> with a summary component & a expanded summary component</small></div></div> }
+						header={ <div><div>This is a multiline foldable card</div><div><small> with a summary component & an expanded summary component</small></div></div> }
 						summary={ <button className="button">Update</button> }
 						expandedSummary={ <button className="button">Update</button> }>
 						Nothing to see here. Keep walking!
@@ -64,7 +64,7 @@ export default React.createClass( {
 				</p>
 				<p>
 					<FoldableCard
-						header={ <div><div>This is a multiline foldable card</div><div><small> with a summary component & a expanded summary component</small></div></div> }
+						header={ <div><div>This is a multiline foldable card</div><div><small> with a summary component & an expanded summary component</small></div></div> }
 						summary={ <Button compact scary>Update</Button> }
 						expandedSummary={ <Button compact scary>Update</Button> }>
 						Nothing to see here. Keep walking!

--- a/client/devdocs/design/app-components.jsx
+++ b/client/devdocs/design/app-components.jsx
@@ -40,6 +40,8 @@ export default React.createClass( {
 	render() {
 		return (
 			<div className="design-assets" role="main">
+				<h1>App Components</h1>
+				<p>A visual reference for all application components used in Calypso.</p>
 				{
 					this.props.component
 					? <HeaderCake onClick={ this.backToComponents } backText="All App Components">

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -68,6 +68,8 @@ export default React.createClass( {
 	render() {
 		return (
 			<div className="design-assets" role="main">
+				<h1>Design Reference</h1>
+				<p>A visual reference for all internal React components used to build the Calypso UI.</p>
 				{
 					this.props.component
 					? <HeaderCake onClick={ this.backToComponents } backText="All Components">

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -71,10 +71,9 @@ export default React.createClass( {
 		return (
 			<Main className="design-assets">
 				<div className="design-assets__group">
-					<h2>
-						<a href="/devdocs/design/typography">Typography</a>
-					</h2>
-					<h3>Interface Typography</h3>
+					<h1>Typography Reference</h1>
+					<p>A visual reference for all typography used in the Calypso UI.</p>
+					<h2>Interface Typography</h2>
 					<Card>
 						<p style={ interfaceTitle }>Quick foxes jump nightly above wizards.</p>
 						<p style={ interfaceSubtitle }>Pack my box with five dozen liquor jugs</p>
@@ -82,7 +81,7 @@ export default React.createClass( {
 						<p style={ interfaceLabel }>Site description</p>
 						<p style={ interfaceCaption }>Views per page</p>
 					</Card>
-					<h3>Content Typography</h3>
+					<h2>Content Typography</h2>
 					<Card>
 						<p style={ contentTitle }>Quick foxes jump nightly above wizards.</p>
 						<p style={ contentSubtitle }>Pack my box with five dozen liquor jugs</p>


### PR DESCRIPTION
Suggested by @nb in #1162.

These changes add Title and Intro Paragraph for `/devdocs/design`, `/devdocs/app-components`, and `/design/typography`.

<img width="1140" alt="screen shot 2016-03-11 at 15 03 03" src="https://cloud.githubusercontent.com/assets/66797/13716834/b87faf7c-e79a-11e5-81c9-b180328b474b.png">

CSS change: added `design-assets` to typography handling to mimic other devdocs pages.