### PR TITLE
Reader: Remove urls that we cannot make safe from srcsets

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -603,7 +603,7 @@ normalizePost.content = {
 						}
 						imgSrc.url = safeImageURL( imgSrc.url );
 						return imgSrc;
-					} );
+					} ).filter( imgSrc => imgSrc.url );
 					image.setAttribute( 'srcset', srcset.stringify( imgSrcSet ) );
 				}
 


### PR DESCRIPTION
Some images have `srcset` attributes that we try to process and cannot make safe. Instead of dying trying to `stringify` the `srcset`, just remove them from it instead.