### PR TITLE
Components: Remove wrapper from global notice rendering

### DIFF
--- a/client/components/global-notices/docs/example.jsx
+++ b/client/components/global-notices/docs/example.jsx
@@ -1,42 +1,72 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
+import FormCheckbox from 'components/forms/form-checkbox';
 import notices from 'notices';
+import { createNotice } from 'state/notices/actions';
 
-function showSuccessNotice() {
-	notices.success( 'This is a global success notice' );
+class GlobalNotices extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = { useState: true };
+		this.toggleUseState = this.toggleUseState.bind( this );
+		this.showSuccessNotice = this.showNotice.bind( this, 'success' );
+		this.showErrorNotice = this.showNotice.bind( this, 'error' );
+		this.showInfoNotice = this.showNotice.bind( this, 'info' );
+		this.showWarningNotice = this.showNotice.bind( this, 'warning' );
+	}
+
+	toggleUseState( event ) {
+		this.setState( {
+			useState: event.target.checked
+		} );
+	}
+
+	showNotice( type ) {
+		const message = `This is a ${ type } notice`;
+		if ( this.state.useState ) {
+			this.props.createNotice( `is-${ type }`, message );
+		} else {
+			notices[ type ]( message );
+		}
+	}
+
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/design/global-notices">Global Notices</a>
+				</h2>
+				<label>
+					<FormCheckbox
+						onChange={ this.toggleUseState }
+						checked={ this.state.useState } />
+					Use global application state
+				</label>
+				<ButtonGroup>
+					<Button onClick={ this.showSuccessNotice }>Show success notice</Button>
+					<Button onClick={ this.showErrorNotice }>Show error notice</Button>
+					<Button onClick={ this.showInfoNotice }>Show info notice</Button>
+					<Button onClick={ this.showWarningNotice }>Show warning notice</Button>
+				</ButtonGroup>
+			</div>
+		);
+	}
 }
 
-function showErrorNotice() {
-	notices.error( 'This is a global error notice' );
-}
+GlobalNotices.propTypes = {
+	createNotice: PropTypes.func
+};
 
-function showInfoNotice() {
-	notices.info( 'This is a global info notice' );
-}
-
-function showWarningNotice() {
-	notices.warning( 'This is a global warning notice' );
-}
-
-const GlobalNotices = () => (
-	<div>
-		<h2>Global Notices</h2>
-		<ButtonGroup>
-			<Button onClick={ showSuccessNotice }>Show success notice</Button>
-			<Button onClick={ showErrorNotice }>Show error notice</Button>
-			<Button onClick={ showInfoNotice }>Show info notice</Button>
-			<Button onClick={ showWarningNotice }>Show warning notice</Button>
-		</ButtonGroup>
-	</div>
-);
-GlobalNotices.displayName = 'GlobalNotices';
-
-module.exports = GlobalNotices;
+const ConnectedGlobalNotices = connect( null, { createNotice } )( GlobalNotices );
+ConnectedGlobalNotices.displayName = 'GlobalNotices';
+export default ConnectedGlobalNotices;

--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -51,41 +51,40 @@ const NoticesList = React.createClass( {
 	render() {
 		const noticesRaw = this.props.notices[ this.props.id ] || [];
 		let noticesList = noticesRaw.map( function( notice, index ) {
-				return (
-					<Notice
-						key={ 'notice-old-' + index }
-						status={ notice.status }
-						duration={ notice.duration || null }
-						text={ notice.text }
-						isCompact={ notice.isCompact }
-						onDismissClick={ this.removeNotice.bind( this, notice ) }
-						showDismiss={ notice.showDismiss }
-					>
-						{ notice.button &&
-							<NoticeAction
-								href={ notice.href }
-								onClick={ notice.onClick }
-							>
-								{ notice.button }
-							</NoticeAction> }
-						</Notice>
-				);
-			}, this );
+			return (
+				<Notice
+					key={ 'notice-old-' + index }
+					status={ notice.status }
+					duration={ notice.duration || null }
+					text={ notice.text }
+					isCompact={ notice.isCompact }
+					onDismissClick={ this.removeNotice.bind( this, notice ) }
+					showDismiss={ notice.showDismiss }
+				>
+					{ notice.button &&
+						<NoticeAction
+							href={ notice.href }
+							onClick={ notice.onClick }
+						>
+							{ notice.button }
+						</NoticeAction> }
+					</Notice>
+			);
+		}, this );
 
 		//This is an interim solution for displaying both notices from redux store
 		//and from the old component. When all notices are moved to redux store, this component
 		//needs to be updated.
 		noticesList = noticesList.concat( this.props.storeNotices.map( function( notice, index ) {
 			return (
-				<div className='global-notices__notice' key={ 'notice-' + index }>
-					<Notice
-						status={ notice.status }
-						duration = { notice.duration || null }
-						showDismiss={ notice.showDismiss }
-						onDismissClick={ this.props.removeNotice.bind( this, notice.noticeId ) }
-						text={ notice.text }>
-					</Notice>
-				</div>
+				<Notice
+					key={ 'notice-' + index }
+					status={ notice.status }
+					duration = { notice.duration || null }
+					showDismiss={ notice.showDismiss }
+					onDismissClick={ this.props.removeNotice.bind( this, notice.noticeId ) }
+					text={ notice.text }>
+				</Notice>
 			);
 		}, this ) );
 

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -37,7 +37,7 @@
 	pointer-events: auto;
 
 	@include breakpoint( ">660px" ) {
-		display: inline-flex;
+		display: flex;
 		border-radius: 20px;
 		overflow: hidden;
 		margin-bottom: 24px;

--- a/client/state/notices/actions.js
+++ b/client/state/notices/actions.js
@@ -19,7 +19,7 @@ export function removeNotice( noticeId ) {
 	};
 }
 
-function createNotice( status, text, options = {} ) {
+export function createNotice( status, text, options = {} ) {
 	const notice = {
 		noticeId: options.id || uniqueId(),
 		duration: options.duration,


### PR DESCRIPTION
This pull request seeks to remove the notice wrapper element added in #3910, as it is not currently in use and causes warnings to appear in the console due to lack of an assigned `key` prop.

[See previous discussion](https://github.com/Automattic/wp-calypso/pull/3910#discussion_r58777946)

__Testing instructions:__

Verify that no regressions occur in the removal of the wrapper element.

/cc @MichaelArestad , @rickybanister