### PR TITLE
Reader: Basics for search stream

### DIFF
--- a/client/lib/feed-stream-store/feed-stream-cache.js
+++ b/client/lib/feed-stream-store/feed-stream-cache.js
@@ -1,10 +1,24 @@
-var feedStreams = {};
+import lruCache from 'lru-cache';
+
+const cache = lruCache( 10 );
+const specialCache = {};
+
+function isSpecialStream( id ) {
+	return /^following|a8c|likes/.test( id );
+}
 
 module.exports = {
 	get: function( id ) {
-		return feedStreams[ id ];
+		if ( isSpecialStream( id ) ) {
+			return specialCache[ id ];
+		}
+		return cache.get( id );
 	},
 	set: function( id, store ) {
-		feedStreams[ id ] = store ;
+		if ( isSpecialStream( id ) ) {
+			specialCache[ id ] = store;
+		} else {
+			cache.set( id, store );
+		}
 	}
 };

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -3,6 +3,7 @@
  */
 var Dispatcher = require( 'dispatcher' ),
 	FeedStream = require( './feed-stream' ),
+	PagedStream = require( './paged-stream' ),
 	FeedStreamCache = require( './feed-stream-cache' ),
 	wpcomUndoc = require( 'lib/wp' ).undocumented();
 
@@ -72,6 +73,20 @@ function getStoreForTag( storeId ) {
 		onGapFetch: limitSiteParams,
 		onUpdateFetch: limitSiteParams,
 		dateProperty: 'tagged_on'
+	} );
+}
+
+function getStoreForSearch( storeId ) {
+	const slug = storeId.split( ':' )[ 1 ];
+	const fetcher = function( query, callback ) {
+		query.q = slug;
+		wpcomUndoc.readSearch( query, callback );
+	};
+
+	return new PagedStream( {
+		id: storeId,
+		fetcher: fetcher,
+		keyMaker: siteKeyMaker
 	} );
 }
 
@@ -164,7 +179,9 @@ function feedStoreFactory( storeId ) {
 		store = getStoreForSite( storeId );
 	} else if ( storeId.indexOf( 'featured:' ) === 0 ) {
 		store = getStoreForFeatured( storeId );
-	} else {
+	} else if ( storeId.indexOf( 'search:' ) === 0 ) {
+		store = getStoreForSearch( storeId );
+	}else {
 		throw new Error( 'Unknown feed store ID' );
 	}
 

--- a/client/lib/feed-stream-store/paged-stream.js
+++ b/client/lib/feed-stream-store/paged-stream.js
@@ -1,0 +1,258 @@
+/**
+ * External Dependencies
+ */
+var assign = require( 'lodash/assign' ),
+	debug = require( 'debug' )( 'calypso:feed-store:post-list-store' ),
+	filter = require( 'lodash/filter' ),
+	forEach = require( 'lodash/forEach' ),
+	map = require( 'lodash/map' );
+
+/**
+ * Internal Dependencies
+ */
+var Dispatcher = require( 'dispatcher' ),
+	Emitter = require( 'lib/mixins/emitter' ),
+	FeedPostStore = require( 'lib/feed-post-store' ),
+	ActionTypes = require( './constants' ).action;
+
+var PagedStream = function( spec ) {
+	if ( ! spec ) {
+		throw new Error( 'must supply a paged stream spec' );
+	}
+
+	if ( ! spec.id ) {
+		throw new Error( 'missing id' );
+	}
+
+	if ( ! spec.fetcher ) {
+		throw new Error( 'missing fetcher' );
+	}
+
+	if ( ! spec.keyMaker ) {
+		throw new Error( 'must supply keyMaker' );
+	}
+
+	this.id = spec.id;
+
+	assign( this, {
+		id: spec.id,
+		postKeys: [], // an array of keys, as determined by the key maker,
+		pendingPostKeys: [],
+		postById: {},
+		errors: [],
+		fetcher: spec.fetcher,
+		page: 1,
+		perPage: 20,
+		query: spec.query,
+		selectedIndex: -1,
+		orderBy: 'date',
+		_isLastPage: false,
+		_isFetchingNextPage: false,
+		keyMaker: spec.keyMaker
+	} );
+};
+
+assign( PagedStream.prototype, {
+
+	handlePayload: function( payload ) {
+		var action = payload && payload.action;
+
+		if ( ! action ) {
+			return;
+		}
+
+		if ( action.id !== this.id ) {
+			return;
+		}
+
+		Dispatcher.waitFor( [ FeedPostStore.dispatchToken ] );
+
+		switch ( action.type ) {
+
+			case ActionTypes.RECEIVE_PAGE:
+				this.receivePage( action.id, action.error, action.data );
+				break;
+			case ActionTypes.FETCH_NEXT_PAGE:
+				this.setIsFetchingNextPage( true );
+				break;
+			case ActionTypes.SELECT_ITEM:
+				this.selectItem( action.selectedIndex );
+				break;
+			case ActionTypes.SELECT_NEXT_ITEM:
+				this.selectNextItem( action.selectedIndex );
+				break;
+			case ActionTypes.SELECT_PREV_ITEM:
+				this.selectPrevItem( action.selectedIndex );
+				break;
+			case ActionTypes.CHANGE_QUERY:
+				this.resetQuery( action.query );
+				break;
+		}
+	},
+
+	get: function() {
+		return this.postKeys;
+	},
+
+	getID: function() {
+		return this.id;
+	},
+
+	getAll: function() {
+		return map( this.postKeys, function( key ) {
+			return FeedPostStore.get( key );
+		} );
+	},
+
+	getPage: function() {
+		return this.page;
+	},
+
+	getPerPage: function() {
+		return this.perPage;
+	},
+
+	getUpdateCount: function() {
+		return 0;
+	},
+
+	getSelectedPost: function() {
+		if ( this.selectedIndex >= 0 && this.selectedIndex < this.postKeys.length ) {
+			return this.postKeys[ this.selectedIndex ];
+		}
+		return null;
+	},
+
+	getSelectedIndex: function() {
+		return this.selectedIndex;
+	},
+
+	isLastPage: function() {
+		return this._isLastPage;
+	},
+
+	isFetchingNextPage: function() {
+		return this._isFetchingNextPage;
+	},
+
+	_isValidPostOrGap: function( postKey ) {
+		var post = FeedPostStore.get( postKey );
+		return post && post._state !== 'error' && post._state !== 'pending' &&
+			post._state !== 'minimal';
+	},
+
+	selectNextItem: function( selectedIndex ) {
+		var nextIndex = selectedIndex + 1;
+		if ( nextIndex > -1 && nextIndex < this.postKeys.length ) {
+			if ( this._isValidPostOrGap( this.postKeys[ nextIndex ] ) ) {
+				this.selectedIndex = nextIndex;
+				this.emit( 'change' );
+			} else {
+				this.selectNextItem( nextIndex );
+			}
+		}
+	},
+
+	selectPrevItem: function( selectedIndex ) {
+		var nextIndex = selectedIndex - 1;
+		if ( nextIndex > -1 && nextIndex < this.postKeys.length ) {
+			if ( this._isValidPostOrGap( this.postKeys[ nextIndex ] ) ) {
+				this.selectedIndex = nextIndex;
+				this.emit( 'change' );
+			} else {
+				this.selectPrevItem( nextIndex );
+			}
+		}
+	},
+
+	selectItem: function( selectedIndex ) {
+		this.selectNextItem( selectedIndex - 1 );
+	},
+
+	onNextPageFetch: function( params ) {
+		params.offset = this.page * this.perPage;
+		params.before = undefined;
+		params.after = undefined;
+		params.number = 5;
+	},
+
+	getLastItemWithDate: function() {
+		return null;
+	},
+
+	getFirstItemWithDate: function() {
+		return null;
+	},
+
+	hasRecentError: function( errorType ) {
+		var aMinuteAgo = Date.now() - ( 60 * 1000 );
+		return this.errors.some( function( error ) {
+			return ( error.timestamp && error.timestamp > aMinuteAgo ) && ( ! errorType || errorType === error.error );
+		} );
+	},
+
+	setIsFetchingNextPage: function( val ) {
+		this._isFetchingNextPage = val;
+		this.emit( 'change' );
+	},
+
+	filterNewPosts: function( posts ) {
+		const postById = this.postById;
+		posts = filter( posts, function( post ) {
+			return ! ( post.ID in postById );
+		} );
+		return map( posts, this.keyMaker );
+	},
+
+	getSitesCrossPostedTo: function() {
+		return null;
+	},
+
+	receivePage: function( id, error, data ) {
+		var posts, postKeys;
+
+		if ( id !== this.id ) {
+			return;
+		}
+
+		debug( 'receiving page in %s', this.id );
+
+		this._isFetchingNextPage = false;
+
+		if ( error ) {
+			debug( 'Error fetching posts from API:', error );
+			error.timestamp = Date.now();
+			this.errors.push( error );
+			this.emit( 'change' );
+			return;
+		}
+
+		posts = data && data.posts;
+
+		if ( ! posts ) {
+			return;
+		}
+
+		if ( ! posts.length ) {
+			this._isLastPage = true;
+			this.emit( 'change' );
+			return;
+		}
+
+		postKeys = this.filterNewPosts( posts );
+
+		if ( postKeys.length ) {
+			const postById = this.postById;
+			forEach( postKeys, function( postKey ) {
+				postById[ postKey.postId ] = true;
+			} );
+			this.postKeys = this.postKeys.concat( postKeys );
+			this.page++;
+			this.emit( 'change' );
+		}
+	}
+} );
+
+Emitter( PagedStream.prototype );
+
+module.exports = PagedStream;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1091,6 +1091,12 @@ Undocumented.prototype.readFeedPost = function( query, fn ) {
 	this.wpcom.req.get( '/read/feed/' + encodeURIComponent( query.feedId ) + '/posts/' + encodeURIComponent( query.postId ), params, fn );
 };
 
+Undocumented.prototype.readSearch = function( query, fn ) {
+	debug( '/read/search', query );
+	const params = Object.assign( { apiVersion: '1.2' }, query );
+	this.wpcom.req.get( '/read/search', params, fn );
+};
+
 Undocumented.prototype.readTag = function( query, fn ) {
 	var params = omit( query, 'slug' );
 	debug( '/read/tag/' + query.slug );

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -7,7 +7,8 @@ const ReactDom = require( 'react-dom' ),
 	debug = require( 'debug' )( 'calypso:reader:controller' ),
 	trim = require( 'lodash/trim' ),
 	moment = require( 'moment' ),
-	ReduxProvider = require( 'react-redux' ).Provider;
+	ReduxProvider = require( 'react-redux' ).Provider,
+	qs = require( 'qs' );
 
 /**
  * Internal Dependencies
@@ -85,7 +86,7 @@ function userHasHistory( context ) {
 
 function ensureStoreLoading( store, context ) {
 	if ( store.getPage() === 1 ) {
-		if ( context.query.at ) {
+		if ( context && context.query && context.query.at ) {
 			const startDate = moment( context.query.at );
 			if ( startDate.isValid() ) {
 				store.startDate = startDate.format();
@@ -390,6 +391,51 @@ module.exports = {
 				),
 				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
 				showBack: userHasHistory( context )
+			} ),
+			document.getElementById( 'primary' )
+		);
+	},
+
+	search: function( context ) {
+		var SearchStream = require( 'reader/search-stream' ),
+			basePath = '/read/search',
+			fullAnalyticsPageTitle = analyticsPageTitle + ' > Search',
+			searchSlug = context.query.q,
+			mcKey = 'search';
+
+		let store;
+		if ( searchSlug ) {
+			store = feedStreamFactory( 'search:' + searchSlug ),
+			ensureStoreLoading( store, context );
+		}
+
+		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+		stats.recordTrack( 'calypso_reader_search_loaded', searchSlug && {
+			query: searchSlug
+		} );
+
+		ReactDom.render(
+			React.createElement( SearchStream, {
+				key: 'search',
+				store: store,
+				query: searchSlug,
+				setPageTitle: setPageTitle,
+				trackScrollPage: trackScrollPage.bind(
+					null,
+					basePath,
+					fullAnalyticsPageTitle,
+					analyticsPageTitle,
+					mcKey
+				),
+				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+				showBack: false,
+				onQueryChange: function( newValue ) {
+					let searchUrl = '/read/search';
+					if ( newValue ) {
+						searchUrl += '?' + qs.stringify( { q: newValue } );
+					}
+					page.replace( searchUrl );
+				}
 			} ),
 			document.getElementById( 'primary' )
 		);

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -64,6 +64,9 @@ module.exports = function() {
 	}
 
 	page( '/read/a8c', updateLastRoute, controller.removePost, controller.sidebar, forceTeamA8C, controller.readA8C );
+	if ( config.isEnabled( 'reader/search' ) ) {
+		page( '/read/search', updateLastRoute, controller.removePost, controller.sidebar, controller.search );
+	}
 
 	page( '/read/list/:user/:list', updateLastRoute, controller.removePost, controller.sidebar, controller.listListing );
 

--- a/client/reader/search-stream/README.md
+++ b/client/reader/search-stream/README.md
@@ -1,0 +1,8 @@
+# Search Stream
+
+A post stream that shows posts from a search
+
+## Props
+
+- `query`: a string representing the query
+- see `reader/following-stream` for more

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -1,0 +1,57 @@
+const React = require( 'react' );
+
+const EmptyContent = require( 'components/empty-content' ),
+	stats = require( 'reader/stats' ),
+	discoverHelper = require( 'reader/discover/helper' );
+
+const SearchEmptyContent = React.createClass( {
+
+	propTypes: {
+		query: React.PropTypes.string
+	},
+
+	shouldComponentUpdate: function() {
+		return false;
+	},
+
+	recordAction: function() {
+		stats.recordAction( 'clicked_following_on_empty' );
+		stats.recordGaEvent( 'Clicked Following on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_following_on_empty_search_stream_clicked' );
+	},
+
+	recordSecondaryAction: function() {
+		stats.recordAction( 'clicked_discover_on_empty' );
+		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_discover_on_empty_search_stream_clicked' );
+	},
+
+	render: function() {
+		const action = ( <a
+			className="empty-content__action button is-primary"
+			onClick={ this.recordAction }
+			href="/">{ this.translate( 'Back to Following' ) }</a> );
+
+		const secondaryAction = discoverHelper.isEnabled()
+			? ( <a
+			className="empty-content__action button"
+			onClick={ this.recordSecondaryAction }
+			href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
+
+		const message = this.translate(
+			'No posts found for {{query /}} for your language.',
+			{ components: { query: <em>{ this.props.query }</em> } }
+		);
+
+		return ( <EmptyContent
+			title={ this.translate( 'No Results' ) }
+			line={ message }
+			action={ action }
+			secondaryAction={ secondaryAction }
+			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+			illustrationWidth={ 500 }
+			/> );
+	}
+} );
+
+module.exports = SearchEmptyContent;

--- a/client/reader/search-stream/index.jsx
+++ b/client/reader/search-stream/index.jsx
@@ -1,0 +1,114 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import ReactDom from 'react-dom';
+import debounce from 'lodash/debounce';
+
+/**
+ * Internal Dependencies
+ */
+import FollowingStream from 'reader/following-stream';
+import EmptyContent from './empty';
+import StreamHeader from 'reader/stream-header';
+import HeaderBack from 'reader/header-back';
+import Gridicon from 'components/gridicon';
+import FormTextInput from 'components/forms/form-text-input';
+
+//const stats = require( 'reader/stats' );
+
+const emptyStore = {
+	get() {
+		return [];
+	},
+	isLastPage() {
+		return true;
+	},
+	getUpdateCount() {
+		return 0;
+	},
+	getSelectedIndex() {
+		return -1;
+	},
+	on() {},
+	off() {}
+}
+
+const FeedStream = React.createClass( {
+
+	propTypes: {
+		query: React.PropTypes.string
+	},
+
+	getInitialState() {
+		return {
+			title: this.getTitle()
+		};
+	},
+
+	componentWillMount() {
+		this.debouncedUpdate = debounce( this.updateQuery, 300 );
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.query !== this.props.query ) {
+			this.updateState( nextProps );
+		}
+	},
+
+	updateState( props = this.props ) {
+		var newState = {
+			title: this.getTitle( props )
+		};
+		if ( newState.title !== this.state.title ) {
+			this.setState( newState );
+		}
+	},
+
+	getTitle( props = this.props ) {
+		return props.query;
+	},
+
+	updateQuery() {
+		console.log( 'checking at ', Date.now() );
+		if ( ! this.isMounted() ) {
+			return;
+		}
+		const newValue = ReactDom.findDOMNode( this.refs.searchInput ).value;
+		console.log( 'new value', newValue );
+		this.props.onQueryChange( newValue );
+	},
+
+	render() {
+		const emptyContent = this.props.query
+			? <EmptyContent query={ this.props.query } />
+			: <div>{ this.translate( 'What would you like to find?' ) }</div>;
+
+		if ( this.props.setPageTitle ) {
+			this.props.setPageTitle( this.state.title || this.translate( 'Search' ) );
+		}
+
+		const store = this.props.store || emptyStore;
+
+		return (
+			<FollowingStream { ...this.props } store={ store }
+				listName={ this.state.title }
+				emptyContent={ emptyContent }
+				showFollowInHeader={ true } >
+				{ this.props.showBack && <HeaderBack /> }
+				<h2>{ this.translate( 'Search' ) }</h2>
+				<p>
+					<FormTextInput type="text" value={ undefined } defaultValue={ this.props.query } ref="searchInput" onChange={ this.debouncedUpdate } placeholder={ this.translate( 'Enter a search term' ) } />
+				</p>
+				{ this.props.query && <StreamHeader
+					isPlaceholder={ false }
+					icon={ <Gridicon icon="search" /> }
+					title={ this.state.title }
+					showFollow={ false } />
+				}
+			</FollowingStream>
+		);
+	}
+} );
+
+export default FeedStream;

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -181,6 +181,17 @@ const ReaderSidebar = React.createClass( {
 								) : null
 						}
 
+						{ config.isEnabled( 'reader/search' ) &&
+							(
+								<li className={ ReaderSidebarHelper.itemLinkClass( '/read/search', this.props.path, { 'sidebar-streams__search': true } ) }>
+									<a href="/read/search">
+										<Gridicon icon="search" size={ 24 } />
+										<span className="menu-link-text">{ this.translate( 'Search' ) }</span>
+									</a>
+								</li>
+							)
+						}
+
 						<li className={ ReaderSidebarHelper.itemLinkClassStartsWithOneOf( [ '/recommendations', '/tags' ], this.props.path, { 'sidebar-streams__recommendations': true } ) }>
 							<a href="/recommendations">
 								<Gridicon icon="thumbs-up" size={ 24 } />

--- a/config/development.json
+++ b/config/development.json
@@ -100,6 +100,7 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
+		"reader/search": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -77,6 +77,7 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
+		"reader/search": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,


### PR DESCRIPTION
Hooks up a basic search sidebar item and screen so the data folks can iterate on results and algos. This is _not_ the final look and feel for this, just the first step to get them on their way.

It does make one slightly scary change: introducing an LRU cache to manage feed streams. This is something I've been wanting to do for ages and this seemed like a good spot to do it, since we have a search store per search term.