### PR TITLE
Devdocs: Fixes a JS error caused by no displayName

### DIFF
--- a/client/components/global-notices/docs/example.jsx
+++ b/client/components/global-notices/docs/example.jsx
@@ -37,5 +37,6 @@ const GlobalNotices = () => (
 		</ButtonGroup>
 	</div>
 );
+GlobalNotices.displayName = 'GlobalNotices';
 
 module.exports = GlobalNotices;


### PR DESCRIPTION
It seems as if #3961 causes JS errors when not on the main `/devdocs/design` route.

`Uncaught TypeError: Cannot read property 'toLowerCase' of undefined`
`Uncaught TypeError: Cannot read property 'componentWillUnmount' of null`

The error occurs, because the [SearchCollection](https://github.com/Automattic/wp-calypso/blob/master/client/devdocs/design/search-collection.jsx#L56) component expects each component to have a display name.

To test error:
- Go to https://wpcalypso.wordpress.com/devdocs/design
- Click any component's name
- Notice that you can not navigate
- Check console

This PR fixes the issue by giving a `displayName` to the `GlobalNotices` example.

To test fix:
- Checkout `update/devdocs-design-stateless-js-error` branch
- Follow steps above
- Can you navigate successfully?

cc @scruffian 