### PR TITLE
Add sending contextmenu event to Desktop app

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -654,7 +654,7 @@ function mediaButton( editor ) {
 
 	// send contextmenu event up to desktop app
 	if ( config.isEnabled( 'desktop' ) ) {
-		ipc = require( 'electron' ).ipcRenderer,          // From Electron
+		const ipc = require( 'electron' ).ipcRenderer; // From Electron
 		editor.on( 'contextmenu', function( ev ) {
 			ipc.send( 'mce-context-menu', ev );
 		} );

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -656,7 +656,7 @@ function mediaButton( editor ) {
 	if ( config.isEnabled( 'desktop' ) ) {
 		const ipc = require( 'electron' ).ipcRenderer; // From Electron
 		editor.on( 'contextmenu', function( ev ) {
-			ipc.send( 'mce-context-menu', ev );
+			ipc.send( 'mce-contextmenu', ev );
 		} );
 	}
 

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -654,6 +654,7 @@ function mediaButton( editor ) {
 
 	// send contextmenu event up to desktop app
 	if ( config.isEnabled( 'desktop' ) ) {
+		ipc = require( 'electron' ).ipcRenderer,          // From Electron
 		editor.on( 'contextmenu', function( ev ) {
 			ipc.send( 'mce-context-menu', ev );
 		} );

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -652,6 +652,13 @@ function mediaButton( editor ) {
 
 	editor.on( 'keydown', preventCaptionBackspaceRemove );
 
+	// send contextmenu event up to desktop app
+	if ( config.isEnabled( 'desktop' ) ) {
+		editor.on( 'contextmenu', function( ev ) {
+			ipc.send( 'mce-context-menu', ev );
+		} );
+	}
+
 	editor.on( 'touchstart touchmove touchend', selectImageOnTap() );
 
 	editor.on( 'init', function() {


### PR DESCRIPTION
In order to display the contextmenu within the visual editor, since it is in an iframe, we need to send the contextmenu event up to the app using IPC. With the Desktop app changes in https://github.com/Automattic/wp-desktop/pull/116 the Context Menu will include spelling suggestions and copy/paste functionality.