### PR TITLE
Build: check for exact node and npm versions so we match production

### DIFF
--- a/bin/check-node-version
+++ b/bin/check-node-version
@@ -1,14 +1,19 @@
 #!/usr/bin/env node
 
 const semver = require( 'semver' );
+const child_process = require( 'child_process' );
+const engines = require( '../package' ).engines;
 
-const requiredVersion = require( '../package' ).engines.node;
+const hasAllowedNodeVersion = semver.satisfies( process.version, engines.node );
+const results = child_process.spawnSync( 'npm', [ '-v' ], { encoding : 'utf8' } );
+const hasAllowedNpmVersion = results.stdout && semver.satisfies( results.stdout, engines.npm );
 
-if ( ! semver.satisfies( process.version, requiredVersion ) ) {
+if ( ! hasAllowedNodeVersion || ! hasAllowedNpmVersion ) {
 	console.error(
-		'wp-calypso requires node %s (found %s). Please upgrade! See https://nodejs.org for instructions.',
-		requiredVersion,
-		process.version
+		'wp-calypso requires node %s and npm %s, found node %s and npm %s Please switch using nvm or n! Or see https://nodejs.org for instructions.',
+		engines.node,
+		engines.npm,
+		process.version,
+		results.stdout || 'unknown'
 	);
-	process.exit( 1 );
 }

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "xgettext-js": "0.3.0"
   },
   "engines": {
-    "node": ">=4.3.0",
+    "node": "4.3.0",
     "npm": "2.14.12"
   },
   "scripts": {


### PR DESCRIPTION
This adds an explicit check for node and npm versions, so we exactly match our production values. This helps to avoid issues with shrinkwraping with the wrong npm version, as well as help minimize behavior differences between prod/local.

We'll likely try an upgrade to node latest soon to keep in sync with Desktop.

## Testing
- Switch to any version of node other than `4.3.0`
- run `make run` or `make node-version`
- You should see a message to switch to node version `4.3.0`
- Switch to any version of npm other than `2.14.12`
- run `make run` or `make node-version`
- You should see a message to switch to npm version `2.14.12`
- Switch back to node `4.3.0` and npm `2.14.12`
- Output of `make node-version` is silent
- `make run` works

cc @rralian @blowery @aduth @mtias