### PR TITLE
CPT: Show empty content display when no posts exist

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -5,6 +5,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import map from 'lodash/map';
 import find from 'lodash/find';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -38,7 +39,7 @@ const PostTypeFilter = React.createClass( {
 		const { query, siteSlug, counts } = this.props;
 
 		return map( counts, ( count, status ) => {
-			if ( ! count ) {
+			if ( ! count && ! includes( [ 'publish', 'draft' ], status ) ) {
 				return;
 			}
 

--- a/client/my-sites/post-type-list/empty-content.jsx
+++ b/client/my-sites/post-type-list/empty-content.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import localize from 'lib/mixins/i18n/localize';
+import { getPostType } from 'state/post-types/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPath } from 'state/ui/editor/selectors';
+import QueryPostTypes from 'components/data/query-post-types';
+import EmptyContent from 'components/empty-content/empty-content';
+
+function PostTypeListEmptyContent( { siteId, translate, status, typeObject, editPath } ) {
+	let title, action;
+
+	if ( 'draft' === status ) {
+		title = translate( 'You don\'t have any drafts.' );
+	} else if ( typeObject ) {
+		title = translate( 'You don\'t have any %s.', {
+			args: [ typeObject.label.toLocaleLowerCase() ]
+		} );
+	}
+
+	if ( typeObject ) {
+		action = translate( 'Start a %s', {
+			args: [ typeObject.labels.singular_name ]
+		} );
+	}
+
+	return (
+		<div>
+			{ siteId && (
+				<QueryPostTypes siteId={ siteId } />
+			) }
+			<EmptyContent
+				title={ title }
+				line={ translate( 'Would you like to create one?' ) }
+				action={ action }
+				actionURL={ editPath }
+				illustration="/calypso/images/pages/illustration-pages.svg"
+				illustrationWidth={ 150 } />
+		</div>
+	);
+}
+
+PostTypeListEmptyContent.propTypes = {
+	siteId: PropTypes.number,
+	translate: PropTypes.func,
+	type: PropTypes.string,
+	status: PropTypes.string,
+	typeObject: PropTypes.object,
+	editPath: PropTypes.string
+};
+
+export default connect( ( state, ownProps ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+		typeObject: getPostType( state, siteId, ownProps.type ),
+		editPath: getEditorPath( state, siteId, null, ownProps.type )
+	};
+} )( localize( PostTypeListEmptyContent ) );

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -15,6 +15,7 @@ import {
 } from 'state/posts/selectors';
 import PostTypeListPost from './post';
 import PostTypeListPostPlaceholder from './post-placeholder';
+import PostTypeListEmptyContent from './empty-content';
 
 function PostTypeList( { query, siteId, posts, requesting } ) {
 	return (
@@ -22,6 +23,11 @@ function PostTypeList( { query, siteId, posts, requesting } ) {
 			<QueryPosts
 				siteId={ siteId }
 				query={ query } />
+			{ posts && ! posts.length && ! requesting && (
+				<PostTypeListEmptyContent
+					type={ query.type }
+					status={ query.status } />
+			) }
 			<ul className="post-type-list__posts">
 				{ requesting && (
 					<li><PostTypeListPostPlaceholder /></li>


### PR DESCRIPTION
This pull request seeks to display an `<EmptyContent />` component on the custom post type list page when no posts are found. Further, it changes the behavior of the filter bar to always display Published and Drafts statuses, mirroring the behavior of posts listing screen.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/14294212/dc396a0a-fb3d-11e5-814b-7b549fd4691b.png)|![After](https://cloud.githubusercontent.com/assets/1779930/14294107/71177f28-fb3d-11e5-9bc1-00ec38e45e3e.png)

__Testing instructions:__

Verify that an `<EmptyContent />` component is displayed for a site or status where no custom post types exist.

1. Navigate to [My Sites](http://calypso.localhost:3000/sites)
2. Select a site where a custom post type is supported
3. Navigate to the custom post type from its sidebar navigation item
4. Note that...
 - While posts are requested, a temporary placeholder is shown
 - If posts exist, they are shown after request completes (or if posts have been persisted previously)
 - If no posts exist, an `<EmptyContent />` component is shown