### PR TITLE
Editor: fix huge icons in IE11

### DIFF
--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -38,3 +38,9 @@
 		color: darken( $gray, 10% );
 	}
 }
+
+.editor-action-bar__last-group .editor-sticky .gridicon,
+.editor-action-bar__last-group .editor-visibility .gridicon {
+	width: 24px;
+	height: 24px;
+}


### PR DESCRIPTION
## Testing
* Using IE11 navigate to calypso.localhost:3000/post
* Choose a site if prompted

Before:
<img width="899" alt="screen shot 2016-03-23 at 5 39 28 pm" src="https://cloud.githubusercontent.com/assets/1270189/14005208/7fdcda18-f11e-11e5-8e82-84ccfc428656.png">

After:
<img width="785" alt="screen shot 2016-03-23 at 5 40 21 pm" src="https://cloud.githubusercontent.com/assets/1270189/14005210/8411e5ce-f11e-11e5-899c-c667c41812c3.png">

This is a quick fix. We should ideally fix the issue in the gridicons component.

cc @mtias @aduth @blowery @rralian