### PR TITLE
Checkout: Display plan discount in `SecondaryCount`

### DIFF
--- a/client/my-sites/upgrades/cart/cart-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-ad.jsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const CartAd = ( { children } ) => (
+	<div className="cart__cart-ad">{ children }</div>
+);
+
+CartAd.displayName = 'CartAd';
+
+export default CartAd;

--- a/client/my-sites/upgrades/cart/cart-domain-discount-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-domain-discount-ad.jsx
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import find from 'lodash/find';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CartAd from './cart-ad';
+import { cartItems } from 'lib/cart-values';
+import { fetchSitePlans } from 'state/sites/plans/actions';
+import { getPlansBySite } from 'state/sites/plans/selectors';
+import { isBusiness, isPlan, isPremium } from 'lib/products-values';
+import i18n from 'lib/mixins/i18n';
+import { shouldFetchSitePlans } from 'lib/plans';
+
+const CartDomainDiscountAd = React.createClass( {
+	propTypes: {
+		cart: React.PropTypes.object,
+		sitePlans: React.PropTypes.object
+	},
+
+	componentDidMount() {
+		this.props.fetchSitePlans( this.props.sitePlans, this.props.selectedSite );
+	},
+
+	render() {
+		const { cart, sitePlans } = this.props;
+		let plan;
+
+		if ( ! sitePlans.hasLoadedFromServer || ! cart.hasLoadedFromServer || ! cartItems.getAll( cart ).some( isPlan ) ) {
+			return null;
+		}
+
+		if ( cartItems.getAll( cart ).some( isPremium ) ) {
+			plan = find( sitePlans.data, isPremium );
+		}
+
+		if ( cartItems.getAll( cart ).some( isBusiness ) ) {
+			plan = find( sitePlans.data, isBusiness );
+		}
+
+		if ( plan.rawDiscount === 0 ) {
+			return null;
+		}
+
+		return (
+			<CartAd>
+				{
+					i18n.translate(
+						"{{strong}}You're saving %(discount)s!{{/strong}} Your recent domain purchase is " +
+						'deducted from the price (%(fullPrice)s), since the plan includes a free domain.', {
+							args: { discount: plan.formattedDiscount, fullPrice: plan.formattedPrice },
+							components: { strong: <strong /> }
+						}
+					)
+				}
+			</CartAd>
+		);
+	}
+} );
+
+export default connect(
+	( state, { selectedSite } ) => {
+		return {
+			sitePlans: getPlansBySite( state, selectedSite )
+		}
+	},
+	( dispatch ) => {
+		return {
+			fetchSitePlans: ( sitePlans, site ) => {
+				if ( shouldFetchSitePlans( sitePlans, site ) ) {
+					dispatch( fetchSitePlans( site.ID ) );
+				}
+			}
+		}
+	}
+)( CartDomainDiscountAd );

--- a/client/my-sites/upgrades/cart/cart-plan-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-plan-ad.jsx
@@ -7,6 +7,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
 import { isPlan } from 'lib/products-values';
 import * as upgradesActions from 'lib/upgrades/actions';
@@ -32,12 +33,15 @@ const CartPlanAd = React.createClass( {
 		}
 
 		return (
-			<div className="cart-plan-ad">{
-				this.translate( 'Get this domain for free when you upgrade to {{strong}}WordPress.com Premium{{/strong}}!', {
-					components: { strong: <strong /> }
-				} )
-			} <a href="" onClick={ this.addToCartAndRedirect }>{ this.translate( 'Upgrade Now' ) }</a>
-			</div>
+			<CartAd>
+				{
+					this.translate( 'Get this domain for free when you upgrade to {{strong}}WordPress.com Premium{{/strong}}!', {
+						components: { strong: <strong /> }
+					} )
+				}
+				{ ' ' }
+				<a href="" onClick={ this.addToCartAndRedirect }>{ this.translate( 'Upgrade Now' ) }</a>
+			</CartAd>
 		);
 	}
 } );

--- a/client/my-sites/upgrades/cart/cart-plan-discount-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-plan-discount-ad.jsx
@@ -16,7 +16,7 @@ import { isBusiness, isPlan, isPremium } from 'lib/products-values';
 import i18n from 'lib/mixins/i18n';
 import { shouldFetchSitePlans } from 'lib/plans';
 
-const CartDomainDiscountAd = React.createClass( {
+const CartPlanDiscountAd = React.createClass( {
 	propTypes: {
 		cart: React.PropTypes.object,
 		sitePlans: React.PropTypes.object
@@ -48,15 +48,15 @@ const CartDomainDiscountAd = React.createClass( {
 
 		return (
 			<CartAd>
-				{
-					i18n.translate(
-						"{{strong}}You're saving %(discount)s!{{/strong}} Your recent domain purchase is " +
-						'deducted from the price (%(fullPrice)s), since the plan includes a free domain.', {
-							args: { discount: plan.formattedDiscount, fullPrice: plan.formattedPrice },
-							components: { strong: <strong /> }
+				<strong>
+					{ i18n.translate( "You're saving %(discount)s!", {
+						args: {
+							discount: plan.formattedDiscount
 						}
-					)
-				}
+					} ) }
+				</strong>
+				{ ' ' }
+				{ plan.discountReason }
 			</CartAd>
 		);
 	}
@@ -77,4 +77,4 @@ export default connect(
 			}
 		}
 	}
-)( CartDomainDiscountAd );
+)( CartPlanDiscountAd );

--- a/client/my-sites/upgrades/cart/cart-plan-discount-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-plan-discount-ad.jsx
@@ -12,7 +12,7 @@ import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
-import { isBusiness, isPlan, isPremium } from 'lib/products-values';
+import { isBusiness, isPremium } from 'lib/products-values';
 import i18n from 'lib/mixins/i18n';
 import { shouldFetchSitePlans } from 'lib/plans';
 
@@ -30,7 +30,7 @@ const CartPlanDiscountAd = React.createClass( {
 		const { cart, sitePlans } = this.props;
 		let plan;
 
-		if ( ! sitePlans.hasLoadedFromServer || ! cart.hasLoadedFromServer || ! cartItems.getAll( cart ).some( isPlan ) ) {
+		if ( ! sitePlans.hasLoadedFromServer || ! cart.hasLoadedFromServer || ! cartItems.hasPlan( cart ) ) {
 			return null;
 		}
 

--- a/client/my-sites/upgrades/cart/cart-trial-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-trial-ad.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
 import { addCurrentPlanToCartAndRedirect, getCurrentPlan, getDayOfTrial } from 'lib/plans';
 import i18n from 'lib/mixins/i18n';
@@ -39,7 +40,7 @@ const CartTrialAd = React.createClass( {
 		}
 
 		return (
-			<div className="popover-cart__cart-trial-ad">
+			<CartAd>
 				{
 					i18n.translate( 'You are currently on day %(days)d of your {{strong}}%(planName)s trial{{/strong}}.', {
 						components: { strong: <strong /> },
@@ -59,7 +60,7 @@ const CartTrialAd = React.createClass( {
 					onClick={ this.addPlanAndRedirect }>
 						{ i18n.translate( 'Upgrade Now' ) }
 				</a>
-			</div>
+			</CartAd>
 		);
 	}
 } );

--- a/client/my-sites/upgrades/cart/secondary-cart.jsx
+++ b/client/my-sites/upgrades/cart/secondary-cart.jsx
@@ -10,7 +10,7 @@ var CartBody = require( 'my-sites/upgrades/cart/cart-body' ),
 	CartMessagesMixin = require( './cart-messages-mixin' ),
 	CartSummaryBar = require( 'my-sites/upgrades/cart/cart-summary-bar' ),
 	CartPlanAd = require( './cart-plan-ad' ),
-	CartDomainDiscountAd = require( './cart-domain-discount-ad' ),
+	CartPlanDiscountAd = require( './cart-plan-discount-ad' ),
 	Sidebar = require( 'layout/sidebar' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	{ isSidebarHiddenForCart } = require( 'lib/cart-values' );
@@ -35,7 +35,7 @@ var SecondaryCart = React.createClass( {
 					cart={ cart }
 					selectedSite={ selectedSite }
 					showCoupon={ true } />
-				<CartDomainDiscountAd
+				<CartPlanDiscountAd
 					cart={ cart }
 					selectedSite={ selectedSite } />
 			</Sidebar>

--- a/client/my-sites/upgrades/cart/secondary-cart.jsx
+++ b/client/my-sites/upgrades/cart/secondary-cart.jsx
@@ -10,6 +10,7 @@ var CartBody = require( 'my-sites/upgrades/cart/cart-body' ),
 	CartMessagesMixin = require( './cart-messages-mixin' ),
 	CartSummaryBar = require( 'my-sites/upgrades/cart/cart-summary-bar' ),
 	CartPlanAd = require( './cart-plan-ad' ),
+	CartDomainDiscountAd = require( './cart-domain-discount-ad' ),
 	Sidebar = require( 'layout/sidebar' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	{ isSidebarHiddenForCart } = require( 'lib/cart-values' );
@@ -34,6 +35,9 @@ var SecondaryCart = React.createClass( {
 					cart={ cart }
 					selectedSite={ selectedSite }
 					showCoupon={ true } />
+				<CartDomainDiscountAd
+					cart={ cart }
+					selectedSite={ selectedSite } />
 			</Sidebar>
 		);
 	}

--- a/client/my-sites/upgrades/cart/style.scss
+++ b/client/my-sites/upgrades/cart/style.scss
@@ -146,8 +146,7 @@
 	font-size: 14px;
 }
 
-.cart-plan-ad,
-.popover-cart__cart-trial-ad {
+.cart__cart-ad {
 	background: lighten( $gray, 34% );
 	border: 1px solid lighten( $gray, 30% );
 	border-radius: 4px;

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -22,7 +22,6 @@ import DomainMappingDetails from './domain-mapping-details';
 import DomainRegistrationDetails from './domain-registration-details';
 import { fetchReceipt } from 'state/receipts/actions';
 import FreeTrialNudge from './free-trial-nudge'
-import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getReceiptById } from 'state/receipts/selectors';
 import GoogleAppsDetails from './google-apps-details';
 import HappinessSupport from 'components/happiness-support';
@@ -89,7 +88,8 @@ const CheckoutThankYou = React.createClass( {
 	},
 
 	refreshSitesAndSitePlansIfPlanPurchased() {
-		if ( this.props.receipt.hasLoadedFromServer && getPurchases( this.props ).some( isPlan ) ) {
+		if ( this.props.receipt.hasLoadedFromServer &&
+			getPurchases( this.props ).some( purchase => isPlan( purchase ) || isDomainRegistration( purchase ) ) ) {
 			// Refresh selected site plans if the user just purchased a plan
 			this.props.refreshSitePlans( this.props.selectedSite.ID );
 

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -87,9 +87,12 @@ const CheckoutThankYou = React.createClass( {
 		this.refreshSitesAndSitePlansIfPlanPurchased();
 	},
 
+	hasPlanOrDomainRegistration() {
+		return getPurchases( this.props ).some( purchase => isPlan( purchase ) || isDomainRegistration( purchase ) );
+	},
+
 	refreshSitesAndSitePlansIfPlanPurchased() {
-		if ( this.props.receipt.hasLoadedFromServer &&
-			getPurchases( this.props ).some( purchase => isPlan( purchase ) || isDomainRegistration( purchase ) ) ) {
+		if ( this.props.receipt.hasLoadedFromServer && this.hasPlanOrDomainRegistration() ) {
 			// Refresh selected site plans if the user just purchased a plan
 			this.props.refreshSitePlans( this.props.selectedSite.ID );
 

--- a/client/my-sites/upgrades/controller.jsx
+++ b/client/my-sites/upgrades/controller.jsx
@@ -191,13 +191,14 @@ module.exports = {
 			context.store
 		);
 
-		ReactDom.render(
+		renderWithReduxStore(
 			(
 				<CartData>
 					<SecondaryCart selectedSite={ sites.getSelectedSite() } />
 				</CartData>
 			),
-			document.getElementById( 'secondary' )
+			document.getElementById( 'secondary' ),
+			context.store
 		);
 	},
 

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -7,6 +7,7 @@ const createSitePlanObject = ( plan ) => {
 	return {
 		canStartTrial: Boolean( plan.can_start_trial ),
 		currentPlan: Boolean( plan.current_plan ),
+		discountReason: plan.discount_reason,
 		expiry: plan.expiry,
 		expiryMoment: moment( plan.expiry ).startOf( 'day' ),
 		formattedDiscount: plan.formatted_discount,


### PR DESCRIPTION
This PR adds these messages to checkout when purchasing a plan with a discount:

![screen shot 2016-03-18 at 2 50 32 pm](https://cloud.githubusercontent.com/assets/1130674/13893069/d0dadd02-ed18-11e5-82d7-bc1a287a4d7b.png)
![screen shot 2016-03-18 at 2 59 11 pm](https://cloud.githubusercontent.com/assets/1130674/13893245/02648480-ed1a-11e5-8f6d-2cba1cadca96.png)

Requires D1365-code. Also fixes #4039.

**Testing**
*Discount from a prior domain purchase*
- Visit `/start` and create a new site without selecting a domain or a paid plan.
- Visit `/domains/add/:site` and add a domain to your cart.
- Purchase the domain.
- When you reach the thank you page, click 'My Sites' in the masterbar.
- Click 'Plan' in the sidebar.
- Assert that the premium/business plans each have a discount.
- Add either plan to your cart.
- Assert that you see a message indicating why the plan is cheaper in the cart at checkout:
![screen shot 2016-03-18 at 2 50 32 pm](https://cloud.githubusercontent.com/assets/1130674/13893069/d0dadd02-ed18-11e5-82d7-bc1a287a4d7b.png)

*Discount from a prior premium plan purchase when upgrading to  #business*
- Visit `/start` and create a new site without selecting a domain or a paid plan.
- Visit `/plans/:site` and add the premium plan to your cart.
- Purchase the premium plan.
- Visit `/plans/:site` and add the business plan to your cart.
- Assert that you see a message indicating why the plan is cheaper in the cart at checkout:
![screen shot 2016-03-18 at 2 59 11 pm](https://cloud.githubusercontent.com/assets/1130674/13893245/02648480-ed1a-11e5-8f6d-2cba1cadca96.png)

- [x] Code review
- [x] Product review