### PR TITLE
Editor: Use a back button link all the time

### DIFF
--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import get from 'lodash/get';
 import { translate } from 'lib/mixins/i18n';
-import noop from 'lodash/noop';
 import page from 'page';
 
 /**
@@ -30,20 +29,10 @@ function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts
 		'is-drafts-visible': showDrafts,
 		'is-loading': isCustomPostType && ! type
 	} );
-	const useBackButton = page.len > 0;
-	let closeLabel;
-	if ( useBackButton ) {
-		closeLabel = translate( 'Back' );
-	} else {
-		switch ( typeSlug ) {
-			case 'post': closeLabel = translate( 'Posts' ); break;
-			case 'page': closeLabel = translate( 'Pages' ); break;
-			default: closeLabel = get( type, 'labels.menu_name' ) || translate( 'Loading…' );
-		}
-	}
-	const closeButtonAction = useBackButton ? page.back : noop;
-	const closeButtonUrl = useBackButton ? '' : allPostsUrl;
-	const closeButtonAriaLabel = useBackButton ? translate( 'Go back' ) : translate( 'View list of posts' );
+	const closeLabel = translate( 'Back' );
+	const closeButtonAction = page.back.bind( page, allPostsUrl );
+	const closeButtonUrl = '';
+	const closeButtonAriaLabel = translate( 'Go back' );
 
 	return (
 		<div className={ className }>


### PR DESCRIPTION
We can't use page.len reliably because the header renders _before_ page.len has updated when going from the first page to the second page of the app. That is, the following sequence results in  when rendering the sidebar header:

1. Load /
2. Pick a post, click Share, pick a site
3. Editor renders, sidebar renders

This is because we kick off the editor render as part of the page route handling, before it's had a chance to update.

This also piggy-backs on an "odd" `page.back` behavior. If you pass it a URL, it'll only use that URL if there's no in-app history available. It's used here to default the back button to load My Posts for the selected site. We can't update the label though, because the render happens before `page.len` updates, but the click handler happens after.

Another solution would be to watch `page.len`, but `page` doesn't offer an event to watch to determine when routes change. We might be able to hook into the `page-notifier` and update that way...

Fixes #4370, screenshots there