### PR TITLE
Signup: Update category value in vertical survey

### DIFF
--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -113,24 +113,39 @@ export default React.createClass( {
 
 	showStepOne() {
 		const { value, label } = this.state.stepOne;
-		analytics.tracks.recordEvent( 'calypso_survey_category_back_click', { category: JSON.stringify( { value, label } ) } );
+		analytics.tracks.recordEvent( 'calypso_survey_category_back_click', {
+			category_id: value,
+			category_label: label
+		} );
 		this.setState( { stepOne: null } );
 	},
 
 	showStepTwo( stepOne ) {
 		const { value, label } = stepOne;
-		analytics.tracks.recordEvent( 'calypso_survey_category_click_level_one', { category: JSON.stringify( { value, label } ) } );
+		analytics.tracks.recordEvent( 'calypso_survey_category_click_level_one', {
+			category_id: value,
+			category_label: label
+		} );
 		this.setState( { stepOne } );
 	},
 
 	handleNextStep( vertical ) {
 		const { value, label } = vertical;
 		analytics.tracks.recordEvent( 'calypso_survey_site_type', { type: this.props.surveySiteType } );
-		analytics.tracks.recordEvent( 'calypso_survey_category_chosen', { category: JSON.stringify( { value, label } ) } );
+		analytics.tracks.recordEvent( 'calypso_survey_category_chosen', {
+			category_id: value,
+			category_label: label
+		} );
 		if ( this.state.stepOne ) {
-			analytics.tracks.recordEvent( 'calypso_survey_category_click_level_two', { category: JSON.stringify( { value, label } ) } );
+			analytics.tracks.recordEvent( 'calypso_survey_category_click_level_two', {
+				category_id: value,
+				category_label: label
+			} );
 		} else {
-			analytics.tracks.recordEvent( 'calypso_survey_category_click_level_one', { category: JSON.stringify( { value, label } ) } );
+			analytics.tracks.recordEvent( 'calypso_survey_category_click_level_one', {
+				category_id: value,
+				category_label: label
+			} );
 		}
 		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], { surveySiteType: this.props.surveySiteType, surveyQuestion: vertical.value } );
 		this.props.goToNextStep();


### PR DESCRIPTION
Currently, each category value in the vertical survey is a combination of ID and label. For example,
`{"value":"a8c.1.1.3","label":"Author Site"}`

Now the survey is translated to supported languages, and each category has as many labels as languages. And they are stored as if they were different categories, this makes the stats hard to analyse for some cases. 

For example,
`{"value":"a8c.1.1.3","label":"Site do autor"}`
and
`{"value":"a8c.1.1.3","label":"Author Site"}`

With this PR, we're going to track each category's ID and label separately so that the data can be flexible to segment depending on the purpose.

For example, 
`category_id: "a8c.1.1.3"`
and
`category_label: "Author Site"`