### PR TITLE
Framework: useMockery callback

### DIFF
--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -31,7 +31,7 @@ describe( 'initial-state', () => {
 		const initialState = require( 'state/initial-state' );
 		createReduxStoreFromPersistedInitialState = initialState.default;
 		MAX_AGE = initialState.MAX_AGE;
-	}, null );
+	} );
 
 	describe( 'createReduxStoreFromPersistedInitialState', () => {
 		describe( 'persist-redux disabled', () => {

--- a/test/test/helpers/use-filesystem-mocks/index.js
+++ b/test/test/helpers/use-filesystem-mocks/index.js
@@ -3,6 +3,7 @@ import glob from 'glob';
 import mockery from 'mockery';
 import path from 'path';
 import debug from 'debug';
+import partial from 'lodash/partial';
 
 const log = debug( 'calypso:test:quick-mock' );
 
@@ -28,5 +29,5 @@ function findQuickMocks( dirpath ) {
 }
 
 export default function( dirpath ) {
-	useMockery( findQuickMocks.bind( null, dirpath ), null );
+	useMockery( partial( findQuickMocks, dirpath ) );
 }

--- a/test/test/helpers/use-mockery/README.md
+++ b/test/test/helpers/use-mockery/README.md
@@ -6,6 +6,12 @@ Lots of tests use `mockery` to mock out the underlying requirements of a module 
 
 Generally, we see `mockery` based mocking as a last resort. We prefer passing dependencies when we can, as `mockery` can be slow and invasive.
 
+## Format:
+```js
+	useMockery( beforeHookCallback, afterHookCallback )
+```
+`beforeHookCallback` and `afterHookCallback` are called with one argument: The `mockery` instance.
+
 ## Usage
 
 ```js
@@ -19,9 +25,8 @@ describe('my test suite', () = {
 		// THINGS REQUIRED HERE WILL NOT HAVE MOCKED DEPENDENCIES
 	} );
 
-	useMockery();
-
-	before( () => {
+	useMockery( mockery => {
+		// attached to before hook
 		mockery.registerMock( 'lib/network', {
 			fetch() {
 				return Promise.resolve( { success: true } );
@@ -29,7 +34,9 @@ describe('my test suite', () = {
 		} );
 		// you can require things that have mocked dependencies now!
 		const myNetworkThing = require( 'thing/that/uses/lib/network' );
-	} );
+	}, mockery => {
+		// attached to after hook
+	});
 
 	it ( 'mockery is alive now', () = {
 		mockery.registerMock( 'lib/best-number', function() {

--- a/test/test/helpers/use-mockery/index.js
+++ b/test/test/helpers/use-mockery/index.js
@@ -1,5 +1,6 @@
 import mockery from 'mockery';
 import debug from 'debug';
+import noop from 'lodash/noop';
 
 const log = debug( 'calypso:test:use-mockery' );
 
@@ -11,7 +12,7 @@ const log = debug( 'calypso:test:use-mockery' );
  * @param  {Function} beforeActions A callback invoked after mockery has been set up. Called with no params. Can return a Promise to indicate that it's doing async work.
  * @param  {[type]} afterActions  A callback invoked just before mockery has been spun down. Called with no params. Can return a Promise to indicate that it's doing async work.
  */
-export default function useMockery( beforeActions, afterActions ) {
+export default function useMockery( beforeActions = noop, afterActions = noop ) {
 	before( function turnOnMockery() {
 		log( 'turning on mockery' );
 		mockery.enable( {
@@ -19,17 +20,12 @@ export default function useMockery( beforeActions, afterActions ) {
 			warnOnUnregistered: false,
 			useCleanCache: true // have to use this with a large set of tests
 		} );
-		if ( beforeActions ) {
-			return beforeActions();
-		}
+		return beforeActions( mockery );
 	} );
 
 	after( function turnOffMockery() {
 		log( 'turning off mockery' );
-		let actionReturn;
-		if ( afterActions ) {
-			actionReturn = afterActions();
-		}
+		const actionReturn = afterActions( mockery );
 		mockery.deregisterAll();
 		mockery.disable();
 		return actionReturn;


### PR DESCRIPTION
Uses callback to provide `mockery` to the consumer. Also, uses ES6 default arguments for a cleanup.

/cc: @blowery @gziolo