### PR TITLE
Smileys in comments: Fix sizing issue

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -46,6 +46,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
+		link(rel='stylesheet', href='//s1.wp.com/wp-content/mu-plugins/wpcom-smileys/wpcom-smileys.css?v=20160330')
 		if isRTL
 			link(rel='stylesheet', href=urls['style-rtl.css'])
 		else


### PR DESCRIPTION
Yesterday in #4385 I removed a smiley stylesheet I thought was redundant. I was wrong, as it turns out, as this stylesheet is still needed for smileys shown in the zoomed reader view, and posts.

![screen shot 2016-03-30 at 10 26 20](https://cloud.githubusercontent.com/assets/1204802/14136336/a4abf844-f662-11e5-8ce3-678453e015eb.png)

This PR restores that stylesheet and fixes the issue.