### PR TITLE
Fix #1225 loading posts color transperant removed

### DIFF
--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -101,7 +101,6 @@
 
 		.reader__placeholder-text,
 		.site-icon {
-			color: transparent;
 			background-color: lighten( $gray, 30% );
 			animation: loading-fade 1.6s ease-in-out infinite;
 		}


### PR DESCRIPTION
<img width="799" alt="screen shot 2016-04-14 at 2 14 25 pm" src="https://cloud.githubusercontent.com/assets/12471122/14518566/41cdce10-024b-11e6-8ae0-d0d6181e7cbb.png">