### PR TITLE
Notification Settings: Fix classname type

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -46,7 +46,7 @@ module.exports = React.createClass( {
 
 	render() {
 		return (
-			<Main className="notifications">
+			<Main className="notifications-settings">
 				<MeSidebarNavigation />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 


### PR DESCRIPTION
This is the smallest of PRs. It basically renames a class from `notifications` to `notifications-settings`. There's no visual change in master, however in a previous experiment involving a flexbox rewrite, the need for this proper classname became apparent, as CSS would bleed in on mobile breakpoints. (https://github.com/Automattic/wp-calypso/pull/3742/commits/b819dce2cd4f3652d6f57b0b51e99fa45ef392e3).

The flexbox experiment has been retired, but there's no reason not to fix this typo.