### PR TITLE
Jetpack Connect: logged out users

### DIFF
--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -32,8 +32,11 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'jetpack/calypso-first-signup-flow' ) ) {
 		page( '/jetpack/connect', jetpackConnectController.connect );
-		page( '/jetpack/connect/authorize',
-              jetpackConnectController.saveQueryObject,
-              jetpackConnectController.authorize );
+		page(
+			'/jetpack/connect/authorize',
+			jetpackConnectController.updateNonce,
+			jetpackConnectController.saveQueryObject,
+			jetpackConnectController.authorize
+		);
 	}
 };

--- a/client/signup/jetpack-connect/authorize-action.js
+++ b/client/signup/jetpack-connect/authorize-action.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import Debug from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+
+/**
+ * Module variables
+ */
+const debug = new Debug( 'calypso:jetpack-connect-authorize' );
+
+export function createAccount( userData, callback ) {
+	wpcom.undocumented().usersNew(
+		userData,
+		( error, response ) => {
+			callback( error, response );
+		}
+	);
+}
+
+export function jetpackAuthorize( queryObject, callback ) {
+	debug( 'Trying jetpack login: ', queryObject );
+	wpcom.undocumented().jetpackLogin( queryObject, function( error, data ) {
+		if ( error ) {
+			debug( 'Jetpack login error:', error );
+			callback( error );
+			return;
+		}
+		debug( 'Jetpack login success! Trying jetpack authorize:', queryObject.client_id, data );
+		wpcom.undocumented().jetpackAuthorize(
+			queryObject.client_id,
+			data.code,
+			queryObject.state,
+			queryObject.redirect_uri,
+			queryObject.secret,
+			function( error2, data2 ) {
+				if ( error2 ) {
+					debug( 'Jetpack authorize error:', error2 );
+					callback( error2 );
+					return;
+				}
+				debug( 'Jetpack authorization complete!', data2 );
+				callback( false, data2 );
+			} );
+	} );
+}

--- a/client/signup/jetpack-connect/authorize-action.js
+++ b/client/signup/jetpack-connect/authorize-action.js
@@ -11,7 +11,7 @@ import wpcom from 'lib/wp';
 /**
  * Module variables
  */
-const debug = new Debug( 'calypso:jetpack-connect-authorize' );
+const debug = new Debug( 'calypso:jetpack-connect:authorize' );
 
 export function createAccount( userData, callback ) {
 	wpcom.undocumented().usersNew(

--- a/client/signup/jetpack-connect/authorize.jsx
+++ b/client/signup/jetpack-connect/authorize.jsx
@@ -50,7 +50,7 @@ var LoggedOutForm = React.createClass( {
 
 	loginUser() {
 		const { userData, bearerToken } = this.state;
-		const extraFields = { jetpack_calypso_login: true, _wp_nonce: this.props.queryObject._wp_nonce };
+		const extraFields = { jetpack_calypso_login: '1', _wp_nonce: this.props.queryObject._wp_nonce };
 		return (
 			<WpcomLoginForm
 				log={ userData.username }
@@ -161,10 +161,10 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { autoConnecting } = this.props;
+		const { autoAuthorizing } = this.props;
 
-		if ( autoConnecting ) {
-			return ( <p>Connecting Jetpack...</p> );
+		if ( autoAuthorizing ) {
+			return ( <p>Authorizing...</p> );
 		}
 
 		return (

--- a/client/signup/jetpack-connect/authorize.jsx
+++ b/client/signup/jetpack-connect/authorize.jsx
@@ -2,64 +2,113 @@
  * External dependencies
  */
 import React from 'react';
-import Debug from 'debug';
+import store from 'store';
 
 /**
  * Internal dependencies
  */
 import ConnectHeader from './connect-header';
 import Main from 'components/main';
-import wpcom from 'lib/wp';
+import { jetpackAuthorize, createAccount } from './authorize-action';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import SignupForm from 'components/signup-form';
+import WpcomLoginForm from 'signup/wpcom-login-form';
+import _user from 'lib/user';
+import config from 'config';
 
 /**
  * Module variables
  */
-const debug = new Debug( 'calypso:jetpack-connect-authorize' );
+const userModule = _user();
 
-export default React.createClass( {
-	displayName: 'JetpackConnectAuthorize',
+var LoggedOutForm = React.createClass( {
+	displayName: 'LoggedOutForm',
 
 	getInitialState() {
-		return {
-			isSubmitting: false,
-			authorizeError: false,
-			authorizeSuccess: false
+		return { error: false, userData: false, bearerToken: false, isSubmitting: false };
+	},
+
+	submitForm( form, userData ) {
+		this.setState( { submitting: true } );
+
+		const createAccountCallback = ( error, data ) => {
+			if ( error ) {
+				this.setState( { submitting: false } );
+			} else if ( data.bearer_token ) {
+				this.setState( { userData, bearerToken: data.bearer_token } );
+			}
 		};
+
+		store.set( 'jetpack_connect_authorize_after_signup', '1' );
+
+		createAccount(
+			userData,
+			createAccountCallback
+		);
+	},
+
+	loginUser() {
+		const { userData, bearerToken } = this.state;
+		const extraFields = { jetpack_calypso_login: true, _wp_nonce: this.props.queryObject._wp_nonce };
+		return (
+			<WpcomLoginForm
+				log={ userData.username }
+				authorization={ 'Bearer ' + bearerToken }
+				extraFields={ extraFields }
+				redirectTo={ window.location.href } />
+		)
+	},
+
+	renderFooterLink() {
+		const loginUrl = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
+		return (
+			<LoggedOutFormLinks>
+				<LoggedOutFormLinkItem href={ loginUrl }>
+					{ this.translate( 'Already have an account? Sign in' ) }
+				</LoggedOutFormLinkItem>
+			</LoggedOutFormLinks>
+		);
+	},
+
+	render() {
+		return (
+			<div>
+				<SignupForm
+					getRedirectToAfterLoginUrl={ window.location.href }
+					disabled={ this.state.isSubmitting }
+					submitting={ this.state.isSubmitting }
+					save={ this.save }
+					submitForm={ this.submitForm }
+					submitButtonText={ this.translate( 'Sign Up and Connect Jetpack' ) }
+					footerLink={ this.renderFooterLink() } />
+				{ this.state.userData && this.loginUser() }
+			</div>
+		);
+	}
+} );
+
+var LoggedInForm = React.createClass( {
+	displayName: 'LoggedInForm',
+
+	getInitialState() {
+		return { isSubmitting: false, authorizeError: false, authorizeSuccess: false };
 	},
 
 	handleSubmit() {
 		const { queryObject } = this.props;
-		debug( 'trying jetpack login', queryObject );
 		this.setState( { isSubmitting: true, authorizeError: false } );
-
-		if ( 1 === this.props.positionInFlow ) {
-			queryObject._wp_nonce = this.props.signupDependencies._wp_nonce;
-		}
-
-		wpcom.undocumented().jetpackLogin( queryObject, this.handleJetpackLoginComplete );
+		jetpackAuthorize( queryObject, this.handleResponse );
 	},
 
-	handleJetpackLoginComplete( error, data ) {
-		const { queryObject } = this.props;
+	handleResponse( error ) {
+		this.setState( { isSubmitting: false } );
 		if ( error ) {
-			debug( 'jetpack login error', error );
-			this.setState( { authorizeError: true, isSubmitting: false } );
+			this.setState( { authorizeError: true } );
 			return;
 		}
-		debug( 'jetpack login success. trying jetpack authorize.', queryObject.client_id, data );
-		wpcom.undocumented().jetpackAuthorize( queryObject.client_id, data.code, queryObject.state, queryObject.redirect_uri, queryObject.secret, this.handleAuthorizeComplete );
-	},
-
-	handleAuthorizeComplete( error, data ) {
-		if ( error ) {
-			debug( 'jetpack authorize error', error );
-			console.log( error );
-			this.setState( { authorizeError: true, isSubmitting: false } );
-			return;
-		}
-
-		debug( 'authorization complete!', data );
-		this.setState( { isSubmitting: false, authorizeSuccess: true } );
+		store.remove( 'jetpack_connect_query' );
+		window.location = '/';
 	},
 
 	renderErrorMessage() {
@@ -69,29 +118,63 @@ export default React.createClass( {
 		return null;
 	},
 
-	renderButton() {
+	render() {
+		const loginUrl = config( 'login_url' ) + '?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) + '&_wp_nonce=' + encodeURIComponent( this.props.queryObject._wp_nonce );
+		const logoutUrl = config( 'login_url' ) + '?action=logout&redirect_to=' + encodeURIComponent( window.location.href );
+
 		if ( this.state.authorizeSuccess ) {
-			return <p>Jetpack Connected!</p>;
+			return <p>{ this.translate( 'Jetpack connected!' ) }</p>;
 		}
 
 		return (
-			<button disabled={ this.state.isSubmitting } onClick={ this.handleSubmit } className="button is-primary">
-				{ this.translate( 'Approve' ) }
-			</button>
+			<div>
+				<p>{ this.translate( 'Connecting as %(user)s', { args: { user: this.props.user.display_name } } ) }</p>
+				<button disabled={ this.state.isSubmitting } onClick={ this.handleSubmit } className="button is-primary">
+					{ this.translate( 'Approve' ) }
+				</button>
+				{ this.renderErrorMessage() }
+				<LoggedOutFormLinks>
+					<LoggedOutFormLinkItem href={ loginUrl }>
+						{ this.translate( 'Sign in as a different user' ) }
+					</LoggedOutFormLinkItem>
+					<LoggedOutFormLinkItem href={ logoutUrl }>
+						{ this.translate( 'Create a new account' ) }
+					</LoggedOutFormLinkItem>
+			</LoggedOutFormLinks>
+			</div>
 		);
+	}
+} );
+
+export default React.createClass( {
+	displayName: 'JetpackConnectAuthorize',
+
+	getInitialState() {
+		return ( { user: userModule.get() } );
+	},
+
+	renderForm() {
+		const { user } = this.state;
+		return ( user )
+			? <LoggedInForm { ...this.props } user={ user } />
+			: <LoggedOutForm { ...this.props } />
 	},
 
 	render() {
+		const { autoConnecting } = this.props;
+
+		if ( autoConnecting ) {
+			return ( <p>Connecting Jetpack...</p> );
+		}
+
 		return (
 			<Main className="jetpack-connect">
-
 				<div className="jetpack-connect__site-url-entry-container">
 					<ConnectHeader headerText={ this.translate( 'Connect a self-hosted WordPress' ) }
 						subHeaderText={ this.translate( 'Jetpack would like to connect to your WordPress.com account' ) }
 						step={ 1 }
 						steps={ 3 } />
-					{ this.renderButton() }
-					{ this.renderErrorMessage() }
+					{ this.renderForm() }
 				</div>
 			</Main>
 		);

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -4,6 +4,8 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import isEmpty from 'lodash/isEmpty';
+import store from 'store';
+import page from 'page';
 
 /**
  * Internal Dependencies
@@ -11,16 +13,35 @@ import isEmpty from 'lodash/isEmpty';
 import JetpackConnect from './index';
 import jetpackConnectAuthorize from './authorize';
 import { setSection } from 'state/ui/actions';
+import { jetpackAuthorize } from './authorize-action';
 
 /**
  * Module variables
  */
-let queryObject;
+let queryObject,
+	autoConnecting = false;
 
 export default {
 	saveQueryObject( context, next ) {
 		if ( ! isEmpty( context.query ) ) {
-			queryObject = context.query;
+			store.set( 'jetpack_connect_query', context.query );
+			page.redirect( context.pathname );
+			return;
+		}
+
+		queryObject = store.get( 'jetpack_connect_query' );
+
+		next();
+	},
+
+	updateNonce( context, next ) {
+		if ( ! isEmpty( context.query ) && context.query.update_nonce ) {
+			store.set(
+				'jetpack_connect_query',
+				Object.assign( {}, store.get( 'jetpack_connect_query' ), { _wp_nonce: context.query.update_nonce } )
+			);
+			page.redirect( context.pathname );
+			return;
 		}
 
 		next();
@@ -41,6 +62,20 @@ export default {
 	},
 
 	authorize( context ) {
+		if ( store.get( 'jetpack_connect_authorize_after_signup' ) ) {
+			autoConnecting = true;
+			const authorizeCallback = error => {
+				if ( error ) {
+					console.log( error );
+					return;
+				}
+				store.remove( 'jetpack_connect_query' );
+				page( '/' );
+			}
+			store.remove( 'jetpack_connect_authorize_after_signup' );
+			jetpackAuthorize( queryObject, authorizeCallback );
+		}
+
 		context.store.dispatch( setSection( 'jetpackConnect', {
 			hasSidebar: false
 		} ) );
@@ -49,7 +84,8 @@ export default {
 			React.createElement( jetpackConnectAuthorize, {
 				path: context.path,
 				locale: context.params.lang,
-				queryObject: queryObject
+				queryObject: queryObject,
+				autoConnecting: autoConnecting
 			} ),
 			document.getElementById( 'primary' )
 		);

--- a/client/signup/wpcom-login-form/index.jsx
+++ b/client/signup/wpcom-login-form/index.jsx
@@ -30,6 +30,22 @@ module.exports = React.createClass( {
 		return 'https://' + subdomain + 'wordpress.com/wp-login.php';
 	},
 
+	renderExtraFields: function() {
+		const { extraFields } = this.props;
+
+		if ( ! extraFields ) {
+			return null;
+		}
+
+		return (
+			<div>
+				{ Object.keys( extraFields ).map( function( field ) {
+					return <input key={ field } type="hidden" name={ field } value={ extraFields[ field ] } />;
+				} ) }
+			</div>
+		);
+	},
+
 	render: function() {
 		return (
 			<form method="post" action={ this.action() } ref="wpcomLoginForm">
@@ -37,6 +53,7 @@ module.exports = React.createClass( {
 				<input type="hidden" name="pwd" value={ this.props.pwd } />
 				<input type="hidden" name="authorization" value={ this.props.authorization } />
 				<input type="hidden" name="redirect_to" value={ this.props.redirectTo } />
+				{ this.renderExtraFields() }
 			</form>
 		);
 	}


### PR DESCRIPTION
Adding logic so that a connection can be made for a logged out user
who needs to create an account, or signs in to an existing account.

There is no fancy UI or notifications yet, so don't expect it! There's just a simply redirect if every thing goes well, and an ugly error message otherwise. Up next is switching this to Redux, so we can make with notifications.

CC @johnHackworth @oskosk @ryelle for pre-review

### Testing instructions:

- Run this PR locally at calypso.localhost:3000
- apply this PR to a jetpack testing site: https://github.com/Automattic/jetpack/pull/3364
- ensure your testing site is disconnected

#### Logged out of wpcom, create new account
1. Log out from wpcom
2. Click 'Connect' from the Jetpack menu on your site
3. Create a new account, and click 'Sign Up and Connect Jetpack'
4. Wait a few seconds and you should be logged in, connected, and redirected to wordpress.com!

#### Logged out of wpcom, existing account
1.  Log out from wpcom, and disconnect your site
2. Click 'Connect' from the Jetpack menu on your site
3. Click 'Already have an account? Sign in'
4. Login to an existing account
5. Click 'Aprove'
6. You should be connected and redirected to wordpress.com!

#### Logged into wpcom, switch account
1. Login to wpcom, and disconnect your site
2. Click 'Connect' from the Jetpack menu on your site
3. Click 'Switch User', and re-login as a different user
4. Click 'Approve' you should be connected and redirected to wordpress.com!

#### Logged into wpcom, create a new account
1. Login to wpcom, and disconnect your site
2. Click 'Connect' from the Jetpack menu on your site
3. Click 'Create new account'
4. Create a new account, and click 'Sign Up and Connect Jetpack'
4. Wait a few seconds and you should be logged in, connected, and redirected to wordpress.com!