### PR TITLE
Framework: add metric for plan-storage component

### DIFF
--- a/client/my-sites/plan-storage/README.md
+++ b/client/my-sites/plan-storage/README.md
@@ -18,6 +18,7 @@ will query media storage limits for you.
 
 * `siteId`: A site ID (required)
 * `onClick`: An on click handler that is fired when the plan button is clicked.
+* `onMount`: An on mount click handler that is called in componentDidMount.
 * `className`: A string that adds additional class names to this component.
 
 
@@ -57,6 +58,7 @@ export default connect( ( state, ownProps ) => {
 * `sitePlanName`: A plan name ( Free or Premium ) (required)
 * `mediaStorage`: Media Storage limits for a given site. If this is not provided, the button will not render.
 * `onClick`: An on click handler that is fired when the plan storage button is clicked.
+* `onMount`: An on mount click handler that is called in componentDidMount.
 * `className`: A string that adds additional class names to this component.
 
 

--- a/client/my-sites/plan-storage/button.jsx
+++ b/client/my-sites/plan-storage/button.jsx
@@ -23,12 +23,14 @@ export default React.createClass( {
 		sitePlanName: React.PropTypes.string.isRequired,
 		mediaStorage: React.PropTypes.object,
 		onClick: React.PropTypes.func,
+		onMount: React.PropTypes.func,
 		className: React.PropTypes.string
 	},
 
 	getDefaultProps() {
 		return {
-			onClick: noop
+			onClick: noop,
+			onMount: noop
 		}
 	},
 
@@ -40,6 +42,10 @@ export default React.createClass( {
 		}
 		//This is a fallback if we add a new plan. We ideally want to add any plan levels for proper i18n.
 		return this.translate( '%(planName)s Plan', { args: { planName: this.props.sitePlanName } } );
+	},
+
+	componentDidMount() {
+		this.props.onMount();
 	},
 
 	render() {

--- a/client/my-sites/plan-storage/index.jsx
+++ b/client/my-sites/plan-storage/index.jsx
@@ -20,12 +20,14 @@ const PlanStorage = React.createClass( {
 		className: React.PropTypes.string,
 		mediaStorage: React.PropTypes.object,
 		siteId: React.PropTypes.number.isRequired,
+		onMount: React.PropTypes.func,
 		onClick: React.PropTypes.func
 	},
 
 	getDefaultProps() {
 		return {
-			onClick: noop
+			onClick: noop,
+			onMount: noop
 		}
 	},
 
@@ -40,6 +42,7 @@ const PlanStorage = React.createClass( {
 				<PlanStorageButton
 					sitePlanName={ this.props.site.plan.product_name_short }
 					mediaStorage={ this.props.mediaStorage }
+					onMount={ this.props.onMount }
 					onClick={ this.props.onClick }
 				/>
 			</div>

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -73,6 +73,12 @@ const MediaModalSecondaryActions = React.createClass( {
 		page( `/plans/${ this.props.siteSlug }` );
 	},
 
+	countImpression() {
+		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_impression', {
+			cta_name: 'plan-media-storage'
+		} );
+	},
+
 	getButtons() {
 		const {
 			user,
@@ -178,6 +184,7 @@ const MediaModalSecondaryActions = React.createClass( {
 			return (
 				<PlanStorage
 					onClick={ this.navigateToPlans }
+					onMount={ this.countImpression }
 					siteId={ this.props.site.ID } />
 			);
 		}


### PR DESCRIPTION
This PR adds a trac metric to count when the plan-storage component is viewed in the media modal.

<img width="811" alt="screen shot 2016-03-24 at 4 18 36 pm" src="https://cloud.githubusercontent.com/assets/1270189/14033984/1a8c26be-f1dc-11e5-9cac-124f09cb87c0.png">


## Testing:
- In the console call: `localStorage.setItem('debug', 'calypso:analytics');`
- Navigate to http://calypso.localhost:3000/post
- Select a wpcom site with a Free or Premium plan when propmted
- Click on the media modal (picture icon)
A message like the following appears in the console:
<img width="842" alt="screen shot 2016-03-24 at 4 16 16 pm" src="https://cloud.githubusercontent.com/assets/1270189/14033966/f13428a2-f1db-11e5-9a5e-e59071fb644f.png">
Click on the plan-storage component
<img width="829" alt="screen shot 2016-03-24 at 4 16 52 pm" src="https://cloud.githubusercontent.com/assets/1270189/14033969/faead986-f1db-11e5-83be-9e1f378b0056.png">



cc @rralian @adambbecker @mtias @artpi @retrofox