### PR TITLE
Plugin: select all plugins by default on 'Edit all' event

### DIFF
--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -43,7 +43,7 @@ export default React.createClass( {
 	getInitialState() {
 		return {
 			disconnectJetpackDialog: false,
-			bulkManagement: false,
+			bulkManagementActive: false,
 			selectedPlugins: {}
 		};
 	},
@@ -128,17 +128,17 @@ export default React.createClass( {
 
 	// Actions
 	toggleBulkManagement() {
-		const bulkManagement = ! this.state.bulkManagement;
+		const activateBulkManagement = ! this.state.bulkManagementActive;
 
-		if ( bulkManagement ) {
+		if ( activateBulkManagement ) {
 			this.setBulkSelectionState( this.props.plugins, true );
-			this.setState( { bulkManagement } );
-			return this.recordEvent( 'Clicked Manage' );
+			this.setState( { bulkManagementActive: true } );
+			this.recordEvent( 'Clicked Manage' );
+		} else {
+			this.setState( { bulkManagementActive: false } );
+			this.removePluginsNotices();
+			this.recordEvent( 'Clicked Manage Done' );
 		}
-
-		this.setState( { bulkManagement } );
-		this.removePluginsNotices();
-		this.recordEvent( 'Clicked Manage Done' );
 	},
 
 	removePluginsNotices() {
@@ -319,7 +319,7 @@ export default React.createClass( {
 	// Renders
 	render() {
 		const itemListClasses = classNames( 'list-cards-compact', 'plugins-list', {
-			'is-bulk-editing': this.state.bulkManagement
+			'is-bulk-editing': this.state.bulkManagementActive
 		} );
 
 		if ( this.props.isPlaceholder ) {
@@ -338,7 +338,7 @@ export default React.createClass( {
 		return (
 			<div className="plugins-list" >
 				<PluginsListHeader label={ this.props.header }
-					isBulkManagementActive={ !! this.state.bulkManagement }
+					isBulkManagementActive={ this.state.bulkManagementActive }
 					sites={ this.props.sites }
 					plugins={ this.props.plugins }
 					selected={ this.getSelected() }
@@ -374,7 +374,7 @@ export default React.createClass( {
 				errors={ this.state.notices.errors.filter( log => log.plugin && log.plugin.slug === plugin.slug ) }
 				notices={ this.state.notices }
 				isSelected={ this.isSelected( plugin ) }
-				isSelectable={ this.state.bulkManagement }
+				isSelectable={ this.state.bulkManagementActive }
 				onClick={ selectThisPlugin }
 				selectedSite={ this.props.selectedSite }
 				pluginLink={ '/plugins/' + encodeURIComponent( plugin.slug ) + this.siteSuffix() } />

--- a/client/my-sites/plugins/plugins-list/index.jsx
+++ b/client/my-sites/plugins/plugins-list/index.jsx
@@ -131,12 +131,12 @@ export default React.createClass( {
 		const bulkManagement = ! this.state.bulkManagement;
 
 		if ( bulkManagement ) {
+			this.setBulkSelectionState( this.props.plugins, true );
 			this.setState( { bulkManagement } );
 			return this.recordEvent( 'Clicked Manage' );
 		}
 
-		// Unselect all plugins.
-		this.setState( { selectedPlugins: {}, bulkManagement } );
+		this.setState( { bulkManagement } );
 		this.removePluginsNotices();
 		this.recordEvent( 'Clicked Manage Done' );
 	},

--- a/client/my-sites/plugins/plugins-list/test/fixtures/index.js
+++ b/client/my-sites/plugins/plugins-list/test/fixtures/index.js
@@ -1,0 +1,53 @@
+export const sites = [ {
+	'ID': 43889156,
+	'name': 'bitswapping development',
+	'description': 'Just another WordPress site',
+	'URL': 'http://demo.bitswapping.com',
+	'jetpack': true,
+	'post_count': 3,
+	'subscribers_count': 1,
+	'lang': 'en',
+	'visible': true,
+	'is_private': false,
+	'is_following': true,
+	'options': {
+		'timezone': '',
+		'gmt_offset': 0,
+		'videopress_enabled': false,
+		'login_url': 'https://demo.bitswapping.com/wp-login.php',
+		'admin_url': 'https://demo.bitswapping.com/wp-admin/',
+		'featured_images_enabled': true,
+		'header_image': false,
+		'image_default_link_type': 'file',
+		'image_thumbnail_width': 150,
+		'image_thumbnail_height': 150,
+		'image_thumbnail_crop': 0,
+		'image_medium_width': 300,
+		'image_medium_height': 300,
+		'image_large_width': 1024,
+		'image_large_height': 1024,
+		'post_formats': {
+			'aside': 'Aside',
+			'link': 'Link',
+			'gallery': 'Gallery',
+			'status': 'Status',
+			'quote': 'Quote',
+			'image': 'Image'
+		},
+		'default_likes_enabled': true,
+		'default_sharing_status': false,
+		'default_comment_status': true,
+		'default_ping_status': true,
+		'software_version': '4.0-beta2-20140728'
+	},
+	'meta': {
+		'links': {
+			'self': 'https://public-api.wordpress.com/rest/v1/sites/43889156',
+			'help': 'https://public-api.wordpress.com/rest/v1/sites/43889156/help',
+			'posts': 'https://public-api.wordpress.com/rest/v1/sites/43889156/posts/',
+			'comments': 'https://public-api.wordpress.com/rest/v1/sites/43889156/comments/',
+			'xmlrpc': 'https://demo.bitswapping.com/xmlrpc.php'
+		}
+	},
+	'user_can_manage': true
+}];

--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -1,0 +1,87 @@
+/*
+ * External dependencies
+*/
+import { expect } from 'chai';
+
+/*
+ * Internal dependencies
+*/
+import useMockery from 'test/helpers/use-mockery';
+import useFakeDom from 'test/helpers/use-fake-dom';
+
+import { sites } from './fixtures';
+import i18n from 'lib/mixins/i18n';
+
+describe( 'PluginsList', () => {
+	let React, testRenderer, PluginsList, siteListMock;
+
+	useFakeDom();
+
+	useMockery( mockery => {
+		mockery.registerSubstitute( 'matches-selector', 'component-matches-selector' );
+		mockery.registerSubstitute( 'query', 'component-query' );
+
+		let emptyComponent = require( 'test/helpers/react/empty-component' );
+		mockery.registerMock( 'my-sites/plugins/plugin-item/plugin-item', emptyComponent );
+		mockery.registerMock( 'my-sites/plugins/plugin-list-header', emptyComponent );
+
+		mockery.registerMock( 'lib/sites-list', () => siteListMock );
+	} );
+
+	before( () => {
+		React = require( 'react' );
+
+		const TestUtils = require( 'react-addons-test-utils' ),
+			ReactInjection = require( 'react/lib/ReactInjection' );
+
+		i18n.initialize();
+		ReactInjection.Class.injectMixin( i18n.mixin );
+
+		testRenderer = TestUtils.renderIntoDocument;
+
+		siteListMock = { getSelectedSite: () => sites[ 0 ] };
+		PluginsList = require( '../' );
+	} );
+
+	describe.only( 'rendering bulk actions', function() {
+		let renderedPluginsList, plugins, props;
+
+		before( () => {
+			plugins = [
+				{sites, slug: 'hello', name: 'Hello Dolly'},
+				{sites, slug: 'jetpack', name: 'Jetpack'} ];
+
+			props = {
+				plugins,
+				header: 'Plugins',
+				sites: siteListMock,
+				selectedSite: sites[ 0 ],
+				isPlaceholder: false,
+				pluginUpdateCount: plugins.length
+			}
+		} );
+
+		beforeEach( () => {
+			renderedPluginsList = testRenderer( <PluginsList { ...props } /> );
+		} );
+
+		it( 'should be intialized with no selectedPlugins', () => {
+			expect( renderedPluginsList.state.selectedPlugins ).to.be.empty;
+		} );
+
+		it( 'should select all plugins when toggled on', () => {
+			renderedPluginsList.toggleBulkManagement();
+			expect( renderedPluginsList.state.selectedPlugins ).to.contain.all.keys( 'hello', 'jetpack' );
+			expect( Object.keys( renderedPluginsList.state.selectedPlugins ) ).to.have.lengthOf( 2 );
+		} );
+
+		it( 'should always reset to all selected when toggled on', () => {
+			renderedPluginsList.togglePlugin( plugins[0] );
+			expect( Object.keys( renderedPluginsList.state.selectedPlugins ) ).to.have.lengthOf( 1 );
+
+			renderedPluginsList.toggleBulkManagement();
+			expect( renderedPluginsList.state.selectedPlugins ).to.contain.all.keys( 'hello', 'jetpack' );
+			expect( Object.keys( renderedPluginsList.state.selectedPlugins ) ).to.have.lengthOf( 2 );
+		} );
+	} );
+} );

--- a/client/tests.json
+++ b/client/tests.json
@@ -438,6 +438,9 @@
 			},
 			"plugin-autoupdate-toggle" : {
 				"test": [ "index" ]
+			},
+			"plugins-list": {
+				"test": [ "index" ]
 			}
 		},
 		"upgrades": {


### PR DESCRIPTION
This PR addresses #2789 

With this change, when a user hits 'Edit all' the bulk selector is enabled with all plugins selected. 

The code change is around setting the state of `pluginsSelected` in `PluginsList` component. 
Currently the state is emptied out when the bulk selector is toggled off. 
This changes this so that all the available plugins are selected when the bulk selector is toggled on.

![select_all3](https://cloud.githubusercontent.com/assets/744755/13993037/cbf7ebec-f0db-11e5-892a-27be5854f3c4.gif)

cc @rickybanister

**To Test**

via unit tests:

`npm run test-client -- --grep "my-sites plugins plugins-list"`

from development

visit `http://calypso.localhost:3000/plugins/`
click `Edit all`
all plugins will be selected
