### PR TITLE
Purchases: Use different fetching/loaded flags for site/user purchases

### DIFF
--- a/client/components/data/purchases/edit-card-details/index.jsx
+++ b/client/components/data/purchases/edit-card-details/index.jsx
@@ -10,7 +10,7 @@ import CountriesList from 'lib/countries-list';
 import { fetchStoredCards, fetchUserPurchases } from 'lib/upgrades/actions';
 import observe from 'lib/mixins/data-observe';
 import PurchasesStore from 'lib/purchases/store';
-import { shouldFetchPurchases } from 'lib/purchases';
+import { shouldFetchUserPurchases } from 'lib/purchases';
 import StoreConnection from 'components/data/store-connection';
 import StoredCardsStore from 'lib/purchases/stored-cards/store';
 import userFactory from 'lib/user';
@@ -38,7 +38,7 @@ function getStateFromStores( props ) {
 function isDataLoading( state ) {
 	return (
 		state.card.isFetching ||
-		! state.selectedPurchase.hasLoadedFromServer ||
+		! state.selectedPurchase.hasLoadedUserPurchasesFromServer ||
 		! state.hasLoadedSites
 	);
 }
@@ -56,7 +56,7 @@ const EditCardDetailsData = React.createClass( {
 
 	componentWillMount() {
 		fetchStoredCards();
-		if ( shouldFetchPurchases( PurchasesStore.get() ) ) {
+		if ( shouldFetchUserPurchases( PurchasesStore.get() ) ) {
 			fetchUserPurchases( user.get().ID );
 		}
 	},

--- a/client/components/data/purchases/index.jsx
+++ b/client/components/data/purchases/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { fetchUserPurchases } from 'lib/upgrades/actions';
 import observe from 'lib/mixins/data-observe';
 import PurchasesStore from 'lib/purchases/store';
-import { shouldFetchPurchases } from 'lib/purchases';
+import { shouldFetchUserPurchases } from 'lib/purchases';
 import StoreConnection from 'components/data/store-connection';
 import userFactory from 'lib/user';
 
@@ -38,7 +38,7 @@ const PurchasesData = React.createClass( {
 	mixins: [ observe( 'sites' ) ],
 
 	componentDidMount() {
-		if ( shouldFetchPurchases( PurchasesStore.get() ) ) {
+		if ( shouldFetchUserPurchases( PurchasesStore.get() ) ) {
 			fetchUserPurchases( user.get().ID );
 		}
 	},

--- a/client/components/data/purchases/manage-purchase/index.jsx
+++ b/client/components/data/purchases/manage-purchase/index.jsx
@@ -10,7 +10,7 @@ import CartStore from 'lib/cart/store';
 import { fetchUserPurchases } from 'lib/upgrades/actions';
 import observe from 'lib/mixins/data-observe';
 import PurchasesStore from 'lib/purchases/store';
-import { shouldFetchPurchases } from 'lib/purchases';
+import { shouldFetchUserPurchases } from 'lib/purchases';
 import StoreConnection from 'components/data/store-connection';
 import userFactory from 'lib/user';
 
@@ -49,7 +49,7 @@ const ManagePurchaseData = React.createClass( {
 	mixins: [ observe( 'sites' ) ],
 
 	componentWillMount() {
-		if ( shouldFetchPurchases( PurchasesStore.get() ) ) {
+		if ( shouldFetchUserPurchases( PurchasesStore.get() ) ) {
 			fetchUserPurchases( user.get().ID );
 		}
 	},

--- a/client/components/data/purchases/site-purchases/index.jsx
+++ b/client/components/data/purchases/site-purchases/index.jsx
@@ -32,7 +32,7 @@ const SitePurchasesData = React.createClass( {
 		const purchases = PurchasesStore.get(),
 			selectedSite = sites.getSelectedSite();
 
-		return selectedSite && ! purchases.isFetching && ! purchases.hasLoadedFromServer;
+		return selectedSite && ! purchases.isFetchingSitePurchases && ! purchases.hasLoadedSitePurchasesFromServer;
 	},
 
 	componentWillMount() {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -224,8 +224,8 @@ function purchaseType( purchase ) {
 	return null;
 }
 
-function shouldFetchPurchases( purchases ) {
-	return ! purchases.hasLoadedFromServer && ! purchases.isFetching;
+function shouldFetchUserPurchases( purchases ) {
+	return ! purchases.hasLoadedUserPurchasesFromServer && ! purchases.isFetchingUserPurchases;
 }
 
 function showCreditCardExpiringWarning( purchase ) {
@@ -259,6 +259,6 @@ export {
 	isSubscription,
 	paymentLogoType,
 	purchaseType,
-	shouldFetchPurchases,
+	shouldFetchUserPurchases,
 	showCreditCardExpiringWarning,
 }

--- a/client/lib/purchases/reducer.js
+++ b/client/lib/purchases/reducer.js
@@ -16,8 +16,10 @@ import { action as ActionTypes } from 'lib/upgrades/constants';
 const initialState = {
 	data: [],
 	error: null,
-	isFetching: false,
-	hasLoadedFromServer: false
+	isFetchingSitePurchases: false,
+	isFetchingUserPurchases: false,
+	hasLoadedSitePurchasesFromServer: false,
+	hasLoadedUserPurchasesFromServer: false
 };
 
 function updatePurchaseById( state, id, properties ) {
@@ -99,21 +101,44 @@ const reducer = ( state, payload ) => {
 
 	switch ( action.type ) {
 		case ActionTypes.PURCHASES_REMOVE:
-			return assign( {}, state, { data: [], hasLoadedFromServer: false } );
-
+			return assign( {}, state, {
+				data: [],
+				hasLoadedSitePurchasesFromServer: false,
+				hasLoadedUserPurchasesFromServer: false
+			} );
 		case ActionTypes.PURCHASE_REMOVE:
+			return assign( {}, state, {
+				data: [],
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false
+			} );
 		case ActionTypes.PURCHASES_SITE_FETCH:
+			return assign( {}, state, { isFetchingSitePurchases: true } );
 		case ActionTypes.PURCHASES_USER_FETCH:
-			return assign( {}, state, { isFetching: true } );
+			return assign( {}, state, { isFetchingUserPurchases: true } );
 
 		case ActionTypes.PURCHASE_REMOVE_COMPLETED:
+			return assign( {}, state, {
+				data: updatePurchases( state.data, action ),
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: true
+			} );
 		case ActionTypes.PURCHASES_SITE_FETCH_COMPLETED:
+			return assign( {}, state, {
+				data: updatePurchases( state.data, action ),
+				error: null,
+				isFetchingSitePurchases: false,
+				hasLoadedSitePurchasesFromServer: true
+			} );
 		case ActionTypes.PURCHASES_USER_FETCH_COMPLETED:
 			return assign( {}, state, {
 				data: updatePurchases( state.data, action ),
 				error: null,
-				isFetching: false,
-				hasLoadedFromServer: true
+				isFetchingUserPurchases: false,
+				hasLoadedUserPurchasesFromServer: true
 			} );
 
 		case ActionTypes.PURCHASE_REMOVE_FAILED:

--- a/client/lib/purchases/test/store.js
+++ b/client/lib/purchases/test/store.js
@@ -23,8 +23,10 @@ describe( 'store', () => {
 		expect( PurchasesStore.get() ).to.be.eql( {
 			data: [],
 			error: null,
-			hasLoadedFromServer: false,
-			isFetching: false
+			isFetchingSitePurchases: false,
+			isFetchingUserPurchases: false,
+			hasLoadedSitePurchasesFromServer: false,
+			hasLoadedUserPurchasesFromServer: false
 		} );
 	} );
 
@@ -36,8 +38,10 @@ describe( 'store', () => {
 		expect( PurchasesStore.get() ).to.be.eql( {
 			data: [],
 			error: null,
-			hasLoadedFromServer: false,
-			isFetching: true
+			isFetchingSitePurchases: false,
+			isFetchingUserPurchases: true,
+			hasLoadedSitePurchasesFromServer: false,
+			hasLoadedUserPurchasesFromServer: false
 		} );
 	} );
 
@@ -59,8 +63,10 @@ describe( 'store', () => {
 					{ id: 3, siteId, userId },
 					{ id: 1, siteId, userId } ],
 				error: null,
-				hasLoadedFromServer: true,
-				isFetching: false
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: true
 			} );
 
 			done();
@@ -89,8 +95,10 @@ describe( 'store', () => {
 				newPurchase // purchase with ID 3 was removed, `newPurchase` was added
 			],
 			error: null,
-			hasLoadedFromServer: true,
-			isFetching: false
+			isFetchingSitePurchases: false,
+			isFetchingUserPurchases: false,
+			hasLoadedSitePurchasesFromServer: true,
+			hasLoadedUserPurchasesFromServer: true
 		} );
 
 		defer( () => {
@@ -106,8 +114,10 @@ describe( 'store', () => {
 					newPurchase // the new purchase was not removed because it has a different `siteId`
 				],
 				error: null,
-				hasLoadedFromServer: true,
-				isFetching: false
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: true
 			} );
 
 			done();
@@ -123,8 +133,10 @@ describe( 'store', () => {
 		expect( PurchasesStore.getByPurchaseId( 2 ) ).to.be.eql( {
 			data: { id: 2, siteId, userId },
 			error: null,
-			hasLoadedFromServer: true,
-			isFetching: false
+			isFetchingSitePurchases: false,
+			isFetchingUserPurchases: false,
+			hasLoadedSitePurchasesFromServer: true,
+			hasLoadedUserPurchasesFromServer: true
 		} );
 	} );
 
@@ -143,8 +155,10 @@ describe( 'store', () => {
 				userId
 			},
 			error: null,
-			hasLoadedFromServer: true,
-			isFetching: false
+			isFetchingSitePurchases: false,
+			isFetchingUserPurchases: false,
+			hasLoadedSitePurchasesFromServer: true,
+			hasLoadedUserPurchasesFromServer: true
 		} );
 	} );
 
@@ -171,8 +185,10 @@ describe( 'store', () => {
 				userId
 			},
 			error: null,
-			hasLoadedFromServer: true,
-			isFetching: false
+			isFetchingSitePurchases: false,
+			isFetchingUserPurchases: false,
+			hasLoadedSitePurchasesFromServer: true,
+			hasLoadedUserPurchasesFromServer: true
 		} );
 	} );
 } );

--- a/client/me/purchases/list/index.jsx
+++ b/client/me/purchases/list/index.jsx
@@ -22,7 +22,7 @@ const PurchasesList = React.createClass( {
 	},
 
 	isDataLoading() {
-		if ( this.props.purchases.isFetching && ! this.props.purchases.hasLoadedFromServer ) {
+		if ( this.props.purchases.isFetchingUserPurchases && ! this.props.purchases.hasLoadedUserPurchasesFromServer ) {
 			return true;
 		}
 
@@ -36,7 +36,7 @@ const PurchasesList = React.createClass( {
 			content = <PurchasesSite isPlaceholder />;
 		}
 
-		if ( this.props.purchases.hasLoadedFromServer && this.props.purchases.data.length ) {
+		if ( this.props.purchases.hasLoadedUserPurchasesFromServer && this.props.purchases.data.length ) {
 			content = getPurchasesBySite( this.props.purchases.data, this.props.sites.get() ).map(
 				site => (
 					<PurchasesSite
@@ -48,7 +48,7 @@ const PurchasesList = React.createClass( {
 			);
 		}
 
-		if ( this.props.purchases.hasLoadedFromServer && ! this.props.purchases.data.length ) {
+		if ( this.props.purchases.hasLoadedUserPurchasesFromServer && ! this.props.purchases.data.length ) {
 			content = (
 				<CompactCard className="purchases-list__no-content">
 					<EmptyContent

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -61,7 +61,7 @@ function canEditPaymentDetails( purchase ) {
  * @return {boolean} Whether or not the data is loading
  */
 function isDataLoading( props ) {
-	return ! props.hasLoadedSites || ! props.selectedPurchase.hasLoadedFromServer;
+	return ! props.hasLoadedSites || ! props.selectedPurchase.hasLoadedUserPurchasesFromServer;
 }
 
 const ManagePurchase = React.createClass( {

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -43,7 +43,7 @@ function goToManagePurchase( props ) {
 }
 
 function isDataLoading( props ) {
-	return ! props.hasLoadedSites || ! props.selectedPurchase.hasLoadedFromServer;
+	return ! props.hasLoadedSites || ! props.selectedPurchase.hasLoadedUserPurchasesFromServer;
 }
 
 function recordPageView( trackingSlug, props, nextProps = null ) {
@@ -52,7 +52,7 @@ function recordPageView( trackingSlug, props, nextProps = null ) {
 	}
 
 	if ( nextProps &&
-		( props.selectedPurchase.hasLoadedFromServer || ! nextProps.selectedPurchase.hasLoadedFromServer ) ) {
+		( props.selectedPurchase.hasLoadedUserPurchasesFromServer || ! nextProps.selectedPurchase.hasLoadedUserPurchasesFromServer ) ) {
 		// only record the page view the first time the purchase loads from the server
 		return null;
 	}

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -49,7 +49,7 @@ module.exports = React.createClass( {
 			deleteSite: this.translate( 'Delete Site' )
 		};
 
-		if ( this.props.purchases.isFetching ) {
+		if ( this.props.purchases.isFetchingSitePurchases ) {
 			return null;
 		}
 

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -168,7 +168,7 @@ module.exports = React.createClass( {
 					<ActionPanelFooter>
 						<Button
 							scary
-							disabled={ ! this.state.site || this.props.purchases.isFetching }
+							disabled={ ! this.state.site || this.props.purchases.isFetchingSitePurchases }
 							onClick={ this.handleDeleteSiteClick }>
 							<Gridicon icon="trash" />
 							{ strings.deleteSite }
@@ -201,7 +201,7 @@ module.exports = React.createClass( {
 
 		event.preventDefault();
 
-		if ( ! this.props.purchases.hasLoadedFromServer ) {
+		if ( ! this.props.purchases.hasLoadedSitePurchasesFromServer ) {
 			return;
 		}
 


### PR DESCRIPTION
`PurchasesStore` contains purchases that come from two endpoints:

- `/me/purchases`, which returns purchases associated with the current user.
- `/sites/:site/purchases`, which returns purchases associated with the given site.

The purchases returned by these endpoints do not always overlap. The site-specific purchases endpoint is used to determine if a site is safe to delete, as it returns all purchases associated with a given site.

Currently, we use `isFetching` and `hasLoadedFromServer` flags to determine if we need to fetch purchases when visiting `DeleteSite` or `PurchasesList`. However, `hasLoadedFromServer` will be set to true if only user purchases have loaded, and vice versa, meaning that a request will not be triggered when visiting the aforementioned components if either type (e.g. site purchases) of purchases have been fetched, even if the given component needs the other type (e.g. user purchases).

This PR updates the purchases reducer to use separate flags to track the fetching/loaded state of user/site purchases.

Fixes #1111.

**Testing**
This PR updates `isFetching` / `hasLoadedFromServer` in several components. We should assert that the pages load properly when accessing the following routes directly:

- `/purchases`
- `/purchases/:site/:purchaseId/`
- `/purchases/:site/:purchaseId/cancel` where `:purchaseId` is for a purchase that is cancelable (e.g. inside the refund window).
- `/purchases/:site/:purchaseId/confirm-cancel-domain` where `:purchaseId` is for a domain within the refund window.
- `/purchases/:site/:purchaseId/cancel-private-registration` where `:purchaseId` is for a domain that has private registration.
- `/purchases/:site/:purchaseId/payment/edit`
- `/settings/general/:site` - assert that the 'Delete Site' link at the bottom loads properly.
- `/settings/delete-site/:site` - assert that the 'Delete Site' button is activated after the `/sites/:site/purchases` response comes in.

- [x] Code review
- [x] Product review