### PR TITLE
Add wrapper component to record page views

### DIFF
--- a/client/analytics/page-view-tracker/README.md
+++ b/client/analytics/page-view-tracker/README.md
@@ -1,0 +1,46 @@
+# Page View Tracking Component
+
+Use this component to automatically record page views when they are loaded. There are two modes of operation: immediate and delayed. In the immediate mode, the page view tracking event will fire off as soon as the component mounts. In the delayed mode, the event will fire off no sooner than the given delay, and will not send at all if the component unmounts before that delay has expired.
+
+## Examples
+
+### Immediate Page View Tracking
+
+```js
+import PageViewTracker from 'analytics/page-view-tracker';
+
+render() {
+    return (
+        <div>
+            <PageViewTracker path="/my/trackers" title="tracking_dashboard" />
+            <MyCoolComponent>
+                <MyCoolChildren />
+            </MyCoolComponent>
+        </div>
+    );
+);
+```
+
+### Delayed Page View Tracking
+
+```js
+import PageViewTracker from 'analytics/page-view-tracker';
+
+render() {
+    // consider a view for less than 500ms as an
+    // accidental view and thus don't track
+
+    return (
+        <div>
+            <PageViewTracker 
+                delay={ 500 } 
+                path="/my/trackers" 
+                title="tracking_dashboard"
+            />
+            <MyCoolComponent>
+                <MyCoolChildren />
+            </MyCoolComponent>
+        </div>
+    );
+);
+```

--- a/client/analytics/page-view-tracker/component.jsx
+++ b/client/analytics/page-view-tracker/component.jsx
@@ -1,0 +1,45 @@
+import React, { PropTypes } from 'react';
+
+export const PageViewTracker = recorder => React.createClass( {
+	getInitialState: () => ( {
+		timer: null
+	} ),
+
+	componentDidMount() {
+		this.queuePageView();
+	},
+
+	componentWillUnmount() {
+		clearTimeout( this.state.timer );
+	},
+
+	queuePageView() {
+		const {
+			delay = 0,
+			path,
+			title
+		} = this.props;
+
+		if ( this.state.timer ) {
+			return;
+		}
+
+		if ( ! delay ) {
+			return recorder( path, title );
+		}
+
+		this.setState( {
+			timer: setTimeout( () => recorder( path, title ), delay )
+		} );
+	},
+
+	render: () => null
+} );
+
+PageViewTracker.propTypes = {
+	delay: PropTypes.number,
+	path: PropTypes.string.isRequired,
+	title: PropTypes.string.isRequired
+};
+
+export default PageViewTracker;

--- a/client/analytics/page-view-tracker/index.jsx
+++ b/client/analytics/page-view-tracker/index.jsx
@@ -1,0 +1,8 @@
+import analytics from 'analytics';
+import PageViewTracker from './component';
+
+const recorder = ( path, title ) => analytics.pageView( path, title );
+
+const Tracker = PageViewTracker( recorder );
+
+export default Tracker;

--- a/client/analytics/page-view-tracker/test/index.jsx
+++ b/client/analytics/page-view-tracker/test/index.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import useFakeDom from 'test/helpers/use-fake-dom';
+import { useFakeTimers } from 'test/helpers/use-sinon';
+
+import PageViewTracker from 'analytics/page-view-tracker/component';
+
+describe( 'PageViewTracker', () => {
+	let clock;
+
+	useFakeDom();
+	useFakeTimers( fakeClock => {
+		clock = fakeClock
+	} );
+
+	it( 'should immediately fire off event when given no delay', done => {
+		const state = { value: false };
+		const Tracker = PageViewTracker( () => { state.value = true; } );
+
+		mount( <Tracker path="/test" title="test" /> );
+
+		expect( state.value ).to.be.true;
+
+		done();
+	} );
+
+	it( 'should wait for the delay before firing off the event', done => {
+		const state = { value: false };
+		const Tracker = PageViewTracker( () => { state.value = true; } );
+
+		mount( <Tracker delay={ 500 } path="/test" title="test" /> );
+
+		expect( state.value ).to.be.false;
+
+		clock.tick( 250 );
+
+		expect( state.value ).to.be.false;
+
+		clock.tick( 250 );
+
+		expect( state.value ).to.be.true;
+
+		done();
+	} );
+
+	it( 'should pass the appropriate event information', done => {
+		const Tracker = PageViewTracker( ( path, title ) => {
+			expect( path ).to.equal( '/test' );
+			expect( title ).to.equal( 'test' );
+
+			done();
+		} );
+
+		mount( <Tracker path="/test" title="test" /> );
+
+		clock.tick( 10 );
+	} );
+} );

--- a/client/tests.json
+++ b/client/tests.json
@@ -1,5 +1,8 @@
 {
 	"analytics": {
+		"page-view-tracker" : {
+			"test": [ "index" ]
+		},
 		"test": [ "index" ]
 	},
 	"components": {


### PR DESCRIPTION
Tracking a page view is a piece of logic separate from what should be
happening in most React components; these components shouldn't need to
mix in the functionality to make that happen.

This new wrapper will automatically record page view events and provides
a mechanism to wait up to a given delay to prevent recording
"accidental" views, such as when someone is simply scanning through the
links.

The heart of this component is separated from the actual analytics
tracking code, making it easy to inject a different recording behavior.

cc: @mtias @aduth @blowery @gwwar - I didn't want to embed all the tracking logic inside of my new plugins page component and I felt like we needed something like this and could use it in other places. It _does_ add a level or two of wrapping, but I think the result is a clean way to organize page view tracking.