### PR TITLE
Domains: change main nav item's label for Email to Google Apps

### DIFF
--- a/client/my-sites/upgrades/navigation.jsx
+++ b/client/my-sites/upgrades/navigation.jsx
@@ -44,7 +44,7 @@ var NAV_ITEMS = {
 
 	Email: {
 		paths: [ upgradesPaths.domainManagementEmail() ],
-		label: i18n.translate( 'Email' ),
+		label: i18n.translate( 'Google Apps' ),
 		allSitesPath: false
 	},
 


### PR DESCRIPTION
Calling it "Email", when it is only relevant to Google Apps can be confusing, especially since we have a domain specific "Email" page too - and that one contains Email Forwarding. So the user could be confused why it's not present in the main "Email" view (when it's in fact "hidden" in the per-domain "Email" view).

Before:
<img width="761" alt="screen shot 2016-03-24 at 23 58 23" src="https://cloud.githubusercontent.com/assets/3392497/14033658/5e7c2aa0-f21c-11e5-813a-dfd599fc64e3.png">

After:
<img width="754" alt="screen shot 2016-03-25 at 00 00 10" src="https://cloud.githubusercontent.com/assets/3392497/14033689/925762c2-f21c-11e5-90e1-8ed374da86a4.png">

/cc @breezyskies