### PR TITLE
Support User: Enable feature flag in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -67,6 +67,7 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
+		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,


### PR DESCRIPTION
This enables the `support-user` feature flag in production. The feature has been enabled and in use in staging for over a week.

Since the feature can't be used without proxy (ie it's typically used on staging), this won't actually enable any functionality that's not already being used; but will bring the staging and production flags into sync.