### PR TITLE
Checkout: Thank You: Check for the domain credit when displaying message

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -1,32 +1,38 @@
 /**
  * External dependencies
  */
+import find from 'lodash/find';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
 import i18n from 'lib/mixins/i18n';
+import { isBusiness } from 'lib/products-values';
 import PurchaseDetail from 'components/purchase-detail';
 
-const BusinessPlanDetails = ( { selectedSite } ) => {
+const BusinessPlanDetails = ( { selectedSite, sitePlans } ) => {
+	const plan = find( sitePlans.data, isBusiness );
+
 	return (
 		<div>
-			<PurchaseDetail
-				icon="globe"
-				title={ i18n.translate( 'Get your custom domain' ) }
-				description={
-					i18n.translate(
-						"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
-						'A free domain is included with your plan.',
-						{
-							args: { siteDomain: selectedSite.domain },
-							components: { em: <em /> }
-						}
-					)
-				}
-				buttonText={ i18n.translate( 'Claim your free domain' ) }
-				href={ '/domains/add/' + selectedSite.slug } />
+			{ plan.hasDomainCredit && (
+				<PurchaseDetail
+					icon="globe"
+					title={ i18n.translate( 'Get your custom domain' ) }
+					description={
+						i18n.translate(
+							"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
+							'A free domain is included with your plan.',
+							{
+								args: { siteDomain: selectedSite.domain },
+								components: { em: <em /> }
+							}
+						)
+					}
+					buttonText={ i18n.translate( 'Claim your free domain' ) }
+					href={ '/domains/add/' + selectedSite.slug } />
+			) }
 
 			<PurchaseDetail
 				icon="customize"
@@ -49,7 +55,9 @@ BusinessPlanDetails.propTypes = {
 	selectedSite: React.PropTypes.oneOfType( [
 		React.PropTypes.bool,
 		React.PropTypes.object
-	] ).isRequired
+	] ).isRequired,
+	sitePlans: React.PropTypes.object.isRequired
+
 };
 
 export default BusinessPlanDetails;

--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import i18n from 'lib/mixins/i18n';
 import { isBusiness } from 'lib/products-values';
 import PurchaseDetail from 'components/purchase-detail';
@@ -16,23 +17,7 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans } ) => {
 
 	return (
 		<div>
-			{ plan.hasDomainCredit && (
-				<PurchaseDetail
-					icon="globe"
-					title={ i18n.translate( 'Get your custom domain' ) }
-					description={
-						i18n.translate(
-							"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
-							'A free domain is included with your plan.',
-							{
-								args: { siteDomain: selectedSite.domain },
-								components: { em: <em /> }
-							}
-						)
-					}
-					buttonText={ i18n.translate( 'Claim your free domain' ) }
-					href={ '/domains/add/' + selectedSite.slug } />
-			) }
+			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
 
 			<PurchaseDetail
 				icon="customize"

--- a/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import i18n from 'lib/mixins/i18n';
+import PurchaseDetail from 'components/purchase-detail';
+
+const CustomDomainPurchaseDetail = ( { selectedSite } ) => {
+	return (
+		<PurchaseDetail
+			icon="globe"
+			title={ i18n.translate( 'Get your custom domain' ) }
+			description={
+				i18n.translate(
+					"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
+					'A free domain is included with your plan.',
+					{
+						args: { siteDomain: selectedSite.domain },
+						components: { em: <em /> }
+					}
+				)
+			}
+			buttonText={ i18n.translate( 'Claim your free domain' ) }
+			href={ '/domains/add/' + selectedSite.slug } />
+	);
+};
+
+CustomDomainPurchaseDetail.propTypes = {
+	selectedSite: React.PropTypes.oneOfType( [
+		React.PropTypes.bool,
+		React.PropTypes.object
+	] ).isRequired
+};
+
+export default CustomDomainPurchaseDetail;

--- a/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
@@ -11,7 +11,6 @@ import React from 'react';
  */
 import { cartItems } from 'lib/cart-values';
 import { getABTestVariation } from 'lib/abtest';
-import { getPlansBySite } from 'state/sites/plans/selectors';
 import {
 	isBusiness,
 	isDomainMapping,
@@ -21,10 +20,8 @@ import {
 import paths from 'my-sites/plans/paths';
 import PurchaseDetail from 'components/purchase-detail';
 import {
-	fetchSitePlans,
 	refreshSitePlans
 } from 'state/sites/plans/actions';
-import { shouldFetchSitePlans } from 'lib/plans';
 import { startFreeTrial } from 'lib/upgrades/actions';
 import * as upgradesNotices from 'lib/upgrades/notices';
 
@@ -36,10 +33,6 @@ const FreeTrialNudge = React.createClass( {
 			React.PropTypes.object
 		] ).isRequired,
 		sitePlans: React.PropTypes.object.isRequired
-	},
-
-	componentWillMount() {
-		this.props.fetchSitePlans( this.props.sitePlans, this.props.selectedSite );
 	},
 
 	getInitialState() {
@@ -106,18 +99,9 @@ const FreeTrialNudge = React.createClass( {
 } );
 
 export default connect(
-	( state, props ) => {
-		return {
-			sitePlans: getPlansBySite( state, props.selectedSite )
-		};
-	},
+	undefined,
 	( dispatch ) => {
 		return {
-			fetchSitePlans( sitePlans, site ) {
-				if ( shouldFetchSitePlans( sitePlans, site ) ) {
-					dispatch( fetchSitePlans( site.ID ) );
-				}
-			},
 			refreshSitePlans: ( siteId ) => {
 				dispatch( refreshSitePlans( siteId ) );
 			}

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -17,11 +17,12 @@ import Card from 'components/card';
 import ChargebackDetails from './chargeback-details';
 import CheckoutThankYouFeaturesHeader from './features-header';
 import CheckoutThankYouHeader from './header';
-import Dispatcher from 'dispatcher';
 import DomainMappingDetails from './domain-mapping-details';
 import DomainRegistrationDetails from './domain-registration-details';
 import { fetchReceipt } from 'state/receipts/actions';
-import FreeTrialNudge from './free-trial-nudge'
+import { fetchSitePlans, refreshSitePlans } from 'state/sites/plans/actions';
+import FreeTrialNudge from './free-trial-nudge';
+import { getPlansBySite } from 'state/sites/plans/selectors';
 import { getReceiptById } from 'state/receipts/selectors';
 import GoogleAppsDetails from './google-apps-details';
 import HappinessSupport from 'components/happiness-support';
@@ -45,7 +46,7 @@ import Main from 'components/main';
 import plansPaths from 'my-sites/plans/paths';
 import PremiumPlanDetails from './premium-plan-details';
 import PurchaseDetail from 'components/purchase-detail';
-import { refreshSitePlans } from 'state/sites/plans/actions';
+import { shouldFetchSitePlans } from 'lib/plans';
 import SiteRedirectDetails from './site-redirect-details';
 import upgradesPaths from 'my-sites/upgrades/paths';
 
@@ -71,7 +72,10 @@ const CheckoutThankYou = React.createClass( {
 
 	componentDidMount() {
 		this.redirectIfThemePurchased();
-		this.refreshSitesAndSitePlansIfPlanPurchased();
+
+		if ( this.props.receipt.hasLoadedFromServer && this.hasPlanOrDomainRegistration() ) {
+			this.props.refreshSitePlans( this.props.selectedSite.ID );
+		}
 
 		if ( this.props.receiptId && ! this.props.receipt.hasLoadedFromServer && ! this.props.receipt.isRequesting ) {
 			this.props.fetchReceipt( this.props.receiptId );
@@ -82,30 +86,24 @@ const CheckoutThankYou = React.createClass( {
 		window.scrollTo( 0, 0 );
 	},
 
-	componentWillReceiveProps() {
+	componentWillReceiveProps( nextProps ) {
 		this.redirectIfThemePurchased();
-		this.refreshSitesAndSitePlansIfPlanPurchased();
-	},
 
-	hasPlanOrDomainRegistration() {
-		return getPurchases( this.props ).some( purchase => isPlan( purchase ) || isDomainRegistration( purchase ) );
-	},
-
-	refreshSitesAndSitePlansIfPlanPurchased() {
-		if ( this.props.receipt.hasLoadedFromServer && this.hasPlanOrDomainRegistration() ) {
-			// Refresh selected site plans if the user just purchased a plan
+		if ( ! this.props.receipt.hasLoadedFromServer && nextProps.receipt.hasLoadedFromServer && this.hasPlanOrDomainRegistration( nextProps ) ) {
 			this.props.refreshSitePlans( this.props.selectedSite.ID );
-
-			// Refresh the list of sites to update the `site.plan` property
-			// needed to display the plan name on the right of the `Plans` menu item
-			Dispatcher.handleViewAction( {
-				type: 'FETCH_SITES'
-			} );
 		}
 	},
 
+	hasPlanOrDomainRegistration( props = this.props ) {
+		return getPurchases( props ).some( purchase => isPlan( purchase ) || isDomainRegistration( purchase ) );
+	},
+
 	isDataLoaded() {
-		return this.isGenericReceipt() || this.props.receipt.hasLoadedFromServer;
+		if ( this.isGenericReceipt() ) {
+			return true;
+		}
+
+		return this.props.sitePlans.hasLoadedFromServer && this.props.receipt.hasLoadedFromServer;
 	},
 
 	isGenericReceipt() {
@@ -197,7 +195,7 @@ const CheckoutThankYou = React.createClass( {
 	},
 
 	productRelatedMessages() {
-		const { selectedSite } = this.props,
+		const { selectedSite, sitePlans } = this.props,
 			[ ComponentClass, primaryPurchase, domain ] = this.getComponentAndPrimaryPurchaseAndDomain();
 
 		if ( ! this.isDataLoaded() ) {
@@ -243,11 +241,13 @@ const CheckoutThankYou = React.createClass( {
 							domain={ domain }
 							purchases={ purchases }
 							registrarSupportUrl={ this.isGenericReceipt() ? null : primaryPurchase.registrarSupportUrl }
-							selectedSite={ selectedSite } />
+							selectedSite={ selectedSite }
+							sitePlans={ sitePlans } />
 
 						<FreeTrialNudge
 							purchases={ purchases }
-							selectedSite={ selectedSite } />
+							selectedSite={ selectedSite }
+							sitePlans={ sitePlans } />
 					</div>
 				) }
 			</div>
@@ -258,7 +258,8 @@ const CheckoutThankYou = React.createClass( {
 export default connect(
 	( state, props ) => {
 		return {
-			receipt: getReceiptById( state, props.receiptId )
+			receipt: getReceiptById( state, props.receiptId ),
+			sitePlans: getPlansBySite( state, props.selectedSite )
 		};
 	},
 	( dispatch ) => {
@@ -268,6 +269,11 @@ export default connect(
 			},
 			fetchReceipt: ( receiptId ) => {
 				dispatch( fetchReceipt( receiptId ) );
+			},
+			fetchSitePlans( sitePlans, site ) {
+				if ( shouldFetchSitePlans( sitePlans, site ) ) {
+					dispatch( fetchSitePlans( site.ID ) );
+				}
 			},
 			refreshSitePlans: ( siteId ) => {
 				dispatch( refreshSitePlans( siteId ) );

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import find from 'lodash/find';
 import React from 'react';
 
 /**
@@ -8,30 +9,34 @@ import React from 'react';
  */
 import config from 'config';
 import i18n from 'lib/mixins/i18n';
+import { isPremium } from 'lib/products-values';
 import paths from 'lib/paths';
 import PurchaseDetail from 'components/purchase-detail';
 
-const PremiumPlanDetails = ( { selectedSite } ) => {
+const PremiumPlanDetails = ( { selectedSite, sitePlans } ) => {
 	const adminUrl = selectedSite.URL + '/wp-admin/',
-		customizeLink = config.isEnabled( 'manage/customize' ) ? '/customize/' + selectedSite.slug : adminUrl + 'customize.php?return=' + encodeURIComponent( window.location.href );
+		customizeLink = config.isEnabled( 'manage/customize' ) ? '/customize/' + selectedSite.slug : adminUrl + 'customize.php?return=' + encodeURIComponent( window.location.href ),
+		plan = find( sitePlans.data, isPremium );
 
 	return (
 		<div>
-			<PurchaseDetail
-				icon="globe"
-				title={ i18n.translate( 'Get your custom domain' ) }
-				description={
-					i18n.translate(
-						"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
-						'A free domain is included with your plan.',
-						{
-							args: { siteDomain: selectedSite.domain },
-							components: { em: <em /> }
-						}
-					)
-				}
-				buttonText={ i18n.translate( 'Claim your free domain' ) }
-				href={ '/domains/add/' + selectedSite.slug } />
+			{ plan.hasDomainCredit && (
+				<PurchaseDetail
+					icon="globe"
+					title={ i18n.translate( 'Get your custom domain' ) }
+					description={
+						i18n.translate(
+							"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
+							'A free domain is included with your plan.',
+							{
+								args: { siteDomain: selectedSite.domain },
+								components: { em: <em /> }
+							}
+						)
+					}
+					buttonText={ i18n.translate( 'Claim your free domain' ) }
+					href={ '/domains/add/' + selectedSite.slug } />
+			) }
 
 			<PurchaseDetail
 				icon="customize"
@@ -66,7 +71,8 @@ PremiumPlanDetails.propTypes = {
 	selectedSite: React.PropTypes.oneOfType( [
 		React.PropTypes.bool,
 		React.PropTypes.object
-	] ).isRequired
+	] ).isRequired,
+	sitePlans: React.PropTypes.object.isRequired
 };
 
 export default PremiumPlanDetails;

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -8,6 +8,7 @@ import React from 'react';
  * Internal dependencies
  */
 import config from 'config';
+import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import i18n from 'lib/mixins/i18n';
 import { isPremium } from 'lib/products-values';
 import paths from 'lib/paths';
@@ -20,23 +21,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans } ) => {
 
 	return (
 		<div>
-			{ plan.hasDomainCredit && (
-				<PurchaseDetail
-					icon="globe"
-					title={ i18n.translate( 'Get your custom domain' ) }
-					description={
-						i18n.translate(
-							"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
-							'A free domain is included with your plan.',
-							{
-								args: { siteDomain: selectedSite.domain },
-								components: { em: <em /> }
-							}
-						)
-					}
-					buttonText={ i18n.translate( 'Claim your free domain' ) }
-					href={ '/domains/add/' + selectedSite.slug } />
-			) }
+			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
 
 			<PurchaseDetail
 				icon="customize"

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -13,6 +13,7 @@ const createSitePlanObject = ( plan ) => {
 		formattedDiscount: plan.formatted_discount,
 		formattedPrice: plan.formatted_price,
 		freeTrial: Boolean( plan.free_trial ),
+		hasDomainCredit: Boolean( plan.has_domain_credit ),
 		id: Number( plan.id ),
 		productName: plan.product_name,
 		productSlug: plan.product_slug,


### PR DESCRIPTION
Fixes #4040.

This PR updates the thank you page to hide this message when the user has already used their domain credit:

<img width="739" alt="screen shot 2016-03-15 at 10 28 58" src="https://cloud.githubusercontent.com/assets/275961/13775427/54722992-ea9c-11e5-88e3-23b72faf2d56.png">

**Testing**
*With the 'Get your custom domain' message*
- Visit `/plans/:site` for a site with no plan or domains.
- Add the premium or business plan to your cart.
- Complete the checkout process for the plan.
- Assert that the thank you page includes the 'Get your custom domain' message.

*Without the 'Get your custom domain' message*
- Visit `/domains/add/:site` for a site with no plan or domains.
- Add a domain to your cart.
- Purchase the domain.
- Visit `/plans/:site`.
- Add the premium or business plan to your cart.
- Complete the checkout process for the plan.
- Assert that the thank you page does not include the 'Get your custom domain' message.

- [x] Code review
- [x] Product review