### PR TITLE
Sites: fix site selection in mobile

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -76,7 +76,7 @@ export default React.createClass( {
 		}
 
 		// ignore mouse events as the default page() click event will handle navigation
-		if ( this.props.siteBasePath && ( ! ( event.type === 'mouseup' || event.type === 'touchend' ) ) ) {
+		if ( this.props.siteBasePath && ( ! ( event.type === 'mouseup' ) ) ) {
 			page( event.currentTarget.pathname );
 		}
 	},


### PR DESCRIPTION
This fixes #4362, where we were unable to select a site on any mobile device.

## Testing Instructions
- Have more than one site
- Navigate to calypso.localhost:3000 on any mobile device (devtool emulation works here too)
- Touch 'My Sites'
- Click on 'Switch Sites'
- Select a different site
Expected: We should be able to switch to that site.

cc @blowery @matias @aduth @designsimply