### PR TITLE
Plans: monthly plan pricing

### DIFF
--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
+import config from 'config';
 import WpcomPlanPrice from 'my-sites/plans/wpcom-plan-price';
 
 const PlanPrice = React.createClass( {
@@ -24,7 +24,7 @@ const PlanPrice = React.createClass( {
 				return this.translate( 'Free', { context: 'Zero cost product price' } );
 			}
 
-			if ( abtest( 'monthlyPlanPricing' ) === 'monthly' && this.props.isInSignup ) {
+			if ( config.isEnabled( 'monthly-plan-pricing' ) ) {
 				const monthlyPrice = +( rawPrice / 12 ).toFixed( 2 );
 				formattedPrice = formattedPrice.replace( rawPrice, monthlyPrice );
 			}
@@ -55,7 +55,7 @@ const PlanPrice = React.createClass( {
 			return <div className="plan-price is-placeholder" />;
 		}
 
-		if ( abtest( 'monthlyPlanPricing' ) === 'monthly' && this.props.isInSignup && plan.raw_price !== 0 ) {
+		if ( config.isEnabled( 'monthly-plan-pricing' ) && plan.raw_price !== 0 ) {
 			periodLabel = this.translate( 'per month, billed yearly' );
 		} else {
 			periodLabel = hasDiscount ? this.translate( 'due today when you upgrade' ) : plan.bill_period_label

--- a/client/components/plans/plans-compare/style.scss
+++ b/client/components/plans/plans-compare/style.scss
@@ -35,7 +35,7 @@
 	}
 
 	.wpcom-plan-price .wpcom-plan-price__billing-period {
-		display: inline;
+		display: block;
 		margin-left: 3px;
 	}
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -37,14 +37,6 @@ module.exports = {
 		},
 		defaultVariation: 'disabled'
 	},
-	monthlyPlanPricing: {
-		datestamp: '20160118',
-		variations: {
-			yearly: 50,
-			monthly: 50
-		},
-		defaultVariation: 'yearly'
-	},
 	privacyCheckbox: {
 		datestamp: '20160310',
 		variations: {

--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -1,24 +1,25 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'lib/analytics' ),
-	canRemoveFromCart = require( 'lib/cart-values' ).canRemoveFromCart,
-	cartItems = require( 'lib/cart-values' ).cartItems,
-	getIncludedDomain = cartItems.getIncludedDomain,
-	isCredits = require( 'lib/products-values' ).isCredits,
-	isDomainProduct = require( 'lib/products-values' ).isDomainProduct,
-	isGoogleApps = require( 'lib/products-values' ).isGoogleApps,
-	upgradesActions = require( 'lib/upgrades/actions' ),
-	abtest = require( 'lib/abtest' ).abtest,
-	{ isPremium, isBusiness } = require( 'lib/products-values' ),
-	isTheme = require( 'lib/products-values' ).isTheme;
+import analytics from 'lib/analytics';
+import { canRemoveFromCart, cartItems } from 'lib/cart-values';
+import {
+	isCredits,
+	isDomainProduct,
+	isGoogleApps,
+	isTheme
+} from 'lib/products-values';
+import * as upgradesActions from 'lib/upgrades/actions';
+import config from 'config';
 
-module.exports = React.createClass( {
+const getIncludedDomain = cartItems.getIncludedDomain;
+
+export default React.createClass( {
 	displayName: 'CartItem',
 
 	removeFromCart: function( event ) {
@@ -55,12 +56,8 @@ module.exports = React.createClass( {
 	},
 
 	monthlyPrice: function() {
-		const { cost, currency } = this.props.cartItem,
-			isInSignup = this.props.cartItem.extra && this.props.cartItem.extra.context === 'signup';
-		if ( ! isInSignup ||
-				! ( isPremium( this.props.cartItem ) || isBusiness( this.props.cartItem ) ) ||
-				abtest( 'monthlyPlanPricing' ) === 'yearly' ||
-				cost === 0 ) {
+		const { cost, currency } = this.props.cartItem;
+		if ( ! config.isEnabled( 'monthly-plan-pricing' ) || cost === 0 ) {
 			return null;
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -86,6 +86,7 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"muse": true,
+		"monthly-plan-pricing": true,
 		"network-connection": true,
 		"notifications2beta": true,
 		"olark": true,


### PR DESCRIPTION
This PR updates plan pricing to monthly behind a `monthly-plan-pricing` feature flag. This flag is only enabled on dev atm. Closes #4681

![screen shot 2016-04-13 at 3 58 30 pm](https://cloud.githubusercontent.com/assets/1270189/14512681/036e583e-0196-11e6-96dc-50180bf2c2e7.png)
![screen shot 2016-04-13 at 3 58 15 pm](https://cloud.githubusercontent.com/assets/1270189/14512682/0586900a-0196-11e6-9860-ecfa8c3f4088.png)
![screen shot 2016-04-14 at 2 39 01 pm](https://cloud.githubusercontent.com/assets/1270189/14544644/06a8b18e-024f-11e6-8593-74d958f06fbb.png)
![screen shot 2016-04-14 at 2 39 13 pm](https://cloud.githubusercontent.com/assets/1270189/14544650/0ca60dd4-024f-11e6-83f7-ba6afd00ce05.png)

~~Could use a bit of design ❤️  on the comparison page.~~

## Testing Instructions
- Select a site with a free/premium plan
- Navigate to /plans, where monthly pricing is visible
- Add a plan to cart
- Monthly pricing also displays in /plans/compare, and in cart items as displayed above
- You can remove item from cart/checkout normally

cc @rralian @drw158 @retrofox @mtias @artpi