### PR TITLE
localforage: Proxy localforage methods to ensure our config has been applied before executing

### DIFF
--- a/client/lib/localforage/README.md
+++ b/client/lib/localforage/README.md
@@ -1,14 +1,12 @@
 localforage
 =============
 
-This exports a getLocalForage function which returns a localforage instance that has been setup with our default Calypso 
-config.
+This exports a localforage proxy object that ensures our configuration has been applied.
 
 ## Usage:
 
 ```
-import { getLocalForage } from 'lib/localforage';
-const localforage = getLocalForage();
+import localforage from 'lib/localforage';
 
 //use localforage as you would normally
 localforage.getItem( 'my-stored-key', callback );

--- a/client/lib/localforage/index.js
+++ b/client/lib/localforage/index.js
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import localforage from 'localforage';
+import reduce from 'lodash/reduce';
 
-export const config = {
+const config = {
 	name: 'calypso',
 	storeName: 'calypso_store',
 	version: 1.0,
@@ -15,7 +16,35 @@ export const config = {
 	]
 };
 
-export function getLocalForage() {
+// Promise that resolves when our localforage configuration has been applied
+const localForagePromise = new Promise( ( resolve ) => {
 	localforage.config( config );
-	return localforage;
+	resolve( localforage );
+} );
+
+// Wraps a function to run after waiting until a promise has resolved.
+// The promise should contain the original object for context.
+const wrapOriginalFunc = ( promise, original ) => {
+	return function( ...args ) {
+		return promise.then( ( context ) => original.apply( context, args ) );
+	};
 }
+
+// List of localforage methods that should wait for localForagePromise to resolve
+const wrapFuncs = [
+	'getItem', 'setItem', 'removeItem',
+	'length', 'key', 'keys', 'iterate', 'clear'
+];
+
+// Proxy each localforage method to ensure our configuration is initialized first
+// NOTE: This means every localForage method returns a promise
+const localForageProxy = reduce(
+		wrapFuncs,
+		( result, fn ) => {
+			result[ fn ] = wrapOriginalFunc( localForagePromise, localforage[ fn ] );
+			return result;
+		},
+		{}
+);
+
+export default Object.assign( {}, localforage, localForageProxy );

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -18,12 +18,7 @@ var store = require( 'store' ),
 var wpcom = require( 'lib/wp' ),
 	Emitter = require( 'lib/mixins/emitter' ),
 	userUtils = require( './shared-utils' ),
-	getLocalForage = require( 'lib/localforage' ).getLocalForage;
-
-/**
- * Module variables
- */
-var localforage = getLocalForage();
+	localforage = require( 'lib/localforage' );
 
 /**
  * User component

--- a/client/lib/wp/sync-handler/cache-index.js
+++ b/client/lib/wp/sync-handler/cache-index.js
@@ -11,14 +11,13 @@ import difference from 'lodash/difference';
 /**
  * Internal dependencies
  */
-import { getLocalForage } from 'lib/localforage';
+import localforage from 'lib/localforage';
 import { generatePageSeriesKey } from './utils';
 import { RECORDS_LIST_KEY, SYNC_RECORD_NAMESPACE, LIFETIME } from './constants';
 
 /**
  * Module variables
  */
-const localforage = getLocalForage();
 const debug = debugFactory( 'calypso:sync-handler:cache' );
 
 /**

--- a/client/lib/wp/sync-handler/index.js
+++ b/client/lib/wp/sync-handler/index.js
@@ -8,7 +8,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import warn from 'lib/warn';
-import { getLocalForage } from 'lib/localforage';
+import localforage from 'lib/localforage';
 import { isWhitelisted } from './whitelist-handler';
 import { cacheIndex } from './cache-index';
 import { generateKey, generatePageSeriesKey } from './utils';
@@ -16,7 +16,6 @@ import { generateKey, generatePageSeriesKey } from './utils';
 /**
  * Module variables
  */
-const localforage = getLocalForage();
 const debug = debugFactory( 'calypso:sync-handler' );
 
 /**

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -9,7 +9,7 @@ import pick from 'lodash/pick';
  */
 import { createReduxStore, reducer } from 'state';
 import { SERIALIZE, DESERIALIZE, SERVER_DESERIALIZE } from 'state/action-types'
-import { getLocalForage } from 'lib/localforage';
+import localforage from 'lib/localforage';
 import { isSupportUserSession } from 'lib/user/support-user-interop';
 import config from 'config';
 
@@ -17,7 +17,6 @@ import config from 'config';
  * Module variables
  */
 const debug = debugModule( 'calypso:state' );
-const localforage = getLocalForage();
 
 const DAY_IN_HOURS = 24;
 const HOUR_IN_MS = 3600000;

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -27,7 +27,7 @@ describe( 'initial-state', () => {
 		configMock.isEnabled = isEnabled;
 		mockery.registerMock( 'lib/user/support-user-interop', { isSupportUserSession: isSupportUserSession } );
 		mockery.registerMock( 'config', configMock );
-		localforage = require( 'localforage' );
+		localforage = require( 'lib/localforage' );
 		const initialState = require( 'state/initial-state' );
 		createReduxStoreFromPersistedInitialState = initialState.default;
 		MAX_AGE = initialState.MAX_AGE;


### PR DESCRIPTION
Blocks #3977

This change proxies each Promise based method on the localForage API to ensure that the Calypso specific configuration has been loaded before executing. This removes the need for the `getLocalForage()` method, instead allowing us to call the localforage API methods on the proxy object directly.

This allows us to do any async localforage initialization before returning the localforage object to modules that use it. This is required to use `localforage.defineDriver` during init as it returns a Promise.

Since the localForage API is already async, this requires few changes.

This is a simpler alternative to adding a pre-boot sequence for support user (#4068) to enable a localForage bypass driver (#3977). To add a bypass driver, in a future PR we can simply modify `localForagePromise` to:

```diff
const localForagePromise = new Promise( ( resolve ) => {
	localforage.config( config );
-	resolve( localforage );
+	return localforage.defineDriver( localForageBypass )
+		.then( () => resolve( localforage ) );
} );
```

This change updates all current usages of `getLocalForage()`

 - [x] sync-handler @retrofox 
 - [x] cache-index @retrofox 
 - [x] initial-state @gwwar

Tested:
 - [x] `development` environment
 - [x] local `production` environment