### PR TITLE
Reader: fix Manage Following misaligned gridicon

### DIFF
--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -162,6 +162,7 @@
 		}
 
 		&.is-valid {
+
 			.gridicon {
 				fill: $blue-medium;
 
@@ -169,6 +170,10 @@
 				&:active {
 					cursor: pointer;
 				}
+			}
+
+			.reader-list-item__icon .gridicon {
+				fill: $white;
 			}
 
 			.follow-button {

--- a/client/reader/list-item/style.scss
+++ b/client/reader/list-item/style.scss
@@ -64,7 +64,7 @@
 		background: lighten( $gray, 20 );
 		fill: $white;
 		position: relative;
-			top: 12px;
+			top: 1px;
 	}
 }
 


### PR DESCRIPTION
This fixes the globe gridicon that's misaligned on the Manage Following page.

**Before:**
![screenshot 2016-04-13 18 35 39](https://cloud.githubusercontent.com/assets/4924246/14514548/90c4bb5a-01a6-11e6-8e59-5f7f9b5f4098.png)

**After:**
![screenshot 2016-04-13 18 35 49](https://cloud.githubusercontent.com/assets/4924246/14514550/93a9dc74-01a6-11e6-96a1-a48782191af7.png)