### PR TITLE
WP-API: Move to new URL structure

### DIFF
--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -186,13 +186,13 @@ UndocumentedSite.prototype.setOption = function( query, callback ) {
 UndocumentedSite.prototype.postCounts = function( options, callback ) {
 	let query = Object.assign( {
 		type: 'post',
-		apiNamespace: 'wp' // This currently has no bearing on the route, wpcom-xhr-request needs to be updated to remove the namespace whitelist
+		apiNamespace: 'wpcom/v2'
 	}, options );
 
 	const type = query.type;
 	delete query.type;
 
-	return this.wpcom.req.get( '/sites/' + this._id + '/wpcom/v2/post-counts/' + type, query, callback );
+	return this.wpcom.req.get( '/sites/' + this._id + '/post-counts/' + type, query, callback );
 };
 
 /**

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1954,8 +1954,8 @@ Undocumented.prototype.timezones = function( params, fn ) {
 		params = {};
 	}
 
-	let query = Object.assign( {}, params, { apiNamespace: 'wp' } );
-	return this.wpcom.req.get( '/wpcom/v2/timezones', query, fn );
+	let query = Object.assign( {}, params, { apiNamespace: 'wpcom/v2' } );
+	return this.wpcom.req.get( '/timezones', query, fn );
 }
 
 /**

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8319,10 +8319,10 @@
       }
     },
     "wpcom-unpublished": {
-      "version": "1.0.10",
+      "version": "1.1.0",
       "dependencies": {
         "wpcom": {
-          "version": "4.8.5",
+          "version": "4.9.0",
           "dependencies": {
             "babel": {
               "version": "5.8.38",
@@ -8397,9 +8397,6 @@
                             "filename-regex": {
                               "version": "2.0.0"
                             },
-                            "is-extglob": {
-                              "version": "1.0.0"
-                            },
                             "kind-of": {
                               "version": "3.0.2",
                               "dependencies": {
@@ -8456,6 +8453,455 @@
                     "async-each": {
                       "version": "1.0.0"
                     },
+                    "fsevents": {
+                      "version": "1.0.9",
+                      "dependencies": {
+                        "node-pre-gyp": {
+                          "version": "0.6.24",
+                          "dependencies": {
+                            "mkdirp": {
+                              "version": "0.5.1",
+                              "dependencies": {
+                                "minimist": {
+                                  "version": "0.0.8"
+                                }
+                              }
+                            },
+                            "nopt": {
+                              "version": "3.0.6",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.7"
+                                }
+                              }
+                            },
+                            "npmlog": {
+                              "version": "2.0.3",
+                              "dependencies": {
+                                "ansi": {
+                                  "version": "0.3.1"
+                                },
+                                "are-we-there-yet": {
+                                  "version": "1.1.2",
+                                  "dependencies": {
+                                    "delegates": {
+                                      "version": "1.0.0"
+                                    }
+                                  }
+                                },
+                                "gauge": {
+                                  "version": "1.2.7",
+                                  "dependencies": {
+                                    "has-unicode": {
+                                      "version": "2.0.0"
+                                    },
+                                    "lodash.pad": {
+                                      "version": "4.1.0",
+                                      "dependencies": {
+                                        "lodash.repeat": {
+                                          "version": "4.0.0"
+                                        },
+                                        "lodash.tostring": {
+                                          "version": "4.1.2"
+                                        }
+                                      }
+                                    },
+                                    "lodash.padend": {
+                                      "version": "4.2.0"
+                                    },
+                                    "lodash.padstart": {
+                                      "version": "4.2.0"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "rc": {
+                              "version": "1.1.6",
+                              "dependencies": {
+                                "deep-extend": {
+                                  "version": "0.4.1"
+                                },
+                                "ini": {
+                                  "version": "1.3.4"
+                                },
+                                "minimist": {
+                                  "version": "1.2.0"
+                                },
+                                "strip-json-comments": {
+                                  "version": "1.0.4"
+                                }
+                              }
+                            },
+                            "request": {
+                              "version": "2.69.0",
+                              "dependencies": {
+                                "aws-sign2": {
+                                  "version": "0.6.0"
+                                },
+                                "aws4": {
+                                  "version": "1.3.2",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "4.0.0",
+                                      "dependencies": {
+                                        "pseudomap": {
+                                          "version": "1.0.2"
+                                        },
+                                        "yallist": {
+                                          "version": "2.0.0"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "bl": {
+                                  "version": "1.0.3"
+                                },
+                                "caseless": {
+                                  "version": "0.11.0"
+                                },
+                                "combined-stream": {
+                                  "version": "1.0.5",
+                                  "dependencies": {
+                                    "delayed-stream": {
+                                      "version": "1.0.0"
+                                    }
+                                  }
+                                },
+                                "extend": {
+                                  "version": "3.0.0"
+                                },
+                                "forever-agent": {
+                                  "version": "0.6.1"
+                                },
+                                "form-data": {
+                                  "version": "1.0.0-rc4",
+                                  "dependencies": {
+                                    "async": {
+                                      "version": "1.5.2"
+                                    }
+                                  }
+                                },
+                                "har-validator": {
+                                  "version": "2.0.6",
+                                  "dependencies": {
+                                    "chalk": {
+                                      "version": "1.1.1",
+                                      "dependencies": {
+                                        "ansi-styles": {
+                                          "version": "2.2.0",
+                                          "dependencies": {
+                                            "color-convert": {
+                                              "version": "1.0.0"
+                                            }
+                                          }
+                                        },
+                                        "escape-string-regexp": {
+                                          "version": "1.0.5"
+                                        },
+                                        "has-ansi": {
+                                          "version": "2.0.0",
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0"
+                                            }
+                                          }
+                                        },
+                                        "strip-ansi": {
+                                          "version": "3.0.1"
+                                        },
+                                        "supports-color": {
+                                          "version": "2.0.0"
+                                        }
+                                      }
+                                    },
+                                    "commander": {
+                                      "version": "2.9.0",
+                                      "dependencies": {
+                                        "graceful-readlink": {
+                                          "version": "1.0.1"
+                                        }
+                                      }
+                                    },
+                                    "is-my-json-valid": {
+                                      "version": "2.13.1",
+                                      "dependencies": {
+                                        "generate-function": {
+                                          "version": "2.0.0"
+                                        },
+                                        "generate-object-property": {
+                                          "version": "1.2.0",
+                                          "dependencies": {
+                                            "is-property": {
+                                              "version": "1.0.2"
+                                            }
+                                          }
+                                        },
+                                        "jsonpointer": {
+                                          "version": "2.0.0"
+                                        },
+                                        "xtend": {
+                                          "version": "4.0.1"
+                                        }
+                                      }
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.4"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "hawk": {
+                                  "version": "3.1.3",
+                                  "dependencies": {
+                                    "boom": {
+                                      "version": "2.10.1"
+                                    },
+                                    "cryptiles": {
+                                      "version": "2.0.5"
+                                    },
+                                    "hoek": {
+                                      "version": "2.16.3"
+                                    },
+                                    "sntp": {
+                                      "version": "1.0.9"
+                                    }
+                                  }
+                                },
+                                "http-signature": {
+                                  "version": "1.1.1",
+                                  "dependencies": {
+                                    "assert-plus": {
+                                      "version": "0.2.0"
+                                    },
+                                    "jsprim": {
+                                      "version": "1.2.2",
+                                      "dependencies": {
+                                        "extsprintf": {
+                                          "version": "1.0.2"
+                                        },
+                                        "json-schema": {
+                                          "version": "0.2.2"
+                                        },
+                                        "verror": {
+                                          "version": "1.3.6"
+                                        }
+                                      }
+                                    },
+                                    "sshpk": {
+                                      "version": "1.7.4",
+                                      "dependencies": {
+                                        "asn1": {
+                                          "version": "0.2.3"
+                                        },
+                                        "dashdash": {
+                                          "version": "1.13.0",
+                                          "dependencies": {
+                                            "assert-plus": {
+                                              "version": "1.0.0"
+                                            }
+                                          }
+                                        },
+                                        "ecc-jsbn": {
+                                          "version": "0.1.1"
+                                        },
+                                        "jodid25519": {
+                                          "version": "1.0.2"
+                                        },
+                                        "jsbn": {
+                                          "version": "0.1.0"
+                                        },
+                                        "tweetnacl": {
+                                          "version": "0.14.1"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "is-typedarray": {
+                                  "version": "1.0.0"
+                                },
+                                "isstream": {
+                                  "version": "0.1.2"
+                                },
+                                "json-stringify-safe": {
+                                  "version": "5.0.1"
+                                },
+                                "mime-types": {
+                                  "version": "2.1.10",
+                                  "dependencies": {
+                                    "mime-db": {
+                                      "version": "1.22.0"
+                                    }
+                                  }
+                                },
+                                "node-uuid": {
+                                  "version": "1.4.7"
+                                },
+                                "oauth-sign": {
+                                  "version": "0.8.1"
+                                },
+                                "qs": {
+                                  "version": "6.0.2"
+                                },
+                                "stringstream": {
+                                  "version": "0.0.5"
+                                },
+                                "tough-cookie": {
+                                  "version": "2.2.2"
+                                },
+                                "tunnel-agent": {
+                                  "version": "0.4.2"
+                                }
+                              }
+                            },
+                            "rimraf": {
+                              "version": "2.5.2",
+                              "dependencies": {
+                                "glob": {
+                                  "version": "7.0.3",
+                                  "dependencies": {
+                                    "inflight": {
+                                      "version": "1.0.4",
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1"
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1"
+                                    },
+                                    "minimatch": {
+                                      "version": "3.0.0",
+                                      "dependencies": {
+                                        "brace-expansion": {
+                                          "version": "1.1.3",
+                                          "dependencies": {
+                                            "balanced-match": {
+                                              "version": "0.3.0"
+                                            },
+                                            "concat-map": {
+                                              "version": "0.0.1"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "once": {
+                                      "version": "1.3.3",
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1"
+                                        }
+                                      }
+                                    },
+                                    "path-is-absolute": {
+                                      "version": "1.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "semver": {
+                              "version": "5.1.0"
+                            },
+                            "tar": {
+                              "version": "2.2.1",
+                              "dependencies": {
+                                "block-stream": {
+                                  "version": "0.0.8"
+                                },
+                                "fstream": {
+                                  "version": "1.0.8",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.3"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1"
+                                }
+                              }
+                            },
+                            "tar-pack": {
+                              "version": "3.1.3",
+                              "dependencies": {
+                                "debug": {
+                                  "version": "2.2.0",
+                                  "dependencies": {
+                                    "ms": {
+                                      "version": "0.7.1"
+                                    }
+                                  }
+                                },
+                                "fstream-ignore": {
+                                  "version": "1.0.3",
+                                  "dependencies": {
+                                    "minimatch": {
+                                      "version": "3.0.0",
+                                      "dependencies": {
+                                        "brace-expansion": {
+                                          "version": "1.1.3",
+                                          "dependencies": {
+                                            "balanced-match": {
+                                              "version": "0.3.0"
+                                            },
+                                            "concat-map": {
+                                              "version": "0.0.1"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.3.3",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1"
+                                    }
+                                  }
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.6",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.2"
+                                    },
+                                    "isarray": {
+                                      "version": "1.0.0"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.6"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.2"
+                                    }
+                                  }
+                                },
+                                "uid-number": {
+                                  "version": "0.0.6"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "nan": {
+                          "version": "2.2.0"
+                        }
+                      }
+                    },
                     "glob-parent": {
                       "version": "2.0.0"
                     },
@@ -8481,33 +8927,17 @@
                         "graceful-fs": {
                           "version": "4.1.3"
                         },
-                        "minimatch": {
-                          "version": "2.0.10",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.3",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.3.0"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
                         "readable-stream": {
                           "version": "2.0.6",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2"
                             },
-                            "isarray": {
-                              "version": "1.0.0"
-                            },
                             "process-nextick-args": {
                               "version": "1.0.6"
+                            },
+                            "isarray": {
+                              "version": "1.0.0"
                             },
                             "string_decoder": {
                               "version": "0.10.31"
@@ -8518,409 +8948,6 @@
                           }
                         }
                       }
-                    },
-                    "fsevents": {
-                      "version": "1.0.9",
-                      "dependencies": {
-                        "nan": {
-                          "version": "2.2.0"
-                        },
-                        "node-pre-gyp": {
-                          "version": "0.6.24",
-                          "dependencies": {
-                            "nopt": {
-                              "version": "3.0.6",
-                              "dependencies": {
-                                "abbrev": {
-                                  "version": "1.0.7"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "ansi": {
-                          "version": "0.3.1"
-                        },
-                        "ansi-regex": {
-                          "version": "2.0.0"
-                        },
-                        "ansi-styles": {
-                          "version": "2.2.0"
-                        },
-                        "are-we-there-yet": {
-                          "version": "1.1.2"
-                        },
-                        "asn1": {
-                          "version": "0.2.3"
-                        },
-                        "assert-plus": {
-                          "version": "0.2.0"
-                        },
-                        "async": {
-                          "version": "1.5.2"
-                        },
-                        "aws-sign2": {
-                          "version": "0.6.0"
-                        },
-                        "bl": {
-                          "version": "1.0.3"
-                        },
-                        "block-stream": {
-                          "version": "0.0.8"
-                        },
-                        "caseless": {
-                          "version": "0.11.0"
-                        },
-                        "chalk": {
-                          "version": "1.1.1"
-                        },
-                        "color-convert": {
-                          "version": "1.0.0"
-                        },
-                        "boom": {
-                          "version": "2.10.1"
-                        },
-                        "combined-stream": {
-                          "version": "1.0.5"
-                        },
-                        "commander": {
-                          "version": "2.9.0"
-                        },
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "cryptiles": {
-                          "version": "2.0.5"
-                        },
-                        "delayed-stream": {
-                          "version": "1.0.0"
-                        },
-                        "debug": {
-                          "version": "2.2.0"
-                        },
-                        "deep-extend": {
-                          "version": "0.4.1"
-                        },
-                        "delegates": {
-                          "version": "1.0.0"
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5"
-                        },
-                        "forever-agent": {
-                          "version": "0.6.1"
-                        },
-                        "extend": {
-                          "version": "3.0.0"
-                        },
-                        "extsprintf": {
-                          "version": "1.0.2"
-                        },
-                        "form-data": {
-                          "version": "1.0.0-rc4"
-                        },
-                        "fstream": {
-                          "version": "1.0.8"
-                        },
-                        "gauge": {
-                          "version": "1.2.7"
-                        },
-                        "generate-function": {
-                          "version": "2.0.0"
-                        },
-                        "generate-object-property": {
-                          "version": "1.2.0"
-                        },
-                        "graceful-fs": {
-                          "version": "4.1.3"
-                        },
-                        "graceful-readlink": {
-                          "version": "1.0.1"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0"
-                        },
-                        "har-validator": {
-                          "version": "2.0.6"
-                        },
-                        "hawk": {
-                          "version": "3.1.3"
-                        },
-                        "has-unicode": {
-                          "version": "2.0.0"
-                        },
-                        "hoek": {
-                          "version": "2.16.3"
-                        },
-                        "http-signature": {
-                          "version": "1.1.1"
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        },
-                        "ini": {
-                          "version": "1.3.4"
-                        },
-                        "is-typedarray": {
-                          "version": "1.0.0"
-                        },
-                        "isarray": {
-                          "version": "1.0.0"
-                        },
-                        "is-my-json-valid": {
-                          "version": "2.13.1"
-                        },
-                        "is-property": {
-                          "version": "1.0.2"
-                        },
-                        "isstream": {
-                          "version": "0.1.2"
-                        },
-                        "json-stringify-safe": {
-                          "version": "5.0.1"
-                        },
-                        "jsbn": {
-                          "version": "0.1.0"
-                        },
-                        "json-schema": {
-                          "version": "0.2.2"
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2"
-                        },
-                        "jsonpointer": {
-                          "version": "2.0.0"
-                        },
-                        "jsprim": {
-                          "version": "1.2.2"
-                        },
-                        "lodash.pad": {
-                          "version": "4.1.0"
-                        },
-                        "lodash.padstart": {
-                          "version": "4.2.0"
-                        },
-                        "lodash.repeat": {
-                          "version": "4.0.0"
-                        },
-                        "lodash.tostring": {
-                          "version": "4.1.2"
-                        },
-                        "mime-db": {
-                          "version": "1.22.0"
-                        },
-                        "minimist": {
-                          "version": "0.0.8"
-                        },
-                        "ms": {
-                          "version": "0.7.1"
-                        },
-                        "mkdirp": {
-                          "version": "0.5.1"
-                        },
-                        "mime-types": {
-                          "version": "2.1.10"
-                        },
-                        "lodash.padend": {
-                          "version": "4.2.0"
-                        },
-                        "node-uuid": {
-                          "version": "1.4.7"
-                        },
-                        "oauth-sign": {
-                          "version": "0.8.1"
-                        },
-                        "npmlog": {
-                          "version": "2.0.3"
-                        },
-                        "once": {
-                          "version": "1.3.3"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0"
-                        },
-                        "pinkie": {
-                          "version": "2.0.4"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "readable-stream": {
-                          "version": "2.0.6"
-                        },
-                        "qs": {
-                          "version": "6.0.2"
-                        },
-                        "request": {
-                          "version": "2.69.0"
-                        },
-                        "semver": {
-                          "version": "5.1.0"
-                        },
-                        "sntp": {
-                          "version": "1.0.9"
-                        },
-                        "strip-json-comments": {
-                          "version": "1.0.4"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1"
-                        },
-                        "stringstream": {
-                          "version": "0.0.5"
-                        },
-                        "tar": {
-                          "version": "2.2.1"
-                        },
-                        "supports-color": {
-                          "version": "2.0.0"
-                        },
-                        "tar-pack": {
-                          "version": "3.1.3"
-                        },
-                        "tough-cookie": {
-                          "version": "2.2.2"
-                        },
-                        "tweetnacl": {
-                          "version": "0.14.1"
-                        },
-                        "tunnel-agent": {
-                          "version": "0.4.2"
-                        },
-                        "sshpk": {
-                          "version": "1.7.4"
-                        },
-                        "uid-number": {
-                          "version": "0.0.6"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        },
-                        "xtend": {
-                          "version": "4.0.1"
-                        },
-                        "wrappy": {
-                          "version": "1.0.1"
-                        },
-                        "verror": {
-                          "version": "1.3.6"
-                        },
-                        "dashdash": {
-                          "version": "1.13.0",
-                          "dependencies": {
-                            "assert-plus": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        },
-                        "rc": {
-                          "version": "1.1.6",
-                          "dependencies": {
-                            "minimist": {
-                              "version": "1.2.0"
-                            }
-                          }
-                        },
-                        "aws4": {
-                          "version": "1.3.2",
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "4.0.0",
-                              "dependencies": {
-                                "pseudomap": {
-                                  "version": "1.0.2"
-                                },
-                                "yallist": {
-                                  "version": "2.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "fstream-ignore": {
-                          "version": "1.0.3",
-                          "dependencies": {
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.3",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.3.0"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "rimraf": {
-                          "version": "2.5.2",
-                          "dependencies": {
-                            "glob": {
-                              "version": "7.0.3",
-                              "dependencies": {
-                                "inflight": {
-                                  "version": "1.0.4",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.1"
-                                    }
-                                  }
-                                },
-                                "inherits": {
-                                  "version": "2.0.1"
-                                },
-                                "minimatch": {
-                                  "version": "3.0.0",
-                                  "dependencies": {
-                                    "brace-expansion": {
-                                      "version": "1.1.3",
-                                      "dependencies": {
-                                        "balanced-match": {
-                                          "version": "0.3.0"
-                                        },
-                                        "concat-map": {
-                                          "version": "0.0.1"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "once": {
-                                  "version": "1.3.3",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.1"
-                                    }
-                                  }
-                                },
-                                "path-is-absolute": {
-                                  "version": "1.0.0"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1"
                     }
                   }
                 },
@@ -8929,46 +8956,6 @@
                 },
                 "fs-readdir-recursive": {
                   "version": "0.1.2"
-                },
-                "glob": {
-                  "version": "5.0.15",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "3.10.1"
                 },
                 "output-file-sync": {
                   "version": "1.1.1",
@@ -8992,20 +8979,84 @@
                 "path-is-absolute": {
                   "version": "1.0.0"
                 },
-                "source-map": {
-                  "version": "0.5.3"
-                },
                 "slash": {
                   "version": "1.0.0"
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "3.10.1"
+                },
+                "source-map": {
+                  "version": "0.5.3"
                 }
               }
+            },
+            "wpcom-xhr-request": {
+              "version": "0.5.0"
             }
           }
         }
       }
     },
     "wpcom-xhr-request": {
-      "version": "0.3.4"
+      "version": "0.5.0",
+      "dependencies": {
+        "wp-error": {
+          "version": "1.2.0",
+          "dependencies": {
+            "builtin-status-codes": {
+              "version": "2.0.0"
+            },
+            "uppercamelcase": {
+              "version": "1.1.0",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "xgettext-js": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",
     "wpcom-proxy-request": "1.0.5",
-    "wpcom-unpublished": "1.0.10",
-    "wpcom-xhr-request": "0.3.4",
+    "wpcom-unpublished": "1.1.0",
+    "wpcom-xhr-request": "0.5.0",
     "xgettext-js": "0.3.0"
   },
   "engines": {


### PR DESCRIPTION
We're in the process of migrating WP-API URLs as follows (ref: pMz3w-5l5-p2)

```diff
- https://public-api.wordpress.com/wp-json/sites/4/wp/v2/types
+ https://public-api.wordpress.com/wp/v2/sites/4/types

- https://public-api.wordpress.com/wp-json/sites/4/wpcom/v2/post-counts
+ https://public-api.wordpress.com/wpcom/v2/sites/4/post-counts
```

This PR incorporates previous releases of client libraries:

- https://github.com/Automattic/wpcom-xhr-request/commits/v0.5.0
- https://github.com/Automattic/wpcom.js/commits/4.9.0
- https://github.com/Automattic/wpcom-unpublished/commits/1.1.0

At the end of this chain of npm dependencies is [this change](https://github.com/Automattic/wpcom-xhr-request/commit/4e1000b53d05d9a5042d298652559bb481043850):

```diff
  var basePath = '/rest/v' + apiVersion;
  
- // if this is a wp-api request, adjust basePath
- if ( apiNamespace && wpApiNamespaces.indexOf( apiNamespace ) !== -1 ) {
+ // If this is a WP-API request, adjust basePath
+ if ( apiNamespace && /\//.test( apiNamespace ) ) {
+     // New-style WP-API URL: /wpcom/v2/sites/%s/post-counts
+     basePath = '/' + apiNamespace;
+ } else if ( apiNamespace ) {
+     // Old-style WP-API URL (deprecated): /wp-json/sites/%s/wpcom/v2/post-counts
      basePath = '/wp-json';
  }
```

If the `apiNamespace` parameter uses a slash, direct the request to the new URLs.  This PR updates Calypso to use the new code and pass namespaces with slashes (`wpcom/v2` so far).  This fits with the [intent of WP-API namespaces](http://v2.wp-api.org/extending/adding/#namespacing).

### To test

- Open the Network tab in the console and filter on `wpcom/v2`
- Visit the [post editor](http://calypso.localhost:3000/post) for a WordPress.com (not Jetpack) site that has one or more drafts, and verify that the drafts button loads a count and becomes enabled:
![image](https://cloud.githubusercontent.com/assets/227022/14122296/c61b10de-f5c0-11e5-9364-9b4ac6c8fed0.png)
- Verify that there is a successful network request to `/wpcom/v2/sites/%s/post-counts/post` (no `wp-json` prefix; `wpcom/v2` comes before `sites/%s`)
- Visit the [site settings page](http://calypso.localhost:3000/settings/general) for a WordPress.com site and verify that the "Site Timezone" dropdown loads a bunch of options from `/wpcom/v2/timezones` (no `wp-json` prefix)
