### PR TITLE
Reader & Site Selector: Teach Site Selector that hosts can handle selection

### DIFF
--- a/client/reader/share/index.jsx
+++ b/client/reader/share/index.jsx
@@ -90,6 +90,17 @@ const ReaderShare = React.createClass( {
 		}
 	},
 
+	_deferMenuChange( showing ) {
+		if ( this._closeHandle ) {
+			clearTimeout( this._closeHandle );
+		}
+
+		this._closeHandle = defer( () => {
+			this._closeHandle = null;
+			this.setState( { showingMenu: showing } );
+		} );
+	},
+
 	toggle( event ) {
 		event.preventDefault();
 		if ( ! this.state.showingMenu ) {
@@ -100,9 +111,7 @@ const ReaderShare = React.createClass( {
 				target
 			} );
 		}
-		this._closeHandle = defer( () => {
-			this.setState( { showingMenu: ! this.state.showingMenu } );
-		} );
+		this._deferMenuChange( ! this.state.showingMenu );
 	},
 
 	killClick( event ) {
@@ -113,16 +122,17 @@ const ReaderShare = React.createClass( {
 		// have to defer this to let the mouseup / click escape.
 		// If we don't defer and remove the DOM node on this turn of the event loop,
 		// Chrome (at least) will not fire the click
-		this._closeHandle = defer( () => {
-			this.setState( { showingMenu: false } );
-		} );
+		if ( this.isMounted() ) {
+			this._deferMenuChange( false );
+		}
 	},
 
-	pickSiteToShareTo( slug, event ) {
+	pickSiteToShareTo( slug ) {
 		stats.recordAction( 'share_wordpress' );
 		stats.recordGaEvent( 'Clicked on Share to WordPress' );
 		stats.recordTrack( 'calypso_reader_share_to_site' );
 		page( `/post/${slug}?` + buildQuerystringForPost( this.props.post ) );
+		return true;
 	},
 
 	closeExternalShareMenu( action ) {


### PR DESCRIPTION
This is a pain.

We're using `onTouchTap` to handle site-selector clicks and touches. This fires on `mouseup` on non-touch devices, and on `touchend` on touch devices. We preventDefault in both cases.

preventDefault on `mouseup` doesn't actually do anything
preventDefault on `touchend` prevents the click from happening

So the current code is hitting the anchor's URL on touch devices as a fallback, to compensate for preventing the touchend.

This patch gives the site-selector a new way of determining if a host handled the click. If the host returns a truthy value from `onSiteSelect`, the site selector will not call into `page`, assuming that the host did whatever was necessary.

This also cleans up how we defer closing the menu a bit.

To Test:
1. Pull up the Reader
2. Find a post you like, Click Share, pick a WP site
3. Get taken to the editor, notice the title is filled out

Do this both for touch and normal browsers. On prod, it will "work" on touch devices, but the title will not be filled out.