### PR TITLE
Framework: update posts schema

### DIFF
--- a/client/state/posts/schema.js
+++ b/client/state/posts/schema.js
@@ -41,7 +41,7 @@ export const itemsSchema = {
 				tags: { type: 'object' },
 				categories: { type: 'object' },
 				attachments: { type: 'object' },
-				attachment_count: { type: 'integer' },
+				attachment_count: { type: [ 'integer', 'string' ] },
 				metadata: { type: 'array' },
 				meta: { type: 'object' },
 				capabilities: { type: 'object' },


### PR DESCRIPTION
It turns out that the attachment_count property may be an integer or a string. e.g `0` or `"4"`. This should be merged before #4302

## Testing
- navigate to: http://calypso.localhost:3000/devdocs/app-components
- set console debug to 'calypso:state'
- refresh the page
- you no longer see the schema warning:

<img width="1197" alt="screen shot 2016-03-24 at 1 02 02 pm" src="https://cloud.githubusercontent.com/assets/1270189/14029795/5f124e1e-f1c1-11e5-8eec-932a8167ddbe.png">

cc @rralian @aduth @artpi @retrofox