### PR TITLE
Tooltip: Add showOnMobile prop to allow display on mobile devices

### DIFF
--- a/client/components/token-field/token.jsx
+++ b/client/components/token-field/token.jsx
@@ -57,7 +57,7 @@ export default React.createClass( {
 					className="token-field__remove-token noticon noticon-close-alt"
 					onClick={ ! this.props.disabled && this._onClickRemove } />
 				{ tooltip &&
-					<Tooltip context={ this } status={ status } isVisible={ true } position="bottom">
+					<Tooltip showOnMobile context={ this } status={ status } isVisible={ true } position="bottom">
 						{ tooltip }
 					</Tooltip>
 				}

--- a/client/components/tooltip/README.md
+++ b/client/components/tooltip/README.md
@@ -1,0 +1,18 @@
+Tooltip
+=======
+A `Tooltip` allows you to add contextual and other information where needed. For example, `Tooltip` is used to display extra information, on hover, about icon-only buttons.
+
+### Properties
+- `status` - (string) Modifies the style of the `Tooltip`. Can be one of the following: `error`, `warning`, or `success`.
+- `showOnMobile` - (bool) When true, will show `Tooltip` on mobile screens. By default, `Tooltip` is not displayed for mobile devices.
+- `isVisible` - (bool) Whether to display the `Tooltip` or not.
+- `position` - (string) The `position` property can be one of the following values:
+
+  - `top`
+  - `top left`
+  - `top right`
+  - `bottom`
+  - `bottom left`
+  - `bottom right`
+  - `left`
+  - `right`

--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -17,18 +17,20 @@ export default React.createClass( {
 
 	getDefaultProps() {
 		return {
-			position: 'top'
+			position: 'top',
+			showOnMobile: false
 		};
 	},
 
 	propTypes: {
 		isVisible: React.PropTypes.bool,
 		position: React.PropTypes.string,
-		status: React.PropTypes.string
+		status: React.PropTypes.string,
+		showOnMobile: React.PropTypes.bool
 	},
 
 	render() {
-		if ( viewport.isMobile() ) {
+		if ( ! this.props.showOnMobile && viewport.isMobile() ) {
 			return null;
 		}
 


### PR DESCRIPTION
Closes #4082

Fixes an issue where tooltips did not show on mobile. Previously, this may have made sense where tooltips were displayed on hover, since hover isn't supported on touch devices.

But, in invites, we display tooltips after validation, and do not require hover functionality.

cc @rickybanister and @mtias for thoughts and review.

To test:
- Checkout `update/tooltip-show-mobile` branch
- Go to `/people/new/$site` where `$site` is a WP.com site
- Attempt to invite a non-existent user. `0` should do the trick.
- Note that the tooltip shows
- Resize browser to be "mobile". Does tooltip show?
- Repeat on device. Does tooltip show?