### PR TITLE
Plans: Add nudge on Plan Overview page

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-status/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/index.jsx
@@ -76,6 +76,43 @@ const PlanStatus = React.createClass( {
 		);
 	},
 
+	getPrices() {
+		const { formattedPrice, rawDiscount, rawPrice } = this.props.plan,
+			rawOriginalPrice = rawPrice + rawDiscount;
+
+		return {
+			original: formattedPrice.replace( rawPrice, rawOriginalPrice ),
+			new: formattedPrice
+		};
+	},
+
+	renderNudge() {
+		const { rawDiscount: hasDiscount } = this.props.plan;
+
+		if ( hasDiscount ) {
+			const prices = this.getPrices();
+
+			return (
+				<div className="plan-status__nudge">
+					{ this.translate(
+						'{{del}}%(originalPrice)s{{/del}} {{strong}}%(newPrice)s{{/strong}} - Save when you combine your domain and plan',
+						{
+							args: {
+								originalPrice: prices.original,
+								newPrice: prices.new
+							},
+							components: {
+								del: <del />,
+								strong: <strong />
+							},
+							context: "Discount shown on the Plan Overview page"
+						}
+					) }
+				</div>
+			);
+		}
+	},
+
 	render() {
 		const { plan } = this.props,
 			iconClasses = classNames( 'plan-status__icon', {
@@ -103,6 +140,9 @@ const PlanStatus = React.createClass( {
 								} )
 							}
 						</h1>
+
+						{ this.renderNudge() }
+
 						{ this.renderNotice() }
 					</div>
 

--- a/client/my-sites/plans/plan-overview/plan-status/style.scss
+++ b/client/my-sites/plans/plan-overview/plan-status/style.scss
@@ -72,3 +72,16 @@
 		font-size: 21px;
 	}
 }
+
+.plan-status__nudge {
+	color: $alert-green;
+	font-style: italic;
+
+	del {
+		color: initial;
+	}
+
+	+ .notice {
+		margin-top: 8px;
+	}
+}


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/wp-calypso/issues/4017 by adding a nudge on the `Plan Overview` page (also known as _trial hub_) to highlight the discount users can get from purchasing a plan when they already have purchased a domain mapping or a domain registration. This nudge is only displayed within five days from free trial expiration:
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/13748963/97e1bd8e-e9ff-11e5-8d94-0daecb855be3.png)

#### Testing instructions
 
1. Run `git checkout add/nudge-plan-overview` and start your server
2. Sandbox the API and apply patch D1286-code
3. Open the [`Map A Domain` page](http://calypso.localhost:3000/domains/add/mapping/)
4. Purchase a domain mapping
5. Execute `localStorage.setItem( 'ABTests', '{"freeTrials_20160120":"offered"}' )` in your browser's console
6. Open the [`Plans` page](http://calypso.localhost:3000/plans)
7. Click the `Start Free Trial` button
8. Check that you are redirected to the `Plan Overview` page
9. Update purchase and expiration dates of the free trial subscription in our internal administration tool
10. Reload the `Plan Overview` page
11. Check that the nudge is displayed depending on the dates set
 
#### Reviews
 
- [x] Code
- [x] Product
