### PR TITLE
Themes: Prevent images in description overflowing the column

### DIFF
--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -188,6 +188,11 @@
 	padding: 20px;
 	// whilst loading
 	min-height: 900px;
+
+	div {
+		// override inline style in content markup
+		width: auto !important;
+	}
 }
 
 .themes__sheet-placeholder {


### PR DESCRIPTION
**Before**
<img width="790" alt="screen shot 2016-03-23 at 11 11 48" src="https://cloud.githubusercontent.com/assets/7767559/13983542/3dcca7d8-f0e8-11e5-869b-741bb4dccb0d.png">

**After**
<img width="730" alt="screen shot 2016-03-23 at 11 12 49" src="https://cloud.githubusercontent.com/assets/7767559/13983546/44dca50a-f0e8-11e5-8842-988c6f2bf0db.png">

Prevent images in theme description and documentation from overflowing the column. The markup in the API comes straight from theme.wordpress.com posts and contains inline styles.

**To Test**
* Go to http://calypso.localhost:3000/theme/owari/details and http://calypso.localhost:3000/theme/owari/documentation
* Check that nothing overflows the left column and compare with equivalent pages on wpcalypso.wordpress.com