### PR TITLE
My Sites: Fixes ESLint issues in sidebar component

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -218,9 +218,7 @@ module.exports = React.createClass( {
 	plugins: function() {
 		var site = this.getSelectedSite(),
 			pluginsLink = '/plugins' + this.siteSuffix(),
-			addPluginsLink,
-			noticon,
-			target;
+			addPluginsLink;
 
 		if ( ! config.isEnabled( 'manage/plugins' ) ) {
 			if ( ! this.isSingle() ) {
@@ -230,9 +228,6 @@ module.exports = React.createClass( {
 			if ( site.options ) {
 				pluginsLink = site.options.admin_url + 'plugins.php';
 			}
-
-			target = '_blank';
-			noticon = <span className="noticon noticon-external" />;
 		}
 
 		if ( ! this.props.sites.canManageSelectedOrAll() ) {
@@ -387,9 +382,7 @@ module.exports = React.createClass( {
 	users: function() {
 		var site = this.getSelectedSite(),
 			usersLink = '/people/team' + this.siteSuffix(),
-			addPeopleLink = '/people/new' + this.siteSuffix(),
-			addPeopleTarget = null,
-			addPeopleButton;
+			addPeopleLink = '/people/new' + this.siteSuffix();
 
 		if ( ! site.capabilities ) {
 			return null;
@@ -411,7 +404,6 @@ module.exports = React.createClass( {
 			addPeopleLink = ( site.jetpack )
 				? site.options.admin_url + 'user-new.php'
 				: site.options.admin_url + 'users.php?page=wpcom-invite-users';
-			addPeopleTarget = '_blank';
 		}
 
 		return (


### PR DESCRIPTION
In #4071, while converting to SidebarItem, we inadvertently adding a few ESLint issues with variables that were declared but no longer used. This PR removes those issues.

To test:
- Checkout `update/my-sites-sidebar-eslint` branch
- Go to `/stats/$site`
- For a Jetpack site, do you see the plugins link?
  - Are you able to click the "Add" button?
- Do you see the people link?
  - Does the "Add" button show and does it work?
- Are there any JS errors?

cc @mtias for review.