### PR TITLE
Revert "Framework: point to left-pad clone because 0.0.3 is no longer available"

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -849,9 +849,7 @@
           "version": "0.2.0",
           "dependencies": {
             "left-pad": {
-              "version": "0.0.3",
-              "from": "git+https://github.com/Automattic/left-pad-0.0.3#0d758ece0b84137533516d7758b07df8be8a283e",
-              "resolved": "git+https://github.com/Automattic/left-pad-0.0.3#0d758ece0b84137533516d7758b07df8be8a283e"
+              "version": "0.0.3"
             }
           }
         },
@@ -1324,9 +1322,7 @@
               "version": "0.2.0",
               "dependencies": {
                 "left-pad": {
-                  "version": "0.0.3",
-                  "from": "git+https://github.com/Automattic/left-pad-0.0.3#0d758ece0b84137533516d7758b07df8be8a283e",
-                  "resolved": "git+https://github.com/Automattic/left-pad-0.0.3#0d758ece0b84137533516d7758b07df8be8a283e"
+                  "version": "0.0.3"
                 }
               }
             },


### PR DESCRIPTION
Reverts Automattic/wp-calypso#4240

This has been un-un-published: https://twitter.com/seldo/status/712414400808755200

cc @rralian @aduth @blowery @dmsnell @jkudish 