### PR TITLE
Jetpack-connect: Check for jetpack versions

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -22,7 +22,7 @@ import versionCompare from 'lib/version-compare';
 const JetpackConnectMain = React.createClass( {
 	displayName: 'JetpackConnectSiteURLStep',
 
-	MINIMUM_JETPACK_VERSION: '4.0',
+	MINIMUM_JETPACK_VERSION: '3.9.6',
 
 	getInitialState() {
 		return {

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -19,10 +19,14 @@ import SiteURLInput from './site-url-input';
 import { dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation, checkUrl } from 'state/jetpack-connect/actions';
 import versionCompare from 'lib/version-compare';
 
+
+/**
+ * Constants
+ */
+const MINIMUM_JETPACK_VERSION = '3.9.6';
+
 const JetpackConnectMain = React.createClass( {
 	displayName: 'JetpackConnectSiteURLStep',
-
-	MINIMUM_JETPACK_VERSION: '3.9.6',
 
 	getInitialState() {
 		return {
@@ -143,7 +147,7 @@ const JetpackConnectMain = React.createClass( {
 			return 'notJetpack';
 		}
 		const jetpackVersion = this.checkProperty( 'jetpackVersion' );
-		if ( jetpackVersion && versionCompare( jetpackVersion, this.MINIMUM_JETPACK_VERSION, '<' ) ) {
+		if ( jetpackVersion && versionCompare( jetpackVersion, MINIMUM_JETPACK_VERSION, '<' ) ) {
 			return 'outdatedJetpack';
 		}
 		if ( ! this.checkProperty( 'isJetpackActive' ) ) {

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -17,9 +17,12 @@ import Main from 'components/main';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
 import { dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation, checkUrl } from 'state/jetpack-connect/actions';
+import versionCompare from 'lib/version-compare';
 
 const JetpackConnectMain = React.createClass( {
 	displayName: 'JetpackConnectSiteURLStep',
+
+	MINIMUM_JETPACK_VERSION: '4.0',
 
 	getInitialState() {
 		return {
@@ -138,6 +141,10 @@ const JetpackConnectMain = React.createClass( {
 		}
 		if ( ! this.checkProperty( 'hasJetpack' ) ) {
 			return 'notJetpack';
+		}
+		const jetpackVersion = this.checkProperty( 'jetpackVersion' );
+		if ( jetpackVersion && versionCompare( jetpackVersion, this.MINIMUM_JETPACK_VERSION, '<' ) ) {
+			return 'outdatedJetpack';
 		}
 		if ( ! this.checkProperty( 'isJetpackActive' ) ) {
 			return 'notActiveJetpack';

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -47,6 +47,11 @@ export default React.createClass( {
 			noticeValues.text = this.translate( 'Jetpack is deactivated' );
 			return noticeValues
 		}
+		if ( this.props.noticeType === 'outdatedJetpack' ) {
+			noticeValues.icon = 'block';
+			noticeValues.text = this.translate( 'You need to update Jetpack before connecting' );
+			return noticeValues
+		}
 		if ( this.props.noticeType === 'jetpackIsDisconnected' ) {
 			noticeValues.icon = 'link-break';
 			noticeValues.text = this.translate( 'Jetpack is disconnected' );


### PR DESCRIPTION
This PR adds a minimum jetpack version required for jetpack-connect to work.

![image](https://cloud.githubusercontent.com/assets/1554855/14462192/3bb874ca-00c6-11e6-9d63-2f053195fe12.png)

For any jetpack lesser than 3.9.6 we are going to show this message. We need to create some instructions to show the user about how to update.

How to test
========
1. ~~You need to have a .com sandbox running `D1581-code`~~ not anymore, already merged
2. Go to http://calypso.localhost:3000/jetpack/connect and enter the url of a jetpack site with a jetpack version smaller than 3.9.6
3. You should see a warning about your jetpack version


ping @roccotripaldi  @alternatekev 