### PR TITLE
Notice: Fix dismiss button regression

### DIFF
--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -117,7 +117,9 @@ export default React.createClass( {
 		return (
 			<div className={ classnames( this.props.className, noticeClass ) }>
 				<Gridicon className="notice__icon" icon={ this.props.icon || this.getIcon() } size={ 24 } />
-				{ this.renderChildren() }
+				<div className="notice__content">
+					{ this.renderChildren() }
+				</div>
 				{ dismiss }
 			</div>
 		);

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -31,10 +31,6 @@
 	&.is-info {
 		background: $blue-wordpress;
 	}
-
-	@include breakpoint( "<480px" ) {
-		flex-direction: column;
-	}
 }
 
 .notice__icon {
@@ -45,8 +41,16 @@
 	}
 }
 
-.notice__text {
+.notice__content {
+	display: flex;
 	flex-grow: 1;
+
+	@include breakpoint( "<480px" ) {
+		flex-direction: column;
+	}
+}
+
+.notice__text {
 	font-size: 15px;
 	padding: 11px 24px;
 


### PR DESCRIPTION
Fixes #4243

This PR updates `Notice` to separate the notice content (text, and sometimes an action) and the dismiss button, so that we can use flex boxes to arrange the latter differently than the former in small viewports.

**Testing**
*With the dismiss button (global)*
- Visit `/people/new/:site` and invite any user to your site.
- Assert that the dismiss button in the notice that appears is properly aligned in all viewports > 960px and especially < 480px:

![screen shot 2016-03-23 at 11 28 16 am](https://cloud.githubusercontent.com/assets/1130674/13996380/a98c78e8-f0ea-11e5-8a80-a42b52d65be0.png)

*With the dismiss button (inline)*
- Visit `/people/edit/:username/:site` and click on a user that is not the owner of `:site`. You may need to invite a user to `:site` if there is only one user listed.
- Update the role of this user.
- Assert that the dismiss button in the notice that appears is properly aligned in all viewports > 960px and especially < 480px:

![screen shot 2016-03-23 at 11 05 13 am](https://cloud.githubusercontent.com/assets/1130674/14001612/29030ac4-f104-11e5-9149-6a7724a770c0.png)

*With an action*
- Visit `/post/:site`.
- Publish a post.
- Assert that the notice that appears is properly aligned in all viewports > 960px and especially < 480px:

![screen shot 2016-03-23 at 11 05 22 am](https://cloud.githubusercontent.com/assets/1130674/13996647/febe4138-f0eb-11e5-98d9-5d4b39408f73.png)

- [x] Code review
- [x] Product review