### PR TITLE
Editor: Remove toolbar left and right borders when floating

### DIFF
--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -42,6 +42,8 @@
 		&:after {
 			position: fixed;
 				top: 47px;
+            border-left-width: 0px;
+            border-right-width: 0px;
 		}
 
 		& > .mce-toolbar-grp {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -42,8 +42,8 @@
 		&:after {
 			position: fixed;
 				top: 47px;
-            border-left-width: 0px;
-            border-right-width: 0px;
+			border-left-width: 0px;
+			border-right-width: 0px;
 		}
 
 		& > .mce-toolbar-grp {


### PR DESCRIPTION
<img width="429" alt="screen shot 2016-03-29 at 2 19 40 pm" src="https://cloud.githubusercontent.com/assets/12471122/14099576/4ec927de-f5b9-11e5-8b84-e693b0cede6f.png">