### PR TITLE
Reader lists: show 404 when list owner and slug is not recognised

### DIFF
--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -61,7 +61,7 @@ const ListStream = React.createClass( {
 		}
 
 		if ( this.props.isMissing ) {
-			return <ListMissing />;
+			return <ListMissing owner={ this.props.owner } slug={ this.props.slug } />;
 		}
 
 		return (

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -11,9 +11,10 @@ import config from 'config';
  */
 import FollowingStream from 'reader/following-stream';
 import EmptyContent from './empty';
+import ListMissing from './missing';
 import StreamHeader from 'reader/stream-header';
 import { followList, unfollowList } from 'state/reader/lists/actions';
-import { getListByOwnerAndSlug, isSubscribedByOwnerAndSlug } from 'state/reader/lists/selectors';
+import { getListByOwnerAndSlug, isSubscribedByOwnerAndSlug, isMissingByOwnerAndSlug } from 'state/reader/lists/selectors';
 import QueryReaderList from 'components/data/query-reader-list';
 
 const stats = require( 'reader/stats' );
@@ -59,6 +60,10 @@ const ListStream = React.createClass( {
 			this.props.setPageTitle( title );
 		}
 
+		if ( this.props.isMissing ) {
+			return <ListMissing />;
+		}
+
 		return (
 			<FollowingStream { ...this.props } store={ this.props.postStore } listName={ title } emptyContent={ emptyContent } showFollowInHeader={ shouldShowFollow }>
 				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
@@ -82,7 +87,8 @@ export default connect(
 	( state, ownProps ) => {
 		return {
 			list: getListByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
-			isSubscribed: isSubscribedByOwnerAndSlug( state, ownProps.owner, ownProps.slug )
+			isSubscribed: isSubscribedByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
+			isMissing: isMissingByOwnerAndSlug( state, ownProps.owner, ownProps.slug )
 		};
 	},
 	( dispatch ) => {

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import EmptyContent from 'components/empty-content';
+import discoverHelper from 'reader/discover/helper';
+
+const stats = require( 'reader/stats' );
+
+const ListEmptyContent = React.createClass( {
+	shouldComponentUpdate() {
+		return false;
+	},
+
+	recordAction() {
+		stats.recordAction( 'clicked_following_on_empty' );
+		stats.recordGaEvent( 'Clicked Following on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_following_on_missing_list_clicked' );
+	},
+
+	recordSecondaryAction() {
+		stats.recordAction( 'clicked_discover_on_empty' );
+		stats.recordGaEvent( 'Clicked Discover on EmptyContent' );
+		stats.recordTrack( 'calypso_reader_discover_on_missing_list_clicked' );
+	},
+
+	render() {
+		var action = ( <a
+			className="empty-content__action button is-primary"
+			onClick={ this.recordAction }
+			href="/">{ this.translate( 'Back to Following' ) }</a> ),
+			secondaryAction = discoverHelper.isEnabled()
+			? ( <a
+				className="empty-content__action button"
+				onClick={ this.recordSecondaryAction }
+				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
+
+		return ( <EmptyContent
+			title={ this.translate( 'List not found' ) }
+			line={ this.translate( 'Sorry, we couldn\'t find that list.' ) }
+			action={ action }
+			secondaryAction={ secondaryAction }
+			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+			illustrationWidth={ 500 }
+			/> );
+	}
+} );
+
+export default ListEmptyContent;

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -1,13 +1,22 @@
+/**
+ * External dependencies
+ */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
 import EmptyContent from 'components/empty-content';
 import discoverHelper from 'reader/discover/helper';
+import QueryReaderList from 'components/data/query-reader-list';
 
 const stats = require( 'reader/stats' );
 
-const ListEmptyContent = React.createClass( {
-	shouldComponentUpdate() {
-		return false;
+const ListMissing = React.createClass( {
+
+	propTypes: {
+		owner: React.PropTypes.string.isRequired,
+		slug: React.PropTypes.string.isRequired
 	},
 
 	recordAction() {
@@ -26,22 +35,28 @@ const ListEmptyContent = React.createClass( {
 		var action = ( <a
 			className="empty-content__action button is-primary"
 			onClick={ this.recordAction }
-			href="/">{ this.translate( 'Back to Following' ) }</a> ),
+			href="/">{ this.translate( 'Back to Followed Sites' ) }</a> ),
 			secondaryAction = discoverHelper.isEnabled()
 			? ( <a
 				className="empty-content__action button"
 				onClick={ this.recordSecondaryAction }
 				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
 
-		return ( <EmptyContent
-			title={ this.translate( 'List not found' ) }
-			line={ this.translate( 'Sorry, we couldn\'t find that list.' ) }
-			action={ action }
-			secondaryAction={ secondaryAction }
-			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
-			illustrationWidth={ 500 }
-			/> );
+		return (
+			<div>
+				<QueryReaderList owner={ this.props.owner } slug={ this.props.slug } />
+				<EmptyContent
+				title={ this.translate( 'List not found' ) }
+				line={ this.translate( 'Sorry, we couldn\'t find that list.' ) }
+				action={ action }
+				secondaryAction={ secondaryAction }
+				illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+				illustrationWidth={ 500 }
+				/>
+			</div>
+		);
 	}
 } );
 
-export default ListEmptyContent;
+export default ListMissing
+;

--- a/client/state/reader/lists/actions.js
+++ b/client/state/reader/lists/actions.js
@@ -89,7 +89,9 @@ export function requestList( owner, slug ) {
 				if ( error ) {
 					dispatch( {
 						type: READER_LIST_REQUEST_FAILURE,
-						error
+						error,
+						owner,
+						slug
 					} );
 					reject();
 				} else {

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -8,6 +8,7 @@ import union from 'lodash/union';
 import filter from 'lodash/filter';
 import get from 'lodash/get';
 import omit from 'lodash/omit';
+import find from 'lodash/find';
 
 /**
  * Internal dependencies
@@ -209,9 +210,20 @@ export function errors( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function missingLists( state = false, action ) {
+export function missingLists( state = [], action ) {
 	switch ( action.type ) {
+		case READER_LISTS_RECEIVE:
+			// Remove any valid lists from missingLists
+			return filter( state, ( list ) => {
+				return ! find( action.lists, { owner: list.owner, slug: list.slug } );
+			} );
+		case READER_LIST_REQUEST_SUCCESS:
+			// Remove any valid lists from missingLists
+			return filter( state, ( list ) => {
+				return action.data.list.owner !== list.owner && action.data.list.slug !== list.slug;
+			} );
 		case READER_LIST_REQUEST_FAILURE:
+			// Add lists that have failed with a 404 to missingLists
 			if ( ! action.error || action.error.statusCode !== 404 ) {
 				return state;
 			}

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -202,11 +202,34 @@ export function errors( state = {}, action ) {
 	return state;
 }
 
+/**
+ * A missing list is one that's been requested, but we couldn't find (API response 404-ed).
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function missingLists( state = false, action ) {
+	switch ( action.type ) {
+		case READER_LIST_REQUEST_FAILURE:
+			if ( ! action.error || action.error.statusCode !== 404 ) {
+				return state;
+			}
+			return union( state, [ { owner: action.owner, slug: action.slug } ] );
+		case SERIALIZE:
+		case DESERIALIZE:
+			return state;
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	items,
 	subscribedLists,
 	updatedLists,
 	isRequestingList,
 	isRequestingLists,
-	errors
+	errors,
+	missingLists
 } );

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -114,3 +114,20 @@ export function isSubscribedByOwnerAndSlug( state, owner, slug ) {
 	}
 	return includes( state.reader.lists.subscribedLists, list.ID );
 }
+
+/**
+ * Check if the requested list is missing (i.e. API 404ed when requesting it)
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {String}  owner  List owner
+ * @param  {String}  slug  List slug
+ * @return {Boolean} Is the list missing?
+ */
+export function isMissingByOwnerAndSlug( state, owner, slug ) {
+	const preparedOwner = owner.toLowerCase();
+	const preparedSlug = slug.toLowerCase();
+
+	return !! find( state.reader.lists.missingLists, ( list ) => {
+		return list.owner === preparedOwner && list.slug === preparedSlug
+	} );
+}

--- a/client/state/reader/lists/test/reducer.js
+++ b/client/state/reader/lists/test/reducer.js
@@ -12,12 +12,15 @@ import {
 	READER_LIST_UPDATE_SUCCESS,
 	READER_LIST_DISMISS_NOTICE,
 	READER_LIST_UPDATE_TITLE,
-	READER_LIST_UPDATE_DESCRIPTION
+	READER_LIST_UPDATE_DESCRIPTION,
+	READER_LIST_REQUEST_SUCCESS,
+	READER_LIST_REQUEST_FAILURE
 } from 'state/action-types';
 
 import {
 	items,
-	updatedLists
+	updatedLists,
+	missingLists
 } from '../reducer';
 
 describe( 'reducer', () => {
@@ -125,6 +128,90 @@ describe( 'reducer', () => {
 			state = updatedLists( null, {
 				type: READER_LIST_DISMISS_NOTICE,
 				listId: 841
+			} );
+
+			expect( state ).to.eql( [] );
+		} );
+	} );
+
+	describe( '#missingLists()', () => {
+		it( 'should default to an empty array', () => {
+			const state = missingLists( undefined, {} );
+			expect( state ).to.eql( [] );
+		} );
+
+		it( 'should store new missing lists in the case of a 404', () => {
+			const state = missingLists( undefined, {
+				type: READER_LIST_REQUEST_FAILURE,
+				error: {
+					statusCode: 404
+				},
+				owner: 'lister',
+				slug: 'banana'
+			} );
+
+			expect( state ).to.eql( [
+				{ owner: 'lister', slug: 'banana'}
+			] );
+		} );
+
+		it( 'should not store new missing lists in the case of a different error', () => {
+			const state = missingLists( undefined, {
+				type: READER_LIST_REQUEST_FAILURE,
+				error: {
+					statusCode: 400
+				},
+				owner: 'lister',
+				slug: 'banana'
+			} );
+
+			expect( state ).to.eql( [] );
+		} );
+
+		it( 'should remove a missing list if a successful lists response is received', () => {
+			const initialState = missingLists( undefined, {
+				type: READER_LIST_REQUEST_FAILURE,
+				error: {
+					statusCode: 404
+				},
+				owner: 'lister',
+				slug: 'banana'
+			} );
+
+			expect( initialState ).to.eql( [
+				{ owner: 'lister', slug: 'banana'}
+			] );
+
+			const state = missingLists( initialState, {
+				type: READER_LISTS_RECEIVE,
+				lists: [
+					{ ID: 841, title: 'Hello World', owner: 'lister', slug: 'banana' },
+					{ ID: 413, title: 'Mangos and feijoas', owner: 'lister', slug: 'mango' }
+				]
+			} );
+
+			expect( state ).to.eql( [] );
+		} );
+
+		it( 'should remove a missing list if a successful single list response is received', () => {
+			const initialState = missingLists( undefined, {
+				type: READER_LIST_REQUEST_FAILURE,
+				error: {
+					statusCode: 404
+				},
+				owner: 'lister',
+				slug: 'banana'
+			} );
+
+			expect( initialState ).to.eql( [
+				{ owner: 'lister', slug: 'banana'}
+			] );
+
+			const state = missingLists( initialState, {
+				type: READER_LIST_REQUEST_SUCCESS,
+				data: {
+					list: { ID: 841, title: 'Hello World', owner: 'lister', slug: 'banana' }
+				}
 			} );
 
 			expect( state ).to.eql( [] );

--- a/client/state/reader/lists/test/selectors.js
+++ b/client/state/reader/lists/test/selectors.js
@@ -13,7 +13,8 @@ import {
 	isUpdatedList,
 	getListByOwnerAndSlug,
 	isSubscribedByOwnerAndSlug,
-	hasError
+	hasError,
+	isMissingByOwnerAndSlug
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -146,7 +147,7 @@ describe( 'selectors', () => {
 				reader: {
 					lists: {}
 				}
-			}, 'restapitests', 'bananas' );
+			}, 'lister', 'bananas' );
 
 			expect( list ).to.eql( undefined );
 		} );
@@ -158,22 +159,22 @@ describe( 'selectors', () => {
 						items: {
 							123: {
 								ID: 123,
-								owner: 'restapitests',
+								owner: 'lister',
 								slug: 'bananas'
 							},
 							456: {
 								ID: 456,
-								owner: 'restapitests',
+								owner: 'lister',
 								slug: 'ants'
 							}
 						}
 					}
 				}
-			}, 'restapitests', 'bananas' );
+			}, 'lister', 'bananas' );
 
 			expect( list ).to.eql( {
 				ID: 123,
-				owner: 'restapitests',
+				owner: 'lister',
 				slug: 'bananas'
 			} );
 		} );
@@ -186,7 +187,7 @@ describe( 'selectors', () => {
 					lists: {},
 					subscribedLists: []
 				}
-			}, 'restapitests', 'bananas' );
+			}, 'lister', 'bananas' );
 
 			expect( isSubscribed ).to.eql( false );
 		} );
@@ -198,19 +199,19 @@ describe( 'selectors', () => {
 						items: {
 							123: {
 								ID: 123,
-								owner: 'restapitests',
+								owner: 'lister',
 								slug: 'bananas'
 							},
 							456: {
 								ID: 456,
-								owner: 'restapitests',
+								owner: 'lister',
 								slug: 'ants'
 							}
 						},
 						subscribedLists: [ 123 ]
 					}
 				}
-			}, 'restapitests', 'bananas' );
+			}, 'lister', 'bananas' );
 
 			expect( isSubscribed ).to.eql( true );
 		} );
@@ -239,6 +240,32 @@ describe( 'selectors', () => {
 			}, 123 );
 
 			expect( result ).to.be.true;
+		} );
+	} );
+
+	describe( '#isMissingByOwnerAndSlug()', () => {
+		it( 'should return false if the missing list does not exist', () => {
+			const isMissing = isMissingByOwnerAndSlug( {
+				reader: {
+					lists: {
+						missingLists: []
+					}
+				}
+			}, 'lister', 'bananas' );
+
+			expect( isMissing ).to.eql( false );
+		} );
+
+		it( 'should return true if the owner and slug match a missing list', () => {
+			const isMissing = isMissingByOwnerAndSlug( {
+				reader: {
+					lists: {
+						missingLists: [ { owner: 'lister', slug: 'bananas' } ]
+					}
+				}
+			}, 'lister', 'bananas' );
+
+			expect( isMissing ).to.eql( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
When a list owner and slug is not recognised, it isn't currently handled very well in the list stream:

![screen shot 2016-04-14 at 17 53 08](https://cloud.githubusercontent.com/assets/17325/14536358/e4dd8a78-0269-11e6-9a59-aa79de80c53d.png)

This PR maintains a list of 'missing' owners and slugs in Redux state, so we know which ones to show a 'List not found' page for.

After:

![screen shot 2016-04-15 at 13 14 16](https://cloud.githubusercontent.com/assets/17325/14561098/fe88f9e2-030b-11e6-86ad-2d2ebf6b84c3.png)

Fixes #3681.