### PR TITLE
Framework: Bootstrap when isorouting

### DIFF
--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -11,8 +11,8 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 		expressApp.get(
 			route,
 			setUpRoute,
+			setUpI18n,
 			combineMiddlewares(
-				setUpI18n,
 				setSectionMiddlewareFactory( section ),
 				...middlewares
 			),
@@ -52,7 +52,7 @@ function compose( ...functions ) {
 	), () => {} );
 }
 
-function setUpI18n( context, next ) {
+function setUpI18n( req, res, next ) {
 	i18n.initialize();
 	next();
 }

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -15,7 +15,7 @@ export function serverRouter( expressApp, setUpRoute, section ) {
 function combinedMiddlewares( middlewares, section ) {
 	return function( req, res, next ) {
 		req.context = getEnhancedContext( req );
-		applyMiddlewares( req.context, ...[
+		applyMiddlewares( req.context, [
 			setUpI18n,
 			setSectionMiddlewareFactory( section ),
 			...middlewares
@@ -36,7 +36,7 @@ function getEnhancedContext( req ) {
 	} );
 }
 
-function applyMiddlewares( context, ...middlewares ) {
+function applyMiddlewares( context, middlewares ) {
 	const liftedMiddlewares = middlewares.map( middleware => next => middleware( context, next ) );
 	compose( ...liftedMiddlewares )();
 }

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -37,8 +37,8 @@ function getEnhancedContext( req ) {
 }
 
 function applyMiddlewares( context, ...middlewares ) {
-	const liftedmiddlewares = middlewares.map( middleware => next => middleware( context, next ) );
-	compose( ...liftedmiddlewares )();
+	const liftedMiddlewares = middlewares.map( middleware => next => middleware( context, next ) );
+	compose( ...liftedMiddlewares )();
 }
 
 function compose( ...functions ) {

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -34,9 +34,10 @@ function getEnhancedContext( req ) {
 	return Object.assign( {}, req.context, {
 		isLoggedIn: req.cookies.wordpress_logged_in,
 		isServerSide: true,
-		path: req.path,
+		path: req.url,
+		pathname: req.path,
 		params: req.params,
-		query: {}, // Why?
+		query: req.query,
 		store: createReduxStore()
 	} );
 }

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -2,20 +2,11 @@
  * Internal dependencies
  */
 import i18n from 'lib/mixins/i18n';
-import sections from '../../client/sections';
 import { serverRender } from 'render';
 import { createReduxStore } from 'state';
 import { setSection as setSectionMiddlewareFactory } from '../../client/controller';
 
-export default function( expressApp, setUpRoute ) {
-	sections.get()
-		.filter( section => section.isomorphic )
-		.forEach( section => {
-			sections.require( section.module )( serverRouter( expressApp, setUpRoute, section ) );
-		} );
-}
-
-function serverRouter( expressApp, setUpRoute, section ) {
+export function serverRouter( expressApp, setUpRoute, section ) {
 	return function( route, ...middlewares ) {
 		expressApp.get( route, setUpRoute, combinedMiddlewares( middlewares, section ), serverRender );
 	}

--- a/server/isomorphic-routing/index.js
+++ b/server/isomorphic-routing/index.js
@@ -8,18 +8,23 @@ import { setSection as setSectionMiddlewareFactory } from '../../client/controll
 
 export function serverRouter( expressApp, setUpRoute, section ) {
 	return function( route, ...middlewares ) {
-		expressApp.get( route, setUpRoute, combinedMiddlewares( middlewares, section ), serverRender );
+		expressApp.get(
+			route,
+			setUpRoute,
+			combineMiddlewares(
+				setUpI18n,
+				setSectionMiddlewareFactory( section ),
+				...middlewares
+			),
+			serverRender
+		);
 	}
 }
 
-function combinedMiddlewares( middlewares, section ) {
+function combineMiddlewares( ...middlewares ) {
 	return function( req, res, next ) {
 		req.context = getEnhancedContext( req );
-		applyMiddlewares( req.context, [
-			setUpI18n,
-			setSectionMiddlewareFactory( section ),
-			...middlewares
-		] );
+		applyMiddlewares( req.context, middlewares );
 		next();
 	}
 }

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -374,7 +374,7 @@ module.exports = function() {
 
 	app.get( '/start/:flowName?/:stepName?/:stepSectionName?/:lang?', setUpRoute, render );
 
-	isomorphicRouting( app, getDefaultContext );
+	isomorphicRouting( app, setUpRoute );
 
 	app.get( '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',
 		setUpRoute,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -11,7 +11,8 @@ var config = require( 'config' ),
 	sanitize = require( 'sanitize' ),
 	utils = require( 'bundler/utils' ),
 	sections = require( '../../client/sections' ).get(),
-	isomorphicRouting = require( 'isomorphic-routing' );
+	isomorphicRouting = require( 'isomorphic-routing' ),
+	serverRender = require( 'server/render' ).serverRender;
 
 var HASH_LENGTH = 10,
 	URL_BASE_PATH = '/calypso',
@@ -321,14 +322,6 @@ function setUpRoute( req, res, next ) {
 	}
 }
 
-function render( req, res ) {
-	if ( config.isEnabled( 'desktop' ) ) {
-		res.render( 'desktop.jade', req.context );
-	} else {
-		res.render( 'index.jade', req.context );
-	}
-}
-
 module.exports = function() {
 	var app = express();
 
@@ -369,24 +362,24 @@ module.exports = function() {
 	} );
 
 	if ( config.isEnabled( 'login' ) ) {
-		app.get( '/log-in/:lang?', setUpLoggedOutRoute, render );
+		app.get( '/log-in/:lang?', setUpLoggedOutRoute, serverRender );
 	}
 
-	app.get( '/start/:flowName?/:stepName?/:stepSectionName?/:lang?', setUpRoute, render );
+	app.get( '/start/:flowName?/:stepName?/:stepSectionName?/:lang?', setUpRoute, serverRender );
 
 	isomorphicRouting( app, setUpRoute );
 
 	app.get( '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',
 		setUpRoute,
-		render
+		serverRender
 	);
 
 	if ( config.isEnabled( 'phone_signup' ) ) {
-		app.get( '/phone/:lang?', setUpLoggedOutRoute, render );
+		app.get( '/phone/:lang?', setUpLoggedOutRoute, serverRender );
 	}
 
 	if ( config.isEnabled( 'mailing-lists/unsubscribe' ) ) {
-		app.get( '/mailing-lists/unsubscribe', setUpRoute, render );
+		app.get( '/mailing-lists/unsubscribe', setUpRoute, serverRender );
 	}
 
 	if ( config.isEnabled( 'reader/discover' ) && config( 'env' ) !== 'development' ) {
@@ -400,7 +393,7 @@ module.exports = function() {
 	}
 
 	// catchall path to serve shell for all non-static-file requests (other than auth routes)
-	app.get( '*', setUpLoggedInRoute, render );
+	app.get( '*', setUpLoggedInRoute, serverRender );
 
 	return app;
 };

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -369,13 +369,6 @@ module.exports = function() {
 
 	app.get( '/start/:flowName?/:stepName?/:stepSectionName?/:lang?', setUpRoute, serverRender );
 
-	// Isomorphic routing
-	sections
-		.filter( section => section.isomorphic )
-		.forEach( section => {
-			sectionsModule.require( section.module )( serverRouter( app, setUpRoute, section ) );
-		} );
-
 	app.get( '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',
 		setUpRoute,
 		serverRender
@@ -398,6 +391,13 @@ module.exports = function() {
 			}
 		} );
 	}
+
+	// Isomorphic routing
+	sections
+		.filter( section => section.isomorphic )
+		.forEach( section => {
+			sectionsModule.require( section.module )( serverRouter( app, setUpRoute, section ) );
+		} );
 
 	// catchall path to serve shell for all non-static-file requests (other than auth routes)
 	app.get( '*', setUpLoggedInRoute, serverRender );

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -74,7 +74,7 @@ export function serverRender( req, res ) {
 	if ( config.isEnabled( 'server-side-rendering' ) && context.store && context.layout ) {
 		context.initialReduxState = pick( context.store.getState(), 'ui', 'themes' );
 		const path = url.parse( req.url ).path;
-		const key = JSON.stringify( context.renderedLayout ) + path + JSON.stringify( context.initialReduxState );
+		const key = JSON.stringify( context.layout ) + path + JSON.stringify( context.initialReduxState );
 		Object.assign( context, render( context.layout, key ) );
 	}
 

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -68,12 +68,19 @@ export function render( element, key = JSON.stringify( element ) ) {
 	//todo: render an error?
 }
 
-export function serverRender( context ) {
-	if ( config.isEnabled( 'server-side-rendering' ) ) {
+export function serverRender( req, res ) {
+	const context = req.context;
+
+	if ( config.isEnabled( 'server-side-rendering' ) && context.store && context.layout ) {
 		context.initialReduxState = pick( context.store.getState(), 'ui', 'themes' );
-		const path = url.parse( context.url ).path;
+		const path = url.parse( req.url ).path;
 		const key = JSON.stringify( context.renderedLayout ) + path + JSON.stringify( context.initialReduxState );
 		Object.assign( context, render( context.layout, key ) );
 	}
-	context.res.render( 'index.jade', context );
+
+	if ( config.isEnabled( 'desktop' ) ) {
+		res.render( 'desktop.jade', context );
+	} else {
+		res.render( 'index.jade', context );
+	}
 }

--- a/server/render/index.js
+++ b/server/render/index.js
@@ -5,7 +5,6 @@ import ReactDomServer from 'react-dom/server';
 import Helmet from 'react-helmet';
 import superagent from 'superagent';
 import Lru from 'lru-cache';
-import url from 'url';
 import pick from 'lodash/pick';
 
 /**
@@ -73,8 +72,7 @@ export function serverRender( req, res ) {
 
 	if ( config.isEnabled( 'server-side-rendering' ) && context.store && context.layout ) {
 		context.initialReduxState = pick( context.store.getState(), 'ui', 'themes' );
-		const path = url.parse( req.url ).path;
-		const key = JSON.stringify( context.layout ) + path + JSON.stringify( context.initialReduxState );
+		const key = JSON.stringify( context.layout ) + req.path + JSON.stringify( context.initialReduxState );
 		Object.assign( context, render( context.layout, key ) );
 	}
 


### PR DESCRIPTION
Take care of boostrapping for isomorphic sections. This is achieved by removing the actual rendering part from `server/pages`'s `renderLoggedInRoute` and `renderLoggedOutRoute`, leveraging that they're middlewares, and using the `serverRender` middleware instead.

This PR also streamlines some of `server/isomorphic-routing` by turning the `serverRender` page.js-style middlewares that is only ever used for express.js via an adaptor into an actual express.js-style middleware.

Fixes #4081 

To test:
* Since this PR touches basically all of Calypso's server-side routing, it's important to test it thoroughly by directly hitting various routes as used in `server/pages`'s `app.get()` calls (not just navigating within the app!)
* In particular, verify that when logged in, directly hitting calypso.localhost:3000/design will now display the Theme Showcase correctly (i.e. with a sidebar, and with the logged-in masterbar) as opposed to the `master` branch, where it's displayed as if logged-out when directly hit.

Possible future TODO, not necessarily as part of this PR:
* Possibly move rename `server/isomorphic-routing/index.js` to `server/route/isomorphic.js`, and move `getDefaultContext`, `setUpLoggedInRoute`, `setUpLoggedOutRoute`, `setUpRoute` from `server/pages` to `server/route/index.js`.

/cc @seear for review