### PR TITLE
Fix: Notice link underlines

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -148,17 +148,7 @@ a.notice__action {
 	button.is-link {
 		line-height: 1.4285;
 		font-weight: 600;
-
-		// Medium text underline hack
-		background-image: linear-gradient(to bottom, rgba(0,0,0,0) 75%, #fff 50%);
-		background-repeat: repeat-x;
-		background-size: 2px 2px;
-		background-position: 0 1.14em; // ~18/15
-
-		@media not all, only screen and (min-resolution: 2dppx), only screen and (-webkit-min-device-pixel-ratio: 2) {
-			background-image: linear-gradient(to bottom, rgba(0,0,0,0) 75%, #fff 75%);
-			background-repeat: repeat-x;
-		}
+		text-decoration: underline;
 	}
 
 	ul {

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -99,51 +99,53 @@
 }
 
 // specificity for general `a` elements within notice is too great
-a.notice__action {
-	display: flex;
-		align-items: center;
-		flex-shrink: 0;
-	box-sizing: border-box;
-	cursor: pointer;
-	font-size: 15px;
-	font-weight: 400;
-	margin-left: auto; // forces the element to the right;
-	padding: 13px 16px;
-	text-decoration: none;
-	white-space: nowrap;
+.notice {
+	a.notice__action {
+		display: flex;
+			align-items: center;
+			flex-shrink: 0;
+		box-sizing: border-box;
+		cursor: pointer;
+		font-size: 15px;
+		font-weight: 400;
+		margin-left: auto; // forces the element to the right;
+		padding: 13px 16px;
+		text-decoration: none;
+		white-space: nowrap;
+		
+		.gridicon {
+			margin-left: 8px;
+			opacity: 0.7;
+		}
 
-	.is-success &,
-	.is-error &,
-	.is-warning &,
-	.is-info & {
+		&:hover,
+		&:focus {
+			background: rgba( 255, 255, 255, 0.2 );
+			text-decoration: underline;
+		}
+
+		@include breakpoint( "<480px" ) {
+			margin: 0;
+			justify-content: flex-end;
+		}
+	}
+
+	&.is-success a.notice__action,
+	&.is-error a.notice__action,
+	&.is-warning a.notice__action,
+	&.is-info a.notice__action {
 		color: $white;
 	}
 
-	.is-success & { background: darken( $alert-green, 15 ); }
-	.is-error & { background: darken( $alert-red, 15 ); }
-	.is-warning & { background: darken( $alert-yellow, 15 ); }
-	.is-info & { background: darken( $blue-wordpress, 15 ); }
-
-	.gridicon {
-		margin-left: 8px;
-		opacity: 0.7;
-	}
-
-	&:hover,
-	&:focus {
-		background: rgba( 255, 255, 255, 0.2 );
-	}
-
-	@include breakpoint( "<480px" ) {
-		margin: 0;
-		justify-content: flex-end;
-	}
+	&.is-success a.notice__action { background: darken( $alert-green, 15 ); }
+	&.is-error a.notice__action { background: darken( $alert-red, 15 ); }
+	&.is-warning a.notice__action { background: darken( $alert-yellow, 15 ); }
+	&.is-info a.notice__action { background: darken( $blue-wordpress, 15 ); }
 }
 
 // General styles for html elements
 // rendered inside a notice
 .notice {
-
 	a,
 	button.is-link {
 		line-height: 1.4285;


### PR DESCRIPTION
Removing the “Medium text underline hack” from notice links. It causes issues with the action styles, and just doesn’t seem worth the hassle and bugs.

Here's how things look on `master`:

![screen shot 2016-04-18 at 11 06 14 am](https://cloud.githubusercontent.com/assets/191598/14609043/24808498-0556-11e6-8b00-03fce4dd32d2.png)

![screen shot 2016-04-18 at 11 07 04 am](https://cloud.githubusercontent.com/assets/191598/14609049/28e21d30-0556-11e6-94eb-ad38247d6110.png)

You'll notice that the underline is always white, very subtle, and shows up on the top of action links.

This PR simply removes the hack in favor of a standard underline:

![screen shot 2016-04-18 at 11 06 34 am](https://cloud.githubusercontent.com/assets/191598/14609082/48615e78-0556-11e6-817a-ec2226d301f1.png)

![screen shot 2016-04-18 at 11 06 24 am](https://cloud.githubusercontent.com/assets/191598/14609087/4bafc81c-0556-11e6-95cb-184cc39afab5.png)

