### PR TITLE
WPCOM Plugins: Plugins Link for All Sites

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -236,14 +236,6 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		if ( ! config.isEnabled( 'manage/plugins/wpcom' ) && ! this.props.sites.hasSiteWithPlugins() ) {
-			return null;
-		}
-
-		if ( config.isEnabled( 'manage/plugins/wpcom' ) && ( ! this.isSingle() && this.hasJetpackSites() ) ) {
-			return null;
-		}
-
 		if ( ( this.isSingle() && site.jetpack ) || ( ! this.isSingle() && this.hasJetpackSites() ) ) {
 			addPluginsLink = '/plugins/browse' + this.siteSuffix();
 		}


### PR DESCRIPTION
Part of #4572 

Plugins link shows for all sites, keeping its default behavior for JetPack sites.