### PR TITLE
Signup: fix Plans Compare page

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -173,6 +173,14 @@ var PlansCompare = React.createClass( {
 		}
 	},
 
+	isSubmitting: function() {
+		if ( ! this.props.transaction ) {
+			return false;
+		}
+
+		return this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST
+	},
+
 	getColumnCount: function() {
 		if ( ! this.props.selectedSite ) {
 			return 4;
@@ -240,7 +248,7 @@ var PlansCompare = React.createClass( {
 								site={ this.props.selectedSite }
 								cart={ this.props.cart }
 								enableFreeTrials={ this.props.enableFreeTrials }
-								isSubmitting={ this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST }
+								isSubmitting={ this.isSubmitting() }
 								isImageButton />
 							<span className="plans-compare__plan-name">
 								{ plan.product_name_short }
@@ -359,7 +367,7 @@ var PlansCompare = React.createClass( {
 						plan={ plan }
 						site={ this.props.selectedSite }
 						sitePlan={ sitePlan }
-						isSubmitting={ this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST }
+						isSubmitting={ this.isSubmitting() }
 						cart={ this.props.cart } />
 				</td>
 			);


### PR DESCRIPTION
Fixes #4005 

This fixes a bug happening in Signup when trying to visit the Compare Plans page.
The console would show an error: `Uncaught TypeError: Cannot read property 'step' of undefined`
This was probably introduced in #3839, where `<CheckoutData>` is not given in signup thus the `transaction` property will be undefined.
This fix just checks if the `transaction` property exists before checking if we're actually submitting.

### Testing instructions
- Checkout this branch `git checkout fix/4005-signup-compare-plans`
- Check that you can visit the Plans Compare page in signup and go back
- Check that you can visit the Plans Compare page from the `/start/free-trial` flow and that you can start a free trial using the default checkout

### Reviews
- [x] Product Review
- [x] Code Review
