### PR TITLE
Upgrades: create reusable nudge component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -262,6 +262,7 @@
 @import 'my-sites/themes/current-theme/style';
 @import 'my-sites/themes/style';
 @import 'my-sites/themes/themes-search-card/style';
+@import 'my-sites/upgrade-nudge/style';
 @import 'my-sites/upgrades/cart/style';
 @import 'my-sites/upgrades/checkout/stored-card';
 @import 'my-sites/upgrades/checkout/style';

--- a/client/devdocs/design/app-components.jsx
+++ b/client/devdocs/design/app-components.jsx
@@ -23,6 +23,7 @@ import Collection from 'devdocs/design/search-collection';
 import HappinessSupport from 'components/happiness-support/docs/example';
 import ThemesListExample from 'components/themes-list/docs/example';
 import PlanStorage from 'my-sites/plan-storage/docs/example';
+import UpgradeNudge from 'my-sites/upgrade-nudge/docs/example';
 
 export default React.createClass( {
 
@@ -67,6 +68,7 @@ export default React.createClass( {
 					<SitesDropdown />
 					<Theme />
 					<ThemesListExample />
+					<UpgradeNudge />
 				</Collection>
 			</div>
 		);

--- a/client/my-sites/upgrade-nudge/docs/example.jsx
+++ b/client/my-sites/upgrade-nudge/docs/example.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import UpgradeNudge from 'my-sites/upgrade-nudge';
+
+export default React.createClass( {
+
+	displayName: 'UpgradeNudge',
+
+	render: function() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/app-components/sites-dropdown">Upgrade Nudges</a>
+				</h2>
+				<div>
+					<UpgradeNudge />
+				</div>
+				<div>
+					<UpgradeNudge
+						title="This is a title"
+						message="This is a custom message"
+						icon="customize"
+					/>
+				</div>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+import analytics from 'analytics';
+import sitesList from 'lib/sites-list';
+
+const sites = sitesList();
+
+export default React.createClass( {
+
+	displayName: 'UpgradeNudge',
+
+	propTypes: {
+		onClick: React.PropTypes.func,
+		className: React.PropTypes.string,
+		message: React.PropTypes.string,
+		icon: React.PropTypes.string,
+		event: React.PropTypes.string,
+		href: React.PropTypes.string,
+		jetpack: React.PropTypes.bool
+	},
+
+	getDefaultProps() {
+		return {
+			onClick: noop,
+			message: 'And get your own domain address.',
+			icon: 'star',
+			event: null,
+			jetpack: false
+		}
+	},
+
+	handleClick() {
+		if ( this.props.event ) {
+			analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
+				cta_name: this.props.event
+			} );
+		}
+		this.props.onClick();
+	},
+
+	render() {
+		const classes = classNames( this.props.className, 'upgrade-nudge' );
+		const site = sites.getSelectedSite();
+		let href = this.props.href;
+
+		if ( site && site.plan && site.plan.product_name_short !== 'Free' ) {
+			return null;
+		}
+
+		if ( ! this.props.jetpack && site.jetpack || this.props.jetpack && ! site.jetpack ) {
+			return null;
+		}
+
+		if ( ! this.props.href && site ) {
+			href = '/plans/' + site.slug;
+		}
+
+		return (
+			<Button className={ classes } onClick={ this.handleClick } href={ href }>
+				<div className="upgrade-nudge__info">
+					<span className="upgrade-nudge__title">
+						{ this.props.title || this.translate( 'Upgrade to Premium' ) }
+					</span>
+					<span className="upgrade-nudge__message" >
+						{ this.props.message }
+					</span>
+				</div>
+				<Gridicon icon={ this.props.icon } />
+			</Button>
+		);
+	}
+} );

--- a/client/my-sites/upgrade-nudge/style.scss
+++ b/client/my-sites/upgrade-nudge/style.scss
@@ -1,0 +1,20 @@
+.upgrade-nudge.button {
+	margin-bottom: 16px;
+	text-align: left;
+	display: inline-flex;
+
+	.gridicon {
+		background: $alert-green;
+		border-radius: 50%;
+		margin-left: 32px;
+		color: $white;
+		padding: 6px;
+		align-self: center;
+	}
+}
+
+.upgrade-nudge__message {
+	color: $gray;
+	font-size: 12px;
+	display: block;
+}


### PR DESCRIPTION
This component seeks to standardize how we display plans offerings to users. It can be customized to any need. By default it looks like:

![image](https://cloud.githubusercontent.com/assets/548849/13948487/a2421392-f020-11e5-948c-b054b563b2f1.png)

This is an example variation:

```
<UpgradeNudge
	title="Upgrade to a Jetpack Plan"
	message="Get automatic site backups and security"
	event="site_settings_jetpack"
	icon="cloud"
	jetpack={ true }
/>
```

![image](https://cloud.githubusercontent.com/assets/548849/13948570/05736646-f021-11e5-89d9-91404787d291.png)