### PR TITLE
jetpack-connect: avoid store fetched url info in permanent storage

### DIFF
--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -44,6 +44,9 @@ export function jetpackConnectSite( state = {}, action ) {
 				return Object.assign( {}, state, { isRedirecting: true } );
 			}
 			return state;
+		case SERIALIZE:
+		case DESERIALIZE:
+			return {};
 	}
 	return state;
 }


### PR DESCRIPTION
Very simple PR to avoid storing the redux subtree with the last fetched url info.

This was creating a bug that made impossible to use the same url in two consecutive sessions. This PR fix it.

How to test
========
1. Go to http://calypso.localhost:3000/jetpack/connect and enter any url
2. After getting the result (any type of error is valid for our purpose), go back to calypso.localhost:3000/jetpack/connect (or reload the page if you are still there)
3. Enter the same url again. Nothing should happen until you click connect. (previously the component would have changed like if it were still fetching the url without clicking the connect button)

/cc @roccotripaldi  @beaulebens