### PR TITLE
Domains: don't trim numeric values

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -73,7 +73,11 @@ export default React.createClass( {
 	trimWhitespace( fieldValues, onComplete ) {
 		const trimmedFieldValues = Object.assign( {}, fieldValues );
 		this.fieldNames.forEach( ( fieldName ) => {
-			trimmedFieldValues[ fieldName ] = fieldValues[ fieldName ] && fieldValues[ fieldName ].trim();
+			if ( typeof fieldValues[ fieldName ] === 'string' ) {
+				trimmedFieldValues[ fieldName ] = fieldValues[ fieldName ].trim();
+			} else {
+				trimmedFieldValues[ fieldName ] = fieldValues[ fieldName ];
+			}
 		} );
 
 		onComplete( trimmedFieldValues );


### PR DESCRIPTION
It's impossible to add Privacy to domains if the country states have numeric like Japan because trimWhitespace will attempt to trim an integer.

To test: 
1. Add a domain to your cart
2. In domain contact information, select Japan and a state
3. Add privacy
4. It should work.