### PR TITLE
Domains: increase the allocation for domainsbot in the A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -65,8 +65,8 @@ module.exports = {
 	domainSuggestionVendor: {
 		datestamp: '20160408',
 		variations: {
-			namegen: 95,
-			domainsbot: 5,
+			namegen: 75,
+			domainsbot: 25,
 		},
 		defaultVariation: 'namegen'
 	},


### PR DESCRIPTION
We aren't getting anywhere near significant results with 5% allocation.

To test:
1. localStorage.setItem( 'ABTests', '{"domainSuggestionVendor_20160408":"domainsbot"}' )
2. Go to domains/add and search for something. You should see results
3. localStorage.setItem( 'ABTests', '{"domainSuggestionVendor_20160408":"namegen"}' ) (or delete the entry)
4. Search for a domain. You should still see results, but slightly different than the last time.