### PR TITLE
Media: display current plan and site storage limits

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1324,3 +1324,34 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
+
+### https://github.com/avoidwork/filesize.js
+```text
+Copyright (c) 2015, Jason Mulligan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of filesize nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -195,6 +195,7 @@
 @import 'my-sites/people/people-list-item/style';
 @import 'my-sites/people/people-profile/style';
 @import 'my-sites/people/people-notices/style';
+@import 'my-sites/plan-storage/style';
 @import 'my-sites/plans/style';
 @import 'my-sites/plans/plan-overview/style';
 @import 'my-sites/plans/plan-overview/plan-feature/style';

--- a/client/devdocs/design/app-components.jsx
+++ b/client/devdocs/design/app-components.jsx
@@ -22,6 +22,7 @@ import Theme from 'components/theme/docs/example';
 import Collection from 'devdocs/design/search-collection';
 import HappinessSupport from 'components/happiness-support/docs/example';
 import ThemesListExample from 'components/themes-list/docs/example';
+import PlanStorage from 'my-sites/plan-storage/docs/example';
 
 export default React.createClass( {
 
@@ -59,6 +60,7 @@ export default React.createClass( {
 					<FollowButtons />
 					<HappinessSupport />
 					<LikeButtons />
+					<PlanStorage />
 					<PostSchedule />
 					<PostSelector />
 					<Sites />

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -1,30 +1,35 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	createFragment = require( 'react-addons-create-fragment' ),
-	noop = require( 'lodash/noop' ),
-	head = require( 'lodash/head' ),
-	values = require( 'lodash/values' ),
-	mapValues = require( 'lodash/mapValues' ),
-	groupBy = require( 'lodash/groupBy' ),
-	debounce = require( 'lodash/debounce' ),
-	debug = require( 'debug' )( 'calypso:media-library:content' );
+import React from 'react';
+import createFragment from 'react-addons-create-fragment';
+import noop from 'lodash/noop';
+import head from 'lodash/head';
+import values from 'lodash/values';
+import mapValues from 'lodash/mapValues';
+import groupBy from 'lodash/groupBy';
+import debounce from 'lodash/debounce';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-var Notice = require( 'components/notice' ),
-	MediaListData = require( 'components/data/media-list-data' ),
-	MediaLibrarySelectedData = require( 'components/data/media-library-selected-data' ),
-	MediaActions = require( 'lib/media/actions' ),
-	MediaValidationErrors = require( 'lib/media/constants' ).ValidationErrors,
-	PreferencesActions = require( 'lib/preferences/actions' ),
-	isMobile = require( 'lib/viewport' ).isMobile,
-	MediaLibraryHeader = require( './header' ),
-	MediaLibraryList = require( './list' );
+import Notice from 'components/notice';
+import MediaListData from 'components/data/media-list-data';
+import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
+import MediaActions from 'lib/media/actions';
+import { ValidationErrors as MediaValidationErrors } from 'lib/media/constants';
+import PreferencesActions from 'lib/preferences/actions';
+import { isMobile } from 'lib/viewport';
+import MediaLibraryHeader from './header';
+import MediaLibraryList from './list';
 
-module.exports = React.createClass( {
+/**
+ * Module variables
+ */
+const debug = debugFactory( 'calypso:media-library:content' );
+
+export default React.createClass( {
 	displayName: 'MediaLibraryContent',
 
 	propTypes: {

--- a/client/my-sites/plan-storage/README.md
+++ b/client/my-sites/plan-storage/README.md
@@ -1,0 +1,63 @@
+Plan Storage
+==============
+
+This component is used to display the remaining media storage limits. Using PlanStorage
+will query media storage limits for you. 
+
+#### Usage:
+
+```javascript
+	<PlanStorage
+		siteId={ this.props.siteId }
+		onClick={ this.onClickHandler } 
+	/>
+}
+```
+
+#### Props
+
+* `siteId`: A site ID (required)
+* `onClick`: An on click handler that is fired when the plan button is clicked.
+* `className`: A string that adds additional class names to this component.
+
+
+You can also use PlanStorageButton directly if you need more control over when
+media storage limits are fetched.
+
+#### Usage:
+
+```javascript
+import PlanStorageButton from 'my-sites/plan-storage/button';
+import QueryMediaStorage from 'components/data/query-media-storage';
+import { getMediaStorage } from 'state/sites/media-storage/selectors';
+
+render() {
+	const planName = this.props.site.plan.product_name_short;
+	return (
+		<div>
+			<QueryMediaStorage siteId={ this.props.siteId } />
+			<PlanStorageButton
+				sitePlanName={ planName }
+				mediaStorage={ this.props.mediaStorage }
+				onClick={ this.onClickHandler }
+			/>
+		</div>
+	);
+}
+//...
+export default connect( ( state, ownProps ) => {
+	return {
+		mediaStorage: getMediaStorage( state, ownProps.siteId )
+	};
+} )( MyComponent );
+```
+
+#### Props
+
+* `sitePlanName`: A plan name ( Free or Premium ) (required)
+* `mediaStorage`: Media Storage limits for a given site. If this is not provided, the button will not render.
+* `onClick`: An on click handler that is fired when the plan storage button is clicked.
+* `className`: A string that adds additional class names to this component.
+
+
+

--- a/client/my-sites/plan-storage/button.jsx
+++ b/client/my-sites/plan-storage/button.jsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+import filesize from 'filesize';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import ProgressBar from 'components/progress-bar';
+
+const ALERT_PERCENT = 80;
+const WARN_PERCENT = 60;
+
+export default React.createClass( {
+
+	displayName: 'PlanStorageButton',
+
+	propTypes: {
+		sitePlanName: React.PropTypes.string.isRequired,
+		mediaStorage: React.PropTypes.object,
+		onClick: React.PropTypes.func,
+		className: React.PropTypes.string
+	},
+
+	getDefaultProps() {
+		return {
+			onClick: noop
+		}
+	},
+
+	getPlanTranslation() {
+		if ( this.props.sitePlanName === 'Premium' ) {
+			return this.translate( 'Premium Plan', { context: 'Short plan name on storage button' } );
+		} else if ( this.props.sitePlanName === 'Free' ) {
+			return this.translate( 'Free Plan', { context: 'Short plan name on storage button' } );
+		}
+		//This is a fallback if we add a new plan. We ideally want to add any plan levels for proper i18n.
+		return this.translate( '%(planName)s Plan', { args: { planName: this.props.sitePlanName } } );
+	},
+
+	render() {
+		if ( ! this.props.mediaStorage || this.props.mediaStorage.max_storage_bytes === -1 ) {
+			return null;
+		}
+		const percent = Math.min(
+			Math.round( this.props.mediaStorage.storage_used_bytes / this.props.mediaStorage.max_storage_bytes * 1000 ) / 10,
+			100 );
+		const classes = classNames( this.props.className, 'plan-storage__button', {
+			'is-alert': percent > ALERT_PERCENT,
+			'is-warn': percent > WARN_PERCENT && percent <= ALERT_PERCENT
+		} );
+		const max = filesize( this.props.mediaStorage.max_storage_bytes );
+		return (
+			<Button className={ classes } onClick={ this.props.onClick }>
+				<span className="plan-storage__plan-label">
+					{ this.getPlanTranslation() }
+				</span>
+				<span className="plan-storage__storage-label" >
+					{ this.translate( '%(percent)f%% of %(max)s used', {
+						args: {
+							percent: percent,
+							max: max
+						}
+					} ) }
+				</span>
+				<ProgressBar
+					className="plan-storage__bar"
+					value={ percent }
+					total={ 100 }
+					compact={ true } />
+			</Button>
+		);
+	}
+} );

--- a/client/my-sites/plan-storage/docs/example.jsx
+++ b/client/my-sites/plan-storage/docs/example.jsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+
+/**
+ * Internal dependencies
+ */
+import PlanStorage from '../index';
+import PlanStorageButton from '../button';
+import sitesList from 'lib/sites-list';
+
+const sites = sitesList();
+
+export default React.createClass( {
+
+	displayName: 'PlanStorageExample',
+
+	mixins: [ PureRenderMixin ],
+
+	render() {
+		const plans = {
+			free: 'Free',
+			premium: 'Premium'
+		};
+		const mediaStorage = {
+			red: {
+				storage_used_bytes: 11362335981,
+				max_storage_bytes: 13958643712
+			},
+			yellow: {
+				storage_used_bytes: 1971389988,
+				max_storage_bytes: 3221225472
+			},
+			green: {
+				storage_used_bytes: 167503724,
+				max_storage_bytes: 3221225472
+			}
+		};
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/app-components/plan-storage">Plan Storage</a>
+				</h2>
+				<div>
+					<PlanStorage siteId={ sites.getPrimary().ID } />
+				</div>
+				<div>
+					<PlanStorageButton
+						sitePlanName={ plans.free }
+						mediaStorage={ mediaStorage.green }
+					/>
+				</div>
+				<div>
+					<PlanStorageButton
+						sitePlanName={ plans.free }
+						mediaStorage={ mediaStorage.yellow }
+					/>
+				</div>
+				<div>
+					<PlanStorageButton
+						sitePlanName={ plans.premium }
+						mediaStorage={ mediaStorage.red }
+					/>
+				</div>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/plan-storage/index.jsx
+++ b/client/my-sites/plan-storage/index.jsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React from 'react';
+import { connect } from 'react-redux';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import QueryMediaStorage from 'components/data/query-media-storage';
+import { getMediaStorage } from 'state/sites/media-storage/selectors';
+import { getSite } from 'state/sites/selectors';
+import PlanStorageButton from 'my-sites/plan-storage/button';
+
+const PlanStorage = React.createClass( {
+
+	propTypes: {
+		className: React.PropTypes.string,
+		mediaStorage: React.PropTypes.object,
+		siteId: React.PropTypes.number.isRequired,
+		onClick: React.PropTypes.func
+	},
+
+	getDefaultProps() {
+		return {
+			onClick: noop
+		}
+	},
+
+	render() {
+		if ( ! this.props.site || this.props.site.jetpack ) {
+			return null;
+		}
+		const classes = classNames( this.props.className, 'plan-storage' );
+		return (
+			<div className={ classes } >
+				<QueryMediaStorage siteId={ this.props.siteId } />
+				<PlanStorageButton
+					sitePlanName={ this.props.site.plan.product_name_short }
+					mediaStorage={ this.props.mediaStorage }
+					onClick={ this.props.onClick }
+				/>
+			</div>
+		);
+	}
+} );
+
+export default connect( ( state, ownProps ) => {
+	return {
+		mediaStorage: getMediaStorage( state, ownProps.siteId ),
+		site: getSite( state, ownProps.siteId )
+	};
+} )( PlanStorage );

--- a/client/my-sites/plan-storage/style.scss
+++ b/client/my-sites/plan-storage/style.scss
@@ -1,0 +1,34 @@
+.plan-storage__plan-label {
+	font-size: 12px;
+	font-weight: normal;
+}
+
+.plan-storage__storage-label {
+	font-size: 11px;
+	color: $gray;
+	margin-left: 20px;
+}
+
+.plan-storage__button {
+	line-height: 12px;
+}
+
+.plan-storage__bar .progress-bar__progress {
+	background-color: $alert-green;
+}
+
+.plan-storage__button.is-warn .progress-bar__progress {
+	background-color: $alert-yellow;
+}
+
+.plan-storage__button.is-alert .progress-bar__progress {
+	background-color: $alert-red;
+}
+
+.plan-storage__button {
+	display: none;
+
+	@include breakpoint( ">480px" ) {
+		display: inline-block;
+	}
+}

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -8,6 +8,7 @@ import values from 'lodash/values';
 import noop from 'lodash/noop';
 import some from 'lodash/some';
 import every from 'lodash/every';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -19,6 +20,8 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'components/gridicon';
 import { canUserDeleteItem } from 'lib/media/utils';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import PlanStorage from 'my-sites/plan-storage';
 
 const MediaModalSecondaryActions = React.createClass( {
 	propTypes: {
@@ -60,6 +63,14 @@ const MediaModalSecondaryActions = React.createClass( {
 		analytics.ga.recordEvent( 'Media', 'Clicked Dialog Edit Button' );
 
 		this.props.onChangeView( ModalViews.DETAIL );
+	},
+
+	navigateToPlans() {
+		analytics.ga.recordEvent( 'Media', 'Clicked Plan Storage Button' );
+		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
+			cta_name: 'plan-media-storage'
+		} );
+		page( `/plans/${ this.props.siteSlug }` );
 	},
 
 	getButtons() {
@@ -162,18 +173,31 @@ const MediaModalSecondaryActions = React.createClass( {
 		} );
 	},
 
+	renderPlanStorage() {
+		if ( this.props.selectedItems.length === 0 ) {
+			return (
+				<PlanStorage
+					onClick={ this.navigateToPlans }
+					siteId={ this.props.site.ID } />
+			);
+		}
+		return null;
+	},
+
 	render() {
 		return (
 			<div className="editor-media-modal__secondary-actions">
 				{ this.renderMobileButtons() }
 				{ this.renderDesktopButtons() }
+				{ this.renderPlanStorage() }
 			</div>
 		);
 	}
 } );
 
-export default connect( ( state ) => {
+export default connect( ( state, ownProps ) => {
 	return {
-		user: getCurrentUser( state )
+		user: getCurrentUser( state ),
+		siteSlug: ownProps.site ? getSiteSlug( state, ownProps.site.ID ) : ''
 	};
 } )( MediaModalSecondaryActions );

--- a/client/state/sites/media-storage/selectors.js
+++ b/client/state/sites/media-storage/selectors.js
@@ -17,3 +17,21 @@ export function getMediaStorage( state, siteId ) {
 export function isRequestingMediaStorage( state, siteId ) {
 	return !! state.sites.mediaStorage.fetchingItems[ siteId ];
 }
+
+/**
+ * Returns true, if a site is over current plan limits
+ * @param   {Object}  state  Global state tree
+ * @param   {Number}  siteId Site ID
+ * @returns {?Boolean}       True if site is over storage limits, and null if
+ *                           mediaStorage is unavailable.
+ */
+export function isOverMediaLimit( state, siteId ) {
+	const mediaStorage = state.sites.mediaStorage.items[ siteId ];
+	if ( ! mediaStorage ) {
+		return null;
+	}
+	if ( mediaStorage.max_storage_bytes === -1 ) {
+		return false;
+	}
+	return mediaStorage.storage_used_bytes >= mediaStorage.max_storage_bytes;
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8583,6 +8583,9 @@
         }
       }
     },
+    "filesize": {
+      "version": "3.2.1"
+    },
     "blob": {
       "version": "0.0.4"
     }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "exports-loader": "0.6.2",
     "express": "4.13.3",
     "fbjs": "0.5.0",
+    "filesize": "3.2.1",
     "flux": "2.1.1",
     "he": "0.5.0",
     "html-loader": "0.4.0",


### PR DESCRIPTION
This PR adds a new plan-storage component that displays your plan and media storage usage. This will close #3897. 

<img width="328" alt="plan" src="https://cloud.githubusercontent.com/assets/1270189/13967842/762b7ae4-f036-11e5-8324-fc31e5b6714a.png">

This component should not be displayed if a site has unlimited storage or is a jetpack site.

<img width="796" alt="screen" src="https://cloud.githubusercontent.com/assets/1270189/13967878/a2ea6f72-f036-11e5-8580-7740555e91e9.png">

Mobile:
<img width="487" alt="mobile" src="https://cloud.githubusercontent.com/assets/1270189/13968001/5ec9d02a-f037-11e5-9aa9-726f756085fc.png">

Mobile < 480
<img width="397" alt="small" src="https://cloud.githubusercontent.com/assets/1270189/13968024/7a41670a-f037-11e5-9120-5f8b955c9f99.png">

## Testing
- Navigate to calypso.localhost:3000/posts
- Click on the media modal (picture icon in editor)
- In the bottom left you should see a button that displays the plan, and usage.
- Click on the button, this should take you to the plans page.
- Navigate to calypso.localhost:3000/posts
- Select some media
- The component should hide itself in favor of edit/delete buttons
- Unselect all media
- The plan-storage component should reappear.

A future improvement will be to fetch limits again if an item is finished uploading/removed. Right now this occurs whenever the plan storage button is rendered. This occurs frequently enough (modal render/items select/deselect) that it shouldn't be a blocker.

cc @adambbecker @rralian @artpi @mtias @retrofox @aduth @apeatling 