### PR TITLE
Themes: Add theme download in sheet view.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -275,6 +275,7 @@
 @import 'my-sites/stats/stats-overview-placeholder/style';
 @import 'my-sites/stats/stats-site-overview/style';
 @import 'my-sites/stats/stats-tabs/style';
+@import 'my-sites/theme/theme-download-card/style';
 @import 'my-sites/themes/current-theme/style';
 @import 'my-sites/themes/style';
 @import 'my-sites/themes/themes-search-card/style';

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -17,6 +17,7 @@ import { isPremium } from 'my-sites/themes/helpers';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
+import ThemeDownloadCard from './theme-download-card';
 import Button from 'components/button';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
@@ -41,6 +42,7 @@ const ThemeSheet = React.createClass( {
 		description: React.PropTypes.string,
 		descriptionLong: React.PropTypes.string,
 		supportDocumentation: React.PropTypes.string,
+		download: React.PropTypes.string,
 		taxonomies: React.PropTypes.object,
 		stylesheet: React.PropTypes.string,
 		isLoggedIn: React.PropTypes.bool,
@@ -151,6 +153,7 @@ const ThemeSheet = React.createClass( {
 					<div dangerouslySetInnerHTML={ { __html: this.props.descriptionLong } } />
 				</Card>
 				{ this.renderFeaturesCard() }
+				{ this.renderDownload() }
 			</div>
 		);
 	},
@@ -204,6 +207,13 @@ const ThemeSheet = React.createClass( {
 				</Card>
 			</div>
 		);
+	},
+
+	renderDownload() {
+		if ( 'Free' !== this.props.price ) {
+			return null;
+		}
+		return <ThemeDownloadCard theme={ this.props.id } href={ this.props.download } />;
 	},
 
 	render() {

--- a/client/my-sites/theme/theme-download-card/index.jsx
+++ b/client/my-sites/theme/theme-download-card/index.jsx
@@ -1,0 +1,41 @@
+/** @ssr-ready **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+import i18n from 'lib/mixins/i18n';
+
+var ThemeDownloadCard = React.createClass( {
+
+	propTypes: {
+		theme: React.PropTypes.string.isRequired,
+		href: React.PropTypes.string
+	},
+
+	render() {
+		// When we don't generate zips, it's because we have released the theme on .org.
+		const downloadURI = this.props.href || ( 'https://downloads.wordpress.org/theme/' + this.props.theme + '.zip' );
+		const downloadText = i18n.translate( 'This theme is available for download to be used on your {{a}}WordPress self-hosted{{/a}} installation.', {
+			components: {
+				a: <a href={ 'https://wordpress.org' } />
+			}
+		} );
+		return (
+			<Card className="themes__sheet-download">
+				<Gridicon icon="cloud-download" size={ 48 } />
+				<p>{ downloadText }</p>
+				<Button href={ downloadURI }>{ i18n.translate( 'Download' ) }</Button>
+			</Card>
+		);
+	}
+} );
+
+module.exports = ThemeDownloadCard;

--- a/client/my-sites/theme/theme-download-card/style.scss
+++ b/client/my-sites/theme/theme-download-card/style.scss
@@ -1,0 +1,50 @@
+.themes__sheet-download {
+
+	text-align: center;
+
+	.gridicon {
+		display: inline-block;
+		margin: -0.5em 0 -1.1em;
+		fill: #C8D7E1;
+	}
+
+	.button {
+		display: inline-block;
+	}
+
+	p {
+		margin: 1.15em 0;
+		a {
+			color: inherit;
+			text-decoration: underline;
+		}
+	}
+
+}
+
+@include breakpoint( ">1040px" ) {
+
+	.themes__sheet-download {
+		text-align: inherit;
+
+		.gridicon {
+			position: absolute;
+			transform: translateY( -50% );
+			margin: 0.3em 0 0 0;
+			float: left;
+			top: 50%;
+		}
+
+		.button {
+			position: absolute;
+			transform: translateY( -50% );
+			top: 50%;
+			right: 26px;
+		}
+
+		p {
+			margin: 0 122px 0 71px;
+		}
+	}
+
+}

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -115,6 +115,7 @@ export function receiveThemeDetails( theme ) {
 		themeDescription: theme.description,
 		themeDescriptionLong: theme.description_long,
 		themeSupportDocumentation: theme.extended ? theme.extended.support_documentation : undefined,
+		themeDownload: theme.download_uri || undefined,
 		themeTaxonomies: theme.taxonomies,
 		themeStylesheet: theme.stylesheet,
 	};

--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -25,6 +25,7 @@ export default ( state = Map(), action ) => {
 					description: action.themeDescription,
 					descriptionLong: action.themeDescriptionLong,
 					supportDocumentation: action.themeSupportDocumentation,
+					download: action.themeDownload,
 					taxonomies: action.themeTaxonomies,
 					stylesheet: action.themeStylesheet,
 				} ) );

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -35,6 +35,7 @@ describe( 'reducer', () => {
 			themeDescriptionLong: 'the plato form of a theme',
 			themeSupportDocumentation: 'support comes from within',
 			themeStylesheet: 'premium/mood',
+			themeDownload: 'mood.zip',
 			themeTaxonomies: {
 				features: [ {
 					term_id: null,
@@ -60,6 +61,7 @@ describe( 'reducer', () => {
 			descriptionLong: 'the plato form of a theme',
 			supportDocumentation: 'support comes from within',
 			stylesheet: 'premium/mood',
+			download: 'mood.zip',
 			taxonomies: {
 				features: [ {
 					term_id: null,


### PR DESCRIPTION
Implements theme downloads into sheet view as specified in #3660.

Tracking of downloads coming down the road.

Premium themes are not downloaded, therefore not showing the card on those.

There are cases, in which themes do not have `download_uri` set. Such as the case with Twenty Sixteen, which recommends downloading from WordPress.org. In this particular case, the card is shown like this:

![screen shot 2016-03-31 at 4 26 46 pm](https://cloud.githubusercontent.com/assets/5881557/14189892/bf2c271a-f75d-11e5-8ff1-421b742dcc32.png)

The download button (and link in the description) will point to `http://wordpress.org/themes/twentysixteen`.

The text above has been adapted from the original Twenty Sixteen page from the theme showcase: https://theme.wordpress.com/themes/twentysixteen/

Feedback and suggestions welcome!