### PR TITLE
LayoutLoggedOut: Set has-no-sidebar class

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -22,7 +22,7 @@ const LayoutLoggedOut = ( {
 		[ 'is-group-' + section.group ]: !! section,
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
-		'has-no-sidebar': ! section.secondary
+		'has-no-sidebar': true // Logged-out never has a sidebar
 	} );
 
 	return (


### PR DESCRIPTION
Commit a069a33 set this class depending on `section.secondary`. However, this is
`true` for `/design` (since when logged-in, we want it to display the sidebar).
This commit overrides that setting again, since when logged-out, we always want
to hide the sidebar.

/cc @seear @lamosty