### PR TITLE
People: Add title to invite form header cake

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -309,7 +309,9 @@ const InvitePeople = React.createClass( {
 		return (
 			<Main>
 				<SidebarNavigation />
-				<HeaderCake isCompact onClick={ this.goBack }/>
+				<HeaderCake isCompact onClick={ this.goBack }>
+					{ this.translate( 'Invite People' ) }
+				</HeaderCake>
 				<Card>
 					<form onSubmit={ this.submitForm } >
 						<FormFieldset>


### PR DESCRIPTION
Today, @rickybanister pinged me in Slack and suggested that we add a page title to the header cake that is displayed on the invite people form: `/people/new/$site`. This PR does that.

To test:
- Checkout `update/invites-header-cake-text` branch
- Go to `/people/new/$site` where `$site` is a WP.com site
- Do you see the header text?
- Just to make sure, are there no JS errors? :smile: 

cc @lezama for review.

After:

![screen shot 2016-04-04 at 2 45 08 pm](https://cloud.githubusercontent.com/assets/1126811/14261028/51495e7e-fa74-11e5-9fad-2e7bdab2b1a5.png)
![screen shot 2016-04-04 at 2 45 01 pm](https://cloud.githubusercontent.com/assets/1126811/14261029/514c2e42-fa74-11e5-898a-8c48b1cda55d.png)
