### PR TITLE
Fix huge gridicons in borderless buttons

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -172,8 +172,8 @@ button {
 	}
 
 	.gridicon {
-		width: auto;
-		height: auto;
+		width: 24px;
+		height: 24px;
 		top: 6px;
 	}
 

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -38,10 +38,3 @@
 		color: darken( $gray, 10% );
 	}
 }
-
-.editor-action-bar__last-group .editor-delete-post .gridicon,
-.editor-action-bar__last-group .editor-sticky .gridicon,
-.editor-action-bar__last-group .editor-visibility .gridicon {
-	width: 24px;
-	height: 24px;
-}


### PR DESCRIPTION
This fixes the huge gridicons in borderless buttons on IE11. This fixes #3460

Why this happened:
* css width/height of `auto` in IE11 will override the width/height props on the SVG element, and resets it to it's default size which is very large
* No versions of IE support `initial` width
* We have an 18px width rule on `.button .gridicon` which was why we had the auto rule in the first place.

In the future, I would suggest removing the 18px rule, and move it onto a more specific rule, so we don't need to reset the gridicon sizes in other places.

Before:
<img width="538" alt="screen shot 2016-03-29 at 2 38 47 pm" src="https://cloud.githubusercontent.com/assets/1270189/14124945/6818119c-f5bd-11e5-83f2-1d47d8589ebc.png">

After:
<img width="544" alt="screen shot 2016-03-29 at 2 38 41 pm" src="https://cloud.githubusercontent.com/assets/1270189/14124947/6d4612cc-f5bd-11e5-8bd7-312cab787b0b.png">

## Testing
Using IE11:
- Navigate to http://calypso.localhost:3000/devdocs/design
- Scroll down to Buttons
- Buttons should look normal
- Navigate to http://calypso.localhost:3000/post
- Select a size
- Gridicons in the top right look normal

cc @aduth @klimeryk @lancewillett 