### PR TITLE
Plugins: select all plugins by default on 'Edit all' event

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -131,12 +131,12 @@ export default React.createClass( {
 		const bulkManagement = ! this.state.bulkManagement;
 
 		if ( bulkManagement ) {
+			this.setBulkSelectionState( this.props.plugins, bulkManagement );
 			this.setState( { bulkManagement } );
 			return this.recordEvent( 'Clicked Manage' );
 		}
 
-		// Unselect all plugins.
-		this.setState( { selectedPlugins: {}, bulkManagement } );
+		this.setState( { bulkManagement } );
 		this.removePluginsNotices();
 		this.recordEvent( 'Clicked Manage Done' );
 	},


### PR DESCRIPTION
This PR addresses #2789 

Currently the `selectedPlugins` state in `PluginsList