### PR TITLE
Sidebar: Add footer

### DIFF
--- a/client/layout/sidebar/footer.jsx
+++ b/client/layout/sidebar/footer.jsx
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const SidebarFooter = ( { children, onClick } ) => (
+	<ul className="sidebar__footer" onClick={ onClick }>{ children }</ul>
+);
+
+export default SidebarFooter;

--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -4,6 +4,14 @@
 import React from 'react';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+
+var SidebarFooter = require( 'layout/sidebar/footer' );
+
+import ExternalLink from 'components/external-link';
+
 export default React.createClass( {
 	displayName: 'Sidebar',
 
@@ -16,6 +24,10 @@ export default React.createClass( {
 		return (
 			<ul className={ classNames( 'sidebar', this.props.className ) } onClick={ this.props.onClick }>
 				{ this.props.children }
+				<SidebarFooter>
+					<li><ExternalLink icon={ false } href="https://en.support.wordpress.com/" target="_blank">{ this.translate( 'Help' ) }</ExternalLink></li>
+					<li><a href="#">{ this.translate( 'Support' ) }</a></li>
+				</SidebarFooter>
 			</ul>
 		);
 	}

--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
  */
 
 var SidebarFooter = require( 'layout/sidebar/footer' );
+import Button from 'components/button';
 
 import ExternalLink from 'components/external-link';
 
@@ -26,7 +27,8 @@ export default React.createClass( {
 				{ this.props.children }
 				<SidebarFooter>
 					<li><ExternalLink icon={ false } href="https://en.support.wordpress.com/" target="_blank">{ this.translate( 'Help' ) }</ExternalLink></li>
-					<li><a href="#">{ this.translate( 'Support' ) }</a></li>
+					<li><ExternalLink icon={ false } href="https://en.wordpress.com/tos/" target="_blank">{ this.translate( 'Terms' ) }</ExternalLink></li>
+					<li><ExternalLink icon={ false } href="https://automattic.com/privacy/" target="_blank">{ this.translate( 'Privacy' ) }</ExternalLink></li>
 				</SidebarFooter>
 			</ul>
 		);

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -306,3 +306,35 @@
 		color: $blue-medium;
 	}
 }
+
+
+// Sidebar footer 
+.sidebar__footer {
+	position: absolute;
+	overflow: hidden;
+	padding: 0 6px;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	border-top: 1px solid lighten( $gray, 25% );
+
+	li {
+		display: inline;
+	}
+
+	li a {
+		display: inline-block;
+		text-transform: uppercase;
+		font-size: 11px;
+		font-weight: 600;
+		padding: 11px 6px;
+		color: darken( $gray, 10% );
+
+		&:hover {
+			color: $gray-dark;
+		}
+
+	}
+
+}
+

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -316,7 +316,7 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
-	border-top: 1px solid lighten( $gray, 25% );
+	border-top: 1px solid lighten( $gray, 20% );
 
 	li {
 		display: inline;


### PR DESCRIPTION
This PR fixes #1134 by adding a sidebar footer component, containing three links: Help, Terms and Privacy. It looks like this:

![screen shot 2016-03-31 at 13 22 24](https://cloud.githubusercontent.com/assets/1204802/14174274/a5b1a216-f743-11e5-8fa6-ed3037d4acb8.png)

It uses the same design language as is seen in the "Add new WordPress" button at the bottom of the site switcher:

![screen shot 2016-03-31 at 13 22 16](https://cloud.githubusercontent.com/assets/1204802/14174290/c3f56fe6-f743-11e5-9760-f883577b0b1a.png)

Aside from adding a consistent place for accessing helpful information, we in the future utilize this space for other helpful features, such as a language switcher, or a support chat button.