### PR TITLE
Editor: add sticky button in action bar

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -295,6 +295,7 @@
 @import 'post-editor/editor-sharing/style';
 @import 'post-editor/editor-sidebar/style';
 @import 'post-editor/editor-slug/style';
+@import 'post-editor/editor-sticky/style';
 @import 'post-editor/editor-title/style';
 @import 'post-editor/editor-visibility/style';
 @import 'post-editor/editor-word-count/style';

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -10,7 +10,7 @@
 			border-bottom-color: darken( $gray, 30% );
 			position: absolute;
 			top: 9px;
-			margin-left: -6px;
+			right: 10px;
 
 			&::before {
 				display: none;

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import EditorAuthor from 'post-editor/editor-author';
 import EditorDeletePost from 'post-editor/editor-delete-post';
 import EditorPostType from 'post-editor/editor-post-type';
+import EditorSticky from 'post-editor/editor-sticky';
 import EditorVisibility from 'post-editor/editor-visibility';
 import Gridicon from 'components/gridicon';
 import utils from 'lib/posts/utils';
@@ -69,6 +70,7 @@ export default React.createClass( {
 				</div>
 				<EditorPostType />
 				<div className="editor-action-bar__last-group">
+					{ this.props.type === 'post' && <EditorSticky post={ this.props.post } /> }
 					{ this.renderPostVisibility() }
 					<EditorDeletePost
 						post={ this.props.post }

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -70,7 +70,7 @@ export default React.createClass( {
 				</div>
 				<EditorPostType />
 				<div className="editor-action-bar__last-group">
-					{ this.props.type === 'post' && <EditorSticky post={ this.props.post } /> }
+					{ this.props.post && this.props.type === 'post' && <EditorSticky post={ this.props.post } /> }
 					{ this.renderPostVisibility() }
 					<EditorDeletePost
 						post={ this.props.post }
@@ -91,9 +91,9 @@ export default React.createClass( {
 								isVisible={ this.state.viewLinkTooltip }
 								position="bottom left"
 							>
-								{ this.props.type === 'page' ?
-									this.translate( 'View page' ) :
-									this.translate( 'View post' )
+								{ this.props.type === 'page'
+									? this.translate( 'View page' )
+									: this.translate( 'View post' )
 								}
 							</Tooltip>
 						</a> }

--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -12,6 +12,7 @@ import { bindActionCreators } from 'redux';
 import actions from 'lib/posts/actions';
 import accept from 'lib/accept';
 import utils from 'lib/posts/utils';
+import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import Tooltip from 'components/tooltip';
 import { trashPost } from 'state/ui/editor/post/actions';
@@ -87,7 +88,8 @@ const EditorDeletePost = React.createClass( {
 		}
 
 		return (
-			<button
+			<Button
+				borderless
 				className={ classes }
 				onClick={ ! this.state.isTrashing && this.onSendToTrash }
 				onMouseEnter={ () => this.setState( { tooltip: true } ) }
@@ -103,7 +105,7 @@ const EditorDeletePost = React.createClass( {
 				>
 					{ tooltipText }
 				</Tooltip>
-			</button>
+			</Button>
 		);
 	}
 } );

--- a/client/post-editor/editor-delete-post/style.scss
+++ b/client/post-editor/editor-delete-post/style.scss
@@ -1,9 +1,8 @@
-.editor-delete-post {
+.editor-delete-post.button {
 	color: lighten( $gray, 20% );
-	cursor: pointer;
-	font-size: 13px;
 	margin-left: 12px;
 	transition: color 200ms;
+	padding: 0;
 
 	&:hover {
 		color: $orange-fire;

--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -24,11 +24,12 @@ const EditorSticky = React.createClass( {
 	getInitialState: function() {
 		return {
 			tooltip: false
-		}
+		};
 	},
 
 	toggleStickyStatus: function() {
-		var stickyStat, stickyEventLabel;
+		let stickyStat;
+		let stickyEventLabel;
 
 		if ( ! this.props.post.sticky ) {
 			stickyStat = 'advanced_sticky_enabled_toolbar';

--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import postActions from 'lib/posts/actions';
+import Tooltip from 'components/tooltip';
+import Gridicon from 'components/gridicon';
+import Button from 'components/button';
+import { recordStat, recordEvent } from 'lib/posts/stats';
+import { toggleStickyStatus } from 'state/ui/editor/post/actions';
+
+const EditorSticky = React.createClass( {
+	propTypes: {
+		post: React.PropTypes.object
+	},
+
+	getInitialState: function() {
+		return {
+			tooltip: false
+		}
+	},
+
+	toggleStickyStatus: function() {
+		var stickyStat, stickyEventLabel;
+
+		if ( ! this.props.post.sticky ) {
+			stickyStat = 'advanced_sticky_enabled_toolbar';
+			stickyEventLabel = 'On';
+		} else {
+			stickyStat = 'advanced_sticky_disabled_toolbar';
+			stickyEventLabel = 'Off';
+		}
+
+		recordStat( stickyStat );
+		recordEvent( 'Changed Sticky Setting', stickyEventLabel );
+
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
+		postActions.edit( { sticky: ! this.props.post.sticky } );
+		this.setState( { tooltip: false } );
+	},
+
+	render: function() {
+		const classes = classnames( 'editor-sticky', {
+			'is-sticky': this.props.post && this.props.post.sticky
+		} );
+
+		return (
+			<Button
+				borderless
+				className={ classes }
+				onClick={ this.toggleStickyStatus }
+				onMouseEnter={ () => this.setState( { tooltip: true } ) }
+				onMouseLeave={ () => this.setState( { tooltip: false } ) }
+				aria-label={ this.translate( 'Stick post to the front page' ) }
+				ref="stickyPostButton"
+			>
+				<Gridicon icon="bookmark" />
+				<Tooltip
+					context={ this.refs && this.refs.stickyPostButton }
+					isVisible={ this.state.tooltip }
+					position="bottom"
+				>
+					{ this.props.post && this.props.post.sticky
+						? <span>{ this.translate( 'Marked as sticky' ) }</span>
+						: <div>
+							{ this.translate( 'Mark post as sticky' ) }
+							<span className="editor-sticky__explanation">
+								{ this.translate( 'Displayed at the top' ) }
+							</span>
+						</div>
+					}
+				</Tooltip>
+			</Button>
+		);
+	}
+} );
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( {
+		toggleStickyStatus
+	}, dispatch ),
+	null,
+	{ pure: false }
+)( EditorSticky );

--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -66,14 +66,14 @@ const EditorSticky = React.createClass( {
 				<Tooltip
 					context={ this.refs && this.refs.stickyPostButton }
 					isVisible={ this.state.tooltip }
-					position="bottom"
+					position="bottom left"
 				>
 					{ this.props.post && this.props.post.sticky
 						? <span>{ this.translate( 'Marked as sticky' ) }</span>
 						: <div>
-							{ this.translate( 'Mark post as sticky' ) }
+							{ this.translate( 'Mark as sticky' ) }
 							<span className="editor-sticky__explanation">
-								{ this.translate( 'Displayed at the top' ) }
+								{ this.translate( 'Displayed at top' ) }
 							</span>
 						</div>
 					}

--- a/client/post-editor/editor-sticky/style.scss
+++ b/client/post-editor/editor-sticky/style.scss
@@ -1,0 +1,15 @@
+.editor-sticky.button {
+	color: lighten( $gray, 20% );
+	margin-right: 12px;
+	padding: 0;
+	transition: color 200ms;
+
+	&.is-sticky{
+		color: $orange-jazzy;
+	}
+}
+
+.editor-sticky__explanation {
+	display: block;
+	font-size: 11px;
+}

--- a/client/post-editor/editor-sticky/style.scss
+++ b/client/post-editor/editor-sticky/style.scss
@@ -4,7 +4,7 @@
 	padding: 0;
 	transition: color 200ms;
 
-	&.is-sticky{
+	&.is-sticky {
 		color: $orange-jazzy;
 	}
 }

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -18,6 +18,7 @@ import FormLegend from 'components/forms/form-legend';
 import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import Popover from 'components/popover';
 import touchDetect from 'lib/touch-detect';
@@ -345,7 +346,9 @@ const EditorVisibility = React.createClass( {
 		} );
 
 		return (
-			<div className={ classes }
+			<Button
+				borderless
+				className={ classes }
 				onClick={ this.togglePopover }
 				onMouseEnter={ this.showTooltip }
 				onMouseLeave={ this.hideTooltip }
@@ -417,7 +420,7 @@ const EditorVisibility = React.createClass( {
 						</FormFieldset>
 					</div>
 				</Popover>
-			</div>
+			</Button>
 		);
 	}
 

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -1,8 +1,6 @@
-.editor-visibility {
+.editor-visibility.button {
 	color: lighten( $gray, 20% );
-	height: 26px;
-	overflow: hidden;
-	display: inline;
+	padding: 0;
 	transition: color 200ms;
 
 	&.is-dialog-open,
@@ -14,11 +12,6 @@
 			color: darken( $gray, 10% );
 		}
 	}
-
-	.gridicon {
-		cursor: pointer;
-	}
-
 }
 
 .editor-visibility__dialog{


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/548849/13918288/86d86152-ef66-11e5-9d14-163d9dc78a27.png)

![image](https://cloud.githubusercontent.com/assets/548849/13918297/94db9d46-ef66-11e5-85bc-ec368e818a34.png)

Note: retaining the other sticky option in the advanced-status menu so we can compare usage.

![image](https://cloud.githubusercontent.com/assets/548849/13918312/acff3a86-ef66-11e5-9168-53d0a624fa37.png)