### PR TITLE
Free Trials: Add `freeTrials` test

### DIFF
--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -90,7 +90,6 @@ module.exports = React.createClass( {
 						onOpen={ this.openPlan }
 						onSelectPlan={ this.props.onSelectPlan }
 						site={ site }
-						enableFreeTrials={ this.props.enableFreeTrials }
 						cart={ this.props.cart }
 						isSubmitting={ this.props.isSubmitting } />
 				);

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -182,7 +182,6 @@ module.exports = React.createClass( {
 				sitePlan={ this.getSitePlan() }
 				site={ this.props.site }
 				cart={ this.props.cart }
-				enableFreeTrials={ this.props.enableFreeTrials }
 				isPlaceholder={ this.isPlaceholder() }
 				isSubmitting={ this.props.isSubmitting } />
 		);
@@ -197,7 +196,6 @@ module.exports = React.createClass( {
 				sitePlan={ this.getSitePlan() }
 				site={ this.props.site }
 				cart={ this.props.cart }
-				enableFreeTrials={ this.props.enableFreeTrials }
 				isPlaceholder={ this.isPlaceholder() }
 				isSubmitting={ this.props.isSubmitting }
 				isImageButton />

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -6,14 +6,12 @@ var React = require( 'react' ),
 	connect = require( 'react-redux' ).connect,
 	find = require( 'lodash/find' ),
 	page = require( 'page' ),
-	property = require( 'lodash/property' ),
 	times = require( 'lodash/times' );
 
 /**
  * Internal dependencies
  */
 var observe = require( 'lib/mixins/data-observe' ),
-	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	Gridicon = require( 'components/gridicon' ),
 	PlanActions = require( 'components/plans/plan-actions' ),
@@ -27,7 +25,6 @@ var observe = require( 'lib/mixins/data-observe' ),
 	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
 	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
 	Card = require( 'components/card' ),
-	featuresListUtils = require( 'lib/features-list/utils' ),
 	filterPlansBySiteAndProps = require( 'lib/plans' ).filterPlansBySiteAndProps,
 	NavItem = require( 'components/section-nav/item' ),
 	NavTabs = require( 'components/section-nav/tabs' ),
@@ -84,59 +81,6 @@ var PlansCompare = React.createClass( {
 
 		this.recordViewAllPlansClick();
 		page( plansLink );
-	},
-
-	showFreeTrialException: function() {
-		const hasTrial = this.props.selectedSite
-				? this.props.selectedSite.plan.free_trial
-				: false,
-			canStartTrial = this.props.sitePlans && this.props.sitePlans.hasLoadedFromServer
-				? this.props.sitePlans.data.some( property( 'canStartTrial' ) )
-				: false;
-
-		if ( getABTestVariation( 'freeTrials' ) !== 'offered' ) {
-			return false;
-		}
-
-		// always show if the user is currently in trial
-		if ( hasTrial ) {
-			return true;
-		}
-
-		// show if the site is eligible for a trial (it never had a free trial before)
-		// and free trial is enabled for this component
-		if ( canStartTrial && this.props.enableFreeTrials ) {
-			return true;
-		}
-
-		// show if we are in signup and free trial is enabled for this component
-		if ( this.props.isInSignup && this.props.enableFreeTrials ) {
-			return true;
-		}
-
-		return false;
-	},
-
-	freeTrialExceptionMarker: function( feature ) {
-		if ( this.showFreeTrialException() && featuresListUtils.featureNotPartOfTrial( feature ) ) {
-			return '*';
-		}
-
-		return null;
-	},
-
-	freeTrialExceptionMessage: function() {
-		if ( ! this.isDataLoading() &&
-			this.showFreeTrialException() &&
-			this.getFeatures().some( featuresListUtils.featureNotPartOfTrial ) ) {
-			return (
-				<div className="plans-compare__free-trial-exception-message">
-					{ this.translate( '* Not included during the free trial period' ) }
-				</div>
-			);
-		}
-
-		return null;
 	},
 
 	isDataLoading: function() {
@@ -247,7 +191,6 @@ var PlansCompare = React.createClass( {
 								sitePlan={ sitePlan }
 								site={ this.props.selectedSite }
 								cart={ this.props.cart }
-								enableFreeTrials={ this.props.enableFreeTrials }
 								isSubmitting={ this.isSubmitting() }
 								isImageButton />
 							<span className="plans-compare__plan-name">
@@ -316,7 +259,7 @@ var PlansCompare = React.createClass( {
 							className={ classes }
 							key={ plan.product_id }>
 							<div className={ mobileClasses }>
-								{ feature.title } { this.freeTrialExceptionMarker( feature ) }
+								{ feature.title }
 							</div>
 							<div className="plans-compare__cell-content">
 								{ content }
@@ -331,7 +274,6 @@ var PlansCompare = React.createClass( {
 							className="plans-compare__cell"
 							key={ feature.title }>
 							{ feature.title }
-							{ this.freeTrialExceptionMarker( feature ) }
 						</td>
 						{ planFeatures }
 					</tr>
@@ -361,7 +303,6 @@ var PlansCompare = React.createClass( {
 			return (
 				<td className={ classes } key={ plan.product_id }>
 					<PlanActions
-						enableFreeTrials={ this.props.enableFreeTrials }
 						onSelectPlan={ this.props.onSelectPlan }
 						isInSignup={ this.props.isInSignup }
 						plan={ plan }
@@ -459,7 +400,6 @@ var PlansCompare = React.createClass( {
 				{ this.sectionNavigationForMobile() }
 				<Card>
 					{ this.comparisonTable() }
-					{ this.freeTrialExceptionMessage() }
 				</Card>
 			</div>
 		);

--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -14,17 +14,6 @@
 	}
 }
 
-.plans-compare__free-trial-exception-message {
-	font-size: .8em;
-	font-style: italic;
-	text-align: right;
-	margin-top: 15px;
-
-	@include breakpoint( "<660px" ) {
-		margin: 0;
-	}
-}
-
 .plans-compare {
 	.plan-actions {
 		padding: 16px;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -30,7 +30,7 @@ module.exports = {
 		defaultVariation: 'originalA'
 	},
 	freeTrialsInSignup: {
-		datestamp: '20160322',
+		datestamp: '20160328',
 		variations: {
 			disabled: 85,
 			enabled: 15
@@ -38,7 +38,7 @@ module.exports = {
 		defaultVariation: 'disabled'
 	},
 	freeTrialNudgeOnThankYouPage: {
-		datestamp: '20160322',
+		datestamp: '20160328',
 		variations: {
 			disabled: 50,
 			enabled: 50

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -29,13 +29,21 @@ module.exports = {
 		},
 		defaultVariation: 'originalA'
 	},
-	freeTrials: {
-		datestamp: '20160120',
+	freeTrialsInSignup: {
+		datestamp: '20160322',
 		variations: {
-			notOffered: 90,
-			offered: 10
+			disabled: 85,
+			enabled: 15
 		},
-		defaultVariation: 'notOffered'
+		defaultVariation: 'disabled'
+	},
+	freeTrialNudgeOnThankYouPage: {
+		datestamp: '20160322',
+		variations: {
+			disabled: 50,
+			enabled: 50
+		},
+		defaultVariation: 'disabled'
 	},
 	monthlyPlanPricing: {
 		datestamp: '20160118',

--- a/client/lib/features-list/utils.js
+++ b/client/lib/features-list/utils.js
@@ -1,7 +1,0 @@
-function featureNotPartOfTrial( feature ) {
-	return feature.not_part_of_free_trial;
-}
-
-export default {
-	featureNotPartOfTrial
-};

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -12,7 +12,6 @@ var sites = require( 'lib/sites-list' )(),
 	route = require( 'lib/route' ),
 	i18n = require( 'lib/mixins/i18n' ),
 	analytics = require( 'analytics' ),
-	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	plans = require( 'lib/plans-list' )(),
 	config = require( 'config' ),
 	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
@@ -106,7 +105,6 @@ module.exports = {
 			<Main className="plans has-sidebar">
 				<CheckoutData>
 					<PlansCompare
-						enableFreeTrials={ getABTestVariation( 'freeTrials' ) === 'offered' }
 						selectedSite={ site }
 						plans={ plans }
 						features={ features }

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var connect = require( 'react-redux' ).connect,
-	find = require( 'lodash/find' ),
 	page = require( 'page' ),
 	React = require( 'react' );
 
@@ -11,21 +10,17 @@ var connect = require( 'react-redux' ).connect,
  */
 var analytics = require( 'analytics' ),
 	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
-	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	getCurrentPlan = require( 'lib/plans' ).getCurrentPlan,
 	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans,
 	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
 	Gridicon = require( 'components/gridicon' ),
-	isBusiness = require( 'lib/products-values' ).isBusiness,
 	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle,
-	isPremium = require( 'lib/products-values' ).isPremium,
 	Main = require( 'components/main' ),
 	Notice = require( 'components/notice' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	paths = require( './paths' ),
 	PlanList = require( 'components/plans/plan-list' ),
 	PlanOverview = require( './plan-overview' ),
-	preventWidows = require( 'lib/formatting' ).preventWidows,
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	UpgradesNavigation = require( 'my-sites/upgrades/navigation' ),
 	transactionStepTypes = require( 'lib/store-transactions/step-types' );
@@ -100,43 +95,6 @@ var Plans = React.createClass( {
 		}
 	},
 
-	renderTrialCopy: function() {
-		var message,
-			businessPlan,
-			premiumPlan;
-
-		if ( ! this.props.sitePlans.hasLoadedFromServer || getABTestVariation( 'freeTrials' ) !== 'offered' ) {
-			return null;
-		}
-
-		businessPlan = find( this.props.sitePlans.data, isBusiness );
-		premiumPlan = find( this.props.sitePlans.data, isPremium );
-
-		if ( businessPlan.canStartTrial && premiumPlan.canStartTrial ) {
-			message = this.translate( 'Try WordPress.com Premium or Business free for 14 days, no credit card required' );
-		}
-
-		if ( businessPlan.canStartTrial && ! premiumPlan.canStartTrial ) {
-			message = this.translate( 'Try WordPress.com Business free for 14 days, no credit card required' );
-		}
-
-		if ( ! businessPlan.canStartTrial && premiumPlan.canStartTrial ) {
-			message = this.translate( 'Try WordPress.com Premium free for 14 days, no credit card required' );
-		}
-
-		if ( ! businessPlan.canStartTrial && ! premiumPlan.canStartTrial ) {
-			return null;
-		}
-
-		return (
-			<div className="plans__trial-copy">
-				<span className="plans__trial-copy-text">
-					{ preventWidows( message, 2 ) }
-				</span>
-			</div>
-		);
-	},
-
 	render: function() {
 		var selectedSite = this.props.sites.getSelectedSite(),
 			hasJpphpBundle,
@@ -173,12 +131,9 @@ var Plans = React.createClass( {
 							cart={ this.props.cart }
 							selectedSite={ selectedSite } />
 
-						{ this.renderTrialCopy() }
-
 						<PlanList
 							site={ selectedSite }
 							plans={ this.props.plans.get() }
-							enableFreeTrials={ getABTestVariation( 'freeTrials' ) === 'offered' }
 							sitePlans={ this.props.sitePlans }
 							onOpen={ this.openPlan }
 							onSelectPlan={ this.props.onSelectPlan }

--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -12,29 +12,3 @@
 		}
 	}
 }
-
-.plans__trial-copy {
-	color: $gray;
-	position: relative;
-	text-align: center;
-	margin-bottom: 12px;
-
-	&:after,
-	&:before {
-	    border-bottom: solid 1px #d9e3ea;
-		content: '';
-	    position: absolute;
-	    	top: 50%;
-	    	left: 0;
-	    	right: 0;
-	    z-index: -1;
-	}
-}
-
-.plans__trial-copy-text {
-	background-color: $gray-light;
-	display: inline-block;
-	font-style:italic;
-	margin: 0 8%;
-	padding: 0 6px;
-}

--- a/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
@@ -9,8 +9,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { cartItems } from 'lib/cart-values';
-import { getABTestVariation } from 'lib/abtest';
 import {
 	isBusiness,
 	isDomainMapping,
@@ -60,10 +60,6 @@ const FreeTrialNudge = React.createClass( {
 	},
 
 	render() {
-		if ( getABTestVariation( 'freeTrials' ) !== 'offered' ) {
-			return null;
-		}
-
 		if ( ! this.props.purchases.some( isDomainMapping ) && ! this.props.purchases.some( isDomainRegistration ) ) {
 			return null;
 		}
@@ -83,6 +79,10 @@ const FreeTrialNudge = React.createClass( {
 		const premiumPlan = find( this.props.sitePlans.data, isPremium );
 
 		if ( ! premiumPlan.canStartTrial ) {
+			return null;
+		}
+
+		if ( abtest( 'freeTrialNudgeOnThankYouPage' ) === 'disabled' ) {
 			return null;
 		}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import assign from 'lodash/assign';
+import includes from 'lodash/includes';
 import reject from 'lodash/reject';
 
 /**
@@ -255,6 +256,12 @@ function removeUserStepFromFlow( flow ) {
 }
 
 function filterFlowName( flowName ) {
+	const defaultFlows = [ 'main', 'website' ];
+
+	if ( includes( defaultFlows, flowName ) && abtest( 'freeTrialsInSignup' ) === 'enabled' ) {
+		return 'free-trial';
+	}
+
 	const locale = getLocaleSlug();
 	// Only allow the `headstart` flow for EN users.
 	if ( 'headstart' === flowName && 'en' !== locale && 'en-gb' !== locale ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -1,19 +1,20 @@
 /**
  * External dependencies
  */
-var assign = require( 'lodash/assign' ),
-	reject = require( 'lodash/reject' );
+import assign from 'lodash/assign';
+import reject from 'lodash/reject';
 
 /**
  * Internal dependencies
  */
-var config = require( 'config' ),
-	plansPaths = require( 'my-sites/plans/paths' ),
-	stepConfig = require( './steps' ),
-	abtest = require( 'lib/abtest' ).abtest,
-	user = require( 'lib/user' )();
-
+import { abtest } from 'lib/abtest';
+import config from 'config';
 import { getLocaleSlug } from 'lib/i18n-utils';
+import plansPaths from 'my-sites/plans/paths';
+import stepConfig from './steps';
+import userFactory from 'lib/user';
+
+const user = userFactory();
 
 function getCheckoutUrl( dependencies ) {
 	return '/checkout/' + dependencies.siteSlug;
@@ -268,16 +269,16 @@ function filterFlowName( flowName ) {
 	return flowName;
 }
 
-module.exports = {
+export default {
 	filterFlowName: filterFlowName,
 
 	defaultFlowName: 'main',
 
-	getFlow: function( flowName ) {
+	getFlow( flowName ) {
 		return user.get() ? removeUserStepFromFlow( flows[ flowName ] ) : flows[ flowName ];
 	},
 
-	getFlows: function() {
+	getFlows() {
 		return flows;
 	}
 };

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -9,7 +9,6 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var productsList = require( 'lib/products-list' )(),
-	getABTestVariation = require( 'lib/abtest' ).getABTestVariation,
 	analytics = require( 'analytics' ),
 	featuresList = require( 'lib/features-list' )(),
 	plansList = require( 'lib/plans-list' )(),
@@ -82,21 +81,12 @@ module.exports = React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_signup_compare_plans_click', { location: linkLocation } );
 	},
 
-	areFreeTrialsEnabled: function() {
-		if ( this.props.enableFreeTrials ) {
-			return true;
-		}
-
-		return getABTestVariation( 'freeTrials' ) === 'offered' && 'free-trial' === this.props.flowName;
-	},
-
 	plansList: function() {
 		return (
 			<div>
 				<PlanList
 					plans={ this.state.plans }
 					comparePlansUrl={ this.comparePlansUrl() }
-					enableFreeTrials={ this.areFreeTrialsEnabled() }
 					hideFreePlan={ this.props.hideFreePlan }
 					isInSignup={ true }
 					onSelectPlan={ this.onSelectPlan } />
@@ -113,13 +103,6 @@ module.exports = React.createClass( {
 
 	plansSelection: function() {
 		let headerText = this.translate( 'Pick a plan that\'s right for you.' ),
-			subHeaderText;
-
-		if ( this.areFreeTrialsEnabled() && getABTestVariation( 'freeTrials' ) === 'offered' ) {
-			subHeaderText = this.translate(
-				'Try WordPress.com Premium or Business free for 14 days, no credit card required.'
-			);
-		} else {
 			subHeaderText = this.translate(
 				'Not sure which plan to choose? Take a look at our {{a}}plan comparison chart{{/a}}.', {
 					components: { a: <a
@@ -127,7 +110,6 @@ module.exports = React.createClass( {
 						onClick={ this.handleComparePlansLinkClick.bind( null, 'header' ) } /> }
 				}
 			);
-		}
 
 		return (
 			<StepWrapper
@@ -146,7 +128,6 @@ module.exports = React.createClass( {
 	plansCompare: function() {
 		return <PlansCompare
 			className="plans-step__compare"
-			enableFreeTrials={ this.areFreeTrialsEnabled() }
 			hideFreePlan={ this.props.hideFreePlan }
 			onSelectPlan={ this.onSelectPlan }
 			isInSignup={ true }


### PR DESCRIPTION
This PR:

- Removes the `freeTrials` test.
- Adds the `freeTrialsInSignup` test, a variation of which redirects users to `/start/free-trial` when visiting `/start`.
- Adds the `freeTrialNudgeOnThankYouPage` test, a variation of which displays a nudge on the thank you page to users that purchased a domain.

**Testing**
*`freeTrialsInSignup`*
- Visit `/start`
- Execute `localStorage.setItem( 'ABTests', '{"freeTrialsInSignup_20160328":"enabled"}' );` in your browser's console.
- Refresh the page.
- Assert that you are redirected to the free trial flow under `/start/free-trial`.
- Complete signup and assert that you are not offered a plan at any point.
- Assert that you land on `/plans/:site` or in checkout if you selected a domain.

*`freeTrialNudgeOnThankYouPage`*
![](https://cloud.githubusercontent.com/assets/3011211/13357284/63feee0a-dc5e-11e5-89ec-8d4f6152b06f.png)
- Execute `localStorage.setItem( 'ABTests', '{"freeTrialNudgeOnThankYouPage_20160328":"enabled"}' );` in your browser's console.
- Visit `/start`.
- Continue through signup, selecting a domain registration on the domains page. 
- Complete signup, and purchase the domain registration.
- Assert that you see [this nudge](https://cloud.githubusercontent.com/assets/3011211/13357284/63feee0a-dc5e-11e5-89ec-8d4f6152b06f.png) on the thank you page.

*`freeTrials`*
~200 lines from the previous `freeTrials` test were removed. We should assert that the following pages are not broken and don't contain any references to free trials when in the now non-existent `offered` variation. Execute `localStorage.setItem( 'ABTests', '{"freeTrials_20160322":"offered"}' );` in your browser and visit:

- `/plans/site`
- `/plans/compare/:site`
- `/start/plans` and `/start/plans/compare` - You must reach these during signup through `/start`

- [ ] Code review
- [x] Product review