### PR TITLE
Framework: Allow generic isomorphic routing

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -135,7 +135,8 @@ sections = [
 		module: 'my-sites/themes',
 		enableLoggedOut: config.isEnabled( 'manage/themes/logged-out' ),
 		secondary: false,
-		group: 'sites'
+		group: 'sites',
+		isomorphic: true
 	},
 	{
 		name: 'themes',
@@ -143,7 +144,8 @@ sections = [
 		module: 'my-sites/themes',
 		enableLoggedOut: config.isEnabled( 'manage/themes/logged-out' ),
 		secondary: true,
-		group: 'sites'
+		group: 'sites',
+		isomorphic: true
 	},
 	{
 		name: 'upgrades',

--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -6,6 +6,9 @@ run for which path) only once, using them both on the client, and the server.
 
 For an example of isomorphic routing, see `client/my-sites/themes`.
 
+In order to enable isomorphic routing for a section, set `isomorphic: true`
+for that section in `client/sections.js`.
+
 The constraints required for isomporphic routing are:
 * In `client/mysection/index.js`, export a default function that accepts
 `router` as an argument. Instead of defining routes by invoking `page`, use

--- a/server/isomorphic-routing/README.md
+++ b/server/isomorphic-routing/README.md
@@ -1,9 +1,16 @@
 Isomorphic Routing Middleware Adapters
 ======================================
 
+## index.js
+
 This module provides functions to adapt `page.js`-style middleware (with
 `( context, next )` signature) to work with `express.js` (`( req, res, next )`),
 so `client` middleware satisfying a couple of constraints can be re-used on the
 server side.
+
+## loader.js
+
+The Webpack loader is required in order for the dynamic module `require()`
+(code splitting!) in index.js to work.
 
 For more information, see [Isomorphic Routing docs](docs/isomorphic-routing.md).

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -2,10 +2,19 @@
  * Internal dependencies
  */
 import i18n from 'lib/mixins/i18n';
+import sections from '../../client/sections';
 import { serverRender } from 'render';
 import { createReduxStore } from 'state';
 
-export function serverRouter( expressApp, mapExpressToPageContext ) {
+export default function( expressApp, getDefaultContext ) {
+	sections.get()
+		.filter( section => section.isomorphic )
+		.forEach( section => {
+			sections.require( section.module )( serverRouter( expressApp, getDefaultContext ) );
+		} );
+}
+
+function serverRouter( expressApp, mapExpressToPageContext ) {
 	return function( route, ...middlewares ) {
 		expressApp.get( route, combinedMiddlewares( mapExpressToPageContext, middlewares ) );
 	}

--- a/server/isomorphic-routing/loader.js
+++ b/server/isomorphic-routing/loader.js
@@ -1,0 +1,38 @@
+function getSectionsModule( sections ) {
+	var caseSections = ''
+	sections.forEach( function( section ) {
+		if ( section.isomorphic ) {
+			caseSections += 'case ' + JSON.stringify( section.module ) + ': return require( ' + JSON.stringify( section.module ) + ' );\n';
+		}
+	} );
+
+	return [
+		'module.exports = {',
+		'	get: function() {',
+		'		return ' + JSON.stringify( sections ) + ';',
+		'	},',
+		' require: function( module ) {',
+		'		switch ( module ) {',
+					caseSections,
+		'			default:',
+		'				return null;',
+		'   }',
+		' }',
+		'};'
+	].join( '\n' );
+}
+
+module.exports = function( content ) {
+	var sections;
+
+	this.cacheable && this.cacheable();
+
+	sections = require( this.resourcePath );
+
+	if ( ! Array.isArray( sections ) ) {
+		this.emitError( 'Chunks module is not an array' );
+		return content;
+	}
+
+	return getSectionsModule( sections );
+};

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -10,7 +10,7 @@ var express = require( 'express' ),
 var config = require( 'config' ),
 	sanitize = require( 'sanitize' ),
 	utils = require( 'bundler/utils' ),
-	sections = require( '../../client/sections' ),
+	sections = require( '../../client/sections' ).get(),
 	isomorphicRouting = require( 'isomorphic-routing' );
 
 var HASH_LENGTH = 10,
@@ -365,8 +365,7 @@ module.exports = function() {
 		}
 	} );
 
-	// Isomorphic Routing for the themes sections
-	require( 'my-sites/themes' )( isomorphicRouting.serverRouter( app, getDefaultContext ) );
+	isomorphicRouting( app, getDefaultContext );
 
 	app.get( '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?', function( req, res ) {
 		if ( req.cookies.wordpress_logged_in ) {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -51,6 +51,11 @@ module.exports = {
 	module: {
 		loaders: [
 			{
+				test: /sections.js$/,
+				exclude: 'node_modules',
+				loader: path.join( __dirname, 'server', 'isomorphic-routing', 'loader' )
+			},
+			{
 				test: /\.jsx?$/,
 				exclude: /(node_modules|devdocs\/search-index)/,
 				loader: 'babel-loader?optional[]=runtime'


### PR DESCRIPTION
The Webpack loader (/server/isomorphic-routing/loader.js) is required in order
for the dynamic module `require()` in /server/isomorphic-routing/index.js
(code splitting!) to work.

To test:
Make sure everything still works. Test single-site, multi-site, and logged-out /design, /theme/sometheme, JS on and off.

Note -- if you're interested in isorouting, keep #4081 in mind. And ping me :-)