### PR TITLE
Coding Guidelines: suggest a more legible standard for var/let/const

### DIFF
--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -191,23 +191,25 @@ if ( firstCondition() && secondCondition() &&
 
 ### Declaring Variables With `var`
 
-Each function should begin with a single comma-delimited var statement that declares any local variables necessary. If a function does not declare a variable using var, that variable can leak into an outer scope (which is frequently the global scope, a worst-case scenario), and can unwittingly refer to and modify that data.
+It's preferable for `var`, `const`, and `let` statements to stay each one on an individual line, ideally at the top of the function. This is due to individual declarations being more readable at a glance and to be more easily parsed by diff.
 
-Assignments within the var statement should be listed on individual lines, while declarations can be grouped on a single line. Any additional lines should be indented with an additional tab. Objects and functions that occupy more than a handful of lines should be assigned outside of the var statement, to avoid over-indentation.
+Variable declarations and assignments work as normal on individual lines, while objects and functions that occupy more than a handful of lines should be properly indented as required.
 
 
 ```js
 // Good
+const foo = true;
+let bar = 'It\'s dangerous to go alone!';
+var a;
+var b = {
+    pineapples: 7,
+}
+var c;
+
+// Bad
 var k, m, length,
     // Indent subsequent lines by one tab
     value = 'WordPress';
-
-// Bad
-var foo = true;
-var bar = false;
-var a;
-var b;
-var c;
 ```
 
 ### Globals

--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -189,27 +189,21 @@ if ( firstCondition() && secondCondition() &&
 
 ## Assignments and Globals
 
-### Declaring Variables With `var`
+### Variable Declarations
 
-It's preferable for `var`, `const`, and `let` statements to stay each one on an individual line, ideally at the top of the function. This is due to individual declarations being more readable at a glance and to be more easily parsed by diff.
+When possible, variables should be declared using a `const` declaration. Use 
+`let` only when you anticipate that the variable value will be reassigned 
+during runtime. `var` should not be used in any new code.
 
-Variable declarations and assignments work as normal on individual lines, while objects and functions that occupy more than a handful of lines should be properly indented as required.
+Note that `const` does not protect against mutations to an object, so do not
+use it as an indicator of immutability.
 
+```javascript
+const foo = {};
+foo.bar = true;
 
-```js
-// Good
-const foo = true;
-let bar = 'It\'s dangerous to go alone!';
-var a;
-var b = {
-    pineapples: 7,
-}
-var c;
-
-// Bad
-var k, m, length,
-    // Indent subsequent lines by one tab
-    value = 'WordPress';
+let counter = 0;
+counter++;
 ```
 
 ### Globals


### PR DESCRIPTION
After some brief chats with @aduth, @mcsf and @ehg I decided to suggest a small change to our guidelines. The reasoning behind this change follows these criteria:

1. It's more readable at a glance: it's obvious how many variables are declared, and there are no exceptions for things being on single lines vs multiple lines, nor indenting.
2. It's way better for diffs, since it would make single-line changes instead of double lines (due to commas)
3. The updated language is more open. This is not a strict mandatory change, but a highly advisable preference.
4. It's something we are already doing in new code, to an extent.

The only downside I see is having slightly taller declarations, but with a cursory check in the existing code most of the times shouldn't be an issue.

For these reason I hope it's a fairly straightforward change, but... let's see. :) 

```
### Declaring Variables With `var`

It's preferable for `var`, `const`, and `let` statements to stay each one 
on an individual line, ideally at the top of the function. This is due to 
individual declarations being more readable at a glance and to be more 
easily parsed by diff.

Ideally, try to ditch `var`: start with `const` and then fall back to `let` 
otherwise. Variable declarations and assignments work as normal 
on individual lines, while objects and functions that occupy more than 
a handful of lines should be properly indented as required.

// Good
const foo = true;
let bar = 'It\'s dangerous to go alone!';
var a;
var b = {
    pineapples: 7,
}
var c;

// Bad
var k, m, length,
    // Indent subsequent lines by one tab
    value = 'WordPress';
```