### PR TITLE
GuidedTours: implement the first tour

### DIFF
--- a/client/guidestours/config.js
+++ b/client/guidestours/config.js
@@ -8,66 +8,48 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
 import i18n from 'lib/mixins/i18n';
 
 function get() {
 	return {
 		init: {
-			text: i18n.translate( '{{strong}}Need a hand?{{/strong}} We\'d love to show you around the place, and give you some ideas for what to do next.', {
+			text: i18n.translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, and give you some ideas for what to do next.", {
 				components: {
 					strong: <strong />,
 				}
 			} ),
 			type: 'GuidesFirstStep',
-			next: 'my-sites',
+			placement: 'right',
+			next: 'sidebar',
 		},
-		'my-sites': {
-			target: 'my-sites',
-			type: 'GuidesActionStep',
-			icon: 'my-sites',
-			placement: 'below',
-			text: i18n.translate( "{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing your site's content and design.", {
-				components: {
-					strong: <strong />,
-				}
-			} ),
-			next: 'posts-pages',
-		},
-		'posts-pages': {
-			text: i18n.translate( "{{strong}}Posts{{/strong}} aren't the same thing as {{strong}}Pages{{/strong}}. Would you like to know more?", {
-				components: {
-					strong: <strong />,
-				}
-			} ),
-			type: 'GuidesLinkStep',
-			linkLabel: i18n.translate( 'Learn more about Posts and Pages' ),
-			linkUrl: 'https://en.support.wordpress.com/post-vs-page/',
-			next: 'reader',
-		},
-		reader: {
-			target: 'reader',
-			type: 'GuidesActionStep',
-			icon: 'reader',
+		sidebar: {
+			text: i18n.translate( 'The sidebar menu lets you navigate around, and will adapt to give you the tools you need when you need them.' ),
+			type: 'GuidesBasicStep',
+			target: 'sidebar',
 			placement: 'beside',
-			text: i18n.translate( "This is the {{strong}}Reader{{/strong}}. It shows you fresh posts from other sites you're following.", {
+			next: 'themes',
+		},
+		themes: {
+			text: i18n.translate( "Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} your theme's colors, font, and more.", {
 				components: {
 					strong: <strong />,
 				}
 			} ),
-			next: 'finish'
+			type: 'GuidesBasicStep',
+			target: 'themes',
+			placement: 'below',
+			next: 'finish',
 		},
 		finish: {
 			target: 'me',
 			placement: 'beside',
-			text: i18n.translate( "{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around. You can get more help by going to the {{gridicon/}} {{strong}}Me{{/strong}} section.", {
+			text: i18n.translate( "{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.", {
 				components: {
 					strong: <strong />,
-					gridicon: <Gridicon icon="user-circle" size={ 18 } />,
 				}
 			} ),
 			type: 'GuidesFinishStep',
-			linkLabel: 'Get the Most from WordPress.com',
+			linkLabel: i18n.translate( 'Get the Most from WordPress.com' ),
 			linkUrl: 'https://learn.wordpress.com',
 		}
 	}

--- a/client/guidestours/index.js
+++ b/client/guidestours/index.js
@@ -30,13 +30,12 @@ class GuidesTours extends Component {
 
 	componentDidMount() {
 		const { stepConfig } = this.props.tourState;
-		this.tipTargets = this.getTipTargets();
 		this.updateTarget( stepConfig );
 	}
 
 	shouldComponentUpdate( nextProps ) {
 		return this.props.tourState !== nextProps.tourState;
-	}
+		}
 
 	componentWillUpdate( nextProps ) {
 		const { stepConfig } = nextProps.tourState;
@@ -44,6 +43,7 @@ class GuidesTours extends Component {
 	}
 
 	updateTarget( step ) {
+		this.tipTargets = this.getTipTargets();
 		this.currentTarget = step && step.target
 			? this.tipTargets[ step.target ]
 			: null;

--- a/client/guidestours/positioning.js
+++ b/client/guidestours/positioning.js
@@ -28,6 +28,10 @@ const dialogPositioners = {
 		x: middle( left, right ) - DIALOG_WIDTH / 2,
 		y: MASTERBAR_HEIGHT / 2,
 	} ),
+	right: () => ( {
+		x: document.documentElement.clientWidth - DIALOG_WIDTH - ( 3 * DIALOG_PADDING ),
+		y: MASTERBAR_HEIGHT + ( 3 * DIALOG_PADDING ),
+	} ),
 };
 
 export const query = selector =>

--- a/client/guidestours/steps.js
+++ b/client/guidestours/steps.js
@@ -38,10 +38,10 @@ class GuidesFirstStep extends Component {
 
 		const { text, onNext, onQuit } = this.props;
 		return (
-			<Card className="guidestours__step" style={ stepCoords } >
+			<Card className="guidestours__step guidestours__step-first" style={ stepCoords } >
 				<p>{ text }</p>
 				<div className="guidestours__choice-button-row">
-					<Button onClick={ onNext } primary>{ this.props.translate( 'Continue' ) }</Button>
+					<Button onClick={ onNext } primary>{ this.props.translate( "Let's do it!" ) }</Button>
 					<Button onClick={ onQuit } >
 						{ this.props.translate( 'No, thanks.' ) }
 					</Button>

--- a/client/guidestours/style.scss
+++ b/client/guidestours/style.scss
@@ -3,7 +3,7 @@
 	width: 410px;
 	z-index: z-index( 'root', '.guidestours__step' );
 	border: 1px solid lighten( $gray, 10 );
-	box-shadow: 0px 10px 23px 0px rgba( 0, 0, 0, 0.50 );
+	box-shadow: 1px 2px 3px 0px rgba( $gray-dark, 0.3 );
 	border-radius: 4px;
 	padding-top: 19px;
 	font-size: 14px;
@@ -27,6 +27,24 @@
 	.gridicon[height="18"] {
 		position: relative;
 		top: 3px;
+	}
+}
+
+.guidestours__step-first {
+	animation-duration: 900ms;
+	animation-name: guidestours__step-slidein;
+	animation-timing-function: ease-in-out;
+	animation-delay: 2s;
+	animation-fill-mode: both;
+}
+
+@keyframes guidestours__step-slidein {
+	0% {
+		transform: translateX( 200% );
+	}
+
+	100% {
+		transform: translateX( 0 );
 	}
 }
 

--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -14,7 +14,7 @@ export default React.createClass( {
 
 	render: function() {
 		return (
-			<ul className={ classNames( 'sidebar', this.props.className ) } onClick={ this.props.onClick }>
+			<ul className={ classNames( 'sidebar', this.props.className ) } onClick={ this.props.onClick } data-tip-target="sidebar">
 				{ this.props.children }
 			</ul>
 		);

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -109,7 +109,7 @@ describe( 'selectors', () => {
 			const tourState = getGuidesTourState( {
 				ui: {
 					guidesTour: {
-						stepName: 'my-sites',
+						stepName: 'sidebar',
 						shouldShow: true,
 						tour: 'main',
 						siteId: 2916284,
@@ -117,7 +117,7 @@ describe( 'selectors', () => {
 				}
 			} );
 
-			const stepConfig = guidesToursConfig.get()[ 'my-sites' ];
+			const stepConfig = guidesToursConfig.get()[ 'sidebar' ];
 
 			expect( tourState ).to.deep.equal( Object.assign( {}, tourState, {
 				stepConfig


### PR DESCRIPTION
This PR implements the first simple tour for GuidedTours. 

It consist of four steps: 

- an introduction (that starts on a page where the sidebar is visible)
- an explanation of the sidebar
- an explanation of themes and customization
- a closing step

Screenshot:

![first-tour](https://cloud.githubusercontent.com/assets/23619/14527872/e227b866-024c-11e6-9d2f-e68372b5f4fe.gif)

To test:

- open e.g. http://calypso.localhost:3000/stats/insights/?tour=main
- check whether the steps mentioned above appear
- check whether the steps are positioned correctly (cf. GIF above)
