### PR TITLE
Framework: Refactor numeric parsing of site ID from path

### DIFF
--- a/client/lib/route/path.js
+++ b/client/lib/route/path.js
@@ -25,27 +25,26 @@ function getSiteFragment( path ) {
 	const pieces = basePath.split( '/' );
 
 	// There are 2 URL positions where we should look for the site fragment:
-	// last (most sections) and second to last (the editor, since post ID can
-	// come last).
-	const maybeSiteInEditor = pieces[ pieces.length - 2 ] || '';
-	const maybeSiteOther = pieces[ pieces.length - 1 ] || '';
+	// last (most sections) and second-to-last (post ID is last in editor)
 
-	if ( maybeSiteInEditor.indexOf( '.' ) >= 0 ) {
-		// This is an editor-style URL like /post/:site/:id or /edit/:cpt/:site/:id
-		return maybeSiteInEditor;
-	} else if ( maybeSiteOther.indexOf( '.' ) >= 0 ) {
-		// This is a URL like /:section/:filter/:site
-		return maybeSiteOther;
-	} else if ( maybeSiteInEditor && ! isNaN( maybeSiteInEditor ) ) {
-		// Allow numeric site IDs in editor URLs
-		return parseInt( maybeSiteInEditor, 10 );
-	} else if ( maybeSiteOther && ! isNaN( maybeSiteOther ) ) {
-		// Allow numeric site IDs in other URLs
-		return parseInt( maybeSiteOther, 10 );
-	} else {
-		// No site fragment here
-		return false;
+	// Check last and second-to-last piece for site slug
+	for ( let i = 2; i > 0; i-- ) {
+		const piece = pieces[ pieces.length - i ];
+		if ( piece && -1 !== piece.indexOf( '.' ) ) {
+			return piece;
+		}
 	}
+
+	// Check last and second-to-last piece for numeric site ID
+	for ( let i = 2; i > 0; i-- ) {
+		const piece = parseInt( pieces[ pieces.length - i ], 10 );
+		if ( Number.isSafeInteger( piece ) ) {
+			return piece;
+		}
+	}
+
+	// No site fragment here
+	return false;
 }
 
 function addSiteFragment( path, site ) {

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -95,6 +95,11 @@ describe( 'lib/route', function() {
 					route.getSiteFragment( '/edit/jetpack-portfolio/2916284/new' )
 				).to.equal( 2916284 );
 			} );
+			it( 'should not return a non-safe numeric site', () => {
+				expect(
+					route.getSiteFragment( '/edit/jetpack-portfolio/1000000000000000000000/new' )
+				).to.be.false;
+			} );
 		} );
 		describe( 'for listing paths', function() {
 			it( 'should return false when there is no site yet', function() {
@@ -143,6 +148,11 @@ describe( 'lib/route', function() {
 					route.getSiteFragment( '/pages/drafts/2916284' )
 				).to.equal( 2916284 );
 			} );
+			it( 'should not return a non-safe numeric site', () => {
+				expect(
+					route.getSiteFragment( '/pages/drafts/1000000000000000000000' )
+				).to.be.false;
+			} );
 		} );
 		describe( 'for stats paths', function() {
 			it( 'should return false when there is no site yet', function() {
@@ -160,6 +170,11 @@ describe( 'lib/route', function() {
 				expect(
 					route.getSiteFragment( '/stats/day/2916284' )
 				).to.equal( 2916284 );
+			} );
+			it( 'should not return a non-safe numeric site', () => {
+				expect(
+					route.getSiteFragment( '/stats/day/1000000000000000000000' )
+				).to.be.false;
 			} );
 		} );
 	} );


### PR DESCRIPTION
This pull request seeks to resolve a case where we'd interpret a path containing an unreasonably large number as including a site ID. This could lead to unexpected behavior when attempting to coerce the large number value to a string.

__Testing instructions:__

Verify that tests continue to pass, and that there are no regressions when navigating the application (specifically on pages where a site is selected).

```make test```