### PR TITLE
Editor / CPT: Use type label for saved post view button

### DIFF
--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -14,6 +14,7 @@ import EditorVisibility from 'post-editor/editor-visibility';
 import Gridicon from 'components/gridicon';
 import utils from 'lib/posts/utils';
 import Tooltip from 'components/tooltip';
+import Button from 'components/button';
 import EditorActionBarViewLabel from './view-label';
 
 export default React.createClass( {
@@ -77,14 +78,14 @@ export default React.createClass( {
 						post={ this.props.post }
 						onTrashingPost={ this.props.onTrashingPost }
 					/>
-					{ utils.isPublished( this.props.savedPost ) &&
-						<a
-							className="editor-action-bar__view-link"
+					{ utils.isPublished( this.props.savedPost ) && (
+						<Button
 							href={ this.props.savedPost.URL }
 							target="_blank"
 							onMouseEnter={ () => this.setState( { viewLinkTooltip: true } ) }
 							onMouseLeave={ () => this.setState( { viewLinkTooltip: false } ) }
 							ref="viewLink"
+							borderless
 						>
 							<Gridicon icon="external" />
 							<Tooltip
@@ -94,7 +95,8 @@ export default React.createClass( {
 							>
 								<EditorActionBarViewLabel />
 							</Tooltip>
-						</a> }
+						</Button>
+					) }
 				</div>
 			</div>
 		);

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -14,6 +14,7 @@ import EditorVisibility from 'post-editor/editor-visibility';
 import Gridicon from 'components/gridicon';
 import utils from 'lib/posts/utils';
 import Tooltip from 'components/tooltip';
+import EditorActionBarViewLabel from './view-label';
 
 export default React.createClass( {
 
@@ -91,10 +92,7 @@ export default React.createClass( {
 								isVisible={ this.state.viewLinkTooltip }
 								position="bottom left"
 							>
-								{ this.props.type === 'page'
-									? this.translate( 'View page' )
-									: this.translate( 'View post' )
-								}
+								<EditorActionBarViewLabel />
 							</Tooltip>
 						</a> }
 				</div>

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -28,10 +28,11 @@
 	text-align: right;
 }
 
-.editor-action-bar__view-link {
+.editor-action-bar .button {
 	color: lighten( $gray, 20% );
 	margin-left: 12px;
 	transition: color 200ms;
+	padding: 0;
 
 	&:hover,
 	&:focus {

--- a/client/post-editor/editor-action-bar/view-label.jsx
+++ b/client/post-editor/editor-action-bar/view-label.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import localize from 'lib/mixins/i18n/localize';
+import { getEditedPost } from 'state/posts/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getPostType } from 'state/post-types/selectors';
+import QueryPostTypes from 'components/data/query-post-types';
+
+function EditorActionBarViewLabel( { translate, siteId, typeSlug, type } ) {
+	let label;
+	if ( 'page' === typeSlug ) {
+		label = translate( 'View page' );
+	} else if ( 'post' === typeSlug ) {
+		label = translate( 'View post' );
+	} else if ( type ) {
+		label = type.labels.view_item;
+	} else {
+		label = translate( 'View', { context: 'verb' } );
+	}
+
+	return (
+		<span className="editor-action-bar__view-label">
+			{ siteId && 'page' !== typeSlug && 'post' !== typeSlug && (
+				<QueryPostTypes siteId={ siteId } />
+			) }
+			{ label }
+		</span>
+	);
+}
+
+EditorActionBarViewLabel.propTypes = {
+	translate: PropTypes.func,
+	siteId: PropTypes.number,
+	typeSlug: PropTypes.string,
+	type: PropTypes.object
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const props = { siteId };
+	const post = getEditedPost( state, siteId, getEditorPostId( state ) );
+	if ( ! post ) {
+		return props;
+	}
+
+	return Object.assign( props, {
+		typeSlug: post.type,
+		type: getPostType( state, siteId, post.type )
+	} );
+} )( localize( EditorActionBarViewLabel ) );

--- a/client/post-editor/editor-delete-post/style.scss
+++ b/client/post-editor/editor-delete-post/style.scss
@@ -1,9 +1,4 @@
 .editor-delete-post.button {
-	color: lighten( $gray, 20% );
-	margin-left: 12px;
-	transition: color 200ms;
-	padding: 0;
-
 	&:hover {
 		color: $orange-fire;
 	}

--- a/client/post-editor/editor-sticky/style.scss
+++ b/client/post-editor/editor-sticky/style.scss
@@ -1,9 +1,4 @@
 .editor-sticky.button {
-	color: lighten( $gray, 20% );
-	margin-right: 12px;
-	padding: 0;
-	transition: color 200ms;
-
 	&.is-sticky {
 		color: $orange-jazzy;
 	}

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -1,13 +1,7 @@
 .editor-visibility.button {
-	color: lighten( $gray, 20% );
-	padding: 0;
-	transition: color 200ms;
-
 	&.is-dialog-open,
 	&.is-touch,
 	&:hover {
-		color: darken( $gray, 10% );
-
 		.editor-visibility__label {
 			color: darken( $gray, 10% );
 		}


### PR DESCRIPTION
Related: #3695

This pull request seeks to use a post type's `labels.view_item` string in rendering the action bar View button tooltip text. This furthers our focus on custom post types, as the current editor only supports from hard-coded post types (page and post).

Further, it also resolves a styling issue where the View button is misaligned with other buttons in the action bar. It does so by refactoring the link to be displayed as a `<Button borderless />` component and applying consolidated styling to all buttons in the action bar.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/13994835/0512f1d0-f0fd-11e5-8ff2-c9a7ec745856.png)|![After](https://cloud.githubusercontent.com/assets/1779930/13994826/fb15020e-f0fc-11e5-9174-b175e3c771ee.png)

__Testing instructions:__

Verifying custom post type labels is currently blocked by #4193. In the interim, test to ensure that "View Post" and "View Page" labels display correctly for saved posts and pages, respectively. Also verify that alignment of buttons is corrected, while still preserving targeted styling (e.g. red hover on delete).