### PR TITLE
State: Use new util createReducer in state code

### DIFF
--- a/client/state/application/reducer.js
+++ b/client/state/application/reducer.js
@@ -8,25 +8,14 @@ import { combineReducers } from 'redux';
  */
 import {
 	CONNECTION_LOST,
-	CONNECTION_RESTORED,
-	SERIALIZE,
-	DESERIALIZE
+	CONNECTION_RESTORED
 } from 'state/action-types';
+import { createReducer } from 'state/utils';
 
-export function connectionState( state = 'CHECKING', action ) {
-	switch ( action.type ) {
-		case CONNECTION_LOST:
-			return 'OFFLINE';
-		case CONNECTION_RESTORED:
-			return 'ONLINE';
-		case SERIALIZE:
-			return 'CHECKING';
-		case DESERIALIZE:
-			return 'CHECKING';
-	}
-
-	return state;
-}
+export const connectionState = createReducer( {
+	[CONNECTION_LOST]: () => 'OFFLINE',
+	[CONNECTION_RESTORED]: () => 'ONLINE'
+}, 'CHECKING' );
 
 export default combineReducers( {
 	connectionState

--- a/client/state/application/reducer.js
+++ b/client/state/application/reducer.js
@@ -12,10 +12,10 @@ import {
 } from 'state/action-types';
 import { createReducer } from 'state/utils';
 
-export const connectionState = createReducer( {
+export const connectionState = createReducer( 'CHECKING', {
 	[CONNECTION_LOST]: () => 'OFFLINE',
 	[CONNECTION_RESTORED]: () => 'ONLINE'
-}, 'CHECKING' );
+} );
 
 export default combineReducers( {
 	connectionState

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -9,11 +9,9 @@ import { combineReducers } from 'redux';
 import {
 	CURRENT_USER_ID_SET,
 	SITE_RECEIVE,
-	SITES_RECEIVE,
-	SERIALIZE,
-	DESERIALIZE
+	SITES_RECEIVE
 } from 'state/action-types';
-import { createReducer, isValidStateWithSchema } from 'state/utils';
+import { createReducer } from 'state/utils';
 import { idSchema, capabilitiesSchema } from './schema';
 
 /**
@@ -36,38 +34,28 @@ export const id = createReducer( null, {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function capabilities( state = {}, action ) {
-	switch ( action.type ) {
-		case SITE_RECEIVE:
-			if ( ! action.site.capabilities ) {
-				return state;
+export const capabilities = createReducer( {}, {
+	[SITE_RECEIVE]: ( state, action ) => {
+		if ( ! action.site.capabilities ) {
+			return state;
+		}
+
+		return Object.assign( {}, state, {
+			[ action.site.ID ]: action.site.capabilities
+		} );
+	},
+	[SITES_RECEIVE]: ( state, action ) => {
+		const siteCapabilities = action.sites.reduce( ( memo, site ) => {
+			if ( site.capabilities ) {
+				memo[ site.ID ] = site.capabilities;
 			}
 
-			return Object.assign( {}, state, {
-				[ action.site.ID ]: action.site.capabilities
-			} );
+			return memo;
+		}, {} );
 
-		case SITES_RECEIVE:
-			const siteCapabilities = action.sites.reduce( ( memo, site ) => {
-				if ( site.capabilities ) {
-					memo[ site.ID ] = site.capabilities;
-				}
-
-				return memo;
-			}, {} );
-
-			return Object.assign( {}, state, siteCapabilities );
-
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, capabilitiesSchema ) ) {
-				return state;
-			}
-
-			return {};
+		return Object.assign( {}, state, siteCapabilities );
 	}
-
-	return state;
-}
+}, capabilitiesSchema );
 
 export default combineReducers( {
 	id,

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -23,9 +23,9 @@ import { idSchema, capabilitiesSchema } from './schema';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const id = createReducer( {
+export const id = createReducer( null, {
 	[CURRENT_USER_ID_SET]: ( state, action ) => action.userId
-}, null, idSchema );
+}, idSchema );
 
 /**
  * Returns the updated capabilities state after an action has been dispatched.

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -13,7 +13,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import { isValidStateWithSchema } from 'state/utils';
+import { createReducer, isValidStateWithSchema } from 'state/utils';
 import { idSchema, capabilitiesSchema } from './schema';
 
 /**
@@ -23,22 +23,9 @@ import { idSchema, capabilitiesSchema } from './schema';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function id( state = null, action ) {
-	switch ( action.type ) {
-		case CURRENT_USER_ID_SET:
-			state = action.userId;
-			break;
-		case SERIALIZE:
-			return state;
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, idSchema ) ) {
-				return state;
-			}
-			return null;
-	}
-
-	return state;
-}
+export const id = createReducer( {
+	[CURRENT_USER_ID_SET]: ( state, action ) => action.userId
+}, null, idSchema );
 
 /**
  * Returns the updated capabilities state after an action has been dispatched.

--- a/client/state/test/mocks/schema.js
+++ b/client/state/test/mocks/schema.js
@@ -1,0 +1,12 @@
+export const testSchema = {
+	type: 'object',
+	patternProperties: {
+		test: {
+			type: 'array',
+			items: {
+				type: 'string'
+			}
+		}
+	},
+	additionalProperties: false
+};

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -16,7 +16,7 @@ import { testSchema } from './mocks/schema';
 import useMockery from 'test/helpers/use-mockery';
 
 describe( 'utils', () => {
-	const initialState = deepFreeze( {
+	const currentState = deepFreeze( {
 			test: [ 'one', 'two', 'three' ]
 		} ),
 		actionSerialize = { type: SERIALIZE },
@@ -43,8 +43,8 @@ describe( 'utils', () => {
 				const invalidAction = {};
 
 				expect(
-					reducer( initialState, invalidAction )
-				).to.be.deep.equal( initialState );
+					reducer( currentState, invalidAction )
+				).to.be.deep.equal( currentState );
 			} );
 
 			it( 'should return initial state when unknown action type passed', () => {
@@ -53,47 +53,47 @@ describe( 'utils', () => {
 				};
 
 				expect(
-					reducer( initialState, unknownAction )
-				).to.be.deep.equal( initialState );
+					reducer( currentState, unknownAction )
+				).to.be.deep.equal( currentState );
 			} );
 
 			it( 'should return default null state when serialize action type passed', () => {
 				expect(
-					reducer( initialState, actionSerialize )
+					reducer( currentState, actionSerialize )
 				).to.be.null;
 			} );
 
 			it( 'should return default null state when deserialize action type passed', () => {
 				expect(
-					reducer( initialState, actionDeserialize )
+					reducer( currentState, actionDeserialize )
 				).to.be.null;
 			} );
 		} );
 
 		context( 'with reducers and default state provided', () => {
-			const defaultState = {},
+			const initialState = {},
 				TEST_ADD = 'TEST_ADD';
 
 			before( () => {
-				reducer = createReducer( {
+				reducer = createReducer( initialState, {
 					[TEST_ADD]: ( state, action ) => {
 						return {
 							test: [ ...state.test, action.value ]
 						};
 					}
-				}, defaultState );
+				} );
 			} );
 
 			it( 'should return default {} state when SERIALIZE action type passed', () => {
 				expect(
-					reducer( initialState, actionSerialize )
-				).to.be.equal( defaultState );
+					reducer( currentState, actionSerialize )
+				).to.be.equal( initialState );
 			} );
 
 			it( 'should return default {} state when DESERIALIZE action type passed', () => {
 				expect(
-					reducer( initialState, actionDeserialize )
-				).to.be.equal( defaultState );
+					reducer( currentState, actionDeserialize )
+				).to.be.equal( initialState );
 			} );
 
 			it( 'should add new value to test array when acc action passed', () => {
@@ -102,9 +102,9 @@ describe( 'utils', () => {
 					value: 'four'
 				};
 
-				const newState = reducer( initialState, addAction );
+				const newState = reducer( currentState, addAction );
 
-				expect( newState ).to.not.equal( initialState );
+				expect( newState ).to.not.equal( currentState );
 				expect( newState ).to.be.eql( {
 					test: [ 'one', 'two', 'three', 'four' ]
 				} );
@@ -112,28 +112,28 @@ describe( 'utils', () => {
 		} );
 
 		context( 'with schema provided', () => {
-			const defaultState = {};
+			const initialState = {};
 
 			before( () => {
-				reducer = createReducer( {}, defaultState, testSchema );
+				reducer = createReducer( initialState, {}, testSchema );
 			} );
 
 			it( 'should return initial state when serialize action type passed', () => {
 				expect(
-					reducer( initialState, actionSerialize )
-				).to.be.deep.equal( initialState );
+					reducer( currentState, actionSerialize )
+				).to.be.deep.equal( currentState );
 			} );
 
 			it( 'should return initial state when valid initial state and deserialize action type passed', () => {
 				expect(
-					reducer( initialState, actionDeserialize )
-				).to.be.deep.equal( initialState );
+					reducer( currentState, actionDeserialize )
+				).to.be.deep.equal( currentState );
 			} );
 
 			it( 'should return default state when invalid initial state and deserialize action type passed', () => {
 				expect(
 					reducer( { invalid: 'state' }, actionDeserialize )
-				).to.be.deep.equal( defaultState );
+				).to.be.deep.equal( initialState );
 			} );
 		} );
 
@@ -141,7 +141,7 @@ describe( 'utils', () => {
 			const overriddenState = { overridden: 'state' };
 
 			before( () => {
-				reducer = createReducer( {
+				reducer = createReducer( null, {
 					[SERIALIZE]: () => overriddenState,
 					[DESERIALIZE]: () => overriddenState
 				} );
@@ -149,13 +149,13 @@ describe( 'utils', () => {
 
 			it( 'should return overridden state when serialize action type passed', () => {
 				expect(
-					reducer( initialState, actionSerialize )
+					reducer( currentState, actionSerialize )
 				).to.be.deep.equal( overriddenState );
 			} );
 
 			it( 'should return overridden state when deserialize action type passed', () => {
 				expect(
-					reducer( initialState, actionDeserialize )
+					reducer( currentState, actionDeserialize )
 				).to.be.deep.equal( overriddenState );
 			} );
 		} );

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -142,8 +142,8 @@ describe( 'utils', () => {
 
 			before( () => {
 				reducer = createReducer( {
-					[SERIALIZE]: state => overriddenState,
-					[DESERIALIZE]: state => overriddenState
+					[SERIALIZE]: () => overriddenState,
+					[DESERIALIZE]: () => overriddenState
 				} );
 			} );
 

--- a/client/state/test/utils.js
+++ b/client/state/test/utils.js
@@ -1,0 +1,163 @@
+/**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+import { expect } from 'chai';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import {
+	DESERIALIZE,
+	SERIALIZE,
+} from 'state/action-types';
+import { testSchema } from './mocks/schema';
+import useMockery from 'test/helpers/use-mockery';
+
+describe( 'utils', () => {
+	const initialState = deepFreeze( {
+			test: [ 'one', 'two', 'three' ]
+		} ),
+		actionSerialize = { type: SERIALIZE },
+		actionDeserialize = { type: DESERIALIZE };
+	let createReducer, reducer;
+
+	useMockery( ( mockery ) => {
+		mockery.registerMock( 'lib/warn', noop );
+
+		createReducer = require( 'state/utils' ).createReducer;
+	} );
+
+	describe( '#createReducer()', () => {
+		context( 'only default behavior', () => {
+			before( () => {
+				reducer = createReducer();
+			} );
+
+			it( 'should return a function', () => {
+				expect( reducer ).to.be.a.function;
+			} );
+
+			it( 'should return initial state when invalid action passed', () => {
+				const invalidAction = {};
+
+				expect(
+					reducer( initialState, invalidAction )
+				).to.be.deep.equal( initialState );
+			} );
+
+			it( 'should return initial state when unknown action type passed', () => {
+				const unknownAction = {
+					type: 'UNKNOWN'
+				};
+
+				expect(
+					reducer( initialState, unknownAction )
+				).to.be.deep.equal( initialState );
+			} );
+
+			it( 'should return default null state when serialize action type passed', () => {
+				expect(
+					reducer( initialState, actionSerialize )
+				).to.be.null;
+			} );
+
+			it( 'should return default null state when deserialize action type passed', () => {
+				expect(
+					reducer( initialState, actionDeserialize )
+				).to.be.null;
+			} );
+		} );
+
+		context( 'with reducers and default state provided', () => {
+			const defaultState = {},
+				TEST_ADD = 'TEST_ADD';
+
+			before( () => {
+				reducer = createReducer( {
+					[TEST_ADD]: ( state, action ) => {
+						return {
+							test: [ ...state.test, action.value ]
+						};
+					}
+				}, defaultState );
+			} );
+
+			it( 'should return default {} state when SERIALIZE action type passed', () => {
+				expect(
+					reducer( initialState, actionSerialize )
+				).to.be.equal( defaultState );
+			} );
+
+			it( 'should return default {} state when DESERIALIZE action type passed', () => {
+				expect(
+					reducer( initialState, actionDeserialize )
+				).to.be.equal( defaultState );
+			} );
+
+			it( 'should add new value to test array when acc action passed', () => {
+				const addAction = {
+					type: TEST_ADD,
+					value: 'four'
+				};
+
+				const newState = reducer( initialState, addAction );
+
+				expect( newState ).to.not.equal( initialState );
+				expect( newState ).to.be.eql( {
+					test: [ 'one', 'two', 'three', 'four' ]
+				} );
+			} );
+		} );
+
+		context( 'with schema provided', () => {
+			const defaultState = {};
+
+			before( () => {
+				reducer = createReducer( {}, defaultState, testSchema );
+			} );
+
+			it( 'should return initial state when serialize action type passed', () => {
+				expect(
+					reducer( initialState, actionSerialize )
+				).to.be.deep.equal( initialState );
+			} );
+
+			it( 'should return initial state when valid initial state and deserialize action type passed', () => {
+				expect(
+					reducer( initialState, actionDeserialize )
+				).to.be.deep.equal( initialState );
+			} );
+
+			it( 'should return default state when invalid initial state and deserialize action type passed', () => {
+				expect(
+					reducer( { invalid: 'state' }, actionDeserialize )
+				).to.be.deep.equal( defaultState );
+			} );
+		} );
+
+		context( 'with default actions overrides', () => {
+			const overriddenState = { overridden: 'state' };
+
+			before( () => {
+				reducer = createReducer( {
+					[SERIALIZE]: state => overriddenState,
+					[DESERIALIZE]: state => overriddenState
+				} );
+			} );
+
+			it( 'should return overridden state when serialize action type passed', () => {
+				expect(
+					reducer( initialState, actionSerialize )
+				).to.be.deep.equal( overriddenState );
+			} );
+
+			it( 'should return overridden state when deserialize action type passed', () => {
+				expect(
+					reducer( initialState, actionDeserialize )
+				).to.be.deep.equal( overriddenState );
+			} );
+		} );
+	} );
+} );

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -6,6 +6,10 @@ import tv4 from 'tv4';
 /**
  * Internal dependencies
  */
+import {
+	DESERIALIZE,
+	SERIALIZE,
+} from './action-types';
 import warn from 'lib/warn';
 
 /**
@@ -18,4 +22,35 @@ export function isValidStateWithSchema( state, schema, checkForCycles = false, b
 		warn( 'state validation failed', state, result.error );
 	}
 	return result.valid;
+}
+
+export function createReducer( actionReducers, defaultState = null, schema = null ) {
+	const defaultActionReducers = {
+		[SERIALIZE]: ( state ) => {
+			if ( schema !== null ) {
+				return state;
+			}
+
+			return defaultState;
+		},
+		[DESERIALIZE]: ( state ) => {
+			if ( schema !== null && isValidStateWithSchema( state, schema ) ) {
+				return state;
+			}
+
+			return defaultState;
+		}
+	};
+
+	actionReducers = Object.assign( {}, defaultActionReducers, actionReducers );
+
+	return ( state = defaultState, action ) => {
+		const { type } = action;
+
+		if ( actionReducers[ type ] ) {
+			return actionReducers[ type ]( state, action );
+		}
+
+		return state;
+	};
 }

--- a/client/state/utils.js
+++ b/client/state/utils.js
@@ -24,31 +24,31 @@ export function isValidStateWithSchema( state, schema, checkForCycles = false, b
 	return result.valid;
 }
 
-export function createReducer( actionReducers, defaultState = null, schema = null ) {
-	const defaultActionReducers = {
+export function createReducer( initialState = null, handlers = {}, schema = null ) {
+	const defaultHandlers = {
 		[SERIALIZE]: ( state ) => {
 			if ( schema !== null ) {
 				return state;
 			}
 
-			return defaultState;
+			return initialState;
 		},
 		[DESERIALIZE]: ( state ) => {
 			if ( schema !== null && isValidStateWithSchema( state, schema ) ) {
 				return state;
 			}
 
-			return defaultState;
+			return initialState;
 		}
 	};
 
-	actionReducers = Object.assign( {}, defaultActionReducers, actionReducers );
+	handlers = Object.assign( {}, defaultHandlers, handlers );
 
-	return ( state = defaultState, action ) => {
+	return ( state = initialState, action ) => {
 		const { type } = action;
 
-		if ( actionReducers[ type ] ) {
-			return actionReducers[ type ]( state, action );
+		if ( handlers.hasOwnProperty( type ) ) {
+			return handlers[ type ]( state, action );
 		}
 
 		return state;


### PR DESCRIPTION
I never liked the way we define reducers in `Redux`. There were also many discussions where I could see common agreement that we should optimize that part of our `Redux state` code.

I attended [local React meetup](http://www.meetup.com/ReactJS-Wroclaw/events/229484716/) last month. @chodorowicz gave quite interesting talk how he migrated his codebase [from Alt to Redux](https://gist.github.com/chodorowicz/c4916dbe1c81ccb14caf). He mentioned `handleActions` helper from [redux-actions](https://github.com/acdlite/redux-actions#handleactionsreducermap-defaultstate) library.

I decided to take a similar approach and build our own util that not only replaces `switch` with hashmap lookup, but also adds default handling for our data persistence layer. I also moved 2 simple reducers to show new util in action.

### Testing
Everything should work as before. I refactored 2 existing reducers nicely covered with unit tests. So all tests should pass as before:
* `npm run test-client`

### TODO
* We need to add `REAMDE.md` part that documents `createReducer` util usage.
