### PR TITLE
Site settings: Add link to empty site support page

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -17,6 +17,7 @@ export default {
 	DOMAINS: `${root}/domains`,
 	EMAIL_FORWARDING: `${root}/email-forwarding`,
 	EMAIL_VALIDATION_AND_VERIFICATION: `${root}/domains/register-domain/#email-validation-and-verification`,
+	EMPTY_SITE: `${root}/empty-site/`,
 	ENABLE_DISABLE_COMMENTS: `${root}/enable-disable-comments`,
 	EVENTBRITE: `${root}/eventbrite`,
 	EVENTBRITE_EVENT_CALENDARLISTING_WIDGET: `${root}/widgets/eventbrite-event-calendarlisting-widget`,

--- a/client/my-sites/site-settings/start-over/index.jsx
+++ b/client/my-sites/site-settings/start-over/index.jsx
@@ -15,7 +15,8 @@ var HeaderCake = require( 'components/header-cake' ),
 	ActionPanelFigure = require( 'my-sites/site-settings/action-panel/figure' ),
 	ActionPanelFooter = require( 'my-sites/site-settings/action-panel/footer' ),
 	Button = require ( 'components/button' ),
-	Gridicon = require ( 'components/gridicon' );
+	Gridicon = require ( 'components/gridicon' ),
+	support = require('lib/url/support');
 
 module.exports = React.createClass( {
 
@@ -58,6 +59,15 @@ module.exports = React.createClass( {
 						<p>{
 							this.translate( 'This will keep your site and URL active, but give you a fresh start on your content ' +
 								'creation. Just contact us to have your current content cleared out.' )
+						}</p>
+						<p>{
+							this.translate( 'Alternatively, you can delete all content from your site by following {{link}}the steps here{{/link}}.',
+							{
+								components: {
+									link: <a href={ support.EMPTY_SITE } target="_blank" />
+								}
+							}
+						)
 						}</p>
 					</ActionPanelBody>
 					<ActionPanelFooter>


### PR DESCRIPTION
In response to the suggestion in #4634, this adds a link to the "Empty Site" support page so that users can empty their site if they would like instead of contacting support. Here's the line that gets added:

> Alternatively, you can delete all content from your site by following the steps here.

To test, run the branch and then visit this page for one of your sites:

http://calypso.localhost:3000/settings/start-over/SITE.wordpress.com

In case we want to use it in the future, I added `EMPTY_SITE` as a support URL in `lib/url/support.js`. Screenshot with change:

![screen shot 2016-04-10 at 12 13 14 pm](https://cloud.githubusercontent.com/assets/7240478/14412027/b3e6edd0-ff15-11e5-90c9-52059a3b4f9c.png)