### PR TITLE
Tests: Remove .js extension since files can be resolved without it

### DIFF
--- a/test/load-suite.js
+++ b/test/load-suite.js
@@ -3,7 +3,7 @@ function requireTestFiles( config, path = '' ) {
 		const folderConfig = config[ folderName ];
 
 		if ( folderName === 'test' ) {
-			folderConfig.forEach( fileName => require( `${path}test/${fileName}.js` ) );
+			folderConfig.forEach( fileName => require( `${path}test/${fileName}` ) );
 		} else {
 			describe( folderName, () => {
 				requireTestFiles( folderConfig, `${path}${folderName}/` );


### PR DESCRIPTION
This removes adding `.js` to the filename while requiring the test files since they can be resolved without the extensions and this will allow us to import `jsx` test files without any other changes.

/cc: @gziolo @blowery