### PR TITLE
Domains: Update/email forwarding confirmation

### DIFF
--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -447,6 +447,25 @@ const EVENTS = {
 				);
 			},
 
+			resendVerificationClick( domainName, mailbox, destination, success ) {
+				analytics.ga.recordEvent(
+					'Domain Management',
+					'Clicked resend verification email Button in Email Forwarding',
+					'Domain Name',
+					domainName
+				);
+
+				analytics.tracks.recordEvent(
+					'calypso_domain_management_email_forwarding_resend_verification_email_click',
+					{
+						destination,
+						domain_name: domainName,
+						mailbox,
+						success
+					}
+				);
+			},
+
 			inputFocus( domainName, fieldName ) {
 				analytics.ga.recordEvent(
 					'Domain Management',

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -116,6 +116,10 @@ function deleteEmailForwarding( domainName, mailbox, onComplete ) {
 	} );
 }
 
+function resendVerificationEmailForwarding( domainName, mailbox, onComplete ) {
+	wpcom.resendVerificationEmailForward( domainName, mailbox, onComplete );
+}
+
 function fetchDomains( siteId ) {
 	if ( ! isDomainInitialized( DomainsStore.get(), siteId ) ) {
 		Dispatcher.handleViewAction( {
@@ -540,6 +544,7 @@ export {
 	fetchWhois,
 	requestTransferCode,
 	resendIcannVerification,
+	resendVerificationEmailForwarding,
 	setPrimaryDomain,
 	updateNameservers,
 	updateSiteRedirect,

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1601,6 +1601,17 @@ Undocumented.prototype.deleteEmailForward = function( domain, mailbox, callback 
 	} );
 };
 
+Undocumented.prototype.resendVerificationEmailForward = function( domain, mailbox, callback ) {
+	this.wpcom.req.post( '/domains/' + domain + '/email/' + mailbox + '/resend-verification', {}, {}, function( error, response ) {
+		if ( error ) {
+			callback( error );
+			return;
+		}
+
+		callback( null, response );
+	} );
+};
+
 Undocumented.prototype.nameservers = function( domain, callback ) {
 	this.wpcom.req.get( '/domains/' + domain + '/nameservers', function( error, response ) {
 		if ( error ) {

--- a/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-add-new.jsx
+++ b/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-add-new.jsx
@@ -20,6 +20,7 @@ import analyticsMixin from 'lib/mixins/analytics';
 import notices from 'notices';
 import * as upgradesActions from 'lib/upgrades/actions';
 import { validateAllFields } from 'lib/domains/email-forwarding';
+import supportUrls from 'lib/url/support';
 
 const EmailForwardingAddNew = React.createClass( {
 	propTypes: {
@@ -77,13 +78,20 @@ const EmailForwardingAddNew = React.createClass( {
 				this.recordEvent( 'addNewEmailForwardClick', this.props.selectedDomainName, mailbox, destination, ! Boolean( error ) );
 
 				if ( error ) {
-					notices.error( error.message || this.translate( 'Failed to add email forwarding record. Please try again or contact customer support if error persists.' ) );
+					notices.error( error.message || this.translate( 'Failed to add email forwarding record. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
+						{
+							components: {
+								contactSupportLink: <a href={ supportUrls.CONTACT }/>
+							}
+						} )
+					);
 				} else {
 					this.formStateController.resetFields( this.getInitialState().fields );
 
 					notices.success(
-						this.translate( 'Yay, %(email)s has been successfully added!', { args: {
-							email: mailbox + '@' + this.props.selectedDomainName
+						this.translate( '%(email)s has been successfully added! You must confirm your email before it starts working. Please check your inbox for %(destination)s.', { args: {
+							email: mailbox + '@' + this.props.selectedDomainName,
+							destination: destination
 						} } ), {
 							duration: 5000
 						} );

--- a/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-item.jsx
@@ -9,11 +9,12 @@ import { bindActionCreators } from 'redux';
  * Internal dependencies
  */
 import analyticsMixin from 'lib/mixins/analytics';
-import notices from 'notices';
-import * as upgradesActions from 'lib/upgrades/actions';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
+import notices from 'notices';
 import { successNotice } from 'state/notices/actions';
+import supportUrls from 'lib/url/support';
+import * as upgradesActions from 'lib/upgrades/actions';
 
 const EmailForwardingItem = React.createClass( {
 	mixins: [ analyticsMixin( 'domainManagement', 'emailForwarding' ) ],
@@ -26,12 +27,56 @@ const EmailForwardingItem = React.createClass( {
 		}
 
 		upgradesActions.deleteEmailForwarding( domain, mailbox, ( error ) => {
-			this.recordEvent( 'deleteClick', domain, mailbox, forward_address, ! Boolean( error ) );
+			this.recordEvent( 'deleteClick', domain, mailbox, forward_address, ! error );
 
 			if ( error ) {
-				notices.error( error.message );
+				notices.error( error.message || this.translate( 'Failed to delete email forwarding record. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
+					{
+						components: {
+							contactSupportLink: <a href={ supportUrls.CONTACT }/>
+						}
+					} )
+				);
 			} else {
-				this.props.successNotice( this.translate( 'Yay, %(email)s has been successfully deleted!', { args: { email: email } } ) );
+				notices.success(
+					this.translate( 'Yay, e-mail forwarding for %(email)s has been successfully deleted.', {
+						args: {
+							email: email
+						}
+					} ), {
+						duration: 5000
+					} );
+			}
+		} );
+	},
+
+	resendVerificationEmail: function() {
+		const { temporary, domain, mailbox, forward_address } = this.props.emailData;
+
+		if ( temporary ) {
+			return;
+		}
+
+		upgradesActions.resendVerificationEmailForwarding( domain, mailbox, ( error, response ) => {
+			this.recordEvent( 'resendVerificationClick', domain, mailbox, forward_address, ! error );
+
+			if ( error || ! response.sent ) {
+				notices.error( this.translate( 'Failed to resend verification email for email forwarding record. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
+					{
+						components: {
+							contactSupportLink: <a href={ supportUrls.CONTACT }/>
+						}
+					} )
+				);
+			} else {
+				notices.success(
+					this.translate( 'Yay, successfully sent confirmation email to %(email)s!', {
+						args: {
+							email: forward_address
+						}
+					} ), {
+						duration: 5000
+					} );
 			}
 		} );
 	},
@@ -42,6 +87,9 @@ const EmailForwardingItem = React.createClass( {
 				<Button borderless disabled={ this.props.emailData.temporary } onClick={ this.deleteItem }>
 					<Gridicon icon="trash" />
 				</Button>
+
+				{ ! this.props.emailData.active && <Button disabled={ this.props.emailData.temporary } borderless onClick={ this.resendVerificationEmail } title={ this.translate( 'Resend Verification Email', { context: 'Email Forwarding' } ) }><Gridicon icon="mail" /></Button> }
+
 				<span>{ this.translate( '{{strong1}}%(email)s{{/strong1}} {{em}}forwards to{{/em}} {{strong2}}%(forwardTo)s{{/strong2}}',
 					{
 						components: {


### PR DESCRIPTION
**What:**
- Change messaging when adding e-mail forwards
- Add a button to `Resend Verification Email` for unconfirmed forwards
- Add Tracks event for `Resend Verification Email` clicks

**Why:**
- Users must confirm they own the email before the forward will start working
- Users should have a way to resend the verification email

**Testing:** Calypso -> Domains -> Click on a Domain Registration -> Email -> Add Email Forwards
- Add 2 forwards
- You should see a mail and trash icon next to the email forwads
- Check that you received 2 confirmation emails for the added forwards
- Confirm one
- Refresh Calypso
- The confirmed email shouldn't have the email icon

**Visual Changes:**
_Before_
![before](https://cloud.githubusercontent.com/assets/1103398/14003412/af678e48-f152-11e5-8aab-c2ba95feb39a.png)


_After_
![after](https://cloud.githubusercontent.com/assets/1103398/14003413/b1b649c8-f152-11e5-8ffb-c3bf3c01c9af.png)
