### PR TITLE
SiteSettings: add domain nudge in settings general section

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -8,6 +8,7 @@ module.exports = {
 		},
 		defaultVariation: 'singlePurchaseFlow'
 	},
+
 	translatorInvitation: {
 		datestamp: '20150910',
 		variations: {
@@ -21,6 +22,7 @@ module.exports = {
 		defaultVariation: 'noNotice',
 		allowAnyLocale: true
 	},
+
 	freeTrialsInSignup: {
 		datestamp: '20160328',
 		variations: {
@@ -30,6 +32,7 @@ module.exports = {
 		},
 		defaultVariation: 'disabled'
 	},
+
 	freeTrialNudgeOnThankYouPage: {
 		datestamp: '20160328',
 		variations: {
@@ -38,6 +41,7 @@ module.exports = {
 		},
 		defaultVariation: 'disabled'
 	},
+
 	privacyCheckbox: {
 		datestamp: '20160310',
 		variations: {
@@ -46,6 +50,7 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
+
 	domainSuggestionVendor: {
 		datestamp: '20160408',
 		variations: {
@@ -54,6 +59,7 @@ module.exports = {
 		},
 		defaultVariation: 'namegen'
 	},
+
 	contextualGoogleAnalyticsNudge: {
 		datestamp: '20160409',
 		variations: {
@@ -65,6 +71,18 @@ module.exports = {
 		defaultVariation: 'drake',
 		allowExistingUsers: true,
 	},
+
+	addCustomDomainOnSiteSettingsPage: {
+		datestamp: '20160425',
+		variations: {
+			byAddCustomDomainButton: 50,
+			byUpgradePlanNudge: 50
+		},
+		defaultVariation: 'byUpgradePlanNudge',
+		allowExistingUsers: true,
+		allowAnyLocale: true
+	},
+
 	swapButtonsMySiteSidebar: {
 		datestamp: '20160414',
 		variations: {
@@ -73,6 +91,7 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
+
 	guidedTours: {
 		datestamp: '20160418',
 		variations: {
@@ -83,6 +102,7 @@ module.exports = {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
+
 	domainCreditsInfoNotice: {
 		datestamp: '20160420',
 		variations: {

--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -64,6 +64,10 @@ export default {
 		}
 	},
 
+	hasCustomDomain( site ) {
+		return ! ( /[a-zA-Z]\.wordpress\.com$/.test( site.domain ) );
+	},
+
 	getSiteFileModDisableReason( site, action = 'modifyFiles' ) {
 		if ( ! site || ! site.options || ! site.options.file_mod_disabled ) {
 			return;

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -211,13 +211,15 @@ export default React.createClass( {
 	},
 
 	isEnabled() {
-		return productsValues.isBusiness( this.props.site.plan ) || productsValues.isEnterprise( this.props.site.plan );
+		return productsValues.isBusiness( this.props.site.plan ) ||
+			productsValues.isEnterprise( this.props.site.plan );
 	},
 
 	renderNudge() {
 		if ( this.isEnabled() ) {
 			return;
 		}
+
 		const abtestVariant = abtest( 'contextualGoogleAnalyticsNudge' );
 		const eventName = `google_analytics_${ abtestVariant }`;
 		const upgradeLink = this.getUpgradeLink();

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -20,6 +20,7 @@ import EmptyContent from 'components/empty-content';
 import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
 
 const debug = debugFactory( 'calypso:my-sites:site-settings' );
 
@@ -230,7 +231,7 @@ export default React.createClass( {
 			<UpgradeNudge
 				title={ this.translate( 'Add Google Analytics' ) }
 				message={ this.translate( 'Upgrade to the business plan and include your own analytics tracking ID.' ) }
-				feature="google-analytics"
+				feature={ FEATURE_GOOGLE_ANALYTICS }
 				event={ eventName }
 				href={ upgradeLink }
 				icon="stats-alt"

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -26,7 +26,14 @@ import FormRadio from 'components/forms/form-radio';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import TimezoneDropdown from 'components/timezone-dropdown';
+import { isFreePlan as siteHasFreePlan } from 'lib/products-values';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
+import { hasCustomDomain as siteHasCustomDomain } from 'lib/site/utils';
+
+/**
+ * Module vars
+ */
+const CUSTOM_DOMAIN = 'custom-domain';
 
 module.exports = React.createClass( {
 
@@ -424,11 +431,21 @@ module.exports = React.createClass( {
 	},
 
 	renderDomainNudge() {
+		// do not nudge if the site already has a custom domain
+		if ( siteHasCustomDomain( this.props.site ) ) {
+			return;
+		}
+
+		// render nudge if the site plan is not free
+		if ( ! siteHasFreePlan( this.props.site.plan ) ) {
+			return;
+		}
+
 		return (
 			<UpgradeNudge
 				title={ this.translate( 'Add A Custom Domain' ) }
 				message={ this.translate( 'Upgrade now and get a free custom domain.' ) }
-				href={ `/domains/manage/${ this.props.site.slug }` }
+				feature={ CUSTOM_DOMAIN }
 				icon="star"
 			/>
 		);

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -152,21 +152,14 @@ module.exports = React.createClass( {
 	},
 
 	blogAddress() {
-		var site = this.props.site,
-			customAddress = '',
-			addressDescription = '';
+		var { site } = this.props;
+		let addressDescription = '';
 
 		if ( site.jetpack ) {
 			return null;
 		}
 
 		if ( config.isEnabled( 'upgrades/domain-search' ) ) {
-			customAddress = (
-				<Button href={ '/domains/add/' + site.slug } onClick={ this.trackUpgradeClick }>
-					<Gridicon icon="plus" /> { this.translate( 'Add a Custom Address', { context: 'Site address, domain' } ) }
-				</Button>
-			);
-
 			addressDescription =
 				<FormSettingExplanation>
 					{
@@ -194,7 +187,7 @@ module.exports = React.createClass( {
 						id="blogaddress"
 						value={ this.props.site.domain }
 						disabled="disabled" />
-					{ customAddress }
+					{ this.renderCustomAddress() }
 				</div>
 				{ addressDescription }
 				{ this.renderDomainNudge() }
@@ -423,6 +416,22 @@ module.exports = React.createClass( {
 					{ this.translate( 'Choose a city in your timezone.' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
+		);
+	},
+
+	renderCustomAddress() {
+		if ( ! config.isEnabled( 'upgrades/domain-search' ) ) {
+			return null;
+		}
+
+		return (
+			<Button
+				href={ `/domains/add/'${ this.props.site.slug }` }
+				onClick={ this.trackUpgradeClick }
+			>
+				<Gridicon icon="plus" />
+				{ this.translate( 'Add a Custom Address', { context: 'Site address, domain' } ) }
+			</Button>
 		);
 	},
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -29,11 +29,7 @@ import TimezoneDropdown from 'components/timezone-dropdown';
 import { isFreePlan as siteHasFreePlan } from 'lib/products-values';
 import UpgradeNudge from 'my-sites/upgrade-nudge';
 import { hasCustomDomain as siteHasCustomDomain } from 'lib/site/utils';
-
-/**
- * Module vars
- */
-const CUSTOM_DOMAIN = 'custom-domain';
+import { CUSTOM_DOMAIN } from 'lib/plans/constants';
 
 module.exports = React.createClass( {
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -26,6 +26,7 @@ import FormRadio from 'components/forms/form-radio';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import TimezoneDropdown from 'components/timezone-dropdown';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
 
 module.exports = React.createClass( {
 
@@ -179,7 +180,10 @@ module.exports = React.createClass( {
 
 		return (
 			<FormFieldset className="has-divider">
-				<FormLabel htmlFor="blogaddress">{ this.translate( 'Site Address' ) }</FormLabel>
+				<FormLabel htmlFor="blogaddress">
+					{ this.translate( 'Site Address' ) }
+				</FormLabel>
+
 				<div className="blogaddress-settings">
 					<FormInput
 						name="blogaddress"
@@ -190,6 +194,7 @@ module.exports = React.createClass( {
 					{ customAddress }
 				</div>
 				{ addressDescription }
+				{ this.renderDomainNudge() }
 			</FormFieldset>
 		);
 	},
@@ -415,6 +420,17 @@ module.exports = React.createClass( {
 					{ this.translate( 'Choose a city in your timezone.' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
+		);
+	},
+
+	renderDomainNudge() {
+		return (
+			<UpgradeNudge
+				title={ this.translate( 'Add A Custom Domain' ) }
+				message={ this.translate( 'Upgrade now and get a free custom domain.' ) }
+				href={ `/domains/manage/${ this.props.site.slug }` }
+				icon="star"
+			/>
 		);
 	},
 

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -43,7 +43,7 @@ export default React.createClass( {
 			jetpack: false,
 			feature: false,
 			compact: false
-		}
+		};
 	},
 
 	handleClick() {
@@ -69,7 +69,7 @@ export default React.createClass( {
 		const classes = classNames( this.props.className, 'upgrade-nudge' );
 
 		const site = sites.getSelectedSite();
-		let href = this.props.href;
+		let { href } = this.props;
 
 		if ( site && this.props.feature ) {
 			if ( hasFeature( this.props.feature, site.siteID ) ) {


### PR DESCRIPTION
Issue: #4679

![image](https://cloud.githubusercontent.com/assets/77539/14798706/4958d590-0b0f-11e6-87e7-d8552dabea31.png)
_updated 2016-04-25_

### Questions / Suggestions

* Should we remove / update the nudge when the site already has a custom domain?
* What about the current description below to domain input field?
* icon?

### Testing

1) go to site settings page - general section
2) locate the nudge in site address block.
3) click in the nudge and go to domains page.