### PR TITLE
Media: Omit empty content upload action when user lacks capability

### DIFF
--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -1,15 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var EmptyContent = require( 'components/empty-content' ),
-	UploadButton = require( './upload-button' );
+import EmptyContent from 'components/empty-content';
+import UploadButton from './upload-button';
+import { userCan } from 'lib/site/utils';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'MediaLibraryListNoContent',
 
 	propTypes: {
@@ -17,41 +18,55 @@ module.exports = React.createClass( {
 		filter: React.PropTypes.string
 	},
 
-	getLabel: function() {
-		var label;
-
+	getLabel() {
 		switch ( this.props.filter ) {
 			case 'images':
-				label = this.translate( 'You don\'t have any images.', { textOnly: true, context: 'Media no results' } );
-				break;
-			case 'videos':
-				label = this.translate( 'You don\'t have any videos.', { textOnly: true, context: 'Media no results' } );
-				break;
-			case 'audio':
-				label = this.translate( 'You don\'t have any audio files.', { textOnly: true, context: 'Media no results' } );
-				break;
-			case 'documents':
-				label = this.translate( 'You don\'t have any documents.', { textOnly: true, context: 'Media no results' } );
-				break;
-			default:
-				label = this.translate( 'You don\'t have any media.', { textOnly: true, context: 'Media no results' } );
-				break;
-		}
+				return this.translate( 'You don\'t have any images.', {
+					textOnly: true,
+					context: 'Media no results'
+				} );
 
-		return label;
+			case 'videos':
+				return this.translate( 'You don\'t have any videos.', {
+					textOnly: true,
+					context: 'Media no results'
+				} );
+
+			case 'audio':
+				return this.translate( 'You don\'t have any audio files.', {
+					textOnly: true,
+					context: 'Media no results'
+				} );
+
+			case 'documents':
+				return this.translate( 'You don\'t have any documents.', {
+					textOnly: true,
+					context: 'Media no results'
+				} );
+
+			default:
+				return this.translate( 'You don\'t have any media.', {
+					textOnly: true,
+					context: 'Media no results'
+				} );
+		}
 	},
 
-	render: function() {
-		var action = (
-			<UploadButton className="button is-primary" site={ this.props.site }>
-				{ this.translate( 'Upload Media' ) }
-			</UploadButton>
-		);
+	render() {
+		let line, action;
+		if ( userCan( 'upload_files', this.props.site ) ) {
+			line = this.translate( 'Would you like to upload something?' );
+			action = (
+				<UploadButton className="button is-primary" site={ this.props.site }>
+					{ this.translate( 'Upload Media' ) }
+				</UploadButton>
+			);
+		}
 
 		return (
 			<EmptyContent
 				title={ this.getLabel() }
-				line={ this.translate( 'Would you like to upload something?' ) }
+				line={ line }
 				action={ action }
 				illustration={ '/calypso/images/drake/drake-nomedia.svg' } />
 		);


### PR DESCRIPTION
This pull request seeks to resolve an issue where a user who does not have the proper capabilities for uploading files will be offered the option to upload a new item when the media library is empty. Props to @ryanmarkel for noting this issue.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/14319317/bcbf1318-fbde-11e5-8e02-bf74ac52e109.png)|![After](https://cloud.githubusercontent.com/assets/1779930/14319306/b0e5d216-fbde-11e5-91cc-b830b1bc021e.png)

__Testing instructions:__

Verify that the empty content upload button is only shown when the current user has the capability for uploading a file to a site (a contributor does not have access).

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted 
 - Choose a site where at least one category of media will be empty, or where you'd be willing to delete media on that site
3. Click the media button in the editor toolbar
4. (Optional) If necessary, choose a filter where media list would be empty
5. Note that...
 - If you have capability for uploading files to that site, you are prompted to "upload something"
 - If you do not have capability for uploading files to that site, only the text indicating no files is shown, but not a prompt to upload a new file