### PR TITLE
Framework: Center Drake when user has no sites

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -46,6 +46,11 @@ function renderNavigation( context, allSitesPath, siteBasePath ) {
 }
 
 function removeSidebar( context ) {
+	context.store.dispatch( uiActions.setSection( {
+		group: 'sites',
+		secondary: false
+	} ) );
+
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 }
 
@@ -268,11 +273,7 @@ module.exports = {
 		 * Sites is rendered on #primary but it doesn't expect a sidebar to exist
 		 * so section needs to be set explicitly and #secondary cleaned up
 		 */
-		context.store.dispatch( uiActions.setSection( {
-			group: 'sites',
-			secondary: false
-		} ) );
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+		removeSidebar( context );
 		layoutFocus.set( 'content' );
 
 		// This path sets the URL to be visited once a site is selected


### PR DESCRIPTION
Similar to #4077, this PR fixes a tiny regression after the cleanup work done in #3913. Similar to site selection, Drake is now off center when the user has no sites at https://wordpress.com/stats/insights because it expects a sidebar.

![screen shot 2016-04-10 at 7 50 44 am](https://cloud.githubusercontent.com/assets/7240478/14410621/f5d25a60-fef0-11e5-9171-a7a1efe081a0.png)

I reintroduced a dispatch that sets the `secondary` to `false`, which removes the sidebar. Similar code was being used in [the `sites` function](https://github.com/Automattic/wp-calypso/blob/b2d858dd413f06413c13e2a3ec66362ccad2f3d9/client/my-sites/controller.js#L256), which renders the selector at https://wordpress.com/sites. I pulled out the code in that section and just called the `removeSidebar` created above.

**To test:**
1. Load up this branch. 
2. Log into an account that has site(s).
3. Visit https://wordpress.com/sites. The site selector should be centered with the blue background.
4. Click a site. Sidebar should now load. Content is still aligned correctly.
5. Login to new account without any sites. 
6. Click "My Sites," which loads https://wordpress.com/stats/insights. Drake should now be centered.

![screen shot 2016-04-10 at 7 57 43 am](https://cloud.githubusercontent.com/assets/7240478/14410685/ef7b9982-fef1-11e5-9589-eaf33eaf0062.png)

Based on the cleanup work mentioned above, I realize we're trying to get away from this type of work:

> This is an approach to move us away from controllers doing layout configuration work that we can declare in sections.js and let the application handle it for developers.

cc @mtias is there an easier solution that I'm missing here?