### PR TITLE
Test: Move client/lib/local-list and client/lib/local-storage to single test runner

### DIFF
--- a/client/lib/local-list/Makefile
+++ b/client/lib/local-list/Makefile
@@ -1,7 +1,0 @@
-REPORTER ?= spec
-MOCHA ?= ../../../node_modules/.bin/mocha
-
-test:
-	@NODE_ENV=test NODE_PATH=test:../../../client $(MOCHA) --reporter $(REPORTER)
-
-.PHONY: test

--- a/client/lib/local-list/test/index.js
+++ b/client/lib/local-list/test/index.js
@@ -1,38 +1,45 @@
-global.localStorage = require( 'localStorage' );
+/**
+ * External dependencies
+ */
+import { assert } from 'chai';
 
-var assert = require('chai').assert;
+/**
+ * Internal dependencies
+ */
+import useFakeDom from 'test/helpers/use-fake-dom';
 
-var LocalList = require( '..' );
-
-var statList = new LocalList( { localStoreKey: 'TestLocalListKey' } ),
-	anExampleKey = 'day:2014-08-01';
+const anExampleKey = 'day:2014-08-01';
 
 // helper functions
-
-function createLocalRecords( qty ) {
-	for( var i = 0; i < qty; i ++ ) {
+function createLocalRecords( statList, qty ) {
+	for ( let i = 0; i < qty; i ++ ) {
 		statList.set( anExampleKey + '||' + i, {} );
 	}
 }
 
 describe( 'LocalList', function() {
+	let LocalList, statList;
+
+	useFakeDom();
+
+	before( () => {
+		LocalList = require( '..' );
+		statList = new LocalList( { localStoreKey: 'TestLocalListKey' } );
+	} );
 
 	describe( 'options', function() {
-
 		it( 'should set the localStoreKey', function() {
-			var statList2 = new LocalList( { localStoreKey: 'RandomKey' } );
+			const statList2 = new LocalList( { localStoreKey: 'RandomKey' } );
 			assert.equal( statList2.localStoreKey, 'RandomKey' );
 		} );
 
 		it( 'should set the limit', function() {
-			var statList2 = new LocalList( { localStoreKey: 'RandomKey2', limit: 25 } );
+			const statList2 = new LocalList( { localStoreKey: 'RandomKey2', limit: 25 } );
 			assert.equal( statList2.limit, 25 );
 		} );
-
 	} );
 
 	describe( 'functions', function() {
-
 		it( 'should have set function', function() {
 			assert.isFunction( statList.set, 'set should be a function' );
 		} );
@@ -48,7 +55,6 @@ describe( 'LocalList', function() {
 		it( 'should have clear function', function() {
 			assert.isFunction( statList.clear, 'clear should be a function' );
 		} );
-
 	} );
 
 	describe( 'getData', function() {
@@ -59,12 +65,11 @@ describe( 'LocalList', function() {
 
 	describe( 'clear', function() {
 		it( 'should empty the localStorage', function() {
-			createLocalRecords( 2 );
+			createLocalRecords( statList, 2 );
 			assert.lengthOf( statList.getData(), 2, 'localData should have two records' );
 
 			statList.clear();
 			assert.lengthOf( statList.getData(), 0, 'localData should have no records' );
-
 		} );
 	} );
 
@@ -95,57 +100,52 @@ describe( 'LocalList', function() {
 			statList.set( anExampleKey, { newest: false } );
 			statList.set( anExampleKey, { newest: true } );
 
-			var localRecord = statList.getData()[ 0 ];
+			const localRecord = statList.getData()[ 0 ];
 			assert.lengthOf( statList.getData(), 1, 'localData should have one record' );
 			assert.isTrue( localRecord.data.newest );
 		} );
 
 		describe( 'record', function() {
-
 			it( 'should set a key attribute', function() {
 				statList.clear();
-				var localRecord = statList.set( anExampleKey, {} );
+				const localRecord = statList.set( anExampleKey, {} );
 
 				assert.equal( localRecord.key, anExampleKey, 'It should have the correct key' );
 			} );
 
 			it( 'should set a createdAt attribute', function() {
-				var localRecord = statList.getData()[ 0 ];
+				const localRecord = statList.getData()[ 0 ];
 				assert.typeOf( localRecord.createdAt, 'number', 'It should have a timestamp' );
 			} );
 
 			it( 'should set the data', function() {
-				var localRecord = statList.getData()[ 0 ];
+				const localRecord = statList.getData()[ 0 ];
 				assert.typeOf( localRecord.data, 'object', 'It should have a data object' );
 			} );
-
 		} );
-
 	} );
 
 	describe( 'limitLocal', function() {
-
 		it( 'should default to only allow 10 records to be stored', function() {
 			statList.clear();
-			createLocalRecords( 12 );
+			createLocalRecords( statList, 12 );
 			assert.lengthOf( statList.getData(), 10, 'localData should have 10 records' );
 			assert.equal( statList.getData()[ 9 ].key, anExampleKey + '||' + 11, 'the last record should be the last created' );
 			assert.equal( statList.getData()[ 0 ].key, anExampleKey + '||' + 2, 'the oldest record should be correct' );
 		} );
 
 		it( 'should allow default limit to be overidden', function() {
-			var limit = 14,
+			const limit = 14,
 				statList2 = new LocalList( { localStoreKey: 'TestLocalListKey2', limit: limit } );
 			assert.equal( statList2.limit, limit );
 
-			for ( var i = 0; i < limit; i ++ ) {
-				var key = anExampleKey + '||' + i;
+			for ( let i = 0; i < limit; i ++ ) {
+				const key = anExampleKey + '||' + i;
 				statList2.set( key, {} );
 			}
 
 			assert.equal( statList2.getData().length, limit, 'localData should have ' + limit + ' records' );
 		} );
-
 	} );
 
 	describe( 'find', function() {
@@ -156,10 +156,9 @@ describe( 'LocalList', function() {
 		it( 'should return the correct record', function() {
 			statList.clear();
 			statList.set( anExampleKey, {} );
-			createLocalRecords( 2 );
-			var record = statList.find( anExampleKey );
+			createLocalRecords( statList, 2 );
+			const record = statList.find( anExampleKey );
 			assert.equal( record.key, anExampleKey, 'Keys should match' );
 		} );
 	} );
-
 } );

--- a/client/lib/local-storage/Makefile
+++ b/client/lib/local-storage/Makefile
@@ -1,7 +1,0 @@
-REPORTER ?= spec
-MOCHA ?= ../../../node_modules/.bin/mocha
-
-test:
-	@NODE_ENV=test NODE_PATH=test:../../../client $(MOCHA) --reporter $(REPORTER)
-
-.PHONY: test

--- a/client/lib/local-storage/test/index.js
+++ b/client/lib/local-storage/test/index.js
@@ -1,17 +1,20 @@
 /**
  * External dependencies
  */
-var assert = require('chai').assert;
+import { assert } from 'chai';
 
 describe( 'localStorage', function() {
-
 	describe( 'when window.localStorage does not exist', function() {
-		var window = {};
-		require( '..' )( window );
+		const window = {};
+
+		before( () => {
+			require( '..' )( window );
+		} );
 
 		it( 'should create a window.localStorage instance', function() {
 			assert( window.localStorage );
 		} );
+
 		it( 'should correctly store and retrieve data', function() {
 			window.localStorage.setItem( 'foo', 'bar' );
 			assert.equal( window.localStorage.getItem( 'foo' ), 'bar' );
@@ -20,10 +23,13 @@ describe( 'localStorage', function() {
 	} );
 
 	describe( 'when window.localStorage is not working correctly', function() {
-		var window = {
+		const window = {
 			localStorage: {}
 		};
-		require( '..' )( window );
+
+		before( () => {
+			require( '..' )( window );
+		} );
 
 		it( 'should overwrite broken or missing methods', function() {
 			assert( window.localStorage.setItem );
@@ -31,13 +37,11 @@ describe( 'localStorage', function() {
 			assert( window.localStorage.removeItem );
 			assert( window.localStorage.clear );
 		} );
+
 		it( 'should correctly store and retrieve data', function() {
 			window.localStorage.setItem( 'foo', 'bar' );
 			assert.equal( window.localStorage.getItem( 'foo' ), 'bar' );
 			assert.equal( window.localStorage.length, 1 );
-
 		} );
-
 	} );
-
 } );

--- a/client/lib/react-test-env-setup/index.js
+++ b/client/lib/react-test-env-setup/index.js
@@ -42,6 +42,11 @@ module.exports.cleanup = function() {
 	delete global.navigator;
 	delete global.Element;
 	delete global.history;
-	delete global.localStorage;
+	if ( global.localStorage ) {
+		if ( global.localStorage.clear ) {
+			global.localStorage.clear();
+		}
+		delete global.localStorage;
+	}
 	delete global.XMLHttpRequest;
 };

--- a/client/tests.json
+++ b/client/tests.json
@@ -192,6 +192,9 @@
 		"like-store": {
 			"test": [ "index" ]
 		},
+		"local-list": {
+			"test": [ "index" ]
+		},
 		"localforage": {
 			"test": [ "localforage-bypass" ]
 		},

--- a/client/tests.json
+++ b/client/tests.json
@@ -195,6 +195,9 @@
 		"local-list": {
 			"test": [ "index" ]
 		},
+		"local-storage": {
+			"test": [ "index" ]
+		},
 		"localforage": {
 			"test": [ "localforage-bypass" ]
 		},


### PR DESCRIPTION
Part of #3942.

Test folders migrated:
* `client/lib/local-list/`
* `client/lib/local-storage/`

### Testing
* `npm run test-client`
* `npm run test-client client/lib/local-list/test/index.js -- -w`
* `npm run test-client client/lib/local-storage/test/index.js -- -w`