### PR TITLE
Invites: Redirect users to wp-admin for VIP sites

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -108,7 +108,9 @@ export function acceptInvite( invite, callback ) {
 						error: error.error
 					} );
 				} else {
-					dispatch( successNotice( ... acceptedNotice( invite ) ) );
+					if ( ! get( invite, 'site.is_vip' ) ) {
+						dispatch( successNotice( ... acceptedNotice( invite ) ) );
+					}
 					analytics.tracks.recordEvent( 'calypso_invite_accepted' );
 				}
 				if ( typeof callback === 'function' ) {

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -5,6 +5,7 @@ import ReactDom from 'react-dom';
 import React from 'react';
 import store from 'store';
 import page from 'page';
+import get from 'lodash/get';
 
 /**
  * Internal Dependencies
@@ -55,6 +56,8 @@ export function acceptInvite( context ) {
 		const acceptInviteCallback = error => {
 			if ( error ) {
 				page( window.location.href );
+			} else if ( get( acceptedInvite, 'site.is_vip' ) ) {
+				window.location.href = getRedirectAfterAccept( acceptedInvite );
 			} else {
 				page( getRedirectAfterAccept( acceptedInvite ) );
 			}

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import page from 'page';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -28,10 +29,12 @@ let InviteAcceptLoggedIn = React.createClass( {
 	accept() {
 		this.setState( { submitting: true } );
 		this.props.acceptInvite( this.props.invite, error => {
-			if ( ! error ) {
-				page( this.props.redirectTo );
-			} else {
+			if ( error ) {
 				this.setState( { submitting: false } );
+			} else if ( get( this.props, 'invite.site.is_vip' ) ) {
+				window.location.href = this.props.redirectTo;
+			} else {
+				page( this.props.redirectTo );
 			}
 		} );
 		analytics.tracks.recordEvent( 'calypso_invite_accept_logged_in_join_button_click' );

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -134,13 +134,27 @@ export default {
 	},
 
 	getRedirectAfterAccept( invite ) {
+		const readerPath = '/';
+		const postsListPath = '/posts/' + invite.site.ID;
+
+		if ( get( invite, 'site.is_vip' ) ) {
+			switch ( invite.role ) {
+				case 'viewer':
+				case 'follower':
+					return get( invite, 'site.URL' ) || readerPath
+					break;
+				default:
+					return get( invite, 'site.admin_url' ) || postsListPath;
+			}
+		}
+
 		switch ( invite.role ) {
 			case 'viewer':
 			case 'follower':
-				return '/';
+				return readerPath;
 				break;
 			default:
-				return '/posts/' + invite.site.ID;
+				return postsListPath;
 		}
 	}
 };


### PR DESCRIPTION
Closes #4588.

Since VIP sites add a lot of custom functionality into wp-admin, let's redirect users that can create/manage content to wp-admin after accepting an invite.

To test:
- Checkout `update/invites-vip-redirect` branch
- Create an invite on a VIP site
- Copy the invitation URL you receive in your email, and replace `wordpress.com` with `calpyso.localhost:3000`
- Accept the invite
- Do you land in `wp-admin` after accepting?

Note that viewers and followers should land on the front page of the VIP site. Author and above should go to wp-admin.

This required a couple of updates on the API side. Specifically r134100-wpcom and r134096-wpcom.

cc @lezama for review.