### PR TITLE
Plans: add current plan page

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -206,6 +206,7 @@
 @import 'my-sites/plan-storage/style';
 @import 'my-sites/plans/style';
 @import 'my-sites/plans/plan-feature/style';
+@import 'my-sites/plans/current-plan/style';
 @import 'my-sites/plans/plan-overview/style';
 @import 'my-sites/plans/plan-overview/plan-feature/style';
 @import 'my-sites/plans/plan-overview/plan-progress/style';

--- a/client/my-sites/plans/current-plan/controller.js
+++ b/client/my-sites/plans/current-plan/controller.js
@@ -1,0 +1,18 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import { renderWithReduxStore } from 'lib/react-helpers';
+import CurrentPlanOverview from './main';
+
+export default function( context ) {
+	renderWithReduxStore(
+		<CurrentPlanOverview/>,
+		document.getElementById( 'primary' ),
+		context.store
+	);
+}

--- a/client/my-sites/plans/current-plan/main.jsx
+++ b/client/my-sites/plans/current-plan/main.jsx
@@ -1,0 +1,133 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import page from 'page';
+import classNames from 'classnames';
+
+/**
+ * Internal Dependencies
+ */
+import Main from 'components/main';
+import Card from 'components/card';
+import HappinessSupport from 'components/happiness-support';
+import PremiumPlanDetails from 'my-sites/upgrades/checkout-thank-you/premium-plan-details';
+import BusinessPlanDetails from 'my-sites/upgrades/checkout-thank-you/business-plan-details';
+import PurchaseDetail from 'components/purchase-detail';
+import { getPlansBySite } from 'state/sites/plans/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
+import { fetchSitePlans } from 'state/sites/plans/actions';
+import {
+	isBusiness,
+	isPremium,
+	isFreePlan
+} from 'lib/products-values';
+import Gridicon from 'components/gridicon';
+import TrackComponentView from 'lib/analytics/track-component-view';
+
+const PlanDetailsComponent = React.createClass( {
+	PropTypes: {
+		selectedSite: React.PropTypes.object.isRequired,
+		sitePlans: React.PropTypes.object.isRequired,
+		fetchPlans: React.PropTypes.func.isRequired
+	},
+	componentWillUpdate: function( props ) {
+		this.props.fetchPlans( props );
+	},
+	componentDidMount: function() {
+		this.props.fetchPlans();
+	},
+	render: function() {
+		const { hasLoadedFromServer } = this.props.sitePlans;
+		let title;
+		let tagLine;
+		let featuresList;
+
+		if ( ! this.props.selectedSite || ! hasLoadedFromServer ) {
+			featuresList = (
+				<div>
+						<PurchaseDetail isPlaceholder />
+						<PurchaseDetail isPlaceholder />
+				</div>
+			);
+		} else if ( this.props.selectedSite.jetpack || isFreePlan( this.props.selectedSite.plan ) ) {
+			page.redirect( '/plans/' + this.props.selectedSite.slug );
+		} else if ( isPremium( this.props.selectedSite.plan ) ) {
+			title = this.translate( 'Your site is on a Premium plan' );
+			tagLine = this.translate( 'Unlock the full potential of your site with the premium features included in your plan.' );
+			featuresList = (
+				<PremiumPlanDetails
+					selectedSite={ this.props.selectedSite }
+					sitePlans={ this.props.sitePlans }
+				/>
+			);
+		} else if ( isBusiness( this.props.selectedSite.plan ) ) {
+			title = this.translate( 'Your site is on a Business plan' );
+			tagLine = this.translate( 'Your site is serious now. Take advantage of these professional features included in a Business plan:' );
+			featuresList = (
+				<BusinessPlanDetails
+					selectedSite={ this.props.selectedSite }
+					sitePlans={ this.props.sitePlans }
+				/>
+			);
+		}
+
+		return (
+			<Main className="current-plan">
+				<Card>
+					<div className="current-plan__header">
+						<div className="current-plan__header-content">
+							<span className="current-plan__header-icon">
+								<Gridicon icon="star" size={ 48 } />
+							</span>
+
+							<div className="current-plan__header-copy">
+								<h1 className={ classNames( { 'current-plan__header-heading': true, 'is-placeholder': ! hasLoadedFromServer } ) }>
+									{ title }
+								</h1>
+
+								<h2 className={ classNames( { 'current-plan__header-text': true, 'is-placeholder': ! hasLoadedFromServer } ) }>
+									{ tagLine }
+								</h2>
+							</div>
+						</div>
+					</div>
+					{ featuresList }
+				</Card>
+				<Card>
+					<HappinessSupport
+						isJetpack={ false }
+						isPlaceholder={ false } />
+				</Card>
+				{ this.props.selectedSite &&
+					<Card href={ '/plans/compare/' + this.props.selectedSite.slug }>
+						{ this.translate( 'Missing some features? Compare our different plans' ) }
+					</Card>
+				}
+				<TrackComponentView eventName={ 'calypso_plans_my-plan_view' } />
+			</Main>
+		);
+	}
+} );
+
+export default connect(
+	( state ) => {
+		return {
+			selectedSite: getSelectedSite( state ),
+			sitePlans: getPlansBySite( state, getSelectedSite( state ) )
+		};
+	},
+	dispatch => ( {
+		fetchSitePlans: siteId => dispatch( fetchSitePlans( siteId ) )
+	} ),
+	( stateProps, dispatchProps ) => {
+		function fetchPlans( props = stateProps ) {
+			if ( props.selectedSite && ! props.sitePlans.hasLoadedFromServer && ! props.sitePlans.isRequesting ) {
+				dispatchProps.fetchSitePlans( props.selectedSite.ID );
+			}
+		}
+
+		return Object.assign( { fetchPlans }, stateProps );
+	}
+)( PlanDetailsComponent );

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -1,0 +1,68 @@
+.current-plan__header {
+	margin: 0 -24px 36px;
+}
+
+.current-plan__header-content {
+	margin: 0 auto;
+	max-width: 700px;
+
+	@include breakpoint( ">660px" ) {
+		display: flex;
+		text-align: left;
+	}
+}
+
+.current-plan__header-icon {
+	display: block;
+	margin: 0 auto;
+	position: relative;
+	text-align: center;
+
+	@include breakpoint( ">660px" ) {
+		height: 132px;
+		margin-right: 16px;
+		width: 132px;
+	}
+
+	.gridicon {
+		background: white;
+		border-radius: 50%;
+		color: $alert-yellow;
+		height: 48px;
+		padding: 21px;
+		width: 48px;
+
+		@include breakpoint( ">660px" ) {
+			height: 72px;
+			padding: 30px;
+			width: 72px;
+		}
+	}
+}
+
+.current-plan__header-copy {
+	padding: 0 30px;
+	@include breakpoint( ">660px" ) {
+		padding: 0;
+		width: 100%;
+	}
+}
+
+.current-plan__header-heading,
+.current-plan__header-text {
+	clear: none;
+	&.is-placeholder {
+		@include placeholder( 23% );
+	}
+}
+
+.current-plan__header-heading {
+	font-size: 24px;
+	font-weight: 400;
+	margin: 24px 0 8px 0;
+}
+
+.current-plan__header-text {
+	font-size: 18px;
+	font-weight: 300;
+}

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -12,6 +12,7 @@ import paths from './paths';
 import plansController from './controller';
 import { retarget } from 'lib/analytics/ad-tracking';
 import googleAnalyticsLandingPage from './plan-feature/google-analytics';
+import yourPlan from './current-plan/controller';
 
 export default function() {
 	if ( config.isEnabled( 'manage/plans' ) ) {
@@ -29,6 +30,16 @@ export default function() {
 			controller.navigation,
 			plansController.plansCompare
 		);
+
+		if ( config.isEnabled( 'manage/plans/my-plan' ) ) {
+			page(
+				'/plans/my-plan/:site',
+				retarget,
+				controller.siteSelection,
+				controller.navigation,
+				yourPlan
+			);
+		}
 
 		page(
 			'/plans/compare/:domain',

--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -17,6 +17,8 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 
 	return (
 		<div>
+			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
+
 			{ ! selectedFeature &&
 				<PurchaseDetail
 					icon="customize"
@@ -32,8 +34,6 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => 
 				description={ i18n.translate( 'Connect to Google Analytics for the perfect complement to WordPress.com stats.' ) }
 				buttonText={ i18n.translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug } />
-
-			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
 		</div>
 	);
 };

--- a/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/premium-plan-details.jsx
@@ -21,6 +21,19 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 
 	return (
 		<div>
+			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
+
+			<PurchaseDetail
+				icon="speaker"
+				title={ i18n.translate( 'No Ads' ) }
+				description={
+					i18n.translate(
+						'Premium plan automatically removes all Ads from your site. ' +
+						'Now your visitors can enjoy your great content without distractions!'
+					)
+				}
+			/>
+
 			{ ! selectedFeature &&
 				<PurchaseDetail
 					icon="customize"
@@ -47,9 +60,6 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 				}
 				buttonText={ i18n.translate( 'Start a new post' ) }
 				href={ paths.newPost( selectedSite ) } />
-
-			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
-
 		</div>
 	);
 };

--- a/client/state/sites/schema.js
+++ b/client/state/sites/schema.js
@@ -13,6 +13,7 @@ export const sitesSchema = {
 				jetpack: { type: 'boolean' },
 				post_count: { type: 'number' },
 				subscribers_count: { type: 'number' },
+				slug: { type: 'string' },
 				lang: { type: 'string' },
 				icon: {
 					type: 'object',

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -86,7 +86,7 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				2916284: { ID: 2916284, name: 'WordPress.com Example Blog' }
+				2916284: { ID: 2916284, name: 'WordPress.com Example Blog', slug: 'example.wordpress.com' }
 			} );
 		} );
 

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -33,6 +33,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
+		"manage/plans/my-plan": false,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -34,6 +34,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
+		"manage/plans/my-plan": false,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,

--- a/config/development.json
+++ b/config/development.json
@@ -61,6 +61,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
+		"manage/plans/my-plan": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/compatibility-warning": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -39,6 +39,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
+		"manage/plans/my-plan": false,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -36,6 +36,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
+		"manage/plans/my-plan": false,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -42,6 +42,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
+		"manage/plans/my-plan": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,


### PR DESCRIPTION
# Don't be afraid of :+1: . This is hidden behind a feature flag.

This repurposes splendid "Thank you" page and shows it instead of /plans for plan owners.
This is intended to:
- make plan owners feel happy about their purchase
- explain how to use their brand new features
- reduce refunds

Props to @drewblaisdell @scruffian for making this components after the checkout flow

## UI

### Premium plan owners

<img width="376" alt="zrzut ekranu 2016-04-15 o 17 01 58" src="https://cloud.githubusercontent.com/assets/3775068/14567416/df3f7e88-032b-11e6-9705-01b925e8eae9.png">


### Business plan owners
<img width="378" alt="zrzut ekranu 2016-04-15 o 17 01 46" src="https://cloud.githubusercontent.com/assets/3775068/14567405/d7e2804a-032b-11e6-87e9-15f76023cd51.png">

## Testing
Go to
http://calypso.localhost:3000/plans/my-plan/planpremium.wordpress.com
replace with your site slug..

Link and ABtest for linking it from sidebar will be introduced in #4783 

CC
@rralian @mtias @gziolo @gwwar