### PR TITLE
Editor: Destroy editor instance only if initialized

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -195,8 +195,16 @@ module.exports = React.createClass( {
 	},
 
 	componentDidMount: function() {
+		this.mounted = true;
+
 		const setup = function( editor ) {
 			this._editor = editor;
+
+			if ( ! this.mounted ) {
+				this.destroyEditor();
+				return;
+			}
+
 			this.bindEditorEvents();
 			editor.on( 'SetTextAreaContent', ( event ) => this.setTextAreaContent( event.content ) );
 
@@ -301,13 +309,22 @@ module.exports = React.createClass( {
 	},
 
 	componentWillUnmount: function() {
+		this.mounted = false;
+
+		window.removeEventListener( 'scroll', this.onScrollPinTools );
+
+		if ( this._editor ) {
+			this.destroyEditor();
+		}
+	},
+
+	destroyEditor() {
 		forEach( EVENTS, function( eventHandler, eventName ) {
 			if ( this.props[ eventHandler ] ) {
 				this._editor.off( eventName, this.props[ eventHandler ] );
 			}
 		}.bind( this ) );
 
-		window.removeEventListener( 'scroll', this.onScrollPinTools );
 		tinymce.remove( this._editor );
 		this._editor = null;
 		autosize.destroy( ReactDom.findDOMNode( this.refs.text ) );


### PR DESCRIPTION
This pull request seeks to resolve an issue where an error can occur when quickly navigating away from the post editor screen before the TinyMCE instance has an opportunity to initialize. The `<TinyMCE />` `componentWillUnmount` logic assumes the existence of a `this._editor` value, but if the editor had not yet been initialized, this will be unset.

The changes herein modify the editor destruction flow such it occurs both during unmount (if initialized) and during editor initialization (if unmounted).

__Testing instructions:__

Verify that no errors occur when __quickly__ navigating away from the editor before TinyMCE initializes.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Before the editor initializes, navigate to another page (e.g. Reader, Posts)
4. Refresh and repeat step 3 if you are too slow

__Note:__ While the changes add logic to destroy the editor if unmounted during `setup`, it appears that the `setup` function is never invoked after having been unmounted. It's possible this is the result of some additional checks performed by TinyMCE to detect the presence of the target node before initializing.