### PR TITLE
Domains: Search for a domain after .5 seconds inactivity, rather than 2

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -192,7 +192,7 @@ var RegisterDomainStep = React.createClass( {
 					placeholder={ placeholderText }
 					autoFocus={ true }
 					delaySearch={ true }
-					delayTimeout={ 2000 }
+					delayTimeout={ 500 }
 				/>
 				{ exampleDomains }
 			</div>


### PR DESCRIPTION
In #2654 we slowed domain search down so that we wait 2 seconds before querying the API. This makes it seem really sluggish. This PR updates that value to .5 seconds, which slows down the wait times.

I also noticed that we use debounce to delay the search. We might want to consider using `throttle` rather than `debounce` so that requests are made while the user is still typing. This would drastically increase the perceived speed.

cc @dzver - what do you think?