### PR TITLE
Upgrades: nudge in stats/searchterms

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -16,6 +16,7 @@ import DatePicker from '../stats-date-picker';
 import Card from 'components/card';
 import StatsModulePlaceholder from './placeholder';
 import SectionHeader from 'components/section-header';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
 
 export default React.createClass( {
 	displayName: 'StatModule',
@@ -107,6 +108,14 @@ export default React.createClass( {
 							<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 							<StatsModulePlaceholder isLoading={ isLoading } />
 							{ statsList }
+							{ this.props.summary && this.props.path === 'searchterms' &&
+								<UpgradeNudge
+									title="Add Google Analytics"
+									message="Upgrade to Premium for Google Analytics integration."
+									feature="google-analytics"
+									event="googleAnalytics-stats-searchterms"
+								/>
+							}
 						</div>
 					</div>
 					{ viewSummary }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -111,7 +111,7 @@ export default React.createClass( {
 							{ this.props.summary && this.props.path === 'searchterms' &&
 								<UpgradeNudge
 									title="Add Google Analytics"
-									message="Upgrade to Premium for Google Analytics integration."
+									message="Upgrade to Business for Google Analytics integration."
 									feature="google-analytics"
 									event="googleAnalytics-stats-searchterms"
 								/>


### PR DESCRIPTION
This is in regard to #4222

- Introduces new nudge in stats for "Power users"
- Uses component merged in #4207
- Continues from #4288

## Visuals

![](http://cldup.com/u8T6_Mqc9BG/5XEVTv.png)

## Testing

- You need a site with some previous traffic and searchterms in stats and `Free` plan
- Navigate to `http://calypso.localhost:3000/stats/year/searchterms/[your-site]?startDate=2016-01-01`
- Confirm nudge is there

CC @rralian @mtias @adambbecker @jonathansadowski