### PR TITLE
Editor: Resolve styling issues in mobile navigation

### DIFF
--- a/client/post-editor/editor-mobile-navigation/index.jsx
+++ b/client/post-editor/editor-mobile-navigation/index.jsx
@@ -27,7 +27,10 @@ const EditorMobileNavigation = React.createClass( {
 				<button className="button editor-mobile-navigation__toggle" onClick={ this.toggleSidebar }>
 					{ this.translate( 'Actions' ) }
 				</button>
-				<Gridicon icon="cross" onClick={ this.props.onClose } />
+				<Gridicon
+					icon="cross"
+					onClick={ this.props.onClose }
+					className="editor-mobile-navigation__close" />
 			</div>
 		);
 	}

--- a/client/post-editor/editor-mobile-navigation/style.scss
+++ b/client/post-editor/editor-mobile-navigation/style.scss
@@ -8,15 +8,16 @@
 	@include breakpoint( ">660px" ) {
 		display: none;
 	}
+}
 
-	.gridicon {
-		cursor: pointer;
-		margin-right: 4px;
-		padding: 8px;
-		&:hover {
-			cursor: button;
-			fill: $gray-dark;
-		}
+.editor-mobile-navigation__close {
+	cursor: pointer;
+	margin-right: 4px;
+	padding: 8px;
+
+	&:hover {
+		cursor: button;
+		fill: $gray-dark;
 	}
 }
 

--- a/client/post-editor/editor-mobile-navigation/style.scss
+++ b/client/post-editor/editor-mobile-navigation/style.scss
@@ -29,6 +29,11 @@
 	.site__domain {
 		display: none;
 	}
+
+	.site__title::after,
+	.site__domain::after {
+		@include long-content-fade( $color: $gray-light );
+	}
 }
 
 .editor-mobile-navigation__toggle {


### PR DESCRIPTION
Fixes #4211 

This pull request seeks to resolve two issues related to styles applied to the post editor mobile navigation:

- The long content fade of the site title was not correctly colored to match the action bar background, thus causing a noticeable edge against the Actions button
- Styling intended for the close button was incorrectly applied to the lock icon used to indicate a private site

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/13987592/ad708bfe-f0de-11e5-8da9-32f1be114254.png)|![After](https://cloud.githubusercontent.com/assets/1779930/13987572/9454b8e8-f0de-11e5-8789-4ee6e9b8f160.png)

__Testing instructions:__

Changes apply only to the `<EditorMobileNavigation />` component, so there is little risk of regressions for larger viewports. Verify that the impacted styles display as expected in a smaller viewport.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Note that the items noted in the above list are correctly displayed

/cc @folletto , @melchoyce