### PR TITLE
Enable the new WPCOM plugins page in `wpcalypso`

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,6 +44,7 @@
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,
+		"manage/plugins/wpcom": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/sharing": true,


### PR DESCRIPTION
Already on in development version and this PR just enables it for wpcalypso.wordpress.com

cc: @apeatling