### PR TITLE
Start tracking clicks on plugins in the wpcom plugins page

### DIFF
--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import has from 'lodash/has';
+import get from 'lodash/get';
 import noop from 'lodash/noop';
 
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -54,9 +54,7 @@ const trackClick = name => recordTracksEvent(
 );
 
 const mapDispatchToProps = ( dispatch, props ) => ( {
-	onClick: has( props, 'onClick' )
-		? props.onClick
-		: () => dispatch( trackClick( props.name ) )
+	onClick: get( props, 'onClick', () => dispatch( trackClick( props.name ) ) )
 } );
 
 export default connect( null, mapDispatchToProps )( BusinessPlugin );

--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -45,10 +45,18 @@ BusinessPlugin.propTypes = {
 	] ).isRequired
 };
 
+const trackClick = name => recordTracksEvent(
+	'calypso_plugin_wpcom_click',
+	{
+		plugin_name: name,
+		plugin_plan: 'business'
+	}
+);
+
 const mapDispatchToProps = ( dispatch, props ) => ( {
 	onClick: has( props, 'onClick' )
 		? props.onClick
-		: () => dispatch( recordTracksEvent( 'wpcom_plugin_clicked', props.name ) )
+		: () => dispatch( trackClick( props.name ) )
 } );
 
 export default connect( null, mapDispatchToProps )( BusinessPlugin );

--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -1,5 +1,9 @@
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import has from 'lodash/has';
 import noop from 'lodash/noop';
+
+import { recordTracksEvent } from 'state/analytics/actions';
 
 import Gridicon from 'components/gridicon';
 
@@ -41,4 +45,10 @@ BusinessPlugin.propTypes = {
 	] ).isRequired
 };
 
-export default BusinessPlugin;
+const mapDispatchToProps = ( dispatch, props ) => ( {
+	onClick: has( props, 'onClick' )
+		? props.onClick
+		: () => dispatch( recordTracksEvent( 'wpcom_plugin_clicked', props.name ) )
+} );
+
+export default connect( null, mapDispatchToProps )( BusinessPlugin );

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -42,10 +42,18 @@ PremiumPlugin.propTypes = {
 	description: PropTypes.string.isRequired
 };
 
+const trackClick = name => recordTracksEvent(
+	'calypso_plugin_wpcom_click',
+	{
+		plugin_name: name,
+		plugin_plan: 'premium'
+	}
+);
+
 const mapDispatchToProps = ( dispatch, props ) => ( {
 	onClick: has( props, 'onClick' )
 		? props.onClick
-		: () => dispatch( recordTracksEvent( 'wpcom_plugin_clicked', props.name ) )
+		: () => dispatch( trackClick( props.name ) )
 } );
 
 export default connect( null, mapDispatchToProps )( PremiumPlugin );

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -1,5 +1,9 @@
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import has from 'lodash/has';
 import noop from 'lodash/noop';
+
+import { recordTracksEvent } from 'state/analytics/actions';
 
 import Gridicon from 'components/gridicon';
 
@@ -38,4 +42,10 @@ PremiumPlugin.propTypes = {
 	description: PropTypes.string.isRequired
 };
 
-export default PremiumPlugin;
+const mapDispatchToProps = ( dispatch, props ) => ( {
+	onClick: has( props, 'onClick' )
+		? props.onClick
+		: () => dispatch( recordTracksEvent( 'wpcom_plugin_clicked', props.name ) )
+} );
+
+export default connect( null, mapDispatchToProps )( PremiumPlugin );

--- a/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/premium-plugin.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import has from 'lodash/has';
+import get from 'lodash/get';
 import noop from 'lodash/noop';
 
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -51,9 +51,7 @@ const trackClick = name => recordTracksEvent(
 );
 
 const mapDispatchToProps = ( dispatch, props ) => ( {
-	onClick: has( props, 'onClick' )
-		? props.onClick
-		: () => dispatch( trackClick( props.name ) )
+	onClick: get( props, 'onClick', () => dispatch( trackClick( props.name ) ) )
 } );
 
 export default connect( null, mapDispatchToProps )( PremiumPlugin );

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import has from 'lodash/has';
+import get from 'lodash/get';
 import noop from 'lodash/noop';
 
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -51,9 +51,7 @@ const trackClick = name => recordTracksEvent(
 );
 
 const mapDispatchToProps = ( dispatch, props ) => ( {
-	onClick: has( props, 'onClick' )
-		? props.onClick
-		: () => dispatch( trackClick( props.name ) )
+	onClick: get( props, 'onClick', () => dispatch( trackClick( props.name  ) ) )
 } );
 
 export default connect( null, mapDispatchToProps )( StandardPlugin );

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -51,7 +51,7 @@ const trackClick = name => recordTracksEvent(
 );
 
 const mapDispatchToProps = ( dispatch, props ) => ( {
-	onClick: get( props, 'onClick', () => dispatch( trackClick( props.name  ) ) )
+	onClick: get( props, 'onClick', () => dispatch( trackClick( props.name ) ) )
 } );
 
 export default connect( null, mapDispatchToProps )( StandardPlugin );

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -1,5 +1,9 @@
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import has from 'lodash/has';
 import noop from 'lodash/noop';
+
+import { recordTracksEvent } from 'state/analytics/actions';
 
 import Gridicon from 'components/gridicon';
 
@@ -38,4 +42,10 @@ StandardPlugin.propTypes = {
 	supportLink: PropTypes.string.isRequired
 };
 
-export default StandardPlugin;
+const mapDispatchToProps = ( dispatch, props ) => ( {
+	onClick: has( props, 'onClick' )
+		? props.onClick
+		: () => dispatch( recordTracksEvent( 'wpcom_plugin_clicked', props.name ) )
+} );
+
+export default connect( null, mapDispatchToProps )( StandardPlugin );

--- a/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/standard-plugin.jsx
@@ -42,10 +42,18 @@ StandardPlugin.propTypes = {
 	supportLink: PropTypes.string.isRequired
 };
 
+const trackClick = name => recordTracksEvent(
+	'calypso_plugin_wpcom_click',
+	{
+		plugin_name: name,
+		plugin_plan: 'standard'
+	}
+);
+
 const mapDispatchToProps = ( dispatch, props ) => ( {
 	onClick: has( props, 'onClick' )
 		? props.onClick
-		: () => dispatch( recordTracksEvent( 'wpcom_plugin_clicked', props.name ) )
+		: () => dispatch( trackClick( props.name ) )
 } );
 
 export default connect( null, mapDispatchToProps )( StandardPlugin );


### PR DESCRIPTION
Part of #4572 

The plugins page for WordPress.com sites shows a list of plugins and
users can click on those for more information.

This PR introduces some new trackers to fire off Tracks events on those
clicks. The screenshot below shows the screen where the analytics get sent.

**My Sites** > some wpcom site > **Plugins**

<img width="1258" alt="screen shot 2016-04-14 at 8 07 03 pm" src="https://cloud.githubusercontent.com/assets/5431237/14540354/8397894a-027c-11e6-9c93-a7ef2c1680c8.png">

**Questions for review**
 - Are these event names right?
 - Should I be using Google Analytics instead?
 - Should we ship more info in the event?