### PR TITLE
Tests: Enable running mocha directly

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -79,3 +79,17 @@ describe.only( 'just run this suite', function() {
 	} );
 } );
 ```
+
+### How to run Mocha directly
+
+You can run Mocha directly by using `run-mocha.js` as the entry point for Mocha. Note that this only works for tests 
+inside single test runner. This gives you more flexibility to integrate with different toolings.
+
+Example:
+```shell
+# Run all client tests within the single test runner
+$ NODE_ENV=test NODE_PATH=client:test node_modules/.bin/mocha test/run-mocha.js 
+
+# Run all server tests within the single test runner
+$ NODE_ENV=test NODE_PATH=server:client:test node_modules/.bin/mocha test/run-mocha.js
+```

--- a/test/boot-test.js
+++ b/test/boot-test.js
@@ -1,0 +1,20 @@
+require( 'babel/register' );
+const Chai = require( 'chai' ),
+	sinonChai = require( 'sinon-chai' ),
+	sinon = require( 'sinon' ),
+	immutableChai = require( './test/helpers/immutable-chai' ),
+	nock = require( 'nock' );
+
+module.exports = {
+	before: function() {
+		Chai.use( immutableChai );
+		Chai.use( sinonChai );
+		sinon.assert.expose( Chai.assert, { prefix: '' } );
+		nock.disableNetConnect();
+	},
+	after: function() {
+		nock.cleanAll();
+		nock.enableNetConnect();
+		nock.restore();
+	}
+};

--- a/test/run-mocha.js
+++ b/test/run-mocha.js
@@ -1,0 +1,10 @@
+/**
+ * Used for running mocha directly – allows integration with tooling such as Webstorm
+ * $ NODE_ENV=test NODE_PATH=client:test node_modules/.bin/mocha test/run-mocha.js
+ */
+
+require( 'babel/register' );
+const boot = require( './boot-test' );
+before( boot.before );
+after( boot.after );
+require( './load-suite.js' );

--- a/test/runner.js
+++ b/test/runner.js
@@ -3,12 +3,8 @@ require( 'babel/register' );
 
 const program = require( 'commander' ),
 	Mocha = require( 'mocha' ),
-	Chai = require( 'chai' ),
-	sinon = require( 'sinon' ),
-	sinonChai = require( 'sinon-chai' ),
-	immutableChai = require( './test/helpers/immutable-chai' ),
-	nock = require( 'nock' ),
-	path = require( 'path' );
+	path = require( 'path' ),
+	boot = require( './boot-test' );
 
 program
 	.usage( '[options] [files]' )
@@ -28,18 +24,8 @@ if ( program.grep ) {
 	mocha.grep( new RegExp( program.grep ) );
 }
 
-mocha.suite.beforeAll( function() {
-	Chai.use( immutableChai );
-	Chai.use( sinonChai );
-	sinon.assert.expose( Chai.assert, { prefix: '' } );
-	nock.disableNetConnect();
-} );
-
-mocha.suite.afterAll( function() {
-	nock.cleanAll();
-	nock.enableNetConnect();
-	nock.restore();
-} );
+mocha.suite.beforeAll( boot.before );
+mocha.suite.afterAll( boot.after );
 
 // we could also discover all the tests using a glob?
 if ( program.args.length ) {


### PR DESCRIPTION
This allows the single test runner to be ran directly from command line over mocha executable. Enables integration options including Webstorm Mocha runner.

Teaser: 
![screen shot 2016-03-16 at 6 46 02 pm](https://cloud.githubusercontent.com/assets/991022/13833911/7fd53d20-eba7-11e5-864f-8edf884700cf.png)


/cc: @blowery @gziolo