### PR TITLE
jetpack-connect: Store requested url

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1990,6 +1990,24 @@ Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters ) {
 }
 
 /**
+ * Post an url to be stored under user's settings, so we can know that they have started a jetpack-connect flow for that site
+ *
+ * @param {String}    url          The url of the site to store
+ * @returns {Promise}
+ */
+Undocumented.prototype.storeJetpackConnectUrl = function( url ) {
+	return new Promise( ( resolve, reject ) => {
+		const resolver = ( error, data ) => {
+			error ? reject( error ) : resolve( data );
+		};
+
+		this.wpcom.req.post( { path: '/me/settings' }, {}, {
+			jetpack_connect: url
+		}, resolver );
+	} );
+}
+
+/**
  * Exports the user's Reader feed as an OPML XML file.
  * A JSON object is returned with the XML given as a String
  * in the `opml` field.

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -63,6 +63,9 @@ export default {
 					data: data ? Object.assign.apply( Object, data ) : null,
 					error: error
 				} );
+				if( ! error ) {
+					wpcom.undocumented().storeJetpackConnectUrl( url );
+				}
 			} )
 			.catch( ( error ) => {
 				_fetching[ url ] = null;


### PR DESCRIPTION
This PR adds the http request required to store the urls a user have entered in the jetpack connect first step to their user settings, so we can later know that a site has been connected using jetpack-connect.

how to test
=======
1. Go to http://calypso.localhost:3000/jetpack/connect and enter any url
2. If you go to the developer console, with the same user logged, and do a GET request to /me/settings, you should have a 'jetpack_connect' attribute storing the datetime and the url you have entered 

/cc @roccotripaldi @ryelle @oskosk