### PR TITLE
Puchases: Clear the list of purchase after they have been cancelled

### DIFF
--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -187,7 +187,13 @@ function removePurchase( purchaseId, userId, onComplete ) {
 }
 
 function cancelAndRefundPurchase( purchaseId, data, onComplete ) {
-	wpcom.cancelAndRefundPurchase( purchaseId, data, onComplete );
+	wpcom.cancelAndRefundPurchase( purchaseId, data, function( error, response ) {
+		if ( ! error ) {
+			clearPurchases();
+		}
+
+		onComplete( error, response );
+	} );
 }
 
 export {


### PR DESCRIPTION
In #4475 I introduced a regression where we no longer clear the list of purchases after one is cancelled. This PR ensures that the purchases list is cleared when a user cancels and refunds a purchase.

Props to @drewblaisdell who noticed.
 
#### Testing instructions

1. Run `git checkout fix/clear-purchases-after-cancel` and start your server
2. Open the [`Purchases` page](http://calypso.localhost:3000/purchases)
3. Cancel a purchase that is in the refund period
4. Assert that the purchase no longer appears on the /purchases screen

#### Reviews

- [x] Code
- [x] Product