### PR TITLE
Media: Fix case where corrupt media prevents media library from displaying correctly

### DIFF
--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -39,6 +39,12 @@ var MediaUtils = {
 			return media.URL;
 		}
 
+		// We've found that some media can be corrupt with an unusable URL.
+		// Return early so attempts to parse the URL don't result in an error.
+		if ( ! media.URL ) {
+			return;
+		}
+
 		options = options || {};
 
 		if ( options.photon ) {
@@ -53,7 +59,7 @@ var MediaUtils = {
 			return media.thumbnails[ options.size ];
 		}
 
-		if ( media.URL && options.maxWidth ) {
+		if ( options.maxWidth ) {
 			return resize( media.URL, {
 				w: options.maxWidth
 			} );


### PR DESCRIPTION
This pull request seeks to resolve an issue where the media library may not load correctly if the library contains a media item with a falsey URL value. While there was a condition to check for this already in the utility function, it was performed too late to avoid an error from being thrown by the `photon` library attempting to parse the `false` URL.

__Testing instructions:__

Verify that the media library loads as expected, with or without corrupt media items.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click the media button in the editor toolbar
4. Note that media items are displayed correctly

/cc @timmyc