### PR TITLE
CPT / Sites: Decode entities from post type labels

### DIFF
--- a/client/my-sites/sidebar/publish-menu.jsx
+++ b/client/my-sites/sidebar/publish-menu.jsx
@@ -17,6 +17,7 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import analytics from 'analytics';
+import { decodeEntities } from 'lib/formatting';
 
 const PublishMenu = React.createClass( {
 	propTypes: {
@@ -151,7 +152,7 @@ const PublishMenu = React.createClass( {
 		return map( customPostTypes, function( postType ) {
 			return {
 				name: postType.name,
-				label: get( postType.labels, 'menu_name', postType.label ),
+				label: decodeEntities( get( postType.labels, 'menu_name', postType.label ) ),
 				className: postType.name,
 				config: 'manage/custom-post-types',
 				queryable: postType.api_queryable,

--- a/client/post-editor/editor-action-bar/view-label.jsx
+++ b/client/post-editor/editor-action-bar/view-label.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import localize from 'lib/mixins/i18n/localize';
+import { decodeEntities } from 'lib/formatting';
 import { getEditedPost } from 'state/posts/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -21,7 +22,7 @@ function EditorActionBarViewLabel( { translate, siteId, typeSlug, type } ) {
 	} else if ( 'post' === typeSlug ) {
 		label = translate( 'View post' );
 	} else if ( type ) {
-		label = type.labels.view_item;
+		label = decodeEntities( type.labels.view_item );
 	} else {
 		label = translate( 'View', { context: 'verb' } );
 	}

--- a/client/post-editor/editor-post-type/index.jsx
+++ b/client/post-editor/editor-post-type/index.jsx
@@ -4,7 +4,6 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
-import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -15,31 +14,32 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { getEditorPostId, isEditorNewPost } from 'state/ui/editor/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
+import { decodeEntities } from 'lib/formatting';
 
 function EditorPostType( { translate, siteId, isNew, typeSlug, type } ) {
 	let label;
-	switch ( typeSlug ) {
-		case 'page':
-			if ( isNew ) {
-				label = translate( 'New Page' );
-			} else {
-				label = translate( 'Page', { context: 'noun' } );
-			}
-			break;
-		case 'post':
-			if ( isNew ) {
-				label = translate( 'New Post' );
-			} else {
-				label = translate( 'Post', { context: 'noun' } );
-			}
-			break;
-		default:
-			if ( isNew ) {
-				label = get( type, 'labels.new_item' );
-			} else {
-				label = get( type, 'labels.singular_name' );
-			}
-			break;
+	if ( 'page' === typeSlug ) {
+		if ( isNew ) {
+			label = translate( 'New Page' );
+		} else {
+			label = translate( 'Page', { context: 'noun' } );
+		}
+	} else if ( 'post' === typeSlug ) {
+		if ( isNew ) {
+			label = translate( 'New Post' );
+		} else {
+			label = translate( 'Post', { context: 'noun' } );
+		}
+	} else if ( type ) {
+		if ( isNew ) {
+			label = type.labels.new_item;
+		} else {
+			label = type.labels.singular_name;
+		}
+
+		label = decodeEntities( label );
+	} else {
+		label = translate( 'Loading…' );
 	}
 
 	const classes = classnames( 'editor-post-type', {
@@ -51,7 +51,7 @@ function EditorPostType( { translate, siteId, isNew, typeSlug, type } ) {
 			{ siteId && 'page' !== typeSlug && 'post' !== typeSlug && (
 				<QueryPostTypes siteId={ siteId } />
 			) }
-			{ label || translate( 'Loading…' ) }
+			{ label }
 		</span>
 	);
 }


### PR DESCRIPTION
This pull request seeks to resolve an issue where encoded entities in a post type label are not correctly decoded before being rendered to the page. __This does affect production environments__, where publish bar navigation items are not correctly decoded.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/13997207/61b23e28-f107-11e5-90ea-4adce58632f0.png)|![After](https://cloud.githubusercontent.com/assets/1779930/13997156/1e5fb59c-f107-11e5-9b68-68a3c565bc7f.png)

__Implementation notes:__

These changes also affect translated post type labels for the post editor, whose usage is blocked by #4193.

__Testing instructions:__

Verify that, for a language where custom post type labels include encoded entities, that the text is properly decoded before rendered to the page. For example, the French language "Testimonials" label should display as `Témoignages`, not `T&eacute;moignages`.

1. Change interface language to "French" from [account settings](http://calypso.localhost:3000/me/account)
2. Navigate to [My Sites](http://calypso.localhost:3000/post)
3. Select a site where Testimonials custom type is enabled
4. Note that sidebar navigation item for Testimonials is correctly decoded