### PR TITLE
Publicize: mention authors can use publicize as well as admins and editors

### DIFF
--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -135,7 +135,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( userCanUpdate || this.props.connection.shared ) {
-			content.push( <span key="label">{ this.translate( 'Connection available to all Administrators, Editors, and Authors', { context: 'Sharing: Publicize' } ) }</span> );
+			content.push( <span key="label">{ this.translate( 'Connection available to all administrators, editors, and authors', { context: 'Sharing: Publicize' } ) }</span> );
 		}
 
 		if ( content.length ) {

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -135,7 +135,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( userCanUpdate || this.props.connection.shared ) {
-			content.push( <span key="label">{ this.translate( 'Connection available to all editors and site admins', { context: 'Sharing: Publicize' } ) }</span> );
+			content.push( <span key="label">{ this.translate( 'Connection available to all Administrators, Editors, and Authors', { context: 'Sharing: Publicize' } ) }</span> );
 		}
 
 		if ( content.length ) {


### PR DESCRIPTION
Authors (as well as admins and editors) are able to use publicize buttons
(see https://jetpack.com/support/publicize/), so we should say that at the
checkbox.

You can see this string after connecting any account in `http://calypso.localhost:3000/sharing/your-blog`:
![sharing_ _wordpress_com](https://cloud.githubusercontent.com/assets/5952255/14007813/e09e189c-f1c5-11e5-93f5-9881721b4c01.jpg)

h/t @naokomc 