### PR TITLE
Support: Update support URL to relative path

### DIFF
--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -10,7 +10,7 @@ import sample from 'lodash/sample';
  */
 import Button from 'components/button';
 import Gravatar from 'components/gravatar';
-import supportUrls from 'lib/url/support';
+import support from 'lib/url/support';
 
 const HappinessSupport = React.createClass( {
 	propTypes: {
@@ -28,11 +28,11 @@ const HappinessSupport = React.createClass( {
 	},
 
 	renderContactButton() {
-		let url = supportUrls.CONTACT,
+		let url = support.CALYPSO_CONTACT,
 			target = '';
 
 		if ( this.props.isJetpack ) {
-			url = supportUrls.JETPACK_CONTACT_SUPPORT;
+			url = support.JETPACK_CONTACT_SUPPORT;
 			target = '_blank';
 		}
 
@@ -55,10 +55,10 @@ const HappinessSupport = React.createClass( {
 	},
 
 	renderSupportButton() {
-		let url = supportUrls.SUPPORT_ROOT;
+		let url = support.SUPPORT_ROOT;
 
 		if ( this.props.isJetpack ) {
-			url = supportUrls.JETPACK_SUPPORT;
+			url = support.JETPACK_SUPPORT;
 		}
 
 		return (

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -12,7 +12,7 @@ export default {
 	CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS: `${root}/domains/change-name-servers/#finding-out-your-new-name-server`,
 	COMMENTS: `${root}/category/comments`,
 	COMMUNITY_TRANSLATOR: `${root}/community-translator`,
-	CONTACT: `https://wordpress.com/help/contact`,
+	CALYPSO_CONTACT: `/help/contact`,
 	CUSTOM_DNS: `${root}/domains/custom-dns`,
 	DOMAINS: `${root}/domains`,
 	EMAIL_FORWARDING: `${root}/email-forwarding`,

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -18,7 +18,7 @@ import { isDomainRegistration } from 'lib/products-values';
 import Main from 'components/main';
 import paths from '../paths';
 import ProductLink from 'me/purchases/product-link';
-import supportPaths from 'lib/url/support';
+import support from 'lib/url/support';
 import titles from 'me/purchases/titles';
 
 const CancelPurchase = React.createClass( {
@@ -128,7 +128,7 @@ const CancelPurchase = React.createClass( {
 						<strong className="cancel-purchase__support-information">
 							{ this.translate( 'Have a question? {{contactLink}}Ask a Happiness Engineer!{{/contactLink}}', {
 								components: {
-									contactLink: <a href={ supportPaths.CONTACT } />
+									contactLink: <a href={ support.CALYPSO_CONTACT } />
 								}
 							} ) }
 						</strong>

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -14,6 +14,7 @@ import MeSidebarNavigation from 'me/sidebar-navigation';
 import Notice from 'components/notice';
 import PurchasesHeader from './header';
 import PurchasesSite from './site';
+import support from 'lib/url/support';
 
 const PurchasesList = React.createClass( {
 	propTypes: {
@@ -46,7 +47,7 @@ const PurchasesList = React.createClass( {
 				'Please {{a}}contact support{{/a}} for more information.',
 				{
 					components: {
-						a: <a href="https://support.wordpress.com/" />
+						a: <a href={ support.CALYPSO_CONTACT } />
 					}
 				}
 			);

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -44,7 +44,7 @@ import paths from '../paths';
 import PaymentLogo from 'components/payment-logo';
 import ProductLink from 'me/purchases/product-link';
 import RemovePurchase from '../remove-purchase';
-import supportPaths from 'lib/url/support';
+import support from 'lib/url/support';
 import titles from 'me/purchases/titles';
 import VerticalNavItem from 'components/vertical-nav/item';
 import * as upgradesActions from 'lib/upgrades/actions';
@@ -126,7 +126,7 @@ const ManagePurchase = React.createClass( {
 					},
 					components: {
 						strong: <strong />,
-						contactSupportLink: <a href={ supportPaths.CONTACT } />
+						contactSupportLink: <a href={ support.CALYPSO_CONTACT } />
 					}
 				} ) }
 			</div>

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -11,7 +11,8 @@ var Notice = require( 'components/notice' ),
 	Security2faBackupCodesList = require( 'me/security-2fa-backup-codes-list' ),
 	Security2faProgress = require( 'me/security-2fa-progress' ),
 	twoStepAuthorization = require( 'lib/two-step-authorization' ),
-	eventRecorder = require( 'me/event-recorder' );
+	eventRecorder = require( 'me/event-recorder' ),
+	support = require( 'lib/url/support' );
 
 module.exports = React.createClass( {
 
@@ -68,7 +69,7 @@ module.exports = React.createClass( {
 				components: {
 					supportLink: (
 						<a
-							href="https://support.wordpress.com/contact/"
+							href={ support.CALYPSO_CONTACT }
 							onClick={ this.recordClickEvent( 'No Backup Codes Contact Support Link' ) }
 						/>
 					)

--- a/client/my-sites/exporter/exporter.jsx
+++ b/client/my-sites/exporter/exporter.jsx
@@ -12,6 +12,7 @@ import SpinnerButton from './spinner-button';
 import Interval, { EVERY_SECOND } from 'lib/interval';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import support from 'lib/url/support';
 
 export default React.createClass( {
 	displayName: 'Exporter',
@@ -75,7 +76,7 @@ export default React.createClass( {
 					showDismiss={ false }
 					text={ this.translate( 'There was a problem preparing your export file. Please check your connection and try again, or contact support.' ) }
 				>
-					<NoticeAction href={ '/help/contact' }>
+					<NoticeAction href={ support.CALYPSO_CONTACT }>
 						{ this.translate( 'Get Help' ) }
 					</NoticeAction>
 				</Notice>

--- a/client/my-sites/upgrades/domain-management/edit-contact-info/privacy-enabled-card.jsx
+++ b/client/my-sites/upgrades/domain-management/edit-contact-info/privacy-enabled-card.jsx
@@ -19,7 +19,7 @@ const EditContactInfoPrivacyEnabledCard = React.createClass( {
 						'If you need to make a change to your domain\'s contact info, please {{a}}contact support{{/a}}.',
 						{
 							components: {
-								a: <a href={ support.CONTACT } target="_blank" />
+								a: <a href={ support.CALYPSO_CONTACT } target="_blank" />
 							}
 						}
 					) }

--- a/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-add-new.jsx
+++ b/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-add-new.jsx
@@ -20,7 +20,7 @@ import analyticsMixin from 'lib/mixins/analytics';
 import notices from 'notices';
 import * as upgradesActions from 'lib/upgrades/actions';
 import { validateAllFields } from 'lib/domains/email-forwarding';
-import supportUrls from 'lib/url/support';
+import support from 'lib/url/support';
 
 const EmailForwardingAddNew = React.createClass( {
 	propTypes: {
@@ -81,7 +81,7 @@ const EmailForwardingAddNew = React.createClass( {
 					notices.error( error.message || this.translate( 'Failed to add email forwarding record. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
 						{
 							components: {
-								contactSupportLink: <a href={ supportUrls.CONTACT }/>
+								contactSupportLink: <a href={ support.CALYPSO_CONTACT }/>
 							}
 						} )
 					);

--- a/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/upgrades/domain-management/email-forwarding/email-forwarding-item.jsx
@@ -13,7 +13,7 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import notices from 'notices';
 import { successNotice } from 'state/notices/actions';
-import supportUrls from 'lib/url/support';
+import support from 'lib/url/support';
 import * as upgradesActions from 'lib/upgrades/actions';
 
 const EmailForwardingItem = React.createClass( {
@@ -33,7 +33,7 @@ const EmailForwardingItem = React.createClass( {
 				notices.error( error.message || this.translate( 'Failed to delete email forwarding record. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
 					{
 						components: {
-							contactSupportLink: <a href={ supportUrls.CONTACT }/>
+							contactSupportLink: <a href={ support.CALYPSO_CONTACT }/>
 						}
 					} )
 				);
@@ -64,7 +64,7 @@ const EmailForwardingItem = React.createClass( {
 				notices.error( this.translate( 'Failed to resend verification email for email forwarding record. Please try again or {{contactSupportLink}}contact support{{/contactSupportLink}}.',
 					{
 						components: {
-							contactSupportLink: <a href={ supportUrls.CONTACT }/>
+							contactSupportLink: <a href={ support.CALYPSO_CONTACT }/>
 						}
 					} )
 				);

--- a/client/my-sites/upgrades/domain-management/transfer/shared.js
+++ b/client/my-sites/upgrades/domain-management/transfer/shared.js
@@ -36,7 +36,7 @@ export const displayResponseError = ( responseError ) => {
 					args: errorMessages[ responseError.error ],
 					components: {
 						strong: <strong />,
-						a: <a href={ support.CONTACT } target="_blank"/>
+						a: <a href={ support.CALYPSO_CONTACT } target="_blank"/>
 					}
 				}
 			)
@@ -49,7 +49,7 @@ export const displayResponseError = ( responseError ) => {
 				'to have trouble.',
 				{
 					components: {
-						a: <a href={ support.CONTACT } target="_blank"/>
+						a: <a href={ support.CALYPSO_CONTACT } target="_blank"/>
 					}
 				}
 			)

--- a/client/my-sites/upgrades/domain-management/transfer/unlocked.jsx
+++ b/client/my-sites/upgrades/domain-management/transfer/unlocked.jsx
@@ -34,7 +34,7 @@ const Unlocked = React.createClass( {
 			siteId: this.props.selectedSite.ID
 		}, ( error ) => {
 			if ( error ) {
-				const contactLink = <a href={ support.CONTACT } target="_blank"/>;
+				const contactLink = <a href={ support.CALYPSO_CONTACT } target="_blank"/>;
 				let errorMessage;
 
 				switch ( error.error ) {


### PR DESCRIPTION
This is an anticipated fix for #4320. It updates the URL in [`client/lib/url/support.js`](https://github.com/Automattic/wp-calypso/blob/master/client/lib/url/support.js#L15) from `https://wordpress.com/help/contact` to `/help/contact` so the URL works in all environments.

I also updated the reference we're using for "Contact" in two other areas:
-  [`purchases/list/index.jsx`](https://github.com/Automattic/wp-calypso/blob/4810232ff5c7e85accaddd8888a335a0c8ee99be/client/me/purchases/list/index.jsx#L37) when there's a cancellation problem. You can test this when running the branch by visiting `purchases/cancel-problem` and viewing the link in "Please contact support for more information."
- [`me/security-2fa-setup-backup-codes/index.jsx`](https://github.com/Automattic/wp-calypso/blob/8aa30953c0aec9647b59f05984967c5b337fad28/client/me/security-2fa-setup-backup-codes/index.jsx#L71) when there's an error obtaining backup codes. **I honestly haven't found a way to test this**, but I can't see why it couldn't work.

To make sure this was working correctly, I found a few cases where it's used and gave it a go:

First, [`client/components/happiness-support/index.jsx`](https://github.com/Automattic/wp-calypso/blob/96c5d26189b74a9f1bfcb7568f22ce3215e160ce/client/components/happiness-support/index.jsx#L31), which loads on the "Thank You" page, for example.

![screen shot 2016-03-29 at 4 06 10 pm](https://cloud.githubusercontent.com/assets/7240478/14125390/311ba5a4-f5c8-11e5-8f8d-9cbb751b70d8.png)

Second, [`domain-management/edit-contact-info/privacy-enabled-card.jsx`](https://github.com/Automattic/wp-calypso/blob/b229c821d3f17064e32487b2ada2d01dabbcceca/client/my-sites/upgrades/domain-management/edit-contact-info/privacy-enabled-card.jsx), which loads when users want to change contact information on a domain that has privacy active.

![screen shot 2016-03-29 at 16 07 52](https://cloud.githubusercontent.com/assets/7240478/14125433/6c16d570-f5c8-11e5-8405-3228ad7cadb4.png)

Finally, I loaded http://calypso.localhost:3000/purchases/cancel-problem with the branch running. The "contact support" link was correctly updated.

All three appear to work correctly. The easiest way to test this though is by checking out the App Components:

1. Run this branch locally
2. Visit the App Components here: http://calypso.localhost:3000/devdocs/app-components
3. View the link for "Ask a Question" under the `HappinessSupport` component