### PR TITLE
Framework: Add a meta referrer=origin to send referrers.

### DIFF
--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -20,6 +20,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		meta(name='viewport', content='width=device-width, initial-scale=1, maximum-scale=1')
 		meta(name='format-detection', content='telephone=no')
 		meta(name='mobile-web-app-capable', content='yes')
+		meta(name='referrer', content='origin')
 
 		if helmetMeta
 			!= helmetMeta


### PR DESCRIPTION
This allows modern browsers to send a Referrer of https://wordpress.com when a user click on an outside link in Calypso. This will allows stats collectors to see when a click came from the Reader instead of totally dropping the referrer information. Matches the old Atlas behavior.