### PR TITLE
Signup: Fix the domain mapping link for non-en locales

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -75,7 +75,7 @@ var DomainSearchResults = React.createClass( {
 						className="domain-search-results__domain-availability-copy"
 						status="is-warning"
 						showDismiss={ false }>
-						{ domainUnavailableMessage} { mappingOffer }
+						{ domainUnavailableMessage } { mappingOffer }
 					</Notice>
 				);
 			}
@@ -130,7 +130,12 @@ var DomainSearchResults = React.createClass( {
 			}, this );
 
 			if ( this.props.offerMappingOption ) {
-				mappingOffer = <DomainMappingSuggestion onButtonClick={ this.props.onClickMapping } products={ this.props.products } cart={ this.props.cart } />;
+				mappingOffer = (
+					<DomainMappingSuggestion
+						onButtonClick={ this.props.onClickMapping }
+						products={ this.props.products }
+						cart={ this.props.cart } />
+				);
 			}
 		} else {
 			suggestionElements = this.placeholders();

--- a/client/components/domains/example-domain-suggestions/index.jsx
+++ b/client/components/domains/example-domain-suggestions/index.jsx
@@ -81,7 +81,6 @@ module.exports = React.createClass( {
 
 	render: function() {
 		let examples, mappingInformation;
-		const mappingUrl = this.props.path + '/mapping';
 
 		if ( ! isEmpty( this.props.products ) ) {
 			mappingInformation = this.translate(
@@ -92,7 +91,7 @@ module.exports = React.createClass( {
 					},
 
 					components: {
-						mappingLink: <a onClick={ this.handleClickMappingLink } href={ mappingUrl } />,
+						mappingLink: <a onClick={ this.handleClickMappingLink } href={ this.props.mapDomainUrl } />,
 						strong: <strong />
 					}
 				}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -157,10 +157,13 @@ var RegisterDomainStep = React.createClass( {
 		}
 
 		if ( this.props.showExampleSuggestions ) {
-			return <ExampleDomainSuggestions
-				onClickExampleSuggestion={ this.handleClickExampleSuggestion }
-				path={ this.props.path }
-				products={ this.props.products } />;
+			return (
+				<ExampleDomainSuggestions
+					onClickExampleSuggestion={ this.handleClickExampleSuggestion }
+					mapDomainUrl={ this.getMapDomainUrl() }
+					path={ this.props.path }
+					products={ this.props.products } />
+			);
 		}
 
 		return this.initialSuggestions();
@@ -359,7 +362,12 @@ var RegisterDomainStep = React.createClass( {
 			// the search returned no results
 
 			if ( this.props.showExampleSuggestions ) {
-				return <ExampleDomainSuggestions path={ this.props.path } products={ this.props.products } />;
+				return (
+					<ExampleDomainSuggestions
+						mapDomainUrl={ this.getMapDomainUrl() }
+						path={ this.props.path }
+						products={ this.props.products } />
+				);
 			}
 
 			suggestions = this.state.defaultSuggestions;
@@ -384,16 +392,28 @@ var RegisterDomainStep = React.createClass( {
 		);
 	},
 
-	goToMapDomainStep: function( event ) {
-		const query = qs.stringify( { initialQuery: this.state.lastQuery.trim() } );
-		let mapDomainPath = `${this.props.basePath}/mapping`;
-		if ( this.props.selectedSite ) {
-			mapDomainPath += `/${ this.props.selectedSite.slug }?${ query }`;
+	getMapDomainUrl: function() {
+		let mapDomainUrl;
+
+		if ( this.props.mapDomainUrl ) {
+			mapDomainUrl = this.props.mapDomainUrl;
+		} else {
+			const query = qs.stringify( { initialQuery: this.state.lastQuery.trim() } );
+			mapDomainUrl = `${this.props.basePath}/mapping`;
+			if ( this.props.selectedSite ) {
+				mapDomainUrl += `/${ this.props.selectedSite.slug }?${ query }`;
+			}
 		}
 
+		return mapDomainUrl;
+	},
+
+	goToMapDomainStep: function( event ) {
 		event.preventDefault();
+
 		this.recordEvent( 'mapDomainButtonClick', this.props.analyticsSection );
-		page( mapDomainPath );
+
+		page( this.getMapDomainUrl() );
 	},
 
 	addRemoveDomainToCart: function( suggestion, event ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -29,6 +29,10 @@ module.exports = React.createClass( {
 		page( signupUtils.getStepUrl( this.props.flowName, this.props.stepName, this.props.locale ) );
 	},
 
+	getMapDomainUrl: function() {
+		return signupUtils.getStepUrl( this.props.flowName, this.props.stepName, 'mapping', this.props.locale );
+	},
+
 	getInitialState: function() {
 		return { products: productsList.get() };
 	},
@@ -158,6 +162,7 @@ module.exports = React.createClass( {
 				products={ this.state.products }
 				buttonLabel={ this.translate( 'Select' ) }
 				basePath={ this.props.path }
+				mapDomainUrl={ this.getMapDomainUrl() }
 				onAddMapping={ this.handleAddMapping.bind( this, 'domainForm' ) }
 				onSave={ this.handleSave.bind( this, 'domainForm' ) }
 				offerMappingOption


### PR DESCRIPTION
Currently, when visiting signup with a non-en locale, e.g. `/start/es`, the domain mapping page is broken, as `RegisterDomainStep` and its children simply append `/mapping` to the current path instead of redirecting the user to the actual path for this page: `/start/domains/mapping/es`.

This PR updates `RegisterDomainStep` and its children to redirect to `this.props.mapDomainUrl` if it is present.

**Testing**
*Signup*
- Visit `/start/website/es` in an incognito window.
- Proceed to the domains step.
- Assert that clicking the "Asígnalo a" link in `ExampleDomainSuggestions` takes you to the [domain mapping section](https://cloudup.com/caCkUMj6Cqq).
- Enter a search query.
- Assert that clicking the "Asignar" button in the search results also takes you to the domain mapping section.

*Domain search*
- Visit `/domains/add/:site`.
- Assert that clicking the "Map it" button takes you to the [domain mapping section](https://cloudup.com/cZPR4Qgs4Cc).

- [ ] Code review
- [x] Product review