### PR TITLE
WPCOM Plugins: add plugin panel styles

### DIFF
--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -1,6 +1,9 @@
 import React, { PropTypes } from 'react';
 
 import FoldableCard from 'components/foldable-card';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 
 import BusinessPlugin from './plugin-types/business-plugin';
@@ -10,12 +13,7 @@ const defaultPlugins = [
 		name: 'Google Analytics',
 		supportLink: 'https://en.support.wordpress.com/google-analytics/',
 		plan: 'Business',
-		description: (
-			<div>
-				Advanced features to complement <a href="http://wordpress.com/">WordPress.com stats</a>.
-				Funnel reports, goal conversion, and more.
-			</div>
-		)
+		description: 'Advanced features to complement WordPress.com stats. Funnel reports, goal conversion, and more.'
 	}
 ];
 
@@ -28,19 +26,22 @@ export const BusinessPluginsPanel = React.createClass( {
 		const actionButton = <div><Gridicon icon="checkmark" /> Active</div>;
 
 		return (
-			<FoldableCard
-				actionButton={ actionButton }
-				actionButtonExpanded={ actionButton }
-				className="wpcom-plugins__business-panel"
-				expanded={ true }
-				header="Business Upgrades"
-			>
-				{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
-					<BusinessPlugin
-						{ ...{ name, key: name, supportLink, icon, plan, description } }
-					/>
-				) }
-			</FoldableCard>
+			<div>
+				<SectionHeader label={ this.translate( 'Business Upgrades' ) }>
+					<Button compact primary>
+        		{ this.translate( 'Purchase' ) }
+        	</Button>
+				</SectionHeader>
+				<Card className="wpcom-plugins__business-panel">
+					<div className="wpcom-plugins__list">
+						{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
+							<BusinessPlugin
+								{ ...{ name, key: name, supportLink, icon, plan, description } }
+								/>
+						) }
+					</div>
+				</Card>
+			</div>
 		);
 	}
 } );

--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -3,7 +3,6 @@ import React, { PropTypes } from 'react';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
-import Gridicon from 'components/gridicon';
 
 import BusinessPlugin from './plugin-types/business-plugin';
 
@@ -22,21 +21,18 @@ export const BusinessPluginsPanel = React.createClass( {
 		const plugins = givenPlugins.length
 			? givenPlugins
 			: defaultPlugins;
-		const actionButton = <div><Gridicon icon="checkmark" /> Active</div>;
 
 		return (
 			<div>
 				<SectionHeader label={ this.translate( 'Business Upgrades' ) }>
-					<Button compact primary>
-        		{ this.translate( 'Purchase' ) }
-        	</Button>
+					<Button compact primary>{ this.translate( 'Purchase' ) }</Button>
 				</SectionHeader>
 				<Card className="wpcom-plugins__business-panel">
 					<div className="wpcom-plugins__list">
 						{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
 							<BusinessPlugin
 								{ ...{ name, key: name, supportLink, icon, plan, description } }
-								/>
+							/>
 						) }
 					</div>
 				</Card>

--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 
-import FoldableCard from 'components/foldable-card';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -1,23 +1,19 @@
 import React from 'react';
 
 import Card from 'components/card';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
 
 export const InfoHeader = React.createClass( {
 	render() {
 		return (
-			<Card className="wpcom-plugins__info-header">
-				<div>
-					Uploading and installing your own plugins is not
-					available on WordPress.com, but we offer the most
-					essential ones below.
-					<a
-						href="https://en.support.wordpress.com/plugins/"
-						target="_blank"
-					>
-						Learn more
-					</a>.
-				</div>
-			</Card>
+			<Notice
+				showDismiss={ false }
+				text={ "Uploading and installing your own plugins is not available on WordPress.com, but we offer the most essential ones below." }>
+				<NoticeAction href="https://en.support.wordpress.com/plugins/">
+					{ "Learn More" }
+				</NoticeAction> 
+			</Notice>
 		);
 	}
 } );

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import Card from 'components/card';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 
@@ -9,10 +8,11 @@ export const InfoHeader = React.createClass( {
 		return (
 			<Notice
 				showDismiss={ false }
-				text={ "Uploading and installing your own plugins is not available on WordPress.com, but we offer the most essential ones below." }>
+				text={ "Uploading and installing your own plugins is not available on WordPress.com, but we offer the most essential ones below." }
+			>
 				<NoticeAction href="https://en.support.wordpress.com/plugins/">
 					{ "Learn More" }
-				</NoticeAction> 
+				</NoticeAction>
 			</Notice>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -13,16 +13,16 @@ export const BusinessPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<div className="wpcom-plugins__plugin-item">
-				<div>
-					<Gridicon { ...{ icon } } />
-					<a href={ supportLink } target="_blank">{ name }</a>
-					<div>{ plan }</div>
-				</div>
-				<div>
-					{ description }
-				</div>
-			</div>
+			<li className="wpcom-plugins__plugin-item">
+				<a href={ supportLink } target="_blank">
+					<div className="wpcom-plugins__plugin-icon">
+						<Gridicon { ...{ icon } } />
+					</div>
+					<div className="wpcom-plugins__plugin-title">{ name }</div>
+					<div className="wpcom-plugins__plugin-plan">{ plan }</div>
+					<div className="wpcom-plugins__plugin-description">{ description }</div>
+				</a>
+			</li>
 		);
 	}
 } );

--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -20,7 +20,7 @@ export const BusinessPlugin = React.createClass( {
 					</div>
 					<div className="wpcom-plugins__plugin-title">{ name }</div>
 					<div className="wpcom-plugins__plugin-plan">{ plan }</div>
-					<div className="wpcom-plugins__plugin-description">{ description }</div>
+					<p className="wpcom-plugins__plugin-description">{ description }</p>
 				</a>
 			</li>
 		);

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -20,7 +20,7 @@ export const PremiumPlugin = React.createClass( {
 					</div>
 					<div className="wpcom-plugins__plugin-title">{ name }</div>
 					<div className="wpcom-plugins__plugin-plan">{ plan }</div>
-					<div className="wpcom-plugins__plugin-description">{ description }</div>
+					<p className="wpcom-plugins__plugin-description">{ description }</p>
 				</a>
 			</li>
 		);

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -13,16 +13,16 @@ export const PremiumPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<div className="wpcom-plugins__plugin-item">
-				<div>
-					<Gridicon { ...{ icon } } />
-					<a href={ supportLink } target="_blank">{ name }</a>
-					<div>{ plan }</div>
-				</div>
-				<div>
-					{ description }
-				</div>
-			</div>
+			<li className="wpcom-plugins__plugin-item">
+				<a href={ supportLink } target="_blank">
+					<div className="wpcom-plugins__plugin-icon">
+						<Gridicon { ...{ icon } } />
+					</div>
+					<div className="wpcom-plugins__plugin-title">{ name }</div>
+					<div className="wpcom-plugins__plugin-plan">{ plan }</div>
+					<div className="wpcom-plugins__plugin-description">{ description }</div>
+				</a>
+			</li>
 		);
 	}
 } );

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -13,16 +13,16 @@ export const StandardPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<div className="wpcom-plugins__plugin-item">
-				<div>
-					<Gridicon { ...{ icon } } />
-					<a href={ supportLink } target="_blank">{ name }</a>
-					<div>{ category }</div>
-				</div>
-				<div>
-					{ description }
-				</div>
-			</div>
+			<li className="wpcom-plugins__plugin-item">
+				<a href={ supportLink } target="_blank">
+					<div className="wpcom-plugins__plugin-icon">
+						<Gridicon { ...{ icon } } />
+					</div>
+					<div className="wpcom-plugins__plugin-title">{ name }</div>
+					<div className="wpcom-plugins__plugin-category">{ category }</div>
+					<p className="wpcom-plugins__plugin-description">{ description }</p>
+				</a>
+			</li>
 		);
 	}
 } );

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 
-import FoldableCard from 'components/foldable-card';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
@@ -19,7 +18,7 @@ const defaultPlugins = [
 		name: 'Custom Design',
 		supportLink: 'https://en.support.wordpress.com/custom-design/',
 		plan: 'Premium',
-		description: 'With Customize you can personalize your blog\'s look and feel with intelligent color tools, custom fonts, and a CSS editor.'
+		description: 'Customize your blog\'s look with custom fonts, a CSS editor, and more.'
 	},
 	{
 		name: 'Video Uploads',

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -3,7 +3,6 @@ import React, { PropTypes } from 'react';
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
-import Gridicon from 'components/gridicon';
 
 import PremiumPlugin from './plugin-types/premium-plugin';
 
@@ -34,24 +33,21 @@ export const PremiumPluginsPanel = React.createClass( {
 		const plugins = givenPlugins.length
 			? givenPlugins
 			: defaultPlugins;
-		const actionButton = <div><Gridicon icon="checkmark" /> Active</div>;
 
 		return (
 			<div>
-			<SectionHeader label={ this.translate( 'Premium Upgrades' ) }>
-				<Button compact primary>
-					{ this.translate( 'Purchase' ) }
-				</Button>
-			</SectionHeader>
-			<Card className="wpcom-plugins__premium-panel">
-				<div className="wpcom-plugins__list">
-					{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
-						<PremiumPlugin
-							{ ...{ name, key: name, supportLink, icon, plan, description } }
+				<SectionHeader label={ this.translate( 'Premium Upgrades' ) }>
+					<Button compact primary>{ this.translate( 'Purchase' ) }</Button>
+				</SectionHeader>
+				<Card className="wpcom-plugins__premium-panel">
+					<div className="wpcom-plugins__list">
+						{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
+							<PremiumPlugin
+								{ ...{ name, key: name, supportLink, icon, plan, description } }
 							/>
-					) }
-				</div>
-			</Card>
+						) }
+					</div>
+				</Card>
 			</div>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -1,6 +1,9 @@
 import React, { PropTypes } from 'react';
 
 import FoldableCard from 'components/foldable-card';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 
 import PremiumPlugin from './plugin-types/premium-plugin';
@@ -35,19 +38,22 @@ export const PremiumPluginsPanel = React.createClass( {
 		const actionButton = <div><Gridicon icon="checkmark" /> Active</div>;
 
 		return (
-			<FoldableCard
-				actionButton={ actionButton }
-				actionButtonExpanded={ actionButton }
-				className="wpcom-plugins__premium-panel"
-				expanded={ true }
-				header="Premium Upgrades"
-			>
-				{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
-					<PremiumPlugin
-						{ ...{ name, key: name, supportLink, icon, plan, description } }
-					/>
-				) }
-			</FoldableCard>
+			<div>
+			<SectionHeader label={ this.translate( 'Premium Upgrades' ) }>
+				<Button compact primary>
+					{ this.translate( 'Purchase' ) }
+				</Button>
+			</SectionHeader>
+			<Card className="wpcom-plugins__premium-panel">
+				<div className="wpcom-plugins__list">
+					{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
+						<PremiumPlugin
+							{ ...{ name, key: name, supportLink, icon, plan, description } }
+							/>
+					) }
+				</div>
+			</Card>
+			</div>
 		);
 	}
 } );

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -53,28 +53,26 @@ export const StandardPluginsPanel = React.createClass( {
 		const plugins = givenPlugins.length
 			? givenPlugins
 			: defaultPlugins;
-		const actionButton = <div className="wpcom-plugins__action-button"><Gridicon icon="checkmark" /> Active</div>;
 
 		return (
 			<div>
-			<SectionHeader label={ this.translate( 'Standard Plugin Suite' ) }>
+				<SectionHeader label={ this.translate( 'Standard Plugin Suite' ) }>
 					<Button className="is-active-plugin" compact borderless>
-						<Gridicon icon="checkmark" />
-        		{ this.translate( 'Active' ) }
-        	</Button>
-			</SectionHeader>
-			<CompactCard className="wpcom-plugins__standard-panel">
-				<div className="wpcom-plugins__list">
-					{ plugins.map( ( { name, supportLink, icon, category, description } ) =>
-						<StandardPlugin
-							{ ...{ name, key: name, supportLink, icon, category, description } }
+						<Gridicon icon="checkmark" />{ this.translate( 'Active' ) }
+					</Button>
+				</SectionHeader>
+				<CompactCard className="wpcom-plugins__standard-panel">
+					<div className="wpcom-plugins__list">
+						{ plugins.map( ( { name, supportLink, icon, category, description } ) =>
+							<StandardPlugin
+								{ ...{ name, key: name, supportLink, icon, category, description } }
 							/>
-					) }
-				</div>
-			</CompactCard>
-			<Card className="wpcom-plugins__panel-footer" href="#">
-				{ this.translate( 'View all standard plugins' ) }
-			</Card>
+						) }
+					</div>
+				</CompactCard>
+				<Card className="wpcom-plugins__panel-footer" href="#">
+					{ this.translate( 'View all standard plugins' ) }
+				</Card>
 			</div>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 
-import FoldableCard from 'components/foldable-card';
 import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
@@ -58,12 +58,12 @@ export const StandardPluginsPanel = React.createClass( {
 		return (
 			<div>
 			<SectionHeader label={ this.translate( 'Standard Plugin Suite' ) }>
-					<Button compact borderless>
+					<Button className="is-active-plugin" compact borderless>
 						<Gridicon icon="checkmark" />
         		{ this.translate( 'Active' ) }
         	</Button>
 			</SectionHeader>
-			<Card className="wpcom-plugins__standard-panel">
+			<CompactCard className="wpcom-plugins__standard-panel">
 				<div className="wpcom-plugins__list">
 					{ plugins.map( ( { name, supportLink, icon, category, description } ) =>
 						<StandardPlugin
@@ -71,12 +71,9 @@ export const StandardPluginsPanel = React.createClass( {
 							/>
 					) }
 				</div>
-				<div className="wpcom-plugins__panel-footer">
-					<Button borderless>
-						<Gridicon icon="plus-small" />
-						{ this.translate( 'View all standard plugins' ) }
-					</Button>
-				</div>
+			</CompactCard>
+			<Card className="wpcom-plugins__panel-footer" href="#">
+				{ this.translate( 'View all standard plugins' ) }
 			</Card>
 			</div>
 		);

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -1,6 +1,9 @@
 import React, { PropTypes } from 'react';
 
 import FoldableCard from 'components/foldable-card';
+import Card from 'components/card';
+import SectionHeader from 'components/section-header';
+import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 
 import StandardPlugin from './plugin-types/standard-plugin';
@@ -41,12 +44,6 @@ const defaultPlugins = [
 		supportLink: 'http://support.wordpress.com/contact-form/',
 		category: 'Appearance',
 		description: 'Build contact forms so visitors can get in touch.'
-	},
-	{
-		name: 'Extended Customizer',
-		supportLink: 'https://en.support.wordpress.com/customizer/',
-		category: 'Appearance',
-		description: 'Edit colors and backgrounds.'
 	}
 ];
 
@@ -59,22 +56,29 @@ export const StandardPluginsPanel = React.createClass( {
 		const actionButton = <div className="wpcom-plugins__action-button"><Gridicon icon="checkmark" /> Active</div>;
 
 		return (
-			<FoldableCard
-				actionButton={ actionButton }
-				actionButtonExpanded={ actionButton }
-				className="wpcom-plugins__standard-panel"
-				expanded={ true }
-				header="Standard Plugin Suite"
-			>
-				{ plugins.map( ( { name, supportLink, icon, category, description } ) =>
-					<StandardPlugin
-						{ ...{ name, key: name, supportLink, icon, category, description } }
-					/>
-				) }
-				<div>
-					<Gridicon icon="plus" />View all standard plugins
+			<div>
+			<SectionHeader label={ this.translate( 'Standard Plugin Suite' ) }>
+					<Button compact borderless>
+						<Gridicon icon="checkmark" />
+        		{ this.translate( 'Active' ) }
+        	</Button>
+			</SectionHeader>
+			<Card className="wpcom-plugins__standard-panel">
+				<div className="wpcom-plugins__list">
+					{ plugins.map( ( { name, supportLink, icon, category, description } ) =>
+						<StandardPlugin
+							{ ...{ name, key: name, supportLink, icon, category, description } }
+							/>
+					) }
 				</div>
-			</FoldableCard>
+				<div className="wpcom-plugins__panel-footer">
+					<Button borderless>
+						<Gridicon icon="plus-small" />
+						{ this.translate( 'View all standard plugins' ) }
+					</Button>
+				</div>
+			</Card>
+			</div>
 		);
 	}
 } );

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -1,4 +1,4 @@
-.wpcom-plugins__standard-panel,
+.wpcom-plugins__standard-panel.is-compact,
 .wpcom-plugins__premium-panel,
 .wpcom-plugins__business-panel {
 	padding: 0;
@@ -11,27 +11,38 @@
 
 .wpcom-plugins__plugin-item {
 	list-style: none;
-	flex: 1 0 33.33%;
+	// flex: 1 0 33.33%;
 	box-sizing: border-box;
 	padding: 16px;
 	border-bottom: 1px solid lighten( $gray, 20% );
-	border-right: 1px solid lighten( $gray, 20% );
-	max-width: 33.33%;
+	width: 100%;
+	
+	&:last-child {
+		border-bottom: none;
+	}
+	
+	@include breakpoint( ">960px" ) {
+		width: 33.33%;
+		border-right: 1px solid lighten( $gray, 20% );
+	}
 }
 
-// Select every third item
-.wpcom-plugins__plugin-item:nth-child(3n+3) {
-	border-right: none;
+// Styles for 3 columns
+.wpcom-plugins__plugin-item:nth-child(3n+3) { // Select every third item
+	@include breakpoint( ">960px" ) {
+		border-right: none;
+	}
 }
 
-// Select last three items
-.wpcom-plugins__plugin-item:nth-last-child(-n+3) {
-	border-bottom: none;
+.wpcom-plugins__plugin-item:nth-last-child(-n+3) { // Select last three items
+	@include breakpoint( ">960px" ) {
+		border-bottom: none;
+	}
 }
 
 // Special styles for displaying only one plugin
 .wpcom-plugins__business-panel .wpcom-plugins__plugin-item {
-	max-width: none;
+	width: 100%;
 	border: none;
 }
 
@@ -43,7 +54,6 @@
 	width: 40px;
 	height: 40px;
 	background: $blue-wordpress;
-	border-radius: 4px;
 	float: left;
 	display: flex;
 	justify-content: center;
@@ -64,28 +74,31 @@
 }
 
 .wpcom-plugins__plugin-title {
-	font-weight: bold;
 	font-size: 14px;
+	font-weight: 600;
 }
 
 .wpcom-plugins__plugin-category,
 .wpcom-plugins__plugin-plan {
+	font-size: 11px;
 	color: $gray;
 	text-transform: uppercase;
-	font-size: 13px;
 }
 
 .wpcom-plugins__plugin-description {
-	font-size: 13px;
-	margin-top: 5px;
+	font-size: 14px;
+	margin-top: 10px;
 	margin-bottom: 0;
 }
 
-.wpcom-plugins__action-button {
-	margin-top: 6px;
-	margin-right: 6px;
+.wpcom-plugin-panel button.is-active-plugin {
+	color: $alert-green;
+	
+	&:hover {
+		color: $alert-green;
+	}
 }
 
-.wpcom-plugins__panel-footer {
-	border-top: 1px solid lighten( $gray, 20% );
+.wpcom-plugin-panel .notice__icon {
+	flex-shrink: 0; // Prevent the notice icon from shrinking
 }

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -1,4 +1,91 @@
+.wpcom-plugins__standard-panel,
+.wpcom-plugins__premium-panel,
+.wpcom-plugins__business-panel {
+	padding: 0;
+}
+
+.wpcom-plugins__list {
+	display: flex;
+	flex-flow: row wrap;
+}
+
+.wpcom-plugins__plugin-item {
+	list-style: none;
+	flex: 1 0 33.33%;
+	box-sizing: border-box;
+	padding: 16px;
+	border-bottom: 1px solid lighten( $gray, 20% );
+	border-right: 1px solid lighten( $gray, 20% );
+	max-width: 33.33%;
+}
+
+// Select every third item
+.wpcom-plugins__plugin-item:nth-child(3n+3) {
+	border-right: none;
+}
+
+// Select last three items
+.wpcom-plugins__plugin-item:nth-last-child(-n+3) {
+	border-bottom: none;
+}
+
+// Special styles for displaying only one plugin
+.wpcom-plugins__business-panel .wpcom-plugins__plugin-item {
+	max-width: none;
+	border: none;
+}
+
+.wpcom-plugins__plugin-item a {
+	color: $gray-dark;
+}
+
+.wpcom-plugins__plugin-icon {
+	width: 40px;
+	height: 40px;
+	background: $blue-wordpress;
+	border-radius: 4px;
+	float: left;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
+.wpcom-plugins__plugin-icon .gridicon {
+	fill: $white;
+}
+
+.wpcom-plugins__plugin-title,
+.wpcom-plugins__plugin-category,
+.wpcom-plugins__plugin-plan {
+	margin-left: 52px;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.wpcom-plugins__plugin-title {
+	font-weight: bold;
+	font-size: 14px;
+}
+
+.wpcom-plugins__plugin-category,
+.wpcom-plugins__plugin-plan {
+	color: $gray;
+	text-transform: uppercase;
+	font-size: 13px;
+}
+
+.wpcom-plugins__plugin-description {
+	font-size: 13px;
+	margin-top: 5px;
+	margin-bottom: 0;
+}
+
 .wpcom-plugins__action-button {
 	margin-top: 6px;
 	margin-right: 6px;
+}
+
+.wpcom-plugins__panel-footer {
+	border-top: 1px solid lighten( $gray, 20% );
 }


### PR DESCRIPTION
To test, go to http://calypso.localhost:3000/plugins/test.wordpress.com

This PR updates the design of the wpcom Plugins view. **This view is not launched, it is hidden.**

- small viewports get a 1 column grid
- `View all standard plugins` link goes to another view with all standard plugins, similar to http://calypso.localhost:3000/plugins/browse/popular/test.wordpress.com

To do in another PR:

- Link up actions for the Purchase buttons
- Add the `View all standard plugins` view
- Change gridicon for each plugin

Before:
![screen shot 2016-03-25 at 5 33 03 pm](https://cloud.githubusercontent.com/assets/618551/14055415/c254dfa2-f2af-11e5-80bd-0f087f2e7c48.png)

After:
![screen shot 2016-03-28 at 4 09 21 pm](https://cloud.githubusercontent.com/assets/618551/14090373/95b956b0-f4ff-11e5-9a85-ccaa18d217cb.png)