### PR TITLE
Framework/CPT: Proof of concept for using the `state.page` and `<Page />` component.

### DIFF
--- a/client/lib/screen-title/index.js
+++ b/client/lib/screen-title/index.js
@@ -13,16 +13,19 @@ import { setTitle as legacySetTitle } from './actions';
 export function subscribeToStore( store ) {
 	let title = store.getState().page.title;
 	let count = store.getState().page.unreadCount;
+	let siteId = store.getState().ui.selectedSiteId;
 
 	store.subscribe( () => {
 		let nextTitle = store.getState().page.title;
 		let nextCount = store.getState().page.unreadCount;
+		let nextSiteId = store.getState().ui.selectedSiteId;
 
-		if ( nextTitle !== title || nextCount !== count ) {
+		if ( nextTitle !== title || nextCount !== count || nextSiteId !== siteId ) {
 			title = nextTitle;
 			count = nextCount;
+			siteId = nextSiteId;
 
-			legacySetTitle( title, { count: count } );
+			legacySetTitle( title, { siteID: siteId, count: count } );
 		}
 	} );
 }

--- a/client/lib/screen-title/index.js
+++ b/client/lib/screen-title/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { setTitle as legacySetTitle } from './actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Given a Redux store instance, subscribes to the store, updating the page
@@ -13,12 +14,14 @@ import { setTitle as legacySetTitle } from './actions';
 export function subscribeToStore( store ) {
 	let title = store.getState().page.title;
 	let count = store.getState().page.unreadCount;
-	let siteId = store.getState().ui.selectedSiteId;
+	let siteId = getSelectedSiteId( store.getState() );
 
 	store.subscribe( () => {
-		let nextTitle = store.getState().page.title;
-		let nextCount = store.getState().page.unreadCount;
-		let nextSiteId = store.getState().ui.selectedSiteId;
+		const state = store.getState();
+
+		let nextTitle = state.page.title;
+		let nextCount = state.page.unreadCount;
+		let nextSiteId = getSelectedSiteId( state );
 
 		if ( nextTitle !== title || nextCount !== count || nextSiteId !== siteId ) {
 			title = nextTitle;

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -11,7 +11,6 @@ import page from 'page';
  */
 import { getSiteFragment, sectionify } from 'lib/route';
 import { pageView } from 'analytics';
-import { setTitle } from 'lib/screen-title/actions';
 import Types from './main';
 
 export function redirect() {
@@ -21,9 +20,6 @@ export function redirect() {
 export function list( context ) {
 	const siteId = getSiteFragment( context.path );
 	const sectionedPath = sectionify( context.path );
-
-	// [TODO]: Translate title text when settled upon
-	setTitle( 'Custom Post Type', { siteId: siteId } );
 
 	// Analytics
 	let baseAnalyticsPath = sectionedPath;

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -7,12 +7,15 @@ import React, { PropTypes } from 'react';
  * Internal dependencies
  */
 import Main from 'components/main';
+import Page from 'components/data/page';
 import PostTypeFilter from 'my-sites/post-type-filter';
 import PostTypeList from 'my-sites/post-type-list';
 
 export default function Types( { query } ) {
+	// [TODO]: Translate title text when settled upon
 	return (
 		<Main>
+			<Page title="Custom Post Type" />
 			<PostTypeFilter />
 			<PostTypeList query={ query } />
 		</Main>


### PR DESCRIPTION
This pull request implements the new `<Page />` component that we introduced into #4090 as a proof of concept. Our end goal is to remove the use of `lib/screen-title` completely (see #3796), but in this PR we are only focussing on testing out our new functionality on one part of the application.

**Background:**

Custom post type labels can be localized. The localized label should be used in the `<title>` element of the page. The labels are accessed on the post types tracked in global application state. Rather than subscribe to state from the controller, it seems more reasonable to adopt our newer [query component](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#query-components) pattern in assigning title to state via a rendered component at the top of the section render hierarchy.

**Implementation notes:**

Since many sections continue to rely on the `screen-title` Flux store, the title tracked in state may become inaccurate as the user navigates through the application, even with these changes. For example, after navigating from Types listing to stats, `state.page.title` will continue to be assigned as "Custom Post Type". This issue will be alleviated if more sections adopt the Redux state approach introduced here.

**Testing instructions:**

Ensure that the title is updated correctly when navigating to the Custom Post Types route for a site. You must navigate to the URL directly in your development environment, as there are no navigable links yet available.

1. Navigate to [Calypso custom post types listing](http://calypso.localhost:3000/types/jetpack-portfolio) (e.g. portfolio)
2. Select a site
3. Note that the tab title reflects both "Custom Post Types" and the title of the selected site
4. Click Switch Sites in the sidebar navigation
5. Select a site
6. Note that the tab title reflects both "Custom Post Types" and the title of the selected site
7. Navigate to another page in Calypso
8. Note that the tab title reflects the section you chose

cc @mjangda 
cc @aduth