### PR TITLE
Plans: Fix Javascript error thrown when leaving Plan Overview page

### DIFF
--- a/client/my-sites/plans/plan-overview/plan-features/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-features/index.jsx
@@ -45,6 +45,10 @@ const PlanFeatures = React.createClass( {
 	render() {
 		const willBeRemoved = isInGracePeriod( this.props.plan );
 
+		if ( ! this.props.selectedSite ) {
+			return null;
+		}
+
 		return (
 			<div>
 				{ ! willBeRemoved && <SectionHeader label={ this.translate( "Your Site's Features" ) } /> }


### PR DESCRIPTION
This pull request fixes the following Javascript error that is raised when leaving the `Plan Overview` page for a different section such as [the reader](http://calypso.localhost:3000/) or the [user profile](http://calypso.localhost:3000/me):

```
Uncaught TypeError: Cannot read property 'product_slug' of undefined
```
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/14079257/a9fce66c-f4fc-11e5-96ac-d82a75b25199.png)
  
#### Testing instructions
 
1. Run `git checkout fix/plans-error` and start your server
2. Execute `localStorage.setItem( 'ABTests', '{"freeTrials_20160120":"offered"}' )` in your browser's console
3. Open the [`Plans` page](http://calypso.localhost:3000/) and start a free trial
4. Click either `Reader` or the gravatar in the top menu bar
5. Check that no error is thrown in your browser's console
 
#### Reviews
 
- [x] Code
- [x] Product