### PR TITLE
Checkout: Thank You: Refresh site plans when purchasing a domain mapping

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -73,7 +73,7 @@ const CheckoutThankYou = React.createClass( {
 	componentDidMount() {
 		this.redirectIfThemePurchased();
 
-		if ( this.props.receipt.hasLoadedFromServer && this.hasPlanOrDomainRegistration() ) {
+		if ( this.props.receipt.hasLoadedFromServer && this.hasPlanOrDomainProduct() ) {
 			this.props.refreshSitePlans( this.props.selectedSite );
 		} else if ( shouldFetchSitePlans( this.props.sitePlans, this.props.selectedSite ) ) {
 			this.props.fetchSitePlans( this.props.selectedSite );
@@ -91,13 +91,13 @@ const CheckoutThankYou = React.createClass( {
 	componentWillReceiveProps( nextProps ) {
 		this.redirectIfThemePurchased();
 
-		if ( ! this.props.receipt.hasLoadedFromServer && nextProps.receipt.hasLoadedFromServer && this.hasPlanOrDomainRegistration( nextProps ) ) {
+		if ( ! this.props.receipt.hasLoadedFromServer && nextProps.receipt.hasLoadedFromServer && this.hasPlanOrDomainProduct( nextProps ) ) {
 			this.props.refreshSitePlans( this.props.selectedSite.ID );
 		}
 	},
 
-	hasPlanOrDomainRegistration( props = this.props ) {
-		return getPurchases( props ).some( purchase => isPlan( purchase ) || isDomainRegistration( purchase ) );
+	hasPlanOrDomainProduct( props = this.props ) {
+		return getPurchases( props ).some( purchase => isPlan( purchase ) || isDomainProduct( purchase ) );
 	},
 
 	isDataLoaded() {


### PR DESCRIPTION
Fixes #4233 by updating the condition we use to refresh the site's plans to include a domain mapping, as we offer discounted plans when the user has purchased a domain registration or mapping. Previously, we only reloaded site-specific plans when the user purchased a plan or domain registration.

**Testing**
- Visit `/plans/:site` for a site with the free plan.
- Navigate to `/domains/add/mapping/:site` in the same session and add a domain mapping to the cart.
- Purchase a domain mapping.
- Once the thank you page loads, navigate back to `/plans/:site` in the same session, i.e. click My Sites → Plans.
- Assert that the plans appear to be discounted:
<img src="https://camo.githubusercontent.com/1bc2d818898235b534450131f185be225470585d/68747470733a2f2f636c6f756475702e636f6d2f634b49715f3261767275672b" />

cc @rralian

#### Reviews
 
- [x] Code
- [x] Product
