### PR TITLE
Fix smileyproject CSS 404

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -46,7 +46,6 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
-		link(rel='stylesheet', href='//s1.wp.com/wp-content/mu-plugins/smileyproject/smileyproject.css')
 		if isRTL
 			link(rel='stylesheet', href=urls['style-rtl.css'])
 		else


### PR DESCRIPTION
We renamed the smileyproject plugin today, which made the old CSS reference 404.

Upon investigation, however, it seems the stylesheet isn't necessary at all. It was written for the frontend, to prevent CSS bleed, which is less an issue inside Calypso. Here, in fact, it would be overriding CSS styles set by Calypso itself, on the `emoji` class.