### PR TITLE
General: Update Contributing link in DevDocs and README

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,10 @@
 <!-- Thanks for contributing to Calypso! Pick a clear title ("Editor: add spell check") and proceed. -->
 
 #### Steps to reproduce
-1. Starting at URL: 
-2. 
-3. 
-4. 
+1. Starting at URL:
+2.
+3.
+4.
 
 #### What I expected
 
@@ -24,7 +24,7 @@ PLEASE NOTE
 - If requesting a new feature, explain why you'd like to see it added.
 
 Docs & troubleshooting:
-https://github.com/Automattic/wp-calypso/blob/master/CONTRIBUTING.md
+https://github.com/Automattic/wp-calypso/blob/master/.github/CONTRIBUTING.md
 https://github.com/Automattic/wp-calypso/blob/master/docs/troubleshooting.md
 
 Helpful tips for screenshots:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Need more detailed installation instructions? [We have them](docs/install.md).
 
 ## Contributing
 
-If Calypso sparks your interest, don’t hesitate to send a pull request, send a suggestion, file a bug, or just ask a question. We promise we’ll be nice. Just don’t forget to check out our [CONTRIBUTING](CONTRIBUTING.md) doc – it includes a few technical details that will make the process a lot smoother.
+If Calypso sparks your interest, don’t hesitate to send a pull request, send a suggestion, file a bug, or just ask a question. We promise we’ll be nice. Just don’t forget to check out our [CONTRIBUTING](./.github/CONTRIBUTING.md) doc – it includes a few technical details that will make the process a lot smoother.
 
 Calypso welcomes – and indeed has been built by – contributors from all walks of life, with different backgrounds, and with a wide range of experience. We're committed to doing our part to make both Calypso and the wider WordPress community welcoming to everyone.
 

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -2,7 +2,7 @@
 
 PATH="$PATH:/usr/local/bin"
 
-printf "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see CONTRIBUTING.md for details.\n\n"
+printf "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n"
 
 files=$(git diff --cached --name-only --diff-filter=ACM | grep ".jsx*$")
 if [ "$files" = "" ]; then

--- a/bin/pre-push
+++ b/bin/pre-push
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see CONTRIBUTING.md for details.\n\n"
+echo "\nBy contributing to this project, you license the materials you contribute under the GNU General Public License v2 (or later). All materials must have GPLv2 compatible licenses — see .github/CONTRIBUTING.md for details.\n\n"
 
 current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 if [ 'master' = $current_branch ]

--- a/client/devdocs/main.jsx
+++ b/client/devdocs/main.jsx
@@ -16,7 +16,7 @@ var DocService = require( './service' ),
 var DEFAULT_FILES = [
 		'docs/guide/index.md',
 		'README.md',
-		'CONTRIBUTING.md',
+		'.github/CONTRIBUTING.md',
 		'docs/coding-guidelines.md',
 		'client/lib/mixins/i18n/README.md',
 		'docs/coding-guidelines/javascript.md',

--- a/client/devdocs/sidebar.jsx
+++ b/client/devdocs/sidebar.jsx
@@ -42,8 +42,8 @@ export default React.createClass( {
 							className="devdocs__navigation-item"
 							icon="pencil"
 							label="Contributing"
-							link="/devdocs/CONTRIBUTING.md"
-							selected={ '/devdocs/CONTRIBUTING.md' === this.props.path }
+							link="/devdocs/.github/CONTRIBUTING.md"
+							selected={ '/devdocs/.github/CONTRIBUTING.md' === this.props.path }
 						/>
 					</ul>
 				</SidebarMenu>

--- a/docs/guide/tech-behind-calypso.md
+++ b/docs/guide/tech-behind-calypso.md
@@ -90,4 +90,4 @@ The way we use Git with Calypso is described in the [Git Workflow document](../g
 * [webpack](http://webpack.github.io) – building a JavaScript bundle of all of our modules and making sure loading them works just fine
 * [make](http://www.gnu.org/software/make/manual/make.html) – our build tool of choice
 
-Previous: [Hello, World!](hello-world.md) Next: [Contributing to Calypso](../../CONTRIBUTING.md)
+Previous: [Hello, World!](hello-world.md) Next: [Contributing to Calypso](../../.github/CONTRIBUTING.md)

--- a/server/devdocs/test/index.js
+++ b/server/devdocs/test/index.js
@@ -68,7 +68,7 @@ describe( 'devdocs', () => {
 			( err, res ) => {
 				expect( err ).to.be.null;
 				expect( res.statusCode ).to.equal( 200 );
-				expect( res.text ).to.contain( '<a href="CONTRIBUTING.md">' );
+				expect( res.text ).to.contain( '<a href="./.github/CONTRIBUTING.md">' );
 				done();
 			} );
 	} );


### PR DESCRIPTION
In #4479, we moved the `CONTRIBUTING.md` file into a `.github/` directory to clean up the main folder. This PR just changes the link in two places to match:

1. The README so it works correctly in "Just don’t forget to check out our CONTRIBUTING doc..."
2. The DevDocs so they link to the correct file. I updated `client/devdocs/main.jsx` and `client/devdocs/sidebar.jsx` to use `/devdocs/.github/CONTRIBUTING.md` instead of `/devdocs/CONTRIBUTING.md`.

You can test the DevDocs by visiting http://calypso.localhost:3000/devdocs with the branch up and running. The sidebar "Contributing" link should work. When you click on "Search", the suggestion for "Contributing to Calypso" should also work due to the change in `client/devdocs/main.jsx`.