### PR TITLE
Framework: fix uncaught error in sidebar

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -158,7 +158,7 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		if ( site.jetpack && ! jetpackEnabled && site.options ) {
+		if ( site && site.jetpack && ! jetpackEnabled && site.options ) {
 			themesLink = site.options.admin_url + 'themes.php';
 		} else if ( this.isSingle() ) {
 			themesLink = '/design' + this.siteSuffix();


### PR DESCRIPTION
Fixes a js error in sidebar:

```
Uncaught TypeError: Cannot read property 'jetpack' of undefined
```