### PR TITLE
GuidedTours: Enable in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -19,6 +19,7 @@
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": false,
+		"guidestours": true,
 		"help": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,


### PR DESCRIPTION
Let's make it a little easier to see the current state of guides. Once merged, example tour will be available at `<calypso url>?tour=main`

/cc @lsinger @mcsf