### PR TITLE
Signup: Add a new Headstart flow with the vertical survey.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -118,6 +118,13 @@ const flows = {
 		lastModified: '2016-01-28'
 	},
 
+	newsite: {
+		steps: [ 'survey', 'themes-headstart', 'domains-with-theme', 'plans', 'survey-user' ],
+		destination: getSiteDestination,
+		description: 'Headstarted flow with verticals for EN users clicking "Create Website" on the homepage.',
+		lastModified: '2016-03-21'
+	},
+
 	blog: {
 		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getSiteDestination,
@@ -230,9 +237,16 @@ function removeUserStepFromFlow( flow ) {
 
 function filterFlowName( flowName ) {
 	const locale = getLocaleSlug();
+	// Only allow the `headstart` flow for EN users.
 	if ( 'headstart' === flowName && 'en' !== locale && 'en-gb' !== locale ) {
 		return 'main';
 	}
+
+	// Headstarted "default" flow (`newsite`) with vertical selection for EN users, coming from the homepage single button.
+	if ( 'website' === flowName && ( 'en' === locale || 'en-gb' === locale ) ) {
+		return 'newsite';
+	}
+
 	return flowName;
 }
 


### PR DESCRIPTION
This flow will be assigned to EN users clicking "Create Website" on the home page.

Relies on #3837 (and will need a `rebase` after it's merged).