### PR TITLE
Help: Change the title "WordPress.org vs WordPress.com" to a more straightforward one.

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -26,8 +26,8 @@ module.exports = React.createClass( {
 		const helpfulResults = [
 			{
 				link: 'https://en.support.wordpress.com/com-vs-org/',
-				title: this.translate( 'WordPress.com and WordPress.org' ),
-				description: this.translate( 'Learn about the differences between a fully hosted WordPress.com site and a self-hosted WordPress.org site.' )
+				title: this.translate( 'Can\'t add your theme or plugin?' ),
+				description: this.translate( 'Learn about the differences between a fully hosted WordPress.com site and a self-hosted WordPress.org site. Themes and plugins can be uploaded to self-hosted sites only.' )
 			},
 			{
 				link: 'https://en.support.wordpress.com/all-about-domains/',


### PR DESCRIPTION
## Summary
A common frustration from our users is that they can't find why
they can't upload their own themes and plugins until they found the
difference between .org sites and .com sites. However, the original
wording is general and vague, and probably not the first choice for
people struggling on it. Changing the wording to a more straightforward
one could be helpful.

## How to test
Visit `/help/` and you should be able to see the new description on the first item in the section `Most Useful Articles`.