### PR TITLE
Framework: Add isomorphic dispatchSetSection fn

### DIFF
--- a/client/controller.js
+++ b/client/controller.js
@@ -4,6 +4,8 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 import { Provider as ReduxProvider } from 'react-redux';
+import { setSection as setSectionAction } from 'state/ui/actions';
+import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
@@ -49,6 +51,14 @@ export function makeLoggedOutLayout( context, next ) {
  */
 export function clientRouter( route, ...middlewares ) {
 	page( route, ...[ ...middlewares, render ] );
+}
+
+export function setSection( section ) {
+	return ( context, next = noop ) => {
+		context.store.dispatch( setSectionAction( section ) );
+
+		next();
+	}
 }
 
 function render( context ) {

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -22,7 +22,7 @@ const LayoutLoggedOut = ( {
 		[ 'is-group-' + section.group ]: !! section,
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
-		'has-no-sidebar': true,
+		'has-no-sidebar': ! section.secondary
 	} );
 
 	return (
@@ -41,18 +41,18 @@ const LayoutLoggedOut = ( {
 			</div>
 		</div>
 	);
-}
+};
 
 LayoutLoggedOut.displayName = 'LayoutLoggedOut';
 LayoutLoggedOut.propTypes = {
 	primary: React.PropTypes.element,
 	secondary: React.PropTypes.element,
 	tertiary: React.PropTypes.element,
-	section: React.PropTypes.object,
-}
+	section: React.PropTypes.object
+};
 
 export default connect(
 	state => ( {
-		section: state.ui.section,
+		section: state.ui.section
 	} )
 )( LayoutLoggedOut );

--- a/client/my-sites/themes/controller/index.node.js
+++ b/client/my-sites/themes/controller/index.node.js
@@ -14,7 +14,6 @@ import ThemeDetailsComponent from 'components/data/theme-details';
 import i18n from 'lib/mixins/i18n';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getThemeDetails } from 'state/themes/theme-details/selectors';
-import { setSection } from 'state/ui/actions';
 import ClientSideEffects from 'components/client-side-effects';
 import { receiveThemeDetails } from 'state/themes/actions';
 import wpcom from 'lib/wp';
@@ -84,12 +83,6 @@ export function details( context, next ) {
 		title: decodeEntities( title ) + ' — WordPress.com', // TODO: Use lib/screen-title's buildTitle. Cf. https://github.com/Automattic/wp-calypso/issues/3796
 		isLoggedIn: !! user
 	};
-
-	context.store.dispatch( setSection( {
-		name: 'theme',
-		group: 'sites',
-		secondary: false,
-	} ) );
 
 	const ConnectedComponent = ( { themeSlug, contentSection } ) => (
 		<ThemeDetailsComponent id={ themeSlug } >

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -4,16 +4,6 @@
 import config from 'config';
 import { makeLoggedOutLayout } from 'controller';
 import { details, fetchThemeDetailsData } from './controller';
-import { setSection } from 'state/ui/actions';
-
-function dispatchSetSection( context, next ) {
-	context.store.dispatch( setSection( {
-		name: 'themes',
-		group: 'sites',
-		secondary: true,
-	} ) );
-	next();
-}
 
 // FIXME: These routes will SSR the logged-out Layout even if logged-in.
 // While subsequently replaced by the logged-in Layout on the client-side,
@@ -23,8 +13,8 @@ function dispatchSetSection( context, next ) {
 // the layout.
 // FIXME: Also create loggedOut/multiSite/singleSite elements, depending on route.
 const designRoutes = {
-	'/design': [ dispatchSetSection, makeLoggedOutLayout ],
-	'/design/type/:tier': [ dispatchSetSection, makeLoggedOutLayout ]
+	'/design': [ makeLoggedOutLayout ],
+	'/design/type/:tier': [ makeLoggedOutLayout ]
 };
 
 const themesRoutes = {
@@ -34,7 +24,7 @@ const themesRoutes = {
 const routes = Object.assign( {},
 	config.isEnabled( 'manage/themes' ) ? designRoutes : {},
 	config.isEnabled( 'manage/themes/details' ) ? themesRoutes : {}
-)
+);
 
 export default function( router ) {
 	Object.keys( routes ).forEach( route => {

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -69,7 +69,7 @@ function splitTemplate( path, section ) {
 	result = [
 		'page( ' + path + ', function( context, next ) {',
 		'	if ( _loadedSections[ ' + JSON.stringify( section.module ) + ' ] ) {',
-		'		context.store.dispatch( { type: "SET_SECTION", section: ' + JSON.stringify( section ) + ' } );',
+		'		controller.setSection( ' + JSON.stringify( section ) + ' )( context );',
 		'		layoutFocus.next();',
 		'		return next();',
 		'	}',
@@ -85,7 +85,7 @@ function splitTemplate( path, section ) {
 		'			return;',
 		'		}',
 		'		context.store.dispatch( { type: "SET_SECTION", isLoading: false } );',
-		'		context.store.dispatch( { type: "SET_SECTION", section: ' + JSON.stringify( section ) + ' } );',
+		'		controller.setSection( ' + JSON.stringify( section ) + ' )( context );',
 		'		if ( ! _loadedSections[ ' + JSON.stringify( section.module ) + ' ] ) {',
 		'			require( ' + JSON.stringify( section.module ) + ' )( controller.clientRouter );',
 		'			_loadedSections[ ' + JSON.stringify( section.module ) + ' ] = true;',


### PR DESCRIPTION
This PR introduces an isomorphic fn to dispatch `setSection`. It is used as a middleware in SSR and as a function call in `bundler/loader` (for client side). 

## More info

Coming from #3829 (which can be deleted now), I was a little lost of how the SSR should work. Fortunately, @ockham was kind enough and explained/suggested to me  how isomorphic dispatch `setSection` could work. Citing our Slack conversation:

> we should mimic client-side as much as possible. On the client-side, the loader now automatically does that `setSection` dispatch for us, so we shouldn't need to call it manually on the server side
> and to not duplicate code, we should then use that same middleware [or function] on the client side

I tried to follow his instructions as much as possible and this is the result.

## Testing

### SSR

At the moment, only `theme` and `themes` sections are SSR ready. Try navigating to `/theme/passenger` and see if the `.wp` has `.has-no-sidebar`. Now, change the `secondary` to `true` for this section in `sections.js`, clear IndexedDB cache (Calypso stores its store there), re-run `make run` and reload the page. The `.wp` should now __not__ contain `.has-no-sidebar`.

### Client

Try if everything works as before.


cc @ockham 
