### PR TITLE
Components: Links in notices are not underlined

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -137,15 +137,10 @@
 		font-weight: 600;
 
 		// Medium text underline hack
-		background-image: linear-gradient(to bottom, rgba(0,0,0,0) 75%, #fff 50%);
+		background-image: linear-gradient(to bottom, rgba(0,0,0,0) 50%, #fff 50%);
 		background-repeat: repeat-x;
 		background-size: 2px 2px;
-		background-position: 0 1.14em; // ~18/15
-
-		@media not all, only screen and (min-resolution: 2dppx), only screen and (-webkit-min-device-pixel-ratio: 2) {
-			background-image: linear-gradient(to bottom, rgba(0,0,0,0) 75%, #fff 75%);
-			background-repeat: repeat-x;
-		}
+		background-position: 0 1em;
 	}
 
 	ul {


### PR DESCRIPTION
**Issue**
When the user is presented with a notice, links are missing an underline. The problem is addressed in issue https://github.com/Automattic/wp-calypso/issues/4321.

**Steps to reproduce**
1. Try to add a new domain to your site.
2. Enter cnn.com in the search domain field. 
3. A notice should show up saying:
>cnn.com is taken.
If you purchased cnn.com elsewhere, you can map it for €13.00.

The ```map it``` part is the link that is missing the underline.

**What should happen**

![screen shot 2016-04-01 at 11 06 42 am](https://cloud.githubusercontent.com/assets/1922453/14192415/04b3eb0a-f7fa-11e5-8e83-7422611220fc.png)

**What does happen** - Chrome 49 (retina and normal), Safari 9.1 (retina and normal)

![screen shot 2016-04-01 at 11 06 59 am](https://cloud.githubusercontent.com/assets/1922453/14192424/12c09a72-f7fa-11e5-9003-67d64b0d7e1e.png)

**Notes**
Why not use ```text-decoration: underline```? Browser support is [really bad!](http://caniuse.com/#search=text-decoration). There are several approaches to solve the problem, outlined [in a nice blog post](http://benjam.info/blog/posts/2015-01-31-css-underline) with ```linear-gradient``` as a background image being the most suited to this situation. 

**Fix**
* The underline was placed too far down, so it wasn't showing up. I made it exactly the ```line-height```
* The height of the background needs to take into account retina display.

**Tested**
* Chrome 49 (retina, normal)
* Safari 9.1 (retina, normal)
* Firefox 44 (retina, normal)
* IE 11 using a this [code pen](http://codepen.io/jxnblk/pen/jCmwK/) (retina, normal)

ping @mtias @klimeryk