### PR TITLE
Update "Loading the customizer..." text styles

### DIFF
--- a/client/my-sites/customize/style.scss
+++ b/client/my-sites/customize/style.scss
@@ -45,6 +45,11 @@
 	color: #2e4453;
 	font-size: 34px;
 	font-weight: 300;
+
+	@include breakpoint( "<660px" ) {
+		background-position: center 70px;
+		font-size: 24px;
+	}
 }
 
 .customizer-loading-panel__muse-status {

--- a/client/my-sites/customize/style.scss
+++ b/client/my-sites/customize/style.scss
@@ -42,7 +42,9 @@
 	margin-top: 200px;
 	padding: 20px;
 	text-align: center;
-	width: 140px;
+	color: #2e4453;
+	font-size: 34px;
+	font-weight: 300;
 }
 
 .customizer-loading-panel__muse-status {


### PR DESCRIPTION
Very small style update

If you click on the customize button, then stop the page loading, you can see the unformatted text that wraps onto 2 lines. This PR aims to prettify that text :)
Wait a bit longer (30 sec) and the page should automatically change to "Sorry, the customizing tools did not load correctly", which looks nice and has better formatting. I just took the text styles from that message (.empty-content__title) and applied them to the loading message to match.