### PR TITLE
Server-side Rendering: Route based on sections whitelist, fall back to 404

### DIFF
--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -12,5 +12,6 @@ export default function( router ) {
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		router( '/design', makeLayout );
 		router( '/design/type/:tier', makeLayout );
+		router( '/design/*', makeLayout ); // Needed so direct hits don't result in a 404.
 	}
 }

--- a/server/pages/404.jade
+++ b/server/pages/404.jade
@@ -23,5 +23,4 @@ html(lang='en')
 							h2.empty-content__title Uh oh. Page not found.
 							h3.empty-content__line.
 								Sorry, the page you were looking for doesn't exist or has been moved.
-							a(href='/' class='empty-content__action button button-primary') Go back home
-
+							a(href='/' class='empty-content__action button button-primary') Return to Home

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -339,6 +339,12 @@ function setUpRoute( req, res, next ) {
 	}
 }
 
+function render404( request, response ) {
+	response.status( 404 ).render( '404.jade', {
+		urls: generateStaticUrls( request )
+	} );
+}
+
 module.exports = function() {
 	var app = express();
 
@@ -372,11 +378,7 @@ module.exports = function() {
 		res.redirect( redirectUrl );
 	} );
 
-	app.get( '/calypso/?*', function( request, response ) {
-		response.status( 404 ).render( '404.jade', {
-			urls: generateStaticUrls( request )
-		} );
-	} );
+	app.get( '/calypso/?*', render404 );
 
 	if ( config.isEnabled( 'login' ) ) {
 		app.get( '/log-in/:lang?', setUpLoggedOutRoute, serverRender );

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -28,15 +28,7 @@ var staticFiles = [
 	{ path: 'style-rtl.css' }
 ];
 
-var chunksByPath = {};
-
 var sections = sectionsModule.get();
-
-sections.forEach( function( section ) {
-	section.paths.forEach( function( path ) {
-		chunksByPath[ path ] = section.name;
-	} );
-} );
 
 // TODO: Move into an `app.get()` route handler (e.g. next to language setting),
 // and pass the bootstrap locale as a parameter.

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -418,13 +418,22 @@ module.exports = function() {
 
 	// Isomorphic routing
 	sections
-		.filter( section => section.isomorphic )
 		.forEach( section => {
-			sectionsModule.require( section.module )( serverRouter( app, setUpRoute, section ) );
+			section.paths.forEach( path => {
+				const pathRegex = utils.pathToRegExp( path );
+
+				if ( ! section.isomorphic ) {
+					app.get( pathRegex, setUpLoggedInRoute, serverRender );
+				}
+			} );
+
+			if ( section.isomorphic ) {
+				sectionsModule.require( section.module )( serverRouter( app, setUpRoute, section ) );
+			}
 		} );
 
-	// catchall path to serve shell for all non-static-file requests (other than auth routes)
-	app.get( '*', setUpLoggedInRoute, serverRender );
+	// catchall to render 404 for all routes not whitelisted in client/sections
+	app.get( '*', render404 );
 
 	return app;
 };


### PR DESCRIPTION
Use paths from `client/sections` for routing, and fall back to a 404 otherwise.
Also, use express middleware to add chunk `<script>` to HTML output (instead of manually testing RegEx compiled from `client/sections` path).

Before (http://calypso.localhost:3000/noexiste):

![before](https://cloud.githubusercontent.com/assets/96308/14406354/8be6fd5e-fea5-11e5-9587-c13930492f03.png)

After (http://calypso.localhost:3000/noexiste):

![after](https://cloud.githubusercontent.com/assets/96308/14406356/9394482c-fea5-11e5-80fe-cc4c41166e93.png)


To test:
* Try directly landing on different sections of Calypso and make sure they still work. In particular, check http://calypso.localhost:3000/design/<yoursite>
 * Check page source to see if there is a `<script>` for the corresponding chunk (e.g. for `/pages`, watch out for `<script src="/calypso/posts-pages.fb43c97d94c0abab7702.js">`).
 * Verify that server side rendering of theme sheets still works, e.g. http://calypso.localhost:3000/theme/prosperity/overview
* Try directly landing on a route that doesn't exist, and verify that you get a 404.

/CCing potentially interested parties @mtias @aduth @lamosty
@folletto -- do we need any more styling for the 404s?