### PR TITLE
Signup: merge Headstart into `themes` step

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -86,7 +86,7 @@ const flows = {
 	},
 
 	businessv2: {
-		steps: [ 'domains', 'user' ],
+		steps: [ 'domains-without-theme', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
@@ -95,7 +95,7 @@ const flows = {
 	},
 
 	premiumv2: {
-		steps: [ 'domains', 'user' ],
+		steps: [ 'domains-without-theme', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
@@ -104,7 +104,7 @@ const flows = {
 	},
 
 	'with-theme': {
-		steps: [ 'domains', 'plans', 'user' ],
+		steps: [ 'domains-without-theme', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Preselect a theme to activate/buy from an external source',
 		lastModified: '2016-01-27'
@@ -133,7 +133,7 @@ const flows = {
 	},
 
 	newsite: {
-		steps: [ 'survey', 'themes-headstart', 'domains-with-theme', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getSiteDestination,
 		description: 'Headstarted flow with verticals for EN users clicking "Create Website" on the homepage.',
 		lastModified: '2016-03-21'
@@ -192,7 +192,7 @@ const flows = {
 	},
 
 	headstart: {
-		steps: [ 'themes-headstart', 'domains-with-theme', 'plans', 'user' ],
+		steps: [ 'themes', 'domains', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Regular flow but with Headstart enabled to pre-populate site content',
 		lastModified: '2015-02-01'
@@ -232,7 +232,7 @@ const flows = {
 	},
 
 	'new-vertical-site': {
-		steps: [ 'survey', 'themes-headstart', 'domains-with-theme', 'plans', 'survey-user' ],
+		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getSiteDestination,
 		description: 'Test flow showing Headstarted vertical themes for EN users clicking "Create Website" on the homepage.',
 		lastModified: '2016-03-22'

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -86,7 +86,7 @@ const flows = {
 	},
 
 	businessv2: {
-		steps: [ 'domains-without-theme', 'user' ],
+		steps: [ 'domains-only', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/business/' + dependencies.siteSlug;
 		},
@@ -95,7 +95,7 @@ const flows = {
 	},
 
 	premiumv2: {
-		steps: [ 'domains-without-theme', 'user' ],
+		steps: [ 'domains-only', 'user' ],
 		destination: function( dependencies ) {
 			return '/plans/select/premium/' + dependencies.siteSlug;
 		},
@@ -104,7 +104,7 @@ const flows = {
 	},
 
 	'with-theme': {
-		steps: [ 'domains-without-theme', 'plans', 'user' ],
+		steps: [ 'domains-only', 'plans', 'user' ],
 		destination: getSiteDestination,
 		description: 'Preselect a theme to activate/buy from an external source',
 		lastModified: '2016-01-27'

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -15,7 +15,7 @@ module.exports = {
 	'design-type': DesignTypeComponent,
 	domains: DomainsStepComponent,
 	'domains-with-plan': DomainsStepComponent,
-	'domains-with-theme': DomainsStepComponent,
+	'domains-without-theme': DomainsStepComponent,
 	'jetpack-user': UserSignupComponent,
 	plans: PlansStepComponent,
 	'select-plan': PaidPlansOnly,
@@ -24,6 +24,5 @@ module.exports = {
 	'survey-user': UserSignupComponent,
 	test: config( 'env' ) === 'development' ? require( 'signup/steps/test-step' ) : undefined,
 	themes: ThemeSelectionComponent,
-	'themes-headstart': ThemeSelectionComponent,
 	user: UserSignupComponent
 };

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -15,7 +15,7 @@ module.exports = {
 	'design-type': DesignTypeComponent,
 	domains: DomainsStepComponent,
 	'domains-with-plan': DomainsStepComponent,
-	'domains-without-theme': DomainsStepComponent,
+	'domains-only': DomainsStepComponent,
 	'jetpack-user': UserSignupComponent,
 	plans: PlansStepComponent,
 	'select-plan': PaidPlansOnly,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -12,15 +12,6 @@ import i18n from 'lib/mixins/i18n';
 module.exports = {
 	themes: {
 		stepName: 'themes',
-		apiRequestFunction: stepActions.setThemeOnSite,
-		dependencies: [ 'siteSlug' ]
-	},
-
-	'themes-headstart': {
-		stepName: 'themes-headstart',
-		props: {
-			useHeadstart: true
-		},
 		dependencies: [ 'siteSlug' ],
 		providesDependencies: [ 'theme' ]
 	},
@@ -81,6 +72,7 @@ module.exports = {
 		stepName: 'domains',
 		apiRequestFunction: stepActions.addDomainItemsToCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+		dependencies: [ 'theme' ],
 		delayApiRequestUntilComplete: true
 	},
 
@@ -88,14 +80,14 @@ module.exports = {
 		stepName: 'domains-with-plan',
 		apiRequestFunction: stepActions.addDomainItemsToCartAndStartFreeTrial,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+		dependencies: [ 'theme' ],
 		delayApiRequestUntilComplete: true
 	},
 
-	'domains-with-theme': {
-		stepName: 'domains-with-theme',
+	'domains-without-theme': {
+		stepName: 'domains-without-theme',
 		apiRequestFunction: stepActions.addDomainItemsToCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
-		dependencies: [ 'theme' ],
 		delayApiRequestUntilComplete: true
 	},
 

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -84,8 +84,8 @@ module.exports = {
 		delayApiRequestUntilComplete: true
 	},
 
-	'domains-without-theme': {
-		stepName: 'domains-without-theme',
+	'domains-only': {
+		stepName: 'domains-only',
 		apiRequestFunction: stepActions.addDomainItemsToCart,
 		providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
 		delayApiRequestUntilComplete: true

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -38,32 +38,22 @@ module.exports = React.createClass( {
 				{ name: 'Harmonic', slug: 'harmonic' },
 			],
 
-			useHeadstart: false
+			useHeadstart: true,
 		};
 	},
 
 	handleScreenshotClick: function( theme ) {
 		var themeSlug = theme.id;
 
-		if ( true === this.props.useHeadstart && themeSlug ) {
-			analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: true } );
+		analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: true } );
 
-			SignupActions.submitSignupStep( {
-				stepName: this.props.stepName,
-				processingMessage: this.translate( 'Adding your theme' ),
-				themeSlug
-			}, null, {
-				theme: 'pub/' + themeSlug
-			} );
-		} else {
-			analytics.tracks.recordEvent( 'calypso_signup_theme_select', { theme: themeSlug, headstart: false } );
-
-			SignupActions.submitSignupStep( {
-				stepName: this.props.stepName,
-				processingMessage: this.translate( 'Adding your theme' ),
-				themeSlug
-			} );
-		}
+		SignupActions.submitSignupStep( {
+			stepName: this.props.stepName,
+			processingMessage: this.translate( 'Adding your theme' ),
+			themeSlug
+		}, null, {
+			theme: 'pub/' + themeSlug
+		} );
 
 		this.props.goToNextStep();
 	},


### PR DESCRIPTION
In #4141, Headstart became the default for all signups from the homepage. After letting it run in production, it's time to make Headstart functionality the default for the `themes` step in Signup, and remove the need for the `themes-headstart` and `domains-with-themes` steps.

This will essentially pass all Signups that include the `themes` step through the Headstart pre-flight check, where the plugin will check theme and locale support before proceeding.