### PR TITLE
Webpack: Use a root instead of a module directory for client

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,8 @@ webpackConfig = {
 	},
 	resolve: {
 		extensions: [ '', '.json', '.js', '.jsx' ],
-		modulesDirectories: [ 'node_modules', path.join( __dirname, 'client' ) ]
+		root: path.join( __dirname, 'client' ),
+		modulesDirectories: [ 'node_modules' ]
 	},
 	node: {
 		console: false,


### PR DESCRIPTION
This shaves about 10s off of the initial build on my laptop. See https://github.com/webpack/webpack/issues/1574#issuecomment-157520561 for details on why this might help.