### PR TITLE
Editor: Fix size of delete icon in IE11

### DIFF
--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -39,6 +39,7 @@
 	}
 }
 
+.editor-action-bar__last-group .editor-delete-post .gridicon,
 .editor-action-bar__last-group .editor-sticky .gridicon,
 .editor-action-bar__last-group .editor-visibility .gridicon {
 	width: 24px;


### PR DESCRIPTION
Fixes #4399
Related: #4280, #4263

This pull request seeks to resolve an issue where the trash icon is displayed at a very large size in Internet Explorer.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/14122631/99ffe416-f5ca-11e5-9fe2-c7da182ca91c.png)|![After](https://cloud.githubusercontent.com/assets/1779930/14122622/93f83cd0-f5ca-11e5-904b-0b70e9a7769b.png)

__Testing instructions:__

Repeat steps described in #4399, verifying that the icon appears at the correct size in Internet Explorer and your preferred browser.

__Follow-up tasks:__

#4263 converts the view button to `<Button borderless />` and will need to have a similar style applied.

/cc @gwwar , @lancewillett