### PR TITLE
Domains: Fix error on mapping domains with no expiry

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/mapped-domain.jsx
@@ -29,9 +29,12 @@ const MappedDomain = React.createClass( {
 			);
 		}
 
+		const expirationMessage = domain.expirationMoment && domain.expirationMoment.format( 'MMMM D, YYYY' ) ||
+			<em>{ this.translate( 'Never Expires', { context: 'Expiration detail for a mapped domain' } ) }</em>;
+
 		return (
 			<Property label={ this.translate( 'Mapping expires on' ) }>
-				{ domain.expirationMoment.format( 'MMMM D, YYYY' ) }
+				{ expirationMessage }
 			</Property>
 		);
 	},
@@ -79,7 +82,7 @@ const MappedDomain = React.createClass( {
 
 	emailNavItem() {
 		const path = paths.domainManagementEmail(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.domain.name
 		);
 
@@ -92,7 +95,7 @@ const MappedDomain = React.createClass( {
 
 	dnsRecordsNavItem() {
 		const path = paths.domainManagementDns(
-			this.props.selectedSite.domain,
+			this.props.selectedSite.slug,
 			this.props.domain.name
 		);
 

--- a/client/my-sites/upgrades/domain-management/edit/test/test-mapped-domain.js
+++ b/client/my-sites/upgrades/domain-management/edit/test/test-mapped-domain.js
@@ -1,0 +1,56 @@
+import assert from 'assert';
+
+describe( 'domain-management/edit/mapped-domain', () => {
+	let React,
+		MappedDomain,
+		i18n,
+		props,
+		sinonWrapper,
+		TestUtils;
+
+	before( () => {
+		props = {
+			selectedSite: {
+				slug: 'neverexpires.wordpress.com',
+				domain: 'neverexpires.com'
+			},
+			domain: {
+				name: 'neverexpires.com',
+				expirationMoment: null
+			}
+		};
+	} );
+
+	require( 'test/helpers/use-fake-dom' ).withContainer();
+	sinonWrapper = require( 'test/helpers/use-sinon' ).useSandbox();
+
+	require( 'test/helpers/use-mockery' )( mockery => {
+		React = require( 'react' );
+		TestUtils = require( 'react-addons-test-utils' );
+		i18n = require( 'test/helpers/mocks/i18n' )( mockery );
+		const ReactInjection = require( 'react/lib/ReactInjection' );
+		ReactInjection.Class.injectMixin( i18n );
+		MappedDomain = require( '../mapped-domain.jsx' );
+	} );
+
+	it( 'should render when props.domain.expirationMoment is null', () => {
+		const renderer = TestUtils.createRenderer();
+		renderer.render( <MappedDomain { ...props } /> );
+		const out = renderer.getRenderOutput();
+
+		assert( out );
+	} );
+
+	it( 'should use selectedSite.slug for URLs', () => {
+		const paths = require( 'my-sites/upgrades/paths' );
+		const dnsStub = sinonWrapper.sandbox.stub( paths, 'domainManagementDns' );
+		const emailStub = sinonWrapper.sandbox.stub( paths, 'domainManagementEmail' );
+
+		const renderer = TestUtils.createRenderer();
+		renderer.render( <MappedDomain { ...props } /> );
+		renderer.getRenderOutput();
+
+		assert( dnsStub.calledWith( 'neverexpires.wordpress.com', 'neverexpires.com' ) );
+		assert( emailStub.calledWith( 'neverexpires.wordpress.com', 'neverexpires.com' ) );
+	} );
+} );

--- a/client/tests.json
+++ b/client/tests.json
@@ -298,6 +298,9 @@
 					"test": [
 						"index"
 					]
+				},
+				"edit": {
+					"test": [ "test-mapped-domain" ]
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #4338, which broke mapped domains with no expiration (notably VIP sites). It'll now say "Never" on expiration time.

Also changes the usage of `selectedSite.domain` to `selectedSite.slug` which is the proper usage in case of a name conflict between the sites. 

Added tests for both.

Testing:
- Go to VIP site and confirm everything works as expected.

/cc: @klimeryk @aidvu