### PR TITLE
Media: Show upsell message for audio and video tabs in media uploader

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -41,6 +41,7 @@ const MediaLibraryContent = React.createClass( {
 		preferences: React.PropTypes.object,
 		mediaValidationErrors: React.PropTypes.object,
 		filter: React.PropTypes.string,
+		filterRequiresUpgrade: React.PropTypes.bool,
 		search: React.PropTypes.string,
 		containerWidth: React.PropTypes.number,
 		single: React.PropTypes.bool,
@@ -217,6 +218,7 @@ const MediaLibraryContent = React.createClass( {
 						key={ 'list-' + ( [ this.props.site.ID, this.props.search, this.props.filter ].join() ) }
 						site={ this.props.site }
 						filter={ this.props.filter }
+						filterRequiresUpgrade={ this.props.filterRequiresUpgrade }
 						search={ this.props.search }
 						containerWidth={ this.props.containerWidth }
 						mediaScale={ this.getMediaScale() }
@@ -232,13 +234,15 @@ const MediaLibraryContent = React.createClass( {
 	render: function() {
 		return (
 			<div className="media-library__content">
-				<MediaLibraryHeader
-					site={ this.props.site }
-					filter={ this.props.filter }
-					mediaScale={ this.getMediaScale() }
-					mediaScaleChoices={ this.props.mediaScaleChoices }
-					onMediaScaleChange={ this.onMediaScaleChange }
-					onAddMedia={ this.props.onAddMedia } />
+				{ ! this.props.filterRequiresUpgrade &&
+					<MediaLibraryHeader
+						site={ this.props.site }
+						filter={ this.props.filter }
+						mediaScale={ this.getMediaScale() }
+						mediaScaleChoices={ this.props.mediaScaleChoices }
+						onMediaScaleChange={ this.onMediaScaleChange }
+						onAddMedia={ this.props.onAddMedia } />
+				}
 				{ this.renderErrors() }
 				{ this.renderMediaList() }
 			</div>

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -20,6 +20,7 @@ module.exports = React.createClass( {
 		site: React.PropTypes.object,
 		basePath: React.PropTypes.string,
 		filter: React.PropTypes.string,
+		filterRequiresUpgrade: React.PropTypes.bool,
 		enabledFilters: React.PropTypes.arrayOf( React.PropTypes.string ),
 		search: React.PropTypes.string,
 		onFilterChange: React.PropTypes.func,
@@ -88,16 +89,7 @@ module.exports = React.createClass( {
 	},
 
 	renderTabItems: function() {
-		var tabs = [ '', 'images', 'documents' ],
-			site = this.props.site;
-
-		if ( site && ( site.options.videopress_enabled || site.jetpack ) ) {
-			tabs.push( 'videos' );
-		}
-
-		if ( site && ( site.options.upgraded_filetypes_enabled || site.jetpack ) ) {
-			tabs.push( 'audio' );
-		}
+		const tabs = [ '', 'images', 'documents', 'videos', 'audio' ];
 
 		return tabs.map( function( filter ) {
 			return (
@@ -118,13 +110,15 @@ module.exports = React.createClass( {
 				<SectionNavTabs>
 					{ this.renderTabItems() }
 				</SectionNavTabs>
-				<Search
-					analyticsGroup="Media"
-					pinned={ true }
-					onSearch={ this.props.onSearch }
-					initialValue={ this.props.search }
-					placeholder={ this.getSearchPlaceholderText() }
-					delaySearch={ true } />
+				{ ! this.props.filterRequiresUpgrade &&
+					<Search
+						analyticsGroup="Media"
+						pinned={ true }
+						onSearch={ this.props.onSearch }
+						initialValue={ this.props.search }
+						placeholder={ this.getSearchPlaceholderText() }
+						delaySearch={ true } />
+				}
 			</SectionNav>
 		);
 	}

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -90,6 +90,20 @@ module.exports = React.createClass( {
 		this.props.onAddMedia();
 	},
 
+	filterRequiresUpgrade: function() {
+		const { filter, site } = this.props;
+		switch ( filter ) {
+			case 'audio':
+				return ! ( site && site.options.upgraded_filetypes_enabled || site.jetpack );
+				break;
+			case 'videos':
+				return ! ( site && site.options.videopress_enabled || site.jetpack );
+				break;
+		}
+
+		return false;
+	},
+
 	renderDropZone: function() {
 		return (
 			<MediaLibraryDropZone
@@ -107,6 +121,7 @@ module.exports = React.createClass( {
 			<Content
 				site={ this.props.site }
 				filter={ this.props.filter }
+				filterRequiresUpgrade={ this.filterRequiresUpgrade() }
 				search={ this.props.search }
 				containerWidth={ this.props.containerWidth }
 				single={ this.props.single }
@@ -134,6 +149,7 @@ module.exports = React.createClass( {
 				<FilterBar
 					site={ this.props.site }
 					filter={ this.props.filter }
+					filterRequiresUpgrade={ this.filterRequiresUpgrade() }
 					enabledFilters={ this.props.enabledFilters }
 					search={ this.props.search }
 					onFilterChange={ this.props.onFilterChange }

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import page from 'page';
+import analytics from 'analytics';
+import { preventWidows } from 'lib/formatting';
+
+/**
+ * Internal dependencies
+ */
+const EmptyContent = require( 'components/empty-content' ),
+	Button = require( 'components/button' );
+
+module.exports = React.createClass( {
+	displayName: 'MediaLibraryListPlanPromo',
+
+	propTypes: {
+		site: React.PropTypes.object,
+		filter: React.PropTypes.string
+	},
+
+	getTitle: function() {
+		switch ( this.props.filter ) {
+			case 'videos':
+				return this.translate( 'Upload Videos', { textOnly: true, context: 'Media upload plan needed' } );
+				break;
+			case 'audio':
+				return this.translate( 'Upload Audio', { textOnly: true, context: 'Media upload plan needed' } );
+				break;
+			default:
+				return this.translate( 'Upload Media', { textOnly: true, context: 'Media upload plan needed' } );
+		}
+	},
+
+	getSummary: function() {
+		switch ( this.props.filter ) {
+			case 'videos':
+				return preventWidows(
+					this.translate(
+						'To upload video files to your site, upgrade your plan.',
+						{ textOnly: true, context: 'Media upgrade promo' }
+				), 2 );
+				break;
+			case 'audio':
+				return preventWidows(
+					this.translate(
+						'To upload audio files to your site, upgrade your plan.',
+						{ textOnly: true, context: 'Media upgrade promo' }
+				), 2 );
+				break;
+			default:
+				return preventWidows(
+					this.translate(
+						'To upload audio and video files to your site, upgrade your plan.',
+						{ textOnly: true, context: 'Media upgrade promo' }
+				), 2 );
+		}
+	},
+
+	viewPlansPage: function() {
+		const { slug = '' } = this.props.site;
+
+		analytics.tracks.recordEvent( 'calypso_media_plans_button_click' );
+
+		page( `/plans/${ slug }` );
+	},
+
+	render: function() {
+		const action = (
+			<Button className="button is-primary" onClick={ this.viewPlansPage }>{ this.translate( 'See Plans' ) }</Button>
+		);
+
+		return (
+			<EmptyContent
+				title={ this.getTitle() }
+				line={ this.getSummary() }
+				action={ action }
+				illustration={ '' } />
+		);
+	}
+} );

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -16,6 +16,7 @@ var MediaActions = require( 'lib/media/actions' ),
 	ListItem = require( './list-item' ),
 	ListNoResults = require( './list-no-results' ),
 	ListNoContent = require( './list-no-content' ),
+	ListPlanPromo = require( './list-plan-promo' ),
 	InfiniteList = require( 'components/infinite-list' ),
 	user = require( 'lib/user' )();
 
@@ -27,6 +28,7 @@ module.exports = React.createClass( {
 		media: React.PropTypes.arrayOf( React.PropTypes.object ),
 		mediaLibrarySelectedItems: React.PropTypes.arrayOf( React.PropTypes.object ),
 		filter: React.PropTypes.string,
+		filterRequiresUpgrade: React.PropTypes.bool.isRequired,
 		search: React.PropTypes.string,
 		containerWidth: React.PropTypes.number,
 		rowPadding: React.PropTypes.number,
@@ -194,6 +196,12 @@ module.exports = React.createClass( {
 
 	render: function() {
 		var onFetchNextPage;
+
+		if ( this.props.filterRequiresUpgrade ) {
+			return (
+				<ListPlanPromo site={ this.props.site } filter={ this.props.filter } />
+			);
+		}
 
 		if ( ! this.props.mediaHasNextPage && this.props.media && 0 === this.props.media.length ) {
 			return React.createElement( this.props.search ? ListNoResults : ListNoContent, {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -95,6 +95,10 @@
 	}
 }
 
+.media-library__list {
+	padding: 0 16px;
+}
+
 .media-library__list-item:hover .media-library__list-item-edit {
 	opacity: 1;
 }


### PR DESCRIPTION
Previously, the `audio` and `video` tabs in the media uploader were hidden if the site didn't have the appropriate plan or upgrade. This PR enables all media uploader tabs by default. If the site doesn't have the upgrade needed for audio or video, we show an upsell message with a button to view the plans page.

<img width="1154" alt="screen shot 2016-03-30 at 5 28 37 pm" src="https://cloud.githubusercontent.com/assets/789137/14162004/e4e29488-f69c-11e5-89bc-fc54bfcded54.png">

**To Test**
* Load the post media selector on a site that has no upgrades. Both the audio and video tabs should show the promo message.
* Load the post media selector on a site that has only VideoPress. The videos tab should allow videos but the audio tab will show the promo.
* Load the post media selector on a site that has only the file storage upgrade. The audio tab should allow uploads but the video tab should show the promo.
* Load the post media selector on a site that has a plan of any kind, or both the VideoPress and storage upgrades. No promos should be displayed.

This is my first sizable calypso PR, so any feedback is welcome to help me learn! :)

Fixes #4311