### PR TITLE
AB Test: Removing the promote free domain test

### DIFF
--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -13,7 +13,6 @@ var abtest = require( 'lib/abtest' ).abtest,
 	testFeatures = require( 'lib/features-list/test-features' ),
 	Gridicon = require( 'components/gridicon' ),
 	isJetpackPlan = require( 'lib/products-values' ).isJetpackPlan,
-	isPlan = require( 'lib/products-values' ).isPlan,
 	JetpackPlanDetails = require( 'my-sites/plans/jetpack-plan-details' ),
 	PlanActions = require( 'components/plans/plan-actions' ),
 	PlanHeader = require( 'components/plans/plan-header' ),
@@ -252,25 +251,6 @@ module.exports = React.createClass( {
 		);
 	},
 
-	getFreeDomainMessage: function() {
-		if ( abtest( 'promoteFreeDomain' ) !== 'freeDomain' ) {
-			return null;
-		}
-
-		if ( this.props.plan && isPlan( this.props.plan ) ) {
-			return (
-				<div className="plan__free-domain-message">
-					<Gridicon icon="checkmark" size={ 12 } />
-					{ this.translate( 'Includes a free domain' ) }
-				</div>
-			);
-		}
-
-		return (
-			<div className="plan__free-plan-message">&nbsp;</div>
-		);
-	},
-
 	render: function() {
 		var shouldDisplayFeatureList = this.props.plan && ! isJetpackPlan( this.props.plan ) && abtest( 'plansFeatureList' ) !== 'description';
 		return (
@@ -283,7 +263,6 @@ module.exports = React.createClass( {
 
 					{ this.getImagePlanAction() }
 					{ this.getPlanPrice() }
-					{ this.getFreeDomainMessage() }
 				</PlanHeader>
 				<div className="plan__plan-expand">
 					<div className="plan__plan-details">

--- a/client/components/plans/plan/style.scss
+++ b/client/components/plans/plan/style.scss
@@ -97,14 +97,6 @@
 		border-top: 2px solid lighten( $gray, 20% );
 		float: left;
 	}
-
-	.plan__free-plan-message {
-		display: none;
-	}
-
-	.plan__free-domain-message {
-		padding-left: 40px;
-	}
 }
 
 @mixin plans-in-three-columns() {
@@ -141,11 +133,6 @@
 			flex-wrap: nowrap;
 			justify-content: center;
 	}
-
-	.plan__free-domain-message {
-		margin-top: 5px;
-		text-align: center;
-	}
 }
 
 .plans.has-sidebar {
@@ -181,13 +168,4 @@
 	position: relative;
 		left: -5px;
 		top: 2px;
-}
-
-.plan__free-domain-message {
-	color: $alert-green;
-	font-size: 13px;
-
-	.gridicon {
-		margin-right: 5px;
-	}
 }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -70,15 +70,6 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
-	promoteFreeDomain: {
-		datestamp: '20160302',
-		variations: {
-			original: 50,
-			freeDomain: 50
-		},
-		defaultVariation: 'original',
-		excludeSitesWithPaidPlan: true
-	},
 	domainSearchPlaceholderText: {
 		datestamp: '20160304',
 		variations: {


### PR DESCRIPTION
This removes an AB test promoting a free domain in a plan.

Before:
<img width="763" alt="screen shot 2016-03-02 at 10 54 38" src="https://cloud.githubusercontent.com/assets/275961/13814705/393d0492-eb7f-11e5-8ea0-e0d767f00650.png">

After:
<img width="775" alt="screen shot 2016-03-02 at 10 53 18" src="https://cloud.githubusercontent.com/assets/275961/13814709/3b83dece-eb7f-11e5-806c-ad55f5384c05.png">
 
#### Testing instructions

1. Run `git checkout remove/promote-free-domain-test` and start your server
2. Open the [`Plans` page](http://calypso.localhost:3000/plans)
3. Add yourself to the AB test: `localStorage.setItem( 'ABTests', '{"promoteFreeDomain_20160302":"freeDomain"}' )`
4. Ensure that you don't see a message promoting a free domain.

#### Reviews

- [x] Code
- [x] Product