### PR TITLE
UpgradeNudge: fix url structure

### DIFF
--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -84,11 +84,12 @@ export default React.createClass( {
 		}
 
 		if ( ! this.props.href && site ) {
-			href = '/plans/' + site.slug;
+			href = '/plans/';
 
 			if ( this.props.feature ) {
-				href += '/feature/' + this.props.feature
+				href += 'features/' + this.props.feature + '/';
 			}
+			href += site.slug;
 		}
 
 		if ( this.props.compact ) {


### PR DESCRIPTION
Fix url strcture for the nudge to match new route

CC @gwwar @mtias

Redirects to `/plans/feature/google-analytics/artpitesting.wordpress.com`