### PR TITLE
People: Prevent submitting invite form when errored

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -201,6 +201,10 @@ const InvitePeople = React.createClass( {
 		event.preventDefault();
 		debug( 'Submitting invite form. State: ' + JSON.stringify( this.state ) );
 
+		if ( this.isSubmitDisabled() ) {
+			return false;
+		}
+
 		const formId = uniqueId();
 		const { usernamesOrEmails, message, role } = this.state;
 


### PR DESCRIPTION
Currently, hitting "Next" or "Go" multiple times while on iOS or Android will submit the form, even if it's errored.

This is because we previously disabled the form by disabling the submit button, but we didn't handle the case where the form was submitted through other methods.

In the case where validation has failed or a user has not input data, we don't want to disable the form through the `disabled` prop. So, short-circuiting the `onSubmit` event seems to be a good choice.

cc @lezama for code review

To test:
- On iOS/Android go to `/people/new/$site`
- Select the first input, hit enter.
- Does form submit. Good.
- Checkout `update/people-double-return-not-submit` branch
- Follow steps above
- Form should not submit

