### PR TITLE
Smileys & Emoji: Refactor and improve display

### DIFF
--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -280,6 +280,13 @@ html.iframed {
 	line-height: 1;
 }
 
+/* Emoji and smileys */
+.emoji,
+.wp-smiley {
+	height: 1em;
+	max-height: 1em;
+}
+
 
 /* =General Layout
 ----------------------------------------------- */

--- a/assets/stylesheets/layout/_main.scss
+++ b/assets/stylesheets/layout/_main.scss
@@ -281,10 +281,14 @@ html.iframed {
 }
 
 /* Emoji and smileys */
-.emoji,
-.wp-smiley {
+img.emoji,
+img.wp-smiley {
 	height: 1em;
 	max-height: 1em;
+	display: inline;
+	margin: 0;
+	padding: 0 0.2em;
+	vertical-align: -0.1em;
 }
 
 

--- a/client/reader/_style.scss
+++ b/client/reader/_style.scss
@@ -6,16 +6,6 @@
 			color: $blue-light;
 		}
 	}
-
-	img.emoji,
-	img.wp-smiley {
-		display: inline;
-		height: 1em;
-		width: 1em;
-		margin: 0;
-		padding: 0 0.2em;
-		vertical-align: -0.1em;
-	}
 }
 
 .reader__content,

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -213,14 +213,6 @@
 		height: auto;
 		display: inline;
 		margin: auto;
-
-		&.emoji, &.wp-smiley  {
-			height: 1em;
-			width: 1em;
-			margin: 0;
-			padding: 0 0.2em;
-			vertical-align: -0.1em;
-		}
 	}
 
 	@include breakpoint( ">660px" ) {

--- a/client/reader/post-byline/_style.scss
+++ b/client/reader/post-byline/_style.scss
@@ -4,15 +4,6 @@
 	margin: 0;
 	padding: 16px 0 8px 0;
 
-	img.emoji, img.wp-smiley {
-		display: inline;
-		height: 1em;
-		width: 1em;
-		margin: 0;
-		padding: 0 0.2em;
-		vertical-align: -0.1em;
-	}
-
 	li {
 		margin: 0 16px 0 0;
 		display: inline-block;

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -46,7 +46,6 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		link(rel='stylesheet', href='//s1.wp.com/i/fonts/merriweather/merriweather.css?v=20160210')
 		link(rel='stylesheet', href='//s1.wp.com/i/noticons/noticons.css?v=20150727')
 		link(rel='stylesheet', href='//s1.wp.com/wp-includes/css/dashicons.css?v=20150727')
-		link(rel='stylesheet', href='//s1.wp.com/wp-content/mu-plugins/wpcom-smileys/wpcom-smileys.css?v=20160330')
 		if isRTL
 			link(rel='stylesheet', href=urls['style-rtl.css'])
 		else


### PR DESCRIPTION
This PR makes two changes:

1. It adds CSS to size emoji and WordPress smileys the same.
2. It retires the global stylesheet that added CSS to just the WordPress smileys.

Before it looked like this:

![before](https://cloud.githubusercontent.com/assets/1204802/14139300/7bf41dfe-f672-11e5-8b6f-ebe668289ac3.png)

(The big emoji are unscaled 36px Twemoji graphics)

With this PR it looks like this: 

![after](https://cloud.githubusercontent.com/assets/1204802/14139316/8f1a5e0c-f672-11e5-8671-c625f079512f.png)

Previously: #4414 and #4385