### PR TITLE
Reader: fix Follow button hover color in Tag and List streams

### DIFF
--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -38,11 +38,46 @@
 		z-index: z-index( 'reader-card-follow-button-parent', '.reader__card.card .follow-button' );
 		padding-right: 0;
 
+		.follow-button__label {
+			color: $gray;
+		}
+
+		&:hover {
+			background: none;
+
+			.gridicon {
+				fill: $blue-medium;
+			}
+
+			.follow-button__label {
+				cursor: pointer;
+				color: $blue-medium;
+			}
+		}
+
 		@include breakpoint( "<480px" ) {
 			top: 0;
 			right: 8px;
 		}
+	}
 
+	.follow-button.is-following {
+		.follow-button__label {
+			color: $alert-green;
+		}
+
+		&:hover {
+			background: none;
+
+			.gridicon {
+				fill: lighten( $gray, 10% );
+			}
+
+			.follow-button__label {
+				cursor: pointer;
+				color: lighten( $gray, 10% );
+			}
+		}
 	}
 
 	.reader-post-byline {


### PR DESCRIPTION
This PR updates the Follow button hover color in Tag and List streams from `$alert-green` to `$blue-medium`. 

Small fix that I missed in: https://github.com/Automattic/wp-calypso/pull/3721

**Before:**
<img width="736" alt="screenshot 2016-04-05 10 03 18" src="https://cloud.githubusercontent.com/assets/4924246/14291000/2608d74c-fb16-11e5-8c15-12f1ff227411.png">

**After:**
<img width="735" alt="screenshot 2016-04-05 10 07 34" src="https://cloud.githubusercontent.com/assets/4924246/14291010/3bab9648-fb16-11e5-8767-595c89ad0373.png">

