### PR TITLE
CPT: Render basic post details in custom post type listing

### DIFF
--- a/client/lib/create-selector/index.js
+++ b/client/lib/create-selector/index.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/lib/warn/index.js
+++ b/client/lib/warn/index.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * Internal Dependencies
  */

--- a/client/my-sites/post-type-list/post.jsx
+++ b/client/my-sites/post-type-list/post.jsx
@@ -7,13 +7,42 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { getEditorPath } from 'state/ui/editor/selectors';
 import { getPost } from 'state/posts/selectors';
 import Card from 'components/card';
+import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import resizeImageUrl from 'lib/resize-image-url';
 
-function PostTypePost( { post } ) {
+function PostTypePost( { post, editUrl } ) {
 	return (
 		<Card compact className="post-type-list__post">
-			{ post.title }
+			<div className="post-type-list__post-detail">
+				{ post.featured_image && (
+					<div className="post-type-list__post-thumbnail-wrapper">
+						<img
+							alt="Post thumbnail"
+							src={ resizeImageUrl( post.featured_image, { w: 80 } ) }
+							className="post-type-list__post-thumbnail" />
+					</div>
+				) }
+				<div className="post-type-list__post-title-meta">
+					<h1 className="post-type-list__post-title">
+						<a href={ editUrl }>
+							{ post.title }
+						</a>
+					</h1>
+					<div className="post-type-list__post-meta">
+						<PostRelativeTimeStatus post={ post } />
+					</div>
+				</div>
+			</div>
+			<div className="post-type-list__post-actions">
+				<Button href={ post.URL } target="_blank" borderless>
+					<Gridicon icon="external" />
+				</Button>
+			</div>
 		</Card>
 	);
 }
@@ -24,7 +53,10 @@ PostTypePost.propTypes = {
 };
 
 export default connect( ( state, ownProps ) => {
+	const post = getPost( state, ownProps.globalId );
+
 	return {
-		post: getPost( state, ownProps.globalId )
+		post,
+		editUrl: getEditorPath( state, state.ui.selectedSiteId, post.ID )
 	};
 } )( PostTypePost );

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -2,3 +2,81 @@
 	list-style: none;
 	margin-left: 0;
 }
+
+.post-type-list__post {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.post-type-list__post-detail {
+	display: flex;
+}
+
+.post-type-list__post-thumbnail-wrapper {
+	position: relative;
+	width: 80px;
+	margin-right: 12px;
+	overflow: hidden;
+}
+
+.post-type-list__post-thumbnail {
+	position: absolute;
+		top: 50%;
+		left: 50%;
+	transform: translate( -50%, -50% );
+}
+
+.post-type-list__post-title-meta {
+	padding: 6px 0;
+}
+
+.post-type-list__post-title {
+	@extend %content-font;
+	margin-bottom: 2px;
+
+	a {
+		color: $gray-dark;
+
+		&:hover {
+			color: darken( $gray, 20% );
+		}
+	}
+}
+
+.post-type-list__post-meta {
+	font-size: 12px;
+	color: lighten( $gray, 10% );
+}
+
+.post-type-list__post-meta .post-relative-time-status {
+	margin-bottom: 0;
+}
+
+.post-type-list__post-meta .post-relative-time-status .gridicon {
+	width: 14px;
+	height: 14px;
+	margin-top: -3px;
+	margin-right: 6px;
+}
+
+.post-type-list__post-actions {
+	margin-left: auto;
+	margin-right: -8px;
+}
+
+.post-type-list__post-actions .button {
+	opacity: 0.5;
+	padding-left: 8px;
+	padding-right: 8px;
+
+	&:hover {
+		opacity: 1;
+	}
+}
+
+.post-type-list__post-actions .gridicon {
+	&.gridicons-external {
+		top: 4px;
+	}
+}

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -10,3 +10,23 @@
 export function getSite( state, siteId ) {
 	return state.sites.items[ siteId ] || null;
 }
+
+/**
+ * Returns the slug for a site, or null if the site is unknown.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?String}        Site slug
+ */
+export function getSiteSlug( state, siteId ) {
+	const site = getSite( state, siteId );
+	if ( ! site ) {
+		return null;
+	}
+
+	if ( site.options && site.options.is_redirect ) {
+		return site.options.unmapped_url.replace( /^https?:\/\//, '' );
+	}
+
+	return site.URL.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+}

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1,0 +1,12 @@
+/** @ssr-ready **/
+
+/**
+ * Returns a site object by its ID.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?Object}        Site object
+ */
+export function getSite( state, siteId ) {
+	return state.sites.items[ siteId ] || null;
+}

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -1,6 +1,19 @@
 /** @ssr-ready **/
 
 /**
+ * External dependencies
+ */
+import map from 'lodash/map';
+import filter from 'lodash/filter';
+import some from 'lodash/some';
+import includes from 'lodash/includes';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+
+/**
  * Returns a site object by its ID.
  *
  * @param  {Object}  state  Global state tree
@@ -9,6 +22,39 @@
  */
 export function getSite( state, siteId ) {
 	return state.sites.items[ siteId ] || null;
+}
+
+/**
+ * Returns a filtered array of WordPress.com site IDs where a Jetpack site
+ * exists in the set of sites with the same URL.
+ *
+ * @param  {Object}   state Global state tree
+ * @return {Number[]}       WordPress.com site IDs with collisions
+ */
+export const getSiteCollisions = createSelector(
+	( state ) => {
+		return map( filter( state.sites.items, ( wpcomSite ) => {
+			const wpcomSiteUrlSansProtocol = wpcomSite.URL.replace( /^https?:\/\//, '' );
+			return ! wpcomSite.jetpack && some( state.sites.items, ( jetpackSite ) => {
+				return (
+					jetpackSite.jetpack &&
+					wpcomSiteUrlSansProtocol === jetpackSite.URL.replace( /^https?:\/\//, '' )
+				);
+			} );
+		} ), 'ID' );
+	},
+	( state ) => state.sites.items
+);
+
+/**
+ * Returns true if a collision exists for the specified WordPress.com site ID.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {Boolean}        Whether collision exists
+ */
+export function isSiteConflicting( state, siteId ) {
+	return includes( getSiteCollisions( state ), siteId );
 }
 
 /**
@@ -24,7 +70,7 @@ export function getSiteSlug( state, siteId ) {
 		return null;
 	}
 
-	if ( site.options && site.options.is_redirect ) {
+	if ( ( site.options && site.options.is_redirect ) || isSiteConflicting( state, siteId ) ) {
 		return site.options.unmapped_url.replace( /^https?:\/\//, '' );
 	}
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getSite } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( '#getSite()', () => {
+		it( 'should return null if the site is not known', () => {
+			const site = getSite( {
+				sites: {
+					items: {}
+				}
+			}, 2916284 );
+
+			expect( site ).to.be.null;
+		} );
+
+		it( 'should return the site object', () => {
+			const site = getSite( {
+				sites: {
+					items: {
+						2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
+					}
+				}
+			}, 2916284 );
+
+			expect( site ).to.eql( { ID: 2916284, name: 'WordPress.com Example Blog' } );
+		} );
+	} );
+} );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getSite, getSiteSlug } from '../selectors';
+import { getSite, getSiteCollisions, isSiteConflicting, getSiteSlug } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#getSite()', () => {
@@ -33,7 +33,88 @@ describe( 'selectors', () => {
 		} );
 	} );
 
+	describe( '#getSiteCollisions', () => {
+		beforeEach( () => {
+			getSiteCollisions.memoizedSelector.cache.clear();
+		} );
+
+		it( 'should not consider distinct URLs as conflicting', () => {
+			const collisions = getSiteCollisions( {
+				sites: {
+					items: {
+						77203199: { ID: 77203199, URL: 'https://example.com', jetpack: false },
+						77203074: { ID: 77203074, URL: 'https://example.net', jetpack: true }
+					}
+				}
+			} );
+
+			expect( collisions ).to.eql( [] );
+		} );
+
+		it( 'should return an array of conflicting site IDs', () => {
+			const collisions = getSiteCollisions( {
+				sites: {
+					items: {
+						77203199: { ID: 77203199, URL: 'https://example.com', jetpack: false },
+						77203074: { ID: 77203074, URL: 'https://example.com', jetpack: true }
+					}
+				}
+			} );
+
+			expect( collisions ).to.eql( [ 77203199 ] );
+		} );
+
+		it( 'should ignore URL protocol in considering conflict', () => {
+			const collisions = getSiteCollisions( {
+				sites: {
+					items: {
+						77203199: { ID: 77203199, URL: 'https://example.com', jetpack: false },
+						77203074: { ID: 77203074, URL: 'http://example.com', jetpack: true }
+					}
+				}
+			} );
+
+			expect( collisions ).to.eql( [ 77203199 ] );
+		} );
+	} );
+
+	describe( '#isSiteConflicting()', () => {
+		beforeEach( () => {
+			getSiteCollisions.memoizedSelector.cache.clear();
+		} );
+
+		it( 'it should return false if the specified site ID is not included in conflicting set', () => {
+			const isConflicting = isSiteConflicting( {
+				sites: {
+					items: {
+						77203199: { ID: 77203199, URL: 'https://example.com', jetpack: false },
+						77203074: { ID: 77203074, URL: 'https://example.net', jetpack: true }
+					}
+				}
+			}, 77203199 );
+
+			expect( isConflicting ).to.be.false;
+		} );
+
+		it( 'should return true if the specified site ID is included in the conflicting set', () => {
+			const isConflicting = isSiteConflicting( {
+				sites: {
+					items: {
+						77203199: { ID: 77203199, URL: 'https://example.com', jetpack: false },
+						77203074: { ID: 77203074, URL: 'https://example.com', jetpack: true }
+					}
+				}
+			}, 77203199 );
+
+			expect( isConflicting ).to.be.true;
+		} );
+	} );
+
 	describe( '#getSiteSlug()', () => {
+		beforeEach( () => {
+			getSiteCollisions.memoizedSelector.cache.clear();
+		} );
+
 		it( 'should return null if the site is not known', () => {
 			const slug = getSiteSlug( {
 				sites: {
@@ -60,7 +141,28 @@ describe( 'selectors', () => {
 				}
 			}, 77203074 );
 
-			expect( site ).to.equal( 'example.wordpress.com' );
+			expect( slug ).to.equal( 'example.wordpress.com' );
+		} );
+
+		it( 'should return the unmapped hostname for a conflicting site', () => {
+			const slug = getSiteSlug( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://example.com',
+							jetpack: false,
+							options: {
+								is_redirect: false,
+								unmapped_url: 'https://testtwosites2014.wordpress.com'
+							}
+						},
+						77203074: { ID: 77203074, URL: 'https://example.com', jetpack: true }
+					}
+				}
+			}, 77203199 );
+
+			expect( slug ).to.equal( 'testtwosites2014.wordpress.com' );
 		} );
 
 		it( 'should return the URL with scheme removed and paths separated', () => {

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getSite } from '../selectors';
+import { getSite, getSiteSlug } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#getSite()', () => {
@@ -30,6 +30,52 @@ describe( 'selectors', () => {
 			}, 2916284 );
 
 			expect( site ).to.eql( { ID: 2916284, name: 'WordPress.com Example Blog' } );
+		} );
+	} );
+
+	describe( '#getSiteSlug()', () => {
+		it( 'should return null if the site is not known', () => {
+			const slug = getSiteSlug( {
+				sites: {
+					items: {}
+				}
+			}, 2916284 );
+
+			expect( slug ).to.be.null;
+		} );
+
+		it( 'should return the unmapped hostname for a redirect site', () => {
+			const slug = getSiteSlug( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							options: {
+								is_redirect: true,
+								unmapped_url: 'https://example.wordpress.com'
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( site ).to.equal( 'example.wordpress.com' );
+		} );
+
+		it( 'should return the URL with scheme removed and paths separated', () => {
+			const slug = getSiteSlug( {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://testtwosites2014.wordpress.com/path/to/site'
+						}
+					}
+				}
+			}, 77203199 );
+
+			expect( slug ).to.equal( 'testtwosites2014.wordpress.com::path::to::site' );
 		} );
 	} );
 } );

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -1,4 +1,15 @@
 /**
+ * External dependencies
+ */
+import get from 'lodash/get';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteSlug } from 'state/sites/selectors';
+import { getSitePost } from 'state/posts/selectors';
+
+/**
  * Returns the current editor post ID, or `null` if a new post.
  *
  * @param  {Object}  state Global state tree
@@ -26,4 +37,36 @@ export function isEditorNewPost( state ) {
  */
 export function isEditorDraftsVisible( state ) {
 	return state.ui.editor.showDrafts;
+}
+
+/**
+ * Returns the editor URL path for the given site ID, post ID pair.
+ *
+ * @param  {Object} state  Global state tree
+ * @param  {Number} siteId Site ID
+ * @param  {Number} postId Post ID
+ * @return {String}        Editor URL path
+ */
+export function getEditorPath( state, siteId, postId ) {
+	const type = get( getSitePost( state, siteId, postId ), 'type', 'post' );
+
+	let path;
+	switch ( type ) {
+		case 'post': path = '/post'; break;
+		case 'page': path = '/page'; break;
+		default: path = `/type/${ type }`; break;
+	}
+
+	const siteSlug = getSiteSlug( state, siteId );
+	if ( siteSlug ) {
+		path += `/${ siteSlug }`;
+	} else {
+		path += `/${ siteId }`;
+	}
+
+	if ( postId ) {
+		path += `/${ postId }`;
+	}
+
+	return path;
 }

--- a/client/state/ui/editor/test/selectors.js
+++ b/client/state/ui/editor/test/selectors.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getEditorPostId, isEditorNewPost, isEditorDraftsVisible } from '../selectors';
+import { getEditorPostId, isEditorNewPost, isEditorDraftsVisible, getEditorPath } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#getEditorPostId()', () => {
@@ -60,6 +60,99 @@ describe( 'selectors', () => {
 			} );
 
 			expect( showDrafts ).to.be.true;
+		} );
+	} );
+
+	describe( '#getEditorPath()', () => {
+		it( 'should return the post path with the post ID if post unknown', () => {
+			const path = getEditorPath( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
+				posts: {
+					items: {}
+				}
+			}, 2916284, 841 );
+
+			expect( path ).to.equal( '/post/example.wordpress.com/841' );
+		} );
+
+		it( 'should return the post path with the site ID if site unknown', () => {
+			const path = getEditorPath( {
+				sites: {
+					items: {}
+				},
+				posts: {
+					items: {}
+				}
+			}, 2916284, 841 );
+
+			expect( path ).to.equal( '/post/2916284/841' );
+		} );
+
+		it( 'should prefix the post route for post types', () => {
+			const path = getEditorPath( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', type: 'post' }
+					}
+				}
+			}, 2916284, 841 );
+
+			expect( path ).to.equal( '/post/example.wordpress.com/841' );
+		} );
+
+		it( 'should prefix the page route for page types', () => {
+			const path = getEditorPath( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
+				posts: {
+					items: {
+						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', type: 'page' }
+					}
+				}
+			}, 2916284, 413 );
+
+			expect( path ).to.equal( '/page/example.wordpress.com/413' );
+		} );
+
+		it.only( 'should prefix the type route for custom post types', () => {
+			const path = getEditorPath( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
+				posts: {
+					items: {
+						'0fcb4eb16f493c19b627438fdc18d57c': { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', type: 'jetpack-portfolio' }
+					}
+				}
+			}, 2916284, 120 );
+
+			expect( path ).to.equal( '/type/jetpack-portfolio/example.wordpress.com/120' );
 		} );
 	} );
 } );

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -1,6 +1,11 @@
 /** @ssr-ready **/
 
 /**
+ * Internal dependencies
+ */
+import { getSite } from 'state/sites/selectors';
+
+/**
  * Returns the site object for the currently selected site.
  *
  * @param  {Object}  state  Global state tree
@@ -12,7 +17,7 @@ export function getSelectedSite( state ) {
 		return null;
 	}
 
-	return state.sites.items[ siteId ];
+	return getSite( state, siteId );
 }
 
 /**

--- a/client/tests.json
+++ b/client/tests.json
@@ -258,7 +258,7 @@
 			"plans": {
 				"test": [ "actions", "reducer" ]
 			},
-			"test": [ "actions", "reducer" ]
+			"test": [ "actions", "reducer", "selectors" ]
 		},
 		"support": {
 			"test": [ "actions", "reducer" ]


### PR DESCRIPTION
This pull request seeks to continue iterating on the layout of the custom post type post listing screen, adding featured image, last edited date, a view button, and edit link to each post list entry.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/13787063/bdbc65ca-eab0-11e5-9337-efc3281cc011.png)|![After](https://cloud.githubusercontent.com/assets/1779930/13786827/d6048f96-eaaf-11e5-9e61-81dfa9e370dc.png)

__Note:__ The layout is very much a work-in-progress and will continue to be refined over time.

__Reference design:__ https://cloudup.com/cdHFJ0ddwl7

__Implementation notes:__

- `getSiteSlug` must have been reimplemented, as while it does currently exist on the decorated `site` object, this is non-ideal and calculated values will be removed from the Redux store site state in the near future. See [`Site.prototype.updateComputedAttributes`](https://github.com/Automattic/wp-calypso/blob/3bde0a6b63d087b31cc4d026fe52b67c03bb0a27/client/lib/site/index.js#L85-L116) for the reference implementation and #2757 as the tracking issue for site state cleanup.
- `<PostTypePost />` will likely be split into separate components in a future iteration as each piece of the layout continues to be fleshed out.

__Testing instructions:__

1. Navigate to My Sites
2. If the current site does not have a custom post type enabled (e.g. Testimonials, Portfolio), switch to a site which has at least one enabled
3. Click the custom post type navigation item in the sidebar
4. Note that after posts have loaded, the layout reflects the "After" screenshot above for any posts which exist
5. Note that the edit link (title), view link, updated date, and featured image are accurate

Caveats:

- There is no loading indicator for posts
- There is no warning shown if no posts exist, only a blank page