### PR TITLE
People: Add invite form to horizon and desktop environments

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -20,7 +20,7 @@
 		"help": true,
 		"login": false,
 		"mailing-lists/unsubscribe": true,
-		"manage/add-people": false,
+		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -23,7 +23,7 @@
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"login": false,
-		"manage/add-people": false,
+		"manage/add-people": true,
 		"manage/ads": true,
 		"manage/ads/jetpack": true,
 		"manage/customize": true,


### PR DESCRIPTION
Today, @rachelmcr pointed our that we hadn't launched the new invite form within the Desktop app. This PR adds the invites form to the `horizon` and `desktop` environments.

To test:
- Checkout `update/invites-to-desktop` branch
- In terminal, `CALYPSO_ENV=horizon make run`
- Go to `/people/new/$site` where `$site` is a WP.com site
- Do you see the form?
- If you send an invite, does the user receive an email?

cc @mkaz for review since I'm not sure how to test for Desktop apps.