### PR TITLE
GuidedTours: fix element highlighting

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import scrollTo from 'lib/scroll-to';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
@@ -63,6 +64,9 @@ class GuidedTours extends Component {
 	}
 
 	quit( options = {} ) {
+		const container = query( '#secondary .sidebar' )[ 0 ];
+		scrollTo( { y: 0, container: container } );
+
 		this.currentTarget && this.currentTarget.classList.remove( 'guided-tours__overlay' );
 		this.props.quitGuidedTour( Object.assign( {
 			stepName: this.props.tourState.stepName

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -64,8 +64,8 @@ class GuidedTours extends Component {
 	}
 
 	quit( options = {} ) {
-		const container = query( '#secondary .sidebar' )[ 0 ];
-		scrollTo( { y: 0, container: container } );
+		const sidebar = query( '#secondary .sidebar' )[ 0 ];
+		scrollTo( { y: 0, container: sidebar } );
 
 		this.currentTarget && this.currentTarget.classList.remove( 'guided-tours__overlay' );
 		this.props.quitGuidedTour( Object.assign( {

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -110,25 +110,85 @@ function validatePlacement( placement, target ) {
 		: placement;
 }
 
-function scrollIntoView( target ) {
-	const targetSlug = target && target.dataset && target.dataset.tipTarget;
-
+export function getScrollDiff( targetSlug, container ) {
+	const target = targetForSlug( targetSlug );
+	const { top, bottom } = target.getBoundingClientRect();
 	if ( targetSlug !== 'themes' ) {
 		return 0;
 	}
-
-	const { top, bottom } = target.getBoundingClientRect();
-
 	if ( bottom + DIALOG_PADDING + DIALOG_HEIGHT <=
 			document.documentElement.clientHeight ) {
 		return 0;
 	}
-
-	const container = query( '#secondary .sidebar' )[ 0 ];
 	const scrollMax = container.scrollHeight -
 		container.clientHeight - container.scrollTop;
-	const y = Math.min( .75 * top, scrollMax );
 
-	scrollTo( { y, container } );
+	return Math.min( .75 * top, scrollMax );
+}
+
+function scrollIntoView( target ) {
+	const targetSlug = target && target.dataset && target.dataset.tipTarget;
+	if ( targetSlug !== 'themes' ) {
+		return 0;
+	}
+
+	const container = query( '#secondary .sidebar' )[ 0 ];
+	const y = getScrollDiff( targetSlug, container );
+
+	scrollTo( { y: y, container: container, duration: 300 } );
 	return y;
+}
+
+export function getScrolledRect( { targetSlug, scrollY } ) {
+	const target = targetForSlug( targetSlug );
+	let rect = target.getBoundingClientRect();
+	const scrolledRect = {
+		top: rect.top - scrollY,
+		bottom: rect.bottom - scrollY,
+		left: rect.left,
+		right: rect.right,
+		height: rect.height,
+		width: rect.width,
+	};
+	return scrolledRect;
+}
+
+export function getOverlayStyle( { rect } ) {
+	const clientWidth = document.documentElement.clientWidth;
+	const clientHeight = document.documentElement.clientHeight;
+	const correctedRect = {
+		top: rect.top,
+		left: rect.left < 0 ? 0 : rect.left,
+		height: rect.height,
+		width: rect.width,
+		right: rect.left < 0 ? rect.right - rect.left : rect.right,
+		bottom: rect.bottom,
+	};
+
+	return {
+		top: {
+			top: '0px',
+			left: '0px',
+			right: '0px',
+			height: correctedRect.top + 'px',
+		},
+		left: {
+			top: correctedRect.top + 'px',
+			left: '0px',
+			width: correctedRect.left + 'px',
+			height: correctedRect.height + 'px',
+		},
+		right: {
+			top: correctedRect.top + 'px',
+			right: '0px',
+			height: correctedRect.height + 'px',
+			width: ( clientWidth - correctedRect.right ) + 'px',
+		},
+		bottom: {
+			bottom: '0px',
+			height: ( clientHeight - correctedRect.bottom ) + 'px',
+			left: '0px',
+			right: '0px',
+		},
+	};
 }

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -110,7 +110,7 @@ function validatePlacement( placement, target ) {
 		: placement;
 }
 
-export function getScrollDiff( targetSlug, container ) {
+function getScrollDiff( targetSlug, container ) {
 	if ( targetSlug !== 'themes' ) {
 		return 0;
 	}
@@ -144,7 +144,7 @@ function scrollIntoView( target ) {
 	return y;
 }
 
-export function getScrolledRect( { targetSlug, scrollY } ) {
+function getScrolledRect( targetSlug, scrollY ) {
 	const target = targetForSlug( targetSlug );
 	const rect = target.getBoundingClientRect();
 	return {
@@ -155,7 +155,11 @@ export function getScrolledRect( { targetSlug, scrollY } ) {
 		height: rect.height,
 		width: rect.width,
 	};
-	return scrolledRect;
+}
+
+export function getScrolledRectFromBase( targetSlug, baseElement ) {
+	const scrollY = getScrollDiff( targetSlug, baseElement );
+	return getScrolledRect( targetSlug, scrollY );
 }
 
 export function getOverlayStyle( { rect } ) {

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -163,7 +163,6 @@ export function getScrolledRectFromBase( targetSlug, baseElement ) {
 }
 
 export function getOverlayStyle( { rect } ) {
-	const clientWidth = document.documentElement.clientWidth;
 	const clientHeight = document.documentElement.clientHeight;
 	const correctedRect = {
 		top: rect.top,
@@ -177,27 +176,27 @@ export function getOverlayStyle( { rect } ) {
 	return {
 		top: {
 			top: '0px',
-			left: '0px',
 			right: '0px',
 			height: correctedRect.top + 'px',
+			left: '0px',
 		},
 		left: {
 			top: correctedRect.top + 'px',
-			left: '0px',
 			width: correctedRect.left + 'px',
-			height: correctedRect.height + 'px',
+			bottom: clientHeight - correctedRect.height - correctedRect.top + 'px',
+			left: '0px',
 		},
 		right: {
 			top: correctedRect.top + 'px',
 			right: '0px',
-			height: correctedRect.height + 'px',
-			width: ( clientWidth - correctedRect.right ) + 'px',
+			bottom: clientHeight - correctedRect.height - correctedRect.top + 'px',
+			left: correctedRect.right + 'px',
 		},
 		bottom: {
-			bottom: '0px',
-			height: ( clientHeight - correctedRect.bottom ) + 'px',
-			left: '0px',
+			top: correctedRect.bottom + 'px',
 			right: '0px',
+			bottom: '0px',
+			left: '0px',
 		},
 	};
 }

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -111,15 +111,19 @@ function validatePlacement( placement, target ) {
 }
 
 export function getScrollDiff( targetSlug, container ) {
-	const target = targetForSlug( targetSlug );
-	const { top, bottom } = target.getBoundingClientRect();
 	if ( targetSlug !== 'themes' ) {
 		return 0;
 	}
-	if ( bottom + DIALOG_PADDING + DIALOG_HEIGHT <=
-			document.documentElement.clientHeight ) {
+
+	const target = targetForSlug( targetSlug );
+	const { top, bottom } = target.getBoundingClientRect();
+	const dialogWillFit = bottom + DIALOG_PADDING + DIALOG_HEIGHT <=
+			document.documentElement.clientHeight;
+
+	if ( dialogWillFit ) {
 		return 0;
 	}
+
 	const scrollMax = container.scrollHeight -
 		container.clientHeight - container.scrollTop;
 
@@ -128,21 +132,22 @@ export function getScrollDiff( targetSlug, container ) {
 
 function scrollIntoView( target ) {
 	const targetSlug = target && target.dataset && target.dataset.tipTarget;
+
 	if ( targetSlug !== 'themes' ) {
 		return 0;
 	}
 
-	const container = query( '#secondary .sidebar' )[ 0 ];
-	const y = getScrollDiff( targetSlug, container );
+	const sidebar = query( '#secondary .sidebar' )[ 0 ];
+	const y = getScrollDiff( targetSlug, sidebar );
 
-	scrollTo( { y: y, container: container, duration: 300 } );
+	scrollTo( { y: y, container: sidebar, duration: 300 } );
 	return y;
 }
 
 export function getScrolledRect( { targetSlug, scrollY } ) {
 	const target = targetForSlug( targetSlug );
-	let rect = target.getBoundingClientRect();
-	const scrolledRect = {
+	const rect = target.getBoundingClientRect();
+	return {
 		top: rect.top - scrollY,
 		bottom: rect.bottom - scrollY,
 		left: rect.left,

--- a/client/layout/guided-tours/steps.js
+++ b/client/layout/guided-tours/steps.js
@@ -11,7 +11,15 @@ import Card from 'components/card';
 import Button from 'components/button';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'components/gridicon';
-import { posToCss, getStepPosition, getBullseyePosition, getOverlayStyle, getScrollDiff, targetForSlug, getScrolledRect, query } from './positioning';
+import {
+	query,
+	posToCss,
+	getStepPosition,
+	getBullseyePosition,
+	getOverlayStyle,
+	targetForSlug,
+	getScrolledRectFromBase,
+} from './positioning';
 
 class BasicStep extends Component {
 	render() {
@@ -160,12 +168,11 @@ class ActionStep extends Component {
 
 const withHighlighting = StepComponent => class extends Component {
 	componentWillMount() {
-		const container = query( '#secondary .sidebar' )[ 0 ];
-		const scrollY = getScrollDiff( this.props.targetSlug, container );
-		const stepPosition = posToCss( getStepPosition( this.props ) );
-		const targetRect = getScrolledRect( { targetSlug: this.props.targetSlug, scrollY: scrollY } );
-
-		this.computedProps = { stepPosition, targetRect };
+		const sidebar = query( '#secondary .sidebar' )[ 0 ];
+		this.computedProps = {
+			stepPosition: posToCss( getStepPosition( this.props ) ),
+			targetRect: getScrolledRectFromBase( this.props.targetSlug, sidebar ),
+		};
 	}
 
 	render() {

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -10,6 +10,12 @@
 	margin-right: 5px;
 	font-size: 14px;
 
+	animation-duration: 200ms;
+	animation-name: guided-tours__step-fadein;
+	animation-timing-function: ease-in-out;
+	animation-delay: 300ms;
+	animation-fill-mode: both;
+
 	p {
 		color: $gray-dark;
 		margin-bottom: 16px;
@@ -31,6 +37,17 @@
 		top: 3px;
 	}
 }
+
+@keyframes guided-tours__step-fadein {
+	0% {
+		opacity: 0;
+	}
+
+	100% {
+		opacity: 1;
+	}
+}
+
 
 .guided-tours__step-first {
 	animation-duration: 900ms;
@@ -145,33 +162,39 @@ $zoom-scale: 5; // the multiplier determining the size of the animated rings
 	animation-delay: #{ $animation-speed / 4 };
 }
 
-// the overlay with animation present when showing a bullseye
-@keyframes guided-tours__overlay-animation {
-	0%, 100% {
-		opacity: 0.4;
-	}
-
-	50% {
-		opacity: 0.7
-	}
-}
-
-.guided-tours__overlay,
-.guided-tours__overlay:hover,
-.guided-tours__overlay:focus,
-.guided-tours__overlay:visited,
-.guided-tours__overlay:active {
-	box-shadow: 0 0 0 9999px rgba( $gray-light, 0.8 );
-	transition: box-shadow 300ms ease-in-out;
-	z-index: z-index( 'root', '.guided-tours__overlay' );
-}
-
-.guided-tours__overlay:before {
-	position: absolute;
+.guided-tours__overlay-container {
+	position: fixed;
+		top: 0px;
+		bottom: 0px;
+		left: 0px;
+		right: 0px;
 	width: 100%;
 	height: 100%;
-	content: " ";
-	margin-left: -15px;
-	animation: guided-tours__overlay-animation 3s ease-in-out 300ms infinite;
-	opacity: 0.4;
+	background: none;
+	z-index: z-index( 'root', '.guided-tours__overlay' );
+	pointer-events: none;
 }
+
+.guided-tours__overlay {
+	opacity: 0.85;
+	position: fixed;
+	background-color: $white;
+	pointer-events: none;
+
+	animation-duration: 400ms;
+	animation-name: guided-tours__overlay-fadein;
+	animation-timing-function: ease-in-out;
+	animation-delay: 300ms;
+	animation-fill-mode: both;
+}
+
+@keyframes guided-tours__overlay-fadein {
+	0% {
+		opacity: 0;
+	}
+
+	100% {
+		opacity: 0.85;
+	}
+}
+


### PR DESCRIPTION
Element highlighting fades out the Calypso UI except for the target element the current step is trying to tell the user something about. We assume this helps the user identify and focus on it. 

This is currently used in `ActionStep` steps, but should also be used in all `BasicStep` steps that have a `target`. 

The current approach doesn't seem to work in all cases where we need it. Specifically it only fades out the sidebar if the `target` is an element within the sidebar. Possibly because of [this](http://stackoverflow.com/questions/7590772/absolute-positioned-div-with-overflow-auto-causing-child-absolute-div-to-be-cut) (cf. screenshot below). See also [this](https://github.com/Automattic/wp-calypso/pull/4689#issuecomment-209830307) discussion. 

<img width="536" alt="screen shot 2016-04-13 at 4 33 54 pm" src="https://cloud.githubusercontent.com/assets/23619/14530790/c971e0b8-025a-11e6-8ea0-c001007d49c7.png">

(only the sidebar is faded out, and also only above the `target`, which is `Themes` in this case)

This PR make highlighting work with both the `BasicStep` and the `ActionStep` components. It also works when we scroll the viewport for the user e.g. under mobile resolutions. 

To test: 

- go to http://calypso.localhost:3000/stats/?tour=main
- go through the 5 steps on different devices / resolutions
- make sure steps 2, 3, and 4 have most of the UI faded out properly
  - step 2 should show only the "My Site(s)" link
  - step 3 should show the whole sidebar
  - step 4 should show only the Themes / Customize menu item from the sidebar
