### PR TITLE
Framework: update localforage to 1.4.0 & Fix Mobile Chrome on iOS

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4631,7 +4631,7 @@
       "version": "1.0.2"
     },
     "localforage": {
-      "version": "1.3.3",
+      "version": "1.4.0",
       "dependencies": {
         "promise": {
           "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "jstimezonedetect": "1.0.5",
     "key-mirror": "1.0.1",
     "keymaster": "1.6.2",
-    "localforage": "1.3.3",
+    "localforage": "1.4.0",
     "lodash": "4.5.0",
     "lru-cache": "4.0.0",
     "lunr": "0.5.7",


### PR DESCRIPTION
This branch updates `localforage` to version 1.4.0 which includes a fix for an [infinite loop bug](https://github.com/mozilla/localForage/issues/511) in localforage that makes calypso crash on both Chrome for iOS and Firefox for iOS ( fixes #4010 ).

It appears that calypso on Chrome for iOS ( and Firefox on iOS - though I did not test ) have both been broken since localforage was first merged in as part of #2754 on February 3rd ( /cc @gwwar ).

To confirm that localforage was at fault, I checked out the last sha prior to `localforage` being added to our `package.json`:

`git checkout b2b578aa5df7981207ce8d8ae197f1605b2d1566` [#](https://github.com/Automattic/wp-calypso/commit/b2b578aa5df7981207ce8d8ae197f1605b2d1566#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)

And under this branch locally, calypso would load in Chrome for iOS.

Then when I checked out the next merge sha for package.json where `localforage` was added - the infinite loop / freeze was experienced:

`git checkout 69a7535499e9082df1e20113b9ec0c2c4c2883d3 ` [#](https://github.com/Automattic/wp-calypso/commit/69a7535499e9082df1e20113b9ec0c2c4c2883d3#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)

__To Test__
- Checkout this branch with the updated version of `localforage`
- Setup your iOS device to use charles proxy so you can load your local calypso
- Confirm that calypso loads on Chrome iOS, and you can navigate to different sections

hat tip to @jblz for reporting the issue ( and hopefully you can test the fix )