### PR TITLE
Sites: Set section and hide sidebar on site selection

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -268,6 +268,10 @@ module.exports = {
 		 * Sites is rendered on #primary but it doesn't expect a sidebar to exist
 		 * so section needs to be set explicitly and #secondary cleaned up
 		 */
+		context.store.dispatch( uiActions.setSection( {
+			group: 'sites',
+			secondary: false
+		} ) );
 		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		layoutFocus.set( 'content' );
 


### PR DESCRIPTION
This pull request seeks to resolve a few regressions introduced in section refactoring of #3913 ([see noted issues](https://github.com/Automattic/wp-calypso/pull/3913/files#r56334832)).

This does not refactor the flow by which the site selector is rendered to the page, nor offer a standalone usage to which site selection is redirected. Rather, it simply reintroduces the original intent to set the sites section and hide the sidebar.

__Testing instructions:__

1. Navigate to [editor non-site route](http://calypso.localhost:3000/post) and [stats non-site route](http://calypso.localhost:3000/stats/insights)
2. Note in both cases that the site selector is center-aligned, with standard Calypso blue background
3. Choose a site
4. Note that upon choosing a site, you are directed to the editor/stats page, with sidebar visible and content aligned correctly in primary content area

/cc @mtias