### PR TITLE
Purchases: Sort sites on `/purchases` alphabetically by site title

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -44,13 +44,13 @@ function getPurchasesBySite( purchases, sites ) {
 				 * there will be no site with this ID in `sites`, so
 				 * we fall back on the domain. */
 				slug: siteObject ? siteObject.slug : currentValue.domain,
-				title: currentValue.siteName ? currentValue.siteName : currentValue.domain,
+				title: currentValue.siteName || currentValue.domain || '',
 				purchases: [ currentValue ]
 			} );
 		}
 
 		return result;
-	}, [] );
+	}, [] ).sort( ( a, b ) => a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1 );
 }
 
 function getName( purchase ) {


### PR DESCRIPTION
This PR updates the list of purchases grouped by sites on `/purchases` to be sorted by the site's title, alphabetically.

Initially, I attempted to sort these based on the order of the list of sites, which is alphabetical, by title, with recently selected sites at the top of the list. I chose not to do this, in favor of a simple alphabetical sort by title regardless of the order of the sites list, because not all of the purchases have sites associated with them, as a user could have a purchase on a site they can no longer access.

Fixes #165.

**Testing**
- Visit `/purchases` for an account that has multiple purchases on multiple sites.
- Assert that the list of sites is ordered alphabetically by the site's title.

- [x] Code review
- [x] Product review