### PR TITLE
Framework: Ignore bind and/or arrows functions for refs in JSX

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,7 @@ module.exports = {
 		'react/no-did-mount-set-state': 1,
 		'react/no-did-update-set-state': 1,
 		'jsx-quotes': [ 1, 'prefer-double' ],
-		'react/jsx-no-bind': 1,
+		'react/jsx-no-bind': [ 1, { 'ignoreRefs': true } ],
 		'react/jsx-curly-spacing': [ 1, 'always' ],
 		// Allows function use before declaration
 		'no-use-before-define': [ 2, 'nofunc' ],


### PR DESCRIPTION
Since string refs are [considered legacy](https://facebook.github.io/react/docs/more-about-refs.html#the-ref-string-attribute) and passing callbacks for saving the ref is the preferred method now, we should add [this exception to the `jsx-no-bind` rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md#ignorerefs).

Example of a use case: https://github.com/Automattic/wp-calypso/commit/a051f1129867a7a83f652c458adfdd9c51b5b5f6#diff-4765afd67f511e59da9c639ead0d3fbaR45