### PR TITLE
GuidesTours: Add element highlighting

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -131,6 +131,7 @@ $z-layers: (
 		'popover.is-dialog-visible': 100300,
 		'body .webui-popover': 100300,
 		'.fullscreen-fader': 200000,
+		'.guidestours__overlay': 200050,
 		'.guidestours__step': 201000,
 		'#habla_window_div.habla_window_div_base': 99999999 //olark
 	),

--- a/client/guidestours/index.js
+++ b/client/guidestours/index.js
@@ -32,6 +32,14 @@ export default class GuidesTours extends Component {
 		this.updateTarget( this.state.currentStep );
 	}
 
+	shouldComponentUpdate( nextProps, nextState ) {
+		if ( this.state.currentStep === nextState.currentStep &&
+			this.state.target === nextState.target ) {
+			return false;
+		}
+		return true;
+	}
+
 	componentWillUpdate( nextProps, nextState ) {
 		this.updateTarget( nextState.currentStep );
 	}

--- a/client/guidestours/index.js
+++ b/client/guidestours/index.js
@@ -55,6 +55,7 @@ export default class GuidesTours extends Component {
 
 	quit() {
 		//TODO: should we dispatch a showGuidesTour action here instead?
+		this.currentTarget && this.currentTarget.classList.remove( 'guidestours__overlay' );
 		this.setState( { currentStep: null } );
 	}
 

--- a/client/guidestours/steps.js
+++ b/client/guidestours/steps.js
@@ -116,6 +116,7 @@ class GuidesActionStep extends Component {
 		if ( onNext && target.addEventListener ) {
 			target.addEventListener( 'click', onNext );
 		}
+		target && target.classList.add( 'guidestours__overlay' );
 	}
 
 	removeTargetListener() {
@@ -123,6 +124,7 @@ class GuidesActionStep extends Component {
 		if ( onNext && target.removeEventListener ) {
 			target.removeEventListener( 'click', onNext );
 		}
+		target && target.classList.remove( 'guidestours__overlay' );
 	}
 
 	getBullseyePosition() {

--- a/client/guidestours/style.scss
+++ b/client/guidestours/style.scss
@@ -30,7 +30,51 @@
 	}
 }
 
-// variables for the guidestours__bullseye
+.guidestours__choice-button-row {
+	button {
+		width: 48%;
+	}
+	button:nth-child(1) {
+		margin-right: 4%;
+	}
+	button.guidestours__secondary-button {
+		background: $gray-light;
+		color: darken( $gray, 20% );
+	}
+}
+
+.guidestours__single-button-row {
+	button {
+		width: 100%;
+	}
+}
+
+.guidestours__external-link,
+.guidestours__bullseye-instructions {
+	p {
+		color: darken( $gray, 10 );
+		margin-bottom: 0;
+		font-style: italic;
+	}
+
+	.gridicon {
+		position: relative;
+		top: 7px;
+	}
+
+	.external-link {
+		border-top: 1px solid $gray-light;
+		display: block;
+		padding-top: 8px;
+		margin-top: 16px;
+	}
+}
+
+.guidestours__bullseye-instructions {
+	margin-top: -7px;
+}
+
+// the bullseye used for showing an action step's target
 $animation-speed: 2s;
 $size: 10px;
 $zoom-scale: 5; // the multiplier determining the size of the animated rings
@@ -85,46 +129,33 @@ $zoom-scale: 5; // the multiplier determining the size of the animated rings
 	animation-delay: #{ $animation-speed / 4 };
 }
 
-.guidestours__choice-button-row {
-	button {
-		width: 48%;
+// the overlay with animation present when showing a bullseye
+@keyframes guidestours__overlay-animation {
+	0%, 100% {
+		opacity: 0.4;
 	}
-	button:nth-child(1) {
-		margin-right: 4%;
-	}
-	button.guidestours__secondary-button {
-		background: $gray-light;
-		color: darken( $gray, 20% );
+
+	50% {
+		opacity: 0.7
 	}
 }
 
-.guidestours__single-button-row {
-	button {
-		width: 100%;
-	}
+.guidestours__overlay,
+.guidestours__overlay:hover,
+.guidestours__overlay:focus,
+.guidestours__overlay:visited,
+.guidestours__overlay:active {
+	box-shadow: 0 0 0 9999px rgba( $gray-light, 0.8 );
+	transition: box-shadow 300ms ease-in-out;
+	z-index: z-index( 'root', '.guidestours__overlay' );
 }
 
-.guidestours__external-link,
-.guidestours__bullseye-instructions {
-	p {
-		color: darken( $gray, 10 );
-		margin-bottom: 0;
-		font-style: italic;
-	}
-
-	.gridicon {
-		position: relative;
-		top: 7px;
-	}
-
-	.external-link {
-		border-top: 1px solid $gray-light;
-		display: block;
-		padding-top: 8px;
-		margin-top: 16px;
-	}
-}
-
-.guidestours__bullseye-instructions {
-	margin-top: -7px;
+.guidestours__overlay:before {
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	content: " ";
+	margin-left: -15px;
+	animation: guidestours__overlay-animation 3s ease-in-out 300ms infinite;
+	opacity: 0.4;
 }


### PR DESCRIPTION
Closes #4381. 

In GuidesTours / GuidedTours, an `ActionStep` highlights a UI element we want the user to click to move the tour forward. So far, the highlighting has been done with a little pulsating dot. It looks nice, but isn't too attention-grabbing. 

To help the user focus on the element better, this PR adds an overlay that fades out the rest of the UI and adds a pulsating border to the element (see screenshot). 

The fading out is done using a ridiculously large box-shadow — props to @ehg for coming up with this. It works better cross-browser than CSS masks (not supported in IE) and is less brittle than using canvas. 

The pulsating border is a box shadow on the `::before` pseudo-element that is animated using the element's `opacity`, which is much easier on the CPU than animating the box shadow directly. 

While working on this we also discovered that the whole `GuidesTours` component re-rendered itself and its children every 30 seconds, which apparently was some polling going on somewhere else. The added `shouldComponentUpdate` helps remove these unnecessary re-renders. 

<img width="589" alt="screen shot 2016-04-11 at 11 58 07 am" src="https://cloud.githubusercontent.com/assets/23619/14423891/788edb16-ffde-11e5-9ee2-2b70a239fb0b.png">

To test:

- open (e.g.) http://calypso.localhost:3000/me?tour=yes
- click through the sample tour
- for the steps that highlight UI elements, check whether everything is positioned correctly and is performant enough
- we're grateful for checks across different platforms, mobile support is forthcoming though
