### PR TITLE
General settings: disable site settings timezone for jetpack

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -145,22 +145,7 @@ module.exports = React.createClass( {
 					</FormSettingExplanation>
 				</FormFieldset>
 
-				<FormFieldset>
-					<FormLabel htmlFor="blogtimezone">
-						{ this.translate( 'Site Timezone' ) }
-					</FormLabel>
-
-					<TimezoneDropdown
-						valueLink={ this.linkState( 'timezone_string' ) }
-						selectedZone={ this.linkState( 'timezone_string' ).value }
-						disabled={ this.state.fetchingSettings }
-						onSelect={ this.onTimezoneSelect }
-					/>
-
-					<FormSettingExplanation>
-						{ this.translate( 'Choose a city in your timezone.' ) }
-					</FormSettingExplanation>
-				</FormFieldset>
+				{ this.renderTimezoneDropdown() }
 			</div>
 		);
 	},
@@ -407,6 +392,31 @@ module.exports = React.createClass( {
 						</FormLabel>
 					</li>
 				</ul>
+			</FormFieldset>
+		);
+	},
+
+	renderTimezoneDropdown() {
+		if ( this.props.site.jetpack ) {
+			return;
+		}
+
+		return (
+			<FormFieldset>
+				<FormLabel htmlFor="blogtimezone">
+					{ this.translate( 'Site Timezone' ) }
+				</FormLabel>
+
+				<TimezoneDropdown
+					valueLink={ this.linkState( 'timezone_string' ) }
+					selectedZone={ this.linkState( 'timezone_string' ).value }
+					disabled={ this.state.fetchingSettings }
+					onSelect={ this.onTimezoneSelect }
+				/>
+
+				<FormSettingExplanation>
+					{ this.translate( 'Choose a city in your timezone.' ) }
+				</FormSettingExplanation>
 			</FormFieldset>
 		);
 	},


### PR DESCRIPTION
This PR disables timezone dropdown for jetpack sites since we aren't handling some properties in site-settings endpoint yet.

### Testing

#### 1) Go to a Jetpack site. Timezone dropdown shouldn't be there

![image](https://cloud.githubusercontent.com/assets/77539/14352179/2368e6b0-fccb-11e5-9d09-4be133d42125.png)

#### 2) Go to .com site

![image](https://cloud.githubusercontent.com/assets/77539/14352208/437a376a-fccb-11e5-908a-914cca29f3b0.png)

cc @rralian @aduth