### PR TITLE
Notice: Adjust styles for default actions

### DIFF
--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -53,10 +53,30 @@ var Notices = React.createClass( {
 						isCompact={ this.state.compactNotices ? true : null } />
 				</div>
 				<div>
+					<Notice
+						status="is-info"
+						showDismiss={ false }
+						text="I'm an `is-info` notice with custom icon and an action."
+						icon="heart"
+						isCompact={ this.state.compactNotices ? true : null }>
+						<NoticeAction href="#">
+							{ "Update" }
+						</NoticeAction>
+					</Notice>
+				</div>
+				<div>
 					<Notice status="is-success" text="I'm an `is-success` notice." isCompact={ this.state.compactNotices ? true : null } />
 				</div>
 				<div>
-					<Notice status="is-error" text="I'm an `is-error` notice." isCompact={ this.state.compactNotices ? true : null } />
+					<Notice
+						status="is-error"
+						showDismiss={ false }
+						text="I'm an `is-error` notice."
+						isCompact={ this.state.compactNotices ? true : null }>
+						<NoticeAction href="#">
+							{ "Update" }
+						</NoticeAction>
+					</Notice>
 				</div>
 				<div>
 					<Notice

--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -37,6 +37,16 @@ var Notices = React.createClass( {
 				</div>
 				<div>
 					<Notice
+						text="I'm a notice with no status and an action."
+						showDismiss={ false }
+						isCompact={ this.state.compactNotices ? true : null }>
+						<NoticeAction href="#">
+							{ "Update" }
+						</NoticeAction>
+					</Notice>
+				</div>
+				<div>
+					<Notice
 						status="is-info"
 						text="I'm an `is-info` notice with custom icon."
 						icon="heart"

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -99,13 +99,11 @@
 }
 
 // specificity for general `a` elements within notice is too great
-.notice a.notice__action {
+a.notice__action {
 	display: flex;
 		align-items: center;
 		flex-shrink: 0;
-	background: rgba( 0, 0, 0, 0.2 );
 	box-sizing: border-box;
-	color: $white;
 	cursor: pointer;
 	font-size: 15px;
 	font-weight: 400;
@@ -113,6 +111,14 @@
 	padding: 13px 16px;
 	text-decoration: none;
 	white-space: nowrap;
+
+	.is-success &,
+	.is-error &,
+	.is-warning &,
+	.is-info & {
+		background: rgba( 0, 0, 0, 0.2 );
+		color: $white;
+	}
 
 	.gridicon {
 		margin-left: 8px;

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -116,9 +116,13 @@ a.notice__action {
 	.is-error &,
 	.is-warning &,
 	.is-info & {
-		background: rgba( 0, 0, 0, 0.2 );
 		color: $white;
 	}
+
+	.is-success & { background: darken( $alert-green, 15 ); }
+	.is-error & { background: darken( $alert-red, 15 ); }
+	.is-warning & { background: darken( $alert-yellow, 15 ); }
+	.is-info & { background: darken( $blue-wordpress, 15 ); }
 
 	.gridicon {
 		margin-left: 8px;


### PR DESCRIPTION
Adding an example of a default status notice with an action, and then adjusting the styles to make that action look better.

![screen shot 2016-04-14 at 10 54 22 am](https://cloud.githubusercontent.com/assets/191598/14532520/48fe8d94-022f-11e6-99ab-db7a6ebd1c2e.png)

![screen shot 2016-04-14 at 11 19 47 am](https://cloud.githubusercontent.com/assets/191598/14533405/f8a9936c-0232-11e6-8e57-d2c9c20aada4.png)

/cc @mtias 