### PR TITLE
Framework: Show long content fade on resume editing button

### DIFF
--- a/client/my-sites/resume-editing/style.scss
+++ b/client/my-sites/resume-editing/style.scss
@@ -33,9 +33,20 @@
 }
 
 .resume-editing__post-title {
+	position: relative;
+	overflow: hidden;
 	color: $white;
 	display: block;
+	max-width: 25vw;
+	white-space: nowrap;
 	font-family: $serif;
 	font-size: 14px;
 	line-height: 1;
+
+	&::after {
+		@include long-content-fade( $size: 24px, $color: $blue-wordpress );
+		left: 25vw;
+		right: auto;
+		margin-left: -24px;
+	}
 }


### PR DESCRIPTION
This pull request seeks to resolve an issue where the Continue Editing button causes the post title to split onto multiple lines when longer than the viewport width would allow.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/14442723/4156ca5c-0009-11e6-93d9-17b2239f4d59.png)|![After](https://cloud.githubusercontent.com/assets/1779930/14442556/6a6c8ea0-0008-11e6-8bd5-507e26be9dc9.png)

__Testing instructions:__

Verify that the post title never splits to multiple lines. Ensure that a gradient fade is shown, but only for post titles which would otherwise be too long to fit within the allotted space.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Enter a post title
4. Save the post
5. Navigate to the Reader from the master bar
6. Note that the post title never splits to multiple lines when changing the viewport width

/cc @mtias 

Ref: p69Idv-aP-p2