### PR TITLE
Editor: fix publish without email validation

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -61,6 +61,7 @@ function renderEditor( context, postType ) {
 		React.createElement( ReduxProvider, { store: context.store },
 			React.createElement( PreferencesData, null,
 				React.createElement( PostEditor, {
+					user: user,
 					sites: sites,
 					type: postType
 				} )

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -766,12 +766,19 @@ const PostEditor = React.createClass( {
 		user.fetch();
 	},
 
+	needsVerification: function( user, site ) {
+		// do not allow publish for unverified e-mails,
+		// but allow if the site is VIP
+		return !user.email_verified && !( site && site.is_vip );
+	},
+
 	onPublish: function() {
 		var edits = { status: 'publish' };
-		var userInfo = this.props.user.get();
+		var post = this.state.post;
+		var user = this.props.user.get();
+		var site = this.props.sites.getSite( post.site_ID );
 
-		// do not allow publish for unverified e-mails
-		if ( ! userInfo.email_verified ) {
+		if ( this.needsVerification( user, site ) ) {
 			this.setState( {
 				showVerifyEmailDialog: true
 			} );
@@ -888,7 +895,7 @@ const PostEditor = React.createClass( {
 	},
 
 	getEditorMode: function() {
-		var editorMode = 'tinymce'
+		var editorMode = 'tinymce';
 		if ( this.props.preferences ) {
 			if ( this.props.preferences[ 'editor-mode' ] ) {
 				editorMode = this.props.preferences[ 'editor-mode' ];

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -38,6 +38,7 @@ const actions = require( 'lib/posts/actions' ),
 	PreferencesActions = require( 'lib/preferences/actions' ),
 	InvalidURLDialog = require( 'post-editor/invalid-url-dialog' ),
 	RestorePostDialog = require( 'post-editor/restore-post-dialog' ),
+	VerifyEmailDialog = require( 'post-editor/verify-email-dialog' ),
 	utils = require( 'lib/posts/utils' ),
 	i18n = require( 'lib/mixins/i18n' ),
 	EditorPreview = require( './editor-preview' ),
@@ -215,6 +216,7 @@ const PostEditor = React.createClass( {
 			isSaving: false,
 			isPublishing: false,
 			notice: false,
+			showVerifyEmailDialog: false,
 			showAutosaveDialog: true,
 			isLoadingAutosave: false,
 			isTitleFocused: false
@@ -435,6 +437,13 @@ const PostEditor = React.createClass( {
 						onRestore={ this.onSaveTrashed }
 					/>
 				: null }
+				{ this.state.showVerifyEmailDialog
+					? <VerifyEmailDialog
+						user={ this.props.user }
+						onClose={ this.closeVerifyEmailDialog }
+						onTryAgain={ this.onPublishAfterVerify }
+					/>
+				: null }
 				{ isInvalidURL
 					? <InvalidURLDialog
 						post={ this.state.post }
@@ -475,6 +484,10 @@ const PostEditor = React.createClass( {
 
 	closeAutosaveDialog: function() {
 		this.setState( { showAutosaveDialog: false } );
+	},
+
+	closeVerifyEmailDialog: function() {
+		this.setState( { showVerifyEmailDialog: false } );
 	},
 
 	getMessage: function( name ) {
@@ -744,8 +757,29 @@ const PostEditor = React.createClass( {
 		}
 	},
 
+	onPublishAfterVerify: function() {
+		var user = this.props.user;
+
+		user.off( 'change', this.onPublish );
+		user.once( 'change', this.onPublish );
+
+		user.fetch();
+	},
+
 	onPublish: function() {
 		var edits = { status: 'publish' };
+		var userInfo = this.props.user.get();
+
+		// do not allow publish for unverified e-mails
+		if ( ! userInfo.email_verified ) {
+			this.setState( {
+				showVerifyEmailDialog: true
+			} );
+
+			return;
+		}
+
+		this.setState( { showVerifyEmailDialog: false } );
 
 		// determine if this is a private publish
 		if ( utils.isPrivate( this.state.post ) ) {

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -1,3 +1,12 @@
+.dialog.verification-modal {
+	max-width: 475px;
+
+	h1 {
+		height: auto;
+		min-height: 2em;
+	}
+}
+
 .is-group-editor::before {
 	content: '';
 	position: fixed;
@@ -15,11 +24,7 @@
 }
 
 .is-group-editor .email-verification-notice {
-	margin: 8px;
-
-	@include breakpoint( ">660px" ) {
-		margin: 0;
-	}
+	display: none;
 }
 
 .post-editor__inner {
@@ -38,7 +43,6 @@
 	}
 }
 
-.is-group-editor .email-verification-notice,
 .post-editor__content {
 	@include breakpoint( ">660px" ) {
 		margin-left: ( $sidebar-width-min + 1 );

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -13,7 +13,7 @@ import useMockery from 'test/helpers/use-mockery';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'PostEditor', function() {
-	let sandbox, TestUtils, PostEditor, SitesList, PostEditStore;
+	let sandbox, TestUtils, PostEditor, SitesList, Site, PostEditStore;
 
 	useFakeDom();
 	useSandbox( ( newSandbox ) => sandbox = newSandbox );
@@ -55,6 +55,7 @@ describe( 'PostEditor', function() {
 		mockery.registerMock( 'post-editor/invalid-url-dialog', MOCK_COMPONENT );
 		mockery.registerMock( 'post-editor/restore-post-dialog', MOCK_COMPONENT );
 		mockery.registerMock( 'post-editor/editor-sidebar/header', MOCK_COMPONENT );
+		mockery.registerMock( 'post-editor/verify-email-dialog', MOCK_COMPONENT );
 		mockery.registerMock( './editor-preview', MOCK_COMPONENT );
 		mockery.registerMock( 'my-sites/drafts/draft-list', MOCK_COMPONENT );
 		mockery.registerMock( 'lib/layout-focus', { set() {} } );
@@ -65,6 +66,7 @@ describe( 'PostEditor', function() {
 		} );
 
 		SitesList = require( 'lib/sites-list/list' );
+		Site = require( 'lib/site' );
 		PostEditStore = require( 'lib/posts/post-edit-store' );
 		PostEditor = require( '../post-editor' );
 		PostEditor.prototype.__reactAutoBindMap.translate = ( string ) => string;
@@ -159,6 +161,50 @@ describe( 'PostEditor', function() {
 			tree.onEditedPostChange();
 
 			expect( tree.refs.editor.setEditorContent ).to.not.have.been.called;
+		} );
+	} );
+
+	describe( 'onPublish', function() {
+		it( 'should show verify email dialog if email is not verified', function() {
+			const user = { email_verified: false };
+			user.get = () => user;
+
+			const tree = TestUtils.renderIntoDocument(
+				<PostEditor
+					preferences={ {} }
+					sites={ new SitesList() }
+					user={ user }
+				/>
+			);
+
+			tree.setState( { post: { site_ID: 1 } } );
+			tree.onPublish();
+
+			expect( tree.state.showVerifyEmailDialog ).to.equal( true );
+		} );
+
+		it( 'should not show verify email dialog if site is VIP', function() {
+			const user = { email_verified: false };
+			user.get = () => user;
+
+			const sites = new SitesList();
+			sites.initialize( [
+				new Site( { ID: 1, is_vip: true } )
+			] );
+
+			const tree = TestUtils.renderIntoDocument(
+				<PostEditor
+					preferences={ {} }
+					sites={ sites }
+					user={ user }
+				/>
+			);
+
+			tree.refs.editor.getContent = () => '';
+			tree.setState( { post: { site_ID: 1 } } );
+			tree.onPublish();
+
+			expect( tree.state.showVerifyEmailDialog ).to.equal( false );
 		} );
 	} );
 } );

--- a/client/post-editor/verify-email-dialog.jsx
+++ b/client/post-editor/verify-email-dialog.jsx
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import FormButton from 'components/forms/form-button';
+import i18n from 'lib/mixins/i18n';
+
+class VerifyEmailDialog extends React.Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			pendingRequest: false,
+			emailSent: false,
+			error: false
+		};
+
+		this.handleSendVerification = this.sendVerification.bind( this );
+	}
+
+	sendVerification( e ) {
+		e.preventDefault();
+
+		if ( this.state.pendingRequest ) {
+			return;
+		}
+
+		this.setState( { pendingRequest: true } );
+
+		this.props.user.sendVerificationEmail( function( error, response ) {
+			this.setState( {
+				emailSent: response && response.success,
+				error: error,
+				pendingRequest: false
+			} );
+		}.bind( this ) );
+	}
+
+	getDialogButtons() {
+		return [
+			<FormButton
+				key="publish"
+				isPrimary={ true }
+				onClick={ this.props.onTryAgain }>
+					{ i18n.translate( 'I clicked on the email, publish' ) }
+			</FormButton>,
+			<FormButton
+				key="close"
+				isPrimary={ false }
+				onClick={ this.props.onClose }>
+					{ i18n.translate( 'Back' ) }
+			</FormButton>
+		];
+	}
+
+	render() {
+		const strings = {
+			postSaved: i18n.translate( 'Post saved.' ),
+			urgeToVerify: i18n.translate( 'To publish, please verify your email address.' ),
+			validationEmailSent: i18n.translate(
+				'You should have received an email at {{strong}}%(email)s{{/strong}} when you registered, with a link to validate your email address. If you can\'t find the email, just {{sendAgain}}click here to send it again{{/sendAgain}}.',
+				{
+					components: {
+						strong: <strong />,
+						sendAgain: <a href="#" onClick={ this.handleSendVerification } />
+					},
+					args: {
+						email: this.props.user.data.email
+					}
+				}
+			),
+			userEmailWrong: i18n.translate(
+				'If the email address above is wrong, {{emailPreferences}}click here to change it{{/emailPreferences}} in your preferences.',
+				{
+					components: {
+						emailPreferences: <a href="/me/account" />
+					}
+				}
+			)
+		};
+
+		return (
+			<Dialog
+				isVisible={ true }
+				buttons={ this.getDialogButtons() }
+				additionalClassNames="verification-modal"
+			>
+				<h1>
+					{ strings.postSaved }<br />
+					{ strings.urgeToVerify }
+				</h1>
+				<p>{ strings.validationEmailSent }</p>
+				<p>{ strings.userEmailWrong }</p>
+			</Dialog>
+		);
+	}
+}
+
+VerifyEmailDialog.propTypes = {
+	user: React.PropTypes.object.isRequired,
+	onClose: React.PropTypes.func,
+	onTryAgain: React.PropTypes.func
+};
+
+VerifyEmailDialog.defaultProps = {
+	onClose: noop,
+	onTryAgain: noop
+};
+
+export default VerifyEmailDialog;


### PR DESCRIPTION
I decided to take a shot at fixing #2650, as it seems to be bothering a lot of people.

It's a bit scary to make such a big change, so I decided to ask beforehand. Judging from #2650 and #4744, it seems best for the email verification notice to be removed, and request email verification only when necessary. be3894b9 removes it, and 501c052 adds a dialog that prompts users to verify their email when they try to publish. As @folletto said, this doesn't break the user flow, and users are more compelled to verify their email when their post is finished.

A few questions:
1. Is a single dialog enough? Are there more places where an email verification is required? It may be too early to remove the notice box.
2. Architecturally, is this the proper place for the email verification dialog, or should it be moved on a more general level?
3. Is it better to reuse translated messages from prior components, rather than introducing new ones? It may not always be feasible, especially when introducing new UI, but is that something that one should strive for?

The dialog still requires some love (more feedback while the dialog actions execute), but I wanted to ask if I'm on the right track.