### PR TITLE
Purchases: Update me/purchases module to ECMAScript 6

### DIFF
--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -20,6 +20,11 @@ import paths from '../paths';
 import titles from 'me/purchases/titles';
 
 const CancelPrivateRegistration = React.createClass( {
+	propTypes: {
+		selectedPurchase: React.PropTypes.object.isRequired,
+		selectedSite: React.PropTypes.object.isRequired
+	},
+
 	getInitialState() {
 		return {
 			disabled: false,

--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -12,12 +12,12 @@ import Button from 'components/button';
 import { cancelPrivateRegistration } from 'lib/upgrades/actions';
 import Card from 'components/card';
 import HeaderCake from 'components/header-cake';
+import { isDataLoading, goToManagePurchase, recordPageView } from '../utils';
 import { isRefundable } from 'lib/purchases';
 import Main from 'components/main';
-import paths from '../paths';
 import Notice from 'components/notice';
+import paths from '../paths';
 import titles from 'me/purchases/titles';
-import { goToManagePurchase, isDataLoading, recordPageView } from '../utils';
 
 const CancelPrivateRegistration = React.createClass( {
 	getInitialState() {

--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -22,7 +22,10 @@ import titles from 'me/purchases/titles';
 const CancelPrivateRegistration = React.createClass( {
 	propTypes: {
 		selectedPurchase: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.object.isRequired
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.object
+		] ).isRequired
 	},
 
 	getInitialState() {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -13,12 +13,12 @@ import CancelPurchaseProductInformation from './product-information';
 import CancelPurchaseRefundInformation from './refund-information';
 import CancelPurchaseSupportBox from './support-box';
 import CompactCard from 'components/card/compact';
+import { getName, isCancelable } from 'lib/purchases';
+import { getPurchase, getSelectedSite, goToManagePurchase, recordPageView } from 'me/purchases/utils';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import paths from '../paths';
 import titles from 'me/purchases/titles';
-import { getName, isCancelable } from 'lib/purchases';
-import { getPurchase, getSelectedSite, goToManagePurchase, recordPageView } from 'me/purchases/utils';
 
 const CancelPurchase = React.createClass( {
 	propTypes: {

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -13,32 +13,31 @@ import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
 import { managePurchase } from 'me/purchases/paths';
 import titles from 'me/purchases/titles';
 
-const CancelPurchaseLoadingPlaceholder = React.createClass( {
-	propTypes: {
-		purchaseId: React.PropTypes.string.isRequired,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.bool,
-			React.PropTypes.object
-		] ).isRequired
-	},
+const CancelPurchaseLoadingPlaceholder = ( { purchaseId, selectedSite } ) => {
+	return (
+		<LoadingPlaceholder
+			title={ titles.cancelPurchase }
+			path={ managePurchase( selectedSite.slug, purchaseId ) }>
+			<Card className="cancel-purchase-loading-placeholder__card">
+				<h2 className="loading-placeholder__content cancel-purchase-loading-placeholder__header" />
+				<div className="loading-placeholder__content cancel-purchase-loading-placeholder__subheader" />
+				<div className="loading-placeholder__content cancel-purchase-loading-placeholder__reason" />
+				<div className="loading-placeholder__content cancel-purchase-loading-placeholder__reason" />
+			</Card>
 
-	render() {
-		return (
-			<LoadingPlaceholder
-				title={ titles.cancelPurchase }
-				path={ managePurchase( this.props.selectedSite.slug, this.props.purchaseId ) }>
-				<Card className="cancel-purchase-loading-placeholder__card">
-					<h2 className="loading-placeholder__content cancel-purchase-loading-placeholder__header" />
-					<div className="loading-placeholder__content cancel-purchase-loading-placeholder__subheader" />
-					<div className="loading-placeholder__content cancel-purchase-loading-placeholder__reason" />
-					<div className="loading-placeholder__content cancel-purchase-loading-placeholder__reason" />
-				</Card>
-				<CompactCard>
-					<Button className="cancel-purchase-loading-placeholder__cancel-button" />
-				</CompactCard>
-			</LoadingPlaceholder>
-		);
-	}
-} );
+			<CompactCard>
+				<Button className="cancel-purchase-loading-placeholder__cancel-button" />
+			</CompactCard>
+		</LoadingPlaceholder>
+	);
+};
+
+CancelPurchaseLoadingPlaceholder.propTypes = {
+	purchaseId: React.PropTypes.string.isRequired,
+	selectedSite: React.PropTypes.oneOfType( [
+		React.PropTypes.bool,
+		React.PropTypes.object
+	] ).isRequired
+};
 
 export default CancelPurchaseLoadingPlaceholder;

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -6,9 +6,9 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
-import Button from 'components/button';
 import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
 import { managePurchase } from 'me/purchases/paths';
 import titles from 'me/purchases/titles';

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -14,10 +14,16 @@ import { managePurchase } from 'me/purchases/paths';
 import titles from 'me/purchases/titles';
 
 const CancelPurchaseLoadingPlaceholder = ( { purchaseId, selectedSite } ) => {
+	let path;
+
+	if ( selectedSite ) {
+		path = managePurchase( selectedSite.slug, purchaseId );
+	}
+
 	return (
 		<LoadingPlaceholder
 			title={ titles.cancelPurchase }
-			path={ managePurchase( selectedSite.slug, purchaseId ) }>
+			path={ path }>
 			<Card className="cancel-purchase-loading-placeholder__card">
 				<h2 className="loading-placeholder__content cancel-purchase-loading-placeholder__header" />
 				<div className="loading-placeholder__content cancel-purchase-loading-placeholder__subheader" />

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -17,8 +17,8 @@ const CancelPurchaseLoadingPlaceholder = React.createClass( {
 	propTypes: {
 		purchaseId: React.PropTypes.string.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.object,
-			React.PropTypes.bool
+			React.PropTypes.bool,
+			React.PropTypes.object
 		] ).isRequired
 	},
 

--- a/client/me/purchases/cancel-purchase/product-information.jsx
+++ b/client/me/purchases/cancel-purchase/product-information.jsx
@@ -7,10 +7,10 @@ import React from 'react';
  * Internal Dependencies
  */
 import { domainManagementEdit } from 'my-sites/upgrades/paths';
+import { getDetailsUrl as getThemeDetailsUrl } from 'my-sites/themes/helpers';
 import { googleAppsSettingsUrl } from 'lib/google-apps';
 import Gridicon from 'components/gridicon';
 import { isBusiness, isGoogleApps, isPlan, isTheme } from 'lib/products-values';
-import { getDetailsUrl as getThemeDetailsUrl } from 'my-sites/themes/helpers';
 
 const CancelPurchaseProductInformation = React.createClass( {
 	propTypes: {

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -6,54 +6,52 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
+import i18n from 'lib/mixins/i18n';
 import { getSubscriptionEndDate, isRefundable } from 'lib/purchases';
 
-const CancelPurchaseRefundInformation = React.createClass( {
-	propTypes: {
-		purchase: React.PropTypes.object.isRequired
-	},
+const CancelPurchaseRefundInformation = ( { purchase } ) => {
+	const { priceText, refundPeriodInDays } = purchase,
+		refundsSupportLink = <a href="https://support.wordpress.com/refunds/" target="_blank" />;
 
-	render() {
-		const purchase = this.props.purchase,
-			{ priceText, refundPeriodInDays } = purchase,
-			refundsSupportLink = <a href="https://support.wordpress.com/refunds/" target="_blank" />;
-
-		if ( isRefundable( purchase ) ) {
-			return (
-				<p>{ this.translate(
-					'Yes! You are canceling this purchase within the %(refundPeriodInDays)d day refund period. ' +
-					'Once you confirm, your card will be refunded %(priceText)s. {{a}}Learn more{{/a}}.',
-					{
-						args: {
-							refundPeriodInDays,
-							priceText
-						},
-						components: {
-							a: refundsSupportLink
-						},
-						context: 'priceText is of the form "[currency-symbol][amount] [currency-code]" i.e. "$20 USD"'
-					}
-				) }</p>
-			);
-		}
-
+	if ( isRefundable( purchase ) ) {
 		return (
-			<p>{ this.translate(
-				'You are canceling after the %(refundPeriodInDays)d day refund period, so you will not receive a refund. ' +
-				'Canceling will prevent automatic renewal, and we will leave this purchase active until %(subscriptionEndDate)s. ' +
-				'{{a}}Learn more.{{/a}}',
+			<p>{ i18n.translate(
+				'Yes! You are canceling this purchase within the %(refundPeriodInDays)d day refund period. ' +
+				'Once you confirm, your card will be refunded %(priceText)s. {{a}}Learn more{{/a}}.',
 				{
 					args: {
-						subscriptionEndDate: getSubscriptionEndDate( purchase ),
-						refundPeriodInDays
+						refundPeriodInDays,
+						priceText
 					},
 					components: {
 						a: refundsSupportLink
-					}
+					},
+					context: 'priceText is of the form "[currency-symbol][amount] [currency-code]" i.e. "$20 USD"'
 				}
 			) }</p>
 		);
 	}
-} );
+
+	return (
+		<p>{ i18n.translate(
+			'You are canceling after the %(refundPeriodInDays)d day refund period, so you will not receive a refund. ' +
+			'Canceling will prevent automatic renewal, and we will leave this purchase active until %(subscriptionEndDate)s. ' +
+			'{{a}}Learn more.{{/a}}',
+			{
+				args: {
+					subscriptionEndDate: getSubscriptionEndDate( purchase ),
+					refundPeriodInDays
+				},
+				components: {
+					a: refundsSupportLink
+				}
+			}
+		) }</p>
+	);
+};
+
+CancelPurchaseRefundInformation.propTypes = {
+	purchase: React.PropTypes.object.isRequired
+};
 
 export default CancelPurchaseRefundInformation;

--- a/client/me/purchases/cancel-purchase/support-box.jsx
+++ b/client/me/purchases/cancel-purchase/support-box.jsx
@@ -10,7 +10,7 @@ import analytics from 'analytics';
 
 const CancelPurchaseSupportBox = React.createClass( {
 	propTypes: {
-		purchase: React.PropTypes.object.isRequired,
+		purchase: React.PropTypes.object.isRequired
 	},
 
 	trackClickContactSupport() {

--- a/client/me/purchases/components/loading-placeholder/README.md
+++ b/client/me/purchases/components/loading-placeholder/README.md
@@ -12,7 +12,6 @@ const MyComponentLoadingPlaceholder = React.createClass( {
 	render() {
 		return (
 			<LoadingPlaceholder
-				className="my-component-loading-placeholder"
 				title={ this.translate( 'Header title' ) }>
 				<Card>
 					{ this.translate( 'Loading…' ) }
@@ -26,6 +25,5 @@ const MyComponentLoadingPlaceholder = React.createClass( {
 
 ## Props
 
-* `className` - **optional** Add a custom class property.
 * `path` - **optional** Add a path where back button should lead to.
 * `title` - Add a header title.

--- a/client/me/purchases/components/loading-placeholder/index.jsx
+++ b/client/me/purchases/components/loading-placeholder/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
+import classNames from 'classnames';
 import page from 'page';
 import React from 'react';
 
@@ -24,7 +24,7 @@ const LoadingPlaceholder = React.createClass( {
 
 	render() {
 		return (
-			<Main className={ classnames( 'loading-placeholder', this.props.className ) }>
+			<Main className={ classNames( 'loading-placeholder', this.props.className ) }>
 				<HeaderCake className="loading-placeholder__header" onClick={ this.goBack }>
 					{ this.props.title }
 				</HeaderCake>

--- a/client/me/purchases/components/loading-placeholder/index.jsx
+++ b/client/me/purchases/components/loading-placeholder/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import page from 'page';
 import React from 'react';
 
@@ -13,7 +12,6 @@ import Main from 'components/main';
 
 const LoadingPlaceholder = React.createClass( {
 	propTypes: {
-		className: React.PropTypes.string,
 		path: React.PropTypes.string,
 		title: React.PropTypes.string.isRequired
 	},
@@ -24,7 +22,7 @@ const LoadingPlaceholder = React.createClass( {
 
 	render() {
 		return (
-			<Main className={ classNames( 'loading-placeholder', this.props.className ) }>
+			<Main className="loading-placeholder">
 				<HeaderCake className="loading-placeholder__header" onClick={ this.goBack }>
 					{ this.props.title }
 				</HeaderCake>

--- a/client/me/purchases/confirm-cancel-purchase/index.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/index.jsx
@@ -1,9 +1,9 @@
 /**
  * External Dependencies
- **/
+ */
 import page from 'page';
-import ReactDom from 'react-dom';
 import React from 'react';
+import ReactDom from 'react-dom';
 
 /**
  * Internal Dependencies
@@ -12,12 +12,12 @@ import analytics from 'analytics';
 import Card from 'components/card';
 import ConfirmCancelPurchaseLoadingPlaceholder from './loading-placeholder';
 import HeaderCake from 'components/header-cake';
+import { getPurchase, goToCancelPurchase, recordPageView } from '../utils';
 import loadEndpointForm from './load-endpoint-form';
 import Main from 'components/main';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
 import titles from 'me/purchases/titles';
-import { getPurchase, goToCancelPurchase, recordPageView } from '../utils';
 
 const ConfirmCancelPurchase = React.createClass( {
 	propTypes: {

--- a/client/me/purchases/confirm-cancel-purchase/index.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/index.jsx
@@ -22,8 +22,11 @@ import titles from 'me/purchases/titles';
 const ConfirmCancelPurchase = React.createClass( {
 	propTypes: {
 		purchaseId: React.PropTypes.string.isRequired,
-		selectedPurchase: React.PropTypes.object,
-		selectedSite: React.PropTypes.object
+		selectedPurchase: React.PropTypes.object.isRequired,
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.object
+		] ).isRequired
 	},
 
 	getInitialState() {

--- a/client/me/purchases/confirm-cancel-purchase/index.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/index.jsx
@@ -21,6 +21,7 @@ import titles from 'me/purchases/titles';
 
 const ConfirmCancelPurchase = React.createClass( {
 	propTypes: {
+		purchaseId: React.PropTypes.string.isRequired,
 		selectedPurchase: React.PropTypes.object,
 		selectedSite: React.PropTypes.object
 	},

--- a/client/me/purchases/confirm-cancel-purchase/load-endpoint-form.js
+++ b/client/me/purchases/confirm-cancel-purchase/load-endpoint-form.js
@@ -1,12 +1,12 @@
 /**
  * External Dependencies
- **/
-import toArray from 'lodash/toArray';
+ */
 import fromPairs from 'lodash/fromPairs';
+import toArray from 'lodash/toArray';
 
 /**
  * Internal Dependencies
- **/
+ */
 import wp from 'lib/wp';
 
 const wpcom = wp.undocumented();

--- a/client/me/purchases/confirm-cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/loading-placeholder.jsx
@@ -6,11 +6,11 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
+import { cancelPurchase } from 'me/purchases/paths';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
-import Button from 'components/button';
 import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
-import { cancelPurchase } from 'me/purchases/paths';
 import titles from 'me/purchases/titles';
 
 const ConfirmCancelPurchaseLoadingPlaceholder = React.createClass( {

--- a/client/me/purchases/confirm-cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/loading-placeholder.jsx
@@ -13,32 +13,31 @@ import CompactCard from 'components/card/compact';
 import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
 import titles from 'me/purchases/titles';
 
-const ConfirmCancelPurchaseLoadingPlaceholder = React.createClass( {
-	propTypes: {
-		purchaseId: React.PropTypes.string.isRequired,
-		selectedSite: React.PropTypes.oneOfType( [
-			React.PropTypes.bool,
-			React.PropTypes.object
-		] ).isRequired
-	},
+const ConfirmCancelPurchaseLoadingPlaceholder = ( { purchaseId, selectedSite } ) => {
+	return (
+		<LoadingPlaceholder
+			title={ titles.confirmCancelPurchase }
+			path={ cancelPurchase( selectedSite.slug, purchaseId ) }>
+			<Card className="confirm-cancel-purchase-loading-placeholder__card">
+				<h2 className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__header" />
+				<div className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__subheader" />
+				<div className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__reason" />
+				<div className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__reason" />
+			</Card>
 
-	render() {
-		return (
-			<LoadingPlaceholder
-				title={ titles.confirmCancelPurchase }
-				path={ cancelPurchase( this.props.selectedSite.slug, this.props.purchaseId ) }>
-				<Card className="confirm-cancel-purchase-loading-placeholder__card">
-					<h2 className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__header" />
-					<div className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__subheader" />
-					<div className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__reason" />
-					<div className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__reason" />
-				</Card>
-				<CompactCard>
-					<Button className="confirm-cancel-purchase-loading-placeholder__cancel-button" />
-				</CompactCard>
-			</LoadingPlaceholder>
-		);
-	}
-} );
+			<CompactCard>
+				<Button className="confirm-cancel-purchase-loading-placeholder__cancel-button" />
+			</CompactCard>
+		</LoadingPlaceholder>
+	);
+};
+
+ConfirmCancelPurchaseLoadingPlaceholder.propTypes = {
+	purchaseId: React.PropTypes.string.isRequired,
+	selectedSite: React.PropTypes.oneOfType( [
+		React.PropTypes.bool,
+		React.PropTypes.object
+	] ).isRequired
+};
 
 export default ConfirmCancelPurchaseLoadingPlaceholder;

--- a/client/me/purchases/confirm-cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/loading-placeholder.jsx
@@ -16,7 +16,10 @@ import titles from 'me/purchases/titles';
 const ConfirmCancelPurchaseLoadingPlaceholder = React.createClass( {
 	propTypes: {
 		purchaseId: React.PropTypes.string.isRequired,
-		selectedSite: React.PropTypes.object.isRequired
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.object
+		] ).isRequired
 	},
 
 	render() {

--- a/client/me/purchases/confirm-cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/loading-placeholder.jsx
@@ -14,10 +14,16 @@ import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
 import titles from 'me/purchases/titles';
 
 const ConfirmCancelPurchaseLoadingPlaceholder = ( { purchaseId, selectedSite } ) => {
+	let path;
+
+	if ( selectedSite ) {
+		path = cancelPurchase( selectedSite.slug, purchaseId );
+	}
+
 	return (
 		<LoadingPlaceholder
 			title={ titles.confirmCancelPurchase }
-			path={ cancelPurchase( selectedSite.slug, purchaseId ) }>
+			path={ path }>
 			<Card className="confirm-cancel-purchase-loading-placeholder__card">
 				<h2 className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__header" />
 				<div className="loading-placeholder__content confirm-cancel-purchase-loading-placeholder__subheader" />

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,25 +1,26 @@
 /**
  * External Dependencies
  */
-import ReactDom from 'react-dom';
 import React from 'react';
+import ReactDom from 'react-dom';
 
 /**
  * Internal Dependencies
  */
 import analytics from 'analytics';
-import ConfirmCancelPurchase from './confirm-cancel-purchase';
-import ConfirmCancelPurchaseLoadingPlaceholder from './confirm-cancel-purchase/loading-placeholder';
+import CancelPrivateRegistration from './cancel-private-registration';
 import CancelPurchase from './cancel-purchase';
 import CancelPurchaseLoadingPlaceholder from './cancel-purchase/loading-placeholder';
-import CancelPrivateRegistration from './cancel-private-registration';
+import ConfirmCancelPurchase from './confirm-cancel-purchase';
+import ConfirmCancelPurchaseLoadingPlaceholder from './confirm-cancel-purchase/loading-placeholder';
 import EditCardDetails from './payment/edit-card-details';
 import EditCardDetailsData from 'components/data/purchases/edit-card-details';
 import EditCardDetailsLoadingPlaceholder from './payment/edit-card-details/loading-placeholder';
 import EditPaymentMethod from './payment/edit-payment-method';
+import { isDataLoading } from './utils';
 import Main from 'components/main';
-import ManagePurchaseData from 'components/data/purchases/manage-purchase';
 import ManagePurchase from './manage-purchase';
+import ManagePurchaseData from 'components/data/purchases/manage-purchase';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
 import paths from './paths';
 import PurchasesData from 'components/data/purchases';
@@ -29,7 +30,6 @@ import sitesFactory from 'lib/sites-list';
 import titleActions from 'lib/screen-title/actions';
 import titles from './titles';
 import userFactory from 'lib/user';
-import { isDataLoading } from './utils';
 
 const sites = sitesFactory();
 const user = userFactory();

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -59,6 +59,26 @@ function setTitle( ...title ) {
 }
 
 export default {
+	cancelPrivateRegistration( context ) {
+		setTitle(
+			titles.cancelPrivateRegistration
+		);
+
+		recordPageView(
+			paths.cancelPrivateRegistration(),
+			'Cancel Private Registration'
+		);
+
+		sites.setSelectedSite( context.params.site );
+
+		renderPage(
+			<ManagePurchaseData
+				component={ CancelPrivateRegistration }
+				purchaseId={ context.params.purchaseId }
+				sites={ sites } />
+		);
+	},
+
 	cancelPurchase( context ) {
 		setTitle(
 			titles.cancelPurchase
@@ -76,26 +96,6 @@ export default {
 				component={ CancelPurchase }
 				isDataLoading={ isDataLoading }
 				loadingPlaceholder={ CancelPurchaseLoadingPlaceholder }
-				purchaseId={ context.params.purchaseId }
-				sites={ sites } />
-		);
-	},
-
-	cancelPrivateRegistration( context ) {
-		setTitle(
-			titles.cancelPrivateRegistration
-		);
-
-		recordPageView(
-			paths.cancelPrivateRegistration(),
-			'Cancel Private Registration'
-		);
-
-		sites.setSelectedSite( context.params.site );
-
-		renderPage(
-			<ManagePurchaseData
-				component={ CancelPrivateRegistration }
 				purchaseId={ context.params.purchaseId }
 				sites={ sites } />
 		);

--- a/client/me/purchases/list/header/index.jsx
+++ b/client/me/purchases/list/header/index.jsx
@@ -6,35 +6,36 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import i18n from 'lib/mixins/i18n';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
 import paths from '../../paths.js';
 import SectionNav from 'components/section-nav';
 
-const PurchasesHeader = React.createClass( {
-	propTypes: {
-		section: React.PropTypes.string.isRequired
-	},
+const PurchasesHeader = ( { section } ) => {
+	let text = i18n.translate( 'Billing History' );
 
-	getSelectedText( activeSection ) {
-		if ( activeSection === 'purchases' ) {
-			return this.translate( 'Purchases' );
-		}
-		return this.translate( 'Billing History' );
-	},
-
-	render() {
-		const activeSection = this.props.section;
-
-		return(
-			<SectionNav selectedText={ this.getSelectedText( activeSection ) }>
-				<NavTabs>
-					<NavItem path={ paths.list() } selected={ activeSection === 'purchases' }>{ this.translate( 'Purchases' ) }</NavItem>
-					<NavItem path="/me/billing" selected= { activeSection === 'billing' } >{ this.translate( 'Billing History' ) }</NavItem>
-				</NavTabs>
-			</SectionNav>
-		);
+	if ( section === 'purchases' ) {
+		text = i18n.translate( 'Purchases' );
 	}
-} );
+
+	return (
+		<SectionNav selectedText={ text }>
+			<NavTabs>
+				<NavItem path={ paths.list() } selected={ section === 'purchases' }>
+					{ i18n.translate( 'Purchases' ) }
+				</NavItem>
+				
+				<NavItem path="/me/billing" selected={ section === 'billing' }>
+					{ i18n.translate( 'Billing History' ) }
+				</NavItem>
+			</NavTabs>
+		</SectionNav>
+	);
+};
+
+PurchasesHeader.propTypes = {
+	section: React.PropTypes.string.isRequired
+};
 
 export default PurchasesHeader;

--- a/client/me/purchases/list/header/index.jsx
+++ b/client/me/purchases/list/header/index.jsx
@@ -12,6 +12,10 @@ import paths from '../../paths.js';
 import SectionNav from 'components/section-nav';
 
 const PurchasesHeader = React.createClass( {
+	propTypes: {
+		section: React.PropTypes.string.isRequired
+	},
+
 	getSelectedText( activeSection ) {
 		if ( activeSection === 'purchases' ) {
 			return this.translate( 'Purchases' );

--- a/client/me/purchases/list/header/index.jsx
+++ b/client/me/purchases/list/header/index.jsx
@@ -20,7 +20,7 @@ const PurchasesHeader = React.createClass( {
 	},
 
 	render() {
-		var activeSection = this.props.section;
+		const activeSection = this.props.section;
 
 		return(
 			<SectionNav selectedText={ this.getSelectedText( activeSection ) }>

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -16,6 +16,12 @@ import PurchasesHeader from './header';
 import PurchasesSite from './site';
 
 const PurchasesList = React.createClass( {
+	propTypes: {
+		noticeType: React.PropTypes.string,
+		purchases: React.PropTypes.object.isRequired,
+		sites: React.PropTypes.object.isRequired
+	},
+
 	renderNotice() {
 		const { noticeType } = this.props;
 

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -66,11 +66,7 @@ const PurchasesList = React.createClass( {
 			return true;
 		}
 
-		if ( ! this.props.sites.initialized ) {
-			return true;
-		}
-
-		return false;
+		return ! this.props.sites.initialized;
 	},
 
 	render() {

--- a/client/me/purchases/list/item/index.jsx
+++ b/client/me/purchases/list/item/index.jsx
@@ -1,25 +1,25 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import classNames from 'classnames';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import paths from '../../paths';
 import CompactCard from 'components/card/compact';
-import Notice from 'components/notice';
 import {
 	getName,
 	isExpired,
 	isExpiring,
-	isRenewing,
 	isIncludedWithPlan,
 	isOneTimePurchase,
+	isRenewing,
 	purchaseType,
 	showCreditCardExpiringWarning
 } from 'lib/purchases';
+import Notice from 'components/notice';
+import paths from '../../paths';
 
 const PurchaseItem = React.createClass( {
 	propTypes: {

--- a/client/me/purchases/list/item/index.jsx
+++ b/client/me/purchases/list/item/index.jsx
@@ -23,9 +23,9 @@ import paths from '../../paths';
 
 const PurchaseItem = React.createClass( {
 	propTypes: {
-		slug: React.PropTypes.string,
+		isPlaceholder: React.PropTypes.bool,
 		purchase: React.PropTypes.object,
-		isPlaceholder: React.PropTypes.bool
+		slug: React.PropTypes.string
 	},
 
 	renewsOrExpiresOn() {

--- a/client/me/purchases/list/site/index.jsx
+++ b/client/me/purchases/list/site/index.jsx
@@ -8,44 +8,45 @@ import times from 'lodash/times';
 /**
  * Internal dependencies
  */
+import i18n from 'lib/mixins/i18n';
 import PurchaseItem from '../item';
 import SectionHeader from 'components/section-header';
 
-const PurchasesSite = React.createClass( {
-	propTypes: {
-		isPlaceholder: React.PropTypes.bool,
-		name: React.PropTypes.string,
-		purchases: React.PropTypes.array,
-		slug: React.PropTypes.string
-	},
+const PurchasesSite = ( { isPlaceholder, name, purchases, slug } ) => {
+	let items, label = name;
 
-	placeholders() {
-		return times( 2, index => <PurchaseItem isPlaceholder key={ index } /> );
-	},
+	if ( isPlaceholder ) {
+		items = times( 2, index => (
+			<PurchaseItem
+				isPlaceholder key={ index } />
+		) );
 
-	render() {
-		const { isPlaceholder } = this.props,
-			classes = classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } );
-
-		return (
-			<div className={ classes }>
-				<SectionHeader label={ isPlaceholder ? this.translate( 'Loading…' ) : this.props.name }>
-					<span className="purchases-site__slug">{ this.props.slug }</span>
-				</SectionHeader>
-				{
-					isPlaceholder ?
-					this.placeholders() :
-					this.props.purchases.map( purchase => (
-						<PurchaseItem
-							key={ purchase.id }
-							slug={ this.props.slug }
-							purchase={ purchase } />
-						)
-					)
-				}
-			</div>
-		);
+		label = i18n.translate( 'Loading…' );
+	} else {
+		items = purchases.map( purchase => (
+			<PurchaseItem
+				key={ purchase.id }
+				slug={ slug }
+				purchase={ purchase } />
+		) );
 	}
-} );
+
+	return (
+		<div className={ classNames( 'purchases-site', { 'is-placeholder': isPlaceholder } ) }>
+			<SectionHeader label={ label }>
+				<span className="purchases-site__slug">{ slug }</span>
+			</SectionHeader>
+
+			{ items }
+		</div>
+	);
+};
+
+PurchasesSite.propTypes = {
+	isPlaceholder: React.PropTypes.bool,
+	name: React.PropTypes.string,
+	purchases: React.PropTypes.array,
+	slug: React.PropTypes.string
+};
 
 export default PurchasesSite;

--- a/client/me/purchases/list/site/index.jsx
+++ b/client/me/purchases/list/site/index.jsx
@@ -13,10 +13,10 @@ import SectionHeader from 'components/section-header';
 
 const PurchasesSite = React.createClass( {
 	propTypes: {
-		slug: React.PropTypes.string,
+		isPlaceholder: React.PropTypes.bool,
 		name: React.PropTypes.string,
 		purchases: React.PropTypes.array,
-		isPlaceholder: React.PropTypes.bool
+		slug: React.PropTypes.string
 	},
 
 	placeholders() {

--- a/client/me/purchases/list/site/index.jsx
+++ b/client/me/purchases/list/site/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import classNames from 'classnames';
+import React from 'react';
 import times from 'lodash/times';
 
 /**

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -67,6 +67,7 @@ function isDataLoading( props ) {
 
 const ManagePurchase = React.createClass( {
 	propTypes: {
+		destinationType: React.PropTypes.string,
 		hasLoadedSites: React.PropTypes.bool.isRequired,
 		selectedPurchase: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
@@ -74,7 +75,6 @@ const ManagePurchase = React.createClass( {
 			React.PropTypes.bool,
 			React.PropTypes.undefined
 		] ),
-		destinationType: React.PropTypes.string,
 		user: React.PropTypes.object.isRequired
 	},
 

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -67,7 +67,7 @@ function isDataLoading( props ) {
 
 const ManagePurchase = React.createClass( {
 	propTypes: {
-		cart: React.PropTypes.object.isRequired,
+		hasLoadedSites: React.PropTypes.bool.isRequired,
 		selectedPurchase: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -11,23 +11,9 @@ import React from 'react';
 import analytics from 'analytics';
 import Button from 'components/button';
 import Card from 'components/card';
-import CompactCard from 'components/card/compact';
 import { cartItems } from 'lib/cart-values';
+import CompactCard from 'components/card/compact';
 import config from 'config';
-import { domainManagementEdit } from 'my-sites/upgrades/paths';
-import { googleAppsSettingsUrl } from 'lib/google-apps';
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import { getDetailsUrl as getThemeDetailsUrl } from 'my-sites/themes/helpers';
-import paths from '../paths';
-import PaymentLogo from 'components/payment-logo';
-import RemovePurchase from '../remove-purchase';
-import supportPaths from 'lib/url/support';
-import titles from 'me/purchases/titles';
-import VerticalNavItem from 'components/vertical-nav/item';
-import * as upgradesActions from 'lib/upgrades/actions';
 import {
 	creditCardExpiresBeforeSubscription,
 	getName,
@@ -36,19 +22,33 @@ import {
 	isCancelable,
 	isExpired,
 	isExpiring,
+	isIncludedWithPlan,
+	isOneTimePurchase,
 	isPaidWithCreditCard,
 	isRedeemable,
 	isRefundable,
 	isRenewable,
 	isRenewing,
-	isIncludedWithPlan,
-	isOneTimePurchase,
 	paymentLogoType,
 	purchaseType,
-	showCreditCardExpiringWarning,
+	showCreditCardExpiringWarning
 } from 'lib/purchases';
+import { domainManagementEdit } from 'my-sites/upgrades/paths';
+import { getDetailsUrl as getThemeDetailsUrl } from 'my-sites/themes/helpers';
 import { getPurchase, getSelectedSite, goToList, recordPageView } from '../utils';
+import { googleAppsSettingsUrl } from 'lib/google-apps';
+import HeaderCake from 'components/header-cake';
 import { isDomainProduct, isGoogleApps, isPlan, isSiteRedirect, isTheme } from 'lib/products-values';
+import Main from 'components/main';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+import paths from '../paths';
+import PaymentLogo from 'components/payment-logo';
+import RemovePurchase from '../remove-purchase';
+import supportPaths from 'lib/url/support';
+import titles from 'me/purchases/titles';
+import VerticalNavItem from 'components/vertical-nav/item';
+import * as upgradesActions from 'lib/upgrades/actions';
 
 function canEditPaymentDetails( purchase ) {
 	return config.isEnabled( 'upgrades/credit-cards' ) && ! isExpired( purchase ) && ! isOneTimePurchase( purchase ) && ! isIncludedWithPlan( purchase );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -59,7 +59,7 @@ function canEditPaymentDetails( purchase ) {
  * because this page can be rendered without a selected site.
  *
  * @param {object} props The props passed to `ManagePurchase`
- * @return {bool} Whether or not the data is loading
+ * @return {boolean} Whether or not the data is loading
  */
 function isDataLoading( props ) {
 	return ! props.hasLoadedSites || ! props.selectedPurchase.hasLoadedFromServer;

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -39,12 +39,12 @@ function editPaymentMethod( siteName, purchaseId ) {
 }
 
 export default {
+	cancelPrivateRegistration,
 	cancelPurchase,
 	confirmCancelPurchase,
-	cancelPrivateRegistration,
 	editCardDetails,
-	editSpecificCardDetails,
 	editPaymentMethod,
+	editSpecificCardDetails,
 	list,
 	listNotice,
 	managePurchase,

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -19,6 +19,7 @@ import FormButton from 'components/forms/form-button';
 import formState from 'lib/form-state';
 import forOwn from 'lodash/forOwn';
 import HeaderCake from 'components/header-cake' ;
+import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
 import kebabCase from 'lodash/kebabCase';
 import Main from 'components/main';
 import mapKeys from 'lodash/mapKeys';
@@ -28,7 +29,6 @@ import titles from 'me/purchases/titles';
 import { validateCardDetails } from 'lib/credit-card-details';
 import ValidationErrorList from 'notices/validation-error-list';
 import wpcomFactory from 'lib/wp';
-import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
 
 const wpcom = wpcomFactory.undocumented();
 

--- a/client/me/purchases/payment/edit-card-details/loading-placeholder.jsx
+++ b/client/me/purchases/payment/edit-card-details/loading-placeholder.jsx
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import React from 'react';
 
@@ -14,41 +14,44 @@ import FormSelect from 'components/forms/form-select';
 import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
 import titles from 'me/purchases/titles';
 
-const EditCardDetailsLoadingPlaceholder = React.createClass( {
-	render() {
-		return (
-			<LoadingPlaceholder title={ titles.editCardDetails }>
-				<Card className="edit-card-details__content">
-					<div className="credit-card-form">
-						<div className="credit-card-form__field">
+const EditCardDetailsLoadingPlaceholder = () => {
+	return (
+		<LoadingPlaceholder title={ titles.editCardDetails }>
+			<Card className="edit-card-details__content">
+				<div className="credit-card-form">
+					<div className="credit-card-form__field">
+						<FormTextInput />
+					</div>
+
+					<div className="credit-card-form__field">
+						<FormTextInput />
+					</div>
+
+					<div className="credit-card-form__extras">
+						<div className="credit-card-form__field expiration-date">
 							<FormTextInput />
 						</div>
-						<div className="credit-card-form__field">
+
+						<div className="credit-card-form__field cvv">
 							<FormTextInput />
 						</div>
-						<div className="credit-card-form__extras">
-							<div className="credit-card-form__field expiration-date">
-								<FormTextInput />
-							</div>
-							<div className="credit-card-form__field cvv">
-								<FormTextInput />
-							</div>
-							<div className="credit-card-form__field country">
-								<FormSelect />
-							</div>
-							<div className="credit-card-form__field postal-code">
-								<FormTextInput />
-							</div>
+
+						<div className="credit-card-form__field country">
+							<FormSelect />
+						</div>
+
+						<div className="credit-card-form__field postal-code">
+							<FormTextInput />
 						</div>
 					</div>
-				</Card>
+				</div>
+			</Card>
 
-				<CompactCard className="edit-card-details__footer">
-					<FormButton isPrimary={ false } />
-				</CompactCard>
-			</LoadingPlaceholder>
-		);
-	}
-} );
+			<CompactCard className="edit-card-details__footer">
+				<FormButton isPrimary={ false } />
+			</CompactCard>
+		</LoadingPlaceholder>
+	);
+};
 
 export default EditCardDetailsLoadingPlaceholder;

--- a/client/me/purchases/payment/edit-payment-method/credit-card.jsx
+++ b/client/me/purchases/payment/edit-payment-method/credit-card.jsx
@@ -18,7 +18,8 @@ import { successNotice } from 'state/notices/actions';
 const EditPaymentMethodCreditCard = React.createClass( {
 	propTypes: {
 		selectedPurchase: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.object.isRequired
+		selectedSite: React.PropTypes.object.isRequired,
+		successNotice: React.PropTypes.object.isRequired
 	},
 
 	getInitialState() {

--- a/client/me/purchases/payment/edit-payment-method/credit-card.jsx
+++ b/client/me/purchases/payment/edit-payment-method/credit-card.jsx
@@ -1,9 +1,10 @@
 /**
  * External Dependencies
  */
-import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import React from 'react';
+
 /**
  * Internal Dependencies
  */

--- a/client/me/purchases/payment/edit-payment-method/index.jsx
+++ b/client/me/purchases/payment/edit-payment-method/index.jsx
@@ -6,13 +6,13 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import EditPaymentMethodPaypal from './paypal';
 import EditPaymentMethodCreditCard from './credit-card';
+import EditPaymentMethodPaypal from './paypal';
 import HeaderCake from 'components/header-cake';
+import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
 import { isPaidWithCreditCard, isPaidWithPaypal } from 'lib/purchases';
 import Main from 'components/main';
 import titles from 'me/purchases/titles';
-import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
 
 const EditPaymentMethod = React.createClass( {
 	propTypes: {

--- a/client/me/purchases/payment/edit-payment-method/paypal.jsx
+++ b/client/me/purchases/payment/edit-payment-method/paypal.jsx
@@ -1,9 +1,9 @@
 /**
  * External Dependencies
  */
-import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import React from 'react';
 
 /**
  * Internal Dependencies

--- a/client/me/purchases/payment/edit-payment-method/paypal.jsx
+++ b/client/me/purchases/payment/edit-payment-method/paypal.jsx
@@ -18,7 +18,8 @@ import { successNotice } from 'state/notices/actions';
 const EditPaymentMethodPaypal = React.createClass( {
 	propTypes: {
 		selectedPurchase: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.object.isRequired
+		selectedSite: React.PropTypes.object.isRequired,
+		successNotice: React.PropTypes.object.isRequired
 	},
 
 	getInitialState() {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -9,8 +9,8 @@ import React from 'react';
  */
 import CompactCard from 'components/card/compact';
 import Dialog from 'components/dialog';
-import { getPurchase, isDataLoading } from '../utils';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
+import { getPurchase, isDataLoading } from '../utils';
 import Gridicon from 'components/gridicon';
 import { isDomainRegistration, isPlan } from 'lib/products-values';
 import notices from 'notices';


### PR DESCRIPTION
This pull request updates the `client/me/purchases` section to use as many [ES6](https://github.com/Automattic/calypso-pre-oss/blob/master/docs/coding-guidelines/javascript.md#es6) features as possible. It also fixes and improves a few minor things in the process - such as missing props validation.
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/14077217/be9c28e8-f4e9-11e5-978a-66cc6d8554cb.png)

#### Additional notes
 
You should probably consider browsing commits [one by one](https://github.com/Automattic/wp-calypso/pull/4346/commits) to review this pull request since it might be easier to understand the changes rather than in the [unified diff view](https://github.com/Automattic/wp-calypso/pull/4346/files).

#### Testing instructions
 
1. Run `git checkout update/me-purchases-to-es6` and start your server
2. Purchase different types of products, using different methods of payment
3. Check that the [`Purchases` section](http://calypso.localhost:3000/purchases) behave as before

#### Reviews
 
- [x] Code
- [x] Product