### PR TITLE
Purchases: Close the dialog when an error happens

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -133,8 +133,16 @@ const CancelPurchaseButton = React.createClass( {
 						args: { purchaseName }
 					}
 				) );
-				this.toggleDisabled();
+				this.cancellationFailed();
 			}
+		} );
+	},
+
+	cancellationFailed() {
+		this.closeDialog();
+
+		this.setState( {
+			submitting: false
 		} );
 	},
 
@@ -147,6 +155,9 @@ const CancelPurchaseButton = React.createClass( {
 	handleSubmit( error, response ) {
 		if ( error ) {
 			notices.error( error.message );
+
+			this.cancellationFailed();
+
 			return;
 		}
 


### PR DESCRIPTION
This pull request fixes #4547 by closing the dialog when the request to the cancel endpoint fails.

<img width="888" alt="screen shot 2016-04-06 at 13 44 25" src="https://cloud.githubusercontent.com/assets/275961/14316941/b5b12060-fbfd-11e5-9ee4-1123ea79a0dd.png">
 
#### Testing instructions

1. Run `git checkout fix/4547-cancellation-errors` and start your server
2. Apply this patch: 12c75-pb
2. Open the [`Purchases` page](http://calypso.localhost:3000/purchases)
3. Find a purchase within the refund period
4. Assert that you see the "Forced error" message, the dialog is closed and the "Yes, Cancel now" button is enabled when you try again.
3. Find a purchase outside the refund period
4. Assert that you see the "Forced error" message, the dialog is closed and the "Yes, Cancel now" button is enabled when you try again.

#### Reviews

- [x] Code
- [x] Product