### PR TITLE
Update/track clicks on suggested help topics

### DIFF
--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -17,8 +17,10 @@ module.exports = React.createClass( {
 
 	onClick: function( event ) {
 		if ( this.props.helpLink.disabled ) {
-			event.preventDefault();
+			return event.preventDefault();
 		}
+
+		this.props.onClick && this.props.onClick( event );
 	},
 
 	getResultIcon: function() {

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -9,15 +9,11 @@ var React = require( 'react' ),
  */
 var Main = require( 'components/main' ),
 	HappinessEngineers = require( 'me/help/help-happiness-engineers' ),
-	FormSectionHeading = require( 'components/forms/form-section-heading' ),
 	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	HelpSearch = require( './help-search' ),
-	ExternalLink = require( 'components/external-link' ),
-	Card = require( 'components/card' ),
 	CompactCard = require( 'components/card/compact' ),
 	Button = require( 'components/button' ),
 	SectionHeader = require( 'components/section-header' ),
-	Gridicon = require( 'components/gridicon' ),
 	HelpResult = require( './help-results/item' );
 
 module.exports = React.createClass( {
@@ -60,7 +56,7 @@ module.exports = React.createClass( {
 			</div>
 		);
 	},
-	
+
 	getSupportLinks: function() {
 		return (
 			<div className="help__support-links">

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -2,12 +2,13 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
-
+	PureRenderMixin = require( 'react-pure-render/mixin' ),
+	debug = require( 'debug' )( 'calypso:help-search' );
 /**
  * Internal dependencies
  */
 var Main = require( 'components/main' ),
+	analytics = require( 'analytics' ),
 	HappinessEngineers = require( 'me/help/help-happiness-engineers' ),
 	MeSidebarNavigation = require( 'me/sidebar-navigation' ),
 	HelpSearch = require( './help-search' ),
@@ -22,37 +23,43 @@ module.exports = React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	getHelpfulArticles: function() {
-		const resultItemWP = {
-			link: 'https://en.support.wordpress.com/com-vs-org/',
-			title: this.translate( 'WordPress.com and WordPress.org' ),
-			description: this.translate( 'Learn about the differences between a fully hosted WordPress.com site and a self-hosted WordPress.org site.' )
-		};
-
-		const resultItemDomains = {
-			link: 'https://en.support.wordpress.com/all-about-domains/',
-			title: this.translate( 'All About Domains' ),
-			description: this.translate( 'Set up your domain whether it’s registered with WordPress.com or elsewhere.' )
-		};
-
-		const resultItemStart = {
-			link: 'https://en.support.wordpress.com/start/',
-			title: this.translate( 'Get Started' ),
-			description: this.translate( 'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.' )
-		};
-
-		const resultItemPrivate = {
-			link: 'https://en.support.wordpress.com/settings/privacy-settings/',
-			title: this.translate( 'Privacy Settings' ),
-			description: this.translate( 'Limit your site’s visibility or make it completely private.' )
-		};
+		const helpfulResults = [
+			{
+				link: 'https://en.support.wordpress.com/com-vs-org/',
+				title: this.translate( 'WordPress.com and WordPress.org' ),
+				description: this.translate( 'Learn about the differences between a fully hosted WordPress.com site and a self-hosted WordPress.org site.' )
+			},
+			{
+				link: 'https://en.support.wordpress.com/all-about-domains/',
+				title: this.translate( 'All About Domains' ),
+				description: this.translate( 'Set up your domain whether it’s registered with WordPress.com or elsewhere.' )
+			},
+			{
+				link: 'https://en.support.wordpress.com/start/',
+				title: this.translate( 'Get Started' ),
+				description: this.translate( 'No matter what kind of site you want to build, our five-step checklists will get you set up and ready to publish.' )
+			},
+			{
+				link: 'https://en.support.wordpress.com/settings/privacy-settings/',
+				title: this.translate( 'Privacy Settings' ),
+				description: this.translate( 'Limit your site’s visibility or make it completely private.' )
+			}
+		];
 
 		return (
 			<div className="help-results">
-				<SectionHeader label={ this.translate( 'Most Helpful Articles' ) }/>
-				<HelpResult key={ resultItemWP.link } helpLink={ resultItemWP } iconTypeDescription="book" />
-				<HelpResult key={ resultItemDomains.link } helpLink={ resultItemDomains } iconTypeDescription="book" />
-				<HelpResult key={ resultItemStart.link } helpLink={ resultItemStart } iconTypeDescription="book" />
-				<HelpResult key={ resultItemPrivate.link } helpLink={ resultItemPrivate } iconTypeDescription="book" />
+				<SectionHeader label={ this.translate( 'Most Helpful Articles' ) } />
+				{ helpfulResults.map( ( result, index ) => {
+					const trackClick = () => {
+						debug( 'Suggested result click: ', result.link );
+						analytics.tracks.recordEvent( 'calypso_help_suggested_result_click', {
+							link: result.link,
+							position: index
+						} );
+					};
+
+					return <HelpResult key={ result.link } helpLink={ result } iconTypeDescription="book" onClick={ trackClick } />
+				} ) }
 			</div>
 		);
 	},


### PR DESCRIPTION
Add Tracks pings to clicks on the items we suggest as popular topics:

![screen shot 2016-04-08 at 3 00 03 pm](https://cloud.githubusercontent.com/assets/2738252/14394772/e9ba12b4-fd9b-11e5-833d-40dbe3e728b4.png)

#### How to test
1. Navigate to calypso help at http://calypso.localhost:3000/help
2. Pick a link under "Most helpful articles" and click it.
3. Notice that a tracks ping no appears for it under `calypso_help_suggested_result_click`