### PR TITLE
Update linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
 		'no-dupe-keys': 2,
 		'no-else-return': 1,
 		'no-empty': 1,
+		'no-extra-semi': 1,
 		// Flux stores use switch case fallthrough
 		'no-fallthrough': 0,
 		'no-lonely-if': 1,
@@ -75,6 +76,7 @@ module.exports = {
 		'padded-blocks': [ 1, 'never' ],
 		'quote-props': [ 1, 'as-needed' ],
 		'quotes': [ 1, 'single', 'avoid-escape' ],
+		'semi': 1,
 		'semi-spacing': 1,
 		'space-after-keywords': [ 1, 'always' ],
 		'space-before-blocks': [ 1, 'always' ],

--- a/client/lib/paygate-loader/index.js
+++ b/client/lib/paygate-loader/index.js
@@ -12,6 +12,7 @@ var loadScript = require( 'lib/load-script' );
  * PaygateLoader component
  *
  * @api public
+ * @returns { PaygateLoader } - an instance of PaygateLoader
  */
 function PaygateLoader() {
 	if ( ! ( this instanceof PaygateLoader ) ) {
@@ -24,6 +25,9 @@ function PaygateLoader() {
  * `callback` with the `Paygate` class as its first argument
  *
  * @api public
+ * @param {string} paygateUrl - the URL to fetch the paygate script
+ * @param {function} callback - the callback function
+ * @returns {void}
  */
 PaygateLoader.prototype.ready = function( paygateUrl, callback ) {
 	if ( window.Paygate ) {


### PR DESCRIPTION
This adds two new linting rules to Calypso:

1. `semi` - This rule will require semicolons at the end of statements, as per our coding standards
2. `no-extra-semi` -iThis rule is aimed at eliminating extra unnecessary semicolons. While not technically an error, extra semicolons can be a source of confusion when reading code.

More details:
https://github.com/eslint/eslint/blob/master/docs/rules/semi.md
https://github.com/eslint/eslint/blob/master/docs/rules/no-extra-semi.md

Also fixes some linting is the paygate loader lib