### PR TITLE
CPT: Display placeholder while posts load

### DIFF
--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -16,6 +16,10 @@ const IMAGE_SCALE_FACTOR = ( typeof window !== 'undefined' && window.devicePixel
 function resizeImageUrl( imageUrl, params ) {
 	var parsedUrl = url.parse( imageUrl, true, true );
 
+	if ( ! /^https?:$/.test( parsedUrl.protocol ) ) {
+		return imageUrl;
+	}
+
 	parsedUrl.query = omit( parsedUrl.query, [ 'w', 'h', 'resize', 'fit' ] );
 
 	const localParams = assign( {}, params );

--- a/client/lib/resize-image-url/test/index.js
+++ b/client/lib/resize-image-url/test/index.js
@@ -20,4 +20,10 @@ describe( 'index', function() {
 		var resizedImageUrl = resizeImageUrl( safeImageUrl, { resize: '40,40' } );
 		assert.equal( resizedImageUrl, 'https://testonesite2014.files.wordpress.com/2014/11/image5.jpg?resize=40%2C40' );
 	} );
+
+	it( 'should not attempt to resize non-HTTP protocols', function() {
+		var imageUrl = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+		var resizedImageUrl = resizeImageUrl( imageUrl, { resize: '40,40' } );
+		assert.equal( resizedImageUrl, imageUrl );
+	} );
 } );

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -9,19 +9,26 @@ import { connect } from 'react-redux';
  */
 import QueryPosts from 'components/data/query-posts';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSitePostsForQueryIgnoringPage } from 'state/posts/selectors';
-import PostTypePost from './post';
+import {
+	isRequestingSitePostsForQuery,
+	getSitePostsForQueryIgnoringPage
+} from 'state/posts/selectors';
+import PostTypeListPost from './post';
+import PostTypeListPostPlaceholder from './post-placeholder';
 
-function PostTypeList( { query, siteId, posts } ) {
+function PostTypeList( { query, siteId, posts, requesting } ) {
 	return (
 		<div className="post-type-list">
 			<QueryPosts
 				siteId={ siteId }
 				query={ query } />
 			<ul className="post-type-list__posts">
+				{ requesting && (
+					<li><PostTypeListPostPlaceholder /></li>
+				) }
 				{ posts && posts.map( ( post ) => (
 					<li key={ post.global_ID }>
-						<PostTypePost globalId={ post.global_ID } />
+						<PostTypeListPost globalId={ post.global_ID } />
 					</li>
 				) ) }
 			</ul>
@@ -32,7 +39,8 @@ function PostTypeList( { query, siteId, posts } ) {
 PostTypeList.propTypes = {
 	query: PropTypes.object,
 	siteId: PropTypes.number,
-	posts: PropTypes.array
+	posts: PropTypes.array,
+	requesting: PropTypes.bool
 };
 
 export default connect( ( state, ownProps ) => {
@@ -40,6 +48,7 @@ export default connect( ( state, ownProps ) => {
 
 	return {
 		siteId,
-		posts: getSitePostsForQueryIgnoringPage( state, siteId, ownProps.query )
+		posts: getSitePostsForQueryIgnoringPage( state, siteId, ownProps.query ),
+		requesting: isRequestingSitePostsForQuery( state, siteId, ownProps.query )
 	};
 } )( PostTypeList );

--- a/client/my-sites/post-type-list/post-placeholder.jsx
+++ b/client/my-sites/post-type-list/post-placeholder.jsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import localize from 'lib/mixins/i18n/localize';
+import { PostTypeListPost } from './post';
+
+function PostTypeListPostPlaceholder( { translate } ) {
+	const post = {
+		title: translate( 'Loading…' ),
+		featured_image: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+		status: 'draft',
+		modified: '2015-08-10T19:44:08+00:00'
+	};
+
+	return (
+		<PostTypeListPost
+			post={ post }
+			className="post-type-list__post-placeholder" />
+	);
+}
+
+export default localize( PostTypeListPostPlaceholder );

--- a/client/my-sites/post-type-list/post.jsx
+++ b/client/my-sites/post-type-list/post.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import classnames from 'classnames';
 import { connect } from 'react-redux';
 
 /**
@@ -15,9 +16,11 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import resizeImageUrl from 'lib/resize-image-url';
 
-function PostTypePost( { post, editUrl } ) {
+export function PostTypeListPost( { post, editUrl, className } ) {
+	const classes = classnames( 'post-type-list__post', className )
+
 	return (
-		<Card compact className="post-type-list__post">
+		<Card compact className={ classes }>
 			<div className="post-type-list__post-detail">
 				{ post.featured_image && (
 					<div className="post-type-list__post-thumbnail-wrapper">
@@ -47,9 +50,10 @@ function PostTypePost( { post, editUrl } ) {
 	);
 }
 
-PostTypePost.propTypes = {
-	globalId: PropTypes.string.isRequired,
-	post: PropTypes.object
+PostTypeListPost.propTypes = {
+	globalId: PropTypes.string,
+	post: PropTypes.object,
+	className: PropTypes.string
 };
 
 export default connect( ( state, ownProps ) => {
@@ -59,4 +63,4 @@ export default connect( ( state, ownProps ) => {
 		post,
 		editUrl: getEditorPath( state, state.ui.selectedSiteId, post.ID )
 	};
-} )( PostTypePost );
+} )( PostTypeListPost );

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -18,6 +18,10 @@
 	width: 80px;
 	margin-right: 12px;
 	overflow: hidden;
+
+	.post-type-list__post-placeholder & {
+		@include placeholder;
+	}
 }
 
 .post-type-list__post-thumbnail {
@@ -41,6 +45,10 @@
 		&:hover {
 			color: darken( $gray, 20% );
 		}
+
+		.post-type-list__post-placeholder & {
+			@include placeholder;
+		}
 	}
 }
 
@@ -51,6 +59,10 @@
 
 .post-type-list__post-meta .post-relative-time-status {
 	margin-bottom: 0;
+
+	.post-type-list__post-placeholder & {
+		@include placeholder;
+	}
 }
 
 .post-type-list__post-meta .post-relative-time-status .gridicon {


### PR DESCRIPTION
This pull request seeks to display a placeholder post while the posts for a `<PostTypeList />` component are being requested from the REST API.

![placeholder](https://cloud.githubusercontent.com/assets/1779930/13996065/7c4e73c8-f102-11e5-8c47-a1d463601232.gif)

__Testing instructions:__

1. Navigate to [My Sites](http://calypso.localhost:3000/sites)
2. Select a site which has at least one custom post type enabled
3. Navigate to the custom post type in the sidebar
4. Note that while posts load, a placeholder is shown