### PR TITLE
People: Enable invites form in staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -20,7 +20,7 @@
 		"help": true,
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,
-		"manage/add-people": false,
+		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,


### PR DESCRIPTION
Before launching in production, let's launch to staging and check that everything works as expected.

To test:
- Checkout `update/invites-to-staging` branch
- Change `wpcom_user_bootstrap` to `false` in `stage.json`
- In terminal `CALYPSO_ENV=stage make run`
- Load up `/people/new/$site`

cc @lezama for review