### PR TITLE
Editor: Display featured image media modal on clicking selected

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -162,6 +162,7 @@ button {
 	color: darken( $gray, 10% );
 	padding-left: 0;
 	padding-right: 0;
+	border-radius: 0;
 
 	&:hover {
 		color: $gray-dark;
@@ -202,7 +203,7 @@ button {
 
 	&.is-compact {
 		background: transparent;
-		border-radius: 0;
+
 		.gridicon {
 			width: 18px;
 			height: 18px;

--- a/client/post-editor/editor-drawer-well/index.jsx
+++ b/client/post-editor/editor-drawer-well/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
-import createFragment from 'react-addons-create-fragment';
 import classNames from 'classnames';
 import noop from 'lodash/noop';
 
@@ -10,6 +9,7 @@ import noop from 'lodash/noop';
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
+import Button from 'components/button';
 
 export default React.createClass( {
 	displayName: 'EditorDrawerWell',
@@ -17,6 +17,7 @@ export default React.createClass( {
 	propTypes: {
 		icon: PropTypes.string,
 		label: PropTypes.node,
+		empty: PropTypes.bool,
 		disabled: PropTypes.bool,
 		onClick: PropTypes.func,
 		onRemove: PropTypes.func,
@@ -31,49 +32,46 @@ export default React.createClass( {
 		};
 	},
 
-	renderPlaceholder() {
-		const { icon, onClick, disabled, label } = this.props;
-
-		let iconElement;
-		if ( icon ) {
-			iconElement = <Gridicon icon={ icon } className="editor-drawer-well__icon" />;
-		}
-
-		return (
-			<button type="button" className="editor-drawer-well__placeholder" onClick={ onClick } disabled={ disabled }>
-				{ iconElement }
-				<span className="editor-drawer-well__button button is-secondary">
-					{ label }
-				</span>
-			</button>
-		);
-	},
-
-	renderChildren() {
-		const { children, onRemove } = this.props;
-		let fragments = { children };
-
-		if ( onRemove ) {
-			fragments.remove = (
-				<button type="button" onClick={ onRemove } className="editor-drawer-well__remove">
-					<span className="screen-reader-text">{ this.translate( 'Remove' ) }</span>
-					<span className="editor-drawer-well__remove-icon noticon noticon-close-alt" />
-				</button>
-			);
-		}
-
-		return createFragment( fragments );
-	},
-
 	render() {
-		const hasChildren = React.Children.count( this.props.children ) > 0;
+		const { empty, onRemove, onClick, disabled, icon, label, children } = this.props;
 		const classes = classNames( 'editor-drawer-well', {
-			'is-empty': ! hasChildren
+			'is-empty': empty
 		} );
 
 		return (
 			<div className={ classes }>
-				{ hasChildren ? this.renderChildren() : this.renderPlaceholder() }
+				<div className="editor-drawer-well__content">
+					{ children }
+					{ onRemove && (
+						<Button
+							onClick={ onRemove }
+							className="editor-drawer-well__remove">
+							<span className="screen-reader-text">
+								{ this.translate( 'Remove' ) }
+							</span>
+							<Gridicon
+								icon="cross"
+								size={ 24 }
+								className="editor-drawer-well__remove-icon" />
+						</Button>
+					) }
+				</div>
+				{ empty && (
+					<button
+						type="button"
+						onClick={ onClick }
+						disabled={ disabled }
+						className="editor-drawer-well__placeholder">
+						{ icon && (
+							<Gridicon
+								icon={ icon }
+								className="editor-drawer-well__icon" />
+						) }
+						<span className="editor-drawer-well__button button is-secondary">
+							{ label }
+						</span>
+					</button>
+				) }
 			</div>
 		);
 	}

--- a/client/post-editor/editor-drawer-well/style.scss
+++ b/client/post-editor/editor-drawer-well/style.scss
@@ -2,6 +2,10 @@
 	position: relative;
 }
 
+.editor-drawer-well.is-empty .editor-drawer-well__content {
+	display: none;
+}
+
 .editor-drawer-well__placeholder {
 	@extend .card;
 	display: block;
@@ -49,14 +53,13 @@
 	cursor: pointer;
 }
 
-.editor-drawer-well__remove-icon {
+.editor-drawer-well__remove .editor-drawer-well__remove-icon.gridicon {
 	position: absolute;
 		top: 50%;
-		right: 0;
-		left: 0;
-	transform: translateY( -50% );
-	font-size: 14px;
-	font-weight: bold;
-	text-align: center;
+		left: 50%;
+	transform: translate( -50%, -50% );
+	width: 24px;
+	height: 24px;
+	margin: 0;
 	color: lighten( $gray, 10% );
 }

--- a/client/post-editor/editor-drawer/featured-image.jsx
+++ b/client/post-editor/editor-drawer/featured-image.jsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import localize from 'lib/mixins/i18n/localize';
+import PostActions from 'lib/posts/actions';
+import * as stats from 'lib/posts/stats';
+import { getFeaturedImageId } from 'lib/posts/utils';
+import Accordion from 'components/accordion';
+import Gridicon from 'components/gridicon';
+import EditorDrawerWell from 'post-editor/editor-drawer-well';
+import FeaturedImage from 'post-editor/editor-featured-image';
+
+class EditorDrawerFeaturedImage extends Component {
+	constructor( props ) {
+		super( props );
+		this.startSelecting = () => this.setState( { isSelecting: true } );
+		this.endSelecting = () => this.setState( { isSelecting: false } );
+		this.state = { isSelecting: false };
+	}
+
+	removeImage() {
+		PostActions.edit( {
+			featured_image: ''
+		} );
+
+		stats.recordStat( 'featured_image_removed' );
+		stats.recordEvent( 'Featured image removed' );
+	}
+
+	render() {
+		const { translate, site, post } = this.props;
+
+		return (
+			<Accordion
+				title={ translate( 'Featured Image' ) }
+				icon={ <Gridicon icon="image" /> }>
+				<EditorDrawerWell
+					icon="image"
+					label={ translate( 'Set Featured Image' ) }
+					empty={ ! site || ! post || ! getFeaturedImageId( post ) }
+					onClick={ this.startSelecting }
+					onRemove={ this.removeImage }>
+					<FeaturedImage
+						selecting={ this.state.isSelecting }
+						onImageSelected={ this.endSelecting }
+						site={ site }
+						post={ post } />
+				</EditorDrawerWell>
+			</Accordion>
+		);
+	}
+}
+
+EditorDrawerFeaturedImage.propTypes = {
+	site: PropTypes.object,
+	post: PropTypes.object,
+	translate: PropTypes.func
+};
+
+export default localize( EditorDrawerFeaturedImage );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -15,7 +15,6 @@ import Gridicon from 'components/gridicon';
 import TaxonomiesAccordion from 'post-editor/editor-taxonomies/accordion';
 import CategoryListData from 'components/data/category-list-data';
 import TagListData from 'components/data/tag-list-data';
-import FeaturedImage from 'post-editor/editor-featured-image';
 import EditorSharingAccordion from 'post-editor/editor-sharing/accordion';
 import FormTextarea from 'components/forms/form-textarea';
 import PostFormatsData from 'components/data/post-formats-data';
@@ -37,6 +36,7 @@ import { setExcerpt } from 'state/ui/editor/post/actions';
 import QueryPostTypes from 'components/data/query-post-types';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
+import EditorDrawerFeaturedImage from './featured-image';
 
 const EditorDrawer = React.createClass( {
 	propTypes: {
@@ -144,15 +144,9 @@ const EditorDrawer = React.createClass( {
 		}
 
 		return (
-			<Accordion
-				title={ this.translate( 'Featured Image' ) }
-				icon={ <Gridicon icon="image" /> }
-			>
-				<FeaturedImage
-					editable={ true }
-					site={ this.props.site }
-					post={ this.props.post } />
-			</Accordion>
+			<EditorDrawerFeaturedImage
+				site={ this.props.site }
+				post={ this.props.post } />
 		);
 	},
 

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -10,12 +10,11 @@ import { bindActionCreators } from 'redux';
  */
 const MediaLibrarySelectedData = require( 'components/data/media-library-selected-data' ),
 	EditorMediaModal = require( 'post-editor/media-modal' ),
-	EditorDrawerWell = require( 'post-editor/editor-drawer-well' ),
 	PostActions = require( 'lib/posts/actions' ),
 	PostUtils = require( 'lib/posts/utils' ),
 	stats = require( 'lib/posts/stats' ),
-	AccordionSection = require( 'components/accordion/section' ),
 	EditorFeaturedImagePreviewContainer = require( './preview-container' );
+import Button from 'components/button';
 import {
 	setFeaturedImage,
 	removeFeaturedImage
@@ -28,15 +27,17 @@ const EditorFeaturedImage = React.createClass( {
 		site: React.PropTypes.object,
 		post: React.PropTypes.object,
 		setFeaturedImage: React.PropTypes.func,
-		removeFeaturedImage: React.PropTypes.func
+		removeFeaturedImage: React.PropTypes.func,
+		selecting: React.PropTypes.bool,
+		onImageSelected: React.PropTypes.func
 	},
 
 	getDefaultProps: function() {
 		return {
-			editable: false,
 			maxWidth: 450,
 			setFeaturedImage: () => {},
-			removeFeaturedImage: () => {}
+			removeFeaturedImage: () => {},
+			onImageSelected: () => {}
 		};
 	},
 
@@ -54,6 +55,7 @@ const EditorFeaturedImage = React.createClass( {
 
 	setImage: function( items ) {
 		this.toggleMediaModal( 'hide' );
+		this.props.onImageSelected();
 
 		if ( ! items || ! items.length ) {
 			return;
@@ -70,18 +72,6 @@ const EditorFeaturedImage = React.createClass( {
 		stats.recordEvent( 'Featured image set' );
 	},
 
-	removeImage: function() {
-		this.props.removeFeaturedImage();
-
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		PostActions.edit( {
-			featured_image: ''
-		} );
-
-		stats.recordStat( 'featured_image_removed' );
-		stats.recordEvent( 'Featured image removed' );
-	},
-
 	renderMediaModal: function() {
 		if ( ! this.props.site ) {
 			return;
@@ -90,7 +80,7 @@ const EditorFeaturedImage = React.createClass( {
 		return (
 			<MediaLibrarySelectedData siteId={ this.props.site.ID }>
 				<EditorMediaModal
-					visible={ this.state.isSelecting }
+					visible={ this.props.selecting || this.state.isSelecting }
 					onClose={ this.setImage }
 					site={ this.props.site }
 					labels={ { confirm: this.translate( 'Set Featured Image' ) } }
@@ -125,25 +115,14 @@ const EditorFeaturedImage = React.createClass( {
 			'is-assigned': !! PostUtils.getFeaturedImageId( this.props.post )
 		} );
 
-		if ( this.props.editable ) {
-			return (
-				<AccordionSection className={ classes }>
-					{ this.renderMediaModal() }
-					<EditorDrawerWell
-						icon="image"
-						label={ this.translate( 'Set Featured Image' ) }
-						onClick={ () => this.toggleMediaModal( 'show' ) }
-						onRemove={ this.removeImage }>
-						{ this.renderCurrentImage() }
-					</EditorDrawerWell>
-				</AccordionSection>
-			);
-		}
-
 		return (
-			<div className={ classes }>
+			<Button
+				onClick={ () => this.toggleMediaModal( 'show' ) }
+				borderless
+				className={ classes }>
+				{ this.renderMediaModal() }
 				{ this.renderCurrentImage() }
-			</div>
+			</Button>
 		);
 	}
 } );

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -15,6 +15,7 @@ const MediaLibrarySelectedData = require( 'components/data/media-library-selecte
 	stats = require( 'lib/posts/stats' ),
 	EditorFeaturedImagePreviewContainer = require( './preview-container' );
 import Button from 'components/button';
+import Gridicon from 'components/gridicon';
 import {
 	setFeaturedImage,
 	removeFeaturedImage
@@ -121,7 +122,12 @@ const EditorFeaturedImage = React.createClass( {
 				borderless
 				className={ classes }>
 				{ this.renderMediaModal() }
-				{ this.renderCurrentImage() }
+				<div className="editor-featured-image__current-image">
+					{ this.renderCurrentImage() }
+					<Gridicon
+						icon="pencil"
+						className="editor-featured-image__edit-icon" />
+				</div>
 			</Button>
 		);
 	}

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -3,8 +3,7 @@
  */
 import React from 'react';
 import classnames from 'classnames';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+
 /**
  * Internal dependencies
  */
@@ -16,18 +15,14 @@ import * as stats from 'lib/posts/stats';
 import EditorFeaturedImagePreviewContainer from './preview-container';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
-import {
-	setFeaturedImage,
-	removeFeaturedImage
-} from 'state/ui/editor/post/actions';
 
-const EditorFeaturedImage = React.createClass( {
+export default React.createClass( {
+	displayName: 'EditorFeaturedImage',
+
 	propTypes: {
 		maxWidth: React.PropTypes.number,
 		site: React.PropTypes.object,
 		post: React.PropTypes.object,
-		setFeaturedImage: React.PropTypes.func,
-		removeFeaturedImage: React.PropTypes.func,
 		selecting: React.PropTypes.bool,
 		onImageSelected: React.PropTypes.func
 	},
@@ -35,8 +30,6 @@ const EditorFeaturedImage = React.createClass( {
 	getDefaultProps() {
 		return {
 			maxWidth: 450,
-			setFeaturedImage: () => {},
-			removeFeaturedImage: () => {},
 			onImageSelected: () => {}
 		};
 	},
@@ -67,9 +60,6 @@ const EditorFeaturedImage = React.createClass( {
 			return;
 		}
 
-		this.props.setFeaturedImage( items[0].ID );
-
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		PostActions.edit( {
 			featured_image: items[0].ID
 		} );
@@ -135,10 +125,3 @@ const EditorFeaturedImage = React.createClass( {
 		);
 	}
 } );
-
-export default connect(
-	null,
-	dispatch => bindActionCreators( { setFeaturedImage, removeFeaturedImage }, dispatch ),
-	null,
-	{ pure: false }
-)( EditorFeaturedImage );

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -1,19 +1,19 @@
 /**
  * External dependencies
  */
-const React = require( 'react' ),
-	classnames = require( 'classnames' );
+import React from 'react';
+import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 /**
  * Internal dependencies
  */
-const MediaLibrarySelectedData = require( 'components/data/media-library-selected-data' ),
-	EditorMediaModal = require( 'post-editor/media-modal' ),
-	PostActions = require( 'lib/posts/actions' ),
-	PostUtils = require( 'lib/posts/utils' ),
-	stats = require( 'lib/posts/stats' ),
-	EditorFeaturedImagePreviewContainer = require( './preview-container' );
+import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
+import EditorMediaModal from 'post-editor/media-modal';
+import PostActions from 'lib/posts/actions';
+import PostUtils from 'lib/posts/utils';
+import * as stats from 'lib/posts/stats';
+import EditorFeaturedImagePreviewContainer from './preview-container';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import {
@@ -22,7 +22,6 @@ import {
 } from 'state/ui/editor/post/actions';
 
 const EditorFeaturedImage = React.createClass( {
-
 	propTypes: {
 		maxWidth: React.PropTypes.number,
 		site: React.PropTypes.object,
@@ -33,7 +32,7 @@ const EditorFeaturedImage = React.createClass( {
 		onImageSelected: React.PropTypes.func
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			maxWidth: 450,
 			setFeaturedImage: () => {},
@@ -42,20 +41,26 @@ const EditorFeaturedImage = React.createClass( {
 		};
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			isSelecting: false
 		};
 	},
 
-	toggleMediaModal: function( action ) {
+	showMediaModal() {
 		this.setState( {
-			isSelecting: ( 'show' === action )
+			isSelecting: true
 		} );
 	},
 
-	setImage: function( items ) {
-		this.toggleMediaModal( 'hide' );
+	hideMediaModal() {
+		this.setState( {
+			isSelecting: false
+		} );
+	},
+
+	setImage( items ) {
+		this.hideMediaModal();
 		this.props.onImageSelected();
 
 		if ( ! items || ! items.length ) {
@@ -73,7 +78,7 @@ const EditorFeaturedImage = React.createClass( {
 		stats.recordEvent( 'Featured image set' );
 	},
 
-	renderMediaModal: function() {
+	renderMediaModal() {
 		if ( ! this.props.site ) {
 			return;
 		}
@@ -91,14 +96,12 @@ const EditorFeaturedImage = React.createClass( {
 		);
 	},
 
-	renderCurrentImage: function() {
-		var itemId;
-
+	renderCurrentImage() {
 		if ( ! this.props.site || ! this.props.post ) {
 			return;
 		}
 
-		itemId = PostUtils.getFeaturedImageId( this.props.post );
+		const itemId = PostUtils.getFeaturedImageId( this.props.post );
 		if ( ! itemId ) {
 			return;
 		}
@@ -111,14 +114,14 @@ const EditorFeaturedImage = React.createClass( {
 		);
 	},
 
-	render: function() {
+	render() {
 		const classes = classnames( 'editor-featured-image', {
 			'is-assigned': !! PostUtils.getFeaturedImageId( this.props.post )
 		} );
 
 		return (
 			<Button
-				onClick={ () => this.toggleMediaModal( 'show' ) }
+				onClick={ this.showMediaModal }
 				borderless
 				className={ classes }>
 				{ this.renderMediaModal() }

--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -110,7 +110,8 @@ const EditorFeaturedImagePreview = React.createClass( {
 				<ImagePreloader
 					placeholder={ placeholder }
 					src={ this.src() }
-					onLoad={ this.clearState } />
+					onLoad={ this.clearState }
+					className="editor-featured-image__preview-image" />
 			</div>
 		);
 	}

--- a/client/post-editor/editor-featured-image/style.scss
+++ b/client/post-editor/editor-featured-image/style.scss
@@ -1,3 +1,9 @@
+.editor-featured-image {
+	display: block;
+	width: 100%;
+	padding: 0;
+}
+
 .editor-featured-image__preview {
 	position: relative;
 }

--- a/client/post-editor/editor-featured-image/style.scss
+++ b/client/post-editor/editor-featured-image/style.scss
@@ -1,11 +1,28 @@
 .editor-featured-image {
-	display: block;
 	width: 100%;
 	padding: 0;
+	text-align: center;
+	line-height: 0;
 }
 
-.editor-featured-image__preview {
+.editor-featured-image__current-image {
 	position: relative;
+	display: inline-block;
+	vertical-align: top;
+	max-width: 100%;
+
+	.button.is-borderless & .editor-featured-image__edit-icon {
+		position: absolute;
+			top: auto;
+			bottom: 8px;
+			right: 8px;
+		color: $white;
+		opacity: 0.9;
+	}
+
+	.button.is-borderless &:hover .editor-featured-image__edit-icon {
+		opacity: 1;
+	}
 }
 
 .editor-featured-image__preview.is-transient::after {
@@ -44,17 +61,25 @@
 }
 
 .editor-featured-image__preview .spinner-line {
+	width: 100vw;
 	margin: 0;
+}
+
+.editor-featured-image__preview.has-assigned-height ~ .editor-featured-image__edit-icon {
+	display: none;
 }
 
 .editor-featured-image__preview.has-assigned-height .spinner-line {
 	position: absolute;
 		top: 50%;
-		left: 0;
-		right: 0;
-	transform: translateY( -50% );
+		left: 50%;
+	transform: translate( -50%, -50% );
 }
 
 .editor-featured-image__preview .spinner__border {
 	fill: transparent;
+}
+
+.editor-featured-image__preview-image {
+	display: block;
 }

--- a/client/post-editor/editor-location/index.jsx
+++ b/client/post-editor/editor-location/index.jsx
@@ -150,6 +150,7 @@ const EditorLocation = React.createClass( {
 				<EditorDrawerWell
 					icon="location"
 					label={ buttonText }
+					empty={ ! this.props.coordinates }
 					onClick={ this.geolocate }
 					onRemove={ this.clear }
 					disabled={ this.state.locating }>

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -219,7 +219,6 @@
 
 	img {
 		margin: 0 auto;
-		display: block;
 		max-height: 400px;
 	}
 }


### PR DESCRIPTION
Closes #4453 

This pull request seeks to enable a user to change the selected featured image by clicking on the currently selected image. This works both in the context of the featured image header display, and in the sidebar accordion.

![select-featured](https://cloud.githubusercontent.com/assets/1779930/14260292/dbe5bbc8-fa78-11e5-99bd-6e27d43400dc.gif)

__Implementation notes:__

This was a bit more of a rabbit hole than I had originally anticipated. Notably, the editor featured image component had made some assumptions about its usage in the sidebar vs. in the header, which should have been generalized. Next, the editor drawer well component worked on the implicit assumption that the existence of children indicated a non-empty value. This was not ideal and did not accommodate the updated use-case. It was updated to accept an explicit `empty` prop.

__Testing instructions:__

Verify that existing featured image flows remain unaffected, that no regressions have been introduced to other editor drawer well usages (e.g. location), and that you can reassign a featured image by clicking the currently selected image.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Expand the Featured Image sidebar accordion
4. Click Set Featured Image
5. Assign a featured image
6. Note that the featured image is shown both in the sidebar and in the header
7. Click the image in the sidebar or in the header
8. Note that the media library is shown
9. Change and assign the featured image
10. Note that the featured image is updated per your selection

__Caveats:__

You cannot currently remove a featured image from the media modal after clicking the image in the header of a post. The image must be removed from the sidebar accordion. This is non-ideal and we should probably enable a user to remove the featured image from the media modal selection step.