### PR TITLE
Plans: adds event name to track analytics control group

### DIFF
--- a/client/components/empty-content/empty-content.jsx
+++ b/client/components/empty-content/empty-content.jsx
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:components:emptyContent' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import debugFactory from 'debug';
+import classNames from 'classnames';
+
+const debug = debugFactory( 'calypso:components:emptyContent' );
 
 module.exports = React.createClass( {
 
@@ -87,19 +89,9 @@ module.exports = React.createClass( {
 	},
 
 	render: function() {
-		var action, secondaryAction, illustration;
-
-		if ( this.props.action ) {
-			action = this.primaryAction();
-		}
-
-		if ( this.props.secondaryAction ) {
-			secondaryAction = this.secondaryAction();
-		}
-
-		if ( this.props.illustration ) {
-			illustration = <img src={ this.props.illustration } width={ this.props.illustrationWidth } className="empty-content__illustration" />;
-		}
+		const action = this.props.action && this.primaryAction();
+		const secondaryAction = this.props.secondaryActino && this.secondaryAction();
+		const illustration = this.props.illustration && <img src={ this.props.illustration } width={ this.props.illustrationWidth } className="empty-content__illustration" />;
 
 		return (
 			<div className={ classNames( 'empty-content', this.props.className, { 'is-compact': this.props.isCompact, 'has-title-only': this.props.title && ! this.props.line } ) }>

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -19,6 +19,7 @@ import ExternalLink from 'components/external-link';
 import EmptyContent from 'components/empty-content';
 import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 const debug = debugFactory( 'calypso:my-sites:site-settings' );
 
@@ -128,14 +129,21 @@ export default React.createClass( {
 
 		if ( abtest( 'contextualGoogleAnalyticsNudge' ) === 'drake' && ! this.isEnabled() ) {
 			const upgradeLink = this.getUpgradeLink();
-			return <EmptyContent
-				illustration="/calypso/images/drake/drake-whoops.svg"
-				title={ this.translate( 'Want to use Google Analytics on your site?', { context: 'site setting upgrade' } ) }
-				line={ this.translate( 'Support for Google Analytics is now available with WordPress.com Business.', { context: 'site setting upgrade' } ) }
-				action={ this.translate( 'Upgrade Now', { context: 'site setting upgrade' } ) }
-				actionURL={ upgradeLink }
-				isCompact={ true }
-				actionCallback={ this.trackUpgradeClick } />;
+			const eventName = 'calypso_empty_content_component_impression';
+			const eventProperties = { empty_content_name: 'google_analytics_drake' };
+			return (
+				<div>
+					<EmptyContent
+					illustration="/calypso/images/drake/drake-whoops.svg"
+					title={ this.translate( 'Want to use Google Analytics on your site?', { context: 'site setting upgrade' } ) }
+					line={ this.translate( 'Support for Google Analytics is now available with WordPress.com Business.', { context: 'site setting upgrade' } ) }
+					action={ this.translate( 'Upgrade Now', { context: 'site setting upgrade' } ) }
+					actionURL={ upgradeLink }
+					isCompact={ true }
+					actionCallback={ this.trackUpgradeClick } />
+					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+				</div>
+			);
 		}
 
 		return (
@@ -228,7 +236,7 @@ export default React.createClass( {
 		);
 	},
 
-	trackUpgradeClick: function() {
+	trackUpgradeClick() {
 		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', { cta_name: 'google_analytics' } );
 	},
 


### PR DESCRIPTION
We need to track the original variant to compare our results for the different nudge variants.