### PR TITLE
Update: Prefix WhatsApp with jetpack

### DIFF
--- a/client/my-sites/sharing/buttons/preview-button.jsx
+++ b/client/my-sites/sharing/buttons/preview-button.jsx
@@ -36,6 +36,7 @@ module.exports = React.createClass( {
 			'google-plus-1': 'google-plus-alt',
 			pinterest: 'pinterest-alt',
 			tumblr: 'tumblr-alt',
+			'jetpack-whatsapp': 'whatsapp',
 			'press-this': 'wordpress',
 			twitter: 'twitter-alt',
 			more: 'share'

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -1003,7 +1003,7 @@ $color-whatsapp: #43d854;
 @include sharing-button-service( "print", $color-print );
 @include sharing-button-service( "skype", $color-skype );
 @include sharing-button-service( "telegram", $color-telegram );
-@include sharing-button-service( "whatsapp", $color-whatsapp );
+@include sharing-button-service( "jetpack-whatsapp", $color-whatsapp );
 
 
 .sharing-buttons-preview__panel {


### PR DESCRIPTION
WhatsApp needs to be prefixed with Jetpack so that we don't break existing plugins/ sites that user the same id. 

cc: @lezama 


