### PR TITLE
Upgrades: Test nudge in stats/countries

### DIFF
--- a/client/my-sites/stats/stats-countries/index.jsx
+++ b/client/my-sites/stats/stats-countries/index.jsx
@@ -8,9 +8,11 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import toggle from '../mixin-toggle';
 import Geochart from '../geochart';
 import StatsList from '../stats-list';
 import observe from 'lib/mixins/data-observe';
+import skeleton from '../mixin-skeleton';
 import DownloadCsv from '../stats-download-csv';
 import DatePicker from '../stats-date-picker';
 import ErrorPanel from '../stats-error';
@@ -19,6 +21,7 @@ import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsListLegend from '../stats-list/legend';
 import Gridicon from 'components/gridicon';
 import SectionHeader from 'components/section-header';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
 
 export default React.createClass( {
 	displayName: 'StatCountries',
@@ -127,6 +130,16 @@ export default React.createClass( {
 								<StatsListLegend value={ this.translate( 'Views' ) } label={ this.translate( 'Country' ) } />
 								<StatsModulePlaceholder isLoading={ isLoading } />
 								<StatsList moduleName={ path } data={ data } />
+								{ this.props.summary && <div className="module-content-text nudge" key="nudge">
+									<UpgradeNudge
+										className="is-full-width"
+										title="Add Google Analytics"
+										message="Upgrade to Premium for Google Analytics integration."
+										event="googleAnalytics-stats-countries"
+										feature="google-analytics"
+										icon="stats"
+									/>
+								</div>  }
 								{ hasError
 									? <ErrorPanel className={ 'network-error' } />
 									: null }

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -347,6 +347,10 @@ ul.module-header-actions {
 			}
 		}
 	}
+
+	&.nudge {
+		text-align:left;
+	}
 }
 
 .tab-email-followers .tab-content.email-followers,

--- a/client/my-sites/upgrade-nudge/style.scss
+++ b/client/my-sites/upgrade-nudge/style.scss
@@ -11,6 +11,13 @@
 		padding: 6px;
 		align-self: center;
 	}
+
+	&.is-full-width {
+		width:100%;
+		@include breakpoint( ">660px" ) {
+			max-width: 420px;
+		}
+	}
 }
 
 .upgrade-nudge__message {


### PR DESCRIPTION
This is in regard to #4222

- Introduces new nudge in stats for "Power users"
- Uses component merged in #4207
- Introduces new test

## Visuals

![](http://cldup.com/u8T6_Mqc9BG/PCF3pY.png)

## Testing

- You need a site with some previous traffic and `Free` plan
- Put yourself in a test: `localStorage.setItem('ABTests','{"nudgeStatsGoogleAnalytics_20160320":"countries"}')`
- Navigate to `http://calypso.localhost:3000/stats/year/countryviews/[your-site]?startDate=2016-01-01`
- Confirm nudge is there

CC @rralian @mtias @adambbecker @jonathansadowski