### PR TITLE
Themes: Move Theme Details sheet to my-sites/theme

### DIFF
--- a/client/controller.js
+++ b/client/controller.js
@@ -24,28 +24,27 @@ const debug = debugFactory( 'calypso:controller' );
 export function makeLayout( context, next ) {
 	const isLoggedIn = !! getCurrentUser( context.store.getState() );
 	if ( ! isLoggedIn ) {
-		makeLoggedOutLayout( context, next );
-	} // TODO: else { makeLoggedInLayout( context, next ); }
+		context.layout = makeLoggedOutLayout( context );
+	} // TODO: else { makeLoggedInLayout( context ); }
 	next();
 }
 
 /**
  * @param { object } context -- Middleware context
- * @param { function } next -- Call next middleware in chain
+ * @returns { object } `LoggedOutLayout` element
  *
- * Produce a `LayoutLoggedOut` element in `context.layout`, using
- * `context.primary`, `context.secondary`, and `context.tertiary` to populate it.
+ * Return a `LayoutLoggedOut` element, using `context.primary`,
+ * `context.secondary`, and `context.tertiary` to populate it.
 */
-function makeLoggedOutLayout( context, next ) {
+function makeLoggedOutLayout( context ) {
 	const { store, primary, secondary, tertiary } = context;
-	context.layout = (
+	return (
 		<ReduxProvider store={ store }>
 			<LayoutLoggedOut primary={ primary }
 				secondary={ secondary }
 				tertiary={ tertiary } />
 		</ReduxProvider>
 	);
-	next();
 }
 
 /**

--- a/client/controller.js
+++ b/client/controller.js
@@ -20,9 +20,6 @@ const debug = debugFactory( 'calypso:controller' );
 /**
  * @param { object } context -- Middleware context
  * @param { function } next -- Call next middleware in chain
- *
- * When logged-out, call makeLoggedOutLayout( context, next );
- * otherwise, just call next();
 */
 export function makeLayout( context, next ) {
 	const isLoggedIn = !! getCurrentUser( context.store.getState() );

--- a/client/controller.js
+++ b/client/controller.js
@@ -12,6 +12,7 @@ import noop from 'lodash/noop';
  */
 import page from 'page';
 import LayoutLoggedOut from 'layout/logged-out';
+import { getCurrentUser } from 'state/current-user/selectors';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:controller' );
@@ -20,10 +21,25 @@ const debug = debugFactory( 'calypso:controller' );
  * @param { object } context -- Middleware context
  * @param { function } next -- Call next middleware in chain
  *
+ * When logged-out, call makeLoggedOutLayout( context, next );
+ * otherwise, just call next();
+*/
+export function makeLayout( context, next ) {
+	const isLoggedIn = !! getCurrentUser( context.store.getState() );
+	if ( ! isLoggedIn ) {
+		makeLoggedOutLayout( context, next );
+	} // TODO: else { makeLoggedInLayout( context, next ); }
+	next();
+}
+
+/**
+ * @param { object } context -- Middleware context
+ * @param { function } next -- Call next middleware in chain
+ *
  * Produce a `LayoutLoggedOut` element in `context.layout`, using
  * `context.primary`, `context.secondary`, and `context.tertiary` to populate it.
 */
-export function makeLoggedOutLayout( context, next ) {
+function makeLoggedOutLayout( context, next ) {
 	const { store, primary, secondary, tertiary } = context;
 	context.layout = (
 		<ReduxProvider store={ store }>
@@ -33,7 +49,7 @@ export function makeLoggedOutLayout( context, next ) {
 		</ReduxProvider>
 	);
 	next();
-};
+}
 
 /**
  * Isomorphic routing helper, client side
@@ -58,7 +74,7 @@ export function setSection( section ) {
 		context.store.dispatch( setSectionAction( section ) );
 
 		next();
-	}
+	};
 }
 
 function render( context ) {

--- a/client/my-sites/theme/controller.jsx
+++ b/client/my-sites/theme/controller.jsx
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 /**
  * Internal Dependencies
  */
-import ThemeSheetComponent from 'my-sites/themes/sheet';
+import ThemeSheetComponent from './main';
 import ThemeDetailsComponent from 'components/data/theme-details';
 import i18n from 'lib/mixins/i18n';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -34,10 +34,10 @@ export function makeElement( ThemesComponent, Head, store, props ) {
 			</Head>
 		</ReduxProvider>
 	);
-};
+}
 
 export function fetchThemeDetailsData( context, next ) {
-	if ( ! config.isEnabled( 'manage/themes/details' ) ) {
+	if ( ! config.isEnabled( 'manage/themes/details' ) || ! context.isServerSide ) {
 		return next();
 	}
 

--- a/client/my-sites/theme/index.js
+++ b/client/my-sites/theme/index.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { makeLayout } from 'controller';
+import { details, fetchThemeDetailsData } from './controller';
+
+export default function( router ) {
+	if ( config.isEnabled( 'manage/themes/details' ) ) {
+		router( '/theme/:slug/:section?/:site_id?', fetchThemeDetailsData, details, makeLayout );
+	}
+}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -82,7 +82,7 @@ const ThemeSheet = React.createClass( {
 				<span className="themes__sheet-bar-title">{ title }</span>
 				<span className="themes__sheet-bar-tag">{ tag }</span>
 			</div>
-		)
+		);
 	},
 
 	renderScreenshot() {
@@ -172,6 +172,6 @@ const ThemeSheet = React.createClass( {
 			</Main>
 		);
 	}
-} )
+} );
 
 export default connect()( ThemeSheet );

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -8,13 +8,8 @@ import analytics from 'lib/analytics';
 import i18n from 'lib/mixins/i18n';
 import trackScrollPage from 'lib/track-scroll-page';
 import buildTitle from 'lib/screen-title/utils';
-import { getAnalyticsData } from '../helpers';
-import { makeElement } from './index.node.js';
-
-/**
- * Re-export
- */
-export { details } from './index.node.js';
+import { getAnalyticsData } from './helpers';
+import { makeElement } from 'my-sites/theme/controller';
 
 function getProps( context ) {
 	const { tier, site_id: siteId } = context.params;

--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,9 +1,9 @@
 /**
  * Internal Dependencies
  */
-import SingleSiteComponent from 'my-sites/themes/single-site';
-import MultiSiteComponent from 'my-sites/themes/multi-site';
-import LoggedOutComponent from 'my-sites/themes/logged-out';
+import SingleSiteComponent from './single-site';
+import MultiSiteComponent from './multi-site';
+import LoggedOutComponent from './logged-out';
 import analytics from 'lib/analytics';
 import i18n from 'lib/mixins/i18n';
 import trackScrollPage from 'lib/track-scroll-page';

--- a/client/my-sites/themes/controller/package.json
+++ b/client/my-sites/themes/controller/package.json
@@ -1,4 +1,0 @@
-{
-	"main": "index.node.js",
-	"browser": "index.web.js"
-}

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -2,32 +2,15 @@
  * Internal dependencies
  */
 import config from 'config';
-import { makeLoggedOutLayout } from 'controller';
-import { details, fetchThemeDetailsData } from './controller';
-
-// FIXME: These routes will SSR the logged-out Layout even if logged-in.
-// While subsequently replaced by the logged-in Layout on the client-side,
-// we'll want to render it on the server, too.
+import { makeLayout } from 'controller';
 
 // `logged-out` middleware isn't SSR-compliant yet, but we can at least render
 // the layout.
 // FIXME: Also create loggedOut/multiSite/singleSite elements, depending on route.
-const designRoutes = {
-	'/design': [ makeLoggedOutLayout ],
-	'/design/type/:tier': [ makeLoggedOutLayout ]
-};
-
-const themesRoutes = {
-	'/theme/:slug/:section?/:site_id?': [ fetchThemeDetailsData, details, makeLoggedOutLayout ]
-};
-
-const routes = Object.assign( {},
-	config.isEnabled( 'manage/themes' ) ? designRoutes : {},
-	config.isEnabled( 'manage/themes/details' ) ? themesRoutes : {}
-);
 
 export default function( router ) {
-	Object.keys( routes ).forEach( route => {
-		router( route, ...routes[ route ] );
-	} );
+	if ( config.isEnabled( 'manage/themes' ) ) {
+		router( '/design', makeLayout );
+		router( '/design/type/:tier', makeLayout );
+	}
 }

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -3,41 +3,31 @@
  */
 import config from 'config';
 import userFactory from 'lib/user';
-import { makeLoggedOutLayout } from 'controller';
+import { makeLayout } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
-import { singleSite, multiSite, loggedOut, details } from './controller';
+import { singleSite, multiSite, loggedOut } from './controller';
 
-const user = userFactory();
+// FIXME: These routes will SSR the logged-out Layout even if logged-in.
+// While subsequently replaced by the logged-in Layout on the client-side,
+// we'll want to render it on the server, too.
 
-const isLoggedIn = !! user.get();
-
-const designRoutes = isLoggedIn
-	? {
-		'/design': [ multiSite, navigation, siteSelection ],
-		'/design/:site_id': [ singleSite, navigation, siteSelection ],
-		'/design/type/:tier': [ multiSite, navigation, siteSelection ],
-		'/design/type/:tier/:site_id': [ singleSite, navigation, siteSelection ],
-	}
-	: {
-		'/design': [ loggedOut, makeLoggedOutLayout ],
-		'/design/type/:tier': [ loggedOut, makeLoggedOutLayout ]
-	};
-
-const themesRoutes = isLoggedIn
-	? {
-		'/theme/:slug/:section?/:site_id?': [ details ],
-	}
-	: {
-		'/theme/:slug/:section?': [ details, makeLoggedOutLayout ],
-	};
-
-const routes = Object.assign( {},
-	config.isEnabled( 'manage/themes' ) ? designRoutes : {},
-	config.isEnabled( 'manage/themes/details' ) ? themesRoutes : {}
-);
+// `logged-out` middleware isn't SSR-compliant yet, but we can at least render
+// the layout.
+// FIXME: Also create loggedOut/multiSite/singleSite elements, depending on route.
 
 export default function( router ) {
-	Object.keys( routes ).forEach( route => {
-		router( route, ...routes[ route ] );
-	} );
+	const user = userFactory();
+	const isLoggedIn = !! user.get();
+
+	if ( config.isEnabled( 'manage/themes' ) ) {
+		if ( isLoggedIn ) {
+			router( '/design', multiSite, navigation, siteSelection );
+			router( '/design/:site_id', singleSite, navigation, siteSelection );
+			router( '/design/type/:tier', multiSite, navigation, siteSelection );
+			router( '/design/type/:tier/:site_id', singleSite, navigation, siteSelection );
+		} else {
+			router( '/design', loggedOut, makeLayout );
+			router( '/design/type/:tier', loggedOut, makeLayout );
+		}
+	}
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -133,8 +133,8 @@ sections = [
 	{
 		name: 'theme',
 		paths: [ '/theme' ],
-		module: 'my-sites/themes',
-		enableLoggedOut: config.isEnabled( 'manage/themes/logged-out' ),
+		module: 'my-sites/theme',
+		enableLoggedOut: true,
 		secondary: false,
 		group: 'sites',
 		isomorphic: true,

--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -16,7 +16,7 @@ The constraints required for isomorphic routing are:
 
 ```js
 export default function( router ) {
-  router( '/themes/:slug/:section?/:site_id?', details, makeLoggedOutLayout );
+  router( '/themes/:slug/:section?/:site_id?', details, makeLayout );
 }
 ```
 
@@ -26,13 +26,12 @@ by either the client or the server render, as appropriate. (This is clearly
 different from the previous client-side-only routing approach where you'd have
 to render to `#primary`/`#secondary`/`#tertiary` DOM elements.)
 
-To facilitate that, you can (but don't have to) use the `makeLoggedOutLayout`
+To facilitate that, you can (but don't have to) use the `makeLayout`
 generic middleware found in `client/controller`. So in the above example, the
 details middleware will just create an element in `context.primary` (instead of
 rendering it to the `#primary` DOM element, as previously).
-Note that there is no logged-in counterpart to `makeLoggedOutLayout` yet, as the
-logged-in layout has a lot of dependencies that aren't ready for server-side
-rendering.
+Note that `makeLayout` cannot produce a logged-in `Layout` on the server side yet,
+as that has a lot of dependencies that aren't ready for server-side rendering.
 
 * Realistically, you will probably need to write separate `index.node.js` and
 `index.web.js` files for the server and client side inside your section, as many


### PR DESCRIPTION
Fixes one of the [many reasons](https://github.com/Automattic/wp-calypso/issues/2299#issuecomment-209127605) for React tree reconciliation errors, and fixes #4633.

Reason for the reconc error: https://github.com/Automattic/wp-calypso/blob/master/server/pages/index.js#L395-L400 iterates over sections as found in https://github.com/Automattic/wp-calypso/blob/master/client/sections.js, requiring and calling each isomorphic module. https://github.com/Automattic/wp-calypso/blob/master/server/isomorphic-routing/index.js#L16 then dispatches `setSection` (which among other things sets a `class` to `is-section-{sectionName}`) to the current one -- ignorant of the actual route it was called for! Since `theme` and `themes` sections both require the same module in sections.js, `my-sites/themes` (which I think is something only we do), any route that starts with either `/design` or `/theme` will set the section to `theme`. This will cause aforementioned class in the server-side rendered HTML for `/design` routes to be falsely set to `is-section-theme`.

Since there are hardly any overlapping dependencies between the Theme Showcase list view and the details sheet (see e.g. imports in `sheet.jsx` -- nothing imported from `./`), I'm moving the sheet to `my-sites/theme` (singular). This way, there is only one section per module again, fixing the error.

Furthermore, this PR moves the burden of providing different server and client route definitions (because of the need for e.g. `makeLoggedOutLayout` on the server) from individual sections to `client/controller`.

Note that https://github.com/Automattic/wp-calypso/pull/4668/files#diff-750f44a78dda5cf536254ebb29b69f5eR13 and R14 will not populate `primary`, and thus there will be no `wp-singletree-layout` class added -- even though those are isomorphic/layout-last routes. This leads to yet another reconc error for logged-out `/design`.

No visual changes.
To test:
* Check that the app works as before.
* Check that #4633 is fixed.
* For logged-out `/design`, check that the reconc error is no longer about `is-section-theme` vs `is-section-themes` classes (but about `wp-singletree-layout`, see above. Will fix that separately).

/cc @seear 