### PR TITLE
GuidedTours: Remove custom secondary button CSS

### DIFF
--- a/client/guidestours/steps.js
+++ b/client/guidestours/steps.js
@@ -42,7 +42,7 @@ class GuidesFirstStep extends Component {
 				<p>{ text }</p>
 				<div className="guidestours__choice-button-row">
 					<Button onClick={ onNext } primary>{ this.props.translate( 'Continue' ) }</Button>
-					<Button onClick={ onQuit } className="guidestours__secondary-button">
+					<Button onClick={ onQuit } >
 						{ this.props.translate( 'No, thanks.' ) }
 					</Button>
 				</div>

--- a/client/guidestours/style.scss
+++ b/client/guidestours/style.scss
@@ -37,10 +37,6 @@
 	button:nth-child(1) {
 		margin-right: 4%;
 	}
-	button.guidestours__secondary-button {
-		background: $gray-light;
-		color: darken( $gray, 20% );
-	}
 }
 
 .guidestours__single-button-row {


### PR DESCRIPTION
Carrying on from the discussion in https://github.com/Automattic/wp-calypso/pull/4468#discussion_r58854985

Do we need a grey button here? Should it be specific to our use case? Should we modify `Button` to accept a `grey` `prop`?

UI before:
![screen shot 2016-04-11 at 14 09 55](https://cloud.githubusercontent.com/assets/215074/14428163/ceb35218-ffef-11e5-8f37-6a698ec2a0be.png)

UI after: 
![screen shot 2016-04-11 at 14 11 13](https://cloud.githubusercontent.com/assets/215074/14428167/d5202356-ffef-11e5-9481-f17a1e92b25a.png)