### PR TITLE
Editor: Change info popover to white when limit exceeded

### DIFF
--- a/client/components/forms/counted-textarea/style.scss
+++ b/client/components/forms/counted-textarea/style.scss
@@ -4,7 +4,9 @@
 
 	&.is-exceeding-acceptable-length {
 		background: $alert-red;
-		.counted-textarea__count-panel {
+
+		.counted-textarea__count-panel,
+		.gridicons-info-outline {
 			color: $white;
 		}
 	}


### PR DESCRIPTION
Currently, when you exceed the limit for a Publicize sharing message, the count turns white, but the info popover stays the default blue.

![screen shot 2016-03-14 at 4 25 17 pm](https://cloud.githubusercontent.com/assets/7240478/13761947/5c65449a-ea01-11e5-986f-02bde9e5b81c.png)

I opted to fix this in [`components/forms/counted-textarea`](https://github.com/Automattic/wp-calypso/blob/master/client/components/forms/counted-textarea/style.scss) by adding `color: $white;` to the `.gridicons—info—outline` class. I was honestly a bit conflicted about where to fix this and felt like this was the best fit since we'll want any gridicon in a counted text area to follow the color of `.counted-textarea_count-panel` when the length is exceeded. If this should live elsewhere, definitely let me know. Hover and default behavior of info-popover still work as expected. For reference, the only other area where we use CountedTextarea (and hence where `.is-exceeding-acceptable-length` and `.gridicons-info-outline` would coexist in the future) is [`my-sites/people/invite-people/index.jsx`](https://github.com/Automattic/wp-calypso/blob/c86163b3ed3ee743ede75bb5ec6ac9735aa9d7c3/client/my-sites/people/invite-people/index.jsx#L310).

To test:
1. Check out branch and get it up and running with `make run`
2. Start a new post and begin typing into the sharing message field
3. When you pass the acceptable length, the icon should turn white along with the text

GIF:

![icon](https://cloud.githubusercontent.com/assets/7240478/13762059/0dfdb05c-ea02-11e5-890b-1cca0e6348ea.gif)

This is an anticipated fix for #3125. 