### PR TITLE
Domains: Add a hint to MX record's form Handled by field

### DIFF
--- a/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/mx-record.jsx
@@ -12,6 +12,7 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import FormSettingExplanation from 'components/forms/form-setting-explanation' ;
 
 const MxRecord = React.createClass( {
 	statics: {
@@ -61,6 +62,20 @@ const MxRecord = React.createClass( {
 						value={ this.props.fieldValues.data }
 						placeholder={ this.translate( 'e.g. mail.your-provider.com', { context: 'MX DNS Record', textOnly: true } ) } />
 					{ ! isDataValid ? <FormInputValidation text={ this.translate( 'Invalid Mail Server' ) } isError={ true } /> : null }
+					<FormSettingExplanation>
+						{ this.translate(
+							'Please use a domain name here (e.g. %(domain)s) - an IP address (e.g. %(ipAddress)s) will {{strong}}not{{/strong}} work.', {
+								args: {
+									domain: 'mail.your-provider.com',
+									ipAddress: '123.45.78.9'
+								},
+								components: {
+									strong: <strong />
+								},
+								context: 'Hint for the \'Handled by\' field of a MX record'
+							}
+						) }
+					</FormSettingExplanation>
 				</FormFieldset>
 
 				<FormFieldset>


### PR DESCRIPTION
It's a common mistake to try and input an IP address here - the validation will not allow it, of course, but folks are confused as to why is that. This should make it clear that a domain name is expected
(without going into too much technical details).

Before:
![2016-03-15-143042_1214x593_scrot](https://cloud.githubusercontent.com/assets/3392497/13780212/c77deb02-eabe-11e5-8502-a290663dfdb7.png)

After:
![2016-03-15-143022_1216x648_scrot](https://cloud.githubusercontent.com/assets/3392497/13780215/ce609bfe-eabe-11e5-9816-ce74ebb14e68.png)

/cc @aidvu @umurkontaci 