### PR TITLE
Media: Update media over storage limit error

### DIFF
--- a/client/lib/media/constants.js
+++ b/client/lib/media/constants.js
@@ -13,7 +13,9 @@ export const ValidationErrors = keyMirror( {
 	FILE_TYPE_UNSUPPORTED: null,
 	SERVER_ERROR: null,
 	UPLOAD_VIA_URL_404: null,
-	EXCEEDS_MAX_UPLOAD_SIZE: null
+	EXCEEDS_MAX_UPLOAD_SIZE: null,
+	EXCEEDS_PLAN_STORAGE_LIMIT: null,
+	NOT_ENOUGH_SPACE: null
 } );
 
 export const ThumbnailSizeDimensions = {

--- a/client/lib/media/test/validation-store.js
+++ b/client/lib/media/test/validation-store.js
@@ -254,6 +254,42 @@ describe( 'MediaValidationStore', function() {
 			expect( errors ).to.eql( [ MediaValidationErrors.UPLOAD_VIA_URL_404 ] );
 		} );
 
+		it( 'should detect a not enough space error from received item', function() {
+			var errors;
+
+			dispatchReceiveMediaItem( {
+				error: {
+					statusCode: 400,
+					errors: [ {
+						error: 'upload_error',
+						file: 'https://wordpress.com/hifive.gif',
+						message: 'Not enough space to upload. 20 KB needed.'
+					} ]
+				}
+			} );
+			errors = MediaValidationStore.getErrors( DUMMY_SITE_ID, DUMMY_MEDIA_OBJECT.ID );
+
+			expect( errors ).to.eql( [ MediaValidationErrors.NOT_ENOUGH_SPACE ] );
+		} );
+
+		it( 'should detect an exceeds plan storage limit error from received item', function() {
+			var errors;
+
+			dispatchReceiveMediaItem( {
+				error: {
+					statusCode: 400,
+					errors: [ {
+						error: 'upload_error',
+						file: 'https://wordpress.com/hifive.gif',
+						message: 'You have used your space quota. Please delete files before uploading.'
+					} ]
+				}
+			} );
+			errors = MediaValidationStore.getErrors( DUMMY_SITE_ID, DUMMY_MEDIA_OBJECT.ID );
+
+			expect( errors ).to.eql( [ MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT ] );
+		} );
+
 		it( 'should detect general server error from received item', function() {
 			var errors;
 

--- a/client/lib/media/validation-store.js
+++ b/client/lib/media/validation-store.js
@@ -106,18 +106,20 @@ function receiveServerError( siteId, itemId, errors ) {
 	ensureErrorsObjectForSite( siteId );
 
 	_errors[ siteId ][ itemId ] = errors.map( ( error ) => {
-		let errorType;
-
 		switch ( error.error ) {
 			case 'http_404':
-				errorType = MediaValidationErrors.UPLOAD_VIA_URL_404;
-				break;
+				return MediaValidationErrors.UPLOAD_VIA_URL_404;
+			case 'upload_error':
+				if ( error.message.indexOf( 'Not enough space to upload' ) === 0 ) {
+					return MediaValidationErrors.NOT_ENOUGH_SPACE;
+				}
+				if ( error.message.indexOf( 'You have used your space quota' ) === 0 ) {
+					return MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT
+				}
+				return MediaValidationErrors.SERVER_ERROR;
 			default:
-				errorType = MediaValidationErrors.SERVER_ERROR;
-				break;
+				return MediaValidationErrors.SERVER_ERROR;
 		}
-
-		return errorType;
 	} );
 }
 


### PR DESCRIPTION
This PR fixes #3898 and provides a more descriptive error message when you upload a media item and are out of space. Click on the notice action "Upgrade Plan" should take you to the plans page.

Desktop
<img width="813" alt="screen shot 2016-03-29 at 9 14 43 am" src="https://cloud.githubusercontent.com/assets/1270189/14115227/fc74ae10-f58e-11e5-9e71-d662b25d16ec.png">

Mobile: ( Note that our notices don't handle text + action + dismiss buttons nicely )
<img width="547" alt="screen shot 2016-03-29 at 9 15 12 am" src="https://cloud.githubusercontent.com/assets/1270189/14115236/02bc86f8-f58f-11e5-9886-876beb2b0e6b.png">

(And here when it breaks to the next line )
<img width="396" alt="screen shot 2016-03-29 at 9 15 20 am" src="https://cloud.githubusercontent.com/assets/1270189/14115238/08966d32-f58f-11e5-84df-f32a47143601.png">


## Testing
- In the console call: localStorage.setItem('debug', 'calypso:analytics');
- Navigate to http://calypso.localhost:3000/post
- Select a wpcom site with a Free or Premium plan when prompted
- Add items until you run out of space. (You also have permission to use gwwartest3.wordpress.com if you're lazy )
- You should see the error notice.
- A message like the following appears in the console: 
![screen shot 2016-03-25 at 3 43 15 pm](https://cloud.githubusercontent.com/assets/1270189/14056047/43450a8a-f2a4-11e5-9e54-97933b37c277.png)
- Click on "Upgrade Plan"
- A message like the following appears in the console:
![screen shot 2016-03-25 at 3 43 21 pm](https://cloud.githubusercontent.com/assets/1270189/14056052/52c76764-f2a4-11e5-98e1-fbdfc63f16ac.png)
- The page should navigate to the plans page for your site.

cc @rralian @mtias @artpi @adambbecker @retrofox @aduth @apeatling