### PR TITLE
CPT / Editor: Display Add button for custom post types

### DIFF
--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -42,13 +42,14 @@ export function isEditorDraftsVisible( state ) {
 /**
  * Returns the editor URL path for the given site ID, post ID pair.
  *
- * @param  {Object} state  Global state tree
- * @param  {Number} siteId Site ID
- * @param  {Number} postId Post ID
- * @return {String}        Editor URL path
+ * @param  {Object} state       Global state tree
+ * @param  {Number} siteId      Site ID
+ * @param  {Number} postId      Post ID
+ * @param  {String} defaultType Fallback post type if post not found
+ * @return {String}             Editor URL path
  */
-export function getEditorPath( state, siteId, postId ) {
-	const type = get( getEditedPost( state, siteId, postId ), 'type', 'post' );
+export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
+	const type = get( getEditedPost( state, siteId, postId ), 'type', defaultType );
 
 	let path;
 	switch ( type ) {

--- a/client/state/ui/editor/test/selectors.js
+++ b/client/state/ui/editor/test/selectors.js
@@ -184,5 +184,24 @@ describe( 'selectors', () => {
 
 			expect( path ).to.equal( '/edit/jetpack-portfolio/example.wordpress.com' );
 		} );
+
+		it( 'should allow overriding the fallback post type for unknown post', () => {
+			const path = getEditorPath( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				},
+				posts: {
+					items: {},
+					edits: {}
+				}
+			}, 2916284, null, 'jetpack-portfolio' );
+
+			expect( path ).to.equal( '/edit/jetpack-portfolio/example.wordpress.com' );
+		} );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to add an "Add" button adjacent the publish menu sidebar navigation item for custom post types in environments where `manage/custom-post-types` feature is enabled. The Add button should link to the post editor route for creating a new post of that type.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/13998044/5a4ad222-f10b-11e5-8741-165b6c81d59f.png)|![After](https://cloud.githubusercontent.com/assets/1779930/13997943/d945e36a-f10a-11e5-9835-b9cdbc7c2bdc.png)

__Testing instructions:__

Verify that an "Add" button is shown when `manage/custom-post-types` feature is enabled, and that only the external wp-admin link is shown when `manage/custom-post-types` is disabled. You can quickly disable the feature by restarting the Calypso process with the following command:

```bash
DISABLE_FEATURES=manage/custom-post-types make run
```

1. Navigate to [My Sites](http://calypso.localhost:3000/sites)
2. Select a site where a custom post type is enabled
3. Note that...
 - If `manage/custom-post-types` is enabled, "Add" button is shown next to custom post type navigation item, and links to editor route for that post type
 - If `manage/custom-post-types` is disabled, external link should be shown and should open a new tab directing to wp-admin post type listing when clicked

__Caveats:__

- Editor routes are not enabled yet (blocked by #4193), so you should not expect the Add button to navigate you to a usable editor.