### PR TITLE
Importer: Enable Medium importer

### DIFF
--- a/client/lib/importer/constants.js
+++ b/client/lib/importer/constants.js
@@ -15,6 +15,7 @@ export const appStates = Object.freeze( {
 } );
 
 export const WORDPRESS = 'importer-type-wordpress';
+export const MEDIUM = 'importer-type-medium';
 
 export const actionTypes = Object.freeze( {
 	API_REQUEST: 'importer-api-request',

--- a/client/my-sites/importer/importer-header.jsx
+++ b/client/my-sites/importer/importer-header.jsx
@@ -82,7 +82,7 @@ export default React.createClass( {
 
 		return (
 			<header className="importer-service">
-				{ includes( [ 'wordpress' ], icon )
+				{ includes( [ 'wordpress', 'medium' ], icon )
 					? <SocialLogo className="importer__service-icon" icon={ icon } size={ 48 } />
 					: <svg className="importer__service-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" /> }
 				<Button

--- a/client/my-sites/importer/importer-medium.jsx
+++ b/client/my-sites/importer/importer-medium.jsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+
+/**
+ * Internal dependencies
+ */
+import FileImporter from './file-importer';
+
+/**
+ * Module variables
+ */
+const importerData = {
+	title: 'Medium',
+	icon: 'medium'
+};
+
+export default React.createClass( {
+	displayName: 'ImporterMedium',
+
+	mixins: [ PureRenderMixin ],
+
+	render: function() {
+		importerData.description = this.translate(
+			'Import posts, tags, images and videos ' +
+			'from a Medium export file.'
+		);
+
+		importerData.uploadDescription = this.translate(
+			'Upload a {{b}}Medium export file{{/b}} to start ' +
+			'importing into {{b2}}%(title)s{{/b2}}.',
+			{
+				args: { title: this.props.site.title },
+				components: {
+					b: <strong />,
+					b2: <strong />
+				}
+			}
+		);
+
+		return <FileImporter importerData={ importerData } {...this.props} />;
+	}
+} );

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -38,6 +38,10 @@
 	&.wordpress {
 		background-color: $blue-wordpress;
 	}
+
+	&.medium {
+		background-color: #00AB6C;
+	}
 	
 	@include breakpoint(">960px") {
 		width: 56px;

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -3,6 +3,7 @@
  */
 import React, { PropTypes } from 'react';
 import includes from 'lodash/includes';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -12,8 +13,9 @@ import EmptyContent from 'components/empty-content';
 import ImporterStore, { getState as getImporterState } from 'lib/importer/store';
 import Interval, { EVERY_FIVE_SECONDS } from 'lib/interval';
 import WordPressImporter from 'my-sites/importer/importer-wordpress';
+import MediumImporter from 'my-sites/importer/importer-medium';
 import { fetchState } from 'lib/importer/actions';
-import { appStates, WORDPRESS } from 'lib/importer/constants';
+import { appStates, WORDPRESS, MEDIUM } from 'lib/importer/constants';
 
 export default React.createClass( {
 	displayName: 'SiteSettingsImport',
@@ -117,6 +119,10 @@ export default React.createClass( {
 
 				{ this.getImports( WORDPRESS ).map( ( importerStatus, key ) =>
 					<WordPressImporter { ...{ key, site, importerStatus } } /> ) }
+
+				{ config.isEnabled( 'manage/import/medium' ) &&
+					this.getImports( MEDIUM ).map( ( importerStatus, key ) =>
+						<MediumImporter { ...{ key, site, importerStatus } } /> ) }
 
 				<CompactCard href={ adminUrl + 'import.php' } target="_blank">
 					{ this.translate( 'Other importers') }

--- a/config/development.json
+++ b/config/development.json
@@ -48,6 +48,7 @@
 		"manage/edit-user": true,
 		"manage/export": true,
 		"manage/import": true,
+		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,
 		"manage/media": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,6 +28,7 @@
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/import": true,
+		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,
 		"manage/media": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -31,6 +31,7 @@
 		"manage/drafts": true,
 		"manage/edit-user": true,
 		"manage/import": true,
+		"manage/import/medium": true,
 		"manage/jetpack": true,
 		"manage/jetpack-plans": true,
 		"manage/menus": true,


### PR DESCRIPTION
For the most part this commit reverts the Medium importer related changes
that were introduced in: [Importer: Focus on WordPress WXR Importer](https://github.com/Automattic/wp-calypso/commit/1d5943074280cfb2a59ef59b2662befafb42195d).

Some minor changes were added in section-import.jsx in order to get
this importer to working state. Medium icon is also added.