### PR TITLE
Reader: Add treatment for featured image captions

### DIFF
--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -228,9 +228,30 @@
 		}
 	}
 
+	&.has-caption {
+		border-bottom: 0;
+	}
+
 	// This helps avoid some random whitespace below YourTube embeds.
 	iframe {
 		display: block;
+	}
+}
+
+// Featured image captions
+.reader__post-featured-image-caption {
+	margin: 0;
+	padding: 8px 24px;
+    width: calc( 100% - 48px);
+	border-top: 1px solid lighten( $gray, 20 );
+	background-color: $gray-light;
+	font-size: 11px;
+	font-family: $sans;
+	color: darken( $gray, 10 );
+	position: relative;
+
+	@include breakpoint( "<480px" ) {
+		padding: 8px 16px;
 	}
 }
 

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -205,7 +205,7 @@ const Post = React.createClass( {
 			featuredSize = this.getFeaturedSize( maxWidth );
 		}
 
-		let featuredImageClasses = classnames( 'reader__post-featured-image' );
+		let featuredImageClasses = classnames( 'reader__post-featured-image', 'has-caption' );
 
 		const maxImageHeight = ( {
 			fifty: '50vh',
@@ -235,6 +235,7 @@ const Post = React.createClass( {
 						/>
 					: <img className="reader__post-featured-image-image" src={ featuredImage } />
 				}
+			<div className="reader__post-featured-image-caption">Sample caption <a href="#">and link</a></div>
 			</div>;
 	},
 

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -151,6 +151,18 @@
 	}
 }
 
+.full-post__featured-image-caption {
+	padding: 8px;
+	font-size: 11px;
+	font-family: $sans;
+	color: darken( $gray, 10 );
+	text-align: left;
+
+	a {
+		text-decoration: none;
+	}
+}
+
 .reader__full-post-content {
 	@extend %content-font;
 	margin: 0;

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -214,6 +214,7 @@ FullPostView = React.createClass( {
 					{ hasFeaturedImage
 						? <div className="full-post__featured-image">
 								<img src={ this.props.post.canonical_image.uri } height={ this.props.post.canonical_image.height } width={ 	this.props.post.canonical_image.width } />
+								<div className="full-post__featured-image-caption">Sample caption <a href="#">and link</a></div>
 							</div>
 						: null }
 


### PR DESCRIPTION
When a featured image has a caption assigned to it, we'd like to display it in the Reader. Oftentimes these captions include image attribution/licensing details that should be displayed alongside the featured image.

We'd definitely like to do this for the A8C Editorial blogs (En.Blog, Discover, Longreads, The Daily Post), but we should also consider whether it makes sense to apply this to all blogs.

NOTE: I've hardcoded the captions to start off with — we'll need to hook that up. :) 

## Screenshots: 

![image-captions--stream](https://cloud.githubusercontent.com/assets/1202812/14152849/2739dc70-f683-11e5-8d10-e2f22f355de1.png)

![image-captions--full-post](https://cloud.githubusercontent.com/assets/1202812/14152858/306e1c16-f683-11e5-801f-d681a1535d80.png)

## Test: 

Visit the Discover stream, and view the post illustrated above: 
http://calypso.localhost:3000/read/feeds/41325786?at=2016-03-28T17:00:00Z
http://calypso.localhost:3000/read/blogs/53424024/posts/11801