### PR TITLE
Add `onClick` action for individual plugin components

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import noop from 'lodash/noop';
 
 import Gridicon from 'components/gridicon';
 
@@ -9,12 +10,13 @@ export const BusinessPlugin = React.createClass( {
 			icon = 'plugins',
 			name,
 			plan,
+			onClick = noop,
 			supportLink
 		} = this.props;
 
 		return (
 			<div className="wpcom-plugins__plugin-item">
-				<a href={ supportLink } target="_blank">
+				<a onClick={ onClick } href={ supportLink } target="_blank">
 					<div className="wpcom-plugins__plugin-icon">
 						<Gridicon { ...{ icon } } />
 					</div>
@@ -31,6 +33,7 @@ BusinessPlugin.propTypes = {
 	name: PropTypes.string.isRequired,
 	supportLink: PropTypes.string.isRequired,
 	icon: PropTypes.string,
+	onClick: PropTypes.func,
 	plan: PropTypes.string.isRequired,
 	description: PropTypes.oneOfType( [
 		PropTypes.string,

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import noop from 'lodash/noop';
 
 import Gridicon from 'components/gridicon';
 
@@ -9,12 +10,13 @@ export const PremiumPlugin = React.createClass( {
 			icon = 'plugins',
 			name,
 			plan,
+			onClick = noop,
 			supportLink
 		} = this.props;
 
 		return (
 			<div className="wpcom-plugins__plugin-item">
-				<a href={ supportLink } target="_blank">
+				<a onClick={ onClick } href={ supportLink } target="_blank">
 					<div className="wpcom-plugins__plugin-icon">
 						<Gridicon { ...{ icon } } />
 					</div>
@@ -32,6 +34,7 @@ PremiumPlugin.propTypes = {
 	supportLink: PropTypes.string.isRequired,
 	icon: PropTypes.string,
 	plan: PropTypes.string.isRequired,
+	onClick: PropTypes.func,
 	description: PropTypes.string.isRequired
 };
 

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import noop from 'lodash/noop';
 
 import Gridicon from 'components/gridicon';
 
@@ -9,12 +10,13 @@ export const StandardPlugin = React.createClass( {
 			description,
 			icon = 'plugins',
 			name,
+			onClick = noop,
 			supportLink
 		} = this.props;
 
 		return (
 			<div className="wpcom-plugins__plugin-item">
-				<a href={ supportLink } target="_blank">
+				<a onClick={ onClick } href={ supportLink } target="_blank">
 					<div className="wpcom-plugins__plugin-icon">
 						<Gridicon { ...{ icon } } />
 					</div>
@@ -32,6 +34,7 @@ StandardPlugin.propTypes = {
 	description: PropTypes.string.isRequired,
 	icon: PropTypes.string,
 	name: PropTypes.string.isRequired,
+	onClick: PropTypes.func,
 	supportLink: PropTypes.string.isRequired
 };
 


### PR DESCRIPTION
This is a non-visual change and actuall a non-functional change as well.
It's a preparatory patch so that we can introduce click-tracking for the
WordPress.com plugins page.