### PR TITLE
TimezoneDropdown: get timezones from WP REST-API

### DIFF
--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -43,8 +43,7 @@ class SelectDropdown extends Component {
 		let initialState = { isOpen: false };
 
 		if ( props.options.length ) {
-			initialState.selected = this.props.initialSelected ||
-				props.options[ 0 ].value;
+			initialState.selected = this.getInitialSelectedItem( props );
 		}
 
 		this.state = initialState;
@@ -79,6 +78,20 @@ class SelectDropdown extends Component {
 				open: this.state.isOpen
 			} );
 		}
+	}
+
+	getInitialSelectedItem( props ) {
+		props = props || this.props;
+
+		if ( props.initialSelected ) {
+			return props.initialSelected;
+		}
+
+		if ( ! props.options.length ) {
+			return;
+		}
+
+		return props.options.find( value => ! value.isLabel ).value;
 	}
 
 	dropdownOptions() {

--- a/client/components/timezone-dropdown/README.md
+++ b/client/components/timezone-dropdown/README.md
@@ -13,7 +13,7 @@ module.exports = React.createClass( {
 	// ...
 	
 	onTimezoneSelect( zone ) {
-		console.log( `timezone selected: %s`, zone );
+		console.log( `timezone selected: %s`, zone.value );
 	},
 
 	render() {
@@ -32,5 +32,8 @@ module.exports = React.createClass( {
 #### Props
 
 `selectedZone` - **optional** String value to define the selected timezone.
-`onSelect` - **optional** Bound function executed when the timezone is
-selected.
+
+`onSelect` - **optional** Called when user selects a timezone from the
+dropdown. An object parameter is passed to the function which has two
+properties: `label` usually used to show the selected timezone to the user and
+`value` which is the normalized timezone value.

--- a/client/components/timezone-dropdown/docs/example.jsx
+++ b/client/components/timezone-dropdown/docs/example.jsx
@@ -18,13 +18,13 @@ export default React.createClass( {
 
 	getInitialState() {
 		return {
-			timezone: 'Asia/Tokyo'
+			timezone: 'Tokyo'
 		};
 	},
 
 	onTimezoneSelect( zone ) {
-		console.log( `timzone selected: %s`, zone );
-		this.setState( { timezone: zone } );
+		console.log( 'timezone selected: %o', zone.value );
+		this.setState( { timezone: zone.label } );
 	},
 
 	render() {

--- a/client/components/timezone-dropdown/docs/example.jsx
+++ b/client/components/timezone-dropdown/docs/example.jsx
@@ -34,7 +34,7 @@ export default React.createClass( {
 					<a href="/devdocs/design/timezone-dropdown">TimezoneDropdown</a>
 				</h2>
 
-				<Card style={ { width: '300px', margin: 0 } }>
+				<Card style={ { width: '300px', height: '350px', margin: 0 } }>
 					<TimezoneDropdown
 						selectedZone={ this.state.timezone }
 						onSelect={ this.onTimezoneSelect }

--- a/client/components/timezone-dropdown/index.jsx
+++ b/client/components/timezone-dropdown/index.jsx
@@ -3,7 +3,6 @@
  * External Dependencies
  */
 import React from 'react';
-import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
@@ -11,19 +10,16 @@ import noop from 'lodash/noop';
 import Dropdown from 'components/select-dropdown';
 import i18n from 'lib/mixins/i18n';
 
-export default React.createClass( {
-	displayName: 'TimezoneDropdown',
+const { Component, PropTypes } = React;
+const noop = () => {};
 
-	propTypes: {
-		selectedZone: React.PropTypes.string,
-		onSelect: React.PropTypes.func
-	},
+class TimezoneDropdown extends Component {
+	constructor() {
+		super();
 
-	getDefaultProps() {
-		return {
-			onSelect: noop
-		};
-	},
+		// bound methods
+		this.onSelect = this.onSelect.bind( this );
+	}
 
 	getTimezoneNames() {
 		return i18n.moment.tz.names().map( zone => {
@@ -32,21 +28,33 @@ export default React.createClass( {
 				value: zone
 			} );
 		} );
-	},
+	}
 
 	onSelect( zone ) {
 		this.setState( { selectedZone: zone.value } );
 		this.props.onSelect( zone.value );
-	},
+	}
 
 	render() {
 		return (
 			<Dropdown
 				className="timezone-dropdown"
+				valueLink={ this.props.valueLink }
 				options={ this.getTimezoneNames() }
 				selectedText={ this.props.selectedZone }
 				onSelect={ this.onSelect }
 			/>
 		);
-	},
-} );
+	}
+};
+
+TimezoneDropdown.defaultProps = {
+	onSelect: noop
+};
+
+TimezoneDropdown.propTypes = {
+	selectedZone: PropTypes.string,
+	onSelect: PropTypes.func
+}
+
+export default TimezoneDropdown;

--- a/client/components/timezone-dropdown/index.jsx
+++ b/client/components/timezone-dropdown/index.jsx
@@ -3,6 +3,7 @@
  * External Dependencies
  */
 import React from 'react';
+import i18n from 'lib/mixins/i18n';
 
 /**
  * Internal dependencies
@@ -47,6 +48,26 @@ class TimezoneDropdown extends Component {
 
 				timezones = timezones.concat( cities );
 			}
+
+			timezones = timezones.concat( [
+				{
+					label: 'UTC',
+					value: 'UTC',
+					isLabel: true
+				},
+				{
+					label: 'UTC',
+					value: 'UTC'
+				},
+				null
+			] );
+
+			timezones = timezones.concat( [
+				{
+					label: i18n.translate( 'Manual Offsets' ),
+					value: 'manual-offsets',
+					isLabel: true
+				} ], zones.manual_utc_offsets );
 
 			this.setState( { timezones } );
 		} );

--- a/client/components/timezone-dropdown/index.jsx
+++ b/client/components/timezone-dropdown/index.jsx
@@ -7,11 +7,15 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import wpcom from 'lib/wp';
 import Dropdown from 'components/select-dropdown';
-import i18n from 'lib/mixins/i18n';
 
+/**
+ * Module variables
+ */
 const { Component, PropTypes } = React;
 const noop = () => {};
+const undocumented = wpcom.undocumented();
 
 class TimezoneDropdown extends Component {
 	constructor() {
@@ -19,20 +23,37 @@ class TimezoneDropdown extends Component {
 
 		// bound methods
 		this.onSelect = this.onSelect.bind( this );
+
+		this.state = {
+			timezones: [ { label: '', value: '' } ]
+		};
 	}
 
-	getTimezoneNames() {
-		return i18n.moment.tz.names().map( zone => {
-			return ( {
-				label: zone,
-				value: zone
-			} );
+	componentWillMount() {
+		undocumented.timezones( ( err, zones ) => {
+			if ( err ) {
+				return;
+			}
+
+			let timezones = [];
+
+			for ( let continent in zones.timezones_by_continent ) {
+				let cities = zones.timezones_by_continent[ continent ];
+				cities = [ {
+					label: continent,
+					value: continent,
+					isLabel: true
+				} ].concat( cities, [ null ] );
+
+				timezones = timezones.concat( cities );
+			}
+
+			this.setState( { timezones } );
 		} );
 	}
 
 	onSelect( zone ) {
-		this.setState( { selectedZone: zone.value } );
-		this.props.onSelect( zone.value );
+		this.props.onSelect( zone );
 	}
 
 	render() {
@@ -40,7 +61,7 @@ class TimezoneDropdown extends Component {
 			<Dropdown
 				className="timezone-dropdown"
 				valueLink={ this.props.valueLink }
-				options={ this.getTimezoneNames() }
+				options={ this.state.timezones }
 				selectedText={ this.props.selectedZone }
 				onSelect={ this.onSelect }
 			/>

--- a/client/components/timezone-dropdown/style.scss
+++ b/client/components/timezone-dropdown/style.scss
@@ -1,3 +1,7 @@
+.select-dropdown__item-text {
+	padding-left: 30px;
+}
+
 .timezone-dropdown .select-dropdown__options {
 	max-height: 300px;
 	overflow-y: auto;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -972,7 +972,6 @@ Undocumented.prototype.updateCreditCard = function( params, fn ) {
 
 /**
  * GET paygate configuration
- *
  * @param {Function} fn The callback function
  * @api public
  */
@@ -1936,6 +1935,16 @@ Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
 		apiVersion: '1.1',
 		path: `/sites/${ siteId }/exports/${ exportId }`
 	}, fn );
+}
+
+Undocumented.prototype.timezones = function( params, fn ) {
+	if ( typeof params === 'function' ) {
+		fn = params;
+		params = {};
+	}
+
+	let query = Object.assign( {}, params, { apiNamespace: 'wp' } );
+	return this.wpcom.req.get( '/wpcom/v2/timezones', query, fn );
 }
 
 /**


### PR DESCRIPTION
In this PR the `TimezoneDropdown` is filled with the values gotten from `/timezones` endpoint.
I've removed timezone.js (moment.js) in favor to be consistent between WP.com and calypso.

In this way if the timezones defined in WP.com change the response of `/timezones` will change too keeping the same data structure.

Related issue: #3902

### Testing

1) Go to `TimezoneDropdown` component testing page and play switching the timezones. 
http://calypso.localhost:3000/devdocs/design/timezone-dropdown

2) Open the dev console. Everything should be ok.

![image](https://cloud.githubusercontent.com/assets/77539/13934340/6e626242-ef90-11e5-9799-25a2704b47a9.png)
1