### PR TITLE
Reader: re-add /read/lists to the sidebar batch to fix the list following state

### DIFF
--- a/client/lib/reader-sidebar/actions.js
+++ b/client/lib/reader-sidebar/actions.js
@@ -1,3 +1,4 @@
+
 var Dispatcher = require( 'dispatcher' ),
 	wpcom = require( 'lib/wp' ),
 	RECEIVE_TEAMS = require( 'lib/reader-teams/constants' ).action.RECEIVE_TEAMS;
@@ -14,6 +15,7 @@ module.exports = {
 		let batch = wpcom.batch();
 
 		batch.add( '/read/tags' );
+		batch.add( '/read/lists' );
 		batch.add( '/read/teams' );
 
 		isFetching = true;
@@ -22,6 +24,12 @@ module.exports = {
 			if ( error ) {
 				Dispatcher.handleServerAction( {
 					type: 'RECEIVE_READER_TAG_SUBSCRIPTIONS',
+					data: null,
+					error: error
+				} );
+
+				Dispatcher.handleServerAction( {
+					type: 'RECEIVE_READER_LISTS',
 					data: null,
 					error: error
 				} );
@@ -38,6 +46,12 @@ module.exports = {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_READER_TAG_SUBSCRIPTIONS',
 				data: data[ '/read/tags' ],
+				error: error
+			} );
+
+			Dispatcher.handleServerAction( {
+				type: 'RECEIVE_READER_LISTS',
+				data: data[ '/read/lists' ],
 				error: error
 			} );
 


### PR DESCRIPTION
In #4036 we removed `/read/lists` from the list of requests performed in a batch to populate the sidebar, instead using Redux state to populate the list of Reader lists.

Unfortunately, the list follow button relied on this request to populate the Flux store, so the follow button did not reflect the correct subscribed state.

This PR temporarily re-adds `/read/lists` to the sidebar batch request, until such time as we can switch the list stream over to use Redux.