### PR TITLE
People: Launches invite form to production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -17,7 +17,7 @@
 		"desktop-promo": true,
 		"help": true,
 		"mailing-lists/unsubscribe": true,
-		"manage/add-people": false,
+		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,


### PR DESCRIPTION
Let's share our new invite form with the world. This PR ships the invite form to production. :tada: :wine_glass: :dancers: 

To test:
- Checkout `update/people-invites-to-production` branch
- Change `wpcom_user_bootstrap` to `false` in `production.json`
- In terminal `CALYPSO_ENV=production` make run`
- Load up `/people/new/$site`

cc @lezama for review