### PR TITLE
Notices: Fixing default compact notice font color

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -191,7 +191,6 @@
 // Compact notices
 .notice.is-compact {
 	border-radius: 2px;
-	color: $white;
 	display: inline-flex;
 	flex-wrap: nowrap;
 	min-height: 20px;
@@ -200,6 +199,13 @@
 	text-decoration: none;
 	text-transform: none;
 	vertical-align: middle;
+
+	&.is-success,
+	&.is-error,
+	&.is-warning,
+	&.is-info {
+		color: $white;
+	}
 
 	.notice__text {
 		font-size: 12px;


### PR DESCRIPTION
Fixing the font color of default notices in their compact state.

Fixes #4667

![screen shot 2016-04-12 at 11 28 51 am](https://cloud.githubusercontent.com/assets/191598/14465664/bf1547aa-00a1-11e6-8b77-93d3c2bec7c1.png)
