### PR TITLE
Plans: Update components/plans module to ECMAScript 6

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -1,23 +1,19 @@
 /**
  * External dependencies
  */
-var classNames = require( 'classnames' ),
-	page = require( 'page' ),
-	React = require( 'react' );
+import classNames from 'classnames';
+import page from 'page';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'analytics' ),
-	cartItems = cartValues.cartItems,
-	cartValues = require( 'lib/cart-values' ),
-	config = require( 'config' ),
-	isBusiness = productsValues.isBusiness,
-	isEnterprise = productsValues.isEnterprise,
-	isFreePlan = productsValues.isFreePlan,
-	productsValues = require( 'lib/products-values' ),
-	puchasesPaths = require( 'me/purchases/paths' ),
-	upgradesActions = require( 'lib/upgrades/actions' );
+import analytics from 'analytics';
+import { cartItems } from 'lib/cart-values';
+import config from 'config';
+import { isBusiness, isEnterprise, isFreePlan } from 'lib/products-values';
+import purchasesPaths from 'me/purchases/paths';
+import * as upgradesActions from 'lib/upgrades/actions';
 
 var PlanActions = React.createClass( {
 	propTypes: { plan: React.PropTypes.object },
@@ -195,7 +191,7 @@ var PlanActions = React.createClass( {
 	managePlanButton: function() {
 		var link;
 		if ( this.planHasCost() ) {
-			link = puchasesPaths.managePurchase( this.props.site.slug, this.props.sitePlan.id );
+			link = purchasesPaths.managePurchase( this.props.site.slug, this.props.sitePlan.id );
 			return (
 				<a href={ link } className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>
 			);

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -18,7 +18,7 @@ import * as upgradesActions from 'lib/upgrades/actions';
 const PlanActions = React.createClass( {
 	propTypes: { plan: React.PropTypes.object },
 
-	getButtons: function() {
+	getButtons() {
 		if ( this.props.isImageButton ) {
 			return this.getImageButton();
 		}
@@ -55,7 +55,7 @@ const PlanActions = React.createClass( {
 		}
 	},
 
-	getInternalButtons: function() {
+	getInternalButtons() {
 		if ( ! this.props.cart.hasLoadedFromServer || ! this.props.site ) {
 			return null;
 		}
@@ -63,7 +63,7 @@ const PlanActions = React.createClass( {
 		return this.upgradeActions();
 	},
 
-	freePlanButton: function() {
+	freePlanButton() {
 		return (
 			<div>
 				<button className="button is-primary plan-actions__upgrade-button"
@@ -75,7 +75,7 @@ const PlanActions = React.createClass( {
 		);
 	},
 
-	upgradeActions: function() {
+	upgradeActions() {
 		if ( isFreePlan( this.props.plan ) ) {
 			return this.freePlanButton();
 		}
@@ -102,19 +102,19 @@ const PlanActions = React.createClass( {
 		);
 	},
 
-	recordUpgradeNowClick: function() {
+	recordUpgradeNowClick() {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Upgrade Now Link', 'Product ID', this.props.plan.product_id );
 	},
 
-	recordUpgradeNowButton: function() {
+	recordUpgradeNowButton() {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Upgrade Now Button', 'Product ID', this.props.plan.product_id );
 	},
 
-	getCartItem: function( properties ) {
+	getCartItem( properties ) {
 		return cartItems.getItemForPlan( this.props.plan, properties );
 	},
 
-	handleSelectPlan: function( event ) {
+	handleSelectPlan( event ) {
 		event.preventDefault();
 
 		if ( this.props.isSubmitting ) {
@@ -144,7 +144,7 @@ const PlanActions = React.createClass( {
 		page( '/checkout/' + this.props.site.slug );
 	},
 
-	canSelectPlan: function() {
+	canSelectPlan() {
 		if ( ! config.isEnabled( 'upgrades/checkout' ) ) {
 			return false;
 		}
@@ -162,7 +162,7 @@ const PlanActions = React.createClass( {
 		return true;
 	},
 
-	getImageButton: function() {
+	getImageButton() {
 		const classes = classNames( 'plan-actions__illustration', this.props.plan.product_slug );
 
 		if ( ! this.canSelectPlan( this.props.plan ) ) {
@@ -176,17 +176,17 @@ const PlanActions = React.createClass( {
 		);
 	},
 
-	downgradeMessage: function() {
+	downgradeMessage() {
 		return (
 			<small className="plan-actions__trial-period">{ this.translate( 'Contact support to downgrade your plan.' ) }</small>
 		);
 	},
 
-	siteHasThisPlan: function() {
+	siteHasThisPlan() {
 		return ! this.props.isInSignup && this.props.site && this.props.site.plan.product_id === this.props.plan.product_id;
 	},
 
-	managePlanButton: function() {
+	managePlanButton() {
 		if ( this.planHasCost() ) {
 			const link = purchasesPaths.managePurchase( this.props.site.slug, this.props.sitePlan.id );
 
@@ -196,7 +196,7 @@ const PlanActions = React.createClass( {
 		}
 	},
 
-	freePlanExpiration: function() {
+	freePlanExpiration() {
 		if ( ! this.planHasCost() ) {
 			return (
 				<span className="plan-actions__plan-expiration">{ this.translate( 'Never expires', { context: 'Expiration info for free plan in /plans/' } ) }</span>
@@ -204,11 +204,11 @@ const PlanActions = React.createClass( {
 		}
 	},
 
-	recordCurrentPlanClick: function() {
+	recordCurrentPlanClick() {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Current Plan' );
 	},
 
-	getCurrentPlanHint: function() {
+	getCurrentPlanHint() {
 		return (
 			<div>
 				<span className="plan-actions__current-plan-label" onClick={ this.recordCurrentPlanClick }>
@@ -218,15 +218,15 @@ const PlanActions = React.createClass( {
 		);
 	},
 
-	planHasCost: function() {
+	planHasCost() {
 		return this.props.plan.cost > 0;
 	},
 
-	placeholder: function() {
+	placeholder() {
 		return <span className="button plan-actions__upgrade-button" />;
 	},
 
-	getContent: function() {
+	getContent() {
 		if ( this.props.isPlaceholder ) {
 			return this.placeholder();
 		}
@@ -238,7 +238,7 @@ const PlanActions = React.createClass( {
 		return this.getButtons();
 	},
 
-	render: function() {
+	render() {
 		const classes = classNames( {
 			'plan-actions': true,
 			'is-placeholder': this.props.isPlaceholder,

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -76,8 +76,6 @@ const PlanActions = React.createClass( {
 	},
 
 	upgradeActions: function() {
-		var label;
-
 		if ( isFreePlan( this.props.plan ) ) {
 			return this.freePlanButton();
 		}
@@ -86,10 +84,10 @@ const PlanActions = React.createClass( {
 			return null;
 		}
 
+		let label = this.translate( 'Upgrade Now' );
+
 		if ( this.props.sitePlan && this.props.sitePlan.freeTrial ) {
 			label = this.translate( 'Purchase Now' );
-		} else {
-			label = this.translate( 'Upgrade Now' );
 		}
 
 		return (
@@ -191,7 +189,7 @@ const PlanActions = React.createClass( {
 	managePlanButton: function() {
 		if ( this.planHasCost() ) {
 			const link = purchasesPaths.managePurchase( this.props.site.slug, this.props.sitePlan.id );
-			
+
 			return (
 				<a href={ link } className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>
 			);

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -255,4 +255,4 @@ var PlanActions = React.createClass( {
 	}
 } );
 
-module.exports = PlanActions;
+export default PlanActions;

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -154,11 +154,9 @@ const PlanActions = React.createClass( {
 				return false;
 			}
 
-			if ( this.planHasCost() && ! isBusiness( this.props.site.plan ) ) {
-				return true;
-			}
-			return false;
+			return this.planHasCost() && ! isBusiness( this.props.site.plan );
 		}
+
 		return true;
 	},
 

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -15,7 +15,7 @@ import { isBusiness, isEnterprise, isFreePlan } from 'lib/products-values';
 import purchasesPaths from 'me/purchases/paths';
 import * as upgradesActions from 'lib/upgrades/actions';
 
-var PlanActions = React.createClass( {
+const PlanActions = React.createClass( {
 	propTypes: { plan: React.PropTypes.object },
 
 	getButtons: function() {
@@ -189,9 +189,9 @@ var PlanActions = React.createClass( {
 	},
 
 	managePlanButton: function() {
-		var link;
 		if ( this.planHasCost() ) {
-			link = purchasesPaths.managePurchase( this.props.site.slug, this.props.sitePlan.id );
+			const link = purchasesPaths.managePurchase( this.props.site.slug, this.props.sitePlan.id );
+			
 			return (
 				<a href={ link } className="button plan-actions__upgrade-button">{ this.translate( 'Manage Plan', { context: 'Link to current plan from /plans/' } ) }</a>
 			);
@@ -241,7 +241,7 @@ var PlanActions = React.createClass( {
 	},
 
 	render: function() {
-		var classes = classNames( {
+		const classes = classNames( {
 			'plan-actions': true,
 			'is-placeholder': this.props.isPlaceholder,
 			'is-image-button': this.props.isImageButton

--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -1,21 +1,21 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	page = require( 'page' );
+var classNames = require( 'classnames' ),
+	page = require( 'page' ),
+	React = require( 'react' );
 
 /**
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
-	cartValues = require( 'lib/cart-values' ),
 	cartItems = cartValues.cartItems,
+	cartValues = require( 'lib/cart-values' ),
 	config = require( 'config' ),
-	productsValues = require( 'lib/products-values' ),
-	isFreePlan = productsValues.isFreePlan,
 	isBusiness = productsValues.isBusiness,
 	isEnterprise = productsValues.isEnterprise,
+	isFreePlan = productsValues.isFreePlan,
+	productsValues = require( 'lib/products-values' ),
 	puchasesPaths = require( 'me/purchases/paths' ),
 	upgradesActions = require( 'lib/upgrades/actions' );
 

--- a/client/components/plans/plan-discount-message/index.jsx
+++ b/client/components/plans/plan-discount-message/index.jsx
@@ -8,9 +8,7 @@ import React from 'react';
  */
 import { isBusiness, isPremium } from 'lib/products-values';
 
-module.exports = React.createClass( {
-	displayName: 'PlanDiscountMessage',
-
+var PlanDiscountMessage = React.createClass( {
 	showMostPopularMessage: function() {
 		return (
 			this.props.showMostPopularMessage &&
@@ -48,3 +46,5 @@ module.exports = React.createClass( {
 		return false;
 	}
 } );
+
+export default PlanDiscountMessage;

--- a/client/components/plans/plan-discount-message/index.jsx
+++ b/client/components/plans/plan-discount-message/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
  */
 import { isBusiness, isPremium } from 'lib/products-values';
 
-var PlanDiscountMessage = React.createClass( {
+const PlanDiscountMessage = React.createClass( {
 	showMostPopularMessage: function() {
 		return (
 			this.props.showMostPopularMessage &&
@@ -18,7 +18,7 @@ var PlanDiscountMessage = React.createClass( {
 	},
 
 	mostPopularPlan: function() {
-		var hasBusiness = this.props.site && isBusiness( this.props.site.plan );
+		const hasBusiness = this.props.site && isBusiness( this.props.site.plan );
 
 		return (
 			hasBusiness ? null : <div className="plan-discount-message">{ this.translate( 'Our most popular plan' ) }</div>
@@ -30,7 +30,7 @@ var PlanDiscountMessage = React.createClass( {
 	},
 
 	planDiscountMessage: function() {
-		var message = this.translate( 'Get %(discount)s off your first year', {
+		const message = this.translate( 'Get %(discount)s off your first year', {
 			args: { discount: this.props.sitePlan.formattedDiscount }
 		} );
 

--- a/client/components/plans/plan-discount-message/index.jsx
+++ b/client/components/plans/plan-discount-message/index.jsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var productsValues = require( 'lib/products-values' );
+import { isBusiness, isPremium } from 'lib/products-values';
 
 module.exports = React.createClass( {
 	displayName: 'PlanDiscountMessage',
@@ -14,13 +14,13 @@ module.exports = React.createClass( {
 	showMostPopularMessage: function() {
 		return (
 			this.props.showMostPopularMessage &&
-			productsValues.isPremium( this.props.plan ) &&
+			isPremium( this.props.plan ) &&
 			this.props.plan.product_id !== ( this.props.site && this.props.site.plan.product_id )
 		);
 	},
 
 	mostPopularPlan: function() {
-		var hasBusiness = this.props.site && productsValues.isBusiness( this.props.site.plan );
+		var hasBusiness = this.props.site && isBusiness( this.props.site.plan );
 
 		return (
 			hasBusiness ? null : <div className="plan-discount-message">{ this.translate( 'Our most popular plan' ) }</div>

--- a/client/components/plans/plan-discount-message/index.jsx
+++ b/client/components/plans/plan-discount-message/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { isBusiness, isPremium } from 'lib/products-values';
 
 const PlanDiscountMessage = React.createClass( {
-	showMostPopularMessage: function() {
+	showMostPopularMessage() {
 		return (
 			this.props.showMostPopularMessage &&
 			isPremium( this.props.plan ) &&
@@ -17,7 +17,7 @@ const PlanDiscountMessage = React.createClass( {
 		);
 	},
 
-	mostPopularPlan: function() {
+	mostPopularPlan() {
 		const hasBusiness = this.props.site && isBusiness( this.props.site.plan );
 
 		return (
@@ -25,11 +25,11 @@ const PlanDiscountMessage = React.createClass( {
 		);
 	},
 
-	planHasDiscount: function() {
+	planHasDiscount() {
 		return this.props.sitePlan && this.props.sitePlan.rawDiscount > 0;
 	},
 
-	planDiscountMessage: function() {
+	planDiscountMessage() {
 		const message = this.translate( 'Get %(discount)s off your first year', {
 			args: { discount: this.props.sitePlan.formattedDiscount }
 		} );
@@ -39,7 +39,7 @@ const PlanDiscountMessage = React.createClass( {
 		);
 	},
 
-	render: function() {
+	render() {
 		if ( this.showMostPopularMessage() ) {
 			return this.mostPopularPlan();
 		}

--- a/client/components/plans/plan-header/index.jsx
+++ b/client/components/plans/plan-header/index.jsx
@@ -4,9 +4,9 @@
 import classNames from 'classnames';
 import React from 'react';
 
-var PlanHeader = React.createClass( {
+const PlanHeader = React.createClass( {
 	render: function() {
-		var classes = classNames( {
+		const classes = classNames( {
 			'plan-header': true,
 			'is-placeholder': this.props.isPlaceholder
 		} );

--- a/client/components/plans/plan-header/index.jsx
+++ b/client/components/plans/plan-header/index.jsx
@@ -5,6 +5,11 @@ import classNames from 'classnames';
 import React from 'react';
 
 const PlanHeader = React.createClass( {
+	propTypes: {
+		isPlaceholder: React.PropTypes.bool,
+		text: React.PropTypes.string
+	},
+
 	render() {
 		const classes = classNames( {
 			'plan-header': true,

--- a/client/components/plans/plan-header/index.jsx
+++ b/client/components/plans/plan-header/index.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import React from 'react';
 
 const PlanHeader = React.createClass( {
-	render: function() {
+	render() {
 		const classes = classNames( {
 			'plan-header': true,
 			'is-placeholder': this.props.isPlaceholder

--- a/client/components/plans/plan-header/index.jsx
+++ b/client/components/plans/plan-header/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+var classNames = require( 'classnames' ),
+	React = require( 'react' );
 
 module.exports = React.createClass( {
 	displayName: 'PlanHeader',

--- a/client/components/plans/plan-header/index.jsx
+++ b/client/components/plans/plan-header/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-var classNames = require( 'classnames' ),
-	React = require( 'react' );
+import classNames from 'classnames';
+import React from 'react';
 
 module.exports = React.createClass( {
 	displayName: 'PlanHeader',

--- a/client/components/plans/plan-header/index.jsx
+++ b/client/components/plans/plan-header/index.jsx
@@ -4,9 +4,7 @@
 import classNames from 'classnames';
 import React from 'react';
 
-module.exports = React.createClass( {
-	displayName: 'PlanHeader',
-
+var PlanHeader = React.createClass( {
 	render: function() {
 		var classes = classNames( {
 			'plan-header': true,
@@ -22,3 +20,5 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default PlanHeader;

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -38,7 +38,7 @@ const PlanList = React.createClass( {
 		}
 
 		if ( plans.length === 0 || isLoadingSitePlans ) {
-			plansList = times( numberOfPlaceholders, function( n ) {
+			plansList = times( numberOfPlaceholders, ( n ) => {
 				return (
 					<Plan
 						className={ className }
@@ -46,7 +46,7 @@ const PlanList = React.createClass( {
 						isInSignup={ this.props.isInSignup }
 						key={ `plan-${ n }` } />
 				);
-			}.bind( this ) );
+			} );
 
 			return (
 				<div className="plan-list">{ plansList }</div>
@@ -76,7 +76,7 @@ const PlanList = React.createClass( {
 		if ( plans.length > 0 ) {
 			plans = filterPlansBySiteAndProps( plans, site, this.props.hideFreePlan );
 
-			plansList = plans.map( function( plan ) {
+			plansList = plans.map( ( plan ) => {
 				return (
 					<Plan
 						plan={ plan }
@@ -92,7 +92,7 @@ const PlanList = React.createClass( {
 						cart={ this.props.cart }
 						isSubmitting={ this.props.isSubmitting } />
 				);
-			}, this );
+			} );
 		}
 
 		let aaMarkup;

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -7,12 +7,12 @@ var React = require( 'react' ),
 /**
  * Internal dependencies
  */
-var Plan = require( 'components/plans/plan' ),
+var abtest = require( 'lib/abtest' ).abtest,
 	Card = require( 'components/card' ),
-	abtest = require( 'lib/abtest' ).abtest,
-	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle,
 	filterPlansBySiteAndProps = require( 'lib/plans' ).filterPlansBySiteAndProps,
-	getCurrentPlan = require( 'lib/plans' ).getCurrentPlan;
+	getCurrentPlan = require( 'lib/plans' ).getCurrentPlan,
+	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle,
+	Plan = require( 'components/plans/plan' );
 
 module.exports = React.createClass( {
 	displayName: 'PlanList',

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -14,9 +14,7 @@ import { getCurrentPlan } from 'lib/plans';
 import { isJpphpBundle } from 'lib/products-values'
 import Plan from 'components/plans/plan';
 
-module.exports = React.createClass( {
-	displayName: 'PlanList',
-
+var PlanList = React.createClass( {
 	getInitialState: function() {
 		return { openPlan: '' };
 	},
@@ -106,3 +104,5 @@ module.exports = React.createClass( {
 		return <div className="plan-list">{ aaMarkup }</div>;
 	}
 } );
+
+export default PlanList;

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -14,7 +14,7 @@ import { getCurrentPlan } from 'lib/plans';
 import { isJpphpBundle } from 'lib/products-values'
 import Plan from 'components/plans/plan';
 
-var PlanList = React.createClass( {
+const PlanList = React.createClass( {
 	getInitialState: function() {
 		return { openPlan: '' };
 	},
@@ -24,13 +24,13 @@ var PlanList = React.createClass( {
 	},
 
 	render: function() {
+		const isLoadingSitePlans = ! this.props.isInSignup && ! this.props.sitePlans.hasLoadedFromServer,
+			site = this.props.site;
+
 		var className = '',
 			plans = this.props.plans,
-			isLoadingSitePlans = ! this.props.isInSignup && ! this.props.sitePlans.hasLoadedFromServer,
 			numberOfPlaceholders = 3,
-			site = this.props.site,
-			plansList,
-			currentPlan;
+			plansList;
 
 		if ( this.props.hideFreePlan || ( site && site.jetpack ) ) {
 			numberOfPlaceholders = 2;
@@ -56,7 +56,8 @@ var PlanList = React.createClass( {
 		if ( ! this.props.isInSignup ) {
 			// check if this site was registered via the JPPHP "Jetpack Start" program
 			// if so, we want to display a message that this plan is managed via the hosting partner
-			currentPlan = getCurrentPlan( this.props.sitePlans.data );
+			const currentPlan = getCurrentPlan( this.props.sitePlans.data );
+
 			if ( isJpphpBundle( currentPlan ) ) {
 				return (
 					<Card>

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -15,15 +15,15 @@ import { isJpphpBundle } from 'lib/products-values'
 import Plan from 'components/plans/plan';
 
 const PlanList = React.createClass( {
-	getInitialState: function() {
+	getInitialState() {
 		return { openPlan: '' };
 	},
 
-	openPlan: function( planId ) {
+	openPlan( planId ) {
 		this.setState( { openPlan: planId === this.state.openPlan ? '' : planId } );
 	},
 
-	render: function() {
+	render() {
 		const isLoadingSitePlans = ! this.props.isInSignup && ! this.props.sitePlans.hasLoadedFromServer,
 			site = this.props.site;
 

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -7,7 +7,6 @@ import times from 'lodash/times';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import Card from 'components/card';
 import { filterPlansBySiteAndProps } from 'lib/plans';
 import { getCurrentPlan } from 'lib/plans';
@@ -49,7 +48,9 @@ const PlanList = React.createClass( {
 			} );
 
 			return (
-				<div className="plan-list">{ plansList }</div>
+				<div className="plan-list">
+					{ plansList }
+				</div>
 			);
 		}
 
@@ -95,14 +96,11 @@ const PlanList = React.createClass( {
 			} );
 		}
 
-		let aaMarkup;
-		if ( abtest( 'plansPageBusinessAATest' ) === 'originalA' ) {
-			aaMarkup = plansList;
-		} else {
-			aaMarkup = plansList;
-		}
-
-		return <div className="plan-list">{ aaMarkup }</div>;
+		return (
+			<div className="plan-list">
+				{ plansList }
+			</div>
+		);
 	}
 } );
 

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -1,18 +1,18 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	times = require( 'lodash/times' );
+import React from 'react';
+import times from 'lodash/times';
 
 /**
  * Internal dependencies
  */
-var abtest = require( 'lib/abtest' ).abtest,
-	Card = require( 'components/card' ),
-	filterPlansBySiteAndProps = require( 'lib/plans' ).filterPlansBySiteAndProps,
-	getCurrentPlan = require( 'lib/plans' ).getCurrentPlan,
-	isJpphpBundle = require( 'lib/products-values' ).isJpphpBundle,
-	Plan = require( 'components/plans/plan' );
+import { abtest } from 'lib/abtest';
+import Card from 'components/card';
+import { filterPlansBySiteAndProps } from 'lib/plans';
+import { getCurrentPlan } from 'lib/plans';
+import { isJpphpBundle } from 'lib/products-values'
+import Plan from 'components/plans/plan';
 
 module.exports = React.createClass( {
 	displayName: 'PlanList',

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -27,7 +27,7 @@ const PlanList = React.createClass( {
 		const isLoadingSitePlans = ! this.props.isInSignup && ! this.props.sitePlans.hasLoadedFromServer,
 			site = this.props.site;
 
-		var className = '',
+		let className = '',
 			plans = this.props.plans,
 			numberOfPlaceholders = 3,
 			plansList;

--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	isUndefined = require( 'lodash/isUndefined' );
+var isUndefined = require( 'lodash/isUndefined' ),
+	React = require( 'react' );
 
 /**
  * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
-
 var WpcomPlanPrice = require( 'my-sites/plans/wpcom-plan-price' );
 
 module.exports = React.createClass( {

--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -11,7 +11,7 @@ import { abtest } from 'lib/abtest';
 import WpcomPlanPrice from 'my-sites/plans/wpcom-plan-price';
 
 const PlanPrice = React.createClass( {
-	getFormattedPrice: function( plan ) {
+	getFormattedPrice( plan ) {
 		let rawPrice, formattedPrice;
 
 		if ( plan ) {
@@ -35,7 +35,7 @@ const PlanPrice = React.createClass( {
 		return this.translate( 'Loading' );
 	},
 
-	getPrice: function() {
+	getPrice() {
 		const standardPrice = this.getFormattedPrice( this.props.plan ),
 			discountedPrice = this.getFormattedPrice( this.props.sitePlan );
 
@@ -46,7 +46,7 @@ const PlanPrice = React.createClass( {
 		return ( <span>{ standardPrice }</span> );
 	},
 
-	render: function() {
+	render() {
 		let periodLabel;
 		const { plan, site, sitePlan: details } = this.props,
 			hasDiscount = details && details.rawDiscount > 0;

--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { abtest } from 'lib/abtest';
 import WpcomPlanPrice from 'my-sites/plans/wpcom-plan-price';
 
-var PlanPrice = React.createClass( {
+const PlanPrice = React.createClass( {
 	getFormattedPrice: function( plan ) {
 		let rawPrice, formattedPrice;
 
@@ -36,7 +36,7 @@ var PlanPrice = React.createClass( {
 	},
 
 	getPrice: function() {
-		var standardPrice = this.getFormattedPrice( this.props.plan ),
+		const standardPrice = this.getFormattedPrice( this.props.plan ),
 			discountedPrice = this.getFormattedPrice( this.props.sitePlan );
 
 		if ( this.props.sitePlan && this.props.sitePlan.rawDiscount > 0 ) {

--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -10,9 +10,7 @@ import React from 'react';
 import { abtest } from 'lib/abtest';
 import WpcomPlanPrice from 'my-sites/plans/wpcom-plan-price';
 
-module.exports = React.createClass( {
-	displayName: 'PlanPrice',
-
+var PlanPrice = React.createClass( {
 	getFormattedPrice: function( plan ) {
 		let rawPrice, formattedPrice;
 
@@ -71,3 +69,5 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default PlanPrice;

--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -48,7 +48,7 @@ const PlanPrice = React.createClass( {
 
 	render() {
 		let periodLabel;
-		const { plan, site, sitePlan: details } = this.props,
+		const { plan, sitePlan: details } = this.props,
 			hasDiscount = details && details.rawDiscount > 0;
 
 		if ( this.props.isPlaceholder ) {

--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-var isUndefined = require( 'lodash/isUndefined' ),
-	React = require( 'react' );
+import isUndefined from 'lodash/isUndefined';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
-var WpcomPlanPrice = require( 'my-sites/plans/wpcom-plan-price' );
+import WpcomPlanPrice from 'my-sites/plans/wpcom-plan-price';
 
 module.exports = React.createClass( {
 	displayName: 'PlanPrice',

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -18,7 +18,7 @@ import PlanHeader from 'components/plans/plan-header';
 import PlanPrice from 'components/plans/plan-price';
 import WpcomPlanDetails from 'my-sites/plans/wpcom-plan-details' ;
 
-var Plan = React.createClass( {
+const Plan = React.createClass( {
 	handleLearnMoreClick: function() {
 		window.scrollTo( 0, 0 );
 		this.recordLearnMoreClick();
@@ -36,7 +36,7 @@ var Plan = React.createClass( {
 	},
 
 	getComparePlansUrl: function() {
-		var site = this.props.site,
+		const site = this.props.site,
 			siteSuffix = site ? site.slug : '';
 
 		return this.props.comparePlansUrl ? this.props.comparePlansUrl : '/plans/compare/' + siteSuffix;
@@ -92,7 +92,7 @@ var Plan = React.createClass( {
 	},
 
 	getClassNames: function() {
-		var classObject = {
+		const classObject = {
 			plan: true,
 			'is-active': this.props.open,
 			'is-current-plan': this.selectedSiteHasPlan()
@@ -156,7 +156,8 @@ var Plan = React.createClass( {
 	},
 
 	getPlanPrice: function() {
-		var isAllMySites = ! this.props.site && ! this.props.isInSignup;
+		const isAllMySites = ! this.props.site && ! this.props.isInSignup;
+
 		if ( isAllMySites ) {
 			return;
 		}

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -167,8 +167,7 @@ const Plan = React.createClass( {
 				plan={ this.props.plan }
 				isPlaceholder={ this.isPlaceholder() }
 				isInSignup={ this.props.isInSignup }
-				sitePlan={ this.getSitePlan() }
-				site={ this.props.site } />
+				sitePlan={ this.getSitePlan() } />
 		);
 	},
 

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -19,12 +19,12 @@ import PlanPrice from 'components/plans/plan-price';
 import WpcomPlanDetails from 'my-sites/plans/wpcom-plan-details' ;
 
 const Plan = React.createClass( {
-	handleLearnMoreClick: function() {
+	handleLearnMoreClick() {
 		window.scrollTo( 0, 0 );
 		this.recordLearnMoreClick();
 	},
 
-	recordLearnMoreClick: function() {
+	recordLearnMoreClick() {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Learn More Link', 'Product ID', this.props.plan.product_id );
 
 		if ( this.props.isInSignup ) {
@@ -35,14 +35,14 @@ const Plan = React.createClass( {
 		}
 	},
 
-	getComparePlansUrl: function() {
+	getComparePlansUrl() {
 		const site = this.props.site,
 			siteSuffix = site ? site.slug : '';
 
 		return this.props.comparePlansUrl ? this.props.comparePlansUrl : '/plans/compare/' + siteSuffix;
 	},
 
-	getDescription: function() {
+	getDescription() {
 		const { plan, site } = this.props;
 
 		if ( this.isPlaceholder() ) {
@@ -69,21 +69,21 @@ const Plan = React.createClass( {
 		);
 	},
 
-	showDetails: function() {
+	showDetails() {
 		if ( 'function' === typeof ( this.props.onOpen ) ) {
 			this.props.onOpen( this.props.plan.product_id );
 		}
 	},
 
-	selectedSiteHasPlan: function() {
+	selectedSiteHasPlan() {
 		return this.props.site && this.props.site.plan.product_id === this.props.plan.product_id;
 	},
 
-	isPlaceholder: function() {
+	isPlaceholder() {
 		return this.props.placeholder;
 	},
 
-	getProductSlug: function() {
+	getProductSlug() {
 		if ( this.isPlaceholder() ) {
 			return;
 		}
@@ -91,7 +91,7 @@ const Plan = React.createClass( {
 		return this.props.plan.product_slug;
 	},
 
-	getClassNames: function() {
+	getClassNames() {
 		const classObject = {
 			plan: true,
 			'is-active': this.props.open,
@@ -107,7 +107,7 @@ const Plan = React.createClass( {
 		return classNames( classObject );
 	},
 
-	getSitePlan: function() {
+	getSitePlan() {
 		if ( this.isPlaceholder() || ! this.props.site ) {
 			return;
 		}
@@ -115,7 +115,7 @@ const Plan = React.createClass( {
 		return find( this.props.sitePlans.data, { productSlug: this.getProductSlug() } );
 	},
 
-	getPlanDiscountMessage: function() {
+	getPlanDiscountMessage() {
 		if ( this.isPlaceholder() || this.props.hideDiscountMessage ) {
 			return;
 		}
@@ -129,7 +129,7 @@ const Plan = React.createClass( {
 		);
 	},
 
-	getBadge: function() {
+	getBadge() {
 		if ( this.props.site && ! this.props.site.jetpack ) {
 			if ( this.props.site.plan.product_slug === this.getProductSlug() ) {
 				return (
@@ -139,7 +139,7 @@ const Plan = React.createClass( {
 		}
 	},
 
-	getProductName: function() {
+	getProductName() {
 		if ( this.isPlaceholder() ) {
 			return;
 		}
@@ -147,7 +147,7 @@ const Plan = React.createClass( {
 		return this.props.plan.product_name_short;
 	},
 
-	getPlanTagline: function() {
+	getPlanTagline() {
 		if ( this.isPlaceholder() ) {
 			return;
 		}
@@ -155,7 +155,7 @@ const Plan = React.createClass( {
 		return this.props.plan.tagline;
 	},
 
-	getPlanPrice: function() {
+	getPlanPrice() {
 		const isAllMySites = ! this.props.site && ! this.props.isInSignup;
 
 		if ( isAllMySites ) {
@@ -172,7 +172,7 @@ const Plan = React.createClass( {
 		);
 	},
 
-	getPlanActions: function() {
+	getPlanActions() {
 		return (
 			<PlanActions
 				plan={ this.props.plan }
@@ -186,7 +186,7 @@ const Plan = React.createClass( {
 		);
 	},
 
-	getImagePlanAction: function() {
+	getImagePlanAction() {
 		return (
 			<PlanActions
 				plan={ this.props.plan }
@@ -201,7 +201,7 @@ const Plan = React.createClass( {
 		);
 	},
 
-	render: function() {
+	render() {
 		return (
 			<Card className={ this.getClassNames() } key={ this.getProductSlug() } onClick={ this.showDetails }>
 				{ this.getPlanDiscountMessage() }

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -1,21 +1,21 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
-	find = require( 'lodash/find' );
+var classNames = require( 'classnames' ),
+	find = require( 'lodash/find' ),
+	React = require( 'react' );
 
 /**
  * Internal dependencies
  */
 var analytics = require( 'analytics' ),
+	Card = require( 'components/card' ),
 	Gridicon = require( 'components/gridicon' ),
 	JetpackPlanDetails = require( 'my-sites/plans/jetpack-plan-details' ),
 	PlanActions = require( 'components/plans/plan-actions' ),
+	PlanDiscountMessage = require( 'components/plans/plan-discount-message' ),
 	PlanHeader = require( 'components/plans/plan-header' ),
 	PlanPrice = require( 'components/plans/plan-price' ),
-	PlanDiscountMessage = require( 'components/plans/plan-discount-message' ),
-	Card = require( 'components/card' ),
 	WpcomPlanDetails = require( 'my-sites/plans/wpcom-plan-details' );
 
 module.exports = React.createClass( {

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-var classNames = require( 'classnames' ),
-	find = require( 'lodash/find' ),
-	React = require( 'react' );
+import classNames from 'classnames';
+import find from 'lodash/find';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'analytics' ),
-	Card = require( 'components/card' ),
-	Gridicon = require( 'components/gridicon' ),
-	JetpackPlanDetails = require( 'my-sites/plans/jetpack-plan-details' ),
-	PlanActions = require( 'components/plans/plan-actions' ),
-	PlanDiscountMessage = require( 'components/plans/plan-discount-message' ),
-	PlanHeader = require( 'components/plans/plan-header' ),
-	PlanPrice = require( 'components/plans/plan-price' ),
-	WpcomPlanDetails = require( 'my-sites/plans/wpcom-plan-details' );
+import analytics from 'analytics';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+import JetpackPlanDetails from 'my-sites/plans/jetpack-plan-details';
+import PlanActions from 'components/plans/plan-actions';
+import PlanDiscountMessage from 'components/plans/plan-discount-message';
+import PlanHeader from 'components/plans/plan-header';
+import PlanPrice from 'components/plans/plan-price';
+import WpcomPlanDetails from 'my-sites/plans/wpcom-plan-details' ;
 
 module.exports = React.createClass( {
 	displayName: 'Plan',
@@ -127,7 +127,7 @@ module.exports = React.createClass( {
 				plan={ this.props.plan }
 				sitePlan={ this.getSitePlan() }
 				site={ this.props.site }
-				showMostPopularMessage={ true }/>
+				showMostPopularMessage={ true } />
 		);
 	},
 

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -18,9 +18,7 @@ import PlanHeader from 'components/plans/plan-header';
 import PlanPrice from 'components/plans/plan-price';
 import WpcomPlanDetails from 'my-sites/plans/wpcom-plan-details' ;
 
-module.exports = React.createClass( {
-	displayName: 'Plan',
-
+var Plan = React.createClass( {
 	handleLearnMoreClick: function() {
 		window.scrollTo( 0, 0 );
 		this.recordLearnMoreClick();
@@ -224,3 +222,5 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default Plan;

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -30,8 +30,6 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
 
 const PlansCompare = React.createClass( {
-	displayName: 'PlansCompare',
-
 	mixins: [
 		observe( 'features', 'plans' )
 	],

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -36,21 +36,21 @@ const PlansCompare = React.createClass( {
 		observe( 'features', 'plans' )
 	],
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		this.props.fetchSitePlans( nextProps.sitePlans, nextProps.selectedSite );
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return { selectedPlan: 'premium' }
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			isInSignup: false
 		};
 	},
 
-	componentDidMount: function() {
+	componentDidMount() {
 		analytics.tracks.recordEvent( 'calypso_plans_compare', {
 			is_in_signup: this.props.isInSignup
 		} );
@@ -60,11 +60,11 @@ const PlansCompare = React.createClass( {
 		}
 	},
 
-	recordViewAllPlansClick: function() {
+	recordViewAllPlansClick() {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked View All Plans' );
 	},
 
-	goBack: function() {
+	goBack() {
 		if ( this.props.backUrl ) {
 			return page( this.props.backUrl );
 		}
@@ -80,7 +80,7 @@ const PlansCompare = React.createClass( {
 		page( plansLink );
 	},
 
-	isDataLoading: function() {
+	isDataLoading() {
 		if ( ! this.props.features.get() ) {
 			return true;
 		}
@@ -100,7 +100,7 @@ const PlansCompare = React.createClass( {
 		return true;
 	},
 
-	isSelected: function( plan ) {
+	isSelected( plan ) {
 		if ( this.state.selectedPlan === 'free' ) {
 			return isFreePlan( plan );
 		}
@@ -114,7 +114,7 @@ const PlansCompare = React.createClass( {
 		}
 	},
 
-	isSubmitting: function() {
+	isSubmitting() {
 		if ( ! this.props.transaction ) {
 			return false;
 		}
@@ -122,7 +122,7 @@ const PlansCompare = React.createClass( {
 		return this.props.transaction.step.name === SUBMITTING_WPCOM_REQUEST
 	},
 
-	getColumnCount: function() {
+	getColumnCount() {
 		if ( ! this.props.selectedSite ) {
 			return 4;
 		}
@@ -130,7 +130,7 @@ const PlansCompare = React.createClass( {
 		return this.props.selectedSite.jetpack ? 3 : 4;
 	},
 
-	getFeatures: function() {
+	getFeatures() {
 		const plans = this.getPlans();
 
 		return this.props.features.get().filter( function( feature ) {
@@ -140,7 +140,7 @@ const PlansCompare = React.createClass( {
 		} );
 	},
 
-	getPlans: function() {
+	getPlans() {
 		return filterPlansBySiteAndProps(
 			this.props.plans.get(),
 			this.props.selectedSite,
@@ -148,13 +148,13 @@ const PlansCompare = React.createClass( {
 		);
 	},
 
-	getSitePlan: function( plan ) {
+	getSitePlan( plan ) {
 		return this.props.sitePlans && this.props.sitePlans.hasLoadedFromServer
 			? find( this.props.sitePlans.data, { productSlug: plan.product_slug } )
 			: undefined;
 	},
 
-	getTableHeader: function() {
+	getTableHeader() {
 		let planElements;
 
 		if ( this.isDataLoading() ) {
@@ -210,7 +210,7 @@ const PlansCompare = React.createClass( {
 		);
 	},
 
-	getTableFeatureRows: function() {
+	getTableFeatureRows() {
 		let rows;
 
 		if ( this.isDataLoading() ) {
@@ -284,7 +284,7 @@ const PlansCompare = React.createClass( {
 		return rows;
 	},
 
-	getTableActionRow: function() {
+	getTableActionRow() {
 		if ( this.isDataLoading() ) {
 			return null;
 		}
@@ -318,7 +318,7 @@ const PlansCompare = React.createClass( {
 		);
 	},
 
-	comparisonTable: function() {
+	comparisonTable() {
 		return (
 			<table className="plans-compare__table">
 				<thead>
@@ -332,7 +332,7 @@ const PlansCompare = React.createClass( {
 		);
 	},
 
-	setPlan: function( name ) {
+	setPlan( name ) {
 		this.setState( { selectedPlan: name } );
 	},
 
@@ -376,7 +376,7 @@ const PlansCompare = React.createClass( {
 		);
 	},
 
-	render: function() {
+	render() {
 		const classes = classNames( this.props.className, 'plans-compare', {
 				'is-placeholder': this.isDataLoading(),
 				'is-jetpack-site': this.props.selectedSite && this.props.selectedSite.jetpack

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -1,35 +1,35 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' ),
+var classNames = require( 'classnames' ),
 	connect = require( 'react-redux' ).connect,
 	find = require( 'lodash/find' ),
 	page = require( 'page' ),
+	React = require( 'react' ),
 	times = require( 'lodash/times' );
 
 /**
  * Internal dependencies
  */
-var observe = require( 'lib/mixins/data-observe' ),
-	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
+var analytics = require( 'analytics' ),
+	Card = require( 'components/card' ),
+	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
+	filterPlansBySiteAndProps = require( 'lib/plans' ).filterPlansBySiteAndProps,
+	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
 	Gridicon = require( 'components/gridicon' ),
+	HeaderCake = require( 'components/header-cake' ),
+	isBusiness = require( 'lib/products-values' ).isBusiness,
+	isFreePlan = require( 'lib/products-values' ).isFreePlan,
+	isPremium = require( 'lib/products-values' ).isPremium,
+	NavItem = require( 'components/section-nav/item' ),
+	NavTabs = require( 'components/section-nav/tabs' ),
+	observe = require( 'lib/mixins/data-observe' ),
 	PlanActions = require( 'components/plans/plan-actions' ),
 	PlanHeader = require( 'components/plans/plan-header' ),
 	PlanPrice = require( 'components/plans/plan-price' ),
-	analytics = require( 'analytics' ),
-	HeaderCake = require( 'components/header-cake' ),
-	isFreePlan = require( 'lib/products-values' ).isFreePlan,
-	isBusiness = require( 'lib/products-values' ).isBusiness,
-	isPremium = require( 'lib/products-values' ).isPremium,
-	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
-	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
-	Card = require( 'components/card' ),
-	filterPlansBySiteAndProps = require( 'lib/plans' ).filterPlansBySiteAndProps,
-	NavItem = require( 'components/section-nav/item' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
 	SectionNav = require( 'components/section-nav' ),
 	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans,
+	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
 	transactionStepTypes = require( 'lib/store-transactions/step-types' );
 
 var PlansCompare = React.createClass( {

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -408,12 +408,12 @@ const PlansCompare = React.createClass( {
 } );
 
 export default connect(
-	function mapStateToProps( state, props ) {
+	( state, props ) => {
 		return {
 			sitePlans: getPlansBySite( state, props.selectedSite )
 		};
 	},
-	function mapDispatchToProps( dispatch ) {
+	( dispatch ) => {
 		return {
 			fetchSitePlans( sitePlans, site ) {
 				if ( shouldFetchSitePlans( sitePlans, site ) ) {

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -133,8 +133,8 @@ const PlansCompare = React.createClass( {
 	getFeatures() {
 		const plans = this.getPlans();
 
-		return this.props.features.get().filter( function( feature ) {
-			return plans.some( function( plan ) {
+		return this.props.features.get().filter( ( feature ) => {
+			return plans.some( ( plan ) => {
 				return feature[ plan.product_id ];
 			} );
 		} );
@@ -158,7 +158,7 @@ const PlansCompare = React.createClass( {
 		let planElements;
 
 		if ( this.isDataLoading() ) {
-			planElements = times( this.getColumnCount(), function( n ) {
+			planElements = times( this.getColumnCount(), ( n ) => {
 				if ( n === 0 ) {
 					return <th className="plans-compare__header-cell" key={ n } />;
 				}
@@ -168,13 +168,13 @@ const PlansCompare = React.createClass( {
 						<div className="plans-compare__header-cell-placeholder" />
 					</th>
 				);
-			}.bind( this ) );
+			} );
 		} else {
 			const plans = this.getPlans();
 
 			planElements = [ <th className="plans-compare__header-cell" key="placeholder" /> ];
 
-			planElements = planElements.concat( plans.map( function( plan ) {
+			planElements = planElements.concat( plans.map( ( plan ) => {
 				const sitePlan = this.getSitePlan( plan ),
 					classes = classNames( 'plans-compare__header-cell', {
 						'is-selected': this.isSelected( plan )
@@ -202,7 +202,7 @@ const PlansCompare = React.createClass( {
 						</PlanHeader>
 					</th>
 				);
-			}.bind( this ) ) );
+			} ) );
 		}
 
 		return (
@@ -214,8 +214,8 @@ const PlansCompare = React.createClass( {
 		let rows;
 
 		if ( this.isDataLoading() ) {
-			rows = times( 8, function( i ) {
-				const cells = times( this.getColumnCount(), function( n ) {
+			rows = times( 8, ( i ) => {
+				const cells = times( this.getColumnCount(), ( n ) => {
 					const classes = classNames( 'plans-compare__cell-placeholder', {
 						'is-plan-specific': n !== 0
 					} );
@@ -225,18 +225,18 @@ const PlansCompare = React.createClass( {
 							<div className={ classes } />
 						</td>
 					);
-				}.bind( this ) );
+				} );
 
 				return (
 					<tr className="plans-compare__row" key={ i }>{ cells }</tr>
 				);
-			}.bind( this ) );
+			} );
 		} else {
 			const plans = this.getPlans(),
 				features = this.getFeatures();
 
-			rows = features.map( function( feature ) {
-				const planFeatures = plans.map( function( plan ) {
+			rows = features.map( ( feature ) => {
+				const planFeatures = plans.map( ( plan ) => {
 					const classes = classNames( 'plans-compare__cell', 'is-plan-specific', {
 							'is-selected': this.isSelected( plan )
 						} ),
@@ -266,7 +266,7 @@ const PlansCompare = React.createClass( {
 							</div>
 						</td>
 					);
-				}.bind( this ) );
+				} );
 
 				return (
 					<tr className="plans-compare__row" key={ feature.title }>
@@ -278,7 +278,7 @@ const PlansCompare = React.createClass( {
 						{ planFeatures }
 					</tr>
 				);
-			}.bind( this ) );
+			} );
 		}
 
 		return rows;
@@ -293,7 +293,7 @@ const PlansCompare = React.createClass( {
 
 		let cells = [ <td className="plans-compare__action-cell" key="placeholder" /> ];
 
-		cells = cells.concat( plans.map( function( plan ) {
+		cells = cells.concat( plans.map( ( plan ) => {
 			const sitePlan = this.getSitePlan( plan ),
 				classes = classNames( 'plans-compare__action-cell', {
 					'is-selected': this.isSelected( plan )
@@ -311,7 +311,7 @@ const PlansCompare = React.createClass( {
 						cart={ this.props.cart } />
 				</td>
 			);
-		}.bind( this ) ) );
+		} ) );
 
 		return (
 			<tr>{ cells }</tr>

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -29,7 +29,7 @@ import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
 
-var PlansCompare = React.createClass( {
+const PlansCompare = React.createClass( {
 	displayName: 'PlansCompare',
 
 	mixins: [
@@ -65,8 +65,8 @@ var PlansCompare = React.createClass( {
 	},
 
 	goBack: function() {
-		var selectedSite = this.props.selectedSite,
-			plansLink = '/plans';
+		const selectedSite = this.props.selectedSite;
+		var plansLink = '/plans';
 
 		if ( this.props.backUrl ) {
 			return page( this.props.backUrl );
@@ -131,7 +131,7 @@ var PlansCompare = React.createClass( {
 	},
 
 	getFeatures: function() {
-		var plans = this.getPlans();
+		const plans = this.getPlans();
 
 		return this.props.features.get().filter( function( feature ) {
 			return plans.some( function( plan ) {
@@ -155,7 +155,7 @@ var PlansCompare = React.createClass( {
 	},
 
 	getTableHeader: function() {
-		var plans, planElements;
+		var planElements;
 
 		if ( this.isDataLoading() ) {
 			planElements = times( this.getColumnCount(), function( n ) {
@@ -170,14 +170,16 @@ var PlansCompare = React.createClass( {
 				);
 			}.bind( this ) );
 		} else {
-			plans = this.getPlans();
+			const plans = this.getPlans();
+
 			planElements = [ <th className="plans-compare__header-cell" key="placeholder" /> ];
 
 			planElements = planElements.concat( plans.map( function( plan ) {
-				var sitePlan = this.getSitePlan( plan ),
+				const sitePlan = this.getSitePlan( plan ),
 					classes = classNames( 'plans-compare__header-cell', {
 						'is-selected': this.isSelected( plan )
 					} );
+
 				return (
 					<th className={ classes } key={ plan.product_slug }>
 						<PlanHeader key={ plan.product_slug }>
@@ -209,12 +211,12 @@ var PlansCompare = React.createClass( {
 	},
 
 	getTableFeatureRows: function() {
-		var plans, features, rows;
+		var rows;
 
 		if ( this.isDataLoading() ) {
 			rows = times( 8, function( i ) {
-				var cells = times( this.getColumnCount(), function( n ) {
-					var classes = classNames( 'plans-compare__cell-placeholder', {
+				const cells = times( this.getColumnCount(), function( n ) {
+					const classes = classNames( 'plans-compare__cell-placeholder', {
 						'is-plan-specific': n !== 0
 					} );
 
@@ -230,18 +232,19 @@ var PlansCompare = React.createClass( {
 				);
 			}.bind( this ) );
 		} else {
-			plans = this.getPlans();
-			features = this.getFeatures();
+			const plans = this.getPlans(),
+				features = this.getFeatures();
 
 			rows = features.map( function( feature ) {
-				var planFeatures = plans.map( function( plan ) {
-					var classes = classNames( 'plans-compare__cell', 'is-plan-specific', {
+				const planFeatures = plans.map( function( plan ) {
+					const classes = classNames( 'plans-compare__cell', 'is-plan-specific', {
 							'is-selected': this.isSelected( plan )
 						} ),
 						mobileClasses = classNames( 'plans-compare__feature-title-mobile', {
 							'is-available': feature[ plan.product_id ]
-						} ),
-						content;
+						} );
+					
+					var content;
 
 					if ( typeof feature[ plan.product_id ] === 'boolean' && feature[ plan.product_id ] ) {
 						content = <Gridicon icon="checkmark-circle" size={ 24 } />;
@@ -282,17 +285,17 @@ var PlansCompare = React.createClass( {
 	},
 
 	getTableActionRow: function() {
-		var plans, cells;
+		var cells;
 
 		if ( this.isDataLoading() ) {
 			return null;
 		}
 
-		plans = this.getPlans();
+		const plans = this.getPlans();
 		cells = [ <td className="plans-compare__action-cell" key="placeholder" /> ];
 
 		cells = cells.concat( plans.map( function( plan ) {
-			var sitePlan = this.getSitePlan( plan ),
+			const sitePlan = this.getSitePlan( plan ),
 				classes = classNames( 'plans-compare__action-cell', {
 					'is-selected': this.isSelected( plan )
 				} );
@@ -335,12 +338,13 @@ var PlansCompare = React.createClass( {
 	},
 
 	sectionNavigationForMobile() {
-		var text = {
-				free: this.translate( 'Free' ),
-				premium: this.translate( 'Premium' ),
-				business: this.translate( 'Business' )
-			},
-			freeOption = (
+		const text = {
+			free: this.translate( 'Free' ),
+			premium: this.translate( 'Premium' ),
+			business: this.translate( 'Business' )
+		};
+
+		var freeOption = (
 				<NavItem
 					onClick={ this.setPlan.bind( this, 'free' ) }
 					selected={ 'free' === this.state.selectedPlan }>
@@ -374,11 +378,12 @@ var PlansCompare = React.createClass( {
 	},
 
 	render: function() {
-		var compareString = this.translate( 'Compare Plans' ),
-			classes = classNames( this.props.className, 'plans-compare', {
+		const classes = classNames( this.props.className, 'plans-compare', {
 				'is-placeholder': this.isDataLoading(),
 				'is-jetpack-site': this.props.selectedSite && this.props.selectedSite.jetpack
 			} );
+
+		var compareString = this.translate( 'Compare Plans' );
 
 		if ( this.props.selectedSite && this.props.selectedSite.jetpack ) {
 			compareString = this.translate( 'Compare Options' );

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -403,7 +403,7 @@ var PlansCompare = React.createClass( {
 	}
 } );
 
-module.exports = connect(
+export default connect(
 	function mapStateToProps( state, props ) {
 		return {
 			sitePlans: getPlansBySite( state, props.selectedSite )

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -1,36 +1,33 @@
 /**
  * External dependencies
  */
-var classNames = require( 'classnames' ),
-	connect = require( 'react-redux' ).connect,
-	find = require( 'lodash/find' ),
-	page = require( 'page' ),
-	React = require( 'react' ),
-	times = require( 'lodash/times' );
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import find from 'lodash/find';
+import page from 'page';
+import React from 'react';
+import times from 'lodash/times';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'analytics' ),
-	Card = require( 'components/card' ),
-	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
-	filterPlansBySiteAndProps = require( 'lib/plans' ).filterPlansBySiteAndProps,
-	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite,
-	Gridicon = require( 'components/gridicon' ),
-	HeaderCake = require( 'components/header-cake' ),
-	isBusiness = require( 'lib/products-values' ).isBusiness,
-	isFreePlan = require( 'lib/products-values' ).isFreePlan,
-	isPremium = require( 'lib/products-values' ).isPremium,
-	NavItem = require( 'components/section-nav/item' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	PlanActions = require( 'components/plans/plan-actions' ),
-	PlanHeader = require( 'components/plans/plan-header' ),
-	PlanPrice = require( 'components/plans/plan-price' ),
-	SectionNav = require( 'components/section-nav' ),
-	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans,
-	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	transactionStepTypes = require( 'lib/store-transactions/step-types' );
+import analytics from 'analytics';
+import Card from 'components/card';
+import { fetchSitePlans } from 'state/sites/plans/actions';
+import { filterPlansBySiteAndProps, shouldFetchSitePlans } from 'lib/plans';
+import { getPlansBySite } from 'state/sites/plans/selectors';
+import Gridicon from 'components/gridicon';
+import HeaderCake from 'components/header-cake';
+import { isBusiness, isFreePlan, isPremium } from 'lib/products-values';
+import NavItem from 'components/section-nav/item';
+import NavTabs from 'components/section-nav/tabs';
+import observe from 'lib/mixins/data-observe';
+import PlanActions from 'components/plans/plan-actions';
+import PlanHeader from 'components/plans/plan-header';
+import PlanPrice from 'components/plans/plan-price';
+import SectionNav from 'components/section-nav';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
 
 var PlansCompare = React.createClass( {
 	displayName: 'PlansCompare',
@@ -122,7 +119,7 @@ var PlansCompare = React.createClass( {
 			return false;
 		}
 
-		return this.props.transaction.step.name === transactionStepTypes.SUBMITTING_WPCOM_REQUEST
+		return this.props.transaction.step.name === SUBMITTING_WPCOM_REQUEST
 	},
 
 	getColumnCount: function() {

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -65,12 +65,12 @@ const PlansCompare = React.createClass( {
 	},
 
 	goBack: function() {
-		const selectedSite = this.props.selectedSite;
-		var plansLink = '/plans';
-
 		if ( this.props.backUrl ) {
 			return page( this.props.backUrl );
 		}
+
+		const selectedSite = this.props.selectedSite;
+		let plansLink = '/plans';
 
 		if ( selectedSite ) {
 			plansLink += '/' + selectedSite.slug;
@@ -155,7 +155,7 @@ const PlansCompare = React.createClass( {
 	},
 
 	getTableHeader: function() {
-		var planElements;
+		let planElements;
 
 		if ( this.isDataLoading() ) {
 			planElements = times( this.getColumnCount(), function( n ) {
@@ -211,7 +211,7 @@ const PlansCompare = React.createClass( {
 	},
 
 	getTableFeatureRows: function() {
-		var rows;
+		let rows;
 
 		if ( this.isDataLoading() ) {
 			rows = times( 8, function( i ) {
@@ -243,8 +243,8 @@ const PlansCompare = React.createClass( {
 						mobileClasses = classNames( 'plans-compare__feature-title-mobile', {
 							'is-available': feature[ plan.product_id ]
 						} );
-					
-					var content;
+
+					let content;
 
 					if ( typeof feature[ plan.product_id ] === 'boolean' && feature[ plan.product_id ] ) {
 						content = <Gridicon icon="checkmark-circle" size={ 24 } />;
@@ -285,14 +285,13 @@ const PlansCompare = React.createClass( {
 	},
 
 	getTableActionRow: function() {
-		var cells;
-
 		if ( this.isDataLoading() ) {
 			return null;
 		}
 
 		const plans = this.getPlans();
-		cells = [ <td className="plans-compare__action-cell" key="placeholder" /> ];
+
+		let cells = [ <td className="plans-compare__action-cell" key="placeholder" /> ];
 
 		cells = cells.concat( plans.map( function( plan ) {
 			const sitePlan = this.getSitePlan( plan ),
@@ -344,7 +343,7 @@ const PlansCompare = React.createClass( {
 			business: this.translate( 'Business' )
 		};
 
-		var freeOption = (
+		let freeOption = (
 				<NavItem
 					onClick={ this.setPlan.bind( this, 'free' ) }
 					selected={ 'free' === this.state.selectedPlan }>
@@ -383,7 +382,7 @@ const PlansCompare = React.createClass( {
 				'is-jetpack-site': this.props.selectedSite && this.props.selectedSite.jetpack
 			} );
 
-		var compareString = this.translate( 'Compare Plans' );
+		let compareString = this.translate( 'Compare Plans' );
 
 		if ( this.props.selectedSite && this.props.selectedSite.jetpack ) {
 			compareString = this.translate( 'Compare Options' );

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -195,8 +195,7 @@ const PlansCompare = React.createClass( {
 							</span>
 							<PlanPrice
 								plan={ plan }
-								sitePlan={ sitePlan }
-								site={ this.props.selectedSite } />
+								sitePlan={ sitePlan } />
 						</PlanHeader>
 					</th>
 				);

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -21,14 +21,6 @@ module.exports = {
 		defaultVariation: 'noNotice',
 		allowAnyLocale: true
 	},
-	plansPageBusinessAATest: {
-		datestamp: '20160108',
-		variations: {
-			originalA: 50,
-			originalB: 50
-		},
-		defaultVariation: 'originalA'
-	},
 	freeTrialsInSignup: {
 		datestamp: '20160328',
 		variations: {


### PR DESCRIPTION
This pull request updates the `components/plans` section to use as many [ES6](https://github.com/Automattic/calypso-pre-oss/blob/master/docs/coding-guidelines/javascript.md#es6) features as possible. It also fixes and improves a few minor things in the process - such as unnecessary code.
 
![screenshot](https://cloud.githubusercontent.com/assets/594356/14109625/2d87a6e0-f5c3-11e5-8082-76fbb43df23c.png)

#### Additional notes
 
You should probably consider browsing commits [one by one](https://github.com/Automattic/wp-calypso/pull/4394/commits) to review this pull request since it might be easier to understand the changes rather than in the [unified diff view](https://github.com/Automattic/wp-calypso/pull/4394/files).

#### Testing instructions
 
1. Run `git checkout update/components-plans-to-es6` and start your server
2. Check that the [`Plans` page](http://calypso.localhost:3000/plans) behave as before
3. Check that the [`Compare Plans` page](http://calypso.localhost:3000/plans/compare) behave as before
4. Purchase a Premium plan and check the Plans pages again
5. Execute `localStorage.setItem( 'ABTests', '{"freeTrials_20160120":"offered"}' )` in your browser's console
6. Navigate to the `Plans` page again and start a free trial
7. Check that the [`Plan Overview` page](http://calypso.localhost:3000/plans) behave as before

#### Reviews
 
- [x] Code
- [x] Product