### PR TITLE
Reader: Fixup missing tracks events

### DIFF
--- a/client/reader/comments/comment-likes.jsx
+++ b/client/reader/comments/comment-likes.jsx
@@ -48,6 +48,10 @@ var CommentLikeButtonContainer = React.createClass( {
 		CommentLikeActions[ liked ? 'likeComment' : 'unlikeComment' ]( this.props.siteId, this.props.commentId );
 		stats.recordAction( liked ? 'liked_comment' : 'unliked_comment' );
 		stats.recordGaEvent( liked ? 'Clicked Comment Like' : 'Clicked Comment Unlike' );
+		stats.recordTrack( 'caplyso_reader_' + ( liked ? 'liked' : 'unliked' ) + '_comment', {
+			blog_id: this.props.siteId,
+			comment_id: this.props.commentId
+		} );
 	},
 
 	render: function() {

--- a/client/reader/comments/comment-likes.jsx
+++ b/client/reader/comments/comment-likes.jsx
@@ -48,7 +48,7 @@ var CommentLikeButtonContainer = React.createClass( {
 		CommentLikeActions[ liked ? 'likeComment' : 'unlikeComment' ]( this.props.siteId, this.props.commentId );
 		stats.recordAction( liked ? 'liked_comment' : 'unliked_comment' );
 		stats.recordGaEvent( liked ? 'Clicked Comment Like' : 'Clicked Comment Unlike' );
-		stats.recordTrack( 'caplyso_reader_' + ( liked ? 'liked' : 'unliked' ) + '_comment', {
+		stats.recordTrack( 'calypso_reader_' + ( liked ? 'liked' : 'unliked' ) + '_comment', {
 			blog_id: this.props.siteId,
 			comment_id: this.props.commentId
 		} );

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -35,7 +35,7 @@ import userSettings from 'lib/user-settings';
 let __lastTitle = null;
 const activeAbTests = [
 	'readerShorterFeatures2'
-]
+];
 
 function trackPageLoad( path, title, readerView ) {
 	analytics.pageView.record( path, title );
@@ -45,13 +45,20 @@ function trackPageLoad( path, title, readerView ) {
 function trackUpdatesLoaded( key ) {
 	analytics.mc.bumpStat( 'reader_views', key + '_load_new' );
 	analytics.ga.recordEvent( 'Reader', 'Clicked Load New Posts', key );
+	stats.recordTrack( 'calypso_reader_load_new_posts', {
+		section: key
+	} );
 }
 
 function trackScrollPage( path, title, category, readerView, pageNum ) {
 	debug( 'scroll [%s], [%s], [%s], [%d]', path, title, category, pageNum );
 
 	analytics.ga.recordEvent( category, 'Loaded Next Page', 'page', pageNum );
-	stats.recordTrack( 'calypso_reader_infinite_scroll_performed' );
+	stats.recordTrack( 'calypso_reader_infinite_scroll_performed', {
+		path: path,
+		page: pageNum,
+		section: readerView
+	} );
 	analytics.pageView.record( path, title );
 	analytics.mc.bumpStat( {
 		newdash_pageviews: 'scroll',

--- a/client/reader/discover/post-attribution.jsx
+++ b/client/reader/discover/post-attribution.jsx
@@ -7,7 +7,8 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var DiscoverHelper = require( './helper' );
+var DiscoverHelper = require( './helper' ),
+	stats = require( 'reader/stats' );
 
 var arrowGridicon = ( <svg className="gridicon gridicon-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 11H6.414l6.293-6.293-1.414-1.414L2.586 12l8.707 8.707 1.414-1.414L6.414 13H20"/></svg> );
 
@@ -24,7 +25,19 @@ var DiscoverPostAttribution = React.createClass( {
 		siteUrl: React.PropTypes.string.isRequired
 	},
 
-	render: function() {
+	recordAuthorClick() {
+		stats.recordTrack( 'calypso_reader_author_on_discover_card_clicked', {
+			author_url: this.props.attribution.author_url
+		} );
+	},
+
+	recordSiteClick() {
+		stats.recordTrack( 'calypso_reader_site_on_discover_card_clicked', {
+			site_url: this.props.siteUrl
+		} );
+	},
+
+	render() {
 		const attribution = this.props.attribution;
 		const classes = classNames( 'discover-attribution is-post', {
 			'is-missing-avatar': ! attribution.avatar_url
@@ -37,9 +50,9 @@ var DiscoverPostAttribution = React.createClass( {
 				{ attribution.avatar_url ? <img className="gravatar" src={ encodeURI( attribution.avatar_url ) } alt="Avatar" width="20" height="20" /> : arrowGridicon }
 				<span className="discover-attribution__text">
 					{ this.translate( 'Originally posted by' ) }
-					<a className="discover-attribution__author" rel="external" target="_blank" href={ encodeURI( attribution.author_url ) }>{ attribution.author_name }</a>
+					<a className="discover-attribution__author" rel="external" target="_blank" onClick={ this.recordAuthorClick } href={ encodeURI( attribution.author_url ) }>{ attribution.author_name }</a>
 					{ this.translate( 'on' ) }
-					<a {...siteLinkProps} className={ siteClasses } href={ encodeURI( this.props.siteUrl ) }>{ attribution.blog_name }</a>
+					<a {...siteLinkProps} className={ siteClasses } onClick={ this.recordSiteClick } href={ encodeURI( this.props.siteUrl ) }>{ attribution.blog_name }</a>
 				</span>
 			</div>
 		);

--- a/client/reader/discover/visit-link.jsx
+++ b/client/reader/discover/visit-link.jsx
@@ -14,7 +14,7 @@ var DiscoverVisitLink = React.createClass( {
 	},
 
 	recordClick: function() {
-		stats.recordPermalinkClick( 'summary_card_site_name' );
+		stats.recordPermalinkClick( 'discover_summary_card_site_name' );
 		stats.recordGaEvent( 'Clicked Discover Permalink' );
 	},
 

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -10,17 +10,19 @@ import Main from 'components/main';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import EmptyContent from 'components/empty-content';
 import i18n from 'lib/mixins/i18n';
-import { recordAction, recordGaEvent } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
 const FeedError = React.createClass( {
 	recordAction() {
-		recordAction( 'clicked_discover_on_empty' );
-		recordGaEvent( 'Clicked Discover on EmptyContent' );
+		recordAction( 'clicked_discover_on_404' );
+		recordGaEvent( 'Clicked Discover on 404' );
+		recordTrack( 'calypso_reader_discover_on_feed_error_clicked' );
 	},
 
 	recordSecondaryAction() {
-		recordAction( 'clicked_recommendations_on_empty' );
-		recordGaEvent( 'Clicked Recommendations on EmptyContent' );
+		recordAction( 'clicked_recommendations_on_404' );
+		recordGaEvent( 'Clicked Recommendations on 404' );
+		recordTrack( 'calypso_reader_recommendations_on_feed_error_clicked' );
 	},
 
 	render() {

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -12,11 +12,13 @@ var FeedEmptyContent = React.createClass( {
 	recordAction: function() {
 		stats.recordAction( 'clicked_discover_on_empty' );
 		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_discover_on_empty_feed_clicked' );
 	},
 
 	recordSecondaryAction: function() {
 		stats.recordAction( 'clicked_recommendations_on_empty' );
 		stats.recordGaEvent( 'Clicked Recommendations on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_recommendations_on_empty_feed_clicked' );
 	},
 
 	render: function() {

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -236,6 +236,7 @@ const FollowingEdit = React.createClass( {
 		this.setState( { isAttemptingFollow: false } );
 		stats.recordAction( 'dismiss_follow_error' );
 		stats.recordGaEvent( 'Clicked Dismiss Follow Error' );
+		stats.recordTrack( 'calypso_reader_follow_error_dismissed' );
 	},
 
 	handleNewSubscriptionSearch: function( searchString ) {

--- a/client/reader/following-stream/empty.jsx
+++ b/client/reader/following-stream/empty.jsx
@@ -12,11 +12,13 @@ var FollowingEmptyContent = React.createClass( {
 	recordAction: function() {
 		stats.recordAction( 'clicked_discover_on_empty' );
 		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_discover_on_empty_stream_clicked' );
 	},
 
 	recordSecondaryAction: function() {
 		stats.recordAction( 'clicked_recommendations_on_empty' );
 		stats.recordGaEvent( 'Clicked Recommendations on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_recommendations_on_empty_stream_clicked' );
 	},
 
 	render: function() {

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -216,16 +216,23 @@ const Post = React.createClass( {
 			featuredImageClasses = classnames( featuredImageClasses, 'is-shorter-abtest' );
 		}
 
-		return useFeaturedEmbed ?
-			<div ref="featuredEmbed" className="reader__post-featured-video" key="featuredVideo" dangerouslySetInnerHTML={ { __html: featuredEmbed.iframe } } /> : //eslint-disable-line react/no-danger
-			<div className={ featuredImageClasses } onClick={ this.handlePermalinkClick } style={ { maxHeight: maxImageHeight } }>
-				{ featuredSize ?
-					<img className="reader__post-featured-image-image"
-						ref="featuredImage"
-						src={ featuredImage }
-						style={ featuredSize }
-						/> :
-					<img className="reader__post-featured-image-image" src={ featuredImage } />
+		return useFeaturedEmbed
+			? <div
+					ref="featuredEmbed"
+					className="reader__post-featured-video"
+					key="featuredVideo"
+					dangerouslySetInnerHTML={ { __html: featuredEmbed.iframe } } />  //eslint-disable-line react/no-danger
+			: <div
+					className={ featuredImageClasses }
+					onClick={ this.handlePermalinkClick }
+					style={ { maxHeight: maxImageHeight } }>
+				{ featuredSize
+					? <img className="reader__post-featured-image-image"
+							ref="featuredImage"
+							src={ featuredImage }
+							style={ featuredSize }
+						/>
+					: <img className="reader__post-featured-image-image" src={ featuredImage } />
 				}
 			</div>;
 	},
@@ -299,12 +306,8 @@ const Post = React.createClass( {
 	handleCommentButtonClick: function() {
 		stats.recordAction( 'click_comments' );
 		stats.recordGaEvent( 'Clicked Post Comment Button' );
+		stats.recordTrackForPost( 'calypso_reader_post_comments_button_clicked', this.props.post );
 		this.propagateCardClick( { comments: true } );
-	},
-
-	recordTagClick: function() {
-		stats.recordAction( 'click_tag' );
-		stats.recordGaEvent( 'Clicked Tag Link' );
 	},
 
 	_parseEmoji: function() {
@@ -420,27 +423,29 @@ const Post = React.createClass( {
 
 				<PostByline post={ post } site={ this.props.site } />
 
-				{ shouldUseFullExcerpt ?
-					<div key="full-post-inline" className="reader__full-post-content" dangerouslySetInnerHTML={{ __html: post.content }}></div> : //eslint-disable-line react/no-danger
-					<PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
+				{ shouldUseFullExcerpt
+					? <div key="full-post-inline" className="reader__full-post-content" dangerouslySetInnerHTML={ { __html: post.content } }></div> //eslint-disable-line react/no-danger
+					: <PostExcerpt content={ post.better_excerpt ? post.better_excerpt : post.excerpt } />
 				}
 
-				{ shouldShowExcerptOnly ?
-					<PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> : null }
+				{ shouldShowExcerptOnly
+					? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } />
+					: null }
 
-				{ ! shouldShowExcerptOnly ?
-					<PostImages postImages={ post.content_images || [] } /> : null }
+				{ ! shouldShowExcerptOnly
+					? <PostImages postImages={ post.content_images || [] } />
+					: null }
 
 				{ ( isDiscoverPost && ! isDiscoverSitePick ) ? <DiscoverPostAttribution attribution={ post.discover_metadata.attribution } siteUrl={ discoverSiteUrl } /> : null }
 				{ ( isDiscoverSitePick ) ? <DiscoverSiteAttribution attribution={ post.discover_metadata.attribution } siteUrl={ discoverSiteUrl } /> : null }
 
-				{ this.props.xPostedTo ?
-					<div className="reader__x-post-to">
-						<Gridicon icon="arrow-right" size={ 24 } />
-						<span className="reader__x-post-label">{ this.translate( 'cross-posted to' ) } </span>
-						{ xPostedToContent }
-					</div> :
-					null
+				{ this.props.xPostedTo
+					? <div className="reader__x-post-to">
+							<Gridicon icon="arrow-right" size={ 24 } />
+							<span className="reader__x-post-label">{ this.translate( 'cross-posted to' ) } </span>
+							{ xPostedToContent }
+						</div>
+					: null
 				}
 
 				<ul className="reader__post-footer">

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -287,11 +287,13 @@ FullPostDialog = React.createClass( {
 		this.refs.fullPost.scrollToComments();
 		stats.recordAction( 'click_comments' );
 		stats.recordGaEvent( 'Clicked Post Comment Button' );
+		stats.recordTrackForPost( 'calypso_reader_full_post_comments_button_clicked', this.props.post );
 	},
 
 	handleClose: function( action ) {
-		stats.recordAction( 'modal_close' );
+		stats.recordAction( 'full_post_close' );
 		stats.recordGaEvent( 'Closed Full Post Dialog', action || 'backdrop' );
+		stats.recordTrackForPost( 'calypso_reader_article_closed', this.props.post );
 		this.props.onClose( action );
 	},
 
@@ -449,13 +451,7 @@ FullPostContainer = React.createClass( {
 		}
 
 		if ( ! this.hasLoaded && post && post._state !== 'pending' ) {
-			stats.recordTrack( 'calypso_reader_article_opened', {
-				blog_id: ! post.is_external && post.site_ID > 0 ? post.site_ID : undefined,
-				post_id: ! post.is_external && post.ID > 0 ? post.ID : undefined,
-				feed_id: post.feed_ID > 0 ? post.feed_ID : undefined,
-				feed_item_id: post.feed_item_ID > 0 ? post.feed_item_ID : undefined,
-				is_jetpack: post.is_jetpack
-			} );
+			stats.recordTrackForPost( 'calypso_reader_article_opened', post );
 			this.hasLoaded = true;
 		}
 	},

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -10,13 +10,15 @@ var TagEmptyContent = React.createClass( {
 	},
 
 	recordAction: function() {
-		stats.recordAction( 'clicked_following_on_empty' );
-		stats.recordGaEvent( 'Clicked Following on EmptyContent' );
+		stats.recordAction( 'clicked_following_on_empty_likes' );
+		stats.recordGaEvent( 'Clicked Following on Empty Like Stream' );
+		stats.recordTrack( 'calypso_reader_following_on_empty_like_stream_clicked' );
 	},
 
 	recordSecondaryAction: function() {
-		stats.recordAction( 'clicked_discover_on_empty' );
-		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
+		stats.recordAction( 'clicked_discover_on_empty_likes' );
+		stats.recordGaEvent( 'Clicked Discover on Empty Like Stream' );
+		stats.recordTrack( 'calypso_reader_discover_on_empty_like_stream_clicked' );
 	},
 
 	render: function() {

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -12,11 +12,13 @@ var ListEmptyContent = React.createClass( {
 	recordAction: function() {
 		stats.recordAction( 'clicked_following_on_empty' );
 		stats.recordGaEvent( 'Clicked Following on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_following_on_empty_list_stream_clicked' );
 	},
 
 	recordSecondaryAction: function() {
 		stats.recordAction( 'clicked_discover_on_empty' );
 		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_discover_on_empty_list_stream_clicked' );
 	},
 
 	render: function() {

--- a/client/reader/post-byline/index.jsx
+++ b/client/reader/post-byline/index.jsx
@@ -18,6 +18,9 @@ var PostByline = React.createClass( {
 	recordTagClick: function() {
 		stats.recordAction( 'click_tag' );
 		stats.recordGaEvent( 'Clicked Tag Link' );
+		stats.recordTrackForPost( 'calypso_reader_tag_clicked', this.props.post, {
+			tag: this.props.post.primary_tag.slug
+		} );
 	},
 
 	recordDateClick: function() {
@@ -28,6 +31,7 @@ var PostByline = React.createClass( {
 	recordAuthorClick: function() {
 		stats.recordAction( 'click_author' );
 		stats.recordGaEvent( 'Clicked Author Link' );
+		stats.recordTrackForPost( 'calypso_reader_author_link_clicked', this.props.post );
 	},
 
 	renderAuthorName: function() {

--- a/client/reader/post-errors/index.jsx
+++ b/client/reader/post-errors/index.jsx
@@ -105,10 +105,12 @@ var PostError = React.createClass( {
 			FeedSubscriptionActions.dismissError( error );
 			stats.recordAction( 'dismiss_follow_error' );
 			stats.recordGaEvent( 'Clicked Dismiss Follow Error' );
+			stats.recordTrack( 'calypso_reader_follow_error_dismissed' );
 		} else if ( error.errorType === SiteBlockStoreErrorTypes.UNABLE_TO_BLOCK ) {
 			SiteBlockActions.dismissError( error );
 			stats.recordAction( 'dismiss_block_error' );
 			stats.recordGaEvent( 'Clicked Dismiss Block Error' );
+			stats.recordTrack( 'calypso_reader_block_error_dismissed' );
 		}
 	},
 

--- a/client/reader/post-images/index.jsx
+++ b/client/reader/post-images/index.jsx
@@ -87,6 +87,9 @@ var PostImages = React.createClass( {
 
 		stats.recordAction( newState ? 'open_gallery' : 'close_gallery' );
 		stats.recordGaEvent( newState ? 'Clicked Open Gallery' : 'Clicked Close Gallery' );
+		stats.recordTrack( 'calypso_reader_post_gallery_' + ( newState ? 'opened' : 'closed' ), {
+			image_count: this.props.postImages && this.props.postImages.length
+		} );
 
 		this.setState( {
 			viewing: newState

--- a/client/reader/post-options/index.jsx
+++ b/client/reader/post-options/index.jsx
@@ -83,9 +83,7 @@ const PostOptions = React.createClass( {
 	blockSite() {
 		stats.recordAction( 'blocked_blog' );
 		stats.recordGaEvent( 'Clicked Block Site' );
-		stats.recordTrack( 'calypso_reader_block_site', {
-			blog_id: this.props.post.site_ID
-		} );
+		stats.recordTrackForPost( 'calypso_reader_block_site', this.props.post );
 		SiteBlockActions.block( this.props.post.site_ID );
 		this.props.onBlock();
 	},
@@ -97,6 +95,7 @@ const PostOptions = React.createClass( {
 
 		stats.recordAction( 'report_post' );
 		stats.recordGaEvent( 'Clicked Report Post', 'post_options' );
+		stats.recordTrackForPost( 'calypso_reader_post_reported', this.props.post );
 
 		window.open( 'https://wordpress.com/abuse/?report_url=' + encodeURIComponent( this.props.post.URL ), '_blank' );
 	},
@@ -128,6 +127,7 @@ const PostOptions = React.createClass( {
 		} );
 		stats.recordAction( newState ? 'open_post_options_menu' : 'close_post_options_menu' );
 		stats.recordGaEvent( newState ? 'Open Post Options Menu' : 'Close Post Options Menu' );
+		stats.recordTrackForPost( 'calypso_reader_post_options_menu_' + ( newState ? 'opened' : 'closed' ), this.props.post );
 	},
 
 	_closePopoverMenu() {
@@ -149,6 +149,7 @@ const PostOptions = React.createClass( {
 
 		stats.recordAction( 'edit_post' );
 		stats.recordGaEvent( 'Clicked Edit Post', 'post_options' );
+		stats.recordTrackForPost( 'calypso_reader_edit_post_clicked', this.props.post );
 
 		setTimeout( function() { // give the analytics a chance to escape
 			if ( editUrl.indexOf( '//' ) === 0 ) {

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -115,7 +115,7 @@ const RecommendedForYou = React.createClass( {
 			<ListItem key={ itemKey } ref={ itemKey }>
 				<Icon><SiteIcon site={ site } size={ 48 } /></Icon>
 				<Title>
-					<a href={ siteUrl } onclick={ this.trackSiteClick }>{ title }</a>
+					<a href={ siteUrl } onClick={ this.trackSiteClick }>{ title }</a>
 				</Title>
 				<Description>{ decodeEntities( rec.reason ) }</Description>
 				<Actions>

--- a/client/reader/recommendations/for-you/index.jsx
+++ b/client/reader/recommendations/for-you/index.jsx
@@ -16,7 +16,7 @@ import FollowButton from 'reader/follow-button';
 import RecommendedSites from 'lib/recommended-sites-store/store';
 import { fetchMore } from 'lib/recommended-sites-store/actions';
 import SiteStore from 'lib/reader-site-store';
-import { recordAction, recordGaEvent } from 'reader/stats';
+import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { getSiteUrl } from 'reader/route';
 import { decodeEntities } from 'lib/formatting';
 
@@ -96,9 +96,13 @@ const RecommendedForYou = React.createClass( {
 		return 'recommendation-' + rec.blog_id;
 	},
 
-	trackSiteClick() {
+	trackSiteClick( event ) {
+		const clickedUrl = event.currentTarget.getAttribute( 'href' );
 		recordAction( 'click_site_on_recommended_for_you' );
 		recordGaEvent( 'Clicked Site on Recommended For You' );
+		recordTrack( 'calypso_reader_recommended_site_clicked', {
+			clicked_url: clickedUrl
+		} );
 	},
 
 	renderItem( rec ) {

--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -90,6 +90,9 @@ var ReaderShare = React.createClass( {
 		if ( actionFunc ) {
 			stats.recordAction( 'share_' + action );
 			stats.recordGaEvent( 'Clicked on Share to ' + action );
+			stats.recordTrack( 'calypso_reader_share_action_picked', {
+				action: action
+			} );
 			actionFunc( this.props.post );
 		}
 		this.setState( { showingMenu: false } );

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -26,12 +26,14 @@ const ReaderSidebarLists = React.createClass( {
 	createList( list ) {
 		stats.recordAction( 'add_list' );
 		stats.recordGaEvent( 'Clicked Create List' );
+		stats.recordTrack( 'calypso_reader_create_list_clicked' );
 		ReaderListsActions.create( list );
 	},
 
 	handleAddClick() {
 		stats.recordAction( 'add_list_open_input' );
 		stats.recordGaEvent( 'Clicked Add List to Open Input' );
+		stats.recordTrack( 'calypso_reader_add_list_clicked' );
 	},
 
 	render() {

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -55,6 +55,7 @@ const ReaderSidebarTags = React.createClass( {
 	handleAddClick() {
 		stats.recordAction( 'follow_topic_open_input' );
 		stats.recordGaEvent( 'Clicked Add Topic to Open Input' );
+		stats.recordTrack( 'calypso_reader_add_tag_clicked' );
 	},
 
 	render() {

--- a/client/reader/site-link/index.jsx
+++ b/client/reader/site-link/index.jsx
@@ -8,6 +8,7 @@ var SiteLink = React.createClass( {
 	recordClick: function() {
 		stats.recordAction( 'visit_blog_feed' );
 		stats.recordGaEvent( 'Clicked Feed Link' );
+		stats.recordTrackForPost( 'calypso_reader_feed_link_clicked', this.props.post );
 	},
 
 	render: function() {

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -12,11 +12,13 @@ var SiteEmptyContent = React.createClass( {
 	recordAction: function() {
 		stats.recordAction( 'clicked_discover_on_empty' );
 		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_discover_on_empty_site_stream_clicked' );
 	},
 
 	recordSecondaryAction: function() {
 		stats.recordAction( 'clicked_recommendations_on_empty' );
 		stats.recordGaEvent( 'Clicked Recommendations on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_recommendations_on_empty_site_stream_clicked' );
 	},
 
 	render: function() {

--- a/client/reader/site-stream/featured.jsx
+++ b/client/reader/site-stream/featured.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
-import get from 'lodash/get';
 
 /**
  * Internal Dependencies
@@ -88,7 +87,7 @@ export default React.createClass( {
 
 	handleClick( postData ) {
 		let post = postData.post;
-		stats.recordTrack( 'calypso_reader_clicked_featured_post', { blog_id: post.site_ID, post_id: post.ID } )
+		stats.recordTrackForPost( 'calypso_reader_clicked_featured_post', post );
 		stats.recordAction( 'clicked_featured_post' );
 		stats.recordGaEvent( 'Clicked Featured Post' );
 

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -1,3 +1,5 @@
+import assign from 'lodash/assign';
+
 import { mc, ga, tracks } from 'analytics';
 
 import SubscriptionStore from 'lib/reader-feed-subscriptions';
@@ -14,6 +16,9 @@ export function recordPermalinkClick( where ) {
 	mc.bumpStat( {
 		reader_actions: 'visited_post_permalink',
 		reader_permalink_source: where
+	} );
+	recordTrack( 'calypso_reader_permalink_click', {
+		source: where
 	} );
 }
 
@@ -84,4 +89,14 @@ export function recordTrack( eventName, eventProperties ) {
 		eventProperties = Object.assign( { subscription_count: subCount }, eventProperties );
 	}
 	tracks.recordEvent( eventName, eventProperties );
+}
+
+export function recordTrackForPost( eventName, post = {}, additionalProps = {} ) {
+	recordTrack( eventName, assign( {
+		blog_id: ! post.is_external && post.site_ID > 0 ? post.site_ID : undefined,
+		post_id: ! post.is_external && post.ID > 0 ? post.ID : undefined,
+		feed_id: post.feed_ID > 0 ? post.feed_ID : undefined,
+		feed_item_id: post.feed_item_ID > 0 ? post.feed_item_ID : undefined,
+		is_jetpack: post.is_jetpack
+	}, additionalProps ) );
 }

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -15,13 +15,15 @@ var TagEmptyContent = React.createClass( {
 	},
 
 	recordAction: function() {
-		stats.recordAction( 'clicked_tags_on_empty' );
-		stats.recordGaEvent( 'Clicked Tags on EmptyContent' );
+		stats.recordAction( 'clicked_following_on_empty' );
+		stats.recordGaEvent( 'Clicked Following on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_following_on_empty_tag_stream_clicked' );
 	},
 
 	recordSecondaryAction: function() {
 		stats.recordAction( 'clicked_discover_on_empty' );
 		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_discover_on_empty_tag_stream_clicked' );
 	},
 
 	render: function() {


### PR DESCRIPTION
Fix some busted ones, add more info in a common way to many that use posts, add many that were missing.

Things to check:
- [x] Comment like / unlike
- [x] Load new posts
- [x] More info in infinite scroll event
- [x] Click on site name on discover card
- [x] Click button on feed error
- [x] Click buttons on empty feed stream
- [x] Dismiss follow error on edit page
- [x] Click buttons on empty following stream
- [x] Click comment button on a post card
- [x] Closing the full post now fires full_post_close instead of modal_close mc action
- [x] Closing the full post fires a tracks event
- [x] Clicks on buttons on empty like stream
- [x] Clicks on buttons on empty list stream
- [x] Click on a tag in a post card or full post
- [x] Click on an author in a post card or full post
- [x] Dismiss follow error from a post card
- [x] Dismiss block error from a post card
- [x] Open or Close a post gallery
- [x] Report a post
- [x] Click Edit on a post you can edit (in the actions menu)
- [x] Click on a site title in /recommended
- [x] Use a share action
- [x] Click the add a list button
- [x] Actually create a list
- [x] Visit a site link
- [x] Click on suggestions on an empty site stream
- [x] Click on a permalink in a post card or in full post
- [x] Click on suggestions in an empty tag stream
