### PR TITLE
People: Fix send invites error notices and form recovery

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -141,8 +141,9 @@ export function sendInvites( siteId, usernamesOrEmails, role, message, formId ) 
 			} );
 
 			if ( isErrored ) {
+				// If there are no validation errors but the form errored, assume that all errored
 				const countErrors = ( error || isEmpty( validationErrors ) || 'object' !== typeof validationErrors )
-					? 0
+					? usernamesOrEmails.length
 					: Object.keys( data.errors ).length;
 
 				if ( countErrors === usernamesOrEmails.length ) {

--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -3,6 +3,7 @@
  */
 import Debug from 'debug';
 import isEmpty from 'lodash/isEmpty';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -125,7 +126,9 @@ export function sendInvites( siteId, usernamesOrEmails, role, message, formId ) 
 			siteId, usernamesOrEmails, role, message
 		} );
 		wpcom.undocumented().sendInvites( siteId, usernamesOrEmails, role, message, ( error, data ) => {
-			const isErrored = !! error || ! isEmpty( data.errors );
+			const validationErrors = get( data, 'errors' );
+			const isErrored = !! error || ! isEmpty( validationErrors );
+
 			Dispatcher.handleServerAction( {
 				type: isErrored ? ActionTypes.RECEIVE_SENDING_INVITES_ERROR : ActionTypes.RECEIVE_SENDING_INVITES_SUCCESS,
 				error,
@@ -138,7 +141,7 @@ export function sendInvites( siteId, usernamesOrEmails, role, message, formId ) 
 			} );
 
 			if ( isErrored ) {
-				const countErrors = ( isEmpty( data.errors ) || 'object' !== typeof data.errors )
+				const countErrors = ( error || isEmpty( validationErrors ) || 'object' !== typeof validationErrors )
 					? 0
 					: Object.keys( data.errors ).length;
 

--- a/client/lib/invites/stores/invites-sent.js
+++ b/client/lib/invites/stores/invites-sent.js
@@ -7,6 +7,6 @@ import { reducer, initialState } from 'lib/invites/reducers/invites-sent';
 const InvitesSentStore = createReducerStore( reducer, initialState );
 
 InvitesSentStore.getSuccess = ( formId ) => InvitesSentStore.get().getIn( [ 'success', formId ] );
-InvitesSentStore.getError = ( formId ) => InvitesSentStore.get().getIn( [ 'error', formId ] );
+InvitesSentStore.getErrors = ( formId ) => InvitesSentStore.get().getIn( [ 'error', formId ] );
 
 export default InvitesSentStore;


### PR DESCRIPTION
Fixes #4073 (in my testing) cc @v18 

I noticed that the logic for showing error notices when the invite form errors was wrong. 

Previously, we only considered the form submission as errored when the API returned an error object. But, we also want to show an error notice when the submission succeeds but there are some errors.

To test:
- Checkout `fix/invite-send-error-state` branch
- Go to `/people/new/$site` where `$site` is a WP.com site
- Send an invite that is successful. Are you shown a success notice?
- Go to `invite-people/index.jsx` and add a `return false;` to the top of `isSubmitDisabled()`.
- Try to submit the form with at least one errored invitee and at least one successful invitee
- After the form submits, do you see an error notice?
- Are the successful invitees removed?
- Do the errored invitees remain?

cc @lezama for code review and @rickybanister for design/flow review