### PR TITLE
Checkout: Thank You: Fix persistent loading in `CheckoutThankYou`

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -74,7 +74,9 @@ const CheckoutThankYou = React.createClass( {
 		this.redirectIfThemePurchased();
 
 		if ( this.props.receipt.hasLoadedFromServer && this.hasPlanOrDomainRegistration() ) {
-			this.props.refreshSitePlans( this.props.selectedSite.ID );
+			this.props.refreshSitePlans( this.props.selectedSite );
+		} else if ( shouldFetchSitePlans( this.props.sitePlans, this.props.selectedSite ) ) {
+			this.props.fetchSitePlans( this.props.selectedSite );
 		}
 
 		if ( this.props.receiptId && ! this.props.receipt.hasLoadedFromServer && ! this.props.receipt.isRequesting ) {
@@ -264,19 +266,17 @@ export default connect(
 	},
 	( dispatch ) => {
 		return {
-			activatedTheme: ( meta, site ) => {
+			activatedTheme( meta, site ) {
 				dispatch( activated( meta, site, 'calypstore', true ) );
 			},
-			fetchReceipt: ( receiptId ) => {
+			fetchReceipt( receiptId ) {
 				dispatch( fetchReceipt( receiptId ) );
 			},
-			fetchSitePlans( sitePlans, site ) {
-				if ( shouldFetchSitePlans( sitePlans, site ) ) {
-					dispatch( fetchSitePlans( site.ID ) );
-				}
+			fetchSitePlans( site ) {
+				dispatch( fetchSitePlans( site.ID ) );
 			},
-			refreshSitePlans: ( siteId ) => {
-				dispatch( refreshSitePlans( siteId ) );
+			refreshSitePlans( site ) {
+				dispatch( refreshSitePlans( site.ID ) );
 			}
 		};
 	}


### PR DESCRIPTION
Currently, when visiting `/checkout/:site/:receiptId/thank-you` directly (or after signup, where site plans aren't loaded) for a receipt that includes no plan or domain registrations, a persistent loading screen is displayed. This is because we never fetch site plans in this case.

This is an oversight from a previous PR - `fetchSitePlans` is even provided as a prop for `CheckoutThankYou`, but never used. This PR fixes this issue.

**Testing**
- Visit `/domains/add/mapping/:site` and add a domain mapping to your cart.
- Purchase the domain mapping.
- Once you reach the thank you page, hit refresh.
- Assert the page eventually loads.

- [x] Code review
- [x] Product review