### PR TITLE
Site Indicator: Fixes JS error when site.callHome is not defined

### DIFF
--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -55,7 +55,9 @@ export default React.createClass( {
 			if ( site.callingHome ) {
 				return false;
 			} else if ( typeof site.unreachable === 'undefined' ) {
-				site.callHome();
+				if ( 'function' === typeof site.callHome ) {
+					site.callHome();
+				}
 				return false;
 			}
 			return true;


### PR DESCRIPTION
I noticed that I was getting an error while in the reader:

`Uncaught TypeError: site.callHome is not a function` in `site-indicator.jsx`

I'm not sure why this happened, and I'm not sure this is the most correct fix. That being said, we should probably check that `site.callHome` is set and is a function before we use it as a function.

cc @blowery for thoughts and review.