### PR TITLE
Layout: Add design layout focus and preview updaters

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -343,7 +343,8 @@ $sidebar-width-min: 228px;
 .sidebar,
 .wp-secondary .site-selector,
 .current-site,
-.sidebar__menu {
+.sidebar__menu,
+.design-menu {
 	transform: translateX( 0 );
 	transition: all 0.15s cubic-bezier(0.075, 0.820, 0.165, 1.000);
 }
@@ -375,8 +376,54 @@ $sidebar-width-min: 228px;
 	}
 }
 
+.focus-design {
+	.wp-primary {
+		opacity: 0.2;
+		pointer-events: none;
+	}
+
+	.wp-secondary .design-menu {
+		opacity: 1;
+		transform: translateX( 272px );
+		pointer-events: auto;
+	}
+
+	.sidebar,
+	.wp-secondary .site-selector {
+		pointer-events: none;
+	}
+}
+
 .focus-sidebar {
 	overflow: hidden;
+}
+
+.design-menu {
+	background: lighten( $gray, 30% );
+	position: fixed;
+		top: 0;
+		bottom: 0;
+		left: -272px;
+	width: 272px;
+	overflow: hidden;
+	opacity: 0.8;
+	z-index: 181;
+	border-right: 1px solid lighten( $gray, 25% );
+}
+
+.layout__design.web-preview.is-visible,
+.layout__design.web-preview {
+	left: 273px;
+	.web-preview__content {
+		top: 0;
+		transform: scale( 1 );
+	}
+}
+
+.layout__design.web-preview.is-visible {
+	.web-preview__content {
+		transform: scale( 1 );
+	}
 }
 
 // site selector in the sidebar

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	connect = require( 'react-redux' ).connect,
 	classnames = require( 'classnames' ),
 	property = require( 'lodash/property' ),
 	sortBy = require( 'lodash/sortBy' );
@@ -22,7 +23,6 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	WelcomeMessage = require( 'nux-welcome/welcome-message' ),
 	analytics = require( 'analytics' ),
 	config = require( 'config' ),
-	connect = require( 'react-redux' ).connect,
 	PulsingDot = require( 'components/pulsing-dot' ),
 	SitesListNotices = require( 'lib/sites-list/notices' ),
 	OfflineStatus = require( 'layout/offline-status' ),
@@ -32,6 +32,7 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	SupportUser;
 
 import { isOffline } from 'state/application/selectors';
+import DesignPreview from 'my-sites/design-preview';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -168,6 +169,12 @@ Layout = React.createClass( {
 				<TranslatorLauncher
 					isEnabled={ translator.isEnabled() }
 					isActive={ translator.isActivated() }/>
+				{ this.props.section === 'sites' &&
+					<DesignPreview
+						className="layout__design"
+						showPreview={ this.props.focus.getCurrent() === 'design' }
+					/>
+				}
 			</div>
 		);
 	}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -169,7 +169,7 @@ Layout = React.createClass( {
 				<TranslatorLauncher
 					isEnabled={ translator.isEnabled() }
 					isActive={ translator.isActivated() }/>
-				{ this.props.section === 'sites' &&
+				{ config.isEnabled( 'design-layout' ) && this.props.section.group === 'sites' &&
 					<DesignPreview
 						className="layout__design"
 						showPreview={ this.props.focus.getCurrent() === 'design' }

--- a/client/lib/design-preview/index.js
+++ b/client/lib/design-preview/index.js
@@ -1,0 +1,11 @@
+import siteTitle from './updaters/site-title';
+import headerImage from './updaters/header-image';
+
+const updaterFunctions = [
+	siteTitle,
+	headerImage,
+];
+
+export function updatePreviewWithChanges( previewDocument, customizations ) {
+	updaterFunctions.map( callback => callback( previewDocument, customizations ) );
+}

--- a/client/lib/design-preview/updaters/header-image.js
+++ b/client/lib/design-preview/updaters/header-image.js
@@ -1,0 +1,27 @@
+export default function headerImage( previewDoc, customizations ) {
+	if ( ! customizations.headerImage ) {
+		return;
+	}
+	const headerImageSelector = [
+		'.header-image a img[src]',
+		'.header-image img[src]',
+		'.site-branding a img[src]',
+		'.site-header-image img',
+		'.header-image-link img[src]',
+		'img.header-image[src]',
+		'img.header-img[src]',
+		'img.headerimage[src]',
+		'img.custom-header[src]',
+		'.featured-header-image a img[src]',
+	].join();
+	const headerImageElement = previewDoc.querySelector( headerImageSelector );
+	if ( ! headerImageElement ) {
+		return;
+	}
+	if ( ! customizations.headerImage.headerImageUrl ) {
+		headerImageElement.style.display = 'none';
+		return;
+	}
+	headerImageElement.src = customizations.headerImage.headerImageUrl;
+	headerImageElement.style.display = 'block';
+}

--- a/client/lib/design-preview/updaters/site-title.js
+++ b/client/lib/design-preview/updaters/site-title.js
@@ -1,0 +1,13 @@
+export default function siteTitle( previewDoc, customizations ) {
+	if ( ! customizations.siteTitle ) {
+		return;
+	}
+	const blognameElement = previewDoc.querySelector( '.site-title a' );
+	const blogdescriptionElement = previewDoc.querySelector( '.site-description' );
+	if ( blognameElement ) {
+		blognameElement.innerHTML = customizations.siteTitle.blogname;
+	}
+	if ( blogdescriptionElement ) {
+		blogdescriptionElement.innerHTML = customizations.siteTitle.blogdescription;
+	}
+}

--- a/client/lib/layout-focus/index.js
+++ b/client/lib/layout-focus/index.js
@@ -28,7 +28,7 @@ var layoutFocus = {
 
 	// These are the three structural areas
 	// of the main body of Calypso
-	_areas: [ 'content', 'sidebar', 'sites' ],
+	_areas: [ 'content', 'sidebar', 'sites', 'design' ],
 
 	getCurrent: function() {
 		return this._current || 'content';

--- a/client/my-sites/design-menu/index.jsx
+++ b/client/my-sites/design-menu/index.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import layoutFocus from 'lib/layout-focus';
+
+const DesignMenu = React.createClass( {
+
+	onBack() {
+		layoutFocus.set( 'sidebar' );
+	},
+
+	render() {
+		return (
+			<div className="design-menu">
+				<span className="current-site__switch-sites">
+					<Button compact borderless onClick={ this.onBack }>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ this.translate( 'Back' ) }
+					</Button>
+				</span>
+				<Card>
+					Design Tools!
+				</Card>
+			</div>
+		);
+	}
+} );
+
+export default DesignMenu;

--- a/client/my-sites/design-preview/README.md
+++ b/client/my-sites/design-preview/README.md
@@ -1,0 +1,4 @@
+# DesignPreview
+
+A wrapper for the always-available instance of `WebPreview` that's activated
+when `layoutFocus` is set to `design`.

--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -1,0 +1,157 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import noop from 'lodash/noop';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import WebPreview from 'components/web-preview';
+import accept from 'lib/accept';
+import { updatePreviewWithChanges } from 'lib/design-preview';
+import layoutFocus from 'lib/layout-focus';
+
+const debug = debugFactory( 'calypso:design-preview' );
+
+const DesignPreview = React.createClass( {
+
+	propTypes: {
+		className: React.PropTypes.string,
+		showPreview: React.PropTypes.bool,
+		previewMarkup: React.PropTypes.string,
+		customizations: React.PropTypes.object,
+		actions: React.PropTypes.object,
+		isCustomizationsSaved: React.PropTypes.bool,
+		onLoad: React.PropTypes.func,
+		selectedSiteId: React.PropTypes.number,
+	},
+
+	getDefaultProps() {
+		return {
+			customizations: {},
+			actions: {},
+			isCustomizationsSaved: true,
+			onLoad: noop,
+		};
+	},
+
+	componentDidUpdate( prevProps ) {
+		// If the customizations have been removed, restore the original markup
+		if ( this.props.previewMarkup && this.props.customizations && this.props.previewMarkup === prevProps.previewMarkup && prevProps.customizations ) {
+			if ( Object.keys( this.props.customizations ).length === 0 && Object.keys( prevProps.customizations ).length > 0 ) {
+				debug( 'restoring original markup' );
+				// Force the initial markup to be restored because the DOM may have been
+				// changed, and simply not applying customizations will not restore it.
+				if ( this.props.selectedSiteId && this.props.actions.fetchPreviewMarkup ) {
+					this.props.actions.fetchPreviewMarkup( this.props.selectedSiteId, '' );
+				}
+			}
+		}
+		// Apply customizations
+		if ( this.props.customizations && this.previewDocument ) {
+			debug( 'updating preview with customizations', this.props.customizations );
+			updatePreviewWithChanges( this.previewDocument, this.props.customizations );
+		}
+	},
+
+	undoCustomization() {
+		if ( this.props.actions.undoCustomization ) {
+			this.props.actions.undoCustomization();
+		}
+	},
+
+	saveCustomizations() {
+		if ( this.props.actions.saveCustomizations ) {
+			this.props.actions.saveCustomizations();
+		}
+	},
+
+	onLoad( previewDocument ) {
+		this.previewDocument = previewDocument;
+		previewDocument.body.onclick = this.onPreviewClick;
+		this.props.onLoad( previewDocument );
+	},
+
+	onClosePreview() {
+		if ( this.props.customizations && ! this.props.isCustomizationsSaved ) {
+			return accept( this.translate( 'You have unsaved changes. Are you sure you want to close the preview?' ), accepted => {
+				if ( accepted ) {
+					if ( this.props.actions.clearCustomizations ) {
+						this.props.actions.clearCustomizations();
+					}
+					layoutFocus.set( 'sidebar' );
+				}
+			} );
+		}
+		if ( this.props.actions.clearCustomizations ) {
+			this.props.actions.clearCustomizations();
+		}
+		layoutFocus.set( 'sidebar' );
+	},
+
+	onPreviewClick( event ) {
+		debug( 'click detected for element', event.target );
+		if ( ! event.target.href ) {
+			return;
+		}
+		event.preventDefault();
+		// TODO: if the href is on the current site, load the href as a preview and fetch markup for that url
+	},
+
+	renderToolBarButtons() {
+		if ( this.props.customizations && this.props.actions.saveCustomizations ) {
+			const saveButtonText = this.props.isCustomizationsSaved ? this.translate( 'Saved' ) : this.translate( 'Save & Publish' );
+			return (
+				<div>
+					<Button compact onClick={ this.undoCustomization } >{ this.translate( 'Undo last change' ) }</Button>
+					<Button compact primary disabled={ this.props.isCustomizationsSaved } onClick={ this.saveCustomizations } >{ saveButtonText }</Button>
+				</div>
+			);
+		}
+	},
+
+	render() {
+		return (
+			<WebPreview
+				className={ this.props.className }
+				showExternal={ false }
+				showClose={ false }
+				showPreview={ this.props.showPreview }
+				previewMarkup={ this.props.previewMarkup }
+				onClose={ this.onClosePreview }
+				onLoad={ this.onLoad }
+			>
+			{ this.renderToolBarButtons() }
+			</WebPreview>
+		);
+	}
+} );
+
+function mapStateToProps( state ) {
+	if ( ! state.preview ) {
+		return {};
+	}
+	const selectedSiteId = state.ui.selectedSiteId;
+	const { previewMarkup, customizations, isSaved } = state.preview;
+	return {
+		selectedSiteId,
+		previewMarkup,
+		customizations,
+		isCustomizationsSaved: isSaved,
+	};
+}
+
+function mapDispatchToProps() {
+	return {
+		actions: {},
+	}
+}
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( DesignPreview );

--- a/client/my-sites/navigation/navigation.jsx
+++ b/client/my-sites/navigation/navigation.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import observe from 'lib/mixins/data-observe';
 import SitePicker from 'my-sites/picker';
 import Sidebar from 'my-sites/sidebar';
+import DesignMenu from 'my-sites/design-menu';
 
 module.exports = React.createClass( {
 	displayName: 'MySitesNavigation',
@@ -41,6 +42,7 @@ module.exports = React.createClass( {
 					siteBasePath={ this.props.siteBasePath }
 					user={ this.props.user }
 				/>
+				<DesignMenu />
 			</div>
 		);
 	}

--- a/client/my-sites/navigation/navigation.jsx
+++ b/client/my-sites/navigation/navigation.jsx
@@ -10,6 +10,7 @@ import observe from 'lib/mixins/data-observe';
 import SitePicker from 'my-sites/picker';
 import Sidebar from 'my-sites/sidebar';
 import DesignMenu from 'my-sites/design-menu';
+import config from 'config';
 
 module.exports = React.createClass( {
 	displayName: 'MySitesNavigation',
@@ -42,7 +43,9 @@ module.exports = React.createClass( {
 					siteBasePath={ this.props.siteBasePath }
 					user={ this.props.user }
 				/>
-				<DesignMenu />
+				{ config.isEnabled( 'design-layout' ) &&
+					<DesignMenu />
+				}
 			</div>
 		);
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -81,6 +81,7 @@
 		"me/security": true,
 		"me/security/checkup": true,
 		"me/trophies": false,
+		"design-layout": true,
 		"muse": true,
 		"network-connection": true,
 		"notifications2beta": true,


### PR DESCRIPTION
Relies on #4136 being merged first.

To quote @mtias from #4019 where much of this code originates:

> This PR creates a new layoutFocus area called "design". We can then set focus from anywhere in the app as easily as `layoutFocus.set( 'design' )` and design tools will slide in and the preview appear.

When the `design` layout is active, two panels appear and cover up the rest of the Calypso UI: `DesignMenu` (as a sidebar) and `DesignPreview` as a main area.

- `DesignMenu` is currently empty but can contain design tools to update the preview.

- `DesignPreview` is a wrapper for `WebPreview` that allows for customizations to be applied to the DOM of the preview iframe.

When the `customizations` prop in `DesignPreview` is set to an object, that object will be passed through a series of functions called "updaters" to update the iframe's content. Those functions are defined in `client/lib/design-preview`. Each one will be passed two arguments whenever the `customizations` prop is changed:

1. The document object of the iframe.
2. The current value of `customizations`.

The `customizations` object and the `previewMarkup` used by the preview will be stored in the Redux state tree, but that is in a separate PR (#4153).

This PR does not create any design tools by default, only sets the stage for them to be created. Nor does it activate the new layout focus anywhere in Calypso yet (that's in #4156). 

Also, the new layout is only available if the config feature flag `design-layout` is enabled, which is only true in development right now.
