### PR TITLE
Checkout: Allow non-admins to renew their subscriptions

### DIFF
--- a/client/components/data/purchases/manage-purchase/index.jsx
+++ b/client/components/data/purchases/manage-purchase/index.jsx
@@ -27,6 +27,7 @@ const user = userFactory(),
 function getStateFromStores( props ) {
 	return {
 		cart: CartStore.get(),
+		hasLoadedSites: props.hasLoadedSites,
 		purchaseId: props.purchaseId,
 		selectedPurchase: PurchasesStore.getByPurchaseId( parseInt( props.purchaseId, 10 ) ),
 		selectedSite: props.selectedSite,
@@ -57,6 +58,7 @@ const ManagePurchaseData = React.createClass( {
 		return (
 			<StoreConnection
 				component={ this.props.component }
+				hasLoadedSites={ this.props.sites.fetched }
 				isDataLoading={ this.props.isDataLoading }
 				loadingPlaceholder={ this.props.loadingPlaceholder }
 				stores={ stores }

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -40,6 +40,10 @@ var PlanActions = React.createClass( {
 			return null;
 		}
 
+		if ( this.props.site && ! this.props.site.isUpgradeable() ) {
+			return null;
+		}
+
 		if ( this.siteHasThisPlan() ) {
 			if ( this.props.sitePlan.freeTrial ) {
 				return this.upgradeActions();
@@ -129,6 +133,10 @@ var PlanActions = React.createClass( {
 		event.preventDefault();
 
 		if ( this.props.isSubmitting ) {
+			return;
+		}
+
+		if ( this.props.site && ! this.props.site.isUpgradeable() ) {
 			return;
 		}
 

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -61,10 +61,6 @@ function setSelectedSite() {
 		return;
 	}
 
-	if ( ! selectedSite.isUpgradeable() ) {
-		return;
-	}
-
 	if ( _synchronizer && _poller ) {
 		PollerPool.remove( _poller );
 		_synchronizer.off( 'change', emitChange );

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -223,3 +223,10 @@
 			top: 16px;
 	}
 }
+
+.manage-purchase__contact-support {
+	border-top: solid 1px lighten( $gray, 30% );
+	color: $gray;
+	margin-top: 15px;
+	padding-top: 10px;
+}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -22,8 +22,9 @@ const RemovePurchase = React.createClass( {
 		selectedPurchase: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
-			React.PropTypes.bool
-		] ).isRequired,
+			React.PropTypes.bool,
+			React.PropTypes.undefined
+		] ),
 		user: React.PropTypes.object.isRequired
 	},
 


### PR DESCRIPTION
Fixes #3141 and #1870. Requires D1331-code.

Currently, only admins can purchase upgrades for a site. When an admin is demoted to e.g. a contributor, their purchases still show up on `/purchases`, but they cannot renew them.

This PR updates checkout so that non-admins can renew purchases.

**Testing**
- Create a site through `/start`. We'll refer to the user that created this site as **Alice**.
- Invite another user you have access to to be an administrator on this site through `/people/new/:site`. We'll call the user you invited **Bob**.
- Log in to **Bob** in an incognito window.
- **Bob**'s email account will have received an email for this invitation with a link to accept. Paste this link into the incognito window to accept the invite with **Bob**.
- Visit `/plans/:site` as **Bob** and purchase a plan.
- Using our internal admin tools, change the expiry of the subscription for this plan to very soon (< 2 weeks in the future).
- As **Alice**, visit `/people/team/:site`, click on **Bob**, and change the account's role to either contributor, author, or editor.
- In the incognito window for **Bob**, execute `localStorage.clear()` in the console and refresh the page.
- Visit `/purchases`.
- Click on the expiring plan.
- Assert that, as **Bob**, you can renew the plan.
- As **Alice**, visit `/people/team/:site`, click on **Bob**, and remove the account from the site.
- As **Bob**, visit `/purchases` and click on the plan.
- Assert that the component loads and information about the purchase is displayed, even though **Bob** is not a member of the site to which the purchase is attached.

- [x] Code review
- [x] Product review