### PR TITLE
Adds `useNock` as a helper to cleanup tests using `nock`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,11 @@ test:
         files:
           - server/**/test/*.js
           - server/**/test/*.jsx
+    - NODE_ENV=test make client/config/index.js && MOCHA_FILE=./test-results-tests.xml npm run test-tests -- --reporter=mocha-junit-reporter -w:
+        parallel: true
+        files:
+          - test/test/**/test/*.js
+          - test/test/**/test/*.jsx
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/ && find . -type f -regex  "./test-results.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;:
         parallel: true

--- a/client/lib/importer/test/api-interaction.js
+++ b/client/lib/importer/test/api-interaction.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import Dispatcher from 'dispatcher';
-import nock from 'nock';
 import partial from 'lodash/partial';
+
+import { nock, useNock } from 'test/helpers/use-nock';
 
 import { fetchState } from '../actions';
 import { actionTypes } from '../constants';
@@ -18,7 +19,7 @@ const queuePayload = payload =>
 		.replyWithFile( 200, `${ __dirname }/api-payloads/${ payload }.json` );
 
 describe( 'Importer store', () => {
-	after( () => nock.cleanAll() );
+	useNock();
 
 	beforeEach( resetStore );
 

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "test": "make test",
     "test-client": "NODE_ENV=test NODE_PATH=test:client test/runner.js",
     "test-server": "NODE_ENV=test NODE_PATH=test:server:client test/runner.js",
+    "test-tests": "NODE_ENV=test NODE_PATH=test:test/test test/runner.js",
     "lint": "bin/run-lint"
   },
   "devDependencies": {

--- a/test/load-suite.js
+++ b/test/load-suite.js
@@ -4,7 +4,7 @@ function requireTestFiles( config, path = '' ) {
 	Object.keys( config ).forEach( ( folderName ) => {
 		const folderConfig = config[ folderName ];
 
-		if ( folderName === 'test' ) {
+		if ( folderName === 'test' && Array.isArray( folderConfig ) ) {
 			folderConfig.forEach( fileName => require( `${path}test/${fileName}` ) );
 		} else {
 			describe( folderName, () => {

--- a/test/test/helpers/use-mockery/README.md
+++ b/test/test/helpers/use-mockery/README.md
@@ -40,7 +40,7 @@ describe('my test suite', () = {
 		// attached to after hook
 	});
 
-	it ( 'mockery is alive now', () = {
+	it ( 'mockery is alive now', () => {
 		mockery.registerMock( 'lib/best-number', function() {
 			return 42;
 		} );

--- a/test/test/helpers/use-nock/README.md
+++ b/test/test/helpers/use-nock/README.md
@@ -1,0 +1,55 @@
+# Use Nock
+
+##### Ensure `nock` unloads properly after tests are finished
+
+`nock` allows you to intercept and mock network requests through a variety of filters and functions, providing such abilities as setting custom headers, HTTP response codes, and content.
+
+Because it's possible to allow `nock` interceptions and modifiers to persist beyond a single test, this helper ensures that all of the changes are cleared out after the current tests finish.
+
+`nock` is re-exported as a convenience so you don't have to import both `nock` and this module.
+
+## Format:
+```js
+useNock();
+```
+
+## Usage
+
+```js
+import useNock, { nock } from 'test/helpers/use-nock';
+//or
+import { useNock, nock } from 'text/helpers/use-nock';
+//or
+import useNock from 'test/helpers/use-nock';
+import nock from 'nock';
+
+describe('my test suite', () = {
+
+    // call at the beginning of a describe block to
+    // ensure a proper clean-up at the end
+    useNock();
+
+	it( 'is sloppy with a persistent nock', () => {
+	    nock( 'wordpress.com' )
+	        .persist()
+	        .get( '/me' )
+	        .reply( 200, {
+	            id: 42,
+	            name: 'Leeroy Jenkins'
+            } );
+        
+        expect( nock.isDone() ).to.be.false;
+	} );
+	
+	it( 'persists beyond where it was used', () => {
+	    expect( nock.isDone() ).to.be.false;
+	} );
+
+} );
+
+describe( 'my second suite', () => {
+	it ('has cleared out any remaining nock interceptions', () = {
+	    expect( nock.isDone() ).to.be.true;
+	} );
+} );
+```

--- a/test/test/helpers/use-nock/index.js
+++ b/test/test/helpers/use-nock/index.js
@@ -1,0 +1,15 @@
+import debug from 'debug';
+import nock from 'nock';
+
+export { nock };
+
+const log = debug( 'calypso:test:use-nock' );
+
+export const useNock = () => {
+	after( () => {
+		log( 'Cleaning up nock' );
+		nock.cleanAll();
+	} )
+};
+
+export default useNock;

--- a/test/test/helpers/use-nock/test.js
+++ b/test/test/helpers/use-nock/test.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+
+import { nock, useNock } from './index.js';
+
+describe( 'useNock', () => {
+	useNock();
+
+	describe( 'Messy without useNock', () => {
+		it( 'sets up a persistent interceptor', () => {
+			nock( 'wordpress.com' )
+				.persist()
+				.get( '/me' )
+				.reply( 200, { id: 42 } );
+		} );
+	} );
+
+	describe( 'Illustration Block', () => {
+		it( 'still sees the earlier persistent connection', () => {
+			expect( nock.isDone() ).to.be.false;
+		} );
+
+		after( () => nock.cleanAll() );
+	} );
+
+	describe( 'Clean with useNock', () => {
+		useNock();
+
+		it( 'sets up a persistent interceptor', () => {
+			nock( 'wordpress.com' )
+				.persist()
+				.get( '/me' )
+				.reply( 200, { id: 42 } );
+
+			expect( nock.isDone() ).to.be.false;
+		} );
+
+		it( 'persists inside the same `describe` block', () => {
+			expect( nock.isDone() ).to.be.false;
+		} );
+	} );
+
+	describe( 'Test Block', () => {
+		it( 'should have reset all remaining nocks', () => {
+			expect( nock.isDone() ).to.be.true;
+		} );
+	} );
+} );

--- a/test/test/helpers/use-nock/test/index.js
+++ b/test/test/helpers/use-nock/test/index.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { nock, useNock } from './index.js';
+import { nock, useNock } from '../index.js';
 
 describe( 'useNock', () => {
 	useNock();

--- a/test/test/tests.json
+++ b/test/test/tests.json
@@ -1,0 +1,7 @@
+{
+  "helpers" : {
+    "use-nock": {
+      "test": [ "index" ]
+    }
+  }
+}


### PR DESCRIPTION
`nock` offers some useful tools to intercept and mock network request.
Unfortunately it also offers the ability to persist those interceptions
and if left dangling can interfere with other tests.

This patch creates a helper function in `test/helpers/use-nock` that
will automatically ensure that those persistent and dangling
interceptors are automatically cleaned up.

It also corrects a small typo in the README for the mockery helper.

cc: @blowery @aduth