### PR TITLE
People: Adds SidebarNavigation to invite form; Used for mobile sidebar

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -32,6 +32,7 @@ import { createInviteValidation } from 'lib/invites/actions';
 import InvitesCreateValidationStore from 'lib/invites/stores/invites-create-validation';
 import InvitesSentStore from 'lib/invites/stores/invites-sent';
 import analytics from 'analytics';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 /**
  * Module variables
@@ -271,6 +272,7 @@ const InvitePeople = React.createClass( {
 	render() {
 		return (
 			<Main>
+				<SidebarNavigation />
 				<HeaderCake isCompact onClick={ this.goBack }/>
 				<Card>
 					<form onSubmit={ this.submitForm } >


### PR DESCRIPTION
Currently, if a user is viewing `/people/new/$site`, then the user is not able to access the sidebar. This is because we use the `SidebarNavigation` component to show the sidebar on mobile devices. This PR adds that component to the invite form.

To test:
- Checkout `update/people-new-sidebar-nav`
- Go to `/people/new/$site`
- Resize viewport and ensure sidebar nav shows up
- Test that sidebar nav shows up on mobile device

After:

![screen shot 2016-03-17 at 11 43 06 am](https://cloud.githubusercontent.com/assets/1126811/13853651/ae30ad2e-ec35-11e5-94c9-5ef32eed17d3.png)

Before:

![screen shot 2016-03-17 at 11 42 43 am](https://cloud.githubusercontent.com/assets/1126811/13853664/bb5a5266-ec35-11e5-95a1-f5031db6cd73.png)