### PR TITLE
Stats: fix view all footer links in stats modules.

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -85,7 +85,7 @@ export default React.createClass( {
 		if ( ! summary && dataList.response.viewAll ) {
 			viewSummary = (
 				<div key="view-all" className="module-expand">
-					<a href="#" onClick={ this.viewAllHandler }>{ this.translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }<span className="right"></span></a>
+					<a href={ this.getHref() }>{ this.translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }<span className="right"></span></a>
 				</div>
 			);
 		}


### PR DESCRIPTION
Fixes #4507 

#2863 introduced a regression where the footer version of the "View All" link was not linking properly.  This branch fixes that, even though we are considering removing these links all together in lieu of the header links.

__To Test__
- Open a site stats page for a site with a decent amount of traffic
- Click "View All" in the footer of the Post & Pages module
- Validate the summary page opens as expected

/cc @folletto