### PR TITLE
Components: refactor bulk-select

### DIFF
--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import classNames from 'classnames';
-
 /**
  * Internal dependencies
  */
@@ -21,33 +19,30 @@ export default React.createClass( {
 	},
 
 	getStateIcon() {
-		if ( this.hasSomeElementsSelected() ) {
+		if ( ! this.hasAllElementsSelected() && this.hasSomeElementsSelected() ) {
 			return <Gridicon className="bulk-select__some-checked-icon" icon="minus-small" size={ 18 }/>;
 		}
 	},
 
 	hasAllElementsSelected() {
-		return this.props.selectedElements && this.props.selectedElements === this.props.totalElements;
+		return this.props.selectedElements === this.props.totalElements;
 	},
 
 	hasSomeElementsSelected() {
-		return this.props.selectedElements && this.props.selectedElements < this.props.totalElements;
+		return this.props.selectedElements > 0;
 	},
 
 	handleToggleAll() {
-		const newCheckedState = ! ( this.hasSomeElementsSelected() || this.hasAllElementsSelected() );
-		this.props.onToggle( newCheckedState );
+		this.props.onToggle( this.hasSomeElementsSelected() );
 	},
 
 	render() {
 		const isChecked = this.hasAllElementsSelected();
-		const inputClasses = classNames( 'bulk-select__box', {
-			'is-checked': isChecked // we need to add this css class to be able to test if the input if checked, since enzyme still doesn't support :checked pseudoselector
-		} );
+
 		return (
 			<span className="bulk-select" onClick={ this.handleToggleAll }>
 				<span className="bulk-select__container">
-					<input type="checkbox" className={ inputClasses } checked={ isChecked } readOnly />
+					<input type="checkbox" checked={ isChecked } readOnly />
 					<Count count={ this.props.selectedElements } />
 					{ this.getStateIcon() }
 				</span>

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -5,70 +5,70 @@ import { assert } from 'chai';
 import React from 'react';
 import { shallow } from 'enzyme';
 import noop from 'lodash/noop';
+import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
+import useFakeDom from 'test/helpers/use-fake-dom';
 import BulkSelect from '../index';
 
-describe( 'index', function() {
-	require( 'test/helpers/use-fake-dom' )();
-	it( 'should have BulkSelect class', function() {
+describe.only( 'index', () => {
+	useFakeDom();
+
+	it( 'should have BulkSelect class', () => {
 		const bulkSelect = shallow( <BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ noop } /> );
-		assert.equal( 1, bulkSelect.find( '.bulk-select' ).length );
+		assert.isDefined( bulkSelect.find( '.bulk-select' ).node );
 	} );
 
-	it( 'should not be checked when initialized without selectedElements', function() {
+	it( 'should not be checked when initialized without selectedElements', () => {
 		const bulkSelect = shallow( <BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ noop } /> );
-		assert.equal( 0, bulkSelect.find( '.is-checked' ).length );
+		assert.isUndefined( bulkSelect.find( { checked: true } ).node );
 	} );
 
-	it( 'should be checked when initialized with all elements selected', function() {
+	it( 'should be checked when initialized with all elements selected', () => {
 		const bulkSelect = shallow( <BulkSelect selectedElements={ 3 } totalElements={ 3 } onToggle={ noop } /> );
-		assert.equal( 1, bulkSelect.find( '.is-checked' ).length );
+		assert.isDefined( bulkSelect.find( { checked: true } ).node );
 	} );
 
-	it( 'should not be checked when initialized with some elements selected', function() {
+	it( 'should not be checked when initialized with some elements selected', () => {
 		const bulkSelect = shallow( <BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } /> );
-		assert.equal( 0, bulkSelect.find( '.is-checked' ).length );
+		assert.isUndefined( bulkSelect.find( { checked: true } ).node );
 	} );
 
-	it( 'should render line gridicon when initialized with some elements selected', function() {
+	it( 'should render line gridicon when initialized with some elements selected', () => {
 		const bulkSelect = shallow( <BulkSelect selectedElements={ 2 } totalElements={ 3 } onToggle={ noop } /> );
-		assert.equal( 1, bulkSelect.find( '.bulk-select__some-checked-icon' ).length );
+		assert.isDefined( bulkSelect.find( '.bulk-select__some-checked-icon' ).node );
 	} );
 
-	it( 'should be call onToggle when clicked', function() {
-		let hasBeenCalled = false;
-		const callback = function() {
-			hasBeenCalled = true;
-		};
+	it( 'should call onToggle when clicked', () => {
+		const callback = sinon.spy();
 		const bulkSelect = shallow( <BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ callback } /> );
 		bulkSelect.simulate( 'click' );
-		assert.equal( hasBeenCalled, true );
+		assert.isTrue( callback.called );
 	} );
 
-	it( 'should be call onToggle with the new state when there are no selected elements', function( done ) {
-		const callback = function( newState ) {
-			assert.equal( newState, true );
+	it( 'should call onToggle with the new state when there are no selected elements', done => {
+		const callback = newState => {
+			assert.isFalse( newState );
 			done();
 		};
 		const bulkSelect = shallow( <BulkSelect selectedElements={ 0 } totalElements={ 3 } onToggle={ callback } /> );
 		bulkSelect.simulate( 'click' );
 	} );
 
-	it( 'should be call onToggle with the new state when there are some selected elements', function( done ) {
-		const callback = function( newState ) {
-			assert.equal( newState, false );
+	it( 'should call onToggle with the new state when there are some selected elements', done => {
+		const callback = newState => {
+			assert.isTrue( newState );
 			done();
 		};
 		const bulkSelect = shallow( <BulkSelect selectedElements={ 1 } totalElements={ 3 } onToggle={ callback } /> );
 		bulkSelect.simulate( 'click' );
 	} );
 
-	it( 'should be call onToggle with the new state when there all elements are selected', function( done ) {
-		const callback = function( newState ) {
-			assert.equal( newState, false );
+	it( 'should call onToggle with the new state when there all elements are selected', done => {
+		const callback = newState => {
+			assert.isTrue( newState );
 			done();
 		};
 		const bulkSelect = shallow( <BulkSelect selectedElements={ 3 } totalElements={ 3 } onToggle={ callback } /> );


### PR DESCRIPTION
This PR changes the behavior of the `onToggle` callback in bulk-select component. 

The current behavior is to call `onToggle` with `false` if there are some or all elements selected. This PR inverts that to send `true` to suggest that some elements **are** selected.

The PR also includes some minor refactoring of the `BulkSelect` class.

paired with @nb 

**Testing**

```
npm run test-client client/components/bulk-select/index.js -- -w
```