### PR TITLE
Help: fix text overflow on button

### DIFF
--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -25,7 +25,7 @@
 }
 
 .help__support-link-button {
-	flex: 0 0 106px; // make sure that the width doesn't shrink
+	flex: 0 0 auto;
 	align-self: center;
 }
 


### PR DESCRIPTION
Before, the Help page had a button with a fixed width. Bad for long strings in other languages.

Flex auto width seems to work.

Before
<img width="524" alt="screen shot 2016-04-08 at 10 28 55 pm" src="https://cloud.githubusercontent.com/assets/618551/14398170/0b9596a4-fdda-11e5-811b-439938dead7f.png">

After
<img width="526" alt="screen shot 2016-04-08 at 10 28 26 pm" src="https://cloud.githubusercontent.com/assets/618551/14398173/0d648bca-fdda-11e5-99d5-1bd1e132184f.png">

cc @mtias 