### PR TITLE
WordPress.com standard plugins page

### DIFF
--- a/client/components/header-cake/README.md
+++ b/client/components/header-cake/README.md
@@ -16,4 +16,5 @@ The "header cake" component should be used at the top of an item's detail page. 
 * `onClick` - (**required**) Function to trigger when the back text is clicked
 * `onTitleClick` - Function to trigger when the title is clicked
 * `backText` - React Element or string to use in place of default "Back" text
+* `backHref` - URL to specify where the back button should redirect
 * `isCompact` - Optional variant of a more visually compact header cake

--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -19,7 +19,8 @@ export default React.createClass( {
 	propTypes: {
 		onClick: PropTypes.func.isRequired,
 		onTitleClick: PropTypes.func,
-		backText: PropTypes.string
+		backText: PropTypes.string,
+		backHref: PropTypes.string,
 	},
 
 	getDefaultProps() {
@@ -29,7 +30,7 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { backText } = this.props;
+		const { backText, backHref } = this.props;
 		const classes = classNames(
 			'header-cake',
 			this.props.className,
@@ -40,11 +41,11 @@ export default React.createClass( {
 
 		return (
 			<Card className={ classes }>
-				<HeaderCakeBack text={ backText } onClick={ this.props.onClick } />
+				<HeaderCakeBack text={ backText } href={ backHref } onClick={ this.props.onClick } />
 				<div className="header-cake__title" onClick={ this.props.onTitleClick }>
 					{ this.props.children }
 				</div>
-				<HeaderCakeBack text={ backText } spacer />
+				<HeaderCakeBack text={ backText } href={ backHref } spacer />
 			</Card>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -17,7 +17,7 @@ export const PluginPanel = React.createClass( {
 		return (
 			<div className="wpcom-plugin-panel">
 				<InfoHeader />
-				<StandardPluginsPanel />
+				<StandardPluginsPanel displayCount={ 6 } />
 				<Card className="wpcom-plugin-panel__panel-footer" href={ standardPluginsLink }>
 					{ this.translate( 'View all standard plugins' ) }
 				</Card>

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import Card from 'components/card';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 
 import InfoHeader from './info-header';
 import StandardPluginsPanel from './standard-plugins-panel';
@@ -9,10 +12,8 @@ import BusinessPluginsPanel from './business-plugins-panel';
 
 export const PluginPanel = React.createClass( {
 	render() {
-		/* For development purposes only */
-		const siteSlug = window.location.pathname.split( '/' ).pop();
+		const { siteSlug } = this.props;
 		const standardPluginsLink = `/plugins/standard/${ siteSlug }`;
-		/* End development section */
 
 		return (
 			<div className="wpcom-plugin-panel">
@@ -28,4 +29,8 @@ export const PluginPanel = React.createClass( {
 	}
 } );
 
-export default PluginPanel;
+const mapStateToProps = state => ( {
+	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
+} );
+
+export default connect( mapStateToProps )( PluginPanel );

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import Card from 'components/card';
+
 import InfoHeader from './info-header';
 import StandardPluginsPanel from './standard-plugins-panel';
 import PremiumPluginsPanel from './premium-plugins-panel';
@@ -7,10 +9,18 @@ import BusinessPluginsPanel from './business-plugins-panel';
 
 export const PluginPanel = React.createClass( {
 	render() {
+		/* For development purposes only */
+		const siteSlug = window.location.pathname.split( '/' ).pop();
+		const standardPluginsLink = `/plugins/standard/${ siteSlug }`;
+		/* End development section */
+
 		return (
 			<div className="wpcom-plugin-panel">
 				<InfoHeader />
 				<StandardPluginsPanel />
+				<Card className="wpcom-plugin-panel__panel-footer" href={ standardPluginsLink }>
+					{ this.translate( 'View all standard plugins' ) }
+				</Card>
 				<PremiumPluginsPanel />
 				<BusinessPluginsPanel />
 			</div>

--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -14,14 +14,14 @@ export const BusinessPlugin = React.createClass( {
 
 		return (
 			<div className="wpcom-plugins__plugin-item">
-				<div className="wpcom-plugins__plugin-icon">
-					<Gridicon { ...{ icon } } />
-				</div>
 				<a href={ supportLink } target="_blank">
+					<div className="wpcom-plugins__plugin-icon">
+						<Gridicon { ...{ icon } } />
+					</div>
 					<div className="wpcom-plugins__plugin-title">{ name }</div>
+					<div className="wpcom-plugins__plugin-plan">{ plan }</div>
+					<p className="wpcom-plugins__plugin-description">{ description }</p>
 				</a>
-				<div className="wpcom-plugins__plugin-plan">{ plan }</div>
-				<p className="wpcom-plugins__plugin-description">{ description }</p>
 			</div>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -13,16 +13,16 @@ export const BusinessPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<li className="wpcom-plugins__plugin-item">
+			<div className="wpcom-plugins__plugin-item">
+				<div className="wpcom-plugins__plugin-icon">
+					<Gridicon { ...{ icon } } />
+				</div>
 				<a href={ supportLink } target="_blank">
-					<div className="wpcom-plugins__plugin-icon">
-						<Gridicon { ...{ icon } } />
-					</div>
 					<div className="wpcom-plugins__plugin-title">{ name }</div>
-					<div className="wpcom-plugins__plugin-plan">{ plan }</div>
-					<p className="wpcom-plugins__plugin-description">{ description }</p>
 				</a>
-			</li>
+				<div className="wpcom-plugins__plugin-plan">{ plan }</div>
+				<p className="wpcom-plugins__plugin-description">{ description }</p>
+			</div>
 		);
 	}
 } );

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -14,14 +14,14 @@ export const PremiumPlugin = React.createClass( {
 
 		return (
 			<div className="wpcom-plugins__plugin-item">
-				<div className="wpcom-plugins__plugin-icon">
-					<Gridicon { ...{ icon } } />
-				</div>
 				<a href={ supportLink } target="_blank">
+					<div className="wpcom-plugins__plugin-icon">
+						<Gridicon { ...{ icon } } />
+					</div>
 					<div className="wpcom-plugins__plugin-title">{ name }</div>
+					<div className="wpcom-plugins__plugin-plan">{ plan }</div>
+					<p className="wpcom-plugins__plugin-description">{ description }</p>
 				</a>
-				<div className="wpcom-plugins__plugin-plan">{ plan }</div>
-				<p className="wpcom-plugins__plugin-description">{ description }</p>
 			</div>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -13,16 +13,16 @@ export const PremiumPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<li className="wpcom-plugins__plugin-item">
+			<div className="wpcom-plugins__plugin-item">
+				<div className="wpcom-plugins__plugin-icon">
+					<Gridicon { ...{ icon } } />
+				</div>
 				<a href={ supportLink } target="_blank">
-					<div className="wpcom-plugins__plugin-icon">
-						<Gridicon { ...{ icon } } />
-					</div>
 					<div className="wpcom-plugins__plugin-title">{ name }</div>
-					<div className="wpcom-plugins__plugin-plan">{ plan }</div>
-					<p className="wpcom-plugins__plugin-description">{ description }</p>
 				</a>
-			</li>
+				<div className="wpcom-plugins__plugin-plan">{ plan }</div>
+				<p className="wpcom-plugins__plugin-description">{ description }</p>
+			</div>
 		);
 	}
 } );

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -13,16 +13,16 @@ export const StandardPlugin = React.createClass( {
 		} = this.props;
 
 		return (
-			<li className="wpcom-plugins__plugin-item">
+			<div className="wpcom-plugins__plugin-item">
+				<div className="wpcom-plugins__plugin-icon">
+					<Gridicon { ...{ icon } } />
+				</div>
 				<a href={ supportLink } target="_blank">
-					<div className="wpcom-plugins__plugin-icon">
-						<Gridicon { ...{ icon } } />
-					</div>
 					<div className="wpcom-plugins__plugin-title">{ name }</div>
-					<div className="wpcom-plugins__plugin-category">{ category }</div>
-					<p className="wpcom-plugins__plugin-description">{ description }</p>
 				</a>
-			</li>
+				<div className="wpcom-plugins__plugin-category">{ category }</div>
+				<p className="wpcom-plugins__plugin-description">{ description }</p>
+			</div>
 		);
 	}
 } );

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -14,14 +14,14 @@ export const StandardPlugin = React.createClass( {
 
 		return (
 			<div className="wpcom-plugins__plugin-item">
-				<div className="wpcom-plugins__plugin-icon">
-					<Gridicon { ...{ icon } } />
-				</div>
 				<a href={ supportLink } target="_blank">
+					<div className="wpcom-plugins__plugin-icon">
+						<Gridicon { ...{ icon } } />
+					</div>
 					<div className="wpcom-plugins__plugin-title">{ name }</div>
+					<div className="wpcom-plugins__plugin-category">{ category }</div>
+					<p className="wpcom-plugins__plugin-description">{ description }</p>
 				</a>
-				<div className="wpcom-plugins__plugin-category">{ category }</div>
-				<p className="wpcom-plugins__plugin-description">{ description }</p>
 			</div>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import matchesProperty from 'lodash/matchesProperty';
+import noop from 'lodash/noop';
 
 import HeaderCake from 'components/header-cake';
 
@@ -11,20 +12,17 @@ export const PluginsList = React.createClass( {
 		selectedPlugin: null
 	} ),
 
-	goBack() {
-		/* For development work only */
-		const siteSlug = window.location.pathname.split( '/' ).pop();
-
-		window.location = `/plugins/${ siteSlug }`;
-		/* End development work section */
-	},
-
 	selectPlugin( selectedPlugin ) {
 		return () => this.setState( { selectedPlugin } );
 	},
 
 	render() {
 		const { selectedPlugin } = this.state;
+
+		/* development-only code - don't deploy! */
+		const siteSlug = window.location.pathname.split( '/' ).pop();
+		const backHref = `/plugins/${ siteSlug }`;
+		/* end development-only section */
 
 		if ( selectedPlugin ) {
 			const plugin = standardPlugins
@@ -44,7 +42,7 @@ export const PluginsList = React.createClass( {
 
 		return (
 			<div className="wpcom-plugins-list">
-				<HeaderCake onClick={ this.goBack }>Standard Plugins</HeaderCake>
+				<HeaderCake backHref={ backHref } onClick={ noop }>Standard Plugins</HeaderCake>
 					{ standardPlugins.map( plugin =>
 						<div
 							key={ plugin.name }

--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import matchesProperty from 'lodash/matchesProperty';
+
+import HeaderCake from 'components/header-cake';
+
+import StandardPlugin from './plugin-types/standard-plugin';
+import standardPlugins from './standard-plugins';
+
+export const PluginsList = React.createClass( {
+	getInitialState: () => ( {
+		selectedPlugin: null
+	} ),
+
+	goBack() {
+		return this.selectPlugin( null );
+	},
+
+	selectPlugin( selectedPlugin ) {
+		return () => this.setState( { selectedPlugin } );
+	},
+
+	render() {
+		const { selectedPlugin } = this.state;
+
+		if ( selectedPlugin ) {
+			const plugin = standardPlugins
+				.find( matchesProperty( 'name', selectedPlugin ) );
+
+			return (
+				<div className="wpcom-plugins-list__plugin-detail">
+					<HeaderCake onClick={ this.selectPlugin( null ) }>
+						{ plugin.name }
+					</HeaderCake>
+					<StandardPlugin
+						{ ...plugin }
+					/>
+				</div>
+			);
+		}
+
+		return (
+			<div className="wpcom-plugins-list">
+				<HeaderCake onClick={ this.goBack() }>Standard Plugins</HeaderCake>
+					{ standardPlugins.map( plugin =>
+						<div
+							key={ plugin.name }
+							onClick={ this.selectPlugin( plugin.name ) }
+						>
+							<StandardPlugin
+								{ ...plugin }
+							/>
+						</div>
+					) }
+			</div>
+		);
+	}
+} );
+
+export default PluginsList;

--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -12,7 +12,11 @@ export const PluginsList = React.createClass( {
 	} ),
 
 	goBack() {
-		return this.selectPlugin( null );
+		/* For development work only */
+		const siteSlug = window.location.pathname.split( '/' ).pop();
+
+		window.location = `/plugins/${ siteSlug }`;
+		/* End development work section */
 	},
 
 	selectPlugin( selectedPlugin ) {
@@ -40,7 +44,7 @@ export const PluginsList = React.createClass( {
 
 		return (
 			<div className="wpcom-plugins-list">
-				<HeaderCake onClick={ this.goBack() }>Standard Plugins</HeaderCake>
+				<HeaderCake onClick={ this.goBack }>Standard Plugins</HeaderCake>
 					{ standardPlugins.map( plugin =>
 						<div
 							key={ plugin.name }

--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 
 import HeaderCake from 'components/header-cake';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
 
 import StandardPluginsPanel from './standard-plugins-panel';
 
 export const PluginsList = React.createClass( {
 	render() {
-		/* development-only code - don't deploy! */
-		const siteSlug = window.location.pathname.split( '/' ).pop();
+		const { siteSlug } = this.props;
 		const backHref = `/plugins/${ siteSlug }`;
-		/* end development-only section */
 
 		return (
 			<div className="wpcom-plugin-panel wpcom-plugins-list">
@@ -21,4 +22,8 @@ export const PluginsList = React.createClass( {
 	}
 } );
 
-export default PluginsList;
+const mapStateToProps = state => ( {
+	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
+} );
+
+export default connect( mapStateToProps )( PluginsList );

--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -13,7 +13,7 @@ export const PluginsList = React.createClass( {
 		/* end development-only section */
 
 		return (
-			<div className="wpcom-plugins-list">
+			<div className="wpcom-plugin-panel wpcom-plugins-list">
 				<HeaderCake backHref={ backHref } onClick={ noop }>Standard Plugins</HeaderCake>
 				<StandardPluginsPanel />
 			</div>

--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -1,58 +1,21 @@
 import React from 'react';
-import matchesProperty from 'lodash/matchesProperty';
 import noop from 'lodash/noop';
 
 import HeaderCake from 'components/header-cake';
 
-import StandardPlugin from './plugin-types/standard-plugin';
-import standardPlugins from './standard-plugins';
+import StandardPluginsPanel from './standard-plugins-panel';
 
 export const PluginsList = React.createClass( {
-	getInitialState: () => ( {
-		selectedPlugin: null
-	} ),
-
-	selectPlugin( selectedPlugin ) {
-		return () => this.setState( { selectedPlugin } );
-	},
-
 	render() {
-		const { selectedPlugin } = this.state;
-
 		/* development-only code - don't deploy! */
 		const siteSlug = window.location.pathname.split( '/' ).pop();
 		const backHref = `/plugins/${ siteSlug }`;
 		/* end development-only section */
 
-		if ( selectedPlugin ) {
-			const plugin = standardPlugins
-				.find( matchesProperty( 'name', selectedPlugin ) );
-
-			return (
-				<div className="wpcom-plugins-list__plugin-detail">
-					<HeaderCake onClick={ this.selectPlugin( null ) }>
-						{ plugin.name }
-					</HeaderCake>
-					<StandardPlugin
-						{ ...plugin }
-					/>
-				</div>
-			);
-		}
-
 		return (
 			<div className="wpcom-plugins-list">
 				<HeaderCake backHref={ backHref } onClick={ noop }>Standard Plugins</HeaderCake>
-					{ standardPlugins.map( plugin =>
-						<div
-							key={ plugin.name }
-							onClick={ this.selectPlugin( plugin.name ) }
-						>
-							<StandardPlugin
-								{ ...plugin }
-							/>
-						</div>
-					) }
+				<StandardPluginsPanel />
 			</div>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -32,9 +32,6 @@ export const StandardPluginsPanel = React.createClass( {
 						) }
 					</div>
 				</CompactCard>
-				<Card className="wpcom-plugins__panel-footer" href="#">
-					{ this.translate( 'View all standard plugins' ) }
-				</Card>
 			</div>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -7,52 +7,14 @@ import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 
 import StandardPlugin from './plugin-types/standard-plugin';
-
-const defaultPlugins = [
-	{
-		name: 'WordPress.com Stats',
-		supportLink: 'http://support.wordpress.com/stats/',
-		category: 'Traffic Growth',
-		description: 'View your site\'s visits, referrers, and more.'
-	},
-	{
-		name: 'Essential SEO',
-		supportLink: 'http://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/',
-		category: 'Traffic Growth',
-		description: 'Search engine optimization and sitemaps.'
-	},
-	{
-		name: 'Security Scanning',
-		supportLink: 'http://support.wordpress.com/security/',
-		category: 'Performance',
-		description: 'Constant monitoring of your site for threats.'
-	},
-	{
-		name: 'Advanced Galleries',
-		supportLink: 'http://support.wordpress.com/images/gallery/',
-		category: 'Appearance',
-		description: 'Tiled, mosaic, slideshows, and more.'
-	},
-	{
-		name: 'Social Media Sharing',
-		supportLink: 'http://support.wordpress.com/sharing/',
-		category: 'Traffic Growth',
-		description: 'Add share buttons to your posts and pages.'
-	},
-	{
-		name: 'Contact Form Builder',
-		supportLink: 'http://support.wordpress.com/contact-form/',
-		category: 'Appearance',
-		description: 'Build contact forms so visitors can get in touch.'
-	}
-];
+import standardPlugins from './standard-plugins';
 
 export const StandardPluginsPanel = React.createClass( {
 	render() {
 		const { plugins: givenPlugins = [] } = this.props;
 		const plugins = givenPlugins.length
 			? givenPlugins
-			: defaultPlugins;
+			: standardPlugins;
 
 		return (
 			<div>

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 
-import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
@@ -11,10 +10,12 @@ import standardPlugins from './standard-plugins';
 
 export const StandardPluginsPanel = React.createClass( {
 	render() {
-		const { plugins: givenPlugins = [] } = this.props;
-		const plugins = givenPlugins.length
-			? givenPlugins
-			: standardPlugins;
+		const {
+			displayCount,
+			plugins: givenPlugins = standardPlugins
+		} = this.props;
+		
+		const plugins = givenPlugins.slice( 0, displayCount );
 
 		return (
 			<div>
@@ -38,6 +39,7 @@ export const StandardPluginsPanel = React.createClass( {
 } );
 
 StandardPluginsPanel.propTypes = {
+	displayCount: PropTypes.number,
 	plugins: PropTypes.array
 };
 

--- a/client/my-sites/plugins-wpcom/standard-plugins.js
+++ b/client/my-sites/plugins-wpcom/standard-plugins.js
@@ -40,6 +40,72 @@ export const standardPlugins = [
 		supportLink: 'https://en.support.wordpress.com/customizer/',
 		category: 'Appearance',
 		description: 'Edit colors and backgrounds.'
+	},
+	{
+		name: 'Extended Widgets',
+		supportLink: 'https://en.support.wordpress.com/category/widgets-sidebars/',
+		category: 'Appearance',
+		description: 'Eventbrite, Flickr, Google Calendar, and more.'
+	},
+	{
+		name: 'Akismet',
+		supportLink: 'http://akismet.com/',
+		category: 'Security',
+		description: 'Advanced anti-spam security.'
+	},
+	{
+		name: 'Backup',
+		supportLink: 'https://en.support.wordpress.com/export/#backups',
+		category: 'Security',
+		description: '24/7 backup of your entire site.'
+	},
+	{
+		name: 'Photon CDN',
+		supportLink: 'https://jetpack.com/support/photon/',
+		category: 'Performance',
+		description: 'Faster image loading and editing.'
+	},
+	{
+		name: 'Extended Shortcodes',
+		supportLink: 'https://en.support.wordpress.com/shortcodes/',
+		category: 'Misc',
+		description: 'YouTube, Twitter, Instagram, Spotify, and more.'
+	},
+	{
+		name: 'Importer',
+		supportLink: 'http://support.wordpress.com/import/',
+		category: 'Misc',
+		description: 'Import your blog content from a variety of other blogging platforms.'
+	},
+	{
+		name: 'Infinite Scroll',
+		supportLink: 'https://en.support.wordpress.com/infinite-scroll/',
+		category: 'Appearance',
+		description: 'Load more posts when you reach the bottom of a page.'
+	},
+	{
+		name: 'Related Posts',
+		supportLink: 'https://en.support.wordpress.com/related-posts/',
+		category: 'Appearance',
+		description: 'Pulls relevant content from your blog to display at the bottom of your posts.'
+	},
+	{
+		name: 'Email Subscriptions',
+		supportLink: 'https://en.support.wordpress.com/widgets/follow-blog-widget/',
+		category: 'Misc',
+		description: 'Enables your readers to sign up to receive your posts via email.'
+	},
+	{
+		name: 'Markdown',
+		supportLink: 'https://en.support.wordpress.com/markdown/',
+		category: 'Misc',
+		description: 'Text formatting using a lightweight markup language. '
+	},
+	{
+		name: 'Advanced Commenting',
+		supportLink: 'https://en.support.wordpress.com/category/comments/',
+		category: 'Misc',
+		description: 'Comment likes, user mentions, notifications, and more.'
 	}
 ];
 

--- a/client/my-sites/plugins-wpcom/standard-plugins.js
+++ b/client/my-sites/plugins-wpcom/standard-plugins.js
@@ -1,0 +1,46 @@
+export const standardPlugins = [
+	{
+		name: 'WordPress.com Stats',
+		supportLink: 'http://support.wordpress.com/stats/',
+		category: 'Traffic Growth',
+		description: 'View your site\'s visits, referrers, and more.'
+	},
+	{
+		name: 'Essential SEO',
+		supportLink: 'http://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/',
+		category: 'Traffic Growth',
+		description: 'Search engine optimization and sitemaps.'
+	},
+	{
+		name: 'Security Scanning',
+		supportLink: 'http://support.wordpress.com/security/',
+		category: 'Performance',
+		description: 'Constant monitoring of your site for threats.'
+	},
+	{
+		name: 'Advanced Galleries',
+		supportLink: 'http://support.wordpress.com/images/gallery/',
+		category: 'Appearance',
+		description: 'Tiled, mosaic, slideshows, and more.'
+	},
+	{
+		name: 'Social Media Sharing',
+		supportLink: 'http://support.wordpress.com/sharing/',
+		category: 'Traffic Growth',
+		description: 'Add share buttons to your posts and pages.'
+	},
+	{
+		name: 'Contact Form Builder',
+		supportLink: 'http://support.wordpress.com/contact-form/',
+		category: 'Appearance',
+		description: 'Build contact forms so visitors can get in touch.'
+	},
+	{
+		name: 'Extended Customizer',
+		supportLink: 'https://en.support.wordpress.com/customizer/',
+		category: 'Appearance',
+		description: 'Edit colors and backgrounds.'
+	}
+];
+
+export default standardPlugins;

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -29,6 +29,7 @@ import PluginSections from 'my-sites/plugins/plugin-sections';
 import pluginsAccessControl from 'my-sites/plugins/access-control';
 import EmptyContent from 'components/empty-content';
 import FeatureExample from 'components/feature-example'
+import WpcomPluginsList from 'my-sites/plugins-wpcom/plugins-list';
 
 /**
  * Module variables
@@ -301,10 +302,7 @@ const SinglePlugin = React.createClass( {
 			return (
 				<MainComponent>
 					<SidebarNavigation />
-					<EmptyContent
-						title={ this.translate( 'Oops! Not supported' ) }
-						line={ this.translate( 'This site doesn\'t support installing plugins. Switch to a self-hosted site to install and manage plugins' ) }
-						illustration={ '/calypso/images/drake/drake-whoops.svg' } />
+					<WpcomPluginsList />
 				</MainComponent>
 			);
 		}


### PR DESCRIPTION
Part of #4572 

This adds some basic structure for a page displaying information about
the standard suite of plugins that come with WordPress.com.

This page doesn't currently rely on standard routing, instead using
component state to handle navigation. This will change once other PRs
get merged which add in the routing.

**Plugins Page**
This page appears when the plugins menu item is clicked for a WordPress.com site. It limits the list of standard plugins to six for now.
<img width="765" alt="screen shot 2016-04-07 at 11 41 13 am" src="https://cloud.githubusercontent.com/assets/5431237/14348640/c4f38316-fcb5-11e5-80d3-391571c923b2.png">

**_Show all standard plugins_ Page**
After clicking on "Show all standard plugins", the full list of standard plugins is reveal and the business and premium plugins disappear. Navigating back to the first page is made available by the addition of a new "back" button in the header.

> There will be more plugins to come, but they weren't all added at the development time

<img width="755" alt="screen shot 2016-04-07 at 11 41 20 am" src="https://cloud.githubusercontent.com/assets/5431237/14348650/ce95e5e4-fcb5-11e5-80f6-48d61cfb507b.png">


cc: @drw158