### PR TITLE
JetpackManageErrorPage: Use selectors instead of computed `site` attributes

### DIFF
--- a/client/lib/plugins/notices.jsx
+++ b/client/lib/plugins/notices.jsx
@@ -745,6 +745,8 @@ module.exports = {
 		if ( log.error.error !== 'unauthorized_full_access' ) {
 			return null;
 		}
+		// TODO: Use client/state/sites/selectors#getJetpackSiteRemoteManagementUrl()
+		// as soon as this is connected to Redux.
 		remoteManagementUrl = log.site.options.admin_url + 'admin.php?page=jetpack&configure=json-api';
 		if ( versionCompare( log.site.options.jetpack_version, 3.4 ) >= 0 ) {
 			remoteManagementUrl = log.site.options.admin_url + 'admin.php?page=jetpack&configure=manage';

--- a/client/lib/version-compare/index.js
+++ b/client/lib/version-compare/index.js
@@ -1,5 +1,7 @@
 /*eslint-disable */
 
+/** @ssr-ready **/
+
 /**
  * Modified from phpjs original to convert to a module
  * https://github.com/kvz/phpjs/tree/af99785b02

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react'
+import { connect } from 'react-redux'
 
 /**
  * Internal dependencies
@@ -9,10 +10,9 @@ import React from 'react'
 import analytics from 'analytics'
 import EmptyContent from 'components/empty-content'
 import FeatureExample from 'components/feature-example'
+import { getSiteSlug, getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors'
 
-module.exports = React.createClass( {
-
-	displayName: 'JetpackManageErrorPage',
+const JetpackManageErrorPage = React.createClass( {
 
 	mixins: [ 'pluginsData' ],
 
@@ -38,7 +38,7 @@ module.exports = React.createClass( {
 				action: this.translate( 'Update Jetpack' ),
 				illustration: null,
 				actionURL: ( this.props.site && this.props.site.jetpack )
-					? '../../plugins/jetpack/' + this.props.site.slug
+					? '../../plugins/jetpack/' + this.props.siteSlug
 					: undefined,
 				version: version
 			},
@@ -48,7 +48,7 @@ module.exports = React.createClass( {
 				illustration: '/calypso/images/jetpack/jetpack-manage.svg',
 				action: this.translate( 'Enable Jetpack Manage' ),
 				actionURL: ( this.props.site && this.props.site.jetpack )
-					? this.props.site.getRemoteManagementURL() + ( this.props.section ? '&section=' + this.props.section : '' )
+					? this.props.remoteManagementUrl + ( this.props.section ? '&section=' + this.props.section : '' )
 					: undefined,
 				actionTarget: '_blank'
 			},
@@ -56,7 +56,7 @@ module.exports = React.createClass( {
 				title: this.translate( 'Domains are not available for this site.' ),
 				line: this.translate( 'You can only purchase domains for sites hosted on WordPress.com at this time.' ),
 				action: this.translate( 'View Plans' ),
-				actionURL: '/plans/' + ( this.props.site ? this.props.site.slug : '' )
+				actionURL: '/plans/' + ( this.props.siteSlug || '' )
 			},
 			default: {}
 		};
@@ -82,3 +82,10 @@ module.exports = React.createClass( {
 	}
 
 } );
+
+export default connect(
+	( state, props ) => ( {
+		siteSlug: getSiteSlug( state, props.site.ID ),
+		remoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, props.site.ID )
+	} )
+)( JetpackManageErrorPage );

--- a/client/my-sites/plugins/plugin-site-disabled-manage/index.jsx
+++ b/client/my-sites/plugins/plugin-site-disabled-manage/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -9,16 +10,15 @@ import React from 'react';
 import analytics from 'analytics';
 import Button from 'components/button';
 import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
+import { getJetpackSiteRemoteManagementUrl } from 'state/sites/selectors';
 
-module.exports = React.createClass( {
-
-	displayName: 'PluginSiteDisabledManage',
+const PluginSiteDisabledManage = React.createClass( {
 
 	render: function() {
 		const message = this.props.isNetwork ?
 				this.translate( 'Network management disabled' ) :
 				this.translate( 'Management disabled' ),
-			url = this.props.site.getRemoteManagementURL() + '&section=plugins';
+			url = this.props.siteRemoteManagementUrl + '&section=plugins';
 
 		if ( this.props.plugin.slug === 'jetpack' ) {
 			return (
@@ -36,3 +36,9 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default connect(
+	( state, props ) => ( {
+		siteRemoteManagementUrl: getJetpackSiteRemoteManagementUrl( state, props.site.ID )
+	} )
+)( PluginSiteDisabledManage );

--- a/client/my-sites/plugins/plugin-site-disabled-manage/index.jsx
+++ b/client/my-sites/plugins/plugin-site-disabled-manage/index.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'analytics' ),
-	Button = require( 'components/button' ),
-	DisconnectJetpackButton = require( 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button' );
+import analytics from 'analytics';
+import Button from 'components/button';
+import DisconnectJetpackButton from 'my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button';
 
 module.exports = React.createClass( {
 

--- a/client/my-sites/themes/jetpack-manage-disabled-message.jsx
+++ b/client/my-sites/themes/jetpack-manage-disabled-message.jsx
@@ -18,7 +18,7 @@ export default React.createClass( {
 
 	propTypes: {
 		site: PropTypes.shape( {
-			getRemoteManagementURL: PropTypes.func.isRequired,
+			ID: PropTypes.number.isRequired,
 			options: PropTypes.shape( { admin_url: PropTypes.string.isRequired } ).isRequired
 		} ).isRequired
 	},

--- a/client/my-sites/themes/jetpack-upgrade-message.jsx
+++ b/client/my-sites/themes/jetpack-upgrade-message.jsx
@@ -12,7 +12,9 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 
 export default React.createClass( {
 	propTypes: {
-		site: PropTypes.object
+		site: PropTypes.shape( {
+			options: PropTypes.shape( { admin_url: PropTypes.string.isRequired } ).isRequired
+		} ).isRequired
 	},
 
 	render() {

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -12,6 +12,7 @@ import includes from 'lodash/includes';
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
+import versionCompare from 'lib/version-compare';
 
 /**
  * Returns a site object by its ID.
@@ -76,3 +77,22 @@ export function getSiteSlug( state, siteId ) {
 
 	return site.URL.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
 }
+
+/**
+ * Returns the URL for a site's remote Jetpack wp-admin screen, or null if the
+ * site is unknown, or not a Jetpack site.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?String}       Jetpack site's wp-admin screen
+ */
+export function getJetpackSiteRemoteManagementUrl( state, siteId ) {
+	const site = getSite( state, siteId );
+
+	if ( ! site || ! site.jetpack ) {
+		return null;
+	}
+
+	const configure = versionCompare( site.options.jetpack_version, 3.4 ) ? 'manage' : 'json-api';
+	return site.options.admin_url + 'admin.php?page=jetpack&configure=' + configure;
+};

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -6,7 +6,13 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getSite, getSiteCollisions, isSiteConflicting, getSiteSlug } from '../selectors';
+import {
+	getSite,
+	getSiteCollisions,
+	isSiteConflicting,
+	getSiteSlug,
+	getJetpackSiteRemoteManagementUrl
+} from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#getSite()', () => {
@@ -178,6 +184,58 @@ describe( 'selectors', () => {
 			}, 77203199 );
 
 			expect( slug ).to.equal( 'testtwosites2014.wordpress.com::path::to::site' );
+		} );
+	} );
+
+	describe( '#getJetpackSiteRemoteManagementUrl()', () => {
+		beforeEach( () => {
+			getSiteCollisions.memoizedSelector.cache.clear();
+		} );
+
+		it( 'should return null if the site is not known', () => {
+			const remoteManagementUrl = getJetpackSiteRemoteManagementUrl( {
+				sites: {
+					items: {}
+				}
+			}, 2916284 );
+
+			expect( remoteManagementUrl ).to.be.null;
+		} );
+
+		it( 'should return null if the site is not a Jetpack site', () => {
+			const remoteManagementUrl = getJetpackSiteRemoteManagementUrl( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://testonesite2014.wordpress.com',
+							jetpack: false,
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( remoteManagementUrl ).to.be.null;
+		} );
+
+		it( 'should return the URL for a Jetpack site\'s remote wp-admin screen', () => {
+			const remoteManagementUrl = getJetpackSiteRemoteManagementUrl( {
+				sites: {
+					items: {
+						77203074: {
+							ID: 77203074,
+							URL: 'https://example.com',
+							jetpack: true,
+							options: {
+								admin_url: 'https://example.com/wp-admin/',
+								jetpack_version: '3.9.4'
+							}
+						}
+					}
+				}
+			}, 77203074 );
+
+			expect( remoteManagementUrl ).to.equal( 'https://example.com/wp-admin/admin.php?page=jetpack&configure=manage' );
 		} );
 	} );
 } );


### PR DESCRIPTION
WIP, will fix #4160 

TODO:
* [ ] Make sure `JetpackManageErrorPage` and `PluginSiteDisabledManage` always have a `ReduxProvider` as an ancestor component.
* [ ] In `lib/site/jetpack`, can we get rid of `getRemoteManagementURL()`? Needed by `remoteManagementUrl` <- needed by `handleError()` <- needed by `my-sites/site-settings/form-base#toggleJetpackModule()`