### PR TITLE
Update: Single Plugin view : Update All sites icons to count

### DIFF
--- a/client/my-sites/plugins/plugin-site-network/index.jsx
+++ b/client/my-sites/plugins/plugin-site-network/index.jsx
@@ -8,7 +8,7 @@ var React = require( 'react' );
  */
 var FoldableCard = require( 'components/foldable-card' ),
 	CompactCard = require( 'components/card/compact' ),
-	AllSitesIcon = require( 'my-sites/all-sites-icon' ),
+	Count = require( 'components/count' ),
 	PluginsLog = require( 'lib/plugins/log-store' ),
 	PluginActivateToggle = require( 'my-sites/plugins/plugin-activate-toggle' ),
 	PluginAutoupdateToggle = require( 'my-sites/plugins/plugin-autoupdate-toggle' ),
@@ -46,7 +46,7 @@ module.exports = React.createClass( {
 	renderMultisiteHeader: function() {
 		return (
 			<div className="plugin-site-network__header">
-				<AllSitesIcon sites={ this.props.secondarySites } />
+				<Count count={ this.props.secondarySites.length } />
 				<div className="plugin-site-network__header_info">
 					<div className="site__title">{ this.translate( '%(mainSiteName)s\'s Network', {
 						args: {

--- a/client/my-sites/plugins/plugin-site-network/style.scss
+++ b/client/my-sites/plugins/plugin-site-network/style.scss
@@ -39,8 +39,17 @@
 		padding: 8px;
 	}
 
-	.all-sites-icon {
-		display: inline-block;
+	.count {
+		display: inline-flex;
+		width: 32px;
+		height: 32px;
+		border-radius: 4px;
+		margin-right: 8px;
+		align-items: center;
+		align-self: center;
+		justify-content: center;
+		padding: 0;
+		vertical-align: top;
 	}
 
 	.plugin-install-button__install {


### PR DESCRIPTION
Currently the Single Plugin view looks a bit broken. This PR fixes it by implementing the count component instead of the All Sites Icon as suggested in https://github.com/Automattic/wp-calypso/pull/4581#issuecomment-208456175

After:
![screen_shot_2016-04-11_at_13_41_19](https://cloud.githubusercontent.com/assets/115071/14441769/432be39e-ffeb-11e5-9705-5bb87f50372b.png)

Before:
![screen_shot_2016-04-11_at_13_42_45](https://cloud.githubusercontent.com/assets/115071/14441791/5cefcd7c-ffeb-11e5-8491-5e272efa88d9.png)

cc: @folletto, @mtias, @beaulebens