### PR TITLE
Menus: allow easy reverting of changes

### DIFF
--- a/client/my-sites/menus/README.md
+++ b/client/my-sites/menus/README.md
@@ -42,3 +42,9 @@ Accepts the props `name` for the item name, and `items` as an array of sub-menu 
 Allows a menu title to be edited, when either the pencil icon or the text itself is clicked. It returns the edited text via the `onChange` callback.
 
 Accepts the props `value` and `onChange`.
+
+### `menu-revert-button.jsx`
+
+Discards any unsaved changes and reloads the menu state from the server.
+
+Accepts the prop `menuData` which should be an instance of `MenuData`.

--- a/client/my-sites/menus/menu-name.jsx
+++ b/client/my-sites/menus/menu-name.jsx
@@ -30,7 +30,11 @@ var MenuName = React.createClass({
 			analytics.ga.recordEvent( 'Menus', 'Clicked Edit Menu Title' );
 		}
 
-		this.setState( { editing: ! editing } );
+		const newEditingState = ! editing;
+		this.setState( { editing: newEditingState } );
+		if ( this.props.onTitleEdit ) {
+			this.props.onTitleEdit( newEditingState );
+		}
 	},
 
 	updateName: function( newValue ) {
@@ -40,6 +44,10 @@ var MenuName = React.createClass({
 		} );
 		if ( this.props.onChange ) {
 			this.props.onChange( newValue );
+		}
+
+		if ( this.props.onTitleEdit ) {
+			this.props.onTitleEdit( false );
 		}
 	},
 

--- a/client/my-sites/menus/menu.jsx
+++ b/client/my-sites/menus/menu.jsx
@@ -10,10 +10,12 @@ var React = require( 'react' ),
 var protectForm = require( 'lib/mixins/protect-form' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	assign = require( 'lodash/assign' ),
+	classNames = require( 'classnames' ),
 	MenuName = require( './menu-name' ),
 	MenuItemList = require( './menu-item-list' ),
 	MenuDeleteButton = require ( './menu-delete-button' ),
 	MenuSaveButton = require( './menus-save-button' ),
+	MenuRevertButton = require( './menus-revert-button' ),
 	analytics = require( 'lib/analytics' );
 
 /**
@@ -30,7 +32,8 @@ var Menu = React.createClass( {
 			moveState: {},
 			addState: {},
 			confirmDeleteItem: null,
-			editItemId: null
+			editItemId: null,
+			editingTitle: false
 		};
 	},
 
@@ -206,6 +209,10 @@ var Menu = React.createClass( {
 			</div> : null;
 	},
 
+	updateTitleEditing: function( editing ) {
+		this.setState( { editingTitle: editing } );
+	},
+
 	render: function() {
 		var menuName, menuItemList;
 
@@ -215,6 +222,7 @@ var Menu = React.createClass( {
 					<MenuName
 						className="is-editable"
 						value={ this.props.selectedMenu.name }
+						onTitleEdit={ this.updateTitleEditing }
 						onChange={ this.setMenuName } />
 				</h2>
 			);
@@ -233,15 +241,21 @@ var Menu = React.createClass( {
 			);
 		}
 
+		const classes = classNames( {
+			'menus__menu-header': true,
+			'is-editing-title': this.state.editingTitle
+		} );
+
 		return (
 			<div>
-				<div className="menus__menu-header">
+				<div className={ classes }>
 					{ menuName }
 					<div className="menus__menu-actions">
 						<MenuDeleteButton selectedMenu={ this.props.selectedMenu }
 								selectedLocation={ this.props.selectedLocation }
 								setBusy={ this.props.setBusy }
 								confirmDiscard={ this.props.confirmDiscard } />
+						<MenuRevertButton menuData={ this.props.siteMenus } />
 						<MenuSaveButton menuData={ this.props.siteMenus }
 								selectedMenu={ this.props.selectedMenu } />
 					</div>

--- a/client/my-sites/menus/menus-revert-button.jsx
+++ b/client/my-sites/menus/menus-revert-button.jsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const debug = debugFactory( 'calypso:menus:revert-button' ); // eslint-disable-line no-unused-vars
+
+const MenuRevertButton = React.createClass( {
+	componentWillMount() {
+		this.props.menuData.on( 'saved', this.endReverting );
+		this.props.menuData.on( 'error', this.endReverting );
+		this.props.menuData.on( 'saving', this.disable );
+	},
+
+	componentWillUnmount() {
+		this.props.menuData.off( 'saved', this.endReverting );
+		this.props.menuData.off( 'error', this.endReverting );
+		this.props.menuData.off( 'saving', this.disable );
+	},
+
+	getInitialState() {
+		return {
+			reverting: false,
+			disabled: false
+		};
+	},
+
+	startReverting() {
+		this.setState( {
+			reverting: true,
+			disabled: true
+		} );
+	},
+
+	endReverting() {
+		this.setState( {
+			reverting: false,
+			disabled: false
+		} );
+	},
+
+	disable() {
+		this.setState( { disabled: true } );
+	},
+
+	revert() {
+		this.startReverting();
+		return this.props.menuData.discard();
+	},
+
+	render() {
+		const { hasChanged } = this.props.menuData.get();
+		const disabled = this.state.disabled || ! hasChanged;
+
+		return (
+			<Button disabled={ disabled }
+					onClick={ this.revert }>
+				{ this.state.reverting ? this.translate( 'Canceling…' ) : this.translate( 'Cancel' ) }
+			</Button>
+		);
+	}
+} );
+
+export default MenuRevertButton;

--- a/client/my-sites/menus/style.scss
+++ b/client/my-sites/menus/style.scss
@@ -194,7 +194,7 @@
 		span {
 			display: block;
 			float: left;
-			max-width: 90%; /* should be less to avoid a bug on touch + <a> tag that auto-closes the area, but ellipsis wouldn't work */
+			max-width: calc( 100% - 20px );
 			text-overflow: ellipsis;
 			overflow: hidden;
 			white-space: nowrap;
@@ -218,6 +218,9 @@
 		font-weight: inherit;
 		width: calc(100% - 40px);
 		margin-right: 40px;
+		@include breakpoint( "<480px" ) {
+			width: 100%;
+		}
 	}
 }
 
@@ -238,6 +241,18 @@
 	}
 }
 
+
+.is-editing-title {
+	@include breakpoint( "<480px" ) {
+		.menus__menu-name {
+			line-height: 41px;
+		}
+
+		.menus__menu-actions {
+			display: none;
+		}
+	}
+}
 
 /**
  * Menu: List


### PR DESCRIPTION
This PR will address #22 - Menus: allow easy reverting of changes

The goal is to provide a way to revert changes to the menu without having to trigger a full page reload. Right now the only way to cancel your changes is to navigate away and back, which is not intuitive.

The implementation will be to create a `MenuRevertButton` component and attach it to the `Menu` component by the Save and Delete buttons. When clicked it will call `MenuData.discard()` which reloads directly from the server.

![screenshot 2016-03-27 21 08 28](https://cloud.githubusercontent.com/assets/128240/14068962/397b088e-f460-11e5-8126-8a2efa291e67.png)

**Testing**

* Go into Menus
* Confirm the Cancel button is disabled
* Make some changes to a menu
* Click the Cancel button
* Confirm the changes have been reverted
