### PR TITLE
Domains: A/B test for domain suggestion vendor

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -109,7 +109,7 @@ var RegisterDomainStep = React.createClass( {
 
 		initialQuery = this.props.selectedSite.domain.split( '.' )[ 0 ];
 
-		wpcom.fetchDomainSuggestions( initialQuery, { quantity: SUGGESTION_QUANTITY }, function( error, suggestions ) {
+		wpcom.fetchDomainSuggestions( initialQuery, { quantity: SUGGESTION_QUANTITY, vendor: abtest( 'domainSuggestionVendor' ) }, function( error, suggestions ) {
 			if ( ! this.isMounted() ) {
 				return;
 			}
@@ -251,10 +251,10 @@ var RegisterDomainStep = React.createClass( {
 					} );
 				},
 				callback => {
-					
 					const params = {
 						quantity: SUGGESTION_QUANTITY,
-						includeWordPressDotCom: this.props.includeWordPressDotCom
+						includeWordPressDotCom: this.props.includeWordPressDotCom,
+						vendor: abtest( 'domainSuggestionVendor' )
 					};
 
 					wpcom.fetchDomainSuggestions( domain, params, ( error, domainSuggestions ) => {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -62,4 +62,12 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
+	domainSuggestionVendor: {
+		datestamp: '20160408',
+		variations: {
+			namegen: 95,
+			domainsbot: 5,
+		},
+		defaultVariation: 'namegen'
+	},
 };

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1020,6 +1020,7 @@ Undocumented.prototype.fetchDomainSuggestions = function( searchQuery, functionP
 		query: searchQuery,
 		quantity: functionParams.quantity,
 		include_wordpressdotcom: functionParams.includeWordPressDotCom,
+		vendor: functionParams.vendor,
 	};
 
 	this.wpcom.req.get( '/domains/suggestions', query, function( error, response ) {


### PR DESCRIPTION
Add a new A/B test for domain suggestion vendor:
* `namegen` - the old, default one
* `domainsbot` - the new, shiny one

/cc @matthusby @aidvu @rads @dzver