### PR TITLE
Domains: Fix null reference error on DomainManagement.Edit

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/index.jsx
+++ b/client/my-sites/upgrades/domain-management/edit/index.jsx
@@ -20,7 +20,7 @@ import { getSelectedDomain } from 'lib/domains';
 
 const Edit = React.createClass( {
 	render() {
-		const domain = getSelectedDomain( this.props ),
+		const domain = this.props.domains && getSelectedDomain( this.props ),
 			Details = this.getDetailsForType( domain && domain.type );
 
 		if ( ! domain || ! Details ) {


### PR DESCRIPTION
Fixes #4491, where clicking `Payment Settings` button would throw an error.

Testing:
 
1. Go to Domain Management -> Edit
2. Click Payment Settings
3. Confirm everything looks OK and no console errors.

cc: @drewblaisdell