### PR TITLE
Fix: Fetch site updates again.

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -49,8 +49,8 @@ Layout = React.createClass( {
 	_sitesPoller: null,
 
 	componentWillUpdate: function( nextProps ) {
-		if ( this.props.section.name !== nextProps.section.name ) {
-			if ( nextProps.section.name === 'sites' ) {
+		if ( this.props.section.group !== nextProps.section.group ) {
+			if ( nextProps.section.group === 'sites' ) {
 				setTimeout( function() {
 					if ( ! this.isMounted() || this._sitesPoller ) {
 						return;


### PR DESCRIPTION
We used to fetch site updates every time a user is on the sites portion
of calypso. This PR brings back the functionality. 

cc @mtias, @beaulebens 

**To test**
Notice that your sites show the site indicator again.