### PR TITLE
Tests: Enable parallel tests for single test runners

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,16 @@ test:
         files:
           - client/**/Makefile
           - server/**/Makefile
-    - case $CIRCLE_NODE_INDEX in 0) NODE_ENV=test make client/config/index.js && MOCHA_FILE=./test-results.xml npm run test-client -- --reporter=mocha-junit-reporter ;; 1) NODE_ENV=test make client/config/index.js && MOCHA_FILE=./test-results.xml npm run test-server -- --reporter=mocha-junit-reporter ;; esac:
+    - NODE_ENV=test make client/config/index.js && MOCHA_FILE=./test-results-client.xml npm run test-client -- --reporter=mocha-junit-reporter -w:
         parallel: true
+        files:
+          - client/**/test/*.js
+          - client/**/test/*.jsx
+    - NODE_ENV=test make client/config/index.js && MOCHA_FILE=./test-results-server.xml npm run test-server -- --reporter=mocha-junit-reporter -w:
+        parallel: true
+        files:
+          - server/**/test/*.js
+          - server/**/test/*.jsx
   post:
-    - mkdir -p $CIRCLE_TEST_REPORTS/junit/ && find . -type f -name "test-results.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/ && find . -type f -regex  "./test-results.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;:
         parallel: true

--- a/test/boot-test.js
+++ b/test/boot-test.js
@@ -1,4 +1,3 @@
-require( 'babel/register' );
 const Chai = require( 'chai' ),
 	sinonChai = require( 'sinon-chai' ),
 	sinon = require( 'sinon' ),

--- a/test/boot-test.js
+++ b/test/boot-test.js
@@ -6,12 +6,6 @@ const Chai = require( 'chai' ),
 
 module.exports = {
 	before: function() {
-		if ( process.env.CIRCLECI ) {
-			console.log( 'Hello Circle!' );
-			// give circle more time by default because containers are slow
-			// why 10 seconds? a guess.
-			this.timeout( 10000 );
-		}
 		Chai.use( immutableChai );
 		Chai.use( sinonChai );
 		sinon.assert.expose( Chai.assert, { prefix: '' } );

--- a/test/load-suite.js
+++ b/test/load-suite.js
@@ -1,3 +1,5 @@
+const setup = require( 'setup' );
+
 function requireTestFiles( config, path = '' ) {
 	Object.keys( config ).forEach( ( folderName ) => {
 		const folderConfig = config[ folderName ];
@@ -12,5 +14,4 @@ function requireTestFiles( config, path = '' ) {
 	} );
 }
 
-// this assumes that there's a tests.json at the root of NODE_PATH
-requireTestFiles( require( 'tests.json' ) );
+requireTestFiles( setup.getConfig() );

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 require( 'babel/register' );
 
-const program = require( 'commander' ),
+const debug = require( 'debug' )( 'test-runner' ),
+	program = require( 'commander' ),
 	Mocha = require( 'mocha' ),
 	path = require( 'path' ),
 	boot = require( './boot-test' ),
@@ -31,7 +32,7 @@ if ( program.whitelist ) {
 }
 
 if ( process.env.CIRCLECI ) {
-	console.log( 'Hello Circle!' );
+	debug( 'Hello Circle!' );
 	// give circle more time by default because containers are slow
 	// why 10 seconds? a guess.
 	mocha.suite.timeout( 10000 );

--- a/test/runner.js
+++ b/test/runner.js
@@ -30,6 +30,13 @@ if ( program.whitelist ) {
 	setup.enableWhitelist();
 }
 
+if ( process.env.CIRCLECI ) {
+	console.log( 'Hello Circle!' );
+	// give circle more time by default because containers are slow
+	// why 10 seconds? a guess.
+	mocha.suite.timeout( 10000 );
+}
+
 mocha.suite.beforeAll( boot.before );
 mocha.suite.afterAll( boot.after );
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -4,12 +4,14 @@ require( 'babel/register' );
 const program = require( 'commander' ),
 	Mocha = require( 'mocha' ),
 	path = require( 'path' ),
-	boot = require( './boot-test' );
+	boot = require( './boot-test' ),
+	setup = require( './setup' );
 
 program
 	.usage( '[options] [files]' )
 	.option( '-R, --reporter <name>', 'specify the reporter to use', 'spec' )
-	.option( '-g, --grep <pattern>', 'only run tests matching <pattern>' );
+	.option( '-g, --grep <pattern>', 'only run tests matching <pattern>' )
+	.option( '-w, --whitelist', 'only run whitelisted tests when using a glob' );
 
 program.name = 'runner';
 
@@ -24,17 +26,21 @@ if ( program.grep ) {
 	mocha.grep( new RegExp( program.grep ) );
 }
 
+if ( program.whitelist ) {
+	setup.enableWhitelist();
+}
+
 mocha.suite.beforeAll( boot.before );
 mocha.suite.afterAll( boot.after );
 
 // we could also discover all the tests using a glob?
 if ( program.args.length ) {
 	program.args.forEach( function( file ) {
-		mocha.addFile( file );
+		setup.addFile( file );
 	} );
-} else {
-	mocha.addFile( path.join( __dirname, 'load-suite.js' ) );
 }
+
+mocha.addFile( path.join( __dirname, 'load-suite.js' ) );
 
 mocha.run( function( failures ) {
 	process.on( 'exit', function() {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,84 @@
+import head from 'lodash/head';
+import last from 'lodash/last';
+import mergeWith from 'lodash/mergeWith';
+import reduce from 'lodash/reduce';
+import tail from 'lodash/tail';
+
+const files = [];
+let whitelistConfig;
+
+function enableWhitelist() {
+	whitelistConfig = require( 'tests.json' );
+}
+
+function addFile( file ) {
+	if ( whitelistConfig ) {
+		const pathParts = tail( file.split( '/' ) );
+
+		if ( ! isFileWhitelisted( whitelistConfig, pathParts ) ) {
+			console.log( `Skipping file: ${file}.` );
+			return;
+		}
+	}
+	files.push( file );
+}
+
+function isFileWhitelisted( config, pathParts ) {
+	const folder = head( pathParts );
+
+	if ( config[ folder ] ) {
+		if ( folder === 'test' ) {
+			return ( config[ folder ].indexOf( getFileName( pathParts ) ) !== false );
+		}
+
+		return isFileWhitelisted( config[ folder ], tail( pathParts ) );
+	}
+
+	return false;
+}
+
+function getConfig() {
+	if ( files.length === 0 ) {
+		// this assumes that there's a tests.json at the root of NODE_PATH
+		console.log( 'No valid tests provided, loading whitelisted tests.' );
+		return require( 'tests.json' );
+	}
+
+	return filesToConfig();
+}
+
+function filesToConfig() {
+	return reduce( files, ( config, file ) => {
+		const fileConfig = fileToConfig( tail( file.split( '/' ) ) );
+
+		return mergeWith( config, fileConfig, ( object, source ) => {
+			if ( Array.isArray( object ) ) {
+				return object.concat( source );
+			}
+		} );
+	}, {} );
+}
+
+function fileToConfig( pathParts, folderConfig = {} ) {
+	const folder = head( pathParts );
+
+	if ( folder === 'test' ) {
+		folderConfig[ folder ] = [ getFileName( pathParts ) ];
+	} else {
+		folderConfig[ folder ] = fileToConfig( tail( pathParts ) );
+	}
+
+	return folderConfig;
+}
+
+function getFileName( pathParts ) {
+	const [ fileName ] = last( pathParts ).split( '.' );
+
+	return fileName;
+}
+
+module.exports = {
+	enableWhitelist,
+	addFile,
+	getConfig
+};

--- a/test/setup.js
+++ b/test/setup.js
@@ -38,7 +38,7 @@ function isFileWhitelisted( config, pathParts ) {
 }
 
 function getConfig() {
-	if ( files.length === 0 ) {
+	if ( ! whitelistConfig && files.length === 0 ) {
 		// this assumes that there's a tests.json at the root of NODE_PATH
 		console.log( 'No valid tests provided, loading whitelisted tests.' );
 		return require( 'tests.json' );

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,10 +1,15 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
 import head from 'lodash/head';
 import last from 'lodash/last';
 import mergeWith from 'lodash/mergeWith';
 import reduce from 'lodash/reduce';
 import tail from 'lodash/tail';
 
-const files = [];
+const debug = debugFactory( 'test-runner' ),
+	files = [];
 let whitelistConfig;
 
 function enableWhitelist() {
@@ -16,7 +21,7 @@ function addFile( file ) {
 		const pathParts = tail( file.split( '/' ) );
 
 		if ( ! isFileWhitelisted( whitelistConfig, pathParts ) ) {
-			console.log( `Skipping file: ${file}.` );
+			debug( `Skipping file: ${file}.` );
 			return;
 		}
 	}
@@ -40,7 +45,7 @@ function isFileWhitelisted( config, pathParts ) {
 function getConfig() {
 	if ( ! whitelistConfig && files.length === 0 ) {
 		// this assumes that there's a tests.json at the root of NODE_PATH
-		console.log( 'No valid tests provided, loading whitelisted tests.' );
+		debug( 'No tests provided, loading whitelisted tests config.' );
 		return require( 'tests.json' );
 	}
 


### PR DESCRIPTION
This PR enabled parallel tests execution for single test runners on Circle CI.

It was possible by introducing new flag for test runner:
`-w, --whitelist` - only run whitelisted tests when using a glob or files list

I also moved the code responsible for longer timeout on Circle CI because I noticed it doesn't work properly.

/cc @blowery 