### PR TITLE
Framework: protect-form needs to check previous before using it

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -221,7 +221,7 @@ function reduxStoreReady( reduxStore ) {
 	page( '*', require( 'lib/route/normalize' ) );
 
 	// warn against navigating from changed, unsaved forms
-	page( '*', require( 'lib/mixins/protect-form' ).checkFormHandler );
+	page.exit( '*', require( 'lib/mixins/protect-form' ).checkFormHandler );
 
 	page( '*', function( context, next ) {
 		var path = context.pathname;

--- a/client/lib/mixins/protect-form/index.js
+++ b/client/lib/mixins/protect-form/index.js
@@ -13,8 +13,7 @@ var confirmText = i18n.translate( 'You have unsaved changes. Are you sure you wa
 	beforeUnloadText = i18n.translate( 'You have unsaved changes.' ),
 	formsChanged = [];
 
-module.exports =  {
-
+module.exports = {
 	mixin: {
 		componentDidMount: function() {
 			window.addEventListener( 'beforeunload', this.warnIfChanged );
@@ -44,7 +43,7 @@ module.exports =  {
 		}
 	},
 	checkFormHandler: function( context, next ) {
-		if( ! formsChanged.length ) {
+		if ( ! formsChanged.length ) {
 			return next();
 		}
 		debug( 'unsaved form changes detected' );
@@ -52,9 +51,11 @@ module.exports =  {
 			formsChanged = [];
 			next();
 		} else {
+			// save off the current path just in case context changes after this call
+			const currentPath = context.canonicalPath;
 			setTimeout( function() {
-				page.replace( context.prevPath , null, false, false);
-			}, 0);
+				page.replace( currentPath, null, false, false );
+			}, 0 );
 		}
 	}
 


### PR DESCRIPTION
### Repro
1. Load the reader
2. Hit the new page icon in the masterbar
3. Enter a bit of text, and _then hit back before autosaving_
4. Get the 'save changes' prompt. **Hit Cancel**. 
5. protect-form explodes trying to set page to the previous url, which isn't available. Notice error in console

### With Patch
no :boom: just leaves you alone

### Movie
https://cloudup.com/ceGtKpD4z5G

tune is https://open.spotify.com/track/5K37bWvP5ycFokOEDemJvW