### PR TITLE
Purchases: Clear purchases store after purchasing any item

### DIFF
--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -136,9 +136,9 @@ const Checkout = React.createClass( {
 		var renewalItem,
 			receiptId = ':receiptId';
 
-		if ( cartItems.hasRenewalItem( this.props.cart ) ) {
-			clearPurchases();
+		clearPurchases();
 
+		if ( cartItems.hasRenewalItem( this.props.cart ) ) {
 			renewalItem = cartItems.getRenewalItems( this.props.cart )[ 0 ];
 
 			return purchasePaths.managePurchaseDestination( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId, 'thank-you' );


### PR DESCRIPTION
Currently, we only clear the purchases store when a user purchases a renewal. Because any purchase affects the list on `/purchases`, we should clear the purchases whenever the user purchases anything.

Fixes #4499.

**Testing**
- Visit `/purchases`.
- Visit `/plans/:site` for a site without a plan.
- Upgrade to either the premium or business plan.
- Visit `/purchases` in the same browsing session by navigating through the avatar link in the masterbar.
- Assert that the purchases are reloaded and that the plan you just purchased appears once the list loads.

- [x] Code review
- [x] Product review