### PR TITLE
WPCOM Plugins: update notice type and tweak business plan

### DIFF
--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -12,7 +12,17 @@ const defaultPlugins = [
 		supportLink: 'https://en.support.wordpress.com/google-analytics/',
 		icon: 'stats',
 		plan: 'Business',
-		description: 'Advanced features to complement WordPress.com stats. Funnel reports, goal conversion, and more.'
+		description: 'Advanced features to complement you site stats. Funnel reports, goal conversion, and more.'
+	},
+	{
+		name: 'Comming Soon',
+		plan: 'Business',
+		description: 'More plugins and features are coming soon...'
+	},
+	{
+		name: 'Coming Soon',
+		plan: 'Business',
+		description: 'More plugins and features are coming soon...'
 	}
 ];
 

--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -12,17 +12,7 @@ const defaultPlugins = [
 		supportLink: 'https://en.support.wordpress.com/google-analytics/',
 		icon: 'stats',
 		plan: 'Business',
-		description: 'Advanced features to complement you site stats. Funnel reports, goal conversion, and more.'
-	},
-	{
-		name: 'Comming Soon',
-		plan: 'Business',
-		description: 'More plugins and features are coming soon...'
-	},
-	{
-		name: 'Coming Soon',
-		plan: 'Business',
-		description: 'More plugins and features are coming soon...'
+		description: 'Advanced features to complement WordPress.com stats. Funnel reports, goal conversion, and more.'
 	}
 ];
 

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -7,6 +7,7 @@ export const InfoHeader = React.createClass( {
 	render() {
 		return (
 			<Notice
+				status="is-info"
 				showDismiss={ false }
 				text={ "Your site comes pre-installed with a wide variety of plugins. Uploading your own plugins is not available on WordPress.com." }
 			>

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -11,7 +11,7 @@ export const InfoHeader = React.createClass( {
 				showDismiss={ false }
 				text={ "Your site comes pre-installed with a wide variety of plugins. Uploading your own plugins is not available on WordPress.com." }
 			>
-				<NoticeAction href="https://en.support.wordpress.com/plugins/">
+				<NoticeAction href="https://en.support.wordpress.com/plugins/" external="true">
 					{ "Learn More" }
 				</NoticeAction>
 			</Notice>

--- a/client/my-sites/plugins-wpcom/info-header.jsx
+++ b/client/my-sites/plugins-wpcom/info-header.jsx
@@ -11,7 +11,7 @@ export const InfoHeader = React.createClass( {
 				showDismiss={ false }
 				text={ "Your site comes pre-installed with a wide variety of plugins. Uploading your own plugins is not available on WordPress.com." }
 			>
-				<NoticeAction href="https://en.support.wordpress.com/plugins/" external="true">
+				<NoticeAction href="https://en.support.wordpress.com/plugins/" external={ true }>
 					{ "Learn More" }
 				</NoticeAction>
 			</Notice>

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -8,7 +8,7 @@
 .wpcom-plugins__premium-panel.is-disabled,
 .wpcom-plugins__business-panel.is-disabled {
 	.wpcom-plugins__plugin-item {
-		opacity: 0.35;
+		opacity: 0.5;
 	}
 }
 

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -8,7 +8,7 @@
 .wpcom-plugins__premium-panel.is-disabled,
 .wpcom-plugins__business-panel.is-disabled {
 	.wpcom-plugins__plugin-item {
-		opacity: 0.5;
+		opacity: 0.35;
 	}
 }
 
@@ -51,6 +51,12 @@
 	@include breakpoint( ">960px" ) {
 		border-bottom: none;
 	}
+}
+
+// Special styles for displaying only one plugin
+.wpcom-plugins__business-panel .wpcom-plugins__plugin-item {
+	width: 100%;
+	border: none;
 }
 
 .wpcom-plugins__plugin-item a {

--- a/client/my-sites/plugins-wpcom/style.scss
+++ b/client/my-sites/plugins-wpcom/style.scss
@@ -8,7 +8,7 @@
 .wpcom-plugins__premium-panel.is-disabled,
 .wpcom-plugins__business-panel.is-disabled {
 	.wpcom-plugins__plugin-item {
-		opacity: 0.35;
+		opacity: 0.5;
 	}
 }
 
@@ -51,12 +51,6 @@
 	@include breakpoint( ">960px" ) {
 		border-bottom: none;
 	}
-}
-
-// Special styles for displaying only one plugin
-.wpcom-plugins__business-panel .wpcom-plugins__plugin-item {
-	width: 100%;
-	border: none;
 }
 
 .wpcom-plugins__plugin-item a {


### PR DESCRIPTION
Reasoning for adding "Coming Soon" items to business plan:

 Looks empty, doesn't look compelling. By adding filler items, it at least looks like we are working on making the plan better. Is it disingenuous though, because we don't have any concrete plan for adding value to business?

cc @rralian 

@adambbecker what do you think of the design changes?

## Before

![9l3xqiz3gi7aaaaaelftksuqmcc](https://cloud.githubusercontent.com/assets/618551/14569234/05319cda-0303-11e6-84bc-a00e5f1f8acc.png)

## After

![ef0hdddixf8dmmmmgtkztpiaaaaasuvork5cyii](https://cloud.githubusercontent.com/assets/618551/14573313/e86481b4-0319-11e6-8f58-d42a38cdcba5.png)
