### PR TITLE
Settings: Fix/site settings empty localstorage

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -44,7 +44,7 @@ module.exports = {
 		site = sites.getSelectedSite();
 
 		// if site loaded, but user cannot manage site, redirect
-		if ( ! utils.userCan( 'manage_options', site ) ) {
+		if ( site && ! utils.userCan( 'manage_options', site ) ) {
 			page.redirect( '/stats' );
 			return;
 		}

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -71,7 +71,6 @@ module.exports = {
 				<SiteSettingsComponent
 					context={ context }
 					sites={ sites }
-					subsection={ context.params.subsection }
 					section={ context.params.section }
 					path={ context.path } />
 			</SitePurchasesData>,
@@ -80,9 +79,6 @@ module.exports = {
 
 		// analytics tracking
 		if ( 'undefined' !== typeof context.params.section ) {
-			analyticsPageTitle += ' > ' + titlecase( context.params.section );
-		}
-		if ( 'undefined' !== typeof context.params.subsection ) {
 			analyticsPageTitle += ' > ' + titlecase( context.params.section );
 		}
 		analytics.pageView.record( basePath + '/:site', analyticsPageTitle );

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -18,8 +18,6 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'manage/import' ) ) {
 		page( '/settings/import/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
-		page( '/settings/import/:subsection/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
-		page( '/settings/import/:subsection(upload)/:importerID/:site_id', controller.siteSelection, controller.navigation, settingsController.importSite );
 	}
 	if ( config.isEnabled( 'manage/export' ) ) {
 		page( '/settings/export/:site_id', controller.siteSelection, controller.navigation, settingsController.exportSite );
@@ -29,6 +27,5 @@ module.exports = function() {
 		page( '/settings/start-over/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.startOver );
 	}
 	page( '/settings/:section/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
-	page( '/settings/:section/:subsection/:site_id', controller.siteSelection, controller.navigation, settingsController.setScroll, settingsController.siteSettings );
 	page( '/settings/:section', settingsController.legacyRedirects, controller.siteSelection, controller.sites );
 };

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -89,15 +89,11 @@ module.exports = React.createClass( {
 			selectedText = strings[ section ],
 			settingsSection = this.getSections();
 
-		if ( ! site ) {
-			return null;
-		}
-
 		return (
 			<section className="site-settings">
 				<div className="main main-column" role="main">
 					<SidebarNavigation />
-					{ ! this.props.subsection ?
+					{ site ?
 					<SectionNav selectedText={ selectedText }>
 						<NavTabs>
 							<NavItem path={ '/settings/general/' + site.slug } selected={ section === 'general' }>{ strings.general }</NavItem>
@@ -117,8 +113,8 @@ module.exports = React.createClass( {
 							: null }
 						</NavTabs>
 					</SectionNav>
-					: null }
-					{ settingsSection[ this.props.section ] }
+					: <SectionNav /> }
+					{ site && settingsSection[ this.props.section ] }
 				</div>
 			</section>
 		);

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -21,10 +21,13 @@ export default React.createClass( {
 	displayName: 'SiteSettingsImport',
 
 	propTypes: {
-		site: PropTypes.shape( {
-			slug: PropTypes.string.isRequired,
-			title: PropTypes.string.isRequired
-		} )
+		site: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			PropTypes.shape( {
+				slug: PropTypes.string.isRequired,
+				title: PropTypes.string.isRequired
+			} )
+		] )
 	},
 
 	componentDidMount: function() {


### PR DESCRIPTION
When loading any of the site-settings pages with empty localstorage, you would get redirected to the stats page. I've added a loading page where we show the empty site-settings SectionNav until the site data loads. I would have also added a blank card underneath, but we don't show that on all of the other settings pages (analytics in particular, when it's not enabled). I'd add the card if/when the analytics settings page is updated to have a card underneath the sectionnav component.

I'm also removing the `subsection` parameter from the url, as it's no longer used. It used to be used within the importer section to track the step you're in, but now the address just stays the same throughout the steps.

/cc @mtias