### PR TITLE
API: direct all post-counts traffic to WP-API.

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -533,19 +533,12 @@ PostActions = {
 	},
 
 	fetchCounts: function( siteId, options ) {
-		var wpcomInterface = wpcom;
-
 		Dispatcher.handleViewAction( {
 			type: 'FETCH_POST_COUNTS',
 			siteId: siteId
 		} );
 
-		// Only pass 50%ish of requests to WP-API for now.
-		if ( 0 === ( siteId % 2 ) ) {
-			wpcomInterface = wpcom.undocumented();
-		}
-
-		wpcomInterface.site( siteId ).postCounts( options, function( error, data ) {
+		wpcom.undocumented().site( siteId ).postCounts( options, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_POST_COUNTS',
 				error: error,


### PR DESCRIPTION
A final follow up for #3836 - this moves all `post-counts` traffic to WP-API.  Testing instructions are the same as #3836