### PR TITLE
WebPreview: Add support for injecting markup directly into iframe

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -211,6 +211,7 @@ const WebPreview = React.createClass( {
 					<Toolbar setDeviceViewport={ this.setDeviceViewport }
 						device={ this.state.device }
 						{ ...this.props }
+						showExternal={ ( this.props.previewMarkup ? false : this.props.showExternal ) }
 						showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
 					/>
 					<div className="web-preview__placeholder">

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -151,7 +151,7 @@ const WebPreview = React.createClass( {
 	},
 
 	render() {
-		const className = classnames( 'web-preview', {
+		const className = classnames( this.props.className, 'web-preview', {
 			'is-touch': this._hasTouch,
 			'is-visible': this.props.showPreview,
 			'is-computer': this.state.device === 'computer',

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -40,9 +40,8 @@ const WebPreview = React.createClass( {
 		// Elements to render on the right side of the toolbar
 		children: React.PropTypes.node,
 		// The function to call when the iframe is loaded. Will be passed the iframe document object.
+		// Only called if using previewMarkup.
 		onLoad: React.PropTypes.func,
-		// The function to call when an element is clicked. Will be passed the event.
-		onClick: React.PropTypes.func,
 		// Called when the preview is closed, either via the 'X' button or the escape key
 		onClose: React.PropTypes.func,
 		// Optional loading message to display during loading
@@ -60,7 +59,6 @@ const WebPreview = React.createClass( {
 			showDeviceSwitcher: true,
 			previewUrl: null,
 			previewMarkup: null,
-			onClick: noop,
 			onLoad: noop,
 			onClose: noop,
 		}
@@ -149,11 +147,6 @@ const WebPreview = React.createClass( {
 		this.refs.iframe.contentDocument.close();
 	},
 
-	handleClick( event ) {
-		debug( 'click detected for element', event.target );
-		return this.props.onClick( event );
-	},
-
 	setIframeUrl( iframeUrl ) {
 		// Bail if iframe isn't rendered
 		if ( ! this.shouldRenderIframe() ) {
@@ -189,8 +182,9 @@ const WebPreview = React.createClass( {
 			return;
 		}
 		debug( 'preview loaded:', this.state.iframeUrl );
-		this.props.onLoad( this.refs.iframe.contentDocument );
-		this.refs.iframe.contentDocument.body.onclick = this.handleClick;
+		if ( this.props.previewMarkup ) {
+			this.props.onLoad( this.refs.iframe.contentDocument );
+		}
 		this.setState( { loaded: true } );
 	},
 

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import classnames from 'classnames';
 import debugModule from 'debug';
+import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
@@ -30,10 +31,16 @@ const WebPreview = React.createClass( {
 		showDeviceSwitcher: React.PropTypes.bool,
 		// The URL that should be displayed in the iframe
 		previewUrl: React.PropTypes.string,
+		// The markup to display in the iframe
+		previewMarkup: React.PropTypes.string,
 		// The viewport device to show initially
 		defaultViewportDevice: React.PropTypes.string,
 		// Elements to render on the right side of the toolbar
 		children: React.PropTypes.node,
+		// The function to call when the iframe is loaded. Will be passed the iframe document object.
+		onLoad: React.PropTypes.func,
+		// The function to call when an element is clicked. Will be passed the event.
+		onClick: React.PropTypes.func,
 		// Called when the preview is closed, either via the 'X' button or the escape key
 		onClose: React.PropTypes.func,
 		// Optional loading message to display during loading
@@ -48,7 +55,11 @@ const WebPreview = React.createClass( {
 		return {
 			showExternal: true,
 			showDeviceSwitcher: true,
-			previewUrl: null
+			previewUrl: null,
+			previewMarkup: null,
+			onClick: noop,
+			onLoad: noop,
+			onClose: noop,
 		}
 	},
 
@@ -70,7 +81,9 @@ const WebPreview = React.createClass( {
 		if ( this.props.previewUrl ) {
 			this.setIframeUrl( this.props.previewUrl );
 		}
-
+		if ( this.props.previewMarkup ) {
+			this.setIframeMarkup( this.props.previewMarkup );
+		}
 		if ( this.props.showPreview ) {
 			document.documentElement.classList.add( 'no-scroll' );
 		}
@@ -86,6 +99,15 @@ const WebPreview = React.createClass( {
 				iframeUrl: null,
 				loaded: false,
 			} );
+		}
+		// If the previewMarkup changes, re-render the iframe contents
+		if ( this.props.previewMarkup && this.props.previewMarkup !== prevProps.previewMarkup ) {
+			this.setIframeMarkup( this.props.previewMarkup );
+		}
+		// If the previewMarkup is erased, remove the iframe contents
+		if ( ! this.props.previewMarkup && prevProps.previewMarkup ) {
+			debug( 'removing iframe contents' );
+			this.setIframeMarkup( '' );
 		}
 
 		// add/remove listener if showPreview has changed
@@ -111,6 +133,22 @@ const WebPreview = React.createClass( {
 			this.props.onClose();
 			event.preventDefault();
 		}
+	},
+
+	setIframeMarkup( content ) {
+		if ( ! this.refs.iframe ) {
+			debug( 'no iframe to update' );
+			return;
+		}
+		debug( 'adding markup to iframe', content.length );
+		this.refs.iframe.contentDocument.open();
+		this.refs.iframe.contentDocument.write( content );
+		this.refs.iframe.contentDocument.close();
+	},
+
+	handleClick( event ) {
+		debug( 'click detected for element', event.target );
+		return this.props.onClick( event );
 	},
 
 	setIframeUrl( iframeUrl ) {
@@ -143,10 +181,13 @@ const WebPreview = React.createClass( {
 	},
 
 	setLoaded() {
-		if ( ! this.state.iframeUrl ) {
+		if ( ! this.state.iframeUrl && ! this.props.previewMarkup ) {
+			debug( 'preview loaded, but nothing to show' );
 			return;
 		}
 		debug( 'preview loaded:', this.state.iframeUrl );
+		this.props.onLoad( this.refs.iframe.contentDocument );
+		this.refs.iframe.contentDocument.body.onclick = this.handleClick;
 		this.setState( { loaded: true } );
 	},
 

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -27,6 +27,8 @@ const WebPreview = React.createClass( {
 		showPreview: React.PropTypes.bool,
 		// Show external link button
 		showExternal: React.PropTypes.bool,
+		// Show close button
+		showClose: React.PropTypes.bool,
 		// Show device viewport switcher
 		showDeviceSwitcher: React.PropTypes.bool,
 		// The URL that should be displayed in the iframe
@@ -54,6 +56,7 @@ const WebPreview = React.createClass( {
 	getDefaultProps() {
 		return {
 			showExternal: true,
+			showClose: true,
 			showDeviceSwitcher: true,
 			previewUrl: null,
 			previewMarkup: null,

--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -25,7 +25,7 @@ const WebPreview = React.createClass( {
 	propTypes: {
 		// Display the preview
 		showPreview: React.PropTypes.bool,
-		// Show external link button
+		// Show external link button (only if there is a previewUrl)
 		showExternal: React.PropTypes.bool,
 		// Show close button
 		showClose: React.PropTypes.bool,
@@ -205,7 +205,7 @@ const WebPreview = React.createClass( {
 					<Toolbar setDeviceViewport={ this.setDeviceViewport }
 						device={ this.state.device }
 						{ ...this.props }
-						showExternal={ ( this.props.previewMarkup ? false : this.props.showExternal ) }
+						showExternal={ ( this.props.previewUrl ? this.props.showExternal : false ) }
 						showDeviceSwitcher={ this.props.showDeviceSwitcher && ! this._isMobile }
 					/>
 					<div className="web-preview__placeholder">

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -17,6 +17,8 @@ const PreviewToolbar = React.createClass( {
 		showDeviceSwitcher: React.PropTypes.bool,
 		// Show external link button
 		showExternal: React.PropTypes.bool,
+		// Show close button
+		showClose: React.PropTypes.bool,
 		// The device to display, used for setting preview dimensions
 		device: React.PropTypes.string,
 		// Elements to render on the right side of the toolbar
@@ -49,13 +51,15 @@ const PreviewToolbar = React.createClass( {
 	render() {
 		return (
 			<div className="web-preview__toolbar">
-				<button
-					className="web-preview__close"
-					onClick={ this.props.onClose }
-					aria-label={ this.translate( 'Close preview' ) }
-				>
-					<Gridicon icon="cross" />
-				</button>
+				{ this.props.showClose &&
+					<button
+						className="web-preview__close"
+						onClick={ this.props.onClose }
+						aria-label={ this.translate( 'Close preview' ) }
+					>
+						<Gridicon icon="cross" />
+					</button>
+				}
 				{ this.props.showExternal &&
 					<a className="web-preview__external" href={ this.props.previewUrl } target="_blank">
 						<Gridicon icon="external" />


### PR DESCRIPTION
When creating a `WebPreview` component, typically we are setting the `previewUrl` prop to load markup from a URL into the iframe. This adds another option: injecting markup as a string directly into the iframe by setting the `previewMarkup` prop.

This can be used to separate the preview display from the preview fetch, which can be done separately (eg: via an API call) and cached as local data.

When the iframe source is loaded (if we are using `previewMarkup`), the optional prop function `onLoad` will be called and will be passed a reference to the DOM of the iframe.

Finally, this adds two more props for controlling the output of `WebPreview`:

- `className` (to set additional styles on the component)
- `showClose` (to disable the close button on the preview which is enabled by default)

### Testing

As nothing uses the `previewMarkup` prop yet, the only real test is to make sure nothing has changed when using `WebPreview` in the places where it is currently included (eg: the post editor preview).

To test the actual feature, try applying @jordwest's patch below:

1. download [the patch](https://gist.github.com/jordwest/82e4fdbdb17db532b883) into a file
2. run `git apply <filename>`
3. compile calypso
4. visit http://calypso.localhost:3000/devdocs/app-components and click on the "Show WebPreview" button at the bottom.
5. you should see "Test Markup" visible in the iframe