### PR TITLE
Plans: Update my-sites/plans module to ECMAScript 6

### DIFF
--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -68,8 +68,7 @@ module.exports = React.createClass( {
 			<WpcomPlanPrice
 				getPrice={ this.getPrice }
 				hasDiscount={ hasDiscount }
-				periodLabel={ periodLabel }
-				plan={ plan } />
+				periodLabel={ periodLabel } />
 		);
 	}
 } );

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -1,21 +1,24 @@
 /**
  * External Dependencies
  */
-var page = require( 'page' ),
-	React = require( 'react' ),
-	ReactDom = require( 'react-dom' );
+import page from 'page';
+import React from 'react';
+import ReactDom from 'react-dom';
 
 /**
  * Internal Dependencies
  */
-var analytics = require( 'analytics' ),
-	config = require( 'config' ),
-	i18n = require( 'lib/mixins/i18n' ),
-	plans = require( 'lib/plans-list' )(),
-	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
-	route = require( 'lib/route' ),
-	sites = require( 'lib/sites-list' )(),
-	titleActions = require( 'lib/screen-title/actions' );
+import analytics from 'analytics';
+import config from 'config';
+import i18n from 'lib/mixins/i18n';
+import plansFactory from 'lib/plans-list';
+import { renderWithReduxStore } from 'lib/react-helpers';
+import route from 'lib/route';
+import sitesFactory from 'lib/sites-list';
+import titleActions from 'lib/screen-title/actions';
+
+const plans = plansFactory();
+const sites = sitesFactory();
 
 export default {
 	plans: function( context ) {

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -22,14 +22,14 @@ const sites = sitesFactory();
 
 export default {
 	plans: function( context ) {
-		var Plans = require( 'my-sites/plans/main' ),
+		const Plans = require( 'my-sites/plans/main' ),
 			CheckoutData = require( 'components/data/checkout' ),
 			MainComponent = require( 'components/main' ),
 			EmptyContentComponent = require( 'components/empty-content' ),
 			site = sites.getSelectedSite(),
 			analyticsPageTitle = 'Plans',
-			basePath = route.sectionify( context.path ),
-			analyticsBasePath;
+			basePath = route.sectionify( context.path );
+		var analyticsBasePath;
 
 		// Don't show plans for Jetpack sites
 		if ( site && site.jetpack && ! config.isEnabled( 'manage/jetpack-plans' ) ) {
@@ -77,15 +77,15 @@ export default {
 	},
 
 	plansCompare: function( context ) {
-		var PlansCompare = require( 'components/plans/plans-compare' ),
+		const PlansCompare = require( 'components/plans/plans-compare' ),
 			Main = require( 'components/main' ),
 			CheckoutData = require( 'components/data/checkout' ),
 			features = require( 'lib/features-list' )(),
 			productsList = require( 'lib/products-list' )(),
 			analyticsPageTitle = 'Plans > Compare',
 			site = sites.getSelectedSite(),
-			basePath = route.sectionify( context.path ),
-			baseAnalyticsPath;
+			basePath = route.sectionify( context.path );
+		var baseAnalyticsPath;
 
 		if ( site && ! site.isUpgradeable() ) {
 			return page.redirect( '/plans/compare' );

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -2,23 +2,22 @@
  * External Dependencies
  */
 var page = require( 'page' ),
-	ReactDom = require( 'react-dom' ),
-	React = require( 'react' );
+	React = require( 'react' ),
+	ReactDom = require( 'react-dom' );
 
 /**
  * Internal Dependencies
  */
-var sites = require( 'lib/sites-list' )(),
-	route = require( 'lib/route' ),
-	i18n = require( 'lib/mixins/i18n' ),
-	analytics = require( 'analytics' ),
-	plans = require( 'lib/plans-list' )(),
+var analytics = require( 'analytics' ),
 	config = require( 'config' ),
+	i18n = require( 'lib/mixins/i18n' ),
+	plans = require( 'lib/plans-list' )(),
 	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
+	route = require( 'lib/route' ),
+	sites = require( 'lib/sites-list' )(),
 	titleActions = require( 'lib/screen-title/actions' );
 
 module.exports = {
-
 	plans: function( context ) {
 		var Plans = require( 'my-sites/plans/main' ),
 			CheckoutData = require( 'components/data/checkout' ),

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -29,7 +29,7 @@ export default {
 			site = sites.getSelectedSite(),
 			analyticsPageTitle = 'Plans',
 			basePath = route.sectionify( context.path );
-		var analyticsBasePath;
+		let analyticsBasePath;
 
 		// Don't show plans for Jetpack sites
 		if ( site && site.jetpack && ! config.isEnabled( 'manage/jetpack-plans' ) ) {
@@ -85,7 +85,7 @@ export default {
 			analyticsPageTitle = 'Plans > Compare',
 			site = sites.getSelectedSite(),
 			basePath = route.sectionify( context.path );
-		var baseAnalyticsPath;
+		let baseAnalyticsPath;
 
 		if ( site && ! site.isUpgradeable() ) {
 			return page.redirect( '/plans/compare' );

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -17,7 +17,7 @@ var analytics = require( 'analytics' ),
 	sites = require( 'lib/sites-list' )(),
 	titleActions = require( 'lib/screen-title/actions' );
 
-module.exports = {
+export default {
 	plans: function( context ) {
 		var Plans = require( 'my-sites/plans/main' ),
 			CheckoutData = require( 'components/data/checkout' ),

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -21,7 +21,7 @@ const plans = plansFactory();
 const sites = sitesFactory();
 
 export default {
-	plans: function( context ) {
+	plans( context ) {
 		const Plans = require( 'my-sites/plans/main' ),
 			CheckoutData = require( 'components/data/checkout' ),
 			MainComponent = require( 'components/main' ),
@@ -76,7 +76,7 @@ export default {
 		);
 	},
 
-	plansCompare: function( context ) {
+	plansCompare( context ) {
 		const PlansCompare = require( 'components/plans/plans-compare' ),
 			Main = require( 'components/main' ),
 			CheckoutData = require( 'components/data/checkout' ),
@@ -118,7 +118,7 @@ export default {
 		);
 	},
 
-	redirectToCheckout: function( context ) {
+	redirectToCheckout( context ) {
 		// this route is deprecated, use `/checkout/:site/:plan` to link to plan checkout
 		page.redirect( `/checkout/${ context.params.domain }/${ context.params.plan }` );
 	}

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -12,7 +12,7 @@ var adTracking = require( 'analytics/ad-tracking' ),
 	paths = require( './paths' ),
 	plansController = require( './controller' );
 
-module.exports = function() {
+export default function() {
 	if ( config.isEnabled( 'manage/plans' ) ) {
 		page(
 			'/plans',

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -1,29 +1,29 @@
 /**
  * External dependencies
  */
-var page = require( 'page' );
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-var adTracking = require( 'analytics/ad-tracking' ),
-	config = require( 'config' ),
-	controller = require( 'my-sites/controller' ),
-	paths = require( './paths' ),
-	plansController = require( './controller' );
+import config from 'config';
+import controller from 'my-sites/controller';
+import paths from './paths';
+import plansController from './controller';
+import { retarget } from 'analytics/ad-tracking';
 
 export default function() {
 	if ( config.isEnabled( 'manage/plans' ) ) {
 		page(
 			'/plans',
-			adTracking.retarget,
+			retarget,
 			controller.siteSelection,
 			controller.sites
 		);
 
 		page(
 			'/plans/compare',
-			adTracking.retarget,
+			retarget,
 			controller.siteSelection,
 			controller.navigation,
 			plansController.plansCompare
@@ -31,7 +31,7 @@ export default function() {
 
 		page(
 			'/plans/compare/:domain',
-			adTracking.retarget,
+			retarget,
 			controller.siteSelection,
 			controller.navigation,
 			plansController.plansCompare
@@ -39,14 +39,14 @@ export default function() {
 
 		page(
 			'/plans/select/:plan/:domain',
-			adTracking.retarget,
+			retarget,
 			controller.siteSelection,
 			plansController.redirectToCheckout
 		);
 
 		page(
 			paths.plansDestination(),
-			adTracking.retarget,
+			retarget,
 			controller.siteSelection,
 			controller.navigation,
 			plansController.plans

--- a/client/my-sites/plans/jetpack-plan-details/index.jsx
+++ b/client/my-sites/plans/jetpack-plan-details/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 const JetpackPlanDetails = React.createClass( {
-	render: function() {
+	render() {
 		return (
 			<div>
 				<p>{ this.props.plan.description }</p>

--- a/client/my-sites/plans/jetpack-plan-details/index.jsx
+++ b/client/my-sites/plans/jetpack-plan-details/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 const JetpackPlanDetails = React.createClass( {
 	render: function() {

--- a/client/my-sites/plans/jetpack-plan-details/index.jsx
+++ b/client/my-sites/plans/jetpack-plan-details/index.jsx
@@ -3,23 +3,22 @@
  */
 import React from 'react';
 
-const JetpackPlanDetails = React.createClass( {
-	propTypes: {
-		plan: React.PropTypes.object.isRequired
-	},
-	
-	render() {
-		return (
-			<div>
-				<p>{ this.props.plan.description }</p>
-				<ul>
-					<li>{ this.props.plan.feature_1 }</li>
-					<li>{ this.props.plan.feature_2 }</li>
-					<li>{ this.props.plan.feature_3 }</li>
-				</ul>
-			</div>
-		);
-	}
-} );
+const JetpackPlanDetails = ( { plan } ) => {
+	return (
+		<div>
+			<p>{ plan.description }</p>
+
+			<ul>
+				<li>{ plan.feature_1 }</li>
+				<li>{ plan.feature_2 }</li>
+				<li>{ plan.feature_3 }</li>
+			</ul>
+		</div>
+	);
+};
+
+JetpackPlanDetails.propTypes = {
+	plan: React.PropTypes.object.isRequired
+};
 
 export default JetpackPlanDetails;

--- a/client/my-sites/plans/jetpack-plan-details/index.jsx
+++ b/client/my-sites/plans/jetpack-plan-details/index.jsx
@@ -3,9 +3,7 @@
  */
 var React = require( 'react' );
 
-module.exports = React.createClass( {
-	displayName: 'JetpackPlanDetails',
-
+const JetpackPlanDetails = React.createClass( {
 	render: function() {
 		return (
 			<div>
@@ -19,3 +17,5 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default JetpackPlanDetails;

--- a/client/my-sites/plans/jetpack-plan-details/index.jsx
+++ b/client/my-sites/plans/jetpack-plan-details/index.jsx
@@ -4,6 +4,10 @@
 import React from 'react';
 
 const JetpackPlanDetails = React.createClass( {
+	propTypes: {
+		plan: React.PropTypes.object.isRequired
+	},
+	
 	render() {
 		return (
 			<div>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -157,12 +157,12 @@ const Plans = React.createClass( {
 } );
 
 export default connect(
-	function mapStateToProps( state, props ) {
+	( state, props ) => {
 		return {
 			sitePlans: getPlansBySite( state, props.sites.getSelectedSite() )
 		};
 	},
-	function mapDispatchToProps( dispatch ) {
+	( dispatch ) => {
 		return {
 			fetchSitePlans( sitePlans, site ) {
 				if ( shouldFetchSitePlans( sitePlans, site ) ) {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -145,9 +145,9 @@ const Plans = React.createClass( {
 							plans={ this.props.plans.get() }
 							sitePlans={ this.props.sitePlans }
 							onOpen={ this.openPlan }
-							onSelectPlan={ this.props.onSelectPlan }
 							cart={ this.props.cart }
 							isSubmitting={ this.props.transaction.step.name === SUBMITTING_WPCOM_REQUEST } />
+
 						{ ! hasJpphpBundle && this.comparePlansLink() }
 					</div>
 				</Main>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -26,8 +26,6 @@ import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
 
 const Plans = React.createClass( {
-	displayName: 'Plans',
-
 	mixins: [ observe( 'sites', 'plans' ) ],
 
 	propTypes: {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -1,29 +1,29 @@
 /**
  * External dependencies
  */
-var connect = require( 'react-redux' ).connect,
-	page = require( 'page' ),
-	React = require( 'react' );
+import { connect } from 'react-redux';
+import page from 'page';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'analytics' ),
-	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
-	getCurrentPlan = require( 'lib/plans' ).getCurrentPlan,
-	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
-	Gridicon = require( 'components/gridicon' ),
-	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle,
-	Main = require( 'components/main' ),
-	Notice = require( 'components/notice' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	paths = require( './paths' ),
-	PlanList = require( 'components/plans/plan-list' ),
-	PlanOverview = require( './plan-overview' ),
-	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans,
-	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
-	UpgradesNavigation = require( 'my-sites/upgrades/navigation' );
+import analytics from 'analytics';
+import { fetchSitePlans } from 'state/sites/plans/actions';
+import { getCurrentPlan } from 'lib/plans';
+import { getPlansBySite } from 'state/sites/plans/selectors';
+import Gridicon from 'components/gridicon';
+import { isJpphpBundle } from 'lib/products-values';
+import Main from 'components/main';
+import Notice from 'components/notice';
+import observe from 'lib/mixins/data-observe';
+import paths from './paths';
+import PlanList from 'components/plans/plan-list' ;
+import PlanOverview from './plan-overview';
+import { shouldFetchSitePlans } from 'lib/plans';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
+import UpgradesNavigation from 'my-sites/upgrades/navigation';
 
 var Plans = React.createClass( {
 	displayName: 'Plans',
@@ -138,7 +138,7 @@ var Plans = React.createClass( {
 							onOpen={ this.openPlan }
 							onSelectPlan={ this.props.onSelectPlan }
 							cart={ this.props.cart }
-							isSubmitting={ this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST } />
+							isSubmitting={ this.props.transaction.step.name === SUBMITTING_WPCOM_REQUEST } />
 						{ ! hasJpphpBundle && this.comparePlansLink() }
 					</div>
 				</Main>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -58,9 +58,8 @@ const Plans = React.createClass( {
 
 	comparePlansLink: function() {
 		const selectedSite = this.props.sites.getSelectedSite();
-		var url = '/plans/compare';
-
-		var compareString = this.translate( 'Compare Plans' );
+		let url = '/plans/compare',
+			compareString = this.translate( 'Compare Plans' );
 
 		if ( selectedSite.jetpack ) {
 			compareString = this.translate( 'Compare Options' );
@@ -97,8 +96,8 @@ const Plans = React.createClass( {
 	},
 
 	render: function() {
-		const selectedSite = this.props.sites.getSelectedSite(); 
-		var hasJpphpBundle,
+		const selectedSite = this.props.sites.getSelectedSite();
+		let hasJpphpBundle,
 			currentPlan;
 
 		if ( this.props.sitePlans.hasLoadedFromServer ) {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -11,7 +11,6 @@ var connect = require( 'react-redux' ).connect,
 var analytics = require( 'analytics' ),
 	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
 	getCurrentPlan = require( 'lib/plans' ).getCurrentPlan,
-	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans,
 	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
 	Gridicon = require( 'components/gridicon' ),
 	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle,
@@ -21,9 +20,10 @@ var analytics = require( 'analytics' ),
 	paths = require( './paths' ),
 	PlanList = require( 'components/plans/plan-list' ),
 	PlanOverview = require( './plan-overview' ),
+	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans,
 	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	UpgradesNavigation = require( 'my-sites/upgrades/navigation' ),
-	transactionStepTypes = require( 'lib/store-transactions/step-types' );
+	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
+	UpgradesNavigation = require( 'my-sites/upgrades/navigation' );
 
 var Plans = React.createClass( {
 	displayName: 'Plans',

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -147,7 +147,7 @@ var Plans = React.createClass( {
 	}
 } );
 
-module.exports = connect(
+export default connect(
 	function mapStateToProps( state, props ) {
 		return {
 			sitePlans: getPlansBySite( state, props.sites.getSelectedSite() )

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -30,6 +30,17 @@ const Plans = React.createClass( {
 
 	mixins: [ observe( 'sites', 'plans' ) ],
 
+	propTypes: {
+		cart: React.PropTypes.object.isRequired,
+		context: React.PropTypes.object.isRequired,
+		destinationType: React.PropTypes.string,
+		plans: React.PropTypes.object.isRequired,
+		fetchSitePlans: React.PropTypes.func.isRequired,
+		sites: React.PropTypes.object.isRequired,
+		sitePlans: React.PropTypes.object.isRequired,
+		transaction: React.PropTypes.object.isRequired
+	},
+
 	getInitialState() {
 		return { openPlan: '' };
 	},

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -30,33 +30,33 @@ const Plans = React.createClass( {
 
 	mixins: [ observe( 'sites', 'plans' ) ],
 
-	getInitialState: function() {
+	getInitialState() {
 		return { openPlan: '' };
 	},
 
-	componentDidMount: function() {
+	componentDidMount() {
 		this.updateSitePlans( this.props.sitePlans );
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		this.updateSitePlans( nextProps.sitePlans );
 	},
 
-	updateSitePlans: function( sitePlans ) {
+	updateSitePlans( sitePlans ) {
 		const selectedSite = this.props.sites.getSelectedSite();
 
 		this.props.fetchSitePlans( sitePlans, selectedSite );
 	},
 
-	openPlan: function( planId ) {
+	openPlan( planId ) {
 		this.setState( { openPlan: planId === this.state.openPlan ? '' : planId } );
 	},
 
-	recordComparePlansClick: function() {
+	recordComparePlansClick() {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Compare Plans Link' );
 	},
 
-	comparePlansLink: function() {
+	comparePlansLink() {
 		const selectedSite = this.props.sites.getSelectedSite();
 		let url = '/plans/compare',
 			compareString = this.translate( 'Compare Plans' );
@@ -95,7 +95,7 @@ const Plans = React.createClass( {
 		}
 	},
 
-	render: function() {
+	render() {
 		const selectedSite = this.props.sites.getSelectedSite();
 		let hasJpphpBundle,
 			currentPlan;

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -25,7 +25,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
 
-var Plans = React.createClass( {
+const Plans = React.createClass( {
 	displayName: 'Plans',
 
 	mixins: [ observe( 'sites', 'plans' ) ],
@@ -43,7 +43,8 @@ var Plans = React.createClass( {
 	},
 
 	updateSitePlans: function( sitePlans ) {
-		var selectedSite = this.props.sites.getSelectedSite();
+		const selectedSite = this.props.sites.getSelectedSite();
+
 		this.props.fetchSitePlans( sitePlans, selectedSite );
 	},
 
@@ -56,8 +57,8 @@ var Plans = React.createClass( {
 	},
 
 	comparePlansLink: function() {
-		var url = '/plans/compare',
-			selectedSite = this.props.sites.getSelectedSite();
+		const selectedSite = this.props.sites.getSelectedSite();
+		var url = '/plans/compare';
 
 		var compareString = this.translate( 'Compare Plans' );
 
@@ -96,8 +97,8 @@ var Plans = React.createClass( {
 	},
 
 	render: function() {
-		var selectedSite = this.props.sites.getSelectedSite(),
-			hasJpphpBundle,
+		const selectedSite = this.props.sites.getSelectedSite(); 
+		var hasJpphpBundle,
 			currentPlan;
 
 		if ( this.props.sitePlans.hasLoadedFromServer ) {

--- a/client/my-sites/plans/plan-overview/index.jsx
+++ b/client/my-sites/plans/plan-overview/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import page from 'page';
+import React from 'react';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plans/plan-overview/index.jsx
+++ b/client/my-sites/plans/plan-overview/index.jsx
@@ -20,8 +20,8 @@ const PlanOverview = React.createClass( {
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
 		destinationType: React.PropTypes.string,
-		plan: React.PropTypes.object.isRequired,
 		path: React.PropTypes.string.isRequired,
+		plan: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.bool

--- a/client/my-sites/plans/plan-overview/plan-feature/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-feature/index.jsx
@@ -45,8 +45,8 @@ PlanFeature.propTypes = {
 		href: React.PropTypes.string.isRequired
 	} ),
 	description: React.PropTypes.string.isRequired,
-	removalMessage: React.PropTypes.string,
 	heading: React.PropTypes.string.isRequired,
+	removalMessage: React.PropTypes.string,
 	willBeRemoved: React.PropTypes.bool.isRequired
 };
 

--- a/client/my-sites/plans/plan-overview/plan-features/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-features/index.jsx
@@ -6,11 +6,11 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { isBusiness } from 'lib/products-values';
+import { isInGracePeriod } from 'lib/plans';
 import PlanFeature from '../plan-feature';
 import PlanProgress from '../plan-progress';
 import SectionHeader from 'components/section-header';
-import { isBusiness } from 'lib/products-values';
-import { isInGracePeriod } from 'lib/plans';
 
 const PlanFeatures = React.createClass( {
 	propTypes: {

--- a/client/my-sites/plans/plan-overview/plan-progress/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-progress/index.jsx
@@ -8,7 +8,12 @@ import React from 'react';
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import { getCurrentTrialPeriodInDays, getDaysUntilExpiry, getDaysUntilUserFacingExpiry, isInGracePeriod } from 'lib/plans';
+import {
+	getCurrentTrialPeriodInDays,
+	getDaysUntilExpiry,
+	getDaysUntilUserFacingExpiry,
+	isInGracePeriod
+} from 'lib/plans';
 import ProgressBar from 'components/progress-bar';
 
 const PlanProgress = React.createClass( {

--- a/client/my-sites/plans/plan-overview/plan-remove/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-remove/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import Dispatcher from 'dispatcher';
 import page from 'page';
 import React from 'react';
@@ -10,7 +11,6 @@ import React from 'react';
  */
 import { cancelSitePlanTrial } from 'state/sites/plans/actions';
 import CompactCard from 'components/card/compact';
-import { connect } from 'react-redux';
 import Dialog from 'components/dialog';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import { isInGracePeriod } from 'lib/plans';

--- a/client/my-sites/plans/plan-overview/plan-status/index.jsx
+++ b/client/my-sites/plans/plan-overview/plan-status/index.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import classNames from 'classnames';
 import page from 'page';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -14,9 +14,9 @@ import CompactCard from 'components/card/compact';
 import config from 'config';
 import Gridicon from 'components/gridicon';
 import { getDaysUntilUserFacingExpiry, isInGracePeriod } from 'lib/plans';
+import { isBusiness, isPremium } from 'lib/products-values';
 import Notice from 'components/notice';
 import PlanProgress from '../plan-progress';
-import { isPremium, isBusiness } from 'lib/products-values';
 import * as upgradesActions from 'lib/upgrades/actions';
 
 const PlanStatus = React.createClass( {

--- a/client/my-sites/plans/wpcom-plan-details/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-details/index.jsx
@@ -4,6 +4,12 @@
 import React from 'react';
 
 const WpcomPlanDetails = React.createClass( {
+	propTypes: {
+		comparePlansUrl: React.PropTypes.string.isRequired,
+		handleLearnMoreClick: React.PropTypes.func.isRequired,
+		plan: React.PropTypes.object.isRequired
+	},
+
 	render() {
 		return (
 			<div>

--- a/client/my-sites/plans/wpcom-plan-details/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-details/index.jsx
@@ -3,9 +3,7 @@
  */
 var React = require( 'react' );
 
-module.exports = React.createClass( {
-	displayName: 'WpcomPlanDetails',
-
+const WpcomPlanDetails = React.createClass( {
 	render: function() {
 		return (
 			<div>
@@ -16,3 +14,5 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default WpcomPlanDetails;

--- a/client/my-sites/plans/wpcom-plan-details/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-details/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 const WpcomPlanDetails = React.createClass( {
 	render: function() {

--- a/client/my-sites/plans/wpcom-plan-details/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-details/index.jsx
@@ -3,22 +3,29 @@
  */
 import React from 'react';
 
-const WpcomPlanDetails = React.createClass( {
-	propTypes: {
-		comparePlansUrl: React.PropTypes.string.isRequired,
-		handleLearnMoreClick: React.PropTypes.func.isRequired,
-		plan: React.PropTypes.object.isRequired
-	},
+/**
+ * Internal dependencies
+ */
+import i18n from 'lib/mixins/i18n';
 
-	render() {
-		return (
-			<div>
-				<p>{ this.props.plan.description }</p>
-				<a href={ this.props.comparePlansUrl } onClick={ this.props.handleLearnMoreClick }
-					className="plan__learn-more">{ this.translate( 'Learn more', { context: 'Find out more details about a plan' } ) }</a>
-			</div>
-		);
-	}
-} );
+const WpcomPlanDetails = ( { comparePlansUrl, handleLearnMoreClick, plan } ) => {
+	return (
+		<div>
+			<p>{ plan.description }</p>
+
+			<a href={ comparePlansUrl }
+				onClick={ handleLearnMoreClick }
+				className="plan__learn-more">
+				{ i18n.translate( 'Learn more', { context: 'Find out more details about a plan' } ) }
+			</a>
+		</div>
+	);
+};
+
+WpcomPlanDetails.propTypes = {
+	comparePlansUrl: React.PropTypes.string.isRequired,
+	handleLearnMoreClick: React.PropTypes.func.isRequired,
+	plan: React.PropTypes.object.isRequired
+};
 
 export default WpcomPlanDetails;

--- a/client/my-sites/plans/wpcom-plan-details/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-details/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 const WpcomPlanDetails = React.createClass( {
-	render: function() {
+	render() {
 		return (
 			<div>
 				<p>{ this.props.plan.description }</p>

--- a/client/my-sites/plans/wpcom-plan-price/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-price/index.jsx
@@ -4,6 +4,12 @@
 import React from 'react';
 
 const WpcomPlanPrice = React.createClass( {
+	propTypes: {
+		getPrice: React.PropTypes.func.isRequired,
+		hasDiscount: React.PropTypes.bool,
+		periodLabel: React.PropTypes.string.isRequired
+	},
+
 	render() {
 		return (
 			<div className={ this.props.hasDiscount ? "wpcom-plan-price wpcom-plan-price__discount" : "wpcom-plan-price" }>

--- a/client/my-sites/plans/wpcom-plan-price/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-price/index.jsx
@@ -3,9 +3,7 @@
  */
 var React = require( 'react' );
 
-module.exports = React.createClass( {
-	displayName: 'WpcomPlanPrice',
-
+const WpcomPlanPrice = React.createClass( {
 	render: function() {
 		return (
 			<div className={ this.props.hasDiscount ? "wpcom-plan-price wpcom-plan-price__discount" : "wpcom-plan-price" }>
@@ -17,3 +15,5 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default WpcomPlanPrice;

--- a/client/my-sites/plans/wpcom-plan-price/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-price/index.jsx
@@ -3,23 +3,22 @@
  */
 import React from 'react';
 
-const WpcomPlanPrice = React.createClass( {
-	propTypes: {
-		getPrice: React.PropTypes.func.isRequired,
-		hasDiscount: React.PropTypes.bool,
-		periodLabel: React.PropTypes.string.isRequired
-	},
+const WpcomPlanPrice = ( { getPrice, hasDiscount, periodLabel } ) => {
+	return (
+		<div className={ hasDiscount ? "wpcom-plan-price wpcom-plan-price__discount" : "wpcom-plan-price" }>
+			<span>{ getPrice() }</span>
 
-	render() {
-		return (
-			<div className={ this.props.hasDiscount ? "wpcom-plan-price wpcom-plan-price__discount" : "wpcom-plan-price" }>
-				<span>{ this.props.getPrice() }</span>
-				<small className="wpcom-plan-price__billing-period">
-					{ this.props.periodLabel }
-				</small>
-			</div>
-		);
-	}
-} );
+			<small className="wpcom-plan-price__billing-period">
+				{ periodLabel }
+			</small>
+		</div>
+	);
+};
+
+WpcomPlanPrice.propTypes = {
+	getPrice: React.PropTypes.func.isRequired,
+	hasDiscount: React.PropTypes.bool,
+	periodLabel: React.PropTypes.string.isRequired
+};
 
 export default WpcomPlanPrice;

--- a/client/my-sites/plans/wpcom-plan-price/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-price/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 const WpcomPlanPrice = React.createClass( {
-	render: function() {
+	render() {
 		return (
 			<div className={ this.props.hasDiscount ? "wpcom-plan-price wpcom-plan-price__discount" : "wpcom-plan-price" }>
 				<span>{ this.props.getPrice() }</span>

--- a/client/my-sites/plans/wpcom-plan-price/index.jsx
+++ b/client/my-sites/plans/wpcom-plan-price/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 const WpcomPlanPrice = React.createClass( {
 	render: function() {


### PR DESCRIPTION
This pull request updates the `client/my-sites/plans` section to use as many [ES6](https://github.com/Automattic/calypso-pre-oss/blob/master/docs/coding-guidelines/javascript.md#es6) features as possible. It also fixes and improves a few minor things in the process - such as missing props validation.
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/14109625/2d87a6e0-f5c3-11e5-8082-76fbb43df23c.png)


#### Additional notes
 
You should probably consider browsing commits [one by one](https://github.com/Automattic/wp-calypso/pull/4384/commits) to review this pull request since it might be easier to understand the changes rather than in the [unified diff view](https://github.com/Automattic/wp-calypso/pull/4384/files).

#### Testing instructions
 
1. Run `git checkout update/my-sites-plans-to-es6` and start your server
2. Check that the [`Plans` page](http://calypso.localhost:3000/plans) behave as before
3. Check that the [`Compare Plans` page](http://calypso.localhost:3000/plans/compare) behave as before
4. Purchase a Premium plan and check the Plans pages again
5. Execute `localStorage.setItem( 'ABTests', '{"freeTrials_20160120":"offered"}' )` in your browser's console
6. Navigate to the `Plans` page again and start a free trial
7. Check that the [`Plan Overview` page](http://calypso.localhost:3000/plans) behave as before

#### Reviews
 
- [x] Code
- [x] Product