### PR TITLE
Purchases: Remove cancelation confirmation emails

### DIFF
--- a/client/me/purchases/confirm-cancel-purchase/index.jsx
+++ b/client/me/purchases/confirm-cancel-purchase/index.jsx
@@ -10,8 +10,10 @@ import ReactDom from 'react-dom';
  */
 import analytics from 'analytics';
 import Card from 'components/card';
+import { clearPurchases } from 'lib/upgrades/actions';
 import ConfirmCancelPurchaseLoadingPlaceholder from './loading-placeholder';
 import HeaderCake from 'components/header-cake';
+import { getName } from 'lib/purchases';
 import { getPurchase, goToCancelPurchase, recordPageView } from '../utils';
 import loadEndpointForm from './load-endpoint-form';
 import Main from 'components/main';
@@ -64,18 +66,27 @@ const ConfirmCancelPurchase = React.createClass( {
 
 	handleSubmit( error, response ) {
 		if ( error ) {
-			notices.error( error.message );
+			notices.error( error.message || this.translate( 'Unable to cancel your purchase. Please try again later or contact support.' ) );
+
 			return;
 		}
 
-		notices.success( response.message, { persistent: true } );
+		const purchase = getPurchase( this.props ),
+			purchaseName = getName( purchase );
+
+		notices.success(
+			this.translate( '%(purchaseName)s was successfully cancelled and refunded.', {
+				args: { purchaseName }
+			} ), { persistent: true } );
+
+		clearPurchases();
 
 		analytics.tracks.recordEvent(
 			'calypso_purchases_cancel_form_submit',
 			{ product_slug: getPurchase( this.props ).productSlug }
 		);
 
-		page.redirect( paths.list() );
+		page.redirect( paths.list( this.props.selectedSite.slug ) );
 	},
 
 	render() {


### PR DESCRIPTION
This pull request addresses part of https://github.com/Automattic/wp-calypso/issues/2392 by removing emails that are sent to users when they opt to cancel a purchase - in order to confirm their choice. These emails were only required for certain types of purchases and certain flows:

* Refundable plans
* Refundable domain registrations
* Refundable premium themes
* Refundable site redirects
* Refundable Google Apps

However no email is sent for:

* Domain mappings
* Privacy protections
* Non refundable plans
* Non refundable domain registrations
* Non refundable premium themes (themes are not cancelable nor removable in that case)
* Non refundable site redirects
* Non refundable Google Apps

#### Testing instructions

You must apply the **D1502-code server patch** and sandbox the API first. Another patch is provided below to be able to test non refundable products. You can happily dismiss it if you happen to already have a product in such a state. Also do not hesitate to check our internal administration tools to make sure transactions are refunded when that applies. Finally feel free to purchase products with PayPal in order to test that method of payment as well.

###### Refundable plan

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the [`Plans` page](http://calypso.localhost:3000/plans)
4. Purchase a Business plan with a fake credit card
5. Open the [`Purchases` page](http://calypso.localhost:3000/purchases)
6. Click on the Business plan purchase to open the corresponding `Manage Purchase` page
7. Check that only the `Edit Payment Method` and `Cancel Subscription and Refund` options are available
8. Click the `Cancel Subscription and Refund` link to navigate to the `Cancel Purchase` page
9. Click the `Cancel Subscription and Refund` button
10. Check that you are redirected to the `Confirm Cancel Purchase` page
11. Click the `Cancel WordPress.com Business` button
12. Check that you are redirected on the `Purchases` page with a `WordPress.com Business was successfully cancelled and refunded.` notice

###### Non refundable plan

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the `Plans` page
4. Purchase a Premium plan with a fake credit card
5. Apply patch 12a02-pb
6. Open the `Purchases` page
7. Click on the Premium plan purchase to open the corresponding `Manage Purchase` page
8. Check that only the `Edit Payment Method` and `Cancel Subscription` options are available
9. Click the `Cancel Subscription` link to navigate to the `Cancel Purchase` page
10. Click the `Cancel Subscription` button
11. Check that you are redirected on the `Purchases` page with a `WordPress.com Premium was successfully cancelled. It will be available for use until it expires on March 31, 2017.` notice

###### Refundable domain registration

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the [`Domains` page](http://calypso.localhost:3000/domains/add)
4. Purchase a domain registration without privacy protection with a fake credit card
5. Open the `Purchases` page
6. Click on the domain registration purchase to open the corresponding `Manage Purchase` page
7. Check that only the `Edit Payment Method`, `Cancel Domain and Refund`, and `Cancel Private Registration` options are available
8. Click this `Cancel Domain and Refund` link to navigate to the `Cancel Purchase` page
9. Click the `Cancel Domain and Refund` button
10. Fill in and submit survey form on the `Confirm Cancel Purchase` page
11. Check that you are redirected on the `Manage Purchase` page with a `example.net was successfully cancelled and refunded.` notice

###### Non refundable domain registration

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the `Domains` page
4. Purchase a domain registration without privacy protection with a fake credit card
5. Apply patch 12a02-pb
6. Open the `Purchases` page
7. Click on the domain registration purchase to open the corresponding `Manage Purchase` page
8. Check that only the `Edit Payment Method`, `Cancel Domain`, and `Cancel Private Registration` options are available
9. Click this `Cancel Domain` link to navigate to the `Cancel Purchase` page
10. Click the `Cancel Domain` button
11. Check that you are redirected on the `Manage Purchase` page with a `example.com was successfully cancelled. It will be available for use until it expires on January 31, 2017.` notice

###### Refundable privacy protection

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the `Domains` page
4. Purchase a domain registration with privacy protection with a fake credit card
5. Open the `Purchases` page
6. Click on the domain registration purchase to open the corresponding `Manage Purchase` page
7. Check that only the `Edit Payment Method`, `Cancel Domain and Refund`, and `Cancel Private Registration` options are available
8. Click this `Cancel Private Registration` link to navigate to the `Cancel Private Registration` page
9. Click the `Cancel Private Registration` button
10. Check that you are redirected on the `Manage Purchase` page with a `You have successfully canceled private registration for example.com.` notice

###### Non refundable privacy protection

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the `Domains` page
4. Purchase a domain registration with privacy protection with a fake credit card
5. Apply patch 12a02-pb
6. Open the `Purchases` page
7. Click on the domain registration purchase to open the corresponding `Manage Purchase` page
8. Check that only the `Edit Payment Method`, `Cancel Domain`, and `Cancel Private Registration` options are available
9. Click this `Cancel Private Registration` link to navigate to the `Cancel Private Registration` page
9. Click the `Cancel Private Registration` button
11. Check that you are redirected on the `Manage Purchase` page with a `You have successfully canceled private registration for example.com.` notice

###### Refundable domain mapping

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the [`Map a Domain` page](http://calypso.localhost:3000/domains/add/mapping)
4. Purchase a domain mapping with a fake credit card
5. Open the `Purchases` page
6. Click on the domain mapping purchase to open the corresponding `Manage Purchase` page
7. Check that only the `Edit Payment Method` and `Cancel Subscription and Refund` options are available
8. Click the `Cancel Subscription and Refund` link to navigate to the `Cancel Purchase` page
9. Click the `Cancel Subscription and Refund` button
10. Check that you are redirected to the `Confirm Cancel Purchase` page
11. Click the `Delete Domain Mapping` button
12. Check that you are redirected on the `Purchases` page with a `Domain Mapping was successfully cancelled and refunded.` notice

###### Non refundable domain mapping

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the `Map a Domain` page
4. Purchase a domain mapping with a fake credit card
5. Apply patch 12a02-pb
6. Open the `Purchases` page
7. Click on the domain mapping purchase to open the corresponding `Manage Purchase` page
8. Check that only the `Edit Payment Method` and `Cancel Subscription` options are available
9. Click the `Cancel Subscription` link to navigate to the `Cancel Purchase` page
10. Click the `Cancel Subscription` button
11. Check that you are redirected on the `Purchases` page with a `Domain Mapping was successfully cancelled. It will be available for use until it expires on March 31, 2017.` notice

###### Refundable premium theme

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the [`Themes` page](http://calypso.localhost:3000/design)
4. Purchase a Premium theme with a fake credit card
5. Open the `Purchases` page
6. Click on the theme purchase to open the corresponding `Manage Purchase` page
7. Check that only the `Cancel and Refund` option is available
8. Click the `Cancel and Refund` link to navigate to the `Cancel Purchase` page
9. Click the `Cancel and Refund` button
10. Check that you are redirected to the `Confirm Cancel Purchase` page
11. Click the `Cancel Premium Theme: XXXXXX` button
12. Check that you are redirected on the `Purchases` page with a `XXXXXX was successfully cancelled and refunded.` notice

###### Non refundable premium theme

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the `Themes` page
4. Purchase a Premium theme with a fake credit card
5. Apply patch 12a02-pb
6. Open the `Purchases` page
7. Click on the theme purchase to open the corresponding `Manage Purchase` page
8. Check that no option is available (i.e. that the theme cannot be canceled nor removed)

###### Refundable site redirect

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the [`Redirect a Site` page](http://calypso.localhost:3000/domains/add/site-redirect)
4. Purchase a site redirect with a fake credit card
5. Open the `Purchases` page
6. Click on the site redirect purchase to open the corresponding `Manage Purchase` page
7. Check that only the `Edit Payment Method` and `Cancel Subscription and Refund` options are available
8. Click the `Cancel Subscription and Refund` link to navigate to the `Cancel Purchase` page
9. Click the `Cancel Subscription and Refund` button
10. Check that you are redirected to the `Confirm Cancel Purchase` page
11. Click the `Cancel Site Redirect` button
12. Check that you are redirected on the `Purchases` page with a `Site Redirect was successfully cancelled and refunded.` notice

###### Non refundable site redirect

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the `Redirect a Site` page
4. Purchase a site redirect with a fake credit card
5. Apply patch 12a02-pb
6. Open the `Purchases` page
7. Click on the site redirect purchase to open the corresponding `Manage Purchase` page
8. Check that only the `Edit Payment Method` and `Cancel Subscription` options are available
9. Click the `Cancel Subscription` link to navigate to the `Cancel Purchase` page
10. Click the `Cancel Subscription` button
11. Check that you are redirected on the `Purchases` page with a `Site Redirect was successfully cancelled. It will be available for use until it expires on March 31, 2017.` notice

###### Refundable Google Apps

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the `Domains` page
4. Purchase a domain registration with Google Apps emails with a fake credit card
5. Open the `Purchases` page
6. Click on the Google Apps purchase to open the corresponding `Manage Purchase` page
7. Check that only the `Edit Payment Method` and `Cancel Subscription and Refund` options are available
8. Click the `Cancel Subscription and Refund` link to navigate to the `Cancel Purchase` page
9. Click the `Cancel Subscription and Refund` button
10. Check that you are redirected to the `Confirm Cancel Purchase` page
11. Click the `Cancel Google Apps` button
12. Check that you are redirected on the `Purchases` page with a `Google Apps was successfully cancelled and refunded.` notice

###### Non refundable Google Apps

1. Get a user account with a blog
2. Enable the store sandbox
3. Open the `Domains` page
4. Purchase a domain registration with Google Apps emails with a fake credit card
5. Apply patch 12a02-pb
6. Open the `Purchases` page
7. Click on the Google Apps purchase to open the corresponding `Manage Purchase` page
8. Check that only the `Edit Payment Method` and `Cancel Subscription` options are available
9. Click the `Cancel Subscription` link to navigate to the `Cancel Purchase` page
10. Click the `Cancel Subscription` button
11. Check that you are redirected on the `Purchases` page with a `Google Apps was successfully cancelled. It will be available for use until it expires on April 1, 2017.` notice

###### Non refundable legacy upgrades

These are purchases no longer offered but that can still be renewed by users:

1. Get a user account with a blog
2. Enable the store sandbox
3. Add any legacy upgrade to the blog with tomorrow as expiration date using our internal administration tools
UPDATE purchased date -1YEAR
4. Open the `Purchases` page
5. Click on the upgrade to open the corresponding `Manage Purchase` page
6. Click the `Renow Now` button and renew the upgrade with a fake credit card
7. Navigate to the corresponding `Manage Purchase` page again
8. Check that only the `Edit Payment Method` and `Cancel Subscription` options are available
9. Click the `Cancel Subscription` link to navigate to the `Cancel Purchase` page
10. Click the `Cancel Subscription` button
11. Check that you are redirected on the `Purchases` page with a `XXXXXXXX was successfully cancelled. It will be available for use until it expires on April 1, 2017.` notice

#### Reviews
 
- [x] Code
- [x] Product