### PR TITLE
Domains: Remove "NEW" flag for .live domains

### DIFF
--- a/client/components/domains/domain-suggestion-flag/index.jsx
+++ b/client/components/domains/domain-suggestion-flag/index.jsx
@@ -15,7 +15,7 @@ const DomainSuggestionFlag = React.createClass( {
 	},
 
 	render() {
-		let newTLDs = ['.live'];
+		const newTLDs = [];
 
 		if ( newTLDs.some( function( tld ) {
 				return endsWith( this.props.domain, tld );


### PR DESCRIPTION
**Why:**
It's not new anymore