### PR TITLE
Signup: Remove unused signup flow "delta-new"

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -183,13 +183,6 @@ const flows = {
 		lastModified: null
 	},
 
-	'delta-new': {
-		steps: [ 'themes', 'domains', 'plans', 'user' ],
-		destination: getSiteDestination,
-		description: 'A copy of the `main` flow for the delta-new landing campaign',
-		lastModified: '2016-03-01'
-	},
-
 	'site-user': {
 		steps: [ 'site', 'user' ],
 		destination: '/me/next?welcome',


### PR DESCRIPTION
The "delta-new" landing page that used this flow now uses the "website" flow to benefit from the verticals survey and headstart.