### PR TITLE
Documentation: Update documentation paragraphs related to unit tests

### DIFF
--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -97,7 +97,7 @@ client/state/
 
 For example, the reducer responsible for maintaining the `state.sites` key within the global state can be found in `client/state/sites/reducer.js`. It's quite common that the subject reducer is itself a combined reducer. Just as it helps to split the global state into subdirectories responsible for their own part of the tree, as a subject grows, you may find that it's easier to maintain pieces as nested subdirectories. This ease of composability is one of Redux's strengths.
 
-For your tests to be included in the Redux state test runner, you must require them in `client/state/test/index.js`. Note that each `describe` block in this file should mirror the folder structure of state. If you're only interested in running tests for a single subtree of the global state, suffix the `make test` command with a dash followed by the name of the subtree. For example, to run the sites subtree tests, I would enter `make test-sites` in my Terminal.
+For your tests to be included in the Redux state test runner, you must (temporary) require them in `client/tests.json`. (TODO: Add reference to single runner). If you're only interested in running tests for a single subtree of the global state, use grep option in the `npm run test-client`. For example, to run the sites subtree tests, I would enter `npm run test-client -- --grep "sites"` in my Terminal.
 
 ### Actions
 

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -97,7 +97,7 @@ client/state/
 
 For example, the reducer responsible for maintaining the `state.sites` key within the global state can be found in `client/state/sites/reducer.js`. It's quite common that the subject reducer is itself a combined reducer. Just as it helps to split the global state into subdirectories responsible for their own part of the tree, as a subject grows, you may find that it's easier to maintain pieces as nested subdirectories. This ease of composability is one of Redux's strengths.
 
-For your tests to be included in the Redux state test runner, you must (temporary) require them in `client/tests.json` ([learn how to do it](https://github.com/Automattic/wp-calypso/tree/master/test#extending-testsjson)). If you're only interested in running tests for a single subtree of the global state, use grep option in the `npm run test-client`. For example, to run the sites subtree tests, I would enter `npm run test-client -- --grep "sites"` in my Terminal.
+For your tests to be included in the Redux state test runner, you must add them to `client/tests.json`. [The tests documentation](https://github.com/Automattic/wp-calypso/tree/master/test) includes information about how to include tests in the test runner, and instructions for running a single test file.
 
 ### Actions
 

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -97,7 +97,7 @@ client/state/
 
 For example, the reducer responsible for maintaining the `state.sites` key within the global state can be found in `client/state/sites/reducer.js`. It's quite common that the subject reducer is itself a combined reducer. Just as it helps to split the global state into subdirectories responsible for their own part of the tree, as a subject grows, you may find that it's easier to maintain pieces as nested subdirectories. This ease of composability is one of Redux's strengths.
 
-For your tests to be included in the Redux state test runner, you must (temporary) require them in `client/tests.json`. (TODO: Add reference to single runner). If you're only interested in running tests for a single subtree of the global state, use grep option in the `npm run test-client`. For example, to run the sites subtree tests, I would enter `npm run test-client -- --grep "sites"` in my Terminal.
+For your tests to be included in the Redux state test runner, you must (temporary) require them in `client/tests.json` ([learn how to do it](https://github.com/Automattic/wp-calypso/tree/master/test#extending-testsjson)). If you're only interested in running tests for a single subtree of the global state, use grep option in the `npm run test-client`. For example, to run the sites subtree tests, I would enter `npm run test-client -- --grep "sites"` in my Terminal.
 
 ### Actions
 

--- a/docs/react-component-unit-testing.md
+++ b/docs/react-component-unit-testing.md
@@ -4,17 +4,14 @@ Calypso has a lot of React UI components. (Try for example running `find -name *
 
 ## [Getting started](#getting-started)
 
-To run all current tests, run `make test` in the root source folder. You can also run individual tests by TODO: figure out how.
-
-An easy way to find existing tests, to see how they were done or otherwise, is to run TODO: figure out how to search. Searching the Calypso Github repository also works.
+To run all current tests, run `npm test` in the root source folder. You can also run individual tests. Check [How to run single test runner](https://github.com/Automattic/wp-calypso/blob/master/test/README.md#how-to-run-single-test-runner) documentation for more details.
 
 Going through the current tests is a good way to get ideas for how different kinds of things can be tested.
 
 ### [Set up a test environment](#setting-up-environment)
 
-TODO: Add reference to single runner.
-
-...
+It's highly possible that your tests will require to have DOM environment configured to work properly. We provide test helper that does all work for you.
+Check [Use fake DOM](https://github.com/Automattic/wp-calypso/tree/master/test/test/helpers/use-fake-dom) helper documentation to learn how to simulate DOM existence.
 
 ### [What to test?](#what-to-test)
 

--- a/docs/react-component-unit-testing.md
+++ b/docs/react-component-unit-testing.md
@@ -4,27 +4,17 @@ Calypso has a lot of React UI components. (Try for example running `find -name *
 
 ## [Getting started](#getting-started)
 
-To run all current tests, run `make test` in the root source folder. You can also run individual tests by going into their folder and running `make test` there.
+To run all current tests, run `make test` in the root source folder. You can also run individual tests by TODO: figure out how.
 
-An easy way to find existing tests, to see how they were done or otherwise, is to run `find -name Makefile` under the folder from which you want to find the tests. This works because Makefiles are almost exclusively used for setting up a test environment for a folder. Searching the Calypso Github repository also works.
+An easy way to find existing tests, to see how they were done or otherwise, is to run TODO: figure out how to search. Searching the Calypso Github repository also works.
 
 Going through the current tests is a good way to get ideas for how different kinds of things can be tested.
 
 ### [Set up a test environment](#setting-up-environment)
-Tests are currently set up using Makefiles. If the component you're testing uses jsx syntax (which a lot of the React code uses, read more about it [here](https://facebook.github.io/react/docs/jsx-in-depth.html)) and hence is named .jsx, the --compilers flag with the jsx:jsx-require-extension option is needed. Otherwise you should leave it out.
-```
-REPORTER ?= spec
-MOCHA ?= ../../../node_modules/.bin/mocha
 
-test:
-     @NODE_ENV=test NODE_PATH=test:../../ $(MOCHA) --compilers jsx:babel/register --reporter $(REPORTER)
+TODO: Add reference to single runner.
 
-.PHONY: test
-```
-
-
-Put this next to your component in a file named Makefile. Then make a test folder next to it and place your tests there. Now your tests should be runnable both from your component's folder and from all folders above it.
-
+...
 
 ### [What to test?](#what-to-test)
 

--- a/docs/react-component-unit-testing.md
+++ b/docs/react-component-unit-testing.md
@@ -10,8 +10,8 @@ Going through the current tests is a good way to get ideas for how different kin
 
 ### [Set up a test environment](#setting-up-environment)
 
-It's highly possible that your tests will require to have DOM environment configured to work properly. We provide test helper that does all work for you.
-Check [Use fake DOM](https://github.com/Automattic/wp-calypso/tree/master/test/test/helpers/use-fake-dom) helper documentation to learn how to simulate DOM existence.
+It's very possible that your tests will assume the existence of a browser environment to work properly.
+Refer to the [Use fake DOM](https://github.com/Automattic/wp-calypso/tree/master/test/test/helpers/use-fake-dom) test helper documentation to learn how to configure an emulated DOM for your test.
 
 ### [What to test?](#what-to-test)
 

--- a/test/README.md
+++ b/test/README.md
@@ -42,7 +42,7 @@ state
 
 ### How to run single test runner
 
-You can run all tests from root folder with `npm test` command.
+You can run all tests from the root folder using the `npm test` command.
 
 We provide three single test runners because of different node path rules applied. They contain files located in:
 * `client/` folder

--- a/test/README.md
+++ b/test/README.md
@@ -42,11 +42,14 @@ state
 
 ### How to run single test runner
 
-We provide two single test runners because of different node path rules applied. They contain files located in:
+You can run all tests with `npm test`.
+
+We provide three single test runners because of different node path rules applied. They contain files located in:
 * `client/` folder
 * `server/` folder
+* `test/` folder
 
-We have an `npm run` script for each: `npm run test-client` and `npm run test-server`. You can pass a filename or set of files to these scripts to isolate your test run to just your set of files.
+We have an `npm run` script for each: `npm run test-client`, `npm run test-server` and `npm run test-tests`. You can pass a filename or set of files to these scripts to isolate your test run to just your set of files.
 
 Example for client:
 
@@ -57,6 +60,10 @@ Example for client:
 > npm run test-client -- --reporter=dot #notice the -- separating out the params to pass to the runner
 > # runner knows about Mocha --grep flag
 > npm run test-client -- --grep "state ui" # to just run the state/ui tests
+> # run single test suite from server folder
+> npm run test-server server/config/test/parser.js
+> # run single test suite from test folder
+> npm run test-tests test/helpers/use-nock/test/index.js
 ```
 
 ### How to run specified suite or test-case

--- a/test/README.md
+++ b/test/README.md
@@ -42,14 +42,14 @@ state
 
 ### How to run single test runner
 
-You can run all tests with `npm test`.
+You can run all tests from root folder with `npm test` command.
 
 We provide three single test runners because of different node path rules applied. They contain files located in:
 * `client/` folder
 * `server/` folder
 * `test/` folder
 
-We have an `npm run` script for each: `npm run test-client`, `npm run test-server` and `npm run test-tests`. You can pass a filename or set of files to these scripts to isolate your test run to just your set of files.
+We have an `npm run` script for each of them: `npm run test-client`, `npm run test-server` and `npm run test-tests`. You can pass a filename or set of files to these scripts to isolate your test run to just your set of files.
 
 Example for client:
 


### PR DESCRIPTION
I updated our documentation to reflect our latest changes. I only touched parts directly related to our new single test runner. I'm sure we should spend more time in the near future refactoring React component unit testing document and rewrite it to promote `Enzyme`. We should also take another iteration on all documents once we drop `tests.json` files.

We should also migrate [this wiki page](https://github.com/Automattic/wp-calypso/wiki/Writing-and-Running-Tests) to docs folder and make it up to date :)