### PR TITLE
Test: Improve code that uses use sandbox helper

### DIFF
--- a/client/my-sites/upgrades/domain-management/edit/test/test-mapped-domain.js
+++ b/client/my-sites/upgrades/domain-management/edit/test/test-mapped-domain.js
@@ -1,11 +1,11 @@
 import assert from 'assert';
+import sinon from 'sinon';
 
 describe( 'domain-management/edit/mapped-domain', () => {
 	let React,
 		MappedDomain,
 		i18n,
 		props,
-		sinonWrapper,
 		TestUtils;
 
 	before( () => {
@@ -22,7 +22,6 @@ describe( 'domain-management/edit/mapped-domain', () => {
 	} );
 
 	require( 'test/helpers/use-fake-dom' ).withContainer();
-	sinonWrapper = require( 'test/helpers/use-sinon' ).useSandbox();
 
 	require( 'test/helpers/use-mockery' )( mockery => {
 		React = require( 'react' );
@@ -41,10 +40,10 @@ describe( 'domain-management/edit/mapped-domain', () => {
 		assert( out );
 	} );
 
-	it( 'should use selectedSite.slug for URLs', () => {
+	it( 'should use selectedSite.slug for URLs', sinon.test( function() {
 		const paths = require( 'my-sites/upgrades/paths' );
-		const dnsStub = sinonWrapper.sandbox.stub( paths, 'domainManagementDns' );
-		const emailStub = sinonWrapper.sandbox.stub( paths, 'domainManagementEmail' );
+		const dnsStub = this.stub( paths, 'domainManagementDns' );
+		const emailStub = this.stub( paths, 'domainManagementEmail' );
 
 		const renderer = TestUtils.createRenderer();
 		renderer.render( <MappedDomain { ...props } /> );
@@ -52,5 +51,5 @@ describe( 'domain-management/edit/mapped-domain', () => {
 
 		assert( dnsStub.calledWith( 'neverexpires.wordpress.com', 'neverexpires.com' ) );
 		assert( emailStub.calledWith( 'neverexpires.wordpress.com', 'neverexpires.com' ) );
-	} );
+	} ) );
 } );

--- a/client/my-sites/upgrades/domain-management/list/test/index.js
+++ b/client/my-sites/upgrades/domain-management/list/test/index.js
@@ -1,9 +1,15 @@
+/**
+ * External dependencies
+ */
 import deepFreeze from 'deep-freeze';
 import assert from 'assert';
 
-describe( 'upgrades/domain-management/list', function() {
-	const sinonWrapper = require( 'test/helpers/use-sinon' ).useSandbox();
+/**
+ * Internal dependencies
+ */
+import { useSandbox } from 'test/helpers/use-sinon';
 
+describe( 'upgrades/domain-management/list', function() {
 	let React,
 		ReactDom,
 		ReactInjection,
@@ -11,7 +17,10 @@ describe( 'upgrades/domain-management/list', function() {
 		TestUtils,
 		i18n,
 		noticeTypes,
-		component;
+		component,
+		sandbox;
+
+	useSandbox( newSandbox => sandbox = newSandbox );
 
 	require( 'test/helpers/use-fake-dom' )( '<div id="main" />' );
 	require( 'test/helpers/use-mockery' )(
@@ -141,7 +150,7 @@ describe( 'upgrades/domain-management/list', function() {
 					setPrimaryDomainResolve,
 					setPrimaryDomainReject;
 				beforeEach( () => {
-					setPrimaryDomainStub = sinonWrapper.sandbox.stub( component, 'setPrimaryDomain' ).returns( new Promise( ( resolve, reject ) => {
+					setPrimaryDomainStub = sandbox.stub( component, 'setPrimaryDomain' ).returns( new Promise( ( resolve, reject ) => {
 						setPrimaryDomainResolve = resolve;
 						setPrimaryDomainReject = reject;
 					} ) );

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -34,15 +34,15 @@ describe( 'EditorMediaModal', function() {
 	useMockery();
 	useFakeDom();
 	useI18n();
-	useSandbox( ( _sandbox ) => sandbox = _sandbox );
+	useSandbox( ( newSandbox ) => {
+		sandbox = newSandbox;
+		deleteMedia = sandbox.stub();
+		accept = sandbox.stub().callsArgWithAsync( 1, true );
+	} );
 
 	before( function() {
 		ModalViews = require( '../constants' ).Views;
 		i18n = require( 'lib/mixins/i18n' );
-
-		// Sinon
-		deleteMedia = sandbox.stub();
-		accept = sandbox.stub().callsArgWithAsync( 1, true );
 
 		// Mockery
 		mockery.registerMock( 'my-sites/media-library', EMPTY_COMPONENT );
@@ -57,10 +57,6 @@ describe( 'EditorMediaModal', function() {
 
 		EditorMediaModal = require( '../' );
 		EditorMediaModal.prototype.__reactAutoBindMap.translate = i18n.translate;
-	} );
-
-	beforeEach( function() {
-		sandbox.reset();
 	} );
 
 	it( 'should prompt to delete a single item from the list view', function( done ) {

--- a/client/post-editor/media-modal/test/markup.js
+++ b/client/post-editor/media-modal/test/markup.js
@@ -14,7 +14,7 @@ describe( 'markup', function() {
 	let sandbox, markup, sites;
 
 	useFakeDom();
-	useSandbox( ( _sandbox ) => sandbox = _sandbox );
+	useSandbox( ( newSandbox ) => sandbox = newSandbox );
 
 	before( () => {
 		markup = require( '../markup' );

--- a/client/post-editor/media-modal/test/preload-image.js
+++ b/client/post-editor/media-modal/test/preload-image.js
@@ -14,14 +14,12 @@ describe( '#preloadImage()', function() {
 	let sandbox, Image;
 
 	useFakeDom();
-	useSandbox( ( _sandbox ) => sandbox = _sandbox );
-
-	before( function() {
+	useSandbox( ( newSandbox ) => {
+		sandbox = newSandbox;
 		Image = sandbox.stub( global.window, 'Image' );
 	} );
 
 	beforeEach( function() {
-		sandbox.reset();
 		preloadImage.cache.clear();
 	} );
 

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -16,7 +16,7 @@ describe( 'PostEditor', function() {
 	let sandbox, TestUtils, PostEditor, SitesList, PostEditStore;
 
 	useFakeDom();
-	useSandbox( ( _sandbox ) => sandbox = _sandbox );
+	useSandbox( ( newSandbox ) => sandbox = newSandbox );
 	useMockery();
 
 	before( () => {

--- a/client/state/sites/media-storage/test/actions.js
+++ b/client/state/sites/media-storage/test/actions.js
@@ -21,15 +21,11 @@ import {
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'actions', () => {
-	let spy;
-	let sandbox;
-
-	beforeEach( () => {
-		spy = sandbox.spy();
-	} );
+	let sandbox, spy;
 
 	useSandbox( newSandbox => {
 		sandbox = newSandbox;
+		spy = sandbox.spy();
 	} );
 
 	describe( '#receiveMediaStorage()', () => {

--- a/client/state/sites/media-storage/test/reducer.js
+++ b/client/state/sites/media-storage/test/reducer.js
@@ -26,9 +26,6 @@ describe( 'reducer', () => {
 
 	useSandbox( newSandbox => {
 		sandbox = newSandbox;
-	} );
-
-	before( () => {
 		sandbox.stub( console, 'warn' );
 	} );
 

--- a/test/test/helpers/use-sinon/index.js
+++ b/test/test/helpers/use-sinon/index.js
@@ -43,26 +43,26 @@ export function useFakeTimers( now = 0, clockCallback = noop ) {
  *
  * @param  {Object|Function} config The configuration to use, or a callback that is invoked with the sandbox instance
  * @param  {Function} sandboxCallback A callback function that is invoked with the sandbox instance
- * @returns { {sandbox: Object} } Object with .sandbox property that points to the current sandbox instance
  */
 export function useSandbox( config, sandboxCallback = noop ) {
-	const wrapper = {};
 	if ( isFunction( config ) && sandboxCallback === noop ) {
 		sandboxCallback = config;
 		config = undefined;
 	}
 
 	before( function() {
-		wrapper.sandbox = this.sandbox = sinon.sandbox.create( config );
+		this.sandbox = sinon.sandbox.create( config );
 		sandboxCallback( this.sandbox );
+	} );
+
+	beforeEach( function() {
+		this.sandbox.reset();
 	} );
 
 	after( function() {
 		if ( this.sandbox ) {
 			this.sandbox.restore();
 			this.sandbox = null;
-			wrapper.sandbox = null;
 		}
 	} );
-	return wrapper;
 }


### PR DESCRIPTION
No changes in tests themselves. This PR just tries to improve the way we use `useSandbox` helper in unit tests.

### Testing
`npm run test-client`

/cc @aduth @blowery