### PR TITLE
Framework: Break out section preloading to its own module.

### DIFF
--- a/client/components/site-stats-sticky-link/index.jsx
+++ b/client/components/site-stats-sticky-link/index.jsx
@@ -4,7 +4,7 @@ var React = require( 'react' );
 
 // Internal dependencies
 var siteStatsStickyTabStore = require( 'lib/site-stats-sticky-tab/store' );
-var sections = require( 'sections' );
+var sections = require( 'sections-preload' );
 
 var SiteStatsStickyLink = React.createClass( {
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -14,7 +14,7 @@ import Notifications from './notifications';
 import Gravatar from 'components/gravatar';
 import layoutFocus from 'lib/layout-focus';
 import config from 'config';
-import sections from 'sections';
+import { preload } from 'sections-preload';
 
 export default React.createClass( {
 	displayName: 'Masterbar',
@@ -67,7 +67,7 @@ export default React.createClass( {
 					onClick={ this.clickMySites }
 					isActive={ this.isActive( 'sites' ) }
 					tooltip={ this.translate( 'View a list of your sites and access their dashboards', { textOnly: true } ) }
-					preloadSection={ () => sections.preload( 'stats' ) }
+					preloadSection={ () => preload( 'stats' ) }
 				>
 					{ this.props.user.get().visible_site_count > 1
 						? this.translate( 'My Sites', { comment: 'Toolbar, must be shorter than ~12 chars' } )
@@ -80,7 +80,7 @@ export default React.createClass( {
 					onClick={ this.clickReader }
 					isActive={ this.isActive( 'reader' ) }
 					tooltip={ this.translate( 'Read the blogs and topics you follow', { textOnly: true } ) }
-					preloadSection={ () => sections.preload( 'reader' ) }
+					preloadSection={ () => preload( 'reader' ) }
 				>
 					{ this.translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 				</Item>
@@ -99,7 +99,7 @@ export default React.createClass( {
 					isActive={ this.isActive( 'me' ) }
 					className="masterbar__item-me"
 					tooltip={ this.translate( 'Update your profile, personal settings, and more', { textOnly: true } ) }
-					preloadSection={ () => sections.preload( 'me' ) }
+					preloadSection={ () => preload( 'me' ) }
 				>
 					<Gravatar user={ this.props.user.get() } alt="Me" size={ 18 } />
 					<span className="masterbar__item-me-label">

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -11,7 +11,7 @@ import MasterbarItem from './item';
 import SitesPopover from 'components/sites-popover';
 import paths from 'lib/paths';
 import viewport from 'lib/viewport';
-import sections from 'sections';
+import { preload } from 'sections-preload';
 
 export default React.createClass( {
 	displayName: 'MasterbarItemNew',
@@ -81,7 +81,7 @@ export default React.createClass( {
 				isActive={ this.props.isActive }
 				tooltip={ this.props.tooltip }
 				className={ classes }
-				preloadSection={ () => sections.preload( 'post-editor' ) }
+				preloadSection={ () => preload( 'post-editor' ) }
 			>
 				{ this.props.children }
 				<SitesPopover

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  */
 import { isExternal } from 'lib/url';
 import Gridicon from 'components/gridicon';
-import sections from 'sections';
+import { preload } from 'sections-preload';
 
 export default React.createClass( {
 	displayName: 'SidebarItem',
@@ -48,7 +48,7 @@ export default React.createClass( {
 	preload() {
 		if ( ! this._preloaded && this.props.preloadSectionName ) {
 			this._preloaded = true;
-			sections.preload( this.props.preloadSectionName );
+			preload( this.props.preloadSectionName );
 		}
 	},
 

--- a/client/sections-preload.js
+++ b/client/sections-preload.js
@@ -1,0 +1,8 @@
+import emitter from 'lib/mixins/emitter';
+
+export const hub = {};
+emitter( hub );
+
+export function preload( section ) {
+	hub.emit( 'preload', section );
+}

--- a/server/bundler/loader.js
+++ b/server/bundler/loader.js
@@ -13,7 +13,8 @@ function getSectionsModule( sections ) {
 			"\tReact = require( 'react' ),",
 			"\tLoadingError = require( 'layout/error' ),",
 			"\tclasses = require( 'component-classes' ),",
-			"\tcontroller = require( 'controller' );",
+			"\tcontroller = require( 'controller' ),",
+			"\preloadHub = require( 'sections-preload' ).hub;",
 			'\n',
 			'var _loadedSections = {};'
 		].join( '\n' );
@@ -31,17 +32,18 @@ function getSectionsModule( sections ) {
 
 	return [
 		dependencies,
+		'function preload( section ) {',
+		'	switch ( section ) {',
+		'	' + loadSection,
+		'	}',
+		'}',
+		'preloadHub.on( \'preload\', preload );',
 		'module.exports = {',
 		'	get: function() {',
 		'		return ' + JSON.stringify( sections ) + ';',
 		'	},',
 		'	load: function() {',
 		'		' + sectionLoaders,
-		'	},',
-		'	preload: function( section ) {',
-		'		switch ( section ) {',
-		'		' + loadSection,
-		'		}',
 		'	}',
 		'};'
 	].join( '\n' );


### PR DESCRIPTION
This breaks the dependency cycle present in the current code.

Currently we have a dependency cycle across webpack chunks. This is evident in the `make run` response, as each chunk lists their parents. Notice that currently, most chunks have many many parents. They should only really have one, the build-$env chunk.

This is happening because boot requires section, which requires all of the sub chunks. sub chunks then require section to preload other chunks. This makes them pull a dependency on the sub chunk, so that chunk is then seen as a parent of the requesting chunk. To make this more concrete:

bundle-dev -> section -> reader -> sidebar/item -> section -> stats

Bundle dev requires section which requires reader (through ensure) which requires sidebar/item, which requires section, which requires stats (through ensure).

To break the cycle, this patch introduces a new section-preload module which has no dependencies. It serves as a pubsub hub, dispatching preload messages to anyone who cares to listen. In this case, the only listener is the module output from the section.js loader (server/bundler/loader). This breaks the dependency cycle and lets parents seem normal again.

It also chops the build time down to 31s, from 90+ seconds.

## Testing
1. Spin up the app with `make run`
- Notice in the `make run` output that each chunk is only dependent on one other chunk, not all other chunks
- Notice the build only took ~35s
2. Pull up http://calypso.localhost:3000/
3. Hover over the stats button in the master bar. Notice stats gets preloaded
4. Hover over the profile button in the masterbar, notice /me gets preloaded
5. Hover over the editor icon, notice post-editor gets preloaded

Clicking on any section should then work instantly without hitting the network again for the chunk.