### PR TITLE
Offline: Update/sync moar invalidation

### DIFF
--- a/client/lib/posts/post-list-cache-store.js
+++ b/client/lib/posts/post-list-cache-store.js
@@ -1,77 +1,72 @@
 /**
  * External dependencies
  */
-var intersection = require( 'lodash/intersection' );
+import intersection from 'lodash/intersection';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-var sites = require( 'lib/sites-list' )(),
-	Dispatcher = require( 'dispatcher' );
+import sitesFactory from 'lib/sites-list';
+import Dispatcher from 'dispatcher';
 
-var _cache = {},
-	TTL_IN_MS = 5 * 60 * 1000; // five minutes
+let cache = {};
+const _canonicalCache = {};
+const TTL_IN_MS = 5 * 60 * 1000; // five minutes
+const sites = sitesFactory();
+const PostsListCache = {
+	get,
+	_reset: function() {
+		cache = {};
+	}
+};
+const debug = debugFactory( 'calypso:posts-list:cache' );
 
 function isStale( list ) {
-	var now = new Date().getTime(),
-		timeSaved = list.timeSaved;
+	const now = new Date().getTime();
+	const { timeSaved } = list;
 	return ( now - timeSaved ) > TTL_IN_MS;
 }
 
-function getCacheKey( options ) {
-	var cacheKey = '',
-		keys = Object.keys( options ).sort();
-
-	keys.forEach( function( key ) {
-		if ( cacheKey.length ) {
-			cacheKey += ':';
-		}
-
-		cacheKey += key + '-' + options[ key ];
-	} );
-
-	return cacheKey;
-}
-
-function get( query ) {
-	var key = getCacheKey( query );
-
-	if ( _cache[ key ] && ! isStale( _cache[ key ] ) && ! _cache[ key ].dirty ) {
-		return _cache[ key ].list;
+function get( listKey ) {
+	if ( isListKeyFresh( listKey ) ) {
+		return cache[ listKey ].list;
 	}
 
-	// We assume that when a consumer attempts to access a dirty key that we can safely delete it
-	// because the consumer will get new data to freshen the cache
-	if ( _cache[ key ] && _cache[ key ].dirty ) {
-		delete _cache[ key ];
+	// Delete the dirty cache to force a request for new data
+	if ( cache[ listKey ] && cache[ listKey ].dirty ) {
+		debug( 'delete cached list %o', listKey );
+		delete cache[ listKey ];
+		delete _canonicalCache[ listKey ];
 	}
 }
 
 function set( list ) {
-	var key = getCacheKey( list.query );
+	const listKey = getCacheKey( list.query );
 
 	// To make sure that a list marked dirty is reset the next time
 	// it is retrieved we skip updating entries that are dirty
-	if ( ! _cache[ key ] || ! _cache[ key ].dirty ) {
-		_cache[ key ] = {
+	if ( ! cache[ listKey ] || ! cache[ listKey ].dirty ) {
+		cache[ listKey ] = {
 			timeStored: new Date().getTime(),
-			list: list,
-			dirty: false
+			dirty: false,
+			list,
+			listKey,
 		};
 	}
 }
 
 function markDirty( post, oldStatus ) {
-	var site = sites.getSite( post.site_ID ),
-		affectedSites = [ site.slug, site.ID, false ],
-		affectedStatuses = [ post.status, oldStatus ],
-		listStatuses, key, entry, list;
+	const site = sites.getSite( post.site_ID );
+	const affectedSites = [ site.slug, site.ID, false ];
+	const affectedStatuses = [ post.status, oldStatus ];
+	let listStatuses, key, entry, list;
 
-	for ( key in _cache ) {
-		if ( !_cache.hasOwnProperty( key ) ) {
+	for ( key in cache ) {
+		if ( ! cache.hasOwnProperty( key ) ) {
 			continue;
 		}
-		entry = _cache[ key ];
+		entry = cache[ key ];
 
 		list = entry.list;
 
@@ -93,12 +88,9 @@ function markDirty( post, oldStatus ) {
 	}
 }
 
-let PostsListCache = {
-	get: get,
-	_reset: function() {
-		_cache = {};
-	}
-};
+function isListKeyFresh( listKey ) {
+	return ( cache[ listKey ] && ! isStale( cache[ listKey ] ) && ! cache[ listKey ].dirty );
+}
 
 PostsListCache.dispatchToken = Dispatcher.register( function( payload ) {
 	var action = payload.action,
@@ -128,4 +120,43 @@ PostsListCache.dispatchToken = Dispatcher.register( function( payload ) {
 	}
 } );
 
-module.exports = PostsListCache;
+export function getCacheKey( options ) {
+	const cacheKey = [];
+	const keys = Object.keys( options ).sort();
+	keys.forEach( function( key ) {
+		cacheKey.push( `${ key }-${ options[ key ] }` );
+	} );
+	return cacheKey.join( ':' );
+}
+
+export function setCanonicalList( listKey, requestKey, list ) {
+	debug( 'setCanonicalList %o %o (%o)', listKey, requestKey, list );
+	_canonicalCache[ listKey ] = _canonicalCache[ listKey ] || {};
+	_canonicalCache[ listKey ][ requestKey ] = list;
+}
+
+export function getCanonicalList( listKey, requestKey ) {
+	debug( 'getCanonicalList %o %o', listKey, requestKey );
+	const stream = _canonicalCache[ listKey ];
+	if ( ! stream || typeof stream !== 'object' ) {
+		return false;
+	}
+	const keys = Object.keys( stream );
+	if ( keys[0] !== requestKey ) {
+		// requests processing out of order, clear cache
+		delete cache[ listKey ];
+		delete _canonicalCache[ listKey ];
+		return false;
+	}
+	return stream[ requestKey ];
+}
+
+export function deleteCanonicalList( listKey, requestKey ) {
+	debug( 'deleteCanonicalList %o %o', listKey, requestKey );
+	const stream = _canonicalCache[ listKey ];
+	if ( stream && stream[ requestKey ] ) {
+		delete stream[ requestKey ];
+	}
+}
+
+export default PostsListCache;

--- a/client/lib/posts/posts-store.js
+++ b/client/lib/posts/posts-store.js
@@ -23,20 +23,28 @@ function setPost( post ) {
 	_posts[ post.global_ID ] = post;
 }
 
-function normalizePost( attributes ) {
-	if ( ! attributes.global_ID ) {
-		debug( 'global_ID is required for a post' );
+function normalizePost( responseSource, attributes ) {
+	const { global_ID } = attributes || {};
+	if ( ! global_ID ) {
+		debug( 'global_ID is required for a post', attributes );
 		return;
 	}
 
-	// these methods are synchronous
+	// do not overwrite existing records with localResponse data
+	const cachedPost = PostsStore.get( global_ID );
+	if ( cachedPost && responseSource === 'local' ) {
+		debug( 'existing record (%o), do not overwrite with local response', cachedPost );
+		return;
+	}
+
 	utils.normalizeSync( attributes, function( error, post ) {
 		setPost( post );
 	} );
 }
 
-function setAll( posts ) {
-	posts.forEach( normalizePost );
+function setAll( posts, responseSource ) {
+	const boundNormalizePost = normalizePost.bind( null, responseSource );
+	posts.forEach( boundNormalizePost );
 }
 
 PostsStore = {
@@ -52,13 +60,14 @@ PostsStore.dispatchToken = Dispatcher.register( function( payload ) {
 		case 'RECEIVE_POSTS_PAGE':
 		case 'RECEIVE_UPDATED_POSTS':
 			if ( ! action.error && action.data.posts ) {
-				setAll( action.data.posts );
+				const responseSource = action.data.__sync && action.data.__sync.responseSource;
+				setAll( action.data.posts, responseSource );
 			}
 			break;
 
 		case 'RECEIVE_UPDATED_POST':
 			if ( ! action.error ) {
-				normalizePost( action.post );
+				normalizePost( 'server', action.post );
 			}
 			break;
 	}

--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -41,14 +41,14 @@ describe( 'actions', function() {
 		it( 'should dispatch a post edit with a new metadata value', function() {
 			PostActions.updateMetadata( 'foo', 'bar' );
 
-			expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
+			expect( Dispatcher.handleViewAction.calledWithMatch( {
 				type: 'EDIT_POST',
 				post: {
 					metadata: [
 						{ key: 'foo', value: 'bar', operation: 'update' }
 					]
 				}
-			} );
+			} ) ).to.be.true;
 		} );
 
 		it( 'accepts an object of key value pairs', function() {
@@ -57,7 +57,7 @@ describe( 'actions', function() {
 				baz: 'qux'
 			} );
 
-			expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
+			expect( Dispatcher.handleViewAction.calledWithMatch( {
 				type: 'EDIT_POST',
 				post: {
 					metadata: [
@@ -65,7 +65,7 @@ describe( 'actions', function() {
 						{ key: 'baz', value: 'qux', operation: 'update' }
 					]
 				}
-			} );
+			} ) ).to.be.true;
 		} );
 
 		it( 'should include metadata already existing on the post object', function() {
@@ -78,7 +78,7 @@ describe( 'actions', function() {
 
 			PostActions.updateMetadata( 'foo', 'bar' );
 
-			expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
+			expect( Dispatcher.handleViewAction.calledWithMatch( {
 				type: 'EDIT_POST',
 				post: {
 					metadata: [
@@ -86,7 +86,7 @@ describe( 'actions', function() {
 						{ key: 'foo', value: 'bar', operation: 'update' }
 					]
 				}
-			} );
+			} ) ).to.be.true;
 		} );
 
 		it( 'should include metadata edits made previously', function() {
@@ -99,7 +99,7 @@ describe( 'actions', function() {
 
 			PostActions.updateMetadata( 'foo', 'bar' );
 
-			expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
+			expect( Dispatcher.handleViewAction.calledWithMatch( {
 				type: 'EDIT_POST',
 				post: {
 					metadata: [
@@ -107,7 +107,7 @@ describe( 'actions', function() {
 						{ key: 'foo', value: 'bar', operation: 'update' }
 					]
 				}
-			} );
+			} ) ).to.be.true;
 		} );
 
 		it( 'should not duplicate existing metadata edits', function() {
@@ -121,7 +121,7 @@ describe( 'actions', function() {
 
 			PostActions.updateMetadata( 'foo', 'bar' );
 
-			expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
+			expect( Dispatcher.handleViewAction.calledWithMatch( {
 				type: 'EDIT_POST',
 				post: {
 					metadata: [
@@ -129,7 +129,7 @@ describe( 'actions', function() {
 						{ key: 'foo', value: 'bar', operation: 'update' }
 					]
 				}
-			} );
+			} ) ).to.be.true;
 		} );
 	} );
 
@@ -143,7 +143,7 @@ describe( 'actions', function() {
 			} );
 			PostActions.deleteMetadata( 'foo' );
 
-			expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
+			expect( Dispatcher.handleViewAction.calledWithMatch( {
 				type: 'EDIT_POST',
 				post: {
 					metadata: [
@@ -151,13 +151,13 @@ describe( 'actions', function() {
 						{ key: 'foo', operation: 'delete' }
 					]
 				}
-			} );
+			} ) ).to.be.true;
 		} );
 
 		it( 'should accept an array of metadata keys to delete', function() {
 			PostActions.deleteMetadata( [ 'foo', 'bar' ] );
 
-			expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
+			expect( Dispatcher.handleViewAction.calledWithMatch( {
 				type: 'EDIT_POST',
 				post: {
 					metadata: [
@@ -165,7 +165,7 @@ describe( 'actions', function() {
 						{ key: 'bar', operation: 'delete' }
 					]
 				}
-			} );
+			} ) ).to.be.true;
 		} );
 	} );
 
@@ -231,7 +231,7 @@ describe( 'actions', function() {
 
 			PostActions.saveEdited( null, () => {
 				PostActions.__set__( 'normalizeApiAttributes', normalizeOriginal );
-				expect( normalizeSpy ).to.have.been.calledWith( changedAttributes );
+				expect( normalizeSpy.calledWith( changedAttributes ) ).to.be.true;
 				expect( normalizeSpy.returnValues[0] ).to.deep.equal( {
 					ID: 777,
 					site_ID: 123,

--- a/client/lib/wp/sync-handler/whitelist-handler.js
+++ b/client/lib/wp/sync-handler/whitelist-handler.js
@@ -15,7 +15,7 @@ export const isWhitelisted = params => {
 	const { path } = params;
 
 	if ( params.method && 'get' !== params.method.toLowerCase() ) {
-		debug( 'No allow %o request', params.method );
+		debug( 'Do not allow %o request', params.method, params );
 		return false;
 	};
 


### PR DESCRIPTION
This PR addresses the issue raised here (https://github.com/Automattic/wp-calypso/pull/3696#issuecomment-195050155) and is necessary before merging #3696.

The crux of this PR is to change how we process local and server responses so that new post-lists from a local response are treated as temporary and are re-evaluated when we get the server response for that request.

This has the corner case potential to get out of whack if/when the server responses come in out of order. If that happens, we just wipe the cached list clean so the app has the ability to rebuild the list from scratch.

I am also renaming some variables to be a little more explicit, like `listKey` instead of `key` and `requestKey`, and `newPosts` and `removedPosts`, etc.

/cc @retrofox @gwwar 
