### PR TITLE
Framework: add a compact version of the progress bar

### DIFF
--- a/client/components/progress-bar/README.md
+++ b/client/components/progress-bar/README.md
@@ -26,4 +26,5 @@ render: function() {
 * `total`: a number representing the value corresponding to the 100% of the bar (optional, default == 100).
 * `color`: a string of a css color (optional).
 * `title`: a string for the title attribute (optional).
+* `compact`: If true, displays as a compact progress bar (optional).
 * `className`: You can add classes to either (optional).

--- a/client/components/progress-bar/docs/example.jsx
+++ b/client/components/progress-bar/docs/example.jsx
@@ -10,19 +10,33 @@ var React = require( 'react' ),
 var ProgressBar = require( 'components/progress-bar' );
 
 module.exports = React.createClass( {
+
 	displayName: 'ProgressBar',
 
 	mixins: [ PureRenderMixin ],
 
-	render: function() {
+	getInitialState() {
+		return {
+			compact: false
+		}
+	},
+
+	toggleCompact() {
+		this.setState( { compact: ! this.state.compact } );
+	},
+
+	render() {
+		const toggleText = this.state.compact ? 'Normal Bar' : 'Compact Bar';
+
 		return (
 			<div className="design-assets__group">
 				<h2>
 					<a href="/devdocs/design/progress-bar">Progress Bar</a>
+					<a className="design-assets__toggle button" onClick={ this.toggleCompact }>{ toggleText }</a>
 				</h2>
-				<ProgressBar value={ 0 } title="0% complete"/>
-				<ProgressBar value={ 55 } total={ 100 } />
-				<ProgressBar value={ 100 } color="#1BABDA" />
+				<ProgressBar value={ 0 } title="0% complete" compact={ this.state.compact } />
+				<ProgressBar value={ 55 } total={ 100 } compact={ this.state.compact } />
+				<ProgressBar value={ 100 } color="#1BABDA" compact={ this.state.compact } />
 			</div>
 		);
 	}

--- a/client/components/progress-bar/index.jsx
+++ b/client/components/progress-bar/index.jsx
@@ -8,8 +8,11 @@ module.exports = React.createClass( {
 
 	displayName: 'ProgressBar',
 
-	getDefaultProps: function() {
-		return { total: 100 };
+	getDefaultProps() {
+		return {
+			total: 100,
+			compact: false
+		};
 	},
 
 	propTypes: {
@@ -17,10 +20,11 @@ module.exports = React.createClass( {
 		total: React.PropTypes.number,
 		color: React.PropTypes.string,
 		title: React.PropTypes.string,
+		compact: React.PropTypes.bool,
 		className: React.PropTypes.string
 	},
 
-	renderBar: function() {
+	renderBar() {
 		var styles = { width: Math.ceil( this.props.value / this.props.total * 100 ) + '%' },
 			title = this.props.title
 				? <span className="screen-reader-text">{ this.props.title }</span>
@@ -33,9 +37,12 @@ module.exports = React.createClass( {
 		return <div className="progress-bar__progress" style={ styles } >{ title }</div>;
 	},
 
-	render: function() {
+	render() {
+		const classes = classnames( this.props.className, 'progress-bar', {
+			'is-compact': this.props.compact
+		} );
 		return (
-			<div className={ classnames( this.props.className, 'progress-bar' ) }>
+			<div className={ classes }>
 				{ this.renderBar() }
 			</div>
 		);

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -5,6 +5,10 @@
 	height: 9px;
 	background-color: lighten( $gray, 20% );
 	border-radius: 4.5px;
+
+	&.is-compact {
+		height: 4px;
+	}
 }
 
 .progress-bar__progress {


### PR DESCRIPTION
As requested in #4172 this PR adds an isCompact prop to the progress bar. When this is set to true, our progress bar is set to 4px rather than 9px, and should work much better in smaller spaces. 

## Testing

No visual changes, since this is not in use. Verify that http://calypso.localhost:3000/devdocs/design/progress-bar now shows the compact progress bar when you click on 'Compact Bar':

<img width="733" alt="full" src="https://cloud.githubusercontent.com/assets/1270189/13964765/9c2c33ea-f028-11e5-9ea7-0580e7231b85.png">

<img width="733" alt="compact" src="https://cloud.githubusercontent.com/assets/1270189/13964768/a03fde46-f028-11e5-9e8f-e72d2278ed44.png">


cc @mtias @adambbecker @rralian @aduth