### PR TITLE
Reader: minor fixes to Recommendations and sidebar

### DIFF
--- a/client/reader/list-item/style.scss
+++ b/client/reader/list-item/style.scss
@@ -3,7 +3,7 @@
 	margin-top: 0;
 	margin-bottom: 0;
 	margin-left: 54px;
-	margin-right: 100px;
+	margin-right: 80px;
 	overflow: hidden;
 	white-space: nowrap;
 	position: relative;

--- a/client/reader/recommendations/style.scss
+++ b/client/reader/recommendations/style.scss
@@ -1,6 +1,31 @@
 .reader-recommended__heading {
-	text-transform: uppercase;
-	font-size: 12px;
 	color: $gray;
-	margin: 0 0 12px;
+	font-size: 12px;
+	text-transform: uppercase;
+	margin: 13px 0 12px 18px;
+
+	@include breakpoint( ">480px" ) {
+		margin: 0 0 12px;
+	}
+}
+
+.reader-list-item__title,
+.reader-list-item__description {
+
+	@include breakpoint( "<480px" ) {
+		margin-left: 60px;
+	}
+}
+
+// Search Results Placeholder
+
+.recommended-for-you {
+
+	.is-placeholder {
+
+		.reader-list-item__title,
+		.reader-list-item__description {
+			margin-top: 1px;
+		}
+	}
 }

--- a/client/reader/recommendations/style.scss
+++ b/client/reader/recommendations/style.scss
@@ -2,7 +2,7 @@
 	color: $gray;
 	font-size: 12px;
 	text-transform: uppercase;
-	margin: 13px 0 12px 18px;
+	margin: 13px 0 12px 17px;
 
 	@include breakpoint( ">480px" ) {
 		margin: 0 0 12px;

--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -10,7 +10,11 @@
 			.menu-link-icon,
 			.sidebar__menu-action .gridicon,
 			.sidebar-dynamic-menu-action-icon {
-				fill: $white;
+				fill: $gray;
+
+				@include breakpoint( ">480px" ) {
+					fill: $white;
+				}
 			}
 
 			.sidebar-streams__edit-icon {
@@ -33,6 +37,10 @@
 				background-color: darken( $gray, 10% );
 				color: $white;
 			}
+		}
+
+		.sidebar-streams__team {
+			margin-top: -1px; // Removes extra top border in team subs for <480px
 		}
 	}
 


### PR DESCRIPTION
**Before:**
![screenshot-2016-03-11-13 12 52](https://cloud.githubusercontent.com/assets/4924246/13717233/299aa582-e795-11e5-8e32-7e5926956b56.jpg)

**After:**
![screenshot 2016-03-11 14 27 08](https://cloud.githubusercontent.com/assets/4924246/13717284/62fc849e-e795-11e5-81ce-d89005179cf8.png)

**Before:** Skeleton preloader a pixel higher than blavatar
![screenshot-2016-03-11-13 41 27](https://cloud.githubusercontent.com/assets/4924246/13717192/d0cc8ee8-e794-11e5-9f58-d6ce0ba7eadc.jpg)

**After:**
![screenshot-2016-03-11-14 12 27](https://cloud.githubusercontent.com/assets/4924246/13717193/d258b11a-e794-11e5-8b29-b2a76a312452.jpg)

**Before:** Automattic logo is white (when active) on sidebar in `<480px`
![screenshot 2016-03-11 14 28 45](https://cloud.githubusercontent.com/assets/4924246/13717323/9e39b176-e795-11e5-8aa1-bee1ad7a5a6c.png)

**After:**
![screenshot 2016-03-11 14 28 56](https://cloud.githubusercontent.com/assets/4924246/13717327/a1b5ade6-e795-11e5-8c04-a3b7295cae10.png)


