### PR TITLE
Test: Remove missed console.log in analytics tests

### DIFF
--- a/client/analytics/test/index.js
+++ b/client/analytics/test/index.js
@@ -21,7 +21,6 @@ function logImageLoads() {
 				return this._src;
 			},
 			set: function( value ) {
-				console.log( 'setting', value );
 				this._src = value;
 				imagesLoaded.push( url.parse( value, true, true ) );
 			}


### PR DESCRIPTION
To test, run `npm run test-client -- --reporter=min` and notice there are no statements about setting pixels at the start of the test run.