### PR TITLE
Framework: add metric for plan-storage component

### DIFF
--- a/client/analytics/track-component-view/README.md
+++ b/client/analytics/track-component-view/README.md
@@ -1,0 +1,17 @@
+Track Component View
+===========================
+
+`<TrackComponentView />` is a React component used to help track when container components are seen by a user.
+This is useful in cases where a container component conditionally renders. If children are 
+not rendered, this analytics event will not be fired.
+
+## Usage
+
+Render the component passing an `eventName` string and `eventProperties` object. 
+```
+<ContainerComponent>
+	<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+</ContainerComponent>
+```
+
+It does not accept any children, nor does it render any elements to the page.

--- a/client/analytics/track-component-view/index.jsx
+++ b/client/analytics/track-component-view/index.jsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'analytics';
+
+export default React.createClass( {
+
+	displayName: 'TrackComponentView',
+
+	propTypes: {
+		eventName: PropTypes.string,
+		eventProperties: PropTypes.object
+	},
+
+	getDefaultProps() {
+		return {
+			eventName: null,
+			eventProperties: {}
+		}
+	},
+
+	componentWillMount() {
+		if ( this.props.eventName ) {
+			analytics.tracks.recordEvent( this.props.eventName, this.props.eventProperties );
+		}
+	},
+
+	render() {
+		return null;
+	}
+
+} );
+

--- a/client/my-sites/plan-storage/button.jsx
+++ b/client/my-sites/plan-storage/button.jsx
@@ -72,6 +72,7 @@ export default React.createClass( {
 					value={ percent }
 					total={ 100 }
 					compact={ true } />
+				{ this.props.children }
 			</Button>
 		);
 	}

--- a/client/my-sites/plan-storage/index.jsx
+++ b/client/my-sites/plan-storage/index.jsx
@@ -40,8 +40,9 @@ const PlanStorage = React.createClass( {
 				<PlanStorageButton
 					sitePlanName={ this.props.site.plan.product_name_short }
 					mediaStorage={ this.props.mediaStorage }
-					onClick={ this.props.onClick }
-				/>
+					onClick={ this.props.onClick } >
+					{ this.props.children }
+				</PlanStorageButton>
 			</div>
 		);
 	}

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -14,6 +14,7 @@ import page from 'page';
  * Internal dependencies
  */
 import analytics from 'analytics';
+import TrackComponentView from 'analytics/track-component-view';
 import { Views as ModalViews } from './constants';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
@@ -175,11 +176,15 @@ const MediaModalSecondaryActions = React.createClass( {
 
 	renderPlanStorage() {
 		if ( this.props.selectedItems.length === 0 ) {
+			const eventName = 'calypso_upgrade_nudge_impression';
+			const eventProperties = { cta_name: 'plan-media-storage' };
 			return (
 				<PlanStorage
 					className="editor-media-modal__plan-storage"
 					onClick={ this.navigateToPlans }
-					siteId={ this.props.site.ID } />
+					siteId={ this.props.site.ID } >
+					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+				</PlanStorage>
 			);
 		}
 		return null;


### PR DESCRIPTION
This PR adds a trac metric to count when the plan-storage component is viewed in the media modal.

<img width="811" alt="screen shot 2016-03-24 at 4 18 36 pm" src="https://cloud.githubusercontent.com/assets/1270189/14033984/1a8c26be-f1dc-11e5-9cac-124f09cb87c0.png">


## Testing:
- In the console call: `localStorage.setItem('debug', 'calypso:analytics');`
- Navigate to http://calypso.localhost:3000/post
- Select a wpcom site with a Free or Premium plan when propmted
- Click on the media modal (picture icon)
A message like the following appears in the console:
<img width="842" alt="screen shot 2016-03-24 at 4 16 16 pm" src="https://cloud.githubusercontent.com/assets/1270189/14033966/f13428a2-f1db-11e5-9a5e-e59071fb644f.png">
Click on the plan-storage component
<img width="829" alt="screen shot 2016-03-24 at 4 16 52 pm" src="https://cloud.githubusercontent.com/assets/1270189/14033969/faead986-f1db-11e5-83be-9e1f378b0056.png">



cc @rralian @adambbecker @mtias @artpi @retrofox @aduth