### PR TITLE
Posts: Fix trashing a post

### DIFF
--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -409,7 +409,7 @@ PostActions = {
 	trash: function( post, callback ) {
 		var postHandle = wpcom.site( post.site_ID ).post( post.ID );
 
-		postHandle.del( PostActions.receiveUpdate.bind( null, callback ) );
+		postHandle.delete( PostActions.receiveUpdate.bind( null, callback ) );
 	},
 
 	/**


### PR DESCRIPTION
Fix for #4488

__To Test__
- View post and/or pages list
- Trash a post using the button in the post listing, or by clicking the ... toggle on pages
- Verify no js errors occur and the post/page is indeed trashed