### PR TITLE
Media: Preserve selected order when editing items

### DIFF
--- a/client/post-editor/media-modal/detail/index.jsx
+++ b/client/post-editor/media-modal/detail/index.jsx
@@ -60,7 +60,7 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		const items = MediaUtils.sortItemsByDate( this.props.items );
+		const { items } = this.props;
 
 		return (
 			<div className="editor-media-modal-detail">

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -169,18 +169,19 @@ module.exports = React.createClass( {
 	},
 
 	confirmDeleteMedia: function( accepted ) {
-		var toDelete = this.props.mediaLibrarySelectedItems;
+		const { site, mediaLibrarySelectedItems } = this.props;
 
-		if ( ! this.props.site || ! accepted ) {
+		if ( ! site || ! accepted ) {
 			return;
 		}
 
+		let toDelete = mediaLibrarySelectedItems;
 		if ( ModalViews.DETAIL === this.state.activeView ) {
-			toDelete = MediaUtils.sortItemsByDate( toDelete )[ this.state.detailSelectedIndex ];
+			toDelete = toDelete[ this.state.detailSelectedIndex ];
 			this.setNextAvailableDetailView();
 		}
 
-		MediaActions.delete( this.props.site.ID, toDelete );
+		MediaActions.delete( site.ID, toDelete );
 		analytics.mc.bumpStat( 'editor_media_actions', 'delete_media' );
 	},
 
@@ -252,10 +253,8 @@ module.exports = React.createClass( {
 			MediaActions.setLibrarySelectedItems( site.ID, items );
 		}
 
-		// The detail view sorts items by dates, so to ensure proper selected
-		// index is set, first sort the selected set
-		const sortedItems = MediaUtils.sortItemsByDate( items );
-		this.setDetailSelectedIndex( findIndex( sortedItems, { ID: item.ID } ) );
+		// Find and set detail selected index for the edited item
+		this.setDetailSelectedIndex( findIndex( items, { ID: item.ID } ) );
 
 		analytics.mc.bumpStat( 'editor_media_actions', 'edit_button_contextual' );
 		analytics.ga.recordEvent( 'Media', 'Clicked Contextual Edit Button' );


### PR DESCRIPTION
Closes #4652

This pull request seeks to remove the explicit date sorting applied to selected items when editing (viewing details) for a set of items. With these changes, the selected order should be preserved when clicking "Edit" in the media modal.

__Testing instructions:__

Verify that selected order is preserved when viewing details for a set of items. Verify also that no regressions occur in (a) editing a single item via the hover edit button when multiple items are selected and (b) deleting an item in the detail view deletes the correct single item being viewed at that moment.

Repeat steps to reproduce described at #4652.

/cc @designsimply