### PR TITLE
Jetpack-connect: API request to check for a 3rd party site status

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -7,7 +7,8 @@ var debug = require( 'debug' )( 'calypso:wpcom-undocumented:undocumented' ),
 	omit = require( 'lodash/omit' ),
 	camelCase = require( 'lodash/camelCase' ),
 	snakeCase = require( 'lodash/snakeCase' ),
-	pick = require( 'lodash/pick' );
+	pick = require( 'lodash/pick' ),
+	url = require( 'url' );
 
 /**
  * Internal dependencies.
@@ -1923,6 +1924,29 @@ Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
 		apiVersion: '1.1',
 		path: `/sites/${ siteId }/exports/${ exportId }`
 	}, fn );
+}
+
+/**
+ * Check different info about WordPress and Jetpack status on a url
+ *
+ * @param {String}    targetUrl          The url of the site to check
+ * @param {String}    filters            Comma separated string with the filters to run
+ * @returns {Promise}
+ */
+Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters ) {
+	return new Promise( ( resolve, reject ) => {
+		const resolver = ( error, data ) => {
+			error ? reject( error ) : resolve( data );
+		};
+		const parsedUrl = url.parse( targetUrl );
+		const endpointUrl = `/connect/site-info/${ parsedUrl.protocol.slice( 0, -1 ) }/${ parsedUrl.host }`;
+
+		this.wpcom.req.get( `${ endpointUrl }`, {
+			filters: filters,
+			path: parsedUrl.path,
+			apiVersion: '1.1',
+		}, resolver );
+	} );
 }
 
 /**


### PR DESCRIPTION
Deals with https://github.com/Automattic/wp-calypso/issues/3533. Requires `D1312-code` to work.

This PR implements a new `undocumented` method to interact with the new API endpoint which returns the state of a 3rd party site regarding WordPress and Jetpack availability.

There's not a lot to test, but if you have a sandbox running the above past, you can call `undocumented.getSiteConnectInfo` passing any url and one of the available filters to check you get the correct response.

ping @roccotripaldi 