### PR TITLE
Rebuilt shrinkwrap with shonkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,6 +8,45 @@
     "atob": {
       "version": "1.1.2"
     },
+    "autoprefixer": {
+      "version": "6.3.5",
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.0"
+        },
+        "normalize-range": {
+          "version": "0.1.2"
+        },
+        "num2fraction": {
+          "version": "1.2.2"
+        },
+        "browserslist": {
+          "version": "1.3.0"
+        },
+        "caniuse-db": {
+          "version": "1.0.30000437"
+        },
+        "postcss": {
+          "version": "5.0.19",
+          "dependencies": {
+            "supports-color": {
+              "version": "3.1.2",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.5.3"
+            },
+            "js-base64": {
+              "version": "2.1.9"
+            }
+          }
+        }
+      }
+    },
     "autosize": {
       "version": "3.0.7"
     },
@@ -102,10 +141,10 @@
                       "version": "2.0.0",
                       "dependencies": {
                         "for-own": {
-                          "version": "0.1.3",
+                          "version": "0.1.4",
                           "dependencies": {
                             "for-in": {
-                              "version": "0.1.4"
+                              "version": "0.1.5"
                             }
                           }
                         },
@@ -185,13 +224,13 @@
                   }
                 },
                 "readable-stream": {
-                  "version": "2.0.5",
+                  "version": "2.0.6",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2"
                     },
                     "isarray": {
-                      "version": "0.0.1"
+                      "version": "1.0.0"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6"
@@ -207,13 +246,13 @@
               }
             },
             "fsevents": {
-              "version": "1.0.8",
+              "version": "1.0.9",
               "dependencies": {
                 "nan": {
                   "version": "2.2.0"
                 },
                 "node-pre-gyp": {
-                  "version": "0.6.21",
+                  "version": "0.6.24",
                   "dependencies": {
                     "nopt": {
                       "version": "3.0.6",
@@ -232,37 +271,40 @@
                   "version": "2.0.0"
                 },
                 "ansi-styles": {
-                  "version": "2.1.0"
+                  "version": "2.2.0"
                 },
                 "are-we-there-yet": {
-                  "version": "1.0.6"
+                  "version": "1.1.2"
                 },
                 "asn1": {
                   "version": "0.2.3"
                 },
-                "async": {
-                  "version": "1.5.2"
-                },
                 "assert-plus": {
                   "version": "0.2.0"
+                },
+                "async": {
+                  "version": "1.5.2"
                 },
                 "aws-sign2": {
                   "version": "0.6.0"
                 },
                 "bl": {
-                  "version": "1.0.2"
-                },
-                "block-stream": {
-                  "version": "0.0.8"
+                  "version": "1.0.3"
                 },
                 "boom": {
                   "version": "2.10.1"
+                },
+                "block-stream": {
+                  "version": "0.0.8"
                 },
                 "caseless": {
                   "version": "0.11.0"
                 },
                 "chalk": {
                   "version": "1.1.1"
+                },
+                "color-convert": {
+                  "version": "1.0.0"
                 },
                 "combined-stream": {
                   "version": "1.0.5"
@@ -275,9 +317,6 @@
                 },
                 "cryptiles": {
                   "version": "2.0.5"
-                },
-                "dashdash": {
-                  "version": "1.12.2"
                 },
                 "debug": {
                   "version": "2.2.0"
@@ -295,25 +334,25 @@
                   "version": "0.1.1"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.4"
-                },
-                "extsprintf": {
-                  "version": "1.0.2"
+                  "version": "1.0.5"
                 },
                 "extend": {
                   "version": "3.0.0"
                 },
+                "extsprintf": {
+                  "version": "1.0.2"
+                },
                 "forever-agent": {
                   "version": "0.6.1"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc4"
                 },
                 "fstream": {
                   "version": "1.0.8"
                 },
-                "form-data": {
-                  "version": "1.0.0-rc3"
-                },
                 "gauge": {
-                  "version": "1.2.5"
+                  "version": "1.2.7"
                 },
                 "generate-function": {
                   "version": "2.0.0"
@@ -330,10 +369,10 @@
                 "har-validator": {
                   "version": "2.0.6"
                 },
-                "has-unicode": {
+                "has-ansi": {
                   "version": "2.0.0"
                 },
-                "has-ansi": {
+                "has-unicode": {
                   "version": "2.0.0"
                 },
                 "hawk": {
@@ -352,7 +391,7 @@
                   "version": "2.0.1"
                 },
                 "is-my-json-valid": {
-                  "version": "2.12.4"
+                  "version": "2.13.1"
                 },
                 "is-property": {
                   "version": "1.0.2"
@@ -361,16 +400,16 @@
                   "version": "1.0.0"
                 },
                 "isarray": {
-                  "version": "0.0.1"
+                  "version": "1.0.0"
                 },
                 "isstream": {
                   "version": "0.1.2"
                 },
-                "jsbn": {
-                  "version": "0.1.0"
-                },
                 "jodid25519": {
                   "version": "1.0.2"
+                },
+                "jsbn": {
+                  "version": "0.1.0"
                 },
                 "json-schema": {
                   "version": "0.2.2"
@@ -381,41 +420,35 @@
                 "jsonpointer": {
                   "version": "2.0.0"
                 },
-                "lodash._basetostring": {
-                  "version": "3.0.1"
-                },
                 "jsprim": {
                   "version": "1.2.2"
                 },
-                "lodash._createpadding": {
-                  "version": "3.6.1"
-                },
-                "lodash._root": {
-                  "version": "3.0.0"
-                },
                 "lodash.pad": {
-                  "version": "3.3.0"
+                  "version": "4.1.0"
                 },
-                "lodash.padleft": {
-                  "version": "3.1.1"
+                "lodash.padend": {
+                  "version": "4.2.0"
                 },
-                "lodash.padright": {
-                  "version": "3.1.1"
+                "lodash.padstart": {
+                  "version": "4.2.0"
                 },
                 "lodash.repeat": {
-                  "version": "3.2.0"
+                  "version": "4.0.0"
+                },
+                "lodash.tostring": {
+                  "version": "4.1.2"
                 },
                 "mime-db": {
-                  "version": "1.21.0"
+                  "version": "1.22.0"
                 },
                 "mime-types": {
-                  "version": "2.1.9"
-                },
-                "mkdirp": {
-                  "version": "0.5.1"
+                  "version": "2.1.10"
                 },
                 "minimist": {
                   "version": "0.0.8"
+                },
+                "mkdirp": {
+                  "version": "0.5.1"
                 },
                 "ms": {
                   "version": "0.7.1"
@@ -424,7 +457,7 @@
                   "version": "1.4.7"
                 },
                 "npmlog": {
-                  "version": "2.0.2"
+                  "version": "2.0.3"
                 },
                 "oauth-sign": {
                   "version": "0.8.1"
@@ -435,29 +468,29 @@
                 "pinkie": {
                   "version": "2.0.4"
                 },
-                "process-nextick-args": {
-                  "version": "1.0.6"
-                },
                 "pinkie-promise": {
                   "version": "2.0.0"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6"
                 },
                 "qs": {
                   "version": "6.0.2"
                 },
                 "readable-stream": {
-                  "version": "2.0.5"
+                  "version": "2.0.6"
                 },
                 "request": {
                   "version": "2.69.0"
+                },
+                "semver": {
+                  "version": "5.1.0"
                 },
                 "sntp": {
                   "version": "1.0.9"
                 },
                 "sshpk": {
-                  "version": "1.7.3"
-                },
-                "semver": {
-                  "version": "5.1.0"
+                  "version": "1.7.4"
                 },
                 "string_decoder": {
                   "version": "0.10.31"
@@ -466,49 +499,49 @@
                   "version": "0.0.5"
                 },
                 "strip-ansi": {
-                  "version": "3.0.0"
+                  "version": "3.0.1"
                 },
                 "strip-json-comments": {
                   "version": "1.0.4"
                 },
-                "tar": {
-                  "version": "2.2.1"
-                },
                 "supports-color": {
                   "version": "2.0.0"
+                },
+                "tar": {
+                  "version": "2.2.1"
                 },
                 "tar-pack": {
                   "version": "3.1.3"
                 },
+                "tough-cookie": {
+                  "version": "2.2.2"
+                },
                 "tunnel-agent": {
                   "version": "0.4.2"
                 },
-                "tough-cookie": {
-                  "version": "2.2.1"
-                },
                 "tweetnacl": {
-                  "version": "0.13.3"
-                },
-                "verror": {
-                  "version": "1.3.6"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2"
+                  "version": "0.14.1"
                 },
                 "uid-number": {
                   "version": "0.0.6"
                 },
-                "xtend": {
-                  "version": "4.0.1"
+                "util-deprecate": {
+                  "version": "1.0.2"
+                },
+                "verror": {
+                  "version": "1.3.6"
                 },
                 "wrappy": {
                   "version": "1.0.1"
                 },
-                "aws4": {
-                  "version": "1.2.1",
+                "xtend": {
+                  "version": "4.0.1"
+                },
+                "dashdash": {
+                  "version": "1.13.0",
                   "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.3"
+                    "assert-plus": {
+                      "version": "1.0.0"
                     }
                   }
                 },
@@ -520,6 +553,22 @@
                     }
                   }
                 },
+                "aws4": {
+                  "version": "1.3.2",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "4.0.0",
+                      "dependencies": {
+                        "pseudomap": {
+                          "version": "1.0.2"
+                        },
+                        "yallist": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
                 "fstream-ignore": {
                   "version": "1.0.3",
                   "dependencies": {
@@ -527,7 +576,7 @@
                       "version": "3.0.0",
                       "dependencies": {
                         "brace-expansion": {
-                          "version": "1.1.2",
+                          "version": "1.1.3",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.3.0"
@@ -542,10 +591,10 @@
                   }
                 },
                 "rimraf": {
-                  "version": "2.5.1",
+                  "version": "2.5.2",
                   "dependencies": {
                     "glob": {
-                      "version": "6.0.4",
+                      "version": "7.0.3",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
@@ -562,7 +611,7 @@
                           "version": "3.0.0",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.2",
+                              "version": "1.1.3",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.3.0"
@@ -736,7 +785,7 @@
           "version": "1.1.6"
         },
         "babylon": {
-          "version": "5.8.35"
+          "version": "5.8.38"
         },
         "bluebird": {
           "version": "2.10.2"
@@ -1031,7 +1080,7 @@
                       "version": "0.1.4"
                     },
                     "y18n": {
-                      "version": "3.2.0"
+                      "version": "3.2.1"
                     }
                   }
                 }
@@ -1139,7 +1188,7 @@
           "version": "1.0.4"
         },
         "to-fast-properties": {
-          "version": "1.0.1"
+          "version": "1.0.2"
         },
         "trim-right": {
           "version": "1.0.1"
@@ -1149,557 +1198,11 @@
         }
       }
     },
-    "babel-eslint": {
-      "version": "4.1.8",
-      "dependencies": {
-        "babel-core": {
-          "version": "5.8.35",
-          "dependencies": {
-            "babel-plugin-constant-folding": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-dead-code-elimination": {
-              "version": "1.0.2"
-            },
-            "babel-plugin-eval": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-inline-environment-variables": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-jscript": {
-              "version": "1.0.4"
-            },
-            "babel-plugin-member-expression-literals": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-property-literals": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-proto-to-assign": {
-              "version": "1.0.4"
-            },
-            "babel-plugin-react-constant-elements": {
-              "version": "1.0.3"
-            },
-            "babel-plugin-react-display-name": {
-              "version": "1.0.3"
-            },
-            "babel-plugin-remove-console": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-remove-debugger": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-runtime": {
-              "version": "1.0.7"
-            },
-            "babel-plugin-undeclared-variables-check": {
-              "version": "1.0.2",
-              "dependencies": {
-                "leven": {
-                  "version": "1.0.2"
-                }
-              }
-            },
-            "babel-plugin-undefined-to-void": {
-              "version": "1.1.6"
-            },
-            "babylon": {
-              "version": "5.8.35"
-            },
-            "bluebird": {
-              "version": "2.10.2"
-            },
-            "convert-source-map": {
-              "version": "1.2.0"
-            },
-            "core-js": {
-              "version": "1.2.6"
-            },
-            "detect-indent": {
-              "version": "3.0.1",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1"
-                },
-                "minimist": {
-                  "version": "1.2.0"
-                }
-              }
-            },
-            "esutils": {
-              "version": "2.0.2"
-            },
-            "fs-readdir-recursive": {
-              "version": "0.1.2"
-            },
-            "globals": {
-              "version": "6.4.1"
-            },
-            "home-or-tmp": {
-              "version": "1.0.0",
-              "dependencies": {
-                "os-tmpdir": {
-                  "version": "1.0.1"
-                },
-                "user-home": {
-                  "version": "1.1.1"
-                }
-              }
-            },
-            "is-integer": {
-              "version": "1.0.6",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "js-tokens": {
-              "version": "1.0.1"
-            },
-            "json5": {
-              "version": "0.4.0"
-            },
-            "line-numbers": {
-              "version": "0.2.0",
-              "dependencies": {
-                "left-pad": {
-                  "version": "0.0.3"
-                }
-              }
-            },
-            "lodash": {
-              "version": "3.10.1"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "output-file-sync": {
-              "version": "1.1.1",
-              "dependencies": {
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1"
-                }
-              }
-            },
-            "path-exists": {
-              "version": "1.0.0"
-            },
-            "path-is-absolute": {
-              "version": "1.0.0"
-            },
-            "private": {
-              "version": "0.1.6"
-            },
-            "regenerator": {
-              "version": "0.8.40",
-              "dependencies": {
-                "commoner": {
-                  "version": "0.10.4",
-                  "dependencies": {
-                    "commander": {
-                      "version": "2.9.0",
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "detective": {
-                      "version": "4.3.1",
-                      "dependencies": {
-                        "acorn": {
-                          "version": "1.2.2"
-                        },
-                        "defined": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "glob": {
-                      "version": "5.0.15",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.3",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.3"
-                    },
-                    "iconv-lite": {
-                      "version": "0.4.13"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8"
-                        }
-                      }
-                    },
-                    "q": {
-                      "version": "1.4.1"
-                    }
-                  }
-                },
-                "defs": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "alter": {
-                      "version": "0.2.0",
-                      "dependencies": {
-                        "stable": {
-                          "version": "0.1.5"
-                        }
-                      }
-                    },
-                    "ast-traverse": {
-                      "version": "0.1.1"
-                    },
-                    "breakable": {
-                      "version": "1.0.0"
-                    },
-                    "simple-fmt": {
-                      "version": "0.1.0"
-                    },
-                    "simple-is": {
-                      "version": "0.2.0"
-                    },
-                    "stringmap": {
-                      "version": "0.2.2"
-                    },
-                    "stringset": {
-                      "version": "0.2.1"
-                    },
-                    "tryor": {
-                      "version": "0.1.2"
-                    },
-                    "yargs": {
-                      "version": "3.27.0",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.2.1"
-                        },
-                        "cliui": {
-                          "version": "2.1.0",
-                          "dependencies": {
-                            "center-align": {
-                              "version": "0.1.3",
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.4",
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.0.2",
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.3"
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4"
-                                    }
-                                  }
-                                },
-                                "lazy-cache": {
-                                  "version": "1.0.3"
-                                }
-                              }
-                            },
-                            "right-align": {
-                              "version": "0.1.3",
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.4",
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.0.2",
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.3"
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "wordwrap": {
-                              "version": "0.0.2"
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.2.0"
-                        },
-                        "os-locale": {
-                          "version": "1.4.0",
-                          "dependencies": {
-                            "lcid": {
-                              "version": "1.0.0",
-                              "dependencies": {
-                                "invert-kv": {
-                                  "version": "1.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "window-size": {
-                          "version": "0.1.4"
-                        },
-                        "y18n": {
-                          "version": "3.2.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb"
-                },
-                "recast": {
-                  "version": "0.10.33",
-                  "dependencies": {
-                    "ast-types": {
-                      "version": "0.8.12"
-                    }
-                  }
-                },
-                "through": {
-                  "version": "2.3.8"
-                }
-              }
-            },
-            "regexpu": {
-              "version": "1.3.0",
-              "dependencies": {
-                "esprima": {
-                  "version": "2.7.2"
-                },
-                "recast": {
-                  "version": "0.10.43",
-                  "dependencies": {
-                    "esprima-fb": {
-                      "version": "15001.1001.0-dev-harmony-fb"
-                    },
-                    "ast-types": {
-                      "version": "0.8.15"
-                    }
-                  }
-                },
-                "regenerate": {
-                  "version": "1.2.1"
-                },
-                "regjsgen": {
-                  "version": "0.2.0"
-                },
-                "regjsparser": {
-                  "version": "0.1.5",
-                  "dependencies": {
-                    "jsesc": {
-                      "version": "0.5.0"
-                    }
-                  }
-                }
-              }
-            },
-            "repeating": {
-              "version": "1.1.3",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "resolve": {
-              "version": "1.1.7"
-            },
-            "shebang-regex": {
-              "version": "1.0.0"
-            },
-            "slash": {
-              "version": "1.0.0"
-            },
-            "source-map": {
-              "version": "0.5.3"
-            },
-            "source-map-support": {
-              "version": "0.2.10",
-              "dependencies": {
-                "source-map": {
-                  "version": "0.1.32",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "to-fast-properties": {
-              "version": "1.0.1"
-            },
-            "trim-right": {
-              "version": "1.0.1"
-            },
-            "try-resolve": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "lodash.assign": {
-          "version": "3.2.0",
-          "dependencies": {
-            "lodash._baseassign": {
-              "version": "3.2.0",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1"
-                }
-              }
-            },
-            "lodash._createassigner": {
-              "version": "3.1.1",
-              "dependencies": {
-                "lodash._bindcallback": {
-                  "version": "3.0.1"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9"
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1"
-                }
-              }
-            },
-            "lodash.keys": {
-              "version": "3.1.2",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.8"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            }
-          }
-        },
-        "lodash.pick": {
-          "version": "3.1.0",
-          "dependencies": {
-            "lodash._baseflatten": {
-              "version": "3.1.4",
-              "dependencies": {
-                "lodash.isarguments": {
-                  "version": "3.0.8"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1"
-            },
-            "lodash._pickbyarray": {
-              "version": "3.0.2"
-            },
-            "lodash._pickbycallback": {
-              "version": "3.0.0",
-              "dependencies": {
-                "lodash._basefor": {
-                  "version": "3.0.3"
-                },
-                "lodash.keysin": {
-                  "version": "3.0.8",
-                  "dependencies": {
-                    "lodash.isarguments": {
-                      "version": "3.0.8"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1"
-            }
-          }
-        },
-        "acorn-to-esprima": {
-          "version": "1.0.7"
-        }
-      }
-    },
     "babel-loader": {
       "version": "5.3.2",
       "dependencies": {
         "loader-utils": {
-          "version": "0.2.12",
+          "version": "0.2.13",
           "dependencies": {
             "big.js": {
               "version": "3.1.3"
@@ -1722,32 +1225,8 @@
         }
       }
     },
-    "better-assert": {
-      "version": "1.0.2",
-      "dependencies": {
-        "callsite": {
-          "version": "1.0.0"
-        }
-      }
-    },
-    "blanket": {
-      "version": "1.1.6",
-      "dependencies": {
-        "esprima": {
-          "version": "1.0.4"
-        },
-        "falafel": {
-          "version": "0.1.6"
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "dependencies": {
-            "object-keys": {
-              "version": "0.4.0"
-            }
-          }
-        }
-      }
+    "blob": {
+      "version": "0.0.4"
     },
     "body-parser": {
       "version": "1.15.0",
@@ -1815,22 +1294,6 @@
     "browser-filesaver": {
       "version": "1.1.0"
     },
-    "chai": {
-      "version": "2.0.0",
-      "dependencies": {
-        "assertion-error": {
-          "version": "1.0.0"
-        },
-        "deep-eql": {
-          "version": "0.1.3",
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1"
-            }
-          }
-        }
-      }
-    },
     "chalk": {
       "version": "1.0.0",
       "dependencies": {
@@ -1870,7 +1333,7 @@
       "version": "1.0.1"
     },
     "chrono-node": {
-      "version": "1.1.3"
+      "version": "1.2.1"
     },
     "classnames": {
       "version": "1.1.1"
@@ -1944,6 +1407,14 @@
               "version": "0.0.3"
             }
           }
+        }
+      }
+    },
+    "component-file-picker": {
+      "version": "0.2.1",
+      "dependencies": {
+        "component-event": {
+          "version": "0.1.4"
         }
       }
     },
@@ -2061,9 +1532,6 @@
     "debug": {
       "version": "2.2.0"
     },
-    "deep-freeze": {
-      "version": "0.0.1"
-    },
     "dom-scroll-into-view": {
       "version": "1.0.1"
     },
@@ -2073,1443 +1541,11 @@
     "emitter-component": {
       "version": "1.1.1"
     },
-    "enzyme": {
-      "version": "2.2.0",
-      "dependencies": {
-        "cheerio": {
-          "version": "0.20.0",
-          "dependencies": {
-            "css-select": {
-              "version": "1.2.0",
-              "dependencies": {
-                "css-what": {
-                  "version": "2.1.0"
-                },
-                "domutils": {
-                  "version": "1.5.1",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.3.0"
-                    }
-                  }
-                },
-                "boolbase": {
-                  "version": "1.0.0"
-                },
-                "nth-check": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "entities": {
-              "version": "1.1.1"
-            },
-            "htmlparser2": {
-              "version": "3.8.3",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.3.0"
-                },
-                "domutils": {
-                  "version": "1.5.1"
-                },
-                "domelementtype": {
-                  "version": "1.3.0"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "dom-serializer": {
-              "version": "0.1.0",
-              "dependencies": {
-                "domelementtype": {
-                  "version": "1.1.3"
-                }
-              }
-            },
-            "jsdom": {
-              "version": "7.2.2",
-              "dependencies": {
-                "abab": {
-                  "version": "1.0.3"
-                },
-                "acorn": {
-                  "version": "2.7.0"
-                },
-                "acorn-globals": {
-                  "version": "1.0.9"
-                },
-                "cssom": {
-                  "version": "0.3.1"
-                },
-                "cssstyle": {
-                  "version": "0.2.34"
-                },
-                "escodegen": {
-                  "version": "1.8.0",
-                  "dependencies": {
-                    "estraverse": {
-                      "version": "1.9.3"
-                    },
-                    "esutils": {
-                      "version": "2.0.2"
-                    },
-                    "esprima": {
-                      "version": "2.7.2"
-                    },
-                    "optionator": {
-                      "version": "0.8.1",
-                      "dependencies": {
-                        "prelude-ls": {
-                          "version": "1.1.2"
-                        },
-                        "deep-is": {
-                          "version": "0.1.3"
-                        },
-                        "wordwrap": {
-                          "version": "1.0.0"
-                        },
-                        "type-check": {
-                          "version": "0.3.2"
-                        },
-                        "levn": {
-                          "version": "0.3.0"
-                        },
-                        "fast-levenshtein": {
-                          "version": "1.1.3"
-                        }
-                      }
-                    },
-                    "source-map": {
-                      "version": "0.2.0",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "nwmatcher": {
-                  "version": "1.3.7"
-                },
-                "parse5": {
-                  "version": "1.5.1"
-                },
-                "request": {
-                  "version": "2.69.0",
-                  "dependencies": {
-                    "aws-sign2": {
-                      "version": "0.6.0"
-                    },
-                    "aws4": {
-                      "version": "1.3.2",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "4.0.1",
-                          "dependencies": {
-                            "pseudomap": {
-                              "version": "1.0.2"
-                            },
-                            "yallist": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "bl": {
-                      "version": "1.0.3",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "2.0.6",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2"
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            },
-                            "isarray": {
-                              "version": "1.0.0"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.6"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "caseless": {
-                      "version": "0.11.0"
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "extend": {
-                      "version": "3.0.0"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc4",
-                      "dependencies": {
-                        "async": {
-                          "version": "1.5.2"
-                        }
-                      }
-                    },
-                    "har-validator": {
-                      "version": "2.0.6",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.0",
-                              "dependencies": {
-                                "color-convert": {
-                                  "version": "1.0.0"
-                                }
-                              }
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        },
-                        "commander": {
-                          "version": "2.9.0",
-                          "dependencies": {
-                            "graceful-readlink": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "is-my-json-valid": {
-                          "version": "2.13.1",
-                          "dependencies": {
-                            "generate-function": {
-                              "version": "2.0.0"
-                            },
-                            "generate-object-property": {
-                              "version": "1.2.0",
-                              "dependencies": {
-                                "is-property": {
-                                  "version": "1.0.2"
-                                }
-                              }
-                            },
-                            "jsonpointer": {
-                              "version": "2.0.0"
-                            },
-                            "xtend": {
-                              "version": "4.0.1"
-                            }
-                          }
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "hawk": {
-                      "version": "3.1.3",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "2.16.3"
-                        },
-                        "boom": {
-                          "version": "2.10.1"
-                        },
-                        "cryptiles": {
-                          "version": "2.0.5"
-                        },
-                        "sntp": {
-                          "version": "1.0.9"
-                        }
-                      }
-                    },
-                    "http-signature": {
-                      "version": "1.1.1",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.2.0"
-                        },
-                        "jsprim": {
-                          "version": "1.2.2",
-                          "dependencies": {
-                            "extsprintf": {
-                              "version": "1.0.2"
-                            },
-                            "json-schema": {
-                              "version": "0.2.2"
-                            },
-                            "verror": {
-                              "version": "1.3.6"
-                            }
-                          }
-                        },
-                        "sshpk": {
-                          "version": "1.7.4",
-                          "dependencies": {
-                            "asn1": {
-                              "version": "0.2.3"
-                            },
-                            "dashdash": {
-                              "version": "1.13.0",
-                              "dependencies": {
-                                "assert-plus": {
-                                  "version": "1.0.0"
-                                }
-                              }
-                            },
-                            "jsbn": {
-                              "version": "0.1.0"
-                            },
-                            "tweetnacl": {
-                              "version": "0.14.1"
-                            },
-                            "jodid25519": {
-                              "version": "1.0.2"
-                            },
-                            "ecc-jsbn": {
-                              "version": "0.1.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0"
-                    },
-                    "isstream": {
-                      "version": "0.1.2"
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1"
-                    },
-                    "mime-types": {
-                      "version": "2.1.10",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.22.0"
-                        }
-                      }
-                    },
-                    "node-uuid": {
-                      "version": "1.4.7"
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.1"
-                    },
-                    "qs": {
-                      "version": "6.0.2"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.2"
-                    }
-                  }
-                },
-                "sax": {
-                  "version": "1.2.1"
-                },
-                "symbol-tree": {
-                  "version": "3.1.4"
-                },
-                "tough-cookie": {
-                  "version": "2.2.2"
-                },
-                "webidl-conversions": {
-                  "version": "2.0.1"
-                },
-                "whatwg-url-compat": {
-                  "version": "0.6.5",
-                  "dependencies": {
-                    "tr46": {
-                      "version": "0.0.3"
-                    }
-                  }
-                },
-                "xml-name-validator": {
-                  "version": "2.0.1"
-                }
-              }
-            }
-          }
-        },
-        "is-subset": {
-          "version": "0.1.1"
-        },
-        "lodash": {
-          "version": "4.6.1"
-        },
-        "object.assign": {
-          "version": "4.0.3",
-          "dependencies": {
-            "function-bind": {
-              "version": "1.1.0"
-            },
-            "object-keys": {
-              "version": "1.0.9"
-            },
-            "define-properties": {
-              "version": "1.1.2",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5"
-                }
-              }
-            }
-          }
-        },
-        "object.values": {
-          "version": "1.0.3",
-          "dependencies": {
-            "define-properties": {
-              "version": "1.1.2",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5"
-                },
-                "object-keys": {
-                  "version": "1.0.9"
-                }
-              }
-            },
-            "es-abstract": {
-              "version": "1.5.0",
-              "dependencies": {
-                "is-callable": {
-                  "version": "1.1.3"
-                },
-                "es-to-primitive": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "is-date-object": {
-                      "version": "1.0.1"
-                    },
-                    "is-symbol": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "is-regex": {
-                  "version": "1.0.3"
-                }
-              }
-            },
-            "has": {
-              "version": "1.0.1"
-            },
-            "function-bind": {
-              "version": "1.1.0"
-            }
-          }
-        }
-      }
-    },
     "escape-regexp": {
       "version": "0.0.1"
     },
     "escape-string-regexp": {
       "version": "1.0.3"
-    },
-    "esformatter": {
-      "version": "0.7.3",
-      "dependencies": {
-        "debug": {
-          "version": "0.7.4"
-        },
-        "disparity": {
-          "version": "2.0.0",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.0",
-              "dependencies": {
-                "color-convert": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "diff": {
-              "version": "1.4.0"
-            }
-          }
-        },
-        "espree": {
-          "version": "1.12.3"
-        },
-        "glob": {
-          "version": "5.0.15",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0"
-        },
-        "mout": {
-          "version": "0.12.0"
-        },
-        "npm-run": {
-          "version": "1.1.1",
-          "dependencies": {
-            "npm-path": {
-              "version": "1.1.0",
-              "dependencies": {
-                "which": {
-                  "version": "1.2.4",
-                  "dependencies": {
-                    "is-absolute": {
-                      "version": "0.1.7",
-                      "dependencies": {
-                        "is-relative": {
-                          "version": "0.1.3"
-                        }
-                      }
-                    },
-                    "isexe": {
-                      "version": "1.1.2"
-                    }
-                  }
-                }
-              }
-            },
-            "serializerr": {
-              "version": "1.0.2",
-              "dependencies": {
-                "protochain": {
-                  "version": "1.0.3"
-                }
-              }
-            },
-            "sync-exec": {
-              "version": "0.5.0"
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.1.7"
-        },
-        "rocambole": {
-          "version": "0.7.0",
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.2"
-            }
-          }
-        },
-        "rocambole-indent": {
-          "version": "2.0.4",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0"
-            },
-            "mout": {
-              "version": "0.11.1"
-            }
-          }
-        },
-        "rocambole-linebreak": {
-          "version": "1.0.1",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0"
-            },
-            "semver": {
-              "version": "4.3.6"
-            }
-          }
-        },
-        "rocambole-node": {
-          "version": "1.0.0"
-        },
-        "rocambole-token": {
-          "version": "1.2.1"
-        },
-        "rocambole-whitespace": {
-          "version": "1.0.0",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0"
-            },
-            "repeat-string": {
-              "version": "1.5.4"
-            }
-          }
-        },
-        "semver": {
-          "version": "2.2.1"
-        },
-        "stdin": {
-          "version": "0.0.1"
-        },
-        "strip-json-comments": {
-          "version": "0.1.3"
-        },
-        "supports-color": {
-          "version": "1.3.1"
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1"
-            }
-          }
-        }
-      }
-    },
-    "esformatter-braces": {
-      "version": "1.2.1",
-      "dependencies": {
-        "rocambole-token": {
-          "version": "1.2.1"
-        }
-      }
-    },
-    "esformatter-collapse-objects-a8c": {
-      "version": "0.1.0",
-      "dependencies": {
-        "defaults-deep": {
-          "version": "0.2.3",
-          "dependencies": {
-            "for-own": {
-              "version": "0.1.3",
-              "dependencies": {
-                "for-in": {
-                  "version": "0.1.4"
-                }
-              }
-            },
-            "is-extendable": {
-              "version": "0.1.1"
-            },
-            "lazy-cache": {
-              "version": "0.2.7"
-            }
-          }
-        },
-        "rocambole": {
-          "version": "0.5.1",
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.2"
-            }
-          }
-        },
-        "rocambole-token": {
-          "version": "1.2.1"
-        }
-      }
-    },
-    "esformatter-dot-notation": {
-      "version": "1.3.1",
-      "dependencies": {
-        "rocambole": {
-          "version": "0.6.0",
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.2"
-            }
-          }
-        },
-        "rocambole-token": {
-          "version": "1.2.1"
-        },
-        "unquoted-property-validator": {
-          "version": "1.0.0"
-        }
-      }
-    },
-    "esformatter-quotes": {
-      "version": "1.0.3"
-    },
-    "esformatter-semicolons": {
-      "version": "1.1.1"
-    },
-    "esformatter-special-bangs": {
-      "version": "1.0.1",
-      "dependencies": {
-        "rocambole-token": {
-          "version": "1.2.1"
-        }
-      }
-    },
-    "eslint": {
-      "version": "1.10.3",
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.5.1",
-          "dependencies": {
-            "typedarray": {
-              "version": "0.0.6"
-            },
-            "readable-stream": {
-              "version": "2.0.5",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2"
-                }
-              }
-            }
-          }
-        },
-        "doctrine": {
-          "version": "0.7.2",
-          "dependencies": {
-            "esutils": {
-              "version": "1.1.6"
-            },
-            "isarray": {
-              "version": "0.0.1"
-            }
-          }
-        },
-        "escope": {
-          "version": "3.6.0",
-          "dependencies": {
-            "es6-map": {
-              "version": "0.1.3",
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1"
-                },
-                "es5-ext": {
-                  "version": "0.10.11"
-                },
-                "es6-iterator": {
-                  "version": "2.0.0"
-                },
-                "es6-set": {
-                  "version": "0.1.4"
-                },
-                "es6-symbol": {
-                  "version": "3.0.2"
-                },
-                "event-emitter": {
-                  "version": "0.3.4"
-                }
-              }
-            },
-            "es6-weak-map": {
-              "version": "2.0.1",
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1"
-                },
-                "es5-ext": {
-                  "version": "0.10.11"
-                },
-                "es6-iterator": {
-                  "version": "2.0.0"
-                },
-                "es6-symbol": {
-                  "version": "3.0.2"
-                }
-              }
-            },
-            "esrecurse": {
-              "version": "4.1.0",
-              "dependencies": {
-                "estraverse": {
-                  "version": "4.1.1"
-                }
-              }
-            }
-          }
-        },
-        "espree": {
-          "version": "2.2.5"
-        },
-        "estraverse": {
-          "version": "4.2.0"
-        },
-        "estraverse-fb": {
-          "version": "1.3.1"
-        },
-        "esutils": {
-          "version": "2.0.2"
-        },
-        "file-entry-cache": {
-          "version": "1.2.4",
-          "dependencies": {
-            "flat-cache": {
-              "version": "1.0.10",
-              "dependencies": {
-                "del": {
-                  "version": "2.2.0",
-                  "dependencies": {
-                    "globby": {
-                      "version": "4.0.0",
-                      "dependencies": {
-                        "array-union": {
-                          "version": "1.0.1",
-                          "dependencies": {
-                            "array-uniq": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        },
-                        "arrify": {
-                          "version": "1.0.1"
-                        },
-                        "glob": {
-                          "version": "6.0.4",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "is-path-cwd": {
-                      "version": "1.0.0"
-                    },
-                    "is-path-in-cwd": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "is-path-inside": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "pify": {
-                      "version": "2.3.0"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4"
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.5.2",
-                      "dependencies": {
-                        "glob": {
-                          "version": "7.0.3",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "4.1.3"
-                },
-                "read-json-sync": {
-                  "version": "1.1.1"
-                },
-                "write": {
-                  "version": "0.2.1"
-                }
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "5.0.15",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            }
-          }
-        },
-        "globals": {
-          "version": "8.18.0"
-        },
-        "handlebars": {
-          "version": "4.0.5",
-          "dependencies": {
-            "async": {
-              "version": "1.5.2"
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3"
-                },
-                "minimist": {
-                  "version": "0.0.10"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "inquirer": {
-          "version": "0.11.4",
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.3.0"
-            },
-            "ansi-regex": {
-              "version": "2.0.0"
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "dependencies": {
-                "restore-cursor": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "exit-hook": {
-                      "version": "1.1.1"
-                    },
-                    "onetime": {
-                      "version": "1.1.0"
-                    }
-                  }
-                }
-              }
-            },
-            "cli-width": {
-              "version": "1.1.1"
-            },
-            "figures": {
-              "version": "1.4.0"
-            },
-            "lodash": {
-              "version": "3.10.1"
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "mute-stream": {
-                  "version": "0.0.5"
-                }
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "dependencies": {
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2"
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1"
-            },
-            "through": {
-              "version": "2.3.8"
-            }
-          }
-        },
-        "is-my-json-valid": {
-          "version": "2.13.1",
-          "dependencies": {
-            "generate-function": {
-              "version": "2.0.0"
-            },
-            "generate-object-property": {
-              "version": "1.2.0",
-              "dependencies": {
-                "is-property": {
-                  "version": "1.0.2"
-                }
-              }
-            },
-            "jsonpointer": {
-              "version": "2.0.0"
-            },
-            "xtend": {
-              "version": "4.0.1"
-            }
-          }
-        },
-        "is-resolvable": {
-          "version": "1.0.0",
-          "dependencies": {
-            "tryit": {
-              "version": "1.0.2"
-            }
-          }
-        },
-        "js-yaml": {
-          "version": "3.4.5",
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.6",
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3"
-                }
-              }
-            },
-            "esprima": {
-              "version": "2.7.2"
-            }
-          }
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "dependencies": {
-            "jsonify": {
-              "version": "0.0.0"
-            }
-          }
-        },
-        "lodash.clonedeep": {
-          "version": "3.0.2",
-          "dependencies": {
-            "lodash._baseclone": {
-              "version": "3.3.0",
-              "dependencies": {
-                "lodash._arraycopy": {
-                  "version": "3.0.0"
-                },
-                "lodash._arrayeach": {
-                  "version": "3.0.0"
-                },
-                "lodash._baseassign": {
-                  "version": "3.2.0",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1"
-                    }
-                  }
-                },
-                "lodash._basefor": {
-                  "version": "3.0.3"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.0.8"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1"
-            }
-          }
-        },
-        "lodash.merge": {
-          "version": "3.3.2",
-          "dependencies": {
-            "lodash._arraycopy": {
-              "version": "3.0.0"
-            },
-            "lodash._arrayeach": {
-              "version": "3.0.0"
-            },
-            "lodash._createassigner": {
-              "version": "3.1.1",
-              "dependencies": {
-                "lodash._bindcallback": {
-                  "version": "3.0.1"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9"
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1"
-                }
-              }
-            },
-            "lodash._getnative": {
-              "version": "3.9.1"
-            },
-            "lodash.isarguments": {
-              "version": "3.0.8"
-            },
-            "lodash.isarray": {
-              "version": "3.0.4"
-            },
-            "lodash.isplainobject": {
-              "version": "3.2.0",
-              "dependencies": {
-                "lodash._basefor": {
-                  "version": "3.0.3"
-                }
-              }
-            },
-            "lodash.istypedarray": {
-              "version": "3.0.5"
-            },
-            "lodash.keys": {
-              "version": "3.1.2"
-            },
-            "lodash.keysin": {
-              "version": "3.0.8"
-            },
-            "lodash.toplainobject": {
-              "version": "3.0.0",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1"
-                }
-              }
-            }
-          }
-        },
-        "lodash.omit": {
-          "version": "3.1.0",
-          "dependencies": {
-            "lodash._arraymap": {
-              "version": "3.0.0"
-            },
-            "lodash._basedifference": {
-              "version": "3.0.3",
-              "dependencies": {
-                "lodash._baseindexof": {
-                  "version": "3.1.0"
-                },
-                "lodash._cacheindexof": {
-                  "version": "3.0.2"
-                },
-                "lodash._createcache": {
-                  "version": "3.1.2",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._baseflatten": {
-              "version": "3.1.4",
-              "dependencies": {
-                "lodash.isarguments": {
-                  "version": "3.0.8"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1"
-            },
-            "lodash._pickbyarray": {
-              "version": "3.0.2"
-            },
-            "lodash._pickbycallback": {
-              "version": "3.0.0",
-              "dependencies": {
-                "lodash._basefor": {
-                  "version": "3.0.3"
-                }
-              }
-            },
-            "lodash.keysin": {
-              "version": "3.0.8",
-              "dependencies": {
-                "lodash.isarguments": {
-                  "version": "3.0.8"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1"
-            }
-          }
-        },
-        "minimatch": {
-          "version": "3.0.0",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.3",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0"
-                },
-                "concat-map": {
-                  "version": "0.0.1"
-                }
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.0.1"
-        },
-        "optionator": {
-          "version": "0.6.0",
-          "dependencies": {
-            "prelude-ls": {
-              "version": "1.1.2"
-            },
-            "deep-is": {
-              "version": "0.1.3"
-            },
-            "wordwrap": {
-              "version": "0.0.3"
-            },
-            "type-check": {
-              "version": "0.3.2"
-            },
-            "levn": {
-              "version": "0.2.5"
-            },
-            "fast-levenshtein": {
-              "version": "1.0.7"
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.0"
-        },
-        "path-is-inside": {
-          "version": "1.0.1"
-        },
-        "shelljs": {
-          "version": "0.5.3"
-        },
-        "strip-json-comments": {
-          "version": "1.0.4"
-        },
-        "text-table": {
-          "version": "0.2.0"
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "xml-escape": {
-          "version": "1.0.0"
-        }
-      }
-    },
-    "eslint-plugin-react": {
-      "version": "3.11.3"
-    },
-    "eslint-plugin-wpcalypso": {
-      "version": "1.1.3",
-      "dependencies": {
-        "requireindex": {
-          "version": "1.1.0"
-        }
-      }
     },
     "events": {
       "version": "1.0.2"
@@ -3518,7 +1554,7 @@
       "version": "0.6.2",
       "dependencies": {
         "loader-utils": {
-          "version": "0.2.12",
+          "version": "0.2.13",
           "dependencies": {
             "big.js": {
               "version": "3.1.3"
@@ -3697,7 +1733,7 @@
           "version": "1.1.0",
           "dependencies": {
             "js-tokens": {
-              "version": "1.0.2"
+              "version": "1.0.3"
             }
           }
         },
@@ -3717,6 +1753,9 @@
         }
       }
     },
+    "filesize": {
+      "version": "3.2.1"
+    },
     "flux": {
       "version": "2.1.1",
       "dependencies": {
@@ -3733,7 +1772,7 @@
                   "version": "1.1.0",
                   "dependencies": {
                     "js-tokens": {
-                      "version": "1.0.2"
+                      "version": "1.0.3"
                     }
                   }
                 },
@@ -3741,7 +1780,7 @@
                   "version": "2.2.1",
                   "dependencies": {
                     "node-fetch": {
-                      "version": "1.3.3",
+                      "version": "1.4.1",
                       "dependencies": {
                         "encoding": {
                           "version": "0.1.12",
@@ -3750,6 +1789,9 @@
                               "version": "0.4.13"
                             }
                           }
+                        },
+                        "is-stream": {
+                          "version": "1.0.1"
                         }
                       }
                     },
@@ -3794,46 +1836,6 @@
         }
       }
     },
-    "glob": {
-      "version": "7.0.3",
-      "dependencies": {
-        "inflight": {
-          "version": "1.0.4",
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "minimatch": {
-          "version": "3.0.0",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.3",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0"
-                },
-                "concat-map": {
-                  "version": "0.0.1"
-                }
-              }
-            }
-          }
-        },
-        "once": {
-          "version": "1.3.3",
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.0"
-        }
-      }
-    },
     "he": {
       "version": "0.5.0"
     },
@@ -3874,7 +1876,7 @@
           "version": "1.1.1"
         },
         "html-minifier": {
-          "version": "1.2.0",
+          "version": "1.3.1",
           "dependencies": {
             "change-case": {
               "version": "2.3.1",
@@ -4005,13 +2007,13 @@
                   "version": "0.0.6"
                 },
                 "readable-stream": {
-                  "version": "2.0.5",
+                  "version": "2.0.6",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2"
                     },
                     "isarray": {
-                      "version": "0.0.1"
+                      "version": "1.0.0"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6"
@@ -4026,13 +2028,21 @@
                 }
               }
             },
+            "ncname": {
+              "version": "1.0.0",
+              "dependencies": {
+                "xml-char-classes": {
+                  "version": "1.0.0"
+                }
+              }
+            },
             "relateurl": {
               "version": "0.2.6"
             }
           }
         },
         "loader-utils": {
-          "version": "0.2.12",
+          "version": "0.2.13",
           "dependencies": {
             "big.js": {
               "version": "3.1.3"
@@ -4057,7 +2067,7 @@
       "version": "0.6.5",
       "dependencies": {
         "loader-utils": {
-          "version": "0.2.12",
+          "version": "0.2.13",
           "dependencies": {
             "big.js": {
               "version": "3.1.3"
@@ -4256,335 +2266,6 @@
     "jquery": {
       "version": "1.11.3"
     },
-    "jsdom": {
-      "version": "7.2.0",
-      "dependencies": {
-        "abab": {
-          "version": "1.0.3"
-        },
-        "acorn": {
-          "version": "2.7.0"
-        },
-        "acorn-globals": {
-          "version": "1.0.9"
-        },
-        "cssom": {
-          "version": "0.3.1"
-        },
-        "cssstyle": {
-          "version": "0.2.34"
-        },
-        "escodegen": {
-          "version": "1.8.0",
-          "dependencies": {
-            "estraverse": {
-              "version": "1.9.3"
-            },
-            "esutils": {
-              "version": "2.0.2"
-            },
-            "esprima": {
-              "version": "2.7.2"
-            },
-            "optionator": {
-              "version": "0.8.1",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2"
-                },
-                "deep-is": {
-                  "version": "0.1.3"
-                },
-                "wordwrap": {
-                  "version": "1.0.0"
-                },
-                "type-check": {
-                  "version": "0.3.2"
-                },
-                "levn": {
-                  "version": "0.3.0"
-                },
-                "fast-levenshtein": {
-                  "version": "1.1.3"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.2.0",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "nwmatcher": {
-          "version": "1.3.7"
-        },
-        "parse5": {
-          "version": "1.5.1"
-        },
-        "request": {
-          "version": "2.69.0",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0"
-            },
-            "aws4": {
-              "version": "1.3.2"
-            },
-            "bl": {
-              "version": "1.0.3",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.5",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.11.0"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0"
-            },
-            "forever-agent": {
-              "version": "0.6.1"
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "dependencies": {
-                "async": {
-                  "version": "1.5.2"
-                }
-              }
-            },
-            "har-validator": {
-              "version": "2.0.6",
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.0",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0"
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.13.1",
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0"
-                    },
-                    "xtend": {
-                      "version": "4.0.1"
-                    }
-                  }
-                },
-                "pinkie-promise": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.4"
-                    }
-                  }
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3"
-                },
-                "boom": {
-                  "version": "2.10.1"
-                },
-                "cryptiles": {
-                  "version": "2.0.5"
-                },
-                "sntp": {
-                  "version": "1.0.9"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0"
-                },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.0.2"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2"
-                    },
-                    "verror": {
-                      "version": "1.3.6"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.7.4",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3"
-                    },
-                    "dashdash": {
-                      "version": "1.13.0",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.0"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.1"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1"
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0"
-            },
-            "isstream": {
-              "version": "0.1.2"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1"
-            },
-            "mime-types": {
-              "version": "2.1.10",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.22.0"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7"
-            },
-            "oauth-sign": {
-              "version": "0.8.1"
-            },
-            "qs": {
-              "version": "6.0.2"
-            },
-            "stringstream": {
-              "version": "0.0.5"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2"
-            }
-          }
-        },
-        "sax": {
-          "version": "1.1.6"
-        },
-        "symbol-tree": {
-          "version": "3.1.4"
-        },
-        "tough-cookie": {
-          "version": "2.2.2"
-        },
-        "webidl-conversions": {
-          "version": "2.0.1"
-        },
-        "whatwg-url-compat": {
-          "version": "0.6.5",
-          "dependencies": {
-            "tr46": {
-              "version": "0.0.3"
-            }
-          }
-        },
-        "xml-name-validator": {
-          "version": "2.0.1"
-        }
-      }
-    },
     "jshashes": {
       "version": "1.0.5"
     },
@@ -4599,9 +2280,6 @@
     },
     "keymaster": {
       "version": "1.6.2"
-    },
-    "localStorage": {
-      "version": "1.0.2"
     },
     "localforage": {
       "version": "1.4.0",
@@ -4619,9 +2297,6 @@
     "lodash": {
       "version": "4.5.0"
     },
-    "lodash-deep": {
-      "version": "1.5.3"
-    },
     "lru-cache": {
       "version": "4.0.0",
       "dependencies": {
@@ -4638,72 +2313,6 @@
     },
     "marked": {
       "version": "0.3.5"
-    },
-    "mixedindentlint": {
-      "version": "1.1.1",
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0"
-        }
-      }
-    },
-    "mocha": {
-      "version": "2.3.4",
-      "dependencies": {
-        "diff": {
-          "version": "1.4.0"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.2"
-        },
-        "glob": {
-          "version": "3.2.3",
-          "dependencies": {
-            "minimatch": {
-              "version": "0.2.14",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3"
-                },
-                "sigmund": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "2.0.3"
-            }
-          }
-        },
-        "growl": {
-          "version": "1.8.1"
-        },
-        "jade": {
-          "version": "0.26.3",
-          "dependencies": {
-            "commander": {
-              "version": "0.6.1"
-            },
-            "mkdirp": {
-              "version": "0.3.0"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
-        },
-        "supports-color": {
-          "version": "1.2.0"
-        }
-      }
-    },
-    "mockery": {
-      "version": "1.4.0"
     },
     "moment": {
       "version": "2.10.6"
@@ -4735,36 +2344,6 @@
     },
     "ms": {
       "version": "0.7.1"
-    },
-    "nock": {
-      "version": "2.17.0",
-      "dependencies": {
-        "debug": {
-          "version": "1.0.4",
-          "dependencies": {
-            "ms": {
-              "version": "0.6.2"
-            }
-          }
-        },
-        "deep-equal": {
-          "version": "1.0.1"
-        },
-        "lodash": {
-          "version": "2.4.1"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
-        },
-        "propagate": {
-          "version": "0.3.1"
-        }
-      }
     },
     "node-sass": {
       "version": "3.4.2",
@@ -4838,13 +2417,13 @@
                       "version": "0.0.6"
                     },
                     "readable-stream": {
-                      "version": "2.0.5",
+                      "version": "2.0.6",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2"
                         },
                         "isarray": {
-                          "version": "0.0.1"
+                          "version": "1.0.0"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6"
@@ -4948,10 +2527,10 @@
           "version": "3.7.0",
           "dependencies": {
             "camelcase-keys": {
-              "version": "2.0.0",
+              "version": "2.1.0",
               "dependencies": {
                 "camelcase": {
-                  "version": "2.1.0"
+                  "version": "2.1.1"
                 }
               }
             },
@@ -4988,9 +2567,6 @@
                       "version": "1.1.1"
                     }
                   }
-                },
-                "semver": {
-                  "version": "5.1.0"
                 },
                 "validate-npm-package-license": {
                   "version": "3.0.1",
@@ -5263,25 +2839,25 @@
               }
             },
             "npmlog": {
-              "version": "2.0.2",
+              "version": "2.0.3",
               "dependencies": {
                 "ansi": {
                   "version": "0.3.1"
                 },
                 "are-we-there-yet": {
-                  "version": "1.0.6",
+                  "version": "1.1.2",
                   "dependencies": {
                     "delegates": {
                       "version": "1.0.0"
                     },
                     "readable-stream": {
-                      "version": "2.0.5",
+                      "version": "2.0.6",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2"
                         },
                         "isarray": {
-                          "version": "0.0.1"
+                          "version": "1.0.0"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6"
@@ -5421,9 +2997,6 @@
                 }
               }
             },
-            "semver": {
-              "version": "5.1.0"
-            },
             "tar": {
               "version": "2.2.1",
               "dependencies": {
@@ -5463,13 +3036,13 @@
               "version": "1.0.3",
               "dependencies": {
                 "readable-stream": {
-                  "version": "2.0.5",
+                  "version": "2.0.6",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2"
                     },
                     "isarray": {
-                      "version": "0.0.1"
+                      "version": "1.0.0"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6"
@@ -5502,7 +3075,7 @@
               "version": "0.6.1"
             },
             "form-data": {
-              "version": "1.0.0-rc3",
+              "version": "1.0.0-rc4",
               "dependencies": {
                 "async": {
                   "version": "1.5.2"
@@ -5607,7 +3180,7 @@
                       "version": "0.1.0"
                     },
                     "tweetnacl": {
-                      "version": "0.14.1"
+                      "version": "0.14.2"
                     },
                     "jodid25519": {
                       "version": "1.0.2"
@@ -5703,10 +3276,10 @@
               "version": "3.32.0",
               "dependencies": {
                 "camelcase": {
-                  "version": "2.1.0"
+                  "version": "2.1.1"
                 },
                 "cliui": {
-                  "version": "3.1.0",
+                  "version": "3.1.1",
                   "dependencies": {
                     "strip-ansi": {
                       "version": "3.0.1",
@@ -5717,7 +3290,7 @@
                       }
                     },
                     "wrap-ansi": {
-                      "version": "1.0.0"
+                      "version": "2.0.0"
                     }
                   }
                 },
@@ -5770,7 +3343,7 @@
                   "version": "0.1.4"
                 },
                 "y18n": {
-                  "version": "3.2.0"
+                  "version": "3.2.1"
                 }
               }
             }
@@ -5807,6 +3380,781 @@
         },
         "seed-random": {
           "version": "2.2.0"
+        }
+      }
+    },
+    "postcss-cli": {
+      "version": "2.5.1",
+      "dependencies": {
+        "globby": {
+          "version": "3.0.1",
+          "dependencies": {
+            "array-union": {
+              "version": "1.0.1",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2"
+                }
+              }
+            },
+            "arrify": {
+              "version": "1.0.1"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.0.1"
+            },
+            "pify": {
+              "version": "2.3.0"
+            },
+            "pinkie-promise": {
+              "version": "1.0.0",
+              "dependencies": {
+                "pinkie": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "neo-async": {
+          "version": "1.8.0"
+        },
+        "postcss": {
+          "version": "5.0.19",
+          "dependencies": {
+            "supports-color": {
+              "version": "3.1.2",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.5.3"
+            },
+            "js-base64": {
+              "version": "2.1.9"
+            }
+          }
+        },
+        "read-file-stdin": {
+          "version": "0.2.1",
+          "dependencies": {
+            "gather-stream": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.7"
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "dependencies": {
+            "camelcase": {
+              "version": "2.1.1"
+            },
+            "cliui": {
+              "version": "3.1.1",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0"
+                    }
+                  }
+                },
+                "wrap-ansi": {
+                  "version": "2.0.0"
+                }
+              }
+            },
+            "decamelize": {
+              "version": "1.2.0"
+            },
+            "os-locale": {
+              "version": "1.4.0",
+              "dependencies": {
+                "lcid": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "invert-kv": {
+                      "version": "1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "string-width": {
+              "version": "1.0.1",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "window-size": {
+              "version": "0.1.4"
+            },
+            "y18n": {
+              "version": "3.2.1"
+            }
+          }
+        },
+        "chokidar": {
+          "version": "1.4.3",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.3.0",
+              "dependencies": {
+                "arrify": {
+                  "version": "1.0.1"
+                },
+                "micromatch": {
+                  "version": "2.3.7",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "2.0.0",
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "array-unique": {
+                      "version": "0.2.1"
+                    },
+                    "braces": {
+                      "version": "1.8.3",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.1",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.3",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "2.1.0"
+                                },
+                                "isobject": {
+                                  "version": "2.0.0",
+                                  "dependencies": {
+                                    "isarray": {
+                                      "version": "0.0.1"
+                                    }
+                                  }
+                                },
+                                "randomatic": {
+                                  "version": "1.1.5"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.4"
+                    },
+                    "extglob": {
+                      "version": "0.3.2"
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0"
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0"
+                    },
+                    "kind-of": {
+                      "version": "3.0.2",
+                      "dependencies": {
+                        "is-buffer": {
+                          "version": "1.1.3"
+                        }
+                      }
+                    },
+                    "normalize-path": {
+                      "version": "2.0.1"
+                    },
+                    "object.omit": {
+                      "version": "2.0.0",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.4",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.5"
+                            }
+                          }
+                        },
+                        "is-extendable": {
+                          "version": "0.1.1"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.4",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.3.0"
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.2"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.2",
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.3"
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "async-each": {
+              "version": "1.0.0"
+            },
+            "glob-parent": {
+              "version": "2.0.0"
+            },
+            "is-binary-path": {
+              "version": "1.0.1",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.4.0"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "dependencies": {
+                "is-extglob": {
+                  "version": "1.0.0"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0"
+            },
+            "readdirp": {
+              "version": "2.0.0",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.3"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2"
+                    },
+                    "isarray": {
+                      "version": "1.0.0"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.6"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2"
+                    }
+                  }
+                }
+              }
+            },
+            "fsevents": {
+              "version": "1.0.9",
+              "dependencies": {
+                "nan": {
+                  "version": "2.2.0"
+                },
+                "node-pre-gyp": {
+                  "version": "0.6.24",
+                  "dependencies": {
+                    "nopt": {
+                      "version": "3.0.6",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.7"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ansi": {
+                  "version": "0.3.1"
+                },
+                "ansi-regex": {
+                  "version": "2.0.0"
+                },
+                "ansi-styles": {
+                  "version": "2.2.0"
+                },
+                "are-we-there-yet": {
+                  "version": "1.1.2"
+                },
+                "asn1": {
+                  "version": "0.2.3"
+                },
+                "assert-plus": {
+                  "version": "0.2.0"
+                },
+                "async": {
+                  "version": "1.5.2"
+                },
+                "aws-sign2": {
+                  "version": "0.6.0"
+                },
+                "bl": {
+                  "version": "1.0.3"
+                },
+                "block-stream": {
+                  "version": "0.0.8"
+                },
+                "boom": {
+                  "version": "2.10.1"
+                },
+                "caseless": {
+                  "version": "0.11.0"
+                },
+                "chalk": {
+                  "version": "1.1.1"
+                },
+                "color-convert": {
+                  "version": "1.0.0"
+                },
+                "combined-stream": {
+                  "version": "1.0.5"
+                },
+                "commander": {
+                  "version": "2.9.0"
+                },
+                "core-util-is": {
+                  "version": "1.0.2"
+                },
+                "cryptiles": {
+                  "version": "2.0.5"
+                },
+                "debug": {
+                  "version": "2.2.0"
+                },
+                "deep-extend": {
+                  "version": "0.4.1"
+                },
+                "delayed-stream": {
+                  "version": "1.0.0"
+                },
+                "delegates": {
+                  "version": "1.0.0"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5"
+                },
+                "extend": {
+                  "version": "3.0.0"
+                },
+                "extsprintf": {
+                  "version": "1.0.2"
+                },
+                "forever-agent": {
+                  "version": "0.6.1"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc4"
+                },
+                "fstream": {
+                  "version": "1.0.8"
+                },
+                "gauge": {
+                  "version": "1.2.7"
+                },
+                "generate-function": {
+                  "version": "2.0.0"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0"
+                },
+                "graceful-readlink": {
+                  "version": "1.0.1"
+                },
+                "graceful-fs": {
+                  "version": "4.1.3"
+                },
+                "har-validator": {
+                  "version": "2.0.6"
+                },
+                "has-ansi": {
+                  "version": "2.0.0"
+                },
+                "hawk": {
+                  "version": "3.1.3"
+                },
+                "has-unicode": {
+                  "version": "2.0.0"
+                },
+                "hoek": {
+                  "version": "2.16.3"
+                },
+                "http-signature": {
+                  "version": "1.1.1"
+                },
+                "inherits": {
+                  "version": "2.0.1"
+                },
+                "ini": {
+                  "version": "1.3.4"
+                },
+                "is-my-json-valid": {
+                  "version": "2.13.1"
+                },
+                "is-property": {
+                  "version": "1.0.2"
+                },
+                "is-typedarray": {
+                  "version": "1.0.0"
+                },
+                "isarray": {
+                  "version": "1.0.0"
+                },
+                "isstream": {
+                  "version": "0.1.2"
+                },
+                "jodid25519": {
+                  "version": "1.0.2"
+                },
+                "jsbn": {
+                  "version": "0.1.0"
+                },
+                "json-schema": {
+                  "version": "0.2.2"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1"
+                },
+                "jsonpointer": {
+                  "version": "2.0.0"
+                },
+                "jsprim": {
+                  "version": "1.2.2"
+                },
+                "lodash.pad": {
+                  "version": "4.1.0"
+                },
+                "lodash.padend": {
+                  "version": "4.2.0"
+                },
+                "lodash.padstart": {
+                  "version": "4.2.0"
+                },
+                "lodash.repeat": {
+                  "version": "4.0.0"
+                },
+                "mime-db": {
+                  "version": "1.22.0"
+                },
+                "lodash.tostring": {
+                  "version": "4.1.2"
+                },
+                "mime-types": {
+                  "version": "2.1.10"
+                },
+                "minimist": {
+                  "version": "0.0.8"
+                },
+                "mkdirp": {
+                  "version": "0.5.1"
+                },
+                "ms": {
+                  "version": "0.7.1"
+                },
+                "node-uuid": {
+                  "version": "1.4.7"
+                },
+                "npmlog": {
+                  "version": "2.0.3"
+                },
+                "oauth-sign": {
+                  "version": "0.8.1"
+                },
+                "once": {
+                  "version": "1.3.3"
+                },
+                "pinkie": {
+                  "version": "2.0.4"
+                },
+                "pinkie-promise": {
+                  "version": "2.0.0"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6"
+                },
+                "qs": {
+                  "version": "6.0.2"
+                },
+                "readable-stream": {
+                  "version": "2.0.6"
+                },
+                "request": {
+                  "version": "2.69.0"
+                },
+                "semver": {
+                  "version": "5.1.0"
+                },
+                "sntp": {
+                  "version": "1.0.9"
+                },
+                "sshpk": {
+                  "version": "1.7.4"
+                },
+                "string_decoder": {
+                  "version": "0.10.31"
+                },
+                "stringstream": {
+                  "version": "0.0.5"
+                },
+                "strip-ansi": {
+                  "version": "3.0.1"
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4"
+                },
+                "supports-color": {
+                  "version": "2.0.0"
+                },
+                "tar": {
+                  "version": "2.2.1"
+                },
+                "tar-pack": {
+                  "version": "3.1.3"
+                },
+                "tough-cookie": {
+                  "version": "2.2.2"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2"
+                },
+                "tweetnacl": {
+                  "version": "0.14.1"
+                },
+                "uid-number": {
+                  "version": "0.0.6"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2"
+                },
+                "verror": {
+                  "version": "1.3.6"
+                },
+                "wrappy": {
+                  "version": "1.0.1"
+                },
+                "xtend": {
+                  "version": "4.0.1"
+                },
+                "dashdash": {
+                  "version": "1.13.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0"
+                    }
+                  }
+                },
+                "rc": {
+                  "version": "1.1.6",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0"
+                    }
+                  }
+                },
+                "aws4": {
+                  "version": "1.3.2",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "4.0.0",
+                      "dependencies": {
+                        "pseudomap": {
+                          "version": "1.0.2"
+                        },
+                        "yallist": {
+                          "version": "2.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "1.0.3",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "3.0.0",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.5.2",
+                  "dependencies": {
+                    "glob": {
+                      "version": "7.0.3",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.3",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -5872,7 +4220,7 @@
               "version": "1.1.0",
               "dependencies": {
                 "js-tokens": {
-                  "version": "1.0.2"
+                  "version": "1.0.3"
                 }
               }
             },
@@ -5903,9 +4251,6 @@
     "react-addons-linked-state-mixin": {
       "version": "0.14.3"
     },
-    "react-addons-test-utils": {
-      "version": "0.14.3"
-    },
     "react-addons-update": {
       "version": "0.14.3"
     },
@@ -5934,7 +4279,7 @@
               "version": "1.1.0",
               "dependencies": {
                 "js-tokens": {
-                  "version": "1.0.2"
+                  "version": "1.0.3"
                 }
               }
             }
@@ -5987,25 +4332,9 @@
               "version": "1.1.0",
               "dependencies": {
                 "js-tokens": {
-                  "version": "1.0.2"
+                  "version": "1.0.3"
                 }
               }
-            }
-          }
-        }
-      }
-    },
-    "react-hot-loader": {
-      "version": "1.3.0",
-      "dependencies": {
-        "react-hot-api": {
-          "version": "0.4.7"
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.0"
             }
           }
         }
@@ -6027,7 +4356,7 @@
               "version": "1.1.0",
               "dependencies": {
                 "js-tokens": {
-                  "version": "1.0.2"
+                  "version": "1.0.3"
                 }
               }
             }
@@ -6093,9 +4422,6 @@
     },
     "redux-thunk": {
       "version": "1.0.0"
-    },
-    "rewire": {
-      "version": "2.3.3"
     },
     "rtlcss": {
       "version": "1.6.1",
@@ -6198,309 +4524,8 @@
         }
       }
     },
-    "sinon": {
-      "version": "1.12.2",
-      "dependencies": {
-        "formatio": {
-          "version": "1.1.1",
-          "dependencies": {
-            "samsam": {
-              "version": "1.1.3"
-            }
-          }
-        },
-        "util": {
-          "version": "0.10.3"
-        },
-        "lolex": {
-          "version": "1.1.0"
-        }
-      }
-    },
-    "sinon-chai": {
-      "version": "2.7.0"
-    },
-    "socket.io": {
-      "version": "1.3.7",
-      "dependencies": {
-        "engine.io": {
-          "version": "1.5.4",
-          "dependencies": {
-            "base64id": {
-              "version": "0.1.0"
-            },
-            "debug": {
-              "version": "1.0.3",
-              "dependencies": {
-                "ms": {
-                  "version": "0.6.2"
-                }
-              }
-            },
-            "engine.io-parser": {
-              "version": "1.2.2",
-              "dependencies": {
-                "after": {
-                  "version": "0.8.1"
-                },
-                "arraybuffer.slice": {
-                  "version": "0.0.6"
-                },
-                "base64-arraybuffer": {
-                  "version": "0.1.2"
-                },
-                "blob": {
-                  "version": "0.0.4"
-                },
-                "has-binary": {
-                  "version": "0.1.6",
-                  "dependencies": {
-                    "isarray": {
-                      "version": "0.0.1"
-                    }
-                  }
-                },
-                "utf8": {
-                  "version": "2.1.0"
-                }
-              }
-            },
-            "ws": {
-              "version": "0.8.0",
-              "dependencies": {
-                "options": {
-                  "version": "0.0.6"
-                },
-                "ultron": {
-                  "version": "1.0.2"
-                },
-                "bufferutil": {
-                  "version": "1.2.1",
-                  "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1"
-                    },
-                    "nan": {
-                      "version": "2.2.0"
-                    }
-                  }
-                },
-                "utf-8-validate": {
-                  "version": "1.2.1",
-                  "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1"
-                    },
-                    "nan": {
-                      "version": "2.2.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "socket.io-parser": {
-          "version": "2.2.4",
-          "dependencies": {
-            "debug": {
-              "version": "0.7.4"
-            },
-            "json3": {
-              "version": "3.2.6"
-            },
-            "component-emitter": {
-              "version": "1.1.2"
-            },
-            "isarray": {
-              "version": "0.0.1"
-            },
-            "benchmark": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "socket.io-client": {
-          "version": "1.3.7",
-          "dependencies": {
-            "debug": {
-              "version": "0.7.4"
-            },
-            "engine.io-client": {
-              "version": "1.5.4",
-              "dependencies": {
-                "component-inherit": {
-                  "version": "0.0.3"
-                },
-                "debug": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2"
-                    }
-                  }
-                },
-                "engine.io-parser": {
-                  "version": "1.2.2",
-                  "dependencies": {
-                    "after": {
-                      "version": "0.8.1"
-                    },
-                    "arraybuffer.slice": {
-                      "version": "0.0.6"
-                    },
-                    "base64-arraybuffer": {
-                      "version": "0.1.2"
-                    },
-                    "blob": {
-                      "version": "0.0.4"
-                    },
-                    "utf8": {
-                      "version": "2.1.0"
-                    }
-                  }
-                },
-                "has-cors": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "global": {
-                      "version": "2.0.1",
-                      "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
-                    }
-                  }
-                },
-                "parsejson": {
-                  "version": "0.0.1"
-                },
-                "parseqs": {
-                  "version": "0.0.2"
-                },
-                "parseuri": {
-                  "version": "0.0.4"
-                },
-                "ws": {
-                  "version": "0.8.0",
-                  "dependencies": {
-                    "options": {
-                      "version": "0.0.6"
-                    },
-                    "ultron": {
-                      "version": "1.0.2"
-                    },
-                    "bufferutil": {
-                      "version": "1.2.1",
-                      "dependencies": {
-                        "bindings": {
-                          "version": "1.2.1"
-                        },
-                        "nan": {
-                          "version": "2.2.0"
-                        }
-                      }
-                    },
-                    "utf-8-validate": {
-                      "version": "1.2.1",
-                      "dependencies": {
-                        "bindings": {
-                          "version": "1.2.1"
-                        },
-                        "nan": {
-                          "version": "2.2.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "xmlhttprequest": {
-                  "version": "1.5.0",
-                  "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
-                }
-              }
-            },
-            "component-bind": {
-              "version": "1.0.0"
-            },
-            "component-emitter": {
-              "version": "1.1.2"
-            },
-            "object-component": {
-              "version": "0.0.3"
-            },
-            "has-binary": {
-              "version": "0.1.6",
-              "dependencies": {
-                "isarray": {
-                  "version": "0.0.1"
-                }
-              }
-            },
-            "indexof": {
-              "version": "0.0.1"
-            },
-            "parseuri": {
-              "version": "0.0.2"
-            },
-            "to-array": {
-              "version": "0.1.3"
-            },
-            "backo2": {
-              "version": "1.0.2"
-            }
-          }
-        },
-        "socket.io-adapter": {
-          "version": "0.3.1",
-          "dependencies": {
-            "debug": {
-              "version": "1.0.2",
-              "dependencies": {
-                "ms": {
-                  "version": "0.6.2"
-                }
-              }
-            },
-            "socket.io-parser": {
-              "version": "2.2.2",
-              "dependencies": {
-                "debug": {
-                  "version": "0.7.4"
-                },
-                "json3": {
-                  "version": "3.2.6"
-                },
-                "component-emitter": {
-                  "version": "1.1.2"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "benchmark": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "object-keys": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "has-binary-data": {
-          "version": "0.1.3",
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1"
-            }
-          }
-        },
-        "debug": {
-          "version": "2.1.0",
-          "dependencies": {
-            "ms": {
-              "version": "0.6.2"
-            }
-          }
-        }
-      }
+    "semver": {
+      "version": "5.1.0"
     },
     "source-map": {
       "version": "0.1.39",
@@ -6601,78 +4626,6 @@
               "version": "0.10.31"
             }
           }
-        }
-      }
-    },
-    "supertest": {
-      "version": "1.2.0",
-      "dependencies": {
-        "superagent": {
-          "version": "1.8.0",
-          "dependencies": {
-            "qs": {
-              "version": "2.3.3"
-            },
-            "formidable": {
-              "version": "1.0.17"
-            },
-            "mime": {
-              "version": "1.3.4"
-            },
-            "component-emitter": {
-              "version": "1.2.0"
-            },
-            "cookiejar": {
-              "version": "2.0.6"
-            },
-            "reduce-component": {
-              "version": "1.0.1"
-            },
-            "extend": {
-              "version": "3.0.0"
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "dependencies": {
-                "async": {
-                  "version": "1.5.2"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "mime-types": {
-                  "version": "2.1.10",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.22.0"
-                    }
-                  }
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "1.0.27-1",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                }
-              }
-            }
-          }
-        },
-        "methods": {
-          "version": "1.1.2"
         }
       }
     },
@@ -6794,6 +4747,9 @@
         }
       }
     },
+    "valid-url": {
+      "version": "1.0.9"
+    },
     "walk": {
       "version": "2.3.4",
       "dependencies": {
@@ -6826,7 +4782,7 @@
           "version": "0.6.6"
         },
         "loader-utils": {
-          "version": "0.2.12",
+          "version": "0.2.13",
           "dependencies": {
             "big.js": {
               "version": "3.1.3"
@@ -6924,7 +4880,7 @@
               "version": "0.11.2"
             },
             "punycode": {
-              "version": "1.4.0"
+              "version": "1.4.1"
             },
             "querystring-es3": {
               "version": "0.2.1"
@@ -7092,10 +5048,10 @@
                           "version": "2.0.0",
                           "dependencies": {
                             "for-own": {
-                              "version": "0.1.3",
+                              "version": "0.1.4",
                               "dependencies": {
                                 "for-in": {
-                                  "version": "0.1.4"
+                                  "version": "0.1.5"
                                 }
                               }
                             },
@@ -7175,13 +5131,13 @@
                       }
                     },
                     "readable-stream": {
-                      "version": "2.0.5",
+                      "version": "2.0.6",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2"
                         },
                         "isarray": {
-                          "version": "0.0.1"
+                          "version": "1.0.0"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6"
@@ -7197,13 +5153,13 @@
                   }
                 },
                 "fsevents": {
-                  "version": "1.0.8",
+                  "version": "1.0.9",
                   "dependencies": {
                     "nan": {
                       "version": "2.2.0"
                     },
                     "node-pre-gyp": {
-                      "version": "0.6.21",
+                      "version": "0.6.24",
                       "dependencies": {
                         "nopt": {
                           "version": "3.0.6",
@@ -7215,32 +5171,32 @@
                         }
                       }
                     },
-                    "ansi": {
-                      "version": "0.3.1"
-                    },
                     "ansi-regex": {
                       "version": "2.0.0"
                     },
+                    "ansi": {
+                      "version": "0.3.1"
+                    },
                     "ansi-styles": {
-                      "version": "2.1.0"
+                      "version": "2.2.0"
                     },
                     "are-we-there-yet": {
-                      "version": "1.0.6"
+                      "version": "1.1.2"
                     },
                     "asn1": {
                       "version": "0.2.3"
                     },
-                    "async": {
-                      "version": "1.5.2"
-                    },
                     "assert-plus": {
                       "version": "0.2.0"
+                    },
+                    "async": {
+                      "version": "1.5.2"
                     },
                     "aws-sign2": {
                       "version": "0.6.0"
                     },
                     "bl": {
-                      "version": "1.0.2"
+                      "version": "1.0.3"
                     },
                     "block-stream": {
                       "version": "0.0.8"
@@ -7248,26 +5204,26 @@
                     "boom": {
                       "version": "2.10.1"
                     },
-                    "chalk": {
-                      "version": "1.1.1"
-                    },
                     "caseless": {
                       "version": "0.11.0"
                     },
-                    "commander": {
-                      "version": "2.9.0"
+                    "chalk": {
+                      "version": "1.1.1"
+                    },
+                    "color-convert": {
+                      "version": "1.0.0"
                     },
                     "combined-stream": {
                       "version": "1.0.5"
+                    },
+                    "commander": {
+                      "version": "2.9.0"
                     },
                     "core-util-is": {
                       "version": "1.0.2"
                     },
                     "cryptiles": {
                       "version": "2.0.5"
-                    },
-                    "dashdash": {
-                      "version": "1.12.2"
                     },
                     "debug": {
                       "version": "2.2.0"
@@ -7278,17 +5234,14 @@
                     "delayed-stream": {
                       "version": "1.0.0"
                     },
+                    "delegates": {
+                      "version": "1.0.0"
+                    },
                     "ecc-jsbn": {
                       "version": "0.1.1"
                     },
                     "escape-string-regexp": {
-                      "version": "1.0.4"
-                    },
-                    "delegates": {
-                      "version": "1.0.0"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1"
+                      "version": "1.0.5"
                     },
                     "extend": {
                       "version": "3.0.0"
@@ -7296,17 +5249,20 @@
                     "extsprintf": {
                       "version": "1.0.2"
                     },
+                    "forever-agent": {
+                      "version": "0.6.1"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc4"
+                    },
                     "fstream": {
                       "version": "1.0.8"
                     },
-                    "form-data": {
-                      "version": "1.0.0-rc3"
+                    "gauge": {
+                      "version": "1.2.7"
                     },
                     "generate-function": {
                       "version": "2.0.0"
-                    },
-                    "gauge": {
-                      "version": "1.2.5"
                     },
                     "generate-object-property": {
                       "version": "1.2.0"
@@ -7317,11 +5273,11 @@
                     "graceful-readlink": {
                       "version": "1.0.1"
                     },
-                    "has-ansi": {
-                      "version": "2.0.0"
-                    },
                     "har-validator": {
                       "version": "2.0.6"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0"
                     },
                     "hawk": {
                       "version": "3.1.3"
@@ -7332,26 +5288,26 @@
                     "hoek": {
                       "version": "2.16.3"
                     },
-                    "inherits": {
-                      "version": "2.0.1"
-                    },
                     "http-signature": {
                       "version": "1.1.1"
                     },
-                    "is-property": {
-                      "version": "1.0.2"
+                    "inherits": {
+                      "version": "2.0.1"
                     },
                     "ini": {
                       "version": "1.3.4"
                     },
                     "is-my-json-valid": {
-                      "version": "2.12.4"
+                      "version": "2.13.1"
+                    },
+                    "is-property": {
+                      "version": "1.0.2"
                     },
                     "is-typedarray": {
                       "version": "1.0.0"
                     },
                     "isarray": {
-                      "version": "0.0.1"
+                      "version": "1.0.0"
                     },
                     "isstream": {
                       "version": "0.1.2"
@@ -7368,44 +5324,38 @@
                     "json-stringify-safe": {
                       "version": "5.0.1"
                     },
-                    "jsprim": {
-                      "version": "1.2.2"
-                    },
                     "jsonpointer": {
                       "version": "2.0.0"
                     },
-                    "lodash._basetostring": {
-                      "version": "3.0.1"
-                    },
-                    "lodash._root": {
-                      "version": "3.0.0"
-                    },
-                    "lodash._createpadding": {
-                      "version": "3.6.1"
-                    },
-                    "lodash.padleft": {
-                      "version": "3.1.1"
+                    "jsprim": {
+                      "version": "1.2.2"
                     },
                     "lodash.pad": {
-                      "version": "3.3.0"
+                      "version": "4.1.0"
                     },
-                    "lodash.padright": {
-                      "version": "3.1.1"
+                    "lodash.padend": {
+                      "version": "4.2.0"
+                    },
+                    "lodash.padstart": {
+                      "version": "4.2.0"
                     },
                     "lodash.repeat": {
-                      "version": "3.2.0"
+                      "version": "4.0.0"
+                    },
+                    "lodash.tostring": {
+                      "version": "4.1.2"
                     },
                     "mime-db": {
-                      "version": "1.21.0"
-                    },
-                    "minimist": {
-                      "version": "0.0.8"
+                      "version": "1.22.0"
                     },
                     "mime-types": {
-                      "version": "2.1.9"
+                      "version": "2.1.10"
                     },
                     "mkdirp": {
                       "version": "0.5.1"
+                    },
+                    "minimist": {
+                      "version": "0.0.8"
                     },
                     "ms": {
                       "version": "0.7.1"
@@ -7414,7 +5364,7 @@
                       "version": "1.4.7"
                     },
                     "npmlog": {
-                      "version": "2.0.2"
+                      "version": "2.0.3"
                     },
                     "oauth-sign": {
                       "version": "0.8.1"
@@ -7435,7 +5385,7 @@
                       "version": "6.0.2"
                     },
                     "readable-stream": {
-                      "version": "2.0.5"
+                      "version": "2.0.6"
                     },
                     "request": {
                       "version": "2.69.0"
@@ -7443,41 +5393,41 @@
                     "semver": {
                       "version": "5.1.0"
                     },
+                    "sshpk": {
+                      "version": "1.7.4"
+                    },
                     "sntp": {
                       "version": "1.0.9"
-                    },
-                    "sshpk": {
-                      "version": "1.7.3"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5"
                     },
                     "string_decoder": {
                       "version": "0.10.31"
                     },
                     "strip-ansi": {
-                      "version": "3.0.0"
+                      "version": "3.0.1"
                     },
-                    "strip-json-comments": {
-                      "version": "1.0.4"
+                    "stringstream": {
+                      "version": "0.0.5"
                     },
                     "supports-color": {
                       "version": "2.0.0"
                     },
+                    "strip-json-comments": {
+                      "version": "1.0.4"
+                    },
                     "tar": {
                       "version": "2.2.1"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.1"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.2"
                     },
                     "tar-pack": {
                       "version": "3.1.3"
                     },
+                    "tough-cookie": {
+                      "version": "2.2.2"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.2"
+                    },
                     "tweetnacl": {
-                      "version": "0.13.3"
+                      "version": "0.14.1"
                     },
                     "uid-number": {
                       "version": "0.0.6"
@@ -7488,17 +5438,17 @@
                     "verror": {
                       "version": "1.3.6"
                     },
-                    "xtend": {
-                      "version": "4.0.1"
-                    },
                     "wrappy": {
                       "version": "1.0.1"
                     },
-                    "aws4": {
-                      "version": "1.2.1",
+                    "xtend": {
+                      "version": "4.0.1"
+                    },
+                    "dashdash": {
+                      "version": "1.13.0",
                       "dependencies": {
-                        "lru-cache": {
-                          "version": "2.7.3"
+                        "assert-plus": {
+                          "version": "1.0.0"
                         }
                       }
                     },
@@ -7510,6 +5460,22 @@
                         }
                       }
                     },
+                    "aws4": {
+                      "version": "1.3.2",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "4.0.0",
+                          "dependencies": {
+                            "pseudomap": {
+                              "version": "1.0.2"
+                            },
+                            "yallist": {
+                              "version": "2.0.0"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "fstream-ignore": {
                       "version": "1.0.3",
                       "dependencies": {
@@ -7517,7 +5483,7 @@
                           "version": "3.0.0",
                           "dependencies": {
                             "brace-expansion": {
-                              "version": "1.1.2",
+                              "version": "1.1.3",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.3.0"
@@ -7532,10 +5498,10 @@
                       }
                     },
                     "rimraf": {
-                      "version": "2.5.1",
+                      "version": "2.5.2",
                       "dependencies": {
                         "glob": {
-                          "version": "6.0.4",
+                          "version": "7.0.3",
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.4",
@@ -7552,7 +5518,7 @@
                               "version": "3.0.0",
                               "dependencies": {
                                 "brace-expansion": {
-                                  "version": "1.1.2",
+                                  "version": "1.1.3",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.3.0"
@@ -7600,7 +5566,7 @@
               }
             },
             "source-list-map": {
-              "version": "0.1.5"
+              "version": "0.1.6"
             }
           }
         }
@@ -7614,209 +5580,6 @@
         },
         "mime": {
           "version": "1.3.4"
-        }
-      }
-    },
-    "webpack-dev-server": {
-      "version": "1.11.0",
-      "dependencies": {
-        "connect-history-api-fallback": {
-          "version": "1.1.0"
-        },
-        "http-proxy": {
-          "version": "1.13.2",
-          "dependencies": {
-            "eventemitter3": {
-              "version": "1.1.1"
-            },
-            "requires-port": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3"
-            },
-            "minimist": {
-              "version": "0.0.10"
-            }
-          }
-        },
-        "serve-index": {
-          "version": "1.7.3",
-          "dependencies": {
-            "accepts": {
-              "version": "1.2.13",
-              "dependencies": {
-                "negotiator": {
-                  "version": "0.5.3"
-                }
-              }
-            },
-            "batch": {
-              "version": "0.5.3"
-            },
-            "escape-html": {
-              "version": "1.0.3"
-            },
-            "http-errors": {
-              "version": "1.3.1",
-              "dependencies": {
-                "statuses": {
-                  "version": "1.2.1"
-                }
-              }
-            },
-            "mime-types": {
-              "version": "2.1.10",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.22.0"
-                }
-              }
-            },
-            "parseurl": {
-              "version": "1.3.1"
-            }
-          }
-        },
-        "socket.io-client": {
-          "version": "1.4.5",
-          "dependencies": {
-            "engine.io-client": {
-              "version": "1.6.8",
-              "dependencies": {
-                "has-cors": {
-                  "version": "1.1.0"
-                },
-                "ws": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "options": {
-                      "version": "0.0.6"
-                    },
-                    "ultron": {
-                      "version": "1.0.2"
-                    }
-                  }
-                },
-                "xmlhttprequest-ssl": {
-                  "version": "1.5.1"
-                },
-                "component-emitter": {
-                  "version": "1.1.2"
-                },
-                "engine.io-parser": {
-                  "version": "1.2.4",
-                  "dependencies": {
-                    "after": {
-                      "version": "0.8.1"
-                    },
-                    "arraybuffer.slice": {
-                      "version": "0.0.6"
-                    },
-                    "base64-arraybuffer": {
-                      "version": "0.1.2"
-                    },
-                    "blob": {
-                      "version": "0.0.4"
-                    },
-                    "has-binary": {
-                      "version": "0.1.6",
-                      "dependencies": {
-                        "isarray": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    },
-                    "utf8": {
-                      "version": "2.1.0"
-                    }
-                  }
-                },
-                "parsejson": {
-                  "version": "0.0.1"
-                },
-                "parseqs": {
-                  "version": "0.0.2"
-                },
-                "component-inherit": {
-                  "version": "0.0.3"
-                },
-                "yeast": {
-                  "version": "0.1.2"
-                }
-              }
-            },
-            "component-bind": {
-              "version": "1.0.0"
-            },
-            "component-emitter": {
-              "version": "1.2.0"
-            },
-            "object-component": {
-              "version": "0.0.3"
-            },
-            "socket.io-parser": {
-              "version": "2.2.6",
-              "dependencies": {
-                "json3": {
-                  "version": "3.3.2"
-                },
-                "component-emitter": {
-                  "version": "1.1.2"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "benchmark": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "has-binary": {
-              "version": "0.1.7",
-              "dependencies": {
-                "isarray": {
-                  "version": "0.0.1"
-                }
-              }
-            },
-            "indexof": {
-              "version": "0.0.1"
-            },
-            "parseuri": {
-              "version": "0.0.4"
-            },
-            "to-array": {
-              "version": "0.1.4"
-            },
-            "backo2": {
-              "version": "1.0.2"
-            }
-          }
-        },
-        "stream-cache": {
-          "version": "0.0.2"
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.0.0"
-            }
-          }
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0"
-            }
-          }
         }
       }
     },
@@ -7841,7 +5604,7 @@
           "version": "4.8.5",
           "dependencies": {
             "babel": {
-              "version": "5.8.35",
+              "version": "5.8.38",
               "dependencies": {
                 "chokidar": {
                   "version": "1.4.3",
@@ -7931,10 +5694,10 @@
                               "version": "2.0.0",
                               "dependencies": {
                                 "for-own": {
-                                  "version": "0.1.3",
+                                  "version": "0.1.4",
                                   "dependencies": {
                                     "for-in": {
-                                      "version": "0.1.4"
+                                      "version": "0.1.5"
                                     }
                                   }
                                 },
@@ -8014,13 +5777,13 @@
                           }
                         },
                         "readable-stream": {
-                          "version": "2.0.5",
+                          "version": "2.0.6",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2"
                             },
                             "isarray": {
-                              "version": "0.0.1"
+                              "version": "1.0.0"
                             },
                             "process-nextick-args": {
                               "version": "1.0.6"
@@ -8036,13 +5799,13 @@
                       }
                     },
                     "fsevents": {
-                      "version": "1.0.8",
+                      "version": "1.0.9",
                       "dependencies": {
                         "nan": {
                           "version": "2.2.0"
                         },
                         "node-pre-gyp": {
-                          "version": "0.6.21",
+                          "version": "0.6.24",
                           "dependencies": {
                             "nopt": {
                               "version": "3.0.6",
@@ -8054,32 +5817,32 @@
                             }
                           }
                         },
-                        "ansi-regex": {
-                          "version": "2.0.0"
-                        },
                         "ansi": {
                           "version": "0.3.1"
                         },
+                        "ansi-regex": {
+                          "version": "2.0.0"
+                        },
                         "are-we-there-yet": {
-                          "version": "1.0.6"
+                          "version": "1.1.2"
                         },
                         "ansi-styles": {
-                          "version": "2.1.0"
-                        },
-                        "assert-plus": {
-                          "version": "0.2.0"
+                          "version": "2.2.0"
                         },
                         "asn1": {
                           "version": "0.2.3"
                         },
-                        "aws-sign2": {
-                          "version": "0.6.0"
+                        "assert-plus": {
+                          "version": "0.2.0"
                         },
                         "async": {
                           "version": "1.5.2"
                         },
+                        "aws-sign2": {
+                          "version": "0.6.0"
+                        },
                         "bl": {
-                          "version": "1.0.2"
+                          "version": "1.0.3"
                         },
                         "block-stream": {
                           "version": "0.0.8"
@@ -8087,14 +5850,17 @@
                         "boom": {
                           "version": "2.10.1"
                         },
-                        "combined-stream": {
-                          "version": "1.0.5"
+                        "chalk": {
+                          "version": "1.1.1"
+                        },
+                        "color-convert": {
+                          "version": "1.0.0"
                         },
                         "caseless": {
                           "version": "0.11.0"
                         },
-                        "chalk": {
-                          "version": "1.1.1"
+                        "combined-stream": {
+                          "version": "1.0.5"
                         },
                         "commander": {
                           "version": "2.9.0"
@@ -8102,20 +5868,17 @@
                         "core-util-is": {
                           "version": "1.0.2"
                         },
-                        "dashdash": {
-                          "version": "1.12.2"
+                        "debug": {
+                          "version": "2.2.0"
                         },
                         "cryptiles": {
                           "version": "2.0.5"
                         },
-                        "delayed-stream": {
-                          "version": "1.0.0"
-                        },
-                        "debug": {
-                          "version": "2.2.0"
-                        },
                         "deep-extend": {
                           "version": "0.4.1"
+                        },
+                        "delayed-stream": {
+                          "version": "1.0.0"
                         },
                         "delegates": {
                           "version": "1.0.0"
@@ -8124,10 +5887,7 @@
                           "version": "0.1.1"
                         },
                         "escape-string-regexp": {
-                          "version": "1.0.4"
-                        },
-                        "forever-agent": {
-                          "version": "0.6.1"
+                          "version": "1.0.5"
                         },
                         "extend": {
                           "version": "3.0.0"
@@ -8136,25 +5896,28 @@
                           "version": "1.0.2"
                         },
                         "form-data": {
-                          "version": "1.0.0-rc3"
+                          "version": "1.0.0-rc4"
+                        },
+                        "forever-agent": {
+                          "version": "0.6.1"
                         },
                         "fstream": {
                           "version": "1.0.8"
                         },
+                        "gauge": {
+                          "version": "1.2.7"
+                        },
                         "generate-function": {
                           "version": "2.0.0"
-                        },
-                        "gauge": {
-                          "version": "1.2.5"
                         },
                         "generate-object-property": {
                           "version": "1.2.0"
                         },
-                        "graceful-readlink": {
-                          "version": "1.0.1"
-                        },
                         "graceful-fs": {
                           "version": "4.1.3"
+                        },
+                        "graceful-readlink": {
+                          "version": "1.0.1"
                         },
                         "har-validator": {
                           "version": "2.0.6"
@@ -8165,41 +5928,38 @@
                         "has-unicode": {
                           "version": "2.0.0"
                         },
-                        "hoek": {
-                          "version": "2.16.3"
-                        },
                         "hawk": {
                           "version": "3.1.3"
+                        },
+                        "hoek": {
+                          "version": "2.16.3"
                         },
                         "http-signature": {
                           "version": "1.1.1"
                         },
-                        "ini": {
-                          "version": "1.3.4"
-                        },
                         "inherits": {
                           "version": "2.0.1"
                         },
-                        "is-property": {
-                          "version": "1.0.2"
+                        "ini": {
+                          "version": "1.3.4"
                         },
                         "is-my-json-valid": {
-                          "version": "2.12.4"
+                          "version": "2.13.1"
+                        },
+                        "is-property": {
+                          "version": "1.0.2"
                         },
                         "is-typedarray": {
                           "version": "1.0.0"
                         },
                         "isarray": {
-                          "version": "0.0.1"
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2"
+                          "version": "1.0.0"
                         },
                         "isstream": {
                           "version": "0.1.2"
                         },
-                        "json-schema": {
-                          "version": "0.2.2"
+                        "jodid25519": {
+                          "version": "1.0.2"
                         },
                         "jsbn": {
                           "version": "0.1.0"
@@ -8207,38 +5967,35 @@
                         "json-stringify-safe": {
                           "version": "5.0.1"
                         },
-                        "jsprim": {
-                          "version": "1.2.2"
+                        "json-schema": {
+                          "version": "0.2.2"
                         },
                         "jsonpointer": {
                           "version": "2.0.0"
                         },
-                        "lodash._basetostring": {
-                          "version": "3.0.1"
+                        "lodash.padend": {
+                          "version": "4.2.0"
                         },
-                        "lodash._root": {
-                          "version": "3.0.0"
+                        "jsprim": {
+                          "version": "1.2.2"
                         },
                         "lodash.pad": {
-                          "version": "3.3.0"
+                          "version": "4.1.0"
                         },
-                        "lodash.padleft": {
-                          "version": "3.1.1"
-                        },
-                        "lodash._createpadding": {
-                          "version": "3.6.1"
-                        },
-                        "lodash.padright": {
-                          "version": "3.1.1"
+                        "lodash.padstart": {
+                          "version": "4.2.0"
                         },
                         "lodash.repeat": {
-                          "version": "3.2.0"
+                          "version": "4.0.0"
+                        },
+                        "lodash.tostring": {
+                          "version": "4.1.2"
                         },
                         "mime-db": {
-                          "version": "1.21.0"
+                          "version": "1.22.0"
                         },
                         "mime-types": {
-                          "version": "2.1.9"
+                          "version": "2.1.10"
                         },
                         "mkdirp": {
                           "version": "0.5.1"
@@ -8249,6 +6006,9 @@
                         "ms": {
                           "version": "0.7.1"
                         },
+                        "npmlog": {
+                          "version": "2.0.3"
+                        },
                         "node-uuid": {
                           "version": "1.4.7"
                         },
@@ -8258,23 +6018,20 @@
                         "once": {
                           "version": "1.3.3"
                         },
-                        "npmlog": {
-                          "version": "2.0.2"
+                        "pinkie": {
+                          "version": "2.0.4"
                         },
                         "pinkie-promise": {
                           "version": "2.0.0"
                         },
-                        "pinkie": {
-                          "version": "2.0.4"
+                        "process-nextick-args": {
+                          "version": "1.0.6"
                         },
                         "qs": {
                           "version": "6.0.2"
                         },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
                         "readable-stream": {
-                          "version": "2.0.5"
+                          "version": "2.0.6"
                         },
                         "request": {
                           "version": "2.69.0"
@@ -8286,22 +6043,22 @@
                           "version": "1.0.9"
                         },
                         "sshpk": {
-                          "version": "1.7.3"
-                        },
-                        "stringstream": {
-                          "version": "0.0.5"
+                          "version": "1.7.4"
                         },
                         "string_decoder": {
                           "version": "0.10.31"
                         },
-                        "strip-ansi": {
-                          "version": "3.0.0"
+                        "stringstream": {
+                          "version": "0.0.5"
                         },
-                        "supports-color": {
-                          "version": "2.0.0"
+                        "strip-ansi": {
+                          "version": "3.0.1"
                         },
                         "strip-json-comments": {
                           "version": "1.0.4"
+                        },
+                        "supports-color": {
+                          "version": "2.0.0"
                         },
                         "tar": {
                           "version": "2.2.1"
@@ -8309,35 +6066,35 @@
                         "tar-pack": {
                           "version": "3.1.3"
                         },
+                        "tough-cookie": {
+                          "version": "2.2.2"
+                        },
                         "tunnel-agent": {
                           "version": "0.4.2"
                         },
-                        "tough-cookie": {
-                          "version": "2.2.1"
+                        "tweetnacl": {
+                          "version": "0.14.1"
                         },
                         "uid-number": {
                           "version": "0.0.6"
                         },
-                        "tweetnacl": {
-                          "version": "0.13.3"
-                        },
                         "util-deprecate": {
                           "version": "1.0.2"
-                        },
-                        "verror": {
-                          "version": "1.3.6"
                         },
                         "wrappy": {
                           "version": "1.0.1"
                         },
+                        "verror": {
+                          "version": "1.3.6"
+                        },
                         "xtend": {
                           "version": "4.0.1"
                         },
-                        "aws4": {
-                          "version": "1.2.1",
+                        "dashdash": {
+                          "version": "1.13.0",
                           "dependencies": {
-                            "lru-cache": {
-                              "version": "2.7.3"
+                            "assert-plus": {
+                              "version": "1.0.0"
                             }
                           }
                         },
@@ -8349,6 +6106,22 @@
                             }
                           }
                         },
+                        "aws4": {
+                          "version": "1.3.2",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "4.0.0",
+                              "dependencies": {
+                                "pseudomap": {
+                                  "version": "1.0.2"
+                                },
+                                "yallist": {
+                                  "version": "2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        },
                         "fstream-ignore": {
                           "version": "1.0.3",
                           "dependencies": {
@@ -8356,7 +6129,7 @@
                               "version": "3.0.0",
                               "dependencies": {
                                 "brace-expansion": {
-                                  "version": "1.1.2",
+                                  "version": "1.1.3",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.3.0"
@@ -8371,10 +6144,10 @@
                           }
                         },
                         "rimraf": {
-                          "version": "2.5.1",
+                          "version": "2.5.2",
                           "dependencies": {
                             "glob": {
-                              "version": "6.0.4",
+                              "version": "7.0.3",
                               "dependencies": {
                                 "inflight": {
                                   "version": "1.0.4",
@@ -8391,7 +6164,7 @@
                                   "version": "3.0.0",
                                   "dependencies": {
                                     "brace-expansion": {
-                                      "version": "1.1.2",
+                                      "version": "1.1.3",
                                       "dependencies": {
                                         "balanced-match": {
                                           "version": "0.3.0"
@@ -8521,832 +6294,6 @@
         },
         "lodash": {
           "version": "2.4.2"
-        }
-      }
-    },
-    "semver": {
-      "version": "5.1.0"
-    },
-    "component-file-picker": {
-      "version": "0.2.1",
-      "dependencies": {
-        "component-event": {
-          "version": "0.1.4"
-        }
-      }
-    },
-    "filesize": {
-      "version": "3.2.1"
-    },
-    "blob": {
-      "version": "0.0.4"
-    },
-    "valid-url": {
-      "version": "1.0.9"
-    },
-    "autoprefixer": {
-      "version": "6.3.5",
-      "dependencies": {
-        "browserslist": {
-          "version": "1.3.0"
-        },
-        "caniuse-db": {
-          "version": "1.0.30000436"
-        },
-        "normalize-range": {
-          "version": "0.1.2"
-        },
-        "num2fraction": {
-          "version": "1.2.2"
-        },
-        "postcss": {
-          "version": "5.0.19",
-          "dependencies": {
-            "js-base64": {
-              "version": "2.1.9"
-            },
-            "source-map": {
-              "version": "0.5.3"
-            },
-            "supports-color": {
-              "version": "3.1.2",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "postcss-value-parser": {
-          "version": "3.3.0"
-        }
-      }
-    },
-    "postcss-cli": {
-      "version": "2.5.1",
-      "dependencies": {
-        "chokidar": {
-          "version": "1.4.3",
-          "dependencies": {
-            "anymatch": {
-              "version": "1.3.0",
-              "dependencies": {
-                "micromatch": {
-                  "version": "2.3.7",
-                  "dependencies": {
-                    "arr-diff": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "arr-flatten": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "array-unique": {
-                      "version": "0.2.1"
-                    },
-                    "braces": {
-                      "version": "1.8.3",
-                      "dependencies": {
-                        "expand-range": {
-                          "version": "1.8.1",
-                          "dependencies": {
-                            "fill-range": {
-                              "version": "2.2.3",
-                              "dependencies": {
-                                "is-number": {
-                                  "version": "2.1.0"
-                                },
-                                "isobject": {
-                                  "version": "2.0.0",
-                                  "dependencies": {
-                                    "isarray": {
-                                      "version": "0.0.1"
-                                    }
-                                  }
-                                },
-                                "randomatic": {
-                                  "version": "1.1.5"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "preserve": {
-                          "version": "0.2.0"
-                        },
-                        "repeat-element": {
-                          "version": "1.1.2"
-                        }
-                      }
-                    },
-                    "expand-brackets": {
-                      "version": "0.1.4"
-                    },
-                    "extglob": {
-                      "version": "0.3.2"
-                    },
-                    "filename-regex": {
-                      "version": "2.0.0"
-                    },
-                    "kind-of": {
-                      "version": "3.0.2",
-                      "dependencies": {
-                        "is-buffer": {
-                          "version": "1.1.3"
-                        }
-                      }
-                    },
-                    "normalize-path": {
-                      "version": "2.0.1"
-                    },
-                    "object.omit": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "for-own": {
-                          "version": "0.1.4",
-                          "dependencies": {
-                            "for-in": {
-                              "version": "0.1.5"
-                            }
-                          }
-                        },
-                        "is-extendable": {
-                          "version": "0.1.1"
-                        }
-                      }
-                    },
-                    "parse-glob": {
-                      "version": "3.0.4",
-                      "dependencies": {
-                        "glob-base": {
-                          "version": "0.3.0"
-                        },
-                        "is-dotfile": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    },
-                    "regex-cache": {
-                      "version": "0.4.2",
-                      "dependencies": {
-                        "is-equal-shallow": {
-                          "version": "0.1.3"
-                        },
-                        "is-primitive": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "async-each": {
-              "version": "1.0.0"
-            },
-            "fsevents": {
-              "version": "1.0.9",
-              "dependencies": {
-                "node-pre-gyp": {
-                  "version": "0.6.24",
-                  "dependencies": {
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8"
-                        }
-                      }
-                    },
-                    "nopt": {
-                      "version": "3.0.6",
-                      "dependencies": {
-                        "abbrev": {
-                          "version": "1.0.7"
-                        }
-                      }
-                    },
-                    "npmlog": {
-                      "version": "2.0.3",
-                      "dependencies": {
-                        "ansi": {
-                          "version": "0.3.1"
-                        },
-                        "are-we-there-yet": {
-                          "version": "1.1.2",
-                          "dependencies": {
-                            "delegates": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        },
-                        "gauge": {
-                          "version": "1.2.7",
-                          "dependencies": {
-                            "has-unicode": {
-                              "version": "2.0.0"
-                            },
-                            "lodash.pad": {
-                              "version": "4.1.0",
-                              "dependencies": {
-                                "lodash.repeat": {
-                                  "version": "4.0.0"
-                                },
-                                "lodash.tostring": {
-                                  "version": "4.1.2"
-                                }
-                              }
-                            },
-                            "lodash.padend": {
-                              "version": "4.2.0"
-                            },
-                            "lodash.padstart": {
-                              "version": "4.2.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.1.6",
-                      "dependencies": {
-                        "deep-extend": {
-                          "version": "0.4.1"
-                        },
-                        "ini": {
-                          "version": "1.3.4"
-                        },
-                        "minimist": {
-                          "version": "1.2.0"
-                        },
-                        "strip-json-comments": {
-                          "version": "1.0.4"
-                        }
-                      }
-                    },
-                    "request": {
-                      "version": "2.69.0",
-                      "dependencies": {
-                        "aws-sign2": {
-                          "version": "0.6.0"
-                        },
-                        "aws4": {
-                          "version": "1.3.2",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "4.0.0",
-                              "dependencies": {
-                                "pseudomap": {
-                                  "version": "1.0.2"
-                                },
-                                "yallist": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "bl": {
-                          "version": "1.0.3"
-                        },
-                        "caseless": {
-                          "version": "0.11.0"
-                        },
-                        "combined-stream": {
-                          "version": "1.0.5",
-                          "dependencies": {
-                            "delayed-stream": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        },
-                        "extend": {
-                          "version": "3.0.0"
-                        },
-                        "forever-agent": {
-                          "version": "0.6.1"
-                        },
-                        "form-data": {
-                          "version": "1.0.0-rc4",
-                          "dependencies": {
-                            "async": {
-                              "version": "1.5.2"
-                            }
-                          }
-                        },
-                        "har-validator": {
-                          "version": "2.0.6",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.1",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.0",
-                                  "dependencies": {
-                                    "color-convert": {
-                                      "version": "1.0.0"
-                                    }
-                                  }
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1"
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            },
-                            "commander": {
-                              "version": "2.9.0",
-                              "dependencies": {
-                                "graceful-readlink": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "is-my-json-valid": {
-                              "version": "2.13.1",
-                              "dependencies": {
-                                "generate-function": {
-                                  "version": "2.0.0"
-                                },
-                                "generate-object-property": {
-                                  "version": "1.2.0",
-                                  "dependencies": {
-                                    "is-property": {
-                                      "version": "1.0.2"
-                                    }
-                                  }
-                                },
-                                "jsonpointer": {
-                                  "version": "2.0.0"
-                                },
-                                "xtend": {
-                                  "version": "4.0.1"
-                                }
-                              }
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.0",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "hawk": {
-                          "version": "3.1.3",
-                          "dependencies": {
-                            "boom": {
-                              "version": "2.10.1"
-                            },
-                            "cryptiles": {
-                              "version": "2.0.5"
-                            },
-                            "hoek": {
-                              "version": "2.16.3"
-                            },
-                            "sntp": {
-                              "version": "1.0.9"
-                            }
-                          }
-                        },
-                        "http-signature": {
-                          "version": "1.1.1",
-                          "dependencies": {
-                            "assert-plus": {
-                              "version": "0.2.0"
-                            },
-                            "jsprim": {
-                              "version": "1.2.2",
-                              "dependencies": {
-                                "extsprintf": {
-                                  "version": "1.0.2"
-                                },
-                                "json-schema": {
-                                  "version": "0.2.2"
-                                },
-                                "verror": {
-                                  "version": "1.3.6"
-                                }
-                              }
-                            },
-                            "sshpk": {
-                              "version": "1.7.4",
-                              "dependencies": {
-                                "asn1": {
-                                  "version": "0.2.3"
-                                },
-                                "dashdash": {
-                                  "version": "1.13.0",
-                                  "dependencies": {
-                                    "assert-plus": {
-                                      "version": "1.0.0"
-                                    }
-                                  }
-                                },
-                                "ecc-jsbn": {
-                                  "version": "0.1.1"
-                                },
-                                "jodid25519": {
-                                  "version": "1.0.2"
-                                },
-                                "jsbn": {
-                                  "version": "0.1.0"
-                                },
-                                "tweetnacl": {
-                                  "version": "0.14.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "is-typedarray": {
-                          "version": "1.0.0"
-                        },
-                        "isstream": {
-                          "version": "0.1.2"
-                        },
-                        "json-stringify-safe": {
-                          "version": "5.0.1"
-                        },
-                        "mime-types": {
-                          "version": "2.1.10",
-                          "dependencies": {
-                            "mime-db": {
-                              "version": "1.22.0"
-                            }
-                          }
-                        },
-                        "node-uuid": {
-                          "version": "1.4.7"
-                        },
-                        "oauth-sign": {
-                          "version": "0.8.1"
-                        },
-                        "qs": {
-                          "version": "6.0.2"
-                        },
-                        "stringstream": {
-                          "version": "0.0.5"
-                        },
-                        "tough-cookie": {
-                          "version": "2.2.2"
-                        },
-                        "tunnel-agent": {
-                          "version": "0.4.2"
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.5.2",
-                      "dependencies": {
-                        "glob": {
-                          "version": "7.0.3",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            },
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.3",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.3.0"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "semver": {
-                      "version": "5.1.0"
-                    },
-                    "tar": {
-                      "version": "2.2.1",
-                      "dependencies": {
-                        "block-stream": {
-                          "version": "0.0.8"
-                        },
-                        "fstream": {
-                          "version": "1.0.8",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.3"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        }
-                      }
-                    },
-                    "tar-pack": {
-                      "version": "3.1.3",
-                      "dependencies": {
-                        "debug": {
-                          "version": "2.2.0",
-                          "dependencies": {
-                            "ms": {
-                              "version": "0.7.1"
-                            }
-                          }
-                        },
-                        "fstream-ignore": {
-                          "version": "1.0.3",
-                          "dependencies": {
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.3",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.3.0"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.3",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "readable-stream": {
-                          "version": "2.0.6",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2"
-                            },
-                            "isarray": {
-                              "version": "1.0.0"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.6"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        },
-                        "uid-number": {
-                          "version": "0.0.6"
-                        }
-                      }
-                    }
-                  }
-                },
-                "nan": {
-                  "version": "2.2.0"
-                }
-              }
-            },
-            "glob-parent": {
-              "version": "2.0.0"
-            },
-            "is-binary-path": {
-              "version": "1.0.1",
-              "dependencies": {
-                "binary-extensions": {
-                  "version": "1.4.0"
-                }
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "dependencies": {
-                "is-extglob": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0"
-            },
-            "readdirp": {
-              "version": "2.0.0",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.3"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "isarray": {
-                      "version": "1.0.0"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "globby": {
-          "version": "3.0.1",
-          "dependencies": {
-            "array-union": {
-              "version": "1.0.1",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2"
-                }
-              }
-            },
-            "arrify": {
-              "version": "1.0.1"
-            },
-            "glob": {
-              "version": "5.0.15",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.0.1"
-            },
-            "pify": {
-              "version": "2.3.0"
-            },
-            "pinkie-promise": {
-              "version": "1.0.0",
-              "dependencies": {
-                "pinkie": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "neo-async": {
-          "version": "1.8.0"
-        },
-        "read-file-stdin": {
-          "version": "0.2.1",
-          "dependencies": {
-            "gather-stream": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.1.7"
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "dependencies": {
-            "camelcase": {
-              "version": "2.1.1"
-            },
-            "cliui": {
-              "version": "3.1.1",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    }
-                  }
-                },
-                "wrap-ansi": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.2.0"
-            },
-            "os-locale": {
-              "version": "1.4.0",
-              "dependencies": {
-                "lcid": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "invert-kv": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "window-size": {
-              "version": "0.1.4"
-            },
-            "y18n": {
-              "version": "3.2.1"
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
#4342 rebuilt shrinkwrap with npm3, which seems to be failing local dev for those of us still on npm2, which matches production. This rebuilds `npm-shrinkwrap` entirely using shonkwrap on npm@2.14.12

