### PR TITLE
Editor: Upgrade TinyMCE to latest version (v4.3.8)

### DIFF
--- a/client/components/tinymce/plugins/advanced/plugin.jsx
+++ b/client/components/tinymce/plugins/advanced/plugin.jsx
@@ -1,18 +1,21 @@
 /**
  * External dependencies
  */
-var tinymce = require( 'tinymce/tinymce' ),
-	throttle = require( 'lodash/throttle' );
+import React from 'react';
+import ReactDomServer from 'react-dom/server';
+import tinymce from 'tinymce/tinymce';
+import throttle from 'lodash/throttle';
 
 /**
  * Internal dependencies
  */
-var PreferencesStore = require( 'lib/preferences/store' ),
-	PreferencesActions = require( 'lib/preferences/actions' ),
-	isWithinBreakpoint = require( 'lib/viewport' ).isWithinBreakpoint;
+import PreferencesStore from 'lib/preferences/store';
+import PreferencesActions from 'lib/preferences/actions';
+import { isWithinBreakpoint } from 'lib/viewport';
+import Gridicon from 'components/gridicon';
 
 function advanced( editor ) {
-	var button, updateVisibleState;
+	let menuButton, updateVisibleState;
 
 	function isAdvancedVisible() {
 		return !! PreferencesStore.get( 'editorAdvancedVisible' );
@@ -45,18 +48,26 @@ function advanced( editor ) {
 			'padding-top': containerPadding
 		} );
 
-		if ( button ) {
-			button.active( isAdvancedVisible() );
+		if ( menuButton ) {
+			menuButton.active( isAdvancedVisible() );
 		}
 	}, 500 );
 
 	editor.addButton( 'wpcom_advanced', {
 		text: 'Toggle Advanced',
 		tooltip: 'Toggle Advanced',
-		classes: 'btn advanced',
+		classes: 'btn wpcom-icon-button advanced',
 		cmd: 'WPCOM_ToggleAdvancedVisible',
 		onPostRender: function() {
-			button = this;
+			// Save a reference to the menu button after render so the
+			// visibility update handler can change its active state.
+			menuButton = this;
+
+			this.innerHtml( ReactDomServer.renderToStaticMarkup(
+				<button type="button" role="presentation" tabIndex="-1">
+					<Gridicon icon="ellipsis" size={ 28 } nonStandardSize />
+				</button>
+			) );
 		}
 	} );
 

--- a/client/components/tinymce/plugins/advanced/style.scss
+++ b/client/components/tinymce/plugins/advanced/style.scss
@@ -1,25 +1,18 @@
 .mce-toolbar .mce-advanced button {
-	@extend .button.noticon;
-	@extend .noticon:before;
-	@extend .button.noticon:before;
-
 	transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
-	font-size: 0;
+}
 
-	&:before {
-		content: '\f476';
-		font-size: 24px;
-	}
+.mce-toolbar .mce-advanced .gridicon {
+	width: 28px;
+	height: 28px;
+}
+
+.mce-toolbar .mce-active.mce-advanced button {
+	transform: rotate( 90deg );
 }
 
 .mce-toolbar .mce-advanced.mce-btn button {
 	display: none;
-	color: $gray-dark;
-	padding: 0px 2px;
-
-	&:hover {
-		color: $gray;
-	}
 
 	@include breakpoint( ">960px" ) {
 		display: block;
@@ -28,18 +21,6 @@
 
 .mce-toolbar .mce-btn-group .mce-advanced.mce-btn.mce-last {
 	position: absolute;
-		top: 3px;
-		right: 14px;
-}
-
-.mce-toolbar .mce-btn-group .mce-btn.mce-active.mce-advanced {
-	border: none;
-}
-
-.mce-toolbar .mce-active.mce-advanced button {
-	transform: rotate( 90deg );
-
-	&:hover {
-		color: $gray;
-	}
+		top: 0;
+		right: 8px;
 }

--- a/client/components/tinymce/plugins/contact-form/plugin.js
+++ b/client/components/tinymce/plugins/contact-form/plugin.js
@@ -88,7 +88,7 @@ const wpcomContactForm = editor => {
 	} );
 
 	editor.addButton( 'wpcom_add_contact_form', {
-		classes: 'btn wpcom-button contact-form',
+		classes: 'btn wpcom-icon-button contact-form',
 		title: i18n.translate( 'Add Contact Form' ),
 		cmd: 'wpcomContactForm',
 		onPostRender() {

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -282,7 +282,7 @@ function mediaButton( editor ) {
 	}
 
 	editor.addButton( 'wpcom_add_media', {
-		classes: 'btn wpcom-button media',
+		classes: 'btn wpcom-icon-button media',
 
 		title: i18n.translate( 'Add Media' ),
 

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -189,8 +189,12 @@
 	vertical-align: middle;
 }
 
-.mce-toolbar .mce-wpcom-button.mce-contact-form button,
-.mce-toolbar .mce-wpcom-button.mce-media button {
+.mce-toolbar .mce-btn-group .mce-btn.mce-wpcom-icon-button {
+	margin: 0;
+	border: 0;
+}
+
+.mce-toolbar .mce-btn-group .mce-btn.mce-wpcom-icon-button button {
 	color: darken( $gray, 20% );
 	height: 38px;
 	padding: 0 8px;
@@ -200,45 +204,29 @@
 	-moz-osx-font-smoothing: auto;
 }
 
-.mce-toolbar .mce-wpcom-button.mce-media button {
+.mce-toolbar .mce-btn-group .mce-btn.mce-wpcom-icon-button .gridicon {
+	fill: darken( $gray, 20% );
+
+	&:hover {
+		fill: $gray-dark;
+	}
+}
+
+.mce-toolbar .mce-btn-group .mce-wpcom-icon-button.mce-media button {
 	@include breakpoint( ">660px" ) {
 		border-right: 1px solid lighten( $gray, 30% );
 		font-size: 13px;
 	}
 }
 
-.mce-toolbar .mce-wpcom-button.mce-media span {
-	font-family: $sans;
-	color: darken( $gray, 20% );
-	font-size: 13px;
-}
-
-.mce-toolbar .mce-wpcom-button.mce-contact-form:hover button,
-.mce-toolbar .mce-wpcom-button.mce-media:hover span {
-	color: $gray-dark;
-}
-
-.mce-toolbar .mce-wpcom-button.mce-contact-form svg,
-.mce-toolbar .mce-wpcom-button.mce-media svg {
-	fill: darken( $gray, 20% );
+.mce-toolbar .mce-btn-group .mce-wpcom-icon-button.mce-contact-form .gridicon,
+.mce-toolbar .mce-btn-group .mce-wpcom-icon-button.mce-media .gridicon {
 	width: 20px;
 	margin-right: 4px;
 }
 
-.mce-toolbar .mce-wpcom-button.mce-contact-form svg {
+.mce-toolbar .mce-btn-group .mce-wpcom-icon-button.mce-contact-form .gridicon {
 	margin-left: 4px;
-}
-
-.mce-toolbar .mce-wpcom-button.mce-contact-form:hover svg,
-.mce-toolbar .mce-wpcom-button.mce-media:hover svg {
-	fill: $gray-dark;
-}
-
-// Position media button at the beginning of the toolbar
-.mce-toolbar .mce-wpcom-button.mce-btn.mce-contact-form,
-.mce-toolbar .mce-wpcom-button.mce-btn.mce-media {
-	margin: 0;
-	border: 0;
 }
 
 @import 'plugins/advanced/style';
@@ -708,21 +696,26 @@ div.mce-path {
 
 .mce-toolbar .mce-btn-group .mce-btn.mce-listbox button {
 	padding-right: 20px;
-	color: darken( $gray, 20% );
-	font-family: $sans;
-	font-size: 13px;
 	height: 34px;
 	width: auto;
 	min-width: 110px;
-	text-overflow: initial;
 	text-align: left;
-
-	&:hover {
-		color: $gray-dark;
-	}
 
 	@include breakpoint( "<660px" ) {
 		margin-top: 5px;
+	}
+}
+
+.mce-toolbar .mce-btn-group .mce-btn.mce-listbox button .mce-txt {
+	width: auto;
+	padding: 0;
+	color: darken( $gray, 20% );
+	font-family: $sans;
+	font-size: 13px;
+	text-overflow: initial;
+
+	&:hover {
+		color: $gray-dark;
 	}
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7151,7 +7151,7 @@
       }
     },
     "tinymce": {
-      "version": "4.2.8"
+      "version": "4.3.8"
     },
     "to-title-case": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "store": "1.3.16",
     "striptags": "2.1.1",
     "superagent": "1.2.0",
-    "tinymce": "4.2.8",
+    "tinymce": "4.3.8",
     "to-title-case": "0.1.5",
     "tv4": "1.2.7",
     "tween.js": "16.3.1",


### PR DESCRIPTION
Fixes #4115 

This pull request seeks to upgrade our version of TinyMCE from v4.2.8 to its latest version, 4.3.8. Notably, this resolves an issue where attempts to update a gallery or contact form which had been inserted as the first line of the post content were duplicated, rather than replaced. Since the replacement behavior relies on TinyMCE's `editor.execCommand( 'mceInsertContent', false, markup );`, it was suspected and confirmed that an update may resolve the issue. Upon review of [TinyMCE's changelog](https://www.tinymce.com/docs/changelog/) between v4.2.8 and v4.3.8, it's unclear which update brought about the resolution, but as this is a maintenance upgrade we should make anyways, I'm content with its being fixed as a consequence of the upgrade.

__Implementation notes:__

There were two visual regressions as part of the upgrade, resolved within the changes of this pull request:
- The "Toggle Advanced" button was shown as text, rather than as an icon.
 - I opted to replace the icon with its Gridicon equivalent, as we're slowly deprecating Noticon. Because there are already a few other Gridicon-based menu buttons, I refactored their styles to apply more generally to icon buttons.
- The "Paragraph" (format select) text styling had reset to default TinyMCE styling, as a result of a new `.mce-txt` `span` wrapper element being added to its button.

__Upgrade Notes:__

Two changelog notes stuck out as worth exploring:
- [Version 4.3.0](https://www.tinymce.com/docs/changelog/#version430-november232015) added a [`codesample` plugin](https://www.tinymce.com/docs/plugins/codesample/) for syntax highlighting of code blocks, a feature I've personally expressed interest in. However, since it relies on [prism.js](http://prismjs.com/), enabling the plugin would incur additional weight to the page load, so we should at minimum explore options for minimizing this effect (perhaps loading the plugin only when its known the post content contains code?)
- [Version 4.3.4](https://www.tinymce.com/docs/changelog/#version434-february112016) returns a `Promise` instance from `tinymce.init`. Since we already have [post-setup tasks](https://github.com/Automattic/wp-calypso/blob/82ddc3b336901815202101b8e3c506d66883bdfb/client/components/tinymce/index.jsx#L200-L215), we may consider reimplementing this as a promise chain on the `init` call.

__Testing instructions:__

Thoroughly test [post editor](http://calypso.localhost:3000/post) behavior, ensuring no regressions (code or visual). Recommended to test in a non-standard and small-viewport browser. Verify that I've not overlooked changelog revisions which may have unintended consequences.

Related: https://core.trac.wordpress.org/changeset/37000 (cc @azaozz)

/cc @jkudish , @deBhal , @alisterscott