### PR TITLE
Checkout: Thank You: Update the thank you page route to match editor

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -163,7 +163,7 @@ const Checkout = React.createClass( {
 			} );
 		}
 
-		return `/checkout/${ this.props.sites.getSelectedSite().slug }/${ receiptId }/thank-you`;
+		return `/checkout/thank-you/${ this.props.sites.getSelectedSite().slug }/${ receiptId }`;
 	},
 
 	content: function() {

--- a/client/my-sites/upgrades/index.js
+++ b/client/my-sites/upgrades/index.js
@@ -228,7 +228,7 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'upgrades/checkout' ) ) {
 		page(
-			'/checkout/:site/:receiptId?/thank-you',
+			'/checkout/thank-you/:site/:receiptId?',
 			controller.siteSelection,
 			upgradesController.checkoutThankYou
 		);


### PR DESCRIPTION
The route change in #4193 broke the non-generic thank you page. This update the thank you page routes to match the editor, putting the site slug in the second-to-last or last place.