### PR TITLE
Jetpack Connect: post connection screen

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -24,10 +24,27 @@ import userUtilities from 'lib/user/utils';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
+import i18n from 'lib/mixins/i18n';
 
 /**
  * Module variables
  */
+const renderFormHeader = ( site, isConnected = false ) => {
+	const headerText = ( isConnected )
+		? i18n.translate( 'You are connected!' )
+		: i18n.translate( 'Connect your self-hosted WordPress' );
+	const subHeaderText = ( isConnected )
+		? i18n.translate( 'The power of WordPress.com is yours to command.' )
+		: i18n.translate( 'Jetpack would like to connect to your WordPress.com account' );
+	return(
+		<div>
+			<ConnectHeader headerText={ headerText }
+					subHeaderText={ subHeaderText } />
+			<CompactCard className="jetpack-connect__authorize-form-header">{ site }</CompactCard>
+		</div>
+	);
+};
+
 const LoggedOutForm = React.createClass( {
 	displayName: 'LoggedOutForm',
 
@@ -65,9 +82,10 @@ const LoggedOutForm = React.createClass( {
 
 	render() {
 		const { userData } = this.props.jetpackConnectAuthorize;
+		const { site } = this.props.jetpackConnectAuthorize.queryObject
 		return (
 			<div>
-				{ this.props.renderFormHeader() }
+				{ renderFormHeader( site ) }
 				<SignupForm
 					getRedirectToAfterLoginUrl={ window.location.href }
 					disabled={ this.isSubmitting() }
@@ -190,9 +208,10 @@ const LoggedInForm = React.createClass( {
 
 	render() {
 		const { authorizeSuccess } = this.props.jetpackConnectAuthorize;
+		const { site } = this.props.jetpackConnectAuthorize.queryObject
 		return (
 			<div className="jetpack-connect-logged-in-form">
-				{ this.props.renderFormHeader( authorizeSuccess ) }
+				{ renderFormHeader( site, authorizeSuccess ) }
 				<Card>
 					<Gravatar user={ this.props.user } size={ 64 } />
 					<p className="jetpack-connect-logged-in-form__user-text">{ this.getUserText() }</p>
@@ -210,28 +229,11 @@ const LoggedInForm = React.createClass( {
 const JetpackConnectAuthorizeForm = React.createClass( {
 	displayName: 'JetpackConnectAuthorizeForm',
 	mixins: [ observe( 'userModule' ) ],
-	renderFormHeader( isConnected = false ) {
-		const { site } = this.props.jetpackConnectAuthorize.queryObject;
-		const headerText = ( isConnected )
-			? this.translate( 'You are connected!' )
-			: this.translate( 'Connect your self-hosted WordPress' );
-		const subHeaderText = ( isConnected )
-			? this.translate( 'The power of WordPress.com is yours to command.' )
-			: this.translate( 'Jetpack would like to connect to your WordPress.com account' );
-		return(
-			<div>
-				<ConnectHeader headerText={ headerText }
-						subHeaderText={ subHeaderText } />
-				<CompactCard className="jetpack-connect__authorize-form-header">{ site }</CompactCard>
-			</div>
-		);
-	},
 	renderForm() {
 		const { userModule } = this.props;
 		let user = userModule.get();
 		const props = Object.assign( {}, this.props, {
-			user: user,
-			renderFormHeader: this.renderFormHeader
+			user: user
 		} )
 		return ( user )
 			? <LoggedInForm { ...props } />

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -82,12 +82,6 @@ export default React.createClass( {
 			noticeValues.icon = 'notice';
 			return noticeValues
 		}
-		if ( this.props.noticeType === 'authorizeSuccess' ) {
-			noticeValues.text = this.translate( 'Jetpack connected! Searching for available upgrades.' );
-			noticeValues.status = 'is-success';
-			noticeValues.icon = 'checkmark-circle';
-			return noticeValues
-		}
 		return;
 	},
 

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -58,11 +58,11 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE:
 			if ( ! action.error ) {
 				const { plans_url } = action.data;
-				return Object.assign( {}, state, { isAuthorizing: false, authorizeError: false, authorizeSuccess: true, autoAuthorize: false, plansURL: plans_url, siteReceived: false } );
+				return Object.assign( {}, state, { authorizeError: false, authorizeSuccess: true, autoAuthorize: false, plansURL: plans_url, siteReceived: false } );
 			}
 			return Object.assign( {}, state, { isAuthorizing: false, authorizeError: action.error, authorizeSuccess: false, autoAuthorize: false } );
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST:
-			return Object.assign( {}, state, { siteReceived: true } );
+			return Object.assign( {}, state, { siteReceived: true, isAuthorizing: false } );
 		case JETPACK_CONNECT_QUERY_SET:
 			const queryObject = Object.assign( {}, action.queryObject );
 			return Object.assign( {}, defaultAuthorizeState, { queryObject: queryObject } );


### PR DESCRIPTION
This PR presents a user with this after they've completed their connection:

![screen shot 2016-04-15 at 2 51 37 pm](https://cloud.githubusercontent.com/assets/2694219/14571985/3d47218c-031a-11e6-9b3b-4384fd23a6c0.png)

As opposed to the previous iteration in which the user was auto-redirected to plans page:

![screen shot 2016-04-15 at 2 52 51 pm](https://cloud.githubusercontent.com/assets/2694219/14571993/45dfd83e-031a-11e6-81c4-75c7b8dc8e58.png)

To test

- run the latest master on one of your Jetpack sites
- run this branch locally at calypso.localhost
- disconnect Jetpack from WordPress.com
- login to a whitelisted WordPress.com account ( ask me, and I'll add you to the list )
- Click "Connect Jetpack" in you wp-admin
- Complete the connection experience as yourself, or as a brand new user, and you should see this new screen

cc: @johnHackworth @rickybanister