### PR TITLE
Make wpcom plugins page aware of current plan

### DIFF
--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -1,22 +1,30 @@
 import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
-import Button from 'components/button';
 
 import BusinessPlugin from './plugin-types/business-plugin';
+import PurchaseButton from './purchase-button';
 
 export const BusinessPluginsPanel = React.createClass( {
 	render() {
-		const { plugins } = this.props;
+		const {
+			isActive = false,
+			plugins
+		} = this.props;
+
+		const cardClasses = classNames( 'wpcom-plugins__business-panel', {
+			'is-disabled': ! isActive
+		} );
 
 		return (
 			<div>
 				<SectionHeader label={ this.translate( 'Business Plan Upgrades' ) }>
-					<Button compact primary>{ this.translate( 'Purchase' ) }</Button>
+					<PurchaseButton { ...{ isActive } } />
 				</SectionHeader>
 
-				<Card className="wpcom-plugins__business-panel is-disabled">
+				<Card className={ cardClasses }>
 					<div className="wpcom-plugins__list">
 						{ plugins.map( ( { name, descriptionLink, icon, plan, description } ) =>
 							<BusinessPlugin

--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -11,7 +11,7 @@ export const BusinessPluginsPanel = React.createClass( {
 	render() {
 		const {
 			isActive = false,
-			plugins
+			plugins = []
 		} = this.props;
 
 		const cardClasses = classNames( 'wpcom-plugins__business-panel', {

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import get from 'lodash/get';
 
 import Card from 'components/card';
 import {
@@ -71,7 +72,7 @@ export const PluginPanel = React.createClass( {
 } );
 
 const mapStateToProps = state => ( {
-	plan: getSelectedSite( state ).plan,
+	plan: get( getSelectedSite( state ), 'plan', {} ),
 	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
 } );
 

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -2,8 +2,16 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import Card from 'components/card';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId
+} from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
+import {
+	isPremium,
+	isBusiness,
+	isEnterprise
+} from 'lib/products-values';
 
 import InfoHeader from './info-header';
 
@@ -31,8 +39,13 @@ const linkInterpolator = replacements => plugin => {
 
 export const PluginPanel = React.createClass( {
 	render() {
-		const { siteSlug } = this.props;
+		const {
+			plan,
+			siteSlug
+		} = this.props;
 		const standardPluginsLink = `/plugins/standard/${ siteSlug }`;
+		const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
+		const hasPremium = hasBusiness || isPremium( plan );
 
 		const interpolateLink = linkInterpolator( { siteSlug } );
 
@@ -50,14 +63,15 @@ export const PluginPanel = React.createClass( {
 					{ this.translate( 'View all standard plugins' ) }
 				</Card>
 
-				<PremiumPluginsPanel plugins={ premiumPlugins } />
-				<BusinessPluginsPanel plugins={ businessPlugins } />
+				<PremiumPluginsPanel plugins={ premiumPlugins } isActive={ hasPremium }/>
+				<BusinessPluginsPanel plugins={ businessPlugins } isActive={ hasBusiness }/>
 			</div>
 		);
 	}
 } );
 
 const mapStateToProps = state => ( {
+	plan: getSelectedSite( state ).plan,
 	siteSlug: getSiteSlug( state, getSelectedSiteId( state ) )
 } );
 

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -44,7 +44,9 @@ export const PluginPanel = React.createClass( {
 			plan,
 			siteSlug
 		} = this.props;
+		
 		const standardPluginsLink = `/plugins/standard/${ siteSlug }`;
+
 		const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
 		const hasPremium = hasBusiness || isPremium( plan );
 

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -1,22 +1,29 @@
 import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
-import Button from 'components/button';
 
 import PremiumPlugin from './plugin-types/premium-plugin';
 
 export const PremiumPluginsPanel = React.createClass( {
 	render() {
-		const { plugins } = this.props;
+		const {
+			isActive = false,
+			plugins = []
+		} = this.props;
+
+		const cardClasses = classNames( 'wpcom-plugins__premium-panel', {
+			'is-disabled': ! isActive
+		} );
 
 		return (
 			<div>
 				<SectionHeader label={ this.translate( 'Premium Plan Upgrades' ) }>
-					<Button compact primary>{ this.translate( 'Purchase' ) }</Button>
+					<PurchaseButton { ...{ isActive } } />
 				</SectionHeader>
 
-				<Card className="wpcom-plugins__premium-panel is-disabled">
+				<Card className={ cardClasses }>
 					<div className="wpcom-plugins__list">
 						{ plugins.map( ( { name, descriptionLink, icon, plan, description } ) =>
 							<PremiumPlugin

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -5,6 +5,7 @@ import Card from 'components/card';
 import SectionHeader from 'components/section-header';
 
 import PremiumPlugin from './plugin-types/premium-plugin';
+import PurchaseButton from './purchase-button';
 
 export const PremiumPluginsPanel = React.createClass( {
 	render() {

--- a/client/my-sites/plugins-wpcom/purchase-button.jsx
+++ b/client/my-sites/plugins-wpcom/purchase-button.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
@@ -18,5 +18,9 @@ export const PurchaseButton = React.createClass( {
 		return <Button compact primary>{ this.translate( 'Purchase' ) }</Button>;
 	}
 } );
+
+PurchaseButton.propTypes = {
+	isActive: PropTypes.bool.isRequired
+};
 
 export default PurchaseButton;

--- a/client/my-sites/plugins-wpcom/purchase-button.jsx
+++ b/client/my-sites/plugins-wpcom/purchase-button.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import Button from 'components/button';
+import Gridicon from 'components/gridicon';
+
+export const PurchaseButton = React.createClass( {
+	render() {
+		const { isActive } = this.props;
+
+		if ( isActive ) {
+			return (
+				<Button className="is-active-plugin" compact borderless>
+					<Gridicon icon="checkmark" />{ this.translate( 'Active' ) }
+				</Button>
+			);
+		}
+
+		return <Button compact primary>{ this.translate( 'Purchase' ) }</Button>;
+	}
+} );
+
+export default PurchaseButton;

--- a/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/standard-plugins-panel.jsx
@@ -9,7 +9,11 @@ import StandardPlugin from './plugin-types/standard-plugin';
 
 export const StandardPluginsPanel = React.createClass( {
 	render() {
-		const { displayCount, plugins } = this.props;
+		const {
+			displayCount,
+			plugins = []
+		} = this.props;
+
 		const shownPlugins = plugins.slice( 0, displayCount );
 
 		return (


### PR DESCRIPTION
Part of #4572 

Previously, the list of premium and business plugins on the new
WordPress.com plugins page always appeared with a purchase link, even if
the selected site already had a plan with those featured enabled.

Now, details about the plan for the selected site is passed into the
plugins panel and that determines if the button shows a purchase link or
an "activated" message.

The logic is a bit fragile here because we are defining a hierarchy from
hard-coded plans in the site state. I'm not sure if there is a better
way to accomplish this or not, but at the moment it appears to be the
most suitable solution. The result of this is that if the plan details
change on WordPress.com, this page could get out of sync; further, it's
possible that subtle bugs appear for unexpected plan tiers, such as for
VIP.

**Testing**

Navigate to the WordPress.com plugins page at **My Sites** > [Some WordPress.com site] > **Plugins**

Notice the "Active" link in the standard plugins panel. The premium and business panels should either have that "Active" message or a Purchase link depending on which site you choose. Switch sites and see that it should update as you switch.