### PR TITLE
Help: Show corresponding forum link according to the current user's locale.

### DIFF
--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -78,8 +78,7 @@ module.exports = React.createClass( {
 			);
 		}
 
-		const supportLocale = getLocaleSlug();
-		const localizedForumUrl = 'https://' + supportLocale + '.forums.wordpress.com';
+		const localizedForumUrl = 'https://' + getLocaleSlug() + '.forums.wordpress.com';
 
 		return (
 			<div>

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -15,7 +15,7 @@ import NoResults from 'my-sites/no-results';
 import SearchCard from 'components/search-card';
 import CompactCard from 'components/card/compact';
 import analytics from 'lib/analytics';
-import olarkStore from 'lib/olark-store';
+import { getLocaleSlug } from 'lib/mixins/i18n';
 
 module.exports = React.createClass( {
 	displayName: 'HelpSearch',
@@ -78,7 +78,7 @@ module.exports = React.createClass( {
 			);
 		}
 
-		const supportLocale = olarkStore.get().locale;
+		const supportLocale = getLocaleSlug();
 		const localizedForumUrl = 'https://' + supportLocale + '.forums.wordpress.com';
 
 		return (

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -15,6 +15,7 @@ import NoResults from 'my-sites/no-results';
 import SearchCard from 'components/search-card';
 import CompactCard from 'components/card/compact';
 import analytics from 'lib/analytics';
+import olarkStore from 'lib/olark-store';
 
 module.exports = React.createClass( {
 	displayName: 'HelpSearch',
@@ -77,6 +78,9 @@ module.exports = React.createClass( {
 			);
 		}
 
+		const supportLocale = olarkStore.get().locale;
+		const localizedForumUrl = 'https://' + supportLocale + '.forums.wordpress.com';
+
 		return (
 			<div>
 				<HelpResults
@@ -90,7 +94,7 @@ module.exports = React.createClass( {
 					helpLinks={ this.state.helpLinks.wordpress_forum_links }
 					footer={ this.translate( 'See more from Community Forum…' ) }
 					iconTypeDescription="comment"
-					searchLink={ 'https://en.forums.wordpress.com/search.php?search=' + this.state.searchQuery } />
+					searchLink={ localizedForumUrl + '/search.php?search=' + this.state.searchQuery } />
 				<HelpResults
 					header={ this.translate( 'Jetpack Documentation' ) }
 					helpLinks={ this.state.helpLinks.jetpack_support_links }


### PR DESCRIPTION
## Summary
This should be partially resolve the issue #1510 by replacing the forum link at the bottom of the search result to the one in the user's locale. The locale of the supporting language is in the `locale` property of olark store, so we can compose a proper forum link from it.

If we are are going to make those indexed realtime results the same forum, it would need to reindex and update our /help/search endpoint to accept locale as part of its query parameters. As that could be bigger, we can direct the user to the right forum when one clicks on the link as our first step for the whole.

## How to Test
1. Visit `/me/account`, and change the locale to `pt-br`.
1. Visit `/help/`, try to search anything in the search box, and check if the forum link is to the `pt-br` forum. e.g.
![image](https://cloud.githubusercontent.com/assets/1842898/14547265/815517da-02de-11e6-99d3-8b90ba782c23.png)
1. Changing the locale to `en`, this time the link should point to `en` forum.
1. Changing the locale to anything other than `en` and `pt-br`, the link should point to `en` forum.