### PR TITLE
SectionHeader: Add `href` prop in order to indicate clicakbility

### DIFF
--- a/client/components/section-header/docs/example.jsx
+++ b/client/components/section-header/docs/example.jsx
@@ -38,6 +38,11 @@ var Cards = React.createClass( {
 						{ this.translate( 'Add' ) }
 					</Button>
 				</SectionHeader>
+
+				<h2>Clickable SectionHeader</h2>
+
+				<SectionHeader label={ this.translate( 'Team' ) } count={ 10 } href="/devdocs/design/section-header">
+				</SectionHeader>
 			</div>
 		);
 	}

--- a/client/components/section-header/index.jsx
+++ b/client/components/section-header/index.jsx
@@ -16,6 +16,7 @@ export default React.createClass( {
 	getDefaultProps() {
 		return {
 			label: '',
+			href: null
 		};
 	},
 
@@ -26,7 +27,7 @@ export default React.createClass( {
 		);
 
 		return (
-			<CompactCard className={ classes }>
+			<CompactCard className={ classes } href={ this.props.href }>
 				<div className="section-header__label">
 					{ this.props.label }
 					{


### PR DESCRIPTION
This PR adds an `href` prop to the `SectionHeader` component. This prop is simply passed down as a `boolean` to the `CompactCard` that `SectionHeader` is wrapped around.

The result is a `SectionHeader` that renders exactly like a clickable `CompactCard` would:

<img width="627" alt="screen shot 2016-03-21 at 3 32 16 pm" src="https://cloud.githubusercontent.com/assets/1084656/13934902/24db53c4-ef7a-11e5-9b9e-8dd4c3b85281.png">

This will help these stats screens ( #2863 ) work as it appears they would (i.e., the entire bar will now be clickable, instead of just the arrow):

![untitled-1](https://cloud.githubusercontent.com/assets/1084656/13935226/db64ed0c-ef7b-11e5-8a06-22c1dfb5e83c.png)

cc @mtias @timmyc @designsimply