### PR TITLE
Devdocs: fix example docs for all-sites component.

### DIFF
--- a/client/lib/sites-list/docs/example.jsx
+++ b/client/lib/sites-list/docs/example.jsx
@@ -18,7 +18,7 @@ var Sites = React.createClass( {
 					<a href="/devdocs/app-components/sites">Site and All Sites</a>
 				</h2>
 				<Site site={ sites.getPrimary() } />
-				<AllSites sites={ sites } />
+				<AllSites sites={ sites.get() } />
 			</div>
 		);
 	}

--- a/client/my-sites/all-sites/README.md
+++ b/client/my-sites/all-sites/README.md
@@ -10,7 +10,7 @@ var AllSites = require( 'my-sites/all-sites' );
 
 render: function() {
 	return (
-		<AllSites sites={ sitesListObject } />
+		<AllSites sites={ sitesArray } />
 	);
 }
 ```


### PR DESCRIPTION
Requires array of sites not full object.