### PR TITLE
Revert "Framework: remove `wpcom-unpublished` dependency"

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -97,12 +97,9 @@ function canRedirect( siteId, domainName, onComplete ) {
 }
 
 function getPrimaryDomain( siteId, onComplete ) {
-	wpcom
-		.site( siteId )
-		.domain()
-		.getPrimary( function( serverError, data ) {
-			onComplete( serverError, data );
-		} );
+	wpcom.undocumented().getPrimaryDomain( siteId, function( serverError, data ) {
+		onComplete( serverError, data );
+	} );
 }
 
 function getFixedDomainSearch( domainName ) {

--- a/client/lib/wpcom-undocumented/index.js
+++ b/client/lib/wpcom-undocumented/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import wpcomFactory from 'wpcom';
+import wpcomFactory from 'wpcom-unpublished';
 import inherits from 'inherits';
 import assign from 'lodash/assign';
 import debugFactory from 'debug';

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-import Me from 'wpcom/dist/lib/me';
+import Me from 'wpcom-unpublished/dist/lib/me';
 import inherits from 'inherits';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:wpcom-undocumented:me' );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -881,7 +881,7 @@ Undocumented.prototype.deleteSite = function( siteId, fn ) {
  * @param {Function} fn Method to invoke when request is complete
  */
 Undocumented.prototype.createConnection = function( keyringConnectionId, siteId, externalUserId, options, fn ) {
-	var body, path;
+	var body, url;
 
 	// Method overloading: Optional `options`
 	if ( 'undefined' === typeof fn && 'function' === typeof options ) {
@@ -899,11 +899,12 @@ Undocumented.prototype.createConnection = function( keyringConnectionId, siteId,
 		body.external_user_ID = externalUserId;
 	}
 
-	path = siteId
-		? '/sites/' + siteId + '/publicize-connections/new'
-		: '/me/publicize-connections/new';
-
-	this.wpcom.req.post( { path, body, apiVersion: '1.1' }, fn );
+	url = siteId ? '/sites/' + siteId + '/publicize-connections/new' : '/me/publicize-connections/new';
+	this.wpcom.req.post( {
+		path: url,
+		body: body,
+		apiVersion: '1.1'
+	}, fn );
 };
 
 /**
@@ -915,18 +916,18 @@ Undocumented.prototype.createConnection = function( keyringConnectionId, siteId,
  * @param {Function} fn Function to invoke when request is complete
  */
 Undocumented.prototype.updateConnection = function( siteId, connectionId, data, fn ) {
-	var path;
+	var url;
 
 	if ( siteId ) {
 		debug( '/sites/:site_id:/publicize-connections/:connection_id: query' );
-		path = '/sites/' + siteId + '/publicize-connections/' + connectionId;
+		url = '/sites/' + siteId + '/publicize-connections/' + connectionId;
 	} else {
 		debug( '/me/publicize-connections/:connection_id: query' );
-		path = '/me/publicize-connections/' + connectionId;
+		url = '/me/publicize-connections/' + connectionId;
 	}
 
 	this.wpcom.req.post( {
-		path: path,
+		path: url,
 		body: data,
 		apiVersion: '1.1'
 	}, fn );
@@ -975,15 +976,13 @@ Undocumented.prototype.updateCreditCard = function( params, fn ) {
 
 /**
  * GET paygate configuration
- *
- * @param {Object} query - query parameters
  * @param {Function} fn The callback function
  * @api public
  */
-Undocumented.prototype.paygateConfiguration = function( query, fn ) {
+Undocumented.prototype.paygateConfiguration = function( data, fn ) {
 	debug( '/me/paygate-configuration query' );
 
-	this.wpcom.req.get( '/me/paygate-configuration', query, fn );
+	this.wpcom.req.get( '/me/paygate-configuration', data, fn );
 };
 
 /**
@@ -1045,6 +1044,18 @@ Undocumented.prototype.exampleDomainSuggestions = function( fn ) {
 
 		fn( null, response );
 	} );
+};
+
+/**
+ * GET primary domain for blog
+ *
+ * @param {int} siteId The site ID
+ * @param {Function} fn The callback function
+ * @api public
+ */
+Undocumented.prototype.getPrimaryDomain = function( siteId, fn ) {
+	debug( '/sites/:site_id/domains/primary' );
+	this.wpcom.req.get( '/sites/' + siteId + '/domains/primary', fn );
 };
 
 /**
@@ -1878,7 +1889,6 @@ Undocumented.prototype.submitKayakoTicket = function( subject, message, locale, 
 /**
  * Get the olark configuration for the current user
  *
- * @param {Object} client - current user
  * @param {Function} fn The callback function
  * @api public
  */
@@ -1930,10 +1940,10 @@ Undocumented.prototype.startExport = function( siteId, advancedSettings, fn ) {
 /**
  * Check the status of an export
  *
- * @param {Number|String} siteId - The site ID
- * @param {Object} exportId - Export ID (for future use)
- * @param {Function} fn - The callback function
- * @returns {Promise}  promise
+ * @param {int}       siteId            The site ID
+ * @param {Object}    exportId          Export ID (for future use)
+ * @param {Function}  fn                The callback function
+ * @returns {Promise}
  */
 Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
 	return this.wpcom.req.get( {
@@ -1955,9 +1965,9 @@ Undocumented.prototype.timezones = function( params, fn ) {
 /**
  * Check different info about WordPress and Jetpack status on a url
  *
- * @param {String} targetUrl - The url of the site to check
- * @param {String} filters - Comma separated string with the filters to run
- * @returns {Promise}  promise
+ * @param {String}    targetUrl          The url of the site to check
+ * @param {String}    filters            Comma separated string with the filters to run
+ * @returns {Promise}
  */
 Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters ) {
 	return new Promise( ( resolve, reject ) => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8318,6 +8318,722 @@
         }
       }
     },
+    "wpcom-unpublished": {
+      "version": "1.1.1",
+      "dependencies": {
+        "wpcom": {
+          "version": "4.9.2",
+          "dependencies": {
+            "babel": {
+              "version": "5.8.38",
+              "dependencies": {
+                "chokidar": {
+                  "version": "1.4.3",
+                  "dependencies": {
+                    "anymatch": {
+                      "version": "1.3.0",
+                      "dependencies": {
+                        "arrify": {
+                          "version": "1.0.1"
+                        },
+                        "micromatch": {
+                          "version": "2.3.7",
+                          "dependencies": {
+                            "arr-diff": {
+                              "version": "2.0.0",
+                              "dependencies": {
+                                "arr-flatten": {
+                                  "version": "1.0.1"
+                                }
+                              }
+                            },
+                            "array-unique": {
+                              "version": "0.2.1"
+                            },
+                            "braces": {
+                              "version": "1.8.3",
+                              "dependencies": {
+                                "expand-range": {
+                                  "version": "1.8.1",
+                                  "dependencies": {
+                                    "fill-range": {
+                                      "version": "2.2.3",
+                                      "dependencies": {
+                                        "is-number": {
+                                          "version": "2.1.0"
+                                        },
+                                        "isobject": {
+                                          "version": "2.0.0",
+                                          "dependencies": {
+                                            "isarray": {
+                                              "version": "0.0.1"
+                                            }
+                                          }
+                                        },
+                                        "randomatic": {
+                                          "version": "1.1.5"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.4"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "preserve": {
+                                  "version": "0.2.0"
+                                },
+                                "repeat-element": {
+                                  "version": "1.1.2"
+                                }
+                              }
+                            },
+                            "expand-brackets": {
+                              "version": "0.1.4"
+                            },
+                            "extglob": {
+                              "version": "0.3.2"
+                            },
+                            "filename-regex": {
+                              "version": "2.0.0"
+                            },
+                            "kind-of": {
+                              "version": "3.0.2",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.3"
+                                }
+                              }
+                            },
+                            "normalize-path": {
+                              "version": "2.0.1"
+                            },
+                            "object.omit": {
+                              "version": "2.0.0",
+                              "dependencies": {
+                                "for-own": {
+                                  "version": "0.1.4",
+                                  "dependencies": {
+                                    "for-in": {
+                                      "version": "0.1.5"
+                                    }
+                                  }
+                                },
+                                "is-extendable": {
+                                  "version": "0.1.1"
+                                }
+                              }
+                            },
+                            "parse-glob": {
+                              "version": "3.0.4",
+                              "dependencies": {
+                                "glob-base": {
+                                  "version": "0.3.0"
+                                },
+                                "is-dotfile": {
+                                  "version": "1.0.2"
+                                }
+                              }
+                            },
+                            "regex-cache": {
+                              "version": "0.4.2",
+                              "dependencies": {
+                                "is-equal-shallow": {
+                                  "version": "0.1.3"
+                                },
+                                "is-primitive": {
+                                  "version": "2.0.0"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "async-each": {
+                      "version": "1.0.0"
+                    },
+                    "fsevents": {
+                      "version": "1.0.9",
+                      "dependencies": {
+                        "node-pre-gyp": {
+                          "version": "0.6.24",
+                          "dependencies": {
+                            "mkdirp": {
+                              "version": "0.5.1",
+                              "dependencies": {
+                                "minimist": {
+                                  "version": "0.0.8"
+                                }
+                              }
+                            },
+                            "nopt": {
+                              "version": "3.0.6",
+                              "dependencies": {
+                                "abbrev": {
+                                  "version": "1.0.7"
+                                }
+                              }
+                            },
+                            "npmlog": {
+                              "version": "2.0.3",
+                              "dependencies": {
+                                "ansi": {
+                                  "version": "0.3.1"
+                                },
+                                "are-we-there-yet": {
+                                  "version": "1.1.2",
+                                  "dependencies": {
+                                    "delegates": {
+                                      "version": "1.0.0"
+                                    }
+                                  }
+                                },
+                                "gauge": {
+                                  "version": "1.2.7",
+                                  "dependencies": {
+                                    "has-unicode": {
+                                      "version": "2.0.0"
+                                    },
+                                    "lodash.pad": {
+                                      "version": "4.1.0",
+                                      "dependencies": {
+                                        "lodash.repeat": {
+                                          "version": "4.0.0"
+                                        },
+                                        "lodash.tostring": {
+                                          "version": "4.1.2"
+                                        }
+                                      }
+                                    },
+                                    "lodash.padend": {
+                                      "version": "4.2.0"
+                                    },
+                                    "lodash.padstart": {
+                                      "version": "4.2.0"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "rc": {
+                              "version": "1.1.6",
+                              "dependencies": {
+                                "deep-extend": {
+                                  "version": "0.4.1"
+                                },
+                                "ini": {
+                                  "version": "1.3.4"
+                                },
+                                "minimist": {
+                                  "version": "1.2.0"
+                                },
+                                "strip-json-comments": {
+                                  "version": "1.0.4"
+                                }
+                              }
+                            },
+                            "request": {
+                              "version": "2.69.0",
+                              "dependencies": {
+                                "aws-sign2": {
+                                  "version": "0.6.0"
+                                },
+                                "aws4": {
+                                  "version": "1.3.2",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "4.0.0",
+                                      "dependencies": {
+                                        "pseudomap": {
+                                          "version": "1.0.2"
+                                        },
+                                        "yallist": {
+                                          "version": "2.0.0"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "bl": {
+                                  "version": "1.0.3"
+                                },
+                                "caseless": {
+                                  "version": "0.11.0"
+                                },
+                                "combined-stream": {
+                                  "version": "1.0.5",
+                                  "dependencies": {
+                                    "delayed-stream": {
+                                      "version": "1.0.0"
+                                    }
+                                  }
+                                },
+                                "extend": {
+                                  "version": "3.0.0"
+                                },
+                                "forever-agent": {
+                                  "version": "0.6.1"
+                                },
+                                "form-data": {
+                                  "version": "1.0.0-rc4",
+                                  "dependencies": {
+                                    "async": {
+                                      "version": "1.5.2"
+                                    }
+                                  }
+                                },
+                                "har-validator": {
+                                  "version": "2.0.6",
+                                  "dependencies": {
+                                    "chalk": {
+                                      "version": "1.1.1",
+                                      "dependencies": {
+                                        "ansi-styles": {
+                                          "version": "2.2.0",
+                                          "dependencies": {
+                                            "color-convert": {
+                                              "version": "1.0.0"
+                                            }
+                                          }
+                                        },
+                                        "escape-string-regexp": {
+                                          "version": "1.0.5"
+                                        },
+                                        "has-ansi": {
+                                          "version": "2.0.0",
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0"
+                                            }
+                                          }
+                                        },
+                                        "strip-ansi": {
+                                          "version": "3.0.1"
+                                        },
+                                        "supports-color": {
+                                          "version": "2.0.0"
+                                        }
+                                      }
+                                    },
+                                    "commander": {
+                                      "version": "2.9.0",
+                                      "dependencies": {
+                                        "graceful-readlink": {
+                                          "version": "1.0.1"
+                                        }
+                                      }
+                                    },
+                                    "is-my-json-valid": {
+                                      "version": "2.13.1",
+                                      "dependencies": {
+                                        "generate-function": {
+                                          "version": "2.0.0"
+                                        },
+                                        "generate-object-property": {
+                                          "version": "1.2.0",
+                                          "dependencies": {
+                                            "is-property": {
+                                              "version": "1.0.2"
+                                            }
+                                          }
+                                        },
+                                        "jsonpointer": {
+                                          "version": "2.0.0"
+                                        },
+                                        "xtend": {
+                                          "version": "4.0.1"
+                                        }
+                                      }
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.4"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "hawk": {
+                                  "version": "3.1.3",
+                                  "dependencies": {
+                                    "boom": {
+                                      "version": "2.10.1"
+                                    },
+                                    "cryptiles": {
+                                      "version": "2.0.5"
+                                    },
+                                    "hoek": {
+                                      "version": "2.16.3"
+                                    },
+                                    "sntp": {
+                                      "version": "1.0.9"
+                                    }
+                                  }
+                                },
+                                "http-signature": {
+                                  "version": "1.1.1",
+                                  "dependencies": {
+                                    "assert-plus": {
+                                      "version": "0.2.0"
+                                    },
+                                    "jsprim": {
+                                      "version": "1.2.2",
+                                      "dependencies": {
+                                        "extsprintf": {
+                                          "version": "1.0.2"
+                                        },
+                                        "json-schema": {
+                                          "version": "0.2.2"
+                                        },
+                                        "verror": {
+                                          "version": "1.3.6"
+                                        }
+                                      }
+                                    },
+                                    "sshpk": {
+                                      "version": "1.7.4",
+                                      "dependencies": {
+                                        "asn1": {
+                                          "version": "0.2.3"
+                                        },
+                                        "dashdash": {
+                                          "version": "1.13.0",
+                                          "dependencies": {
+                                            "assert-plus": {
+                                              "version": "1.0.0"
+                                            }
+                                          }
+                                        },
+                                        "ecc-jsbn": {
+                                          "version": "0.1.1"
+                                        },
+                                        "jodid25519": {
+                                          "version": "1.0.2"
+                                        },
+                                        "jsbn": {
+                                          "version": "0.1.0"
+                                        },
+                                        "tweetnacl": {
+                                          "version": "0.14.1"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "is-typedarray": {
+                                  "version": "1.0.0"
+                                },
+                                "isstream": {
+                                  "version": "0.1.2"
+                                },
+                                "json-stringify-safe": {
+                                  "version": "5.0.1"
+                                },
+                                "mime-types": {
+                                  "version": "2.1.10",
+                                  "dependencies": {
+                                    "mime-db": {
+                                      "version": "1.22.0"
+                                    }
+                                  }
+                                },
+                                "node-uuid": {
+                                  "version": "1.4.7"
+                                },
+                                "oauth-sign": {
+                                  "version": "0.8.1"
+                                },
+                                "qs": {
+                                  "version": "6.0.2"
+                                },
+                                "stringstream": {
+                                  "version": "0.0.5"
+                                },
+                                "tough-cookie": {
+                                  "version": "2.2.2"
+                                },
+                                "tunnel-agent": {
+                                  "version": "0.4.2"
+                                }
+                              }
+                            },
+                            "rimraf": {
+                              "version": "2.5.2",
+                              "dependencies": {
+                                "glob": {
+                                  "version": "7.0.3",
+                                  "dependencies": {
+                                    "inflight": {
+                                      "version": "1.0.4",
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1"
+                                        }
+                                      }
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1"
+                                    },
+                                    "minimatch": {
+                                      "version": "3.0.0",
+                                      "dependencies": {
+                                        "brace-expansion": {
+                                          "version": "1.1.3",
+                                          "dependencies": {
+                                            "balanced-match": {
+                                              "version": "0.3.0"
+                                            },
+                                            "concat-map": {
+                                              "version": "0.0.1"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "once": {
+                                      "version": "1.3.3",
+                                      "dependencies": {
+                                        "wrappy": {
+                                          "version": "1.0.1"
+                                        }
+                                      }
+                                    },
+                                    "path-is-absolute": {
+                                      "version": "1.0.0"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "semver": {
+                              "version": "5.1.0"
+                            },
+                            "tar": {
+                              "version": "2.2.1",
+                              "dependencies": {
+                                "block-stream": {
+                                  "version": "0.0.8"
+                                },
+                                "fstream": {
+                                  "version": "1.0.8",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.3"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1"
+                                }
+                              }
+                            },
+                            "tar-pack": {
+                              "version": "3.1.3",
+                              "dependencies": {
+                                "debug": {
+                                  "version": "2.2.0",
+                                  "dependencies": {
+                                    "ms": {
+                                      "version": "0.7.1"
+                                    }
+                                  }
+                                },
+                                "fstream-ignore": {
+                                  "version": "1.0.3",
+                                  "dependencies": {
+                                    "minimatch": {
+                                      "version": "3.0.0",
+                                      "dependencies": {
+                                        "brace-expansion": {
+                                          "version": "1.1.3",
+                                          "dependencies": {
+                                            "balanced-match": {
+                                              "version": "0.3.0"
+                                            },
+                                            "concat-map": {
+                                              "version": "0.0.1"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.3.3",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1"
+                                    }
+                                  }
+                                },
+                                "readable-stream": {
+                                  "version": "2.0.6",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.2"
+                                    },
+                                    "isarray": {
+                                      "version": "1.0.0"
+                                    },
+                                    "process-nextick-args": {
+                                      "version": "1.0.6"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31"
+                                    },
+                                    "util-deprecate": {
+                                      "version": "1.0.2"
+                                    }
+                                  }
+                                },
+                                "uid-number": {
+                                  "version": "0.0.6"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "nan": {
+                          "version": "2.2.1"
+                        }
+                      }
+                    },
+                    "glob-parent": {
+                      "version": "2.0.0"
+                    },
+                    "is-binary-path": {
+                      "version": "1.0.1",
+                      "dependencies": {
+                        "binary-extensions": {
+                          "version": "1.4.0"
+                        }
+                      }
+                    },
+                    "is-glob": {
+                      "version": "2.0.1",
+                      "dependencies": {
+                        "is-extglob": {
+                          "version": "1.0.0"
+                        }
+                      }
+                    },
+                    "readdirp": {
+                      "version": "2.0.0",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.3"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.6",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.6"
+                            },
+                            "isarray": {
+                              "version": "1.0.0"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "convert-source-map": {
+                  "version": "1.2.0"
+                },
+                "fs-readdir-recursive": {
+                  "version": "0.1.2"
+                },
+                "output-file-sync": {
+                  "version": "1.1.1",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.1"
+                    }
+                  }
+                },
+                "path-exists": {
+                  "version": "1.0.0"
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0"
+                },
+                "slash": {
+                  "version": "1.0.0"
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.3",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "3.10.1"
+                },
+                "source-map": {
+                  "version": "0.5.3"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "wpcom-xhr-request": {
       "version": "0.5.0",
       "dependencies": {
@@ -8347,687 +9063,6 @@
         },
         "lodash": {
           "version": "2.4.2"
-        }
-      }
-    },
-    "wpcom": {
-      "version": "4.9.3",
-      "dependencies": {
-        "babel": {
-          "version": "5.8.38",
-          "dependencies": {
-            "chokidar": {
-              "version": "1.4.3",
-              "dependencies": {
-                "anymatch": {
-                  "version": "1.3.0",
-                  "dependencies": {
-                    "arrify": {
-                      "version": "1.0.1"
-                    },
-                    "micromatch": {
-                      "version": "2.3.7",
-                      "dependencies": {
-                        "arr-diff": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "arr-flatten": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "array-unique": {
-                          "version": "0.2.1"
-                        },
-                        "braces": {
-                          "version": "1.8.3",
-                          "dependencies": {
-                            "expand-range": {
-                              "version": "1.8.1",
-                              "dependencies": {
-                                "fill-range": {
-                                  "version": "2.2.3",
-                                  "dependencies": {
-                                    "is-number": {
-                                      "version": "2.1.0"
-                                    },
-                                    "isobject": {
-                                      "version": "2.0.0",
-                                      "dependencies": {
-                                        "isarray": {
-                                          "version": "0.0.1"
-                                        }
-                                      }
-                                    },
-                                    "randomatic": {
-                                      "version": "1.1.5"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "preserve": {
-                              "version": "0.2.0"
-                            },
-                            "repeat-element": {
-                              "version": "1.1.2"
-                            }
-                          }
-                        },
-                        "expand-brackets": {
-                          "version": "0.1.4"
-                        },
-                        "extglob": {
-                          "version": "0.3.2"
-                        },
-                        "filename-regex": {
-                          "version": "2.0.0"
-                        },
-                        "is-extglob": {
-                          "version": "1.0.0"
-                        },
-                        "kind-of": {
-                          "version": "3.0.2",
-                          "dependencies": {
-                            "is-buffer": {
-                              "version": "1.1.3"
-                            }
-                          }
-                        },
-                        "normalize-path": {
-                          "version": "2.0.1"
-                        },
-                        "object.omit": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "for-own": {
-                              "version": "0.1.4",
-                              "dependencies": {
-                                "for-in": {
-                                  "version": "0.1.5"
-                                }
-                              }
-                            },
-                            "is-extendable": {
-                              "version": "0.1.1"
-                            }
-                          }
-                        },
-                        "parse-glob": {
-                          "version": "3.0.4",
-                          "dependencies": {
-                            "glob-base": {
-                              "version": "0.3.0"
-                            },
-                            "is-dotfile": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        },
-                        "regex-cache": {
-                          "version": "0.4.2",
-                          "dependencies": {
-                            "is-equal-shallow": {
-                              "version": "0.1.3"
-                            },
-                            "is-primitive": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "async-each": {
-                  "version": "1.0.0"
-                },
-                "glob-parent": {
-                  "version": "2.0.0"
-                },
-                "is-binary-path": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "binary-extensions": {
-                      "version": "1.4.0"
-                    }
-                  }
-                },
-                "is-glob": {
-                  "version": "2.0.1",
-                  "dependencies": {
-                    "is-extglob": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "readdirp": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.3"
-                    },
-                    "minimatch": {
-                      "version": "2.0.10",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "2.0.6",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "1.0.0"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    }
-                  }
-                },
-                "fsevents": {
-                  "version": "1.0.9",
-                  "dependencies": {
-                    "nan": {
-                      "version": "2.2.1"
-                    },
-                    "node-pre-gyp": {
-                      "version": "0.6.24",
-                      "dependencies": {
-                        "nopt": {
-                          "version": "3.0.6",
-                          "dependencies": {
-                            "abbrev": {
-                              "version": "1.0.7"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    },
-                    "ansi": {
-                      "version": "0.3.1"
-                    },
-                    "ansi-styles": {
-                      "version": "2.2.0"
-                    },
-                    "are-we-there-yet": {
-                      "version": "1.1.2"
-                    },
-                    "asn1": {
-                      "version": "0.2.3"
-                    },
-                    "assert-plus": {
-                      "version": "0.2.0"
-                    },
-                    "aws-sign2": {
-                      "version": "0.6.0"
-                    },
-                    "async": {
-                      "version": "1.5.2"
-                    },
-                    "bl": {
-                      "version": "1.0.3"
-                    },
-                    "block-stream": {
-                      "version": "0.0.8"
-                    },
-                    "boom": {
-                      "version": "2.10.1"
-                    },
-                    "caseless": {
-                      "version": "0.11.0"
-                    },
-                    "chalk": {
-                      "version": "1.1.1"
-                    },
-                    "color-convert": {
-                      "version": "1.0.0"
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5"
-                    },
-                    "commander": {
-                      "version": "2.9.0"
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5"
-                    },
-                    "debug": {
-                      "version": "2.2.0"
-                    },
-                    "deep-extend": {
-                      "version": "0.4.1"
-                    },
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1"
-                    },
-                    "delegates": {
-                      "version": "1.0.0"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5"
-                    },
-                    "extend": {
-                      "version": "3.0.0"
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc4"
-                    },
-                    "fstream": {
-                      "version": "1.0.8"
-                    },
-                    "gauge": {
-                      "version": "1.2.7"
-                    },
-                    "generate-function": {
-                      "version": "2.0.0"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.3"
-                    },
-                    "graceful-readlink": {
-                      "version": "1.0.1"
-                    },
-                    "har-validator": {
-                      "version": "2.0.6"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0"
-                    },
-                    "has-unicode": {
-                      "version": "2.0.0"
-                    },
-                    "hawk": {
-                      "version": "3.1.3"
-                    },
-                    "hoek": {
-                      "version": "2.16.3"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    },
-                    "http-signature": {
-                      "version": "1.1.1"
-                    },
-                    "ini": {
-                      "version": "1.3.4"
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.13.1"
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0"
-                    },
-                    "is-property": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "1.0.0"
-                    },
-                    "isstream": {
-                      "version": "0.1.2"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2"
-                    },
-                    "jsbn": {
-                      "version": "0.1.0"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2"
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0"
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1"
-                    },
-                    "jsprim": {
-                      "version": "1.2.2"
-                    },
-                    "lodash.pad": {
-                      "version": "4.1.0"
-                    },
-                    "lodash.padend": {
-                      "version": "4.2.0"
-                    },
-                    "lodash.padstart": {
-                      "version": "4.2.0"
-                    },
-                    "lodash.repeat": {
-                      "version": "4.0.0"
-                    },
-                    "lodash.tostring": {
-                      "version": "4.1.2"
-                    },
-                    "mime-db": {
-                      "version": "1.22.0"
-                    },
-                    "mime-types": {
-                      "version": "2.1.10"
-                    },
-                    "minimist": {
-                      "version": "0.0.8"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1"
-                    },
-                    "ms": {
-                      "version": "0.7.1"
-                    },
-                    "node-uuid": {
-                      "version": "1.4.7"
-                    },
-                    "npmlog": {
-                      "version": "2.0.3"
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.1"
-                    },
-                    "once": {
-                      "version": "1.3.3"
-                    },
-                    "pinkie": {
-                      "version": "2.0.4"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.0"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "qs": {
-                      "version": "6.0.2"
-                    },
-                    "readable-stream": {
-                      "version": "2.0.6"
-                    },
-                    "request": {
-                      "version": "2.69.0"
-                    },
-                    "semver": {
-                      "version": "5.1.0"
-                    },
-                    "sntp": {
-                      "version": "1.0.9"
-                    },
-                    "sshpk": {
-                      "version": "1.7.4"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5"
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1"
-                    },
-                    "strip-json-comments": {
-                      "version": "1.0.4"
-                    },
-                    "supports-color": {
-                      "version": "2.0.0"
-                    },
-                    "tar": {
-                      "version": "2.2.1"
-                    },
-                    "tar-pack": {
-                      "version": "3.1.3"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.2"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.2"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.1"
-                    },
-                    "uid-number": {
-                      "version": "0.0.6"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    },
-                    "verror": {
-                      "version": "1.3.6"
-                    },
-                    "wrappy": {
-                      "version": "1.0.1"
-                    },
-                    "xtend": {
-                      "version": "4.0.1"
-                    },
-                    "dashdash": {
-                      "version": "1.13.0",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.1.6",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0"
-                        }
-                      }
-                    },
-                    "aws4": {
-                      "version": "1.3.2",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "4.0.0",
-                          "dependencies": {
-                            "pseudomap": {
-                              "version": "1.0.2"
-                            },
-                            "yallist": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "fstream-ignore": {
-                      "version": "1.0.3",
-                      "dependencies": {
-                        "minimatch": {
-                          "version": "3.0.0",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.3",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.3.0"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.5.2",
-                      "dependencies": {
-                        "glob": {
-                          "version": "7.0.3",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            },
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.3",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.3.0"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "commander": {
-              "version": "2.9.0",
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "convert-source-map": {
-              "version": "1.2.0"
-            },
-            "fs-readdir-recursive": {
-              "version": "0.1.2"
-            },
-            "glob": {
-              "version": "5.0.15",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash": {
-              "version": "3.10.1"
-            },
-            "output-file-sync": {
-              "version": "1.1.1",
-              "dependencies": {
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1"
-                }
-              }
-            },
-            "path-exists": {
-              "version": "1.0.0"
-            },
-            "path-is-absolute": {
-              "version": "1.0.0"
-            },
-            "source-map": {
-              "version": "0.5.3"
-            },
-            "slash": {
-              "version": "1.0.0"
-            }
-          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -113,8 +113,8 @@
     "walk": "2.3.4",
     "webpack": "1.12.6",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom": "4.9.3",
     "wpcom-proxy-request": "1.0.5",
+    "wpcom-unpublished": "1.1.1",
     "wpcom-xhr-request": "0.5.0",
     "xgettext-js": "0.3.0"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,7 @@ webpackConfig = {
 if ( CALYPSO_ENV === 'desktop' || CALYPSO_ENV === 'desktop-mac-app-store' ) {
 	webpackConfig.output.filename = '[name].js';
 } else {
-	webpackConfig.entry.vendor = [ 'react', 'store', 'page', 'wpcom', 'jed', 'debug' ];
+	webpackConfig.entry.vendor = [ 'react', 'store', 'page', 'wpcom-unpublished', 'jed', 'debug' ];
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( 'vendor', '[name].[hash].js' ) );
 	webpackConfig.plugins.push( new ChunkFileNamePlugin() );
 	// jquery is only needed in the build for the desktop app


### PR DESCRIPTION
Reverts Automattic/wp-calypso#4369

We were missing the trash options for posts/pages.