### PR TITLE
GuidedTours: Add back in my-sites step

### DIFF
--- a/client/guidestours/config.js
+++ b/client/guidestours/config.js
@@ -20,6 +20,18 @@ function get() {
 			} ),
 			type: 'GuidesFirstStep',
 			placement: 'right',
+			next: 'my-sites',
+		},
+		'my-sites': {
+			target: 'my-sites',
+			type: 'GuidesActionStep',
+			icon: 'my-sites',
+			placement: 'below',
+			text: i18n.translate( "{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing your site's content and design.", {
+				components: {
+					strong: <strong />,
+				}
+			} ),
 			next: 'sidebar',
 		},
 		sidebar: {


### PR DESCRIPTION
Since some signup landing destinations either aren't already on the
my-sites section, or don't show a sidebar at all, let's bring back the
my-sites step.

![screen shot 2016-04-15 at 11 20 14](https://cloud.githubusercontent.com/assets/215074/14558745/0cc75e78-02fc-11e6-88ac-240b67f599de.png)