### PR TITLE
Editor: Display spinner while featured image loads

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -98,6 +98,7 @@
 @import 'components/sites-popover/style';
 @import 'components/social-logo/style';
 @import 'components/spinner/style';
+@import 'components/spinner-line/style';
 @import 'components/stat-update-indicator/style';
 @import 'components/sticky-panel/style';
 @import 'components/theme/style';

--- a/client/components/image-preloader/index.jsx
+++ b/client/components/image-preloader/index.jsx
@@ -1,21 +1,21 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	omit = require( 'lodash/omit' ),
-	noop = require( 'lodash/noop' );
+import React from 'react';
+import omit from 'lodash/omit';
+import noop from 'lodash/noop';
 
 /**
- * Module variables
+ * Constants
  */
-var LoadStatus = {
+const LoadStatus = {
 	PENDING: 'PENDING',
 	LOADING: 'LOADING',
 	LOADED: 'LOADED',
 	FAILED: 'FAILED'
 };
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'ImagePreloader',
 
 	propTypes: {
@@ -26,28 +26,28 @@ module.exports = React.createClass( {
 		onError: React.PropTypes.func
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			status: LoadStatus.PENDING
 		};
 	},
 
-	componentWillMount: function() {
+	componentWillMount() {
 		this.createLoader();
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.src !== this.props.src ) {
 			this.createLoader( nextProps );
 		}
 	},
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		this.destroyLoader();
 	},
 
-	createLoader: function( nextProps ) {
-		var src = ( nextProps || this.props ).src;
+	createLoader( nextProps ) {
+		const src = ( nextProps || this.props ).src;
 
 		this.destroyLoader();
 
@@ -61,7 +61,7 @@ module.exports = React.createClass( {
 		} );
 	},
 
-	destroyLoader: function() {
+	destroyLoader() {
 		if ( ! this.image ) {
 			return;
 		}
@@ -71,7 +71,7 @@ module.exports = React.createClass( {
 		delete this.image;
 	},
 
-	onLoadComplete: function( event ) {
+	onLoadComplete( event ) {
 		this.destroyLoader();
 
 		if ( event.type !== 'load' ) {
@@ -89,8 +89,8 @@ module.exports = React.createClass( {
 		} );
 	},
 
-	render: function() {
-		var children, imageProps;
+	render() {
+		let children, imageProps;
 
 		switch ( this.state.status ) {
 			case LoadStatus.LOADING:

--- a/client/components/image-preloader/index.jsx
+++ b/client/components/image-preloader/index.jsx
@@ -19,7 +19,7 @@ export default React.createClass( {
 	displayName: 'ImagePreloader',
 
 	propTypes: {
-		src: React.PropTypes.string.isRequired,
+		src: React.PropTypes.string,
 		placeholder: React.PropTypes.element.isRequired,
 		children: React.PropTypes.node,
 		onLoad: React.PropTypes.func,
@@ -50,15 +50,18 @@ export default React.createClass( {
 		const src = ( nextProps || this.props ).src;
 
 		this.destroyLoader();
+		this.setState( {
+			status: LoadStatus.LOADING
+		} );
+
+		if ( ! src ) {
+			return;
+		}
 
 		this.image = new Image();
 		this.image.src = src;
 		this.image.onload = this.onLoadComplete;
 		this.image.onerror = this.onLoadComplete;
-
-		this.setState( {
-			status: LoadStatus.LOADING
-		} );
 	},
 
 	destroyLoader() {

--- a/client/components/spinner-line/README.md
+++ b/client/components/spinner-line/README.md
@@ -1,0 +1,32 @@
+SpinnerLine
+===========
+
+`<SpinnerLine />` is a React component for rendering a horizontal rule loading indicator. Contrasted with `<Spinner />`, this component can be used in indicating that a section is pending vertical expansion.
+
+<img src="https://cldup.com/cYmgv_L6r3.gif" alt="Demo" />
+
+__Please exercise caution in deciding to use a spinner in your component.__ A lone spinner is a poor user-experience and conveys little context to what the user should expect from the page. Refer to [the _Reactivity and Loading States_ guide](https://github.com/Automattic/wp-calypso/blob/master/docs/reactivity.md) for more information on building fast interfaces and making the most of data already available to use.
+
+## Usage
+
+```jsx
+import SpinnerLine from 'components/spinner-line';
+
+export default function MyComponent() {
+	return <SpinnerLine />;
+}
+```
+
+## Props
+
+The following props can be passed to the `<SpinnerLine />` component:
+
+### `className`
+
+<table>
+	<tr><td>Type</td><td>String</td></tr>
+	<tr><td>Required</td><td>No</td></tr>
+	<tr><td>Default</td><td><code>null</code></td></tr>
+</table>
+
+A custom class name to apply to the rendered element, in addition to the base `.spinner-line` class.

--- a/client/components/spinner-line/docs/example.jsx
+++ b/client/components/spinner-line/docs/example.jsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureComponent from 'react-pure-render/component';
+
+/**
+ * Internal dependencies
+ */
+import SpinnerLine from 'components/spinner-line';
+
+export default class SpinnerLineExample extends PureComponent {
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/design/spinner-line">SpinnerLine</a>
+				</h2>
+				<SpinnerLine />
+			</div>
+		);
+	}
+}
+
+SpinnerLineExample.displayName = 'SpinnerLine';

--- a/client/components/spinner-line/index.jsx
+++ b/client/components/spinner-line/index.jsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import PureComponent from 'react-pure-render/component';
+import classnames from 'classnames';
+
+export default class SpinnerLine extends PureComponent {
+	render() {
+		const classes = classnames( 'spinner-line', this.props.className );
+
+		return (
+			<hr className={ classes } />
+		);
+	}
+}
+
+SpinnerLine.propTypes = {
+	className: PropTypes.string
+};

--- a/client/components/spinner-line/style.scss
+++ b/client/components/spinner-line/style.scss
@@ -3,7 +3,7 @@
 	100% { background-position: 600px 0; }
 }
 
-.spinner-line {
+hr.spinner-line {
 	border: none;
 	height: 3px;
 	margin: 24px 0;

--- a/client/components/spinner-line/style.scss
+++ b/client/components/spinner-line/style.scss
@@ -1,0 +1,18 @@
+@keyframes spinner-line__animation {
+	0% { background-position: 0 0; }
+	100% { background-position: 600px 0; }
+}
+
+.spinner-line {
+	border: none;
+	height: 3px;
+	margin: 24px 0;
+	background-image: linear-gradient(
+		to right,
+		lighten( $gray, 10% ) 0%,
+		lighten( $gray, 20% ) 50%,
+		lighten( $gray, 10% ) 100%
+	);
+	background-size: 300px 100%;
+	animation: spinner-line__animation 1.2s infinite linear;
+}

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -31,7 +31,8 @@ import Headers from 'components/header-cake/docs/example';
 import DropZones from 'components/drop-zone/docs/example';
 import FormFields from 'components/forms/docs/example';
 import SectionNav from 'components/section-nav/docs/example';
-import Spinners from 'components/spinner/docs/example';
+import Spinner from 'components/spinner/docs/example';
+import SpinnerLine from 'components/spinner-line/docs/example';
 import Rating from 'components/rating/docs/example';
 import DatePicker from 'components/date-picker/docs/example';
 import InputChrono from 'components/input-chrono/docs/example';
@@ -116,7 +117,8 @@ export default React.createClass( {
 					<SegmentedControl />
 					<SelectDropdown searchKeywords="menu" />
 					<SocialLogos />
-					<Spinners searchKeywords="loading" />
+					<Spinner searchKeywords="loading" />
+					<SpinnerLine searchKeywords="loading" />
 					<TimezoneDropdown />
 					<TokenFields />
 					<Version />

--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -2,48 +2,122 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
+import get from 'lodash/get';
+import some from 'lodash/some';
 
 /**
  * Internal dependencies
  */
+import MediaStore from 'lib/media/store';
 import MediaUtils from 'lib/media/utils';
 import Spinner from 'components/spinner';
+import SpinnerLine from 'components/spinner-line';
+import ImagePreloader from 'components/image-preloader';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-export default React.createClass( {
-	displayName: 'EditorFeaturedImagePreview',
-
+const EditorFeaturedImagePreview = React.createClass( {
 	propTypes: {
+		siteId: PropTypes.number,
 		image: PropTypes.object,
 		maxWidth: PropTypes.number
 	},
 
-	src: function() {
-		return MediaUtils.url( this.props.image, {
+	getInitialState() {
+		return {
+			height: null,
+			transientSrc: null
+		};
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		const currentSrc = this.src();
+		if ( ! currentSrc || currentSrc === this.src( nextProps ) ) {
+			return;
+		}
+
+		// To prevent container height from collapsing and expanding rapidly,
+		// we preserve the current height while the next image loads
+		const nextState = {
+			height: this.refs.preview.clientHeight
+		};
+
+		// If the next image is the persisted copy of an in-progress upload, we
+		// should continue to show the transient blob image as the placeholder
+		// instead of a spinner, since we know it'll appear visually identical
+		if ( this.isReceivingPersistedImage( this.props, nextProps ) ) {
+			nextState.transientSrc = currentSrc;
+		}
+
+		this.setState( nextState );
+	},
+
+	isReceivingPersistedImage( props, nextProps ) {
+		const { siteId } = this.props;
+		if ( siteId !== nextProps.siteId ) {
+			return false;
+		}
+
+		const { image } = this.props;
+		if ( ! image || ! image.transient || ! nextProps.image ) {
+			return false;
+		}
+
+		// Compare images by resolving the media store reference for the
+		// transient copy. MediaStore tracks pointers from transient media
+		// to its persisted copy, so we can compare the resolved object IDs
+		const media = MediaStore.get( siteId, image.ID );
+		return media && media.ID === nextProps.image.ID;
+	},
+
+	src( props = this.props ) {
+		if ( ! props.image ) {
+			return;
+		}
+
+		return MediaUtils.url( props.image, {
 			maxWidth: this.props.maxWidth,
 			size: 'post-thumbnail'
 		} );
 	},
 
+	clearState() {
+		if ( ! some( this.state ) ) {
+			return;
+		}
+
+		this.setState( this.getInitialState() );
+	},
+
 	render() {
-		if ( ! this.props.image ) {
-			return null;
-		}
-
-		const src = this.src();
-		if ( ! src ) {
-			return null;
-		}
-
+		const { height } = this.state;
 		const classes = classNames( 'editor-featured-image__preview', {
-			'is-transient': this.props.image.transient
+			'is-transient': get( this.props.image, 'transient' ),
+			'has-assigned-height': !! height
 		} );
 
+		let placeholder;
+		if ( this.state.transientSrc ) {
+			placeholder = <img src={ this.state.transientSrc } />;
+		} else {
+			placeholder = <SpinnerLine />;
+		}
+
 		return (
-			<div className={ classes }>
+			<div ref="preview" className={ classes } style={ { height } }>
 				<Spinner />
-				<img src={ src } />
+				<ImagePreloader
+					placeholder={ placeholder }
+					src={ this.src() }
+					onLoad={ this.clearState } />
 			</div>
 		);
 	}
 } );
+
+export default connect( ( state ) => {
+	return {
+		siteId: getSelectedSiteId( state )
+	};
+} )( EditorFeaturedImagePreview );

--- a/client/post-editor/editor-featured-image/style.scss
+++ b/client/post-editor/editor-featured-image/style.scss
@@ -33,7 +33,22 @@
 	transform: translate( -50%, -50% );
 }
 
+.editor-featured-image__preview .image-preloader {
+	overflow: hidden;
+}
+
+.editor-featured-image__preview .spinner-line {
+	margin: 0;
+}
+
+.editor-featured-image__preview.has-assigned-height .spinner-line {
+	position: absolute;
+		top: 50%;
+		left: 0;
+		right: 0;
+	transform: translateY( -50% );
+}
+
 .editor-featured-image__preview .spinner__border {
 	fill: transparent;
 }
-


### PR DESCRIPTION
Related: #4510

This pull request seeks to enhance the featured image component to display a spinner while the featured image loads. Currently, when loading the editor, once a featured image is detected to exist, the header borders are shown, but the image does not display until it has loaded, at which point it appears suddenly. Since we can know earlier in the page lifecycle that a featured image exists, we can display a loading indicator while the image is being shown. This will also improve the feeling of responsiveness in #4510 when changing existing featured images.

Before|After
---|---
![before](https://cloud.githubusercontent.com/assets/1779930/14475129/65700488-00ce-11e6-9096-956b7b57012a.gif)|![after](https://cloud.githubusercontent.com/assets/1779930/14475128/656f6a6e-00ce-11e6-8c4d-996744b0eeb5.gif)

__Design Notes:__

Per previous discussion, it's argued that the use of a spinner is justified in indicating an incoming image:

>Premise 1: Absence of any loading indicator may lead user to believe that no preview will be rendered, and provides a jarring experience once the image loads.
>Premise 2: Using the traditional "pulsing" element effect may wrongly convince the user that the placeholder itself is the previewed item
>Conclusion: <img src="https://cldup.com/JiXZUOcvQM.svg" width="16" height="16" />

Ref: 8565-gh-calypso-pre-oss

__Testing instructions:__

Verify that no regressions occur in the display of a featured image, whether its in the header of in the sidebar. Display of a featured image should mirror that of the master branch. Notably, when displayed in the header, an image should be restricted to a maximum height of 400 pixels.

~~Note that the included changes try to adjust the height of the container to the known height of the image prior to its being loaded, but because the media must first be loaded, we display the container at 400 pixels tall until the height of the image is known. Therefore, for images smaller than 400 pixels tall, it'll appear briefly as taller, then shrink to the appropriate size.~~ Due to complications noted in https://github.com/Automattic/wp-calypso/pull/4687#issuecomment-216995101 , height estimating behavior has been removed.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Expand the Featured Image accordion
4. Click Set Featured Image
5. Choose and assign a featured image
6. Note that the featured image displays correctly in the header and sidebar
7. Enter a title or post content
8. Save the post
9. Refresh the page
10 Note that the following progression occurs while the page loads:
 - Until the post is loaded, no featured image element is shown on the page
 - When the post loads and a featured image exists, until the media item has been loaded, a placeholder will be shown in the header
 - ~~When the featured image media item is loaded but the image itself has yet to be loaded, the placeholder should occupy the space equivalent to its height, capped at 400 pixels tall~~
 - When the featured image is shown, it replaces the placeholder and the spinner is no longer shown