### PR TITLE
Editor: Remove post type querying for sidebar header close button

### DIFF
--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -14,20 +14,16 @@ import page from 'page';
  */
 import { getSelectedSite } from 'state/ui/selectors';
 import { getEditedPost } from 'state/posts/selectors';
-import { getPostType } from 'state/post-types/selectors';
 import { getEditorPostId, isEditorDraftsVisible } from 'state/ui/editor/selectors';
 import { toggleEditorDraftsVisible } from 'state/ui/editor/actions';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import DraftsButton from 'post-editor/drafts-button';
 import PostCountsData from 'components/data/post-counts-data';
-import QueryPostTypes from 'components/data/query-post-types';
 
-function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts, allPostsUrl, toggleSidebar } ) {
-	const isCustomPostType = ( 'post' !== typeSlug && 'page' !== typeSlug );
+function EditorSidebarHeader( { type, siteId, showDrafts, toggleDrafts, allPostsUrl, toggleSidebar } ) {
 	const className = classnames( 'editor-sidebar__header', {
-		'is-drafts-visible': showDrafts,
-		'is-loading': isCustomPostType && ! type
+		'is-drafts-visible': showDrafts
 	} );
 	const closeLabel = translate( 'Back' );
 	const closeButtonAction = page.back.bind( page, allPostsUrl );
@@ -36,9 +32,6 @@ function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts
 
 	return (
 		<div className={ className }>
-			{ isCustomPostType && (
-				<QueryPostTypes siteId={ siteId } />
-			) }
 			{ showDrafts && (
 				<Button
 					compact borderless
@@ -60,7 +53,7 @@ function EditorSidebarHeader( { typeSlug, type, siteId, showDrafts, toggleDrafts
 					{ closeLabel }
 				</Button>
 			) }
-			{ typeSlug === 'post' && siteId && (
+			{ type === 'post' && siteId && (
 				<PostCountsData siteId={ siteId } status="draft">
 					<DraftsButton onClick={ toggleDrafts } />
 				</PostCountsData>
@@ -78,12 +71,10 @@ export default connect(
 	( state ) => {
 		const siteId = get( getSelectedSite( state ), 'ID' );
 		const postId = getEditorPostId( state );
-		const typeSlug = get( getEditedPost( state, siteId, postId ), 'type' );
 
 		return {
 			siteId,
-			typeSlug,
-			type: getPostType( state, siteId, typeSlug ),
+			type: get( getEditedPost( state, siteId, postId ), 'type' ),
 			showDrafts: isEditorDraftsVisible( state )
 		};
 	},

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import get from 'lodash/get';
-import { translate } from 'lib/mixins/i18n';
 import page from 'page';
 
 /**
@@ -16,12 +15,13 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { getEditorPostId, isEditorDraftsVisible } from 'state/ui/editor/selectors';
 import { toggleEditorDraftsVisible } from 'state/ui/editor/actions';
+import localize from 'lib/mixins/i18n/localize';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import DraftsButton from 'post-editor/drafts-button';
 import PostCountsData from 'components/data/post-counts-data';
 
-function EditorSidebarHeader( { type, siteId, showDrafts, toggleDrafts, allPostsUrl, toggleSidebar } ) {
+function EditorSidebarHeader( { translate, type, siteId, showDrafts, toggleDrafts, allPostsUrl, toggleSidebar } ) {
 	const className = classnames( 'editor-sidebar__header', {
 		'is-drafts-visible': showDrafts
 	} );
@@ -83,4 +83,4 @@ export default connect(
 			toggleDrafts: toggleEditorDraftsVisible
 		}, dispatch );
 	}
-)( EditorSidebarHeader );
+)( localize( EditorSidebarHeader ) );

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -66,6 +66,16 @@ function EditorSidebarHeader( { translate, type, siteId, showDrafts, toggleDraft
 		</div>
 	);
 }
+
+EditorSidebarHeader.propTypes = {
+	translate: PropTypes.func,
+	type: PropTypes.string,
+	siteId: PropTypes.number,
+	showDrafts: PropTypes.bool,
+	toggleDrafts: PropTypes.func,
+	allPostsUrl: PropTypes.string,
+	toggleSidebar: PropTypes.func
+};
 
 export default connect(
 	( state ) => {

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -12,7 +12,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { getEditorPostId, isEditorDraftsVisible } from 'state/ui/editor/selectors';
 import { toggleEditorDraftsVisible } from 'state/ui/editor/actions';
@@ -69,7 +69,7 @@ function EditorSidebarHeader( { type, siteId, showDrafts, toggleDrafts, allPosts
 
 export default connect(
 	( state ) => {
-		const siteId = get( getSelectedSite( state ), 'ID' );
+		const siteId = getSelectedSiteId( state );
 		const postId = getEditorPostId( state );
 
 		return {

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -22,12 +22,6 @@
 	}
 }
 
-.editor-sidebar__header.is-loading:not( .is-drafts-visible ) .editor-sidebar__close {
-	@include placeholder( $lighten-percentage: 20% );
-	padding: 4px;
-	margin: 4px;
-}
-
 .editor-sidebar__toggle-sidebar {
 	margin-left: 16px;
 	@include breakpoint( ">660px" ) {


### PR DESCRIPTION
Related: #4371

This pull request seeks to remove post type querying behavior from the editor sidebar header. With the change to always display "Back" instead of the post type menu label, it's no longer necessary for us to request post types.

Included are a handful of refactorings, including using more appropriate state selectors (13db03b), using `localize` higher-order component (b347224), and adding `propTypes` (5a71436).

__Testing instructions:__

Verify that no regressions are introduced, repeating testing instructions from #4371. Notably, when loading the post editor, the sidebar header should continue to display a "Back" button.

/cc @blowery , @gwwar