### PR TITLE
Stats: enable stats link in All Sites sidebar

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -109,11 +109,11 @@ module.exports = React.createClass( {
 	stats: function() {
 		var site = this.getSelectedSite();
 
-		if ( ! site.capabilities ) {
+		if ( site && ! site.capabilities ) {
 			return null;
 		}
 
-		if ( site.capabilities && ! site.capabilities.view_stats ) {
+		if ( site && site.capabilities && ! site.capabilities.view_stats ) {
 			return null;
 		}
 

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -8,7 +8,10 @@ export default React.createClass( {
 
 	propTypes: {
 		period: PropTypes.string.isRequired,
-		date: PropTypes.object.isRequired,
+		date: PropTypes.oneOfType( [
+			PropTypes.object.isRequired,
+			PropTypes.string.isRequired
+		] ),
 		summary: PropTypes.bool
 	},
 


### PR DESCRIPTION
Fixes #3708

Currently when viewing "All Sites", the link to `Stats` is no longer shown.  This branch adds a check for a `site` in the `sidebar.jsx` conditionals for the stats link - so if no `site` is active, it will still display the stats link.  Additionally a propType conflict was fixed.

__Before__
<img width="274" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/14116230/847e7576-f593-11e5-9b56-ada6a75ed31f.png">

__After__
<img width="259" alt="stats_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/14116245/97826b6e-f593-11e5-89e1-97386f1101a8.png">

__To Test__
- Click `My Sites`
- Select `All My Sites` from site selector
- Validate the Stats link appears in the All Sites sidebar

/cc @folletto