### PR TITLE
Offline: sync handler status change

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -55,7 +55,7 @@ function init() {
 	debug( 'Starting Calypso. Let\'s do this.' );
 
 	// prune sync-handler records more than two days old
-	syncHandler.pruneRecordsFrom( '2 days' );
+	syncHandler.pruneStaleRecords( '2 days' );
 
 	// Initialize i18n
 	if ( window.i18nLocaleStrings ) {

--- a/client/lib/wp/sync-handler/README.md
+++ b/client/lib/wp/sync-handler/README.md
@@ -1,9 +1,9 @@
 sync-handler
 ===========
 
-`sync-handler` is an abstraction layer used to sync the data that flowing between 
-the client (calypso) and the server (WordPress.com REST-API). It works wrapping 
-the request handler of the wpcom.js library which allows it intercept, handler 
+`sync-handler` is an abstraction layer used to sync the data that flowing between
+the client (calypso) and the server (WordPress.com REST-API). It works wrapping
+the request handler of the wpcom.js library which allows it intercept, handler
 and store any requests that the client does.
 
 ### How to use
@@ -26,17 +26,17 @@ const wpcom = wpcomUndocumented( handler );
 `sync-handler` which allows us to prune records from our local cache. There are
 two methods to invalidate records:
 
-### syncHandler#pruneRecordsFrom( [lifetime] );
+### syncHandler#pruneStaleRecords( [lifetime] );
 Prune records older than the given `lifetime` (milliseconds or [natural
 language](https://github.com/rauchg/ms.js)). By default the value of the lifetime is `2 days`.
 
 ```es6
 // prune the records that are older than one hour of life
-syncHandler.pruneRecordsFrom( 1000 * 60 * 60 );
+syncHandler.pruneStaleRecords( 1000 * 60 * 60 );
 
 // prune older than 10 hours old
 syncHandler
-	.pruneRecordsFrom( '10 hours' )
+	.pruneStaleRecords( '10 hours' )
 	.then( records => {
 		console.log( 'current records count: %s', records.length );
 	} );
@@ -67,5 +67,5 @@ It allows access to `cache-index` API from the dev console. For instance:
 
 ```es6
 // prune records older than 25 minutes of lifetime.
-cacheIndex.pruneRecordsFrom( '25 minutes' );
+cacheIndex.pruneStaleRecords( '25 minutes' );
 ```

--- a/client/lib/wp/sync-handler/index.js
+++ b/client/lib/wp/sync-handler/index.js
@@ -11,7 +11,7 @@ import warn from 'lib/warn';
 import localforage from 'lib/localforage';
 import { isWhitelisted } from './whitelist-handler';
 import { cacheIndex } from './cache-index';
-import { generateKey, generatePageSeriesKey } from './utils';
+import { generateKey, generatePageSeriesKey, normalizeRequestParams } from './utils';
 
 /**
  * Module variables
@@ -242,13 +242,14 @@ export class SyncHandler {
 	storeRecord( requestKey, data ) {
 		debug( 'storing data in %o requestKey\n', requestKey );
 		let pageSeriesKey;
+		const reqParams = normalizeRequestParams( data.params );
 		if ( data && data.body && data.body.meta && data.body.meta.next_page ) {
 			pageSeriesKey = generatePageSeriesKey( data.params );
 		}
 
 		// add this record to history
 		return cacheIndex
-			.addItem( requestKey, pageSeriesKey )
+			.addItem( requestKey, reqParams, pageSeriesKey )
 				.then( localforage.setItem( requestKey, data ) );
 	}
 
@@ -260,8 +261,8 @@ export class SyncHandler {
 	}
 }
 
-export const pruneRecordsFrom = lifetime => {
-	return cacheIndex.pruneRecordsFrom( lifetime );
+export const pruneStaleRecords = lifetime => {
+	return cacheIndex.pruneStaleRecords( lifetime );
 }
 
 export const clearAll = () => {

--- a/client/lib/wp/sync-handler/test/data.js
+++ b/client/lib/wp/sync-handler/test/data.js
@@ -4,14 +4,15 @@
 import { RECORDS_LIST_KEY } from '../constants';
 
 /**
- * Keys
+ * Keys -- these have been pre-generated using generateKey and generatePageSeriesKey
  */
 export const postListKey = 'sync-record-c8234aa4facc43d9bf2a2ef4037c595200f282f2';
 export const postListNextPageKey = 'sync-record-e1e623dc2933ed96ead4b0508b053660cd4542c3';
-export const postListDifferentKey = 'sync-record-5c73482c2934a7f40601935c92e734748026fe70';
+export const postListDifferentSiteKey = 'sync-record-47c8614e439761ed4406915f31bc16b06ce5181e';
+export const postListWithSearchKey = 'sync-record-5c73482c2934a7f40601935c92e734748026fe70';
 
 export const postListPageSeriesKey = 'sync-record-c8234aa4facc43d9bf2a2ef4037c595200f282f2';
-export const postListPageSeriesKeyDifferent = 'sync-record-5c73482c2934a7f40601935c92e734748026fe70';
+export const postListDifferentPageSeriesKey = 'sync-record-5c73482c2934a7f40601935c92e734748026fe70';
 
 /*
  * Request Parameters
@@ -24,21 +25,26 @@ export const postListParams = {
 	query: 'status=publish%2Cprivate&order_by=date&order=DESC&author=6617482&type=post&site_visibility=visible&meta=counts',
 };
 
-export const postListParamsDifferentOrder = {
+// the same query parameters but in a different order
+export const postListDifferentOrderParams = {
 	apiVersion: '1.1',
 	method: 'GET',
 	path: '/sites/bobinprogress.wordpress.com/posts',
 	query: 'order_by=date&order=DESC&author=6617482&type=post&site_visibility=visible&meta=counts&status=publish%2Cprivate',
 };
 
-export const postListParamsNextPage = {
+// the same parameters, but with a page_handle
+export const postListNextPageParams = {
 	apiVersion: '1.1',
 	method: 'GET',
 	path: '/sites/bobinprogress.wordpress.com/posts',
 	query: 'status=publish%2Cprivate&order_by=date&order=DESC&author=6617482&type=post&site_visibility=visible&meta=counts&page_handle=2014-11-24T13%3A39%3A39-08%3A00%26id=1307',
 };
 
-export const postListParamsDifferent = Object.assign( {}, postListParams, { query: 'filter=test' } );
+// the same post-list request but against a different site
+export const postListDifferentSiteParams = Object.assign( {}, postListParams, { path: '/sites/bobinprogress2.wordpress.com/posts' } );
+
+export const postListWithSearchParams = Object.assign( {}, postListParams, { query: 'search=test' } );
 
 export const nonWhiteListedRequest = {
 	apiVersion: '1.1',
@@ -63,7 +69,7 @@ export const postListResponseBody = {
 	],
 };
 
-export const postListResponseBodyNextPage = {
+export const postListNextPageResponseBody = {
 	found: 3,
 	meta: {
 		data: {},
@@ -77,7 +83,19 @@ export const postListResponseBodyNextPage = {
 	],
 };
 
-export const postListResponseBodyDifferent = {
+export const postListDifferentSiteResponseBody = {
+	found: 1,
+	meta: {
+		data: {},
+		links: {},
+		next_page: 'value=2015-11-24T13%3A39%3A39-08%3A00&id=1234',
+	},
+	posts: [
+		{ ID: 1234 }
+	],
+}
+
+export const postListWithSearchResponseBody = {
 	found: 2,
 	meta: {
 		data: {},
@@ -90,7 +108,7 @@ export const postListResponseBodyDifferent = {
 	],
 };
 
-export const postListResponseBodyFresh = {
+export const postListFreshResponseBody = {
 	found: 3,
 	meta: {
 		data: {},
@@ -104,7 +122,7 @@ export const postListResponseBodyFresh = {
 	]
 }
 
-export const postListResponseBodyNoHandle = Object.assign( {}, postListResponseBody, { meta: {} } );
+export const postListNoHandleResponseBody = Object.assign( {}, postListResponseBody, { meta: {} } );
 
 /*
  * Local Data
@@ -120,24 +138,34 @@ export const postListLocalRecord = {
 	params: Object.assign( {}, postListParams ),
 };
 
-export const postListLocalRecordNextPage = {
+export const postListNextPageLocalRecord = {
 	__sync: {
 		key: postListNextPageKey,
 		synced: 1457329263679,
 		syncing: false,
 	},
-	body: postListResponseBodyNextPage,
-	params: Object.assign( {}, postListParamsNextPage ),
+	body: postListNextPageResponseBody,
+	params: Object.assign( {}, postListNextPageParams ),
 };
 
-export const postListLocalRecordDifferent = {
+export const postListDifferentSiteLocalRecord = {
 	__sync: {
-		key: postListDifferentKey,
+		key: postListDifferentSiteKey,
 		synced: 1457329263679,
 		syncing: false,
 	},
-	body: postListResponseBodyDifferent,
-	params: Object.assign( {}, postListParamsDifferent ),
+	body: postListDifferentSiteResponseBody,
+	params: Object.assign( {}, postListDifferentSiteParams ),
+}
+
+export const postListWithSearchLocalRecord = {
+	__sync: {
+		key: postListWithSearchKey,
+		synced: 1457329263679,
+		syncing: false,
+	},
+	body: postListWithSearchResponseBody,
+	params: Object.assign( {}, postListWithSearchParams ),
 };
 
 export const recordsList = [
@@ -152,15 +180,15 @@ export const recordsList = [
 		timestamp: 1457329263835,
 	},
 	{
-		key: postListDifferentKey,
-		pageSeriesKey: postListPageSeriesKeyDifferent,
+		key: postListWithSearchKey,
+		pageSeriesKey: postListDifferentPageSeriesKey,
 		timestamp: 1457329442428,
 	},
 ];
 
 export const localDataFull = {
 	[ postListKey ]: postListLocalRecord,
-	[ postListNextPageKey ]: postListLocalRecordNextPage,
-	[ postListDifferentKey ]: postListLocalRecordDifferent,
+	[ postListNextPageKey ]: postListNextPageLocalRecord,
+	[ postListWithSearchKey ]: postListWithSearchLocalRecord,
 	[ RECORDS_LIST_KEY ]: recordsList,
 }

--- a/client/lib/wp/sync-handler/test/index.js
+++ b/client/lib/wp/sync-handler/test/index.js
@@ -73,35 +73,35 @@ describe( 'sync-handler', () => {
 			postListParams,
 			postListLocalRecord,
 			postListResponseBody,
-			postListResponseBodyFresh
+			postListFreshResponseBody
 		} = testData;
 		const callback = sinon.spy();
 		setLocalData( {
 			[ postListKey ]: postListLocalRecord
 		} );
-		responseData[ postListKey ] = postListResponseBodyFresh;
+		responseData[ postListKey ] = postListFreshResponseBody;
 		wpcom( postListParams, callback );
 		expect( callback ).to.have.been.calledTwice;
 		expect( callback.calledWith( null, postListResponseBody ) );
-		expect( callback.calledWith( null, postListResponseBodyFresh ) );
+		expect( callback.calledWith( null, postListFreshResponseBody ) );
 	} );
 	it( 'should store cacheIndex records with matching pageSeriesKey for paginated responses', ( done ) => {
 		const {
 			postListKey,
 			postListNextPageKey,
 			postListParams,
-			postListParamsNextPage,
+			postListNextPageParams,
 			postListResponseBody,
-			postListResponseBodyNextPage,
+			postListNextPageResponseBody,
 		} = testData;
 		responseData = {
 			[ postListKey ]: postListResponseBody,
-			[ postListNextPageKey ]: postListResponseBodyNextPage,
+			[ postListNextPageKey ]: postListNextPageResponseBody,
 		};
 		wpcom( postListParams, () => {} );
 		setTimeout( () => {
 			try {
-				wpcom( postListParamsNextPage, () => {} );
+				wpcom( postListNextPageParams, () => {} );
 				setTimeout( () => {
 					try {
 						const freshData = localforageMock.getLocalData();
@@ -123,11 +123,11 @@ describe( 'sync-handler', () => {
 		const {
 			postListParams,
 			postListLocalRecord,
-			postListResponseBodyFresh,
+			postListFreshResponseBody,
 			postListKey,
 		} = testData;
 		setLocalData( { [ postListKey ]: postListLocalRecord } );
-		responseData[ postListKey ] = postListResponseBodyFresh;
+		responseData[ postListKey ] = postListFreshResponseBody;
 		sinon.spy( cacheIndex, 'clearPageSeries' );
 		wpcom( postListParams, () => {} );
 		setTimeout( () => {
@@ -163,9 +163,9 @@ describe( 'sync-handler', () => {
 			expect( key1 ).to.not.equal( key2 );
 		} );
 		it( 'should return the same key if parameters are in different order', () => {
-			const { postListParams, postListParamsDifferentOrder } = testData;
+			const { postListParams, postListDifferentOrderParams } = testData;
 			const key1 = generateKey( postListParams );
-			const key2 = generateKey( postListParamsDifferentOrder );
+			const key2 = generateKey( postListDifferentOrderParams );
 			expect( typeof key1 ).to.equal( 'string' );
 			expect( key1 ).to.equal( key2 );
 		} );
@@ -173,8 +173,8 @@ describe( 'sync-handler', () => {
 
 	describe( 'hasPaginationChanged', () => {
 		it( 'should return false if requestResponse has no page handle', () => {
-			const { postListResponseBodyNoHandle } = testData;
-			const result = hasPaginationChanged( postListResponseBodyNoHandle, null );
+			const { postListNoHandleResponseBody } = testData;
+			const result = hasPaginationChanged( postListNoHandleResponseBody, null );
 			expect( result ).to.equal( false );
 		} );
 		it( 'should return false for call with identical response', () => {
@@ -184,8 +184,8 @@ describe( 'sync-handler', () => {
 			expect( result ).to.equal( false );
 		} );
 		it( 'should return true if page handle is different', () => {
-			const { postListResponseBody, postListResponseBodyFresh } = testData;
-			const result = hasPaginationChanged( postListResponseBody, postListResponseBodyFresh );
+			const { postListResponseBody, postListFreshResponseBody } = testData;
+			const result = hasPaginationChanged( postListResponseBody, postListFreshResponseBody );
 			expect( result ).to.equal( true );
 		} );
 		it( 'should return false with empty local response', () => {

--- a/client/lib/wp/sync-handler/utils.js
+++ b/client/lib/wp/sync-handler/utils.js
@@ -44,3 +44,16 @@ export const generatePageSeriesKey = ( reqParams ) => {
 	const paramsWithoutPage = Object.assign( {}, reqParams, { query: qs.stringify( queryParams ) } );
 	return generateKey( paramsWithoutPage );
 }
+
+/**
+ * generate normalized reqestParams object
+ * @param {Object} reqParams - request parameters
+ * @return {Object} - request params in a more usable format
+ */
+export const normalizeRequestParams = ( reqParams ) => {
+	const query = qs.parse( reqParams.query );
+	const normalizedParams = Object.assign( {}, reqParams, { query } );
+	delete normalizedParams.supports_args;
+	delete normalizedParams.supports_progress;
+	return normalizedParams;
+}


### PR DESCRIPTION
This gives us one more method to clear local records from the sync-handler, which is useful for lists of data, particularly in post-lists.

When you change the status of a post, we know that the local records will be stale for several different lists... for example if you trash a draft on siteA, we know we can clear the local data for; siteA drafts, siteA trash, allSites drafts, allSites trash.

Prior to this change we would briefly show you the stale data before it gets refreshed with the server response. This was particularly noticeable if you go back-and-forth between lists. So in master, if you go to drafts, then trash a post, then view the trashed posts, and then view drafts again, you will briefly see that trashed post in the list. With this branch we instead clear the local data and re-fetch it so there is no longer a flash of incorrect content.

I did quite a bit of renaming of functions and variables to make them more clear and consistent. It may be best to review this branch by checking the individual commits, as I kept them small and targeted.