### PR TITLE
package: update "wpcom-proxy-request" to v2.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -95,7 +95,7 @@
       "version": "0.2.3"
     },
     "assert": {
-      "version": "1.4.0"
+      "version": "1.4.1"
     },
     "assert-plus": {
       "version": "0.2.0"
@@ -368,7 +368,7 @@
       "version": "0.1.4"
     },
     "browserslist": {
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     "buffer": {
       "version": "3.6.0"
@@ -403,7 +403,7 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000469"
+      "version": "1.0.30000471"
     },
     "caseless": {
       "version": "0.11.0"
@@ -457,7 +457,7 @@
       "version": "1.1.1"
     },
     "clean-css": {
-      "version": "3.4.13",
+      "version": "3.4.16",
       "dependencies": {
         "commander": {
           "version": "2.8.1"
@@ -674,7 +674,7 @@
       "version": "0.1.1"
     },
     "dashdash": {
-      "version": "1.13.1",
+      "version": "1.14.0",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0"
@@ -891,7 +891,7 @@
       "version": "1.3.0"
     },
     "es-abstract": {
-      "version": "1.5.0"
+      "version": "1.5.1"
     },
     "es-to-primitive": {
       "version": "1.1.1"
@@ -904,9 +904,6 @@
     },
     "es6-map": {
       "version": "0.1.3"
-    },
-    "es6-promise": {
-      "version": "2.3.0"
     },
     "es6-set": {
       "version": "0.1.4"
@@ -2146,7 +2143,7 @@
       "version": "0.0.5"
     },
     "nan": {
-      "version": "2.3.3"
+      "version": "2.3.5"
     },
     "ncname": {
       "version": "1.0.0"
@@ -2669,7 +2666,7 @@
       "version": "1.0.0"
     },
     "regenerate": {
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     "regenerator": {
       "version": "0.8.34"
@@ -2779,17 +2776,8 @@
     "rtlcss": {
       "version": "2.0.5",
       "dependencies": {
-        "minimist": {
-          "version": "0.0.8"
-        },
-        "mkdirp": {
-          "version": "0.5.1"
-        },
-        "postcss": {
-          "version": "5.0.21"
-        },
-        "source-map": {
-          "version": "0.4.4"
+        "strip-json-comments": {
+          "version": "2.0.1"
         }
       }
     },
@@ -2857,7 +2845,7 @@
       }
     },
     "serve-static": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "dependencies": {
         "destroy": {
           "version": "1.0.4"
@@ -2869,7 +2857,7 @@
           "version": "1.3.1"
         },
         "send": {
-          "version": "0.13.1"
+          "version": "0.13.2"
         },
         "statuses": {
           "version": "1.2.1"
@@ -3437,7 +3425,7 @@
       "version": "0.0.2"
     },
     "wp-error": {
-      "version": "1.2.0"
+      "version": "1.3.0"
     },
     "wpcom": {
       "version": "4.9.13",
@@ -3460,7 +3448,7 @@
       }
     },
     "wpcom-proxy-request": {
-      "version": "1.0.5"
+      "version": "2.0.0"
     },
     "wpcom-xhr-request": {
       "version": "0.5.0"

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "webpack": "1.12.15",
     "webpack-dev-middleware": "1.2.0",
     "wpcom": "4.9.13",
-    "wpcom-proxy-request": "1.0.5",
+    "wpcom-proxy-request": "2.0.0",
     "wpcom-xhr-request": "0.5.0",
     "xgettext-js": "0.3.0"
   },


### PR DESCRIPTION
Better HTTP-level error handling. So for example, if the API throws
a 404 error for a non-existant endpoint, the Error object's `name`
will now be `NotFoundError` and the `err.statusCode` will properly
be 404 (used to be 0).

Related to https://github.com/Automattic/wpcom-proxy-request/issues/9.