### PR TITLE
Upgrades: Cart: increase the polling time to the default

### DIFF
--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -22,8 +22,6 @@ var UpgradesActionTypes = require( 'lib/upgrades/constants' ).action,
 	applyCoupon = cartValues.applyCoupon,
 	cartItems = cartValues.cartItems;
 
-var POLLING_INTERVAL = 5000;
-
 var _selectedSiteID = null,
 	_synchronizer = null,
 	_poller = null;
@@ -71,7 +69,7 @@ function setSelectedSite() {
 	_synchronizer = cartSynchronizer( selectedSite.ID, wpcom );
 	_synchronizer.on( 'change', emitChange );
 
-	_poller = PollerPool.add( CartStore, _synchronizer._poll.bind( _synchronizer ), { interval: POLLING_INTERVAL } );
+	_poller = PollerPool.add( CartStore, _synchronizer._poll.bind( _synchronizer ) );
 }
 
 function emitChange() {


### PR DESCRIPTION
The default is 30 sec. The cart synchronizer does too little to justify hundreds of requests per typical user session. These requests cost resources.

To test:
1. Go to /domains/add, open the network tab of your browser and wait. You should see one GET to the cart endpoint every 30 sec.