### PR TITLE
Jetpack Connect: Update authorize screen

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -94,16 +94,17 @@ const LoggedInForm = React.createClass( {
 	},
 
 	componentDidUpdate() {
-		const { authorizeSuccess, queryObject } = this.props.jetpackConnectAuthorize;
-		if ( authorizeSuccess ) {
-			Notices.success(
-				this.translate( 'Authorization complete. Use the buttons below to upgrade your site.' ),
+		const { authorizeSuccess, queryObject, siteReceived, plansURL } = this.props.jetpackConnectAuthorize;
+		if ( authorizeSuccess && siteReceived && plansURL ) {
+			Notices.info(
+				this.translate( 'We thought you would enjoy these upgrades.' ),
 				{
-					button: this.translate( 'Go to site' ),
+					button: this.translate( 'Skip upgrade and return to your site' ),
 					href: queryObject.redirect_after_auth,
 					persistent: true
 				}
 			);
+			page( plansURL );
 		}
 	},
 
@@ -126,15 +127,18 @@ const LoggedInForm = React.createClass( {
 	},
 
 	renderNotices() {
-		const { authorizeError } = this.props.jetpackConnectAuthorize;
+		const { authorizeError, authorizeSuccess } = this.props.jetpackConnectAuthorize;
 		if ( authorizeError ) {
 			return <JetpackConnectNotices noticeType="authorizeError" />;
+		}
+		if ( authorizeSuccess ) {
+			return <JetpackConnectNotices noticeType="authorizeSuccess" />;
 		}
 		return null;
 	},
 
 	renderFormControls() {
-		const { queryObject, isAuthorizing, autoAuthorize, authorizeSuccess } = this.props.jetpackConnectAuthorize;
+		const { isAuthorizing, autoAuthorize, authorizeSuccess } = this.props.jetpackConnectAuthorize;
 
 		if ( autoAuthorize ) {
 			return isAuthorizing
@@ -143,9 +147,6 @@ const LoggedInForm = React.createClass( {
 		}
 
 		if ( authorizeSuccess ) {
-			if ( siteReceived && plansURL ) {
-				page( plansURL );
-			}
 			return null;
 		}
 
@@ -180,7 +181,7 @@ const LoggedInForm = React.createClass( {
 		return (
 			<div className="jetpack-connect-logged-in-form">
 				<Card>
-					<Gravatar user={ this.props.user } size={ 128 } />
+					<Gravatar user={ this.props.user } size={ 64 } />
 					<p className="jetpack-connect-logged-in-form__user-text">{
 						this.translate( 'Connecting as {{strong}}%(user)s{{/strong}}', {
 							args: { user: this.props.user.display_name },

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -22,6 +22,9 @@ import JetpackConnectNotices from './jetpack-connect-notices';
 import observe from 'lib/mixins/data-observe';
 import userUtilities from 'lib/user/utils';
 import Notices from 'notices';
+import Card from 'components/card';
+import CompactCard from 'components/card/compact';
+import Gravatar from 'components/gravatar';
 
 /**
  * Module variables
@@ -131,8 +134,7 @@ const LoggedInForm = React.createClass( {
 	},
 
 	renderFormControls() {
-		const { queryObject, isAuthorizing, autoAuthorize, authorizeSuccess, plansURL, siteReceived } = this.props.jetpackConnectAuthorize;
-		const loginUrl = config( 'login_url' ) + '?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) + '&_wp_nonce=' + encodeURIComponent( queryObject._wp_nonce );
+		const { queryObject, isAuthorizing, autoAuthorize, authorizeSuccess } = this.props.jetpackConnectAuthorize;
 
 		if ( autoAuthorize ) {
 			return isAuthorizing
@@ -148,28 +150,47 @@ const LoggedInForm = React.createClass( {
 		}
 
 		return (
-			<div>
-				<button disabled={ this.isAuthorizing() } onClick={ this.handleSubmit } className="button is-primary">
-					{ this.translate( 'Approve' ) }
-				</button>
-				<LoggedOutFormLinks>
-					<LoggedOutFormLinkItem href={ loginUrl }>
-						{ this.translate( 'Sign in as a different user' ) }
-					</LoggedOutFormLinkItem>
-					<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
-						{ this.translate( 'Create a new account' ) }
-					</LoggedOutFormLinkItem>
-				</LoggedOutFormLinks>
-			</div>
+			<button disabled={ this.isAuthorizing() } onClick={ this.handleSubmit } className="button is-primary">
+				{ this.translate( 'Approve' ) }
+			</button>
+		);
+	},
+
+	renderFooterLinks() {
+		const { queryObject, autoAuthorize, authorizeSuccess } = this.props.jetpackConnectAuthorize;
+		const loginUrl = config( 'login_url' ) + '?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) + '&_wp_nonce=' + encodeURIComponent( queryObject._wp_nonce );
+
+		if ( autoAuthorize || authorizeSuccess ) {
+			return null;
+		}
+
+		return(
+			<LoggedOutFormLinks>
+				<LoggedOutFormLinkItem href={ loginUrl }>
+					{ this.translate( 'Sign in as a different user' ) }
+				</LoggedOutFormLinkItem>
+				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
+					{ this.translate( 'Create a new account' ) }
+				</LoggedOutFormLinkItem>
+			</LoggedOutFormLinks>
 		);
 	},
 
 	render() {
 		return (
-			<div>
-				<p>{ this.translate( 'Connecting as %(user)s', { args: { user: this.props.user.display_name } } ) }</p>
-				{ this.renderNotices() }
-				{ this.renderFormControls() }
+			<div className="jetpack-connect-logged-in-form">
+				<Card>
+					<Gravatar user={ this.props.user } size={ 128 } />
+					<p className="jetpack-connect-logged-in-form__user-text">{
+						this.translate( 'Connecting as {{strong}}%(user)s{{/strong}}', {
+							args: { user: this.props.user.display_name },
+							components: { strong: <strong /> }
+						} )
+					}</p>
+					{ this.renderNotices() }
+					{ this.renderFormControls() }
+				</Card>
+				{ this.renderFooterLinks() }
 			</div>
 		);
 	}
@@ -178,6 +199,10 @@ const LoggedInForm = React.createClass( {
 const JetpackConnectAuthorizeForm = React.createClass( {
 	displayName: 'JetpackConnectAuthorizeForm',
 	mixins: [ observe( 'userModule' ) ],
+	renderFormHeader() {
+		const { site } = this.props.jetpackConnectAuthorize.queryObject;
+		return( <CompactCard className="jetpack-connect__authorize-form-header">{ site }</CompactCard> );
+	},
 	renderForm() {
 		const { userModule } = this.props;
 		let user = userModule.get();
@@ -185,15 +210,13 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 			? <LoggedInForm { ...this.props } user={ user } />
 			: <LoggedOutForm { ...this.props } />
 	},
-
 	render() {
 		return (
 			<Main className="jetpack-connect">
-				<div className="jetpack-connect__site-url-entry-container">
+				<div className="jetpack-connect__authorize-form">
 					<ConnectHeader headerText={ this.translate( 'Connect a self-hosted WordPress' ) }
-						subHeaderText={ this.translate( 'Jetpack would like to connect to your WordPress.com account' ) }
-						step={ 1 }
-						steps={ 3 } />
+						subHeaderText={ this.translate( 'Jetpack would like to connect to your WordPress.com account' ) } />
+					{ this.renderFormHeader() }
 					{ this.renderForm() }
 				</div>
 			</Main>

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -83,7 +83,7 @@ export default React.createClass( {
 			return noticeValues
 		}
 		if ( this.props.noticeType === 'authorizeSuccess' ) {
-			noticeValues.text = this.translate( 'Jetpack connection complete.' );
+			noticeValues.text = this.translate( 'Jetpack connected! Searching for available upgrades.' );
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'checkmark-circle';
 			return noticeValues

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -69,3 +69,24 @@
 	}
 
 }
+
+.jetpack-connect__authorize-form {
+	.jetpack-connect__authorize-form-header {
+		text-align: center;
+	}
+}
+
+.jetpack-connect-logged-in-form {
+	.jetpack-connect-logged-in-form__user-text {
+		text-align: center;
+	}
+
+	.gravatar {
+		display: block;
+		margin: 0 auto 8px auto;
+	}
+
+	.button {
+		width: 100%;
+	}
+}


### PR DESCRIPTION
We'd like to get Jetpack connect into wpcalypso environment soon, so here is a more polished UI for the Authorize screen. I do not consider it final, but good enough for wpcalypso.
![screen shot 2016-04-12 at 5 12 43 pm](https://cloud.githubusercontent.com/assets/2694219/14480232/d3d66b58-00f4-11e6-8749-31c204d58225.png)

To test
- run the latest master on one of your Jetpack sites
- run this branch locally at calypso.localhost
- disconnect Jetpack from WordPress.com
- login to a whitelisted WordPress.com account ( ask me, and I'll add you to the list )
- Click "Connect Jetpack" in you wp-admin, and you should see the screen above
- Complete the connection experience as yourself, or as a brand new user

cc: @johnHackworth @rickybanister