### PR TITLE
People: Fixes issue where followers were polled multimple times

### DIFF
--- a/client/components/data/email-followers-data/index.jsx
+++ b/client/components/data/email-followers-data/index.jsx
@@ -54,7 +54,7 @@ export default React.createClass( {
 			pollers.remove( this._poller );
 			this._poller = pollers.add(
 				EmailFollowersStore,
-				EmailFollowersActions.fetchFollowers.bind( EmailFollowersActions, this.props.fetchOptions, true ),
+				EmailFollowersActions.fetchFollowers.bind( EmailFollowersActions, nextProps.fetchOptions, true ),
 				{ leading: false }
 			);
 		}
@@ -62,6 +62,7 @@ export default React.createClass( {
 
 	componentWillUnmount() {
 		EmailFollowersStore.removeListener( 'change', this.refreshFollowers );
+		pollers.remove( this._poller );
 	},
 
 	fetchIfEmpty( fetchOptions ) {

--- a/client/components/data/followers-data/index.jsx
+++ b/client/components/data/followers-data/index.jsx
@@ -54,7 +54,7 @@ export default React.createClass( {
 			pollers.remove( this._poller );
 			this._poller = pollers.add(
 				FollowersStore,
-				FollowersActions.fetchFollowers.bind( FollowersActions, this.props.fetchOptions, true ),
+				FollowersActions.fetchFollowers.bind( FollowersActions, nextProps.fetchOptions, true ),
 				{ leading: false }
 			);
 		}
@@ -62,6 +62,7 @@ export default React.createClass( {
 
 	componentWillUnmount() {
 		FollowersStore.removeListener( 'change', this.refreshFollowers );
+		pollers.remove( this._poller );
 	},
 
 	fetchIfEmpty( fetchOptions ) {


### PR DESCRIPTION
Fixes an issue where follower and email followers polling would make multiple requests. The issue was that we were not removing the poll when unmounting the component. I also fixed an issue where stale fetch options would be used when switching sites.

To test existence of bug:
- Go to `wpcalypso.wordpress.com/people/followers/$site`
- Switch to "Team" then back to "Followers.
- Open up console, and look at "Network" tab
- When polling occurs (every 30 seconds), there should be multiple requests

To test fix:
- Repeat above. Make sure that only one request is made for each poll

cc @lezama for review