### PR TITLE
Fix for Safari 8 CSS layout issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ NPM ?= npm
 BUNDLER ?= $(BIN)/bundler
 SASS ?= $(NODE_BIN)/node-sass --include-path 'client'
 RTLCSS ?= $(NODE_BIN)/rtlcss
-AUTOPREFIXER ?= $(NODE_BIN)/autoprefixer
+AUTOPREFIXER ?= $(NODE_BIN)/autoprefixer -b "last 2 versions, > 1%, Safari >= 8, iOS >= 8, Firefox ESR, Opera 12.1"
 RECORD_ENV ?= $(BIN)/record-env
 GET_I18N ?= $(BIN)/get-i18n
 LIST_ASSETS ?= $(BIN)/list-assets


### PR DESCRIPTION
Configure `autoprefixer` to specifically add prefixes to Safari 8 (desktop and iOS), apart from the usual "latest 2 versions" of every other browser.

Note: This is a minimal solution. A more complete solution (bumping the `autoprefixer` dependency version so it detects newer browsers like Edge) can be found in https://github.com/Automattic/wp-calypso/pull/4342 .

cc @apeatling