### PR TITLE
Reader: Sort lists by slug.

### DIFF
--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -3,6 +3,7 @@
  */
 import filter from 'lodash/filter';
 import includes from 'lodash/includes';
+import sortBy from 'lodash/sortBy';
 
 /**
  * Internal dependencies
@@ -27,9 +28,10 @@ export function isRequestingSubscribedLists( state ) {
  * @return {?Object}        Reader lists
  */
 export const getSubscribedLists = createSelector(
-	( state ) => filter( state.reader.lists.items, ( item ) => {
-		// Is the user subscribed to this list?
-		return includes( state.reader.lists.subscribedLists, item.ID );
-	} ),
+	( state ) => sortBy(
+		filter( state.reader.lists.items, ( item ) => {
+			// Is the user subscribed to this list?
+			return includes( state.reader.lists.subscribedLists, item.ID );
+		} ), 'slug' ),
 	( state ) => [ state.reader.lists.items ]
 );

--- a/client/state/reader/lists/test/selectors.js
+++ b/client/state/reader/lists/test/selectors.js
@@ -57,7 +57,7 @@ describe( 'selectors', () => {
 			expect( subscribedLists ).to.eql( [] );
 		} );
 
-		it( 'should return an empty array if the user is not subscribed to any lists', () => {
+		it( 'should items in a-z slug order', () => {
 			const subscribedLists = getSubscribedLists( {
 				reader: {
 					lists: {
@@ -65,6 +65,10 @@ describe( 'selectors', () => {
 							123: {
 								ID: 123,
 								slug: 'bananas'
+							},
+							456: {
+								ID: 456,
+								slug: 'ants'
 							}
 						},
 						subscribedLists: [ 123, 456 ]
@@ -72,7 +76,10 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			expect( subscribedLists ).to.eql( [ { ID: 123, slug: 'bananas' } ] );
+			expect( subscribedLists ).to.eql( [
+				{ ID: 456, slug: 'ants'},
+				{ ID: 123, slug: 'bananas' }
+			] );
 		} );
 	} );
 } );


### PR DESCRIPTION
Missed in the reduxification was item sorting. This takes care of it.

To test, pull up the reader and check your lists. They should be in a-z order, by slug.