### PR TITLE
Editor: Prevent sidebar header from shrinking

### DIFF
--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -1,5 +1,6 @@
 .editor-sidebar__header {
 	display: flex;
+	flex-shrink: 0;
 	justify-content: flex-end;
 	align-items: center;
 	padding: 8px;


### PR DESCRIPTION
This pull request seeks to resolve an issue where the editor sidebar header would shrink if the viewport were shortened vertically, or if enough sidebar accordions are open such that scroll occurs.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/14498502/b4b28102-0168-11e6-8978-cc6aa0732797.png)|![After](https://cloud.githubusercontent.com/assets/1779930/14498496/b052757c-0168-11e6-96b6-03be9eefdc86.png)

__Testing instructions:__

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Expand several sidebar accordions or shorten your browser height
4. Note that the sidebar header never shrinks

/cc @melchoyce