### PR TITLE
Add: Add colours for future share icons.

### DIFF
--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -12,6 +12,9 @@ $color-pinterest: #cc2127;
 $color-pocket: #ee4256;
 $color-email: #f8f8f8;
 $color-print: #f8f8f8;
+$color-skype: #00AFF0;
+$color-telegram: #0088cc;
+$color-whatsapp: #43d854;
 
 .foldable-card.sharing-service {
 
@@ -997,7 +1000,11 @@ $color-print: #f8f8f8;
 @include sharing-button-service( "pinterest", $color-pinterest );
 @include sharing-button-service( "pocket", $color-pocket );
 @include sharing-button-service( "email", $color-email );
-@include sharing-button-service( "print", $color-email );
+@include sharing-button-service( "print", $color-print );
+@include sharing-button-service( "skype", $color-skype );
+@include sharing-button-service( "telegram", $color-telegram );
+@include sharing-button-service( "whatsapp", $color-whatsapp );
+
 
 .sharing-buttons-preview__panel {
 	position: relative;


### PR DESCRIPTION
Skype is already supported by Jetpack. Telegram and Whatsapp are in the works.

I got the colours from http://brandcolors.net 

Before:
![screen shot 2016-04-06 at 14 40 49](https://cloud.githubusercontent.com/assets/115071/14333866/a2b1b1f2-fc05-11e5-9bb8-6eda74ab6e97.png)

After:
![screen shot 2016-04-06 at 14 41 09](https://cloud.githubusercontent.com/assets/115071/14333874/a858e044-fc05-11e5-8d1f-a53d4e50b2c1.png)

*To test*: 
Visit  http://calypso.localhost:3000/sharing/buttons/jetpacksite.com

cc: @aduth, @lezama 