### PR TITLE
Signup: Update free trial flow to offer Premium plan to all users

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -72,7 +72,7 @@ module.exports = {
 			const providedDependencies = {
 				siteSlug,
 				domainItem,
-				themeItem,
+				themeItem
 			};
 			const addToCartAndProceed = () => {
 				let newCartItems = [];

--- a/client/lib/sites-list/list.js
+++ b/client/lib/sites-list/list.js
@@ -235,19 +235,21 @@ SitesList.prototype.update = function( sites ) {
  * @param {array} purchases - Array of purchases indexed by site IDs
  */
 SitesList.prototype.updatePlans = function( purchases ) {
-	this.data = this.data.map( function( site ) {
-		var plan;
+	if ( this.data ) {
+		this.data = this.data.map( function( site ) {
+			var plan;
 
-		if ( purchases[ site.ID ] ) {
-			plan = find( purchases[ site.ID ], isPlan );
+			if ( purchases[ site.ID ] ) {
+				plan = find( purchases[ site.ID ], isPlan );
 
-			if ( plan ) {
-				site.set( { plan: plan } );
+				if ( plan ) {
+					site.set( { plan: plan } );
+				}
 			}
-		}
 
-		return site;
-	} );
+			return site;
+		} );
+	}
 };
 
 /**

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var connect = require( 'react-redux' ).connect,
-	Dispatcher = require( 'dispatcher' ),
 	forEach = require( 'lodash/forEach' ),
 	isEmpty = require( 'lodash/isEmpty' ),
 	isEqual = require( 'lodash/isEqual' ),
@@ -102,8 +101,7 @@ const Checkout = React.createClass( {
 	},
 
 	redirectIfEmptyCart: function() {
-		var redirectTo = '/plans/',
-			renewalItem;
+		var redirectTo = '/plans/';
 
 		if ( ! this.state.previousCart && this.props.planName ) {
 			// the plan hasn't been added to the cart yet

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -218,10 +218,10 @@ const flows = {
 	},
 
 	'free-trial': {
-		steps: [ 'themes', 'site', 'plans', 'user' ],
+		steps: [ 'themes', 'domains-with-plan', 'user' ],
 		destination: getSiteDestination,
 		description: 'Signup flow for free trials',
-		lastModified: '2015-12-18'
+		lastModified: '2016-03-21'
 	}
 };
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -8,8 +8,10 @@ var assign = require( 'lodash/assign' ),
  * Internal dependencies
  */
 var config = require( 'config' ),
+	plansPaths = require( 'my-sites/plans/paths' ),
 	stepConfig = require( './steps' ),
 	user = require( 'lib/user' )();
+
 import { getLocaleSlug } from 'lib/i18n-utils';
 
 function getCheckoutUrl( dependencies ) {
@@ -18,6 +20,14 @@ function getCheckoutUrl( dependencies ) {
 
 function dependenciesContainCartItem( dependencies ) {
 	return dependencies.cartItem || dependencies.domainItem || dependencies.themeItem;
+}
+
+function getFreeTrialDestination( dependencies ) {
+	if ( dependenciesContainCartItem( dependencies ) ) {
+		return getCheckoutUrl( dependencies );
+	}
+
+	return plansPaths.plans( dependencies.siteSlug );
 }
 
 function getSiteDestination( dependencies ) {
@@ -219,7 +229,7 @@ const flows = {
 
 	'free-trial': {
 		steps: [ 'themes', 'domains-with-plan', 'user' ],
-		destination: getSiteDestination,
+		destination: getFreeTrialDestination,
 		description: 'Signup flow for free trials',
 		lastModified: '2016-03-21'
 	}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -5,8 +5,8 @@ var assign = require( 'lodash/assign' ),
 	reject = require( 'lodash/reject' );
 
 /**
-* Internal dependencies
-*/
+ * Internal dependencies
+ */
 var config = require( 'config' ),
 	stepConfig = require( './steps' ),
 	user = require( 'lib/user' )();
@@ -72,7 +72,7 @@ const flows = {
 	},
 
 	businessv2: {
-		steps: ['domains', 'user' ],
+		steps: [ 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
@@ -81,7 +81,7 @@ const flows = {
 	},
 
 	premiumv2: {
-		steps: ['domains', 'user' ],
+		steps: [ 'domains', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
@@ -222,7 +222,7 @@ const flows = {
 		destination: getSiteDestination,
 		description: 'Signup flow for free trials',
 		lastModified: '2015-12-18'
-	},
+	}
 };
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -1,28 +1,28 @@
 /**
  * Internal dependencies
  */
-var UserSignupComponent = require( 'signup/steps/user' ),
-	SiteComponent = require( 'signup/steps/site' ),
-	ThemeSelectionComponent = require( 'signup/steps/theme-selection' ),
+var config = require( 'config' ),
+	DesignTypeComponent = require( 'signup/steps/design-type' ),
+	DomainsStepComponent = require( 'signup/steps/domains' ),
 	PaidPlansOnly = require( 'signup/steps/paid-plans-only' ),
 	PlansStepComponent = require( 'signup/steps/plans' ),
-	DomainsStepComponent = require( 'signup/steps/domains' ),
-	DesignTypeComponent = require( 'signup/steps/design-type' ),
+	SiteComponent = require( 'signup/steps/site' ),
 	SurveyStepComponent = require( 'signup/steps/survey' ),
-	config = require( 'config' );
+	ThemeSelectionComponent = require( 'signup/steps/theme-selection' ),
+	UserSignupComponent = require( 'signup/steps/user' );
 
 module.exports = {
-	themes: ThemeSelectionComponent,
-	site: SiteComponent,
-	user: UserSignupComponent,
-	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
+	'design-type': DesignTypeComponent,
+	domains: DomainsStepComponent,
+	'domains-with-theme': DomainsStepComponent,
+	'jetpack-user': UserSignupComponent,
 	plans: PlansStepComponent,
 	'select-plan': PaidPlansOnly,
-	domains: DomainsStepComponent,
+	site: SiteComponent,
 	survey: SurveyStepComponent,
 	'survey-user': UserSignupComponent,
-	'design-type': DesignTypeComponent,
+	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
+	themes: ThemeSelectionComponent,
 	'themes-headstart': ThemeSelectionComponent,
-	'domains-with-theme': DomainsStepComponent,
-	'jetpack-user': UserSignupComponent
+	user: UserSignupComponent
 };

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -14,6 +14,7 @@ var config = require( 'config' ),
 module.exports = {
 	'design-type': DesignTypeComponent,
 	domains: DomainsStepComponent,
+	'domains-with-plan': DomainsStepComponent,
 	'domains-with-theme': DomainsStepComponent,
 	'jetpack-user': UserSignupComponent,
 	plans: PlansStepComponent,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -84,6 +84,13 @@ module.exports = {
 		delayApiRequestUntilComplete: true
 	},
 
+	'domains-with-plan': {
+		stepName: 'domains-with-plan',
+		apiRequestFunction: stepActions.addDomainAndPlanFreeTrialToCart,
+		providesDependencies: [ 'cartItem', 'domainItem', 'siteSlug', 'themeItem' ],
+		delayApiRequestUntilComplete: true
+	},
+
 	'domains-with-theme': {
 		stepName: 'domains-with-theme',
 		apiRequestFunction: stepActions.addDomainItemsToCart,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -80,21 +80,21 @@ module.exports = {
 	domains: {
 		stepName: 'domains',
 		apiRequestFunction: stepActions.addDomainItemsToCart,
-		providesDependencies: [ 'siteSlug', 'domainItem', 'themeItem' ],
+		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
 		delayApiRequestUntilComplete: true
 	},
 
 	'domains-with-plan': {
 		stepName: 'domains-with-plan',
-		apiRequestFunction: stepActions.addDomainAndPlanFreeTrialToCart,
-		providesDependencies: [ 'cartItem', 'domainItem', 'siteSlug', 'themeItem' ],
+		apiRequestFunction: stepActions.addDomainItemsToCartAndStartFreeTrial,
+		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
 		delayApiRequestUntilComplete: true
 	},
 
 	'domains-with-theme': {
 		stepName: 'domains-with-theme',
 		apiRequestFunction: stepActions.addDomainItemsToCart,
-		providesDependencies: [ 'siteSlug', 'domainItem', 'themeItem' ],
+		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
 		dependencies: [ 'theme' ],
 		delayApiRequestUntilComplete: true
 	},

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -44,7 +44,7 @@ module.exports = {
 	},
 
 	test: {
-		stepName: 'test',
+		stepName: 'test'
 	},
 
 	survey: {


### PR DESCRIPTION
This pull request modifies the signup flow for free trials in order to offer the Premium plan as free trial to **any user entering this flow**. More specifically it:
* Removes the step where users could select a plan
* Adds the step where users can select a domain
* Adds the free trial to the shopping cart in the background

Users are redirected at the end of the signup flow to the `Checkout` page in all cases (i.e. even if they they didn't purchase anything).
 
#### Testing instructions - without domain
0. Apply this patch `code-D1377` 
1. Run `git checkout update/free-trial-signup` and start your server
2. Open the [`Signup` page](http://calypso.localhost:3000/start/free-trial)
3. Select a theme
4. Select a free address
5. Create a user account
6. Verify that you are redirected to the free trial hub
7. Verify that your new site has a free trial

#### Testing instructions - with domain
0. Apply this patch `code-D1377`
1. Run `git checkout update/free-trial-signup` and start your server
2. Open the [`Signup` page](http://calypso.localhost:3000/start/free-trial)
3. Select a theme
4. Select a custom domain
5. Create a user account
6. Verify that you are redirected to the checkout
7. Verify that your new site has a free trial

#### Additional notes
You also need to test the following flows:
- `main`
- `headstart`

Other flows are also effected, but testing these two should be sufficient.

#### Reviews

- [x] Code
- [x] Product