### PR TITLE
Me: Profile links buttons overlap on small screens

### DIFF
--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -1,51 +1,66 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 // Internal dependencies
-var Button = require( 'components/button' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	eventRecorder = require( 'me/event-recorder' ),
-	Gridicon = require( 'components/gridicon' );
+import Button from 'components/button';
+import observe from 'lib/mixins/data-observe';
+import eventRecorder from 'me/event-recorder';
+import Gridicon from 'components/gridicon';
+import PopoverMenu from 'components/popover/menu';
+import PopoverMenuItem from 'components/popover/menu-item';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 
 	displayName: 'AddProfileLinksButtons',
 
 	mixins: [ observe( 'userProfileLinks' ), eventRecorder ],
 
 	propTypes: {
-		showingForm: React.PropTypes.bool
+		showingForm: React.PropTypes.bool,
+		showPopoverMenu: React.PropTypes.bool
 	},
 
-	getDefaultProps: function() {
-		return{
+	getDefaultProps() {
+		return {
 			showingForm: false
 		};
 	},
 
-	render: function() {
+	getInitialState() {
+		return {
+			popoverPosition: 'top'
+		};
+	},
+
+	render() {
 		return(
 			<div>
-				<Button
-					compact
-					disabled={ this.props.showingForm }
-					onClick={ this.recordClickEvent( 'Add Other Site Button', this.props.onShowAddOther ) }
-				>
-					<Gridicon icon="plus-small" size={ 18 } />
-					{ this.translate( 'Add URL' ) }
-				</Button>
+
+				<PopoverMenu
+					isVisible={ this.props.showPopoverMenu }
+					onClose={ this.props.onClosePopoverMenu }
+					position={ this.state.popoverPosition }
+					context={ this.refs && this.refs.popoverMenuButton }
+					>
+					<PopoverMenuItem
+						onClick={ this.recordClickEvent( 'Add a WordPress Site Button', this.props.onShowAddWordPress ) }>
+						{ this.translate( 'Add WordPress Site' ) }
+					</PopoverMenuItem>
+					<PopoverMenuItem
+						onClick={ this.recordClickEvent( 'Add Other Site Button', this.props.onShowAddOther ) }>
+						{ this.translate( 'Add URL' ) }
+					</PopoverMenuItem>
+				</PopoverMenu>
 
 				<Button
 					compact
-					disabled={ this.props.showingForm }
-					primary
-					className="add-buttons__add-wp-site"
-					onClick={ this.recordClickEvent( 'Add a WordPress Site Button', this.props.onShowAddWordPress ) }
-				>
-					<Gridicon icon="plus-small" size={ 18 } />
-					{ this.translate( 'Add WordPress Site' ) }
+					ref="popoverMenuButton"
+					className="popover-icon"
+					onClick={ this.props.onShowPopoverMenu }>
+						<Gridicon icon="add-outline" />
+						{ this.translate( 'Add' ) }
 				</Button>
 			</div>
 		);

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -56,18 +56,27 @@ module.exports = React.createClass( {
 	getInitialState: function() {
 		return {
 			showingForm: false,
-			lastError: false
+			lastError: false,
+			showPopoverMenu: false
 		};
 	},
 
-	showAddWordPress: function( event ) {
-		event.preventDefault();
-		this.setState( { showingForm: 'wordpress' } );
+	showAddWordPress: function() {
+		this.setState( { showingForm: 'wordpress', showPopoverMenu: false } );
 	},
 
-	showAddOther: function( event ) {
-		event.preventDefault();
-		this.setState( { showingForm: 'other' } );
+	showAddOther: function() {
+		this.setState( { showingForm: 'other', showPopoverMenu: false } );
+	},
+
+	showPopoverMenu: function() {
+		this.setState( {
+			showPopoverMenu: ! this.state.showPopoverMenu
+		} );
+	},
+
+	closePopoverMenu: function() {
+		this.setState( { showPopoverMenu: false } );
 	},
 
 	hideForms: function() {
@@ -201,7 +210,10 @@ module.exports = React.createClass( {
 						userProfileLinks={ this.props.userProfileLinks }
 						showingForm={ !! this.state.showingForm }
 						onShowAddOther={ this.showAddOther }
-						onShowAddWordPress={ this.showAddWordPress } />
+						showPopoverMenu={ this.state.showPopoverMenu }
+						onShowAddWordPress={ this.showAddWordPress }
+						onShowPopoverMenu={ this.showPopoverMenu }
+						onClosePopoverMenu={ this.closePopoverMenu }/>
 				</SectionHeader>
 				<Card>
 					{ !! this.state.showingForm ? this.renderForm() : this.renderProfileLinks() }

--- a/client/me/profile-links/style.scss
+++ b/client/me/profile-links/style.scss
@@ -13,12 +13,6 @@
 	margin-bottom: 1.5em;
 }
 
-@include breakpoint( "<480px" ) {
-	.profile-links button {
-		margin-bottom: 10px;
-	}
-}
-
 .button.add-buttons__add-wp-site{
 	margin-left: 8px;
 }


### PR DESCRIPTION
In #2936, @bluefuton noted that on small screen sizes the buttons in the Profile Links section header overlap:

<img src="https://cloud.githubusercontent.com/assets/17325/12707848/fdd337bc-c8fd-11e5-9ec1-d3ca58c1ede5.png" />

This PR seeks to add an ellipsis menu on smaller screens:

![screen shot 2016-04-08 at 11 43 09 am](https://cloud.githubusercontent.com/assets/1084656/14392544/14f41618-fd7f-11e5-983d-46e3964808f4.png)

To test:
- Go to your profile on small device or narrow browser, and scroll down to the module.
- Use the popover to add a URL or WordPress site

pinging @mtias & @folletto for review