### PR TITLE
Reader: removed feature flags for released features

### DIFF
--- a/client/reader/discover/helper.jsx
+++ b/client/reader/discover/helper.jsx
@@ -14,8 +14,7 @@ var config = require( 'config' ),
 
 module.exports = {
 	isEnabled: function() {
-		return config.isEnabled( 'reader/discover' ) &&
-			userUtils.getLocaleSlug() === 'en';
+		return userUtils.getLocaleSlug() === 'en';
 	},
 
 	isDiscoverPost: function( post ) {

--- a/client/reader/discover/helper.jsx
+++ b/client/reader/discover/helper.jsx
@@ -8,8 +8,7 @@ var find = require( 'lodash/find' ),
 /**
  * Internal Dependencies
  */
-var config = require( 'config' ),
-	userUtils = require( 'lib/user/utils' ),
+var userUtils = require( 'lib/user/utils' ),
 	readerRoute = require( 'reader/route' );
 
 module.exports = {

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -78,9 +78,7 @@ module.exports = function() {
 		page( '/read/list/:user/:list/followers', updateLastRoute, controller.removePost, controller.sidebar, controller.listManagementFollowers );
 	}
 
-	if ( config.isEnabled( 'reader/activities' ) ) {
-		page( '/activities/likes', controller.loadSubscriptions, controller.initAbTests, updateLastRoute, controller.removePost, controller.sidebar, controller.likes );
-	}
+	page( '/activities/likes', controller.loadSubscriptions, controller.initAbTests, updateLastRoute, controller.removePost, controller.sidebar, controller.likes );
 
 	if ( config.isEnabled( 'reader/following-edit' ) ) {
 		page( '/following/*', controller.loadSubscriptions, controller.initAbTests );

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -63,9 +63,7 @@ module.exports = function() {
 		page( '/tag/:tag', updateLastRoute, controller.removePost, controller.sidebar, controller.tagListing );
 	}
 
-	if ( config.isEnabled( 'reader/teams' ) ) {
-		page( '/read/a8c', updateLastRoute, controller.removePost, controller.sidebar, forceTeamA8C, controller.readA8C );
-	}
+	page( '/read/a8c', updateLastRoute, controller.removePost, controller.sidebar, forceTeamA8C, controller.readA8C );
 
 	page( '/read/list/:user/:list', updateLastRoute, controller.removePost, controller.sidebar, controller.listListing );
 

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -81,10 +81,8 @@ module.exports = function() {
 	page( '/following/*', controller.loadSubscriptions, controller.initAbTests );
 	page( '/following/edit', updateLastRoute, controller.removePost, controller.sidebar, controller.followingEdit );
 
-	if ( config.isEnabled( 'reader/recommendations' ) ) {
-		page( '/recommendations', controller.loadSubscriptions, controller.initAbTests, updateLastRoute, controller.removePost, controller.sidebar, controller.recommendedForYou );
-		page( '/tags', controller.loadSubscriptions, controller.initAbTests, updateLastRoute, controller.removePost, controller.sidebar, controller.recommendedTags );
-	}
+	page( '/recommendations', controller.loadSubscriptions, controller.initAbTests, updateLastRoute, controller.removePost, controller.sidebar, controller.recommendedForYou );
+	page( '/tags', controller.loadSubscriptions, controller.initAbTests, updateLastRoute, controller.removePost, controller.sidebar, controller.recommendedTags );
 
 	page( '/discover', updateLastRoute, controller.loadSubscriptions, controller.initAbTests, controller.removePost, controller.sidebar, controller.discover );
 };

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -80,10 +80,8 @@ module.exports = function() {
 
 	page( '/activities/likes', controller.loadSubscriptions, controller.initAbTests, updateLastRoute, controller.removePost, controller.sidebar, controller.likes );
 
-	if ( config.isEnabled( 'reader/following-edit' ) ) {
-		page( '/following/*', controller.loadSubscriptions, controller.initAbTests );
-		page( '/following/edit', updateLastRoute, controller.removePost, controller.sidebar, controller.followingEdit );
-	}
+	page( '/following/*', controller.loadSubscriptions, controller.initAbTests );
+	page( '/following/edit', updateLastRoute, controller.removePost, controller.sidebar, controller.followingEdit );
 
 	if ( config.isEnabled( 'reader/recommendations' ) ) {
 		page( '/recommendations', controller.loadSubscriptions, controller.initAbTests, updateLastRoute, controller.removePost, controller.sidebar, controller.recommendedForYou );

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -90,7 +90,5 @@ module.exports = function() {
 		page( '/tags', controller.loadSubscriptions, controller.initAbTests, updateLastRoute, controller.removePost, controller.sidebar, controller.recommendedTags );
 	}
 
-	if ( config.isEnabled( 'reader/discover' ) ) {
-		page( '/discover', updateLastRoute, controller.loadSubscriptions, controller.initAbTests, controller.removePost, controller.sidebar, controller.discover );
-	}
+	page( '/discover', updateLastRoute, controller.loadSubscriptions, controller.initAbTests, controller.removePost, controller.sidebar, controller.discover );
 };

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -67,9 +67,7 @@ module.exports = function() {
 		page( '/read/a8c', updateLastRoute, controller.removePost, controller.sidebar, forceTeamA8C, controller.readA8C );
 	}
 
-	if ( config.isEnabled( 'reader/lists' ) ) {
-		page( '/read/list/:user/:list', updateLastRoute, controller.removePost, controller.sidebar, controller.listListing );
-	}
+	page( '/read/list/:user/:list', updateLastRoute, controller.removePost, controller.sidebar, controller.listListing );
 
 	if ( config.isEnabled( 'reader/list-management' ) ) {
 		page( '/read/list/:user/:list/sites', updateLastRoute, controller.removePost, controller.sidebar, controller.listManagementSites );

--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -149,9 +149,7 @@ const ReaderShare = React.createClass( {
 				'ignore-click': true,
 				'is-active': this.state.showingMenu
 			} );
-		if ( ! config.isEnabled( 'reader/share' ) ) {
-			return null;
-		}
+
 		return React.createElement( this.props.tagName, {
 			className: 'reader-share',
 			onClick: this.killClick,

--- a/client/sections.js
+++ b/client/sections.js
@@ -184,7 +184,7 @@ if ( config.isEnabled( 'manage/drafts' ) ) {
 }
 
 if ( config.isEnabled( 'reader' ) ) {
-	readerPaths = [ '/', '/read', '/fresh', '/activities', '/find-friends', '/tag' ];
+	readerPaths = [ '/', '/read', '/fresh', '/activities', '/find-friends', '/tag', '/discover' ];
 
 	if ( config.isEnabled( 'reader/following-edit' ) ) {
 		readerPaths.push( '/following' );
@@ -193,10 +193,6 @@ if ( config.isEnabled( 'reader' ) ) {
 	if ( config.isEnabled( 'reader/recommendations' ) ) {
 		readerPaths.push( '/recommendations' );
 		readerPaths.push( '/tags' );
-	}
-
-	if ( config.isEnabled( 'reader/discover' ) ) {
-		readerPaths.push( '/discover' );
 	}
 
 	sections.push( {

--- a/client/sections.js
+++ b/client/sections.js
@@ -192,13 +192,10 @@ if ( config.isEnabled( 'reader' ) ) {
 		'/find-friends',
 		'/tag',
 		'/discover',
-		'/following'
+		'/following',
+		'/recommendations',
+		'/tags'
 	];
-
-	if ( config.isEnabled( 'reader/recommendations' ) ) {
-		readerPaths.push( '/recommendations' );
-		readerPaths.push( '/tags' );
-	}
 
 	sections.push( {
 		name: 'reader',

--- a/client/sections.js
+++ b/client/sections.js
@@ -184,11 +184,16 @@ if ( config.isEnabled( 'manage/drafts' ) ) {
 }
 
 if ( config.isEnabled( 'reader' ) ) {
-	readerPaths = [ '/', '/read', '/fresh', '/activities', '/find-friends', '/tag', '/discover' ];
-
-	if ( config.isEnabled( 'reader/following-edit' ) ) {
-		readerPaths.push( '/following' );
-	}
+	readerPaths = [
+		'/',
+		'/read',
+		'/fresh',
+		'/activities',
+		'/find-friends',
+		'/tag',
+		'/discover',
+		'/following'
+	];
 
 	if ( config.isEnabled( 'reader/recommendations' ) ) {
 		readerPaths.push( '/recommendations' );

--- a/client/sections.js
+++ b/client/sections.js
@@ -187,9 +187,7 @@ if ( config.isEnabled( 'reader' ) ) {
 	readerPaths = [
 		'/',
 		'/read',
-		'/fresh',
 		'/activities',
-		'/find-friends',
 		'/tag',
 		'/discover',
 		'/following',

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -63,7 +63,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": false,
 		"reader": true,
-		"reader/activities": true,
 		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": false,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -64,7 +64,6 @@
 		"press-this": false,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": true,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -63,7 +63,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": false,
 		"reader": true,
-		"reader/following-edit": true,
 		"reader/full-errors": false,
 		"reader/lists": true,
 		"reader/recommendations": true,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -64,7 +64,6 @@
 		"press-this": false,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/teams": true,
 		"rubberband-scroll-disable": true,
 		"settings/security/monitor": true,
 		"upgrades/checkout": false,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -63,7 +63,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": false,
 		"reader": true,
-		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": false,
 		"reader/lists": true,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -64,7 +64,6 @@
 		"press-this": false,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/lists": true,
 		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -64,7 +64,6 @@
 		"press-this": false,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": true,
 		"settings/security/monitor": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -65,7 +65,6 @@
 		"press-this": false,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/teams": true,
 		"rubberband-scroll-disable": true,
 		"settings/security/monitor": true,
 		"upgrades/checkout": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -64,7 +64,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": false,
 		"reader": true,
-		"reader/following-edit": true,
 		"reader/full-errors": false,
 		"reader/lists": true,
 		"reader/recommendations": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -65,7 +65,6 @@
 		"press-this": false,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -65,7 +65,6 @@
 		"press-this": false,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/lists": true,
 		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -64,7 +64,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": false,
 		"reader": true,
-		"reader/activities": true,
 		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -64,7 +64,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": false,
 		"reader": true,
-		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": false,
 		"reader/lists": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -65,7 +65,6 @@
 		"press-this": false,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": true,
 		"settings/security/monitor": true,

--- a/config/development.json
+++ b/config/development.json
@@ -96,7 +96,6 @@
 		"post-editor/media-advanced": true,
 		"press-this": true,
 		"reader": true,
-		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,

--- a/config/development.json
+++ b/config/development.json
@@ -98,7 +98,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/lists": true,
 		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,

--- a/config/development.json
+++ b/config/development.json
@@ -96,7 +96,6 @@
 		"post-editor/media-advanced": true,
 		"press-this": true,
 		"reader": true,
-		"reader/activities": true,
 		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": true,

--- a/config/development.json
+++ b/config/development.json
@@ -98,7 +98,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/development.json
+++ b/config/development.json
@@ -96,7 +96,6 @@
 		"post-editor/media-advanced": true,
 		"press-this": true,
 		"reader": true,
-		"reader/following-edit": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/lists": true,

--- a/config/development.json
+++ b/config/development.json
@@ -98,7 +98,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,

--- a/config/development.json
+++ b/config/development.json
@@ -98,7 +98,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,7 +68,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/following-edit": true,
 		"reader/lists": true,
 		"reader/recommendations": true,
 		"reader/share": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,7 +68,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,7 +68,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,7 +68,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,7 +68,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/lists": true,
 		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,7 +68,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/activities": true,
 		"reader/discover": true,
 		"reader/discovery": true,
 		"reader/following-edit": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,8 +68,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/discover": true,
-		"reader/discovery": true,
 		"reader/following-edit": true,
 		"reader/lists": true,
 		"reader/recommendations": true,

--- a/config/production.json
+++ b/config/production.json
@@ -64,7 +64,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/lists": true,
 		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,

--- a/config/production.json
+++ b/config/production.json
@@ -64,7 +64,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/production.json
+++ b/config/production.json
@@ -64,7 +64,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/production.json
+++ b/config/production.json
@@ -63,7 +63,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/following-edit": true,
 		"reader/full-errors": false,
 		"reader/lists": true,
 		"reader/recommendations": true,

--- a/config/production.json
+++ b/config/production.json
@@ -63,7 +63,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/activities": true,
 		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": false,

--- a/config/production.json
+++ b/config/production.json
@@ -64,7 +64,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": false,
-		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,

--- a/config/production.json
+++ b/config/production.json
@@ -63,7 +63,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": false,
 		"reader/lists": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -66,7 +66,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/lists": true,
 		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -65,7 +65,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/activities": true,
 		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -65,7 +65,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/following-edit": true,
 		"reader/full-errors": true,
 		"reader/lists": true,
 		"reader/recommendations": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -66,7 +66,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -66,7 +66,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -66,7 +66,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -65,7 +65,6 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
-		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": true,
 		"reader/lists": true,

--- a/config/test.json
+++ b/config/test.json
@@ -96,7 +96,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,

--- a/config/test.json
+++ b/config/test.json
@@ -94,7 +94,6 @@
 		"post-editor/media-advanced": true,
 		"press-this": true,
 		"reader": true,
-		"reader/following-edit": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/lists": true,

--- a/config/test.json
+++ b/config/test.json
@@ -96,7 +96,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/test.json
+++ b/config/test.json
@@ -94,7 +94,6 @@
 		"post-editor/media-advanced": true,
 		"press-this": true,
 		"reader": true,
-		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,

--- a/config/test.json
+++ b/config/test.json
@@ -94,7 +94,6 @@
 		"post-editor/media-advanced": true,
 		"press-this": true,
 		"reader": true,
-		"reader/activities": true,
 		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": true,

--- a/config/test.json
+++ b/config/test.json
@@ -96,7 +96,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/lists": true,
 		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,

--- a/config/test.json
+++ b/config/test.json
@@ -96,7 +96,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
-		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -74,7 +74,6 @@
 		"post-editor/contact-form": true,
 		"press-this": true,
 		"reader": true,
-		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": true,
 		"reader/lists": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -75,7 +75,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -75,7 +75,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/lists": true,
 		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -75,7 +75,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -75,7 +75,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/recommendations": true,
 		"reader/share": true,
 		"reader/teams": true,
 		"rubberband-scroll-disable": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -74,7 +74,6 @@
 		"post-editor/contact-form": true,
 		"press-this": true,
 		"reader": true,
-		"reader/activities": true,
 		"reader/discover": true,
 		"reader/following-edit": true,
 		"reader/full-errors": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -74,7 +74,6 @@
 		"post-editor/contact-form": true,
 		"press-this": true,
 		"reader": true,
-		"reader/following-edit": true,
 		"reader/full-errors": true,
 		"reader/lists": true,
 		"reader/recommendations": true,


### PR DESCRIPTION
The following features are now deployed across environments. This PR removes their feature flags.

- [x] reader/activities
- [x] reader/discover
- [x] reader/following-edit
- [x] reader/lists
- [x] reader/recommendations
- [x] reader/share
- [x] reader/teams

### To test

Ensure you're able to reach My Likes, Discover, Following Management, List Streams, Recommendations and see the share option on post cards. If you're an Automattician, make sure you can see the Automattic link in your sidebar.

Fixes #3636.