### PR TITLE
Sidebar: minor hover improvements for mobile

### DIFF
--- a/client/components/mobile-back-to-sidebar/style.scss
+++ b/client/components/mobile-back-to-sidebar/style.scss
@@ -5,6 +5,7 @@
 	position: relative;
 	background: $white;
 	border-bottom: 1px solid lighten( $gray, 20% );
+	cursor: pointer;
 
 	@include breakpoint( ">660px" ) {
 		display: none;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -275,6 +275,30 @@
 			fill: $blue-medium;
 		}
 	}
+
+	@include breakpoint( "<660px" ) {
+		background-color: $gray-light;
+
+		a {
+			color: $blue-medium;
+
+			&:first-child:after {
+				background: linear-gradient(
+					to right,
+					rgba( $gray-light, 0 ),
+					rgba( $gray-light, 1 ) 50% );
+			}
+
+			&.add-new {
+				background-color: $white;
+				color: $gray-dark;
+			}
+		}
+
+		.gridicon {
+			fill: $blue-medium;
+		}
+	}
 }
 
 .notouch .sidebar__menu li:not(.selected) a {


### PR DESCRIPTION
* Use `cursor: pointer` on the MobileBackToSidebar component, to help indicate that it's clickable.
* Enable hover state on all menu items for small viewports, since there's no 'currently selected' page in view.

To test, use a < 660px viewport.

Demo: https://cloudup.com/ibTD_wc0EQO