### PR TITLE
Framework: Use a more functional programming approach to remove headers returned by the API

### DIFF
--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -21,11 +21,8 @@ function preprocessCartFromServer( cart ) {
 		products: castProductIDsToNumbers( cart.products )
 	} );
 
-	// Get rid of `_headers` data from `wpcom.js` until we actually need to use
-	// it.
-	newCart = omit( newCart, '_headers' );
-
-	return newCart;
+	// Gets rid of headers returned by the API
+	return omit( newCart, '_headers' );
 }
 
 // Add a server response date so we can distinguish between carts with the

--- a/client/lib/countries-list/index.js
+++ b/client/lib/countries-list/index.js
@@ -3,6 +3,7 @@
  */
 var debug = require( 'debug' )( 'calypso:CountriesList' ),
 	inherits = require( 'inherits' ),
+	reject = require( 'lodash/reject' ),
 	store = require( 'store' );
 
 /**
@@ -114,16 +115,13 @@ CountriesList.prototype.initialize = function( data ) {
 };
 
 /**
- * Parses the specified data retrieved from the server and extracts the list of countries.
+ * Parses the specified data retrieved from the API and extracts the list of countries.
  *
- * @param {object} data - raw data
- * @return {object} the list of countries
+ * @param {array} data - raw data
+ * @return {array} a list of countries
  */
 CountriesList.prototype.parse = function( data ) {
-	// Removes useless data
-	delete data._headers;
-
-	return data;
+	return reject( data, '_headers' );
 };
 
 /**

--- a/client/lib/features-list/index.js
+++ b/client/lib/features-list/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var debug = require( 'debug' )( 'calypso:features-list' ),
+	reject = require( 'lodash/reject' ),
 	store = require( 'store' );
 
 /**
@@ -87,15 +88,13 @@ FeaturesList.prototype.initialize = function( features ) {
 };
 
 /**
- * Parse data returned from the API
+ * Parses data retrieved from the API and extracts the list of features.
  *
- * @param {array} data
- * @return {array} features
+ * @param {array} data - raw data
+ * @return {array} a list of features
  **/
 FeaturesList.prototype.parse = function( data ) {
-	delete data._headers;
-
-	return data;
+	return reject( data, '_headers' );
 };
 
 /**

--- a/client/lib/plans-list/index.js
+++ b/client/lib/plans-list/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var debug = require( 'debug' )( 'calypso:plans-list' ),
+	reject = require( 'lodash/reject' ),
 	store = require( 'store' );
 
 /**
@@ -96,15 +97,13 @@ PlansList.prototype.initialize = function( plans ) {
 };
 
 /**
- * Parse data returned from the API
+ * Parses data retrieved from the API and extracts the list of plans.
  *
- * @param {array} data
- * @return {array} plans
+ * @param {array} data - raw data
+ * @return {array} a list of plans
  **/
 PlansList.prototype.parse = function( data ) {
-	delete data._headers;
-
-	return data;
+	return reject( data, '_headers' );
 };
 
 /**

--- a/client/lib/products-list/index.js
+++ b/client/lib/products-list/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var debug = require( 'debug' )( 'calypso:ProductsList' ),
+	omit = require( 'lodash/omit' ),
 	store = require( 'store' );
 
 /**
@@ -100,15 +101,13 @@ ProductsList.prototype.initialize = function( productsList ) {
 };
 
 /**
- * Parses data returned from the API.
+ * Parses data retrieved from the API and extracts the list of products.
  *
- * @param {array} data
- * @return {array}
+ * @param {object} data - raw data
+ * @return {object} a list of products
  **/
 ProductsList.prototype.parse = function( data ) {
-	delete data._headers;
-
-	return data;
+	return omit( data, '_headers' );
 };
 
 /**

--- a/client/lib/states-list/index.js
+++ b/client/lib/states-list/index.js
@@ -4,6 +4,7 @@
 var debug = require( 'debug' )( 'calypso:StatesList' ),
 	inherits = require( 'inherits' ),
 	isEmpty = require( 'lodash/isEmpty' ),
+	reject = require( 'lodash/reject' ),
 	store = require( 'store' );
 
 /**
@@ -131,14 +132,11 @@ StatesList.prototype.initialize = function( data ) {
 /**
  * Parses the specified data retrieved from the server and extracts the list of states.
  *
- * @param {object} data - raw data
- * @return {object} the list of states
+ * @param {array} data - raw data
+ * @return {array} a list of states
  */
 StatesList.prototype.parse = function( data ) {
-	// Removes useless data
-	delete data._headers;
-
-	return data;
+	return reject( data, '_headers' );
 };
 
 /**

--- a/client/lib/stats/summary/index.js
+++ b/client/lib/stats/summary/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var debug = require( 'debug' )( 'calypso:stats-data-summary' ),
+	omit = require( 'lodash/omit' ),
 	store = require( 'store' );
 
 /**
@@ -64,17 +65,16 @@ function fetchNewRecord( record ) {
  * Fetch calls undocumnted api method for stats/summary
  *
  * @api public
- *
  */
 StatsDataSummary.prototype.fetch = function( callback ) {
 	var query = {
 		period: this.period,
 		date: this.date
 	};
-	
+
 	wpcom.site( this.siteId ).statsSummary( query, function( error, data ) {
 		// Remove the header response from API, and add in a localized timestamp
-		delete data.headers;
+		data = omit( data, '_headers' );
 		data.updatedAt = new Date().getTime();
 
 		this.data = data;

--- a/client/lib/stored-cards/index.js
+++ b/client/lib/stored-cards/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var debug = require( 'debug' )( 'calypso:stored-cards' ),
+	reject = require( 'lodash/reject' ),
 	store = require( 'store' );
 
 /**
@@ -87,15 +88,13 @@ StoredCards.prototype.initialize = function( storedCards ) {
 };
 
 /**
- * Parse data returned from the API
+ * Parses data retrieved from the API and extracts the list of stored cards.
  *
- * @param {array} data
- * @return {array} stored cards
+ * @param {array} data - raw data
+ * @return {array} a list of stored cards
  **/
 StoredCards.prototype.parse = function( data ) {
-	delete data._headers;
-
-	return data;
+	return reject( data, '_headers' );
 };
 
 /**

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -3,6 +3,7 @@
  */
 import debugFactory from 'debug';
 import map from 'lodash/map';
+import omit from 'lodash/omit';
 
 const debug = debugFactory( 'calypso:site-plans:actions' );
 
@@ -121,7 +122,7 @@ export function fetchSitePlans( siteId ) {
  * @returns {Object} the corresponding action object
  */
 export function fetchSitePlansCompleted( siteId, data ) {
-	delete data._headers;
+	data = omit( data, '_headers' );
 
 	return {
 		type: SITE_PLANS_FETCH_COMPLETED,


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/3844. It updates code that removes headers returned by the API to use a [more functional programming approach](https://github.com/Automattic/wp-calypso/pull/3844#discussion_r55972607). To be more specific it replaces:

```javascript
delete data._headers
```

With:

```javascript
omit( data, '_headers' );
```

#### Testing instructions
 
1. Run `git checkout fix/delete-headers` and start your server
2. Get a test account and blog
3. Enable the store sandbox
4. Open the [`Stats` page](http://calypso.localhost:3000/stats/insights) and check that it displays as before
5. Open the [`Plans` page](http://calypso.localhost:3000/plans) and check that it displays as before
6. Open the [`Compare Plans` page](http://calypso.localhost:3000/plans/compare) and check that it displays as before
7. Navigate to the [`Domains` page](http://calypso.localhost:3000/domains/add)
8. Click on any `Add` button to add a domain to the shopping cart
9. Click on the `No thanks, I don't need email or will use another provider.` link on the next page
10. Check that the shopping cart is correct on the `Domain Contact Information` page 
11. Check that lists of countries and states display correctly on the `Domain Contact Information` page 
12. Fill in the form and click on the `Add Privacy Protection` button
13. Submit the form on the `Secure Payment` page with fake credit card information
14. Navigate to the [`Billing History` page](https://calypso.localhost:3000/me/billing)
15. Check that you can see your credit card at the bottom of the page
 
#### Reviews
 
- [x] Code
- [x] Product