### PR TITLE
Framework: add features route

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -118,6 +118,16 @@ export default {
 		);
 	},
 
+	features( context ) {
+		const domain = context.params.domain;
+		const comparePath = domain ? `/plans/compare/${ domain }` : '/plans/compare';
+
+		// check against feature enum
+
+		// otherwise redirect to the compare page if not found
+		page.redirect( comparePath );
+	},
+
 	redirectToCheckout( context ) {
 		// this route is deprecated, use `/checkout/:site/:plan` to link to plan checkout
 		page.redirect( `/checkout/${ context.params.domain }/${ context.params.plan }` );

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -45,6 +45,13 @@ export default function() {
 		);
 
 		page(
+			'/plans/features/:feature/:domain',
+			retarget,
+			controller.siteSelection,
+			plansController.features
+		);
+
+		page(
 			paths.plansDestination(),
 			retarget,
 			controller.siteSelection,


### PR DESCRIPTION
Adds a `/plans/features/:feature:/:domain:` route. This currently will redirect to the plans comparison page since no feature pages have been implemented yet.

cc @rralian @artpi @dmsnell @adambbecker @rodrigoi @mtias 