### PR TITLE
Fix Undo Notice on Menu Delete

### DIFF
--- a/client/notices/index.js
+++ b/client/notices/index.js
@@ -11,8 +11,7 @@ var list = { containerNames: {} };
 Emitter( list );
 var delayedNotices = [];
 
-module.exports = {
-
+const notices = {
 	/**
 	 * Creates a new notice
 	 * @private
@@ -37,7 +36,12 @@ module.exports = {
 			container: container,
 			button: options.button,
 			href: options.href,
-			onClick: options.onClick,
+			onClick: ( event ) => {
+				if ( typeof options.onClick === 'function' ) {
+					const closeFn = notices.removeNotice.bind( notices, noticeObject );
+					return options.onClick( event, closeFn );
+				}
+			},
 			onRemoveCallback: options.onRemoveCallback || function() {},
 			arrow: options.arrow,
 			isCompact: options.isCompact,
@@ -189,3 +193,5 @@ module.exports = {
 	}
 
 };
+
+export default notices;


### PR DESCRIPTION
This fixes #3379 

After deleting a menu, the undo notice was not working because it was expecting a close method from notices. The solution is to store the notice so that we can tell notices to remove it when undo-ing.

The root cause is that notices isn't sending the close function to the onClick handler ([per the documentation](https://github.com/Automattic/wp-calypso/tree/master/client/notices#onclick)), but I couldn't find where that was being used or any history of that close function being sent. This was the only instance of it being used I could see. ~~I wasn't sure if the documentation was wrong or the implementation, so my first pass is to work around the discrepancy. If someone more familiar with notices can comment I would prefer to implement the close function instead of this workaround.~~

Update: I've changed the fix to add a close function to notices, which will get the code in line with the documentation and make it easier to manage notices.

@ockham @nb please take a look

Testing procedure: delete a menu and click the undo notice that appears. Confirm that the menu you deleted is back and no script errors are triggered.