### PR TITLE
Editor: Fix Facebook (and potentially other) embeds where script dependencies exist

### DIFF
--- a/client/components/shortcode/frame.jsx
+++ b/client/components/shortcode/frame.jsx
@@ -1,78 +1,16 @@
 /**
  * External dependencies
  */
-import ReactDomServer from 'react-dom/server';
 import React, { PropTypes } from 'react';
-import createFragment from 'react-addons-create-fragment';
 import omit from 'lodash/omit';
 import isEqual from 'lodash/isEqual';
 import classNames from 'classnames';
-import mapValues from 'lodash/mapValues';
 
 /**
  * Internal dependencies
  */
+import generateEmbedFrameMarkup from 'lib/embed-frame-markup';
 import ResizableIframe from 'components/resizable-iframe'
-
-/**
- * Module variables
- */
-const JQUERY_URL = 'https://s0.wp.com/wp-includes/js/jquery/jquery.js';
-
-function buildFrameBody( { body, scripts, styles } = { body: '', scripts: {}, styles: {} } ) {
-	if ( ! body && ! scripts && ! styles ) {
-		return '';
-	}
-
-	let fragment = {};
-
-	fragment.styles = mapValues( styles, ( style ) => {
-		return <link rel="stylesheet" media={ style.media } href={ style.src } />;
-	} );
-
-	fragment.scripts = mapValues( scripts, ( script ) => {
-		let extra;
-		if ( script.extra ) {
-			/*eslint-disable react/no-danger*/
-			extra = (
-				<script dangerouslySetInnerHTML={ {
-					__html: script.extra
-				} } />
-			);
-			/*eslint-enable react/no-danger*/
-		}
-
-		return createFragment( {
-			extra: extra,
-			script: <script src={ script.src } />
-		} );
-	} );
-
-	/*eslint-disable react/no-danger*/
-	return ReactDomServer.renderToStaticMarkup(
-		<html>
-			<head>
-				{ createFragment( fragment.styles ) }
-				<style dangerouslySetInnerHTML={ { __html: 'a { cursor: default; }' } } />
-			</head>
-			<body style={ { margin: 0 } }>
-				<div dangerouslySetInnerHTML={ { __html: body } } />
-				{ /* Many shortcode scripts assume jQuery is already defined */ }
-				<script src={ JQUERY_URL } />
-				<script dangerouslySetInnerHTML={ { __html: `
-					[ 'click', 'dragstart' ].forEach( function( type ) {
-						document.addEventListener( type, function( event ) {
-							event.preventDefault();
-							event.stopImmediatePropagation();
-						}, true );
-					} );
-				` } } />
-				{ createFragment( fragment.scripts ) }
-			</body>
-		</html>
-	);
-	/*eslint-enable react/no-danger*/
-}
 
 export default React.createClass( {
 	displayName: 'ShortcodeFrame',
@@ -113,7 +51,7 @@ export default React.createClass( {
 
 	updateHtmlState( props ) {
 		this.setState( {
-			html: buildFrameBody( props )
+			html: generateEmbedFrameMarkup( props )
 		} );
 	},
 

--- a/client/components/tinymce/plugins/wpcom-view/views/embed/view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/embed/view.jsx
@@ -4,12 +4,14 @@
 import ReactDom from 'react-dom';
 import React, { Component, PropTypes } from 'react';
 import { Container } from 'flux/utils';
+import pick from 'lodash/pick';
 
 /**
  * Internal dependencies
  */
 import ResizableIframe from 'components/resizable-iframe';
 import EmbedsStore from 'lib/embeds/store';
+import generateEmbedFrameMarkup from 'lib/embed-frame-markup';
 
 class EmbedView extends Component {
 	static getStores() {
@@ -79,9 +81,9 @@ class EmbedView extends Component {
 			return;
 		}
 
+		const markup = generateEmbedFrameMarkup( pick( this.state, 'body', 'scripts', 'styles' ) );
 		iframe.contentDocument.open();
-		iframe.contentDocument.write( this.state.body );
-		iframe.contentDocument.body.style.margin = 0;
+		iframe.contentDocument.write( markup );
 		iframe.contentDocument.body.style.width = '100%';
 		iframe.contentDocument.body.style.overflow = 'hidden';
 		iframe.contentDocument.close();

--- a/client/lib/embed-frame-markup/README.md
+++ b/client/lib/embed-frame-markup/README.md
@@ -1,0 +1,31 @@
+Embed Frame Markup
+==================
+
+Exports a single default function which, when invoked with an object containing one or more of `body`, `styles`, `scripts`, returns a generated page markup including those assets. Scripts and styles should be passed as objects reflecting the response structure from the [`GET /sites/%s/embeds/render`](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/embeds/render/) or [`GET /sites/%s/shortcodes/render`](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/shortcodes/render/) endpoints.
+
+__WARNING:__ You should be extremely careful when using this module, and it should only be used when you're certain that user input is properly sanitized and/or the generated output is used in a sandboxed context. If in doubt, you should probably avoid using this utility.
+
+## Usage
+
+```js
+import generateEmbedFrameMarkup from 'lib/embed-frame-markup';
+
+const markup = generateEmbedFrameMarkup( {
+	body: 'Hello World',
+	styles: {
+		'jetpack-carousel': {
+			src: 'https://s1.wp.com/wp-content/mu-plugins/carousel/jetpack-carousel.css?m=1458924076h&ver=20120629',
+			media: 'all'
+		}
+	},
+	scripts: {
+		'jetpack-facebook-embed': {
+			src: 'https://s2.wp.com/wp-content/mu-plugins/shortcodes/js/facebook.js?ver',
+			extra: 'var jpfbembed = {"appid":"249643311490"};'
+		}
+	}
+} );
+
+console.log( markup );
+// -> '<html>…</html>'
+```

--- a/client/lib/embed-frame-markup/index.jsx
+++ b/client/lib/embed-frame-markup/index.jsx
@@ -1,0 +1,60 @@
+// Here be dragons...
+/* eslint-disable react/no-danger */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import createFragment from 'react-addons-create-fragment';
+import mapValues from 'lodash/mapValues';
+
+/**
+ * Constants
+ */
+const JQUERY_URL = 'https://s0.wp.com/wp-includes/js/jquery/jquery.js';
+
+export default function generateEmbedFrameMarkup( { body, scripts, styles } = {} ) {
+	if ( ! body && ! scripts && ! styles ) {
+		return '';
+	}
+
+	return renderToStaticMarkup(
+		<html>
+			<head>
+				{ createFragment( mapValues( styles, ( style ) => {
+					return <link rel="stylesheet" media={ style.media } href={ style.src } />;
+				} ) ) }
+				<style dangerouslySetInnerHTML={ { __html: 'a { cursor: default; }' } } />
+			</head>
+			<body style={ { margin: 0 } }>
+				<div dangerouslySetInnerHTML={ { __html: body } } />
+				{ /* Many embed/shortcode scripts assume jQuery is already defined */ }
+				<script src={ JQUERY_URL } />
+				<script dangerouslySetInnerHTML={ { __html: `
+					[ 'click', 'dragstart' ].forEach( function( type ) {
+						document.addEventListener( type, function( event ) {
+							event.preventDefault();
+							event.stopImmediatePropagation();
+						}, true );
+					} );
+				` } } />
+				{ createFragment( mapValues( scripts, ( script ) => {
+					let extra;
+					if ( script.extra ) {
+						extra = (
+							<script dangerouslySetInnerHTML={ {
+								__html: script.extra
+							} } />
+						);
+					}
+
+					return createFragment( {
+						extra: extra,
+						script: <script src={ script.src } />
+					} );
+				} ) ) }
+			</body>
+		</html>
+	);
+}

--- a/client/lib/embed-frame-markup/test/index.jsx
+++ b/client/lib/embed-frame-markup/test/index.jsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import generateEmbedFrameMarkup from '../';
+
+describe( '#generateEmbedFrameMarkup()', () => {
+	it( 'should return an empty string if no arguments passed', () => {
+		expect( generateEmbedFrameMarkup() ).to.equal( '' );
+	} );
+
+	it( 'should generate markup with the body contents', () => {
+		expect( generateEmbedFrameMarkup( { body: 'Hello World' } ) ).to.equal(
+			'<html><head><style>a { cursor: default; }</style></head><body style="margin:0;"><div>Hello World</div><script src="https://s0.wp.com/wp-includes/js/jquery/jquery.js"></script><script>\n\t\t\t\t\t[ \'click\', \'dragstart\' ].forEach( function( type ) {\n\t\t\t\t\t\tdocument.addEventListener( type, function( event ) {\n\t\t\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t\t\t}, true );\n\t\t\t\t\t} );\n\t\t\t\t</script></body></html>'
+		);
+	} );
+
+	it( 'should generate markup with styles', () => {
+		const styles = {
+			'jetpack-carousel': {
+				src: 'https://s1.wp.com/wp-content/mu-plugins/carousel/jetpack-carousel.css?m=1458924076h&ver=20120629',
+				media: 'all'
+			}
+		};
+
+		expect( generateEmbedFrameMarkup( { styles } ) ).to.equal(
+			'<html><head><link rel="stylesheet" media="all" href="https://s1.wp.com/wp-content/mu-plugins/carousel/jetpack-carousel.css?m=1458924076h&amp;ver=20120629"/><style>a { cursor: default; }</style></head><body style="margin:0;"><div></div><script src="https://s0.wp.com/wp-includes/js/jquery/jquery.js"></script><script>\n\t\t\t\t\t[ \'click\', \'dragstart\' ].forEach( function( type ) {\n\t\t\t\t\t\tdocument.addEventListener( type, function( event ) {\n\t\t\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t\t\t}, true );\n\t\t\t\t\t} );\n\t\t\t\t</script></body></html>'
+		);
+	} );
+
+	it( 'should generate markup with scripts', () => {
+		const scripts = {
+			'jetpack-facebook-embed': {
+				src: 'https://s2.wp.com/wp-content/mu-plugins/shortcodes/js/facebook.js?ver',
+				extra: 'var jpfbembed = {"appid":"249643311490"};'
+			}
+		};
+
+		expect( generateEmbedFrameMarkup( { scripts } ) ).to.equal(
+			'<html><head><style>a { cursor: default; }</style></head><body style="margin:0;"><div></div><script src="https://s0.wp.com/wp-includes/js/jquery/jquery.js"></script><script>\n\t\t\t\t\t[ \'click\', \'dragstart\' ].forEach( function( type ) {\n\t\t\t\t\t\tdocument.addEventListener( type, function( event ) {\n\t\t\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\t\t\tevent.stopImmediatePropagation();\n\t\t\t\t\t\t}, true );\n\t\t\t\t\t} );\n\t\t\t\t</script><script>var jpfbembed = {"appid":"249643311490"};</script><script src="https://s2.wp.com/wp-content/mu-plugins/shortcodes/js/facebook.js?ver"></script></body></html>'
+		);
+	} );
+} );

--- a/client/lib/embeds/actions.js
+++ b/client/lib/embeds/actions.js
@@ -34,7 +34,7 @@ export default {
 					type: 'RECEIVE_EMBED',
 					siteId: siteId,
 					url: url,
-					body: data ? data.result : null,
+					data: data,
 					error: error
 				} );
 			} else {

--- a/client/lib/embeds/store.js
+++ b/client/lib/embeds/store.js
@@ -41,11 +41,13 @@ class PostEditEmbedsStore extends ReduceStore {
 							status: 'ERROR'
 						}
 					} );
-				} else {
+				} else if ( action.data ) {
 					state = Object.assign( {}, state, {
 						[action.url]: {
 							status: 'LOADED',
-							body: action.body
+							body: action.data.result,
+							scripts: action.data.scripts,
+							styles: action.data.styles
 						}
 					} );
 				}

--- a/client/tests.json
+++ b/client/tests.json
@@ -142,6 +142,9 @@
 		"email-followers": {
 		  "test": [ "store" ]
 		},
+		"embed-frame-markup": {
+			"test": [ "index" ]
+		},
 		"features-list": {
 		  "test": [ "index" ]
 		},


### PR DESCRIPTION
Fixes #4583

This pull request seeks to resolve an issue where some oEmbed results would not be rendered correctly, due to lacking dependency scripts or styles which had been included in the oEmbed endpoint response.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/14398144/dbbd31fa-fdaf-11e5-8d76-8f4d439b1ab2.png)|![After](https://cloud.githubusercontent.com/assets/1779930/14398085/73227f74-fdaf-11e5-9e6d-cd25d8d98d53.png)

As noted at https://github.com/Automattic/wp-calypso/issues/4583#issuecomment-206952540, it is not documented that these endpoints return this data, so we should separately seek to correct the endpoint documentation.

__Testing instructions:__

Verify that no regressions exist for affected behavior (shortcode and embed rendering, where shortcode rendering includes galleries). Verify that previously non-working embeds now display correctly.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Paste an embeddable URL (e.g. Twitter Tweet, Facebook video)
4. Note that the embed displays correctly (including previously non-working embeds, e.g. Facebook video)
5. Insert an image gallery into post contents
6. Note that the gallery continues to display correctly