### PR TITLE
Editor: Fix inline gallery toolbar disappearing on scroll

### DIFF
--- a/client/components/tinymce/plugins/wpcom/plugin.js
+++ b/client/components/tinymce/plugins/wpcom/plugin.js
@@ -632,7 +632,7 @@ function wpcomPlugin( editor ) {
 
 				if ( event.type === 'hide' || event.type === 'blur' ) {
 					activeToolbar = false;
-				} else if ( event.type === 'resizewindow' || event.type === 'scroll' ) {
+				} else if ( event.type === 'resizewindow' || event.type === 'scrollwindow' ) {
 					clearTimeout( timeout );
 
 					timeout = setTimeout( function() {


### PR DESCRIPTION
Due to upgrading TinyMCE to 4.3.8 in #4584, the inline gallery editing toolbar currently disappears when you scroll the page and does not reappear.

https://github.com/tinymce/tinymce/commit/2fb8aa48e91101bd3ca4ff2d532bca3a8665fb24 is the commit that caused it (the event type is fired as `ScrollWindow` rather than `scroll` as in previous versions, and lower-cased [here](https://github.com/tinymce/tinymce/blob/4.3.8/js/tinymce/classes/util/EventDispatcher.js#L61)).

### To test

- Open the editor.
- Insert a gallery or load a post with a gallery.
- Focus the gallery to show the inline editing toolbar.
- Scroll the page and verify that the inline toolbar disappears, then reappears when you stop scrolling.  (In `master` it does not reappear.)