### PR TITLE
CPT: Render filter bar with basic searching

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import UrlSearch from 'lib/mixins/url-search';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import Search from 'components/search';
+
+export default React.createClass( {
+	mixins: [ UrlSearch ],
+
+	render() {
+		return (
+			<SectionNav>
+				<NavTabs>
+					<NavItem selected={ true }>
+						{ this.translate( 'Published', { context: 'Filter label for posts list' } ) }
+					</NavItem>
+				</NavTabs>
+				<Search
+					pinned={ true }
+					onSearch={ this.doSearch }
+					placeholder={ this.translate( 'Search…' ) }
+					delaySearch={ true } />
+			</SectionNav>
+		);
+	}
+} );

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -8,16 +8,16 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import QueryPosts from 'components/data/query-posts';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePostsForQueryIgnoringPage } from 'state/posts/selectors';
 import PostTypePost from './post';
 
-function PostTypeList( { type, siteId, posts } ) {
+function PostTypeList( { query, siteId, posts } ) {
 	return (
 		<div className="post-type-list">
 			<QueryPosts
 				siteId={ siteId }
-				query={ { type } } />
+				query={ query } />
 			<ul className="post-type-list__posts">
 				{ posts && posts.map( ( post ) => (
 					<li key={ post.global_ID }>
@@ -30,18 +30,16 @@ function PostTypeList( { type, siteId, posts } ) {
 }
 
 PostTypeList.propTypes = {
-	type: PropTypes.string.isRequired,
+	query: PropTypes.object,
 	siteId: PropTypes.number,
 	posts: PropTypes.array
 };
 
 export default connect( ( state, ownProps ) => {
-	const site = getSelectedSite( state );
-	const siteId = site ? site.ID : null;
-	const { type } = ownProps;
+	const siteId = getSelectedSiteId( state );
 
 	return {
 		siteId,
-		posts: getSitePostsForQueryIgnoringPage( state, siteId, { type } )
+		posts: getSitePostsForQueryIgnoringPage( state, siteId, ownProps.query )
 	};
 } )( PostTypeList );

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -32,12 +32,15 @@ export function list( context ) {
 	}
 	pageView.record( baseAnalyticsPath, 'Custom Post Type' );
 
-	// Derive type
-	const type = sectionedPath.replace( /^\/types\//, '' );
+	// Construct query arguments
+	const query = {
+		type: sectionedPath.replace( /^\/types\//, '' ),
+		search: context.query.s
+	};
 
 	ReactDom.render(
 		<ReduxProvider store={ context.store }>
-			<Types type={ type } />
+			<Types query={ query } />
 		</ReduxProvider>,
 		document.getElementById( 'primary' )
 	);

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -7,16 +7,18 @@ import React, { PropTypes } from 'react';
  * Internal dependencies
  */
 import Main from 'components/main';
+import PostTypeFilter from 'my-sites/post-type-filter';
 import PostTypeList from 'my-sites/post-type-list';
 
-export default function Types( { type } ) {
+export default function Types( { query } ) {
 	return (
 		<Main>
-			<PostTypeList type={ type } />
+			<PostTypeFilter />
+			<PostTypeList query={ query } />
 		</Main>
 	);
 }
 
 Types.propTypes = {
-	type: PropTypes.string.isRequired
+	query: PropTypes.object
 };


### PR DESCRIPTION
This pull request seeks to implement a _very unfinished_ filter bar for use in conjunction with `<PostTypeList />`, notably for custom post type listing pages.

![search](https://cloud.githubusercontent.com/assets/1779930/13999080/fa511812-f110-11e5-87b0-0a605ff65c31.gif)

It includes support for:
- Displaying a navigation bar with "Published" selected
- Searching

It does _not_ include support for:
- Post status count
- Translation of post status labels
- Post status options aside from published
- Rendering "No results found"
- Restoring query results from a refresh while searching

__Testing instructions:__

1. Navigate to [My Sites](http://calypso.localhost:3000/sites)
2. Select a site which has at least one custom post type enabled
3. Click the custom post type sidebar navigation item
4. Note that a filter bar is shown at the top of the listing
5. Click Search
6. Note that the filter bar converts to a search input
7. Enter a search query
8. Note that after a brief delay, post listing disappears then updates to filtered set after having received queried posts