### PR TITLE
Framework: Fix errors on transition from themes to signup

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -10,7 +10,6 @@ These are some of the key modules of the application, kept in `client`'s root fo
 * `boot` - the booting file that sets up the application and requires the main sections.
 * `config` - generated configuration settings.
 * `layout` - handles the main React layout, including the masterbar. Notably, it sets #primary and #secondary used to render the different sections.
-* `controller.js` - isomorphic routing helper, see comments in that file.
 * `sections.js` - defines section groups, paths, and main modules. (Used by webpack to generate separate chunks.)
 
 ### Components

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
+	ReactDom = require( 'react-dom' ),
 	store = require( 'store' ),
 	ReactInjection = require( 'react/lib/ReactInjection' ),
 	some = require( 'lodash/some' ),
@@ -31,24 +32,22 @@ var config = require( 'config' ),
 	i18n = require( 'lib/mixins/i18n' ),
 	perfmon = require( 'lib/perfmon' ),
 	translatorJumpstart = require( 'lib/translator-jumpstart' ),
-	translatorInvitation = require( 'layout/community-translator/invitation-utils' ),
 	layoutFocus = require( 'lib/layout-focus' ),
 	nuxWelcome = require( 'layout/nux-welcome' ),
 	emailVerification = require( 'components/email-verification' ),
 	viewport = require( 'lib/viewport' ),
 	detectHistoryNavigation = require( 'lib/detect-history-navigation' ),
-	sections = require( 'sections' ),
 	touchDetect = require( 'lib/touch-detect' ),
 	setRouteAction = require( 'state/notices/actions' ).setRoute,
 	accessibleFocus = require( 'lib/accessible-focus' ),
 	TitleStore = require( 'lib/screen-title/store' ),
 	bindTitleToStore = require( 'lib/screen-title' ).subscribeToStore,
 	syncHandler = require( 'lib/wp/sync-handler' ),
-	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
 	bindWpLocaleState = require( 'lib/wp/localization' ).bindState,
 	supportUser = require( 'lib/user/support-user-interop' ),
-	// The following components require the i18n mixin, so must be required after i18n is initialized
-	Layout;
+	// The following dependencies require the i18n mixin, so must be required after i18n is initialized
+	Layout,
+	sections;
 
 function init() {
 	var i18nLocaleStringsObject = null;
@@ -169,8 +168,6 @@ function reduxStoreReady( reduxStore ) {
 
 	supportUser.setReduxStore( reduxStore );
 
-	Layout = require( 'layout' );
-
 	if ( user.get() ) {
 		// When logged in the analytics module requires user and superProps objects
 		// Inject these here
@@ -179,19 +176,15 @@ function reduxStoreReady( reduxStore ) {
 		// Set current user in Redux store
 		reduxStore.dispatch( receiveUser( user.get() ) );
 		reduxStore.dispatch( setCurrentUserId( user.get().ID ) );
-
-		// Create layout instance with current user prop
-		layoutElement = React.createElement( Layout, {
-			user: user,
-			sites: sites,
-			focus: layoutFocus,
-			nuxWelcome: nuxWelcome,
-			translatorInvitation: translatorInvitation
-		} );
 	} else {
 		analytics.setSuperProps( superProps );
-		layoutElement = React.createElement( Layout, { focus: layoutFocus } );
 	}
+
+	Layout = require( 'controller' ).ReduxWrappedLayout;
+
+	layoutElement = React.createElement( Layout, {
+		store: reduxStore
+	} );
 
 	if ( config.isEnabled( 'perfmon' ) ) {
 		// Record time spent watching slowly-flashing divs
@@ -202,10 +195,9 @@ function reduxStoreReady( reduxStore ) {
 		require( 'lib/network-connection' ).init( reduxStore );
 	}
 
-	renderWithReduxStore(
+	ReactDom.render(
 		layoutElement,
-		document.getElementById( 'wpcom' ),
-		reduxStore
+		document.getElementById( 'wpcom' )
 	);
 
 	debug( 'Main layout rendered.' );
@@ -287,6 +279,7 @@ function reduxStoreReady( reduxStore ) {
 	}
 
 	// Load the application modules for the various sections and features
+	sections = require( 'sections' );
 	sections.load();
 
 	// delete any lingering local storage data from signup

--- a/client/controller/README.md
+++ b/client/controller/README.md
@@ -1,0 +1,4 @@
+Isomorphic Routing Helpers
+==========================
+
+See inline comments.

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -1,0 +1,39 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { setSection as setSectionAction } from 'state/ui/actions';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import LayoutLoggedOut from 'layout/logged-out';
+
+/**
+ * @param { object } context -- Middleware context
+ * @param { function } next -- Call next middleware in chain
+ *
+ * Produce a `LayoutLoggedOut` element in `context.layout`, using
+ * `context.primary`, `context.secondary`, and `context.tertiary` to populate it.
+*/
+export function makeLoggedOutLayout( context, next ) {
+	const { store, primary, secondary, tertiary } = context;
+	context.layout = (
+		<ReduxProvider store={ store }>
+			<LayoutLoggedOut primary={ primary }
+				secondary={ secondary }
+				tertiary={ tertiary } />
+		</ReduxProvider>
+	);
+	next();
+};
+
+export function setSection( section ) {
+	return ( context, next = noop ) => {
+		context.store.dispatch( setSectionAction( section ) );
+
+		next();
+	}
+}

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -52,7 +52,7 @@ export const ReduxWrappedLayout = ( { store, primary, secondary, tertiary } ) =>
 			: <Layout primary={ primary }
 				secondary={ secondary }
 				tertiary={ tertiary }
-				focus={ layoutFocus } /* FIXME: Don't we need LayoutLoggedOut here? */ />
+				focus={ layoutFocus } />
 		}
 	</ReduxProvider>
 );

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -17,12 +17,14 @@ import userFactory from 'lib/user';
 import sitesFactory from 'lib/sites-list';
 import debugFactory from 'debug';
 
+/**
+ * Re-export
+ */
+export { makeLoggedOutLayout, setSection } from './index.node.js';
+
 const user = userFactory();
 const sites = sitesFactory();
 const debug = debugFactory( 'calypso:controller' );
-
-export { makeLoggedOutLayout } from './index.node.js';
-export { setSection } from './index.node.js';
 
 export function makeLayout( context, next ) {
 	const { store, primary, secondary, tertiary } = context;

--- a/client/controller/package.json
+++ b/client/controller/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "index.node.js",
+	"browser": "index.web.js"
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -63,7 +63,10 @@ Layout = React.createClass( {
 		// connected props
 		isLoading: React.PropTypes.bool,
 		isSupportUser: React.PropTypes.bool,
-		section: React.PropTypes.object,
+		section: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.object,
+		] ),
 		isOffline: React.PropTypes.bool,
 	},
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -51,6 +51,22 @@ Layout = React.createClass( {
 
 	_sitesPoller: null,
 
+	propTypes: {
+		primary: React.PropTypes.element,
+		secondary: React.PropTypes.element,
+		tertiary: React.PropTypes.element,
+		sites: React.PropTypes.object,
+		user: React.PropTypes.object,
+		nuxWelcome: React.PropTypes.object,
+		translatorInvitation: React.PropTypes.object,
+		focus: React.PropTypes.object,
+		// connected props
+		isLoading: React.PropTypes.bool,
+		isSupportUser: React.PropTypes.bool,
+		section: React.PropTypes.object,
+		isOffline: React.PropTypes.bool,
+	},
+
 	componentWillUpdate: function( nextProps ) {
 		if ( this.props.section.group !== nextProps.section.group ) {
 			if ( nextProps.section.group === 'sites' ) {
@@ -170,10 +186,16 @@ Layout = React.createClass( {
 					{ this.renderWelcome() }
 					{ this.renderEmailVerificationNotice() }
 					<GlobalNotices id="notices" notices={ notices.list } forcePinned={ 'post' === this.props.section.name } />
-					<div id="primary" className="wp-primary wp-section" />
-					<div id="secondary" className="wp-secondary" />
+					<div id="primary" className="wp-primary wp-section">
+						{ this.props.primary }
+					</div>
+					<div id="secondary" className="wp-secondary">
+						{ this.props.secondary }
+					</div>
 				</div>
-				<div id="tertiary" />
+				<div id="tertiary">
+					{ this.props.tertiary }
+				</div>
 				<TranslatorLauncher
 					isEnabled={ translator.isEnabled() }
 					isActive={ translator.isActivated() }/>

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import ReactDom from 'react-dom';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import page from 'page';

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -75,7 +75,7 @@ export default {
 		next();
 	},
 
-	start( context ) {
+	start( context, next ) {
 		var basePath = route.sectionify( context.path ),
 			flowName = utils.getFlowName( context.params ),
 			stepName = utils.getStepName( context.params ),
@@ -83,13 +83,11 @@ export default {
 
 		analytics.pageView.record( basePath, basePageTitle + ' > Start > ' + flowName + ' > ' + stepName );
 
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		layoutFocus.set( 'content' );
 
 		titleActions.setTitle( i18n.translate( 'Create an account' ) );
 
-		ReactDom.render(
-			React.createElement( ReduxProvider, { store: context.store },
+		context.primary = React.createElement( ReduxProvider, { store: context.store },
 				React.createElement( SignupComponent, {
 					path: context.path,
 					refParameter,
@@ -99,12 +97,13 @@ export default {
 					stepName: stepName,
 					stepSectionName: stepSectionName
 				} )
-			),
-			document.getElementById( 'primary' )
 		);
+		context.secondary = null;
+
+		next();
 	},
 
-	phoneSignup( context ) {
+	phoneSignup( context, next ) {
 		var PhoneSignupComponent = require( 'signup/phone-signup-form' ),
 			countriesList = require( 'lib/countries-list' ).forSms(),
 			basePath = route.sectionify( context.path );
@@ -113,17 +112,17 @@ export default {
 
 		titleActions.setTitle( i18n.translate( 'Create an account' ) );
 
-		ReactDom.render(
-			React.createElement( PhoneSignupComponent, {
-				path: context.path,
-				countriesList: countriesList,
-				locale: context.params.lang
-			} ),
-			document.getElementById( 'primary' )
-		);
+		context.primary = React.createElement( PhoneSignupComponent, {
+			path: context.path,
+			countriesList: countriesList,
+			locale: context.params.lang
+		} );
+		context.secondary = null;
+
+		next();
 	},
 
-	login( context ) {
+	login( context, next ) {
 		var LogInComponent = require( 'signup/log-in-form' ),
 			basePath = route.sectionify( context.path );
 
@@ -131,12 +130,12 @@ export default {
 
 		titleActions.setTitle( i18n.translate( 'Log in to your WordPress.com account' ) );
 
-		ReactDom.render(
-			React.createElement( LogInComponent, {
-				path: context.path,
-				locale: context.params.lang
-			} ),
-			document.getElementById( 'primary' )
-		);
+		context.primary = React.createElement( LogInComponent, {
+			path: context.path,
+			locale: context.params.lang
+		} );
+		context.secondary = null;
+
+		next();
 	}
 };

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -97,7 +97,6 @@ export default {
 					stepSectionName: stepSectionName
 				} )
 		);
-		context.secondary = null;
 
 		next();
 	},
@@ -116,7 +115,6 @@ export default {
 			countriesList: countriesList,
 			locale: context.params.lang
 		} );
-		context.secondary = null;
 
 		next();
 	},
@@ -133,7 +131,6 @@ export default {
 			path: context.path,
 			locale: context.params.lang
 		} );
-		context.secondary = null;
 
 		next();
 	}

--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-var page = require( 'page' );
-
-/**
  * Internal dependencies
  */
 var controller = require( './controller' ),

--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -9,33 +9,36 @@ var page = require( 'page' );
 var controller = require( './controller' ),
 	jetpackConnectController = require( './jetpack-connect/controller' ),
 	adTracking = require( 'lib/analytics/ad-tracking' ),
-	config = require( 'config' );
+	config = require( 'config' ),
+	makeLayout = require( 'controller' ).makeLayout;
 
-module.exports = function() {
+module.exports = function( router ) {
 	if ( config.isEnabled( 'phone_signup' ) ) {
-		page( '/phone/:lang?', controller.phoneSignup );
+		router( '/phone/:lang?', controller.phoneSignup, makeLayout );
 	}
 
-	page(
+	router(
 		'/start/:flowName?/:stepName?/:stepSectionName?/:lang?',
 		adTracking.retarget,
 		controller.saveRefParameter,
 		controller.saveQueryObject,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,
-		controller.start
+		controller.start,
+		makeLayout
 	);
 
 	if ( config.isEnabled( 'login' ) ) {
-		page( '/log-in/:lang?', controller.login );
+		router( '/log-in/:lang?', controller.login, makeLayout );
 	}
 
 	if ( config.isEnabled( 'jetpack/calypso-first-signup-flow' ) ) {
-		page( '/jetpack/connect', jetpackConnectController.connect );
-		page(
+		router( '/jetpack/connect', jetpackConnectController.connect, makeLayout );
+		router(
 			'/jetpack/connect/authorize',
 			jetpackConnectController.saveQueryObject,
-			jetpackConnectController.authorizeForm
+			jetpackConnectController.authorizeForm,
+			makeLayout
 		);
 	}
 };

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -39,37 +39,27 @@ export default {
 		next();
 	},
 
-	connect( context ) {
-		context.store.dispatch( setSection( 'jetpackConnect', {
-			hasSidebar: false
-		} ) );
+	connect( context, next ) {
+		context.primary = React.createElement( JetpackConnect, {
+			path: context.path,
+			context: context,
+			locale: context.params.lang
+		} );
+		context.secondary = null;
 
-		renderWithReduxStore(
-			React.createElement( JetpackConnect, {
-				path: context.path,
-				context: context,
-				locale: context.params.lang
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		next();
 	},
 
-	authorizeForm( context ) {
-		context.store.dispatch( setSection( 'jetpackConnect', {
-			hasSidebar: false
-		} ) );
-
+	authorizeForm( context, next ) {
 		userModule.fetch();
 
-		renderWithReduxStore(
-			React.createElement( jetpackConnectAuthorizeForm, {
-				path: context.path,
-				locale: context.params.lang,
-				userModule: userModule
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+		context.primary = React.createElement( jetpackConnectAuthorizeForm, {
+			path: context.path,
+			locale: context.params.lang,
+			userModule: userModule
+		} );
+		context.secondary = null;
+
+		next();
 	}
 };

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -45,7 +45,6 @@ export default {
 			context: context,
 			locale: context.params.lang
 		} );
-		context.secondary = null;
 
 		next();
 	},
@@ -58,7 +57,6 @@ export default {
 			locale: context.params.lang,
 			userModule: userModule
 		} );
-		context.secondary = null;
 
 		next();
 	}


### PR DESCRIPTION
Used to be #4467 so a lot of the review comments are there.

Addresses #3549

Because the signup pages use the logged-in Layout component, and logged-out theme showcase uses the lighter-weight logged-out layout, transitioning from logged-out showcase to the signup does not work properly as the signup components are rendered into the wrong layout component:

<img width="885" alt="screen shot 2016-04-15 at 17 04 09" src="https://cloud.githubusercontent.com/assets/7767559/14567485/31772674-032c-11e6-9d17-746084c7a4ae.png">


This PR adds the capability to render a complete logged-in layout (signup uses the logged-in layout), and changes all the signup routes to use the isomorphic router and render a complete tree, meaning that on transition from logged-out showcase to signup, a correct layout is rendered.

**To Test**
1) Check that the following routes are all working as before:
`/start*`
`/log-in*`
`/phone*`
`/jetpack`
(Jetpack testing instructions detailed in #4155)

2) Showcase --> signup flow
* Go to http://calypso.localhost:3000/design, logged-out
* Click on the ... button for a theme and click _Choose this design_
* The signup page should appear, and work, without errors in the console
* the _back_ button should return to /design, without errors

3) Maybe necessary to check that signup still works properly in the desktop app?

