### PR TITLE
Checkout: Thank You: Fix 'Try it now' link on `SiteRedirectDetails`

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/site-redirect-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/site-redirect-details.jsx
@@ -26,7 +26,7 @@ const SiteRedirectDetails = ( { selectedSite, domain } ) => {
 					)
 				}
 				buttonText={ i18n.translate( 'Try it now' ) }
-				href={ `http://${ selectedSite.wpcom_url }` }
+				href={ `${ selectedSite.options.unmapped_url }` }
 				target="_blank" />
 
 			<PurchaseDetail


### PR DESCRIPTION
Fixes #3792.

Currently, `SiteRedirectDetails` links to the user's site with `selectedSite.wpcom_url`, which isn't set until the site is mapped, and is stale when loading this page after checking out with a credit card (but not PayPal). Instead, we can use the value in `selectedSite.options.unmapped_url`, which is always present.

**Testing**
- Visit `/start` and create a new site
- Visit `/domains/add/site-redirect/:site` and add a site redirect to your cart.
- Check out with the site redirect.
- Assert that clicking 'Try it now' takes you to `example.wordpress.com` in a new window (this will redirect you to whatever domain you entered for the site redirect).

- [x] Code review
- [x] Product review