### PR TITLE
Invites: TokenField: Fixes dismissal and refocus issue

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -259,13 +259,10 @@ var TokenField = React.createClass( {
 		}
 	},
 
-	_onClick: function( event ) {
-		var inputContainer = this.refs.tokensAndInput;
-		if ( event.target === inputContainer || inputContainer.contains( event.target ) ) {
-			debug( '_onClick activating component' );
-			this.setState( {
-				isActive: true
-			} );
+	_onClick: function() {
+		if ( this.refs.input && ! this.refs.input.hasFocus() ) {
+			debug( '_onClick focusing input' );
+			this.refs.input.focus();
 		}
 	},
 


### PR DESCRIPTION
Fixes #4109

In #4109, @v18 reported that if she dismisses the keyboard on Android that the keyboard does not display again.

I don't have the dismiss button on my Android, but I was able to simulate something similar by doing the following:

- Click `TokenField`
- Click Android "Back" button
- Click `TokenField`
- Notice that `TokenField` still has "Active" state, but is not editable

In my testing, this seems to be because we are not refocusing the `TokenField` input after dismissing the keyboard, because `active` state is already `true`. To get around this, I suggest that `onClick`, we don't set state ourselves, but instead focus the `TokenField` input. 

Note: The editor's use of `TokenField` for tags does not seem to be affected by the keyboard dismissal issue. I haven't figured out why this is just yet.

To test:
- Checkout `update/token-field-dismiss-refocus` branch
- Go to `/people/new/$site`
- Click top "Username or Emails" field
- Dismiss keyboard
- Click field again
- Does keyboard display? Are you able to add/remove tokens?
- Check `/post/$site` and ensure there are no regressions.

cc @nylen for code review. cc @v18 to ensure that this fixes her issue.