### PR TITLE
Framework: bump wpcom-unpublished to pick up a change in wpcom.js

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8319,10 +8319,10 @@
       }
     },
     "wpcom-unpublished": {
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "wpcom": {
-          "version": "4.9.0",
+          "version": "4.9.2",
           "dependencies": {
             "babel": {
               "version": "5.8.38",
@@ -8898,7 +8898,7 @@
                           }
                         },
                         "nan": {
-                          "version": "2.2.0"
+                          "version": "2.2.1"
                         }
                       }
                     },
@@ -9029,9 +9029,6 @@
                   "version": "0.5.3"
                 }
               }
-            },
-            "wpcom-xhr-request": {
-              "version": "0.5.0"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",
     "wpcom-proxy-request": "1.0.5",
-    "wpcom-unpublished": "1.1.0",
+    "wpcom-unpublished": "1.1.1",
     "wpcom-xhr-request": "0.5.0",
     "xgettext-js": "0.3.0"
   },


### PR DESCRIPTION
There was a bug in wpcom.js that was causing wp-desktop to be unable to build. `wpcom.js` and `wpcom-unpublished` have been updated. I followed the [instructions here](https://github.com/Automattic/wp-calypso/blob/master/docs/shrinkwrap.md) to generate the updated shrinkwrap file. Calypso should run as usual with no regressions in this branch.

/cc @nylen