### PR TITLE
Domains: Checkout: Clear the fax field when it's not needed

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -82,6 +82,11 @@ export default React.createClass( {
 		if ( ! this.isMounted() ) {
 			return;
 		}
+
+		if ( ! this.needsFax() ) {
+			delete form.fax;
+		}
+
 		this.setState( { form } );
 	},
 
@@ -126,7 +131,7 @@ export default React.createClass( {
 		};
 	},
 
-	showFax() {
+	needsFax() {
 		return formState.getFieldValue( this.state.form, 'countryCode' ) === 'NL' && cartItems.hasNlTld( this.props.cart );
 	},
 
@@ -196,7 +201,7 @@ export default React.createClass( {
 					countriesList={ countriesList }
 					{ ...fieldProps( 'country-code' ) }/>
 
-				{ this.showFax() && <Input label={ this.translate( 'Fax', { textOnly } ) } { ...fieldProps( 'fax' ) }/> }
+				{ this.needsFax() && <Input label={ this.translate( 'Fax', { textOnly } ) } { ...fieldProps( 'fax' ) }/> }
 				<Input label={ this.translate( 'Address', { textOnly } ) } { ...fieldProps( 'address-1' ) }/>
 
 				<HiddenInput


### PR DESCRIPTION
This PR clears the fax field when it is not needed (currently, it's only needed when purchasing `.nl` domains in Netherlands). However, there was a very small number of users (<0.5%) that had fax numbers (most of them invalid) and these fax numbers would get prefilled during the next purchase. And this could lead to registration failures.

/cc @umurkontaci @aidvu