### PR TITLE
Add/plugin panel shell

### DIFF
--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -1,0 +1,51 @@
+import React, { PropTypes } from 'react';
+
+import FoldableCard from 'components/foldable-card';
+import Gridicon from 'components/gridicon';
+
+import BusinessPlugin from './plugin-types/business-plugin';
+
+const defaultPlugins = [
+	{
+		name: 'Google Analytics',
+		supportLink: 'https://en.support.wordpress.com/google-analytics/',
+		plan: 'Business',
+		description: (
+			<div>
+				Advanced features to complement <a href="http://wordpress.com/">WordPress.com stats</a>.
+				Funnel reports, goal conversion, and more.
+			</div>
+		)
+	}
+];
+
+export const BusinessPluginsPanel = React.createClass( {
+	render() {
+		const { plugins: givenPlugins  = [] } = this.props;
+		const plugins = givenPlugins.length
+			? givenPlugins
+			: defaultPlugins;
+		const actionButton = <div><Gridicon icon="checkmark" /> Active</div>;
+
+		return (
+			<FoldableCard
+				actionButton={ actionButton }
+				actionButtonExpanded={ actionButton }
+				expanded={ true }
+				header="Premium Upgrades"
+			>
+				{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
+					<BusinessPlugin
+						{ ...{ name, key: name, supportLink, icon, plan, description } }
+					/>
+				) }
+			</FoldableCard>
+		);
+	}
+} );
+
+BusinessPluginsPanel.propTypes = {
+	plugins: PropTypes.array
+}
+
+export default BusinessPluginsPanel;

--- a/client/my-sites/plugins-wpcom/index.jsx
+++ b/client/my-sites/plugins-wpcom/index.jsx
@@ -1,0 +1,11 @@
+import React, { PropTypes } from 'react';
+
+import PluginPanel from 'my-sites/plugins-wpcom/plugin-panel';
+
+export const WpcomPluginsPanel = React.createClass( {
+	render() {
+		return <PluginPanel />;
+	}
+} );
+
+export default WpcomPluginsPanel;

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import Card from 'components/card';
+
+export const InfoHeader = React.createClass( {
+	render() {
+		return (
+			<Card>
+				<div>
+					Uploading and installing your own plugins is not
+					available on WordPress.com, but we offer the most
+					essential ones below.
+					<a
+						href="https://en.support.wordpress.com/plugins/"
+						target="_blank"
+					>
+						Learn more
+					</a>.
+				</div>
+			</Card>
+		);
+	}
+} );
+
+export default InfoHeader;

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import InfoHeader from './info-header';
+import StandardPluginsPanel from './standard-plugins-panel';
+import PremiumPluginsPanel from './premium-plugins-panel';
+import BusinessPluginsPanel from './business-plugins-panel';
+
+export const PluginPanel = React.createClass( {
+	render() {
+		return (
+			<div className="pluginPanel">
+				<InfoHeader />
+				<StandardPluginsPanel />
+				<PremiumPluginsPanel />
+				<BusinessPluginsPanel />
+			</div>
+		);
+	}
+} );
+
+export default PluginPanel;

--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -1,0 +1,41 @@
+import React, { PropTypes } from 'react';
+
+import Gridicon from 'components/gridicon';
+
+export const BusinessPlugin = React.createClass( {
+	render() {
+		const {
+			description,
+			icon = 'plugins',
+			name,
+			plan,
+			supportLink
+		} = this.props;
+
+		return (
+			<div>
+				<div>
+					<Gridicon { ...{ icon } } />
+					<a href={ supportLink } target="_blank">{ name }</a>
+					<div>{ plan }</div>
+				</div>
+				<div>
+					{ description }
+				</div>
+			</div>
+		);
+	}
+} );
+
+BusinessPlugin.propTypes = {
+	name: PropTypes.string.isRequired,
+	supportLink: PropTypes.string.isRequired,
+	icon: PropTypes.string,
+	plan: PropTypes.string.isRequired,
+	description: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.element
+	] ).isRequired
+};
+
+export default BusinessPlugin;

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -1,0 +1,38 @@
+import React, { PropTypes } from 'react';
+
+import Gridicon from 'components/gridicon';
+
+export const PremiumPlugin = React.createClass( {
+	render() {
+		const {
+			description,
+			icon = 'plugins',
+			name,
+			plan,
+			supportLink
+		} = this.props;
+
+		return (
+			<div>
+				<div>
+					<Gridicon { ...{ icon } } />
+					<a href={ supportLink } target="_blank">{ name }</a>
+					<div>{ plan }</div>
+				</div>
+				<div>
+					{ description }
+				</div>
+			</div>
+		);
+	}
+} );
+
+PremiumPlugin.propTypes = {
+	name: PropTypes.string.isRequired,
+	supportLink: PropTypes.string.isRequired,
+	icon: PropTypes.string,
+	plan: PropTypes.string.isRequired,
+	description: PropTypes.string.isRequired
+};
+
+export default PremiumPlugin;

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -1,0 +1,38 @@
+import React, { PropTypes } from 'react';
+
+import Gridicon from 'components/gridicon';
+
+export const StandardPlugin = React.createClass( {
+	render() {
+		const {
+			category,
+			description,
+			icon = 'plugins',
+			name,
+			supportLink
+		} = this.props;
+
+		return (
+			<div>
+				<div>
+					<Gridicon { ...{ icon } } />
+					<a href={ supportLink } target="_blank">{ name }</a>
+					<div>{ category }</div>
+				</div>
+				<div>
+					{ description }
+				</div>
+			</div>
+		);
+	}
+} );
+
+StandardPlugin.propTypes = {
+	category: PropTypes.string.isRequired,
+	description: PropTypes.string.isRequired,
+	icon: PropTypes.string,
+	name: PropTypes.string.isRequired,
+	supportLink: PropTypes.string.isRequired
+};
+
+export default StandardPlugin;

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -1,0 +1,58 @@
+import React, { PropTypes } from 'react';
+
+import FoldableCard from 'components/foldable-card';
+import Gridicon from 'components/gridicon';
+
+import PremiumPlugin from './plugin-types/premium-plugin';
+
+const defaultPlugins = [
+	{
+		name: 'No Advertising',
+		supportLink: 'https://en.support.wordpress.com/no-ads/',
+		plan: 'Premium',
+		description: 'Remove all ads from your site.'
+	},
+	{
+		name: 'Custom Design',
+		supportLink: 'https://en.support.wordpress.com/custom-design/',
+		plan: 'Premium',
+		description: 'With Customize you can personalize your blog\'s look and feel with intelligent color tools, custom fonts, and a CSS editor.'
+	},
+	{
+		name: 'Video Uploads',
+		supportLink: 'https://en.support.wordpress.com/videopress/',
+		plan: 'Premium',
+		description: 'Upload and host your video files on your site with VideoPress.'
+	}
+];
+
+export const PremiumPluginsPanel = React.createClass( {
+	render() {
+		const { plugins: givenPlugins  = [] } = this.props;
+		const plugins = givenPlugins.length
+			? givenPlugins
+			: defaultPlugins;
+		const actionButton = <div><Gridicon icon="checkmark" /> Active</div>;
+
+		return (
+			<FoldableCard
+				actionButton={ actionButton }
+				actionButtonExpanded={ actionButton }
+				expanded={ true }
+				header="Premium Upgrades"
+			>
+				{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
+					<PremiumPlugin
+						{ ...{ name, key: name, supportLink, icon, plan, description } }
+					/>
+				) }
+			</FoldableCard>
+		);
+	}
+} );
+
+PremiumPluginsPanel.propTypes = {
+	plugins: PropTypes.array
+}
+
+export default PremiumPluginsPanel;

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -1,0 +1,85 @@
+import React, { PropTypes } from 'react';
+
+import FoldableCard from 'components/foldable-card';
+import Gridicon from 'components/gridicon';
+
+import StandardPlugin from './plugin-types/standard-plugin';
+
+const defaultPlugins = [
+	{
+		name: 'WordPress.com Stats',
+		supportLink: 'http://support.wordpress.com/stats/',
+		category: 'Traffic Growth',
+		description: 'View your site\'s visits, referrers, and more.'
+	},
+	{
+		name: 'Essential SEO',
+		supportLink: 'http://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/',
+		category: 'Traffic Growth',
+		description: 'Search engine optimization and sitemaps.'
+	},
+	{
+		name: 'Security Scanning',
+		supportLink: 'http://support.wordpress.com/security/',
+		category: 'Performance',
+		description: 'Constant monitoring of your site for threats.'
+	},
+	{
+		name: 'Advanced Galleries',
+		supportLink: 'http://support.wordpress.com/images/gallery/',
+		category: 'Appearance',
+		description: 'Tiled, mosaic, slideshows, and more.'
+	},
+	{
+		name: 'Social Media Sharing',
+		supportLink: 'http://support.wordpress.com/sharing/',
+		category: 'Traffic Growth',
+		description: 'Add share buttons to your posts and pages.'
+	},
+	{
+		name: 'Contact Form Builder',
+		supportLink: 'http://support.wordpress.com/contact-form/',
+		category: 'Appearance',
+		description: 'Build contact forms so visitors can get in touch.'
+	},
+	{
+		name: 'Extended Customizer',
+		supportLink: 'https://en.support.wordpress.com/customizer/',
+		category: 'Appearance',
+		description: 'Edit colors and backgrounds.'
+	}
+];
+
+export const StandardPluginsPanel = React.createClass( {
+	render() {
+		const { plugins: givenPlugins  = [] } = this.props;
+		const plugins = givenPlugins.length
+			? givenPlugins
+			: defaultPlugins;
+		const actionButton = <div><Gridicon icon="checkmark" /> Active</div>;
+
+		return (
+			<FoldableCard
+				actionButton={ actionButton }
+				actionButtonExpanded={ actionButton }
+				expanded={ true }
+				header="Standard Plugin Suite"
+			>
+				{ plugins.map( ( { name, supportLink, icon, category, description } ) =>
+					<StandardPlugin
+						{ ...{ name, key: name, supportLink, icon, category, description } }
+					/>
+				) }
+				<div>
+					<Gridicon icon="plus" />View all standard plugins
+				</div>
+			</FoldableCard>
+		);
+	}
+} );
+
+StandardPluginsPanel.propTypes = {
+	plugins: PropTypes.array
+}
+
+export default StandardPluginsPanel;

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -6,6 +6,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import debugModule from 'debug';
 import classNames from 'classnames';
+import getOr from 'lodash/get';
 import some from 'lodash/some';
 import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
@@ -13,6 +14,7 @@ import isEmpty from 'lodash/isEmpty';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import pluginsAccessControl from 'my-sites/plugins/access-control';
@@ -31,6 +33,8 @@ import WporgPluginsSelectors from 'state/plugins/wporg/selectors';
 import FeatureExample from 'components/feature-example';
 import PluginsList from './plugins-list';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+
+import WpcomPluginPanel from 'my-sites/plugins-wpcom';
 
 /**
  * Module variables
@@ -320,6 +324,15 @@ const PluginsMain = React.createClass( {
 
 	render() {
 		const selectedSite = this.props.sites.getSelectedSite();
+
+		if ( config.isEnabled( 'manage/plugins/wpcom' ) && ! getOr( selectedSite, 'jetpack', true ) ) {
+			return (
+				<Main>
+					<SidebarNavigation />
+					<WpcomPluginPanel />
+				</Main>
+			);
+		}
 
 		if ( this.state.accessError ) {
 			return (

--- a/config/development.json
+++ b/config/development.json
@@ -62,6 +62,7 @@
 		"manage/plugins/cache": false,
 		"manage/plugins/compatibility-warning": false,
 		"manage/plugins/setup": true,
+		"manage/plugins/wpcom": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/sharing": true,


### PR DESCRIPTION
See #3840 

Pulls in a visual shell of the new WordPress.com plugins page. This isn't yet hiding behind a feature flag and is accessible directly via the URL or by navigating to the plugins page for a Jetpack site and then switching to a WordPress.com site.

<a href="calypso.localhost:3000/plugins/wordbacon.wordpress.com">calypso.localhost:3000/plugins/wordbacon.wordpress.com</a>

<img width="984" alt="screen shot 2016-03-21 at 4 19 27 pm" src="https://cloud.githubusercontent.com/assets/5431237/13937290/0bbfa334-ef81-11e5-93da-cf3e02d9f95f.png">

We can start to pick out which existing components we can use to build the UI and start creating some styling properties with this PR.

**Needed before merging**
 - [x] Hidden behind a feature-flag so we can prevent it from deploying to production
 - [ ] Can navigate to this spot when a WordPress.com site is selected in **My Sites**

**Testing**

Navigate to the plugins page on **My Sites**, you should see some plain text.

cc: @drw158 @roundhill 