### PR TITLE
Framework: enable redux persistence on desktop

### DIFF
--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -57,7 +57,7 @@
 		"oauth": true,
 		"olark": false,
 		"olark_use_wpcom_configuration": false,
-		"persist-redux": false,
+		"persist-redux": true,
 		"phone_signup": true,
 		"post-editor/author-selector": true,
 		"post-editor/live-image-updates": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -58,7 +58,7 @@
 		"oauth": true,
 		"olark": true,
 		"olark_use_wpcom_configuration": true,
-		"persist-redux": false,
+		"persist-redux": true,
 		"phone_signup": true,
 		"post-editor/author-selector": true,
 		"post-editor/live-image-updates": true,


### PR DESCRIPTION
This PR enables redux persistence for desktop environments.

## Testing instructions
- `git clone git@github.com:Automattic/wp-desktop.git`
- follow setup instructions: https://github.com/Automattic/wp-desktop/blob/master/docs/install.md
- and generate secrets: https://github.com/Automattic/wp-desktop/blob/master/docs/secrets.md
- After your desktop env is setup switch to this branch:
- `cd wp-desktop/calypso`
- `git pull; git checkout update/enable-persist-redux-desktop`
- Then navigate back to wp-desktop and `make run`
- open up developer tools, you should see a new entry in indexedDB called: 'redux-state' 
<img width="1068" alt="screen shot 2016-03-25 at 8 56 05 am" src="https://cloud.githubusercontent.com/assets/1270189/14047957/62c4894e-f268-11e5-873c-df7d26869e7f.png">
- The app should behave normally. No schema warnings should be seen on the console.

cc @ockham @mkaz @rralian @blowery