### PR TITLE
SelectDropdown: add DropdownLabel subcomponent

### DIFF
--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -79,6 +79,12 @@ Optional URL to navigate to when option is clicked.
 
 Optional callback that will be applied when a `DropdownItem` has been clicked. This could be used for updating a parent's state, tracking analytics, etc.
 
+### Label
+
+An item "label" can be added like as a sibling to `DropdownItem`. The purpose
+of this `DropdownLabel` component is used to display a static item, for example, to group
+items.
+
 ### Separator
 
 As a sibling to `DropdownItem`, an item "separator" or horizontal line can be used to visually separate items.
@@ -97,6 +103,7 @@ module.exports = React.createClass( {
 	render: function() {
 		return (
 			<SelectDropdown selectedText="Published">
+				<DropdownLabel><em>Post status<em></DropdownLabel>
 				<DropdownItem selected={ true } path="/published">Published</DropdownItem>
 				<DropdownItem path="/scheduled">Scheduled</DropdownItem>
 				<DropdownItem path="/drafts">Drafts</DropdownItem>
@@ -121,6 +128,7 @@ A good example for this case is a form element. You don't want to have to write 
 ```js
 var SelectDropdown = require( 'components/select-dropdown' );
 var options = [
+	{ label: 'Post status', isLabel: true },
 	{ value: 'published', label: 'Published' },
 	{ value: 'scheduled', label: 'Scheduled' },
 	{ value: 'drafts', label: 'Drafts' },
@@ -157,6 +165,7 @@ var options = [
 	{
 		value: // *required* - (string) tracked by component
 		label: // *required* - (string) displayed to user
+		isLabel: // optional - (boolean) set this item like a static label
 		path: // optional - (string) URL to navigate when clicked
 	},
 	// ...
@@ -178,6 +187,21 @@ Optional callback that will be run whenever a new selection has been clicked.
 `onToggle`
 
 Optional callback that will be run after the dropdown is opened or closed. An event object is passed, including a `target` property equal to the `SelectDropdown` React element instance, and `open` equal to the current toggle state of the dropdown.
+
+### Label
+
+Adding `isLabel` key set to `true` into the item object will create a `DropdownLabel` component.
+
+```js
+var options = [
+	{ label: 'Post status', isLabel: true },
+	{ value: 'published', label: 'Published' },
+	{ value: 'scheduled', label: 'Scheduled' },
+	{ value: 'drafts', label: 'Drafts' },
+	null,
+	{ value: 'trashed', label: 'Trashed' }
+];
+```
 
 ### Separator
 

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -9,6 +9,7 @@ var React = require( 'react' ),
  */
 var SelectDropdown = require( 'components/select-dropdown' ),
 	DropdownItem = require( 'components/select-dropdown/item' ),
+	DropdownLabel = require( 'components/select-dropdown/label' ),
 	DropdownSeparator = require( 'components/select-dropdown/separator' );
 
 var SelectDropdownDemo = React.createClass( {
@@ -27,6 +28,7 @@ var SelectDropdownDemo = React.createClass( {
 	getDefaultProps: function() {
 		return {
 			options: [
+				{ value: 'status-options', label: 'Statuses', isLabel: true },
 				{ value: 'published', label: 'Published' },
 				{ value: 'scheduled', label: 'Scheduled' },
 				{ value: 'drafts', label: 'Drafts' },
@@ -64,6 +66,9 @@ var SelectDropdownDemo = React.createClass( {
 					selectedText={ this.state.childSelected }
 					selectedCount={ this.state.selectedCount }
 				>
+
+					<DropdownLabel><strong>Statuses</strong></DropdownLabel>
+
 					<DropdownItem
 						count={ 10 }
 						selected={ this.state.childSelected === 'Published' }

--- a/client/components/select-dropdown/label.jsx
+++ b/client/components/select-dropdown/label.jsx
@@ -1,0 +1,25 @@
+/** @ssr-ready **/
+
+/**
+ * External Dependencies
+ */
+import React from 'react'
+
+/**
+ * Module variables
+ */
+const { Component } = React;
+const stopPropagation = event => event.stopPropagation();
+
+export default class SelectDropdownLabel extends Component {
+	render() {
+		return (
+			<li
+				onClick= { stopPropagation }
+				className="select-dropdown__label"
+			>
+				<label>{ this.props.children }</label>
+			</li>
+		);
+	}
+};

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -211,3 +211,16 @@
 	display: block;
 	margin: 8px 0;
 }
+
+.select-dropdown__label {
+	display: block;
+	color: lighten( $gray, 10% );
+	margin-top: 5px;
+	line-height: 20px;
+
+	label {
+		font-size: 12px;
+		text-transform: uppercase;
+		padding: 0px 16px 0px 16px;
+	}
+}


### PR DESCRIPTION
In order to implement a _nice_ `timezone-dropdown` component I've been working in this one to support a _label_ item. The idea here is create items groups combining `DropdownSeparator` and this new `DropdownLabel` component.

Also I've refactored the whole main component using Classes.

Related Issue: #3902

### Native `<select>` html element.
![image](https://cloud.githubusercontent.com/assets/77539/13832206/c1a4a220-ebb8-11e5-93d9-2e991355b96d.png)

### `<SelectDropdown>` component
![image](https://cloud.githubusercontent.com/assets/77539/13890858/6af12460-ed2c-11e5-8afb-ad86811e2e9e.png)

## How to use

### Component
```jsx
    <SelectDropdown selectedText="Published">
      <DropdownLabel><em>Post status</em></DropdownLabel>

      <DropdownItem selected={ true } path="/published">Published</DropdownItem>
      <DropdownItem path="/scheduled">Scheduled</DropdownItem>
      <DropdownItem path="/drafts">Drafts</DropdownItem>

      <DropdownSeparator />

      <DropdownItem path="/trashed">Trashed</DropdownItem>
    </SelectDropdown>
```

### Using options array

```js
var options = [
	{ label: 'Post status', isLabel: true },
	{ value: 'published', label: 'Published' },
	{ value: 'scheduled', label: 'Scheduled' },
	{ value: 'drafts', label: 'Drafts' },
	null,
	{ value: 'trashed', label: 'Trashed' }
];
```

## Testing
1) Go to `select-dropdown` devdocs page to get this isolated component: http://calypso.localhost:3000/devdocs/design/select-dropdown
2) Use this component (clicking, selecting new options through key events, etc )
3) Open the dev console to check if everything is ok

Also you can go to pages that are currently using this component such as posts list page (http://calypso.localhost:3000/posts/<your-testing-blog>)