### PR TITLE
Plugins: Update WPCOM plugins design

### DIFF
--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -10,6 +10,7 @@ const defaultPlugins = [
 	{
 		name: 'Google Analytics',
 		supportLink: 'https://en.support.wordpress.com/google-analytics/',
+		icon: 'stats',
 		plan: 'Business',
 		description: 'Advanced features to complement WordPress.com stats. Funnel reports, goal conversion, and more.'
 	}
@@ -24,10 +25,10 @@ export const BusinessPluginsPanel = React.createClass( {
 
 		return (
 			<div>
-				<SectionHeader label={ this.translate( 'Business Upgrades' ) }>
+				<SectionHeader label={ this.translate( 'Business Plan Upgrades' ) }>
 					<Button compact primary>{ this.translate( 'Purchase' ) }</Button>
 				</SectionHeader>
-				<Card className="wpcom-plugins__business-panel">
+				<Card className="wpcom-plugins__business-panel is-disabled">
 					<div className="wpcom-plugins__list">
 						{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
 							<BusinessPlugin

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -8,7 +8,7 @@ export const InfoHeader = React.createClass( {
 		return (
 			<Notice
 				showDismiss={ false }
-				text={ "Uploading and installing your own plugins is not available on WordPress.com, but we offer the most essential ones below." }
+				text={ "Your site comes pre-installed with a wide variety of plugins. Uploading your own plugins is not available on WordPress.com." }
 			>
 				<NoticeAction href="https://en.support.wordpress.com/plugins/">
 					{ "Learn More" }

--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -14,7 +14,7 @@ export const PluginsList = React.createClass( {
 		const backHref = `/plugins/${ siteSlug }`;
 
 		return (
-			<div className="wpcom-plugin-panel wpcom-plugins-list">
+			<div className="wpcom-plugin-panel wpcom-plugins-expanded">
 				<HeaderCake backHref={ backHref } onClick={ noop }>Standard Plugins</HeaderCake>
 				<StandardPluginsPanel />
 			</div>

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -10,18 +10,21 @@ const defaultPlugins = [
 	{
 		name: 'No Advertising',
 		supportLink: 'https://en.support.wordpress.com/no-ads/',
+		icon: 'block',
 		plan: 'Premium',
 		description: 'Remove all ads from your site.'
 	},
 	{
 		name: 'Custom Design',
 		supportLink: 'https://en.support.wordpress.com/custom-design/',
+		icon: 'customize',
 		plan: 'Premium',
 		description: 'Customize your blog\'s look with custom fonts, a CSS editor, and more.'
 	},
 	{
 		name: 'Video Uploads',
 		supportLink: 'https://en.support.wordpress.com/videopress/',
+		icon: 'video-camera',
 		plan: 'Premium',
 		description: 'Upload and host your video files on your site with VideoPress.'
 	}
@@ -36,10 +39,10 @@ export const PremiumPluginsPanel = React.createClass( {
 
 		return (
 			<div>
-				<SectionHeader label={ this.translate( 'Premium Upgrades' ) }>
+				<SectionHeader label={ this.translate( 'Premium Plan Upgrades' ) }>
 					<Button compact primary>{ this.translate( 'Purchase' ) }</Button>
 				</SectionHeader>
-				<Card className="wpcom-plugins__premium-panel">
+				<Card className="wpcom-plugins__premium-panel is-disabled">
 					<div className="wpcom-plugins__list">
 						{ plugins.map( ( { name, supportLink, icon, plan, description } ) =>
 							<PremiumPlugin

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -19,7 +19,7 @@ export const StandardPluginsPanel = React.createClass( {
 
 		return (
 			<div>
-				<SectionHeader label={ this.translate( 'Standard Plugin Suite' ) }>
+				<SectionHeader label={ this.translate( 'Free Plan Plugin Suite' ) }>
 					<Button className="is-active-plugin" compact borderless>
 						<Gridicon icon="checkmark" />{ this.translate( 'Active' ) }
 					</Button>

--- a/client/my-sites/plugins-wpcom/standard-plugins.js
+++ b/client/my-sites/plugins-wpcom/standard-plugins.js
@@ -1,109 +1,127 @@
 export const standardPlugins = [
 	{
-		name: 'WordPress.com Stats',
+		name: 'Stats',
 		supportLink: 'http://support.wordpress.com/stats/',
+		icon: 'stats',
 		category: 'Traffic Growth',
 		description: 'View your site\'s visits, referrers, and more.'
 	},
 	{
 		name: 'Essential SEO',
 		supportLink: 'http://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/',
+		icon: 'search',
 		category: 'Traffic Growth',
 		description: 'Search engine optimization and sitemaps.'
 	},
 	{
 		name: 'Security Scanning',
 		supportLink: 'http://support.wordpress.com/security/',
+		icon: 'lock',
 		category: 'Performance',
 		description: 'Constant monitoring of your site for threats.'
 	},
 	{
 		name: 'Advanced Galleries',
 		supportLink: 'http://support.wordpress.com/images/gallery/',
+		icon: 'image-multiple',
 		category: 'Appearance',
 		description: 'Tiled, mosaic, slideshows, and more.'
 	},
 	{
-		name: 'Social Media Sharing',
+		name: 'Social Media',
 		supportLink: 'http://support.wordpress.com/sharing/',
+		icon: 'share',
 		category: 'Traffic Growth',
-		description: 'Add share buttons to your posts and pages.'
+		description: 'Add social media buttons to your posts and pages.'
 	},
 	{
-		name: 'Contact Form Builder',
+		name: 'Form Builder',
 		supportLink: 'http://support.wordpress.com/contact-form/',
+		icon: 'mention',
 		category: 'Appearance',
 		description: 'Build contact forms so visitors can get in touch.'
 	},
 	{
 		name: 'Extended Customizer',
 		supportLink: 'https://en.support.wordpress.com/customizer/',
+		icon: 'customize',
 		category: 'Appearance',
 		description: 'Edit colors and backgrounds.'
 	},
 	{
 		name: 'Extended Widgets',
 		supportLink: 'https://en.support.wordpress.com/category/widgets-sidebars/',
+		icon: 'calendar',
 		category: 'Appearance',
 		description: 'Eventbrite, Flickr, Google Calendar, and more.'
 	},
 	{
 		name: 'Akismet',
 		supportLink: 'http://akismet.com/',
+		icon: 'lock',
 		category: 'Security',
 		description: 'Advanced anti-spam security.'
 	},
 	{
 		name: 'Backup',
 		supportLink: 'https://en.support.wordpress.com/export/#backups',
+		icon: 'lock',
 		category: 'Security',
 		description: '24/7 backup of your entire site.'
 	},
 	{
 		name: 'Photon CDN',
 		supportLink: 'https://jetpack.com/support/photon/',
+		icon: 'image',
 		category: 'Performance',
 		description: 'Faster image loading and editing.'
 	},
 	{
 		name: 'Extended Shortcodes',
 		supportLink: 'https://en.support.wordpress.com/shortcodes/',
+		icon: 'pencil',
 		category: 'Misc',
 		description: 'YouTube, Twitter, Instagram, Spotify, and more.'
 	},
 	{
 		name: 'Importer',
 		supportLink: 'http://support.wordpress.com/import/',
+		icon: 'cloud-download',
 		category: 'Misc',
 		description: 'Import your blog content from a variety of other blogging platforms.'
 	},
 	{
 		name: 'Infinite Scroll',
 		supportLink: 'https://en.support.wordpress.com/infinite-scroll/',
+		icon: 'posts',
 		category: 'Appearance',
 		description: 'Load more posts when you reach the bottom of a page.'
 	},
 	{
 		name: 'Related Posts',
 		supportLink: 'https://en.support.wordpress.com/related-posts/',
+		icon: 'posts',
 		category: 'Appearance',
 		description: 'Pulls relevant content from your blog to display at the bottom of your posts.'
 	},
 	{
 		name: 'Email Subscriptions',
 		supportLink: 'https://en.support.wordpress.com/widgets/follow-blog-widget/',
+		icon: 'mail',
 		category: 'Misc',
 		description: 'Enables your readers to sign up to receive your posts via email.'
 	},
 	{
 		name: 'Markdown',
 		supportLink: 'https://en.support.wordpress.com/markdown/',
+		icon: 'pencil',
 		category: 'Misc',
 		description: 'Text formatting using a lightweight markup language. '
 	},
 	{
 		name: 'Advanced Commenting',
 		supportLink: 'https://en.support.wordpress.com/category/comments/',
+		icon: 'comment',
 		category: 'Misc',
 		description: 'Comment likes, user mentions, notifications, and more.'
 	}

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -4,6 +4,19 @@
 	padding: 0;
 }
 
+// Disabled styles for not activated plans
+.wpcom-plugins__premium-panel.is-disabled,
+.wpcom-plugins__business-panel.is-disabled {
+	.wpcom-plugins__plugin-item {
+		opacity: 0.35;
+	}
+}
+
+.wpcom-plugin-panel .section-header {
+	border-bottom: 2px solid $blue-medium;
+	margin-bottom: 0;
+}
+
 .wpcom-plugins__list {
 	display: flex;
 	flex-flow: row wrap;
@@ -53,7 +66,7 @@
 .wpcom-plugins__plugin-icon {
 	width: 40px;
 	height: 40px;
-	background: $blue-wordpress;
+	background: $gray;
 	float: left;
 	display: flex;
 	justify-content: center;
@@ -99,6 +112,15 @@
 	}
 }
 
+.wpcom-plugins-expanded .section-header {
+	border-bottom: none;
+}
+
 .wpcom-plugin-panel .notice__icon {
 	flex-shrink: 0; // Prevent the notice icon from shrinking
+}
+
+.wpcom-plugin-panel__panel-footer {
+	padding-top: 14px;
+	padding-bottom: 14px;
 }

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -61,6 +61,10 @@
 
 .wpcom-plugins__plugin-item a {
 	color: $gray-dark;
+	
+	&:hover .wpcom-plugins__plugin-icon {
+		background: $blue-medium;
+	}
 }
 
 .wpcom-plugins__plugin-icon {


### PR DESCRIPTION
Updates the design of the wpcom plugins page.

- Updated text
- Faded disabled styles for plugins
- New icons for plugins
- New colors

Banner text was updated to be less harsh. We still need to be clear that we don't allow uploading plugins though. Updated a few of the plugin names to be shorter.

Icons are now gray, to be less blue. There is a blue hover style. Section headers now are more prominent with a blue underline.

Progresses #4572

@apeatling I think this addresses your concerns

cc @rralian 

![fptnpqoazlaaaaabjru5erkjggg](https://cloud.githubusercontent.com/assets/618551/14363465/54fb0dd0-fcfc-11e5-8975-5e53933e6670.png)
