### PR TITLE
Support User: Add a pre-Calypso-boot sequence to do any async initialization

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -44,7 +44,7 @@ var config = require( 'config' ),
 	syncHandler = require( 'lib/wp/sync-handler' ),
 	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
 	bindWpLocaleState = require( 'lib/wp/localization' ).bindState,
-	supportUser = require( 'lib/user/support-user-interop' ),
+	supportUser = require( 'lib/support/support-user/support-user-interop' ),
 	// The following components require the i18n mixin, so must be required after i18n is initialized
 	Layout;
 

--- a/client/lib/support/support-user/pre-boot.js
+++ b/client/lib/support/support-user/pre-boot.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import debugModule from 'debug';
+
+// This module is run at page startup when support user is active. It performs
+// any pre-Calypso-boot initialization that is required by support user. Once
+// the pre-boot completes, it loads the main Calypso bundles passed in via
+// `window.supportUser.readyScripts`.
+
+const debug = debugModule( 'calypso:support-user' );
+
+const loadScript = ( script, callback ) => {
+	var bundle = document.createElement( 'script' );
+	bundle.onload = callback;
+	bundle.src = script;
+	document.body.appendChild( bundle )
+}
+
+const bootCalypso = () => {
+	if ( ! window.supportUser || !window.supportUser.readyScripts ) {
+		console.error( 'supportUserReady scripts not specified' );
+	}
+
+	const readyScripts = window.supportUser.readyScripts;
+
+	let loadedScripts = 0;
+	readyScripts.forEach( ( script ) => {
+		debug( 'Booting Calypso bundle', window.supportUserReady );
+
+		loadScript( script, () => {
+			loadedScripts++;
+
+			// Boot Calypso when all scripts have loaded
+			if ( loadedScripts === readyScripts.length ) {
+				window.AppBoot();
+			}
+		} );
+	} );
+}
+
+debug( 'Support user preboot', window.supportUserReady );
+// Do any support user asynchronous pre-boot tasks before calling bootCalypso.
+// This is where localforage.defineDriver will be called in future.
+bootCalypso();

--- a/client/lib/support/support-user/support-user-interop.js
+++ b/client/lib/support/support-user/support-user-interop.js
@@ -45,6 +45,10 @@ const _isSupportUserSession = ( () => {
 		return false;
 	}
 
+	if ( ! window.supportUser ) {
+		return false;
+	}
+
 	const supportUser = store.get( STORAGE_KEY );
 	if ( supportUser && supportUser.user && supportUser.token ) {
 		return true;
@@ -66,7 +70,9 @@ export const rebootNormally = () => {
 	debug( 'Rebooting Calypso normally' );
 
 	store.clear();
-	window.location.reload();
+
+	// This triggers a reboot
+	window.location.search = 'support_user=false';
 };
 
 /**
@@ -82,7 +88,9 @@ export const rebootWithToken = ( user, token ) => {
 	debug( 'Rebooting Calypso with support user' );
 
 	store.set( STORAGE_KEY, { user, token } );
-	window.location.reload();
+
+	// This triggers a reboot
+	window.location.search = 'support_user=true';
 };
 
 // Called when an API call fails due to a token error
@@ -111,6 +119,8 @@ export const boot = () => {
 	reduxStoreReady.then( ( reduxStore ) => {
 		reduxStore.dispatch( supportUserActivate() );
 	} );
+
+	store.remove( STORAGE_KEY );
 };
 
 export const fetchToken = ( user, password ) => {

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isSupportUserSession, boot as supportUserBoot } from 'lib/user/support-user-interop';
+import { isSupportUserSession, boot as supportUserBoot } from 'lib/support/support-user/support-user-interop';
 
 /**
  * External dependencies

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -10,7 +10,7 @@ import pick from 'lodash/pick';
 import { createReduxStore, reducer } from 'state';
 import { SERIALIZE, DESERIALIZE, SERVER_DESERIALIZE } from 'state/action-types'
 import { getLocalForage } from 'lib/localforage';
-import { isSupportUserSession } from 'lib/user/support-user-interop';
+import { isSupportUserSession } from 'lib/support/support-user/support-user-interop';
 import config from 'config';
 
 /**

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -25,7 +25,7 @@ describe( 'initial-state', () => {
 			return 'development'; //needed to mock out lib/warn
 		};
 		configMock.isEnabled = isEnabled;
-		mockery.registerMock( 'lib/user/support-user-interop', { isSupportUserSession: isSupportUserSession } );
+		mockery.registerMock( 'lib/support/support-user/support-user-interop', { isSupportUserSession: isSupportUserSession } );
 		mockery.registerMock( 'config', configMock );
 		localforage = require( 'localforage' );
 		const initialState = require( 'state/initial-state' );

--- a/client/support/support-user/index.jsx
+++ b/client/support/support-user/index.jsx
@@ -10,7 +10,7 @@ import flowRight from 'lodash/flowRight';
  */
 import KeyboardShortcuts from 'lib/keyboard-shortcuts';
 import SupportUserLoginDialog from './login-dialog';
-import { fetchToken, rebootNormally } from 'lib/user/support-user-interop';
+import { fetchToken, rebootNormally } from 'lib/support/support-user/support-user-interop';
 
 import { supportUserToggleDialog } from 'state/support/actions';
 

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -110,6 +110,11 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				}
 			})();
 
+		if supportUser
+			script.
+				window.supportUser = {
+					readyScripts: []
+				};
 		if user
 			script(type='text/javascript')!='var currentUser = ' + sanitize.jsonStringifyForHtml( user )
 		if app
@@ -120,15 +125,30 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			script(src=i18nLocaleScript)
 		if 'development' === env || isDebug
 			script(src=urls[ 'vendor' ])
-			script(src=urls[ jsFile + '-' + env ])
-			if chunk
-				script(src=urls[ chunk ])
+			if supportUser
+				script!='window.supportUser.readyScripts.push( \'' + urls[ jsFile + '-' + env ] + '\' );'
+				if chunk
+					script!='window.supportUser.readyScripts.push( \'' + urls[ chunk ] + '\' );'
+				script(src=urls[ 'support-user' ])
+			else
+				script(src=urls[ jsFile + '-' + env ])
+				if chunk
+					script(src=urls[ chunk ])
 		else
 			script(src=urls[ 'vendor-min' ])
-			script(src=urls[ jsFile + '-' + env + '-min' ])
-			if chunk
-				script(src=urls[ chunk + '-min' ])
-		script(type='text/javascript')!='window.AppBoot();'
+			if supportUser
+				script!='window.supportUser.readyScripts.push( \'' + urls[ jsFile + '-' + env + '-min' ] + '\' );'
+				if chunk
+					script!='window.supportUser.readyScripts.push( \'' + urls[ chunk + '-min' ] + '\' );'
+
+				script(src=urls[ 'support-user-min' ])
+			else
+				script(src=urls[ jsFile + '-' + env + '-min' ])
+				if chunk
+					script(src=urls[ chunk + '-min' ])
+
+		unless supportUser
+			script(type='text/javascript')!='window.AppBoot();'
 
 		noscript.wpcom-site__global-noscript
 			|Please enable JavaScript in your browser to enjoy WordPress.com.

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -181,6 +181,11 @@ function getDefaultContext( request ) {
 		context.commitChecksum = getCurrentCommitShortChecksum();
 	}
 
+	if ( config.isEnabled( 'support-user' ) && request.query.support_user === 'true' ) {
+		context.supportUser = true;
+		context.user = false;
+	}
+
 	if ( config.isEnabled( 'code-splitting' ) ) {
 		chunk = getChunk( request.path );
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,9 +85,12 @@ webpackConfig = {
 if ( CALYPSO_ENV === 'desktop' || CALYPSO_ENV === 'desktop-mac-app-store' ) {
 	webpackConfig.output.filename = '[name].js';
 } else {
-	webpackConfig.entry.vendor = [ 'react', 'store', 'page', 'wpcom-unpublished', 'jed', 'debug' ];
+	webpackConfig.entry.vendor = [ 'react', 'store', 'page', 'wpcom-unpublished', 'jed', 'debug', 'localforage' ];
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( 'vendor', '[name].[hash].js' ) );
 	webpackConfig.plugins.push( new ChunkFileNamePlugin() );
+	if ( config.isEnabled( 'support-user' ) ) {
+		webpackConfig.entry[ 'support-user' ] = [ 'lib/support/support-user/pre-boot' ];
+	}
 	// jquery is only needed in the build for the desktop app
 	// see electron bug: https://github.com/atom/electron/issues/254
 	webpackConfig.externals.push( 'jquery' );


### PR DESCRIPTION
Blocks #3977 (this was originally part of #3977)

### Note: A neater alternative to this is changing `getLocalForage()` to return a Promise. See #4114

-------
### Overview

This change injects a pre-boot sequence when a special query string `?support_user=true` is set. Loading of the Calypso bundle scripts is delayed until **after** any asynchronous support user initialization is completed.

### Why?

The support user feature requires that its setup is done before **any** Calypso modules boot, or risk inconsistent data.

Until now, the support user boot sequence has been done _synchronously_ during the Calypso boot sequence, ensuring that the support user initialization was done before other modules booted. However, now that there is some async initialization required (localForage), the support user initialization gets pushed to the end of the event queue and various Calypso modules take the opportunity to do their initialization before support user has finished setting everything up.

You can verify the opportunistic boot behaviour by commenting out `window.AppBoot()` near the bottom of `/server/pages/index.jade`, set debug to `calypso:*` and notice that many Calypso modules boot up regardless.

### Solution

 - **The build-[env].[hash].js and other Calypso specific webpack chunks are not loaded on boot.** Instead we make sure support user has done any pre-boot async tasks before loading the Calypso bundle. _This only happens when the special query string is set:_
 - **A ?support_user=true query string is passed to inform the server** that this will be a support user session. This instructs the server to inject the special pre-boot sequence, and also leaves out any user specific info including the user bootstrap. When this query string is not set (or the `support-user` config flag is disabled), everything is rendered as usual.

### Testing

1. Grab the `update/support-user/insert-pre-boot-sequence` branch.
2. Start Calypso
3. Click View Source and notice that the webpack bundles are loaded as usual, for example:
```html
<script src="/calypso/vendor.[hash].js"></script>
<script src="/calypso/build-development.[hash].js"></script>
```
4. Add the special query string to the end of the current URL, for example: `http://calypso.localhost:3000/me?support_user=true`
5. Calypso should appear to boot as usual
6. Click View Source and notice that only the following two webpack bundles are loaded:
```html
<script src="/calypso/vendor.[hash].js"></script>
<script src="/calypso/support-user.[hash].js"></script>
```

Tested:
 - [x] With `support-user` feature flag disabled (query string should have no effect)
 - [x] With `wpcom_user_bootstrap` enabled
 - [x] Running in local `production` environment
 - [ ] Logged out pages
 - [x] Running in `development`
 - [x] Chrome 49
 - [x] Firefox
 - [x] Safari
 - [ ] IE

cc @mtias @aduth @gwwar @dllh