### PR TITLE
Reader: Remove comment feed flare from content

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -210,6 +210,7 @@ function isCandidateForContentImage( imageUrl ) {
 
 const bannedUrlParts = [
 	'feeds.feedburner.com',
+	'feeds.wordpress.com/',
 	'.feedsportal.com',
 	'wp-includes',
 	'wp-content/themes',


### PR DESCRIPTION
This bans the feed flare buttons that come from feeds.wordpress.com