### PR TITLE
People: Update follow invite explanation to mention WP.com reader

### DIFF
--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -258,7 +258,7 @@ export default React.createClass( {
 				break;
 			case 'follower':
 				explanation = this.translate(
-					'As a follower, you will receive updates every time there is a new post on %(siteName)s.', {
+					'As a follower, you will receive updates in the WordPress.com reader every time there is a new post on %(siteName)s.', {
 						args: {
 							siteName: this.getSiteName()
 						}

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -258,7 +258,7 @@ export default React.createClass( {
 				break;
 			case 'follower':
 				explanation = this.translate(
-					'As a follower, you will receive updates in the WordPress.com reader every time there is a new post on %(siteName)s.', {
+					'As a follower, you will receive updates in the WordPress.com Reader every time there is a new post on %(siteName)s.', {
 						args: {
 							siteName: this.getSiteName()
 						}

--- a/client/my-sites/invites/invite-form-header/index.jsx
+++ b/client/my-sites/invites/invite-form-header/index.jsx
@@ -258,7 +258,7 @@ export default React.createClass( {
 				break;
 			case 'follower':
 				explanation = this.translate(
-					'As a follower, you will receive updates in the WordPress.com Reader every time there is a new post on %(siteName)s.', {
+					'As a follower, you can read the latest posts from %(siteName)s in the WordPress.com Reader.', {
 						args: {
 							siteName: this.getSiteName()
 						}


### PR DESCRIPTION
Closes #3929.

In #3929, @v18 suggested that we clarify to the user that updates will be shown in the WordPress.com reader for logged in invites.

I went ahead and applied this change to both logged in and logged out invites. I think this makes sense, because the option to follow via email is only displayed for logged out invites. Even then, it's a link at the bottom of the form.

cc @rickybanister for design review

To test:
- Checkout `update/follower-explanation-in-reader` branch
- Go to `/people/new/$site` and send a follower invite to an email you have control over
- Test that wording is updated

![screen shot 2016-03-14 at 11 03 08 am](https://cloud.githubusercontent.com/assets/1126811/13751206/0d5c908a-e9d7-11e5-8c7f-22c056db36bb.png)
