### PR TITLE
People: Adds PeopleListSectionHeader component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -192,6 +192,7 @@
 @import 'my-sites/people/delete-user/style';
 @import 'my-sites/people/edit-team-member-form/style';
 @import 'my-sites/people/people-list-item/style';
+@import 'my-sites/people/people-list-section-header/style';
 @import 'my-sites/people/people-profile/style';
 @import 'my-sites/people/people-notices/style';
 @import 'my-sites/plans/style';

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -11,7 +11,7 @@ var React = require( 'react' ),
  */
 var PeopleListItem = require( 'my-sites/people/people-list-item' ),
 	Card = require( 'components/card' ),
-	SectionHeader = require( 'components/section-header' ),
+	PeopleListSectionHeader = require( 'my-sites/people/people-list-section-header' ),
 	FollowersActions = require( 'lib/followers/actions' ),
 	EmailFollowersActions = require( 'lib/email-followers/actions' ),
 	InfiniteList = require( 'components/infinite-list' ),
@@ -203,7 +203,11 @@ let Followers = React.createClass( {
 		}
 		return (
 			<div>
-				<SectionHeader label={ headerText } count={ this.props.fetching || this.props.fetchOptions.search ? undefined : this.props.totalFollowers } />
+				<PeopleListSectionHeader
+					isFollower
+					label={ headerText }
+					site={ this.props.site }
+					count={ this.props.fetching || this.props.fetchOptions.search ? null : this.props.totalFollowers } />
 				<Card className={ listClass }>
 					{ followers }
 				</Card>

--- a/client/my-sites/people/people-list-section-header/README.md
+++ b/client/my-sites/people/people-list-section-header/README.md
@@ -1,0 +1,10 @@
+PeopleListSectionHeader
+=============
+
+This component is responsible for displaying the "add" button the section header above each list of people.
+
+### Properties
+- `label` - (string) The text to be displayed as a label for the section header
+- `count` - (number) The amount of people that match the current people query
+- `isFollower` - (bool) Should be true when `PeopleListSectionHeader` is being used on the followers and email followers lists.
+- `site` - (object) A Site object

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+import get from 'lodash/get';
+
+/**
+ * Internal dependencies
+ */
+import SectionHeader from 'components/section-header';
+import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
+import Gridicon from 'components/gridicon';
+import Tooltip from 'components/tooltip';
+import config from 'config';
+
+export default React.createClass( {
+	displayName: 'PeopleListSectionHeader',
+
+	PropTypes: {
+		label: React.PropTypes.string.isRequired,
+		count: React.PropTypes.number,
+		isFollower: React.PropTypes.bool,
+		site: React.PropTypes.object
+	},
+
+	getInitialState() {
+		return {
+			addPeopleTooltip: false
+		}
+	},
+
+	getDefaultProps() {
+		return {
+			isFollower: false
+		};
+	},
+
+	showAddTooltip() {
+		this.setState( { addPeopleTooltip: true } );
+	},
+
+	hideAddTooltip() {
+		this.setState( { addPeopleTooltip: false } );
+	},
+
+	getAddLink() {
+		const siteSlug = get( this.props, 'site.slug' );
+		const isJetpack = get( this.props, 'site.jetpack' );
+		const wpAdminUrl = get( this.props, 'site.options.admin_url' );
+
+		if ( ! siteSlug || ( isJetpack && this.props.isFollower ) ) {
+			return false;
+		}
+
+		if ( isJetpack ) {
+			return wpAdminUrl + 'user-new.php';
+		}
+
+		return config.isEnabled( 'manage/add-people' )
+			? '/people/new/' + siteSlug
+			: wpAdminUrl + 'users.php?page=wpcom-invite-users';
+	},
+
+	render() {
+		const { label, count, site } = this.props;
+		const siteLink = this.getAddLink();
+		const classes = classNames(
+			this.props.className,
+			'people-list-section-header'
+		);
+
+		return (
+			<SectionHeader
+				className={ classes }
+				count={ count }
+				label={ label } >
+
+				{ siteLink &&
+					<ButtonGroup>
+						<Button
+							compact
+							href={ siteLink }
+							target={ site && site.jetpack ? '_new' : null }
+							className="people-list-section-header__add-button"
+							onMouseEnter={ this.showAddTooltip }
+							onMouseLeave={ this.hideAddTooltip }
+							ref="addPeopleButton"
+							aria-label={ this.translate( 'Invite user', { context: 'button label' } ) }>
+							<Gridicon icon="plus-small" size={ 12 } /><Gridicon icon="user" size={ 18 } />
+							<Tooltip
+								isVisible={ this.state.addPeopleTooltip }
+								context={ this.refs && this.refs.addPeopleButton }
+								position="bottom">
+								{ this.translate( 'Invite user', { context: 'button tooltip' } ) }
+							</Tooltip>
+						</Button>
+					</ButtonGroup>
+
+				}
+			</SectionHeader>
+		);
+	}
+} );

--- a/client/my-sites/people/people-list-section-header/style.scss
+++ b/client/my-sites/people/people-list-section-header/style.scss
@@ -1,0 +1,14 @@
+.people-list-section-header .people-list-section-header__add-button {
+	.gridicons-plus-small {
+		height: 12px;
+		left: 4px;
+		margin-left: 0;
+		position: absolute;
+		top: 10px;
+		width: 12px;
+	}
+
+	.gridicons-user {
+		margin-left: 2px;
+	}
+}

--- a/client/my-sites/people/team-list/index.jsx
+++ b/client/my-sites/people/team-list/index.jsx
@@ -9,14 +9,14 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var Card = require( 'components/card' ),
-	SectionHeader = require( 'components/section-header' ),
 	PeopleListItem = require( 'my-sites/people/people-list-item' ),
 	SiteUsersFetcher = require( 'components/site-users-fetcher' ),
 	UsersActions = require( 'lib/users/actions' ),
 	InfiniteList = require( 'components/infinite-list' ),
 	deterministicStringify = require( 'lib/deterministic-stringify' ),
 	NoResults = require( 'my-sites/no-results' ),
-	analytics = require( 'analytics' );
+	analytics = require( 'analytics' ),
+	PeopleListSectionHeader = require( 'my-sites/people/people-list-section-header' );
 
 /**
  * Module Variables
@@ -94,7 +94,10 @@ var Team = React.createClass( {
 
 		return (
 			<div>
-				<SectionHeader label={ headerText } count={ this.props.fetchingUsers || this.props.fetchOptions.search ? undefined : this.props.totalUsers } />
+				<PeopleListSectionHeader
+					label={ headerText }
+					site={ this.props.site }
+					count={ this.props.fetchingUsers || this.props.fetchOptions.search ? null : this.props.totalUsers } />
 				<Card className={ listClass }>
 					{ people }
 				</Card>

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -9,7 +9,7 @@ var React = require( 'react' ),
  */
 var PeopleListItem = require( 'my-sites/people/people-list-item' ),
 	Card = require( 'components/card' ),
-	SectionHeader = require( 'components/section-header' ),
+	PeopleListSectionHeader = require( 'my-sites/people/people-list-section-header' ),
 	ViewersActions = require( 'lib/viewers/actions' ),
 	ViewersStore = require( 'lib/viewers/store' ),
 	InfiniteList = require( 'components/infinite-list' ),
@@ -147,7 +147,10 @@ let Viewers = React.createClass( {
 
 		return (
 			<div>
-				<SectionHeader label={ this.props.label } count={ this.props.fetching ? undefined : this.props.totalViewers }/>
+				<PeopleListSectionHeader
+					label={ this.props.label }
+					site={ this.props.site }
+					count={ this.props.fetching ? null : this.props.totalViewers }/>
 				<Card className={ listClass }>
 					{ viewers }
 				</Card>

--- a/client/my-sites/people/viewers-list/index.jsx
+++ b/client/my-sites/people/viewers-list/index.jsx
@@ -72,14 +72,18 @@ let Viewers = React.createClass( {
 	},
 
 	renderViewer( viewer ) {
+		const removeThisViewer = () => {
+			this.removeViewer( viewer );
+		};
+
 		return (
 			<PeopleListItem
 				key={ viewer.ID }
 				user={ viewer }
-				type='viewer'
+				type="viewer"
 				site={ this.props.site }
 				isSelectable={ this.state.bulkEditing }
-				onRemove={ this.removeViewer.bind( this, viewer ) }
+				onRemove={ removeThisViewer }
 			/>
 		);
 	},
@@ -99,9 +103,9 @@ let Viewers = React.createClass( {
 	render() {
 		var viewers,
 			emptyContentArgs = {
-				title: this.props.site && this.props.site.jetpack ?
-					this.translate( "Oops, Jetpack sites don't support viewers." ) :
-					this.translate( "You don't have any viewers yet." )
+				title: this.props.site && this.props.site.jetpack
+					? this.translate( "Oops, Jetpack sites don't support viewers." )
+					: this.translate( "You don't have any viewers yet." )
 			},
 			listClass = ( this.state.bulkEditing ) ? 'bulk-editing' : null;
 


### PR DESCRIPTION
Closes #3999

Adds `PeopleListSectionHeader` component which acts as a wrapper to add an "invite people" button to the section header in various people lists.

To test:
- Checkout `update/people-list-add-button` branch
- Go to `/people/team/$site` where `$site` is a Jetpack site
- You should see the add button only on the team list (not on followers lists)
- Switch sites to a WordPress.com site
- You should see the button on each list

![people-add-button-styles](https://cloud.githubusercontent.com/assets/1126811/13757477/a5093594-e9f2-11e5-8c0c-465d86ad16af.png)

cc @rickybanister for design review and @lezama for code review.
