### PR TITLE
CPT / Site Settings: Add options for toggling custom content types

### DIFF
--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -165,6 +165,11 @@ var FormFields = React.createClass( {
 						disabled={ true }
 					/>
 					<br />
+					<FormToggle
+						checked={ true }
+						disabled={ true }
+					/>
+					<br />
 					<CompactFormToggle
 						checked={ this.state.compactToggled }
 						onChange={ this.handleCompactToggle }

--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -14,7 +14,6 @@
 	padding: 2px;
 	width: 40px;
 	height: 24px;
-	background: lighten( $gray, 10% );
 	vertical-align: middle;
 	outline: 0;
 	cursor: pointer;
@@ -36,11 +35,6 @@
 	}
 	&:before {
 		display: none;
-	}
-	&:hover {
-		background: lighten( $gray, 20% );
-
-
 	}
 	.accessible-focus &:focus{
 		box-shadow: 0 0 0 2px $blue-medium;
@@ -64,6 +58,17 @@
 			box-shadow: 0 0 0 2px $blue-light;
 		}
 	}
+
+	& + .form-toggle__label .form-toggle__switch {
+		background: lighten( $gray, 10% );
+	}
+
+	&:not( :disabled ) {
+		+ .form-toggle__label .form-toggle__switch:hover {
+			background: lighten( $gray, 20% );
+		}
+	}
+
 	&:checked{
 		+ .form-toggle__label .form-toggle__switch {
 			background: $blue-medium;
@@ -73,15 +78,16 @@
 			}
 		}
 	}
-	&:checked {
+
+	&:checked:not( :disabled ) {
 		+ .form-toggle__label .form-toggle__switch:hover {
 			background: $blue-light;
 		}
 	}
+
 	&:disabled {
-		+ label.form-toggle__label span.form-toggle__switch:hover,
 		+ label.form-toggle__label span.form-toggle__switch {
-			background: lighten( $gray, 30% );
+			opacity: 0.25;
 			cursor: default;
 		}
 	}

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -1,5 +1,6 @@
 .section-header.card {
 	display: flex;
+	align-items: center;
 	padding-top: 11px;
 	padding-bottom: 11px;
 	position: relative;

--- a/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
+++ b/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
@@ -1,0 +1,153 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isRequestingPostTypes, getPostTypes } from 'state/post-types/selectors';
+import localize from 'lib/mixins/i18n/localize';
+import QueryPostTypes from 'components/data/query-post-types';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormToggle from 'components/forms/form-toggle';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+
+class CustomPostTypesFieldset extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.boundToggleTestimonial = this.onChange.bind( this, 'jetpack-testimonial' );
+		this.boundTogglePortfolio = this.onChange.bind( this, 'jetpack-portfolio' );
+		this.state = { hadOnceEnabled: {} };
+	}
+
+	componentWillMount() {
+		this.updateHadOnceEnabled();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.siteId !== nextProps.siteId ) {
+			this.setState( { hadOnceEnabled: {} }, this.updateHadOnceEnabled );
+		} else {
+			this.updateHadOnceEnabled( nextProps );
+		}
+	}
+
+	updateHadOnceEnabled( props = this.props ) {
+		this.setState( {
+			hadOnceEnabled: [
+				'jetpack-testimonial',
+				'jetpack-portfolio'
+			].reduce( ( memo, postType ) => {
+				const valueKey = this.getPostTypeValueKey( postType );
+				memo[ postType ] = this.state.hadOnceEnabled[ postType ] || props.value[ valueKey ];
+				return memo;
+			}, {} )
+		} );
+	}
+
+	hasDefaultPostTypeEnabled( postType ) {
+		return (
+			this.props.postTypes &&
+			! this.state.hadOnceEnabled[ postType ] &&
+			false === this.props.value[ this.getPostTypeValueKey( postType ) ] &&
+			!! this.props.postTypes[ postType ]
+		);
+	}
+
+	getPostTypeValueKey( postType ) {
+		if ( 'jetpack-testimonial' === postType ) {
+			return 'jetpack_testimonial';
+		}
+
+		if ( 'jetpack-portfolio' === postType ) {
+			return 'jetpack_portfolio';
+		}
+	}
+
+	isEnabled( postType ) {
+		return (
+			this.hasDefaultPostTypeEnabled( postType ) ||
+			this.props.value[ this.getPostTypeValueKey( postType ) ]
+		);
+	}
+
+	isDisabled( postType ) {
+		const { requestingSettings, requestingPostTypes } = this.props;
+		return requestingSettings || requestingPostTypes || this.hasDefaultPostTypeEnabled( postType );
+	}
+
+	onChange( postType ) {
+		this.props.onChange( {
+			[ this.getPostTypeValueKey( postType ) ]: ! this.isEnabled( postType )
+		} );
+	}
+
+	render() {
+		const { translate, siteId, recordEvent, className } = this.props;
+
+		return (
+			<FormFieldset className={ className }>
+				{ siteId && (
+					<QueryPostTypes siteId={ siteId } />
+				) }
+				<FormLabel>{ translate( 'Custom Content Types' ) }</FormLabel>
+				<p>
+					{ translate( 'Display different types of content on your site with {{link}}custom content types{{/link}}.', {
+						components: {
+							link: <a href="https://jetpack.com/support/custom-content-types/" target="_blank" />
+						}
+					} ) }
+				</p>
+				<FormLabel>
+					<FormToggle
+						checked={ this.isEnabled( 'jetpack-testimonial' ) }
+						onChange={ this.boundToggleTestimonial }
+						disabled={ this.isDisabled( 'jetpack-testimonial' ) }
+						onClick={ recordEvent( 'Clicked Jetpack Testimonial CPT Checkbox' ) }>
+						{ translate( 'Testimonials' ) }
+					</FormToggle>
+				</FormLabel>
+				{ this.hasDefaultPostTypeEnabled( 'jetpack-testimonial' ) && (
+					<FormSettingExplanation>{ translate( 'Your theme supports Testimonials' ) }</FormSettingExplanation>
+				) }
+				<FormLabel>
+					<FormToggle
+						checked={ this.isEnabled( 'jetpack-portfolio' ) }
+						onChange={ this.boundTogglePortfolio }
+						disabled={ this.isDisabled( 'jetpack-portfolio' ) }
+						onClick={ recordEvent( 'Clicked Jetpack Portfolio CPT Checkbox' ) }>
+						{ translate( 'Portfolio Projects' ) }
+					</FormToggle>
+				</FormLabel>
+				{ this.hasDefaultPostTypeEnabled( 'jetpack-portfolio' ) && (
+					<FormSettingExplanation>{ translate( 'Your theme supports Portfolio Projects' ) }</FormSettingExplanation>
+				) }
+			</FormFieldset>
+		);
+	}
+}
+
+CustomPostTypesFieldset.propTypes = {
+	translate: PropTypes.func,
+	siteId: PropTypes.number,
+	requestingPostTypes: PropTypes.bool,
+	requestingSettings: PropTypes.bool,
+	value: PropTypes.object,
+	recordEvent: PropTypes.func,
+	className: PropTypes.string
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+		requestingPostTypes: isRequestingPostTypes( state, siteId ),
+		postTypes: getPostTypes( state, siteId )
+	};
+} )( localize( CustomPostTypesFieldset ) );

--- a/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
+++ b/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
@@ -115,6 +115,15 @@ class CustomPostTypesFieldset extends Component {
 				{ this.hasDefaultPostTypeEnabled( 'jetpack-testimonial' ) && (
 					<FormSettingExplanation>{ translate( 'Your theme supports Testimonials' ) }</FormSettingExplanation>
 				) }
+				<p>
+					{ translate( 'The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the {{shortcodeLink}}testimonial shortcode{{/shortcodeLink}} ( {{code}}[testimonials]{{/code}} ) or you can view a full archive of your testimonials at yourgroovydomain.com/testimonial.', {
+						components: {
+							shortcodeLink: <a href="https://support.wordpress.com/testimonials-shortcode/" />,
+							code: <code />
+						}
+					} ) }
+
+				</p>
 				<FormLabel>
 					<FormToggle
 						checked={ this.isEnabled( 'jetpack-portfolio' ) }
@@ -127,6 +136,14 @@ class CustomPostTypesFieldset extends Component {
 				{ this.hasDefaultPostTypeEnabled( 'jetpack-portfolio' ) && (
 					<FormSettingExplanation>{ translate( 'Your theme supports Portfolio Projects' ) }</FormSettingExplanation>
 				) }
+				<p>
+					{ translate( 'The Portfolio custom content type gives you an easy way to manage and showcase projects on your site. If your theme doesn’t support it yet, you can display the portfolio using the {{shortcodeLink}}portfolio shortcode{{/shortcodeLink}} ( {{code}}[portfolio]{{/code}} ) or with a link to the portfolio in the menu.', {
+						components: {
+							shortcodeLink: <a href="https://support.wordpress.com/portfolios/portfolio-shortcode/" />,
+							code: <code />
+						}
+					} ) }
+				</p>
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
+++ b/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
@@ -15,6 +15,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormToggle from 'components/forms/form-toggle';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import SectionHeader from 'components/section-header';
+import Card from 'components/card';
 
 class CustomPostTypesFieldset extends Component {
 	constructor( props ) {
@@ -103,47 +105,46 @@ class CustomPostTypesFieldset extends Component {
 						}
 					} ) }
 				</p>
-				<FormLabel>
-					<FormToggle
-						checked={ this.isEnabled( 'jetpack-testimonial' ) }
-						onChange={ this.boundToggleTestimonial }
-						disabled={ this.isDisabled( 'jetpack-testimonial' ) }
-						onClick={ recordEvent( 'Clicked Jetpack Testimonial CPT Checkbox' ) }>
-						{ translate( 'Testimonials' ) }
-					</FormToggle>
-				</FormLabel>
-				{ this.hasDefaultPostTypeEnabled( 'jetpack-testimonial' ) && (
-					<FormSettingExplanation>{ translate( 'Your theme supports Testimonials' ) }</FormSettingExplanation>
-				) }
-				<p>
-					{ translate( 'The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the {{shortcodeLink}}testimonial shortcode{{/shortcodeLink}} ( {{code}}[testimonials]{{/code}} ) or you can view a full archive of your testimonials at yourgroovydomain.com/testimonial.', {
-						components: {
-							shortcodeLink: <a href="https://support.wordpress.com/testimonials-shortcode/" />,
-							code: <code />
-						}
-					} ) }
-
-				</p>
-				<FormLabel>
-					<FormToggle
-						checked={ this.isEnabled( 'jetpack-portfolio' ) }
-						onChange={ this.boundTogglePortfolio }
-						disabled={ this.isDisabled( 'jetpack-portfolio' ) }
-						onClick={ recordEvent( 'Clicked Jetpack Portfolio CPT Checkbox' ) }>
-						{ translate( 'Portfolio Projects' ) }
-					</FormToggle>
-				</FormLabel>
-				{ this.hasDefaultPostTypeEnabled( 'jetpack-portfolio' ) && (
-					<FormSettingExplanation>{ translate( 'Your theme supports Portfolio Projects' ) }</FormSettingExplanation>
-				) }
-				<p>
-					{ translate( 'The Portfolio custom content type gives you an easy way to manage and showcase projects on your site. If your theme doesn’t support it yet, you can display the portfolio using the {{shortcodeLink}}portfolio shortcode{{/shortcodeLink}} ( {{code}}[portfolio]{{/code}} ) or with a link to the portfolio in the menu.', {
-						components: {
-							shortcodeLink: <a href="https://support.wordpress.com/portfolios/portfolio-shortcode/" />,
-							code: <code />
-						}
-					} ) }
-				</p>
+				<div className="site-settings__custom-post-type">
+					<SectionHeader label={ translate( 'Testimonials' ) }>
+						<FormToggle
+							checked={ this.isEnabled( 'jetpack-testimonial' ) }
+							onChange={ this.boundToggleTestimonial }
+							disabled={ this.isDisabled( 'jetpack-testimonial' ) }
+							onClick={ recordEvent( 'Clicked Jetpack Testimonial CPT Checkbox' ) } />
+					</SectionHeader>
+					<Card>
+						{ this.hasDefaultPostTypeEnabled( 'jetpack-testimonial' ) && (
+							<FormSettingExplanation>{ translate( 'Your theme supports Testimonials' ) }</FormSettingExplanation>
+						) }
+						{ translate( 'The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the {{shortcodeLink}}testimonial shortcode{{/shortcodeLink}} ( {{code}}[testimonials]{{/code}} ) or you can view a full archive of your testimonials at yourgroovydomain.com/testimonial.', {
+							components: {
+								shortcodeLink: <a href="https://support.wordpress.com/testimonials-shortcode/" />,
+								code: <code />
+							}
+						} ) }
+					</Card>
+				</div>
+				<div className="site-settings__custom-post-type">
+					<SectionHeader label={ translate( 'Portfolio Projects' ) }>
+						<FormToggle
+							checked={ this.isEnabled( 'jetpack-portfolio' ) }
+							onChange={ this.boundTogglePortfolio }
+							disabled={ this.isDisabled( 'jetpack-portfolio' ) }
+							onClick={ recordEvent( 'Clicked Jetpack Portfolio CPT Checkbox' ) } />
+					</SectionHeader>
+					<Card>
+						{ this.hasDefaultPostTypeEnabled( 'jetpack-portfolio' ) && (
+							<FormSettingExplanation>{ translate( 'Your theme supports Portfolio Projects' ) }</FormSettingExplanation>
+						) }
+						{ translate( 'The Portfolio custom content type gives you an easy way to manage and showcase projects on your site. If your theme doesn’t support it yet, you can display the portfolio using the {{shortcodeLink}}portfolio shortcode{{/shortcodeLink}} ( {{code}}[portfolio]{{/code}} ) or with a link to the portfolio in the menu.', {
+							components: {
+								shortcodeLink: <a href="https://support.wordpress.com/portfolios/portfolio-shortcode/" />,
+								code: <code />
+							}
+						} ) }
+					</Card>
+				</div>
 			</FormFieldset>
 		);
 	}

--- a/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
+++ b/client/my-sites/site-settings/custom-post-types-fieldset/index.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { isRequestingPostTypes, getPostTypes } from 'state/post-types/selectors';
 import localize from 'lib/mixins/i18n/localize';
 import QueryPostTypes from 'components/data/query-post-types';
@@ -90,7 +90,7 @@ class CustomPostTypesFieldset extends Component {
 	}
 
 	render() {
-		const { translate, siteId, recordEvent, className } = this.props;
+		const { translate, siteId, siteUrl, recordEvent, className } = this.props;
 
 		return (
 			<FormFieldset className={ className }>
@@ -117,10 +117,11 @@ class CustomPostTypesFieldset extends Component {
 						{ this.hasDefaultPostTypeEnabled( 'jetpack-testimonial' ) && (
 							<FormSettingExplanation>{ translate( 'Your theme supports Testimonials' ) }</FormSettingExplanation>
 						) }
-						{ translate( 'The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the {{shortcodeLink}}testimonial shortcode{{/shortcodeLink}} ( {{code}}[testimonials]{{/code}} ) or you can view a full archive of your testimonials at yourgroovydomain.com/testimonial.', {
+						{ translate( 'The Testimonial custom content type allows you to add, organize, and display your testimonials. If your theme doesn’t support it yet, you can display testimonials using the {{shortcodeLink}}testimonial shortcode{{/shortcodeLink}} ( {{code}}[testimonials]{{/code}} ) or you can {{archiveLink}}view a full archive of your testimonials{{/archiveLink}}.', {
 							components: {
 								shortcodeLink: <a href="https://support.wordpress.com/testimonials-shortcode/" />,
-								code: <code />
+								code: <code />,
+								archiveLink: <a href={ siteUrl.replace( /\/$/, '' ) + '/testimonial' } />
 							}
 						} ) }
 					</Card>
@@ -162,9 +163,11 @@ CustomPostTypesFieldset.propTypes = {
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
+	const site = getSelectedSite( state );
 
 	return {
 		siteId,
+		siteUrl: site ? site.URL : '',
 		requestingPostTypes: isRequestingPostTypes( state, siteId ),
 		postTypes: getPostTypes( state, siteId )
 	};

--- a/client/my-sites/site-settings/form-base.js
+++ b/client/my-sites/site-settings/form-base.js
@@ -167,6 +167,10 @@ module.exports = {
 
 				site.fetchSettings();
 			}
+
+			if ( 'function' === typeof this.onSaveComplete ) {
+				this.onSaveComplete( error );
+			}
 		} );
 
 		this.recordEvent( 'Clicked Save Settings Button' );

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 var React = require( 'react' );
+import each from 'lodash/each';
+import pick from 'lodash/pick';
 
 /**
  * Internal dependencies
@@ -17,6 +19,7 @@ var formBase = require( './form-base' ),
 	SectionHeader = require( 'components/section-header' ),
 	Card = require( 'components/card' ),
 	Button = require( 'components/button' );
+import CustomPostTypeFieldset from './custom-post-types-fieldset';
 
 module.exports = React.createClass( {
 
@@ -28,7 +31,9 @@ module.exports = React.createClass( {
 		var writingAttributes = [
 				'default_category',
 				'post_categories',
-				'default_post_format'
+				'default_post_format',
+				'jetpack_testimonial',
+				'jetpack_portfolio'
 			],
 			settings = {};
 
@@ -52,6 +57,16 @@ module.exports = React.createClass( {
 			post_categories: [],
 			default_post_format: '',
 		} );
+	},
+
+	setCustomPostTypeSetting( revision ) {
+		this.setState( revision );
+
+		each( revision, ( value, key ) => {
+			this.linkState( key ).requestChange( value );
+		} );
+
+		this.markChanged();
 	},
 
 	render: function() {
@@ -102,6 +117,13 @@ module.exports = React.createClass( {
 							<option value="audio">{ this.translate( 'Audio', { context: 'Post format' } ) }</option>
 						</FormSelect>
 					</FormFieldset>
+
+					<CustomPostTypeFieldset
+						requestingSettings={ this.state.fetchingSettings }
+						value={ pick( this.state, 'jetpack_testimonial', 'jetpack_portfolio' ) }
+						onChange={ this.setCustomPostTypeSetting }
+						recordEvent={ this.recordEvent }
+						className="has-divider is-top-only" />
 
 					{ config.isEnabled( 'press-this' ) &&
 						<FormFieldset className="has-divider is-top-only">

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' );
+import { connect } from 'react-redux';
 import each from 'lodash/each';
 import pick from 'lodash/pick';
 
@@ -19,12 +20,10 @@ var formBase = require( './form-base' ),
 	SectionHeader = require( 'components/section-header' ),
 	Card = require( 'components/card' ),
 	Button = require( 'components/button' );
+import { requestPostTypes } from 'state/post-types/actions';
 import CustomPostTypeFieldset from './custom-post-types-fieldset';
 
-module.exports = React.createClass( {
-
-	displayName: 'SiteSettingsFormWriting',
-
+const SiteSettingsFormWriting = React.createClass( {
 	mixins: [ dirtyLinkedState, protectForm.mixin, formBase ],
 
 	getSettingsFromSite: function( site ) {
@@ -57,6 +56,14 @@ module.exports = React.createClass( {
 			post_categories: [],
 			default_post_format: '',
 		} );
+	},
+
+	onSaveComplete() {
+		if ( ! this.props.site ) {
+			return;
+		}
+
+		this.props.requestPostTypes( this.props.site.ID );
 	},
 
 	setCustomPostTypeSetting( revision ) {
@@ -150,3 +157,9 @@ module.exports = React.createClass( {
 		);
 	}
 } );
+
+export default connect( null, {
+	requestPostTypes
+}, null, {
+	pure: false
+} )( SiteSettingsFormWriting );

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 import { connect } from 'react-redux';
 import each from 'lodash/each';
 import pick from 'lodash/pick';
@@ -9,17 +9,17 @@ import pick from 'lodash/pick';
 /**
  * Internal dependencies
  */
-var formBase = require( './form-base' ),
-	protectForm = require( 'lib/mixins/protect-form' ),
-	config = require( 'config' ),
-	PressThisLink = require( './press-this-link' ),
-	dirtyLinkedState = require( 'lib/mixins/dirty-linked-state' ),
-	FormSelect = require( 'components/forms/form-select' ),
-	FormFieldset = require( 'components/forms/form-fieldset' ),
-	FormLabel = require( 'components/forms/form-label' ),
-	SectionHeader = require( 'components/section-header' ),
-	Card = require( 'components/card' ),
-	Button = require( 'components/button' );
+import formBase from './form-base';
+import protectForm from 'lib/mixins/protect-form';
+import config from 'config';
+import PressThisLink from './press-this-link';
+import dirtyLinkedState from 'lib/mixins/dirty-linked-state';
+import FormSelect from 'components/forms/form-select';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import SectionHeader from 'components/section-header';
+import Card from 'components/card';
+import Button from 'components/button';
 import { requestPostTypes } from 'state/post-types/actions';
 import CustomPostTypeFieldset from './custom-post-types-fieldset';
 

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -36,7 +36,7 @@ const SiteSettingsFormWriting = React.createClass( {
 
 		site = site || this.props.site;
 
-		if ( ! site.jetpack ) {
+		if ( ! site.jetpack && config.isEnabled( 'manage/custom-post-types' ) ) {
 			writingAttributes = writingAttributes.concat( [
 				'jetpack_testimonial',
 				'jetpack_portfolio'
@@ -65,7 +65,7 @@ const SiteSettingsFormWriting = React.createClass( {
 
 	onSaveComplete() {
 		const { site } = this.props;
-		if ( ! site || site.jetpack ) {
+		if ( ! site || site.jetpack || ! config.isEnabled( 'manage/custom-post-types' ) ) {
 			return;
 		}
 
@@ -131,7 +131,7 @@ const SiteSettingsFormWriting = React.createClass( {
 						</FormSelect>
 					</FormFieldset>
 
-					{ ( ! this.props.site || ! this.props.site.jetpack ) && (
+					{ config.isEnabled( 'manage/custom-post-types' ) && ( ! this.props.site || ! this.props.site.jetpack ) && (
 						<CustomPostTypeFieldset
 							requestingSettings={ this.state.fetchingSettings }
 							value={ pick( this.state, 'jetpack_testimonial', 'jetpack_portfolio' ) }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -112,6 +112,13 @@
 	}
 }
 
+.site-settings__custom-post-type .form-toggle__label {
+	margin-bottom: 0;
+}
+
+.site-settings .site-settings__custom-post-type p.form-setting-explanation {
+	margin: 0 0 16px;
+}
 
 .press-this {
 	/* press this isn't functional on a touch device */


### PR DESCRIPTION
Closes #4481

This pull request seeks to add a new fieldset to the site settings writing form for toggling whether custom post types are enabled on a site. As described in #4481, until now a user must have navigated to wp-admin to manage these settings.

![CPT Settings](https://cloud.githubusercontent.com/assets/1779930/14252123/efe5a752-fa53-11e5-89e7-8f3ef09110ef.png)

__Implementation notes:__

- Many themes add default support for custom post types. Support for this behavior does not (but could) exist at the REST API. Instead, the checkboxes are shown as checked and disabled when the the setting is not enabled but the post type exists for the site (implying that the theme adds support).
 - ![Implicitly activated](https://cloud.githubusercontent.com/assets/1779930/14252205/40319306-fa54-11e5-829e-062daa97dd6a.png)
- Settings fields for managing custom post types were only recently added to the REST API (r133680-wpcom). Therefore, Jetpack support will not be available until these changes have been migrated to the plugin. The fieldset is hidden for Jetpack sites not satisfying a version compare for `>=4.0.0`.

__Testing instructions:__

Verify that the fields are checked when enabled for a site, are disabled when default support exists for a theme, and can be toggled and saved. After a save, ensure that the corresponding sidebar navigation item is added or removed based on your change. Verify that the form fields are not shown for Jetpack sites, and that navigating directly between sites (via site picker) updates the field values correctly.

1. Navigate to the [writing settings page](http://calypso.localhost:3000/settings/writing)
2. Select a site
3. Note that...
 - If a Jetpack site, the custom post types fieldset is not shown
 - Otherwise, a custom post types fieldset is shown
4. Note that the current checked status reflects the settings for the site
5. Change the checked status
6. Save the form
7. Note that the sidebar item is removed or added based on your chnage in step 5
8. Refresh the page
9. Note that the current status still reflects the settings for the site

__Caveats:__

- Users cannot (yet) manage "display at most" post count setting. Some design feedback would be appreciated here. The setting does exist at the REST API and could be added in this or a subsequent pull request.
- Jetpack support is not yet available