### PR TITLE
Themes: Remove unnecessary `Object.assign` calls in `react-redux` `mapStateToProps` argument:

### DIFF
--- a/client/components/data/activating-theme/index.js
+++ b/client/components/data/activating-theme/index.js
@@ -36,12 +36,9 @@ const ActivatingThemeData = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => Object.assign( {},
-		props,
-		{
-			isActivating: isActivating( state ),
-			hasActivated: hasActivated( state ),
-			currentTheme: getCurrentTheme( state, props.siteId )
-		}
-	)
+	( state, props ) => ( {
+		isActivating: isActivating( state ),
+		hasActivated: hasActivated( state ),
+		currentTheme: getCurrentTheme( state, props.siteId )
+	} )
 )( ActivatingThemeData );

--- a/client/components/data/current-theme/index.js
+++ b/client/components/data/current-theme/index.js
@@ -58,11 +58,8 @@ const CurrentThemeData = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => Object.assign( {},
-		props,
-		{
-			currentTheme: getCurrentTheme( state, props.site.ID )
-		}
-	),
+	( state, props ) => ( {
+		currentTheme: getCurrentTheme( state, props.site.ID )
+	} ),
 	{ fetchCurrentTheme }
 )( CurrentThemeData );

--- a/client/components/data/theme-details/index.js
+++ b/client/components/data/theme-details/index.js
@@ -54,9 +54,6 @@ const ThemeDetailsData = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => Object.assign( {},
-		props,
-		getThemeDetails( state, props.id )
-	),
+	( state, props ) => getThemeDetails( state, props.id ),
 	{ fetchThemeDetails }
 )( ThemeDetailsData );

--- a/client/components/data/themes-list-fetcher/index.jsx
+++ b/client/components/data/themes-list-fetcher/index.jsx
@@ -135,17 +135,14 @@ function join( value ) {
 }
 
 export default connect(
-	( state, props ) => Object.assign( {},
-		props,
-		{
-			themes: getFilteredThemes( state, props.search ),
-			lastPage: isLastPage( state ),
-			loading: isFetchingNextPage( state ),
-			lastQuery: {
-				hasSiteChanged: hasSiteChanged( state ),
-				isJetpack: isJetpack( state )
-			}
+	( state, props ) => ( {
+		themes: getFilteredThemes( state, props.search ),
+		lastPage: isLastPage( state ),
+		loading: isFetchingNextPage( state ),
+		lastQuery: {
+			hasSiteChanged: hasSiteChanged( state ),
+			isJetpack: isJetpack( state )
 		}
-	),
+	} ),
 	{ query, fetchNextPage }
 )( ThemesListFetcher );

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -97,11 +97,8 @@ var ThemesLoggedOut = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => Object.assign( {},
-		props,
-		{
-			queryParams: ThemesListSelectors.getQueryParams( state ),
-			themesList: ThemesListSelectors.getThemesList( state )
-		}
-	)
+	state => ( {
+		queryParams: ThemesListSelectors.getQueryParams( state ),
+		themesList: ThemesListSelectors.getThemesList( state )
+	} )
 )( ThemesLoggedOut );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -135,11 +135,8 @@ var ThemesMultiSite = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => Object.assign( {},
-		props,
-		{
-			queryParams: ThemesListSelectors.getQueryParams( state ),
-			themesList: ThemesListSelectors.getThemesList( state )
-		}
-	)
+	state => ( {
+		queryParams: ThemesListSelectors.getQueryParams( state ),
+		themesList: ThemesListSelectors.getThemesList( state )
+	} )
 )( ThemesMultiSite );

--- a/client/my-sites/themes/sheet.jsx
+++ b/client/my-sites/themes/sheet.jsx
@@ -168,10 +168,7 @@ export const ThemeSheet = React.createClass( {
 } )
 
 export default connect(
-	( state, props ) => Object.assign( {},
-		props,
-		{
-			selectedSite: getSelectedSite( state ) || false,
-		}
-	)
+	state => ( {
+		selectedSite: getSelectedSite( state ) || false,
+	} )
 )( ThemeSheet );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -185,12 +185,9 @@ var ThemesSingleSite = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => Object.assign( {},
-		props,
-		{
-			queryParams: ThemesListSelectors.getQueryParams( state ),
-			themesList: ThemesListSelectors.getThemesList( state ),
-			selectedSite: getSelectedSite( state ) || false,
-		}
-	)
+	state => ( {
+		queryParams: ThemesListSelectors.getQueryParams( state ),
+		themesList: ThemesListSelectors.getThemesList( state ),
+		selectedSite: getSelectedSite( state ) || false,
+	} )
 )( ThemesSingleSite );

--- a/client/state/themes/theme-details/selectors.js
+++ b/client/state/themes/theme-details/selectors.js
@@ -2,5 +2,5 @@
 
 export function getThemeDetails( state, id ) {
 	const theme = state.themes.themeDetails.get( id );
-	return theme ? theme.toJS() : undefined;
+	return theme ? theme.toJS() : {};
 }


### PR DESCRIPTION
Remove unnecessary `Object.assign` calls from `react-redux`'s `connect()`'s
`mapStateToProps` argument, as `connect()` will automatically merge the original
props for us.

See #4057 

To test -- verify that the Theme Showcase still works as before. Test single-site, multi-site, and logged-out /design, /theme/sometheme, JS on and off.

/cc @seear @aduth