### PR TITLE
Revert "Signup: Headstart: Pass the current locale to Headstart."

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -16,15 +16,13 @@ const user = require( 'lib/user' )();
 import { getSavedVariations } from 'lib/abtest';
 import SignupCart from 'lib/signup/cart';
 import { startFreeTrial } from 'lib/upgrades/actions';
-import { getLocaleSlug } from 'lib/i18n-utils';
 
 function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsCartItem, isPurchasingItem, siteUrl, themeSlug, themeItem } ) {
 	wpcom.undocumented().sitesNew( {
 		blog_name: siteUrl,
 		blog_title: siteUrl,
 		options: {
-			theme: dependencies.theme,
-			locale: getLocaleSlug()
+			theme: dependencies.theme
 		},
 		validate: false,
 		find_available_url: isPurchasingItem


### PR DESCRIPTION
Reverts Automattic/wp-calypso#3741

This was totally unnecessary, since `lang_id` is already passed in the `sitesNew` meta. We'll use that server-side for any locale info needed.