### PR TITLE
Domains: display domain warnings for unverified domains

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -269,6 +269,7 @@
 @import 'my-sites/upgrades/checkout/style';
 @import 'my-sites/upgrades/checkout/subscription-text';
 @import 'my-sites/upgrades/checkout-thank-you/style';
+@import 'my-sites/upgrades/components/domain-warnings/style';
 @import 'my-sites/upgrades/domain-management/transfer/style';
 @import 'my-sites/stats/stats-list/style';
 @import 'notices/style';

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -72,7 +72,7 @@ export default React.createClass( {
 			} );
 			renewLink = renewLinkPlural;
 		}
-		return <Notice status="is-error" showDismiss={ false }>{ text } { renewLink }</Notice>
+		return <Notice status="is-error" showDismiss={ false } key="expired-domains">{ text } { renewLink }</Notice>
 	},
 
 	expiringDomains() {
@@ -95,7 +95,7 @@ export default React.createClass( {
 			} );
 			renewLink = renewLinkPlural;
 		}
-		return <Notice status="is-error" showDismiss={ false }>{ text } { renewLink }</Notice>;
+		return <Notice status="is-error" showDismiss={ false } key="expiring-domains">{ text } { renewLink }</Notice>;
 	},
 
 	newDomainsWithPrimary() {
@@ -142,7 +142,7 @@ export default React.createClass( {
 			);
 		}
 
-		return <Notice status="is-warning" showDismiss={ false }>{ text }</Notice>;
+		return <Notice status="is-warning" showDismiss={ false } key="new-domains-with-primary">{ text }</Notice>;
 	},
 
 	newDomains() {
@@ -172,7 +172,7 @@ export default React.createClass( {
 				}
 			);
 		}
-		return <Notice status="is-warning" showDismiss={ false }>{ text }</Notice>;
+		return <Notice status="is-warning" showDismiss={ false } key="new-domains">{ text }</Notice>;
 	},
 
 	unverifiedDomains() {
@@ -192,7 +192,7 @@ export default React.createClass( {
 				{ this.translate( 'Urgent! Some of your domains may be lost forever because your email address is not verified:' ) }
 				<ul>{
 					domains.map( ( domain ) => {
-						return <li>
+						return <li key={ domain.name }>
 							{ domain.name } <a href={ paths.domainManagementEdit( this.props.selectedSite.domain, domain.name ) }>{ this.translate( 'Fix now' ) }</a>
 						</li>;
 					} )
@@ -202,7 +202,7 @@ export default React.createClass( {
 			return null;
 		}
 
-		return <Notice status="is-error" showDismiss={ true } className="domain-warnings__unverified-domains" >{ notice }</Notice>;
+		return <Notice status="is-error" showDismiss={ true } className="domain-warnings__unverified-domains" key="unverified-domains">{ notice }</Notice>;
 	},
 
 	componentWillMount: function() {

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -72,7 +72,7 @@ export default React.createClass( {
 			} );
 			renewLink = renewLinkPlural;
 		}
-		return <Notice status="is-error" showDismiss={false}>{text} {renewLink}</Notice>
+		return <Notice status="is-error" showDismiss={ false }>{ text } { renewLink }</Notice>
 	},
 
 	expiringDomains() {
@@ -95,7 +95,7 @@ export default React.createClass( {
 			} );
 			renewLink = renewLinkPlural;
 		}
-		return <Notice status="is-error" showDismiss={false}>{text} {renewLink}</Notice>;
+		return <Notice status="is-error" showDismiss={ false }>{ text } { renewLink }</Notice>;
 	},
 
 	newDomainsWithPrimary() {

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -202,7 +202,7 @@ export default React.createClass( {
 			return null;
 		}
 
-		return <Notice status="is-error" showDismiss={ true }>{ notice }</Notice>;
+		return <Notice status="is-error" showDismiss={ true } className="domain-warnings__unverified-domains" >{ notice }</Notice>;
 	},
 
 	componentWillMount: function() {

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -180,13 +180,22 @@ export default React.createClass( {
 			domains = this.getDomains().filter( domain => domain.isPendingIcannVerification );
 
 		if ( domains.length === 1 ) {
-			notice = this.translate( 'Urgent! Your domain %(domain)s may be lost forever because your email address is not verified.',
-				{ args: { domain: domains[0].name } } );
+			let domain = domains[0].name;
+
+			notice = this.translate( 'Urgent! Your domain %(domain)s may be lost forever because your email address is not verified. {{a}}Fix now.{{/a}}',
+				{
+					args: { domain },
+					components: { a: <a href={ paths.domainManagementEdit( this.props.selectedSite.domain, domain ) } />},
+				} );
 		} else if ( domains.length ) {
 			notice = <div>
 				{ this.translate( 'Urgent! Some of your domains may be lost forever because your email address is not verified:' ) }
 				<ul>{
-					domains.map( domain => <li>{ domain.name }</li> )
+					domains.map( ( domain ) => {
+						return <li>
+							{ domain.name } <a href={ paths.domainManagementEdit( this.props.selectedSite.domain, domain.name ) }>{ this.translate( 'Fix now' ) }</a>
+						</li>;
+					} )
 				}</ul>
 			</div>
 		} else {

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -10,6 +10,7 @@ import intersection from 'lodash/intersection';
  * Internal Dependencies
  **/
 import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 import purchasesPaths from 'me/purchases/paths';
 import domainConstants from 'lib/domains/constants';
 import i18n from 'lib/mixins/i18n';
@@ -175,20 +176,25 @@ export default React.createClass( {
 		return <Notice status="is-warning" showDismiss={ false } key="new-domains">{ text }</Notice>;
 	},
 
-	unverifiedDomains() {
-		let notice,
-			domains = this.getDomains().filter( domain => domain.isPendingIcannVerification );
+	unverifiedDomainNotice( domain ) {
+		return (
+			<Notice
+				status="is-error"
+				showDismiss={ false }
+				className="domain-warnings__unverified-domains"
+				key="unverified-domains"
+				text={ this.translate( 'Urgent! Your domain %(domain)s may be lost forever because your email address is not verified.', { args: { domain } } ) }>
 
-		if ( domains.length === 1 ) {
-			let domain = domains[0].name;
+				<NoticeAction href={ paths.domainManagementEdit( this.props.selectedSite.domain, domain ) }>
+					{ this.translate( 'Fix now' ) }
+				</NoticeAction>
+			</Notice>
+		);
+	},
 
-			notice = this.translate( 'Urgent! Your domain %(domain)s may be lost forever because your email address is not verified. {{a}}Fix now.{{/a}}',
-				{
-					args: { domain },
-					components: { a: <a href={ paths.domainManagementEdit( this.props.selectedSite.domain, domain ) } />},
-				} );
-		} else if ( domains.length ) {
-			notice = <div>
+	unverifiedDomainsNotice( domains ) {
+		return (
+			<Notice status="is-error" showDismiss={ false } className="domain-warnings__unverified-domains" key="unverified-domains">
 				{ this.translate( 'Urgent! Some of your domains may be lost forever because your email address is not verified:' ) }
 				<ul>{
 					domains.map( ( domain ) => {
@@ -197,12 +203,19 @@ export default React.createClass( {
 						</li>;
 					} )
 				}</ul>
-			</div>
-		} else {
-			return null;
-		}
+			</Notice>
+		);
+	},
 
-		return <Notice status="is-error" showDismiss={ true } className="domain-warnings__unverified-domains" key="unverified-domains">{ notice }</Notice>;
+	unverifiedDomains() {
+		let domains = this.getDomains().filter( domain => domain.isPendingIcannVerification );
+
+		if ( domains.length === 1 ) {
+			return this.unverifiedDomainNotice( domains[0].name );
+		} else if ( domains.length ) {
+			return this.unverifiedDomainsNotice( domains );
+		}
+		return null;
 	},
 
 	componentWillMount: function() {

--- a/client/my-sites/upgrades/components/domain-warnings/style.scss
+++ b/client/my-sites/upgrades/components/domain-warnings/style.scss
@@ -1,0 +1,7 @@
+.domain-warnings__unverified-domains {
+	li {
+		font-size: 12px;
+		list-style: none;
+		margin-left: 0;
+	}
+}

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -46,7 +46,7 @@ const List = React.createClass( {
 			return <DomainWarnings
 				domains={ this.props.domains.list }
 				selectedSite={ this.props.selectedSite }
-				ruleWhiteList={ [ 'newDomainsWithPrimary', 'newDomains' ] } />;
+				ruleWhiteList={ [ 'newDomainsWithPrimary', 'newDomains', 'unverifiedDomains' ] } />;
 		}
 	},
 


### PR DESCRIPTION
Display warnings for domains with unverified emails. Not verifying a domain may lead to that domain being suspended, so it's a critical problem, just like expiration.

To test:
0. The easiest way to reproduce the case with domains that are not verified is by hacking `lib/domains/assembler.js` - set `isPendingIcannVerification` to `true` or `false`
1. On a site with 1 domain, go to `domains/manage/site` and check if the proper notice appears when `isPendingIcannVerification` is `true` and disappears when it's `false`.

![screenshot 2016-03-23 19 08 34](https://cloud.githubusercontent.com/assets/82778/13997097/15c72ee2-f139-11e5-875c-80e3a8e1dfeb.png)

(2) On a site with multiple domains, check if the notice displays a list of domains with unverified emails, each one with a clickable 'Fix now' link.

![screenshot 2016-03-23 19 02 47](https://cloud.githubusercontent.com/assets/82778/13996943/771cb5d2-f138-11e5-96ec-502832198d0f.png)

On the original PR it was suggested to me that I use two patterns to reduce code - both leading to InvariantViolation, so I didn't follow these suggestions.

This is the second half of #2916