### PR TITLE
CPT: Enable filtering by post status where posts exist

### DIFF
--- a/client/components/data/query-post-counts/README.md
+++ b/client/components/data/query-post-counts/README.md
@@ -1,0 +1,44 @@
+Query Post Counts
+================
+
+`<QueryPostCounts />` is a React component used in managing network requests for post counts.
+
+## Usage
+
+Render the component, passing `siteId` and `type`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import QueryPostCounts from 'components/data/query-post-counts';
+
+export default function PostCount( { count } ) {
+	return (
+		<div>
+			<QueryPostCounts
+				siteId={ 3584907 }
+				type="post" />
+			<div>{ count }</div>
+		</div>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site ID for which post counts should be requested.
+
+### `type`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The post type for which counts should be requested.

--- a/client/components/data/query-post-counts/index.jsx
+++ b/client/components/data/query-post-counts/index.jsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestPostCounts } from 'state/posts/counts/actions';
+import { isRequestingPostCounts } from 'state/posts/counts/selectors';
+
+class QueryPostCounts extends Component {
+	componentWillMount() {
+		this.request( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.siteId === nextProps.siteId &&
+				this.props.type === nextProps.type ) {
+			return;
+		}
+
+		this.request( nextProps );
+	}
+
+	request( props ) {
+		if ( props.requesting ) {
+			return;
+		}
+
+		props.requestPostCounts( props.siteId, props.type );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryPostCounts.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	type: PropTypes.string.isRequired,
+	requesting: PropTypes.bool,
+	requestPostCounts: PropTypes.func
+};
+
+export default connect(
+	( state, ownProps ) => {
+		const { siteId, type } = ownProps;
+		return {
+			requesting: isRequestingPostCounts( state, siteId, type )
+		};
+	},
+	{ requestPostCounts }
+)( QueryPostCounts );

--- a/client/my-sites/types/controller.jsx
+++ b/client/my-sites/types/controller.jsx
@@ -34,7 +34,8 @@ export function list( context ) {
 
 	// Construct query arguments
 	const query = {
-		type: sectionedPath.replace( /^\/types\//, '' ),
+		type: context.params.type,
+		status: context.params.status || 'publish',
 		search: context.query.s
 	};
 

--- a/client/my-sites/types/index.js
+++ b/client/my-sites/types/index.js
@@ -15,7 +15,7 @@ export default function() {
 		return;
 	}
 
-	page( '/types/:type/:site', siteSelection, navigation, list );
+	page( '/types/:type/:status?/:site', siteSelection, navigation, list );
 	page( '/types/:type', siteSelection, sites );
 	page( '/types', redirect );
 };

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -13,7 +13,7 @@ import PostTypeList from 'my-sites/post-type-list';
 export default function Types( { query } ) {
 	return (
 		<Main>
-			<PostTypeFilter />
+			<PostTypeFilter query={ query } />
 			<PostTypeList query={ query } />
 		</Main>
 	);

--- a/client/state/posts/counts/actions.js
+++ b/client/state/posts/counts/actions.js
@@ -46,7 +46,7 @@ export function requestPostCounts( siteId, postType ) {
 		return wpcom.undocumented().site( siteId ).postCounts( {
 			type: postType
 		} ).then( ( data ) => {
-			dispatch( receivePostCounts( siteId, postType, data.body.counts ) );
+			dispatch( receivePostCounts( siteId, postType, data.counts ) );
 			dispatch( {
 				type: POST_COUNTS_REQUEST_SUCCESS,
 				siteId,

--- a/client/state/posts/counts/schema.js
+++ b/client/state/posts/counts/schema.js
@@ -4,13 +4,13 @@ export const countsSchema = {
 		'^[0-9]+$': {
 			type: 'object',
 			patternProperties: {
-				'^[A-Za-z0-9]+$': {
+				'^[\\w-]+$': {
 					type: 'object',
 					patternProperties: {
 						'^(all|mine)$': {
 							type: 'object',
 							patternProperties: {
-								'^[A-Za-z0-9]+$': {
+								'^\\w+$': {
 									type: 'integer'
 								}
 							},

--- a/client/state/posts/counts/test/actions.js
+++ b/client/state/posts/counts/test/actions.js
@@ -53,27 +53,15 @@ describe( 'actions', () => {
 				.persist()
 				.get( '/wpcom/v2/sites/2916284/post-counts/post' )
 				.reply( 200, {
-					body: {
-						counts: {
-							all: { publish: 2 },
-							mine: { publish: 1 }
-						}
-					},
-					status: 200,
-					headers: {
-						Allow: 'GET'
+					counts: {
+						all: { publish: 2 },
+						mine: { publish: 1 }
 					}
 				} )
 				.get( '/wpcom/v2/sites/2916284/post-counts/foo' )
 				.reply( 404, {
-					body: {
-						code: 'unknown_post_type',
-						message: 'Unknown post type requested'
-					},
-					status: 404,
-					headers: {
-						Allow: 'GET'
-					}
+					code: 'unknown_post_type',
+					message: 'Unknown post type requested'
 				} );
 		} );
 
@@ -117,7 +105,7 @@ describe( 'actions', () => {
 					type: POST_COUNTS_REQUEST_FAILURE,
 					siteId: 2916284,
 					postType: 'foo',
-					error: sinon.match( { body: { code: 'unknown_post_type' } } )
+					error: sinon.match( { code: 'unknown_post_type' } )
 				} );
 			} );
 		} );

--- a/client/state/posts/schema.js
+++ b/client/state/posts/schema.js
@@ -42,7 +42,7 @@ export const itemsSchema = {
 				categories: { type: 'object' },
 				attachments: { type: 'object' },
 				attachment_count: { type: 'integer' },
-				metadata: { type: 'array' },
+				metadata: { type: [ 'array', 'boolean' ] },
 				meta: { type: 'object' },
 				capabilities: { type: 'object' },
 				other_URLs: { type: 'object' }


### PR DESCRIPTION
Related: #4217

This pull request seeks to iterate on the custom post types list page filter navigation bar by displaying post statuses and counts for posts of that type. Further, it enables route patterns for navigating to those statuses, updating the list accordingly.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/14156555/001b30aa-f695-11e5-8664-06f2e6632a24.png)|![After](https://cloud.githubusercontent.com/assets/1779930/14156509/bb72f898-f694-11e5-9078-f66431058183.png)

__Testing instructions:__

Verify that status filter options are shown where posts exist with that status, while viewing the list page for a custom post type.

1. Navigate to [My Sites](http://calypso.localhost:3000/sites)
2. Select a site where a custom post type exists
3. Navigate to a custom post type navigation item in the sidebar
4. Note that, after post counts have loaded, status labels are shown for available post statuses
5. Navigate between statuses, if more than one is available
6. Note that posts are updated to reflect the currently selected status

__Caveats:__

This section is a work-in-progress. Particularly, note that:
- Searching won't update post count
- There is no loading indicator nor "No Posts Found" warning when no posts exist