### PR TITLE
Signup: Force a re-rendering of translations when the locale changes in props

### DIFF
--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -14,6 +14,7 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import BackButton from 'components/header-cake';
 import Gridicon from 'components/gridicon';
+import i18n from 'lib/mixins/i18n';
 import { getABTestVariation } from 'lib/abtest';
 
 function isSurveyOneStep() {
@@ -39,6 +40,15 @@ export default React.createClass( {
 		return {
 			stepOne: null,
 			verticalList: verticals.get()
+		}
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.locale !== nextProps.locale ) {
+			this.setState( {
+				verticalList: verticals.get()
+			} );
+			i18n.reRenderTranslations();
 		}
 	},
 

--- a/client/signup/steps/survey/verticals.js
+++ b/client/signup/steps/survey/verticals.js
@@ -5,73 +5,75 @@ import shuffle from 'lodash/shuffle';
 import find from 'lodash/find';
 import { translate } from 'lib/mixins/i18n';
 
-const verticals = [
-	{ value: 'a8c.1', label: translate( 'Arts & Entertainment' ), icon: 'video-camera', stepTwo: [
-		{ value: 'a8c.1', label: translate( 'General Arts & Entertainment' ), isGeneral: true },
-		{ value: 'a8c.1.3.1', label: translate( 'Creative Arts & Design' ) },
-		{ value: 'a8c.1.3.2', label: translate( 'Entertainment & Culture' ) },
-		{ value: 'a8c.1.6', label: translate( 'Music' ) },
-		{ value: 'a8c.1.5', label: translate( 'Movies' ) },
-		{ value: 'a8c.9.23', label: translate( 'Photography' ) },
-		{ value: 'a8c.18', label: translate( 'Style & Fashion' ) },
-		{ value: 'a8c.17', label: translate( 'Sports & Recreation' ) },
-	] },
+function getVerticalData() {
+	return [
+		{ value: 'a8c.1', label: translate( 'Arts & Entertainment' ), icon: 'video-camera', stepTwo: [
+			{ value: 'a8c.1', label: translate( 'General Arts & Entertainment' ), isGeneral: true },
+			{ value: 'a8c.1.3.1', label: translate( 'Creative Arts & Design' ) },
+			{ value: 'a8c.1.3.2', label: translate( 'Entertainment & Culture' ) },
+			{ value: 'a8c.1.6', label: translate( 'Music' ) },
+			{ value: 'a8c.1.5', label: translate( 'Movies' ) },
+			{ value: 'a8c.9.23', label: translate( 'Photography' ) },
+			{ value: 'a8c.18', label: translate( 'Style & Fashion' ) },
+			{ value: 'a8c.17', label: translate( 'Sports & Recreation' ) },
+		] },
 
-	{ value: 'a8c.3', label: translate( 'Business & Services' ), icon: 'briefcase', stepTwo: [
-		{ value: 'a8c.3', label: translate( 'General Business & Services' ), isGeneral: true },
-		{ value: 'a8c.3.0.1', label: translate( 'Finance & Law' ) },
-		{ value: 'a8c.3.0.2', label: translate( 'Consulting & Coaching' ) },
-		{ value: 'a8c.3.0.3', label: translate( 'Restaurants & Locales' ) },
-		{ value: 'a8c.3.1.1', label: translate( 'Advertising & Marketing' ) },
-		{ value: 'a8c.2', label: translate( 'Automotive' ) },
-		{ value: 'a8c.21', label: translate( 'Real Estate' ) },
-		{ value: 'a8c.19', label: translate( 'Technology & Computing' ) },
-		{ value: 'a8c.20.18.1', label: translate( 'Hotels & Vacation Rentals' ) },
-		{ value: 'a8c.3.0.4', label: translate( 'Communications' ) },
-	] },
+		{ value: 'a8c.3', label: translate( 'Business & Services' ), icon: 'briefcase', stepTwo: [
+			{ value: 'a8c.3', label: translate( 'General Business & Services' ), isGeneral: true },
+			{ value: 'a8c.3.0.1', label: translate( 'Finance & Law' ) },
+			{ value: 'a8c.3.0.2', label: translate( 'Consulting & Coaching' ) },
+			{ value: 'a8c.3.0.3', label: translate( 'Restaurants & Locales' ) },
+			{ value: 'a8c.3.1.1', label: translate( 'Advertising & Marketing' ) },
+			{ value: 'a8c.2', label: translate( 'Automotive' ) },
+			{ value: 'a8c.21', label: translate( 'Real Estate' ) },
+			{ value: 'a8c.19', label: translate( 'Technology & Computing' ) },
+			{ value: 'a8c.20.18.1', label: translate( 'Hotels & Vacation Rentals' ) },
+			{ value: 'a8c.3.0.4', label: translate( 'Communications' ) },
+		] },
 
-	{ value: 'a8c.9', label: translate( 'Family, Home, & Lifestyle' ), icon: 'house', stepTwo: [
-		{ value: 'a8c.9', label: translate( 'General Family, Home, & Lifestyle' ), isGeneral: true },
-		{ value: 'a8c.6', label: translate( 'Family & Parenting' ) },
-		{ value: 'a8c.14.7', label: translate( 'Events & Weddings' ) },
-		{ value: 'a8c.10', label: translate( 'Home & Garden' ) },
-		{ value: 'a8c.8', label: translate( 'Food & Drink' ) },
-		{ value: 'a8c.9.2', label: translate( 'DIY & Crafting' ) },
-		{ value: 'a8c.20', label: translate( 'Travel' ) },
-		{ value: 'a8c.16', label: translate( 'Pets' ) },
-	] },
+		{ value: 'a8c.9', label: translate( 'Family, Home, & Lifestyle' ), icon: 'house', stepTwo: [
+			{ value: 'a8c.9', label: translate( 'General Family, Home, & Lifestyle' ), isGeneral: true },
+			{ value: 'a8c.6', label: translate( 'Family & Parenting' ) },
+			{ value: 'a8c.14.7', label: translate( 'Events & Weddings' ) },
+			{ value: 'a8c.10', label: translate( 'Home & Garden' ) },
+			{ value: 'a8c.8', label: translate( 'Food & Drink' ) },
+			{ value: 'a8c.9.2', label: translate( 'DIY & Crafting' ) },
+			{ value: 'a8c.20', label: translate( 'Travel' ) },
+			{ value: 'a8c.16', label: translate( 'Pets' ) },
+		] },
 
-	{ value: 'a8c.5', label: translate( 'Education & Organizations' ), icon: 'institution', stepTwo: [
-		{ value: 'a8c.5', label: translate( 'General Education & Organizations' ), isGeneral: true },
-		{ value: 'a8c.3.0.6', label: translate( 'Communities & Associations' ) },
-		{ value: 'a8c.3.0.5', label: translate( 'Non-Profit' ) },
-		{ value: 'a8c.23', label: translate( 'Religion & Spirituality' ) },
-		{ value: 'a8c.5.14', label: translate( 'Special Education' ) },
-		{ value: 'a8c.5.1', label: translate( 'High School Education' ) },
-		{ value: 'a8c.5.5', label: translate( 'College Education' ) },
-		{ value: 'a8c.5.10', label: translate( 'Homeschooling' ) },
-	] },
+		{ value: 'a8c.5', label: translate( 'Education & Organizations' ), icon: 'institution', stepTwo: [
+			{ value: 'a8c.5', label: translate( 'General Education & Organizations' ), isGeneral: true },
+			{ value: 'a8c.3.0.6', label: translate( 'Communities & Associations' ) },
+			{ value: 'a8c.3.0.5', label: translate( 'Non-Profit' ) },
+			{ value: 'a8c.23', label: translate( 'Religion & Spirituality' ) },
+			{ value: 'a8c.5.14', label: translate( 'Special Education' ) },
+			{ value: 'a8c.5.1', label: translate( 'High School Education' ) },
+			{ value: 'a8c.5.5', label: translate( 'College Education' ) },
+			{ value: 'a8c.5.10', label: translate( 'Homeschooling' ) },
+		] },
 
-	{ value: 'a8c.7', label: translate( 'Health & Wellness' ), icon: 'heart', stepTwo: [
-		{ value: 'a8c.7', label: translate( 'General Health & Wellness' ), isGeneral: true },
-		{ value: 'a8c.7.37.1', label: translate( 'Mental Health' ) },
-		{ value: 'a8c.7.1.1', label: translate( 'Exercise / Weight Loss' ) },
-		{ value: 'a8c.7.31', label: translate( 'Men\'s Health' ) },
-		{ value: 'a8c.7.45', label: translate( 'Women\'s Health' ) },
-		{ value: 'a8c.7.37', label: translate( 'Psychology / Psychiatry' ) },
-		{ value: 'a8c.7.32', label: translate( 'Nutrition' ) },
-	] },
+		{ value: 'a8c.7', label: translate( 'Health & Wellness' ), icon: 'heart', stepTwo: [
+			{ value: 'a8c.7', label: translate( 'General Health & Wellness' ), isGeneral: true },
+			{ value: 'a8c.7.37.1', label: translate( 'Mental Health' ) },
+			{ value: 'a8c.7.1.1', label: translate( 'Exercise / Weight Loss' ) },
+			{ value: 'a8c.7.31', label: translate( 'Men\'s Health' ) },
+			{ value: 'a8c.7.45', label: translate( 'Women\'s Health' ) },
+			{ value: 'a8c.7.37', label: translate( 'Psychology / Psychiatry' ) },
+			{ value: 'a8c.7.32', label: translate( 'Nutrition' ) },
+		] },
 
-	{ value: 'a8c.1.1', label: translate( 'Writing & Books' ), icon: 'book', stepTwo: [
-		{ value: 'a8c.1.1', label: translate( 'General Writing & Books' ), isGeneral: true },
-		{ value: 'a8c.1.1.1', label: translate( 'Book Reviews & Clubs' ) },
-		{ value: 'a8c.1.4', label: translate( 'Humor' ) },
-		{ value: 'a8c.1.1.2', label: translate( 'Fiction & Poetry' ) },
-		{ value: 'a8c.1.1.3', label: translate( 'Author Site' ) },
-		{ value: 'a8c.9.28', label: translate( 'Screenwriting' ) },
-		{ value: 'a8c.1.1.4', label: translate( 'Non-fiction & Memoir' ) },
-	] },
-];
+		{ value: 'a8c.1.1', label: translate( 'Writing & Books' ), icon: 'book', stepTwo: [
+			{ value: 'a8c.1.1', label: translate( 'General Writing & Books' ), isGeneral: true },
+			{ value: 'a8c.1.1.1', label: translate( 'Book Reviews & Clubs' ) },
+			{ value: 'a8c.1.4', label: translate( 'Humor' ) },
+			{ value: 'a8c.1.1.2', label: translate( 'Fiction & Poetry' ) },
+			{ value: 'a8c.1.1.3', label: translate( 'Author Site' ) },
+			{ value: 'a8c.9.28', label: translate( 'Screenwriting' ) },
+			{ value: 'a8c.1.1.4', label: translate( 'Non-fiction & Memoir' ) },
+		] },
+	];
+}
 
 /**
  * Shuffle a multi-dimensional array of verticals, but put the General vertical last.
@@ -96,6 +98,6 @@ function shuffleVerticals( elements ) {
 
 export default {
 	get() {
-		return shuffleVerticals( verticals );
+		return shuffleVerticals( getVerticalData() );
 	}
 }


### PR DESCRIPTION
Using the "Also available in..." prompt in signup to switch languages doesn't work properly. For example, from FR to EN works the first time, but not the second (going back to FR).

![screen shot 2016-03-29 at 5 00 05 pm](https://cloud.githubusercontent.com/assets/349751/14127849/21a826c6-f5d0-11e5-8fdd-cfa51c7a4436.png)

![screen shot 2016-03-29 at 5 00 29 pm](https://cloud.githubusercontent.com/assets/349751/14127859/2c16f4de-f5d0-11e5-8a35-3e526355e9f0.png)

![screen shot 2016-03-29 at 5 00 46 pm](https://cloud.githubusercontent.com/assets/349751/14127862/33d05328-f5d0-11e5-8780-b9cd851a5cae.png)
