### PR TITLE
Framework: point to left-pad clone because 0.0.3 is no longer available

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -849,7 +849,9 @@
           "version": "0.2.0",
           "dependencies": {
             "left-pad": {
-              "version": "0.0.3"
+              "version": "0.0.3",
+              "from": "git+https://github.com/Automattic/left-pad-0.0.3#0d758ece0b84137533516d7758b07df8be8a283e",
+              "resolved": "git+https://github.com/Automattic/left-pad-0.0.3#0d758ece0b84137533516d7758b07df8be8a283e"
             }
           }
         },
@@ -1322,7 +1324,9 @@
               "version": "0.2.0",
               "dependencies": {
                 "left-pad": {
-                  "version": "0.0.3"
+                  "version": "0.0.3",
+                  "from": "git+https://github.com/Automattic/left-pad-0.0.3#0d758ece0b84137533516d7758b07df8be8a283e",
+                  "resolved": "git+https://github.com/Automattic/left-pad-0.0.3#0d758ece0b84137533516d7758b07df8be8a283e"
                 }
               }
             },


### PR DESCRIPTION
This PR fixes the following error:
```text
npm ERR! version not found: left-pad@0.0.3
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>
```

One of the sub-dependencies of babel-core has gone AWOL, so this points at our clone: https://github.com/Automattic/left-pad-0.0.3

cc @dmsnell @rralian @blowery