### PR TITLE
Media: fetch media limits when media list changes

### DIFF
--- a/client/components/data/query-media-storage/index.jsx
+++ b/client/components/data/query-media-storage/index.jsx
@@ -10,12 +10,29 @@ import { bindActionCreators } from 'redux';
  */
 import { isRequestingMediaStorage } from 'state/sites/media-storage/selectors';
 import { requestMediaStorage } from 'state/sites/media-storage/actions';
+// until we port media over to redux:
+import MediaStore from 'lib/media/store';
 
 class QueryMediaStorage extends Component {
-	componentWillMount() {
-		if ( ! this.props.requestingMediaStorage && this.props.siteId ) {
-			this.props.requestMediaStorage( this.props.siteId );
+
+	constructor( props ) {
+		super( props );
+		this.requestStorage = this.requestStorage.bind( this );
+	}
+
+	requestStorage( props = this.props ) {
+		if ( ! props.requestingMediaStorage && props.siteId ) {
+			props.requestMediaStorage( props.siteId );
 		}
+	}
+
+	componentWillMount() {
+		this.requestStorage();
+		MediaStore.on( 'fetch-media-limits', this.requestStorage );
+	}
+
+	componentWillUnmount() {
+		MediaStore.off( 'fetch-media-limits', this.requestStorage );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -24,8 +41,7 @@ class QueryMediaStorage extends Component {
 			( this.props.siteId === nextProps.siteId ) ) {
 			return;
 		}
-
-		nextProps.requestMediaStorage( nextProps.siteId );
+		this.requestStorage( nextProps );
 	}
 
 	render() {

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -173,6 +173,11 @@ MediaActions.add = function( siteId, files ) {
 				Dispatcher.handleServerAction( Object.assign( action, {
 					data: data.media[ 0 ]
 				} ) );
+				// also refetch media limits
+				Dispatcher.handleServerAction( {
+					type: 'FETCH_MEDIA_LIMITS',
+					siteId: siteId
+				} );
 			} ).catch( ( error ) => {
 				Dispatcher.handleServerAction( Object.assign( action, { error } ) );
 			} );
@@ -236,6 +241,11 @@ MediaActions.delete = function( siteId, item ) {
 			error: error,
 			siteId: siteId,
 			data: data
+		} );
+		// also refetch storage limits
+		Dispatcher.handleServerAction( {
+			type: 'FETCH_MEDIA_LIMITS',
+			siteId: siteId
 		} );
 	} );
 };

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -123,6 +123,12 @@ MediaStore.dispatchToken = Dispatcher.register( function( payload ) {
 
 			MediaStore.emit( 'change' );
 			break;
+		case 'FETCH_MEDIA_LIMITS':
+			if ( ! action.siteId ) {
+				break;
+			}
+			MediaStore.emit( 'fetch-media-limits' );
+			break;
 	}
 } );
 


### PR DESCRIPTION
This PR will refetch media storage limits when the media list changes.
<img width="860" alt="media" src="https://cloud.githubusercontent.com/assets/1270189/14157350/7a9735a6-f67f-11e5-95d5-d507309353c6.png">

## Testing Instructions
* Navigate to calypso.localhost:3000/post
* Select a wpcom site with free/premium plan
* Click on the media modal (Picture icon)
* Upload new media or Delete media
* Unselect all items before they finish loading ( you should see the Plan Storage button in the bottom left)
* After the items finish loading, the Plan Storage Button should show update

cc @rralian @aduth @mtias @retrofox @artpi 