### PR TITLE
i18n: Higher-order component for passing translate as prop

### DIFF
--- a/client/lib/mixins/i18n/index.js
+++ b/client/lib/mixins/i18n/index.js
@@ -409,7 +409,8 @@ exportMethods = {
 	setLocale: setLocale,
 	reRenderTranslations: reRenderTranslations,
 	setLocaleSlug: setLocaleSlug,
-	getLocaleSlug: getLocaleSlug
+	getLocaleSlug: getLocaleSlug,
+	i18nState: i18nState
 };
 
 // If added as a standalone object, propagate change event

--- a/client/lib/mixins/i18n/localize/README.md
+++ b/client/lib/mixins/i18n/localize/README.md
@@ -1,0 +1,40 @@
+Localize
+========
+
+`localize` is a higher-order component which, when invoked as a function with a component, returns a new component class. The new component wraps the original component, passing all original props plus props to assist in localization (`translate`, `moment`, and `numberFormat`). The advantage of using a higher-order component instead of calling translate directly from the `lib/i18n/mixins` module is that the latter does not properly account for change events which may be emitted by the state emitter object.
+
+It should act as a substitute to the existing i18n mixin which provides the `this.translate`, `this.moment`, and `this.numberFormat` functions. Notably, the higher-order component can be used for components which do not support mixins, including those inheriting the `Component` class or stateless function components.
+
+## Usage
+
+Typically, you'd wrap your exported function with `localize`:
+
+```jsx
+// greeting.jsx
+import React from 'react';
+import localize from 'lib/mixins/i18n/localize';
+
+function Greeting( { translate, className } ) {
+	return (
+		<h1 className={ className }>
+			{ translate( 'Hello!' ) }
+		</h1>
+	);
+}
+
+export default localize( Greeting );
+```
+
+When the wrapped component is rendered, the render behavior of the original component is used, but with access to localization props.
+
+```jsx
+// index.jsx
+import React from 'react';
+import { render } from 'react-dom';
+import Greeting from './greeting';
+
+render(
+	<Greeting className="greeting" />,
+	document.body
+);
+```

--- a/client/lib/mixins/i18n/localize/index.jsx
+++ b/client/lib/mixins/i18n/localize/index.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { i18nState, moment, numberFormat, translate } from '../';
+
+export default function localize( ComposedComponent ) {
+	class LocalizedComponent extends Component {
+		constructor() {
+			super( ...arguments );
+			this.boundForceUpdate = this.forceUpdate.bind( this );
+		}
+
+		componentDidMount() {
+			i18nState.on( 'change', this.boundForceUpdate );
+		}
+
+		componentWillUnmount() {
+			i18nState.off( 'change', this.boundForceUpdate );
+		}
+
+		render() {
+			return (
+				<ComposedComponent
+					{ ...this.props }
+					{ ...{ moment, numberFormat, translate } } />
+			);
+		}
+	};
+
+	const componentName = ComposedComponent.displayName || ComposedComponent.name || '';
+	LocalizedComponent.displayName = `Localized${ componentName }`;
+
+	return LocalizedComponent;
+};

--- a/client/lib/mixins/i18n/localize/test/index.jsx
+++ b/client/lib/mixins/i18n/localize/test/index.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
+import localize from '../';
+
+describe( '#localize()', () => {
+	useFakeDom();
+
+	it( 'should be named using the variable name of the composed component', () => {
+		const MyComponent = React.createClass( {
+			render: () => null
+		} );
+
+		const LocalizedComponent = localize( MyComponent );
+
+		expect( LocalizedComponent.displayName ).to.equal( 'LocalizedMyComponent' );
+	} );
+
+	it( 'should be named using the displayName of the composed component', () => {
+		const MyComponent = React.createClass( {
+			displayName: 'MyComponent',
+
+			render: () => null
+		} );
+
+		const LocalizedComponent = localize( MyComponent );
+
+		expect( LocalizedComponent.displayName ).to.equal( 'LocalizedMyComponent' );
+	} );
+
+	it( 'should be named using the name of the composed function component', () => {
+		function MyComponent() {}
+
+		const LocalizedComponent = localize( MyComponent );
+
+		expect( LocalizedComponent.displayName ).to.equal( 'LocalizedMyComponent' );
+	} );
+
+	it( 'should provide translate, moment, and numberFormat props to rendered child', () => {
+		const MyComponent = React.createClass( {
+			render: () => null
+		} );
+		const LocalizedComponent = localize( MyComponent );
+
+		const mounted = mount( <LocalizedComponent /> );
+		const props = mounted.find( MyComponent ).props();
+
+		expect( props.translate ).to.be.a( 'function' );
+		expect( props.moment ).to.be.a( 'function' );
+		expect( props.numberFormat ).to.be.a( 'function' );
+	} );
+} );

--- a/client/post-editor/editor-post-type/index.jsx
+++ b/client/post-editor/editor-post-type/index.jsx
@@ -9,14 +9,14 @@ import get from 'lodash/get';
 /**
  * Internal dependencies
  */
-import { translate } from 'lib/mixins/i18n';
+import localize from 'lib/mixins/i18n/localize';
 import { getEditedPost } from 'state/posts/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getEditorPostId, isEditorNewPost } from 'state/ui/editor/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 
-function EditorPostType( { siteId, isNew, typeSlug, type } ) {
+function EditorPostType( { translate, siteId, isNew, typeSlug, type } ) {
 	let label;
 	switch ( typeSlug ) {
 		case 'page':
@@ -57,6 +57,7 @@ function EditorPostType( { siteId, isNew, typeSlug, type } ) {
 }
 
 EditorPostType.propTypes = {
+	translate: PropTypes.func,
 	siteId: PropTypes.number,
 	isNew: PropTypes.bool,
 	typeSlug: PropTypes.string,
@@ -80,4 +81,4 @@ export default connect( ( state ) => {
 		typeSlug: post.type,
 		type: getPostType( state, site.ID, post.type )
 	} );
-} )( EditorPostType );
+} )( localize( EditorPostType ) );

--- a/client/tests.json
+++ b/client/tests.json
@@ -95,6 +95,11 @@
 			"test" : [ "menu-data" ]
 		},
 		"mixins" : {
+			"i18n": {
+				"localize": {
+					"test": [ "index" ]
+				}
+			},
 			"pageable": {
 				"test": [ "index" ]
 			},


### PR DESCRIPTION
This pull request seeks to add a new `localize` higher-order component. When called, `localize` returns a new component class with `localize` passed as a prop to the original component when rendered. The advantage of using a higher-order component instead of calling `translate` directly from the `lib/i18n/mixins` module is that the latter does not properly account for `change` events which may be emitted by the `i18nState` object.

__Testing instructions:__

1. Navigate to the [Calypso post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Note that the label at the top center of the screen displays "New Post" translated to your current language