### PR TITLE
Framework: add plan card

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -196,6 +196,7 @@
 @import 'my-sites/people/people-list-item/style';
 @import 'my-sites/people/people-profile/style';
 @import 'my-sites/people/people-notices/style';
+@import 'my-sites/plan-card/style';
 @import 'my-sites/plan-storage/style';
 @import 'my-sites/plans/style';
 @import 'my-sites/plans/plan-overview/style';

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -37,4 +37,6 @@ $link-highlight:         tint($blue-medium, 20%);
 $white:                  rgba(255,255,255,1);
 $transparent:            rgba(255,255,255,0);
 
+// Uncommon
+$gray-super-light:       #fbfcfd;
 $border-ultra-light-gray: #e8f0f5;

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -38,6 +38,7 @@ $z-layers: (
 		'.site-icon.is-blank .noticon': 0,
 		'.chart__bar-section.is-spacer': 0,
 		'.gear-dropdown:after': 0,
+		'.plan-card__ribbon': 1,
 		'.reader__featured-post-title': 1,
 		'.reader-list-gap__button': 1,
 		'.post-trends__title': 1,
@@ -132,6 +133,10 @@ $z-layers: (
 		'.fullscreen-fader': 200000,
 		'.guidestours__step': 201000,
 		'#habla_window_div.habla_window_div_base': 99999999 //olark
+	),
+	'.plan-card__ribbon': (
+		'.plan-card__ribbon-title::before': -1,
+		'.plan-card__ribbon-title::after': -1
 	),
 	'.environment-badge': (
 		'.environment-badge .environment::before': -1,

--- a/client/devdocs/design/app-components.jsx
+++ b/client/devdocs/design/app-components.jsx
@@ -24,6 +24,7 @@ import HappinessSupport from 'components/happiness-support/docs/example';
 import ThemesListExample from 'components/themes-list/docs/example';
 import PlanStorage from 'my-sites/plan-storage/docs/example';
 import UpgradeNudge from 'my-sites/upgrade-nudge/docs/example';
+import PlanCard from 'my-sites/plan-card/docs/example';
 
 export default React.createClass( {
 
@@ -69,6 +70,7 @@ export default React.createClass( {
 					<Theme />
 					<ThemesListExample />
 					<UpgradeNudge />
+					<PlanCard />
 				</Collection>
 			</div>
 		);

--- a/client/my-sites/plan-card/README.md
+++ b/client/my-sites/plan-card/README.md
@@ -1,0 +1,64 @@
+Plan Card
+==============
+
+This component is used to display a current or next plan, highlighting the features you choose.
+
+#### Usage:
+
+```javascript
+	<PlanCard
+		title="Free Plan"
+		line="Free for life"
+		buttonName="Your Plan"
+		currentPlan={ true }>
+		<PlanCardItem highlight={ true }>
+			3GB Space
+		</PlanCardItem>
+		<PlanCardItem unavailable={ true }>
+			Custom Domain
+		</PlanCardItem>
+		<PlanCardItem unavailable={ true }>
+			No Ads
+		</PlanCardItem>
+		<PlanCardItem unavailable={ true }>
+			Custom Design
+		</PlanCardItem>
+		<PlanCardItem unavailable={ true }>
+			VideoPress
+		</PlanCardItem>
+	</PlanCard>
+	
+	<PlanCard
+		title="Premium"
+		line="$99 per year"
+		buttonName="Upgrade"
+		currentPlan={ false }
+		popularRibbon={ true }>
+		<PlanCardItem highlight={ true }>
+			13GB Space
+		</PlanCardItem>
+		<PlanCardItem>
+			Custom Domain
+		</PlanCardItem>
+		<PlanCardItem>
+			No Ads
+		</PlanCardItem>
+		<PlanCardItem>
+			Custom Design
+		</PlanCardItem>
+		<PlanCardItem>
+			VideoPress
+		</PlanCardItem>
+	</PlanCard>
+}
+```
+
+#### Props
+
+* `title`: The plan name (required)
+* `line`: The plan tagline (required)
+* `buttonName`: Button text (required)
+* `currentPlan`: If the plan is current
+* `onClick`: An on click handler that is fired when the plan button is clicked.
+* `popularRibbon`: Displays the popular ribbon
+* `className`: A string that adds additional class names to this component.

--- a/client/my-sites/plan-card/docs/example.jsx
+++ b/client/my-sites/plan-card/docs/example.jsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+
+/**
+ * Internal dependencies
+ */
+import PlanCard from '../index';
+import PlanCardItem from '../item';
+
+export default React.createClass( {
+
+	displayName: 'PlanCardExample',
+
+	mixins: [ PureRenderMixin ],
+
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/app-components/plan-card-example">Plan Card</a>
+				</h2>
+				<div>
+					<PlanCard
+						title="Free Plan"
+						line="Free for life"
+						buttonName="Your Plan"
+						currentPlan={ true }>
+						<PlanCardItem highlight={ true }>
+							3GB Space
+						</PlanCardItem>
+						<PlanCardItem unavailable={ true }>
+							Custom Domain
+						</PlanCardItem>
+						<PlanCardItem unavailable={ true }>
+							No Ads
+						</PlanCardItem>
+						<PlanCardItem unavailable={ true }>
+							Custom Design
+						</PlanCardItem>
+						<PlanCardItem unavailable={ true }>
+							VideoPress
+						</PlanCardItem>
+					</PlanCard>
+				</div>
+				<br />
+				<div>
+					<PlanCard
+						title="Premium"
+						line="$99 per year"
+						buttonName="Upgrade"
+						currentPlan={ false }
+						popularRibbon={ true }>
+						<PlanCardItem highlight={ true }>
+							13GB Space
+						</PlanCardItem>
+						<PlanCardItem>
+							Custom Domain
+						</PlanCardItem>
+						<PlanCardItem>
+							No Ads
+						</PlanCardItem>
+						<PlanCardItem>
+							Custom Design
+						</PlanCardItem>
+						<PlanCardItem>
+							VideoPress
+						</PlanCardItem>
+					</PlanCard>
+				</div>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/plan-card/index.jsx
+++ b/client/my-sites/plan-card/index.jsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React, { PropTypes } from 'react';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+
+import Button from 'components/button';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+
+export default React.createClass( {
+
+	displayName: 'PlanCard',
+
+	propTypes: {
+		className: PropTypes.string,
+		onClick: PropTypes.func,
+		title: PropTypes.string.isRequired,
+		line: PropTypes.string.isRequired,
+		buttonName: PropTypes.string.isRequired,
+		currentPlan: PropTypes.bool,
+		popularRibbon: PropTypes.bool
+	},
+
+	getDefaultProps() {
+		return {
+			onClick: noop,
+			currentPlan: true,
+			popularRibbon: false
+		}
+	},
+
+	buttonClick() {
+		if ( ! this.props.currentPlan ) {
+			this.props.onClick();
+		}
+	},
+
+	render() {
+		const classes = classNames( this.props.className, 'plan-card' );
+		const buttonClasses = classNames( 'plan-card__button', {
+			'is-current': this.props.currentPlan
+		} );
+		return (
+			<div className={ classes } >
+				{ this.props.popularRibbon && <div className="plan-card__ribbon">
+					<span className="plan-card__ribbon-title">{ this.translate( 'popular' ) }</span>
+				</div> }
+				<Card className="plan-card__header">
+					<div className="plan-card__title">{ this.props.title }</div>
+					<div className="plan-card__line">{ this.props.line }</div>
+				</Card>
+				<Card className="plan-card__features">
+					<ul className="plan-card__features-list">
+						{ this.props.children }
+					</ul>
+				</Card>
+				<Card className="plan-card__actions">
+					<Button
+						className={ buttonClasses }
+						disabled={ this.props.currentPlan }
+						primary={ ! this.props.currentPlan }
+						onClick={ this.buttonClick }>
+						{ this.props.currentPlan && <Gridicon className="plan-card__button-checkmark" icon="checkmark" /> }
+						{ this.props.buttonName }
+					</Button>
+				</Card>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/plan-card/item.jsx
+++ b/client/my-sites/plan-card/item.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
+export default React.createClass( {
+
+	displayName: 'PlanCardItem',
+
+	propTypes: {
+		highlight: PropTypes.bool,
+		unavailable: PropTypes.bool
+	},
+
+	getDefaultProps() {
+		return {
+			highlight: false,
+			unavailable: false
+		}
+	},
+
+	render() {
+		const classes = classNames( this.props.className, 'plan-card-item', {
+			'is-highlight': this.props.highlight,
+			'is-unavailable': this.props.unavailable
+		} );
+		const showCheckmark = this.props.highlight || ! this.props.unavailable;
+		return (
+			<li className={ classes }>
+				{ showCheckmark && <Gridicon className="grid-card-item__checkmark" size={ 18 } icon="checkmark" /> }
+				{ this.props.children }
+			</li>
+		);
+	}
+} );

--- a/client/my-sites/plan-card/style.scss
+++ b/client/my-sites/plan-card/style.scss
@@ -1,0 +1,130 @@
+.plan-card {
+	width: 300px;
+	//ribbon
+	position: relative;
+}
+
+.plan-card__header,
+.plan-card__features,
+.plan-card__actions {
+	margin-bottom: 0;
+}
+
+.plan-card__features {
+	padding: 16px 24px;
+	background-color: $gray-super-light;
+	font-size: 14px;
+	color: $gray;
+}
+
+.plan-card__header {
+	text-align: center;
+	border-radius: 4px 4px 0 0;
+}
+
+.plan-card__actions {
+	border-radius: 0 0 4px 4px;
+}
+
+.plan-card__title {
+	font-size: 16px;
+	font-weight: 500;
+	color: lighten( $gray-dark, 10% );
+}
+
+.plan-card__line {
+	font-size: 12px;
+	font-weight: normal;
+	color: $gray;
+	font-style: italic;
+}
+
+.plan-card__features-list {
+	margin: 0;
+}
+
+//needs .button to override button specificity
+.plan-card__button.is-current {
+	width: 100%;
+	border-width: 1px;
+	border-color: $blue-medium;
+	color: $blue-medium;
+	font-weight: 400;
+}
+
+.plan-card__button.is-current:active {
+	border-bottom-width: 1px;
+}
+
+.plan-card__button.is-primary {
+	width: 100%;
+}
+
+.plan-card-item {
+	list-style-type: none;
+}
+
+.plan-card-item.is-highlight {
+	color: $alert-green;
+	margin-left: 0px;
+}
+
+.plan-card-item.is-unavailable {
+	text-decoration: line-through;
+	margin-left: 24px;
+}
+
+.grid-card-item__checkmark {
+	margin-right: 6px;
+	vertical-align: middle;
+	margin-top: -4px;
+}
+
+.plan-card__button-checkmark {
+	margin-right: 6px;
+}
+
+.plan-card__ribbon {
+	position: absolute;
+	right: -5px; top: -5px;
+	z-index: z-index( 'root', '.plan-card__ribbon' );
+	overflow: hidden;
+	width: 75px; height: 75px;
+	text-align: right;
+}
+.plan-card__ribbon .plan-card__ribbon-title {
+	font-size: 10px;
+	font-weight: normal;
+	color: $white;
+	text-align: center;
+	line-height: 20px;
+	transform: rotate(45deg);
+	-webkit-transform: rotate(45deg);
+	width: 100px;
+	display: block;
+	background: $blue-medium;
+	box-shadow: 0 3px 10px -5px rgba(0, 0, 0, 1);
+	position: absolute;
+	top: 19px;
+	right: -21px;
+	text-transform: uppercase;
+}
+.plan-card__ribbon .plan-card__ribbon-title::before {
+	content: "";
+	position: absolute; left: 0px; top: 100%;
+	z-index: z-index( '.plan-card__ribbon', '.plan-card__ribbon-title::before' );
+	border-left: 3px solid $blue-dark;
+	border-right: 3px solid transparent;
+	border-bottom: 3px solid transparent;
+	border-top: 3px solid $blue-dark;
+}
+.plan-card__ribbon .plan-card__ribbon-title::after {
+	content: "";
+	position: absolute;
+	right: 0px; top: 100%;
+	z-index: z-index( '.plan-card__ribbon', '.plan-card__ribbon-title::after' );
+	border-left: 3px solid transparent;
+	border-right: 3px solid $blue-dark;
+	border-bottom: 3px solid transparent;
+	border-top: 3px solid $blue-dark;
+}


### PR DESCRIPTION
This PR adds a component that highlights features in a current or higher plan.

<img width="320" alt="screen shot 2016-04-07 at 8 56 58 pm" src="https://cloud.githubusercontent.com/assets/1270189/14365015/66edaa28-fd03-11e5-94ec-bf1e8381606f.png">

## Testing:
- Navigate to http://calypso.localhost:3000/devdocs/app-components
- The component appears normally

cc @adambbecker @mtias @rralian @retrofox @drw158