### PR TITLE
GuidesTours: Add tours to all signup/new site flows

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -263,6 +263,7 @@ function reduxStoreReady( reduxStore ) {
 		if ( config.isEnabled( 'guidestours' ) && context.query.tour ) {
 			context.store.dispatch( showGuidesTour( {
 				shouldShow: true,
+				shouldDelay: /^\/(checkout|plans\/select)/.test( path ),
 				tour: context.query.tour,
 			} ) );
 		}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -35,6 +35,7 @@ var MasterbarLoggedIn = require( 'layout/masterbar/logged-in' ),
 	SupportUser;
 
 import { isOffline } from 'state/application/selectors';
+import { getGuidesTourState } from 'state/ui/selectors';
 
 if ( config.isEnabled( 'keyboard-shortcuts' ) ) {
 	KeyboardShortcutsMenu = require( 'lib/keyboard-shortcuts/menu' );
@@ -179,7 +180,7 @@ Layout = React.createClass( {
 
 		return (
 			<div className={ sectionClass }>
-				{ config.isEnabled( 'guidestours' ) && this.props.shouldShowGuidesTour ? <GuidesTours /> : null }
+				{ config.isEnabled( 'guidestours' ) && this.props.tourState.shouldShow ? <GuidesTours /> : null }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				{ this.renderMasterbar() }
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
@@ -209,13 +210,13 @@ Layout = React.createClass( {
 
 export default connect(
 	( state ) => {
-		const { isLoading, section, guidesTour } = state.ui;
+		const { isLoading, section } = state.ui;
 		return {
 			isLoading,
 			isSupportUser: state.support.isSupportUser,
 			section,
 			isOffline: isOffline( state ),
-			shouldShowGuidesTour: guidesTour.shouldShow,
+			tourState: getGuidesTourState( state ),
 		};
 	}
 )( Layout );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,4 +81,14 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
+	guidedTours: {
+		datestamp: '20160418',
+		variations: {
+			original: 96,
+			guided: 2,
+			calypsoOnly: 2,
+		},
+		defaultVariation: 'original',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -3,6 +3,7 @@
  */
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import defer from 'lodash/defer';
 import find from 'lodash/find';
 import page from 'page';
 import React from 'react';
@@ -17,6 +18,7 @@ import Card from 'components/card';
 import ChargebackDetails from './chargeback-details';
 import CheckoutThankYouFeaturesHeader from './features-header';
 import CheckoutThankYouHeader from './header';
+import config from 'config';
 import DomainMappingDetails from './domain-mapping-details';
 import DomainRegistrationDetails from './domain-registration-details';
 import { fetchReceipt } from 'state/receipts/actions';
@@ -49,6 +51,7 @@ import PurchaseDetail from 'components/purchase-detail';
 import { getFeatureByKey, shouldFetchSitePlans } from 'lib/plans';
 import SiteRedirectDetails from './site-redirect-details';
 import upgradesPaths from 'my-sites/upgrades/paths';
+import { showGuidesTour } from 'state/ui/actions';
 
 function getPurchases( props ) {
 	return props.receipt.data.purchases;
@@ -72,6 +75,7 @@ const CheckoutThankYou = React.createClass( {
 	},
 
 	componentDidMount() {
+		config.isEnabled( 'guidestours' ) && defer( () => this.props.undelayGuidesTour() );
 		this.redirectIfThemePurchased();
 
 		if ( this.props.receipt.hasLoadedFromServer && this.hasPlanOrDomainProduct() ) {
@@ -282,6 +286,9 @@ export default connect(
 			},
 			refreshSitePlans( site ) {
 				dispatch( refreshSitePlans( site.ID ) );
+			},
+			undelayGuidesTour() {
+				dispatch( showGuidesTour( { shouldDelay: false } ) );
 			}
 		};
 	}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -90,18 +90,18 @@ const Signup = React.createClass( {
 		this.signupFlowController = new SignupFlowController( {
 			flowName: this.props.flowName,
 			onComplete: function( dependencies, destination ) {
-				var timeSinceLoading = this.state.loadingScreenStartTime ?
-					Date.now() - this.state.loadingScreenStartTime :
-					undefined;
+				const timeSinceLoading = this.state.loadingScreenStartTime
+					? Date.now() - this.state.loadingScreenStartTime
+					: undefined;
+				const filteredDestination = utils.getDestination( destination, dependencies, this.props.flowName );
 
 				if ( timeSinceLoading && timeSinceLoading < MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED ) {
 					return delay(
-						this.handleFlowComplete.bind( this, dependencies, destination ),
+						this.handleFlowComplete.bind( this, dependencies, filteredDestination ),
 						MINIMUM_TIME_LOADING_SCREEN_IS_DISPLAYED - timeSinceLoading
 					);
 				}
-
-				return this.handleFlowComplete( dependencies, destination );
+				return this.handleFlowComplete( dependencies, filteredDestination );
 			}.bind( this )
 		} );
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -119,6 +119,10 @@ function mergeFormWithValue( { form, fieldName, fieldValue} ) {
 	return form;
 }
 
+function getDestination( destination, dependencies, flowName ) {
+	return flows.filterDestination( destination, dependencies, flowName );
+}
+
 module.exports = {
 	getFlowName: getFlowName,
 	getFlowSteps: getFlowSteps,
@@ -130,5 +134,6 @@ module.exports = {
 	getPreviousStepName: getPreviousStepName,
 	getNextStepName: getNextStepName,
 	getValueFromProgressStore: getValueFromProgressStore,
+	getDestination: getDestination,
 	mergeFormWithValue: mergeFormWithValue
 };

--- a/client/state/ui/actions.js
+++ b/client/state/ui/actions.js
@@ -50,10 +50,11 @@ export function setSection( section, options = {} ) {
  * @param {Object} options Options object, see fn signature.
  * @return {Object} Action object
  */
-export function showGuidesTour( { shouldShow = false, tour = 'main', siteId = null } ) {
+export function showGuidesTour( { shouldShow, shouldDelay = false, tour = 'main', siteId = null } ) {
 	return {
 		type: SHOW_GUIDESTOUR,
 		shouldShow,
+		shouldDelay,
 		tour,
 		siteId,
 	}

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -86,6 +86,8 @@ export function guidesTour( state = {}, action ) {
 			return {
 				stepName,
 				shouldShow: action.shouldShow,
+				shouldDelay: action.shouldDelay,
+				shouldReallyShow: ( action.shouldShow || state.shouldShow ) && ! action.shouldDelay,
 				tour: action.tour,
 				siteId: action.siteId,
 			};

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -76,9 +76,12 @@ const getRawGuidesTourState = state => get( state, 'ui.guidesTour', false );
 export const getGuidesTourState = createSelector(
 	state => {
 		const tourState = getRawGuidesTourState( state );
-		const { stepName = '' } = tourState;
+		const { shouldReallyShow, stepName = '' } = tourState;
 		const stepConfig = getToursConfig()[ stepName ] || false;
-		return Object.assign( {}, tourState, { stepConfig } );
+		return Object.assign( {}, tourState, {
+			stepConfig,
+			shouldShow: shouldReallyShow || false,
+		} );
 	},
 	getRawGuidesTourState
 );

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -129,11 +129,12 @@ describe( 'selectors', () => {
 		it( 'should return an empty object if no state is present', () => {
 			const tourState = getGuidesTourState( {
 				ui: {
-					guidesTour: false
+					shouldShow: false,
+					guidesTour: false,
 				}
 			} );
 
-			expect( tourState ).to.deep.equal( { stepConfig: false } );
+			expect( tourState ).to.deep.equal( { shouldShow: false, stepConfig: false } );
 		} );
 
 		it( 'should include the config of the current tour step', () => {
@@ -148,7 +149,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			const stepConfig = guidesToursConfig.get()[ 'sidebar' ];
+			const stepConfig = guidesToursConfig.get().sidebar;
 
 			expect( tourState ).to.deep.equal( Object.assign( {}, tourState, {
 				stepConfig


### PR DESCRIPTION
Implements #4378

We want to enable Guided Tours for a subset of new people, across all flows.

This involves modifying the `signup` framework slightly, so we can filter final destinations specified in the flow. It also involves making sure we don't show a tour during checkout.

TODO:
- [x] AB tests: decide on start dates/percentages
- [x] AB test across all flows
- [x] Test all signup flows to make sure they still work, and have decent UX
- [x] Test in desktop app?

To test:
- In console `localStorage.setItem( 'ABTests', '{"guidedTours_20160418":"guided"}' );`
- Add new WordPress when logged in, signup logged out
- Add a plan or theme for some tests
- Check that the tour is shown after signup
- If you've bought something, make sure the tour doesn't show in the checkout, and make sure it appears once you've completed your purchase.

There's also a Calypso-only variant, where we never redirect to the frontend. Test this via:
- `localStorage.setItem( 'ABTests', '{"guidedTours_20160418":"calypsoOnly"}' );`
- Make sure when testing, you land on Calypso, and not the frontend