### PR TITLE
Email Confirmation: Use lighter background and allow notice to be dismissed

### DIFF
--- a/client/components/email-verification/email-verification-notice.jsx
+++ b/client/components/email-verification/email-verification-notice.jsx
@@ -112,18 +112,18 @@ module.exports = React.createClass( {
 		} else {
 			noticeText = ( <div>
 				<p>
-					<strong>{ this.translate( 'Please verify your email address' ) }</strong>
+					<strong>{ this.translate( 'Please confirm your email address' ) }</strong>
 				</p>
 				<p>
 					{ this.translate(
-						'To post and keep using WordPress.com you need to validate your email address. ' +
+						'To post and keep using WordPress.com you need to confirm your email address. ' +
 						'Please click the link in the email we sent at %(email)s.',
 						{ args: { email: user.email } }
 					) }
 				</p>
 				<p>
 					{ this.translate(
-						'{{requestButton}}Re-send your activation email{{/requestButton}} ' +
+						'{{requestButton}}Re-send your confirmation email{{/requestButton}} ' +
 						'or {{changeButton}}change the email address on your account{{/changeButton}}.', {
 							components: {
 								requestButton: <button className="button is-link" onClick={ this.sendVerificationEmail } />,
@@ -139,8 +139,8 @@ module.exports = React.createClass( {
 
 	verifiedNotice: function() {
 		var noticeText = isEmpty( sites.get() )
-			? this.translate( "You've successfully verified your email address." )
-			: this.translate( "Email verified! Now that you've confirmed your email address you can publish posts on your blog." );
+			? this.translate( "You've successfully confirmed your email address." )
+			: this.translate( "Email confirmed! Now that you've confirmed your email address you can publish posts on your blog." );
 
 		return (
 			<Notice status="is-success" onDismissClick={ this.dismissNotice } className="email-verification-notice">

--- a/client/components/email-verification/email-verification-notice.jsx
+++ b/client/components/email-verification/email-verification-notice.jsx
@@ -134,7 +134,7 @@ module.exports = React.createClass( {
 			</div> );
 		}
 
-		return <Notice text={ noticeText } status={ noticeStatus } showDismiss={ false } className="email-verification-notice" />;
+		return <Notice text={ noticeText } status={ noticeStatus } onDismissClick={ this.dismissNotice } className="email-verification-notice" />;
 	},
 
 	verifiedNotice: function() {

--- a/client/components/email-verification/email-verification-notice.jsx
+++ b/client/components/email-verification/email-verification-notice.jsx
@@ -134,7 +134,7 @@ module.exports = React.createClass( {
 			</div> );
 		}
 
-		return <Notice text={ noticeText } status={ noticeStatus } onDismissClick={ this.dismissNotice } className="email-verification-notice" />;
+		return <Notice text={ noticeText } icon="notice" status={ noticeStatus } onDismissClick={ this.dismissNotice } className="email-verification-notice" />;
 	},
 
 	verifiedNotice: function() {

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -17,7 +17,7 @@ export default React.createClass( {
 	getDefaultProps() {
 		return {
 			duration: 0,
-			status: 'is-info',
+			status: null,
 			showDismiss: true,
 			className: '',
 			onDismissClick: noop

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -3,7 +3,7 @@
 	position: relative;
 	margin-bottom: 24px;
 	border-radius: 1px;
-	background: $gray-light;
+	background: lighten( $gray, 30 );
 	box-sizing: border-box;
 	font-size: 14px;
 	animation: appear .3s ease-in-out;


### PR DESCRIPTION
The current email confirmation notice is really bold, and obnoxiously "undismissable". This PR does a few things:

- Updates the `notice` component to use a `null` default prop for it's `status` prop.
- Updates the `notice` component's styles for default notices to use a slightly darker background color.
- Updates the email confirmation message to use the term "confirm" rather than "verify" to better match the emails we send.
- Updates the email confirmation message so it can be dismissed. The notice comes back if you refresh the page.

The end result looks like this:

![screen shot 2016-04-11 at 12 52 24 pm](https://cloud.githubusercontent.com/assets/191598/14435116/42ed816e-ffe4-11e5-96b8-6caf705ae70d.png)
