### PR TITLE
Help: Prompt users about the response language to expect if they are not using the locale we officially support.

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -240,7 +240,7 @@ module.exports = React.createClass( {
 
 				{ showHelpLanguagePrompt && (
 					<div className="help-contact-form__help-language-prompt">
-						<FormLabel>{ this.translate( 'Note: The response will be in English.' ) }</FormLabel>
+						{ this.translate( 'Note: Support is only available in English at the moment.' ) }
 					</div>
 				) }
 				<FormButton disabled={ ! this.canSubmitForm() } type="button" onClick={ this.submitForm }>{ buttonLabel }</FormButton>

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -39,6 +39,7 @@ module.exports = React.createClass( {
 		showHowYouFeelField: React.PropTypes.bool,
 		showSubjectField: React.PropTypes.bool,
 		showSiteField: React.PropTypes.bool,
+		showHelpLanguagePrompt: React.PropTypes.bool,
 		siteFilter: React.PropTypes.func,
 		siteList: React.PropTypes.object,
 		disabled: React.PropTypes.bool,
@@ -55,6 +56,7 @@ module.exports = React.createClass( {
 			showHowYouFeelField: false,
 			showSubjectField: false,
 			showSiteField: false,
+			showHelpLanguagePrompt: false,
 			disabled: false,
 			valueLink: {
 				value: null,
@@ -194,7 +196,10 @@ module.exports = React.createClass( {
 				{ value: 'panicked', label: this.translate( 'Panicked' ) }
 			];
 
-		const { formDescription, buttonLabel, showHowCanWeHelpField, showHowYouFeelField, showSubjectField, showSiteField } = this.props;
+		const {
+			formDescription, buttonLabel, showHowCanWeHelpField,
+			showHowYouFeelField, showSubjectField, showSiteField, showHelpLanguagePrompt,
+		} = this.props;
 
 		return (
 			<div className="help-contact-form">
@@ -233,6 +238,11 @@ module.exports = React.createClass( {
 				<FormLabel>{ this.translate( 'What are you trying to do?' ) }</FormLabel>
 				<FormTextarea valueLink={ this.linkState( 'message' ) } placeholder={ this.translate( 'Please be descriptive' ) }></FormTextarea>
 
+				{ showHelpLanguagePrompt && (
+					<div className="help-contact-form__help-language-prompt">
+						<FormLabel>{ this.translate( 'Note: The response will be in English.' ) }</FormLabel>
+					</div>
+				) }
 				<FormButton disabled={ ! this.canSubmitForm() } type="button" onClick={ this.submitForm }>{ buttonLabel }</FormButton>
 			</div>
 		);

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -197,8 +197,13 @@ module.exports = React.createClass( {
 			];
 
 		const {
-			formDescription, buttonLabel, showHowCanWeHelpField,
-			showHowYouFeelField, showSubjectField, showSiteField, showHelpLanguagePrompt,
+			formDescription,
+			buttonLabel,
+			showHowCanWeHelpField,
+			showHowYouFeelField,
+			showSubjectField,
+			showSiteField,
+			showHelpLanguagePrompt,
 		} = this.props;
 
 		return (
@@ -239,9 +244,9 @@ module.exports = React.createClass( {
 				<FormTextarea valueLink={ this.linkState( 'message' ) } placeholder={ this.translate( 'Please be descriptive' ) }></FormTextarea>
 
 				{ showHelpLanguagePrompt && (
-					<div className="help-contact-form__help-language-prompt">
+					<strong className="help-contact-form__help-language-prompt">
 						{ this.translate( 'Note: Support is only available in English at the moment.' ) }
-					</div>
+					</strong>
 				) }
 				<FormButton disabled={ ! this.canSubmitForm() } type="button" onClick={ this.submitForm }>{ buttonLabel }</FormButton>
 			</div>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -375,6 +375,7 @@ module.exports = React.createClass( {
 				showHowCanWeHelpField: showKayakoVariation || showChatVariation,
 				showHowYouFeelField: showKayakoVariation || showChatVariation,
 				showSiteField: ( showKayakoVariation || showChatVariation ) && ( sites.get().length > 1 ),
+			  	showHelpLanguagePrompt: showHelpLanguagePrompt,
 				valueLink: { value: savedContactForm, requestChange: ( contactForm ) => savedContactForm = contactForm }
 			},
 			showChatVariation && {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -21,6 +21,7 @@ import wpcomLib from 'lib/wp';
 import notices from 'notices';
 import siteList from 'lib/sites-list';
 import analytics from 'lib/analytics';
+import i18n from 'lib/i18n-utils';
 
 /**
  * Module variables
@@ -344,6 +345,7 @@ module.exports = React.createClass( {
 		const showChatVariation = olark.isUserEligible && olark.isOperatorAvailable;
 		const showKayakoVariation = ! showChatVariation && ( olark.details.isConversing || olark.isUserEligible );
 		const showForumsVariation = ! ( showChatVariation || showKayakoVariation );
+		const showHelpLanguagePrompt = olark.locale !== i18n.getLocaleSlug();
 
 		if ( confirmation ) {
 			return <HelpContactConfirmation { ...confirmation } />;
@@ -375,7 +377,7 @@ module.exports = React.createClass( {
 				showHowCanWeHelpField: showKayakoVariation || showChatVariation,
 				showHowYouFeelField: showKayakoVariation || showChatVariation,
 				showSiteField: ( showKayakoVariation || showChatVariation ) && ( sites.get().length > 1 ),
-			  	showHelpLanguagePrompt: showHelpLanguagePrompt,
+				showHelpLanguagePrompt: showHelpLanguagePrompt,
 				valueLink: { value: savedContactForm, requestChange: ( contactForm ) => savedContactForm = contactForm }
 			},
 			showChatVariation && {

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -345,7 +345,7 @@ module.exports = React.createClass( {
 		const showChatVariation = olark.isUserEligible && olark.isOperatorAvailable;
 		const showKayakoVariation = ! showChatVariation && ( olark.details.isConversing || olark.isUserEligible );
 		const showForumsVariation = ! ( showChatVariation || showKayakoVariation );
-		const showHelpLanguagePrompt = olark.locale !== i18n.getLocaleSlug();
+		const showHelpLanguagePrompt = ( olark.locale !== i18n.getLocaleSlug() );
 
 		if ( confirmation ) {
 			return <HelpContactConfirmation { ...confirmation } />;

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -46,3 +46,8 @@
 	font-size: 14px;
 	color: $gray-dark;
 }
+
+.help-contact-form__help-language-prompt {
+    font-size: 14px;
+    font-weight: 600;
+}

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -46,8 +46,3 @@
 	font-size: 14px;
 	color: $gray-dark;
 }
-
-.help-contact-form__help-language-prompt {
-    font-size: 14px;
-    font-weight: 600;
-}


### PR DESCRIPTION
## Summary
We want to prompt the user about the language we would use in response to set the right expectation.
As we can tell the supporting language we would use via the `locale` property of `olark store`, we prompt the user if `olark.locale` is not matched with one's locale.

For example, this is what a zh-tw user seeing:
![image](https://cloud.githubusercontent.com/assets/1842898/14504462/7f2a8dde-01e7-11e6-86b1-86a6a8a04c0f.png)

and, for a pt-br user:
![image](https://cloud.githubusercontent.com/assets/1842898/14504493/a6dc2306-01e7-11e6-8e9a-2193dea6fe81.png)

## How to test
1. Change the locale via `/me/account/`.
2. Visit `/help/contact`. Any locale other than `en` and `pt-br` should see the prompt string.