### PR TITLE
Tests: Move Gravatar tests to single test runner

### DIFF
--- a/client/components/gravatar/Makefile
+++ b/client/components/gravatar/Makefile
@@ -1,7 +1,0 @@
-REPORTER ?= spec
-MOCHA ?= ../../../node_modules/.bin/mocha
-
-test:
-	@NODE_ENV=test NODE_PATH=test:../../../client $(MOCHA) --compilers jsx:babel/register --reporter $(REPORTER)
-
-.PHONY: test

--- a/client/tests.json
+++ b/client/tests.json
@@ -36,6 +36,11 @@
 				"test": [ "index" ]
 			}
 		},
+
+		"gravatar": {
+			"test": [ "index" ]
+		},
+
 		"theme": {
 			"test": [ "index" ]
 		},


### PR DESCRIPTION
This is part of #3942 Makefile migration. Running the test on the mocha runner worked without having to make and changes. I also verified that it will pass with `.only` on the outer `describe`. 
I can note that on the issue with √  after merging.

```
$ npm run test-client -- --grep "components gravatar"

> wp-calypso@0.17.0 test-client /Users/jason/Projects/wp-calypso
> NODE_ENV=test NODE_PATH=test:client test/runner.js "--grep" "components gravatar"



  components
    gravatar
      Gravatar
        rendering
          ✓ should render an image given a user with valid avatar_URL, with default width and height 32
          ✓ should update the width and height when given a size attribute
          ✓ should update source image when given imgSize attribute
          ✓ should serve a default image if no avatar_URL available
          ✓ should allow overriding the alt attribute
          ✓ should promote non-secure avatar urls to secure


  6 passing (164ms)

```


cc @gziolo