### PR TITLE
Checkout: Thank You: Update HEs that appear in `HappinessSupport`

### DIFF
--- a/client/components/happiness-support/docs/example.jsx
+++ b/client/components/happiness-support/docs/example.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import HappinessSupport from 'components/happiness-support';
 
 export default React.createClass( {
@@ -15,8 +16,9 @@ export default React.createClass( {
 		return (
 			<div className="design-assets__group">
 				<h2><a href="/devdocs/app-components/happiness-support">HappinessSupport</a></h2>
-
-				<HappinessSupport />
+				<Card>
+					<HappinessSupport />
+				</Card>
 			</div>
 		);
 	}

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -20,10 +20,8 @@ const HappinessSupport = React.createClass( {
 	getInitialState() {
 		return {
 			user: sample( [
-				{ display_name: 'Andrea', avatar_URL: '//gravatar.com/avatar/e6389004daf6cd236a6fd5a82069b426' },
 				{ display_name: 'Erica', avatar_URL: '//gravatar.com/avatar/066a6509253d682f4e0d05b048b08b2c' },
-				{ display_name: 'Jackie', avatar_URL: '//gravatar.com/avatar/a5eb04ed0c4dbeabf45dc031670ac60f' },
-				{ display_name: 'Siobhan', avatar_URL: '//gravatar.com/avatar/826d5881f45c63c5f7e1271c37e6b2ac' }
+				{ display_name: 'Paolo', avatar_URL: '//gravatar.com/avatar/3cb9afe63d364690c0e188fb16473277' }
 			] )
 		};
 	},

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -14,7 +14,8 @@ import supportUrls from 'lib/url/support';
 
 const HappinessSupport = React.createClass( {
 	propTypes: {
-		isJetpack: React.PropTypes.bool
+		isJetpack: React.PropTypes.bool,
+		isPlaceholder: React.PropTypes.bool
 	},
 
 	getInitialState() {
@@ -70,7 +71,7 @@ const HappinessSupport = React.createClass( {
 	render() {
 		const classes = {
 			'happiness-support': true,
-			'is-placeholder': this.props.isJetpack === undefined || this.props.isJetpack === null
+			'is-placeholder': this.props.isPlaceholder
 		};
 
 		return (

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -156,7 +156,9 @@ const CheckoutThankYou = React.createClass( {
 				</Card>
 
 				<Card className="checkout-thank-you__footer">
-					<HappinessSupport isJetpack={ purchases && purchases.some( isJetpackPlan ) } />
+					<HappinessSupport
+						isJetpack={ purchases && purchases.some( isJetpackPlan ) }
+						isPlaceholder={ ! this.isDataLoaded() && ! this.isGenericReceipt() } />
 				</Card>
 			</Main>
 		);

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -141,10 +141,11 @@ const CheckoutThankYou = React.createClass( {
 			'is-placeholder': ! this.isDataLoaded()
 		} );
 
-		let purchases = null;
-
+		let purchases = null,
+			wasJetpackPlanPurchased = false;
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			purchases = getPurchases( this.props );
+			wasJetpackPlanPurchased = purchases.some( isJetpackPlan );
 		}
 
 		return (
@@ -157,7 +158,7 @@ const CheckoutThankYou = React.createClass( {
 
 				<Card className="checkout-thank-you__footer">
 					<HappinessSupport
-						isJetpack={ purchases && purchases.some( isJetpackPlan ) }
+						isJetpack={ wasJetpackPlanPurchased }
 						isPlaceholder={ ! this.isDataLoaded() && ! this.isGenericReceipt() } />
 				</Card>
 			</Main>


### PR DESCRIPTION
We need to update these per pb6Nl-aSM-p2.

Also fixes #3932 and #3943.

<img width="667" alt="screen shot 2016-03-24 at 2 03 18 pm" src="https://cloud.githubusercontent.com/assets/1130674/14031363/cb7f4964-f1c9-11e5-9167-792d345bc9fe.png">

**Testing**
*In DevDocs*
- Visit `/devdocs/app-components/happiness-support`
- Assert that you see either Paolo or Erica's avatar/name on the right.
- Refresh the page and repeat until you've seen both avatars/names.

*On the thank you page (.com)*
- Visit `/plans/:site` and add a plan to your cart (where `:site` is a .com site).
- Proceed to checkout and purchase the plan.
- Assert that the `HappinessSupport` section on the thank you page shows placeholders until the receipt loads.
- Assert that the 'Ask a question' button links to https://wordpress.com/help/contact

*On the thank you page (Jetpack)*
- Visit `/plans/:site` and add a plan to your cart (where `:site` is a Jetpack site).
- Proceed to checkout and purchase the plan.
- Assert that the `HappinessSupport` section on the thank you page shows placeholders until the receipt loads.
- Assert that the 'Ask a question' button links to https://jetpack.me/support/

*On the thank you page (generic)*
- Visit `/checkout/:site/thank-you`
- Assert that `HappinessSupport` is displayed immediately without placeholders.

- [x] Code review
- [x] Product review