### PR TITLE
Editor/CPT: Enable routes for editing custom post types

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -24,7 +24,7 @@ function getSiteFragment( path ) {
 	var basePath = path.split( '?' )[0],
 		pieces = basePath.split( '/' ),
 		siteOldStyle = pieces[ pieces.length - 1 ],
-		siteNewStyle = pieces[2] || '';
+		siteNewStyle = pieces[ pieces.length - 2 ] || '';
 
 	if ( siteNewStyle.indexOf( '.' ) >= 0 ) {
 		// This is a new-style URL like /:section/:site[/:filter/...]
@@ -49,7 +49,7 @@ function addSiteFragment( path, site ) {
 
 	if ( includes( [ 'post', 'page', 'edit' ], pieces[ 1 ] ) ) {
 		// New-style URL; change /:section[/:filter/...] into /:section/:site/[:filter/...]
-		pieces.splice( 2, 0, site );
+		pieces.splice( 'edit' === pieces[ 1 ] ? pieces.length : 2, 0, site );
 	} else {
 		// Old-style URL; add /:site onto the end
 		pieces.push( site );

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import includes from 'lodash/includes';
+
+/**
  * Internal Dependencies
  */
 var trailingslashit = require( './trailingslashit' ),
@@ -42,7 +47,7 @@ function getSiteFragment( path ) {
 function addSiteFragment( path, site ) {
 	var pieces = sectionify( path ).split( '/' );
 
-	if ( pieces[1] === 'post' || pieces[1] === 'page' ) {
+	if ( includes( [ 'post', 'page', 'edit' ], pieces[ 1 ] ) ) {
 		// New-style URL; change /:section[/:filter/...] into /:section/:site/[:filter/...]
 		pieces.splice( 2, 0, site );
 	} else {

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -49,7 +49,9 @@ function addSiteFragment( path, site ) {
 
 	if ( includes( [ 'post', 'page', 'edit' ], pieces[ 1 ] ) ) {
 		// New-style URL; change /:section[/:filter/...] into /:section/:site/[:filter/...]
-		pieces.splice( 'edit' === pieces[ 1 ] ? pieces.length : 2, 0, site );
+		// /edit/:cpt/:site or /post/:site - /edit has an extra parameter
+		const sitePos = ( 'edit' === pieces[ 1 ] ? 3 : 2 );
+		pieces.splice( sitePos, 0, site );
 	} else {
 		// Old-style URL; add /:site onto the end
 		pieces.push( site );

--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -21,23 +21,27 @@ var statsLocationsByTab = {
 };
 
 function getSiteFragment( path ) {
-	var basePath = path.split( '?' )[0],
-		pieces = basePath.split( '/' ),
-		siteOldStyle = pieces[ pieces.length - 1 ],
-		siteNewStyle = pieces[ pieces.length - 2 ] || '';
+	const basePath = path.split( '?' )[0];
+	const pieces = basePath.split( '/' );
 
-	if ( siteNewStyle.indexOf( '.' ) >= 0 ) {
-		// This is a new-style URL like /:section/:site[/:filter/...]
-		return siteNewStyle;
-	} else if ( siteOldStyle.indexOf( '.' ) >= 0 ) {
-		// This is an old-style URL like /:section/:filter/:site
-		return siteOldStyle;
-	} else if ( siteNewStyle && ! isNaN( siteNewStyle ) ) {
-		// Allow numeric site IDs in /:section/:site[/:filter/...]
-		return parseInt( siteNewStyle, 10 );
-	} else if ( siteOldStyle && ! isNaN( siteOldStyle ) ) {
-		// Allow numeric site IDs in /:section/:filter/:site
-		return parseInt( siteOldStyle, 10 );
+	// There are 2 URL positions where we should look for the site fragment:
+	// last (most sections) and second to last (the editor, since post ID can
+	// come last).
+	const maybeSiteInEditor = pieces[ pieces.length - 2 ] || '';
+	const maybeSiteOther = pieces[ pieces.length - 1 ] || '';
+
+	if ( maybeSiteInEditor.indexOf( '.' ) >= 0 ) {
+		// This is an editor-style URL like /post/:site/:id or /edit/:cpt/:site/:id
+		return maybeSiteInEditor;
+	} else if ( maybeSiteOther.indexOf( '.' ) >= 0 ) {
+		// This is a URL like /:section/:filter/:site
+		return maybeSiteOther;
+	} else if ( maybeSiteInEditor && ! isNaN( maybeSiteInEditor ) ) {
+		// Allow numeric site IDs in editor URLs
+		return parseInt( maybeSiteInEditor, 10 );
+	} else if ( maybeSiteOther && ! isNaN( maybeSiteOther ) ) {
+		// Allow numeric site IDs in other URLs
+		return parseInt( maybeSiteOther, 10 );
 	} else {
 		// No site fragment here
 		return false;
@@ -45,15 +49,15 @@ function getSiteFragment( path ) {
 }
 
 function addSiteFragment( path, site ) {
-	var pieces = sectionify( path ).split( '/' );
+	const pieces = sectionify( path ).split( '/' );
 
 	if ( includes( [ 'post', 'page', 'edit' ], pieces[ 1 ] ) ) {
-		// New-style URL; change /:section[/:filter/...] into /:section/:site/[:filter/...]
-		// /edit/:cpt/:site or /post/:site - /edit has an extra parameter
+		// Editor-style URL; insert the site as either the 2nd or 3rd piece of
+		// the URL ( '/post/:site' or '/edit/:cpt/:site' )
 		const sitePos = ( 'edit' === pieces[ 1 ] ? 3 : 2 );
 		pieces.splice( sitePos, 0, site );
 	} else {
-		// Old-style URL; add /:site onto the end
+		// Somewhere else in Calypso; add /:site onto the end
 		pieces.push( site );
 	}
 

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -35,6 +35,12 @@ describe( 'lib/route', function() {
 			it( 'should return the site when editing a new page', function() {
 				expect( route.getSiteFragment( '/page/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
 			} );
+			it( 'should return the site when editing a an existing custom post type', function() {
+				expect( route.getSiteFragment( '/edit/jetpack-portfolio/example.wordpress.com/218' ) ).to.equal( 'example.wordpress.com' );
+			} );
+			it( 'should return the site when editing a new custom post type', function() {
+				expect( route.getSiteFragment( '/edit/jetpack-portfolio/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
+			} );
 		} );
 		describe( 'for old-style editor paths', function() {
 			it( 'should return the site when editing an existing post', function() {
@@ -87,6 +93,11 @@ describe( 'lib/route', function() {
 					route.addSiteFragment( '/page', 'example.wordpress.com' )
 				).to.equal( '/page/example.wordpress.com' );
 			} );
+			it( 'should add a site when editing a new custom post type', function() {
+				expect(
+					route.addSiteFragment( '/edit/jetpack-portfolio', 'example.wordpress.com' )
+				).to.equal( '/edit/jetpack-portfolio/example.wordpress.com' );
+			} );
 			it( 'should replace the site when editing a new post', function() {
 				expect(
 					route.addSiteFragment( '/post/notexample.wordpress.com', 'example.wordpress.com' )
@@ -96,6 +107,11 @@ describe( 'lib/route', function() {
 				expect(
 					route.addSiteFragment( '/page/notexample.wordpress.com', 'example.wordpress.com' )
 				).to.equal( '/page/example.wordpress.com' );
+			} );
+			it( 'should replace the site when editing a new custom post type', function() {
+				expect(
+					route.addSiteFragment( '/edit/jetpack-portfolio/notexample.wordpress.com', 'example.wordpress.com' )
+				).to.equal( '/edit/jetpack-portfolio/example.wordpress.com' );
 			} );
 			// These two tests are a bit contrived, but still good to have
 			it( 'should replace the site when editing an existing post', function() {

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable vars-on-top */
 require( 'lib/react-test-env-setup' )();
 
 /**
@@ -11,72 +12,154 @@ var expect = require( 'chai' ).expect;
 var route = require( '../index' );
 
 describe( 'lib/route', function() {
-
 	describe( 'getSiteFragment', function() {
 		describe( 'for the root path', function() {
 			it( 'should return false', function() {
-				expect( route.getSiteFragment( '/' ) ).to.equal( false );
+				expect(
+					route.getSiteFragment( '/' )
+				).to.equal( false );
 			} );
 		} );
 		describe( 'for editor paths', function() {
 			it( 'should return false when there is no site yet', function() {
-				expect( route.getSiteFragment( '/post' ) ).to.equal( false );
-				expect( route.getSiteFragment( '/page' ) ).to.equal( false );
+				expect(
+					route.getSiteFragment( '/post' )
+				).to.equal( false );
+				expect(
+					route.getSiteFragment( '/page' )
+				).to.equal( false );
 			} );
 			it( 'should return the site when editing an existing post', function() {
-				expect( route.getSiteFragment( '/post/example.wordpress.com/231' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/post/example.wordpress.com/231' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/post/2916284/231' )
+				).to.equal( 2916284 );
 			} );
 			it( 'should return the site when editing a new post', function() {
-				expect( route.getSiteFragment( '/post/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/post/example.wordpress.com' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/post/2916284' )
+				).to.equal( 2916284 );
+				expect(
+					route.getSiteFragment( '/post/example.wordpress.com/new' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/post/2916284/new' )
+				).to.equal( 2916284 );
 			} );
 			it( 'should return the site when editing an existing page', function() {
-				expect( route.getSiteFragment( '/page/example.wordpress.com/29' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/page/example.wordpress.com/29' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/page/2916284/29' )
+				).to.equal( 2916284 );
 			} );
 			it( 'should return the site when editing a new page', function() {
-				expect( route.getSiteFragment( '/page/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/page/example.wordpress.com' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/page/2916284' )
+				).to.equal( 2916284 );
+				expect(
+					route.getSiteFragment( '/page/example.wordpress.com/new' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/page/2916284/new' )
+				).to.equal( 2916284 );
 			} );
 			it( 'should return the site when editing a an existing custom post type', function() {
-				expect( route.getSiteFragment( '/edit/jetpack-portfolio/example.wordpress.com/218' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/edit/jetpack-portfolio/example.wordpress.com/218' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/edit/jetpack-portfolio/2916284/218' )
+				).to.equal( 2916284 );
 			} );
 			it( 'should return the site when editing a new custom post type', function() {
-				expect( route.getSiteFragment( '/edit/jetpack-portfolio/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
-			} );
-		} );
-		describe( 'for old-style editor paths', function() {
-			it( 'should return the site when editing an existing post', function() {
-				expect( route.getSiteFragment( '/post/231/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
-			} );
-			it( 'should return the site when editing an existing page', function() {
-				expect( route.getSiteFragment( '/page/29/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/edit/jetpack-portfolio/example.wordpress.com' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/edit/jetpack-portfolio/2916284' )
+				).to.equal( 2916284 );
+				expect(
+					route.getSiteFragment( '/edit/jetpack-portfolio/example.wordpress.com/new' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/edit/jetpack-portfolio/2916284/new' )
+				).to.equal( 2916284 );
 			} );
 		} );
 		describe( 'for listing paths', function() {
 			it( 'should return false when there is no site yet', function() {
-				expect( route.getSiteFragment( '/posts' ) ).to.equal( false );
-				expect( route.getSiteFragment( '/posts/drafts' ) ).to.equal( false );
-				expect( route.getSiteFragment( '/pages' ) ).to.equal( false );
-				expect( route.getSiteFragment( '/pages/drafts' ) ).to.equal( false );
+				expect(
+					route.getSiteFragment( '/posts' )
+				).to.equal( false );
+				expect(
+					route.getSiteFragment( '/posts/drafts' )
+				).to.equal( false );
+				expect(
+					route.getSiteFragment( '/pages' )
+				).to.equal( false );
+				expect(
+					route.getSiteFragment( '/pages/drafts' )
+				).to.equal( false );
 			} );
 			it( 'should return the site when viewing posts', function() {
-				expect( route.getSiteFragment( '/posts/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/posts/example.wordpress.com' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/posts/2916284' )
+				).to.equal( 2916284 );
 			} );
 			it( 'should return the site when viewing posts with a filter', function() {
-				expect( route.getSiteFragment( '/posts/drafts/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/posts/drafts/example.wordpress.com' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/posts/drafts/2916284' )
+				).to.equal( 2916284 );
 			} );
 			it( 'should return the site when viewing pages', function() {
-				expect( route.getSiteFragment( '/pages/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/pages/example.wordpress.com' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/pages/2916284' )
+				).to.equal( 2916284 );
 			} );
 			it( 'should return the site when viewing pages with a filter', function() {
-				expect( route.getSiteFragment( '/pages/drafts/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/pages/drafts/example.wordpress.com' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/pages/drafts/2916284' )
+				).to.equal( 2916284 );
 			} );
 		} );
 		describe( 'for stats paths', function() {
 			it( 'should return false when there is no site yet', function() {
-				expect( route.getSiteFragment( '/stats' ) ).to.equal( false );
-				expect( route.getSiteFragment( '/stats/day' ) ).to.equal( false );
+				expect(
+					route.getSiteFragment( '/stats' )
+				).to.equal( false );
+				expect(
+					route.getSiteFragment( '/stats/day' )
+				).to.equal( false );
 			} );
 			it( 'should return the site when viewing the default stats page', function() {
-				expect( route.getSiteFragment( '/stats/day/example.wordpress.com' ) ).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/stats/day/example.wordpress.com' )
+				).to.equal( 'example.wordpress.com' );
+				expect(
+					route.getSiteFragment( '/stats/day/2916284' )
+				).to.equal( 2916284 );
 			} );
 		} );
 	} );
@@ -87,42 +170,102 @@ describe( 'lib/route', function() {
 				expect(
 					route.addSiteFragment( '/post', 'example.wordpress.com' )
 				).to.equal( '/post/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/post', 2916284 )
+				).to.equal( '/post/2916284' );
+				expect(
+					route.addSiteFragment( '/post/new', 'example.wordpress.com' )
+				).to.equal( '/post/example.wordpress.com/new' );
+				expect(
+					route.addSiteFragment( '/post/new', 2916284 )
+				).to.equal( '/post/2916284/new' );
 			} );
 			it( 'should add a site when editing a new page', function() {
 				expect(
 					route.addSiteFragment( '/page', 'example.wordpress.com' )
 				).to.equal( '/page/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/page', 2916284 )
+				).to.equal( '/page/2916284' );
+				expect(
+					route.addSiteFragment( '/page/new', 'example.wordpress.com' )
+				).to.equal( '/page/example.wordpress.com/new' );
+				expect(
+					route.addSiteFragment( '/page/new', 2916284 )
+				).to.equal( '/page/2916284/new' );
 			} );
 			it( 'should add a site when editing a new custom post type', function() {
 				expect(
 					route.addSiteFragment( '/edit/jetpack-portfolio', 'example.wordpress.com' )
 				).to.equal( '/edit/jetpack-portfolio/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/edit/jetpack-portfolio', 2916284 )
+				).to.equal( '/edit/jetpack-portfolio/2916284' );
+				expect(
+					route.addSiteFragment( '/edit/jetpack-portfolio/new', 'example.wordpress.com' )
+				).to.equal( '/edit/jetpack-portfolio/example.wordpress.com/new' );
+				expect(
+					route.addSiteFragment( '/edit/jetpack-portfolio/new', 2916284 )
+				).to.equal( '/edit/jetpack-portfolio/2916284/new' );
 			} );
 			it( 'should replace the site when editing a new post', function() {
 				expect(
 					route.addSiteFragment( '/post/notexample.wordpress.com', 'example.wordpress.com' )
 				).to.equal( '/post/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/post/106782956', 2916284 )
+				).to.equal( '/post/2916284' );
+				expect(
+					route.addSiteFragment( '/post/notexample.wordpress.com/new', 'example.wordpress.com' )
+				).to.equal( '/post/example.wordpress.com/new' );
+				expect(
+					route.addSiteFragment( '/post/106782956/new', 2916284 )
+				).to.equal( '/post/2916284/new' );
 			} );
 			it( 'should replace the site when editing a new page', function() {
 				expect(
 					route.addSiteFragment( '/page/notexample.wordpress.com', 'example.wordpress.com' )
 				).to.equal( '/page/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/page/106782956', 2916284 )
+				).to.equal( '/page/2916284' );
+				expect(
+					route.addSiteFragment( '/page/notexample.wordpress.com/new', 'example.wordpress.com' )
+				).to.equal( '/page/example.wordpress.com/new' );
+				expect(
+					route.addSiteFragment( '/page/106782956/new', 2916284 )
+				).to.equal( '/page/2916284/new' );
 			} );
 			it( 'should replace the site when editing a new custom post type', function() {
 				expect(
 					route.addSiteFragment( '/edit/jetpack-portfolio/notexample.wordpress.com', 'example.wordpress.com' )
 				).to.equal( '/edit/jetpack-portfolio/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/edit/jetpack-portfolio/106782956', 2916284 )
+				).to.equal( '/edit/jetpack-portfolio/2916284' );
+				expect(
+					route.addSiteFragment( '/edit/jetpack-portfolio/notexample.wordpress.com/new', 'example.wordpress.com' )
+				).to.equal( '/edit/jetpack-portfolio/example.wordpress.com/new' );
+				expect(
+					route.addSiteFragment( '/edit/jetpack-portfolio/106782956/new', 2916284 )
+				).to.equal( '/edit/jetpack-portfolio/2916284/new' );
 			} );
 			// These two tests are a bit contrived, but still good to have
 			it( 'should replace the site when editing an existing post', function() {
 				expect(
 					route.addSiteFragment( '/post/notexample.wordpress.com/231', 'example.wordpress.com' )
 				).to.equal( '/post/example.wordpress.com/231' );
+				expect(
+					route.addSiteFragment( '/post/106782956/231', 2916284 )
+				).to.equal( '/post/2916284/231' );
 			} );
 			it( 'should replace the site when editing an existing page', function() {
 				expect(
 					route.addSiteFragment( '/page/notexample.wordpress.com/29', 'example.wordpress.com' )
 				).to.equal( '/page/example.wordpress.com/29' );
+				expect(
+					route.addSiteFragment( '/page/106782956/29', 2916284 )
+				).to.equal( '/page/2916284/29' );
 			} );
 			// Can't test adding a site here (going from /page/29 to
 			// /page/:site/29 for example) because getSiteFragment would think
@@ -134,21 +277,33 @@ describe( 'lib/route', function() {
 				expect(
 					route.addSiteFragment( '/posts', 'example.wordpress.com' )
 				).to.equal( '/posts/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/posts', 2916284 )
+				).to.equal( '/posts/2916284' );
 			} );
 			it( 'should append the site when viewing posts with a filter', function() {
 				expect(
 					route.addSiteFragment( '/posts/drafts', 'example.wordpress.com' )
 				).to.equal( '/posts/drafts/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/posts/drafts', 2916284 )
+				).to.equal( '/posts/drafts/2916284' );
 			} );
 			it( 'should append the site when viewing pages', function() {
 				expect(
 					route.addSiteFragment( '/pages', 'example.wordpress.com' )
 				).to.equal( '/pages/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/pages', 2916284 )
+				).to.equal( '/pages/2916284' );
 			} );
 			it( 'should append the site when viewing pages with a filter', function() {
 				expect(
 					route.addSiteFragment( '/pages/drafts', 'example.wordpress.com' )
 				).to.equal( '/pages/drafts/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/pages/drafts', 2916284 )
+				).to.equal( '/pages/drafts/2916284' );
 			} );
 		} );
 		describe( 'for stats paths', function() {
@@ -156,11 +311,17 @@ describe( 'lib/route', function() {
 				expect(
 					route.addSiteFragment( '/stats', 'example.wordpress.com' )
 				).to.equal( '/stats/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/stats', 2916284 )
+				).to.equal( '/stats/2916284' );
 			} );
 			it( 'should append the site when viewing the default stats page', function() {
 				expect(
 					route.addSiteFragment( '/stats/day', 'example.wordpress.com' )
 				).to.equal( '/stats/day/example.wordpress.com' );
+				expect(
+					route.addSiteFragment( '/stats/day', 2916284 )
+				).to.equal( '/stats/day/2916284' );
 			} );
 		} );
 	} );
@@ -168,64 +329,152 @@ describe( 'lib/route', function() {
 	describe( 'sectionify', function() {
 		describe( 'for the root path', function() {
 			it( 'should return the same path', function() {
-				expect( route.sectionify( '/' ) ).to.equal( '/' );
+				expect(
+					route.sectionify( '/' )
+				).to.equal( '/' );
 			} );
 		} );
 		describe( 'for editor paths', function() {
 			it( 'should return the same path when there is no site yet', function() {
-				expect( route.sectionify( '/post' ) ).to.equal( '/post' );
-				expect( route.sectionify( '/page' ) ).to.equal( '/page' );
+				expect(
+					route.sectionify( '/post' )
+				).to.equal( '/post' );
+				expect(
+					route.sectionify( '/page' )
+				).to.equal( '/page' );
 			} );
 			it( 'should remove the site when editing an existing post', function() {
-				expect( route.sectionify( '/post/example.wordpress.com/231' ) ).to.equal( '/post/231' );
+				expect(
+					route.sectionify( '/post/example.wordpress.com/231' )
+				).to.equal( '/post/231' );
+				expect(
+					route.sectionify( '/post/2916284/231' )
+				).to.equal( '/post/231' );
 			} );
 			it( 'should remove the site when editing a new post', function() {
-				expect( route.sectionify( '/post/example.wordpress.com' ) ).to.equal( '/post' );
+				expect(
+					route.sectionify( '/post/example.wordpress.com' )
+				).to.equal( '/post' );
+				expect(
+					route.sectionify( '/post/2916284' )
+				).to.equal( '/post' );
+				expect(
+					route.sectionify( '/post/example.wordpress.com/new' )
+				).to.equal( '/post/new' );
+				expect(
+					route.sectionify( '/post/2916284/new' )
+				).to.equal( '/post/new' );
 			} );
 			it( 'should remove the site when editing an existing page', function() {
-				expect( route.sectionify( '/page/example.wordpress.com/29' ) ).to.equal( '/page/29' );
+				expect(
+					route.sectionify( '/page/example.wordpress.com/29' )
+				).to.equal( '/page/29' );
+				expect(
+					route.sectionify( '/page/2916284/29' )
+				).to.equal( '/page/29' );
 			} );
 			it( 'should remove the site when editing a new page', function() {
-				expect( route.sectionify( '/page/example.wordpress.com' ) ).to.equal( '/page' );
+				expect(
+					route.sectionify( '/page/example.wordpress.com' )
+				).to.equal( '/page' );
+				expect(
+					route.sectionify( '/page/2916284' )
+				).to.equal( '/page' );
+				expect(
+					route.sectionify( '/page/example.wordpress.com/new' )
+				).to.equal( '/page/new' );
+				expect(
+					route.sectionify( '/page/2916284/new' )
+				).to.equal( '/page/new' );
 			} );
-		} );
-		describe( 'for old-style editor paths', function() {
-			it( 'should remove the site when editing an existing post', function() {
-				expect( route.sectionify( '/post/231/example.wordpress.com' ) ).to.equal( '/post/231' );
+			it( 'should remove the site when editing an existing custom post type', function() {
+				expect(
+					route.sectionify( '/edit/jetpack-portfolio/example.wordpress.com/231' )
+				).to.equal( '/edit/jetpack-portfolio/231' );
+				expect(
+					route.sectionify( '/edit/jetpack-portfolio/2916284/231' )
+				).to.equal( '/edit/jetpack-portfolio/231' );
 			} );
-			it( 'should remove the site when editing an existing page', function() {
-				expect( route.sectionify( '/page/29/example.wordpress.com' ) ).to.equal( '/page/29' );
+			it( 'should remove the site when editing a new custom post type', function() {
+				expect(
+					route.sectionify( '/edit/jetpack-portfolio/example.wordpress.com' )
+				).to.equal( '/edit/jetpack-portfolio' );
+				expect(
+					route.sectionify( '/edit/jetpack-portfolio/2916284' )
+				).to.equal( '/edit/jetpack-portfolio' );
+				expect(
+					route.sectionify( '/edit/jetpack-portfolio/example.wordpress.com/new' )
+				).to.equal( '/edit/jetpack-portfolio/new' );
+				expect(
+					route.sectionify( '/edit/jetpack-portfolio/2916284/new' )
+				).to.equal( '/edit/jetpack-portfolio/new' );
 			} );
 		} );
 		describe( 'for listing paths', function() {
 			it( 'should return the same path when there is no site yet', function() {
-				expect( route.sectionify( '/posts' ) ).to.equal( '/posts' );
-				expect( route.sectionify( '/posts/drafts' ) ).to.equal( '/posts/drafts' );
-				expect( route.sectionify( '/pages' ) ).to.equal( '/pages' );
-				expect( route.sectionify( '/pages/drafts' ) ).to.equal( '/pages/drafts' );
+				expect(
+					route.sectionify( '/posts' )
+				).to.equal( '/posts' );
+				expect(
+					route.sectionify( '/posts/drafts' )
+				).to.equal( '/posts/drafts' );
+				expect(
+					route.sectionify( '/pages' )
+				).to.equal( '/pages' );
+				expect(
+					route.sectionify( '/pages/drafts' )
+				).to.equal( '/pages/drafts' );
 			} );
 			it( 'should remove the site when viewing posts', function() {
-				expect( route.sectionify( '/posts/example.wordpress.com' ) ).to.equal( '/posts' );
+				expect(
+					route.sectionify( '/posts/example.wordpress.com' )
+				).to.equal( '/posts' );
+				expect(
+					route.sectionify( '/posts/2916284' )
+				).to.equal( '/posts' );
 			} );
 			it( 'should remove the site when viewing posts with a filter', function() {
-				expect( route.sectionify( '/posts/drafts/example.wordpress.com' ) ).to.equal( '/posts/drafts' );
+				expect(
+					route.sectionify( '/posts/drafts/example.wordpress.com' )
+				).to.equal( '/posts/drafts' );
+				expect(
+					route.sectionify( '/posts/drafts/2916284' )
+				).to.equal( '/posts/drafts' );
 			} );
 			it( 'should remove the site when viewing pages', function() {
-				expect( route.sectionify( '/pages/example.wordpress.com' ) ).to.equal( '/pages' );
+				expect(
+					route.sectionify( '/pages/example.wordpress.com' )
+				).to.equal( '/pages' );
+				expect(
+					route.sectionify( '/pages/2916284' )
+				).to.equal( '/pages' );
 			} );
 			it( 'should remove the site when viewing pages with a filter', function() {
-				expect( route.sectionify( '/pages/drafts/example.wordpress.com' ) ).to.equal( '/pages/drafts' );
+				expect(
+					route.sectionify( '/pages/drafts/example.wordpress.com' )
+				).to.equal( '/pages/drafts' );
+				expect(
+					route.sectionify( '/pages/drafts/2916284' )
+				).to.equal( '/pages/drafts' );
 			} );
 		} );
 		describe( 'for stats paths', function() {
 			it( 'should return the same path when there is no site yet', function() {
-				expect( route.sectionify( '/stats' ) ).to.equal( '/stats' );
-				expect( route.sectionify( '/stats/day' ) ).to.equal( '/stats/day' );
+				expect(
+					route.sectionify( '/stats' )
+				).to.equal( '/stats' );
+				expect(
+					route.sectionify( '/stats/day' )
+				).to.equal( '/stats/day' );
 			} );
 			it( 'should remove the site when viewing the default stats page', function() {
-				expect( route.sectionify( '/stats/day/example.wordpress.com' ) ).to.equal( '/stats/day' );
+				expect(
+					route.sectionify( '/stats/day/example.wordpress.com' )
+				).to.equal( '/stats/day' );
+				expect(
+					route.sectionify( '/stats/day/2916284' )
+				).to.equal( '/stats/day' );
 			} );
 		} );
 	} );
-
 } );

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -30,6 +30,8 @@ import {
 	EDITING_MODES
 } from 'state/ui/editor/post/actions';
 import { setEditorPostId } from 'state/ui/editor/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
 import { editPost } from 'state/posts/actions';
 
 function getPostID( context ) {
@@ -42,7 +44,15 @@ function getPostID( context ) {
 }
 
 function determinePostType( context ) {
-	return startsWith( context.path, '/page' ) ? 'page' : 'post';
+	if ( startsWith( context.path, '/post' ) ) {
+		return 'post';
+	}
+
+	if ( startsWith( context.path, '/page' ) ) {
+		return 'page';
+	}
+
+	return context.params.type;
 }
 
 function renderEditor( context, postType ) {
@@ -60,31 +70,14 @@ function renderEditor( context, postType ) {
 	);
 }
 
-function maybeRedirect( context, postType, site ) {
-	const siteId = context.params.site;
-	const postId = context.params.post;
-	const basePath = '/' + postType;
+function maybeRedirect( context ) {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	const postId = getEditorPostId( state );
 
-	if ( ! site ) {
-		page.redirect( basePath );
-		return true;
-	}
-
-	// matches `/post/:siteID/new` or `/page/:siteID/new`
-	if ( 'new' === postId ) {
-		page.redirect( basePath + '/' + site.slug );
-		return true;
-	}
-
-	// if siteId is a number
-	if ( /^\d+$/.test( siteId ) ) {
-		if ( postId ) {
-			// matches `/post/:siteID/:postId` OR `/page/:siteID/:postId`
-			page.redirect( basePath + '/' + site.slug + '/' + postId );
-		} else {
-			// matches `/post/:siteID` OR `/page/:siteID`
-			page.redirect( basePath + '/' + site.slug );
-		}
+	const path = getEditorPath( state, siteId, postId );
+	if ( path !== context.pathname ) {
+		page.redirect( path );
 		return true;
 	}
 
@@ -131,27 +124,41 @@ module.exports = {
 		function startEditing() {
 			const site = sites.getSite( route.getSiteFragment( context.path ) );
 
-			if ( maybeRedirect( context, postType, site ) ) {
-				return;
-			}
-
 			context.store.dispatch( setEditorPostId( postID ) );
 			context.store.dispatch( editPost( { type: postType }, site.ID, postID ) );
 
-			let titleStrings;
-			if ( 'page' === postType ) {
-				titleStrings = {
-					edit: i18n.translate( 'Edit Page', { textOnly: true } ),
-					new: i18n.translate( 'New Page', { textOnly: true } ),
-					ga: 'Page'
-				};
-			} else {
-				titleStrings = {
-					edit: i18n.translate( 'Edit Post', { textOnly: true } ),
-					new: i18n.translate( 'New Post', { textOnly: true } ),
-					ga: 'Post'
-				};
+			if ( maybeRedirect( context ) ) {
+				return;
 			}
+
+			let titleStrings;
+			switch ( postType ) {
+				case 'post':
+					titleStrings = {
+						edit: i18n.translate( 'Edit Post', { textOnly: true } ),
+						new: i18n.translate( 'New Post', { textOnly: true } ),
+						ga: 'Post'
+					};
+					break;
+
+				case 'page':
+					titleStrings = {
+						edit: i18n.translate( 'Edit Page', { textOnly: true } ),
+						new: i18n.translate( 'New Page', { textOnly: true } ),
+						ga: 'Page'
+					};
+					break;
+
+				default:
+					// [TODO]: Improve these strings, notably once page query
+					// component is available for assigning title dynamically.
+					titleStrings = {
+						edit: i18n.translate( 'Edit', { textOnly: true } ),
+						new: i18n.translate( 'New', { textOnly: true } ),
+						ga: 'Custom Post Type'
+					};
+			}
+
 			// We have everything we need to start loading the post for editing,
 			// so kick it off here to minimize time spent waiting for it to load
 			// in the view components

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -33,7 +33,7 @@ import { setEditorPostId } from 'state/ui/editor/actions';
 import { editPost } from 'state/posts/actions';
 
 function getPostID( context ) {
-	if ( ! context.params.post ) {
+	if ( ! context.params.post || 'new' === context.params.post ) {
 		return null;
 	}
 

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -196,7 +196,19 @@ module.exports = {
 		if ( sites.initialized ) {
 			startEditing();
 		} else {
-			sites.once( 'change', startEditing );
+			// The site selection flow in the siteSelection route middleware
+			// will cause the change handler here to be invoked before site is
+			// set in Redux store. To account for this, we continue to check
+			// state for site ID to have been set.
+			function startEditingOnSitesInitialized() {
+				if ( getSelectedSiteId( context.store.getState() ) ) {
+					startEditing();
+				} else {
+					sites.once( 'change', startEditingOnSitesInitialized );
+				}
+			}
+
+			sites.once( 'change', startEditingOnSitesInitialized );
 		}
 
 		renderEditor( context, postType );

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -8,6 +8,7 @@ var page = require( 'page' );
  */
 var sitesController = require( 'my-sites/controller' ),
 	controller = require( './controller' );
+import config from 'config';
 
 module.exports = function() {
 	page( '/post', controller.pressThis, sitesController.siteSelection, sitesController.sites );
@@ -17,4 +18,9 @@ module.exports = function() {
 	page( '/page', sitesController.siteSelection, sitesController.sites );
 	page( '/page/new', () => page.redirect( '/page' ) ); // redirect from beep-beep-boop
 	page( '/page/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
+
+	if ( config.isEnabled( 'manage/custom-post-types' ) ) {
+		page( '/edit/:type', sitesController.siteSelection, sitesController.sites );
+		page( '/edit/:site?/:type/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
+	}
 };

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -21,6 +21,7 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'manage/custom-post-types' ) ) {
 		page( '/edit/:type', sitesController.siteSelection, sitesController.sites );
-		page( '/edit/:site?/:type/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
+		page( '/edit/:type/new', ( context ) => page.redirect( `/edit/${ context.params.type }` ) );
+		page( '/edit/:type/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
 	}
 };

--- a/client/sections.js
+++ b/client/sections.js
@@ -1,7 +1,14 @@
-var config = require( 'config' ),
-	readerPaths;
+/**
+ * External dependencies
+ */
+var config = require( 'config' );
 
-var sections;
+/**
+ * Module variables
+ */
+var sections,
+	editorPaths,
+	readerPaths;
 
 sections = [
 	{
@@ -9,13 +16,6 @@ sections = [
 		paths: [ '/customize' ],
 		module: 'my-sites/customize',
 		group: 'sites'
-	},
-	{
-		name: 'post-editor',
-		paths: [ '/post', '/page' ],
-		module: 'post-editor',
-		group: 'editor',
-		secondary: true
 	},
 	{
 		name: 'me',
@@ -162,6 +162,19 @@ sections = [
 		group: 'sites'
 	}
 ];
+
+editorPaths = [ '/post', '/page' ];
+if ( config.isEnabled( 'manage/custom-post-types' ) ) {
+	editorPaths.push( '/edit' );
+}
+
+sections.push( {
+	name: 'post-editor',
+	paths: editorPaths,
+	module: 'post-editor',
+	group: 'editor',
+	secondary: true
+} );
 
 if ( config.isEnabled( 'manage/ads' ) ) {
 	sections.push( {

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import get from 'lodash/get';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -54,7 +55,7 @@ export function getEditorPath( state, siteId, postId ) {
 	switch ( type ) {
 		case 'post': path = '/post'; break;
 		case 'page': path = '/page'; break;
-		default: path = `/type/${ type }`; break;
+		default: path = `/edit`; break;
 	}
 
 	const siteSlug = getSiteSlug( state, siteId );
@@ -62,6 +63,10 @@ export function getEditorPath( state, siteId, postId ) {
 		path += `/${ siteSlug }`;
 	} else {
 		path += `/${ siteId }`;
+	}
+
+	if ( ! includes( [ 'post', 'page' ], type ) ) {
+		path += `/${ type }`;
 	}
 
 	if ( postId ) {

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -7,7 +7,7 @@ import get from 'lodash/get';
  * Internal dependencies
  */
 import { getSiteSlug } from 'state/sites/selectors';
-import { getSitePost } from 'state/posts/selectors';
+import { getEditedPost } from 'state/posts/selectors';
 
 /**
  * Returns the current editor post ID, or `null` if a new post.
@@ -48,7 +48,7 @@ export function isEditorDraftsVisible( state ) {
  * @return {String}        Editor URL path
  */
 export function getEditorPath( state, siteId, postId ) {
-	const type = get( getSitePost( state, siteId, postId ), 'type', 'post' );
+	const type = get( getEditedPost( state, siteId, postId ), 'type', 'post' );
 
 	let path;
 	switch ( type ) {

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import get from 'lodash/get';
-import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -55,7 +54,7 @@ export function getEditorPath( state, siteId, postId ) {
 	switch ( type ) {
 		case 'post': path = '/post'; break;
 		case 'page': path = '/page'; break;
-		default: path = `/edit`; break;
+		default: path = `/edit/${ type }`; break;
 	}
 
 	const siteSlug = getSiteSlug( state, siteId );
@@ -63,10 +62,6 @@ export function getEditorPath( state, siteId, postId ) {
 		path += `/${ siteSlug }`;
 	} else {
 		path += `/${ siteId }`;
-	}
-
-	if ( ! includes( [ 'post', 'page' ], type ) ) {
-		path += `/${ type }`;
 	}
 
 	if ( postId ) {

--- a/client/state/ui/editor/test/selectors.js
+++ b/client/state/ui/editor/test/selectors.js
@@ -75,7 +75,8 @@ describe( 'selectors', () => {
 					}
 				},
 				posts: {
-					items: {}
+					items: {},
+					edits: {}
 				}
 			}, 2916284, 841 );
 
@@ -88,7 +89,8 @@ describe( 'selectors', () => {
 					items: {}
 				},
 				posts: {
-					items: {}
+					items: {},
+					edits: {}
 				}
 			}, 2916284, 841 );
 
@@ -108,7 +110,8 @@ describe( 'selectors', () => {
 				posts: {
 					items: {
 						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', type: 'post' }
-					}
+					},
+					edits: {}
 				}
 			}, 2916284, 841 );
 
@@ -128,7 +131,8 @@ describe( 'selectors', () => {
 				posts: {
 					items: {
 						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', type: 'page' }
-					}
+					},
+					edits: {}
 				}
 			}, 2916284, 413 );
 
@@ -148,11 +152,37 @@ describe( 'selectors', () => {
 				posts: {
 					items: {
 						'0fcb4eb16f493c19b627438fdc18d57c': { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', type: 'jetpack-portfolio' }
-					}
+					},
+					edits: {}
 				}
 			}, 2916284, 120 );
 
 			expect( path ).to.equal( '/type/jetpack-portfolio/example.wordpress.com/120' );
+		} );
+
+		it( 'should derive post type from edited post', () => {
+			const path = getEditorPath( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
+				posts: {
+					items: {},
+					edits: {
+						2916284: {
+							'': {
+								type: 'jetpack-portfolio'
+							}
+						}
+					}
+				}
+			}, 2916284 );
+
+			expect( path ).to.equal( '/edit/example.wordpress.com/jetpack-portfolio' );
 		} );
 	} );
 } );

--- a/client/state/ui/editor/test/selectors.js
+++ b/client/state/ui/editor/test/selectors.js
@@ -139,7 +139,7 @@ describe( 'selectors', () => {
 			expect( path ).to.equal( '/page/example.wordpress.com/413' );
 		} );
 
-		it( 'should suffix the type route for custom post types', () => {
+		it( 'should prefix the type route for custom post types', () => {
 			const path = getEditorPath( {
 				sites: {
 					items: {
@@ -157,7 +157,7 @@ describe( 'selectors', () => {
 				}
 			}, 2916284, 120 );
 
-			expect( path ).to.equal( '/edit/example.wordpress.com/jetpack-portfolio/120' );
+			expect( path ).to.equal( '/edit/jetpack-portfolio/example.wordpress.com/120' );
 		} );
 
 		it( 'should derive post type from edited post', () => {
@@ -182,7 +182,7 @@ describe( 'selectors', () => {
 				}
 			}, 2916284 );
 
-			expect( path ).to.equal( '/edit/example.wordpress.com/jetpack-portfolio' );
+			expect( path ).to.equal( '/edit/jetpack-portfolio/example.wordpress.com' );
 		} );
 	} );
 } );

--- a/client/state/ui/editor/test/selectors.js
+++ b/client/state/ui/editor/test/selectors.js
@@ -139,7 +139,7 @@ describe( 'selectors', () => {
 			expect( path ).to.equal( '/page/example.wordpress.com/413' );
 		} );
 
-		it( 'should prefix the type route for custom post types', () => {
+		it( 'should suffix the type route for custom post types', () => {
 			const path = getEditorPath( {
 				sites: {
 					items: {
@@ -157,7 +157,7 @@ describe( 'selectors', () => {
 				}
 			}, 2916284, 120 );
 
-			expect( path ).to.equal( '/type/jetpack-portfolio/example.wordpress.com/120' );
+			expect( path ).to.equal( '/edit/example.wordpress.com/jetpack-portfolio/120' );
 		} );
 
 		it( 'should derive post type from edited post', () => {


### PR DESCRIPTION
Closes #3694

This pull request seeks to enable editor routing for custom post types in environments where the `manage/custom-post-types` feature flag is enabled (currently, `development` only).

The following route patterns are now supported:

- `/post/new`
- `/post/example.wordpress.com/new`
- `/post/example.wordpress.com`
- `/post/example.wordpress.com/140`
- `/post/2916284/new`
- `/post/2916284`
- `/post/2916284/140`
- `/page/new`
- `/page/example.wordpress.com/new`
- `/page/example.wordpress.com`
- `/page/example.wordpress.com/140`
- `/page/2916284/new`
- `/page/2916284`
- `/page/2916284/140`
- `/edit/jetpack-portfolio`
- `/edit/example.wordpress.com/jetpack-portfolio`
- `/edit/example.wordpress.com/jetpack-portfolio/140`
- `/edit/2916284/jetpack-portfolio`
- `/edit/2916284/jetpack-portfolio/140`

(For patterns beginning with `/edit`, `jetpack-portfolio` can be substituted with the slug of any post type supported for the site)

__Testing instructions:__

Reference the handy route list above, ensuring that all existing paths continue to behave as expected, with or without the `manage/custom-post-types` flag enabled (Tip: Restart the Calypso process with `DISABLE_FEATURES=manage/custom-post-types make run`)

Verify that the post editor loads custom post types correctly, though do be aware that many labels and functionality (e.g. sidebar elements) are not yet updated to account for custom post types (related: #3702, #3697, #3695).

1. Navigate to [My Sites](http://calypso.localhost:3000/sites)
2. Select a site where a custom post type is available
3. Navigate to a custom post type item in the sidebar
4. Assuming a post exists for the custom post type, click the title of the post
5. Note that the editor loads with the title and content correctly populated