### PR TITLE
WPCOM Plugins: Routes Changes

### DIFF
--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -19,10 +19,20 @@ module.exports = function() {
 	if ( config.isEnabled( 'manage/plugins' ) ) {
 		page( '/plugins/browse/:category/:site', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 		page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
-		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
+
+		if ( config.isEnabled( 'manage/plugins/wpcom' ) ) {
+			page( '/plugins', controller.siteSelection, controller.sites );
+			[ 'standard', 'premium', 'business' ].forEach( function( filter ) {
+				page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
+			} );
+		} else {
+			page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
+		}
+
 		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {
 			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
 		} );
+
 		page( '/plugins/:plugin/:business_plugin?/:site_id?', controller.siteSelection, controller.navigation, pluginsController.plugin );
 	}
 };

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -21,13 +21,12 @@ module.exports = function() {
 		page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 
 		if ( config.isEnabled( 'manage/plugins/wpcom' ) ) {
-			page( '/plugins', controller.siteSelection, controller.sites );
 			[ 'standard', 'premium', 'business' ].forEach( function( filter ) {
 				page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
 			} );
-		} else {
-			page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
 		}
+
+		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
 
 		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {
 			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );


### PR DESCRIPTION
Part of #4572 

New routes for WordPress.com plugins page and `/plugins` catch all. 

Controlled by `manage/plugins/wpcom` feature flag.

![plugins-for-all](https://cloud.githubusercontent.com/assets/233601/14164974/c22c0f1c-f6da-11e5-9612-6b49c2da002b.gif)
