### PR TITLE
Build: attempt to upgrade to node latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN     apt-get -y update && apt-get -y install \
           make \
           build-essential
 
-ENV NODE_VERSION 4.3.0
+ENV NODE_VERSION 5.10.1
 
 RUN     wget https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz && \
           tar -zxf node-v$NODE_VERSION-linux-x64.tar.gz -C /usr/local && \

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4.3.0
+    version: 5.10.1
 test:
   override:
     - npm run lint -- :

--- a/docs/shrinkwrap.md
+++ b/docs/shrinkwrap.md
@@ -10,34 +10,25 @@ and therefore need to avoid adding the `from` and `resolved` fields that `npm sh
 
 See also: [shrinkwrap docs](https://docs.npmjs.com/cli/shrinkwrap)
 
-## Modifying Dependencies
+## npm 3
 
-We use clingwrap to avoid creating huge diffs in npm-shrinkwrap.json. clingwrap also removes
-`from` and `resolved` fields which is expected. If you need to update a package that is not published with npm, 
-use the `Bumping Sub-Dependencies in all Packages` instructions instead.
+npm 3 [resolves dependencies differently](https://docs.npmjs.com/how-npm-works/npm3) than npm 2. Specifically:
+- the position in the directory structure no longer predicts the type (primary, secondary, etc) a dependency is
+- dependency resolution depends on install order, or the order in which things are installed will change the node_modules 
+directory tree structure
 
-- Install [clingwrap](https://github.com/goodeggs/clingwrap) globally: `npm install -g clingwrap`
-- Update your desired package, e.g. `npm install lodash@4.0.0 --save`
-- Clingwrap your updated package `clingwrap lodash`
-- Verify that Calypso works as expected and that tests pass.
-- Commit the updated package.json and npm-shrinkwrap.json
+With the upgrade to npm 3, if we make any dependency changes in package.json, we need to regenerate the entire 
+npm-shrinkwrap.json file.
 
-## Bumping Sub-Dependencies in a Single Package
+Before generating the npm-shrinkwrap.json:
+- Make sure your node/npm version matches the versions listed in package.json under engines
+- Delete your local node_modules
+- Delete your local copy of npm-shrinkwrap.json before running `npm install`
 
-Periodically, we'll want to bump our package sub-dependencies to pick up bugfixes.  To update sub-dependencies in a 
-single module, (with lodash as an example) :
-
-- Remove only that package in node_modules `rm -rf node_modules/lodash`
-- Install the same version `npm install lodash@4.0.0 --save`
-- Clingwrap the package `clingwrap lodash`
-- Verify that Calypso works as expected and that tests pass.
-- Commit the changes to npm-shrinkwrap.json.
-
-## Bumping Sub-Dependencies in all Packages
-
-We may also choose to update all package sub-dependencies. This will result in a large diff that is too big to review, 
-so testing instructions should ensure that a clean install works and Calypso runs and tests correctly. It's very 
+Testing instructions should ensure that a clean install works and Calypso runs and tests correctly. It's very 
 important that your node_modules is deleted before you do this to be sure to pick up the latest versions.
+
+## Generating npm-shrinkwrap.json
 
 - Install [shonkwrap](https://github.com/skybet/shonkwrap) globally: `npm install -g shonkwrap`. This package attempts
 to remove the from/resolved fields if possible.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3763,13 +3763,183 @@
       "version": "2.0.1"
     },
     "webpack": {
-      "version": "1.12.6",
+      "version": "1.12.15",
       "dependencies": {
+        "clone": {
+          "version": "1.0.2"
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1"
+        },
+        "interpret": {
+          "version": "0.6.6"
+        },
+        "node-libs-browser": {
+          "version": "0.5.3",
+          "dependencies": {
+            "assert": {
+              "version": "1.3.0"
+            },
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.8"
+                }
+              }
+            },
+            "buffer": {
+              "version": "3.6.0",
+              "dependencies": {
+                "base64-js": {
+                  "version": "0.0.8"
+                },
+                "isarray": {
+                  "version": "1.0.0"
+                },
+                "ieee754": {
+                  "version": "1.1.6"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4"
+                }
+              }
+            },
+            "constants-browserify": {
+              "version": "0.0.1"
+            },
+            "crypto-browserify": {
+              "version": "3.2.8",
+              "dependencies": {
+                "pbkdf2-compat": {
+                  "version": "2.0.1"
+                },
+                "ripemd160": {
+                  "version": "0.2.0"
+                },
+                "sha.js": {
+                  "version": "2.2.6"
+                }
+              }
+            },
+            "domain-browser": {
+              "version": "1.1.7"
+            },
+            "http-browserify": {
+              "version": "1.7.0",
+              "dependencies": {
+                "Base64": {
+                  "version": "0.2.1"
+                }
+              }
+            },
+            "https-browserify": {
+              "version": "0.0.0"
+            },
+            "readable-stream": {
+              "version": "1.1.13"
+            },
+            "os-browserify": {
+              "version": "0.1.2"
+            },
+            "path-browserify": {
+              "version": "0.0.0"
+            },
+            "process": {
+              "version": "0.11.2"
+            },
+            "punycode": {
+              "version": "1.4.1"
+            },
+            "querystring-es3": {
+              "version": "0.2.1"
+            },
+            "stream-browserify": {
+              "version": "1.0.0",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13"
+                }
+              }
+            },
+            "timers-browserify": {
+              "version": "1.4.2"
+            },
+            "tty-browserify": {
+              "version": "0.0.0"
+            },
+            "url": {
+              "version": "0.10.3",
+              "dependencies": {
+                "querystring": {
+                  "version": "0.2.0"
+                },
+                "punycode": {
+                  "version": "1.3.2"
+                }
+              }
+            },
+            "vm-browserify": {
+              "version": "0.0.4"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "tapable": {
+          "version": "0.1.10"
+        },
+        "watchpack": {
+          "version": "0.2.9"
+        },
+        "webpack-core": {
+          "version": "0.6.8",
+          "dependencies": {
+            "source-list-map": {
+              "version": "0.1.6"
+            },
+            "source-map": {
+              "version": "0.4.4"
+            }
+          }
+        },
         "async": {
           "version": "1.5.2"
         },
         "esprima": {
           "version": "2.7.2"
+        },
+        "memory-fs": {
+          "version": "0.3.0",
+          "dependencies": {
+            "errno": {
+              "version": "0.1.4",
+              "dependencies": {
+                "prr": {
+                  "version": "0.0.0"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,213 +2,1581 @@
   "name": "wp-calypso",
   "version": "0.17.0",
   "dependencies": {
+    "abab": {
+      "version": "1.0.3"
+    },
+    "abbrev": {
+      "version": "1.0.7"
+    },
+    "accepts": {
+      "version": "1.2.13"
+    },
+    "acorn": {
+      "version": "1.2.2"
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0"
+        }
+      }
+    },
+    "acorn-to-esprima": {
+      "version": "1.0.7"
+    },
+    "after": {
+      "version": "0.8.1"
+    },
+    "align-text": {
+      "version": "0.1.4"
+    },
+    "alter": {
+      "version": "0.2.0"
+    },
+    "amdefine": {
+      "version": "1.0.0"
+    },
+    "ansi": {
+      "version": "0.3.1"
+    },
+    "ansi-escapes": {
+      "version": "1.3.0"
+    },
+    "ansi-regex": {
+      "version": "1.1.1"
+    },
+    "ansi-styles": {
+      "version": "2.2.1"
+    },
+    "anymatch": {
+      "version": "1.3.0"
+    },
+    "are-we-there-yet": {
+      "version": "1.1.2"
+    },
+    "argparse": {
+      "version": "1.0.7"
+    },
+    "arr-diff": {
+      "version": "2.0.0"
+    },
+    "arr-flatten": {
+      "version": "1.0.1"
+    },
+    "array-find-index": {
+      "version": "1.0.1"
+    },
+    "array-flatten": {
+      "version": "1.1.1"
+    },
+    "array-index": {
+      "version": "1.0.0"
+    },
+    "array-union": {
+      "version": "1.0.1"
+    },
+    "array-uniq": {
+      "version": "1.0.2"
+    },
+    "array-unique": {
+      "version": "0.2.1"
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.6"
+    },
+    "arrify": {
+      "version": "1.0.1"
+    },
+    "asap": {
+      "version": "2.0.3"
+    },
+    "asn1": {
+      "version": "0.2.3"
+    },
+    "assert": {
+      "version": "1.3.0"
+    },
+    "assert-plus": {
+      "version": "0.2.0"
+    },
+    "assertion-error": {
+      "version": "1.0.0"
+    },
+    "ast-traverse": {
+      "version": "0.1.1"
+    },
+    "ast-types": {
+      "version": "0.8.2"
+    },
     "async": {
       "version": "0.9.0"
+    },
+    "async-each": {
+      "version": "1.0.0"
+    },
+    "async-foreach": {
+      "version": "0.1.3"
     },
     "atob": {
       "version": "1.1.2"
     },
     "autoprefixer": {
-      "version": "6.3.5",
+      "version": "6.3.5"
+    },
+    "autosize": {
+      "version": "3.0.7"
+    },
+    "aws-sign2": {
+      "version": "0.6.0"
+    },
+    "aws4": {
+      "version": "1.3.2"
+    },
+    "babel": {
+      "version": "5.8.12",
       "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.0"
+        "commander": {
+          "version": "2.9.0"
         },
-        "normalize-range": {
-          "version": "0.1.2"
+        "glob": {
+          "version": "5.0.15"
         },
-        "num2fraction": {
-          "version": "1.2.2"
+        "lodash": {
+          "version": "3.10.1"
         },
-        "browserslist": {
-          "version": "1.3.0"
+        "source-map": {
+          "version": "0.4.4"
+        }
+      }
+    },
+    "babel-core": {
+      "version": "5.8.12",
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1"
         },
-        "caniuse-db": {
-          "version": "1.0.30000437"
+        "source-map": {
+          "version": "0.4.4"
         },
-        "postcss": {
-          "version": "5.0.19",
+        "source-map-support": {
+          "version": "0.2.10",
           "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0"
-                }
-              }
-            },
             "source-map": {
-              "version": "0.5.3"
-            },
-            "js-base64": {
-              "version": "2.1.9"
+              "version": "0.1.32"
             }
           }
         }
       }
     },
-    "autosize": {
-      "version": "3.0.7"
-    },
-    "babel": {
-      "version": "5.8.12",
+    "babel-eslint": {
+      "version": "4.1.8",
       "dependencies": {
-        "chokidar": {
-          "version": "1.4.3",
+        "ast-types": {
+          "version": "0.8.12"
+        },
+        "babel-core": {
+          "version": "5.8.38"
+        },
+        "core-js": {
+          "version": "1.2.6"
+        },
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb"
+        },
+        "json5": {
+          "version": "0.4.0"
+        },
+        "lodash": {
+          "version": "3.10.1"
+        },
+        "recast": {
+          "version": "0.10.33"
+        },
+        "regenerator": {
+          "version": "0.8.40"
+        },
+        "source-map": {
+          "version": "0.5.3"
+        },
+        "source-map-support": {
+          "version": "0.2.10",
           "dependencies": {
-            "anymatch": {
-              "version": "1.3.0",
+            "source-map": {
+              "version": "0.1.32"
+            }
+          }
+        }
+      }
+    },
+    "babel-loader": {
+      "version": "5.3.2"
+    },
+    "babel-plugin-constant-folding": {
+      "version": "1.0.1"
+    },
+    "babel-plugin-dead-code-elimination": {
+      "version": "1.0.2"
+    },
+    "babel-plugin-eval": {
+      "version": "1.0.1"
+    },
+    "babel-plugin-inline-environment-variables": {
+      "version": "1.0.1"
+    },
+    "babel-plugin-jscript": {
+      "version": "1.0.4"
+    },
+    "babel-plugin-member-expression-literals": {
+      "version": "1.0.1"
+    },
+    "babel-plugin-property-literals": {
+      "version": "1.0.1"
+    },
+    "babel-plugin-proto-to-assign": {
+      "version": "1.0.4",
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1"
+        }
+      }
+    },
+    "babel-plugin-react-constant-elements": {
+      "version": "1.0.3"
+    },
+    "babel-plugin-react-display-name": {
+      "version": "1.0.3"
+    },
+    "babel-plugin-remove-console": {
+      "version": "1.0.1"
+    },
+    "babel-plugin-remove-debugger": {
+      "version": "1.0.1"
+    },
+    "babel-plugin-runtime": {
+      "version": "1.0.7"
+    },
+    "babel-plugin-undeclared-variables-check": {
+      "version": "1.0.2"
+    },
+    "babel-plugin-undefined-to-void": {
+      "version": "1.1.6"
+    },
+    "babel-runtime": {
+      "version": "5.8.12"
+    },
+    "babylon": {
+      "version": "5.8.38"
+    },
+    "backo2": {
+      "version": "1.0.2"
+    },
+    "balanced-match": {
+      "version": "0.3.0"
+    },
+    "base62": {
+      "version": "0.1.1"
+    },
+    "Base64": {
+      "version": "0.2.1"
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.2"
+    },
+    "base64-js": {
+      "version": "0.0.8"
+    },
+    "base64id": {
+      "version": "0.1.0"
+    },
+    "basic-auth": {
+      "version": "1.0.0"
+    },
+    "batch": {
+      "version": "0.5.3"
+    },
+    "benchmark": {
+      "version": "1.0.0"
+    },
+    "better-assert": {
+      "version": "1.0.2"
+    },
+    "big.js": {
+      "version": "3.1.3"
+    },
+    "binary-extensions": {
+      "version": "1.4.0"
+    },
+    "bindings": {
+      "version": "1.2.1"
+    },
+    "bl": {
+      "version": "1.1.2",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.0.6"
+        }
+      }
+    },
+    "blanket": {
+      "version": "1.1.6",
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.4"
+        },
+        "falafel": {
+          "version": "0.1.6"
+        },
+        "object-keys": {
+          "version": "0.4.0"
+        },
+        "xtend": {
+          "version": "2.1.2"
+        }
+      }
+    },
+    "blob": {
+      "version": "0.0.4"
+    },
+    "block-stream": {
+      "version": "0.0.8"
+    },
+    "bluebird": {
+      "version": "2.10.2"
+    },
+    "body-parser": {
+      "version": "1.15.0",
+      "dependencies": {
+        "qs": {
+          "version": "6.1.0"
+        }
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0"
+    },
+    "boom": {
+      "version": "2.10.1"
+    },
+    "bounding-client-rect": {
+      "version": "1.0.5"
+    },
+    "brace-expansion": {
+      "version": "1.1.3"
+    },
+    "braces": {
+      "version": "1.8.3"
+    },
+    "breakable": {
+      "version": "1.0.0"
+    },
+    "browser-filesaver": {
+      "version": "1.1.0"
+    },
+    "browserify-zlib": {
+      "version": "0.1.4"
+    },
+    "browserslist": {
+      "version": "1.3.1"
+    },
+    "buffer": {
+      "version": "3.6.0",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "bufferutil": {
+      "version": "1.2.1"
+    },
+    "builtin-modules": {
+      "version": "1.1.1"
+    },
+    "builtin-status-codes": {
+      "version": "2.0.0"
+    },
+    "bytes": {
+      "version": "2.2.0"
+    },
+    "callsite": {
+      "version": "1.0.0"
+    },
+    "camel-case": {
+      "version": "0.1.0"
+    },
+    "camelcase": {
+      "version": "1.2.1"
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1"
+        }
+      }
+    },
+    "caniuse-db": {
+      "version": "1.0.30000452"
+    },
+    "caseless": {
+      "version": "0.11.0"
+    },
+    "center-align": {
+      "version": "0.1.3"
+    },
+    "chai": {
+      "version": "2.0.0"
+    },
+    "chalk": {
+      "version": "1.0.0",
+      "dependencies": {
+        "supports-color": {
+          "version": "1.3.1"
+        }
+      }
+    },
+    "change-case": {
+      "version": "2.3.1",
+      "dependencies": {
+        "camel-case": {
+          "version": "1.2.2"
+        },
+        "sentence-case": {
+          "version": "1.1.3"
+        }
+      }
+    },
+    "char-spinner": {
+      "version": "1.0.1"
+    },
+    "character-parser": {
+      "version": "2.2.0"
+    },
+    "cheerio": {
+      "version": "0.20.0",
+      "dependencies": {
+        "entities": {
+          "version": "1.1.1"
+        }
+      }
+    },
+    "chokidar": {
+      "version": "1.4.3"
+    },
+    "chrono-node": {
+      "version": "1.2.1"
+    },
+    "classnames": {
+      "version": "1.1.1"
+    },
+    "clean-css": {
+      "version": "3.4.12",
+      "dependencies": {
+        "commander": {
+          "version": "2.8.1"
+        },
+        "source-map": {
+          "version": "0.4.4"
+        }
+      }
+    },
+    "cli-cursor": {
+      "version": "1.0.2"
+    },
+    "cli-width": {
+      "version": "1.1.1"
+    },
+    "click-outside": {
+      "version": "1.0.4",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "4.7.4"
+        },
+        "core-js": {
+          "version": "0.6.1"
+        }
+      }
+    },
+    "clipboard": {
+      "version": "1.5.3"
+    },
+    "cliui": {
+      "version": "2.1.0"
+    },
+    "clone": {
+      "version": "1.0.2"
+    },
+    "closest": {
+      "version": "0.0.1"
+    },
+    "code-point-at": {
+      "version": "1.0.0"
+    },
+    "colors": {
+      "version": "0.6.2"
+    },
+    "combined-stream": {
+      "version": "1.0.5"
+    },
+    "commander": {
+      "version": "2.3.0"
+    },
+    "commoner": {
+      "version": "0.10.4",
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0"
+        },
+        "glob": {
+          "version": "5.0.15"
+        },
+        "q": {
+          "version": "1.4.1"
+        }
+      }
+    },
+    "component-bind": {
+      "version": "1.0.0"
+    },
+    "component-classes": {
+      "version": "1.2.6"
+    },
+    "component-closest": {
+      "version": "0.1.4"
+    },
+    "component-css": {
+      "version": "0.0.8"
+    },
+    "component-delegate": {
+      "version": "0.2.4"
+    },
+    "component-each": {
+      "version": "0.2.6"
+    },
+    "component-emitter": {
+      "version": "1.1.3"
+    },
+    "component-event": {
+      "version": "0.1.4"
+    },
+    "component-events": {
+      "version": "1.0.10"
+    },
+    "component-file-picker": {
+      "version": "0.2.1"
+    },
+    "component-indexof": {
+      "version": "0.0.3"
+    },
+    "component-inherit": {
+      "version": "0.0.3"
+    },
+    "component-matches-selector": {
+      "version": "0.1.6"
+    },
+    "component-props": {
+      "version": "1.1.1"
+    },
+    "component-query": {
+      "version": "0.0.3"
+    },
+    "component-raf": {
+      "version": "1.2.0"
+    },
+    "component-tip": {
+      "version": "3.0.3"
+    },
+    "component-type": {
+      "version": "1.0.0"
+    },
+    "component-uid": {
+      "version": "0.0.2"
+    },
+    "concat-map": {
+      "version": "0.0.1"
+    },
+    "concat-stream": {
+      "version": "1.5.1",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "readable-stream": {
+          "version": "2.0.6"
+        }
+      }
+    },
+    "config-chain": {
+      "version": "1.1.10"
+    },
+    "connect-history-api-fallback": {
+      "version": "1.1.0"
+    },
+    "console-browserify": {
+      "version": "1.1.0"
+    },
+    "constant-case": {
+      "version": "1.1.2"
+    },
+    "constantinople": {
+      "version": "3.0.2",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0"
+        }
+      }
+    },
+    "constants-browserify": {
+      "version": "0.0.1"
+    },
+    "content-disposition": {
+      "version": "0.5.0"
+    },
+    "content-type": {
+      "version": "1.0.1"
+    },
+    "convert-source-map": {
+      "version": "1.2.0"
+    },
+    "cookie": {
+      "version": "0.1.2"
+    },
+    "cookie-parser": {
+      "version": "1.3.2"
+    },
+    "cookie-signature": {
+      "version": "1.0.4"
+    },
+    "cookiejar": {
+      "version": "2.0.1"
+    },
+    "core-js": {
+      "version": "0.9.18"
+    },
+    "core-util-is": {
+      "version": "1.0.2"
+    },
+    "crc32": {
+      "version": "0.2.2"
+    },
+    "creditcards": {
+      "version": "1.1.1"
+    },
+    "cross-spawn": {
+      "version": "2.2.3"
+    },
+    "cross-spawn-async": {
+      "version": "2.2.2"
+    },
+    "cryptiles": {
+      "version": "2.0.5"
+    },
+    "crypto-browserify": {
+      "version": "3.2.8"
+    },
+    "css-select": {
+      "version": "1.2.0"
+    },
+    "css-what": {
+      "version": "2.1.0"
+    },
+    "cssom": {
+      "version": "0.3.1"
+    },
+    "cssstyle": {
+      "version": "0.2.34"
+    },
+    "d": {
+      "version": "0.1.1"
+    },
+    "dashdash": {
+      "version": "1.13.0",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "date-now": {
+      "version": "0.1.4"
+    },
+    "debug": {
+      "version": "2.2.0"
+    },
+    "decamelize": {
+      "version": "1.2.0"
+    },
+    "deep-eql": {
+      "version": "0.1.3"
+    },
+    "deep-equal": {
+      "version": "1.0.1"
+    },
+    "deep-freeze": {
+      "version": "0.0.1"
+    },
+    "deep-is": {
+      "version": "0.1.3"
+    },
+    "defaults-deep": {
+      "version": "0.2.3",
+      "dependencies": {
+        "lazy-cache": {
+          "version": "0.2.7"
+        }
+      }
+    },
+    "define-properties": {
+      "version": "1.1.2"
+    },
+    "defined": {
+      "version": "1.0.0"
+    },
+    "defs": {
+      "version": "1.1.1",
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb"
+        }
+      }
+    },
+    "del": {
+      "version": "2.2.0",
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4"
+        },
+        "globby": {
+          "version": "4.0.0"
+        },
+        "object-assign": {
+          "version": "4.0.1"
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0"
+    },
+    "delegate": {
+      "version": "3.0.1"
+    },
+    "delegates": {
+      "version": "1.0.0"
+    },
+    "depd": {
+      "version": "1.1.0"
+    },
+    "destroy": {
+      "version": "1.0.3"
+    },
+    "detect-indent": {
+      "version": "3.0.1"
+    },
+    "detective": {
+      "version": "4.3.1"
+    },
+    "diff": {
+      "version": "1.4.0"
+    },
+    "disparity": {
+      "version": "2.0.0"
+    },
+    "doctrine": {
+      "version": "0.7.2",
+      "dependencies": {
+        "esutils": {
+          "version": "1.1.6"
+        }
+      }
+    },
+    "doctypes": {
+      "version": "1.0.0"
+    },
+    "dom-scroll-into-view": {
+      "version": "1.0.1"
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3"
+        },
+        "entities": {
+          "version": "1.1.1"
+        }
+      }
+    },
+    "domain-browser": {
+      "version": "1.1.7"
+    },
+    "domelementtype": {
+      "version": "1.3.0"
+    },
+    "domhandler": {
+      "version": "2.3.0"
+    },
+    "domify": {
+      "version": "1.3.0"
+    },
+    "domutils": {
+      "version": "1.5.1"
+    },
+    "dot-case": {
+      "version": "1.1.2",
+      "dependencies": {
+        "sentence-case": {
+          "version": "1.1.3"
+        }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1"
+    },
+    "ee-first": {
+      "version": "1.1.1"
+    },
+    "email-validator": {
+      "version": "1.0.1"
+    },
+    "emitter-component": {
+      "version": "1.1.1"
+    },
+    "emojis-list": {
+      "version": "1.0.1"
+    },
+    "encoding": {
+      "version": "0.1.12"
+    },
+    "engine.io": {
+      "version": "1.5.4",
+      "dependencies": {
+        "debug": {
+          "version": "1.0.3"
+        },
+        "ms": {
+          "version": "0.6.2"
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "1.5.4",
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2"
+        },
+        "debug": {
+          "version": "1.0.4"
+        },
+        "ms": {
+          "version": "0.6.2"
+        },
+        "parseuri": {
+          "version": "0.0.4"
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "1.2.2"
+    },
+    "enhanced-resolve": {
+      "version": "0.9.1"
+    },
+    "entities": {
+      "version": "1.0.0"
+    },
+    "envify": {
+      "version": "3.4.0"
+    },
+    "enzyme": {
+      "version": "2.2.0"
+    },
+    "error-ex": {
+      "version": "1.3.0"
+    },
+    "es-abstract": {
+      "version": "1.5.0"
+    },
+    "es-to-primitive": {
+      "version": "1.1.1"
+    },
+    "es5-ext": {
+      "version": "0.10.11"
+    },
+    "es6-iterator": {
+      "version": "2.0.0"
+    },
+    "es6-map": {
+      "version": "0.1.3"
+    },
+    "es6-promise": {
+      "version": "2.3.0"
+    },
+    "es6-set": {
+      "version": "0.1.4"
+    },
+    "es6-symbol": {
+      "version": "3.0.2"
+    },
+    "es6-templates": {
+      "version": "0.2.2",
+      "dependencies": {
+        "ast-types": {
+          "version": "0.6.16"
+        },
+        "esprima-fb": {
+          "version": "10001.1.0-dev-harmony-fb"
+        },
+        "recast": {
+          "version": "0.9.18"
+        },
+        "source-map": {
+          "version": "0.1.43"
+        }
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.1"
+    },
+    "escape-html": {
+      "version": "1.0.2"
+    },
+    "escape-regexp": {
+      "version": "0.0.1"
+    },
+    "escape-regexp-component": {
+      "version": "1.0.2"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.3"
+    },
+    "escodegen": {
+      "version": "1.8.0",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.2"
+        },
+        "source-map": {
+          "version": "0.2.0"
+        }
+      }
+    },
+    "escope": {
+      "version": "3.6.0",
+      "dependencies": {
+        "estraverse": {
+          "version": "4.2.0"
+        }
+      }
+    },
+    "esformatter": {
+      "version": "0.7.3",
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4"
+        },
+        "espree": {
+          "version": "1.12.3"
+        },
+        "glob": {
+          "version": "5.0.15"
+        },
+        "semver": {
+          "version": "2.2.1"
+        },
+        "strip-json-comments": {
+          "version": "0.1.3"
+        },
+        "supports-color": {
+          "version": "1.3.1"
+        },
+        "user-home": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "esformatter-braces": {
+      "version": "1.2.1"
+    },
+    "esformatter-collapse-objects-a8c": {
+      "version": "0.1.0",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.2"
+        },
+        "rocambole": {
+          "version": "0.5.1"
+        }
+      }
+    },
+    "esformatter-dot-notation": {
+      "version": "1.3.1",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.2"
+        },
+        "rocambole": {
+          "version": "0.6.0"
+        }
+      }
+    },
+    "esformatter-quotes": {
+      "version": "1.0.3"
+    },
+    "esformatter-semicolons": {
+      "version": "1.1.1"
+    },
+    "esformatter-special-bangs": {
+      "version": "1.0.1"
+    },
+    "eslint": {
+      "version": "1.10.3",
+      "dependencies": {
+        "espree": {
+          "version": "2.2.5"
+        },
+        "estraverse": {
+          "version": "4.2.0"
+        },
+        "fast-levenshtein": {
+          "version": "1.0.7"
+        },
+        "glob": {
+          "version": "5.0.15"
+        },
+        "globals": {
+          "version": "8.18.0"
+        },
+        "levn": {
+          "version": "0.2.5"
+        },
+        "minimatch": {
+          "version": "3.0.0"
+        },
+        "object-assign": {
+          "version": "4.0.1"
+        },
+        "optionator": {
+          "version": "0.6.0"
+        },
+        "user-home": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "3.11.3"
+    },
+    "eslint-plugin-wpcalypso": {
+      "version": "1.1.3"
+    },
+    "esmangle-evaluator": {
+      "version": "1.0.0"
+    },
+    "esprima-fb": {
+      "version": "13001.1.0-dev-harmony-fb"
+    },
+    "esrecurse": {
+      "version": "4.1.0",
+      "dependencies": {
+        "estraverse": {
+          "version": "4.1.1"
+        },
+        "object-assign": {
+          "version": "4.0.1"
+        }
+      }
+    },
+    "estraverse": {
+      "version": "1.9.3"
+    },
+    "estraverse-fb": {
+      "version": "1.3.1"
+    },
+    "esutils": {
+      "version": "2.0.2"
+    },
+    "etag": {
+      "version": "1.7.0"
+    },
+    "event-emitter": {
+      "version": "0.3.4"
+    },
+    "eventemitter3": {
+      "version": "1.2.0"
+    },
+    "events": {
+      "version": "1.0.2"
+    },
+    "exit-hook": {
+      "version": "1.1.1"
+    },
+    "expand-brackets": {
+      "version": "0.1.5"
+    },
+    "expand-range": {
+      "version": "1.8.1"
+    },
+    "exports-loader": {
+      "version": "0.6.2"
+    },
+    "express": {
+      "version": "4.13.3",
+      "dependencies": {
+        "cookie": {
+          "version": "0.1.3"
+        },
+        "cookie-signature": {
+          "version": "1.0.6"
+        },
+        "depd": {
+          "version": "1.0.1"
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.0"
+    },
+    "extglob": {
+      "version": "0.3.2"
+    },
+    "extsprintf": {
+      "version": "1.0.2"
+    },
+    "falafel": {
+      "version": "1.2.0"
+    },
+    "fast-levenshtein": {
+      "version": "1.1.3"
+    },
+    "fastparse": {
+      "version": "1.1.1"
+    },
+    "fbemitter": {
+      "version": "2.0.2",
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.6"
+        },
+        "fbjs": {
+          "version": "0.7.2"
+        }
+      }
+    },
+    "fbjs": {
+      "version": "0.5.0",
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.6"
+        }
+      }
+    },
+    "figures": {
+      "version": "1.5.0"
+    },
+    "file-entry-cache": {
+      "version": "1.2.4",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.0.1"
+        }
+      }
+    },
+    "filename-regex": {
+      "version": "2.0.0"
+    },
+    "filesize": {
+      "version": "3.2.1"
+    },
+    "fill-range": {
+      "version": "2.2.3"
+    },
+    "finalhandler": {
+      "version": "0.4.0"
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "dependencies": {
+        "path-exists": {
+          "version": "2.1.0"
+        }
+      }
+    },
+    "findup": {
+      "version": "0.1.5",
+      "dependencies": {
+        "commander": {
+          "version": "2.1.0"
+        }
+      }
+    },
+    "finished": {
+      "version": "1.2.2",
+      "dependencies": {
+        "ee-first": {
+          "version": "1.0.3"
+        }
+      }
+    },
+    "flat-cache": {
+      "version": "1.0.10"
+    },
+    "flux": {
+      "version": "2.1.1",
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.6"
+        },
+        "fbjs": {
+          "version": "0.1.0-alpha.7"
+        }
+      }
+    },
+    "for-in": {
+      "version": "0.1.5"
+    },
+    "for-own": {
+      "version": "0.1.4"
+    },
+    "foreach": {
+      "version": "2.0.5"
+    },
+    "foreachasync": {
+      "version": "3.0.0"
+    },
+    "forever-agent": {
+      "version": "0.6.1"
+    },
+    "form-data": {
+      "version": "1.0.0-rc4",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2"
+        }
+      }
+    },
+    "formatio": {
+      "version": "1.1.1"
+    },
+    "formidable": {
+      "version": "1.0.14"
+    },
+    "forwarded": {
+      "version": "0.1.0"
+    },
+    "fresh": {
+      "version": "0.3.0"
+    },
+    "fs-readdir-recursive": {
+      "version": "0.1.2"
+    },
+    "fsevents": {
+      "version": "1.0.11",
+      "dependencies": {
+        "ansi": {
+          "version": "0.3.1"
+        },
+        "ansi-regex": {
+          "version": "2.0.0"
+        },
+        "ansi-styles": {
+          "version": "2.2.1"
+        },
+        "are-we-there-yet": {
+          "version": "1.1.2"
+        },
+        "asn1": {
+          "version": "0.2.3"
+        },
+        "assert-plus": {
+          "version": "0.2.0"
+        },
+        "async": {
+          "version": "1.5.2"
+        },
+        "aws-sign2": {
+          "version": "0.6.0"
+        },
+        "aws4": {
+          "version": "1.3.2",
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.0.1",
               "dependencies": {
-                "arrify": {
-                  "version": "1.0.1"
+                "pseudomap": {
+                  "version": "1.0.2"
                 },
-                "micromatch": {
-                  "version": "2.3.7",
+                "yallist": {
+                  "version": "2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "bl": {
+          "version": "1.0.3"
+        },
+        "block-stream": {
+          "version": "0.0.8"
+        },
+        "boom": {
+          "version": "2.10.1"
+        },
+        "caseless": {
+          "version": "0.11.0"
+        },
+        "chalk": {
+          "version": "1.1.3"
+        },
+        "combined-stream": {
+          "version": "1.0.5"
+        },
+        "commander": {
+          "version": "2.9.0"
+        },
+        "core-util-is": {
+          "version": "1.0.2"
+        },
+        "cryptiles": {
+          "version": "2.0.5"
+        },
+        "dashdash": {
+          "version": "1.13.0",
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0"
+        },
+        "deep-extend": {
+          "version": "0.4.1"
+        },
+        "delayed-stream": {
+          "version": "1.0.0"
+        },
+        "delegates": {
+          "version": "1.0.0"
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5"
+        },
+        "extend": {
+          "version": "3.0.0"
+        },
+        "extsprintf": {
+          "version": "1.0.2"
+        },
+        "forever-agent": {
+          "version": "0.6.1"
+        },
+        "form-data": {
+          "version": "1.0.0-rc4"
+        },
+        "fstream": {
+          "version": "1.0.8"
+        },
+        "fstream-ignore": {
+          "version": "1.0.3",
+          "dependencies": {
+            "minimatch": {
+              "version": "3.0.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
                   "dependencies": {
-                    "arr-diff": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "arr-flatten": {
-                          "version": "1.0.1"
-                        }
-                      }
+                    "balanced-match": {
+                      "version": "0.3.0"
                     },
-                    "array-unique": {
-                      "version": "0.2.1"
-                    },
-                    "braces": {
-                      "version": "1.8.3",
-                      "dependencies": {
-                        "expand-range": {
-                          "version": "1.8.1",
-                          "dependencies": {
-                            "fill-range": {
-                              "version": "2.2.3",
-                              "dependencies": {
-                                "is-number": {
-                                  "version": "2.1.0"
-                                },
-                                "isobject": {
-                                  "version": "2.0.0",
-                                  "dependencies": {
-                                    "isarray": {
-                                      "version": "0.0.1"
-                                    }
-                                  }
-                                },
-                                "randomatic": {
-                                  "version": "1.1.5"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "preserve": {
-                          "version": "0.2.0"
-                        },
-                        "repeat-element": {
-                          "version": "1.1.2"
-                        }
-                      }
-                    },
-                    "expand-brackets": {
-                      "version": "0.1.4"
-                    },
-                    "extglob": {
-                      "version": "0.3.2"
-                    },
-                    "filename-regex": {
-                      "version": "2.0.0"
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0"
-                    },
-                    "kind-of": {
-                      "version": "3.0.2",
-                      "dependencies": {
-                        "is-buffer": {
-                          "version": "1.1.3"
-                        }
-                      }
-                    },
-                    "normalize-path": {
-                      "version": "2.0.1"
-                    },
-                    "object.omit": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "for-own": {
-                          "version": "0.1.4",
-                          "dependencies": {
-                            "for-in": {
-                              "version": "0.1.5"
-                            }
-                          }
-                        },
-                        "is-extendable": {
-                          "version": "0.1.1"
-                        }
-                      }
-                    },
-                    "parse-glob": {
-                      "version": "3.0.4",
-                      "dependencies": {
-                        "glob-base": {
-                          "version": "0.3.0"
-                        },
-                        "is-dotfile": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    },
-                    "regex-cache": {
-                      "version": "0.4.2",
-                      "dependencies": {
-                        "is-equal-shallow": {
-                          "version": "0.1.3"
-                        },
-                        "is-primitive": {
-                          "version": "2.0.0"
-                        }
-                      }
+                    "concat-map": {
+                      "version": "0.0.1"
                     }
                   }
                 }
               }
-            },
-            "async-each": {
-              "version": "1.0.0"
-            },
-            "glob-parent": {
-              "version": "2.0.0"
-            },
-            "is-binary-path": {
-              "version": "1.0.1",
+            }
+          }
+        },
+        "gauge": {
+          "version": "1.2.7"
+        },
+        "generate-function": {
+          "version": "2.0.0"
+        },
+        "generate-object-property": {
+          "version": "1.2.0"
+        },
+        "graceful-fs": {
+          "version": "4.1.3"
+        },
+        "graceful-readlink": {
+          "version": "1.0.1"
+        },
+        "har-validator": {
+          "version": "2.0.6"
+        },
+        "has-ansi": {
+          "version": "2.0.0"
+        },
+        "has-unicode": {
+          "version": "2.0.0"
+        },
+        "hawk": {
+          "version": "3.1.3"
+        },
+        "hoek": {
+          "version": "2.16.3"
+        },
+        "http-signature": {
+          "version": "1.1.1"
+        },
+        "inherits": {
+          "version": "2.0.1"
+        },
+        "ini": {
+          "version": "1.3.4"
+        },
+        "is-my-json-valid": {
+          "version": "2.13.1"
+        },
+        "is-property": {
+          "version": "1.0.2"
+        },
+        "is-typedarray": {
+          "version": "1.0.0"
+        },
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "isstream": {
+          "version": "0.1.2"
+        },
+        "jodid25519": {
+          "version": "1.0.2"
+        },
+        "jsbn": {
+          "version": "0.1.0"
+        },
+        "json-schema": {
+          "version": "0.2.2"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1"
+        },
+        "jsonpointer": {
+          "version": "2.0.0"
+        },
+        "jsprim": {
+          "version": "1.2.2"
+        },
+        "lodash.pad": {
+          "version": "4.1.0"
+        },
+        "lodash.padend": {
+          "version": "4.2.0"
+        },
+        "lodash.padstart": {
+          "version": "4.2.0"
+        },
+        "lodash.repeat": {
+          "version": "4.0.0"
+        },
+        "lodash.tostring": {
+          "version": "4.1.2"
+        },
+        "mime-db": {
+          "version": "1.22.0"
+        },
+        "mime-types": {
+          "version": "2.1.10"
+        },
+        "minimist": {
+          "version": "0.0.8"
+        },
+        "mkdirp": {
+          "version": "0.5.1"
+        },
+        "ms": {
+          "version": "0.7.1"
+        },
+        "node-pre-gyp": {
+          "version": "0.6.25",
+          "dependencies": {
+            "nopt": {
+              "version": "3.0.6",
               "dependencies": {
-                "binary-extensions": {
-                  "version": "1.4.0"
+                "abbrev": {
+                  "version": "1.0.7"
                 }
               }
-            },
-            "is-glob": {
-              "version": "2.0.1",
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7"
+        },
+        "npmlog": {
+          "version": "2.0.3"
+        },
+        "oauth-sign": {
+          "version": "0.8.1"
+        },
+        "once": {
+          "version": "1.3.3"
+        },
+        "pinkie": {
+          "version": "2.0.4"
+        },
+        "pinkie-promise": {
+          "version": "2.0.0"
+        },
+        "process-nextick-args": {
+          "version": "1.0.6"
+        },
+        "qs": {
+          "version": "6.0.2"
+        },
+        "rc": {
+          "version": "1.1.6",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0"
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.0.6"
+        },
+        "request": {
+          "version": "2.69.0"
+        },
+        "rimraf": {
+          "version": "2.5.2",
+          "dependencies": {
+            "glob": {
+              "version": "7.0.3",
               "dependencies": {
-                "is-extglob": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "readdirp": {
-              "version": "2.0.0",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.3"
+                "inflight": {
+                  "version": "1.0.4",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1"
                 },
                 "minimatch": {
-                  "version": "2.0.10",
+                  "version": "3.0.0",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.3",
@@ -223,2628 +1591,6 @@
                     }
                   }
                 },
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "1.0.0"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                }
-              }
-            },
-            "fsevents": {
-              "version": "1.0.9",
-              "dependencies": {
-                "nan": {
-                  "version": "2.2.0"
-                },
-                "node-pre-gyp": {
-                  "version": "0.6.24",
-                  "dependencies": {
-                    "nopt": {
-                      "version": "3.0.6",
-                      "dependencies": {
-                        "abbrev": {
-                          "version": "1.0.7"
-                        }
-                      }
-                    }
-                  }
-                },
-                "ansi": {
-                  "version": "0.3.1"
-                },
-                "ansi-styles": {
-                  "version": "2.2.0"
-                },
-                "ansi-regex": {
-                  "version": "2.0.0"
-                },
-                "are-we-there-yet": {
-                  "version": "1.1.2"
-                },
-                "asn1": {
-                  "version": "0.2.3"
-                },
-                "assert-plus": {
-                  "version": "0.2.0"
-                },
-                "async": {
-                  "version": "1.5.2"
-                },
-                "aws-sign2": {
-                  "version": "0.6.0"
-                },
-                "bl": {
-                  "version": "1.0.3"
-                },
-                "block-stream": {
-                  "version": "0.0.8"
-                },
-                "boom": {
-                  "version": "2.10.1"
-                },
-                "caseless": {
-                  "version": "0.11.0"
-                },
-                "chalk": {
-                  "version": "1.1.1"
-                },
-                "color-convert": {
-                  "version": "1.0.0"
-                },
-                "combined-stream": {
-                  "version": "1.0.5"
-                },
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "commander": {
-                  "version": "2.9.0"
-                },
-                "cryptiles": {
-                  "version": "2.0.5"
-                },
-                "debug": {
-                  "version": "2.2.0"
-                },
-                "deep-extend": {
-                  "version": "0.4.1"
-                },
-                "delayed-stream": {
-                  "version": "1.0.0"
-                },
-                "delegates": {
-                  "version": "1.0.0"
-                },
-                "ecc-jsbn": {
-                  "version": "0.1.1"
-                },
-                "extend": {
-                  "version": "3.0.0"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5"
-                },
-                "extsprintf": {
-                  "version": "1.0.2"
-                },
-                "forever-agent": {
-                  "version": "0.6.1"
-                },
-                "form-data": {
-                  "version": "1.0.0-rc4"
-                },
-                "fstream": {
-                  "version": "1.0.8"
-                },
-                "generate-object-property": {
-                  "version": "1.2.0"
-                },
-                "generate-function": {
-                  "version": "2.0.0"
-                },
-                "gauge": {
-                  "version": "1.2.7"
-                },
-                "graceful-fs": {
-                  "version": "4.1.3"
-                },
-                "graceful-readlink": {
-                  "version": "1.0.1"
-                },
-                "har-validator": {
-                  "version": "2.0.6"
-                },
-                "has-ansi": {
-                  "version": "2.0.0"
-                },
-                "hawk": {
-                  "version": "3.1.3"
-                },
-                "hoek": {
-                  "version": "2.16.3"
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "http-signature": {
-                  "version": "1.1.1"
-                },
-                "ini": {
-                  "version": "1.3.4"
-                },
-                "is-property": {
-                  "version": "1.0.2"
-                },
-                "is-my-json-valid": {
-                  "version": "2.13.1"
-                },
-                "is-typedarray": {
-                  "version": "1.0.0"
-                },
-                "isarray": {
-                  "version": "1.0.0"
-                },
-                "isstream": {
-                  "version": "0.1.2"
-                },
-                "jodid25519": {
-                  "version": "1.0.2"
-                },
-                "json-schema": {
-                  "version": "0.2.2"
-                },
-                "jsbn": {
-                  "version": "0.1.0"
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1"
-                },
-                "jsonpointer": {
-                  "version": "2.0.0"
-                },
-                "jsprim": {
-                  "version": "1.2.2"
-                },
-                "lodash.pad": {
-                  "version": "4.1.0"
-                },
-                "lodash.padstart": {
-                  "version": "4.2.0"
-                },
-                "lodash.padend": {
-                  "version": "4.2.0"
-                },
-                "lodash.repeat": {
-                  "version": "4.0.0"
-                },
-                "lodash.tostring": {
-                  "version": "4.1.2"
-                },
-                "mime-types": {
-                  "version": "2.1.10"
-                },
-                "mime-db": {
-                  "version": "1.22.0"
-                },
-                "minimist": {
-                  "version": "0.0.8"
-                },
-                "mkdirp": {
-                  "version": "0.5.1"
-                },
-                "ms": {
-                  "version": "0.7.1"
-                },
-                "node-uuid": {
-                  "version": "1.4.7"
-                },
-                "npmlog": {
-                  "version": "2.0.3"
-                },
-                "oauth-sign": {
-                  "version": "0.8.1"
-                },
-                "once": {
-                  "version": "1.3.3"
-                },
-                "pinkie": {
-                  "version": "2.0.4"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6"
-                },
-                "pinkie-promise": {
-                  "version": "2.0.0"
-                },
-                "qs": {
-                  "version": "6.0.2"
-                },
-                "readable-stream": {
-                  "version": "2.0.6"
-                },
-                "request": {
-                  "version": "2.69.0"
-                },
-                "semver": {
-                  "version": "5.1.0"
-                },
-                "sntp": {
-                  "version": "1.0.9"
-                },
-                "sshpk": {
-                  "version": "1.7.4"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                },
-                "stringstream": {
-                  "version": "0.0.5"
-                },
-                "strip-ansi": {
-                  "version": "3.0.1"
-                },
-                "supports-color": {
-                  "version": "2.0.0"
-                },
-                "strip-json-comments": {
-                  "version": "1.0.4"
-                },
-                "tar": {
-                  "version": "2.2.1"
-                },
-                "tar-pack": {
-                  "version": "3.1.3"
-                },
-                "tough-cookie": {
-                  "version": "2.2.2"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.2"
-                },
-                "tweetnacl": {
-                  "version": "0.14.1"
-                },
-                "uid-number": {
-                  "version": "0.0.6"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2"
-                },
-                "verror": {
-                  "version": "1.3.6"
-                },
-                "wrappy": {
-                  "version": "1.0.1"
-                },
-                "xtend": {
-                  "version": "4.0.1"
-                },
-                "has-unicode": {
-                  "version": "2.0.0"
-                },
-                "dashdash": {
-                  "version": "1.13.0",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "rc": {
-                  "version": "1.1.6",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0"
-                    }
-                  }
-                },
-                "aws4": {
-                  "version": "1.3.2",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "4.0.0",
-                      "dependencies": {
-                        "pseudomap": {
-                          "version": "1.0.2"
-                        },
-                        "yallist": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "fstream-ignore": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.5.2",
-                  "dependencies": {
-                    "glob": {
-                      "version": "7.0.3",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        },
-                        "minimatch": {
-                          "version": "3.0.0",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.3",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.3.0"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.3",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "commander": {
-          "version": "2.9.0",
-          "dependencies": {
-            "graceful-readlink": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "convert-source-map": {
-          "version": "1.2.0"
-        },
-        "fs-readdir-recursive": {
-          "version": "0.1.2"
-        },
-        "glob": {
-          "version": "5.0.15",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            }
-          }
-        },
-        "lodash": {
-          "version": "3.10.1"
-        },
-        "output-file-sync": {
-          "version": "1.1.1",
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1"
-            }
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0"
-        },
-        "path-is-absolute": {
-          "version": "1.0.0"
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "slash": {
-          "version": "1.0.0"
-        }
-      }
-    },
-    "babel-core": {
-      "version": "5.8.12",
-      "dependencies": {
-        "babel-plugin-constant-folding": {
-          "version": "1.0.1"
-        },
-        "babel-plugin-dead-code-elimination": {
-          "version": "1.0.2"
-        },
-        "babel-plugin-eval": {
-          "version": "1.0.1"
-        },
-        "babel-plugin-inline-environment-variables": {
-          "version": "1.0.1"
-        },
-        "babel-plugin-jscript": {
-          "version": "1.0.4"
-        },
-        "babel-plugin-member-expression-literals": {
-          "version": "1.0.1"
-        },
-        "babel-plugin-property-literals": {
-          "version": "1.0.1"
-        },
-        "babel-plugin-proto-to-assign": {
-          "version": "1.0.4"
-        },
-        "babel-plugin-react-constant-elements": {
-          "version": "1.0.3"
-        },
-        "babel-plugin-react-display-name": {
-          "version": "1.0.3"
-        },
-        "babel-plugin-remove-console": {
-          "version": "1.0.1"
-        },
-        "babel-plugin-remove-debugger": {
-          "version": "1.0.1"
-        },
-        "babel-plugin-runtime": {
-          "version": "1.0.7"
-        },
-        "babel-plugin-undeclared-variables-check": {
-          "version": "1.0.2",
-          "dependencies": {
-            "leven": {
-              "version": "1.0.2"
-            }
-          }
-        },
-        "babel-plugin-undefined-to-void": {
-          "version": "1.1.6"
-        },
-        "babylon": {
-          "version": "5.8.38"
-        },
-        "bluebird": {
-          "version": "2.10.2"
-        },
-        "convert-source-map": {
-          "version": "1.2.0"
-        },
-        "core-js": {
-          "version": "0.9.18"
-        },
-        "detect-indent": {
-          "version": "3.0.1",
-          "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1"
-            },
-            "minimist": {
-              "version": "1.2.0"
-            }
-          }
-        },
-        "esutils": {
-          "version": "2.0.2"
-        },
-        "fs-readdir-recursive": {
-          "version": "0.1.2"
-        },
-        "globals": {
-          "version": "6.4.1"
-        },
-        "home-or-tmp": {
-          "version": "1.0.0",
-          "dependencies": {
-            "os-tmpdir": {
-              "version": "1.0.1"
-            },
-            "user-home": {
-              "version": "1.1.1"
-            }
-          }
-        },
-        "is-integer": {
-          "version": "1.0.6",
-          "dependencies": {
-            "is-finite": {
-              "version": "1.0.1",
-              "dependencies": {
-                "number-is-nan": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "js-tokens": {
-          "version": "1.0.1"
-        },
-        "line-numbers": {
-          "version": "0.2.0",
-          "dependencies": {
-            "left-pad": {
-              "version": "0.0.3"
-            }
-          }
-        },
-        "lodash": {
-          "version": "3.10.1"
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.3",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0"
-                },
-                "concat-map": {
-                  "version": "0.0.1"
-                }
-              }
-            }
-          }
-        },
-        "output-file-sync": {
-          "version": "1.1.1",
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1"
-            }
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0"
-        },
-        "path-is-absolute": {
-          "version": "1.0.0"
-        },
-        "private": {
-          "version": "0.1.6"
-        },
-        "regenerator": {
-          "version": "0.8.34",
-          "dependencies": {
-            "commoner": {
-              "version": "0.10.4",
-              "dependencies": {
-                "commander": {
-                  "version": "2.9.0",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "detective": {
-                  "version": "4.3.1",
-                  "dependencies": {
-                    "acorn": {
-                      "version": "1.2.2"
-                    },
-                    "defined": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "glob": {
-                  "version": "5.0.15",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "4.1.3"
-                },
-                "iconv-lite": {
-                  "version": "0.4.13"
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8"
-                    }
-                  }
-                },
-                "q": {
-                  "version": "1.4.1"
-                }
-              }
-            },
-            "defs": {
-              "version": "1.1.1",
-              "dependencies": {
-                "alter": {
-                  "version": "0.2.0",
-                  "dependencies": {
-                    "stable": {
-                      "version": "0.1.5"
-                    }
-                  }
-                },
-                "ast-traverse": {
-                  "version": "0.1.1"
-                },
-                "breakable": {
-                  "version": "1.0.0"
-                },
-                "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb"
-                },
-                "simple-fmt": {
-                  "version": "0.1.0"
-                },
-                "simple-is": {
-                  "version": "0.2.0"
-                },
-                "stringmap": {
-                  "version": "0.2.2"
-                },
-                "stringset": {
-                  "version": "0.2.1"
-                },
-                "tryor": {
-                  "version": "0.1.2"
-                },
-                "yargs": {
-                  "version": "3.27.0",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1"
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.3",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.0.2",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.3"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4"
-                                }
-                              }
-                            },
-                            "lazy-cache": {
-                              "version": "1.0.3"
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.0.2",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.3"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2"
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.2.0"
-                    },
-                    "os-locale": {
-                      "version": "1.4.0",
-                      "dependencies": {
-                        "lcid": {
-                          "version": "1.0.0",
-                          "dependencies": {
-                            "invert-kv": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "window-size": {
-                      "version": "0.1.4"
-                    },
-                    "y18n": {
-                      "version": "3.2.1"
-                    }
-                  }
-                }
-              }
-            },
-            "esprima-fb": {
-              "version": "13001.1.0-dev-harmony-fb"
-            },
-            "recast": {
-              "version": "0.10.18",
-              "dependencies": {
-                "esprima-fb": {
-                  "version": "14001.1.0-dev-harmony-fb"
-                },
-                "ast-types": {
-                  "version": "0.8.2"
-                }
-              }
-            },
-            "through": {
-              "version": "2.3.8"
-            }
-          }
-        },
-        "regexpu": {
-          "version": "1.3.0",
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.2"
-            },
-            "recast": {
-              "version": "0.10.43",
-              "dependencies": {
-                "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb"
-                },
-                "source-map": {
-                  "version": "0.5.3"
-                },
-                "ast-types": {
-                  "version": "0.8.15"
-                }
-              }
-            },
-            "regenerate": {
-              "version": "1.2.1"
-            },
-            "regjsgen": {
-              "version": "0.2.0"
-            },
-            "regjsparser": {
-              "version": "0.1.5",
-              "dependencies": {
-                "jsesc": {
-                  "version": "0.5.0"
-                }
-              }
-            }
-          }
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "dependencies": {
-            "is-finite": {
-              "version": "1.0.1",
-              "dependencies": {
-                "number-is-nan": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.1.7"
-        },
-        "shebang-regex": {
-          "version": "1.0.0"
-        },
-        "slash": {
-          "version": "1.0.0"
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "source-map-support": {
-          "version": "0.2.10",
-          "dependencies": {
-            "source-map": {
-              "version": "0.1.32",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "strip-json-comments": {
-          "version": "1.0.4"
-        },
-        "to-fast-properties": {
-          "version": "1.0.2"
-        },
-        "trim-right": {
-          "version": "1.0.1"
-        },
-        "try-resolve": {
-          "version": "1.0.1"
-        }
-      }
-    },
-    "babel-eslint": {
-      "version": "4.1.8",
-      "dependencies": {
-        "babel-core": {
-          "version": "5.8.38",
-          "dependencies": {
-            "babel-plugin-constant-folding": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-dead-code-elimination": {
-              "version": "1.0.2"
-            },
-            "babel-plugin-eval": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-inline-environment-variables": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-jscript": {
-              "version": "1.0.4"
-            },
-            "babel-plugin-member-expression-literals": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-property-literals": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-proto-to-assign": {
-              "version": "1.0.4"
-            },
-            "babel-plugin-react-constant-elements": {
-              "version": "1.0.3"
-            },
-            "babel-plugin-react-display-name": {
-              "version": "1.0.3"
-            },
-            "babel-plugin-remove-console": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-remove-debugger": {
-              "version": "1.0.1"
-            },
-            "babel-plugin-runtime": {
-              "version": "1.0.7"
-            },
-            "babel-plugin-undeclared-variables-check": {
-              "version": "1.0.2",
-              "dependencies": {
-                "leven": {
-                  "version": "1.0.2"
-                }
-              }
-            },
-            "babel-plugin-undefined-to-void": {
-              "version": "1.1.6"
-            },
-            "babylon": {
-              "version": "5.8.38"
-            },
-            "bluebird": {
-              "version": "2.10.2"
-            },
-            "convert-source-map": {
-              "version": "1.2.0"
-            },
-            "core-js": {
-              "version": "1.2.6"
-            },
-            "detect-indent": {
-              "version": "3.0.1",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1"
-                },
-                "minimist": {
-                  "version": "1.2.0"
-                }
-              }
-            },
-            "esutils": {
-              "version": "2.0.2"
-            },
-            "fs-readdir-recursive": {
-              "version": "0.1.2"
-            },
-            "globals": {
-              "version": "6.4.1"
-            },
-            "home-or-tmp": {
-              "version": "1.0.0",
-              "dependencies": {
-                "os-tmpdir": {
-                  "version": "1.0.1"
-                },
-                "user-home": {
-                  "version": "1.1.1"
-                }
-              }
-            },
-            "is-integer": {
-              "version": "1.0.6",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "js-tokens": {
-              "version": "1.0.1"
-            },
-            "json5": {
-              "version": "0.4.0"
-            },
-            "lodash": {
-              "version": "3.10.1"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "output-file-sync": {
-              "version": "1.1.1",
-              "dependencies": {
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1"
-                }
-              }
-            },
-            "path-exists": {
-              "version": "1.0.0"
-            },
-            "path-is-absolute": {
-              "version": "1.0.0"
-            },
-            "private": {
-              "version": "0.1.6"
-            },
-            "regenerator": {
-              "version": "0.8.40",
-              "dependencies": {
-                "commoner": {
-                  "version": "0.10.4",
-                  "dependencies": {
-                    "commander": {
-                      "version": "2.9.0",
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "detective": {
-                      "version": "4.3.1",
-                      "dependencies": {
-                        "acorn": {
-                          "version": "1.2.2"
-                        },
-                        "defined": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "glob": {
-                      "version": "5.0.15",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.3",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.3"
-                    },
-                    "iconv-lite": {
-                      "version": "0.4.13"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8"
-                        }
-                      }
-                    },
-                    "q": {
-                      "version": "1.4.1"
-                    }
-                  }
-                },
-                "defs": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "alter": {
-                      "version": "0.2.0",
-                      "dependencies": {
-                        "stable": {
-                          "version": "0.1.5"
-                        }
-                      }
-                    },
-                    "ast-traverse": {
-                      "version": "0.1.1"
-                    },
-                    "breakable": {
-                      "version": "1.0.0"
-                    },
-                    "simple-fmt": {
-                      "version": "0.1.0"
-                    },
-                    "simple-is": {
-                      "version": "0.2.0"
-                    },
-                    "stringmap": {
-                      "version": "0.2.2"
-                    },
-                    "stringset": {
-                      "version": "0.2.1"
-                    },
-                    "tryor": {
-                      "version": "0.1.2"
-                    },
-                    "yargs": {
-                      "version": "3.27.0",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.2.1"
-                        },
-                        "cliui": {
-                          "version": "2.1.0",
-                          "dependencies": {
-                            "center-align": {
-                              "version": "0.1.3",
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.4",
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.0.2",
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.3"
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4"
-                                    }
-                                  }
-                                },
-                                "lazy-cache": {
-                                  "version": "1.0.3"
-                                }
-                              }
-                            },
-                            "right-align": {
-                              "version": "0.1.3",
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.4",
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.0.2",
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.3"
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "wordwrap": {
-                              "version": "0.0.2"
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.2.0"
-                        },
-                        "os-locale": {
-                          "version": "1.4.0",
-                          "dependencies": {
-                            "lcid": {
-                              "version": "1.0.0",
-                              "dependencies": {
-                                "invert-kv": {
-                                  "version": "1.0.0"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "window-size": {
-                          "version": "0.1.4"
-                        },
-                        "y18n": {
-                          "version": "3.2.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb"
-                },
-                "recast": {
-                  "version": "0.10.33",
-                  "dependencies": {
-                    "ast-types": {
-                      "version": "0.8.12"
-                    }
-                  }
-                },
-                "through": {
-                  "version": "2.3.8"
-                }
-              }
-            },
-            "regexpu": {
-              "version": "1.3.0",
-              "dependencies": {
-                "esprima": {
-                  "version": "2.7.2"
-                },
-                "recast": {
-                  "version": "0.10.43",
-                  "dependencies": {
-                    "esprima-fb": {
-                      "version": "15001.1001.0-dev-harmony-fb"
-                    },
-                    "ast-types": {
-                      "version": "0.8.15"
-                    }
-                  }
-                },
-                "regenerate": {
-                  "version": "1.2.1"
-                },
-                "regjsgen": {
-                  "version": "0.2.0"
-                },
-                "regjsparser": {
-                  "version": "0.1.5",
-                  "dependencies": {
-                    "jsesc": {
-                      "version": "0.5.0"
-                    }
-                  }
-                }
-              }
-            },
-            "repeating": {
-              "version": "1.1.3",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "resolve": {
-              "version": "1.1.7"
-            },
-            "shebang-regex": {
-              "version": "1.0.0"
-            },
-            "slash": {
-              "version": "1.0.0"
-            },
-            "source-map": {
-              "version": "0.5.3"
-            },
-            "source-map-support": {
-              "version": "0.2.10",
-              "dependencies": {
-                "source-map": {
-                  "version": "0.1.32",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "to-fast-properties": {
-              "version": "1.0.2"
-            },
-            "trim-right": {
-              "version": "1.0.1"
-            },
-            "try-resolve": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "lodash.assign": {
-          "version": "3.2.0",
-          "dependencies": {
-            "lodash._baseassign": {
-              "version": "3.2.0",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1"
-                }
-              }
-            },
-            "lodash._createassigner": {
-              "version": "3.1.1",
-              "dependencies": {
-                "lodash._bindcallback": {
-                  "version": "3.0.1"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9"
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1"
-                }
-              }
-            },
-            "lodash.keys": {
-              "version": "3.1.2",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.8"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            }
-          }
-        },
-        "lodash.pick": {
-          "version": "3.1.0",
-          "dependencies": {
-            "lodash._baseflatten": {
-              "version": "3.1.4",
-              "dependencies": {
-                "lodash.isarguments": {
-                  "version": "3.0.8"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1"
-            },
-            "lodash._pickbyarray": {
-              "version": "3.0.2"
-            },
-            "lodash._pickbycallback": {
-              "version": "3.0.0",
-              "dependencies": {
-                "lodash._basefor": {
-                  "version": "3.0.3"
-                },
-                "lodash.keysin": {
-                  "version": "3.0.8",
-                  "dependencies": {
-                    "lodash.isarguments": {
-                      "version": "3.0.8"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1"
-            }
-          }
-        },
-        "acorn-to-esprima": {
-          "version": "1.0.7"
-        }
-      }
-    },
-    "babel-loader": {
-      "version": "5.3.2",
-      "dependencies": {
-        "loader-utils": {
-          "version": "0.2.13",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3"
-            },
-            "json5": {
-              "version": "0.4.0"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "3.0.0"
-        }
-      }
-    },
-    "babel-runtime": {
-      "version": "5.8.12",
-      "dependencies": {
-        "core-js": {
-          "version": "0.9.18"
-        }
-      }
-    },
-    "better-assert": {
-      "version": "1.0.2",
-      "dependencies": {
-        "callsite": {
-          "version": "1.0.0"
-        }
-      }
-    },
-    "blanket": {
-      "version": "1.1.6",
-      "dependencies": {
-        "esprima": {
-          "version": "1.0.4"
-        },
-        "falafel": {
-          "version": "0.1.6"
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "dependencies": {
-            "object-keys": {
-              "version": "0.4.0"
-            }
-          }
-        }
-      }
-    },
-    "blob": {
-      "version": "0.0.4"
-    },
-    "body-parser": {
-      "version": "1.15.0",
-      "dependencies": {
-        "bytes": {
-          "version": "2.2.0"
-        },
-        "content-type": {
-          "version": "1.0.1"
-        },
-        "depd": {
-          "version": "1.1.0"
-        },
-        "http-errors": {
-          "version": "1.4.0",
-          "dependencies": {
-            "statuses": {
-              "version": "1.2.1"
-            }
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.13"
-        },
-        "on-finished": {
-          "version": "2.3.0",
-          "dependencies": {
-            "ee-first": {
-              "version": "1.1.1"
-            }
-          }
-        },
-        "qs": {
-          "version": "6.1.0"
-        },
-        "raw-body": {
-          "version": "2.1.6",
-          "dependencies": {
-            "bytes": {
-              "version": "2.3.0"
-            },
-            "unpipe": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "type-is": {
-          "version": "1.6.12",
-          "dependencies": {
-            "media-typer": {
-              "version": "0.3.0"
-            },
-            "mime-types": {
-              "version": "2.1.10",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.22.0"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "browser-filesaver": {
-      "version": "1.1.0"
-    },
-    "chai": {
-      "version": "2.0.0",
-      "dependencies": {
-        "assertion-error": {
-          "version": "1.0.0"
-        },
-        "deep-eql": {
-          "version": "0.1.3",
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1"
-            }
-          }
-        }
-      }
-    },
-    "chalk": {
-      "version": "1.0.0",
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.1.0"
-        },
-        "has-ansi": {
-          "version": "1.0.3",
-          "dependencies": {
-            "ansi-regex": {
-              "version": "1.1.1"
-            },
-            "get-stdin": {
-              "version": "4.0.1"
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "2.0.1",
-          "dependencies": {
-            "ansi-regex": {
-              "version": "1.1.1"
-            }
-          }
-        },
-        "supports-color": {
-          "version": "1.3.1"
-        }
-      }
-    },
-    "char-spinner": {
-      "version": "1.0.1"
-    },
-    "chrono-node": {
-      "version": "1.2.1"
-    },
-    "classnames": {
-      "version": "1.1.1"
-    },
-    "click-outside": {
-      "version": "1.0.4",
-      "dependencies": {
-        "babel-runtime": {
-          "version": "4.7.4",
-          "dependencies": {
-            "core-js": {
-              "version": "0.6.1"
-            }
-          }
-        },
-        "component-event": {
-          "version": "0.1.4"
-        },
-        "node-contains": {
-          "version": "1.0.0"
-        }
-      }
-    },
-    "clipboard": {
-      "version": "1.5.3",
-      "dependencies": {
-        "good-listener": {
-          "version": "1.1.7",
-          "dependencies": {
-            "delegate": {
-              "version": "3.0.1",
-              "dependencies": {
-                "closest": {
-                  "version": "0.0.1",
-                  "dependencies": {
-                    "matches-selector": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "select": {
-          "version": "1.0.6"
-        },
-        "tiny-emitter": {
-          "version": "1.0.2"
-        }
-      }
-    },
-    "commander": {
-      "version": "2.3.0"
-    },
-    "component-classes": {
-      "version": "1.2.6",
-      "dependencies": {
-        "component-indexof": {
-          "version": "0.0.3"
-        }
-      }
-    },
-    "component-closest": {
-      "version": "0.1.4",
-      "dependencies": {
-        "component-matches-selector": {
-          "version": "0.1.5",
-          "dependencies": {
-            "component-query": {
-              "version": "0.0.3"
-            }
-          }
-        }
-      }
-    },
-    "component-file-picker": {
-      "version": "0.2.1",
-      "dependencies": {
-        "component-event": {
-          "version": "0.1.4"
-        }
-      }
-    },
-    "component-tip": {
-      "version": "3.0.3",
-      "dependencies": {
-        "bounding-client-rect": {
-          "version": "1.0.5",
-          "dependencies": {
-            "get-document": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "component-bind": {
-          "version": "1.0.0"
-        },
-        "component-css": {
-          "version": "0.0.8",
-          "dependencies": {
-            "component-each": {
-              "version": "0.2.6",
-              "dependencies": {
-                "component-type": {
-                  "version": "1.0.0"
-                },
-                "to-function": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "component-props": {
-                      "version": "1.1.1"
-                    }
-                  }
-                }
-              }
-            },
-            "to-camel-case": {
-              "version": "0.2.1",
-              "dependencies": {
-                "to-space-case": {
-                  "version": "0.1.2",
-                  "dependencies": {
-                    "to-no-case": {
-                      "version": "0.1.1"
-                    }
-                  }
-                }
-              }
-            },
-            "within-document": {
-              "version": "0.0.1"
-            }
-          }
-        },
-        "component-emitter": {
-          "version": "1.1.3"
-        },
-        "component-events": {
-          "version": "1.0.10",
-          "dependencies": {
-            "component-delegate": {
-              "version": "0.2.4"
-            },
-            "component-event": {
-              "version": "0.1.4"
-            }
-          }
-        },
-        "component-query": {
-          "version": "0.0.3"
-        },
-        "component-raf": {
-          "version": "1.2.0"
-        },
-        "domify": {
-          "version": "1.3.0"
-        },
-        "html-browserify": {
-          "version": "0.0.4",
-          "dependencies": {
-            "through": {
-              "version": "2.3.8"
-            }
-          }
-        }
-      }
-    },
-    "component-uid": {
-      "version": "0.0.2"
-    },
-    "cookie": {
-      "version": "0.1.2"
-    },
-    "cookie-parser": {
-      "version": "1.3.2",
-      "dependencies": {
-        "cookie-signature": {
-          "version": "1.0.4"
-        }
-      }
-    },
-    "creditcards": {
-      "version": "1.1.1",
-      "dependencies": {
-        "camel-case": {
-          "version": "0.1.0",
-          "dependencies": {
-            "sentence-case": {
-              "version": "0.1.2"
-            }
-          }
-        }
-      }
-    },
-    "debug": {
-      "version": "2.2.0"
-    },
-    "deep-freeze": {
-      "version": "0.0.1"
-    },
-    "dom-scroll-into-view": {
-      "version": "1.0.1"
-    },
-    "email-validator": {
-      "version": "1.0.1"
-    },
-    "emitter-component": {
-      "version": "1.1.1"
-    },
-    "enzyme": {
-      "version": "2.2.0",
-      "dependencies": {
-        "cheerio": {
-          "version": "0.20.0",
-          "dependencies": {
-            "css-select": {
-              "version": "1.2.0",
-              "dependencies": {
-                "css-what": {
-                  "version": "2.1.0"
-                },
-                "domutils": {
-                  "version": "1.5.1",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.3.0"
-                    }
-                  }
-                },
-                "boolbase": {
-                  "version": "1.0.0"
-                },
-                "nth-check": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "entities": {
-              "version": "1.1.1"
-            },
-            "htmlparser2": {
-              "version": "3.8.3",
-              "dependencies": {
-                "domhandler": {
-                  "version": "2.3.0"
-                },
-                "domutils": {
-                  "version": "1.5.1"
-                },
-                "domelementtype": {
-                  "version": "1.3.0"
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "0.0.1"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    }
-                  }
-                },
-                "entities": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "dom-serializer": {
-              "version": "0.1.0",
-              "dependencies": {
-                "domelementtype": {
-                  "version": "1.1.3"
-                }
-              }
-            }
-          }
-        },
-        "is-subset": {
-          "version": "0.1.1"
-        },
-        "object.assign": {
-          "version": "4.0.3",
-          "dependencies": {
-            "function-bind": {
-              "version": "1.1.0"
-            },
-            "object-keys": {
-              "version": "1.0.9"
-            },
-            "define-properties": {
-              "version": "1.1.2",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5"
-                }
-              }
-            }
-          }
-        },
-        "object.values": {
-          "version": "1.0.3",
-          "dependencies": {
-            "define-properties": {
-              "version": "1.1.2",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5"
-                },
-                "object-keys": {
-                  "version": "1.0.9"
-                }
-              }
-            },
-            "es-abstract": {
-              "version": "1.5.0",
-              "dependencies": {
-                "is-callable": {
-                  "version": "1.1.3"
-                },
-                "es-to-primitive": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "is-date-object": {
-                      "version": "1.0.1"
-                    },
-                    "is-symbol": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "is-regex": {
-                  "version": "1.0.3"
-                }
-              }
-            },
-            "has": {
-              "version": "1.0.1"
-            },
-            "function-bind": {
-              "version": "1.1.0"
-            }
-          }
-        }
-      }
-    },
-    "escape-regexp": {
-      "version": "0.0.1"
-    },
-    "escape-string-regexp": {
-      "version": "1.0.3"
-    },
-    "esformatter": {
-      "version": "0.7.3",
-      "dependencies": {
-        "debug": {
-          "version": "0.7.4"
-        },
-        "disparity": {
-          "version": "2.0.0",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0"
-            },
-            "diff": {
-              "version": "1.4.0"
-            }
-          }
-        },
-        "espree": {
-          "version": "1.12.3"
-        },
-        "glob": {
-          "version": "5.0.15",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "minimist": {
-          "version": "1.2.0"
-        },
-        "mout": {
-          "version": "1.0.0"
-        },
-        "npm-run": {
-          "version": "1.1.1",
-          "dependencies": {
-            "npm-path": {
-              "version": "1.1.0",
-              "dependencies": {
-                "which": {
-                  "version": "1.2.4",
-                  "dependencies": {
-                    "is-absolute": {
-                      "version": "0.1.7",
-                      "dependencies": {
-                        "is-relative": {
-                          "version": "0.1.3"
-                        }
-                      }
-                    },
-                    "isexe": {
-                      "version": "1.1.2"
-                    }
-                  }
-                }
-              }
-            },
-            "serializerr": {
-              "version": "1.0.2",
-              "dependencies": {
-                "protochain": {
-                  "version": "1.0.3"
-                }
-              }
-            },
-            "sync-exec": {
-              "version": "0.5.0"
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.1.7"
-        },
-        "rocambole": {
-          "version": "0.7.0",
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.2"
-            }
-          }
-        },
-        "rocambole-indent": {
-          "version": "2.0.4",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0"
-            },
-            "mout": {
-              "version": "0.11.1"
-            }
-          }
-        },
-        "rocambole-linebreak": {
-          "version": "1.0.1",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0"
-            },
-            "semver": {
-              "version": "4.3.6"
-            }
-          }
-        },
-        "rocambole-node": {
-          "version": "1.0.0"
-        },
-        "rocambole-token": {
-          "version": "1.2.1"
-        },
-        "rocambole-whitespace": {
-          "version": "1.0.0",
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0"
-            },
-            "repeat-string": {
-              "version": "1.5.4"
-            }
-          }
-        },
-        "semver": {
-          "version": "2.2.1"
-        },
-        "stdin": {
-          "version": "0.0.1"
-        },
-        "strip-json-comments": {
-          "version": "0.1.3"
-        },
-        "supports-color": {
-          "version": "1.3.1"
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1"
-            }
-          }
-        }
-      }
-    },
-    "esformatter-braces": {
-      "version": "1.2.1",
-      "dependencies": {
-        "rocambole-token": {
-          "version": "1.2.1"
-        }
-      }
-    },
-    "esformatter-collapse-objects-a8c": {
-      "version": "0.1.0",
-      "dependencies": {
-        "defaults-deep": {
-          "version": "0.2.3",
-          "dependencies": {
-            "for-own": {
-              "version": "0.1.4",
-              "dependencies": {
-                "for-in": {
-                  "version": "0.1.5"
-                }
-              }
-            },
-            "is-extendable": {
-              "version": "0.1.1"
-            },
-            "lazy-cache": {
-              "version": "0.2.7"
-            }
-          }
-        },
-        "rocambole": {
-          "version": "0.5.1",
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.2"
-            }
-          }
-        },
-        "rocambole-token": {
-          "version": "1.2.1"
-        }
-      }
-    },
-    "esformatter-dot-notation": {
-      "version": "1.3.1",
-      "dependencies": {
-        "rocambole": {
-          "version": "0.6.0",
-          "dependencies": {
-            "esprima": {
-              "version": "2.7.2"
-            }
-          }
-        },
-        "rocambole-token": {
-          "version": "1.2.1"
-        },
-        "unquoted-property-validator": {
-          "version": "1.0.0"
-        }
-      }
-    },
-    "esformatter-quotes": {
-      "version": "1.0.3"
-    },
-    "esformatter-semicolons": {
-      "version": "1.1.1"
-    },
-    "esformatter-special-bangs": {
-      "version": "1.0.1",
-      "dependencies": {
-        "rocambole-token": {
-          "version": "1.2.1"
-        }
-      }
-    },
-    "eslint": {
-      "version": "1.10.3",
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.5.1",
-          "dependencies": {
-            "typedarray": {
-              "version": "0.0.6"
-            },
-            "readable-stream": {
-              "version": "2.0.6",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "isarray": {
-                  "version": "1.0.0"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2"
-                }
-              }
-            }
-          }
-        },
-        "doctrine": {
-          "version": "0.7.2",
-          "dependencies": {
-            "esutils": {
-              "version": "1.1.6"
-            },
-            "isarray": {
-              "version": "0.0.1"
-            }
-          }
-        },
-        "escope": {
-          "version": "3.6.0",
-          "dependencies": {
-            "es6-map": {
-              "version": "0.1.3",
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1"
-                },
-                "es5-ext": {
-                  "version": "0.10.11"
-                },
-                "es6-iterator": {
-                  "version": "2.0.0"
-                },
-                "es6-set": {
-                  "version": "0.1.4"
-                },
-                "es6-symbol": {
-                  "version": "3.0.2"
-                },
-                "event-emitter": {
-                  "version": "0.3.4"
-                }
-              }
-            },
-            "es6-weak-map": {
-              "version": "2.0.1",
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1"
-                },
-                "es5-ext": {
-                  "version": "0.10.11"
-                },
-                "es6-iterator": {
-                  "version": "2.0.0"
-                },
-                "es6-symbol": {
-                  "version": "3.0.2"
-                }
-              }
-            },
-            "esrecurse": {
-              "version": "4.1.0",
-              "dependencies": {
-                "estraverse": {
-                  "version": "4.1.1"
-                }
-              }
-            }
-          }
-        },
-        "espree": {
-          "version": "2.2.5"
-        },
-        "estraverse": {
-          "version": "4.2.0"
-        },
-        "estraverse-fb": {
-          "version": "1.3.1"
-        },
-        "esutils": {
-          "version": "2.0.2"
-        },
-        "file-entry-cache": {
-          "version": "1.2.4",
-          "dependencies": {
-            "flat-cache": {
-              "version": "1.0.10",
-              "dependencies": {
-                "del": {
-                  "version": "2.2.0",
-                  "dependencies": {
-                    "globby": {
-                      "version": "4.0.0",
-                      "dependencies": {
-                        "array-union": {
-                          "version": "1.0.1",
-                          "dependencies": {
-                            "array-uniq": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        },
-                        "arrify": {
-                          "version": "1.0.1"
-                        },
-                        "glob": {
-                          "version": "6.0.4",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "is-path-cwd": {
-                      "version": "1.0.0"
-                    },
-                    "is-path-in-cwd": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "is-path-inside": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "pify": {
-                      "version": "2.3.0"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4"
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.5.2",
-                      "dependencies": {
-                        "glob": {
-                          "version": "7.0.3",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "4.1.3"
-                },
-                "read-json-sync": {
-                  "version": "1.1.1"
-                },
-                "write": {
-                  "version": "0.2.1"
-                }
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "5.0.15",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            }
-          }
-        },
-        "globals": {
-          "version": "8.18.0"
-        },
-        "handlebars": {
-          "version": "4.0.5",
-          "dependencies": {
-            "async": {
-              "version": "1.5.2"
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3"
-                },
-                "minimist": {
-                  "version": "0.0.10"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "inquirer": {
-          "version": "0.11.4",
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.3.0"
-            },
-            "ansi-regex": {
-              "version": "2.0.0"
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "dependencies": {
-                "restore-cursor": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "exit-hook": {
-                      "version": "1.1.1"
-                    },
-                    "onetime": {
-                      "version": "1.1.0"
-                    }
-                  }
-                }
-              }
-            },
-            "cli-width": {
-              "version": "1.1.1"
-            },
-            "figures": {
-              "version": "1.5.0"
-            },
-            "lodash": {
-              "version": "3.10.1"
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "mute-stream": {
-                  "version": "0.0.5"
-                }
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "dependencies": {
                 "once": {
                   "version": "1.3.3",
                   "dependencies": {
@@ -2852,898 +1598,244 @@
                       "version": "1.0.1"
                     }
                   }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2"
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
                 },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1"
-            },
-            "through": {
-              "version": "2.3.8"
-            }
-          }
-        },
-        "is-my-json-valid": {
-          "version": "2.13.1",
-          "dependencies": {
-            "generate-function": {
-              "version": "2.0.0"
-            },
-            "generate-object-property": {
-              "version": "1.2.0",
-              "dependencies": {
-                "is-property": {
-                  "version": "1.0.2"
-                }
-              }
-            },
-            "jsonpointer": {
-              "version": "2.0.0"
-            },
-            "xtend": {
-              "version": "4.0.1"
-            }
-          }
-        },
-        "is-resolvable": {
-          "version": "1.0.0",
-          "dependencies": {
-            "tryit": {
-              "version": "1.0.2"
-            }
-          }
-        },
-        "js-yaml": {
-          "version": "3.4.5",
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.7",
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3"
-                }
-              }
-            },
-            "esprima": {
-              "version": "2.7.2"
-            }
-          }
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "dependencies": {
-            "jsonify": {
-              "version": "0.0.0"
-            }
-          }
-        },
-        "lodash.clonedeep": {
-          "version": "3.0.2",
-          "dependencies": {
-            "lodash._baseclone": {
-              "version": "3.3.0",
-              "dependencies": {
-                "lodash._arraycopy": {
-                  "version": "3.0.0"
-                },
-                "lodash._arrayeach": {
-                  "version": "3.0.0"
-                },
-                "lodash._baseassign": {
-                  "version": "3.2.0",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1"
-                    }
-                  }
-                },
-                "lodash._basefor": {
-                  "version": "3.0.3"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.0.8"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1"
-            }
-          }
-        },
-        "lodash.merge": {
-          "version": "3.3.2",
-          "dependencies": {
-            "lodash._arraycopy": {
-              "version": "3.0.0"
-            },
-            "lodash._arrayeach": {
-              "version": "3.0.0"
-            },
-            "lodash._createassigner": {
-              "version": "3.1.1",
-              "dependencies": {
-                "lodash._bindcallback": {
-                  "version": "3.0.1"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.9"
-                },
-                "lodash.restparam": {
-                  "version": "3.6.1"
-                }
-              }
-            },
-            "lodash._getnative": {
-              "version": "3.9.1"
-            },
-            "lodash.isarguments": {
-              "version": "3.0.8"
-            },
-            "lodash.isarray": {
-              "version": "3.0.4"
-            },
-            "lodash.isplainobject": {
-              "version": "3.2.0",
-              "dependencies": {
-                "lodash._basefor": {
-                  "version": "3.0.3"
-                }
-              }
-            },
-            "lodash.istypedarray": {
-              "version": "3.0.5"
-            },
-            "lodash.keys": {
-              "version": "3.1.2"
-            },
-            "lodash.keysin": {
-              "version": "3.0.8"
-            },
-            "lodash.toplainobject": {
-              "version": "3.0.0",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1"
+                "path-is-absolute": {
+                  "version": "1.0.0"
                 }
               }
             }
           }
         },
-        "lodash.omit": {
-          "version": "3.1.0",
-          "dependencies": {
-            "lodash._arraymap": {
-              "version": "3.0.0"
-            },
-            "lodash._basedifference": {
-              "version": "3.0.3",
-              "dependencies": {
-                "lodash._baseindexof": {
-                  "version": "3.1.0"
-                },
-                "lodash._cacheindexof": {
-                  "version": "3.0.2"
-                },
-                "lodash._createcache": {
-                  "version": "3.1.2",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._baseflatten": {
-              "version": "3.1.4",
-              "dependencies": {
-                "lodash.isarguments": {
-                  "version": "3.0.8"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            },
-            "lodash._bindcallback": {
-              "version": "3.0.1"
-            },
-            "lodash._pickbyarray": {
-              "version": "3.0.2"
-            },
-            "lodash._pickbycallback": {
-              "version": "3.0.0",
-              "dependencies": {
-                "lodash._basefor": {
-                  "version": "3.0.3"
-                }
-              }
-            },
-            "lodash.keysin": {
-              "version": "3.0.8",
-              "dependencies": {
-                "lodash.isarguments": {
-                  "version": "3.0.8"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1"
-            }
-          }
+        "semver": {
+          "version": "5.1.0"
         },
-        "minimatch": {
-          "version": "3.0.0",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.3",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0"
-                },
-                "concat-map": {
-                  "version": "0.0.1"
-                }
-              }
-            }
-          }
+        "sntp": {
+          "version": "1.0.9"
         },
-        "mkdirp": {
-          "version": "0.5.1",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
+        "sshpk": {
+          "version": "1.7.4"
         },
-        "object-assign": {
-          "version": "4.0.1"
+        "string_decoder": {
+          "version": "0.10.31"
         },
-        "optionator": {
-          "version": "0.6.0",
-          "dependencies": {
-            "prelude-ls": {
-              "version": "1.1.2"
-            },
-            "deep-is": {
-              "version": "0.1.3"
-            },
-            "wordwrap": {
-              "version": "0.0.3"
-            },
-            "type-check": {
-              "version": "0.3.2"
-            },
-            "levn": {
-              "version": "0.2.5"
-            },
-            "fast-levenshtein": {
-              "version": "1.0.7"
-            }
-          }
+        "stringstream": {
+          "version": "0.0.5"
         },
-        "path-is-absolute": {
-          "version": "1.0.0"
-        },
-        "path-is-inside": {
-          "version": "1.0.1"
-        },
-        "shelljs": {
-          "version": "0.5.3"
+        "strip-ansi": {
+          "version": "3.0.1"
         },
         "strip-json-comments": {
           "version": "1.0.4"
         },
-        "text-table": {
-          "version": "0.2.0"
+        "supports-color": {
+          "version": "2.0.0"
         },
-        "user-home": {
-          "version": "2.0.0",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.1"
-            }
-          }
+        "tar": {
+          "version": "2.2.1"
         },
-        "xml-escape": {
-          "version": "1.0.0"
-        }
-      }
-    },
-    "eslint-plugin-react": {
-      "version": "3.11.3"
-    },
-    "eslint-plugin-wpcalypso": {
-      "version": "1.1.3",
-      "dependencies": {
-        "requireindex": {
-          "version": "1.1.0"
-        }
-      }
-    },
-    "events": {
-      "version": "1.0.2"
-    },
-    "exports-loader": {
-      "version": "0.6.2",
-      "dependencies": {
-        "loader-utils": {
-          "version": "0.2.13",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3"
-            },
-            "json5": {
-              "version": "0.4.0"
-            }
-          }
-        }
-      }
-    },
-    "express": {
-      "version": "4.13.3",
-      "dependencies": {
-        "accepts": {
-          "version": "1.2.13",
-          "dependencies": {
-            "mime-types": {
-              "version": "2.1.10",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.22.0"
-                }
-              }
-            },
-            "negotiator": {
-              "version": "0.5.3"
-            }
-          }
+        "tar-pack": {
+          "version": "3.1.3"
         },
-        "array-flatten": {
-          "version": "1.1.1"
+        "tough-cookie": {
+          "version": "2.2.2"
         },
-        "content-disposition": {
-          "version": "0.5.0"
+        "tunnel-agent": {
+          "version": "0.4.2"
         },
-        "content-type": {
-          "version": "1.0.1"
+        "tweetnacl": {
+          "version": "0.14.3"
         },
-        "cookie": {
-          "version": "0.1.3"
+        "uid-number": {
+          "version": "0.0.6"
         },
-        "cookie-signature": {
-          "version": "1.0.6"
-        },
-        "depd": {
-          "version": "1.0.1"
-        },
-        "escape-html": {
+        "util-deprecate": {
           "version": "1.0.2"
         },
-        "etag": {
-          "version": "1.7.0"
+        "verror": {
+          "version": "1.3.6"
         },
-        "finalhandler": {
-          "version": "0.4.0",
-          "dependencies": {
-            "unpipe": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "fresh": {
-          "version": "0.3.0"
-        },
-        "merge-descriptors": {
-          "version": "1.0.0"
-        },
-        "methods": {
-          "version": "1.1.2"
-        },
-        "on-finished": {
-          "version": "2.3.0",
-          "dependencies": {
-            "ee-first": {
-              "version": "1.1.1"
-            }
-          }
-        },
-        "parseurl": {
-          "version": "1.3.1"
-        },
-        "path-to-regexp": {
-          "version": "0.1.7"
-        },
-        "proxy-addr": {
-          "version": "1.0.10",
-          "dependencies": {
-            "forwarded": {
-              "version": "0.1.0"
-            },
-            "ipaddr.js": {
-              "version": "1.0.5"
-            }
-          }
-        },
-        "range-parser": {
-          "version": "1.0.3"
-        },
-        "send": {
-          "version": "0.13.0",
-          "dependencies": {
-            "destroy": {
-              "version": "1.0.3"
-            },
-            "http-errors": {
-              "version": "1.3.1"
-            },
-            "mime": {
-              "version": "1.3.4"
-            },
-            "statuses": {
-              "version": "1.2.1"
-            }
-          }
-        },
-        "serve-static": {
-          "version": "1.10.2",
-          "dependencies": {
-            "escape-html": {
-              "version": "1.0.3"
-            },
-            "send": {
-              "version": "0.13.1",
-              "dependencies": {
-                "depd": {
-                  "version": "1.1.0"
-                },
-                "destroy": {
-                  "version": "1.0.4"
-                },
-                "http-errors": {
-                  "version": "1.3.1"
-                },
-                "mime": {
-                  "version": "1.3.4"
-                },
-                "statuses": {
-                  "version": "1.2.1"
-                }
-              }
-            }
-          }
-        },
-        "type-is": {
-          "version": "1.6.12",
-          "dependencies": {
-            "media-typer": {
-              "version": "0.3.0"
-            },
-            "mime-types": {
-              "version": "2.1.10",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.22.0"
-                }
-              }
-            }
-          }
-        },
-        "utils-merge": {
-          "version": "1.0.0"
-        },
-        "vary": {
+        "wrappy": {
           "version": "1.0.1"
+        },
+        "xtend": {
+          "version": "4.0.1"
         }
       }
     },
-    "fbjs": {
-      "version": "0.5.0",
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.6"
-        },
-        "loose-envify": {
-          "version": "1.1.0",
-          "dependencies": {
-            "js-tokens": {
-              "version": "1.0.3"
-            }
-          }
-        },
-        "promise": {
-          "version": "7.1.1",
-          "dependencies": {
-            "asap": {
-              "version": "2.0.3"
-            }
-          }
-        },
-        "ua-parser-js": {
-          "version": "0.7.10"
-        },
-        "whatwg-fetch": {
-          "version": "0.9.0"
-        }
-      }
+    "fstream": {
+      "version": "1.0.8"
     },
-    "filesize": {
-      "version": "3.2.1"
+    "function-bind": {
+      "version": "1.1.0"
     },
-    "flux": {
-      "version": "2.1.1",
-      "dependencies": {
-        "fbemitter": {
-          "version": "2.0.2",
-          "dependencies": {
-            "fbjs": {
-              "version": "0.7.2",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.6"
-                },
-                "loose-envify": {
-                  "version": "1.1.0",
-                  "dependencies": {
-                    "js-tokens": {
-                      "version": "1.0.3"
-                    }
-                  }
-                },
-                "isomorphic-fetch": {
-                  "version": "2.2.1",
-                  "dependencies": {
-                    "node-fetch": {
-                      "version": "1.4.1",
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.13"
-                            }
-                          }
-                        },
-                        "is-stream": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "whatwg-fetch": {
-                      "version": "0.11.0"
-                    }
-                  }
-                },
-                "promise": {
-                  "version": "7.1.1",
-                  "dependencies": {
-                    "asap": {
-                      "version": "2.0.3"
-                    }
-                  }
-                },
-                "ua-parser-js": {
-                  "version": "0.7.10"
-                }
-              }
-            }
-          }
-        },
-        "fbjs": {
-          "version": "0.1.0-alpha.7",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.6"
-            },
-            "promise": {
-              "version": "7.1.1",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.3"
-                }
-              }
-            },
-            "whatwg-fetch": {
-              "version": "0.9.0"
-            }
-          }
-        }
-      }
+    "gather-stream": {
+      "version": "1.0.0"
+    },
+    "gauge": {
+      "version": "1.2.7"
+    },
+    "gaze": {
+      "version": "0.5.2"
+    },
+    "generate-function": {
+      "version": "2.0.0"
+    },
+    "generate-object-property": {
+      "version": "1.2.0"
+    },
+    "get-document": {
+      "version": "1.0.0"
+    },
+    "get-stdin": {
+      "version": "4.0.1"
     },
     "glob": {
-      "version": "7.0.3",
+      "version": "7.0.3"
+    },
+    "glob-base": {
+      "version": "0.3.0"
+    },
+    "glob-parent": {
+      "version": "2.0.0"
+    },
+    "global": {
+      "version": "2.0.1",
+      "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+    },
+    "globals": {
+      "version": "6.4.1"
+    },
+    "globby": {
+      "version": "3.0.1",
       "dependencies": {
-        "inflight": {
-          "version": "1.0.4",
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1"
-            }
-          }
+        "glob": {
+          "version": "5.0.15"
         },
-        "minimatch": {
-          "version": "3.0.0",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.3",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.3.0"
-                },
-                "concat-map": {
-                  "version": "0.0.1"
-                }
-              }
-            }
-          }
+        "object-assign": {
+          "version": "4.0.1"
         },
-        "once": {
-          "version": "1.3.3",
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1"
-            }
-          }
+        "pinkie": {
+          "version": "1.0.0"
         },
-        "path-is-absolute": {
+        "pinkie-promise": {
           "version": "1.0.0"
         }
       }
+    },
+    "globule": {
+      "version": "0.1.0",
+      "dependencies": {
+        "glob": {
+          "version": "3.1.21"
+        },
+        "graceful-fs": {
+          "version": "1.2.3"
+        },
+        "inherits": {
+          "version": "1.0.2"
+        },
+        "lodash": {
+          "version": "1.0.2"
+        },
+        "lru-cache": {
+          "version": "2.7.3"
+        },
+        "minimatch": {
+          "version": "0.2.14"
+        }
+      }
+    },
+    "good-listener": {
+      "version": "1.1.7"
+    },
+    "graceful-fs": {
+      "version": "4.1.3"
+    },
+    "graceful-readlink": {
+      "version": "1.0.1"
+    },
+    "growl": {
+      "version": "1.8.1"
+    },
+    "handlebars": {
+      "version": "4.0.5",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2"
+        },
+        "source-map": {
+          "version": "0.4.4"
+        }
+      }
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.0.0"
+        },
+        "chalk": {
+          "version": "1.1.3"
+        },
+        "commander": {
+          "version": "2.9.0"
+        },
+        "has-ansi": {
+          "version": "2.0.0"
+        },
+        "strip-ansi": {
+          "version": "3.0.1"
+        },
+        "supports-color": {
+          "version": "2.0.0"
+        }
+      }
+    },
+    "has": {
+      "version": "1.0.1"
+    },
+    "has-ansi": {
+      "version": "1.0.3"
+    },
+    "has-binary": {
+      "version": "0.1.6"
+    },
+    "has-binary-data": {
+      "version": "0.1.3"
+    },
+    "has-cors": {
+      "version": "1.0.3"
+    },
+    "has-flag": {
+      "version": "1.0.0"
+    },
+    "has-unicode": {
+      "version": "2.0.0"
+    },
+    "hawk": {
+      "version": "3.1.3"
     },
     "he": {
       "version": "0.5.0"
     },
+    "hoek": {
+      "version": "2.16.3"
+    },
+    "hoist-non-react-statics": {
+      "version": "1.0.5"
+    },
+    "home-or-tmp": {
+      "version": "1.0.0"
+    },
+    "hosted-git-info": {
+      "version": "2.1.4"
+    },
+    "html-browserify": {
+      "version": "0.0.4"
+    },
     "html-loader": {
       "version": "0.4.0",
       "dependencies": {
-        "es6-templates": {
-          "version": "0.2.2",
-          "dependencies": {
-            "recast": {
-              "version": "0.9.18",
-              "dependencies": {
-                "esprima-fb": {
-                  "version": "10001.1.0-dev-harmony-fb"
-                },
-                "source-map": {
-                  "version": "0.1.43",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "private": {
-                  "version": "0.1.6"
-                },
-                "ast-types": {
-                  "version": "0.6.16"
-                }
-              }
-            },
-            "through": {
-              "version": "2.3.8"
-            }
-          }
-        },
-        "fastparse": {
-          "version": "1.1.1"
-        },
-        "html-minifier": {
-          "version": "1.3.1",
-          "dependencies": {
-            "change-case": {
-              "version": "2.3.1",
-              "dependencies": {
-                "camel-case": {
-                  "version": "1.2.2"
-                },
-                "constant-case": {
-                  "version": "1.1.2"
-                },
-                "dot-case": {
-                  "version": "1.1.2"
-                },
-                "is-lower-case": {
-                  "version": "1.1.3"
-                },
-                "is-upper-case": {
-                  "version": "1.1.2"
-                },
-                "lower-case": {
-                  "version": "1.1.3"
-                },
-                "lower-case-first": {
-                  "version": "1.0.2"
-                },
-                "param-case": {
-                  "version": "1.1.2"
-                },
-                "pascal-case": {
-                  "version": "1.1.2"
-                },
-                "path-case": {
-                  "version": "1.1.2"
-                },
-                "sentence-case": {
-                  "version": "1.1.3"
-                },
-                "snake-case": {
-                  "version": "1.1.2"
-                },
-                "swap-case": {
-                  "version": "1.1.2"
-                },
-                "title-case": {
-                  "version": "1.1.2"
-                },
-                "upper-case": {
-                  "version": "1.1.3"
-                },
-                "upper-case-first": {
-                  "version": "1.1.2"
-                }
-              }
-            },
-            "clean-css": {
-              "version": "3.4.10",
-              "dependencies": {
-                "commander": {
-                  "version": "2.8.1",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.4.4",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "cli": {
-              "version": "0.11.2",
-              "dependencies": {
-                "glob": {
-                  "version": "5.0.15",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "exit": {
-                  "version": "0.1.2"
-                }
-              }
-            },
-            "concat-stream": {
-              "version": "1.5.1",
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6"
-                },
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "1.0.0"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                }
-              }
-            },
-            "ncname": {
-              "version": "1.0.0",
-              "dependencies": {
-                "xml-char-classes": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "relateurl": {
-              "version": "0.2.6"
-            }
-          }
-        },
-        "loader-utils": {
-          "version": "0.2.13",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3"
-            },
-            "json5": {
-              "version": "0.4.0"
-            }
-          }
-        },
         "object-assign": {
           "version": "4.0.1"
         },
@@ -3752,535 +1844,321 @@
         }
       }
     },
+    "html-minifier": {
+      "version": "1.5.0",
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0"
+        },
+        "he": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14"
+        }
+      }
+    },
+    "http-browserify": {
+      "version": "1.7.0"
+    },
+    "http-errors": {
+      "version": "1.4.0"
+    },
+    "http-proxy": {
+      "version": "1.13.2"
+    },
+    "http-signature": {
+      "version": "1.1.1"
+    },
+    "https-browserify": {
+      "version": "0.0.0"
+    },
+    "iconv-lite": {
+      "version": "0.4.13"
+    },
+    "ieee754": {
+      "version": "1.1.6"
+    },
     "immutable": {
       "version": "3.7.5"
     },
     "imports-loader": {
-      "version": "0.6.5",
+      "version": "0.6.5"
+    },
+    "indent-string": {
+      "version": "2.1.0",
       "dependencies": {
-        "loader-utils": {
-          "version": "0.2.13",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3"
-            },
-            "json5": {
-              "version": "0.4.0"
-            }
-          }
+        "repeating": {
+          "version": "2.0.1"
         }
       }
+    },
+    "indexof": {
+      "version": "0.0.1"
+    },
+    "inflight": {
+      "version": "1.0.4"
     },
     "inherits": {
       "version": "2.0.1"
     },
-    "jade": {
-      "version": "1.11.0",
-      "from": "git://github.com/pugjs/jade.git#29784fd1ec6043397f4b43d45b4ee9e25177b940",
-      "resolved": "git://github.com/pugjs/jade.git#29784fd1ec6043397f4b43d45b4ee9e25177b940",
+    "ini": {
+      "version": "1.3.4"
+    },
+    "inline-process-browser": {
+      "version": "2.0.1"
+    },
+    "inquirer": {
+      "version": "0.11.4",
       "dependencies": {
-        "jade-code-gen": {
-          "version": "0.0.4",
-          "dependencies": {
-            "constantinople": {
-              "version": "3.0.2",
-              "dependencies": {
-                "acorn": {
-                  "version": "2.7.0"
-                }
-              }
-            },
-            "doctypes": {
-              "version": "1.0.0"
-            },
-            "jade-attrs": {
-              "version": "2.0.0"
-            },
-            "jade-runtime": {
-              "version": "1.1.0"
-            },
-            "js-stringify": {
-              "version": "1.0.2"
-            },
-            "void-elements": {
-              "version": "2.0.1"
-            },
-            "with": {
-              "version": "5.0.0",
-              "dependencies": {
-                "acorn": {
-                  "version": "1.2.2"
-                },
-                "acorn-globals": {
-                  "version": "1.0.9",
-                  "dependencies": {
-                    "acorn": {
-                      "version": "2.7.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "jade-filters": {
-          "version": "1.1.0",
-          "dependencies": {
-            "clean-css": {
-              "version": "3.4.10",
-              "dependencies": {
-                "commander": {
-                  "version": "2.8.1",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.4.4",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "constantinople": {
-              "version": "3.0.2",
-              "dependencies": {
-                "acorn": {
-                  "version": "2.7.0"
-                }
-              }
-            },
-            "jade-error": {
-              "version": "1.2.0"
-            },
-            "jade-walk": {
-              "version": "0.0.3"
-            },
-            "jstransformer": {
-              "version": "0.0.3",
-              "dependencies": {
-                "is-promise": {
-                  "version": "2.1.0"
-                },
-                "promise": {
-                  "version": "7.1.1",
-                  "dependencies": {
-                    "asap": {
-                      "version": "2.0.3"
-                    }
-                  }
-                }
-              }
-            },
-            "resolve": {
-              "version": "1.1.7"
-            }
-          }
-        },
-        "jade-lexer": {
-          "version": "0.0.9",
-          "dependencies": {
-            "character-parser": {
-              "version": "2.2.0",
-              "dependencies": {
-                "is-regex": {
-                  "version": "1.0.3"
-                }
-              }
-            },
-            "is-expression": {
-              "version": "1.0.2",
-              "dependencies": {
-                "acorn": {
-                  "version": "2.7.0"
-                },
-                "object-assign": {
-                  "version": "4.0.1"
-                }
-              }
-            },
-            "jade-error": {
-              "version": "1.2.0"
-            }
-          }
-        },
-        "jade-linker": {
-          "version": "0.0.3",
-          "dependencies": {
-            "jade-error": {
-              "version": "1.2.0"
-            },
-            "jade-walk": {
-              "version": "0.0.3"
-            }
-          }
-        },
-        "jade-load": {
-          "version": "0.0.4",
-          "dependencies": {
-            "jade-walk": {
-              "version": "0.0.3"
-            }
-          }
-        },
-        "jade-parser": {
-          "version": "0.0.9",
-          "dependencies": {
-            "jade-error": {
-              "version": "1.2.0"
-            },
-            "token-stream": {
-              "version": "0.0.1"
-            }
-          }
-        },
-        "jade-runtime": {
+        "ansi-regex": {
           "version": "2.0.0"
         },
-        "jade-strip-comments": {
-          "version": "1.0.0",
-          "dependencies": {
-            "jade-error": {
-              "version": "1.2.0"
-            }
-          }
+        "lodash": {
+          "version": "3.10.1"
+        },
+        "strip-ansi": {
+          "version": "3.0.1"
         }
       }
     },
+    "interpret": {
+      "version": "0.6.6"
+    },
+    "invariant": {
+      "version": "2.1.2"
+    },
+    "invert-kv": {
+      "version": "1.0.0"
+    },
+    "ipaddr.js": {
+      "version": "1.0.5"
+    },
+    "is-absolute": {
+      "version": "0.1.7"
+    },
+    "is-arrayish": {
+      "version": "0.2.1"
+    },
+    "is-binary-path": {
+      "version": "1.0.1"
+    },
+    "is-buffer": {
+      "version": "1.1.3"
+    },
+    "is-builtin-module": {
+      "version": "1.0.0"
+    },
+    "is-callable": {
+      "version": "1.1.3"
+    },
+    "is-date-object": {
+      "version": "1.0.1"
+    },
+    "is-dotfile": {
+      "version": "1.0.2"
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3"
+    },
+    "is-expression": {
+      "version": "1.0.2",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0"
+        },
+        "object-assign": {
+          "version": "4.0.1"
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1"
+    },
+    "is-extglob": {
+      "version": "1.0.0"
+    },
+    "is-finite": {
+      "version": "1.0.1"
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0"
+    },
+    "is-glob": {
+      "version": "2.0.1"
+    },
+    "is-integer": {
+      "version": "1.0.6"
+    },
+    "is-lower-case": {
+      "version": "1.1.3"
+    },
+    "is-my-json-valid": {
+      "version": "2.13.1"
+    },
+    "is-number": {
+      "version": "2.1.0"
+    },
+    "is-path-cwd": {
+      "version": "1.0.0"
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0"
+    },
+    "is-path-inside": {
+      "version": "1.0.0"
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1"
+    },
+    "is-primitive": {
+      "version": "2.0.0"
+    },
+    "is-promise": {
+      "version": "2.1.0"
+    },
+    "is-property": {
+      "version": "1.0.2"
+    },
+    "is-regex": {
+      "version": "1.0.3"
+    },
+    "is-relative": {
+      "version": "0.1.3"
+    },
+    "is-resolvable": {
+      "version": "1.0.0"
+    },
+    "is-stream": {
+      "version": "1.1.0"
+    },
+    "is-subset": {
+      "version": "0.1.1"
+    },
+    "is-symbol": {
+      "version": "1.0.1"
+    },
+    "is-typedarray": {
+      "version": "1.0.0"
+    },
+    "is-upper-case": {
+      "version": "1.1.2"
+    },
+    "is-utf8": {
+      "version": "0.2.1"
+    },
+    "isarray": {
+      "version": "0.0.1"
+    },
+    "isexe": {
+      "version": "1.1.2"
+    },
+    "isobject": {
+      "version": "2.0.0"
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "0.11.0"
+        }
+      }
+    },
+    "isstream": {
+      "version": "0.1.2"
+    },
+    "jade": {
+      "version": "1.11.0",
+      "from": "git://github.com/pugjs/jade.git#29784fd1ec6043397f4b43d45b4ee9e25177b940",
+      "resolved": "git://github.com/pugjs/jade.git#29784fd1ec6043397f4b43d45b4ee9e25177b940"
+    },
+    "jade-attrs": {
+      "version": "2.0.0",
+      "dependencies": {
+        "jade-runtime": {
+          "version": "1.1.0"
+        }
+      }
+    },
+    "jade-code-gen": {
+      "version": "0.0.4",
+      "dependencies": {
+        "jade-runtime": {
+          "version": "1.1.0"
+        }
+      }
+    },
+    "jade-error": {
+      "version": "1.2.0"
+    },
+    "jade-filters": {
+      "version": "1.1.0"
+    },
+    "jade-lexer": {
+      "version": "0.0.9"
+    },
+    "jade-linker": {
+      "version": "0.0.3"
+    },
+    "jade-load": {
+      "version": "0.0.4"
+    },
+    "jade-parser": {
+      "version": "0.0.9"
+    },
+    "jade-runtime": {
+      "version": "2.0.0"
+    },
+    "jade-strip-comments": {
+      "version": "1.0.0"
+    },
+    "jade-walk": {
+      "version": "0.0.3"
+    },
     "jed": {
+      "version": "1.0.2"
+    },
+    "jodid25519": {
       "version": "1.0.2"
     },
     "jquery": {
       "version": "1.11.3"
     },
+    "js-base64": {
+      "version": "2.1.9"
+    },
+    "js-stringify": {
+      "version": "1.0.2"
+    },
+    "js-tokens": {
+      "version": "1.0.1"
+    },
+    "js-yaml": {
+      "version": "3.4.5",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.2"
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.0"
+    },
     "jsdom": {
       "version": "7.2.0",
       "dependencies": {
-        "abab": {
-          "version": "1.0.3"
-        },
         "acorn": {
           "version": "2.7.0"
-        },
-        "acorn-globals": {
-          "version": "1.0.9"
-        },
-        "cssom": {
-          "version": "0.3.1"
-        },
-        "cssstyle": {
-          "version": "0.2.34"
-        },
-        "escodegen": {
-          "version": "1.8.0",
-          "dependencies": {
-            "estraverse": {
-              "version": "1.9.3"
-            },
-            "esutils": {
-              "version": "2.0.2"
-            },
-            "esprima": {
-              "version": "2.7.2"
-            },
-            "optionator": {
-              "version": "0.8.1",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2"
-                },
-                "deep-is": {
-                  "version": "0.1.3"
-                },
-                "wordwrap": {
-                  "version": "1.0.0"
-                },
-                "type-check": {
-                  "version": "0.3.2"
-                },
-                "levn": {
-                  "version": "0.3.0"
-                },
-                "fast-levenshtein": {
-                  "version": "1.1.3"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.2.0",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "nwmatcher": {
-          "version": "1.3.7"
-        },
-        "parse5": {
-          "version": "1.5.1"
-        },
-        "request": {
-          "version": "2.69.0",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0"
-            },
-            "aws4": {
-              "version": "1.3.2"
-            },
-            "bl": {
-              "version": "1.0.3",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "1.0.0"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.11.0"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0"
-            },
-            "forever-agent": {
-              "version": "0.6.1"
-            },
-            "form-data": {
-              "version": "1.0.0-rc4",
-              "dependencies": {
-                "async": {
-                  "version": "1.5.2"
-                }
-              }
-            },
-            "har-validator": {
-              "version": "2.0.6",
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.1",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.1.0"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0"
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.13.1",
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0"
-                    },
-                    "xtend": {
-                      "version": "4.0.1"
-                    }
-                  }
-                },
-                "pinkie-promise": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.4"
-                    }
-                  }
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3"
-                },
-                "boom": {
-                  "version": "2.10.1"
-                },
-                "cryptiles": {
-                  "version": "2.0.5"
-                },
-                "sntp": {
-                  "version": "1.0.9"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0"
-                },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.0.2"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2"
-                    },
-                    "verror": {
-                      "version": "1.3.6"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.7.4",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3"
-                    },
-                    "dashdash": {
-                      "version": "1.13.0",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.0"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.2"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1"
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0"
-            },
-            "isstream": {
-              "version": "0.1.2"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1"
-            },
-            "mime-types": {
-              "version": "2.1.10",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.22.0"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7"
-            },
-            "oauth-sign": {
-              "version": "0.8.1"
-            },
-            "qs": {
-              "version": "6.0.2"
-            },
-            "stringstream": {
-              "version": "0.0.5"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2"
-            }
-          }
-        },
-        "sax": {
-          "version": "1.2.1"
-        },
-        "symbol-tree": {
-          "version": "3.1.4"
-        },
-        "tough-cookie": {
-          "version": "2.2.2"
-        },
-        "webidl-conversions": {
-          "version": "2.0.1"
-        },
-        "whatwg-url-compat": {
-          "version": "0.6.5",
-          "dependencies": {
-            "tr46": {
-              "version": "0.0.3"
-            }
-          }
-        },
-        "xml-name-validator": {
-          "version": "2.0.1"
         }
       }
+    },
+    "jsesc": {
+      "version": "0.5.0"
     },
     "jshashes": {
       "version": "1.0.5"
@@ -4288,8 +2166,46 @@
     "json-loader": {
       "version": "0.5.4"
     },
+    "json-schema": {
+      "version": "0.2.2"
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1"
+    },
+    "json3": {
+      "version": "3.2.6"
+    },
+    "json5": {
+      "version": "0.5.0"
+    },
+    "jsonify": {
+      "version": "0.0.0"
+    },
+    "jsonpointer": {
+      "version": "2.0.0"
+    },
+    "jsprim": {
+      "version": "1.2.2"
+    },
     "jstimezonedetect": {
       "version": "1.0.5"
+    },
+    "jstransform": {
+      "version": "10.1.0",
+      "dependencies": {
+        "esprima-fb": {
+          "version": "13001.1001.0-dev-harmony-fb"
+        },
+        "source-map": {
+          "version": "0.1.31"
+        }
+      }
+    },
+    "jstransformer": {
+      "version": "0.0.3"
     },
     "key-mirror": {
       "version": "1.0.1"
@@ -4297,21 +2213,51 @@
     "keymaster": {
       "version": "1.6.2"
     },
-    "localStorage": {
+    "kind-of": {
+      "version": "3.0.2"
+    },
+    "lazy-cache": {
+      "version": "1.0.3"
+    },
+    "lcid": {
+      "version": "1.0.0"
+    },
+    "left-pad": {
+      "version": "0.0.3"
+    },
+    "leven": {
       "version": "1.0.2"
+    },
+    "levn": {
+      "version": "0.3.0"
+    },
+    "line-numbers": {
+      "version": "0.2.0"
+    },
+    "load-json-file": {
+      "version": "1.1.0"
+    },
+    "loader-utils": {
+      "version": "0.2.14",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.0.1"
+        }
+      }
     },
     "localforage": {
       "version": "1.4.0",
       "dependencies": {
+        "asap": {
+          "version": "1.0.0"
+        },
         "promise": {
-          "version": "5.0.0",
-          "dependencies": {
-            "asap": {
-              "version": "1.0.0"
-            }
-          }
+          "version": "5.0.0"
         }
       }
+    },
+    "localStorage": {
+      "version": "1.0.2"
     },
     "lodash": {
       "version": "4.5.0"
@@ -4319,61 +2265,207 @@
     "lodash-deep": {
       "version": "1.5.3"
     },
+    "lodash._arraycopy": {
+      "version": "3.0.0"
+    },
+    "lodash._arrayeach": {
+      "version": "3.0.0"
+    },
+    "lodash._arraymap": {
+      "version": "3.0.0"
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0"
+    },
+    "lodash._baseclone": {
+      "version": "3.3.0"
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1"
+    },
+    "lodash._basedifference": {
+      "version": "3.0.3"
+    },
+    "lodash._baseflatten": {
+      "version": "3.1.4"
+    },
+    "lodash._basefor": {
+      "version": "3.0.3"
+    },
+    "lodash._baseindexof": {
+      "version": "3.1.0"
+    },
+    "lodash._baseslice": {
+      "version": "4.0.0"
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1"
+    },
+    "lodash._cacheindexof": {
+      "version": "3.0.2"
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1"
+    },
+    "lodash._createcache": {
+      "version": "3.1.2"
+    },
+    "lodash._getnative": {
+      "version": "3.9.1"
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9"
+    },
+    "lodash._pickbyarray": {
+      "version": "3.0.2"
+    },
+    "lodash._pickbycallback": {
+      "version": "3.0.0"
+    },
+    "lodash.assign": {
+      "version": "3.2.0"
+    },
+    "lodash.clonedeep": {
+      "version": "3.0.2"
+    },
+    "lodash.isarguments": {
+      "version": "3.0.8"
+    },
+    "lodash.isarray": {
+      "version": "3.0.4"
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0"
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6"
+    },
+    "lodash.keys": {
+      "version": "3.1.2"
+    },
+    "lodash.keysin": {
+      "version": "3.0.8"
+    },
+    "lodash.merge": {
+      "version": "3.3.2"
+    },
+    "lodash.omit": {
+      "version": "3.1.0"
+    },
+    "lodash.pad": {
+      "version": "4.3.0"
+    },
+    "lodash.padend": {
+      "version": "4.4.0"
+    },
+    "lodash.padstart": {
+      "version": "4.4.0"
+    },
+    "lodash.pick": {
+      "version": "3.1.0"
+    },
+    "lodash.restparam": {
+      "version": "3.6.1"
+    },
+    "lodash.toplainobject": {
+      "version": "3.0.0"
+    },
+    "lodash.tostring": {
+      "version": "4.1.2"
+    },
+    "lolex": {
+      "version": "1.1.0"
+    },
+    "longest": {
+      "version": "1.0.1"
+    },
+    "loose-envify": {
+      "version": "1.1.0"
+    },
+    "loud-rejection": {
+      "version": "1.3.0"
+    },
+    "lower-case": {
+      "version": "1.1.3"
+    },
+    "lower-case-first": {
+      "version": "1.0.2"
+    },
     "lru-cache": {
-      "version": "4.0.0",
-      "dependencies": {
-        "pseudomap": {
-          "version": "1.0.2"
-        },
-        "yallist": {
-          "version": "2.0.0"
-        }
-      }
+      "version": "4.0.0"
     },
     "lunr": {
       "version": "0.5.7"
     },
+    "map-obj": {
+      "version": "1.0.1"
+    },
     "marked": {
       "version": "0.3.5"
     },
+    "matches-selector": {
+      "version": "0.0.1"
+    },
+    "media-typer": {
+      "version": "0.3.0"
+    },
+    "memory-fs": {
+      "version": "0.2.0"
+    },
+    "meow": {
+      "version": "3.7.0",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.0.1"
+        }
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.0"
+    },
+    "methods": {
+      "version": "1.1.2"
+    },
+    "micromatch": {
+      "version": "2.3.7"
+    },
+    "mime": {
+      "version": "1.3.4"
+    },
+    "mime-db": {
+      "version": "1.22.0"
+    },
+    "mime-types": {
+      "version": "2.1.10"
+    },
+    "minimatch": {
+      "version": "2.0.10"
+    },
+    "minimist": {
+      "version": "1.2.0"
+    },
     "mixedindentlint": {
-      "version": "1.1.1",
+      "version": "1.1.1"
+    },
+    "mkdirp": {
+      "version": "0.5.1",
       "dependencies": {
         "minimist": {
-          "version": "1.2.0"
+          "version": "0.0.8"
         }
       }
     },
     "mocha": {
       "version": "2.3.4",
       "dependencies": {
-        "diff": {
-          "version": "1.4.0"
-        },
         "escape-string-regexp": {
           "version": "1.0.2"
         },
         "glob": {
-          "version": "3.2.3",
-          "dependencies": {
-            "minimatch": {
-              "version": "0.2.14",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3"
-                },
-                "sigmund": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "2.0.3"
-            }
-          }
+          "version": "3.2.3"
         },
-        "growl": {
-          "version": "1.8.1"
+        "graceful-fs": {
+          "version": "2.0.3"
         },
         "jade": {
           "version": "0.26.3",
@@ -4386,13 +2478,17 @@
             }
           }
         },
+        "lru-cache": {
+          "version": "2.7.3"
+        },
+        "minimatch": {
+          "version": "0.2.14"
+        },
+        "minimist": {
+          "version": "0.0.8"
+        },
         "mkdirp": {
-          "version": "0.5.0",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
+          "version": "0.5.0"
         },
         "supports-color": {
           "version": "1.2.0"
@@ -4400,20 +2496,7 @@
       }
     },
     "mocha-junit-reporter": {
-      "version": "1.9.1",
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.1",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
-        },
-        "xml": {
-          "version": "1.0.1"
-        }
-      }
+      "version": "1.9.1"
     },
     "mockery": {
       "version": "1.4.0"
@@ -4427,1074 +2510,307 @@
     "morgan": {
       "version": "1.2.0",
       "dependencies": {
-        "basic-auth": {
-          "version": "1.0.0"
-        },
         "bytes": {
           "version": "1.0.0"
         },
         "depd": {
           "version": "0.4.2"
-        },
-        "finished": {
-          "version": "1.2.2",
-          "dependencies": {
-            "ee-first": {
-              "version": "1.0.3"
-            }
-          }
         }
       }
+    },
+    "mout": {
+      "version": "1.0.0"
     },
     "ms": {
       "version": "0.7.1"
     },
+    "mute-stream": {
+      "version": "0.0.5"
+    },
+    "nan": {
+      "version": "2.2.1"
+    },
+    "ncname": {
+      "version": "1.0.0"
+    },
+    "negotiator": {
+      "version": "0.5.3"
+    },
+    "neo-async": {
+      "version": "1.8.0"
+    },
     "nock": {
       "version": "2.17.0",
       "dependencies": {
-        "propagate": {
-          "version": "0.3.1"
-        },
         "debug": {
-          "version": "1.0.4",
-          "dependencies": {
-            "ms": {
-              "version": "0.6.2"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
-        },
-        "deep-equal": {
-          "version": "1.0.1"
+          "version": "1.0.4"
         },
         "lodash": {
           "version": "2.4.1"
+        },
+        "ms": {
+          "version": "0.6.2"
+        }
+      }
+    },
+    "node-contains": {
+      "version": "1.0.0"
+    },
+    "node-fetch": {
+      "version": "1.5.1"
+    },
+    "node-gyp": {
+      "version": "3.3.1",
+      "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "dependencies": {
+            "minimatch": {
+              "version": "2.0.10"
+            }
+          }
+        },
+        "lru-cache": {
+          "version": "2.7.3"
+        },
+        "minimatch": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "node-libs-browser": {
+      "version": "0.5.3",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14"
         }
       }
     },
     "node-sass": {
       "version": "3.4.2",
       "dependencies": {
-        "async-foreach": {
-          "version": "0.1.3"
+        "ansi-regex": {
+          "version": "2.0.0"
         },
         "chalk": {
-          "version": "1.1.1",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.1.0"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0"
-            }
-          }
-        },
-        "cross-spawn": {
-          "version": "2.1.5",
-          "dependencies": {
-            "cross-spawn-async": {
-              "version": "2.1.9",
-              "dependencies": {
-                "which": {
-                  "version": "1.2.4",
-                  "dependencies": {
-                    "is-absolute": {
-                      "version": "0.1.7",
-                      "dependencies": {
-                        "is-relative": {
-                          "version": "0.1.3"
-                        }
-                      }
-                    },
-                    "isexe": {
-                      "version": "1.1.2"
-                    }
-                  }
-                }
-              }
-            },
-            "spawn-sync": {
-              "version": "1.0.15",
-              "dependencies": {
-                "concat-stream": {
-                  "version": "1.5.1",
-                  "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6"
-                    },
-                    "readable-stream": {
-                      "version": "2.0.6",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "1.0.0"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    }
-                  }
-                },
-                "os-shim": {
-                  "version": "0.1.3"
-                }
-              }
-            }
-          }
-        },
-        "gaze": {
-          "version": "0.5.2",
-          "dependencies": {
-            "globule": {
-              "version": "0.1.0",
-              "dependencies": {
-                "lodash": {
-                  "version": "1.0.2"
-                },
-                "glob": {
-                  "version": "3.1.21",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "1.2.3"
-                    },
-                    "inherits": {
-                      "version": "1.0.2"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "0.2.14",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.3"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1"
+          "version": "1.1.3"
         },
         "glob": {
-          "version": "5.0.15",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.4",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.3",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0"
-            }
-          }
+          "version": "5.0.15"
         },
-        "meow": {
-          "version": "3.7.0",
-          "dependencies": {
-            "camelcase-keys": {
-              "version": "2.1.0",
-              "dependencies": {
-                "camelcase": {
-                  "version": "2.1.1"
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.2.0"
-            },
-            "loud-rejection": {
-              "version": "1.3.0",
-              "dependencies": {
-                "array-find-index": {
-                  "version": "1.0.1"
-                },
-                "signal-exit": {
-                  "version": "2.1.2"
-                }
-              }
-            },
-            "map-obj": {
-              "version": "1.0.1"
-            },
-            "minimist": {
-              "version": "1.2.0"
-            },
-            "normalize-package-data": {
-              "version": "2.3.5",
-              "dependencies": {
-                "hosted-git-info": {
-                  "version": "2.1.4"
-                },
-                "is-builtin-module": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "builtin-modules": {
-                      "version": "1.1.1"
-                    }
-                  }
-                },
-                "validate-npm-package-license": {
-                  "version": "3.0.1",
-                  "dependencies": {
-                    "spdx-correct": {
-                      "version": "1.0.2",
-                      "dependencies": {
-                        "spdx-license-ids": {
-                          "version": "1.2.0"
-                        }
-                      }
-                    },
-                    "spdx-expression-parse": {
-                      "version": "1.0.2",
-                      "dependencies": {
-                        "spdx-exceptions": {
-                          "version": "1.0.4"
-                        },
-                        "spdx-license-ids": {
-                          "version": "1.2.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.0.1"
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "dependencies": {
-                "find-up": {
-                  "version": "1.1.2",
-                  "dependencies": {
-                    "path-exists": {
-                      "version": "2.1.0"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4"
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg": {
-                  "version": "1.1.0",
-                  "dependencies": {
-                    "load-json-file": {
-                      "version": "1.1.0",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.3"
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.0",
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4"
-                            }
-                          }
-                        },
-                        "strip-bom": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "is-utf8": {
-                              "version": "0.2.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "path-type": {
-                      "version": "1.1.0",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.3"
-                        },
-                        "pify": {
-                          "version": "2.3.0"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "redent": {
-              "version": "1.0.0",
-              "dependencies": {
-                "indent-string": {
-                  "version": "2.1.0",
-                  "dependencies": {
-                    "repeating": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.1",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-indent": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "trim-newlines": {
-              "version": "1.0.0"
-            }
-          }
+        "has-ansi": {
+          "version": "2.0.0"
         },
-        "mkdirp": {
-          "version": "0.5.1",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
+        "strip-ansi": {
+          "version": "3.0.1"
         },
-        "nan": {
-          "version": "2.2.0"
-        },
-        "npmconf": {
-          "version": "2.1.2",
-          "dependencies": {
-            "config-chain": {
-              "version": "1.1.10",
-              "dependencies": {
-                "proto-list": {
-                  "version": "1.2.4"
-                }
-              }
-            },
-            "ini": {
-              "version": "1.3.4"
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.7"
-                }
-              }
-            },
-            "once": {
-              "version": "1.3.3",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "semver": {
-              "version": "4.3.6"
-            },
-            "uid-number": {
-              "version": "0.0.5"
-            }
-          }
-        },
-        "node-gyp": {
-          "version": "3.3.1",
-          "dependencies": {
-            "fstream": {
-              "version": "1.0.8"
-            },
-            "glob": {
-              "version": "4.5.3",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.3"
-            },
-            "minimatch": {
-              "version": "1.0.0",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3"
-                },
-                "sigmund": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.0.7"
-                }
-              }
-            },
-            "npmlog": {
-              "version": "2.0.3",
-              "dependencies": {
-                "ansi": {
-                  "version": "0.3.1"
-                },
-                "are-we-there-yet": {
-                  "version": "1.1.2",
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0"
-                    },
-                    "readable-stream": {
-                      "version": "2.0.6",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "1.0.0"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    }
-                  }
-                },
-                "gauge": {
-                  "version": "1.2.7",
-                  "dependencies": {
-                    "has-unicode": {
-                      "version": "2.0.0"
-                    },
-                    "lodash.pad": {
-                      "version": "4.1.0",
-                      "dependencies": {
-                        "lodash.repeat": {
-                          "version": "4.0.0"
-                        },
-                        "lodash.tostring": {
-                          "version": "4.1.2"
-                        }
-                      }
-                    },
-                    "lodash.padend": {
-                      "version": "4.2.0",
-                      "dependencies": {
-                        "lodash.repeat": {
-                          "version": "4.0.0"
-                        },
-                        "lodash.tostring": {
-                          "version": "4.1.2"
-                        }
-                      }
-                    },
-                    "lodash.padstart": {
-                      "version": "4.2.0",
-                      "dependencies": {
-                        "lodash.repeat": {
-                          "version": "4.0.0"
-                        },
-                        "lodash.tostring": {
-                          "version": "4.1.2"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "osenv": {
-              "version": "0.1.3",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "path-array": {
-              "version": "1.0.1",
-              "dependencies": {
-                "array-index": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "es6-symbol": {
-                      "version": "3.0.2",
-                      "dependencies": {
-                        "d": {
-                          "version": "0.1.1"
-                        },
-                        "es5-ext": {
-                          "version": "0.10.11",
-                          "dependencies": {
-                            "es6-iterator": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.5.2",
-              "dependencies": {
-                "glob": {
-                  "version": "7.0.3",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.3",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "tar": {
-              "version": "2.2.1",
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.8"
-                }
-              }
-            },
-            "which": {
-              "version": "1.2.4",
-              "dependencies": {
-                "is-absolute": {
-                  "version": "0.1.7",
-                  "dependencies": {
-                    "is-relative": {
-                      "version": "0.1.3"
-                    }
-                  }
-                },
-                "isexe": {
-                  "version": "1.1.2"
-                }
-              }
-            }
-          }
-        },
-        "request": {
-          "version": "2.69.0",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0"
-            },
-            "aws4": {
-              "version": "1.3.2"
-            },
-            "bl": {
-              "version": "1.0.3",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "1.0.0"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                }
-              }
-            },
-            "caseless": {
-              "version": "0.11.0"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0"
-            },
-            "forever-agent": {
-              "version": "0.6.1"
-            },
-            "form-data": {
-              "version": "1.0.0-rc4",
-              "dependencies": {
-                "async": {
-                  "version": "1.5.2"
-                }
-              }
-            },
-            "har-validator": {
-              "version": "2.0.6",
-              "dependencies": {
-                "commander": {
-                  "version": "2.9.0",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.13.1",
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0"
-                    },
-                    "xtend": {
-                      "version": "4.0.1"
-                    }
-                  }
-                },
-                "pinkie-promise": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.4"
-                    }
-                  }
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3"
-                },
-                "boom": {
-                  "version": "2.10.1"
-                },
-                "cryptiles": {
-                  "version": "2.0.5"
-                },
-                "sntp": {
-                  "version": "1.0.9"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0"
-                },
-                "jsprim": {
-                  "version": "1.2.2",
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.0.2"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2"
-                    },
-                    "verror": {
-                      "version": "1.3.6"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.7.4",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3"
-                    },
-                    "dashdash": {
-                      "version": "1.13.0",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "jsbn": {
-                      "version": "0.1.0"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.2"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1"
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0"
-            },
-            "isstream": {
-              "version": "0.1.2"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1"
-            },
-            "mime-types": {
-              "version": "2.1.10",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.22.0"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7"
-            },
-            "oauth-sign": {
-              "version": "0.8.1"
-            },
-            "qs": {
-              "version": "6.0.2"
-            },
-            "stringstream": {
-              "version": "0.0.5"
-            },
-            "tough-cookie": {
-              "version": "2.2.2"
-            },
-            "tunnel-agent": {
-              "version": "0.4.2"
-            }
-          }
-        },
-        "sass-graph": {
-          "version": "2.1.1",
-          "dependencies": {
-            "glob": {
-              "version": "6.0.4",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "yargs": {
-              "version": "3.32.0",
-              "dependencies": {
-                "camelcase": {
-                  "version": "2.1.1"
-                },
-                "cliui": {
-                  "version": "3.1.1",
-                  "dependencies": {
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    },
-                    "wrap-ansi": {
-                      "version": "2.0.0"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0"
-                },
-                "os-locale": {
-                  "version": "1.4.0",
-                  "dependencies": {
-                    "lcid": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "invert-kv": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "string-width": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "window-size": {
-                  "version": "0.1.4"
-                },
-                "y18n": {
-                  "version": "3.2.1"
-                }
-              }
-            }
-          }
+        "supports-color": {
+          "version": "2.0.0"
         }
       }
+    },
+    "node-uuid": {
+      "version": "1.4.7"
+    },
+    "nopt": {
+      "version": "3.0.6"
+    },
+    "normalize-package-data": {
+      "version": "2.3.5"
+    },
+    "normalize-path": {
+      "version": "2.0.1"
+    },
+    "normalize-range": {
+      "version": "0.1.2"
+    },
+    "npm-path": {
+      "version": "1.1.0"
+    },
+    "npm-run": {
+      "version": "1.1.1"
+    },
+    "npmconf": {
+      "version": "2.1.2",
+      "dependencies": {
+        "semver": {
+          "version": "4.3.6"
+        }
+      }
+    },
+    "npmlog": {
+      "version": "2.0.3"
+    },
+    "nth-check": {
+      "version": "1.0.1"
+    },
+    "num2fraction": {
+      "version": "1.2.2"
+    },
+    "number-is-nan": {
+      "version": "1.0.0"
+    },
+    "nwmatcher": {
+      "version": "1.3.7"
+    },
+    "oauth-sign": {
+      "version": "0.8.1"
+    },
+    "object-assign": {
+      "version": "3.0.0"
+    },
+    "object-component": {
+      "version": "0.0.3"
+    },
+    "object-keys": {
+      "version": "1.0.9"
+    },
+    "object.assign": {
+      "version": "4.0.3"
+    },
+    "object.omit": {
+      "version": "2.0.0"
+    },
+    "object.values": {
+      "version": "1.0.3"
+    },
+    "on-finished": {
+      "version": "2.3.0"
+    },
+    "once": {
+      "version": "1.3.3"
+    },
+    "onetime": {
+      "version": "1.1.0"
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10"
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.1",
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "options": {
+      "version": "0.0.6"
+    },
+    "os-browserify": {
+      "version": "0.1.2"
+    },
+    "os-homedir": {
+      "version": "1.0.1"
+    },
+    "os-locale": {
+      "version": "1.4.0"
+    },
+    "os-shim": {
+      "version": "0.1.3"
+    },
+    "os-tmpdir": {
+      "version": "1.0.1"
+    },
+    "osenv": {
+      "version": "0.1.3"
+    },
+    "output-file-sync": {
+      "version": "1.1.1"
     },
     "page": {
       "version": "1.6.4",
       "dependencies": {
         "path-to-regexp": {
-          "version": "1.2.1",
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1"
-            }
-          }
+          "version": "1.2.1"
         }
       }
     },
+    "pako": {
+      "version": "0.2.8"
+    },
+    "param-case": {
+      "version": "1.1.2",
+      "dependencies": {
+        "sentence-case": {
+          "version": "1.1.3"
+        }
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4"
+    },
+    "parse-json": {
+      "version": "2.2.0"
+    },
+    "parse5": {
+      "version": "1.5.1"
+    },
+    "parsejson": {
+      "version": "0.0.1"
+    },
+    "parseqs": {
+      "version": "0.0.2"
+    },
+    "parseuri": {
+      "version": "0.0.2"
+    },
+    "parseurl": {
+      "version": "1.3.1"
+    },
+    "pascal-case": {
+      "version": "1.1.2",
+      "dependencies": {
+        "camel-case": {
+          "version": "1.2.2"
+        },
+        "sentence-case": {
+          "version": "1.1.3"
+        }
+      }
+    },
+    "path-array": {
+      "version": "1.0.1"
+    },
+    "path-browserify": {
+      "version": "0.0.0"
+    },
+    "path-case": {
+      "version": "1.1.2",
+      "dependencies": {
+        "sentence-case": {
+          "version": "1.1.3"
+        }
+      }
+    },
+    "path-exists": {
+      "version": "1.0.0"
+    },
+    "path-is-absolute": {
+      "version": "1.0.0"
+    },
+    "path-is-inside": {
+      "version": "1.0.1"
+    },
     "path-parser": {
       "version": "1.0.2"
+    },
+    "path-to-regexp": {
+      "version": "0.1.7"
+    },
+    "path-type": {
+      "version": "1.1.0"
+    },
+    "pbkdf2-compat": {
+      "version": "2.0.1"
+    },
+    "performance-now": {
+      "version": "0.1.4"
     },
     "phone": {
       "version": "1.0.4-3",
@@ -5502,872 +2818,113 @@
       "resolved": "git+https://github.com/Automattic/node-phone.git#8f012b153e968038c2ce758b7f34e5b8d792eb20"
     },
     "photon": {
-      "version": "2.0.0",
+      "version": "2.0.0"
+    },
+    "pify": {
+      "version": "2.3.0"
+    },
+    "pinkie": {
+      "version": "2.0.4"
+    },
+    "pinkie-promise": {
+      "version": "2.0.1"
+    },
+    "postcss": {
+      "version": "5.0.19",
       "dependencies": {
-        "crc32": {
-          "version": "0.2.2"
-        },
-        "seed-random": {
-          "version": "2.2.0"
+        "source-map": {
+          "version": "0.5.3"
         }
       }
     },
     "postcss-cli": {
-      "version": "2.5.1",
-      "dependencies": {
-        "globby": {
-          "version": "3.0.1",
-          "dependencies": {
-            "array-union": {
-              "version": "1.0.1",
-              "dependencies": {
-                "array-uniq": {
-                  "version": "1.0.2"
-                }
-              }
-            },
-            "arrify": {
-              "version": "1.0.1"
-            },
-            "glob": {
-              "version": "5.0.15",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.0.1"
-            },
-            "pify": {
-              "version": "2.3.0"
-            },
-            "pinkie-promise": {
-              "version": "1.0.0",
-              "dependencies": {
-                "pinkie": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "neo-async": {
-          "version": "1.8.0"
-        },
-        "postcss": {
-          "version": "5.0.19",
-          "dependencies": {
-            "supports-color": {
-              "version": "3.1.2",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.5.3"
-            },
-            "js-base64": {
-              "version": "2.1.9"
-            }
-          }
-        },
-        "read-file-stdin": {
-          "version": "0.2.1",
-          "dependencies": {
-            "gather-stream": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.1.7"
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "dependencies": {
-            "camelcase": {
-              "version": "2.1.1"
-            },
-            "cliui": {
-              "version": "3.1.1",
-              "dependencies": {
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    }
-                  }
-                },
-                "wrap-ansi": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.2.0"
-            },
-            "os-locale": {
-              "version": "1.4.0",
-              "dependencies": {
-                "lcid": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "invert-kv": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "string-width": {
-              "version": "1.0.1",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    }
-                  }
-                }
-              }
-            },
-            "window-size": {
-              "version": "0.1.4"
-            },
-            "y18n": {
-              "version": "3.2.1"
-            }
-          }
-        },
-        "chokidar": {
-          "version": "1.4.3",
-          "dependencies": {
-            "anymatch": {
-              "version": "1.3.0",
-              "dependencies": {
-                "arrify": {
-                  "version": "1.0.1"
-                },
-                "micromatch": {
-                  "version": "2.3.7",
-                  "dependencies": {
-                    "arr-diff": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "arr-flatten": {
-                          "version": "1.0.1"
-                        }
-                      }
-                    },
-                    "array-unique": {
-                      "version": "0.2.1"
-                    },
-                    "braces": {
-                      "version": "1.8.3",
-                      "dependencies": {
-                        "expand-range": {
-                          "version": "1.8.1",
-                          "dependencies": {
-                            "fill-range": {
-                              "version": "2.2.3",
-                              "dependencies": {
-                                "is-number": {
-                                  "version": "2.1.0"
-                                },
-                                "isobject": {
-                                  "version": "2.0.0",
-                                  "dependencies": {
-                                    "isarray": {
-                                      "version": "0.0.1"
-                                    }
-                                  }
-                                },
-                                "randomatic": {
-                                  "version": "1.1.5"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.4"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "preserve": {
-                          "version": "0.2.0"
-                        },
-                        "repeat-element": {
-                          "version": "1.1.2"
-                        }
-                      }
-                    },
-                    "expand-brackets": {
-                      "version": "0.1.4"
-                    },
-                    "extglob": {
-                      "version": "0.3.2"
-                    },
-                    "filename-regex": {
-                      "version": "2.0.0"
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0"
-                    },
-                    "kind-of": {
-                      "version": "3.0.2",
-                      "dependencies": {
-                        "is-buffer": {
-                          "version": "1.1.3"
-                        }
-                      }
-                    },
-                    "normalize-path": {
-                      "version": "2.0.1"
-                    },
-                    "object.omit": {
-                      "version": "2.0.0",
-                      "dependencies": {
-                        "for-own": {
-                          "version": "0.1.4",
-                          "dependencies": {
-                            "for-in": {
-                              "version": "0.1.5"
-                            }
-                          }
-                        },
-                        "is-extendable": {
-                          "version": "0.1.1"
-                        }
-                      }
-                    },
-                    "parse-glob": {
-                      "version": "3.0.4",
-                      "dependencies": {
-                        "glob-base": {
-                          "version": "0.3.0"
-                        },
-                        "is-dotfile": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    },
-                    "regex-cache": {
-                      "version": "0.4.2",
-                      "dependencies": {
-                        "is-equal-shallow": {
-                          "version": "0.1.3"
-                        },
-                        "is-primitive": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "async-each": {
-              "version": "1.0.0"
-            },
-            "glob-parent": {
-              "version": "2.0.0"
-            },
-            "is-binary-path": {
-              "version": "1.0.1",
-              "dependencies": {
-                "binary-extensions": {
-                  "version": "1.4.0"
-                }
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "dependencies": {
-                "is-extglob": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0"
-            },
-            "readdirp": {
-              "version": "2.0.0",
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.3"
-                },
-                "minimatch": {
-                  "version": "2.0.10",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "1.0.0"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    }
-                  }
-                }
-              }
-            },
-            "fsevents": {
-              "version": "1.0.9",
-              "dependencies": {
-                "nan": {
-                  "version": "2.2.0"
-                },
-                "node-pre-gyp": {
-                  "version": "0.6.24",
-                  "dependencies": {
-                    "nopt": {
-                      "version": "3.0.6",
-                      "dependencies": {
-                        "abbrev": {
-                          "version": "1.0.7"
-                        }
-                      }
-                    }
-                  }
-                },
-                "ansi-regex": {
-                  "version": "2.0.0"
-                },
-                "ansi": {
-                  "version": "0.3.1"
-                },
-                "are-we-there-yet": {
-                  "version": "1.1.2"
-                },
-                "ansi-styles": {
-                  "version": "2.1.0"
-                },
-                "asn1": {
-                  "version": "0.2.3"
-                },
-                "assert-plus": {
-                  "version": "0.2.0"
-                },
-                "async": {
-                  "version": "1.5.2"
-                },
-                "bl": {
-                  "version": "1.0.3"
-                },
-                "block-stream": {
-                  "version": "0.0.8"
-                },
-                "boom": {
-                  "version": "2.10.1"
-                },
-                "chalk": {
-                  "version": "1.1.1"
-                },
-                "caseless": {
-                  "version": "0.11.0"
-                },
-                "color-convert": {
-                  "version": "1.0.0"
-                },
-                "combined-stream": {
-                  "version": "1.0.5"
-                },
-                "commander": {
-                  "version": "2.9.0"
-                },
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "cryptiles": {
-                  "version": "2.0.5"
-                },
-                "debug": {
-                  "version": "2.2.0"
-                },
-                "delayed-stream": {
-                  "version": "1.0.0"
-                },
-                "deep-extend": {
-                  "version": "0.4.1"
-                },
-                "delegates": {
-                  "version": "1.0.0"
-                },
-                "ecc-jsbn": {
-                  "version": "0.1.1"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5"
-                },
-                "extend": {
-                  "version": "3.0.0"
-                },
-                "extsprintf": {
-                  "version": "1.0.2"
-                },
-                "aws-sign2": {
-                  "version": "0.6.0"
-                },
-                "forever-agent": {
-                  "version": "0.6.1"
-                },
-                "form-data": {
-                  "version": "1.0.0-rc4"
-                },
-                "fstream": {
-                  "version": "1.0.8"
-                },
-                "gauge": {
-                  "version": "1.2.7"
-                },
-                "generate-object-property": {
-                  "version": "1.2.0"
-                },
-                "graceful-fs": {
-                  "version": "4.1.3"
-                },
-                "har-validator": {
-                  "version": "2.0.6"
-                },
-                "has-ansi": {
-                  "version": "2.0.0"
-                },
-                "has-unicode": {
-                  "version": "2.0.0"
-                },
-                "generate-function": {
-                  "version": "2.0.0"
-                },
-                "graceful-readlink": {
-                  "version": "1.0.1"
-                },
-                "hawk": {
-                  "version": "3.1.3"
-                },
-                "hoek": {
-                  "version": "2.16.3"
-                },
-                "http-signature": {
-                  "version": "1.1.1"
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "is-my-json-valid": {
-                  "version": "2.13.1"
-                },
-                "is-property": {
-                  "version": "1.0.2"
-                },
-                "is-typedarray": {
-                  "version": "1.0.0"
-                },
-                "ini": {
-                  "version": "1.3.4"
-                },
-                "isarray": {
-                  "version": "1.0.0"
-                },
-                "isstream": {
-                  "version": "0.1.2"
-                },
-                "jodid25519": {
-                  "version": "1.0.2"
-                },
-                "jsbn": {
-                  "version": "0.1.0"
-                },
-                "json-stringify-safe": {
-                  "version": "5.0.1"
-                },
-                "json-schema": {
-                  "version": "0.2.2"
-                },
-                "jsonpointer": {
-                  "version": "2.0.0"
-                },
-                "jsprim": {
-                  "version": "1.2.2"
-                },
-                "lodash.pad": {
-                  "version": "4.1.0"
-                },
-                "lodash.padend": {
-                  "version": "4.2.0"
-                },
-                "lodash.padstart": {
-                  "version": "4.2.0"
-                },
-                "lodash.repeat": {
-                  "version": "4.0.0"
-                },
-                "lodash.tostring": {
-                  "version": "4.1.2"
-                },
-                "mime-db": {
-                  "version": "1.22.0"
-                },
-                "mime-types": {
-                  "version": "2.1.10"
-                },
-                "minimist": {
-                  "version": "0.0.8"
-                },
-                "mkdirp": {
-                  "version": "0.5.1"
-                },
-                "ms": {
-                  "version": "0.7.1"
-                },
-                "npmlog": {
-                  "version": "2.0.3"
-                },
-                "node-uuid": {
-                  "version": "1.4.7"
-                },
-                "oauth-sign": {
-                  "version": "0.8.1"
-                },
-                "once": {
-                  "version": "1.3.3"
-                },
-                "pinkie": {
-                  "version": "2.0.4"
-                },
-                "pinkie-promise": {
-                  "version": "2.0.0"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6"
-                },
-                "qs": {
-                  "version": "6.0.2"
-                },
-                "readable-stream": {
-                  "version": "2.0.6"
-                },
-                "request": {
-                  "version": "2.69.0"
-                },
-                "sntp": {
-                  "version": "1.0.9"
-                },
-                "sshpk": {
-                  "version": "1.7.4"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                },
-                "stringstream": {
-                  "version": "0.0.5"
-                },
-                "strip-ansi": {
-                  "version": "3.0.1"
-                },
-                "strip-json-comments": {
-                  "version": "1.0.4"
-                },
-                "supports-color": {
-                  "version": "2.0.0"
-                },
-                "tar": {
-                  "version": "2.2.1"
-                },
-                "tar-pack": {
-                  "version": "3.1.3"
-                },
-                "semver": {
-                  "version": "5.1.0"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.2"
-                },
-                "tough-cookie": {
-                  "version": "2.2.2"
-                },
-                "tweetnacl": {
-                  "version": "0.14.1"
-                },
-                "uid-number": {
-                  "version": "0.0.6"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2"
-                },
-                "verror": {
-                  "version": "1.3.6"
-                },
-                "wrappy": {
-                  "version": "1.0.1"
-                },
-                "xtend": {
-                  "version": "4.0.1"
-                },
-                "dashdash": {
-                  "version": "1.13.0",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "rc": {
-                  "version": "1.1.6",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "1.2.0"
-                    }
-                  }
-                },
-                "aws4": {
-                  "version": "1.3.2",
-                  "dependencies": {
-                    "lru-cache": {
-                      "version": "4.0.0",
-                      "dependencies": {
-                        "pseudomap": {
-                          "version": "1.0.2"
-                        },
-                        "yallist": {
-                          "version": "2.0.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "fstream-ignore": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "3.0.0",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.5.2",
-                  "dependencies": {
-                    "glob": {
-                      "version": "7.0.3",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1"
-                        },
-                        "minimatch": {
-                          "version": "3.0.0",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.3",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.3.0"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.3.3",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      "version": "2.5.1"
+    },
+    "postcss-value-parser": {
+      "version": "3.3.0"
+    },
+    "prelude-ls": {
+      "version": "1.1.2"
+    },
+    "preserve": {
+      "version": "0.2.0"
+    },
+    "private": {
+      "version": "0.1.6"
+    },
+    "process": {
+      "version": "0.11.2"
+    },
+    "process-nextick-args": {
+      "version": "1.0.6"
+    },
+    "progress-event": {
+      "version": "1.0.0"
+    },
+    "promise": {
+      "version": "7.1.1"
+    },
+    "propagate": {
+      "version": "0.3.1"
+    },
+    "proto-list": {
+      "version": "1.2.4"
+    },
+    "protochain": {
+      "version": "1.0.3"
+    },
+    "proxy-addr": {
+      "version": "1.0.10"
+    },
+    "pseudomap": {
+      "version": "1.0.2"
+    },
+    "punycode": {
+      "version": "1.4.1"
     },
     "q": {
       "version": "1.0.1"
     },
+    "qr.js": {
+      "version": "0.0.0"
+    },
     "qrcode.react": {
-      "version": "0.5.2",
-      "dependencies": {
-        "qr.js": {
-          "version": "0.0.0"
-        }
-      }
+      "version": "0.5.2"
     },
     "qs": {
       "version": "4.0.0"
     },
+    "querystring": {
+      "version": "0.2.0"
+    },
+    "querystring-es3": {
+      "version": "0.2.1"
+    },
     "raf": {
-      "version": "2.0.4",
+      "version": "2.0.4"
+    },
+    "randomatic": {
+      "version": "1.1.5"
+    },
+    "range-parser": {
+      "version": "1.0.3"
+    },
+    "raw-body": {
+      "version": "2.1.6",
       "dependencies": {
-        "performance-now": {
-          "version": "0.1.4"
+        "bytes": {
+          "version": "2.3.0"
         }
       }
     },
     "react": {
       "version": "0.14.3",
       "dependencies": {
-        "envify": {
-          "version": "3.4.0",
-          "dependencies": {
-            "through": {
-              "version": "2.3.8"
-            },
-            "jstransform": {
-              "version": "10.1.0",
-              "dependencies": {
-                "base62": {
-                  "version": "0.1.1"
-                },
-                "esprima-fb": {
-                  "version": "13001.1001.0-dev-harmony-fb"
-                },
-                "source-map": {
-                  "version": "0.1.31",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
+        "core-js": {
+          "version": "1.2.6"
         },
         "fbjs": {
-          "version": "0.3.2",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.6"
-            },
-            "loose-envify": {
-              "version": "1.1.0",
-              "dependencies": {
-                "js-tokens": {
-                  "version": "1.0.3"
-                }
-              }
-            },
-            "promise": {
-              "version": "7.1.1",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.3"
-                }
-              }
-            },
-            "ua-parser-js": {
-              "version": "0.7.10"
-            },
-            "whatwg-fetch": {
-              "version": "0.9.0"
-            }
-          }
+          "version": "0.3.2"
         }
       }
     },
@@ -6400,91 +2957,17 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.6"
-        },
-        "deep-equal": {
-          "version": "1.0.1"
-        },
-        "invariant": {
-          "version": "2.1.2",
-          "dependencies": {
-            "loose-envify": {
-              "version": "1.1.0",
-              "dependencies": {
-                "js-tokens": {
-                  "version": "1.0.3"
-                }
-              }
-            }
-          }
-        },
-        "react-side-effect": {
-          "version": "1.0.2",
-          "dependencies": {
-            "fbjs": {
-              "version": "0.1.0-alpha.10",
-              "dependencies": {
-                "promise": {
-                  "version": "7.1.1",
-                  "dependencies": {
-                    "asap": {
-                      "version": "2.0.3"
-                    }
-                  }
-                },
-                "whatwg-fetch": {
-                  "version": "0.9.0"
-                }
-              }
-            }
-          }
-        },
-        "shallowequal": {
-          "version": "0.2.2",
-          "dependencies": {
-            "lodash.keys": {
-              "version": "3.1.2",
-              "dependencies": {
-                "lodash._getnative": {
-                  "version": "3.9.1"
-                },
-                "lodash.isarguments": {
-                  "version": "3.0.8"
-                },
-                "lodash.isarray": {
-                  "version": "3.0.4"
-                }
-              }
-            }
-          }
-        },
-        "warning": {
-          "version": "2.1.0",
-          "dependencies": {
-            "loose-envify": {
-              "version": "1.1.0",
-              "dependencies": {
-                "js-tokens": {
-                  "version": "1.0.3"
-                }
-              }
-            }
-          }
         }
       }
+    },
+    "react-hot-api": {
+      "version": "0.4.7"
     },
     "react-hot-loader": {
       "version": "1.3.0",
       "dependencies": {
-        "react-hot-api": {
-          "version": "0.4.7"
-        },
         "source-map": {
-          "version": "0.4.4",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.0"
-            }
-          }
+          "version": "0.4.4"
         }
       }
     },
@@ -6492,49 +2975,72 @@
       "version": "1.0.2"
     },
     "react-redux": {
-      "version": "4.0.1",
+      "version": "4.0.1"
+    },
+    "react-side-effect": {
+      "version": "1.0.2",
       "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "1.0.5"
+        "core-js": {
+          "version": "1.2.6"
         },
-        "invariant": {
-          "version": "2.2.1",
-          "dependencies": {
-            "loose-envify": {
-              "version": "1.1.0",
-              "dependencies": {
-                "js-tokens": {
-                  "version": "1.0.3"
-                }
-              }
-            }
-          }
+        "fbjs": {
+          "version": "0.1.0-alpha.10"
         }
       }
     },
     "react-tap-event-plugin": {
       "version": "0.2.1",
       "dependencies": {
+        "core-js": {
+          "version": "1.2.6"
+        },
         "fbjs": {
-          "version": "0.2.1",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.6"
-            },
-            "promise": {
-              "version": "7.1.1",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.3"
-                }
-              }
-            },
-            "whatwg-fetch": {
-              "version": "0.9.0"
-            }
-          }
+          "version": "0.2.1"
         }
       }
+    },
+    "read-file-stdin": {
+      "version": "0.2.1"
+    },
+    "read-json-sync": {
+      "version": "1.1.1"
+    },
+    "read-pkg": {
+      "version": "1.1.0"
+    },
+    "read-pkg-up": {
+      "version": "1.0.1"
+    },
+    "readable-stream": {
+      "version": "2.1.0",
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0"
+        }
+      }
+    },
+    "readdirp": {
+      "version": "2.0.0"
+    },
+    "readline2": {
+      "version": "1.0.1"
+    },
+    "recast": {
+      "version": "0.10.18",
+      "dependencies": {
+        "esprima-fb": {
+          "version": "14001.1.0-dev-harmony-fb"
+        },
+        "source-map": {
+          "version": "0.4.4"
+        }
+      }
+    },
+    "redent": {
+      "version": "1.0.0"
+    },
+    "reduce-component": {
+      "version": "1.0.1"
     },
     "redux": {
       "version": "3.0.4"
@@ -6542,445 +3048,405 @@
     "redux-thunk": {
       "version": "1.0.0"
     },
+    "regenerate": {
+      "version": "1.2.1"
+    },
+    "regenerator": {
+      "version": "0.8.34"
+    },
+    "regex-cache": {
+      "version": "0.4.3"
+    },
+    "regexp-quote": {
+      "version": "0.0.0"
+    },
+    "regexpu": {
+      "version": "1.3.0",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.2"
+        }
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0"
+    },
+    "regjsparser": {
+      "version": "0.1.5"
+    },
+    "relateurl": {
+      "version": "0.2.6"
+    },
+    "repeat-element": {
+      "version": "1.1.2"
+    },
+    "repeat-string": {
+      "version": "1.5.4"
+    },
+    "repeating": {
+      "version": "1.1.3"
+    },
+    "request": {
+      "version": "2.71.0",
+      "dependencies": {
+        "qs": {
+          "version": "6.1.0"
+        }
+      }
+    },
+    "requireindex": {
+      "version": "1.1.0"
+    },
+    "requires-port": {
+      "version": "1.0.0"
+    },
+    "resolve": {
+      "version": "1.1.7"
+    },
+    "restore-cursor": {
+      "version": "1.0.1"
+    },
     "rewire": {
       "version": "2.3.3"
+    },
+    "right-align": {
+      "version": "0.1.3"
+    },
+    "rimraf": {
+      "version": "2.5.2",
+      "dependencies": {
+        "glob": {
+          "version": "7.0.3"
+        }
+      }
+    },
+    "ripemd160": {
+      "version": "0.2.0"
+    },
+    "rocambole": {
+      "version": "0.7.0",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.2"
+        }
+      }
+    },
+    "rocambole-indent": {
+      "version": "2.0.4",
+      "dependencies": {
+        "mout": {
+          "version": "0.11.1"
+        }
+      }
+    },
+    "rocambole-linebreak": {
+      "version": "1.0.1",
+      "dependencies": {
+        "semver": {
+          "version": "4.3.6"
+        }
+      }
+    },
+    "rocambole-node": {
+      "version": "1.0.0"
+    },
+    "rocambole-token": {
+      "version": "1.2.1"
+    },
+    "rocambole-whitespace": {
+      "version": "1.0.0"
     },
     "rtlcss": {
       "version": "1.6.1",
       "dependencies": {
-        "postcss": {
-          "version": "4.1.16",
-          "dependencies": {
-            "es6-promise": {
-              "version": "2.3.0"
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "js-base64": {
-              "version": "2.1.9"
-            }
-          }
-        },
-        "findup": {
-          "version": "0.1.5",
-          "dependencies": {
-            "colors": {
-              "version": "0.6.2"
-            },
-            "commander": {
-              "version": "2.1.0"
-            }
-          }
-        },
-        "strip-json-comments": {
-          "version": "1.0.4"
+        "minimist": {
+          "version": "0.0.8"
         },
         "mkdirp": {
-          "version": "0.5.0",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
+          "version": "0.5.0"
+        },
+        "postcss": {
+          "version": "4.1.16"
+        },
+        "source-map": {
+          "version": "0.4.4"
         }
       }
     },
+    "run-async": {
+      "version": "0.1.0"
+    },
+    "rx-lite": {
+      "version": "3.1.2"
+    },
+    "samsam": {
+      "version": "1.1.3"
+    },
     "sanitize-html": {
-      "version": "1.11.1",
+      "version": "1.11.1"
+    },
+    "sass-graph": {
+      "version": "2.1.1",
       "dependencies": {
-        "htmlparser2": {
-          "version": "3.8.3",
-          "dependencies": {
-            "domhandler": {
-              "version": "2.3.0"
-            },
-            "domutils": {
-              "version": "1.5.1",
-              "dependencies": {
-                "dom-serializer": {
-                  "version": "0.1.0",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.1.3"
-                    },
-                    "entities": {
-                      "version": "1.1.1"
-                    }
-                  }
-                }
-              }
-            },
-            "domelementtype": {
-              "version": "1.3.0"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                }
-              }
-            },
-            "entities": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "regexp-quote": {
-          "version": "0.0.0"
-        },
-        "xtend": {
-          "version": "4.0.1"
+        "glob": {
+          "version": "6.0.4"
         }
       }
+    },
+    "sax": {
+      "version": "1.2.1"
+    },
+    "seed-random": {
+      "version": "2.2.0"
+    },
+    "select": {
+      "version": "1.0.6"
     },
     "semver": {
       "version": "5.1.0"
     },
-    "sinon": {
-      "version": "1.12.2",
+    "send": {
+      "version": "0.13.0",
       "dependencies": {
-        "formatio": {
-          "version": "1.1.1",
-          "dependencies": {
-            "samsam": {
-              "version": "1.1.3"
-            }
-          }
+        "depd": {
+          "version": "1.0.1"
         },
-        "util": {
-          "version": "0.10.3"
-        },
-        "lolex": {
-          "version": "1.1.0"
+        "http-errors": {
+          "version": "1.3.1"
         }
       }
+    },
+    "sentence-case": {
+      "version": "0.1.2"
+    },
+    "serializerr": {
+      "version": "1.0.2"
+    },
+    "serve-index": {
+      "version": "1.7.3",
+      "dependencies": {
+        "escape-html": {
+          "version": "1.0.3"
+        },
+        "http-errors": {
+          "version": "1.3.1"
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.10.2",
+      "dependencies": {
+        "destroy": {
+          "version": "1.0.4"
+        },
+        "escape-html": {
+          "version": "1.0.3"
+        },
+        "http-errors": {
+          "version": "1.3.1"
+        },
+        "send": {
+          "version": "0.13.1"
+        }
+      }
+    },
+    "sha.js": {
+      "version": "2.2.6"
+    },
+    "shallowequal": {
+      "version": "0.2.2"
+    },
+    "shebang-regex": {
+      "version": "1.0.0"
+    },
+    "shelljs": {
+      "version": "0.5.3"
+    },
+    "sigmund": {
+      "version": "1.0.1"
+    },
+    "signal-exit": {
+      "version": "2.1.2"
+    },
+    "simple-fmt": {
+      "version": "0.1.0"
+    },
+    "simple-is": {
+      "version": "0.2.0"
+    },
+    "sinon": {
+      "version": "1.12.2"
     },
     "sinon-chai": {
       "version": "2.7.0"
     },
+    "slash": {
+      "version": "1.0.0"
+    },
+    "snake-case": {
+      "version": "1.1.2",
+      "dependencies": {
+        "sentence-case": {
+          "version": "1.1.3"
+        }
+      }
+    },
+    "sntp": {
+      "version": "1.0.9"
+    },
     "socket.io": {
       "version": "1.3.7",
       "dependencies": {
-        "engine.io": {
-          "version": "1.5.4",
-          "dependencies": {
-            "base64id": {
-              "version": "0.1.0"
-            },
-            "debug": {
-              "version": "1.0.3",
-              "dependencies": {
-                "ms": {
-                  "version": "0.6.2"
-                }
-              }
-            },
-            "engine.io-parser": {
-              "version": "1.2.2",
-              "dependencies": {
-                "after": {
-                  "version": "0.8.1"
-                },
-                "arraybuffer.slice": {
-                  "version": "0.0.6"
-                },
-                "base64-arraybuffer": {
-                  "version": "0.1.2"
-                },
-                "has-binary": {
-                  "version": "0.1.6",
-                  "dependencies": {
-                    "isarray": {
-                      "version": "0.0.1"
-                    }
-                  }
-                },
-                "utf8": {
-                  "version": "2.1.0"
-                }
-              }
-            },
-            "ws": {
-              "version": "0.8.0",
-              "dependencies": {
-                "options": {
-                  "version": "0.0.6"
-                },
-                "ultron": {
-                  "version": "1.0.2"
-                },
-                "bufferutil": {
-                  "version": "1.2.1",
-                  "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1"
-                    },
-                    "nan": {
-                      "version": "2.2.0"
-                    }
-                  }
-                },
-                "utf-8-validate": {
-                  "version": "1.2.1",
-                  "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1"
-                    },
-                    "nan": {
-                      "version": "2.2.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
+        "debug": {
+          "version": "2.1.0"
         },
-        "socket.io-parser": {
-          "version": "2.2.4",
-          "dependencies": {
-            "debug": {
-              "version": "0.7.4"
-            },
-            "json3": {
-              "version": "3.2.6"
-            },
-            "component-emitter": {
-              "version": "1.1.2"
-            },
-            "isarray": {
-              "version": "0.0.1"
-            },
-            "benchmark": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "socket.io-client": {
-          "version": "1.3.7",
-          "dependencies": {
-            "debug": {
-              "version": "0.7.4"
-            },
-            "engine.io-client": {
-              "version": "1.5.4",
-              "dependencies": {
-                "component-inherit": {
-                  "version": "0.0.3"
-                },
-                "debug": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.6.2"
-                    }
-                  }
-                },
-                "engine.io-parser": {
-                  "version": "1.2.2",
-                  "dependencies": {
-                    "after": {
-                      "version": "0.8.1"
-                    },
-                    "arraybuffer.slice": {
-                      "version": "0.0.6"
-                    },
-                    "base64-arraybuffer": {
-                      "version": "0.1.2"
-                    },
-                    "utf8": {
-                      "version": "2.1.0"
-                    }
-                  }
-                },
-                "has-cors": {
-                  "version": "1.0.3",
-                  "dependencies": {
-                    "global": {
-                      "version": "2.0.1",
-                      "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
-                    }
-                  }
-                },
-                "parsejson": {
-                  "version": "0.0.1"
-                },
-                "parseqs": {
-                  "version": "0.0.2"
-                },
-                "parseuri": {
-                  "version": "0.0.4"
-                },
-                "ws": {
-                  "version": "0.8.0",
-                  "dependencies": {
-                    "options": {
-                      "version": "0.0.6"
-                    },
-                    "ultron": {
-                      "version": "1.0.2"
-                    },
-                    "bufferutil": {
-                      "version": "1.2.1",
-                      "dependencies": {
-                        "bindings": {
-                          "version": "1.2.1"
-                        },
-                        "nan": {
-                          "version": "2.2.0"
-                        }
-                      }
-                    },
-                    "utf-8-validate": {
-                      "version": "1.2.1",
-                      "dependencies": {
-                        "bindings": {
-                          "version": "1.2.1"
-                        },
-                        "nan": {
-                          "version": "2.2.0"
-                        }
-                      }
-                    }
-                  }
-                },
-                "xmlhttprequest": {
-                  "version": "1.5.0",
-                  "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
-                }
-              }
-            },
-            "component-bind": {
-              "version": "1.0.0"
-            },
-            "component-emitter": {
-              "version": "1.1.2"
-            },
-            "object-component": {
-              "version": "0.0.3"
-            },
-            "has-binary": {
-              "version": "0.1.6",
-              "dependencies": {
-                "isarray": {
-                  "version": "0.0.1"
-                }
-              }
-            },
-            "indexof": {
-              "version": "0.0.1"
-            },
-            "parseuri": {
-              "version": "0.0.2"
-            },
-            "to-array": {
-              "version": "0.1.3"
-            },
-            "backo2": {
-              "version": "1.0.2"
-            }
-          }
-        },
-        "socket.io-adapter": {
-          "version": "0.3.1",
-          "dependencies": {
-            "debug": {
-              "version": "1.0.2",
-              "dependencies": {
-                "ms": {
-                  "version": "0.6.2"
-                }
-              }
-            },
-            "socket.io-parser": {
-              "version": "2.2.2",
-              "dependencies": {
-                "debug": {
-                  "version": "0.7.4"
-                },
-                "json3": {
-                  "version": "3.2.6"
-                },
-                "component-emitter": {
-                  "version": "1.1.2"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "benchmark": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "object-keys": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "has-binary-data": {
-          "version": "0.1.3",
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1"
-            }
-          }
+        "ms": {
+          "version": "0.6.2"
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "0.3.1",
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2"
         },
         "debug": {
-          "version": "2.1.0",
+          "version": "1.0.2"
+        },
+        "ms": {
+          "version": "0.6.2"
+        },
+        "object-keys": {
+          "version": "1.0.1"
+        },
+        "socket.io-parser": {
+          "version": "2.2.2",
           "dependencies": {
-            "ms": {
-              "version": "0.6.2"
+            "debug": {
+              "version": "0.7.4"
             }
           }
         }
       }
     },
-    "source-map": {
-      "version": "0.1.39",
+    "socket.io-client": {
+      "version": "1.3.7",
       "dependencies": {
-        "amdefine": {
-          "version": "1.0.0"
+        "component-emitter": {
+          "version": "1.1.2"
+        },
+        "debug": {
+          "version": "0.7.4"
         }
       }
+    },
+    "socket.io-parser": {
+      "version": "2.2.4",
+      "dependencies": {
+        "component-emitter": {
+          "version": "1.1.2"
+        },
+        "debug": {
+          "version": "0.7.4"
+        }
+      }
+    },
+    "source-list-map": {
+      "version": "0.1.6"
+    },
+    "source-map": {
+      "version": "0.1.39"
     },
     "source-map-support": {
       "version": "0.3.2",
       "dependencies": {
         "source-map": {
-          "version": "0.1.32",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.0"
-            }
-          }
+          "version": "0.1.32"
         }
       }
     },
+    "spawn-sync": {
+      "version": "1.0.15"
+    },
+    "spdx-correct": {
+      "version": "1.0.2"
+    },
+    "spdx-exceptions": {
+      "version": "1.0.4"
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.2"
+    },
+    "spdx-license-ids": {
+      "version": "1.2.1"
+    },
+    "sprintf-js": {
+      "version": "1.0.3"
+    },
     "srcset": {
-      "version": "1.0.0",
-      "dependencies": {
-        "array-uniq": {
-          "version": "1.0.2"
-        },
-        "number-is-nan": {
-          "version": "1.0.0"
-        }
-      }
+      "version": "1.0.0"
+    },
+    "sshpk": {
+      "version": "1.7.4"
+    },
+    "stable": {
+      "version": "0.1.5"
+    },
+    "statuses": {
+      "version": "1.2.1"
+    },
+    "stdin": {
+      "version": "0.0.1"
     },
     "store": {
       "version": "1.3.16"
+    },
+    "stream-browserify": {
+      "version": "1.0.0",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14"
+        }
+      }
+    },
+    "stream-cache": {
+      "version": "0.0.2"
+    },
+    "string_decoder": {
+      "version": "0.10.31"
+    },
+    "string-width": {
+      "version": "1.0.1",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.0.0"
+        },
+        "strip-ansi": {
+          "version": "3.0.1"
+        }
+      }
+    },
+    "stringmap": {
+      "version": "0.2.2"
+    },
+    "stringset": {
+      "version": "0.2.1"
+    },
+    "stringstream": {
+      "version": "0.0.5"
+    },
+    "strip-ansi": {
+      "version": "2.0.1"
+    },
+    "strip-bom": {
+      "version": "2.0.0"
+    },
+    "strip-indent": {
+      "version": "1.0.1"
+    },
+    "strip-json-comments": {
+      "version": "1.0.4"
     },
     "striptags": {
       "version": "2.1.1"
@@ -6988,160 +3454,169 @@
     "superagent": {
       "version": "1.2.0",
       "dependencies": {
-        "qs": {
-          "version": "2.3.3"
-        },
-        "formidable": {
-          "version": "1.0.14"
-        },
-        "mime": {
-          "version": "1.3.4"
+        "combined-stream": {
+          "version": "0.0.7"
         },
         "component-emitter": {
           "version": "1.1.2"
         },
-        "methods": {
-          "version": "1.0.1"
-        },
-        "cookiejar": {
-          "version": "2.0.1"
-        },
-        "reduce-component": {
-          "version": "1.0.1"
+        "delayed-stream": {
+          "version": "0.0.5"
         },
         "extend": {
           "version": "1.2.1"
         },
         "form-data": {
-          "version": "0.2.0",
-          "dependencies": {
-            "combined-stream": {
-              "version": "0.0.7",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5"
-                }
-              }
-            },
-            "mime-types": {
-              "version": "2.0.14",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.12.0"
-                }
-              }
-            }
-          }
+          "version": "0.2.0"
+        },
+        "methods": {
+          "version": "1.0.1"
+        },
+        "mime-db": {
+          "version": "1.12.0"
+        },
+        "mime-types": {
+          "version": "2.0.14"
+        },
+        "qs": {
+          "version": "2.3.3"
         },
         "readable-stream": {
-          "version": "1.0.27-1",
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.2"
-            },
-            "isarray": {
-              "version": "0.0.1"
-            },
-            "string_decoder": {
-              "version": "0.10.31"
-            }
-          }
+          "version": "1.0.27-1"
         }
       }
     },
     "supertest": {
       "version": "1.2.0",
       "dependencies": {
-        "superagent": {
-          "version": "1.8.3",
-          "dependencies": {
-            "qs": {
-              "version": "2.3.3"
-            },
-            "formidable": {
-              "version": "1.0.17"
-            },
-            "mime": {
-              "version": "1.3.4"
-            },
-            "component-emitter": {
-              "version": "1.2.0"
-            },
-            "cookiejar": {
-              "version": "2.0.6"
-            },
-            "reduce-component": {
-              "version": "1.0.1"
-            },
-            "extend": {
-              "version": "3.0.0"
-            },
-            "form-data": {
-              "version": "1.0.0-rc3",
-              "dependencies": {
-                "async": {
-                  "version": "1.5.2"
-                },
-                "combined-stream": {
-                  "version": "1.0.5",
-                  "dependencies": {
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "mime-types": {
-                  "version": "2.1.10",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.22.0"
-                    }
-                  }
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "1.0.27-1",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                }
-              }
-            }
-          }
+        "async": {
+          "version": "1.5.2"
         },
-        "methods": {
-          "version": "1.1.2"
+        "component-emitter": {
+          "version": "1.2.0"
+        },
+        "cookiejar": {
+          "version": "2.0.6"
+        },
+        "form-data": {
+          "version": "1.0.0-rc3"
+        },
+        "qs": {
+          "version": "2.3.3"
+        },
+        "readable-stream": {
+          "version": "1.0.27-1"
+        },
+        "superagent": {
+          "version": "1.8.3"
         }
       }
+    },
+    "supports-color": {
+      "version": "3.1.2"
+    },
+    "swap-case": {
+      "version": "1.1.2"
+    },
+    "symbol-tree": {
+      "version": "3.1.4"
+    },
+    "sync-exec": {
+      "version": "0.5.0"
+    },
+    "tapable": {
+      "version": "0.1.10"
+    },
+    "tar": {
+      "version": "2.2.1"
+    },
+    "text-table": {
+      "version": "0.2.0"
+    },
+    "through": {
+      "version": "2.3.8"
+    },
+    "through2": {
+      "version": "0.6.5",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34"
+        }
+      }
+    },
+    "timers-browserify": {
+      "version": "1.4.2"
+    },
+    "tiny-emitter": {
+      "version": "1.0.2"
     },
     "tinymce": {
       "version": "4.3.8"
     },
-    "to-title-case": {
-      "version": "0.1.5",
+    "title-case": {
+      "version": "1.1.2",
       "dependencies": {
-        "escape-regexp-component": {
-          "version": "1.0.2"
-        },
-        "title-case-minors": {
-          "version": "0.0.2"
-        },
-        "to-capital-case": {
-          "version": "0.1.1",
-          "dependencies": {
-            "to-no-case": {
-              "version": "0.1.1"
-            }
-          }
+        "sentence-case": {
+          "version": "1.1.3"
         }
       }
+    },
+    "title-case-minors": {
+      "version": "0.0.2"
+    },
+    "to-array": {
+      "version": "0.1.3"
+    },
+    "to-camel-case": {
+      "version": "0.2.1"
+    },
+    "to-capital-case": {
+      "version": "0.1.1"
+    },
+    "to-fast-properties": {
+      "version": "1.0.2"
+    },
+    "to-function": {
+      "version": "2.0.6"
+    },
+    "to-no-case": {
+      "version": "0.1.1"
+    },
+    "to-space-case": {
+      "version": "0.1.2"
+    },
+    "to-title-case": {
+      "version": "0.1.5"
+    },
+    "token-stream": {
+      "version": "0.0.1"
+    },
+    "tough-cookie": {
+      "version": "2.2.2"
+    },
+    "tr46": {
+      "version": "0.0.3"
+    },
+    "trim-newlines": {
+      "version": "1.0.0"
+    },
+    "trim-right": {
+      "version": "1.0.1"
+    },
+    "try-resolve": {
+      "version": "1.0.1"
+    },
+    "tryit": {
+      "version": "1.0.2"
+    },
+    "tryor": {
+      "version": "0.1.2"
+    },
+    "tty-browserify": {
+      "version": "0.0.0"
+    },
+    "tunnel-agent": {
+      "version": "0.4.2"
     },
     "tv4": {
       "version": "1.2.7"
@@ -7149,8 +3624,26 @@
     "tween.js": {
       "version": "16.3.1"
     },
+    "tweetnacl": {
+      "version": "0.14.3"
+    },
     "twemoji": {
       "version": "1.3.2"
+    },
+    "type-check": {
+      "version": "0.3.2"
+    },
+    "type-detect": {
+      "version": "0.1.1"
+    },
+    "type-is": {
+      "version": "1.6.12"
+    },
+    "typedarray": {
+      "version": "0.0.6"
+    },
+    "ua-parser-js": {
+      "version": "0.7.10"
     },
     "uglify-js": {
       "version": "2.6.1",
@@ -7161,94 +3654,113 @@
         "source-map": {
           "version": "0.5.3"
         },
-        "uglify-to-browserify": {
-          "version": "1.0.2"
+        "window-size": {
+          "version": "0.1.0"
         },
         "yargs": {
-          "version": "3.10.0",
-          "dependencies": {
-            "camelcase": {
-              "version": "1.2.1"
-            },
-            "cliui": {
-              "version": "2.1.0",
-              "dependencies": {
-                "center-align": {
-                  "version": "0.1.3",
-                  "dependencies": {
-                    "align-text": {
-                      "version": "0.1.4",
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.0.2",
-                          "dependencies": {
-                            "is-buffer": {
-                              "version": "1.1.3"
-                            }
-                          }
-                        },
-                        "longest": {
-                          "version": "1.0.1"
-                        },
-                        "repeat-string": {
-                          "version": "1.5.4"
-                        }
-                      }
-                    },
-                    "lazy-cache": {
-                      "version": "1.0.3"
-                    }
-                  }
-                },
-                "right-align": {
-                  "version": "0.1.3",
-                  "dependencies": {
-                    "align-text": {
-                      "version": "0.1.4",
-                      "dependencies": {
-                        "kind-of": {
-                          "version": "3.0.2",
-                          "dependencies": {
-                            "is-buffer": {
-                              "version": "1.1.3"
-                            }
-                          }
-                        },
-                        "longest": {
-                          "version": "1.0.1"
-                        },
-                        "repeat-string": {
-                          "version": "1.5.4"
-                        }
-                      }
-                    }
-                  }
-                },
-                "wordwrap": {
-                  "version": "0.0.2"
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.2.0"
-            },
-            "window-size": {
-              "version": "0.1.0"
-            }
-          }
+          "version": "3.10.0"
         }
       }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2"
+    },
+    "uid": {
+      "version": "0.0.2"
+    },
+    "uid-number": {
+      "version": "0.0.5"
+    },
+    "ultron": {
+      "version": "1.0.2"
+    },
+    "unpipe": {
+      "version": "1.0.0"
+    },
+    "unquoted-property-validator": {
+      "version": "1.0.0"
+    },
+    "unreachable-branch-transform": {
+      "version": "0.5.1",
+      "dependencies": {
+        "ast-types": {
+          "version": "0.8.16"
+        },
+        "esprima": {
+          "version": "2.7.2"
+        },
+        "recast": {
+          "version": "0.11.5"
+        },
+        "source-map": {
+          "version": "0.5.3"
+        }
+      }
+    },
+    "upper-case": {
+      "version": "1.1.3"
+    },
+    "upper-case-first": {
+      "version": "1.1.2"
+    },
+    "uppercamelcase": {
+      "version": "1.1.0"
+    },
+    "url": {
+      "version": "0.10.3",
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2"
+        }
+      }
+    },
+    "user-home": {
+      "version": "1.1.1"
+    },
+    "utf-8-validate": {
+      "version": "1.2.1"
+    },
+    "utf8": {
+      "version": "2.1.0"
+    },
+    "util": {
+      "version": "0.10.3"
+    },
+    "util-deprecate": {
+      "version": "1.0.2"
+    },
+    "utils-merge": {
+      "version": "1.0.0"
     },
     "valid-url": {
       "version": "1.0.9"
     },
+    "validate-npm-package-license": {
+      "version": "3.0.1"
+    },
+    "vary": {
+      "version": "1.0.1"
+    },
+    "verror": {
+      "version": "1.3.6"
+    },
+    "vm-browserify": {
+      "version": "0.0.4"
+    },
+    "void-elements": {
+      "version": "2.0.1"
+    },
     "walk": {
-      "version": "2.3.4",
-      "dependencies": {
-        "foreachasync": {
-          "version": "3.0.0"
-        }
-      }
+      "version": "2.3.4"
+    },
+    "warning": {
+      "version": "2.1.0"
+    },
+    "watchpack": {
+      "version": "0.2.9"
+    },
+    "webidl-conversions": {
+      "version": "2.0.1"
     },
     "webpack": {
       "version": "1.12.6",
@@ -7256,1059 +3768,91 @@
         "async": {
           "version": "1.5.2"
         },
-        "clone": {
-          "version": "1.0.2"
-        },
-        "enhanced-resolve": {
-          "version": "0.9.1",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.3"
-            }
-          }
-        },
         "esprima": {
           "version": "2.7.2"
-        },
-        "interpret": {
-          "version": "0.6.6"
-        },
-        "loader-utils": {
-          "version": "0.2.13",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3"
-            },
-            "json5": {
-              "version": "0.4.0"
-            }
-          }
-        },
-        "memory-fs": {
-          "version": "0.2.0"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
-        },
-        "node-libs-browser": {
-          "version": "0.5.3",
-          "dependencies": {
-            "assert": {
-              "version": "1.3.0"
-            },
-            "browserify-zlib": {
-              "version": "0.1.4",
-              "dependencies": {
-                "pako": {
-                  "version": "0.2.8"
-                }
-              }
-            },
-            "buffer": {
-              "version": "3.6.0",
-              "dependencies": {
-                "base64-js": {
-                  "version": "0.0.8"
-                },
-                "ieee754": {
-                  "version": "1.1.6"
-                },
-                "isarray": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "console-browserify": {
-              "version": "1.1.0",
-              "dependencies": {
-                "date-now": {
-                  "version": "0.1.4"
-                }
-              }
-            },
-            "constants-browserify": {
-              "version": "0.0.1"
-            },
-            "crypto-browserify": {
-              "version": "3.2.8",
-              "dependencies": {
-                "pbkdf2-compat": {
-                  "version": "2.0.1"
-                },
-                "ripemd160": {
-                  "version": "0.2.0"
-                },
-                "sha.js": {
-                  "version": "2.2.6"
-                }
-              }
-            },
-            "domain-browser": {
-              "version": "1.1.7"
-            },
-            "http-browserify": {
-              "version": "1.7.0",
-              "dependencies": {
-                "Base64": {
-                  "version": "0.2.1"
-                }
-              }
-            },
-            "https-browserify": {
-              "version": "0.0.0"
-            },
-            "os-browserify": {
-              "version": "0.1.2"
-            },
-            "path-browserify": {
-              "version": "0.0.0"
-            },
-            "process": {
-              "version": "0.11.2"
-            },
-            "punycode": {
-              "version": "1.4.1"
-            },
-            "querystring-es3": {
-              "version": "0.2.1"
-            },
-            "readable-stream": {
-              "version": "1.1.13",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                }
-              }
-            },
-            "stream-browserify": {
-              "version": "1.0.0"
-            },
-            "string_decoder": {
-              "version": "0.10.31"
-            },
-            "timers-browserify": {
-              "version": "1.4.2"
-            },
-            "tty-browserify": {
-              "version": "0.0.0"
-            },
-            "url": {
-              "version": "0.10.3",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.3.2"
-                },
-                "querystring": {
-                  "version": "0.2.0"
-                }
-              }
-            },
-            "util": {
-              "version": "0.10.3"
-            },
-            "vm-browserify": {
-              "version": "0.0.4",
-              "dependencies": {
-                "indexof": {
-                  "version": "0.0.1"
-                }
-              }
-            }
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3"
-            },
-            "minimist": {
-              "version": "0.0.10"
-            }
-          }
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "tapable": {
-          "version": "0.1.10"
-        },
-        "watchpack": {
-          "version": "0.2.9",
-          "dependencies": {
-            "async": {
-              "version": "0.9.2"
-            },
-            "chokidar": {
-              "version": "1.4.3",
-              "dependencies": {
-                "anymatch": {
-                  "version": "1.3.0",
-                  "dependencies": {
-                    "arrify": {
-                      "version": "1.0.1"
-                    },
-                    "micromatch": {
-                      "version": "2.3.7",
-                      "dependencies": {
-                        "arr-diff": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "arr-flatten": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "array-unique": {
-                          "version": "0.2.1"
-                        },
-                        "braces": {
-                          "version": "1.8.3",
-                          "dependencies": {
-                            "expand-range": {
-                              "version": "1.8.1",
-                              "dependencies": {
-                                "fill-range": {
-                                  "version": "2.2.3",
-                                  "dependencies": {
-                                    "is-number": {
-                                      "version": "2.1.0"
-                                    },
-                                    "isobject": {
-                                      "version": "2.0.0",
-                                      "dependencies": {
-                                        "isarray": {
-                                          "version": "0.0.1"
-                                        }
-                                      }
-                                    },
-                                    "randomatic": {
-                                      "version": "1.1.5"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "preserve": {
-                              "version": "0.2.0"
-                            },
-                            "repeat-element": {
-                              "version": "1.1.2"
-                            }
-                          }
-                        },
-                        "expand-brackets": {
-                          "version": "0.1.4"
-                        },
-                        "extglob": {
-                          "version": "0.3.2"
-                        },
-                        "filename-regex": {
-                          "version": "2.0.0"
-                        },
-                        "is-extglob": {
-                          "version": "1.0.0"
-                        },
-                        "kind-of": {
-                          "version": "3.0.2",
-                          "dependencies": {
-                            "is-buffer": {
-                              "version": "1.1.3"
-                            }
-                          }
-                        },
-                        "normalize-path": {
-                          "version": "2.0.1"
-                        },
-                        "object.omit": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "for-own": {
-                              "version": "0.1.4",
-                              "dependencies": {
-                                "for-in": {
-                                  "version": "0.1.5"
-                                }
-                              }
-                            },
-                            "is-extendable": {
-                              "version": "0.1.1"
-                            }
-                          }
-                        },
-                        "parse-glob": {
-                          "version": "3.0.4",
-                          "dependencies": {
-                            "glob-base": {
-                              "version": "0.3.0"
-                            },
-                            "is-dotfile": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        },
-                        "regex-cache": {
-                          "version": "0.4.2",
-                          "dependencies": {
-                            "is-equal-shallow": {
-                              "version": "0.1.3"
-                            },
-                            "is-primitive": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "async-each": {
-                  "version": "1.0.0"
-                },
-                "glob-parent": {
-                  "version": "2.0.0"
-                },
-                "is-binary-path": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "binary-extensions": {
-                      "version": "1.4.0"
-                    }
-                  }
-                },
-                "is-glob": {
-                  "version": "2.0.1",
-                  "dependencies": {
-                    "is-extglob": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0"
-                },
-                "readdirp": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "2.0.10",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "2.0.6",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "1.0.0"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    }
-                  }
-                },
-                "fsevents": {
-                  "version": "1.0.9",
-                  "dependencies": {
-                    "nan": {
-                      "version": "2.2.0"
-                    },
-                    "node-pre-gyp": {
-                      "version": "0.6.24",
-                      "dependencies": {
-                        "nopt": {
-                          "version": "3.0.6",
-                          "dependencies": {
-                            "abbrev": {
-                              "version": "1.0.7"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    },
-                    "ansi-styles": {
-                      "version": "2.2.0"
-                    },
-                    "ansi": {
-                      "version": "0.3.1"
-                    },
-                    "are-we-there-yet": {
-                      "version": "1.1.2"
-                    },
-                    "asn1": {
-                      "version": "0.2.3"
-                    },
-                    "assert-plus": {
-                      "version": "0.2.0"
-                    },
-                    "async": {
-                      "version": "1.5.2"
-                    },
-                    "aws-sign2": {
-                      "version": "0.6.0"
-                    },
-                    "bl": {
-                      "version": "1.0.3"
-                    },
-                    "boom": {
-                      "version": "2.10.1"
-                    },
-                    "caseless": {
-                      "version": "0.11.0"
-                    },
-                    "chalk": {
-                      "version": "1.1.1"
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5"
-                    },
-                    "color-convert": {
-                      "version": "1.0.0"
-                    },
-                    "block-stream": {
-                      "version": "0.0.8"
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5"
-                    },
-                    "commander": {
-                      "version": "2.9.0"
-                    },
-                    "debug": {
-                      "version": "2.2.0"
-                    },
-                    "deep-extend": {
-                      "version": "0.4.1"
-                    },
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    },
-                    "delegates": {
-                      "version": "1.0.0"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1"
-                    },
-                    "extend": {
-                      "version": "3.0.0"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5"
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1"
-                    },
-                    "fstream": {
-                      "version": "1.0.8"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc4"
-                    },
-                    "gauge": {
-                      "version": "1.2.7"
-                    },
-                    "generate-function": {
-                      "version": "2.0.0"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.3"
-                    },
-                    "graceful-readlink": {
-                      "version": "1.0.1"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0"
-                    },
-                    "har-validator": {
-                      "version": "2.0.6"
-                    },
-                    "has-unicode": {
-                      "version": "2.0.0"
-                    },
-                    "hawk": {
-                      "version": "3.1.3"
-                    },
-                    "hoek": {
-                      "version": "2.16.3"
-                    },
-                    "http-signature": {
-                      "version": "1.1.1"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.13.1"
-                    },
-                    "ini": {
-                      "version": "1.3.4"
-                    },
-                    "isarray": {
-                      "version": "1.0.0"
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0"
-                    },
-                    "is-property": {
-                      "version": "1.0.2"
-                    },
-                    "isstream": {
-                      "version": "0.1.2"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2"
-                    },
-                    "jsbn": {
-                      "version": "0.1.0"
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1"
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0"
-                    },
-                    "jsprim": {
-                      "version": "1.2.2"
-                    },
-                    "lodash.pad": {
-                      "version": "4.1.0"
-                    },
-                    "lodash.padend": {
-                      "version": "4.2.0"
-                    },
-                    "lodash.repeat": {
-                      "version": "4.0.0"
-                    },
-                    "mime-db": {
-                      "version": "1.22.0"
-                    },
-                    "lodash.padstart": {
-                      "version": "4.2.0"
-                    },
-                    "mime-types": {
-                      "version": "2.1.10"
-                    },
-                    "minimist": {
-                      "version": "0.0.8"
-                    },
-                    "lodash.tostring": {
-                      "version": "4.1.2"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1"
-                    },
-                    "ms": {
-                      "version": "0.7.1"
-                    },
-                    "npmlog": {
-                      "version": "2.0.3"
-                    },
-                    "node-uuid": {
-                      "version": "1.4.7"
-                    },
-                    "pinkie": {
-                      "version": "2.0.4"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.0"
-                    },
-                    "once": {
-                      "version": "1.3.3"
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.1"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "readable-stream": {
-                      "version": "2.0.6"
-                    },
-                    "request": {
-                      "version": "2.69.0"
-                    },
-                    "semver": {
-                      "version": "5.1.0"
-                    },
-                    "sntp": {
-                      "version": "1.0.9"
-                    },
-                    "qs": {
-                      "version": "6.0.2"
-                    },
-                    "sshpk": {
-                      "version": "1.7.4"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5"
-                    },
-                    "supports-color": {
-                      "version": "2.0.0"
-                    },
-                    "strip-json-comments": {
-                      "version": "1.0.4"
-                    },
-                    "tar": {
-                      "version": "2.2.1"
-                    },
-                    "tar-pack": {
-                      "version": "3.1.3"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.2"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.1"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.2"
-                    },
-                    "uid-number": {
-                      "version": "0.0.6"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    },
-                    "verror": {
-                      "version": "1.3.6"
-                    },
-                    "wrappy": {
-                      "version": "1.0.1"
-                    },
-                    "xtend": {
-                      "version": "4.0.1"
-                    },
-                    "dashdash": {
-                      "version": "1.13.0",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.1.6",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0"
-                        }
-                      }
-                    },
-                    "aws4": {
-                      "version": "1.3.2",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "4.0.0",
-                          "dependencies": {
-                            "pseudomap": {
-                              "version": "1.0.2"
-                            },
-                            "yallist": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "fstream-ignore": {
-                      "version": "1.0.3",
-                      "dependencies": {
-                        "minimatch": {
-                          "version": "3.0.0",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.3",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.3.0"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.5.2",
-                      "dependencies": {
-                        "glob": {
-                          "version": "7.0.3",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            },
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.3",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.3.0"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.3"
-            }
-          }
-        },
-        "webpack-core": {
-          "version": "0.6.8",
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "source-list-map": {
-              "version": "0.1.6"
-            }
-          }
+        }
+      }
+    },
+    "webpack-core": {
+      "version": "0.6.8",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4"
         }
       }
     },
     "webpack-dev-middleware": {
-      "version": "1.2.0",
-      "dependencies": {
-        "memory-fs": {
-          "version": "0.2.0"
-        },
-        "mime": {
-          "version": "1.3.4"
-        }
-      }
+      "version": "1.2.0"
     },
     "webpack-dev-server": {
       "version": "1.11.0",
       "dependencies": {
-        "connect-history-api-fallback": {
-          "version": "1.1.0"
-        },
-        "http-proxy": {
-          "version": "1.13.2",
-          "dependencies": {
-            "eventemitter3": {
-              "version": "1.2.0"
-            },
-            "requires-port": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3"
-            },
-            "minimist": {
-              "version": "0.0.10"
-            }
-          }
-        },
-        "serve-index": {
-          "version": "1.7.3",
-          "dependencies": {
-            "accepts": {
-              "version": "1.2.13",
-              "dependencies": {
-                "negotiator": {
-                  "version": "0.5.3"
-                }
-              }
-            },
-            "batch": {
-              "version": "0.5.3"
-            },
-            "escape-html": {
-              "version": "1.0.3"
-            },
-            "http-errors": {
-              "version": "1.3.1",
-              "dependencies": {
-                "statuses": {
-                  "version": "1.2.1"
-                }
-              }
-            },
-            "mime-types": {
-              "version": "2.1.10",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.22.0"
-                }
-              }
-            },
-            "parseurl": {
-              "version": "1.3.1"
-            }
-          }
-        },
-        "socket.io-client": {
-          "version": "1.4.5",
-          "dependencies": {
-            "engine.io-client": {
-              "version": "1.6.8",
-              "dependencies": {
-                "has-cors": {
-                  "version": "1.1.0"
-                },
-                "ws": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "options": {
-                      "version": "0.0.6"
-                    },
-                    "ultron": {
-                      "version": "1.0.2"
-                    }
-                  }
-                },
-                "xmlhttprequest-ssl": {
-                  "version": "1.5.1"
-                },
-                "component-emitter": {
-                  "version": "1.1.2"
-                },
-                "engine.io-parser": {
-                  "version": "1.2.4",
-                  "dependencies": {
-                    "after": {
-                      "version": "0.8.1"
-                    },
-                    "arraybuffer.slice": {
-                      "version": "0.0.6"
-                    },
-                    "base64-arraybuffer": {
-                      "version": "0.1.2"
-                    },
-                    "has-binary": {
-                      "version": "0.1.6",
-                      "dependencies": {
-                        "isarray": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    },
-                    "utf8": {
-                      "version": "2.1.0"
-                    }
-                  }
-                },
-                "parsejson": {
-                  "version": "0.0.1"
-                },
-                "parseqs": {
-                  "version": "0.0.2"
-                },
-                "component-inherit": {
-                  "version": "0.0.3"
-                },
-                "yeast": {
-                  "version": "0.1.2"
-                }
-              }
-            },
-            "component-bind": {
-              "version": "1.0.0"
-            },
-            "component-emitter": {
-              "version": "1.2.0"
-            },
-            "object-component": {
-              "version": "0.0.3"
-            },
-            "socket.io-parser": {
-              "version": "2.2.6",
-              "dependencies": {
-                "json3": {
-                  "version": "3.3.2"
-                },
-                "component-emitter": {
-                  "version": "1.1.2"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "benchmark": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "has-binary": {
-              "version": "0.1.7",
-              "dependencies": {
-                "isarray": {
-                  "version": "0.0.1"
-                }
-              }
-            },
-            "indexof": {
-              "version": "0.0.1"
-            },
-            "parseuri": {
-              "version": "0.0.4"
-            },
-            "to-array": {
-              "version": "0.1.4"
-            },
-            "backo2": {
-              "version": "1.0.2"
-            }
-          }
-        },
-        "stream-cache": {
-          "version": "0.0.2"
+        "ansi-regex": {
+          "version": "2.0.0"
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.0.0"
-            }
-          }
+          "version": "3.0.1"
+        }
+      }
+    },
+    "whatwg-fetch": {
+      "version": "0.9.0"
+    },
+    "whatwg-url-compat": {
+      "version": "0.6.5"
+    },
+    "which": {
+      "version": "1.2.4"
+    },
+    "window-size": {
+      "version": "0.1.4"
+    },
+    "with": {
+      "version": "5.0.0"
+    },
+    "within-document": {
+      "version": "0.0.1"
+    },
+    "wordwrap": {
+      "version": "0.0.2"
+    },
+    "wp-error": {
+      "version": "1.2.0"
+    },
+    "wpcom": {
+      "version": "4.9.3",
+      "dependencies": {
+        "babel": {
+          "version": "5.8.38"
         },
-        "supports-color": {
-          "version": "3.1.2",
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0"
-            }
-          }
+        "commander": {
+          "version": "2.9.0"
+        },
+        "glob": {
+          "version": "5.0.15"
+        },
+        "lodash": {
+          "version": "3.10.1"
+        },
+        "source-map": {
+          "version": "0.5.3"
         }
       }
     },
     "wpcom-proxy-request": {
-      "version": "1.0.5",
-      "dependencies": {
-        "component-event": {
-          "version": "0.1.4"
-        },
-        "progress-event": {
-          "version": "1.0.0"
-        },
-        "uid": {
-          "version": "0.0.2"
-        }
-      }
+      "version": "1.0.5"
     },
     "wpcom-xhr-request": {
-      "version": "0.5.0",
-      "dependencies": {
-        "wp-error": {
-          "version": "1.2.0",
-          "dependencies": {
-            "builtin-status-codes": {
-              "version": "2.0.0"
-            },
-            "uppercamelcase": {
-              "version": "1.1.0",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1"
-                }
-              }
-            }
-          }
-        }
-      }
+      "version": "0.5.0"
+    },
+    "wrappy": {
+      "version": "1.0.1"
+    },
+    "write": {
+      "version": "0.2.1"
+    },
+    "ws": {
+      "version": "0.8.0"
     },
     "xgettext-js": {
       "version": "0.3.0",
@@ -8321,686 +3865,33 @@
         }
       }
     },
-    "wpcom": {
-      "version": "4.9.3",
-      "dependencies": {
-        "babel": {
-          "version": "5.8.38",
-          "dependencies": {
-            "chokidar": {
-              "version": "1.4.3",
-              "dependencies": {
-                "anymatch": {
-                  "version": "1.3.0",
-                  "dependencies": {
-                    "arrify": {
-                      "version": "1.0.1"
-                    },
-                    "micromatch": {
-                      "version": "2.3.7",
-                      "dependencies": {
-                        "arr-diff": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "arr-flatten": {
-                              "version": "1.0.1"
-                            }
-                          }
-                        },
-                        "array-unique": {
-                          "version": "0.2.1"
-                        },
-                        "braces": {
-                          "version": "1.8.3",
-                          "dependencies": {
-                            "expand-range": {
-                              "version": "1.8.1",
-                              "dependencies": {
-                                "fill-range": {
-                                  "version": "2.2.3",
-                                  "dependencies": {
-                                    "is-number": {
-                                      "version": "2.1.0"
-                                    },
-                                    "isobject": {
-                                      "version": "2.0.0",
-                                      "dependencies": {
-                                        "isarray": {
-                                          "version": "0.0.1"
-                                        }
-                                      }
-                                    },
-                                    "randomatic": {
-                                      "version": "1.1.5"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.4"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "preserve": {
-                              "version": "0.2.0"
-                            },
-                            "repeat-element": {
-                              "version": "1.1.2"
-                            }
-                          }
-                        },
-                        "expand-brackets": {
-                          "version": "0.1.4"
-                        },
-                        "extglob": {
-                          "version": "0.3.2"
-                        },
-                        "filename-regex": {
-                          "version": "2.0.0"
-                        },
-                        "is-extglob": {
-                          "version": "1.0.0"
-                        },
-                        "kind-of": {
-                          "version": "3.0.2",
-                          "dependencies": {
-                            "is-buffer": {
-                              "version": "1.1.3"
-                            }
-                          }
-                        },
-                        "normalize-path": {
-                          "version": "2.0.1"
-                        },
-                        "object.omit": {
-                          "version": "2.0.0",
-                          "dependencies": {
-                            "for-own": {
-                              "version": "0.1.4",
-                              "dependencies": {
-                                "for-in": {
-                                  "version": "0.1.5"
-                                }
-                              }
-                            },
-                            "is-extendable": {
-                              "version": "0.1.1"
-                            }
-                          }
-                        },
-                        "parse-glob": {
-                          "version": "3.0.4",
-                          "dependencies": {
-                            "glob-base": {
-                              "version": "0.3.0"
-                            },
-                            "is-dotfile": {
-                              "version": "1.0.2"
-                            }
-                          }
-                        },
-                        "regex-cache": {
-                          "version": "0.4.2",
-                          "dependencies": {
-                            "is-equal-shallow": {
-                              "version": "0.1.3"
-                            },
-                            "is-primitive": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "async-each": {
-                  "version": "1.0.0"
-                },
-                "glob-parent": {
-                  "version": "2.0.0"
-                },
-                "is-binary-path": {
-                  "version": "1.0.1",
-                  "dependencies": {
-                    "binary-extensions": {
-                      "version": "1.4.0"
-                    }
-                  }
-                },
-                "is-glob": {
-                  "version": "2.0.1",
-                  "dependencies": {
-                    "is-extglob": {
-                      "version": "1.0.0"
-                    }
-                  }
-                },
-                "readdirp": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "graceful-fs": {
-                      "version": "4.1.3"
-                    },
-                    "minimatch": {
-                      "version": "2.0.10",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.3",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.3.0"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "2.0.6",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2"
-                        },
-                        "isarray": {
-                          "version": "1.0.0"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2"
-                        }
-                      }
-                    }
-                  }
-                },
-                "fsevents": {
-                  "version": "1.0.9",
-                  "dependencies": {
-                    "nan": {
-                      "version": "2.2.1"
-                    },
-                    "node-pre-gyp": {
-                      "version": "0.6.24",
-                      "dependencies": {
-                        "nopt": {
-                          "version": "3.0.6",
-                          "dependencies": {
-                            "abbrev": {
-                              "version": "1.0.7"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    },
-                    "ansi": {
-                      "version": "0.3.1"
-                    },
-                    "ansi-styles": {
-                      "version": "2.2.0"
-                    },
-                    "are-we-there-yet": {
-                      "version": "1.1.2"
-                    },
-                    "asn1": {
-                      "version": "0.2.3"
-                    },
-                    "assert-plus": {
-                      "version": "0.2.0"
-                    },
-                    "aws-sign2": {
-                      "version": "0.6.0"
-                    },
-                    "async": {
-                      "version": "1.5.2"
-                    },
-                    "bl": {
-                      "version": "1.0.3"
-                    },
-                    "block-stream": {
-                      "version": "0.0.8"
-                    },
-                    "boom": {
-                      "version": "2.10.1"
-                    },
-                    "caseless": {
-                      "version": "0.11.0"
-                    },
-                    "chalk": {
-                      "version": "1.1.1"
-                    },
-                    "color-convert": {
-                      "version": "1.0.0"
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5"
-                    },
-                    "commander": {
-                      "version": "2.9.0"
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5"
-                    },
-                    "debug": {
-                      "version": "2.2.0"
-                    },
-                    "deep-extend": {
-                      "version": "0.4.1"
-                    },
-                    "delayed-stream": {
-                      "version": "1.0.0"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1"
-                    },
-                    "delegates": {
-                      "version": "1.0.0"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5"
-                    },
-                    "extend": {
-                      "version": "3.0.0"
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc4"
-                    },
-                    "fstream": {
-                      "version": "1.0.8"
-                    },
-                    "gauge": {
-                      "version": "1.2.7"
-                    },
-                    "generate-function": {
-                      "version": "2.0.0"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0"
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.3"
-                    },
-                    "graceful-readlink": {
-                      "version": "1.0.1"
-                    },
-                    "har-validator": {
-                      "version": "2.0.6"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0"
-                    },
-                    "has-unicode": {
-                      "version": "2.0.0"
-                    },
-                    "hawk": {
-                      "version": "3.1.3"
-                    },
-                    "hoek": {
-                      "version": "2.16.3"
-                    },
-                    "inherits": {
-                      "version": "2.0.1"
-                    },
-                    "http-signature": {
-                      "version": "1.1.1"
-                    },
-                    "ini": {
-                      "version": "1.3.4"
-                    },
-                    "is-my-json-valid": {
-                      "version": "2.13.1"
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0"
-                    },
-                    "is-property": {
-                      "version": "1.0.2"
-                    },
-                    "isarray": {
-                      "version": "1.0.0"
-                    },
-                    "isstream": {
-                      "version": "0.1.2"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2"
-                    },
-                    "jsbn": {
-                      "version": "0.1.0"
-                    },
-                    "json-schema": {
-                      "version": "0.2.2"
-                    },
-                    "jsonpointer": {
-                      "version": "2.0.0"
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1"
-                    },
-                    "jsprim": {
-                      "version": "1.2.2"
-                    },
-                    "lodash.pad": {
-                      "version": "4.1.0"
-                    },
-                    "lodash.padend": {
-                      "version": "4.2.0"
-                    },
-                    "lodash.padstart": {
-                      "version": "4.2.0"
-                    },
-                    "lodash.repeat": {
-                      "version": "4.0.0"
-                    },
-                    "lodash.tostring": {
-                      "version": "4.1.2"
-                    },
-                    "mime-db": {
-                      "version": "1.22.0"
-                    },
-                    "mime-types": {
-                      "version": "2.1.10"
-                    },
-                    "minimist": {
-                      "version": "0.0.8"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1"
-                    },
-                    "ms": {
-                      "version": "0.7.1"
-                    },
-                    "node-uuid": {
-                      "version": "1.4.7"
-                    },
-                    "npmlog": {
-                      "version": "2.0.3"
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.1"
-                    },
-                    "once": {
-                      "version": "1.3.3"
-                    },
-                    "pinkie": {
-                      "version": "2.0.4"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.0"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.6"
-                    },
-                    "qs": {
-                      "version": "6.0.2"
-                    },
-                    "readable-stream": {
-                      "version": "2.0.6"
-                    },
-                    "request": {
-                      "version": "2.69.0"
-                    },
-                    "semver": {
-                      "version": "5.1.0"
-                    },
-                    "sntp": {
-                      "version": "1.0.9"
-                    },
-                    "sshpk": {
-                      "version": "1.7.4"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5"
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1"
-                    },
-                    "strip-json-comments": {
-                      "version": "1.0.4"
-                    },
-                    "supports-color": {
-                      "version": "2.0.0"
-                    },
-                    "tar": {
-                      "version": "2.2.1"
-                    },
-                    "tar-pack": {
-                      "version": "3.1.3"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.2"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.2"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.1"
-                    },
-                    "uid-number": {
-                      "version": "0.0.6"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2"
-                    },
-                    "verror": {
-                      "version": "1.3.6"
-                    },
-                    "wrappy": {
-                      "version": "1.0.1"
-                    },
-                    "xtend": {
-                      "version": "4.0.1"
-                    },
-                    "dashdash": {
-                      "version": "1.13.0",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0"
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.1.6",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0"
-                        }
-                      }
-                    },
-                    "aws4": {
-                      "version": "1.3.2",
-                      "dependencies": {
-                        "lru-cache": {
-                          "version": "4.0.0",
-                          "dependencies": {
-                            "pseudomap": {
-                              "version": "1.0.2"
-                            },
-                            "yallist": {
-                              "version": "2.0.0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "fstream-ignore": {
-                      "version": "1.0.3",
-                      "dependencies": {
-                        "minimatch": {
-                          "version": "3.0.0",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.3",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.3.0"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.5.2",
-                      "dependencies": {
-                        "glob": {
-                          "version": "7.0.3",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1"
-                            },
-                            "minimatch": {
-                              "version": "3.0.0",
-                              "dependencies": {
-                                "brace-expansion": {
-                                  "version": "1.1.3",
-                                  "dependencies": {
-                                    "balanced-match": {
-                                      "version": "0.3.0"
-                                    },
-                                    "concat-map": {
-                                      "version": "0.0.1"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "once": {
-                              "version": "1.3.3",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1"
-                                }
-                              }
-                            },
-                            "path-is-absolute": {
-                              "version": "1.0.0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "commander": {
-              "version": "2.9.0",
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "convert-source-map": {
-              "version": "1.2.0"
-            },
-            "fs-readdir-recursive": {
-              "version": "0.1.2"
-            },
-            "glob": {
-              "version": "5.0.15",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.3",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.3.0"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash": {
-              "version": "3.10.1"
-            },
-            "output-file-sync": {
-              "version": "1.1.1",
-              "dependencies": {
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.1"
-                }
-              }
-            },
-            "path-exists": {
-              "version": "1.0.0"
-            },
-            "path-is-absolute": {
-              "version": "1.0.0"
-            },
-            "source-map": {
-              "version": "0.5.3"
-            },
-            "slash": {
-              "version": "1.0.0"
-            }
-          }
-        }
-      }
+    "xml": {
+      "version": "1.0.1"
+    },
+    "xml-char-classes": {
+      "version": "1.0.0"
+    },
+    "xml-escape": {
+      "version": "1.0.0"
+    },
+    "xml-name-validator": {
+      "version": "2.0.1"
+    },
+    "xmlhttprequest": {
+      "version": "1.5.0",
+      "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
+    },
+    "xtend": {
+      "version": "4.0.1"
+    },
+    "y18n": {
+      "version": "3.2.1"
+    },
+    "yallist": {
+      "version": "2.0.0"
+    },
+    "yargs": {
+      "version": "3.27.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -118,8 +118,8 @@
     "xgettext-js": "0.3.0"
   },
   "engines": {
-    "node": "4.3.0",
-    "npm": "2.14.12"
+    "node": "5.10.1",
+    "npm": "3.8.3"
   },
   "scripts": {
     "test": "make test",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "uglify-js": "2.6.1",
     "valid-url": "1.0.9",
     "walk": "2.3.4",
-    "webpack": "1.12.6",
+    "webpack": "1.12.15",
     "webpack-dev-middleware": "1.2.0",
     "wpcom": "4.9.3",
     "wpcom-proxy-request": "1.0.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,11 +58,11 @@ webpackConfig = {
 	},
 	resolve: {
 		extensions: [ '', '.json', '.js', '.jsx' ],
-		root: [ path.join( __dirname, 'client' ), path.join( __dirname, 'node_modules' ) ],
+		root: [ path.join( __dirname, 'client' ), __dirname ],
 		modulesDirectories: [ 'node_modules' ]
 	},
 	resolveLoader: {
-		root: [ path.join( __dirname, 'node_modules' ) ]
+		root: [ __dirname ]
 	},
 	node: {
 		console: false,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,7 @@ webpackConfig = {
 	},
 	resolve: {
 		extensions: [ '', '.json', '.js', '.jsx' ],
-		root: [ path.join( __dirname, 'client' ), __dirname ],
+		root: [ path.join( __dirname, 'client' ) ],
 		modulesDirectories: [ 'node_modules' ]
 	},
 	resolveLoader: {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -68,7 +68,8 @@ module.exports = {
 	},
 	resolve: {
 		extensions: [ '', '.json', '.js', '.jsx' ],
-		modulesDirectories: [ 'node_modules', path.join( __dirname, 'server' ), path.join( __dirname, 'client' ), __dirname ]
+		root: [ path.join( __dirname, 'server' ), path.join( __dirname, 'client' ), __dirname ],
+		modulesDirectories: [ 'node_modules' ]
 	},
 	node: {
 		// Tell webpack we want to supply absolute paths for server code,
@@ -85,4 +86,3 @@ module.exports = {
 	],
 	externals: getExternals()
 };
-


### PR DESCRIPTION
This PR attempts to upgrade our node version to latest 5.10.1, with a new shrinkwrap built with npm 3.8.3. ~~This branch is currently non-functional due to [page.js plugins](https://github.com/visionmedia/page.js#plugins) in boot/index.js not firing properly. Extra 👀 appreciated for debugging this.~~

~~#4684 should land before this to warn developers of new requirements.~~

## Testing Instructions

### Local Dev
- Switch to node version 5.10.1 (npm 3.8.3)
- `make distclean`
- `make run`
- No functional changes to Calypso

### Local Docker Image
- Follow image instructions at: PCYsg-5XR-p2

### Desktop
- Clone the wp-desktop project
- Follow install instructions
- In the calypso submodule checkout this branch
- Desktop behaves normally

cc @mtias @rralian @blowery @aduth