### PR TITLE
Bug: Fix issues with collapsing sidebar elements in /me section

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -79,7 +79,7 @@ module.exports = React.createClass( {
 		return (
 			<Sidebar>
 				<ProfileGravatar user={ this.props.user.get() } />
-				<div>
+				<div className="me-sidebar__menu__signout-wrapper">
 					<FormButton
 						className="me-sidebar__menu__signout"
 						isPrimary={ false }

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -79,9 +79,9 @@ module.exports = React.createClass( {
 		return (
 			<Sidebar>
 				<ProfileGravatar user={ this.props.user.get() } />
-				<div className="me-sidebar__menu__signout-wrapper">
+				<div className="me-sidebar__signout">
 					<FormButton
-						className="me-sidebar__menu__signout"
+						className="me-sidebar__signout-button"
 						isPrimary={ false }
 						onClick={ this.onSignOut }
 						title={ this.translate( 'Sign out of WordPress.com', { textOnly: true } ) }

--- a/client/me/sidebar/style.scss
+++ b/client/me/sidebar/style.scss
@@ -10,3 +10,11 @@
 	padding: 8px 24px;
 	min-height: 40px;
 }
+
+.me-sidebar__menu__signout-wrapper {
+	flex-shrink: 0;	// these are required for the flexed sidebar to not implode in Safari
+}
+
+.profile-gravatar {
+	flex-shrink: 0;
+}

--- a/client/me/sidebar/style.scss
+++ b/client/me/sidebar/style.scss
@@ -2,7 +2,11 @@
 	padding-top: 16px;
 }
 
-.form-button.me-sidebar__menu__signout {
+.me-sidebar__signout {
+	flex-shrink: 0;	// these are required for the flexed sidebar to not implode in Safari
+}
+
+.me-sidebar__signout-button.form-button {
 	display: block;
 	float: none;
 	margin: 0 auto;
@@ -11,10 +15,6 @@
 	min-height: 40px;
 }
 
-.me-sidebar__menu__signout-wrapper {
-	flex-shrink: 0;	// these are required for the flexed sidebar to not implode in Safari
-}
-
-.profile-gravatar {
+.sidebar .profile-gravatar {
 	flex-shrink: 0;
 }


### PR DESCRIPTION
Sidebar is now flexed. Due to Safari bugs, all top level elements under the sidebar have to have `flex-shrink: 0;` applied as sort of a CSS hack. Otherwise they will implode to smaller-than-their-minimum-size when the viewport is vertically resized.

This PR fixes #4796, by applying that CSS to the two remaining elements that was missing it. This is a slight regression from a recent code refactor to scope this hack.

Tested in Safari. I doublechecked all other sidebars to verify that there weren't any more sidebar child elements we had forgotten.