### PR TITLE
WP-API: Increase percentage of requests to wpcom/v2 post-counts.

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -540,8 +540,8 @@ PostActions = {
 			siteId: siteId
 		} );
 
-		// Only pass 20%ish of requests to WP-API for now.
-		if ( 0 === ( siteId % 5 ) ) {
+		// Only pass 50%ish of requests to WP-API for now.
+		if ( 0 === ( siteId % 2 ) ) {
 			wpcomInterface = wpcom.undocumented();
 		}
 


### PR DESCRIPTION
Follow up to #3836 - this increases the percentage of requests headed to WP-API to roughly 50%.  So far the initial test period has been great from a response-time standpoint, so I would like to scale it up a little bit more and see how things go before turning all traffic over.

Testing instructions the same as #3836