### PR TITLE
Framework: Show Notice Action on a new line for small screens

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -31,6 +31,10 @@
 	&.is-info {
 		background: $blue-wordpress;
 	}
+
+	@include breakpoint( "<480px" ) {
+		flex-direction: column;
+	}
 }
 
 .notice__icon {
@@ -111,6 +115,11 @@
 	&:hover,
 	&:focus {
 		background: rgba( 255, 255, 255, 0.2 );
+	}
+
+	@include breakpoint( "<480px" ) {
+		margin: 0;
+		justify-content: flex-end;
 	}
 }
 


### PR DESCRIPTION
Fixes #198

This fixes a layout issue for notices with an action button which appears on small screens.

Before:
![image](https://cloud.githubusercontent.com/assets/230230/13928275/aa075ef8-ef9d-11e5-8acd-6f78e564be54.png)

After:
![image](https://cloud.githubusercontent.com/assets/230230/13928306/bfb74ec0-ef9d-11e5-9d9c-7e5e5a1fa54c.png)


### Testing Instructions
- Checkout this branch
- Go to `/purchases` and click on a plan subscription you have
- Check that the Notice layout is still the same until the screen width is reduced to 480px or less. In this case, the Notice Action is displayed on a new line (as seen on the pic)
- Check that the button still works

### Reviewing
- [x] Product Review
- [x] Code Review
- [x] Design Review