### PR TITLE
Upgrades: test link to plans/my-plan from sidebar

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -45,7 +45,7 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
-	sidebarPlanLink: {
+	sidebarPlanLinkMyPlan: {
 		datestamp: '20160101',
 		variations: {
 			plans: 75,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -48,10 +48,11 @@ module.exports = {
 	sidebarPlanLink: {
 		datestamp: '20160101',
 		variations: {
-			plans: 50,
-			'plans/my-plan': 50,
+			plans: 75,
+			'plans/my-plan': 25,
 		},
-		defaultVariation: 'plans'
+		defaultVariation: 'plans',
+		allowExistingUsers: true,
 	},
 	domainSuggestionVendor: {
 		datestamp: '20160408',

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -48,8 +48,8 @@ module.exports = {
 	sidebarPlanLinkMyPlan: {
 		datestamp: '20160101',
 		variations: {
-			plans: 75,
-			'plans/my-plan': 25,
+			plans: 50,
+			'plans/my-plan': 50,
 		},
 		defaultVariation: 'plans',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -45,6 +45,14 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
+	sidebarPlanLink: {
+		datestamp: '20160101',
+		variations: {
+			plans: 50,
+			'plans/my-plan': 50,
+		},
+		defaultVariation: 'plans'
+	},
 	domainSuggestionVendor: {
 		datestamp: '20160408',
 		variations: {

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -26,15 +26,14 @@
 
 	.gridicon {
 		background: white;
-		border-radius: 50%;
 		color: $alert-yellow;
 		height: 48px;
-		padding: 21px;
+		margin: 21px 0 0 21px;
 		width: 48px;
 
 		@include breakpoint( ">660px" ) {
 			height: 72px;
-			padding: 30px;
+			margin: 30px 0 0 30px;
 			width: 72px;
 		}
 	}

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -31,15 +31,13 @@ export default function() {
 			plansController.plansCompare
 		);
 
-		if ( config.isEnabled( 'manage/plans/my-plan' ) ) {
-			page(
-				'/plans/my-plan/:site',
-				retarget,
-				controller.siteSelection,
-				controller.navigation,
-				yourPlan
-			);
-		}
+		page(
+			'/plans/my-plan/:site',
+			retarget,
+			controller.siteSelection,
+			controller.navigation,
+			yourPlan
+		);
 
 		page(
 			'/plans/compare/:domain',

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -348,7 +348,7 @@ module.exports = React.createClass( {
 
 		// Show plan details for upgraded sites
 		if (
-			abtest( 'sidebarPlanLink' ) === 'plans/my-plan' &&
+			abtest( 'sidebarPlanLinkMyPlan' ) === 'plans/my-plan' &&
 			site &&
 			( isPremium( site.plan ) || isBusiness( site.plan ) )
 		) {
@@ -383,7 +383,7 @@ module.exports = React.createClass( {
 	trackUpgradeClick: function() {
 		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
 			cta_name: 'sidebar_upgrade_default',
-			cta_landing: abtest( 'sidebarPlanLink' )
+			cta_landing: abtest( 'sidebarPlanLinkMyPlan' )
 		} );
 		this.onNavigate();
 	},

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -348,7 +348,6 @@ module.exports = React.createClass( {
 
 		// Show plan details for upgraded sites
 		if (
-			config.isEnabled( 'manage/plans/my-plan' ) &&
 			abtest( 'sidebarPlanLink' ) === 'plans/my-plan' &&
 			site &&
 			( isPremium( site.plan ) || isBusiness( site.plan ) )

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -372,19 +372,19 @@ module.exports = React.createClass( {
 
 		return (
 			<li className={ this.itemLinkClass( [ '/plans' ], linkClass ) }>
-				<a onClick={ this.trackUpgradeClick.bind( this, planLink ) } href={ planLink }>
+				<a onClick={ this.trackUpgradeClick } href={ planLink }>
 					<Gridicon icon="clipboard" size={ 24 } />
 					<span className="menu-link-text">{ this.translate( 'Plan', { context: 'noun' } ) }</span>
 				</a>
-				<a href={ planLink } className="plan-name" onClick={ this.trackUpgradeClick.bind( this, planLink ) }>{ planName }</a>
+				<a href={ planLink } className="plan-name" onClick={ this.trackUpgradeClick }>{ planName }</a>
 			</li>
 		);
 	},
 
-	trackUpgradeClick: function( planLink ) {
+	trackUpgradeClick: function() {
 		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
 			cta_name: 'sidebar_upgrade_default',
-			path: planLink
+			cta_landing: abtest( 'sidebarPlanLink' )
 		} );
 		this.onNavigate();
 	},

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -346,7 +346,7 @@ module.exports = React.createClass( {
 
 		let planLink = '/plans' + this.siteSuffix();
 
-		//Show plan details for upgraded sites
+		// Show plan details for upgraded sites
 		if (
 			config.isEnabled( 'manage/plans/my-plan' ) &&
 			abtest( 'sidebarPlanLink' ) === 'plans/my-plan' &&

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -372,17 +372,20 @@ module.exports = React.createClass( {
 
 		return (
 			<li className={ this.itemLinkClass( [ '/plans' ], linkClass ) }>
-				<a onClick={ this.trackUpgradeClick } href={ planLink }>
+				<a onClick={ this.trackUpgradeClick.bind( this, planLink ) } href={ planLink }>
 					<Gridicon icon="clipboard" size={ 24 } />
 					<span className="menu-link-text">{ this.translate( 'Plan', { context: 'noun' } ) }</span>
 				</a>
-				<a href={ planLink } className="plan-name" onClick={ this.trackUpgradeClick }>{ planName }</a>
+				<a href={ planLink } className="plan-name" onClick={ this.trackUpgradeClick.bind( this, planLink ) }>{ planName }</a>
 			</li>
 		);
 	},
 
-	trackUpgradeClick: function() {
-		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'sidebar_upgrade_default' } );
+	trackUpgradeClick: function( planLink ) {
+		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
+			cta_name: 'sidebar_upgrade_default',
+			path: planLink
+		} );
 		this.onNavigate();
 	},
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -33,7 +33,6 @@ import SidebarFooter from 'layout/sidebar/footer';
 import DraftsButton from 'post-editor/drafts-button';
 import Tooltip from 'components/tooltip';
 import { isPremium, isBusiness } from 'lib/products-values';
-import { abtest } from 'lib/abtest';
 
 module.exports = React.createClass( {
 	displayName: 'MySitesSidebar',
@@ -344,7 +343,6 @@ module.exports = React.createClass( {
 		if ( site.capabilities && ! site.capabilities.manage_options ) {
 			return null;
 		}
-
 
 		let planLink = '/plans' + this.siteSuffix();
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -348,6 +348,7 @@ module.exports = React.createClass( {
 
 		//Show plan details for upgraded sites
 		if (
+			config.isEnabled( 'manage/plans/my-plan' ) &&
 			abtest( 'sidebarPlanLink' ) === 'plans/my-plan' &&
 			site &&
 			( isPremium( site.plan ) || isBusiness( site.plan ) )

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -32,6 +32,8 @@ import Button from 'components/button';
 import SidebarFooter from 'layout/sidebar/footer';
 import DraftsButton from 'post-editor/drafts-button';
 import Tooltip from 'components/tooltip';
+import { isPremium, isBusiness } from 'lib/products-values';
+import { abtest } from 'lib/abtest';
 
 module.exports = React.createClass( {
 	displayName: 'MySitesSidebar',
@@ -343,7 +345,17 @@ module.exports = React.createClass( {
 			return null;
 		}
 
-		const planLink = '/plans' + this.siteSuffix();
+
+		let planLink = '/plans' + this.siteSuffix();
+
+		//Show plan details for upgraded sites
+		if (
+			abtest( 'sidebarPlanLink' ) === 'plans/my-plan' &&
+			site &&
+			( isPremium( site.plan ) || isBusiness( site.plan ) )
+		) {
+			planLink = '/plans/my-plan' + this.siteSuffix();
+		}
 
 		let linkClass = 'upgrades-nudge';
 

--- a/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -19,7 +19,7 @@ const CustomDomainPurchaseDetail = ( { selectedSite } ) => {
 					"Replace your site's address, {{em}}%(siteDomain)s{{/em}}, with a custom domain. " +
 					'A free domain is included with your plan.',
 					{
-						args: { siteDomain: selectedSite.domain },
+						args: { siteDomain: selectedSite.slug },
 						components: { em: <em /> }
 					}
 				)

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -33,7 +33,6 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plans/my-plan": false,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -34,7 +34,6 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plans/my-plan": false,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,

--- a/config/development.json
+++ b/config/development.json
@@ -61,7 +61,6 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plans/my-plan": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/compatibility-warning": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -39,7 +39,6 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plans/my-plan": false,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,

--- a/config/production.json
+++ b/config/production.json
@@ -33,7 +33,6 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plans/my-plan": true,
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,

--- a/config/production.json
+++ b/config/production.json
@@ -33,6 +33,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
+		"manage/plans/my-plan": false,
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,

--- a/config/production.json
+++ b/config/production.json
@@ -33,7 +33,7 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plans/my-plan": false,
+		"manage/plans/my-plan": true,
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/cache": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -36,7 +36,6 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plans/my-plan": false,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -42,7 +42,6 @@
 		"manage/people": true,
 		"manage/people/readers": true,
 		"manage/plans": true,
-		"manage/plans/my-plan": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,


### PR DESCRIPTION
Links and tests #4747 
This replaces sidebar `plan` link with `/plans/my-plan/siteSlug`
and introduces a proper ABtest