### PR TITLE
Webpack: Add a loader resolver and node_modules as a module root

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,8 +58,11 @@ webpackConfig = {
 	},
 	resolve: {
 		extensions: [ '', '.json', '.js', '.jsx' ],
-		root: path.join( __dirname, 'client' ),
+		root: [ path.join( __dirname, 'client' ), path.join( __dirname, 'node_modules' ) ],
 		modulesDirectories: [ 'node_modules' ]
+	},
+	resolveLoader: {
+		root: [ path.join( __dirname, 'node_modules' ) ]
 	},
 	node: {
 		console: false,


### PR DESCRIPTION
This allows webpack to properly load packages that have been `npm link`'d into wp-calypso for testing. Currently, if those projects indirectly use any loader, they will fail the build.

This forces webpack to use our copy of node_modules to resolve loaders, which lets modules in linked packages work as expected.

To prove it doesn't work on master:

1. Clone component-tip to a local folder outside wp-calypso ( `git clone https://github.com/component/tip.git` )
2. Run `npm install` for it
3. Link it with `npm link`
4. cd into your wp-calypso checkout
5. `npm link component-tip`
6. `make run` and watch it fail trying to load modules from tip

After checking out this PR, try `make run` and it should work.