### PR TITLE
Purchases: Redirect in `CancelPrivateRegistration` and `EditCardDetails` for invalid data

### DIFF
--- a/client/components/data/purchases/edit-card-details/index.jsx
+++ b/client/components/data/purchases/edit-card-details/index.jsx
@@ -29,6 +29,7 @@ function getStateFromStores( props ) {
 		card: StoredCardsStore.getByCardId( parseInt( props.cardId, 10 ) ),
 		isEditingSpecificCard: Boolean( props.cardId ),
 		countriesList: CountriesList.forPayments(),
+		hasLoadedSites: props.hasLoadedSites,
 		selectedPurchase: PurchasesStore.getByPurchaseId( parseInt( props.purchaseId, 10 ) ),
 		selectedSite: props.selectedSite
 	};
@@ -38,7 +39,7 @@ function isDataLoading( state ) {
 	return (
 		state.card.isFetching ||
 		! state.selectedPurchase.hasLoadedFromServer ||
-		! state.selectedSite
+		! state.hasLoadedSites
 	);
 }
 
@@ -66,6 +67,7 @@ const EditCardDetailsData = React.createClass( {
 				cardId={ this.props.cardId }
 				component={ this.props.component }
 				getStateFromStores={ getStateFromStores }
+				hasLoadedSites={ this.props.sites.fetched }
 				isDataLoading={ isDataLoading }
 				loadingPlaceholder={ this.props.loadingPlaceholder }
 				purchaseId={ this.props.purchaseId }

--- a/client/components/data/purchases/edit-card-details/index.jsx
+++ b/client/components/data/purchases/edit-card-details/index.jsx
@@ -27,6 +27,7 @@ const stores = [
 function getStateFromStores( props ) {
 	return {
 		card: StoredCardsStore.getByCardId( parseInt( props.cardId, 10 ) ),
+		isEditingSpecificCard: Boolean( props.cardId ),
 		countriesList: CountriesList.forPayments(),
 		selectedPurchase: PurchasesStore.getByPurchaseId( parseInt( props.purchaseId, 10 ) ),
 		selectedSite: props.selectedSite

--- a/client/components/data/purchases/index.jsx
+++ b/client/components/data/purchases/index.jsx
@@ -21,6 +21,7 @@ const user = userFactory(),
 
 function getStateFromStores( props ) {
 	return {
+		hasLoadedSites: props.hasLoadedSites,
 		noticeType: props.noticeType,
 		purchases: PurchasesStore.getByUser( user.get().ID ),
 		sites: props.sites
@@ -47,6 +48,7 @@ const PurchasesData = React.createClass( {
 			<StoreConnection
 				component={ this.props.component }
 				noticeType={ this.props.noticeType }
+				hasLoadedSites={ this.props.sites.fetched }
 				sites={ this.props.sites }
 				stores={ stores }
 				getStateFromStores={ getStateFromStores } />

--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -22,11 +22,12 @@ import titles from 'me/purchases/titles';
 
 const CancelPrivateRegistration = React.createClass( {
 	propTypes: {
+		hasLoadedSites: React.PropTypes.bool.isRequired,
 		selectedPurchase: React.PropTypes.object.isRequired,
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.bool,
 			React.PropTypes.object
-		] ).isRequired
+		] )
 	},
 
 	getInitialState() {
@@ -37,18 +38,18 @@ const CancelPrivateRegistration = React.createClass( {
 	},
 
 	componentWillMount() {
-		this.redirectIfPurchaseIsInvalid();
+		this.redirectIfDataIsInvalid();
 
 		recordPageView( 'cancel_private_registration', this.props );
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		this.redirectIfPurchaseIsInvalid( nextProps );
+		this.redirectIfDataIsInvalid( nextProps );
 
 		recordPageView( 'cancel_private_registration', this.props, nextProps );
 	},
 
-	redirectIfPurchaseIsInvalid( props = this.props ) {
+	redirectIfDataIsInvalid( props = this.props ) {
 		if ( ! this.isDataValid( props ) ) {
 			page.redirect( paths.list() );
 		}
@@ -169,7 +170,7 @@ const CancelPrivateRegistration = React.createClass( {
 				</p>
 			);
 
-		if ( ! isDataLoading( this.props ) ) {
+		if ( ! isDataLoading( this.props ) && this.isDataValid() ) {
 			notice = this.renderNotice();
 			button = this.renderButton();
 			descriptionText = this.renderDescriptionText();

--- a/client/me/purchases/cancel-private-registration/index.jsx
+++ b/client/me/purchases/cancel-private-registration/index.jsx
@@ -12,8 +12,8 @@ import Button from 'components/button';
 import { cancelPrivateRegistration } from 'lib/upgrades/actions';
 import Card from 'components/card';
 import HeaderCake from 'components/header-cake';
-import { isDataLoading, goToManagePurchase, recordPageView } from '../utils';
-import { isRefundable } from 'lib/purchases';
+import { getPurchase, isDataLoading, goToManagePurchase, recordPageView } from '../utils';
+import { hasPrivateRegistration, isRefundable } from 'lib/purchases';
 import Main from 'components/main';
 import notices from 'notices';
 import Notice from 'components/notice';
@@ -37,11 +37,32 @@ const CancelPrivateRegistration = React.createClass( {
 	},
 
 	componentWillMount() {
+		this.redirectIfPurchaseIsInvalid();
+
 		recordPageView( 'cancel_private_registration', this.props );
 	},
 
 	componentWillReceiveProps( nextProps ) {
+		this.redirectIfPurchaseIsInvalid( nextProps );
+
 		recordPageView( 'cancel_private_registration', this.props, nextProps );
+	},
+
+	redirectIfPurchaseIsInvalid( props = this.props ) {
+		if ( ! this.isDataValid( props ) ) {
+			page.redirect( paths.list() );
+		}
+	},
+
+	isDataValid( props = this.props ) {
+		if ( isDataLoading( props ) ) {
+			return true;
+		}
+
+		const { selectedSite } = props,
+			purchase = getPurchase( props );
+
+		return selectedSite && purchase && hasPrivateRegistration( purchase );
 	},
 
 	cancel( event ) {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -24,7 +24,10 @@ import titles from 'me/purchases/titles';
 const CancelPurchase = React.createClass( {
 	propTypes: {
 		selectedPurchase: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.object.isRequired
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.object
+		] )
 	},
 
 	componentWillMount() {

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -43,7 +43,7 @@ CancelPurchaseLoadingPlaceholder.propTypes = {
 	selectedSite: React.PropTypes.oneOfType( [
 		React.PropTypes.bool,
 		React.PropTypes.object
-	] ).isRequired
+	] )
 };
 
 export default CancelPurchaseLoadingPlaceholder;

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -61,7 +61,7 @@ const ConfirmCancelDomain = React.createClass( {
 	},
 
 	redirectIfDataIsInvalid( props ) {
-		if ( isDataLoading( props ) ) {
+		if ( isDataLoading( props ) || this.state.submitting ) {
 			return null;
 		}
 

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -36,7 +36,7 @@ const ConfirmCancelDomain = React.createClass( {
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.bool,
 			React.PropTypes.object
-		] ).isRequired
+		] )
 	},
 
 	getInitialState() {
@@ -53,15 +53,21 @@ const ConfirmCancelDomain = React.createClass( {
 	},
 
 	componentDidMount() {
-		this.ensurePurchaseIsADomainRegistration( this.props );
+		this.redirectIfDataIsInvalid( this.props );
 	},
 
 	componentWillReceiveProps( nextProps ) {
-		this.ensurePurchaseIsADomainRegistration( nextProps );
+		this.redirectIfDataIsInvalid( nextProps );
 	},
 
-	ensurePurchaseIsADomainRegistration( props ) {
-		if ( ! isDataLoading( props ) && ! isDomainRegistration( getPurchase( props ) ) ) {
+	redirectIfDataIsInvalid( props ) {
+		if ( isDataLoading( props ) ) {
+			return null;
+		}
+
+		const purchase = getPurchase( props );
+
+		if ( ! purchase || ! isDomainRegistration( purchase ) || ! props.selectedSite ) {
 			page.redirect( paths.list() );
 		}
 	},

--- a/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
@@ -40,7 +40,7 @@ ConfirmCancelDomainLoadingPlaceholder.propTypes = {
 	selectedSite: React.PropTypes.oneOfType( [
 		React.PropTypes.bool,
 		React.PropTypes.object
-	] ).isRequired
+	] )
 };
 
 export default ConfirmCancelDomainLoadingPlaceholder;

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -622,6 +622,7 @@ const ManagePurchase = React.createClass( {
 				{ cancelPrivateRegistrationNavItem }
 
 				<RemovePurchase
+					hasLoadedSites={ this.props.hasLoadedSites }
 					selectedSite={ this.props.selectedSite }
 					selectedPurchase={ this.props.selectedPurchase }
 					user={ this.props.user } />

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -36,8 +36,12 @@ const EditCardDetails = React.createClass( {
 	propTypes: {
 		card: React.PropTypes.object.isRequired,
 		countriesList: React.PropTypes.object.isRequired,
+		isEditingSpecificCard: React.PropTypes.bool.isRequired,
 		selectedPurchase: React.PropTypes.object.isRequired,
-		selectedSite: React.PropTypes.object.isRequired
+		selectedSite: React.PropTypes.oneOfType( [
+			React.PropTypes.object,
+			React.PropTypes.bool
+		] ),
 	},
 
 	getInitialState() {
@@ -70,6 +74,8 @@ const EditCardDetails = React.createClass( {
 	},
 
 	componentWillMount() {
+		this.redirectIfDataIsInvalid();
+
 		recordPageView( 'edit_card_details', this.props );
 
 		let fields = formState.createNullFieldValues( this.fieldNames );
@@ -84,6 +90,10 @@ const EditCardDetails = React.createClass( {
 		} );
 
 		this.setState( { form: this.formStateController.getInitialState() } );
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		this.redirectIfDataIsInvalid( nextProps );
 	},
 
 	validate( formValues, onComplete ) {
@@ -187,6 +197,24 @@ const EditCardDetails = React.createClass( {
 			paygateToken: token,
 			purchaseId: this.props.selectedPurchase.data.id
 		};
+	},
+
+	redirectIfDataIsInvalid( props = this.props ) {
+		if ( ! this.isDataValid( props ) ) {
+			page( paths.list() );
+		}
+	},
+
+	isDataValid( props = this.props ) {
+		if ( isDataLoading( props ) ) {
+			return true;
+		}
+
+		const purchase = getPurchase( props ),
+			{ selectedSite } = props,
+			card = props.isEditingSpecificCard ? props.card.data : true;
+
+		return purchase && card && selectedSite;
 	},
 
 	isFieldInvalid( name ) {

--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -62,7 +62,7 @@ ProductLink.propTypes = {
 	selectedSite: React.PropTypes.oneOfType( [
 		React.PropTypes.bool,
 		React.PropTypes.object
-	] ).isRequired
+	] )
 };
 
 export default ProductLink;

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -182,7 +182,7 @@ const RemovePurchase = React.createClass( {
 	},
 
 	render() {
-		if ( isDataLoading( this.props ) ) {
+		if ( isDataLoading( this.props ) || ! this.props.selectedSite ) {
 			return null;
 		}
 

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -57,7 +57,13 @@ function recordPageView( trackingSlug, props, nextProps = null ) {
 		return null;
 	}
 
-	const { productSlug } = getPurchase( nextProps || props );
+	const purchase = getPurchase( nextProps || props );
+
+	if ( ! purchase ) {
+		return null;
+	}
+
+	const { productSlug } = purchase;
 
 	analytics.tracks.recordEvent( `calypso_${ trackingSlug }_purchase_view`, { product_slug: productSlug } );
 }

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -43,7 +43,7 @@ function goToManagePurchase( props ) {
 }
 
 function isDataLoading( props ) {
-	return ( ! props.selectedSite || ! props.selectedPurchase.hasLoadedFromServer );
+	return ! props.hasLoadedSites || ! props.selectedPurchase.hasLoadedFromServer;
 }
 
 function recordPageView( trackingSlug, props, nextProps = null ) {


### PR DESCRIPTION
This PR adds logic to `CancelPrivateRegistration` and `EditCardDetails` to redirect to `/purchases` if an invalid purchase or card is present.

- In `CancelPrivateRegistration`, this means that the purchase must exist and have a private registration.
- In `EditCardDetails`, this means that the purchase and card must exist.

Fixes #2519 and #1407.

**Testing**
`CancelPrivateRegistration`
- Visit `/purchases` and click on a domain that has a private registration.
- Click 'Cancel Private Registration'.
- Refresh the page and assert that you are not redirected to `/purchases` once the data has loaded.
- Update the site slug or purchase ID in the URL to a random string/number and visit this URL.
- Assert that you are redirected to `/purchases` once the data has loaded.

`EditCardDetails`
- Visit `/purchases` and click on a purchase that was made with a credit card.
- Click 'Edit Payment Method'.
- Assert that you are taken to `EditCardDetails` and that a credit card form is displayed once the data has loaded.
- Update the site slug, purchase ID (the first number) or card ID (the second number) in the URL to a random number and visit this URL.
- Assert that you are redirected to `/purchases` once the data has loaded.

`CancelPurchase`
- Visit `/purchases` and click on a purchase that can be canceled, e.g. any product within its refund window or any subscription with auto-renew enabled.
- Click the cancel link, e.g. 'Cancel Subscription and Refund' or similar.
- Refresh this page and assert that it loads properly.
- Update the site slug or purchase ID in the URL to a random string/number and visit this URL.
- Assert that you are redirected back to `/purchases` once the data has loaded.

`ConfirmCancelDomain`
- Visit `/purchases` and click on a domain within its refund window.
- Click 'Cancel Domain and Refund'.
- Click the 'Cancel Domain and Refund' button.
- Refresh the page and assert that it loads properly.
- Update the site slug or purchase ID in the URL to a random string/number and visit this URL.
- Assert that you are redirected back to `/purchases` once the data has loaded.

- [x] Code review
- [x] Product review