### PR TITLE
Try: design-mode focus + WebPreview

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -332,7 +332,8 @@ $sidebar-width-min: 228px;
 .sidebar,
 .wp-secondary .site-selector,
 .current-site,
-.sidebar__menu {
+.sidebar__menu,
+.design-menu {
 	transform: translateX( 0 );
 	transition: all 0.15s cubic-bezier(0.075, 0.820, 0.165, 1.000);
 }
@@ -364,8 +365,53 @@ $sidebar-width-min: 228px;
 	}
 }
 
+.focus-design {
+	.wp-primary {
+		opacity: 0.2;
+		pointer-events: none;
+	}
+
+	.wp-secondary .design-menu {
+		opacity: 1;
+		transform: translateX( 272px );
+		pointer-events: auto;
+	}
+
+	.sidebar,
+	.wp-secondary .site-selector {
+		pointer-events: none;
+	}
+}
+
 .focus-sidebar {
 	overflow: hidden;
+}
+
+.design-menu {
+	background: lighten( $gray, 30% );
+	position: fixed;
+		top: 47px;
+		bottom: 0;
+		left: -272px;
+	width: 272px;
+	overflow: hidden;
+	opacity: 0.8;
+	z-index: 10;
+}
+
+.layout__design.web-preview.is-visible,
+.layout__design.web-preview {
+	left: 273px;
+	.web-preview__content {
+		top: 0;
+		transform: scale( 1 );
+	}
+}
+
+.layout__design.web-preview.is-visible {
+	.web-preview__content {
+		transform: scale( 1 );
+	}
 }
 
 // site selector in the sidebar

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -399,6 +399,13 @@ $sidebar-width-min: 228px;
 	z-index: 10;
 }
 
+.design-menu__sidebar-actions {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 8px;
+}
+
 .layout__design.web-preview.is-visible,
 .layout__design.web-preview {
 	left: 273px;

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -390,13 +390,14 @@ $sidebar-width-min: 228px;
 .design-menu {
 	background: lighten( $gray, 30% );
 	position: fixed;
-		top: 47px;
+		top: 0;
 		bottom: 0;
 		left: -272px;
 	width: 272px;
 	overflow: hidden;
 	opacity: 0.8;
-	z-index: 10;
+	z-index: 181;
+	border-right: 1px solid lighten( $gray, 25% );
 }
 
 .design-menu__sidebar-actions {

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -149,7 +149,7 @@ const WebPreview = React.createClass( {
 	},
 
 	render() {
-		const className = classnames( 'web-preview', {
+		const className = classnames( this.props.className, 'web-preview', {
 			'is-touch': this._hasTouch,
 			'is-visible': this.props.showPreview,
 			'is-computer': this.state.device === 'computer',

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -32,6 +32,7 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	SupportUser;
 
 import { isOffline } from 'state/application/selectors';
+import WebPreview from 'components/web-preview';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -135,6 +136,10 @@ Layout = React.createClass( {
 		);
 	},
 
+	onClosePreview() {
+		this.props.focus.set( 'sidebar' );
+	},
+
 	render: function() {
 		var sectionClass = classnames(
 				'wp',
@@ -168,6 +173,14 @@ Layout = React.createClass( {
 				<TranslatorLauncher
 					isEnabled={ translator.isEnabled() }
 					isActive={ translator.isActivated() }/>
+				{ this.props.section === 'sites' &&
+					<WebPreview
+						className="layout__design"
+						showPreview={ this.props.focus.getCurrent() === 'design' }
+						onClose={ this.onClosePreview }
+						previewUrl={ this.props.sites.getSelectedSite().URL }
+					/>
+				}
 			</div>
 		);
 	}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -178,7 +178,7 @@ Layout = React.createClass( {
 						className="layout__design"
 						showPreview={ this.props.focus.getCurrent() === 'design' }
 						onClose={ this.onClosePreview }
-						previewUrl={ this.props.sites.getSelectedSite().URL }
+						previewUrl={ this.props.sites.getSelectedSite().URL + '?demo=true&iframe=true&theme_preview=true' }
 					/>
 				}
 			</div>

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -19,6 +19,7 @@ export default React.createClass( {
 		className: React.PropTypes.string,
 		link: React.PropTypes.string.isRequired,
 		buttonLink: React.PropTypes.string,
+		onButtonClick: React.PropTypes.func,
 		buttonLabel: React.PropTypes.string,
 		onNavigate: React.PropTypes.func,
 		icon: React.PropTypes.string,
@@ -36,7 +37,7 @@ export default React.createClass( {
 		return (
 			<a
 				rel={ isExternal( link ) ? 'external' : null }
-				onClick={ this.props.onNavigate }
+				onClick={ this.props.onButtonClick || this.props.onNavigate }
 				href={ link }
 				target={ isExternal( link ) ? '_blank' : null }
 				className="add-new">

--- a/client/lib/layout-focus/index.js
+++ b/client/lib/layout-focus/index.js
@@ -28,7 +28,7 @@ var layoutFocus = {
 
 	// These are the three structural areas
 	// of the main body of Calypso
-	_areas: [ 'content', 'sidebar', 'sites' ],
+	_areas: [ 'content', 'sidebar', 'sites', 'design' ],
 
 	getCurrent: function() {
 		return this._current || 'content';

--- a/client/my-sites/design-menu/index.jsx
+++ b/client/my-sites/design-menu/index.jsx
@@ -20,12 +20,15 @@ const DesignMenu = React.createClass( {
 	render() {
 		return (
 			<div className="design-menu">
-				<span className="current-site__switch-sites">
+				<div className="design-menu__sidebar-actions">
 					<Button compact borderless onClick={ this.onBack }>
 						<Gridicon icon="arrow-left" size={ 18 } />
 						{ this.translate( 'Back' ) }
 					</Button>
-				</span>
+					<Button compact borderless href="/design">
+						{ this.translate( 'Themes' ) } <Gridicon icon="themes" size={ 18 } />
+					</Button>
+				</div>
 				<Card>
 					Design Tools!
 				</Card>

--- a/client/my-sites/design-menu/index.jsx
+++ b/client/my-sites/design-menu/index.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+
+const DesignMenu = React.createClass( {
+
+	render() {
+		return (
+			<div className="design-menu">
+				<Card>
+					Design Tools!
+				</Card>
+			</div>
+		);
+	}
+} );
+
+export default DesignMenu;

--- a/client/my-sites/design-menu/index.jsx
+++ b/client/my-sites/design-menu/index.jsx
@@ -7,12 +7,25 @@ import React from 'react';
  * Internal dependencies
  */
 import Card from 'components/card';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import layoutFocus from 'lib/layout-focus';
 
 const DesignMenu = React.createClass( {
+
+	onBack() {
+		layoutFocus.set( 'sidebar' );
+	},
 
 	render() {
 		return (
 			<div className="design-menu">
+				<span className="current-site__switch-sites">
+					<Button compact borderless onClick={ this.onBack }>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ this.translate( 'Back' ) }
+					</Button>
+				</span>
 				<Card>
 					Design Tools!
 				</Card>

--- a/client/my-sites/navigation/navigation.jsx
+++ b/client/my-sites/navigation/navigation.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import observe from 'lib/mixins/data-observe';
 import SitePicker from 'my-sites/picker';
 import Sidebar from 'my-sites/sidebar';
+import DesignMenu from 'my-sites/design-menu';
 
 module.exports = React.createClass( {
 	displayName: 'MySitesNavigation',
@@ -41,6 +42,7 @@ module.exports = React.createClass( {
 					siteBasePath={ this.props.siteBasePath }
 					user={ this.props.user }
 				/>
+				<DesignMenu />
 			</div>
 		);
 	}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -37,6 +37,11 @@ module.exports = React.createClass( {
 		window.scrollTo( 0, 0 );
 	},
 
+	onCustomize: function( event ) {
+		event.preventDefault();
+		this.props.layoutFocus.set( 'design' );
+	},
+
 	itemLinkClass: function( paths, existingClasses ) {
 		var classSet = {};
 
@@ -173,6 +178,7 @@ module.exports = React.createClass( {
 				link={ themesLink }
 				buttonLink={ getCustomizeUrl( null, site ) }
 				buttonLabel={ this.translate( 'Customize' ) }
+				onButtonClick={ this.onCustomize }
 				onNavigate={ this.onNavigate }
 				icon={ 'themes' }
 				preloadSectionName="themes" />


### PR DESCRIPTION
This PR creates a new `layoutFocus` area called "design". We can then set focus from anywhere in the app as easily as `layoutFocus.set( 'design' )` and design tools would slide in and the preview appear. 

Currently it's hooked up with the "Customize" button in the sidebar.

cc @sirbrillig @mattwiebe @kwight