### PR TITLE
Support User: Enable in staging

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -80,6 +80,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": false,
+		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -77,6 +77,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
+		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,


### PR DESCRIPTION
Support user functionality has been enabled in `wpcalypso` and `development` environments for some time, this just switches it on in `stage` and `horizon`.

Tested locally with a staging configuration.

ref p195om-2GO-p2

cc @dllh 