### PR TITLE
Disable Brazilian survey invitation

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -28,7 +28,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
-		"brazil-survey-invitation": true,
+		"brazil-survey-invitation": false,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -14,7 +14,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
-		"brazil-survey-invitation": true,
+		"brazil-survey-invitation": false,
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -12,7 +12,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": true,
-		"brazil-survey-invitation": true,
+		"brazil-survey-invitation": false,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -14,7 +14,7 @@
 	"features": {
 		"accept-invite": true,
 		"ad-tracking": false,
-		"brazil-survey-invitation": true,
+		"brazil-survey-invitation": false,
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,


### PR DESCRIPTION
This PR disables the Brazilian Survey invitation.  The code needs to be tidied up and componentized (https://github.com/Automattic/wp-calypso/issues/4807) but for right now, we're just turning off the switch because we're moving on to the next stage of the Brazil Survey project.

This is just a config change, so we just need to check that Calypso compiles and runs, and that the survey invitation doesn't appear.

Ideally the test would look like:
1) Change your locale to pt-br at 
2) Load calypso, head to the reader, and note (but don't click on) the invitation
3) Switch to this branch
4) Stop and restart calypso to regenerate the config (hot reload won't work here)
5) Head back to the reader and make sure it's gone.