### PR TITLE
Update Sharing icons to use Social Logo

### DIFF
--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -48,19 +48,6 @@ function stripHTML( string ) {
 }
 
 /**
- * Converts a unicode-encoded character to its string equivalent. This is
- * especially useful in converting characters typically used in CSS `content`
- * properties to text for use in a React view.
- *
- * @param {string} character A unicode-encoded character
- * @example unicodeToString( '\\f2665' ) // -> ♥
- * @return {string} String equivalent of unicode character
- */
-function unicodeToString( character ) {
-	return String.fromCharCode( '0x' + character.replace( /^\\/, '' ) );
-}
-
-/**
  * Prevent widows by replacing spaces between the last `wordsToKeep` words in the text with non-breaking spaces
  * @param  {string} text        the text to work on
  * @param  {number} wordsToKeep the number of words to keep together
@@ -341,7 +328,6 @@ module.exports = {
 	decodeEntities: decodeEntities,
 	interpose: interpose,
 	stripHTML: stripHTML,
-	unicodeToString: unicodeToString,
 	preventWidows: preventWidows,
 	wpautop: wpautop,
 	removep: removep,

--- a/client/my-sites/sharing/buttons/preview-button.jsx
+++ b/client/my-sites/sharing/buttons/preview-button.jsx
@@ -2,13 +2,14 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	classNames = require( 'classnames' );
+	classNames = require( 'classnames' ),
+	photon = require( 'photon' );
 
 /**
  * Internal dependencies
  */
-var formatting = require( 'lib/formatting' ),
-	analytics = require( 'analytics' );
+var analytics = require( 'analytics' ),
+	SocialLogo = require( 'components/social-logo' );
 
 module.exports = React.createClass( {
 	displayName: 'SharingButtonsPreviewButton',
@@ -30,10 +31,21 @@ module.exports = React.createClass( {
 	},
 
 	getIcon: function() {
-		if ( 'string' === typeof this.props.button.genericon ) {
-			return <span className="noticon sharing-buttons-preview-button__glyph" aria-hidden="true">{ formatting.unicodeToString( this.props.button.genericon ) }</span>;
+		const shortnameToSocialLogo = {
+			email: 'mail',
+			'google-plus-1': 'google-plus-alt',
+			pinterest: 'pinterest-alt',
+			tumblr: 'tumblr-alt',
+			'press-this': 'wordpress',
+			twitter: 'twitter-alt',
+			more: 'share'
+		}
+		if ( ! this.props.button.custom ) {
+			const icon = shortnameToSocialLogo[ this.props.button.ID ] || this.props.button.shortname;
+
+			return <SocialLogo icon={ icon } size={ 18 } />;
 		} else if ( 'string' === typeof this.props.button.icon ) {
-			return <span className="sharing-buttons-preview-button__custom-icon" style={ { backgroundImage: 'url(' + this.props.button.icon + ')' } }></span>;
+			return <span className="sharing-buttons-preview-button__custom-icon" style={ { backgroundImage: 'url(' + photon( this.props.button.icon, { width: 16 } ) + ')' } }></span>;
 		}
 	},
 
@@ -44,7 +56,8 @@ module.exports = React.createClass( {
 
 	render: function() {
 		var classes = classNames( 'sharing-buttons-preview-button', 'style-' + this.props.style, 'share-' + this.props.button.ID, {
-			'is-enabled': this.props.enabled
+			'is-enabled': this.props.enabled,
+			'is-custom': this.props.button.custom
 		} );
 
 		return (

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -908,13 +908,18 @@ $color-print: #f8f8f8;
 		border-radius: 50%;
 		border: 0;
 		box-shadow: none;
-		padding: 8px;
+		padding: 7px;
 		position: relative;
 		top: -2px;
 		line-height: 1;
 		width: auto;
 		height: auto;
 		margin-bottom: 0;
+	}
+
+	&.style-icon.is-custom {
+		padding: 8px;
+		top: 2px;
 	}
 }
 
@@ -926,7 +931,7 @@ $color-print: #f8f8f8;
 	}
 }
 
-&.style-text .sharing-buttons-preview-button__glyph,
+&.style-text .social-logo,
 &.style-text .sharing-buttons-preview-button__custom-icon,
 &.style-icon .sharing-buttons-preview-button__service {
 	display: none;
@@ -941,26 +946,26 @@ $color-print: #f8f8f8;
 	line-height: 1;
 }
 
-.sharing-buttons-preview-button__glyph {
+.sharing-buttons-preview-button .social-logo {
 	vertical-align: top;
 	position: relative;
-	top: 3px;
+	top: 2px;
 	text-align: center;
 }
 
-.sharing-buttons-preview-button.style-icon .sharing-buttons-preview-button__glyph {
+.sharing-buttons-preview-button.style-icon .social-logo {
 	top: 0;
 	color: $white;
 }
 
-.sharing-buttons-preview-button.style-icon.share-email .sharing-buttons-preview-button__glyph,
-.sharing-buttons-preview-button.style-icon.share-print .sharing-buttons-preview-button__glyph {
+.sharing-buttons-preview-button.style-icon.share-email .social-logo,
+.sharing-buttons-preview-button.style-icon.share-print .social-logo {
 	color: #777;
 }
 
 .sharing-buttons-preview-button__custom-icon {
 	display: inline-block;
-	vertical-align: top;
+	vertical-align: text-bottom;
 	width: 16px;
 	height: 16px;
 	background-position: left center;


### PR DESCRIPTION
Take the custom icons into account.

Before: 
<img width="719" alt="screen shot 2016-04-06 at 09 58 14" src="https://cloud.githubusercontent.com/assets/115071/14325416/25b5dd12-fbde-11e5-9dbf-e1191bb9c935.png">

<img width="701" alt="screen shot 2016-04-06 at 09 57 34" src="https://cloud.githubusercontent.com/assets/115071/14325422/2b8e76b8-fbde-11e5-9a9b-2733de9fedf2.png">

After:
<img width="705" alt="screen shot 2016-04-06 at 09 59 18" src="https://cloud.githubusercontent.com/assets/115071/14325480/59e37d88-fbde-11e5-846c-791daf49e4a3.png">

<img width="717" alt="screen shot 2016-04-06 at 09 59 25" src="https://cloud.githubusercontent.com/assets/115071/14325482/5f4ae5ae-fbde-11e5-99c5-156fab702162.png">

**to test**
Visit http://calypso.localhost:3000/sharing/buttons/example.com and make sure that everything is working as expected. 

To create a custom share icon visit the wp-admin interface.

cc: @aduth, @lezama,