### PR TITLE
Plans: hightlight plan feature by product slug

### DIFF
--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -28,6 +28,7 @@ import PlanPrice from 'components/plans/plan-price';
 import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
+import { isEnabled } from 'config';
 
 const PlansCompare = React.createClass( {
 	mixins: [
@@ -265,8 +266,12 @@ const PlansCompare = React.createClass( {
 					);
 				} );
 
+				const classes = classNames( 'plans-compare__row', {
+					'is-highlighted': isEnabled( 'manage/plans/compare-highlight' ) && this.props.product && this.props.product.toLowerCase() === feature.product_slug.split( '/' )[0].toLowerCase()
+				} );
+
 				return (
-					<tr className="plans-compare__row" key={ feature.title }>
+					<tr className={ classes } key={ feature.title }>
 						<td
 							className="plans-compare__cell"
 							key={ feature.title }>

--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -74,6 +74,7 @@
 
 @mixin plans-collapsed() {
 	.plans-compare__cell {
+		border-width: 1px;
 		&:not(.is-selected) {
 			display: none;
 		}
@@ -137,6 +138,29 @@
 .plans-compare__row {
 	&:nth-child(odd) {
 		background: $gray-light;
+	}
+
+	&.is-highlighted {
+		background-color: rgba($alert-yellow, 0.1);
+		td {
+			border-style: solid;
+			border-color: $alert-yellow;
+			border-top-width: 1px;
+			border-bottom-width: 1px;
+		}
+
+		td:first-child {
+			border-left-width: 1px;
+		}
+
+		td:last-child {
+			border-right-width: 1px;
+		}
+
+		& > *:not(:last-child):not(:first-child) {
+			border-left-width: 0;
+			border-right-width: 0;
+		}
 	}
 }
 

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -110,6 +110,7 @@ export default {
 						selectedSite={ site }
 						plans={ plans }
 						features={ features }
+						product={ context.params.product }
 						productsList={ productsList } />
 				</CheckoutData>
 			</Main>,

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -38,6 +38,14 @@ export default function() {
 		);
 
 		page(
+			'/plans/compare/:product/:domain',
+			retarget,
+			controller.siteSelection,
+			controller.navigation,
+			plansController.plansCompare
+		);
+
+		page(
 			'/plans/select/:plan/:domain',
 			retarget,
 			controller.siteSelection,

--- a/config/development.json
+++ b/config/development.json
@@ -59,6 +59,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
+		"manage/plans/compare-highlight": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/compatibility-warning": false,


### PR DESCRIPTION
The compare plans page takes an optional _product slug_ parameter. If present, it's compared to each feature product slug.

Feature flag: `manage/plans/compare-highlight`

WordPress.com Sites
- free-blog
- custom-domain
- space
- no-adverts
- custom-design
- videopress
- premium-themes
- google-analytics
- support

![wpcom-site-compare](https://cloud.githubusercontent.com/assets/233601/14211840/97da5142-f806-11e5-8011-e6c163587098.png)

JetPack Sites
- akismet
- vaultpress-backups
- vaultpress-backup-archive
- vaultpress-automated-restores
- vaultpress-security-scanning
- polldaddy
- support

![jetpack-site](https://cloud.githubusercontent.com/assets/233601/14211864/b05f4aba-f806-11e5-9a29-b40f3bd23ba0.png)

Closes #4329 