### PR TITLE
People: Only show invite form for user with promote_users capability

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -276,7 +276,7 @@ const InvitePeople = React.createClass( {
 				<Main>
 					<SidebarNavigation />
 					<EmptyContent
-						title={ this.translate( 'You are not authorized to view this page' ) }
+						title={ this.translate( 'Oops, only administrators can invite other people' ) }
 						illustration={ '/calypso/images/drake/drake-empty-results.svg' }
 					/>
 				</Main>

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -33,6 +33,7 @@ import InvitesCreateValidationStore from 'lib/invites/stores/invites-create-vali
 import InvitesSentStore from 'lib/invites/stores/invites-sent';
 import analytics from 'analytics';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import EmptyContent from 'components/empty-content';
 
 /**
  * Module variables
@@ -270,6 +271,18 @@ const InvitePeople = React.createClass( {
 	},
 
 	render() {
+		if ( this.props.site && ! get( this.props, 'site.capabilities.promote_users' ) ) {
+			return (
+				<Main>
+					<SidebarNavigation />
+					<EmptyContent
+						title={ this.translate( 'You are not authorized to view this page' ) }
+						illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+					/>
+				</Main>
+			);
+		}
+
 		return (
 			<Main>
 				<SidebarNavigation />

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -34,6 +34,7 @@ import InvitesSentStore from 'lib/invites/stores/invites-sent';
 import analytics from 'analytics';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import EmptyContent from 'components/empty-content';
+import { userCan } from 'lib/site/utils';
 
 /**
  * Module variables
@@ -271,7 +272,8 @@ const InvitePeople = React.createClass( {
 	},
 
 	render() {
-		if ( this.props.site && ! get( this.props, 'site.capabilities.promote_users' ) ) {
+		const { site } = this.props;
+		if ( site && ! userCan( 'promote_users', site ) ) {
 			return (
 				<Main>
 					<SidebarNavigation />


### PR DESCRIPTION
Since inviting users requires `promote_users` capability, we should only show the form for users with that capability (administrators). This PR makes use of the `EmptyContent` component and our Drake image to match what we show when attempting to go to `/people/team/$site` without `list_users` capability.

To test:
- Checkout `update/invites-fix-no-permissions` branch
- Log into WordPress.com
- Go to `/people/new/$site` where your user is an admin
- Do you see the form? Good.
- Go to `/people/new/$site` where you are an editor or lower role
- Do you see our good friend Drake? Good
- Run `localStorage.clear()` in console and refresh
- Do you see the invite form until sites are fetched? Good

cc @lezama for code review and @rickybanister for design review.

After:

![screen shot 2016-03-17 at 11 55 41 am](https://cloud.githubusercontent.com/assets/1126811/13854078/c2cdf8fc-ec37-11e5-985e-713645ee612c.png)