### PR TITLE
Themes: Fix showcase for jetpack sites in subdirectories

### DIFF
--- a/client/components/data/themes-list-fetcher/index.jsx
+++ b/client/components/data/themes-list-fetcher/index.jsx
@@ -13,8 +13,9 @@ import { connect } from 'react-redux';
 import { PER_PAGE } from 'state/themes/themes-list/constants';
 import { query, fetchNextPage } from 'state/themes/actions';
 import { hasSiteChanged, isJetpack } from 'state/themes/themes-last-query/selectors';
-import { isLastPage, isFetchingNextPage, getThemesList } from 'state/themes/themes-list/selectors';
+import { isLastPage, isFetchingNextPage, getThemesList, isFetchError } from 'state/themes/themes-list/selectors';
 import { getThemeById } from 'state/themes/themes/selectors';
+import { errorNotice } from 'state/notices/actions';
 
 const ThemesListFetcher = React.createClass( {
 	propTypes: {
@@ -38,6 +39,7 @@ const ThemesListFetcher = React.createClass( {
 		} ).isRequired,
 		query: React.PropTypes.func.isRequired,
 		fetchNextPage: React.PropTypes.func.isRequired,
+		error: React.PropTypes.bool,
 	},
 
 	componentDidMount: function() {
@@ -45,6 +47,9 @@ const ThemesListFetcher = React.createClass( {
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
+		if ( nextProps.error && nextProps.error !== this.props.error ) {
+			this.props.errorNotice( this.translate( 'There was a problem fetching the themes' ) );
+		}
 		if (
 				nextProps.tier !== this.props.tier || (
 					nextProps.search !== this.props.search && (
@@ -142,7 +147,8 @@ export default connect(
 		lastQuery: {
 			hasSiteChanged: hasSiteChanged( state ),
 			isJetpack: isJetpack( state )
-		}
+		},
+		error: isFetchError( state )
 	} ),
-	{ query, fetchNextPage }
+	{ query, fetchNextPage, errorNotice }
 )( ThemesListFetcher );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1492,7 +1492,7 @@ Undocumented.prototype.getLocaleSuggestions = function( fn ) {
 };
 
 Undocumented.prototype.themes = function( site, query, fn ) {
-	var path = site ? '/sites/' + site.slug + '/themes' : '/themes';
+	var path = site ? '/sites/' + site.ID + '/themes' : '/themes';
 	debug( path );
 	this.wpcom.req.get( path, {
 		search: query.search,

--- a/client/state/themes/themes-list/reducer.js
+++ b/client/state/themes/themes-list/reducer.js
@@ -69,7 +69,8 @@ export default ( state = initialState, action ) => {
 						.setIn( [ 'queryState', 'isFetchingNextPage' ], false )
 						.update( 'list', add.bind( null, map( action.themes, 'id' ) ) );
 
-				return newState.setIn( [ 'queryState', 'isLastPage' ],
+				return newState.setIn( [ 'queryState', 'error' ], false )
+						.setIn( [ 'queryState', 'isLastPage' ],
 						isActionForLastPage( newState.get( 'list' ), action ) );
 			}
 			return state;
@@ -82,7 +83,8 @@ export default ( state = initialState, action ) => {
 		case ActionTypes.RECEIVE_THEMES_SERVER_ERROR:
 			return state
 				.setIn( [ 'queryState', 'isFetchingNextPage' ], false )
-				.setIn( [ 'queryState', 'isLastPage' ], true );
+				.setIn( [ 'queryState', 'isLastPage' ], true )
+				.setIn( [ 'queryState', 'error' ], true );
 
 		case ActionTypes.ACTIVATED_THEME:
 			// The `active` attribute isn't ever really read, but since

--- a/client/state/themes/themes-list/reducer.js
+++ b/client/state/themes/themes-list/reducer.js
@@ -82,7 +82,7 @@ export default ( state = initialState, action ) => {
 		case ActionTypes.RECEIVE_THEMES_SERVER_ERROR:
 			return state
 				.setIn( [ 'queryState', 'isFetchingNextPage' ], false )
-				.setIn( [ 'queryState', 'lastPage' ], true );
+				.setIn( [ 'queryState', 'isLastPage' ], true );
 
 		case ActionTypes.ACTIVATED_THEME:
 			// The `active` attribute isn't ever really read, but since

--- a/client/state/themes/themes-list/selectors.js
+++ b/client/state/themes/themes-list/selectors.js
@@ -15,3 +15,7 @@ export function getThemesList( state ) {
 export function getQueryParams( state ) {
 	return state.themes.themesList.get( 'query' ).toObject();
 }
+
+export function isFetchError( state ) {
+	return state.themes.themesList.getIn( [ 'queryState', 'error' ] );
+}


### PR DESCRIPTION
Fixes #4135 

Change to using site ID instead of slug in the API call.

Also adds a notice on error:
<img width="960" alt="screen shot 2016-03-24 at 15 22 15" src="https://cloud.githubusercontent.com/assets/7767559/14021638/41fea1ac-f1d4-11e5-98d5-149c3a4bdf85.png">

To test the notice, change `site.ID` to `'example.com::subdir'` here: https://github.com/Automattic/wp-calypso/pull/4268/files#diff-68ed82f95213dcecd427a2a719f4257bR1495

