### PR TITLE
Framework: enable redux persistence

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -58,7 +58,7 @@
 		"olark": true,
 		"olark_use_wpcom_configuration": true,
 		"perfmon": true,
-		"persist-redux": false,
+		"persist-redux": true,
 		"post-editor/author-selector": true,
 		"post-editor/live-image-updates": true,
 		"press-this": true,


### PR DESCRIPTION
This PR enables redux persistence in production. 

## Testing:
- set console debug to 'calypso:state'
- site works normally
- on refresh, page loads with persisted data
- no schema warnings are thrown

cc @rralian @blowery @nb @mtias @artpi @aduth 