### PR TITLE
Docs: Coding guidelines: CSS: Typo fix

### DIFF
--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -99,7 +99,7 @@ The structure of files will be changing as we move remaining section-specific co
 
 ## Media Queries
 
-We don't do device specific breakpoints, we use layout-specific breakpoints that communicate the state of the UI. DO NOT define your own media queries. Utilize the mixins provided in `_mixins.scss` that have default break points for `960px`, `660px`, and `480px`. Furthermore, we are pushing for a mobile-first approach to media queries, meaning your default styles should apply to mobile, and desktop should build on top of that. This means that devices with smaller screens have to process less CSS (which makes sense since they are generally less powerful). You should avoid the use of `<` breakpoints like this:
+We don't do device specific breakpoints, we use layout-specific breakpoints that communicate the state of the UI. DO NOT define your own media queries. Utilize the mixins [provided in `_mixins.scss`](../../assets/stylesheets/shared/mixins/_breakpoints.scss). Furthermore, we are pushing for a mobile-first approach to media queries, meaning your default styles should apply to mobile, and desktop should build on top of that. This means that devices with smaller screens have to process less CSS (which makes sense since they are generally less powerful). You should avoid the use of `<` breakpoints like this:
 
 Bad:
 ```scss

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -142,11 +142,7 @@ Good:
 }
 ```
 
-The value passed to this mixin is actually a string rather than a pixel value. Accepted values are:
-
-`<480px`, `<660px`, `<960px`, `>480px`, `>660px`, `>960px`, `480px-660px`, `660px-960px`, `480px-960px`.
-
-If you provide any other value to the mixin it will fail and give you a warning in the output from `make run`.
+The value passed to this mixin is actually a string rather than a pixel value. Accepted values are: `"<X"`, `">X"`, or `"X-Y"` — where `X` and `Y` are valid breakpoints, for example `480px`. If you provide any other value to the mixin it will fail and give you a warning in the output from `make run`.
 
 Adding additional breakpoints should not be undertaken lightly.
 

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -99,7 +99,7 @@ The structure of files will be changing as we move remaining section-specific co
 
 ## Media Queries
 
-We don't do device specific breakpoints, we use layout-specific breakpoints that communicate the state of the UI. DO NOT define your own media queries. Utilize the mixins provided in `_.mixins.scss` that have default break points for `960px`, `660px`, and `480px`. Furthermore, we are pushing for a mobile-first approach to media queries, meaning your default styles should apply to mobile, and desktop should build on top of that. This means that devices with smaller screens have to process less CSS (which makes sense since they are generally less powerful). You should avoid the use of `<` breakpoints like this:
+We don't do device specific breakpoints, we use layout-specific breakpoints that communicate the state of the UI. DO NOT define your own media queries. Utilize the mixins provided in `_mixins.scss` that have default break points for `960px`, `660px`, and `480px`. Furthermore, we are pushing for a mobile-first approach to media queries, meaning your default styles should apply to mobile, and desktop should build on top of that. This means that devices with smaller screens have to process less CSS (which makes sense since they are generally less powerful). You should avoid the use of `<` breakpoints like this:
 
 Bad:
 ```scss


### PR DESCRIPTION
Just a typo fix. :o)

There is one other thing that came to my mind while reading this: the [“Media Queries” section](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md#media-queries) mentions specific breakpoints. I checked [the source code](https://github.com/Automattic/wp-calypso/blob/53bde8c3f9c4668e62dbd2c670aaacc2bd820427/assets/stylesheets/shared/mixins/_breakpoints.scss)  and found that there is actually one more added: `1040px`.

There is one more similar little issue close to the end of that section where the accepted values for `breakpoint()` mixin are listed.

I was wondering if it’d be a good idea to remove the specific values altogether, so that they don’t have to be kept in sync on one hand, and, on the other hand, if anyone is interested they’d go straight to the source and find the current values.

What do you think? 8-)