### PR TITLE
Upgrades: Pass nudge feature to plans

### DIFF
--- a/client/my-sites/upgrade-nudge/docs/example.jsx
+++ b/client/my-sites/upgrade-nudge/docs/example.jsx
@@ -19,7 +19,9 @@ export default React.createClass( {
 					<a href="/devdocs/app-components/upgrade-nudge">Upgrade Nudges</a>
 				</h2>
 				<div>
-					<UpgradeNudge />
+					<UpgradeNudge 
+						feature="domain"
+					/>
 				</div>
 				<div>
 					<UpgradeNudge

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -26,7 +26,14 @@ export default React.createClass( {
 		icon: React.PropTypes.string,
 		event: React.PropTypes.string,
 		href: React.PropTypes.string,
-		jetpack: React.PropTypes.bool
+		jetpack: React.PropTypes.bool,
+		feature: React.PropTypes.oneOf( [
+			false,
+			'google-analytics',
+			'domain',
+			'premium-theme',
+			'custom-css'
+		] ),
 	},
 
 	getDefaultProps() {
@@ -35,17 +42,28 @@ export default React.createClass( {
 			message: 'And get your own domain address.',
 			icon: 'star',
 			event: null,
-			jetpack: false
+			jetpack: false,
+			feature: false
 		}
 	},
 
 	handleClick() {
 		if ( this.props.event ) {
 			analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
-				cta_name: this.props.event
+				cta_name: this.props.event,
+				cta_feature: this.props.feature
 			} );
 		}
 		this.props.onClick();
+	},
+
+	componentDidMount() {
+		if ( this.props.event ) {
+			analytics.tracks.recordEvent( 'calypso_upgrade_nudge_impression', {
+				cta_name: this.props.event,
+				cta_feature: this.props.feature
+			} );
+		}
 	},
 
 	render() {
@@ -63,6 +81,10 @@ export default React.createClass( {
 
 		if ( ! this.props.href && site ) {
 			href = '/plans/' + site.slug;
+
+			if ( this.props.feature ) {
+				href += '?feature=' + this.props.feature
+			}
 		}
 
 		return (


### PR DESCRIPTION
Passes "feature" to /plans in order to call out specific feature that user was nudged about
This is needed to implement #4308 

Also: it tracks impressions

CC @mtias @rralian @adambbecker