### PR TITLE
State: Remove computed attributes from Redux site object

### DIFF
--- a/client/my-sites/themes/controller/index.node.js
+++ b/client/my-sites/themes/controller/index.node.js
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 /**
  * Internal Dependencies
  */
-import { ThemeSheet as ThemeSheetComponent } from 'my-sites/themes/sheet';
+import ThemeSheetComponent from 'my-sites/themes/sheet';
 import ThemeDetailsComponent from 'components/data/theme-details';
 import i18n from 'lib/mixins/i18n';
 import { getCurrentUser } from 'state/current-user/selectors';

--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -20,12 +20,10 @@ import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import Card from 'components/card';
-import { purchase, customize, activate, signup } from 'state/themes/actions';
-import { getSelectedSite } from 'state/ui/selectors';
-import ThemeHelpers from 'my-sites/themes/helpers';
+import { signup } from 'state/themes/actions';
 import i18n from 'lib/mixins/i18n';
 
-export const ThemeSheet = React.createClass( {
+const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
 
 	propTypes: {
@@ -48,19 +46,7 @@ export const ThemeSheet = React.createClass( {
 	},
 
 	onPrimaryClick() {
-		let action;
-
-		if ( ThemeHelpers.isPremium( this.props ) && ! this.props.purchased && this.props.isLoggedIn ) { //FIXME: purchased ENOENT
-			action = purchase( this.props, this.props.selectedSite, 'showcase-sheet' );
-		} else if ( this.props.active ) { //FIXME: active ENOENT
-			action = customize( this.props, this.props.selectedSite );
-		} else if ( this.props.isLoggedIn ) {
-			action = activate( this.props, this.props.selectedSite, 'showcase-sheet' );
-		} else {
-			action = signup( this.props );
-		}
-
-		this.props.dispatch( action );
+		this.props.dispatch( signup( this.props ) );
 	},
 
 	getContentElement( section ) {
@@ -167,8 +153,4 @@ export const ThemeSheet = React.createClass( {
 	}
 } )
 
-export default connect(
-	state => ( {
-		selectedSite: getSelectedSite( state ) || false,
-	} )
-)( ThemeSheet );
+export default connect()( ThemeSheet );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -26,7 +26,7 @@ var Main = require( 'components/main' ),
 	ThemeHelpers = require( './helpers' ),
 	actionLabels = require( './action-labels' ),
 	ThemesListSelectors = require( 'state/themes/themes-list/selectors' ),
-	getSelectedSite = require( 'state/ui/selectors' ).getSelectedSite;
+	sites = require( 'lib/sites-list' )();
 
 var ThemesSingleSite = React.createClass( {
 	propTypes: {
@@ -36,11 +36,7 @@ var ThemesSingleSite = React.createClass( {
 		trackScrollPage: React.PropTypes.func,
 		// Connected Props
 		queryParams: React.PropTypes.object,
-		themesList: React.PropTypes.array,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
-		] ).isRequired,
+		themesList: React.PropTypes.array
 	},
 
 	getInitialState: function() {
@@ -51,7 +47,7 @@ var ThemesSingleSite = React.createClass( {
 	},
 
 	togglePreview: function( theme ) {
-		const site = this.props.selectedSite;
+		const site = sites.getSelectedSite();
 		if ( site.jetpack ) {
 			this.props.dispatch( Action.customize( theme, site ) );
 		} else {
@@ -60,7 +56,8 @@ var ThemesSingleSite = React.createClass( {
 	},
 
 	getButtonOptions: function() {
-		const { dispatch, selectedSite: site } = this.props,
+		const { dispatch } = this.props,
+			site = sites.getSelectedSite(),
 			buttonOptions = {
 				preview: {
 					action: theme => this.togglePreview( theme ),
@@ -107,7 +104,7 @@ var ThemesSingleSite = React.createClass( {
 	},
 
 	renderJetpackMessage: function() {
-		var site = this.props.selectedSite;
+		var site = sites.getSelectedSite();
 		return (
 			<EmptyContent title={ this.translate( 'Changing Themes?' ) }
 				line={ this.translate( 'Use your site theme browser to manage themes.' ) }
@@ -119,7 +116,7 @@ var ThemesSingleSite = React.createClass( {
 	},
 
 	render: function() {
-		var site = this.props.selectedSite,
+		var site = sites.getSelectedSite(),
 			isJetpack = site.jetpack,
 			jetpackEnabled = config.isEnabled( 'manage/themes-jetpack' ),
 			buttonOptions = this.getButtonOptions(),
@@ -147,9 +144,9 @@ var ThemesSingleSite = React.createClass( {
 						} ) }
 						onButtonClick={ this.onPreviewButtonClick } />
 				}
-				<ActivatingTheme siteId={ this.props.selectedSite.ID } >
+				<ActivatingTheme siteId={ site.ID } >
 					<ThanksModal
-						site={ this.props.selectedSite }
+						site={ site }
 						clearActivated={ bindActionCreators( Action.clearActivated, this.props.dispatch ) } />
 				</ActivatingTheme>
 				<CurrentThemeData site={ site }>
@@ -187,7 +184,6 @@ var ThemesSingleSite = React.createClass( {
 export default connect(
 	state => ( {
 		queryParams: ThemesListSelectors.getQueryParams( state ),
-		themesList: ThemesListSelectors.getThemesList( state ),
-		selectedSite: getSelectedSite( state ) || false,
+		themesList: ThemesListSelectors.getThemesList( state )
 	} )
 )( ThemesSingleSite );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -131,6 +131,7 @@ const EditorDrawer = React.createClass( {
 	renderSharing: function() {
 		return (
 			<EditorSharingAccordion
+				site={ this.props.site }
 				post={ this.props.post }
 				isNew={ this.props.isNew } />
 		);

--- a/client/post-editor/editor-sharing/accordion.jsx
+++ b/client/post-editor/editor-sharing/accordion.jsx
@@ -143,8 +143,9 @@ export default connect(
 		const user = getCurrentUser( state );
 
 		return {
-			connections: site && user ? getSiteUserConnections( state, site.ID, user.ID ) : null,
-			site
+			// [TODO]: Reintroduce selected site from Redux state once needs
+			// have been met for use (e.g. `site.isModuleActive`)
+			connections: site && user ? getSiteUserConnections( state, site.ID, user.ID ) : null
 		};
 	},
 	( dispatch ) => {

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -2,13 +2,23 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
+import pick from 'lodash/pick';
 
 /**
  * Internal dependencies
  */
 import { plans } from './plans/reducer';
 import mediaStorage from './media-storage/reducer';
-import { SITE_RECEIVE, SERIALIZE, DESERIALIZE } from 'state/action-types';
+import { SITE_RECEIVE, DESERIALIZE } from 'state/action-types';
+import { sitesSchema } from './schema';
+import { isValidStateWithSchema } from 'state/utils';
+
+/**
+ * Constants
+ */
+// [TODO]: This validation is only necessary so long as we continue to receive
+// decorated sites from the `lib/sites-list` module.
+const VALID_SITE_KEYS = Object.keys( sitesSchema.patternProperties[ '^\\d+$' ].properties );
 
 /**
  * Tracks all known site objects, indexed by site ID.
@@ -20,14 +30,19 @@ import { SITE_RECEIVE, SERIALIZE, DESERIALIZE } from 'state/action-types';
 export function items( state = {}, action ) {
 	switch ( action.type ) {
 		case SITE_RECEIVE:
+			const site = pick( action.site, VALID_SITE_KEYS );
 			return Object.assign( {}, state, {
-				[ action.site.ID ]: action.site
+				[ site.ID ]: site
 			} );
-		case SERIALIZE:
-			return {};
+
 		case DESERIALIZE:
+			if ( isValidStateWithSchema( state, sitesSchema ) ) {
+				return state;
+			}
+
 			return {};
 	}
+
 	return state;
 }
 

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -53,9 +53,6 @@ export const sitesSchema = {
 					}
 				},
 				single_user_site: { type: 'boolean' },
-				domain: { type: 'string' },
-				slug: { type: 'string' },
-				title: { type: 'string' }
 			}
 		}
 	},

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -35,7 +35,7 @@ describe( 'reducer', () => {
 		} );
 
 		it( 'should index sites by ID', () => {
-			const state = items( null, {
+			const state = items( undefined, {
 				type: SITE_RECEIVE,
 				site: { ID: 2916284, name: 'WordPress.com Example Blog' }
 			} );
@@ -73,47 +73,54 @@ describe( 'reducer', () => {
 				2916284: { ID: 2916284, name: 'Just You Wait' }
 			} );
 		} );
-		describe( 'persistence', () => {
-			it( 'does not persist state because this is not implemented yet', () => {
-				const original = deepFreeze( {
-					2916284: {
-						ID: 2916284,
-						name: 'WordPress.com Example Blog',
-						somethingDecoratedMe: () => {
-						}
-					}
-				} );
-				const state = items( original, { type: SERIALIZE } );
-				expect( state ).to.eql( {} );
+
+		it( 'should strip invalid keys on the received site object', () => {
+			const state = items( undefined, {
+				type: SITE_RECEIVE,
+				site: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog',
+					slug: 'example.wordpress.com',
+					updateComputedAttributes() {}
+				}
 			} );
-			it( 'does not load persisted state because this is not implemented yet', () => {
-				const original = deepFreeze( {
-					2916284: {
-						ID: 2916284,
-						name: 'WordPress.com Example Blog'
-					},
-					2916285: {
-						ID: 2916285,
-						name: 'WordPress.com Example Blog 2'
-					}
-				} );
-				const state = items( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
+
+			expect( state ).to.eql( {
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
 			} );
-			it.skip( 'returns initial state when state is missing required properties', () => {
-				const original = deepFreeze( {
-					2916284: { name: 'WordPress.com Example Blog' }
-				} );
-				const state = items( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
+		} );
+
+		it( 'should persist state', () => {
+			const original = deepFreeze( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog'
+				}
 			} );
-			it.skip( 'returns initial state when state has invalid keys', () => {
-				const original = deepFreeze( {
-					foobar: { name: 'WordPress.com Example Blog' }
-				} );
-				const state = items( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
+			const state = items( original, { type: SERIALIZE } );
+
+			expect( state ).to.eql( original );
+		} );
+
+		it( 'should load valid persisted state', () => {
+			const original = deepFreeze( {
+				2916284: {
+					ID: 2916284,
+					name: 'WordPress.com Example Blog'
+				}
 			} );
+			const state = items( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( original );
+		} );
+
+		it( 'should return initial state when state is invalid', () => {
+			const original = deepFreeze( {
+				2916284: { bad: true }
+			} );
+			const state = items( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( {} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #2757 
Related: #4057

This pull request seeks to resolve remaining issues preventing us from persisting the Redux site state. Because some areas of the application had already depended upon site objects containing decorated attributes, changes were required to remove any such dependencies before site state could be persisted.

__Testing instructions:__

Ensure Mocha tests pass by running `npm test`

Verify that no regressions occur in affected components. Specifically:
- [Themes offline](http://calypso.localhost:3000/design) (primary actions)
- [Themes logged in single site](http://calypso.localhost:3000/design) (preview, button options, jetpack messaging)
- [Editor](http://calypso.localhost:3000/post) (Sharing accordion connections listing, disabling, etc.)

/cc @gwwar , @ockham , @seear , @ehg