### PR TITLE
Framework: update schema to accept logo sizes as an object or array

### DIFF
--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -25,7 +25,7 @@ export const sitesSchema = {
 					type: 'object',
 					properties: {
 						id: { type: 'number' },
-						sizes: { type: 'array' },
+						sizes: { type: [ 'array', 'object'] },
 						url: { type: 'string' }
 					}
 				},
@@ -52,7 +52,7 @@ export const sitesSchema = {
 						free_trial: { type: 'boolean' }
 					}
 				},
-				single_user_site: { type: 'boolean' },
+				single_user_site: { type: 'boolean' }
 			}
 		}
 	},


### PR DESCRIPTION
This PR updates the sites schema to accept logo sizes as an object or array. This should remove the related schema warnings from the console.

cc @retrofox @rralian