### PR TITLE
Editor: hide drafts number on jetpack and enable drawer

### DIFF
--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -2,44 +2,40 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 import Count from 'components/count';
+import { getSelectedSite } from 'state/ui/selectors';
+import { translate } from 'lib/mixins/i18n';
 
-export default React.createClass( {
-	displayName: 'EditorDraftsButton',
+function EditorDraftsButton( { count, onClick, jetpack } ) {
+	return (
+		<Button
+			compact borderless
+			className="drafts-button"
+			onClick={ onClick }
+			disabled={ ! count && ! jetpack }
+			aria-label={ translate( 'View all drafts' ) }
+		>
+			<span>{ translate( 'Drafts' ) }</span>
+			{ count && ! jetpack ? <Count count={ count } /> : null }
+		</Button>
+	);
+};
 
-	propTypes: {
-		count: PropTypes.number,
-		onClick: PropTypes.func,
-		isJetpack: PropTypes.bool
-	},
+EditorDraftsButton.propTypes = {
+	count: PropTypes.number,
+	onClick: PropTypes.func,
+	jetpack: PropTypes.bool
+};
 
-	getDefaultProps() {
-		return {
-			count: 0,
-			onClick: () => {},
-			isJetpack: false
-		};
-	},
+export default connect( ( state ) => {
+	const jetpack = get( getSelectedSite( state ), 'jetpack' );
 
-	render() {
-		const { count, isJetpack, onClick } = this.props;
-
-		return (
-			<Button
-				compact borderless
-				className="drafts-button"
-				onClick={ onClick }
-				disabled={ ! count && ! isJetpack }
-				aria-label={ this.translate( 'View all drafts' ) }
-			>
-				<span>{ this.translate( 'Drafts' ) }</span>
-				{ count && ! isJetpack ? <Count count={ count } /> : null }
-			</Button>
-		);
-	}
-} );
+	return { jetpack };
+} )( EditorDraftsButton );

--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -14,27 +14,31 @@ export default React.createClass( {
 
 	propTypes: {
 		count: PropTypes.number,
-		onClick: PropTypes.func
+		onClick: PropTypes.func,
+		isJetpack: PropTypes.bool
 	},
 
 	getDefaultProps() {
 		return {
 			count: 0,
-			onClick: () => {}
+			onClick: () => {},
+			isJetpack: false
 		};
 	},
 
 	render() {
+		const { count, isJetpack, onClick } = this.props;
+
 		return (
 			<Button
 				compact borderless
 				className="drafts-button"
-				onClick={ this.props.onClick }
-				disabled={ ! this.props.count }
+				onClick={ onClick }
+				disabled={ ! count && ! isJetpack }
 				aria-label={ this.translate( 'View all drafts' ) }
 			>
 				<span>{ this.translate( 'Drafts' ) }</span>
-				{ this.props.count ? <Count count={ this.props.count } /> : null }
+				{ count && ! isJetpack ? <Count count={ count } /> : null }
 			</Button>
 		);
 	}

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -22,7 +22,7 @@ import DraftsButton from 'post-editor/drafts-button';
 import PostCountsData from 'components/data/post-counts-data';
 import QueryPostTypes from 'components/data/query-post-types';
 
-function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts, allPostsUrl, toggleSidebar, isJetpack } ) {
+function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts, allPostsUrl, toggleSidebar } ) {
 	const isCustomPostType = ( 'post' !== typeSlug && 'page' !== typeSlug );
 	const className = classnames( 'editor-sidebar__header', {
 		'is-drafts-visible': showDrafts,
@@ -63,7 +63,7 @@ function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts
 			) }
 			{ typeSlug === 'post' && siteId && (
 				<PostCountsData siteId={ siteId } status="draft">
-					<DraftsButton onClick={ toggleDrafts } isJetpack={ isJetpack } />
+					<DraftsButton onClick={ toggleDrafts } />
 				</PostCountsData>
 			) }
 			<Button
@@ -77,18 +77,15 @@ function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts
 
 export default connect(
 	( state ) => {
-		const site = getSelectedSite( state );
-		const siteId = get( site, 'ID' );
+		const siteId = get( getSelectedSite( state ), 'ID' );
 		const postId = getEditorPostId( state );
-		const isJetpack = get( site, 'jetpack' );
 		const typeSlug = get( getEditedPost( state, siteId, postId ), 'type' );
 
 		return {
 			siteId,
 			typeSlug,
 			type: getPostType( state, siteId, typeSlug ),
-			showDrafts: isEditorDraftsVisible( state ),
-			isJetpack
+			showDrafts: isEditorDraftsVisible( state )
 		};
 	},
 	( dispatch ) => {

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -22,7 +22,7 @@ import DraftsButton from 'post-editor/drafts-button';
 import PostCountsData from 'components/data/post-counts-data';
 import QueryPostTypes from 'components/data/query-post-types';
 
-function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts, allPostsUrl, toggleSidebar } ) {
+function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts, allPostsUrl, toggleSidebar, isJetpack } ) {
 	const isCustomPostType = ( 'post' !== typeSlug && 'page' !== typeSlug );
 	const className = classnames( 'editor-sidebar__header', {
 		'is-drafts-visible': showDrafts,
@@ -63,7 +63,7 @@ function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts
 			) }
 			{ typeSlug === 'post' && siteId && (
 				<PostCountsData siteId={ siteId } status="draft">
-					<DraftsButton onClick={ toggleDrafts } />
+					<DraftsButton onClick={ toggleDrafts } isJetpack={ isJetpack } />
 				</PostCountsData>
 			) }
 			<Button
@@ -77,15 +77,18 @@ function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts
 
 export default connect(
 	( state ) => {
-		const siteId = get( getSelectedSite( state ), 'ID' );
+		const site = getSelectedSite( state );
+		const siteId = get( site, 'ID' );
 		const postId = getEditorPostId( state );
+		const isJetpack = get( site, 'jetpack' );
 		const typeSlug = get( getEditedPost( state, siteId, postId ), 'type' );
 
 		return {
 			siteId,
 			typeSlug,
 			type: getPostType( state, siteId, typeSlug ),
-			showDrafts: isEditorDraftsVisible( state )
+			showDrafts: isEditorDraftsVisible( state ),
+			isJetpack
 		};
 	},
 	( dispatch ) => {


### PR DESCRIPTION
This branch seeks to provide a work-around for #1555, and a fixes #1897.  Currently the `post-counts` endpoint is set to run on wpcom for Jetpack sites, and as of now, drafts are not synched back to wpcom.  As such the drafts post count is always `0` and the drafts drawer is perpetually disabled for JP sites.

When a draft is created in the editor for a JP site, the incorrect number of drafts as outlined in #1555 happens.  Upon doing a hard refresh of an in-progress JP draft though, the number one goes away, and the drafts drawer is disabled again.

The work-around proposed here adds a new `isJetpack` prop to the `drafts-button` component.  If truthy, the draft post count is hidden ( per @mtias [suggestion](https://github.com/Automattic/wp-calypso/issues/1555#issuecomment-164539068) ), and the drafts drawer is no longer disabled when draft count is 0 for Jetpack sites.

When drafts do finally get synched back to wpcom, we should remove this logic and make it match the existing flow as seen on wpcom sites.

__JP Site Drafts Drawer Before__
<img width="277" alt="new_post_ _haiku2_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/13833147/2c2b891a-eba0-11e5-9068-54cc76f0ebfe.png">

__JP Site Drafts Drawer After__
<img width="272" alt="new_post_ _haiku2_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/13833158/4c77ff3c-eba0-11e5-9f89-9770ebfa6795.png">

__To Test__
- Open the post editor for a wpcom site
- Verify the drafts drawer, with draft count is displayed, and mimics the current experience on production
- If you have not drafts on the wpcom site, verify that the drafts drawer is still disabled
- Open the post editor for a JP connected site
- Check that not draft count is shown in the drafts drawer label
- Also verify that you can open the drafts drawer 
- Save a new draft on the JP site, verify the draft count is still not shown