### PR TITLE
Enable Brazilian survey invitation on production

### DIFF
--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -80,7 +80,7 @@
 
 .translator-invitation__actions {
 	flex-grow: 100%;
-	> .button:last-child {
+	> :last-child {
 		margin-right: 0;
 	}
 }

--- a/config/production.json
+++ b/config/production.json
@@ -12,6 +12,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": true,
+		"brazil-survey-invitation": true,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,


### PR DESCRIPTION
The Survey's been enabled on production and staging over the weekend, and there's no red flags from our braziliamatticians ( https://brazilmarketingtalk.wordpress.com/2016/04/03/brazilian-user-survey-will-be-live-on-april-4th/ ), and the stats look good: https://mc.a8c.com/tracks/trends/?eventname=calypso_poll_invitation_clicked_dismiss_button%20calypso_poll_invitation_dismissed%20calypso_poll_invitation_clicked_accept_button&stat=counts&interval=day

This PR is to add a last-minute style fix to separate the two buttons, and launch on production.

The invitation should pop up on the reader or the sites page if your user interface is set to pt-br.  Clicking either button should make it go away, and the accept button should take you to the survey.