### PR TITLE
Checkout: Update the copy on the checkout button for renewals

### DIFF
--- a/client/my-sites/upgrades/checkout/pay-button.jsx
+++ b/client/my-sites/upgrades/checkout/pay-button.jsx
@@ -84,7 +84,7 @@ var PayButton = React.createClass( {
 			}
 
 			if ( cartItems.hasRenewalItem( this.props.cart ) ) {
-				return this.translate( 'Purchase %(price)s subscription', {
+				return this.translate( 'Renew subscription - %(price)s', {
 					args: { price: cart.total_cost_display },
 					context: 'Renew button on /checkout'
 				} );


### PR DESCRIPTION
This pull request fixes #162 by updating the copy on the purchase button:

<img width="765" alt="screen shot 2016-04-05 at 14 57 27" src="https://cloud.githubusercontent.com/assets/275961/14284272/bd0b226c-fb3e-11e5-829f-a394c2f3e056.png">
 
#### Testing instructions

1. Run `git checkout fix/162-purchase-button-for-renewals` and start your server
2. Open the [`Purchases` page](http://calypso.localhost:3000/purchases)
3. Find a purchase with auto renew disabled
4. Attempt to renew the purchase (with the Renew Now button)
5. Assert that the payment button in checkout says "Renew subscription - $XX"
6. Remove the renewal from the cart and a purchase
7. Assert that the payment button in checkout still says "Pay $XX"

#### Reviews

- [x] Code
- [x] Product