### PR TITLE
Tests: Move TinyMCE plugin tests to single test runner

### DIFF
--- a/client/components/tinymce/plugins/media/restrict-size/index.js
+++ b/client/components/tinymce/plugins/media/restrict-size/index.js
@@ -13,7 +13,7 @@ const MEDIA_RETINA = '( -webkit-min-device-pixel-ratio: 1.5 ), ( min--moz-device
 const BASE_MAX_WIDTH = 680;
 const MAX_WIDTH = getMaxWidth();
 
-function getMaxWidth() {
+export function getMaxWidth() {
 	if ( isFinite( window.devicePixelRatio ) ) {
 		return Math.round( BASE_MAX_WIDTH * window.devicePixelRatio );
 	}
@@ -43,11 +43,11 @@ function setImageSrc( img, opening, src, closing ) {
 	return `${ opening }${ url }" data-wpmedia-src="${ parsed.media.URL }${ closing }`;
 }
 
-function resetImages( content ) {
+export function resetImages( content ) {
 	return content.replace( REGEXP_REPLACED_IMG, resetImageSrc );
 }
 
-function setImages( content ) {
+export function setImages( content ) {
 	return content.replace( REGEXP_ORIGINAL_IMG, setImageSrc );
 }
 

--- a/client/components/tinymce/plugins/media/restrict-size/test/index.js
+++ b/client/components/tinymce/plugins/media/restrict-size/test/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import rewire from 'rewire';
 
 /**
  * Internal dependencies
@@ -10,18 +9,20 @@ import rewire from 'rewire';
 import useFakeDom from 'test/helpers/use-fake-dom';
 
 describe( 'restrictSize', () => {
-	let restrictSize;
+	let getMaxWidth, resetImages, setImages;
 
 	useFakeDom();
 
 	before( () => {
-		restrictSize = rewire( '../' );
+		const restrictSize = require( '../' );
+		getMaxWidth = restrictSize.getMaxWidth;
+		resetImages = restrictSize.resetImages;
+		setImages = restrictSize.setImages;
 	} );
 
 	describe( '#getMaxWidth()', () => {
-		let getMaxWidth, matchMedia, devicePixelRatio;
+		let matchMedia, devicePixelRatio;
 		before( () => {
-			getMaxWidth = restrictSize.__get__( 'getMaxWidth' );
 			matchMedia = window.matchMedia;
 			devicePixelRatio = window.devicePixelRatio;
 		} );
@@ -51,11 +52,6 @@ describe( 'restrictSize', () => {
 	} );
 
 	describe( '#resetImages()', () => {
-		let resetImages;
-		before( () => {
-			resetImages = restrictSize.__get__( 'resetImages' );
-		} );
-
 		it( 'should restore all instances of replaced images', () => {
 			const value = resetImages( '<p><img src="https://wordpress.com/2015/11/forest.jpg?w=680" data-wpmedia-src="https://wordpress.com/2015/11/forest.jpg?w=1024" class="alignnone size-large wp-image-5823" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>' );
 			expect( value ).to.equal( '<p><img src="https://wordpress.com/2015/11/forest.jpg?w=1024" class="alignnone size-large wp-image-5823" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>' );
@@ -73,11 +69,6 @@ describe( 'restrictSize', () => {
 	} );
 
 	describe( '#setImages()', () => {
-		let setImages;
-		before( () => {
-			setImages = restrictSize.__get__( 'setImages' );
-		} );
-
 		it( 'should replace all instances of large images', () => {
 			const value = setImages( '<p><img src="https://wordpress.com/2015/11/forest.jpg?w=1024" class="alignnone size-large wp-image-5823" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>' );
 			expect( value ).to.equal( '<p><img src="https://wordpress.com/2015/11/forest.jpg?w=680" data-wpmedia-src="https://wordpress.com/2015/11/forest.jpg?w=1024" class="alignnone size-large wp-image-5823" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>' );

--- a/client/components/tinymce/plugins/wpcom-sourcecode/test/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/test/plugin.js
@@ -2,9 +2,13 @@
  * External dependencies
  */
 import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
 import useMockery from 'test/helpers/use-mockery';
 
-describe( 'plugin', () => {
+describe( 'wpcom-sourcecode', () => {
 	let wrapPre, unwrapPre;
 
 	useMockery( mockery => {


### PR DESCRIPTION
Related: #3942

This pull request updates and moves the tests contained within the following directories to be compatible with and run by the single test runner:
- `client/components/tinymce/plugins/contact-form`
- `client/components/tinymce/plugins/media/restrict-size`
- `client/components/tinymce/plugins/wpcom-sourcecode`

__Testing instructions:__

Verify all tests pass by running `npm run test-client`.

/cc @gziolo