### PR TITLE
Upgrades: domain nudge in stats/insights

### DIFF
--- a/client/my-sites/stats/insights/index.jsx
+++ b/client/my-sites/stats/insights/index.jsx
@@ -19,6 +19,7 @@ import statsStrings from '../stats-strings';
 import MostPopular from 'my-sites/stats/most-popular';
 import PostPerformance from '../post-performance';
 import touchDetect from 'lib/touch-detect';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
 
 export default React.createClass( {
 	displayName: 'StatsInsights',
@@ -88,6 +89,12 @@ export default React.createClass( {
 						<h3 className="stats-section-title">{ this.translate( 'Other Recent Stats', { context: 'Heading for non periodic site stats' } ) }</h3>
 						<div className="module-list">
 							<div className="module-column">
+								<UpgradeNudge
+									title="Get a domain in Premium plan"
+									message="Sites with custom domain get x% more traffic"
+									icon="stats"
+									event="googleAnalytics-stats-domain-insights"
+								/>
 								<Comments
 									path={ 'comments' }
 									site={ site }


### PR DESCRIPTION
This is in regard to #4224

- Introduces new nudge in insights promoting Premium plan with logic like:

> Sites with a custom domain name get more X% more visitors per week!

- Uses component merged in #4207

### Other Nudges in stats:
- #4288 
- #4296 

## Visuals

![](http://cldup.com/u8T6_Mqc9BG/ODq33K.png)

## Testing

- You need a site with some previous traffic  and `Free` plan
- Navigate to `http://calypso.localhost:3000/stats/[your-site]/insights`
- Confirm nudge is there

CC @adambbecker @rralian @mtias @gwwar @retrofox 