### PR TITLE
Notices: fixed text overflow bug

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -45,7 +45,6 @@
 }
 
 .global-notices .notice__icon {
-	flex-shrink: 0;
 
 	@include breakpoint( ">660px" ) {
 		padding: 8px 0 8px 16px;
@@ -64,7 +63,6 @@
 }
 
 .global-notices .notice a.notice__action {
-	flex-shrink: 0;
 
 	@include breakpoint( ">660px" ) {
 		font-size: 14px;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -34,6 +34,7 @@
 }
 
 .notice__icon {
+	flex-shrink: 0;
 	padding: 13px 0 13px 16px;
 
 	@include breakpoint( "<660px" ) {
@@ -72,6 +73,7 @@
 // "X" for dismissing a notice
 .notice__dismiss {
 	display: flex;
+		flex-shrink: 0;
 	padding: 11px 16px;
 	cursor: pointer;
 	color: $gray;
@@ -98,12 +100,13 @@
 
 // specificity for general `a` elements within notice is too great
 .notice a.notice__action {
+	display: flex;
+		align-items: center;
+		flex-shrink: 0;
 	background: rgba( 0, 0, 0, 0.2 );
 	box-sizing: border-box;
 	color: $white;
 	cursor: pointer;
-	display: flex;
-		align-items: center;
 	font-size: 15px;
 	font-weight: 400;
 	margin-left: auto; // forces the element to the right;


### PR DESCRIPTION
I moved a `flex-shrink: 0;` declaration on the inner bits of notices from global-notices to the notice component. Now inline notices work properly when their text wraps, as well as global notices.

To test, trigger both inline and global notices and compare at many viewports. Make sure the notices have various lengths of text content, action links, dismiss buttons, icons. Nothing should shrink or be clipped off. 

Fixes #4617

cc @drw158 @umurkontaci @scruffian @mtias @MichaelArestad 

**Before**
<img width="469" alt="screen shot 2016-04-08 at 5 57 21 pm" src="https://cloud.githubusercontent.com/assets/437258/14398716/5560d422-fdb4-11e5-872d-a77a54726cae.png">

**After**
<img width="480" alt="screen shot 2016-04-08 at 5 57 37 pm" src="https://cloud.githubusercontent.com/assets/437258/14398721/5becb608-fdb4-11e5-9a50-ad9fc5386655.png">