### PR TITLE
Help: design iteration and cleanup

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -138,7 +138,7 @@ module.exports = React.createClass( {
 
 		return (
 			<div className="help-contact-form__selection">
-				<SegmentedControl>
+				<SegmentedControl primary>
 					{ options.map( option => <ControlItem { ...option.props }>{ option.label }{ option.subtext }</ControlItem> ) }
 				</SegmentedControl>
 				<SelectDropdown selectedText={ selectedItem ? selectedItem.label : this.translate( 'Select an option' ) }>

--- a/client/me/help/help-happiness-engineers/style.scss
+++ b/client/me/help/help-happiness-engineers/style.scss
@@ -1,5 +1,7 @@
 .help-happiness-engineers {
-	margin: 4px 0px 64px 0px;
+	margin: 12px 0px 64px 0px;
+	padding: 0 24px;
+
 	@include breakpoint( ">660px" ) {
 		margin: 24px 0px 64px 0px;
 	}

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -24,7 +24,7 @@ module.exports = React.createClass( {
 		return (
 			<div className="help-results">
 				<SectionHeader label={ this.props.header }/>
-				{ this.props.helpLinks.map( helpLink => <HelpResult key={ helpLink.link } helpLink={ helpLink } iconPathDescription={ this.props.iconPathDescription } /> ) }
+				{ this.props.helpLinks.map( helpLink => <HelpResult key={ helpLink.link } helpLink={ helpLink } iconTypeDescription={ this.props.iconTypeDescription } /> ) }
 				<a href={ this.props.searchLink } target="__blank">
 					<CompactCard className="help-results__footer">
 						<span className="help-results__footer-text">

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -8,6 +8,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
+import Gridicon from 'components/gridicon';
 
 module.exports = React.createClass( {
 	displayName: 'HelpResult',
@@ -20,21 +21,29 @@ module.exports = React.createClass( {
 		}
 	},
 
+	getResultIcon: function() {
+		const { iconTypeDescription = 'book' } = this.props;
+		const iconClass = 'help-result__icon';
+		const iconSize = 24;
+		// By rule, gridicons don't contain logos so we need a special case here
+		if ( iconTypeDescription === 'jetpack' ) {
+			return (
+				<svg className={ iconClass } height={ iconSize } width={ iconSize } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+					<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-.39 12.335l-3.14-.8c-.798-.202-1.18-1.11-.77-1.822l3.91-6.773v9.395zm4.84-2.048l-3.91 6.773V9.665l3.14.8c.798.202 1.18 1.11.77 1.822z"/>
+				</svg>
+			);
+		} else {
+			return(
+				<Gridicon className={ iconClass } icon={ iconTypeDescription } size={ iconSize } />
+			);
+		}
+	},
+
 	render: function() {
 		return (
 			<a className="help-result" href={ this.props.helpLink.link } target="__blank" onClick={ this.onClick }>
 				<CompactCard className="help-result__wrapper">
-					<svg className="help-result__icon" width="24" height="24" viewBox="0 0 24 24">
-						<defs>
-							<path id="a" d="M0 0h656v92H0z" />
-						</defs>
-						<g fill="none" fill-rule="evenodd">
-							<g transform="translate(-16 -15)">
-								<use stroke="#E9EFF3" />
-								<path className="help-result__icon-path" d={ this.props.iconPathDescription } transform="translate(16 15)" mask="url(#b)" fill="#87A6BC" />
-							</g>
-						</g>
-					</svg>
+					{ this.getResultIcon() }
 					<h2 className="help-result__title">{ this.props.helpLink.title }</h2>
 					<p className="help-result__description">{ this.props.helpLink.description }</p>
 				</CompactCard>

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -22,7 +22,7 @@
 .help-result__icon {
 	position: absolute;
 	margin: -2px 16px 0px -8px;
-	fill: $blue-wordpress;
+	fill: $gray;
 }
 
 .help-result__title {

--- a/client/me/help/help-results/style.scss
+++ b/client/me/help/help-results/style.scss
@@ -13,33 +13,22 @@
 
 .help-result {
 	&:hover {
-		background-color: $blue-medium;
-		.help-result__title,
-		.help-result__description {
-			color: $white;
+		.help-result__title {
+			color: $blue-medium;
 		}
-		.help-result__icon-path {
-			fill: $white;
-		}
-	}
-}
-
-.help-result__wrapper {
-	&:hover {
-		background-color: $blue-medium;
 	}
 }
 
 .help-result__icon {
 	position: absolute;
 	margin: -2px 16px 0px -8px;
+	fill: $blue-wordpress;
 }
 
 .help-result__title {
 	margin: -2px 0px 0px 32px;
 	color: $blue-wordpress;
 	font: 16px/20px $sans;
-	font-weight: 600;
 }
 
 .help-result__description {

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -63,7 +63,7 @@ module.exports = React.createClass( {
 							disabled: true
 						} ] }
 						footer="Dummy documentation footer"
-						iconPathDescription=""
+						iconTypeDescription=""
 						searchLink="#" />
 				</div>
 			);
@@ -83,19 +83,19 @@ module.exports = React.createClass( {
 					header={ this.translate( 'WordPress.com Documentation' ) }
 					helpLinks={ this.state.helpLinks.wordpress_support_links }
 					footer={ this.translate( 'See more from WordPress.com Documentation…' ) }
-					iconPathDescription="M18.75 16.5h.75V3h-12c-1.656 0-3 1.344-3 3v12c0 1.656 1.344 3 3 3h12v-1.5h-.75c-.83 0-1.5-.67-1.5-1.5s.67-1.5 1.5-1.5zm-11.25 3c-.828 0-1.5-.67-1.5-1.5s.672-1.5 1.5-1.5h9.585c-.36.4-.585.92-.585 1.5s.225 1.1.585 1.5H7.5z"
+					iconTypeDescription="book"
 					searchLink={ 'https://en.support.wordpress.com?s=' + this.state.searchQuery } />
 				<HelpResults
 					header={ this.translate( 'Community Answers' ) }
 					helpLinks={ this.state.helpLinks.wordpress_forum_links }
 					footer={ this.translate( 'See more from Community Forum…' ) }
-					iconPathDescription="M16.5 3h-12c-1.656 0-3 1.344-3 3v4.5c0 1.656 1.344 3 3 3H6v5.25l5.25-5.25h5.25c1.656 0 3-1.344 3-3V6c0-1.656-1.344-3-3-3zM21 6v4.5c0 2.48-2.02 4.5-4.5 4.5h-4.63l-1.5 1.5h3.88l5.25 5.25V16.5H21c1.656 0 3-1.344 3-3V9c0-1.656-1.344-3-3-3z"
+					iconTypeDescription="comment"
 					searchLink={ 'https://en.forums.wordpress.com/search.php?search=' + this.state.searchQuery } />
 				<HelpResults
 					header={ this.translate( 'Jetpack Documentation' ) }
 					helpLinks={ this.state.helpLinks.jetpack_support_links }
 					footer={ this.translate( 'See more from Jetpack Documentation…' ) }
-					iconPathDescription="M12 1.5C6.15 1.5 1.5 6.15 1.5 12S6.15 22.5 12 22.5 22.5 17.85 22.5 12 17.85 1.5 12 1.5zM10.5 15l-3.45-.9c-.9-.15-1.35-1.2-.9-2.1l4.35-7.5V15zm7.35-3l-4.35 7.5V9l3.45.9c.9.15 1.35 1.2.9 2.1z"
+					iconTypeDescription="jetpack"
 					searchLink="https://jetpack.me/support/" />
 			</div>
 		);
@@ -107,7 +107,7 @@ module.exports = React.createClass( {
 				<SearchCard
 					onSearch={ this.onSearch }
 					initialValue={ this.props.search }
-					placeholder={ this.translate( 'Ask anything' ) }
+					placeholder={ this.translate( 'How can we help?' ) }
 					analyticsGroup="Help"
 					delaySearch={ true } />
 				{ this.displaySearchResults() }

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -65,23 +65,23 @@ module.exports = React.createClass( {
 		return (
 			<div className="help__support-links">
 				<CompactCard className="help__support-link" href="https://support.wordpress.com/" target="__blank">
-					<div>
+					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">{ this.translate( 'All support articles' ) }</h2>
 						<p className="help__support-link-content">{ this.translate( 'Looking to learn more about a feature? Our docs have all the details.' ) }</p>
 					</div>
 				</CompactCard>
 				<CompactCard className="help__support-link" href="https://dailypost.wordpress.com/" target="__blank">
-					<div>
+					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">{ this.translate( 'The Daily Post' ) }</h2>
 						<p className="help__support-link-content">{ this.translate( 'Get daily tips for your blog and connect with others to share your journey.' ) }</p>
 					</div>
 				</CompactCard>
 				<CompactCard className="help__support-link help__support-link-contact" href="/help/contact/">
-					<div>
+					<div className="help__support-link-section">
 						<h2 className="help__support-link-title">{ this.translate( 'Get in touch' ) }</h2>
 						<p className="help__support-link-content">{ this.translate( 'Can\'t find the answer? Drop us a line and we\'ll lend a hand.' ) }</p>
 					</div>
-					<Button primary>{ this.translate( 'Contact Us' ) }</Button>
+					<Button className="help__support-link-button" primary>{ this.translate( 'Contact Us' ) }</Button>
 				</CompactCard>
 		</div>
 		);

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -13,35 +13,77 @@ var Main = require( 'components/main' ),
 	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	HelpSearch = require( './help-search' ),
 	ExternalLink = require( 'components/external-link' ),
-	Card = require( 'components/card' );
+	Card = require( 'components/card' ),
+	CompactCard = require( 'components/card/compact' ),
+	Button = require( 'components/button' ),
+	SectionHeader = require( 'components/section-header' ),
+	Gridicon = require( 'components/gridicon' ),
+	HelpResult = require( './help-results/item' );
 
 module.exports = React.createClass( {
 	displayName: 'Help',
 
 	mixins: [ PureRenderMixin ],
 
+	getHelpfulArticles: function() {
+		const resultItemWP = {
+			link: 'https://en.support.wordpress.com/com-vs-org/',
+			title: this.translate( 'WordPress.com and WordPress.org' ),
+			description: this.translate( 'Learn about the differences between a fully hosted WordPress.com site and a self-hosted WordPress.org site.' )
+		};
+
+		const resultItemDomains = {
+			link: 'https://en.support.wordpress.com/all-about-domains/',
+			title: this.translate( 'All About Domains' ),
+			description: this.translate( 'Set up your domain whether it’s registered with WordPress.com or elsewhere.' )
+		};
+
+		const resultItemStart = {
+			link: 'https://en.support.wordpress.com/start/',
+			title: this.translate( 'Get Started' ),
+			description: this.translate( 'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.' )
+		};
+
+		const resultItemPrivate = {
+			link: 'https://en.support.wordpress.com/settings/privacy-settings/',
+			title: this.translate( 'Privacy Settings' ),
+			description: this.translate( 'Limit your site’s visibility or make it completely private.' )
+		};
+
+		return (
+			<div className="help-results">
+				<SectionHeader label={ this.translate( 'Most Helpful Articles' ) }/>
+				<HelpResult key={ resultItemWP.link } helpLink={ resultItemWP } iconTypeDescription="book" />
+				<HelpResult key={ resultItemDomains.link } helpLink={ resultItemDomains } iconTypeDescription="book" />
+				<HelpResult key={ resultItemStart.link } helpLink={ resultItemStart } iconTypeDescription="book" />
+				<HelpResult key={ resultItemPrivate.link } helpLink={ resultItemPrivate } iconTypeDescription="book" />
+			</div>
+		);
+	},
+	
 	getSupportLinks: function() {
 		return (
-			<Card>
-				<div className="help__support-link">
-					<h2 className="help__support-link-title">
-						<ExternalLink icon={ true } href="https://support.wordpress.com/" target="__blank">{ this.translate( 'Support docs' ) }</ExternalLink>
-					</h2>
-					<p className="help__support-link-content">{ this.translate( 'Looking to learn more about a feature? Our docs have all the details.' ) }</p>
-				</div>
-				<div className="help__support-link">
-					<h2 className="help__support-link-title">
-						<ExternalLink icon={ true } href="https://dailypost.wordpress.com/" target="__blank">{ this.translate( 'The Daily Post' ) }</ExternalLink>
-					</h2>
-					<p className="help__support-link-content">{ this.translate( 'Get daily tips for your blog and connect with others to share your journey.' ) }</p>
-				</div>
-				<div className="help__support-link">
-					<h2 className="help__support-link-title">
-						<a href="/help/contact/">{ this.translate( 'Contact us' ) }</a>
-					</h2>
-					<p className="help__support-link-content">{ this.translate( 'Can\'t find the answer? Drop us a line and we\'ll lend a hand.' ) }</p>
-				</div>
-			</Card>
+			<div className="help__support-links">
+				<CompactCard className="help__support-link" href="https://support.wordpress.com/" target="__blank">
+					<div>
+						<h2 className="help__support-link-title">{ this.translate( 'All support articles' ) }</h2>
+						<p className="help__support-link-content">{ this.translate( 'Looking to learn more about a feature? Our docs have all the details.' ) }</p>
+					</div>
+				</CompactCard>
+				<CompactCard className="help__support-link" href="https://dailypost.wordpress.com/" target="__blank">
+					<div>
+						<h2 className="help__support-link-title">{ this.translate( 'The Daily Post' ) }</h2>
+						<p className="help__support-link-content">{ this.translate( 'Get daily tips for your blog and connect with others to share your journey.' ) }</p>
+					</div>
+				</CompactCard>
+				<CompactCard className="help__support-link help__support-link-contact" href="/help/contact/">
+					<div>
+						<h2 className="help__support-link-title">{ this.translate( 'Get in touch' ) }</h2>
+						<p className="help__support-link-content">{ this.translate( 'Can\'t find the answer? Drop us a line and we\'ll lend a hand.' ) }</p>
+					</div>
+					<Button primary>{ this.translate( 'Contact Us' ) }</Button>
+				</CompactCard>
+		</div>
 		);
 	},
 
@@ -49,8 +91,8 @@ module.exports = React.createClass( {
 		return (
 			<Main className="help">
 				<MeSidebarNavigation />
-				<FormSectionHeading className="help__header">{ this.translate( 'How can we help?' ) }</FormSectionHeading>
 				<HelpSearch />
+				{ this.getHelpfulArticles() }
 				{ this.getSupportLinks() }
 				<HappinessEngineers />
 			</Main>

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -1,29 +1,48 @@
-.help__header {
-	margin-top: 15px;
-	@include breakpoint( "<660px" ) {
-		font: 300 16px/21px $sans;
+.help__support-link {
+	display: flex;
+}
+
+.help__support-link div {
+	padding-right: 32px;
+}
+
+.help__support-link h2 {
+	&:hover {
+		color: $blue-medium;
 	}
 }
 
-.help__support-link {
-	margin-bottom: 10px;
-	@include breakpoint( ">660px" ) {
-		float: left;
-		width: 33%;
-	}
+.help__support-link-contact.is-card-link {
+	padding-right: 24px;
+}
+
+.help__support-link-contact div {
+	flex-grow: 1;
+}
+	
+.help__support-link-contact .gridicon {
+	display: none;
+}
+
+.help__support-link-contact button {
+	flex: 0 0 106px; // make sure that that the width doesn't shrink
+	align-self: center;
+}
+
+.help__support-link.is-compact.is-card-link {
+	padding-right: 16px;
 }
 
 .help__support-link-title {
-	padding: 0px 10px 10px 0px;
-	font: 16px/21px $sans;
+	font-size: 16px;
 	color: $blue-wordpress;
 	@include breakpoint( ">660px" ) {
-		font: 21px/24px $sans;
+		font-size: 21px;
 	}
 }
 
 .help__support-link-content {
-	padding-right: 10px;
-	font: 14px/21px $sans;
-	color: $gray;
+	margin-bottom: 0;
+	font-size: 14px;
+	color: $gray-dark;
 }

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -2,11 +2,11 @@
 	display: flex;
 }
 
-.help__support-link div {
+.help__support-link .help__support-link-section {
 	padding-right: 32px;
 }
 
-.help__support-link h2 {
+.help__support-link .help__support-link-title {
 	&:hover {
 		color: $blue-medium;
 	}
@@ -16,7 +16,7 @@
 	padding-right: 24px;
 }
 
-.help__support-link-contact div {
+.help__support-link-contact .help__support-link-section {
 	flex-grow: 1;
 }
 	
@@ -24,8 +24,8 @@
 	display: none;
 }
 
-.help__support-link-contact button {
-	flex: 0 0 106px; // make sure that that the width doesn't shrink
+.help__support-link-button {
+	flex: 0 0 106px; // make sure that the width doesn't shrink
 	align-self: center;
 }
 


### PR DESCRIPTION
Fixes #3909 

This PR cleans up `/help` to be more helpful for users seeking support. It also tweaks a few design details. I converted some design element to existing components.

- [x] remove page header
- [x] display a "Most Helpful Articles" section
- [x] replace all icons with Gridicons
- [x] convert help links to separate compact cards
- [x] convert segmented controls to `primary`

## "Most Helpful Articles"

This is the biggest change. I found that this page had an opportunity to cut down on support requests by displaying links to the most asked about topics. The 4 docs were chosen based on the most visited docs this year. The article links/descriptions are hardcoded, but they shouldn't change that much— they are relevant topics that are consistently asked about the most or the most visited.

## Before

![screen shot 2016-03-17 at 10 10 57 am](https://cloud.githubusercontent.com/assets/618551/13850628/c828a22a-ec28-11e5-9596-0c7922355d49.png)

![screen shot 2016-03-17 at 10 11 21 am](https://cloud.githubusercontent.com/assets/618551/13850634/caa9f990-ec28-11e5-93e4-5a99201eb706.png)

## After

![screen shot 2016-03-17 at 10 48 58 am](https://cloud.githubusercontent.com/assets/618551/13851895/e8bde50e-ec2d-11e5-8f9e-abdbc9f15861.png)

![screen shot 2016-03-17 at 10 11 51 am](https://cloud.githubusercontent.com/assets/618551/13850660/e70fe95a-ec28-11e5-8850-c81d54a813a8.png)