### PR TITLE
Fix desktop app

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -1,4 +1,4 @@
-var config = require( 'config' ),
+var config = require( './config' ), // './' required for wp-desktop Webpack bundling
 	readerPaths;
 
 var sections;


### PR DESCRIPTION
The desktop app is currently broken because of c3d0ce.
Part of the fix is adding the sections loader to wp-desktop's Webpack config,
see https://github.com/Automattic/wp-desktop/pull/127

However, even with that fix, wp-desktop's Webpack invocation still won't find
the `config` module required by `sections.js`. Making that require relative fixes
that latter issue.

/cc @mkaz @Tug