### PR TITLE
Signup: Headstart: Fix the broken Skip link in Headstart signup flows.

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -19,6 +19,7 @@ export default React.createClass( {
 				<NavigationLink
 					direction="forward"
 					goToNextStep={ this.props.goToNextStep }
+					defaultDependencies={ this.props.defaultDependencies }
 					flowName={ this.props.flowName }
 					stepName={ this.props.stepName } />
 			);


### PR DESCRIPTION
Headstart [passes a known Headstart-able theme](https://github.com/Automattic/wp-calypso/blob/master/client/signup/steps/theme-selection/index.jsx#L104) to use by default if a user skips the theme selection step.

cc/ @drewblaisdell @scruffian if removal of `defaultDependencies` was for a specific reason in 1eca7b8d98671b7de3c0a9d8eee9e0e61e20d921.