### PR TITLE
WebPreview: fix height of the iframe.

### DIFF
--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -147,7 +147,9 @@
 
 .web-preview__placeholder {
 	width: 100%;
-	height: 100%;
+	position: absolute;
+		top: 49px;
+		bottom: 0;
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
Avoid cutting off part of the previewed page.

Fixes #3707.

See #3901.