### PR TITLE
Checkout: Add text to make it clear when a purchase is an annual subscription

### DIFF
--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -109,6 +109,9 @@ module.exports = React.createClass( {
 
 	render: function() {
 		var name = this.getProductName();
+		if ( this.props.cartItem.bill_period && this.props.cartItem.bill_period !== -1 ) {
+			name += ' - ' + this.translate( 'annual subscription' );
+		}
 
 		return (
 			<li className="cart-item">


### PR DESCRIPTION
This pull request fixes #285 by adding ` - annual subscription` to the product name when a product has a bill period. Premium themes are one time purchases.

<img width="234" alt="screen shot 2016-04-05 at 17 23 05" src="https://cloud.githubusercontent.com/assets/275961/14289526/160eb360-fb53-11e5-8f45-98b6b7b97b12.png">
 
#### Testing instructions

1. Run `git checkout fix/285-add-subscription-text` and start your server
2. Add a Premium Plan and a Premium Theme to your cart
3. Go to `/checkout` assert that you see the text ` - annual subscription` next to the Premium plan but not next to the theme.

#### Reviews

- [x] Code
- [x] Product