### PR TITLE
Refactor renderWithReduxStore to use named exports

### DIFF
--- a/client/lib/react-helpers/index.js
+++ b/client/lib/react-helpers/index.js
@@ -5,15 +5,13 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
-export default {
-	renderWithReduxStore( reactElement, domContainer, reduxStore ) {
-		const domContainerNode = ( 'string' === typeof domContainer )
-				? document.getElementById( domContainer )
-				: domContainer;
+export function renderWithReduxStore( reactElement, domContainer, reduxStore ) {
+	const domContainerNode = ( 'string' === typeof domContainer )
+			? document.getElementById( domContainer )
+			: domContainer;
 
-		return ReactDom.render(
-			React.createElement( ReduxProvider, { store: reduxStore }, reactElement ),
-			domContainerNode
-		);
-	}
-};
+	return ReactDom.render(
+		React.createElement( ReduxProvider, { store: reduxStore }, reactElement ),
+		domContainerNode
+	);
+}


### PR DESCRIPTION
As @mcsf pointed out in other PR (unfortunatelly, his comment was deleted by my rebase..), we should use named exports instead of `export default { }` with functions inside it.

## Testing

Make sure Calypso boots up normally.

cc @Tug 