### PR TITLE
Media: hide the plan-storage button <480 on the media modal

### DIFF
--- a/client/my-sites/plan-storage/style.scss
+++ b/client/my-sites/plan-storage/style.scss
@@ -24,11 +24,3 @@
 .plan-storage__button.is-alert .progress-bar__progress {
 	background-color: $alert-red;
 }
-
-.plan-storage__button {
-	display: none;
-
-	@include breakpoint( ">480px" ) {
-		display: inline-block;
-	}
-}

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -322,3 +322,11 @@
 		}
 	}
 }
+
+.editor-media-modal__plan-storage {
+	display: none;
+
+	@include breakpoint( ">480px" ) {
+		display: inline-block;
+	}
+}

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -177,6 +177,7 @@ const MediaModalSecondaryActions = React.createClass( {
 		if ( this.props.selectedItems.length === 0 ) {
 			return (
 				<PlanStorage
+					className="editor-media-modal__plan-storage"
 					onClick={ this.navigateToPlans }
 					siteId={ this.props.site.ID } />
 			);


### PR DESCRIPTION
This fixes #4303 so we only hide the plan-storage component when it's placed on the media modal in viewports of <480px

## Testing instructions:
- Navigate to https://calypso.localhost:3000/devdocs/app-components
- Scroll down to Plan Storage
- Resize the Screen to less than 480px
- Plan Storage component should still be visible
- Navigate to https://calypso.localhost:3000/post 
- Select a site that is a wpcom site, with a free or premium plan
- Click on the media modal
- Plan Storage button should render in bottom left of the modal
- Resize the Screen to less than 480px
- Plan Storage component should not be visible.

cc @hoverduck @rralian