### PR TITLE
Purchases: Live chat: Use the sites endpoint to determine if a user is eligible for chat

### DIFF
--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -54,11 +54,9 @@ const olark = {
 	initialize() {
 		debug( 'Initializing Olark Live Chat' );
 
-		if ( config.isEnabled( 'olark_use_wpcom_configuration' ) ) {
-			this.getOlarkConfiguration()
-				.then( ( configuration ) => this.configureOlark( configuration ) )
-				.catch( ( error ) => this.handleError( error ) );
-		}
+		this.getOlarkConfiguration()
+			.then( ( configuration ) => this.configureOlark( configuration ) )
+			.catch( ( error ) => this.handleError( error ) );
 	},
 
 	handleError: function( error ) {

--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -112,19 +112,23 @@ const olark = {
 	},
 
 	fetchUpgradesCache() {
-		wpcom.req.get( { path: '/me/upgrades' }, ( error, data ) => {
-			if ( error ) {
-				return;
-			}
+		if ( sites.fetched ) {
+			this.setUpgradesCache();
+		} else {
+			sites.once( 'change', this.setUpgradesCache.bind( this ) );
+		}
+	},
 
-			if ( ! this.hasChatEligibleUpgrade( data ) ) {
-				this.storeEligibility( false );
-				return;
-			}
+	setUpgradesCache() {
+		if ( ! this.hasChatEligibleUpgrade() ) {
+			debug( 'User is not eligible for live chat.' )
+			this.storeEligibility( false );
+			return;
+		}
 
-			this.storeEligibility( true );
-			this.emit( 'eligible' );
-		} );
+		debug( 'User is eligible for live chat.' )
+		this.storeEligibility( true );
+		this.emit( 'eligible' );
 	},
 
 	storeEligibility( status ) {
@@ -456,15 +460,15 @@ const olark = {
 		} );
 	},
 
-	hasChatEligibleUpgrade( upgrades ) {
-		return upgrades && upgrades.some( ( upgrade ) => {
+	hasChatEligibleUpgrade() {
+		return sites.data.some( ( site ) => {
 			var userType;
 
-			if ( isBusiness( upgrade ) ) {
+			if ( isBusiness( site.plan ) ) {
 				userType = 'Business';
 			}
 
-			if ( isEnterprise( upgrade ) ) {
+			if ( isEnterprise( site.plan ) ) {
 				userType = 'ENTERPRISE';
 			}
 

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -56,7 +56,6 @@
 		"muse": true,
 		"oauth": true,
 		"olark": false,
-		"olark_use_wpcom_configuration": false,
 		"persist-redux": true,
 		"phone_signup": true,
 		"post-editor/author-selector": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -57,7 +57,6 @@
 		"muse": true,
 		"oauth": true,
 		"olark": true,
-		"olark_use_wpcom_configuration": true,
 		"persist-redux": true,
 		"phone_signup": true,
 		"post-editor/author-selector": true,

--- a/config/development.json
+++ b/config/development.json
@@ -89,7 +89,6 @@
 		"network-connection": true,
 		"notifications2beta": true,
 		"olark": true,
-		"olark_use_wpcom_configuration": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"phone_signup": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -63,7 +63,6 @@
 		"network-connection": true,
 		"notifications2beta": true,
 		"olark": true,
-		"olark_use_wpcom_configuration": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"phone_signup": false,

--- a/config/production.json
+++ b/config/production.json
@@ -57,7 +57,6 @@
 		"me/trophies": false,
 		"muse": true,
 		"olark": true,
-		"olark_use_wpcom_configuration": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"post-editor/author-selector": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -60,7 +60,6 @@
 		"muse": true,
 		"notifications2beta": true,
 		"olark": true,
-		"olark_use_wpcom_configuration": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"post-editor/live-image-updates": true,

--- a/config/test.json
+++ b/config/test.json
@@ -84,7 +84,6 @@
 		"network-connection": true,
 		"notifications2beta": true,
 		"olark": true,
-		"olark_use_wpcom_configuration": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"phone_signup": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -67,7 +67,6 @@
 		"network-connection": true,
 		"notifications2beta": true,
 		"olark": true,
-		"olark_use_wpcom_configuration": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"phone_signup": true,


### PR DESCRIPTION
Calypso uses a deprecated endpoint at /me/upgrades to determine if a user is eligible for live chat. This PR removes an API request, and also removes the last usage of the endpoint, meaning we can remove the code.
 
#### Testing instructions

1. Run `git checkout update/use-sites-not-me-upgrades-for-chat-eligibility`
2. Assert that chat loads if you are eligible and it is enabled for you*

* I am not sure how we force this - any ideas?



#### Reviews

- [x] Code
- [x] Product

cc @dllh for a review