### PR TITLE
Autoprefixer now recognizes iOS 8 and Safari 8 desktop.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ NPM ?= npm
 BUNDLER ?= $(BIN)/bundler
 SASS ?= $(NODE_BIN)/node-sass --include-path 'client'
 RTLCSS ?= $(NODE_BIN)/rtlcss
-AUTOPREFIXER ?= $(NODE_BIN)/autoprefixer -b "last 2 versions, > 1%, Safari >= 8, iOS >= 8, Firefox ESR, Opera 12.1"
+AUTOPREFIXER ?= $(NODE_BIN)/postcss -r --use autoprefixer --autoprefixer.browsers "last 2 versions, > 1%, Safari >= 8, iOS >= 8, Firefox ESR, Opera 12.1"
 RECORD_ENV ?= $(BIN)/record-env
 GET_I18N ?= $(BIN)/get-i18n
 LIST_ASSETS ?= $(BIN)/list-assets

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,57 +8,6 @@
     "atob": {
       "version": "1.1.2"
     },
-    "autoprefixer": {
-      "version": "4.0.0",
-      "dependencies": {
-        "autoprefixer-core": {
-          "version": "4.0.2",
-          "dependencies": {
-            "caniuse-db": {
-              "version": "1.0.30000428"
-            }
-          }
-        },
-        "fs-extra": {
-          "version": "0.11.1",
-          "dependencies": {
-            "ncp": {
-              "version": "0.6.0"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8"
-                }
-              }
-            },
-            "jsonfile": {
-              "version": "2.2.3"
-            },
-            "rimraf": {
-              "version": "2.5.2"
-            }
-          }
-        },
-        "postcss": {
-          "version": "3.0.7",
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.43",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "js-base64": {
-              "version": "2.1.9"
-            }
-          }
-        }
-      }
-    },
     "autosize": {
       "version": "3.0.7"
     },
@@ -8594,6 +8543,812 @@
     },
     "valid-url": {
       "version": "1.0.9"
+    },
+    "autoprefixer": {
+      "version": "6.3.5",
+      "dependencies": {
+        "browserslist": {
+          "version": "1.3.0"
+        },
+        "caniuse-db": {
+          "version": "1.0.30000436"
+        },
+        "normalize-range": {
+          "version": "0.1.2"
+        },
+        "num2fraction": {
+          "version": "1.2.2"
+        },
+        "postcss": {
+          "version": "5.0.19",
+          "dependencies": {
+            "js-base64": {
+              "version": "2.1.9"
+            },
+            "source-map": {
+              "version": "0.5.3"
+            },
+            "supports-color": {
+              "version": "3.1.2",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "postcss-value-parser": {
+          "version": "3.3.0"
+        }
+      }
+    },
+    "postcss-cli": {
+      "version": "2.5.1",
+      "dependencies": {
+        "chokidar": {
+          "version": "1.4.3",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.3.0",
+              "dependencies": {
+                "micromatch": {
+                  "version": "2.3.7",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "2.0.0",
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "array-unique": {
+                      "version": "0.2.1"
+                    },
+                    "braces": {
+                      "version": "1.8.3",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.1",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.3",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "2.1.0"
+                                },
+                                "isobject": {
+                                  "version": "2.0.0",
+                                  "dependencies": {
+                                    "isarray": {
+                                      "version": "0.0.1"
+                                    }
+                                  }
+                                },
+                                "randomatic": {
+                                  "version": "1.1.5"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.4"
+                    },
+                    "extglob": {
+                      "version": "0.3.2"
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0"
+                    },
+                    "kind-of": {
+                      "version": "3.0.2",
+                      "dependencies": {
+                        "is-buffer": {
+                          "version": "1.1.3"
+                        }
+                      }
+                    },
+                    "normalize-path": {
+                      "version": "2.0.1"
+                    },
+                    "object.omit": {
+                      "version": "2.0.0",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.4",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.5"
+                            }
+                          }
+                        },
+                        "is-extendable": {
+                          "version": "0.1.1"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.4",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.3.0"
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.2"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.2",
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.3"
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "async-each": {
+              "version": "1.0.0"
+            },
+            "fsevents": {
+              "version": "1.0.9",
+              "dependencies": {
+                "node-pre-gyp": {
+                  "version": "0.6.24",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8"
+                        }
+                      }
+                    },
+                    "nopt": {
+                      "version": "3.0.6",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.7"
+                        }
+                      }
+                    },
+                    "npmlog": {
+                      "version": "2.0.3",
+                      "dependencies": {
+                        "ansi": {
+                          "version": "0.3.1"
+                        },
+                        "are-we-there-yet": {
+                          "version": "1.1.2",
+                          "dependencies": {
+                            "delegates": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        },
+                        "gauge": {
+                          "version": "1.2.7",
+                          "dependencies": {
+                            "has-unicode": {
+                              "version": "2.0.0"
+                            },
+                            "lodash.pad": {
+                              "version": "4.1.0",
+                              "dependencies": {
+                                "lodash.repeat": {
+                                  "version": "4.0.0"
+                                },
+                                "lodash.tostring": {
+                                  "version": "4.1.2"
+                                }
+                              }
+                            },
+                            "lodash.padend": {
+                              "version": "4.2.0"
+                            },
+                            "lodash.padstart": {
+                              "version": "4.2.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rc": {
+                      "version": "1.1.6",
+                      "dependencies": {
+                        "deep-extend": {
+                          "version": "0.4.1"
+                        },
+                        "ini": {
+                          "version": "1.3.4"
+                        },
+                        "minimist": {
+                          "version": "1.2.0"
+                        },
+                        "strip-json-comments": {
+                          "version": "1.0.4"
+                        }
+                      }
+                    },
+                    "request": {
+                      "version": "2.69.0",
+                      "dependencies": {
+                        "aws-sign2": {
+                          "version": "0.6.0"
+                        },
+                        "aws4": {
+                          "version": "1.3.2",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "4.0.0",
+                              "dependencies": {
+                                "pseudomap": {
+                                  "version": "1.0.2"
+                                },
+                                "yallist": {
+                                  "version": "2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "bl": {
+                          "version": "1.0.3"
+                        },
+                        "caseless": {
+                          "version": "0.11.0"
+                        },
+                        "combined-stream": {
+                          "version": "1.0.5",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        },
+                        "extend": {
+                          "version": "3.0.0"
+                        },
+                        "forever-agent": {
+                          "version": "0.6.1"
+                        },
+                        "form-data": {
+                          "version": "1.0.0-rc4",
+                          "dependencies": {
+                            "async": {
+                              "version": "1.5.2"
+                            }
+                          }
+                        },
+                        "har-validator": {
+                          "version": "2.0.6",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.2.0",
+                                  "dependencies": {
+                                    "color-convert": {
+                                      "version": "1.0.0"
+                                    }
+                                  }
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.5"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1"
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0"
+                                }
+                              }
+                            },
+                            "commander": {
+                              "version": "2.9.0",
+                              "dependencies": {
+                                "graceful-readlink": {
+                                  "version": "1.0.1"
+                                }
+                              }
+                            },
+                            "is-my-json-valid": {
+                              "version": "2.13.1",
+                              "dependencies": {
+                                "generate-function": {
+                                  "version": "2.0.0"
+                                },
+                                "generate-object-property": {
+                                  "version": "1.2.0",
+                                  "dependencies": {
+                                    "is-property": {
+                                      "version": "1.0.2"
+                                    }
+                                  }
+                                },
+                                "jsonpointer": {
+                                  "version": "2.0.0"
+                                },
+                                "xtend": {
+                                  "version": "4.0.1"
+                                }
+                              }
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.0",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "hawk": {
+                          "version": "3.1.3",
+                          "dependencies": {
+                            "boom": {
+                              "version": "2.10.1"
+                            },
+                            "cryptiles": {
+                              "version": "2.0.5"
+                            },
+                            "hoek": {
+                              "version": "2.16.3"
+                            },
+                            "sntp": {
+                              "version": "1.0.9"
+                            }
+                          }
+                        },
+                        "http-signature": {
+                          "version": "1.1.1",
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "0.2.0"
+                            },
+                            "jsprim": {
+                              "version": "1.2.2",
+                              "dependencies": {
+                                "extsprintf": {
+                                  "version": "1.0.2"
+                                },
+                                "json-schema": {
+                                  "version": "0.2.2"
+                                },
+                                "verror": {
+                                  "version": "1.3.6"
+                                }
+                              }
+                            },
+                            "sshpk": {
+                              "version": "1.7.4",
+                              "dependencies": {
+                                "asn1": {
+                                  "version": "0.2.3"
+                                },
+                                "dashdash": {
+                                  "version": "1.13.0",
+                                  "dependencies": {
+                                    "assert-plus": {
+                                      "version": "1.0.0"
+                                    }
+                                  }
+                                },
+                                "ecc-jsbn": {
+                                  "version": "0.1.1"
+                                },
+                                "jodid25519": {
+                                  "version": "1.0.2"
+                                },
+                                "jsbn": {
+                                  "version": "0.1.0"
+                                },
+                                "tweetnacl": {
+                                  "version": "0.14.1"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-typedarray": {
+                          "version": "1.0.0"
+                        },
+                        "isstream": {
+                          "version": "0.1.2"
+                        },
+                        "json-stringify-safe": {
+                          "version": "5.0.1"
+                        },
+                        "mime-types": {
+                          "version": "2.1.10",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.22.0"
+                            }
+                          }
+                        },
+                        "node-uuid": {
+                          "version": "1.4.7"
+                        },
+                        "oauth-sign": {
+                          "version": "0.8.1"
+                        },
+                        "qs": {
+                          "version": "6.0.2"
+                        },
+                        "stringstream": {
+                          "version": "0.0.5"
+                        },
+                        "tough-cookie": {
+                          "version": "2.2.2"
+                        },
+                        "tunnel-agent": {
+                          "version": "0.4.2"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.5.2",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.0.3",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "5.1.0"
+                    },
+                    "tar": {
+                      "version": "2.2.1",
+                      "dependencies": {
+                        "block-stream": {
+                          "version": "0.0.8"
+                        },
+                        "fstream": {
+                          "version": "1.0.8",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.3"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1"
+                        }
+                      }
+                    },
+                    "tar-pack": {
+                      "version": "3.1.3",
+                      "dependencies": {
+                        "debug": {
+                          "version": "2.2.0",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1"
+                            }
+                          }
+                        },
+                        "fstream-ignore": {
+                          "version": "1.0.3",
+                          "dependencies": {
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.3",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "2.0.6",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2"
+                            },
+                            "isarray": {
+                              "version": "1.0.0"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.6"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2"
+                            }
+                          }
+                        },
+                        "uid-number": {
+                          "version": "0.0.6"
+                        }
+                      }
+                    }
+                  }
+                },
+                "nan": {
+                  "version": "2.2.0"
+                }
+              }
+            },
+            "glob-parent": {
+              "version": "2.0.0"
+            },
+            "is-binary-path": {
+              "version": "1.0.1",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.4.0"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "dependencies": {
+                "is-extglob": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0"
+            },
+            "readdirp": {
+              "version": "2.0.0",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.3"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6"
+                    },
+                    "isarray": {
+                      "version": "1.0.0"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "globby": {
+          "version": "3.0.1",
+          "dependencies": {
+            "array-union": {
+              "version": "1.0.1",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "arrify": {
+              "version": "1.0.1"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.0.1"
+            },
+            "pify": {
+              "version": "2.3.0"
+            },
+            "pinkie-promise": {
+              "version": "1.0.0",
+              "dependencies": {
+                "pinkie": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "neo-async": {
+          "version": "1.8.0"
+        },
+        "read-file-stdin": {
+          "version": "0.2.1",
+          "dependencies": {
+            "gather-stream": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7"
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "dependencies": {
+            "camelcase": {
+              "version": "2.1.1"
+            },
+            "cliui": {
+              "version": "3.1.1",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0"
+                    }
+                  }
+                },
+                "wrap-ansi": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "decamelize": {
+              "version": "1.2.0"
+            },
+            "os-locale": {
+              "version": "1.4.0",
+              "dependencies": {
+                "lcid": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "invert-kv": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "string-width": {
+              "version": "1.0.1",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "window-size": {
+              "version": "0.1.4"
+            },
+            "y18n": {
+              "version": "3.2.1"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "async": "0.9.0",
     "atob": "1.1.2",
-    "autoprefixer": "4.0.0",
+    "autoprefixer": "6.3.5",
     "autosize": "3.0.7",
     "babel": "5.8.12",
     "babel-core": "5.8.12",
@@ -74,6 +74,7 @@
     "path-parser": "1.0.2",
     "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-9",
     "photon": "2.0.0",
+    "postcss-cli": "2.5.1",
     "q": "1.0.1",
     "qrcode.react": "0.5.2",
     "qs": "4.0.0",


### PR DESCRIPTION
We claim to support "the latest 2 major versions" of every browser,
but `autoprefixer` was configured to add vendor prefixes to
"the latest 2 versions". Since it has no concept of "major" or
"minor" versions, as soon as iOS 9.3 was released, only
iOS 9 and iOS 9.3 were supported. Since iOS 8 was the last
supported browser to require `-webkit` prefix for Flexbox,
it was removed, thus breaking the page layout in those
older Safari browsers.

The solution was to manually add "Safari >= 8" to the list
of browsers for which to generate vendor prefixes.

Autoprefixer was updated to the latest version in the process.