### PR TITLE
Stats: Take into account generated posts when determining post count.

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -139,6 +139,7 @@ module.exports = {
 			StatsComponent = Insights,
 			twoWeeksAgo = i18n.moment().subtract( 2, 'week' ),
 			siteCreated,
+			postCount,
 			isNux;
 
 		followList = new FollowList();
@@ -188,7 +189,12 @@ module.exports = {
 
 		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
 
-		if ( site.post_count <= 1 &&
+		// Calculate the number of posts created by the user (not Headstarted) to determine if we should show the Insights tab, or the NUX placeholder.
+		postCount = site.post_count;
+		if ( site.options.headstart ) {
+			postCount = site.post_count - site.options.headstart.original.post.length;
+		}
+		if ( postCount <= 1 &&
 				twoWeeksAgo.isBefore( siteCreated ) &&
 				( ! site.jetpack ) ) {
 			isNux = true;

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -195,7 +195,7 @@ module.exports = {
 		if ( site.options && site.options.headstart ) {
 			postCount = site.post_count - get( site, 'options.headstart.original.post.length', 0 );
 		}
-		if ( postCount <= 1 &&
+		if ( postCount < 1 &&
 				twoWeeksAgo.isBefore( siteCreated ) &&
 				( ! site.jetpack ) ) {
 			isNux = true;

--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -4,7 +4,8 @@
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	store = require( 'store' ),
-	page = require( 'page' );
+	page = require( 'page' ),
+	get = require( 'lodash/get' );
 
 /**
  * Internal Dependencies
@@ -191,8 +192,8 @@ module.exports = {
 
 		// Calculate the number of posts created by the user (not Headstarted) to determine if we should show the Insights tab, or the NUX placeholder.
 		postCount = site.post_count;
-		if ( site.options.headstart ) {
-			postCount = site.post_count - site.options.headstart.original.post.length;
+		if ( site.options && site.options.headstart ) {
+			postCount = site.post_count - get( site, 'options.headstart.original.post.length', 0 );
 		}
 		if ( postCount <= 1 &&
 				twoWeeksAgo.isBefore( siteCreated ) &&


### PR DESCRIPTION
Sites that have been Headstarted on signup can contain up to six auto-generated posts, which shouldn't be included in the post count when deciding whether or not to display the full Insights tab.

This can't be merged until the `headstart` option has been added to the WPcom REST API `sites` endpoint.

Fixes #3882.