### PR TITLE
Purchases: Remove notices associated with path fragments when possible

### DIFF
--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -15,6 +15,7 @@ import HeaderCake from 'components/header-cake';
 import { isDataLoading, goToManagePurchase, recordPageView } from '../utils';
 import { isRefundable } from 'lib/purchases';
 import Main from 'components/main';
+import notices from 'notices';
 import Notice from 'components/notice';
 import paths from '../paths';
 import titles from 'me/purchases/titles';
@@ -47,7 +48,7 @@ const CancelPrivateRegistration = React.createClass( {
 		// We call blur on the cancel button to remove the blue outline that shows up when you click on the button
 		event.target.blur();
 
-		const { id } = this.props.selectedPurchase.data;
+		const { id, meta: domain } = this.props.selectedPurchase.data;
 
 		this.setState( {
 			disabled: true,
@@ -61,7 +62,11 @@ const CancelPrivateRegistration = React.createClass( {
 			} );
 
 			if ( success ) {
-				page( paths.managePurchaseDestination( this.props.selectedSite.slug, id, 'canceled-private-registration' ) );
+				notices.success( this.translate( 'You have successfully canceled private registration for %(domain)s.', {
+					args: { domain }
+				} ), { persistent: true } );
+
+				page( paths.managePurchase( this.props.selectedSite.slug, id ) );
 			}
 		} );
 	},

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import page from 'page';
 import React from 'react';
 
 /**
@@ -15,17 +16,20 @@ import EditCardDetails from './payment/edit-card-details';
 import EditCardDetailsData from 'components/data/purchases/edit-card-details';
 import EditCardDetailsLoadingPlaceholder from './payment/edit-card-details/loading-placeholder';
 import EditPaymentMethod from './payment/edit-payment-method';
+import i18n from 'lib/mixins/i18n';
 import { isDataLoading } from './utils';
 import Main from 'components/main';
 import ManagePurchase from './manage-purchase';
 import ManagePurchaseData from 'components/data/purchases/manage-purchase';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
+import notices from 'notices';
 import paths from './paths';
 import PurchasesData from 'components/data/purchases';
 import PurchasesHeader from './list/header';
 import PurchasesList from './list';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import sitesFactory from 'lib/sites-list';
+import supportPaths from 'lib/url/support';
 import titleActions from 'lib/screen-title/actions';
 import titles from './titles';
 import userFactory from 'lib/user';
@@ -182,6 +186,31 @@ export default {
 				noticeType={ context.params.noticeType }
 				sites={ sites } />
 		);
+	},
+
+	listNotice( context ) {
+		page.redirect( paths.list() );
+
+		const { noticeType } = context.params;
+
+		if ( noticeType === 'cancel-success' ) {
+			notices.success( i18n.translate(
+				'Your purchase was canceled and refunded. The refund may take up to ' +
+				'7 days to appear in your PayPal/bank/credit card account.'
+			), { persistent: true } );
+		}
+
+		if ( noticeType === 'cancel-problem' ) {
+			notices.error( i18n.translate(
+				'There was a problem canceling your purchase. ' +
+				'Please {{a}}contact support{{/a}} for more information.',
+				{
+					components: {
+						a: <a href={ supportPaths.CALYPSO_CONTACT } />
+					}
+				}
+			), { persistent: true } );
+		}
 	},
 
 	managePurchase( context ) {

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -64,11 +64,4 @@ export default function() {
 		controller.noSitesMessage,
 		controller.managePurchase
 	);
-
-	page(
-		paths.managePurchaseDestination(),
-		meController.sidebar,
-		controller.noSitesMessage,
-		controller.managePurchase
-	);
 };

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -55,9 +55,7 @@ export default function() {
 
 	page(
 		paths.listNotice(),
-		meController.sidebar,
-		controller.noSitesMessage,
-		controller.list
+		controller.listNotice
 	);
 
 	page(

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -11,55 +11,14 @@ import EmptyContent from 'components/empty-content';
 import { getPurchasesBySite } from 'lib/purchases';
 import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
-import Notice from 'components/notice';
 import PurchasesHeader from './header';
 import PurchasesSite from './site';
-import support from 'lib/url/support';
 
 const PurchasesList = React.createClass( {
 	propTypes: {
 		noticeType: React.PropTypes.string,
 		purchases: React.PropTypes.object.isRequired,
 		sites: React.PropTypes.object.isRequired
-	},
-
-	renderNotice() {
-		const { noticeType } = this.props;
-
-		if ( ! noticeType ) {
-			return null;
-		}
-
-		let message, status;
-
-		if ( 'cancel-success' === noticeType ) {
-			message = this.translate(
-				'Your purchase was canceled and refunded. The refund may take up to ' +
-				'7 days to appear in your PayPal/bank/credit card account.'
-			);
-
-			status = 'is-success';
-		}
-
-		if ( 'cancel-problem' === noticeType ) {
-			message = this.translate(
-				'There was a problem canceling your purchase. ' +
-				'Please {{a}}contact support{{/a}} for more information.',
-				{
-					components: {
-						a: <a href={ support.CALYPSO_CONTACT } />
-					}
-				}
-			);
-
-			status = 'is-error';
-		}
-
-		return (
-			<Notice showDismiss={ false } status={ status }>
-				{ message }
-			</Notice>
-		);
 	},
 
 	isDataLoading() {
@@ -106,7 +65,6 @@ const PurchasesList = React.createClass( {
 
 		return (
 			<span>
-				{ this.renderNotice() }
 				<Main className="purchases-list">
 					<MeSidebarNavigation />
 					<PurchasesHeader section={ 'purchases' } />

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -210,43 +210,6 @@ const ManagePurchase = React.createClass( {
 		}
 	},
 
-	renderPathNotice() {
-		if ( isDataLoading( this.props ) || ! this.props.destinationType ) {
-			return;
-		}
-
-		const purchase = getPurchase( this.props );
-		let text;
-
-		if ( 'thank-you' === this.props.destinationType ) {
-			text = this.translate( '%(purchaseName)s has been renewed and will now auto renew in the future. {{a}}Learn more{{/a}}', {
-				args: {
-					purchaseName: getName( purchase )
-				},
-				components: {
-					a: <a href="https://support.wordpress.com/auto-renewal/" target="_blank" />
-				}
-			} );
-		}
-
-		if ( 'canceled-private-registration' === this.props.destinationType ) {
-			text = this.translate( 'You have successfully canceled private registration for %(domain)s.', {
-				args: {
-					domain: purchase.meta
-				}
-			} );
-		}
-
-		return (
-			<Notice
-				className="manage-purchase__path-notice"
-				showDismiss={ false }
-				status="is-success">
-				{ text }
-			</Notice>
-		);
-	},
-
 	handleRenew() {
 		const purchase = getPurchase( this.props ),
 			renewItem = cartItems.getRenewalItemFromProduct( purchase, {
@@ -673,7 +636,6 @@ const ManagePurchase = React.createClass( {
 
 		return (
 			<span>
-				{ this.renderPathNotice() }
 				<Main className="manage-purchase">
 					<HeaderCake onClick={ goToList }>
 						{ titles.managePurchase }

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -10,10 +10,6 @@ function managePurchase( siteName = ':site', purchaseId = ':purchaseId' ) {
 	return list() + `/${ siteName }/${ purchaseId }`;
 }
 
-function managePurchaseDestination( siteName = ':site', purchaseId = ':purchaseId', destinationType = ':destinationType?' ) {
-	return managePurchase( siteName, purchaseId ) + `/${ destinationType }`;
-}
-
 function cancelPurchase( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/cancel';
 }
@@ -47,6 +43,5 @@ export default {
 	editSpecificCardDetails,
 	list,
 	listNotice,
-	managePurchase,
-	managePurchaseDestination
+	managePurchase
 };

--- a/client/my-sites/upgrades/checkout/checkout.jsx
+++ b/client/my-sites/upgrades/checkout/checkout.jsx
@@ -23,7 +23,9 @@ var analytics = require( 'analytics' ),
 	SecurePaymentForm = require( './secure-payment-form' ),
 	getExitCheckoutUrl = require( 'lib/checkout' ).getExitCheckoutUrl,
 	upgradesActions = require( 'lib/upgrades/actions' ),
-	transactionStepTypes = require( 'lib/store-transactions/step-types' );
+	transactionStepTypes = require( 'lib/store-transactions/step-types' ),
+	notices = require( 'notices' ),
+	supportPaths = require( 'lib/url/support' );
 
 const Checkout = React.createClass( {
 	mixins: [ observe( 'sites', 'cards', 'productsList' ) ],
@@ -141,7 +143,19 @@ const Checkout = React.createClass( {
 		if ( cartItems.hasRenewalItem( this.props.cart ) ) {
 			renewalItem = cartItems.getRenewalItems( this.props.cart )[ 0 ];
 
-			return purchasePaths.managePurchaseDestination( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId, 'thank-you' );
+			notices.success(
+				this.translate( '%(productName)s has been renewed and will now auto renew in the future. {{a}}Learn more{{/a}}', {
+					args: {
+						productName: renewalItem.product_name
+					},
+					components: {
+						a: <a href={ supportPaths.AUTO_RENEWAL } target="_blank" />
+					}
+				} ),
+				{ persistent: true }
+			);
+
+			return purchasePaths.managePurchase( renewalItem.extra.purchaseDomain, renewalItem.extra.purchaseId );
 		} else if ( cartItems.hasFreeTrial( this.props.cart ) ) {
 			this.props.clearSitePlans( this.props.sites.getSelectedSite().ID );
 


### PR DESCRIPTION
Currently, in `/purchases`, we have four routes that are used to display a notice:

- `/purchases/cancel-success`
- `/purchases/cancel-problem`
- `/purchases/:site/:purchaseId/thank-you`
- `/purchases/:site/:purchaseId/canceled-private-registration`

The first two are necessary, because the user can visit those URLs after canceling a domain through wpcom. The latter two were created because of the pattern established by the former, and can be replaced with global notices.

This PR:
- updates the first two routes to use the "flash pattern", where we trigger the notice in the controller and strip the `/cancel-[type]` fragment from the URL with a redirect.
- removes the last two routes in favor of global notices.

**Testing**
`/purchases/cancel-success`
- Visit `/purchases/cancel-success`.
- Assert that you are redirected to `/purchases` and that a success notice is displayed.

`/purchases/cancel-problem`
- Visit `/purchases/cancel-problem`.
- Assert that you are redirected to `/purchases` and that an error notice is displayed.

`/purchases/:site/:purchaseId/thank-you` (removed)
- Visit `/purchases` and click on a purchase that is expiring.
- Click the 'Renew Now' button.
- Assert that you are redirected to checkout.
- Purchase the renewal.
- Assert that you are redirected back to the `ManagePurchase` page for the purchase with a success notice displayed.

`/purchases/:site/:purchaseId/canceled-private-registration` (removed)
- Visit `/purchases` and click on a domain purchase that has private registration.
- Click 'Cancel Private Registration'.
- Cancel the private registration.
- Assert that you are redirected back to the purchase and that a success notice is displayed.

- [x] Code review
- [x] Product review