### PR TITLE
Help: Update contact options on upgrade

### DIFF
--- a/client/lib/olark/index.js
+++ b/client/lib/olark/index.js
@@ -151,6 +151,16 @@ const olark = {
 		}
 	},
 
+	updateOlarkGroupAndEligibility() {
+		this.getOlarkConfiguration()
+			.then( ( configuration ) => {
+				const isUserEligible = ( 'undefined' === typeof configuration.isUserEligible ) ? true : configuration.isUserEligible;
+				olarkApi( 'api.chat.setOperatorGroup', { group: configuration.group } );
+				olarkActions.setUserEligibility( isUserEligible );
+			} )
+			.catch( ( error ) => this.handleError( error ) );
+	},
+
 	syncStoreWithExpandedState() {
 		// We query the dom here because there is no other 100% accurate way to figure this out. Olark does not
 		// provide initial events for api.box.onExpand when the api.box.show event is fired.
@@ -413,3 +423,4 @@ const olark = {
 
 emitter( olark );
 olark.initialize();
+module.exports = olark;

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -9,6 +9,7 @@ import debugFactory from 'debug';
 import { action as ActionTypes } from '../constants';
 import Dispatcher from 'dispatcher';
 import i18n from 'lib/mixins/i18n';
+import olark from 'lib/olark';
 import purchasesAssembler from 'lib/purchases/assembler';
 import wp from 'lib/wp';
 
@@ -64,6 +65,8 @@ function clearPurchases() {
 	Dispatcher.handleViewAction( {
 		type: ActionTypes.PURCHASES_REMOVE
 	} );
+
+	olark.updateOlarkGroupAndEligibility();
 }
 
 function deleteStoredCard( card, onComplete ) {
@@ -180,6 +183,8 @@ function removePurchase( purchaseId, userId, onComplete ) {
 				purchases: purchasesAssembler.createPurchasesArray( data.purchases ),
 				userId
 			} );
+
+			olark.updateOlarkGroupAndEligibility();
 		}
 
 		onComplete( data && data.success );


### PR DESCRIPTION
This is an Intended fix for #1827 by updating the contact form details when the user cancels or purchases an upgrade. 

This PR does a few different things:

1. I added a new action type called `OLARK_NOT_READY` in `/lib/olark-store/index.js` that sets `isOlarkReady` to `false`.
2. I added an action in `lib/olark-store/actions.js` that calls the dispatcher referencing the action type `OLARK_NOT_READY` mentioned above.
3. The action is then called when a user cancels or removes a purchase as well as when we load the Thank you page after a purchase.
4. In `lib/olark/index.js`, I created a new function called `fetchUserEligibility`, which basically just gets the correct configuration based on the user information
5. Finally, in `me/help/help-contact/index.jsx`, I added a call to `fetchUserEligibility` in `componentWillMount`. It checks whether `isOlarkReady` is set to `false,` which now happens when users purchase or cancel an upgrade. If it's set to `false,` it re-grabs the correct configuration.

The branch currently works correctly (screenshots below), but I have a few follow-up questions:

1. Is there a better place to put the action for users cancelling/removing/adding a purchase? Dropping the call in `cancelPurchase` and `removePurchase` seems fine, but I couldn't find a great spot for when completing a purchase.
2. ESLint through an error on `client/me/help/help-contact/index.jsx` because we define `olark` both up top and below. I tried exporting just the function `fetchUserEligibility` from `lib/olark/index.js`, but I couldn't get that to work. Is there a better way to export just the method so I don't have to import `olark` at the top and re-use that name in `help-contact/index.jsx`?

**To test:**
1. Load up this branch and login using an account without any upgrades
2. Visit https://wordpress.com/help/contact. You should see a forum contact form.
3. Without reloading, purchase an upgrade by clicking "Manage Purchases"
4. With the upgrade purchased, navigate back to the contact page without reloading (click "Me" and then "Help" on the left-hand side). You should now see a contact form/live chat box.
5. Click "Manage Purchases" again and cancel the upgrade.
6. Navigate back to the contact page without reloading. You should see a forum submission box.

Before:
![screen shot 2016-04-11 at 9 56 36 am](https://cloud.githubusercontent.com/assets/7240478/14433587/170d114e-ffcc-11e5-81b8-360c63241359.png)

After purchase (no reload):
![screen shot 2016-04-11 at 9 57 05 am](https://cloud.githubusercontent.com/assets/7240478/14433592/1ddeb068-ffcc-11e5-878e-1046e7253ffd.png)