### PR TITLE
Signup: Fix theme purchase on signup

### DIFF
--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -165,7 +165,7 @@ export function receiveThemes( data, site, queryParams, responseTime ) {
 	}
 }
 
-export function activate( theme, site, source = 'unknown' ) {
+export function activate( theme, site, source = 'unknown', purchased = false ) {
 	return dispatch => {
 		dispatch( {
 			type: THEME_ACTIVATE,
@@ -175,7 +175,7 @@ export function activate( theme, site, source = 'unknown' ) {
 
 		wpcom.undocumented().activateTheme( theme, site.ID )
 			.then( () => {
-				dispatch( activated( theme, site, source ) );
+				dispatch( activated( theme, site, source, purchased ) );
 			} )
 			.catch( error => {
 				dispatch( receiveServerError( error ) );
@@ -190,6 +190,19 @@ export function activated( theme, site, source = 'unknown', purchased = false ) 
 
 		if ( typeof theme !== 'object' ) {
 			theme = getThemeById( getState(), theme );
+		}
+
+		console.log( 'theme', theme );
+
+		if ( ! theme ) {
+			wpcom.undocumented().activeTheme( site.ID )
+				.then( maybeTheme => {
+					dispatch( activate( maybeTheme, site, source ) );
+				} )
+				.catch( error => {
+					dispatch( receiveServerError( error ) );
+				} );
+			return;
 		}
 
 		const action = {


### PR DESCRIPTION
We really need a full theme object to be able to properly activate and
track a theme on successful purchase.
- If no theme is found in the `activated` AC, fetch the `activeTheme`,
  then dispatch an `activate` action with the fetched theme.

I guess this could also be done in the checkout thankyou, but I kind of
want all this logic in one place.

Problems:
- Multiple API calls
- We essentially activate a theme twice, since themes are auto-activated
  on the server when purchased.
- active theme endpoint returns different data, so the author isn't
  shown in the thank you modal

/cc @ockham
