### PR TITLE
WPCOM Plugins: Add class names and style file

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -230,6 +230,7 @@
 @import 'my-sites/plugins/plugins-browser-list/style';
 @import 'my-sites/plugins/plugins-browser/style';
 @import 'my-sites/plugins/plugin-version/style';
+@import 'my-sites/plugins-wpcom/style';
 @import 'my-sites/sharing/style';
 @import 'my-sites/sharing/connections/account-dialog';
 @import 'my-sites/sharing/connections/account-dialog-account';

--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -31,8 +31,9 @@ export const BusinessPluginsPanel = React.createClass( {
 			<FoldableCard
 				actionButton={ actionButton }
 				actionButtonExpanded={ actionButton }
+				className="wpcom-business-plugins-panel"
 				expanded={ true }
-				header="Premium Upgrades"
+				header="Business Upgrades"
 			>
 				{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
 					<BusinessPlugin

--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -21,7 +21,7 @@ const defaultPlugins = [
 
 export const BusinessPluginsPanel = React.createClass( {
 	render() {
-		const { plugins: givenPlugins  = [] } = this.props;
+		const { plugins: givenPlugins = [] } = this.props;
 		const plugins = givenPlugins.length
 			? givenPlugins
 			: defaultPlugins;
@@ -31,7 +31,7 @@ export const BusinessPluginsPanel = React.createClass( {
 			<FoldableCard
 				actionButton={ actionButton }
 				actionButtonExpanded={ actionButton }
-				className="wpcom-business-plugins-panel"
+				className="wpcom-plugins__business-panel"
 				expanded={ true }
 				header="Business Upgrades"
 			>
@@ -47,6 +47,6 @@ export const BusinessPluginsPanel = React.createClass( {
 
 BusinessPluginsPanel.propTypes = {
 	plugins: PropTypes.array
-}
+};
 
 export default BusinessPluginsPanel;

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -5,7 +5,7 @@ import Card from 'components/card';
 export const InfoHeader = React.createClass( {
 	render() {
 		return (
-			<Card>
+			<Card className="wpcom-plugins-info-header">
 				<div>
 					Uploading and installing your own plugins is not
 					available on WordPress.com, but we offer the most

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -5,7 +5,7 @@ import Card from 'components/card';
 export const InfoHeader = React.createClass( {
 	render() {
 		return (
-			<Card className="wpcom-plugins-info-header">
+			<Card className="wpcom-plugins__info-header">
 				<div>
 					Uploading and installing your own plugins is not
 					available on WordPress.com, but we offer the most

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -8,7 +8,7 @@ import BusinessPluginsPanel from './business-plugins-panel';
 export const PluginPanel = React.createClass( {
 	render() {
 		return (
-			<div className="pluginPanel">
+			<div className="wpcom-plugin-panel">
 				<InfoHeader />
 				<StandardPluginsPanel />
 				<PremiumPluginsPanel />

--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -13,7 +13,7 @@ export const BusinessPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<div>
+			<div className="wpcom-business-plugin">
 				<div>
 					<Gridicon { ...{ icon } } />
 					<a href={ supportLink } target="_blank">{ name }</a>

--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -13,7 +13,7 @@ export const BusinessPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<div className="wpcom-business-plugin">
+			<div className="wpcom-plugins__plugin-item">
 				<div>
 					<Gridicon { ...{ icon } } />
 					<a href={ supportLink } target="_blank">{ name }</a>

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -13,7 +13,7 @@ export const PremiumPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<div>
+			<div className="wpcom-premium-plugin">
 				<div>
 					<Gridicon { ...{ icon } } />
 					<a href={ supportLink } target="_blank">{ name }</a>

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -13,7 +13,7 @@ export const PremiumPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<div className="wpcom-premium-plugin">
+			<div className="wpcom-plugins__plugin-item">
 				<div>
 					<Gridicon { ...{ icon } } />
 					<a href={ supportLink } target="_blank">{ name }</a>

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -13,7 +13,7 @@ export const StandardPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<div>
+			<div className="wpcom-standard-plugin">
 				<div>
 					<Gridicon { ...{ icon } } />
 					<a href={ supportLink } target="_blank">{ name }</a>

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -13,7 +13,7 @@ export const StandardPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<div className="wpcom-standard-plugin">
+			<div className="wpcom-plugins__plugin-item">
 				<div>
 					<Gridicon { ...{ icon } } />
 					<a href={ supportLink } target="_blank">{ name }</a>

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -38,6 +38,7 @@ export const PremiumPluginsPanel = React.createClass( {
 			<FoldableCard
 				actionButton={ actionButton }
 				actionButtonExpanded={ actionButton }
+				className="wpcom-premium-plugins-panel"
 				expanded={ true }
 				header="Premium Upgrades"
 			>

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -28,7 +28,7 @@ const defaultPlugins = [
 
 export const PremiumPluginsPanel = React.createClass( {
 	render() {
-		const { plugins: givenPlugins  = [] } = this.props;
+		const { plugins: givenPlugins = [] } = this.props;
 		const plugins = givenPlugins.length
 			? givenPlugins
 			: defaultPlugins;
@@ -38,7 +38,7 @@ export const PremiumPluginsPanel = React.createClass( {
 			<FoldableCard
 				actionButton={ actionButton }
 				actionButtonExpanded={ actionButton }
-				className="wpcom-premium-plugins-panel"
+				className="wpcom-plugins__premium-panel"
 				expanded={ true }
 				header="Premium Upgrades"
 			>
@@ -54,6 +54,6 @@ export const PremiumPluginsPanel = React.createClass( {
 
 PremiumPluginsPanel.propTypes = {
 	plugins: PropTypes.array
-}
+};
 
 export default PremiumPluginsPanel;

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -56,12 +56,13 @@ export const StandardPluginsPanel = React.createClass( {
 		const plugins = givenPlugins.length
 			? givenPlugins
 			: defaultPlugins;
-		const actionButton = <div><Gridicon icon="checkmark" /> Active</div>;
+		const actionButton = <div className="wpcom-stanard-plugins-panel__action-button"><Gridicon icon="checkmark" /> Active</div>;
 
 		return (
 			<FoldableCard
 				actionButton={ actionButton }
 				actionButtonExpanded={ actionButton }
+				className="wpcom-standard-plugins-panel"
 				expanded={ true }
 				header="Standard Plugin Suite"
 			>

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -52,17 +52,17 @@ const defaultPlugins = [
 
 export const StandardPluginsPanel = React.createClass( {
 	render() {
-		const { plugins: givenPlugins  = [] } = this.props;
+		const { plugins: givenPlugins = [] } = this.props;
 		const plugins = givenPlugins.length
 			? givenPlugins
 			: defaultPlugins;
-		const actionButton = <div className="wpcom-stanard-plugins-panel__action-button"><Gridicon icon="checkmark" /> Active</div>;
+		const actionButton = <div className="wpcom-plugins__action-button"><Gridicon icon="checkmark" /> Active</div>;
 
 		return (
 			<FoldableCard
 				actionButton={ actionButton }
 				actionButtonExpanded={ actionButton }
-				className="wpcom-standard-plugins-panel"
+				className="wpcom-plugins__standard-panel"
 				expanded={ true }
 				header="Standard Plugin Suite"
 			>
@@ -81,6 +81,6 @@ export const StandardPluginsPanel = React.createClass( {
 
 StandardPluginsPanel.propTypes = {
 	plugins: PropTypes.array
-}
+};
 
 export default StandardPluginsPanel;

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -1,0 +1,4 @@
+.wpcom-stanard-plugins-panel__action-button {
+	margin-top: 6px;
+	margin-right: 6px;
+}

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -1,4 +1,4 @@
-.wpcom-stanard-plugins-panel__action-button {
+.wpcom-plugins__action-button {
 	margin-top: 6px;
 	margin-right: 6px;
 }


### PR DESCRIPTION
This patch introduces some basic class names on the wpcom plugin panel
area and introduces a style file to contain the necessary visual
adjustments.

This area is still hidden behind a feature flag and is only present on
development builds.

**Testing**

Navigate to
http://calypso.localhost:3000/plugins/testblogdomain.wordpress.com

You should see the unstyled panels.

<img width="763" alt="screen shot 2016-03-23 at 5 42 23 pm" src="https://cloud.githubusercontent.com/assets/5431237/14005235/a45c5a6c-f11e-11e5-9f0e-4e9483ff01e9.png">


cc: @drw158 - I'm hoping this will help you get started to see the structure, make some styling, and give me feedback on changes that would help you out