### PR TITLE
Plugins: select all plugins by default on 'Edit all' event

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -131,12 +131,12 @@ export default React.createClass( {
 		const bulkManagement = ! this.state.bulkManagement;
 
 		if ( bulkManagement ) {
+			this.setBulkSelectionState( this.props.plugins, bulkManagement );
 			this.setState( { bulkManagement } );
 			return this.recordEvent( 'Clicked Manage' );
 		}
 
-		// Unselect all plugins.
-		this.setState( { selectedPlugins: {}, bulkManagement } );
+		this.setState( { bulkManagement } );
 		this.removePluginsNotices();
 		this.recordEvent( 'Clicked Manage Done' );
 	},


### PR DESCRIPTION
This PR addresses #2789 

With this change, when a user hits 'Edit all' the bulk selector is enabled with all plugins selected. 

The code change is around setting the state of `pluginsSelected` in `PluginsList` component. 
Currently the state is emptied out when the bulk selector is toggled off. 
This changes this so that all the available plugins are selected when the bulk selector is toggled on.
![select_all3](https://cloud.githubusercontent.com/assets/744755/13993037/cbf7ebec-f0db-11e5-892a-27be5854f3c4.gif)


cc @rickybanister