### PR TITLE
Navigation: add sidebar drafts count and link

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -67,6 +67,7 @@
 	font-weight: 600;
 	font-size: 12px;
 	margin: 16px 8px 6px 14px;
+	display: flex;
 }
 
 // Menu Links
@@ -347,3 +348,28 @@
 
 }
 
+.sidebar__drafts-button {
+	margin-left: auto;
+}
+
+.sidebar .drafts-button.button.is-borderless {
+	color: darken( $gray, 10% );
+	line-height: 0;
+	padding: 0;
+	margin: 0;
+	text-transform: none;
+
+	.count {
+		color: darken( $gray, 10% );
+	}
+
+	&:hover {
+		color: $blue-medium;
+
+		.count {
+			background: $blue-medium;
+			border-color: $blue-medium;
+			color: $white;
+		}
+	}
+}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -9,6 +9,8 @@ var analytics = require( 'lib/analytics' ),
 	React = require( 'react' ),
 	startsWith = require( 'lodash/startsWith' );
 
+import page from 'page';
+
 /**
  * Internal dependencies
  */
@@ -663,6 +665,10 @@ module.exports = React.createClass( {
 		);
 	},
 
+	onDraftsClick: function() {
+		page( '/posts/drafts' + this.siteSuffix() );
+	},
+
 	render: function() {
 		var publish = !! this.publish(),
 			appearance = ( !! this.themes() || !! this.menus() ),
@@ -709,7 +715,7 @@ module.exports = React.createClass( {
 									onMouseLeave={ () => this.setState( { draftsTooltip: false } ) }
 									ref="draftsButton"
 								>
-									<DraftsButton hideText />
+									<DraftsButton hideText onClick={ this.onDraftsClick } />
 									<Tooltip
 										context={ this.refs && this.refs.draftsButton }
 										isVisible={ this.state.draftsTooltip }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -28,12 +28,20 @@ var abtest = require( 'lib/abtest' ).abtest,
 
 import Button from 'components/button';
 import SidebarFooter from 'layout/sidebar/footer';
+import DraftsButton from 'post-editor/drafts-button';
+import Tooltip from 'components/tooltip';
 
 module.exports = React.createClass( {
 	displayName: 'MySitesSidebar',
 
 	componentDidMount: function() {
 		debug( 'The sidebar React component is mounted.' );
+	},
+
+	getInitialState: function() {
+		return {
+			draftsTooltip: false
+		};
 	},
 
 	onNavigate: function() {
@@ -692,7 +700,26 @@ module.exports = React.createClass( {
 
 				{ publish
 					? <SidebarMenu>
-						<SidebarHeading>{ this.translate( 'Publish' ) }</SidebarHeading>
+						<SidebarHeading>
+							{ this.translate( 'Publish' ) }
+							{ config.isEnabled( 'sidebar-drafts-count' ) &&
+								<div
+									className="sidebar__drafts-button"
+									onMouseEnter={ () => this.setState( { draftsTooltip: true } ) }
+									onMouseLeave={ () => this.setState( { draftsTooltip: false } ) }
+									ref="draftsButton"
+								>
+									<DraftsButton hideText />
+									<Tooltip
+										context={ this.refs && this.refs.draftsButton }
+										isVisible={ this.state.draftsTooltip }
+										position="top"
+									>
+										{ this.translate( 'Drafts' ) }
+									</Tooltip>
+								</div>
+							}
+						</SidebarHeading>
 						{ this.publish() }
 					</SidebarMenu>
 					: null

--- a/client/post-editor/drafts-button/index.jsx
+++ b/client/post-editor/drafts-button/index.jsx
@@ -15,7 +15,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import { getAllPostCount } from 'state/posts/counts/selectors';
 import { translate } from 'lib/mixins/i18n';
 
-function EditorDraftsButton( { count, onClick, jetpack, siteId } ) {
+function EditorDraftsButton( { count, onClick, jetpack, siteId, hideText } ) {
 	return (
 		<Button
 			compact borderless
@@ -27,7 +27,7 @@ function EditorDraftsButton( { count, onClick, jetpack, siteId } ) {
 			{ siteId && (
 				<QueryPostCounts siteId={ siteId } type="post" />
 			) }
-			<span>{ translate( 'Drafts' ) }</span>
+			{ ! hideText && <span>{ translate( 'Drafts' ) }</span> }
 			{ count && ! jetpack ? <Count count={ count } /> : null }
 		</Button>
 	);
@@ -37,7 +37,8 @@ EditorDraftsButton.propTypes = {
 	count: PropTypes.number,
 	onClick: PropTypes.func,
 	jetpack: PropTypes.bool,
-	siteId: PropTypes.number
+	siteId: PropTypes.number,
+	hideText: PropTypes.bool
 };
 
 export default connect( ( state ) => {

--- a/config/development.json
+++ b/config/development.json
@@ -107,6 +107,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
+		"sidebar-drafts-count": true,
 		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -74,6 +74,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": false,
+		"sidebar-drafts-count": true,
 		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -70,6 +70,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
+		"sidebar-drafts-count": true,
 		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -83,6 +83,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/scan": true,
+		"sidebar-drafts-count": true,
 		"support-user": true,
 		"sync-handler": true,
 		"upgrades/checkout": true,


### PR DESCRIPTION
This uses `DraftsCount` button in the publish section of the My Sites sidebar to directly link people to the drafts area.

It's enabled behind a feature flag so we can determine whether the lack of text is confusing or not.

![image](https://cloud.githubusercontent.com/assets/548849/14609005/420905da-0588-11e6-9bbb-a6e2b0ba9124.png)

Alternative option:

![image](https://cloud.githubusercontent.com/assets/548849/14609194/037537f2-0589-11e6-8f4c-dd2f4dddbea0.png)