### PR TITLE
Fix flexbox issues in Safari that were introduced in #4254

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -44,12 +44,18 @@
 .sidebar {
 	margin: 0;
 
+	div {
+		flex-shrink: 0;	// prevents items from squishing together under their initial height in Safari
+	}
+
 	ul {
+		flex-shrink: 0;
 		list-style: none;
 		margin: 0;
 	}
 
 	li {
+		flex-shrink: 0;
 		position: relative;
 	}
 }

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -81,14 +81,16 @@ module.exports = React.createClass( {
 		return (
 			<Sidebar>
 				<ProfileGravatar user={ this.props.user.get() } />
-				<FormButton
-					className="me-sidebar__menu__signout"
-					isPrimary={ false }
-					onClick={ this.onSignOut }
-					title={ this.translate( 'Sign out of WordPress.com', { textOnly: true } ) }
-				>
-					{ this.translate( 'Sign Out' ) }
-				</FormButton>
+				<div>
+					<FormButton
+						className="me-sidebar__menu__signout"
+						isPrimary={ false }
+						onClick={ this.onSignOut }
+						title={ this.translate( 'Sign out of WordPress.com', { textOnly: true } ) }
+					>
+						{ this.translate( 'Sign Out' ) }
+					</FormButton>
+				</div>
 				<SidebarMenu>
 					<SidebarHeading>{ this.translate( 'Profile' ) }</SidebarHeading>
 					<ul>

--- a/client/me/sidebar/style.scss
+++ b/client/me/sidebar/style.scss
@@ -4,6 +4,7 @@
 
 .form-button.me-sidebar__menu__signout {
 	display: block;
+	float: none;
 	margin: 0 auto;
 	max-width: 100%;
 	padding: 8px 24px;


### PR DESCRIPTION
This PR fixes a couple of issues that regressed in the merge of #4254:

- Sidebar items no longer squish together on Safari when you vertically size down the viewport
- Sign out button is no longer full width
- Same issues fixed on mobile Safari

#### Screenshots:

![screen shot 2016-04-13 at 19 40 03](https://cloud.githubusercontent.com/assets/1204802/14503327/f6e170c8-01af-11e6-8e62-618477d62cd5.png)

![screen shot 2016-04-13 at 19 40 13](https://cloud.githubusercontent.com/assets/1204802/14503333/f9f662aa-01af-11e6-9b7d-f9a696bbbf6d.png)