### PR TITLE
Editor: When adding a new field in the 'add contact form' dialog, it's expanded automatically for editing it

### DIFF
--- a/client/components/tinymce/plugins/contact-form/dialog/field-list.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field-list.jsx
@@ -28,7 +28,7 @@ export default React.createClass( {
 						return (
 							<Field
 								key={ index }
-								{ ...{ label, type, options, required } }
+								{ ...field }
 								onRemove={ () => this.props.onFieldRemove( index ) }
 								onUpdate={ newField => this.props.onFieldUpdate( index, newField ) } />
 						);

--- a/client/components/tinymce/plugins/contact-form/dialog/field.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field.jsx
@@ -38,7 +38,8 @@ export default React.createClass( {
 		options: PropTypes.string,
 		required: PropTypes.bool,
 		onUpdate: PropTypes.func.isRequired,
-		onRemove: PropTypes.func.isRequired
+		onRemove: PropTypes.func.isRequired,
+		isExpanded: PropTypes.bool
 	},
 
 	renderOptions() {
@@ -76,12 +77,15 @@ export default React.createClass( {
 				header={ <FieldHeader { ...omit( this.props, [ 'onUpdate' ] ) } /> }
 				summary={ remove }
 				expandedSummary={ remove }
-				icon="pencil">
+				icon="pencil"
+				expanded={ this.props.isExpanded }
+				onOpen={ () => this.props.onUpdate( { isExpanded: true } ) }
+				onClose={ () => this.props.onUpdate( { isExpanded: false } ) }>
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Field Label' ) }</FormLabel>
 					<FormTextInput value={ this.props.label } onChange={ this.onLabelChange } isError={ fielLabelValidationError } />
 					{ fielLabelValidationError && <FormTextValidation isError={ true } text={ this.translate( 'Field Label can not be empty.' ) } /> }
-			</FormFieldset>
+				</FormFieldset>
 
 				<FormFieldset>
 					<FormLabel>{ this.translate( 'Field Type' ) }</FormLabel>

--- a/client/state/ui/editor/contact-form/constants.js
+++ b/client/state/ui/editor/contact-form/constants.js
@@ -20,5 +20,6 @@ export const CONTACT_FORM_DEFAULT = {
 
 export const CONTACT_FORM_DEFAULT_NEW_FIELD = {
 	label: 'Text',
-	type: CONTACT_FORM_FIELD_TYPES.text
+	type: CONTACT_FORM_FIELD_TYPES.text,
+	isExpanded: true
 };

--- a/client/state/ui/editor/contact-form/test/reducer.js
+++ b/client/state/ui/editor/contact-form/test/reducer.js
@@ -84,7 +84,7 @@ describe( 'editor\'s contact form state reducer', () => {
 					{ label: 'Email' },
 					{ label: 'Website' },
 					{ label: 'Comment' },
-					{ label: 'Text', type: 'text' }
+					{ label: 'Text', type: 'text', isExpanded: true }
 				]
 			} );
 		} );
@@ -97,7 +97,7 @@ describe( 'editor\'s contact form state reducer', () => {
 				{ label: 'Email', type: 'email', required: true },
 				{ label: 'Website', type: 'url' },
 				{ label: 'Comment', type: 'textarea', required: true },
-				{ label: 'Text', type: 'text' }
+				{ label: 'Text', type: 'text', isExpanded: true }
 			] } );
 			assert.deepEqual( CONTACT_FORM_DEFAULT, { fields: [
 				{ label: 'Name', type: 'name', required: true },


### PR DESCRIPTION
Before this change, when adding a field to the form it appeared collapsed. Now it appears expanded, ready to be edited.

As a side note, when a `FoldableCard` is expanded, the content doesn't auto-scroll into view, so it can appear than it didn't expanded. What do you think about adding [scrollIntoViewIfNeeded](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoViewIfNeeded) to the `FoldableCard.onOpen` by default? This component is used in many places, but I can't think of any situation when we want to **not** scroll into view when the user expands the card.

cc @rodrigoi @alisterscott 
Fixes #4117