### PR TITLE
Editor: Resolve connections not removed, error on navigate

### DIFF
--- a/client/post-editor/editor-sharing/publicize-options.jsx
+++ b/client/post-editor/editor-sharing/publicize-options.jsx
@@ -66,9 +66,11 @@ module.exports = React.createClass( {
 		}
 
 		this.connectionPopupMonitor.open( href );
-		this.connectionPopupMonitor.once( 'close', () => {
-			this.props.fetchConnections( this.props.site.ID )
-		} );
+		this.connectionPopupMonitor.once( 'close', this.onNewConnectionPopupClosed );
+	},
+
+	onNewConnectionPopupClosed() {
+		this.props.fetchConnections( this.props.site.ID );
 	},
 
 	newConnection: function() {

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
+import omitBy from 'lodash/omitBy';
 import keyBy from 'lodash/keyBy';
 
 /**
@@ -55,13 +56,17 @@ export function fetchingConnections( state = {}, action ) {
 export function connections( state = {}, action ) {
 	switch ( action.type ) {
 		case PUBLICIZE_CONNECTIONS_RECEIVE:
-			return Object.assign( {}, state, keyBy( action.data.connections, 'ID' ) );
+			state = omitBy( state, { site_ID: action.siteId } );
+			return Object.assign( state, keyBy( action.data.connections, 'ID' ) );
+
 		case SERIALIZE:
 			return state;
+
 		case DESERIALIZE:
 			if ( isValidStateWithSchema( state, connectionsSchema ) ) {
 				return state;
 			}
+
 			return {};
 	}
 

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -89,9 +89,9 @@ describe( '#connections()', () => {
 	} );
 
 	it( 'should accumulate connections for distinct sites', () => {
-		const state = connections( {
+		const state = connections( deepFreeze( {
 			1: { ID: 1, site_ID: 2916284 }
-		}, {
+		} ), {
 			type: PUBLICIZE_CONNECTIONS_RECEIVE,
 			siteId: 77203074,
 			data: {
@@ -106,9 +106,9 @@ describe( '#connections()', () => {
 	} );
 
 	it( 'should discard connections for the same site ID if no longer present', () => {
-		const state = connections( {
+		const state = connections( deepFreeze( {
 			1: { ID: 1, site_ID: 2916284 }
-		}, {
+		} ), {
 			type: PUBLICIZE_CONNECTIONS_RECEIVE,
 			siteId: 2916284,
 			data: {
@@ -123,9 +123,9 @@ describe( '#connections()', () => {
 
 	it( 'should override previous connections of same ID', () => {
 		const connection = { ID: 1, site_ID: 2916284, foo: true };
-		const state = connections( {
+		const state = connections( deepFreeze( {
 			1: { ID: 1, site_ID: 2916284 }
-		}, {
+		} ), {
 			type: PUBLICIZE_CONNECTIONS_RECEIVE,
 			siteId: 2916284,
 			data: {

--- a/client/state/sharing/publicize/test/reducer.js
+++ b/client/state/sharing/publicize/test/reducer.js
@@ -88,7 +88,24 @@ describe( '#connections()', () => {
 		} );
 	} );
 
-	it( 'should not replace previous connections', () => {
+	it( 'should accumulate connections for distinct sites', () => {
+		const state = connections( {
+			1: { ID: 1, site_ID: 2916284 }
+		}, {
+			type: PUBLICIZE_CONNECTIONS_RECEIVE,
+			siteId: 77203074,
+			data: {
+				connections: [ { ID: 2, site_ID: 77203074 } ]
+			}
+		} );
+
+		expect( state ).to.eql( {
+			1: { ID: 1, site_ID: 2916284 },
+			2: { ID: 2, site_ID: 77203074 }
+		} );
+	} );
+
+	it( 'should discard connections for the same site ID if no longer present', () => {
 		const state = connections( {
 			1: { ID: 1, site_ID: 2916284 }
 		}, {
@@ -100,7 +117,6 @@ describe( '#connections()', () => {
 		} );
 
 		expect( state ).to.eql( {
-			1: { ID: 1, site_ID: 2916284 },
 			2: { ID: 2, site_ID: 2916284 }
 		} );
 	} );


### PR DESCRIPTION
This pull request seeks to resolve two issues related to managing Publicize connections in the context of the post editor:

1. When removing a connection, the connection is not shown as removed until the next page refresh
 - The `sharing/publicize` state did not remove connections from a site if they no longer existed in a subsequent refresh
2. When choosing to add a connection via the editor popup option, if you then navigate away from the editor, the layout breaks and an error is shown in the console
 - This regression was caused by the removal of the `onNewConnectionPopupClosed` method in 1875faa2bb96488fdaaddb582b74717ddce92167

__Testing instructions:__

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Expand the Sharing sidebar accordion menu
4. Click "Connect new service"
5. In the popup window, add or remove a connection
6. Close the popup window
7. Note that the Sharing accordion contents update to reflect the change in connections
8. Navigate away from the editor
9. Note that no errors occur when navigating
10. If you added a connection in step 5, repeat steps 1-7 to verify that the removal process works as expected

/cc @gwwar , as noted at https://github.com/Automattic/wp-calypso/pull/4060#issuecomment-197097563