### PR TITLE
Sidebar: customize button swap A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,4 +81,12 @@ module.exports = {
 		defaultVariation: 'drake',
 		allowExistingUsers: true,
 	},
+	swapButtonsMySiteSidebar: {
+		datestamp: '20160414',
+		variations: {
+			original: 50,
+			swap: 50
+		},
+		defaultVariation: 'original'
+	},
 };

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -12,7 +12,8 @@ var analytics = require( 'analytics' ),
 /**
  * Internal dependencies
  */
-var AdsUtils = require( 'lib/ads/utils' ),
+var abtest = require( 'lib/abtest' ).abtest,
+	AdsUtils = require( 'lib/ads/utils' ),
 	config = require( 'config' ),
 	CurrentSite = require( 'my-sites/current-site' ),
 	getCustomizeUrl = require( '../themes/helpers' ).getCustomizeUrl,
@@ -167,6 +168,21 @@ module.exports = React.createClass( {
 			themesLink = '/design' + this.siteSuffix();
 		} else {
 			themesLink = '/design';
+		}
+
+		if ( abtest( 'swapButtonsMySiteSidebar' ) === 'swap' ) {
+			return (
+				<SidebarItem
+					tipTarget="themes"
+					label={ this.translate( 'Customize' ) }
+					className={ this.itemLinkClass( '/design', 'themes' ) }
+					link={ getCustomizeUrl( null, site ) }
+					buttonLink={ themesLink }
+					buttonLabel={ this.translate( 'Themes' ) }
+					onNavigate={ this.onNavigate }
+					icon={ 'themes' }
+					preloadSectionName="themes" />
+			);
 		}
 
 		return (


### PR DESCRIPTION
This is an A/B test designed to swap the Theme and Customize menu items in Sidebar. In user tests we kept seeing that people were missing Customize. This is an attempt to see if an easy win can be made for discoverability.

This is my first A/B test and also first PR to Calypso, so hopefully everything is all as it should be. Just let me know if I need to adjust labels or do anything else. I think I'm right asking for a review at this stage because it has not had any other eyes on it. Thanks whoever reviews it :)