### PR TITLE
Purchases: Fix premium theme cancellations

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -178,7 +178,7 @@ const CancelPurchaseButton = React.createClass( {
 			submitting: true
 		} );
 
-		cancelAndRefundPurchase( this.props.purchase.id, null, this.handleSubmit );
+		cancelAndRefundPurchase( this.props.purchase.id, { product_id: this.props.purchase.productId }, this.handleSubmit );
 	},
 
 	render() {


### PR DESCRIPTION
This pull request fixes premium theme cancellations by ensuring we send the product_id to the endpoint.
 
#### Testing instructions

1. Run `git checkout fix/cancel-premium-themes` and start your server
2. Open the [`Purchases` page](http://calypso.localhost:3000/purchases)
3. Find a Premium theme purchase that is refundable
4. Attempt to refund the theme and assert that it works.

#### Reviews

- [x] Code
- [x] Product