### PR TITLE
WPCOM Plugins: Configure Menu Item

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -236,7 +236,11 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		if ( ! this.props.sites.hasSiteWithPlugins() ) {
+		if ( ! config.isEnabled( 'manage/plugins/wpcom' ) && ! this.props.sites.hasSiteWithPlugins() ) {
+			return null;
+		}
+
+		if ( config.isEnabled( 'manage/plugins/wpcom' ) && ( ! this.isSingle() && this.hasJetpackSites() ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
Plugins item on My Sites now shows for both JetPack and WordPress.com sites, but is hidden for All Sites.
Controlled with `manage/plugins/wpcom` feature flag.

Menu Item is hidden for _All My Sites_

![all-sites](https://cloud.githubusercontent.com/assets/233601/14162608/c49e20e4-f6c3-11e5-94ed-3937a368e981.png)

Visible for WordPress.com Sites

User with multiple sites

![wpcom-site](https://cloud.githubusercontent.com/assets/233601/14162621/e543df14-f6c3-11e5-97b0-43bf77dd52e3.png)

User with a single site

![only-wpcom](https://cloud.githubusercontent.com/assets/233601/14164848/aa56d62a-f6d9-11e5-942f-71dabbdc40d0.png)

Visible (with _Add_ button) for JetPack Sites

User with multiple sites

![jetpack-site](https://cloud.githubusercontent.com/assets/233601/14162624/eaabcdea-f6c3-11e5-937f-c78699e03054.png)

User with only one jetpack site

![only-jetpack](https://cloud.githubusercontent.com/assets/233601/14164857/c0ef3148-f6d9-11e5-9b70-d52663c2d18b.png)
