### PR TITLE
Upgrade `enzyme` to `2.2.0`

### DIFF
--- a/client/lib/interval/test/component.js
+++ b/client/lib/interval/test/component.js
@@ -98,12 +98,12 @@ describe( 'Interval', function() {
 
 		it( 'Adds the action when mounted', function() {
 			const o = { counter: 0 };
-			const wrapper = mount( <div></div> );
+			mount( <div></div> );
 
 			this.clock.tick( 1000 );
 			assert( 0 === o.counter );
 
-			wrapper.setProps( { children: <Interval onTick={ nudgeObject( o, 1 ) } period={ EVERY_SECOND }><div /></Interval> } );
+			mount( <Interval onTick={ nudgeObject( o, 1 ) } period={ EVERY_SECOND }><div /></Interval> );
 
 			this.clock.tick( 1000 );
 			assert( 2 === o.counter );

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2122,30 +2122,33 @@
       "version": "1.1.1"
     },
     "enzyme": {
-      "version": "1.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "cheerio": {
-          "version": "0.19.0",
+          "version": "0.20.0",
           "dependencies": {
             "css-select": {
-              "version": "1.0.0",
+              "version": "1.2.0",
               "dependencies": {
-                "css-what": {
-                  "version": "1.0.0"
-                },
-                "domutils": {
-                  "version": "1.4.3",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.3.0"
-                    }
-                  }
-                },
                 "boolbase": {
                   "version": "1.0.0"
                 },
+                "css-what": {
+                  "version": "2.1.0"
+                },
+                "domutils": {
+                  "version": "1.5.1"
+                },
                 "nth-check": {
                   "version": "1.0.1"
+                }
+              }
+            },
+            "dom-serializer": {
+              "version": "0.1.0",
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.1.3"
                 }
               }
             },
@@ -2155,14 +2158,14 @@
             "htmlparser2": {
               "version": "3.8.3",
               "dependencies": {
+                "domelementtype": {
+                  "version": "1.3.0"
+                },
                 "domhandler": {
                   "version": "2.3.0"
                 },
-                "domutils": {
-                  "version": "1.5.1"
-                },
-                "domelementtype": {
-                  "version": "1.3.0"
+                "entities": {
+                  "version": "1.0.0"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
@@ -2177,420 +2180,62 @@
                       "version": "0.10.31"
                     }
                   }
-                },
-                "entities": {
-                  "version": "1.0.0"
                 }
               }
-            },
-            "dom-serializer": {
-              "version": "0.1.0",
+            }
+          }
+        },
+        "is-subset": {
+          "version": "0.1.1"
+        },
+        "object.assign": {
+          "version": "4.0.3",
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.2",
               "dependencies": {
-                "domelementtype": {
-                  "version": "1.1.3"
+                "foreach": {
+                  "version": "2.0.5"
                 }
               }
             },
-            "lodash": {
-              "version": "3.10.1"
-            }
-          }
-        },
-        "sinon": {
-          "version": "1.17.3",
-          "dependencies": {
-            "formatio": {
-              "version": "1.1.1"
+            "function-bind": {
+              "version": "1.1.0"
             },
-            "util": {
-              "version": "0.10.3"
-            },
-            "lolex": {
-              "version": "1.3.2"
-            },
-            "samsam": {
-              "version": "1.1.2"
-            }
-          }
-        },
-        "underscore": {
-          "version": "1.8.3"
-        },
-        "jsdom": {
-          "version": "6.5.1",
-          "dependencies": {
-            "acorn": {
-              "version": "2.7.0"
-            },
-            "acorn-globals": {
+            "object-keys": {
               "version": "1.0.9"
-            },
-            "browser-request": {
-              "version": "0.3.3"
-            },
-            "cssom": {
-              "version": "0.3.1"
-            },
-            "cssstyle": {
-              "version": "0.2.34"
-            },
-            "escodegen": {
-              "version": "1.8.0",
+            }
+          }
+        },
+        "object.values": {
+          "version": "1.0.3",
+          "dependencies": {
+            "es-abstract": {
+              "version": "1.5.0",
               "dependencies": {
-                "estraverse": {
-                  "version": "1.9.3"
-                },
-                "esutils": {
-                  "version": "2.0.2"
-                },
-                "esprima": {
-                  "version": "2.7.2"
-                },
-                "optionator": {
-                  "version": "0.8.1",
-                  "dependencies": {
-                    "prelude-ls": {
-                      "version": "1.1.2"
-                    },
-                    "deep-is": {
-                      "version": "0.1.3"
-                    },
-                    "wordwrap": {
-                      "version": "1.0.0"
-                    },
-                    "type-check": {
-                      "version": "0.3.2"
-                    },
-                    "levn": {
-                      "version": "0.3.0"
-                    },
-                    "fast-levenshtein": {
-                      "version": "1.1.3"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.2.0",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "htmlparser2": {
-              "version": "3.9.0",
-              "dependencies": {
-                "domelementtype": {
-                  "version": "1.3.0"
-                },
-                "domhandler": {
-                  "version": "2.3.0"
-                },
-                "domutils": {
-                  "version": "1.5.1",
-                  "dependencies": {
-                    "dom-serializer": {
-                      "version": "0.1.0",
-                      "dependencies": {
-                        "domelementtype": {
-                          "version": "1.1.3"
-                        }
-                      }
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.1.1"
-                },
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                }
-              }
-            },
-            "nwmatcher": {
-              "version": "1.3.7"
-            },
-            "parse5": {
-              "version": "1.5.1"
-            },
-            "request": {
-              "version": "2.69.0",
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0"
-                },
-                "aws4": {
-                  "version": "1.3.2"
-                },
-                "bl": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.5",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    }
-                  }
-                },
-                "caseless": {
-                  "version": "0.11.0"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.0"
-                },
-                "forever-agent": {
-                  "version": "0.6.1"
-                },
-                "form-data": {
-                  "version": "1.0.0-rc3",
-                  "dependencies": {
-                    "async": {
-                      "version": "1.5.2"
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.1",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.0",
-                          "dependencies": {
-                            "color-convert": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    },
-                    "commander": {
-                      "version": "2.9.0",
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.13.1",
-                      "dependencies": {
-                        "generate-function": {
-                          "version": "2.0.0"
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "dependencies": {
-                            "is-property": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        },
-                        "jsonpointer": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4"
-                        }
-                      }
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3"
-                    },
-                    "boom": {
-                      "version": "2.10.1"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5"
-                    },
-                    "sntp": {
-                      "version": "1.0.9"
-                    }
-                  }
-                },
-                "http-signature": {
+                "es-to-primitive": {
                   "version": "1.1.1",
                   "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0"
+                    "is-date-object": {
+                      "version": "1.0.1"
                     },
-                    "jsprim": {
-                      "version": "1.2.2",
-                      "dependencies": {
-                        "extsprintf": {
-                          "version": "1.0.2"
-                        },
-                        "json-schema": {
-                          "version": "0.2.2"
-                        },
-                        "verror": {
-                          "version": "1.3.6"
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.7.4",
-                      "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3"
-                        },
-                        "dashdash": {
-                          "version": "1.13.0",
-                          "dependencies": {
-                            "assert-plus": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        },
-                        "jsbn": {
-                          "version": "0.1.0"
-                        },
-                        "tweetnacl": {
-                          "version": "0.14.1"
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2"
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1"
-                        }
-                      }
+                    "is-symbol": {
+                      "version": "1.0.1"
                     }
                   }
                 },
-                "is-typedarray": {
-                  "version": "1.0.0"
+                "is-callable": {
+                  "version": "1.1.3"
                 },
-                "isstream": {
-                  "version": "0.1.2"
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1"
-                },
-                "mime-types": {
-                  "version": "2.1.10",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.22.0"
-                    }
-                  }
-                },
-                "node-uuid": {
-                  "version": "1.4.7"
-                },
-                "oauth-sign": {
-                  "version": "0.8.1"
-                },
-                "qs": {
-                  "version": "6.0.2"
-                },
-                "stringstream": {
-                  "version": "0.0.5"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.2"
+                "is-regex": {
+                  "version": "1.0.3"
                 }
               }
             },
-            "symbol-tree": {
-              "version": "3.1.4"
-            },
-            "tough-cookie": {
-              "version": "2.2.2"
-            },
-            "whatwg-url-compat": {
-              "version": "0.6.5",
-              "dependencies": {
-                "tr46": {
-                  "version": "0.0.3"
-                }
-              }
-            },
-            "xml-name-validator": {
-              "version": "2.0.1"
-            },
-            "xmlhttprequest": {
-              "version": "1.8.0"
-            },
-            "xtend": {
-              "version": "4.0.1"
+            "has": {
+              "version": "1.0.1"
             }
           }
-        },
-        "mocha-jsdom": {
-          "version": "1.1.0"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2122,19 +2122,19 @@
       "version": "1.1.1"
     },
     "enzyme": {
-      "version": "1.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "cheerio": {
-          "version": "0.19.0",
+          "version": "0.20.0",
           "dependencies": {
             "css-select": {
-              "version": "1.0.0",
+              "version": "1.2.0",
               "dependencies": {
                 "css-what": {
-                  "version": "1.0.0"
+                  "version": "2.1.0"
                 },
                 "domutils": {
-                  "version": "1.4.3",
+                  "version": "1.5.1",
                   "dependencies": {
                     "domelementtype": {
                       "version": "1.3.0"
@@ -2175,6 +2175,9 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31"
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
                     }
                   }
                 },
@@ -2191,406 +2194,424 @@
                 }
               }
             },
-            "lodash": {
-              "version": "3.10.1"
-            }
-          }
-        },
-        "sinon": {
-          "version": "1.17.3",
-          "dependencies": {
-            "formatio": {
-              "version": "1.1.1"
-            },
-            "util": {
-              "version": "0.10.3"
-            },
-            "lolex": {
-              "version": "1.3.2"
-            },
-            "samsam": {
-              "version": "1.1.2"
-            }
-          }
-        },
-        "underscore": {
-          "version": "1.8.3"
-        },
-        "jsdom": {
-          "version": "6.5.1",
-          "dependencies": {
-            "acorn": {
-              "version": "2.7.0"
-            },
-            "acorn-globals": {
-              "version": "1.0.9"
-            },
-            "browser-request": {
-              "version": "0.3.3"
-            },
-            "cssom": {
-              "version": "0.3.1"
-            },
-            "cssstyle": {
-              "version": "0.2.34"
-            },
-            "escodegen": {
-              "version": "1.8.0",
+            "jsdom": {
+              "version": "7.2.2",
               "dependencies": {
-                "estraverse": {
-                  "version": "1.9.3"
+                "abab": {
+                  "version": "1.0.3"
                 },
-                "esutils": {
-                  "version": "2.0.2"
+                "acorn": {
+                  "version": "2.7.0"
                 },
-                "esprima": {
-                  "version": "2.7.2"
+                "acorn-globals": {
+                  "version": "1.0.9"
                 },
-                "optionator": {
-                  "version": "0.8.1",
+                "cssom": {
+                  "version": "0.3.1"
+                },
+                "cssstyle": {
+                  "version": "0.2.34"
+                },
+                "escodegen": {
+                  "version": "1.8.0",
                   "dependencies": {
-                    "prelude-ls": {
-                      "version": "1.1.2"
+                    "estraverse": {
+                      "version": "1.9.3"
                     },
-                    "deep-is": {
-                      "version": "0.1.3"
+                    "esutils": {
+                      "version": "2.0.2"
                     },
-                    "wordwrap": {
-                      "version": "1.0.0"
+                    "esprima": {
+                      "version": "2.7.2"
                     },
-                    "type-check": {
-                      "version": "0.3.2"
-                    },
-                    "levn": {
-                      "version": "0.3.0"
-                    },
-                    "fast-levenshtein": {
-                      "version": "1.1.3"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.2.0",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "htmlparser2": {
-              "version": "3.9.0",
-              "dependencies": {
-                "domelementtype": {
-                  "version": "1.3.0"
-                },
-                "domhandler": {
-                  "version": "2.3.0"
-                },
-                "domutils": {
-                  "version": "1.5.1",
-                  "dependencies": {
-                    "dom-serializer": {
-                      "version": "0.1.0",
+                    "optionator": {
+                      "version": "0.8.1",
                       "dependencies": {
-                        "domelementtype": {
+                        "prelude-ls": {
+                          "version": "1.1.2"
+                        },
+                        "deep-is": {
+                          "version": "0.1.3"
+                        },
+                        "wordwrap": {
+                          "version": "1.0.0"
+                        },
+                        "type-check": {
+                          "version": "0.3.2"
+                        },
+                        "levn": {
+                          "version": "0.3.0"
+                        },
+                        "fast-levenshtein": {
                           "version": "1.1.3"
                         }
                       }
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.1.1"
-                },
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
                     },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                }
-              }
-            },
-            "nwmatcher": {
-              "version": "1.3.7"
-            },
-            "parse5": {
-              "version": "1.5.1"
-            },
-            "request": {
-              "version": "2.69.0",
-              "dependencies": {
-                "aws-sign2": {
-                  "version": "0.6.0"
-                },
-                "aws4": {
-                  "version": "1.3.2"
-                },
-                "bl": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "2.0.5",
+                    "source-map": {
+                      "version": "0.2.0",
                       "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
+                        "amdefine": {
+                          "version": "1.0.0"
                         }
                       }
                     }
                   }
                 },
-                "caseless": {
-                  "version": "0.11.0"
+                "nwmatcher": {
+                  "version": "1.3.7"
                 },
-                "combined-stream": {
-                  "version": "1.0.5",
+                "parse5": {
+                  "version": "1.5.1"
+                },
+                "request": {
+                  "version": "2.69.0",
                   "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "extend": {
-                  "version": "3.0.0"
-                },
-                "forever-agent": {
-                  "version": "0.6.1"
-                },
-                "form-data": {
-                  "version": "1.0.0-rc3",
-                  "dependencies": {
-                    "async": {
-                      "version": "1.5.2"
-                    }
-                  }
-                },
-                "har-validator": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.1",
+                    "aws-sign2": {
+                      "version": "0.6.0"
+                    },
+                    "aws4": {
+                      "version": "1.3.2",
                       "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.0",
+                        "lru-cache": {
+                          "version": "4.0.1",
                           "dependencies": {
-                            "color-convert": {
+                            "pseudomap": {
+                              "version": "1.0.2"
+                            },
+                            "yallist": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "bl": {
+                      "version": "1.0.3",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "2.0.6",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2"
+                            },
+                            "inherits": {
+                              "version": "2.0.1"
+                            },
+                            "isarray": {
                               "version": "1.0.0"
-                            }
-                          }
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    },
-                    "commander": {
-                      "version": "2.9.0",
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.13.1",
-                      "dependencies": {
-                        "generate-function": {
-                          "version": "2.0.0"
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0",
-                          "dependencies": {
-                            "is-property": {
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.6"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31"
+                            },
+                            "util-deprecate": {
                               "version": "1.0.2"
                             }
                           }
-                        },
-                        "jsonpointer": {
-                          "version": "2.0.0"
                         }
                       }
                     },
-                    "pinkie-promise": {
-                      "version": "2.0.0",
+                    "caseless": {
+                      "version": "0.11.0"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
                       "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4"
-                        }
-                      }
-                    }
-                  }
-                },
-                "hawk": {
-                  "version": "3.1.3",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3"
-                    },
-                    "boom": {
-                      "version": "2.10.1"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5"
-                    },
-                    "sntp": {
-                      "version": "1.0.9"
-                    }
-                  }
-                },
-                "http-signature": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.2.0"
-                    },
-                    "jsprim": {
-                      "version": "1.2.2",
-                      "dependencies": {
-                        "extsprintf": {
-                          "version": "1.0.2"
-                        },
-                        "json-schema": {
-                          "version": "0.2.2"
-                        },
-                        "verror": {
-                          "version": "1.3.6"
+                        "delayed-stream": {
+                          "version": "1.0.0"
                         }
                       }
                     },
-                    "sshpk": {
-                      "version": "1.7.4",
+                    "extend": {
+                      "version": "3.0.0"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc4",
                       "dependencies": {
-                        "asn1": {
-                          "version": "0.2.3"
-                        },
-                        "dashdash": {
-                          "version": "1.13.0",
+                        "async": {
+                          "version": "1.5.2"
+                        }
+                      }
+                    },
+                    "har-validator": {
+                      "version": "2.0.6",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
                           "dependencies": {
-                            "assert-plus": {
-                              "version": "1.0.0"
+                            "ansi-styles": {
+                              "version": "2.2.0",
+                              "dependencies": {
+                                "color-convert": {
+                                  "version": "1.0.0"
+                                }
+                              }
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0"
                             }
                           }
                         },
-                        "jsbn": {
-                          "version": "0.1.0"
+                        "commander": {
+                          "version": "2.9.0",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1"
+                            }
+                          }
                         },
-                        "tweetnacl": {
-                          "version": "0.14.1"
+                        "is-my-json-valid": {
+                          "version": "2.13.1",
+                          "dependencies": {
+                            "generate-function": {
+                              "version": "2.0.0"
+                            },
+                            "generate-object-property": {
+                              "version": "1.2.0",
+                              "dependencies": {
+                                "is-property": {
+                                  "version": "1.0.2"
+                                }
+                              }
+                            },
+                            "jsonpointer": {
+                              "version": "2.0.0"
+                            },
+                            "xtend": {
+                              "version": "4.0.1"
+                            }
+                          }
                         },
-                        "jodid25519": {
-                          "version": "1.0.2"
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1"
+                        "pinkie-promise": {
+                          "version": "2.0.0",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4"
+                            }
+                          }
                         }
                       }
+                    },
+                    "hawk": {
+                      "version": "3.1.3",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "2.16.3"
+                        },
+                        "boom": {
+                          "version": "2.10.1"
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5"
+                        },
+                        "sntp": {
+                          "version": "1.0.9"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "1.1.1",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.2.0"
+                        },
+                        "jsprim": {
+                          "version": "1.2.2",
+                          "dependencies": {
+                            "extsprintf": {
+                              "version": "1.0.2"
+                            },
+                            "json-schema": {
+                              "version": "0.2.2"
+                            },
+                            "verror": {
+                              "version": "1.3.6"
+                            }
+                          }
+                        },
+                        "sshpk": {
+                          "version": "1.7.4",
+                          "dependencies": {
+                            "asn1": {
+                              "version": "0.2.3"
+                            },
+                            "dashdash": {
+                              "version": "1.13.0",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "1.0.0"
+                                }
+                              }
+                            },
+                            "jsbn": {
+                              "version": "0.1.0"
+                            },
+                            "tweetnacl": {
+                              "version": "0.14.1"
+                            },
+                            "jodid25519": {
+                              "version": "1.0.2"
+                            },
+                            "ecc-jsbn": {
+                              "version": "0.1.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0"
+                    },
+                    "isstream": {
+                      "version": "0.1.2"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1"
+                    },
+                    "mime-types": {
+                      "version": "2.1.10",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.22.0"
+                        }
+                      }
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.1"
+                    },
+                    "qs": {
+                      "version": "6.0.2"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.2"
                     }
                   }
                 },
-                "is-typedarray": {
-                  "version": "1.0.0"
+                "sax": {
+                  "version": "1.2.1"
                 },
-                "isstream": {
-                  "version": "0.1.2"
+                "symbol-tree": {
+                  "version": "3.1.4"
                 },
-                "json-stringify-safe": {
-                  "version": "5.0.1"
+                "tough-cookie": {
+                  "version": "2.2.2"
                 },
-                "mime-types": {
-                  "version": "2.1.10",
+                "webidl-conversions": {
+                  "version": "2.0.1"
+                },
+                "whatwg-url-compat": {
+                  "version": "0.6.5",
                   "dependencies": {
-                    "mime-db": {
-                      "version": "1.22.0"
+                    "tr46": {
+                      "version": "0.0.3"
                     }
                   }
                 },
-                "node-uuid": {
-                  "version": "1.4.7"
-                },
-                "oauth-sign": {
-                  "version": "0.8.1"
-                },
-                "qs": {
-                  "version": "6.0.2"
-                },
-                "stringstream": {
-                  "version": "0.0.5"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.2"
+                "xml-name-validator": {
+                  "version": "2.0.1"
                 }
               }
-            },
-            "symbol-tree": {
-              "version": "3.1.4"
-            },
-            "tough-cookie": {
-              "version": "2.2.2"
-            },
-            "whatwg-url-compat": {
-              "version": "0.6.5",
-              "dependencies": {
-                "tr46": {
-                  "version": "0.0.3"
-                }
-              }
-            },
-            "xml-name-validator": {
-              "version": "2.0.1"
-            },
-            "xmlhttprequest": {
-              "version": "1.8.0"
-            },
-            "xtend": {
-              "version": "4.0.1"
             }
           }
         },
-        "mocha-jsdom": {
-          "version": "1.1.0"
+        "is-subset": {
+          "version": "0.1.1"
+        },
+        "lodash": {
+          "version": "4.6.1"
+        },
+        "object.assign": {
+          "version": "4.0.3",
+          "dependencies": {
+            "function-bind": {
+              "version": "1.1.0"
+            },
+            "object-keys": {
+              "version": "1.0.9"
+            },
+            "define-properties": {
+              "version": "1.1.2",
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5"
+                }
+              }
+            }
+          }
+        },
+        "object.values": {
+          "version": "1.0.3",
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.2",
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5"
+                },
+                "object-keys": {
+                  "version": "1.0.9"
+                }
+              }
+            },
+            "es-abstract": {
+              "version": "1.5.0",
+              "dependencies": {
+                "is-callable": {
+                  "version": "1.1.3"
+                },
+                "es-to-primitive": {
+                  "version": "1.1.1",
+                  "dependencies": {
+                    "is-date-object": {
+                      "version": "1.0.1"
+                    },
+                    "is-symbol": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "is-regex": {
+                  "version": "1.0.3"
+                }
+              }
+            },
+            "has": {
+              "version": "1.0.1"
+            },
+            "function-bind": {
+              "version": "1.1.0"
+            }
+          }
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2122,33 +2122,30 @@
       "version": "1.1.1"
     },
     "enzyme": {
-      "version": "2.2.0",
+      "version": "1.1.0",
       "dependencies": {
         "cheerio": {
-          "version": "0.20.0",
+          "version": "0.19.0",
           "dependencies": {
             "css-select": {
-              "version": "1.2.0",
+              "version": "1.0.0",
               "dependencies": {
+                "css-what": {
+                  "version": "1.0.0"
+                },
+                "domutils": {
+                  "version": "1.4.3",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0"
+                    }
+                  }
+                },
                 "boolbase": {
                   "version": "1.0.0"
                 },
-                "css-what": {
-                  "version": "2.1.0"
-                },
-                "domutils": {
-                  "version": "1.5.1"
-                },
                 "nth-check": {
                   "version": "1.0.1"
-                }
-              }
-            },
-            "dom-serializer": {
-              "version": "0.1.0",
-              "dependencies": {
-                "domelementtype": {
-                  "version": "1.1.3"
                 }
               }
             },
@@ -2158,14 +2155,14 @@
             "htmlparser2": {
               "version": "3.8.3",
               "dependencies": {
-                "domelementtype": {
-                  "version": "1.3.0"
-                },
                 "domhandler": {
                   "version": "2.3.0"
                 },
-                "entities": {
-                  "version": "1.0.0"
+                "domutils": {
+                  "version": "1.5.1"
+                },
+                "domelementtype": {
+                  "version": "1.3.0"
                 },
                 "readable-stream": {
                   "version": "1.1.13",
@@ -2180,62 +2177,420 @@
                       "version": "0.10.31"
                     }
                   }
+                },
+                "entities": {
+                  "version": "1.0.0"
                 }
               }
+            },
+            "dom-serializer": {
+              "version": "0.1.0",
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.1.3"
+                }
+              }
+            },
+            "lodash": {
+              "version": "3.10.1"
             }
           }
         },
-        "is-subset": {
-          "version": "0.1.1"
-        },
-        "object.assign": {
-          "version": "4.0.3",
+        "sinon": {
+          "version": "1.17.3",
           "dependencies": {
-            "define-properties": {
-              "version": "1.1.2",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5"
-                }
-              }
+            "formatio": {
+              "version": "1.1.1"
             },
-            "function-bind": {
-              "version": "1.1.0"
+            "util": {
+              "version": "0.10.3"
             },
-            "object-keys": {
+            "lolex": {
+              "version": "1.3.2"
+            },
+            "samsam": {
+              "version": "1.1.2"
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.8.3"
+        },
+        "jsdom": {
+          "version": "6.5.1",
+          "dependencies": {
+            "acorn": {
+              "version": "2.7.0"
+            },
+            "acorn-globals": {
               "version": "1.0.9"
-            }
-          }
-        },
-        "object.values": {
-          "version": "1.0.3",
-          "dependencies": {
-            "es-abstract": {
-              "version": "1.5.0",
+            },
+            "browser-request": {
+              "version": "0.3.3"
+            },
+            "cssom": {
+              "version": "0.3.1"
+            },
+            "cssstyle": {
+              "version": "0.2.34"
+            },
+            "escodegen": {
+              "version": "1.8.0",
               "dependencies": {
-                "es-to-primitive": {
-                  "version": "1.1.1",
+                "estraverse": {
+                  "version": "1.9.3"
+                },
+                "esutils": {
+                  "version": "2.0.2"
+                },
+                "esprima": {
+                  "version": "2.7.2"
+                },
+                "optionator": {
+                  "version": "0.8.1",
                   "dependencies": {
-                    "is-date-object": {
-                      "version": "1.0.1"
+                    "prelude-ls": {
+                      "version": "1.1.2"
                     },
-                    "is-symbol": {
-                      "version": "1.0.1"
+                    "deep-is": {
+                      "version": "0.1.3"
+                    },
+                    "wordwrap": {
+                      "version": "1.0.0"
+                    },
+                    "type-check": {
+                      "version": "0.3.2"
+                    },
+                    "levn": {
+                      "version": "0.3.0"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.1.3"
                     }
                   }
                 },
-                "is-callable": {
-                  "version": "1.1.3"
-                },
-                "is-regex": {
-                  "version": "1.0.3"
+                "source-map": {
+                  "version": "0.2.0",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0"
+                    }
+                  }
                 }
               }
             },
-            "has": {
-              "version": "1.0.1"
+            "htmlparser2": {
+              "version": "3.9.0",
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.3.0"
+                },
+                "domhandler": {
+                  "version": "2.3.0"
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3"
+                        }
+                      }
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.1.1"
+                },
+                "readable-stream": {
+                  "version": "2.0.5",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2"
+                    },
+                    "isarray": {
+                      "version": "0.0.1"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "nwmatcher": {
+              "version": "1.3.7"
+            },
+            "parse5": {
+              "version": "1.5.1"
+            },
+            "request": {
+              "version": "2.69.0",
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0"
+                },
+                "aws4": {
+                  "version": "1.3.2"
+                },
+                "bl": {
+                  "version": "1.0.3",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2"
+                        },
+                        "isarray": {
+                          "version": "0.0.1"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.11.0"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0"
+                },
+                "forever-agent": {
+                  "version": "0.6.1"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.5.2"
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.1",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.0",
+                          "dependencies": {
+                            "color-convert": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.13.1",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4"
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.16.3"
+                    },
+                    "boom": {
+                      "version": "2.10.1"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5"
+                    },
+                    "sntp": {
+                      "version": "1.0.9"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0"
+                    },
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2"
+                        },
+                        "json-schema": {
+                          "version": "0.2.2"
+                        },
+                        "verror": {
+                          "version": "1.3.6"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.7.4",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3"
+                        },
+                        "dashdash": {
+                          "version": "1.13.0",
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        },
+                        "jsbn": {
+                          "version": "0.1.0"
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.1"
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0"
+                },
+                "isstream": {
+                  "version": "0.1.2"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1"
+                },
+                "mime-types": {
+                  "version": "2.1.10",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.22.0"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.7"
+                },
+                "oauth-sign": {
+                  "version": "0.8.1"
+                },
+                "qs": {
+                  "version": "6.0.2"
+                },
+                "stringstream": {
+                  "version": "0.0.5"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2"
+                }
+              }
+            },
+            "symbol-tree": {
+              "version": "3.1.4"
+            },
+            "tough-cookie": {
+              "version": "2.2.2"
+            },
+            "whatwg-url-compat": {
+              "version": "0.6.5",
+              "dependencies": {
+                "tr46": {
+                  "version": "0.0.3"
+                }
+              }
+            },
+            "xml-name-validator": {
+              "version": "2.0.1"
+            },
+            "xmlhttprequest": {
+              "version": "1.8.0"
+            },
+            "xtend": {
+              "version": "4.0.1"
             }
           }
+        },
+        "mocha-jsdom": {
+          "version": "1.1.0"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "blanket": "1.1.6",
     "chai": "2.0.0",
     "deep-freeze": "0.0.1",
-    "enzyme": "2.2.0",
+    "enzyme": "1.1.0",
     "esformatter": "0.7.3",
     "esformatter-braces": "1.2.1",
     "esformatter-collapse-objects-a8c": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "blanket": "1.1.6",
     "chai": "2.0.0",
     "deep-freeze": "0.0.1",
-    "enzyme": "1.1.0",
+    "enzyme": "2.2.0",
     "esformatter": "0.7.3",
     "esformatter-braces": "1.2.1",
     "esformatter-collapse-objects-a8c": "0.1.0",


### PR DESCRIPTION
This is a prerequisite for #4205

Updating **enzyme** requiring slightly modifying the test for the
`<Interval />` component due to an issue with React relying on
`document.createElement` and that not being available during the test.

**This updates a node package and requires rebuilding the `node_modules` directory**