### PR TITLE
Test: Refactor components/token-field tests to use enzyme

### DIFF
--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -1,16 +1,19 @@
 /**
  * External dependencies
  */
-const expect = require( 'chai' ).expect,
-	useFakeDom = require( 'test/helpers/use-fake-dom' ),
-	useMockery = require( 'test/helpers/use-mockery' );
-
-var ReactDom, React, TestUtils, EMPTY_COMPONENT;
+import defer from 'lodash/defer';
+import map from 'lodash/map';
+import { expect } from 'chai';
+import React from 'react';
+import { test } from 'sinon';
 
 /**
  * Internal dependencies
  */
-const fixtures = require( './lib/fixtures' );
+import EmptyComponent from 'test/helpers/react/empty-component';
+import fixtures from './lib/fixtures';
+import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
 
 /**
  * Module variables
@@ -32,89 +35,81 @@ const charCodes = {
 };
 
 describe( 'TokenField', function() {
-	var reactContainer, wrapper, tokenFieldNode, textInputNode, TokenFieldWrapper;
+	let wrapper, tokenFieldNode, textInputNode, TokenFieldWrapper, mount;
 
 	function setText( text ) {
-		TestUtils.Simulate.change( textInputNode, { target: { value: text } } );
+		textInputNode.simulate( 'change', { target: { value: text } } );
 	}
 
 	function sendKeyDown( keyCode, shiftKey ) {
-		TestUtils.Simulate.keyDown( textInputNode, {
+		tokenFieldNode.simulate( 'keyDown', {
 			keyCode: keyCode,
 			shiftKey: !! shiftKey
 		} );
 	}
 
 	function sendKeyPress( charCode ) {
-		TestUtils.Simulate.keyPress( textInputNode, {
+		tokenFieldNode.simulate( 'keyPress', {
 			charCode: charCode
 		} );
 	}
 
+	function getNodeInnerHtml( node ) {
+		const div = document.createElement( 'div' );
+		div.innerHTML = node.html();
+		return div.firstChild.innerHTML;
+	}
+
 	function getTokensHTML() {
-		var textNodes = tokenFieldNode.querySelectorAll( '.token-field__token-text' );
-		return Array.prototype.slice.call( textNodes ).map( function( el ) {
-			return el.innerHTML;
-		} );
+		const textNodes = tokenFieldNode.find( '.token-field__token-text' );
+
+		return textNodes.map( getNodeInnerHtml );
 	}
 
 	function getSuggestionsHTML( selector ) {
-		var suggestionNodes = tokenFieldNode.querySelectorAll( selector || '.token-field__suggestion' );
-		return Array.prototype.slice.call( suggestionNodes ).map( getSuggestionNodeHTML );
+		const suggestionNodes = tokenFieldNode.find( selector || '.token-field__suggestion' );
+
+		return suggestionNodes.map( getSuggestionNodeHTML );
 	}
 
 	function getSuggestionNodeHTML( node ) {
-		var suggestionContent = node.childNodes[0];
-		if ( suggestionContent.nodeName === '#text' ) {
-			// This suggestion is not part of a partial match; just return
-			// the whole suggestion
-			return node.innerHTML;
+		if ( ! node.find( 'span' ).length ) {
+			return getNodeInnerHtml( node );
 		}
 
 		// This suggestion is part of a partial match; return the three
 		// sections of the suggestion (before match, match, and after
 		// match)
-		return Array.prototype.slice.call( suggestionContent.childNodes ).map( function( child ) {
-			return child.innerHTML;
-		} );
+		const div = document.createElement( 'div' );
+		div.innerHTML = node.find( 'span' ).html();
+
+		return map( div.firstChild.childNodes, childNode => childNode.innerHTML );
 	}
 
 	function getSelectedSuggestion() {
 		var selectedSuggestions = getSuggestionsHTML( '.token-field__suggestion.is-selected' );
-		return selectedSuggestions[0] || null;
+
+		return selectedSuggestions[ 0 ] || null;
 	}
 
-	useFakeDom.withContainer();
+	useFakeDom();
 
 	useMockery( mockery => {
-		ReactDom = require( 'react-dom' );
-		React = require( 'react' );
-		TestUtils = require( 'react-addons-test-utils' );
-
-		EMPTY_COMPONENT = require( 'test/helpers/react/empty-component' );
-
-		mockery.registerMock( 'components/tooltip', EMPTY_COMPONENT );
+		mount = require( 'enzyme' ).mount;
+		mockery.registerMock( 'components/tooltip', EmptyComponent );
 		TokenFieldWrapper = require( './lib/token-field-wrapper' );
 	} );
 
-	before( function() {
-		reactContainer = useFakeDom.getContainer();
-	} );
-
 	beforeEach( function() {
-		wrapper = ReactDom.render( <TokenFieldWrapper />, reactContainer );
-		tokenFieldNode = ReactDom.findDOMNode( wrapper.refs.tokenField );
-		textInputNode = tokenFieldNode.querySelector( '.token-field__input' );
-		TestUtils.Simulate.focus( textInputNode );
-	} );
-
-	afterEach( function() {
-		ReactDom.unmountComponentAtNode( reactContainer );
+		wrapper = mount( <TokenFieldWrapper /> );
+		tokenFieldNode = wrapper.ref( 'tokenField' );
+		textInputNode = tokenFieldNode.find( '.token-field__input' );
+		textInputNode.simulate( 'focus' )
 	} );
 
 	describe( 'displaying tokens', function() {
 		it( 'should render default tokens', function() {
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should display tokens with escaped special characters properly', function() {
@@ -141,7 +136,7 @@ describe( 'TokenField', function() {
 	describe( 'suggestions', function() {
 		it( 'should render default suggestions', function() {
 			// limited by maxSuggestions (default 100 so doesn't matter here)
-			expect( getSuggestionsHTML() ).to.deep.equal( wrapper.state.tokenSuggestions );
+			expect( getSuggestionsHTML() ).to.deep.equal( wrapper.state( 'tokenSuggestions' ) );
 		} );
 
 		it( 'should suggest partial matches', function() {
@@ -206,22 +201,18 @@ describe( 'TokenField', function() {
 			expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'he' ] );
 			sendKeyDown( keyCodes.downArrow ); // 'to'
 			expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'o' ] );
-			hoverSuggestion = tokenFieldNode.querySelectorAll( '.token-field__suggestion' )[5]; // 'it'
+			hoverSuggestion = tokenFieldNode.find( '.token-field__suggestion' ).at( 5 ); // 'it'
 			expect( getSuggestionNodeHTML( hoverSuggestion ) ).to.deep.equal( [ 'i', 't', '' ] );
 			// before sending a hover event, we need to wait for
 			// SuggestionList#_scrollingIntoView to become false
 			setTimeout( function() {
-				// TestUtils.Simulate.mouseEnter does not work - more details
-				// at https://github.com/facebook/react/issues/1297
-				TestUtils.SimulateNative.mouseOut( textInputNode, { relatedTarget: hoverSuggestion } );
-				// this would happen in a real browser but doesn't seem to be needed here
-				// TestUtils.SimulateNative.mouseOver( hoverSuggestion, { relatedTarget: textInputNode } );
+				hoverSuggestion.simulate( 'mouseEnter' );
 				expect( getSelectedSuggestion() ).to.deep.equal( [ 'i', 't', '' ] );
 				sendKeyDown( keyCodes.upArrow );
 				expect( getSelectedSuggestion() ).to.deep.equal( [ 'wi', 't', 'h' ] );
 				sendKeyDown( keyCodes.upArrow );
 				expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'his' ] );
-				TestUtils.Simulate.click( hoverSuggestion );
+				hoverSuggestion.simulate( 'click' );
 				expect( getSelectedSuggestion() ).to.equal( null );
 				expect( getTokensHTML() ).to.deep.equal( [ 'foo', 'bar', 'it' ] );
 				done();
@@ -233,63 +224,63 @@ describe( 'TokenField', function() {
 		it( 'should add a token when Tab pressed', function() {
 			setText( 'baz' );
 			sendKeyDown( keyCodes.tab );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
-			expect( textInputNode.value ).to.equal( '' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
+			expect( textInputNode.props().value ).to.equal( '' );
 		} );
 
 		it( 'should not allow adding blank tokens with Tab', function() {
 			sendKeyDown( keyCodes.tab );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should not allow adding whitespace tokens with Tab', function() {
 			setText( '   ' );
 			sendKeyDown( keyCodes.tab );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should add a token when Enter pressed', function() {
 			setText( 'baz' );
 			sendKeyDown( keyCodes.enter );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
-			expect( textInputNode.value ).to.equal( '' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
+			expect( textInputNode.props().value ).to.equal( '' );
 		} );
 
 		it( 'should not allow adding blank tokens with Enter', function() {
 			sendKeyDown( keyCodes.enter );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should not allow adding whitespace tokens with Enter', function() {
 			setText( '   ' );
 			sendKeyDown( keyCodes.enter );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should not allow adding whitespace tokens with comma', function() {
 			setText( '   ' );
 			sendKeyPress( charCodes.comma );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should add a token when comma pressed', function() {
 			setText( 'baz' );
 			sendKeyPress( charCodes.comma );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
 		} );
 
 		it( 'should not add a token when < pressed', function() {
 			setText( 'baz' );
 			sendKeyDown( keyCodes.comma, true );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar' ] );
 			// The text input does not register the < keypress when it is sent this way.
-			expect( textInputNode.value ).to.equal( 'baz' );
+			expect( textInputNode.props().value ).to.equal( 'baz' );
 		} );
 
 		it( 'should trim token values when adding', function() {
 			setText( '  baz  ' );
 			sendKeyDown( keyCodes.enter );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'baz' ] );
 		} );
 
 		function testOnBlur( initialText, selectSuggestion, expectedSuggestion, expectedTokens, done ) {
@@ -301,21 +292,22 @@ describe( 'TokenField', function() {
 			expect( getSelectedSuggestion() ).to.deep.equal( expectedSuggestion );
 
 			function testSavedState( isActive ) {
-				expect( wrapper.state.tokens ).to.deep.equal( expectedTokens );
-				expect( textInputNode.value ).to.equal( '' );
+				expect( wrapper.state( 'tokens' ) ).to.deep.equal( expectedTokens );
+				expect( textInputNode.props().value ).to.equal( '' );
 				expect( getSelectedSuggestion() ).to.equal( null );
-				expect( wrapper.refs.tokenField.state.isActive ).to.equal( isActive );
+				expect( tokenFieldNode.find( 'div' ).first().hasClass( 'is-active' ) ).to.equal( isActive );
 			}
 
 			document.activeElement = document.body;
-			TestUtils.Simulate.blur( textInputNode );
-			setTimeout( function() {
-				// After blur, need to wait for TokenField#_blurTimeoutID
+			textInputNode.simulate( 'blur' );
+
+			// After blur, need to wait for TokenField#_blurTimeoutID
+			defer( function() {
 				testSavedState( false );
-				TestUtils.Simulate.focus( textInputNode );
+				textInputNode.simulate( 'focus' );
 				testSavedState( true );
 				done();
-			}, 10 );
+			} );
 		}
 
 		it( 'should add the current text when the input field loses focus', function( done ) {
@@ -352,37 +344,40 @@ describe( 'TokenField', function() {
 		// mouse is released.  These two tests ensure that the component
 		// activates correctly in this situation.
 
-		it( 'should allow clicking on the field in Firefox (click event from input container)', function( done ) {
-			TestUtils.Simulate.blur( textInputNode );
+		it( 'should allow clicking on the field in Firefox (click event from input container)', test( function( done ) {
+			textInputNode.simulate( 'blur' );
 			setTimeout( function() {
 				// The click event comes from here the first time you click to
 				// activate the token field.
-				TestUtils.Simulate.click( wrapper.refs.tokenField.refs.tokensAndInput );
-				expect( wrapper.refs.tokenField.state.isActive ).to.equal( true );
+				tokenFieldNode.find( '.token-field__input-container' ).simulate( 'click' );
+				expect( tokenFieldNode.find( 'div' ).first().hasClass( 'is-active' ) ).to.equal( true );
 				done();
 			}, 50 ); // 50ms is a fast click
-		} );
+			this.clock.tick( 50 );
+		} ) );
 
-		it( 'should allow clicking on the field in Firefox (click event from <input>)', function( done ) {
-			TestUtils.Simulate.blur( textInputNode );
+		it( 'should allow clicking on the field in Firefox (click event from <input>)', test( function( done ) {
+			textInputNode.simulate( 'blur' );
 			setTimeout( function() {
 				// The click event comes from here if you click on the token
 				// field when it is already active.
-				TestUtils.Simulate.click( textInputNode );
-				expect( wrapper.refs.tokenField.state.isActive ).to.equal( true );
+				textInputNode.simulate( 'click' );
+				expect( tokenFieldNode.find( 'div' ).first().hasClass( 'is-active' ) ).to.equal( true );
 				done();
 			}, 50 ); // 50ms is a fast click
-		} );
+			this.clock.tick( 50 );
+		} ) );
 
 		it( 'should not lose focus when a suggestion is clicked', function( done ) {
 			// prevents regression of https://github.com/Automattic/wp-calypso/issues/1884
-			TestUtils.Simulate.blur( textInputNode, {
-				relatedTarget: tokenFieldNode.querySelector( '.token-field__suggestion' )
+
+			textInputNode.simulate( 'blur', {
+				relatedTarget: document.querySelector( '.token-field__suggestion' )
 			} );
-			setTimeout( function() {
-				expect( wrapper.refs.tokenField.state.isActive ).to.equal( true );
+			defer( function() {
+				expect( tokenFieldNode.find( 'div' ).first().hasClass( 'is-active' ) ).to.equal( true );
 				done();
-			}, 10 ); // wait for setState call
+			} ); // wait for setState call
 		} );
 
 		it( 'should add tokens in the middle of the current tokens', function() {
@@ -391,7 +386,7 @@ describe( 'TokenField', function() {
 			sendKeyDown( keyCodes.tab );
 			setText( 'quux' );
 			sendKeyDown( keyCodes.tab );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'baz', 'quux', 'bar' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'baz', 'quux', 'bar' ] );
 		} );
 
 		it( 'should add tokens from the selected matching suggestion using Tab', function() {
@@ -402,7 +397,7 @@ describe( 'TokenField', function() {
 			sendKeyDown( keyCodes.downArrow ); // 'to'
 			expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'o' ] );
 			sendKeyDown( keyCodes.tab );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'to' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'to' ] );
 			expect( getSelectedSuggestion() ).to.equal( null );
 		} );
 
@@ -414,7 +409,7 @@ describe( 'TokenField', function() {
 			sendKeyDown( keyCodes.downArrow ); // 'to'
 			expect( getSelectedSuggestion() ).to.deep.equal( [ '', 't', 'o' ] );
 			sendKeyDown( keyCodes.enter );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'to' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'to' ] );
 			expect( getSelectedSuggestion() ).to.equal( null );
 		} );
 
@@ -425,7 +420,7 @@ describe( 'TokenField', function() {
 			sendKeyDown( keyCodes.downArrow ); // 'of'
 			expect( getSelectedSuggestion() ).to.equal( 'of' );
 			sendKeyDown( keyCodes.tab );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'of' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'of' ] );
 			expect( getSelectedSuggestion() ).to.equal( null );
 		} );
 
@@ -436,27 +431,27 @@ describe( 'TokenField', function() {
 			sendKeyDown( keyCodes.downArrow ); // 'of'
 			expect( getSelectedSuggestion() ).to.equal( 'of' );
 			sendKeyDown( keyCodes.enter );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo', 'bar', 'of' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo', 'bar', 'of' ] );
 			expect( getSelectedSuggestion() ).to.equal( null );
 		} );
 	} );
 
 	describe( 'removing tokens', function() {
 		it( 'should remove tokens when X icon clicked', function() {
-			TestUtils.Simulate.click( tokenFieldNode.querySelector( '.token-field__remove-token' ) );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'bar' ] );
+			tokenFieldNode.find( '.token-field__remove-token' ).first().simulate( 'click' );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'bar' ] );
 		} );
 
 		it( 'should remove the token to the left when backspace pressed', function() {
 			sendKeyDown( keyCodes.backspace );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'foo' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'foo' ] );
 		} );
 
 		it( 'should remove the token to the right when delete pressed', function() {
 			sendKeyDown( keyCodes.leftArrow );
 			sendKeyDown( keyCodes.leftArrow );
 			sendKeyDown( keyCodes.delete );
-			expect( wrapper.state.tokens ).to.deep.equal( [ 'bar' ] );
+			expect( wrapper.state( 'tokens' ) ).to.deep.equal( [ 'bar' ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
`components/token-field` tests got refactored to use `enzyme`.

This is also the slowest test suite. Execution time is on average 0.8s. I didn't make any progress performance wise. It looks like mouse and keyboard events are super slow, but I'm not an expert in this area.

### Testing
* `npm run test-client`
* `npm run test-client client/components/token-field/test/index.jsx -- -w`