### PR TITLE
People: Set default role to Follower on add

### DIFF
--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -32,6 +32,12 @@ export default React.createClass( {
 		} );
 	},
 
+	componentWillMount() {
+		if ( this.props.includeFollower ) {
+			this.refreshRoles();
+		}
+	},
+
 	componentDidMount() {
 		RolesStore.on( 'change', this.refreshRoles );
 		this.fetchRoles();


### PR DESCRIPTION
This is meant to address #4011. As mentioned in the initial issue report, the default user role should be set to either Follower (public sites) or Viewer (private sites) when you load the "Add" page initially. 

Currently though, if you're on another page in Calypso (Domains, for example), and then you click the "Add" button, the default user role is set to "Administrator." When you make a change to the form (adding an email), the form role defaults to Follower. The issue is best explained here in GIF form:

![0dc1a438-e938-11e5-83f3-0ac659be8deb](https://cloud.githubusercontent.com/assets/7240478/13734478/07a364c0-e964-11e5-9444-05f07418dab9.gif)

After a bit of digging, I think I was able to track down the issue. When the page originally loads, we're running `getRoles` in `RoleSelect` ([ref](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/people/role-select/index.jsx#L31)). The issue is that this function doesn't return the follower/viewer role at all so when you load the page already inside of Calypso, the follower/viewer role is missing. You can see that in this screenshot via the React dev tools:

<img width="746" alt="screen shot 2016-03-13 at 21 42 44" src="https://cloud.githubusercontent.com/assets/7240478/13734526/8c49548c-e964-11e5-995e-e227c0204278.png">

In `[role-select/index.jsx ](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/people/role-select/index.jsx)`, I added a check in `componentWillMount()` that looks for the `includeFollower` prop. If the prop is present, it runs `refreshRoles`, which correctly finds the "Follower/Viewer" role. Now, the default role we set in `[invite-people/index.jsx](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/people/invite-people/index.jsx#L65)` works correctly. 

To test:
1. Check out and run this branch with `make run`
2. Visit the Sharing page for a site you own (https://wpcalypso.wordpress.com/sharing/{site}).
3. Click the "Add" button next to "People." You'll notice that the user role is now set to either "Follower" or "Viewer" by default. Previously, it would be set to "Administrator" because the "Follower/Viewer" role wasn't actually loaded.

All previous functionality (switching between public and private sites, inviting users, etc) seems to work as expected. 

cc @ebinnion since you recently worked on [this piece](https://github.com/Automattic/wp-calypso/commit/9c4e932932a23000e1d9d5a69e2fd9d727217613)