### PR TITLE
GuidesTours: add step formatting

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -130,6 +130,7 @@ $z-layers: (
 		'popover.is-dialog-visible': 100300,
 		'body .webui-popover': 100300,
 		'.fullscreen-fader': 200000,
+		'.guidestours__step': 201000,
 		'#habla_window_div.habla_window_div_base': 99999999 //olark
 	),
 	'.environment-badge': (

--- a/client/guidestours/config.js
+++ b/client/guidestours/config.js
@@ -1,26 +1,59 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import i18n from 'lib/mixins/i18n';
+
 const config = {
 	init: {
-		text: 'Welcome to WordPress.com!',
+		text: i18n.translate( '{{strong}}Need a hand?{{/strong}} We\'d love to show you around the place, and give you some ideas for what to do next.', {
+			components: {
+				strong: <strong />,
+			}
+		} ),
+		type: 'GuidesFirstStep',
 		next: 'my-sites',
 	},
 	'my-sites': {
 		target: 'my-sites',
-		type: 'bullseye',
+		type: 'GuidesActionStep',
+		icon: 'my-sites',
 		placement: 'below',
-		text: `First things first. Up here, you'll find tools for managing your site's content and design.`,
-		next: 'reader'
+		text: i18n.translate( "First things first. Up here, you'll find tools for managing your site's content and design." ),
+		next: 'posts-pages',
+	},
+	'posts-pages': {
+		text: i18n.translate( "Posts aren't Pages. Would you like to know more?" ),
+		type: 'GuidesLinkStep',
+		linkLabel: i18n.translate( 'Learn more about Posts and Pages' ),
+		linkUrl: 'https://en.support.wordpress.com/post-vs-page/',
+		next: 'reader',
 	},
 	reader: {
 		target: 'reader',
-		type: 'bullseye',
+		type: 'GuidesActionStep',
+		icon: 'reader',
 		placement: 'beside',
-		text: `This is the Reader. It shows you fresh posts from other sites you're following.`,
+		text: i18n.translate( "This is the Reader. It shows you fresh posts from other sites you're following." ),
 		next: 'finish'
 	},
 	finish: {
-		target: 'reader',
+		target: 'me',
 		placement: 'beside',
-		text: `You're done. Enjoy! :)`
+		text: i18n.translate( "{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around. You can get more help by going to the {{gridicon/}} {{strong}}Me{{/strong}} section.", {
+			components: {
+				strong: <strong />,
+				gridicon: <Gridicon icon="user-circle" size={ 18 } />,
+			}
+		} ),
+		type: 'GuidesFinishStep',
+		linkLabel: 'Get the Most from WordPress.com',
+		linkUrl: 'https://learn.wordpress.com',
 	}
 }
 

--- a/client/guidestours/index.js
+++ b/client/guidestours/index.js
@@ -1,125 +1,20 @@
 /**
  * External dependencies
  */
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
 
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
-import Button from 'components/button';
 import guideConfig from './config';
-
-// Magic numbers make me sad
-const BULLSEYE_RADIUS = 6;
-const DIALOG_WIDTH = 400;
-const DIALOG_PADDING = 10;
-const MASTERBAR_HEIGHT = 48;
-
-const query = selector =>
-	[].slice.call( global.window.document.querySelectorAll( selector ) );
-
-const posToCss = ( { x, y } ) => ( {
-	top: y ? y + 'px' : undefined,
-	left: x ? x + 'px' : undefined,
-} );
-
-const middle = ( a, b ) => Math.abs( b - a ) / 2;
-
-const dialogPositioners = {
-	below: ( { left, bottom } ) => ( { x: left + DIALOG_PADDING, y: bottom + DIALOG_PADDING } ),
-	beside: ( { right, top } ) => ( { x: right + DIALOG_PADDING, y: top + DIALOG_PADDING } ),
-	center: ( { left, right } ) => ( {
-		x: middle( left, right ) - DIALOG_WIDTH / 2,
-		y: MASTERBAR_HEIGHT / 2,
-	} ),
-};
-
-const bullseyePositioners = {
-	below: ( { left, right, bottom } ) => ( {
-		x: left + middle( left, right ) - BULLSEYE_RADIUS,
-		y: bottom - BULLSEYE_RADIUS * 1.5,
-	} ),
-
-	beside: ( { top, bottom, right } ) => ( {
-		x: right - BULLSEYE_RADIUS * 1.5,
-		y: top + middle( top, bottom ) - BULLSEYE_RADIUS,
-	} ),
-
-	center: () => ( {} ),
-};
-
-class GuidesStep extends Component {
-	componentDidMount() {
-		this.addTargetListener();
-	}
-
-	componentWillUnmount() {
-		this.removeTargetListener();
-	}
-
-	componentWillUpdate() {
-		this.removeTargetListener();
-	}
-
-	componentDidUpdate() {
-		this.addTargetListener();
-	}
-
-	addTargetListener() {
-		const { target = false, onNext, type } = this.props;
-		if ( type === 'bullseye' && onNext && target.addEventListener ) {
-			target.addEventListener( 'click', onNext );
-		}
-	}
-
-	removeTargetListener() {
-		const { target = false, onNext, type } = this.props;
-		if ( type === 'bullseye' && onNext && target.removeEventListener ) {
-			target.removeEventListener( 'click', onNext );
-		}
-	}
-
-	render() {
-		const { text, type, style, onNext, onQuit } = this.props;
-		return (
-			<Card className="guidestours__step" style={ style } >
-				<p>{ text }</p>
-				{ type !== 'bullseye' &&
-					<Button onClick={ onNext } primary>Next</Button>
-				}
-				<Button onClick={ onQuit } secondary>Skip all</Button>
-			</Card>
-		);
-	}
-}
-
-GuidesStep.propTypes = {
-	target: PropTypes.object,
-	type: PropTypes.string,
-	text: PropTypes.string,
-	placement: PropTypes.string,
-	next: PropTypes.string,
-	style: PropTypes.object,
-	onNext: PropTypes.func.isRequired,
-	onQuit: PropTypes.func.isRequired,
-};
-
-class GuidesPointer extends Component {
-	render() {
-		return (
-			<div className="guidestours__pointer" style={ this.props.style }>
-				<div className="guidestours__pointer__ring" />
-				<div className="guidestours__pointer__center" />
-			</div>
-		);
-	}
-}
-
-GuidesPointer.propTypes = {
-	style: PropTypes.object.isRequired,
-	onNext: PropTypes.func.isRequired,
-};
+import { query } from './positioning';
+import {
+	GuidesBasicStep,
+	GuidesFirstStep,
+	GuidesLinkStep,
+	GuidesFinishStep,
+	GuidesActionStep,
+} from './steps';
 
 export default class GuidesTours extends Component {
 	constructor() {
@@ -154,22 +49,6 @@ export default class GuidesTours extends Component {
 		} ), {} );
 	}
 
-	getStepPositions() {
-		let coords = { bullseye: {}, dialog: {} };
-
-		const { bullseye = true, placement = 'center' } = this.state.currentStep;
-		const rect = this.currentTarget
-			? this.currentTarget.getBoundingClientRect()
-			: global.window.document.body.getBoundingClientRect();
-
-		if ( bullseye ) {
-			coords.bullseye = bullseyePositioners[ placement ]( rect );
-		}
-
-		coords.dialog = dialogPositioners[ placement ]( rect )
-		return coords;
-	}
-
 	next() {
 		this.setState( { currentStep: guideConfig[ this.state.currentStep.next ] } );
 	}
@@ -184,22 +63,21 @@ export default class GuidesTours extends Component {
 			return null;
 		}
 
-		const { bullseye, dialog } = this.getStepPositions();
-		const stepCoords = posToCss( dialog );
-		const pointerCoords = posToCss( bullseye );
+		const StepComponent = {
+			GuidesFirstStep,
+			GuidesActionStep,
+			GuidesLinkStep,
+			GuidesFinishStep,
+		}[ this.state.currentStep.type ] || GuidesBasicStep;
 
 		return (
 			<div>
-				<GuidesStep
-						{ ...this.state.currentStep }
-						key={ this.state.target }
-						target={ this.currentTarget }
-						style={ stepCoords }
-						onNext={ this.next }
-						onQuit={ this.quit } />
-				{ this.state.currentStep.type === 'bullseye' &&
-					<GuidesPointer style={ pointerCoords } />
-				}
+				<StepComponent
+					{ ...this.state.currentStep }
+					key={ this.state.target }
+					target={ this.currentTarget }
+					onNext={ this.next }
+					onQuit={ this.quit } />
 			</div>
 		);
 	}

--- a/client/guidestours/positioning.js
+++ b/client/guidestours/positioning.js
@@ -1,0 +1,61 @@
+const BULLSEYE_RADIUS = 6;
+const DIALOG_WIDTH = 410;
+const DIALOG_PADDING = 10;
+const MASTERBAR_HEIGHT = 48;
+
+const middle = ( a, b ) => Math.abs( b - a ) / 2;
+
+const wouldBeOffscreen = pos =>
+	( pos + DIALOG_PADDING + DIALOG_WIDTH ) > document.documentElement.clientWidth
+
+const fitOnScreen = pos =>
+	Math.abs( pos - DIALOG_PADDING - DIALOG_WIDTH )
+
+const dialogPositioners = {
+	below: ( { left, bottom } ) => ( {
+		x: wouldBeOffscreen( left )
+			? fitOnScreen( document.documentElement.clientWidth )
+			: left + DIALOG_PADDING,
+		y: bottom + DIALOG_PADDING,
+	} ),
+	beside: ( { left, right, top } ) => ( {
+		x: wouldBeOffscreen( right )
+			? fitOnScreen( left )
+			: right + DIALOG_PADDING,
+		y: top + DIALOG_PADDING,
+	} ),
+	center: ( { left, right } ) => ( {
+		x: middle( left, right ) - DIALOG_WIDTH / 2,
+		y: MASTERBAR_HEIGHT / 2,
+	} ),
+};
+
+export const query = selector =>
+	[].slice.call( global.window.document.querySelectorAll( selector ) );
+
+export const posToCss = ( { x, y } ) => ( {
+	top: y ? y + 'px' : undefined,
+	left: x ? x + 'px' : undefined,
+} );
+
+export const bullseyePositioners = {
+	below: ( { left, right, bottom } ) => ( {
+		x: left + middle( left, right ) - BULLSEYE_RADIUS,
+		y: bottom - BULLSEYE_RADIUS * 1.5,
+	} ),
+
+	beside: ( { top, bottom, right } ) => ( {
+		x: right - BULLSEYE_RADIUS * 1.5,
+		y: top + middle( top, bottom ) - BULLSEYE_RADIUS,
+	} ),
+
+	center: () => ( {} ),
+};
+
+export function getStepPosition( { placement = 'center', target } ) {
+	const rect = target
+		? target.getBoundingClientRect()
+		: global.window.document.body.getBoundingClientRect();
+
+	return dialogPositioners[ placement ]( rect );
+}

--- a/client/guidestours/steps.js
+++ b/client/guidestours/steps.js
@@ -1,0 +1,201 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react'
+
+/**
+ * Internal dependencies
+ */
+import localize from 'lib/mixins/i18n/localize';
+import Card from 'components/card';
+import Button from 'components/button';
+import ExternalLink from 'components/external-link';
+import Gridicon from 'components/gridicon';
+import { posToCss, bullseyePositioners, getStepPosition } from './positioning';
+
+class GuidesBasicStep extends Component {
+	render() {
+		const stepPos = getStepPosition( this.props );
+		const stepCoords = posToCss( stepPos );
+
+		const { text, onNext, onQuit } = this.props;
+		return (
+			<Card className="guidestours__step" style={ stepCoords } >
+				<p>{ text }</p>
+				<div className="guidestours__choice-button-row">
+					<Button onClick={ onNext } primary>{ this.props.translate( 'Continue' ) }</Button>
+					<Button onClick={ onQuit } borderless>{ this.props.translate( 'Do this later.' ) }</Button>
+				</div>
+			</Card>
+		);
+	}
+}
+
+class GuidesFirstStep extends Component {
+	render() {
+		const stepPos = getStepPosition( this.props );
+		const stepCoords = posToCss( stepPos );
+
+		const { text, onNext, onQuit } = this.props;
+		return (
+			<Card className="guidestours__step" style={ stepCoords } >
+				<p>{ text }</p>
+				<div className="guidestours__choice-button-row">
+					<Button onClick={ onNext } primary>{ this.props.translate( 'Continue' ) }</Button>
+					<Button onClick={ onQuit } className="guidestours__secondary-button">
+						{ this.props.translate( 'No, thanks.' ) }
+					</Button>
+				</div>
+			</Card>
+		);
+	}
+}
+
+class GuidesFinishStep extends Component {
+	render() {
+		const stepPos = getStepPosition( this.props );
+		const stepCoords = posToCss( stepPos );
+
+		const { text, onQuit, linkUrl, linkLabel } = this.props;
+
+		return (
+			<Card className="guidestours__step" style={ stepCoords } >
+				<p>{ text }</p>
+				<div className="guidestours__single-button-row">
+					<Button onClick={ onQuit } primary>{ this.props.translate( 'Finish Tour' ) }</Button>
+				</div>
+				<div className="guidestours__external-link">
+					<ExternalLink target="_blank" icon={ true } href={ linkUrl }>{ linkLabel }</ExternalLink>
+				</div>
+			</Card>
+		);
+	}
+}
+
+class GuidesLinkStep extends Component {
+	render() {
+		const stepPos = getStepPosition( this.props );
+		const stepCoords = posToCss( stepPos );
+
+		const { text, onNext, onQuit, linkUrl, linkLabel } = this.props;
+
+		return (
+			<Card className="guidestours__step" style={ stepCoords } >
+				<p>{ text }</p>
+				<div className="guidestours__choice-button-row">
+					<Button onClick={ onNext } primary>{ this.props.translate( 'Continue' ) }</Button>
+					<Button onClick={ onQuit } borderless>{ this.props.translate( 'Do this later.' ) }</Button>
+				</div>
+				<div className="guidestours__external-link">
+					<ExternalLink target="_blank" icon={ true } href={ linkUrl }>{ linkLabel }</ExternalLink>
+				</div>
+			</Card>
+		);
+	}
+}
+
+class GuidesActionStep extends Component {
+	componentDidMount() {
+		this.addTargetListener();
+	}
+
+	componentWillUnmount() {
+		this.removeTargetListener();
+	}
+
+	componentWillUpdate() {
+		this.removeTargetListener();
+	}
+
+	componentDidUpdate() {
+		this.addTargetListener();
+	}
+
+	addTargetListener() {
+		const { target = false, onNext } = this.props;
+		if ( onNext && target.addEventListener ) {
+			target.addEventListener( 'click', onNext );
+		}
+	}
+
+	removeTargetListener() {
+		const { target = false, onNext } = this.props;
+		if ( onNext && target.removeEventListener ) {
+			target.removeEventListener( 'click', onNext );
+		}
+	}
+
+	getBullseyePosition() {
+		const { placement = 'center', target } = this.props;
+		const rect = target
+			? target.getBoundingClientRect()
+			: global.window.document.body.getBoundingClientRect();
+
+		return bullseyePositioners[ placement ]( rect );
+	}
+
+	render() {
+		const stepPos = getStepPosition( this.props );
+		const bullseyePos = this.getBullseyePosition();
+		const stepCoords = posToCss( stepPos );
+		const pointerCoords = posToCss( bullseyePos );
+
+		const { text } = this.props;
+
+		return (
+			<Card className="guidestours__step" style={ stepCoords } >
+				<p>{ text }</p>
+				<div className="guidestours__bullseye-instructions">
+					<p>
+						{ this.props.translate( 'Click the {{gridicon/}} to continue…', {
+							components: {
+								gridicon: <Gridicon icon={ this.props.icon } size={ 24 } />
+							}
+						} ) }
+					</p>
+				</div>
+				<GuidesPointer style={ pointerCoords } />
+			</Card>
+		);
+	}
+}
+
+GuidesBasicStep.propTypes = {
+	target: PropTypes.object,
+	type: PropTypes.string,
+	// text can be a translated string or a translated string with components
+	// attached
+	text: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.array
+	] ),
+	placement: PropTypes.string,
+	next: PropTypes.string,
+	style: PropTypes.object,
+	onNext: PropTypes.func.isRequired,
+	onQuit: PropTypes.func.isRequired,
+};
+
+class GuidesPointer extends Component {
+	render() {
+		return (
+			<div className="guidestours__bullseye" style={ this.props.style }>
+				<div className="guidestours__bullseye-ring" />
+				<div className="guidestours__bullseye-center" />
+			</div>
+		);
+	}
+}
+
+GuidesPointer.propTypes = {
+	style: PropTypes.object.isRequired,
+};
+
+export default {
+	GuidesBasicStep: localize( GuidesBasicStep ),
+	GuidesLinkStep: localize( GuidesLinkStep ),
+	GuidesActionStep: localize( GuidesActionStep ),
+	GuidesFirstStep: localize( GuidesFirstStep ),
+	GuidesFinishStep: localize( GuidesFinishStep ),
+}
+

--- a/client/guidestours/style.scss
+++ b/client/guidestours/style.scss
@@ -1,33 +1,59 @@
 .guidestours__step {
 	position: fixed;
-	width: 400px;
-	z-index: z-index( 'root', '.web-preview' );
+	width: 410px;
+	z-index: z-index( 'root', '.guidestours__step' );
+	border: 1px solid lighten( $gray, 10 );
+	box-shadow: 0px 10px 23px 0px rgba( 0, 0, 0, 0.50 );
+	border-radius: 4px;
+	padding-top: 19px;
+	font-size: 14px;
+
+	p {
+		color: $gray-dark;
+		margin-bottom: 16px;
+	}
+
+	hr {
+		margin-bottom: 0.5em;
+		color: $gray-light;
+		background-color: $gray-light;
+	}
+
+	.gridicon[height="16"] {
+		position: relative;
+		top: 2px;
+	}
+
+	.gridicon[height="18"] {
+		position: relative;
+		top: 3px;
+	}
 }
 
-// variables for the guidestours__pointer
+// variables for the guidestours__bullseye
 $animation-speed: 2s;
 $size: 10px;
 $zoom-scale: 5; // the multiplier determining the size of the animated rings
 
-@keyframes guidestours__pointer__animation {
+@keyframes guidestours__bullseye-animation {
 	0% {
 		transform: scale( .2 );
 		opacity: 1;
 	}
 }
 
-.guidestours__pointer {
+.guidestours__bullseye {
 	position: fixed;
-	z-index: z-index( 'root', '.web-preview' );
+	z-index: z-index( 'root', '.guidestours__step' );
 	width: $size;
 	height: $size;
 	pointer-events: none;
 }
 
-.guidestours__pointer__center,
-.guidestours__pointer__ring,
-.guidestours__pointer__ring:before,
-.guidestours__pointer__ring:after {
+.guidestours__bullseye-center,
+.guidestours__bullseye-ring,
+.guidestours__bullseye-ring:before,
+.guidestours__bullseye-ring:after {
 	position: absolute;
 		top: 0;
 		right: 0;
@@ -37,14 +63,14 @@ $zoom-scale: 5; // the multiplier determining the size of the animated rings
 	z-index: 1;
 }
 
-.guidestours__pointer__center {
+.guidestours__bullseye-center {
 	background: #fff;
 	border: 1px solid #a8bece;
 	box-shadow: 0 1px 2px rgba( 79, 116, 142, .3 );
 }
 
-.guidestours__pointer__ring:before,
-.guidestours__pointer__ring:after {
+.guidestours__bullseye-ring:before,
+.guidestours__bullseye-ring:after {
 	content: "";
 	top: ( -1 * $zoom-scale * $size / 2 ) + ( $size / 2 ) + 1;
 	left: ( -1 * $zoom-scale * $size / 2 ) + ( $size / 2 ) - 1;
@@ -52,9 +78,53 @@ $zoom-scale: 5; // the multiplier determining the size of the animated rings
 	height: $size * $zoom-scale;
 	background-image: radial-gradient( rgb( 0, 170, 220 ), #fff );
 	opacity: 0;
-	animation: guidestours__pointer__animation $animation-speed ease-in-out infinite;
+	animation: guidestours__bullseye-animation $animation-speed ease-in-out infinite;
 }
 
-.guidestours__pointer__ring:after {
+.guidestours__bullseye-ring:after {
 	animation-delay: #{ $animation-speed / 4 };
+}
+
+.guidestours__choice-button-row {
+	button {
+		width: 48%;
+	}
+	button:nth-child(1) {
+		margin-right: 4%;
+	}
+	button.guidestours__secondary-button {
+		background: $gray-light;
+		color: darken( $gray, 20% );
+	}
+}
+
+.guidestours__single-button-row {
+	button {
+		width: 100%;
+	}
+}
+
+.guidestours__external-link,
+.guidestours__bullseye-instructions {
+	p {
+		color: darken( $gray, 10 );
+		margin-bottom: 0;
+		font-style: italic;
+	}
+
+	.gridicon {
+		position: relative;
+		top: 7px;
+	}
+
+	.external-link {
+		border-top: 1px solid $gray-light;
+		display: block;
+		padding-top: 8px;
+		margin-top: 16px;
+	}
+}
+
+.guidestours__bullseye-instructions {
+	margin-top: -7px;
 }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -96,6 +96,7 @@ export default React.createClass( {
 					{ this.translate( 'New Post' ) }
 				</Publish>
 				<Item
+					tipTarget="me"
 					url="/me"
 					icon="user-circle"
 					isActive={ this.isActive( 'me' ) }


### PR DESCRIPTION
Closes #4379.

This PR adds a few additional step types to GuidesTours:

- `GuidesFirstStep`, for the initial step of a tour;
- `GuidesActionStep`, requiring the user to click a target element;
- `GuidesLinkStep`, which provides a link in an "extra" area below; and
- `GuidesFinishStep`, for the final step of a tour.

This isn't the last word on GuidesTours architecture, but a first improvement. We'll keep iterating on it. 

Texts in the GuidesTours configuration file now use i18n.translate. This has the added benefit that we can easily inject styling or even React components into our messages.

Since we needed a "secondary" button type for the first step of a tour, this PR also adds one to the Button component. It has a light gray background that doesn't really come out in the GIF below. 

This is what it should look like:

![additional-step-types](https://cloud.githubusercontent.com/assets/23619/14285228/012b529e-fb4b-11e5-9b30-121281d4be66.gif)

To test:

- check out this branch
- `make run`
- open (e.g.) http://calypso.localhost:3000/me?tour=yes
- check whether the light gray background of the "secondary" button in the initial tour step is discernible from white
- check that the steps in the GIF above work in different browsers and on different devices (mobile support is forthcoming)
