### PR TITLE
State: getSelectedSiteId selector

### DIFF
--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -7,9 +7,20 @@
  * @return {?Object}        Selected site
  */
 export function getSelectedSite( state ) {
-	if ( ! state.ui.selectedSiteId ) {
+	const siteId = getSelectedSiteId( state );
+	if ( ! siteId ) {
 		return null;
 	}
 
-	return state.sites.items[ state.ui.selectedSiteId ];
+	return state.sites.items[ siteId ];
+}
+
+/**
+ * Returns the currently selected site ID.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {?Number}       Selected site ID
+ */
+export function getSelectedSiteId( state ) {
+	return state.ui.selectedSiteId;
 }

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getSelectedSite } from '../selectors';
+import { getSelectedSite, getSelectedSiteId } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#getSelectedSite()', () => {
@@ -33,6 +33,28 @@ describe( 'selectors', () => {
 			} );
 
 			expect( selected ).to.eql( { ID: 2916284, name: 'WordPress.com Example Blog' } );
+		} );
+	} );
+
+	describe( '#getSelectedSiteId()', () => {
+		it( 'should return null if no site is selected', () => {
+			const selected = getSelectedSiteId( {
+				ui: {
+					selectedSiteId: null
+				}
+			} );
+
+			expect( selected ).to.be.null;
+		} );
+
+		it( 'should return ID for the selected site', () => {
+			const selected = getSelectedSiteId( {
+				ui: {
+					selectedSiteId: 2916284
+				}
+			} );
+
+			expect( selected ).to.eql( 2916284 );
 		} );
 	} );
 } );


### PR DESCRIPTION
This selector is ripped out of #3547 which passes site / post id to action creators in editor.

It is helper for, well, quickly getting currently selected siteId

CC & Compliments: @aduth