### PR TITLE
Sign Up: Re-routing jetpack connect flow

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -62,7 +62,7 @@ const flows = {
 		description: 'Create an account and a blog and then add the business plan to the users cart.',
 		lastModified: '2016-01-21'
 	},
-	
+
 	free: {
 		steps: [ 'themes', 'domains', 'user' ],
 		destination: getSiteDestination,
@@ -216,13 +216,6 @@ const flows = {
 		lastModified: '2015-12-18'
 	},
 };
-
-if ( config.isEnabled( 'jetpack-connect' ) ) {
-	flows['jetpack-connect'] = {
-		steps: [ 'user', 'authorize-site' ],
-		destination: '/'
-	};
-}
 
 function removeUserStepFromFlow( flow ) {
 	if ( ! flow ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -9,7 +9,6 @@ var UserSignupComponent = require( 'signup/steps/user' ),
 	DomainsStepComponent = require( 'signup/steps/domains' ),
 	DesignTypeComponent = require( 'signup/steps/design-type' ),
 	SurveyStepComponent = require( 'signup/steps/survey' ),
-	JetpackAuthorizeSite = require( 'signup/steps/jetpack-authorize-site' ),
 	config = require( 'config' );
 
 module.exports = {
@@ -25,6 +24,5 @@ module.exports = {
 	'design-type': DesignTypeComponent,
 	'themes-headstart': ThemeSelectionComponent,
 	'domains-with-theme': DomainsStepComponent,
-	'jetpack-user': UserSignupComponent,
-	'authorize-site': JetpackAuthorizeSite
+	'jetpack-user': UserSignupComponent
 };

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -101,12 +101,5 @@ module.exports = {
 			subHeaderText: i18n.translate( 'You\'re moments away from connecting Jetpack.' )
 		},
 		providesDependencies: [ 'bearer_token', 'username' ]
-	},
-
-	'authorize-site': {
-		stepName: 'authorize-site',
-		props: {
-			headerText: i18n.translate( 'Howdy! Jetpack would like to connect to your WordPress.com account.' ),
-		},
 	}
 };

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -17,11 +17,9 @@ import route from 'lib/route';
 import analytics from 'analytics';
 import layoutFocus from 'lib/layout-focus';
 import SignupComponent from './main';
-import JetpackConnect from './jetpack-connect';
 import utils from './utils';
 import userModule from 'lib/user';
 import titleActions from 'lib/screen-title/actions';
-import { setSection } from 'state/ui/actions';
 const user = userModule();
 
 /**
@@ -135,20 +133,6 @@ export default {
 
 		ReactDom.render(
 			React.createElement( LogInComponent, {
-				path: context.path,
-				locale: context.params.lang
-			} ),
-			document.getElementById( 'primary' )
-		);
-	},
-
-	jetpackConnect( context ) {
-		context.store.dispatch( setSection( 'jetpackConnect', {
-			hasSidebar: false
-		} ) );
-
-		ReactDom.render(
-			React.createElement( JetpackConnect, {
 				path: context.path,
 				locale: context.params.lang
 			} ),

--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -7,6 +7,7 @@ var page = require( 'page' );
  * Internal dependencies
  */
 var controller = require( './controller' ),
+	jetpackConnectController = require( './jetpack-connect/controller' ),
 	adTracking = require( 'analytics/ad-tracking' ),
 	config = require( 'config' );
 
@@ -30,6 +31,12 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'jetpack/calypso-first-signup-flow' ) ) {
-		page( '/jetpack/connect', controller.jetpackConnect );
+		page( '/jetpack/connect', jetpackConnectController.connect );
+	}
+
+	if ( config.isEnabled( 'jetpack-connect' ) ) {
+		page( '/jetpack/connect/authorize',
+              jetpackConnectController.saveQueryObject,
+              jetpackConnectController.authorize );
 	}
 };

--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -32,9 +32,6 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'jetpack/calypso-first-signup-flow' ) ) {
 		page( '/jetpack/connect', jetpackConnectController.connect );
-	}
-
-	if ( config.isEnabled( 'jetpack-connect' ) ) {
 		page( '/jetpack/connect/authorize',
               jetpackConnectController.saveQueryObject,
               jetpackConnectController.authorize );

--- a/client/signup/jetpack-connect/authorize.jsx
+++ b/client/signup/jetpack-connect/authorize.jsx
@@ -1,5 +1,5 @@
 /**
- * Externals dependencies
+ * External dependencies
  */
 import React from 'react';
 import Debug from 'debug';
@@ -7,16 +7,17 @@ import Debug from 'debug';
 /**
  * Internal dependencies
  */
-import StepWrapper from 'signup/step-wrapper';
+import ConnectHeader from './connect-header';
+import Main from 'components/main';
 import wpcom from 'lib/wp';
 
 /**
  * Module variables
  */
-const debug = new Debug( 'calypso:jetpack-authorize' );
+const debug = new Debug( 'calypso:jetpack-connect-authorize' );
 
-module.exports = React.createClass( {
-	displayName: 'JetpackAuthorizeSite',
+export default React.createClass( {
+	displayName: 'JetpackConnectAuthorize',
 
 	getInitialState() {
 		return {
@@ -26,18 +27,15 @@ module.exports = React.createClass( {
 		};
 	},
 
-	getHeaderText() {
-		return this.translate( 'Howdy! Jetpack would like to connect to your WordPress.com account.' );
-	},
-
-	getSubHeaderText() {
-		return this.translate( 'Because Jetpack is awesome.' );
-	},
-
 	handleSubmit() {
 		const { queryObject } = this.props;
 		debug( 'trying jetpack login', queryObject );
 		this.setState( { isSubmitting: true, authorizeError: false } );
+
+		if ( 1 === this.props.positionInFlow ) {
+			queryObject._wp_nonce = this.props.signupDependencies._wp_nonce;
+		}
+
 		wpcom.undocumented().jetpackLogin( queryObject, this.handleJetpackLoginComplete );
 	},
 
@@ -66,36 +64,36 @@ module.exports = React.createClass( {
 
 	renderErrorMessage() {
 		if ( this.state.authorizeError ) {
-			return <p>Error connecting. Run `localStorage.setItem( 'debug', 'calypso:jetpack-authorize' );` and try again.</p>;
+			return <p>Error connecting. Run `localStorage.setItem( 'debug', 'calypso:jetpack-connect-authorize' );` and try again.</p>;
 		}
 		return null;
 	},
 
-	renderForm() {
+	renderButton() {
 		if ( this.state.authorizeSuccess ) {
 			return <p>Jetpack Connected!</p>;
 		}
 
-		return(
-			<div>
-				<button disabled={ this.state.isSubmitting } onClick={ this.handleSubmit } className="button is-primary">
-					{ this.translate( 'Approve' ) }
-				</button>
-				{ this.renderErrorMessage() }
-			</div>
+		return (
+			<button disabled={ this.state.isSubmitting } onClick={ this.handleSubmit } className="button is-primary">
+				{ this.translate( 'Approve' ) }
+			</button>
 		);
 	},
 
 	render() {
-		return(
-			<StepWrapper
-				flowName={ this.props.flowName }
-				stepName={ this.props.stepName }
-				headerText={ this.getHeaderText() }
-				subHeaderText={ this.getSubHeaderText() }
-				positionInFlow={ this.props.positionInFlow }
-				signupProgressStore={ this.props.signupProgressStore }
-				stepContent={ this.renderForm() } />
+		return (
+			<Main className="jetpack-connect">
+
+				<div className="jetpack-connect__site-url-entry-container">
+					<ConnectHeader headerText={ this.translate( 'Connect a self-hosted WordPress' ) }
+						subHeaderText={ this.translate( 'Jetpack would like to connect to your WordPress.com account' ) }
+						step={ 1 }
+						steps={ 3 } />
+					{ this.renderButton() }
+					{ this.renderErrorMessage() }
+				</div>
+			</Main>
 		);
 	}
 } );

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -1,0 +1,57 @@
+/**
+ * External Dependencies
+ */
+import ReactDom from 'react-dom';
+import React from 'react';
+import isEmpty from 'lodash/isEmpty';
+
+/**
+ * Internal Dependencies
+ */
+import JetpackConnect from './index';
+import jetpackConnectAuthorize from './authorize';
+import { setSection } from 'state/ui/actions';
+
+/**
+ * Module variables
+ */
+let queryObject;
+
+export default {
+	saveQueryObject( context, next ) {
+		if ( ! isEmpty( context.query ) ) {
+			queryObject = context.query;
+		}
+
+		next();
+	},
+
+	connect( context ) {
+		context.store.dispatch( setSection( 'jetpackConnect', {
+			hasSidebar: false
+		} ) );
+
+		ReactDom.render(
+			React.createElement( JetpackConnect, {
+				path: context.path,
+				locale: context.params.lang
+			} ),
+			document.getElementById( 'primary' )
+		);
+	},
+
+	authorize( context ) {
+		context.store.dispatch( setSection( 'jetpackConnect', {
+			hasSidebar: false
+		} ) );
+
+		ReactDom.render(
+			React.createElement( jetpackConnectAuthorize, {
+				path: context.path,
+				locale: context.params.lang,
+				queryObject: queryObject
+			} ),
+			document.getElementById( 'primary' )
+		);
+	}
+};

--- a/config/development.json
+++ b/config/development.json
@@ -36,7 +36,6 @@
 		"help": true,
 		"jetpack/calypso-first-signup-flow": true,
 		"jetpack_core_inline_update": true,
-		"jetpack-connect": true,
 		"keyboard-shortcuts": true,
 		"login": true,
 		"mailing-lists/unsubscribe": true,


### PR DESCRIPTION
In working on #3996, I've decided that it will be easier to move jetpack connect out of the standard sign up flows, an into our own custom solution. We used this approach in People Management for invite acceptance, and it provides a greater level of flexibility.

cc: @johnHackworth