### PR TITLE
Test: Fix Dispatcher stub in lib/post/actions test

### DIFF
--- a/client/lib/posts/test/actions.js
+++ b/client/lib/posts/test/actions.js
@@ -27,6 +27,7 @@ describe( 'actions', function() {
 	} );
 
 	beforeEach( () => {
+		sandbox.stub( Dispatcher, 'handleServerAction' );
 		sandbox.stub( Dispatcher, 'handleViewAction' );
 		sandbox.stub( PostEditStore, 'get' ).returns( {
 			metadata: []


### PR DESCRIPTION
I randomly see failing one of the test for `client/lib/post/actions.js` fiile. This PR fixes that issue by stubbing also Dispatcher server action.

Error that was occurring on Circle CI:
<img width="857" alt="screen shot 2016-04-18 at 08 55 13" src="https://cloud.githubusercontent.com/assets/699132/14595958/594462de-0543-11e6-9f20-0dfcbd7a6586.png">
