### PR TITLE
Domains: Checkout: Trim trailing whitespace in domain contact information form

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -57,6 +57,7 @@ export default React.createClass( {
 		this.formStateController = formState.Controller( {
 			fieldNames: this.fieldNames,
 			loadFunction: wpcom.getDomainContactInformation.bind( wpcom ),
+			sanitizerFunction: this.trimWhitespace,
 			validatorFunction: this.validate,
 			onNewState: this.setFormState,
 			onError: this.handleFormControllerError
@@ -69,10 +70,19 @@ export default React.createClass( {
 		analytics.pageView.record( '/checkout/domain-contact-information', 'Checkout > Domain Contact Information' );
 	},
 
-	validate( fieldNames, onComplete ) {
+	trimWhitespace( fieldValues, onComplete ) {
+		const trimmedFieldValues = Object.assign( {}, fieldValues );
+		this.fieldNames.forEach( ( fieldName ) => {
+			trimmedFieldValues[ fieldName ] = fieldValues[ fieldName ].trim();
+		} );
+
+		onComplete( trimmedFieldValues );
+	},
+
+	validate( fieldValues, onComplete ) {
 		const domainNames = map( cartItems.getDomainRegistrations( this.props.cart ), 'meta' );
 
-		wpcom.validateDomainContactInformation( fieldNames, domainNames, ( error, data ) => {
+		wpcom.validateDomainContactInformation( fieldValues, domainNames, ( error, data ) => {
 			const messages = data && data.messages || {};
 			onComplete( error, messages );
 		} );


### PR DESCRIPTION
Trailing whitespace in the domain contact's fields lead to registration errors. Since it's the client's (that is, Calypso's) responsibility to sanitize the data before sending it to the server, rather than fixing this on the backend, we sanitize the input (using the very useful `sanitizerFunction` from `formState` - awesomesauce!) on the client side and the backend receives trimmed values (both for validation and saving).

/cc @umurkontaci @aidvu @dzver