### PR TITLE
SiteSettings: fix typo in timezones section

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -158,7 +158,7 @@ module.exports = React.createClass( {
 					/>
 
 					<FormSettingExplanation>
-						{ this.translate( 'Choose a city in your timezone.' ) };
+						{ this.translate( 'Choose a city in your timezone.' ) }
 					</FormSettingExplanation>
 				</FormFieldset>
 			</div>


### PR DESCRIPTION
Fix type in timezones section: https://github.com/Automattic/wp-calypso/issues/3902#issuecomment-203025610

![](https://cloud.githubusercontent.com/assets/1464705/14118048/74a7f312-f59c-11e5-8358-20fc8b109e28.png)

cc @apeatling