### PR TITLE
Jetpack-connect: Fetch url info when user press enter

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -154,7 +154,6 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	render() {
-		window.bbb = this;
 		const status = this.getStatus();
 		return (
 			<Main className="jetpack-connect">

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -34,7 +34,7 @@ export default React.createClass( {
 		return( this.translate( 'Connecting…' ) )
 	},
 
-	maybeClickIfEnter( event ) {
+	handleKeyPress( event ) {
 		if ( 13 === event.keyCode ) {
 			this.props.onClick();
 		}
@@ -52,7 +52,7 @@ export default React.createClass( {
 						onChange={ this.onChange }
 						disabled={ this.props.isFetching }
 						placeholder={ this.translate( 'http://www.yoursite.com' ) }
-						onKeyUp={ this.maybeClickIfEnter } />
+						onKeyUp={ this.handleKeyPress } />
 					{ this.props.isFetching
 						? ( <Spinner duration={ 30 } /> )
 						: null }

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -34,8 +34,8 @@ export default React.createClass( {
 		return( this.translate( 'Connecting…' ) )
 	},
 
-	maybeClickIfEnter( ev ) {
-		if ( 13 === ev.keyCode ) {
+	maybeClickIfEnter( event ) {
+		if ( 13 === event.keyCode ) {
 			this.props.onClick();
 		}
 	},

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -34,6 +34,12 @@ export default React.createClass( {
 		return( this.translate( 'Connecting…' ) )
 	},
 
+	maybeClickIfEnter( ev ) {
+		if ( 13 === ev.keyCode ) {
+			this.props.onClick();
+		}
+	},
+
 	render() {
 		return (
 			<div>
@@ -45,7 +51,8 @@ export default React.createClass( {
 					<FormTextInput
 						onChange={ this.onChange }
 						disabled={ this.props.isFetching }
-						placeholder={ this.translate( 'http://www.yoursite.com' ) } />
+						placeholder={ this.translate( 'http://www.yoursite.com' ) }
+						onKeyUp={ this.maybeClickIfEnter } />
 					{ this.props.isFetching
 						? ( <Spinner duration={ 30 } /> )
 						: null }


### PR DESCRIPTION
This PR adds an small change allowing users to submit an url in the jetpack connect flow just pressing enter.

How to test:
========
1. Go to http://calypso.localhost:3000/jetpack/connect
2. enter anything in the url input and press enter... you should get the same result than clicking with the pointer in the "connect now" button

/cc @roccotripaldi 