### PR TITLE
Purchases: Clear site plans after a product is cancelled

### DIFF
--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -12,6 +12,7 @@ import cancellationReasons from './cancellation-reasons';
 import { cancelAndRefundPurchase } from 'lib/upgrades/actions';
 import Card from 'components/card';
 import ConfirmCancelDomainLoadingPlaceholder from './loading-placeholder';
+import { connect } from 'react-redux';
 import FormButton from 'components/forms/form-button';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
@@ -24,8 +25,9 @@ import { getName as getDomainName } from 'lib/purchases';
 import Main from 'components/main';
 import notices from 'notices';
 import paths from 'me/purchases/paths';
-import titles from 'me/purchases/titles';
+import { refreshSitePlans } from 'state/sites/plans/actions';
 import SelectDropdown from 'components/select-dropdown';
+import titles from 'me/purchases/titles';
 
 const ConfirmCancelDomain = React.createClass( {
 	propTypes: {
@@ -110,6 +112,8 @@ const ConfirmCancelDomain = React.createClass( {
 				} ),
 				{ persistent: true }
 			);
+
+			this.props.refreshSitePlans( purchase.siteId );
 
 			analytics.tracks.recordEvent(
 				'calypso_domain_cancel_form_submit',
@@ -251,4 +255,13 @@ const ConfirmCancelDomain = React.createClass( {
 	}
 } );
 
-export default ConfirmCancelDomain;
+export default connect(
+	null,
+	( dispatch ) => {
+		return {
+			refreshSitePlans( siteId ) {
+				dispatch( refreshSitePlans( siteId ) );
+			}
+		};
+	}
+)( ConfirmCancelDomain );

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -2,7 +2,6 @@
  * External Dependencies
  */
 import React from 'react';
-import ReactDom from 'react-dom';
 
 /**
  * Internal Dependencies
@@ -25,6 +24,7 @@ import paths from './paths';
 import PurchasesData from 'components/data/purchases';
 import PurchasesHeader from './list/header';
 import PurchasesList from './list';
+import { renderWithReduxStore } from 'lib/react-helpers';
 import sitesFactory from 'lib/sites-list';
 import titleActions from 'lib/screen-title/actions';
 import titles from './titles';
@@ -44,10 +44,11 @@ function recordPageView( path, ...title ) {
 	);
 }
 
-function renderPage( component ) {
-	ReactDom.render(
+function renderPage( context, component ) {
+	renderWithReduxStore(
 		component,
-		document.getElementById( 'primary' )
+		document.getElementById( 'primary' ),
+		context.store
 	);
 }
 
@@ -71,6 +72,7 @@ export default {
 		sites.setSelectedSite( context.params.site );
 
 		renderPage(
+			context,
 			<ManagePurchaseData
 				component={ CancelPrivateRegistration }
 				purchaseId={ context.params.purchaseId }
@@ -91,6 +93,7 @@ export default {
 		sites.setSelectedSite( context.params.site );
 
 		renderPage(
+			context,
 			<ManagePurchaseData
 				component={ CancelPurchase }
 				isDataLoading={ isDataLoading }
@@ -113,6 +116,7 @@ export default {
 		sites.setSelectedSite( context.params.site );
 
 		renderPage(
+			context,
 			<ManagePurchaseData
 				component={ ConfirmCancelDomain }
 				purchaseId={ context.params.purchaseId }
@@ -133,6 +137,7 @@ export default {
 		sites.setSelectedSite( context.params.site );
 
 		renderPage(
+			context,
 			<EditCardDetailsData
 				cardId={ context.params.cardId }
 				component={ EditCardDetails }
@@ -155,6 +160,7 @@ export default {
 		sites.setSelectedSite( context.params.site );
 
 		renderPage(
+			context,
 			<ManagePurchaseData
 				component={ EditPaymentMethod }
 				purchaseId={ context.params.purchaseId }
@@ -170,6 +176,7 @@ export default {
 		);
 
 		renderPage(
+			context,
 			<PurchasesData
 				component={ PurchasesList }
 				noticeType={ context.params.noticeType }
@@ -190,6 +197,7 @@ export default {
 		sites.setSelectedSite( context.params.site );
 
 		renderPage(
+			context,
 			<ManagePurchaseData
 				component={ ManagePurchase }
 				purchaseId={ context.params.purchaseId }
@@ -211,6 +219,7 @@ export default {
 		);
 
 		renderPage(
+			context,
 			<Main>
 				<PurchasesHeader section={ 'purchases' } />
 				<NoSitesMessage />


### PR DESCRIPTION
This pull request fixes #4518 by clearing the site plans when a user cancels a product.

The problem with this solution is it means the logic to clear the site plans has to live in the controller not in the action, but I couldn't find another way.
 
#### Testing instructions

1. Run `git checkout fix/4518-clear-site-plans-after-cancellation` and start your server
1. Purchase a domain
2. Visit /plans/:site and assert that you see a discount on Premium and Business
3. Cancel the domain
4. Visit /plans/:site and assert that you no longer see the discount

#### Reviews

- [x] Code
- [x] Product