### PR TITLE
Pages: show pseudo blog page in list

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -19,6 +19,8 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	CompactCard = require( 'components/card/compact' ),
 	mapStatus = require( 'lib/route' ).mapPostStatus;
 
+import Gridicon from 'components/gridicon';
+
 var PageList = React.createClass( {
 
 	mixins: [ PureRenderMixin ],
@@ -202,11 +204,11 @@ var Pages = React.createClass({
 		return (
 			<CompactCard className="page" key="blog-posts-page">
 				<span className="page__title" href="">
-					<span className="noticon noticon-home" />
+					<Gridicon icon="house" size={ 18 } />
 					{ this.translate( 'Blog Posts' ) }
 				</span>
 				<span className="page__info">
-					Showing latest posts in the frontpage.
+					{ this.translate( 'Showing latest posts in the frontpage.' ) }
 				</span>
 			</CompactCard>
 		);

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -208,7 +208,7 @@ var Pages = React.createClass({
 					{ this.translate( 'Blog Posts' ) }
 				</span>
 				<span className="page__info">
-					{ this.translate( 'Showing latest posts in the frontpage.' ) }
+					{ this.translate( 'Your latest posts' ) }
 				</span>
 			</CompactCard>
 		);

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -16,6 +16,7 @@ var PostListFetcher = require( 'components/post-list-fetcher' ),
 	NoResults = require( 'my-sites/no-results' ),
 	actions = require( 'lib/posts/actions' ),
 	Placeholder = require( './placeholder' ),
+	CompactCard = require( 'components/card/compact' ),
 	mapStatus = require( 'lib/route' ).mapPostStatus;
 
 var PageList = React.createClass( {
@@ -197,6 +198,20 @@ var Pages = React.createClass({
 		}
 	},
 
+	blogPostsPage: function() {
+		return (
+			<CompactCard className="page" key="blog-posts-page">
+				<span className="page__title" href="">
+					<span className="noticon noticon-home" />
+					{ this.translate( 'Blog Posts' ) }
+				</span>
+				<span className="page__info">
+					Showing latest posts in the frontpage.
+				</span>
+			</CompactCard>
+		);
+	},
+
 	render: function() {
 		var pages = this.props.posts,
 			rows = [];
@@ -223,6 +238,12 @@ var Pages = React.createClass({
 			if ( this.props.loading ) {
 				this.addLoadingRows( rows, 1 );
 			}
+
+		const site = this.props.sites.getSelectedSite();
+
+		if ( site && site.options && site.options.show_on_front === 'posts' ) {
+			rows.push( this.blogPostsPage() );
+		}
 
 		} else if ( ( ! this.props.loading ) && this.props.sites.initialized ) {
 			rows.push( <div key="page-list-no-results">{ this.getNoContentMessage() }</div> );

--- a/client/my-sites/pages/page.jsx
+++ b/client/my-sites/pages/page.jsx
@@ -281,7 +281,7 @@ module.exports = React.createClass( {
 					onClick={ this.analyticsEvents.pageTitle }
 					>
 					{ depthIndicator }
-					{ isFrontPage ? <span className="noticon noticon-home" /> : null }
+					{ isFrontPage ? <Gridicon icon="house" size={ 18 } /> : null }
 					{ title }
 				</a>
 				{ this.props.multisite ? <span className="page__site-url">{ this.getSiteDomain() }</span> : null }

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -57,11 +57,9 @@
 	font-family: $serif;
 	margin-right: 33px;
 
-	.noticon-home:before {
+	.gridicon {
 		color: $gray;
-		font-size: 24px;
-		margin-left: -3px;
-		margin-right: 4px;
+		margin: 2px 8px -2px 0;
 	}
 }
 

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -91,6 +91,14 @@
 	text-align: left;
 }
 
+.page__info {
+	color: $gray;
+	font-size: 12px;
+	max-width: 300px;
+	float: right;
+	line-height: 24px;
+}
+
 .page__delete-item.popover__menu-item {
 	&:hover,
 	&:focus {


### PR DESCRIPTION
If site doesn't have a static front page set, show a pseudo-page for the blog indicating it's the current frontpage.

![image](https://cloud.githubusercontent.com/assets/548849/13786933/286e47de-eada-11e5-9736-5fa180bd18a9.png)

Fixes #3905.