### PR TITLE
Menus: Add new Page creation right in Menus

### DIFF
--- a/assets/stylesheets/sections/_menus.scss
+++ b/assets/stylesheets/sections/_menus.scss
@@ -744,6 +744,11 @@
 				}
 			  }
 
+			  li.create-new-item input[type=radio] + label {
+			  	color: #87a6bc;
+				font-style: italic;
+			  }
+
 
 				.menu-item-back-button {
 					display: none;

--- a/client/lib/menu-data/index.js
+++ b/client/lib/menu-data/index.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-var MenuData = require( './menu-data' );
+import MenuData from './menu-data';
 
 /**
  * Singleton instance
  */
-var instance = new MenuData();
+const instance = new MenuData();
 
-module.exports = instance;
+export default instance;

--- a/client/lib/menu-data/test/test-menu-data.js
+++ b/client/lib/menu-data/test/test-menu-data.js
@@ -7,7 +7,7 @@ require( 'lib/react-test-env-setup' )();
 var chai = require( 'chai' ),
 	assert = chai.assert,
 	expect = chai.expect,
-	MenuData = require( '../menu-data' ),
+	MenuData = require( '../menu-data' ).default,
 	sinon = require( 'sinon' ),
 	sinonChai = require( 'sinon-chai' ),
 	wp = require( 'lib/wp' ),
@@ -294,29 +294,6 @@ describe( 'MenuData', function() {
 			socks = this.menuData.find( { name: 'Socks' } );
 
 			expect( socks.items ).to.contain( products );
-		} );
-	} );
-
-	describe( 'saveMenu', function () {
-		beforeEach( function () {
-			this.menusUpdateStub = sinon.stub();
-			this.wpcomUndocumentedStub = sinon.stub( wp, 'undocumented', function () {
-				return { menusUpdate: this.menusUpdateStub };
-			}.bind( this ) );
-			this.isValidMenuStub = sinon.stub( this.menuData, 'isValidMenu', function () {
-				return true;
-			} );
-		} );
-		afterEach( function () {
-			this.wpcomUndocumentedStub.restore();
-			this.isValidMenuStub.restore();
-		} );
-
-		it( 'should call interceptSaveForHomepageLink', function () {
-			var spy = sinon.spy( this.menuData, 'interceptSaveForHomepageLink' ),
-				menu = { items: [] };
-			this.menuData.saveMenu( menu );
-			expect( spy ).to.have.been.calledWith( menu );
 		} );
 	} );
 

--- a/client/my-sites/menus/item-options/option-list.jsx
+++ b/client/my-sites/menus/item-options/option-list.jsx
@@ -25,6 +25,7 @@ var SCROLL_THROTTLE_TIME_MS = 400,
  */
 var Search = React.createClass( {
 	propTypes: {
+		itemType: React.PropTypes.string,
 		searchTerm: React.PropTypes.string,
 		onSearch: React.PropTypes.func.isRequired
 	},
@@ -96,6 +97,7 @@ var OptionList = React.createClass( {
 					{ this.props.children }
 					{ this.props.isLoading && <LoadingPlaceholder/> }
 					{ this.props.isEmpty &&
+						this.props.itemType === 'page' &&
 						<EmptyPlaceholder isSearch={ !! ( this.state.searchTerm && this.state.searchTerm.length ) }
 							createLink={ this.props.itemType.createLink }
 							typeName={ this.props.itemType.name } />

--- a/client/my-sites/menus/item-options/options.jsx
+++ b/client/my-sites/menus/item-options/options.jsx
@@ -1,17 +1,19 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var getContentTitle = require( '../menu-utils' ).getContentTitle;
+import { getContentTitle } from '../menu-utils';
+import { isInjectedNewPageItem } from 'lib/menu-data/menu-data';
+import classNames from 'classnames';
 
 /**
  * Component
  */
-var Options = React.createClass( {
+const Options = React.createClass( {
 	propTypes: {
 		item: React.PropTypes.object.isRequired,
 		options: React.PropTypes.array.isRequired,
@@ -30,10 +32,15 @@ var Options = React.createClass( {
 
 	renderItem: function( item ) {
 		var checked = ( item.ID === this.props.item.content_id ) &&
-			( this.props.itemType.name === this.props.item.type ),
-			isPrivate = item.status && item.status === 'private';
+			( this.props.itemType.name === this.props.item.type );
+
+		const classes = classNames( {
+			'option-is-private': item.status && item.status === 'private',
+			'create-new-item': isInjectedNewPageItem( item )
+		} );
+
 		return (
-			<li key={ this.props.itemType.name + '-' + item.ID } className={ isPrivate ? 'option-is-private' : '' } >
+			<li key={ this.props.itemType.name + '-' + item.ID } className={ classes } >
 				<div>
 					<input id={ "option-" + item.ID } type='radio' name='radios' value={ item.ID }
 						onChange={ this.props.onChange.bind( null, item ) }
@@ -57,4 +64,4 @@ var Options = React.createClass( {
 	}
 } );
 
-module.exports = Options;
+export default Options;

--- a/client/my-sites/menus/item-options/posts.jsx
+++ b/client/my-sites/menus/item-options/posts.jsx
@@ -54,6 +54,7 @@ var Posts = React.createClass( {
 		var posts = this.props.posts.slice();
 		if ( this.props.type === 'page' ) {
 			posts.unshift( siteMenus.generateHomePageMenuItem( this.getHomePageTitle() ) );
+			posts.push( siteMenus.generateNewPageMenuItem() );
 		}
 		return posts;
 	},

--- a/client/my-sites/menus/item-options/test/test-posts.jsx
+++ b/client/my-sites/menus/item-options/test/test-posts.jsx
@@ -22,6 +22,7 @@ describe( 'Posts' , function () {
 
 		beforeEach( function () {
 			this.itemToInject = {};
+			siteMenus.generateNewPageMenuItem = () => ( {} );
 			this.siteMenusStub = sinon.stub( siteMenus, 'generateHomePageMenuItem', function () {
 				return this.itemToInject;
 			}.bind( this ) );


### PR DESCRIPTION
Solves #3899

Introduces **"Add Page"** option to menu creation allowing to create a new page to a newly added menu item.

# Visuals

![](https://cldup.com/IEtAPbqXlK-1200x1200.png)

# Testing

1. Menus
2. Add / Edit item to menu
3. Choose `New Page`
4. Choose proper name
5. Save
6. Verify that:
    - New Page is created
    - Item in menu links properly to it


@rralian @mtias @gwwar 
