### PR TITLE
CPT: Render basic post listing via <PostType /> component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -203,6 +203,7 @@
 @import 'my-sites/plans/jetpack-plan-details/style';
 @import 'my-sites/post/post-image/style';
 @import 'my-sites/post-selector/style';
+@import 'my-sites/post-type-list/style';
 @import 'my-sites/plugins/featured-plugins/style';
 @import 'my-sites/plugins/style';
 @import 'my-sites/plugins/plugin-action/style';

--- a/client/components/card/README.md
+++ b/client/components/card/README.md
@@ -32,3 +32,4 @@ render: function() {
 * `className`: You can add classes to either.
 * `href` (Optional): If set then the card becomes a link, with a Gridicon chevron on the right.
 * `target` (Optional): If set and used with `href` then this controls where the link opens. It also changes the Gridicon to "external"
+* `compact` (Optional): Whether the card should be rendered as compact

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -3,31 +3,34 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	assign = require( 'lodash/assign' ),
-	classnames = require( 'classnames' );
+import React from 'react';
+import assign from 'lodash/assign';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var Gridicon = require( 'components/gridicon' );
+import Gridicon from 'components/gridicon';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'Card',
 
 	propTypes: {
 		className: React.PropTypes.string,
 		href: React.PropTypes.string,
 		tagName: React.PropTypes.string,
-		target: React.PropTypes.string
+		target: React.PropTypes.string,
+		compact: React.PropTypes.bool
 	},
 
 	render: function() {
-		var element = this.props.tagName || 'div',
-			linkClassName = this.props.href ? 'is-card-link' : null,
-			props = assign( {}, this.props, { className: classnames( this.props.className, 'card', linkClassName ) } ),
-			linkIndicator = null;
+		const className = classnames( 'card', this.props.className, {
+			'is-card-link': !! this.props.href,
+			'is-compact': this.props.compact
+		} );
 
+		let element = this.props.tagName || 'div';
+		let linkIndicator;
 		if ( this.props.href ) {
 			element = 'a';
 			linkIndicator = <Gridicon
@@ -37,7 +40,7 @@ module.exports = React.createClass( {
 
 		return React.createElement(
 			element,
-			props,
+			assign( {}, this.props, { className } ),
 			this.props.href ? linkIndicator : null,
 			this.props.children
 		);

--- a/client/my-sites/post-type-list/README.md
+++ b/client/my-sites/post-type-list/README.md
@@ -1,0 +1,30 @@
+Post Type List
+==============
+
+__Note:__ This component is a work-in-progress. As such, the documentation below is incomplete and will change.
+
+`<PostTypeList />` is a React component to be used in rendering an infinitely scrollable list of posts. It is agnostic to any particular post type or query, with flexibility to render any post type, whether it be hierarchical or non-hierarchical, or whether the developer desires to specify custom actions specific to their use-case.
+
+## Usage
+
+Render the component, passing props to describe your query.
+
+```jsx
+import React from 'react';
+import PostTypeList from 'my-sites/post-type-list';
+
+export default function MyComponent() {
+	return <PostTypeList type="jetpack-portfolio" />;
+}
+```
+
+## Props
+
+### `type`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The post type for which posts should be queried.

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import QueryPosts from 'components/data/query-posts';
+import { getSelectedSite } from 'state/ui/selectors';
+import { getSitePostsForQueryIgnoringPage } from 'state/posts/selectors';
+import PostTypePost from './post';
+
+function PostTypeList( { type, siteId, posts } ) {
+	return (
+		<div className="post-type-list">
+			<QueryPosts
+				siteId={ siteId }
+				query={ { type } } />
+			<ul className="post-type-list__posts">
+				{ posts && posts.map( ( post ) => (
+					<li key={ post.global_ID }>
+						<PostTypePost globalId={ post.global_ID } />
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+}
+
+PostTypeList.propTypes = {
+	type: PropTypes.string.isRequired,
+	siteId: PropTypes.number,
+	posts: PropTypes.array
+};
+
+export default connect( ( state, ownProps ) => {
+	const site = getSelectedSite( state );
+	const siteId = site ? site.ID : null;
+	const { type } = ownProps;
+
+	return {
+		siteId,
+		posts: getSitePostsForQueryIgnoringPage( state, siteId, { type } )
+	};
+} )( PostTypeList );

--- a/client/my-sites/post-type-list/post.jsx
+++ b/client/my-sites/post-type-list/post.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getPost } from 'state/posts/selectors';
+import Card from 'components/card';
+
+function PostTypePost( { post } ) {
+	return (
+		<Card compact className="post-type-list__post">
+			{ post.title }
+		</Card>
+	);
+}
+
+PostTypePost.propTypes = {
+	globalId: PropTypes.string.isRequired,
+	post: PropTypes.object
+};
+
+export default connect( ( state, ownProps ) => {
+	return {
+		post: getPost( state, ownProps.globalId )
+	};
+} )( PostTypePost );

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -1,0 +1,4 @@
+.post-type-list__posts {
+	list-style: none;
+	margin-left: 0;
+}

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import ReactDom from 'react-dom';
+import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';
 
 /**
@@ -19,16 +20,25 @@ export function redirect() {
 
 export function list( context ) {
 	const siteId = getSiteFragment( context.path );
+	const sectionedPath = sectionify( context.path );
 
 	// [TODO]: Translate title text when settled upon
 	setTitle( 'Custom Post Type', { siteId: siteId } );
 
-	let baseAnalyticsPath = sectionify( context.path );
+	// Analytics
+	let baseAnalyticsPath = sectionedPath;
 	if ( siteId ) {
 		baseAnalyticsPath += '/:site';
 	}
-
 	pageView.record( baseAnalyticsPath, 'Custom Post Type' );
 
-	ReactDom.render( <Types />, document.getElementById( 'primary' ) );
+	// Derive type
+	const type = sectionedPath.replace( /^\/types\//, '' );
+
+	ReactDom.render(
+		<ReduxProvider store={ context.store }>
+			<Types type={ type } />
+		</ReduxProvider>,
+		document.getElementById( 'primary' )
+	);
 }

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -1,13 +1,22 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 /**
  * Internal dependencies
  */
 import Main from 'components/main';
+import PostTypeList from 'my-sites/post-type-list';
 
-export default function Types() {
-	return <Main>Custom Post Type Listing</Main>;
+export default function Types( { type } ) {
+	return (
+		<Main>
+			<PostTypeList type={ type } />
+		</Main>
+	);
 }
+
+Types.propTypes = {
+	type: PropTypes.string.isRequired
+};


### PR DESCRIPTION
This pull request seeks to introduce the groundwork for a new post-type-agnostic `<PostType />` component for use in rendering a list of posts for a given query. The changes herein render a basic listing of the first page of post type query results for a custom post type.

![Types](https://cloud.githubusercontent.com/assets/1779930/13746994/89d2b078-e9cc-11e5-8996-28e009d4e8c3.png)

__Implementation notes:__

Changes include minor revisions to `<Card />` component to accept a `compact` prop, as an alternative to importing the separate `<CompactCard />` component.

__Testing instructions:__

1. Navigate directly to a custom post type route (e.g. [Portfolio](http://calypso.localhost:3000/types/jetpack-portfolio))
2. Select a site
3. Note that the titles of each post is shown, for the first page of results