### PR TITLE
Editor: Improve toolbar pinning by removing hard-coded thresholds

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -38,6 +38,7 @@ import calypsoAlertPlugin from './plugins/calypso-alert/plugin';
 import contactFormPlugin from './plugins/contact-form/plugin';
 import afterTheDeadlinePlugin from './plugins/after-the-deadline/plugin';
 import wptextpatternPlugin from './plugins/wptextpattern/plugin';
+import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
 
 [
 	wpcomPlugin,
@@ -56,7 +57,8 @@ import wptextpatternPlugin from './plugins/wptextpattern/plugin';
 	calypsoAlertPlugin,
 	contactFormPlugin,
 	afterTheDeadlinePlugin,
-	wptextpatternPlugin
+	wptextpatternPlugin,
+	toolbarPinPlugin
 ].forEach( ( initializePlugin ) => initializePlugin() );
 
 /**
@@ -118,6 +120,7 @@ const PLUGINS = [
 	'wpcom/editorbuttonanalytics',
 	'wpcom/calypsoalert',
 	'wpcom/tabindex',
+	'wpcom/toolbarpin',
 	'wpcom/contactform',
 	'wpcom/sourcecode',
 ];
@@ -173,8 +176,6 @@ module.exports = React.createClass( {
 
 	_editor: null,
 
-	_pinned: false,
-
 	componentWillMount: function() {
 		this._id = 'tinymce-' + _instance;
 		_instance++;
@@ -206,7 +207,6 @@ module.exports = React.createClass( {
 			this.bindEditorEvents();
 			editor.on( 'SetTextAreaContent', ( event ) => this.setTextAreaContent( event.content ) );
 
-			window.addEventListener( 'scroll', this.onScrollPinTools );
 			if ( ! viewport.isMobile() ) {
 				editor.once( 'PostRender', this.toggleEditor.bind( this, { autofocus: ! this.props.isNew } ) );
 			}
@@ -303,9 +303,6 @@ module.exports = React.createClass( {
 
 	componentWillUnmount: function() {
 		this.mounted = false;
-
-		window.removeEventListener( 'scroll', this.onScrollPinTools );
-
 		if ( this._editor ) {
 			this.destroyEditor();
 		}
@@ -339,28 +336,6 @@ module.exports = React.createClass( {
 				}
 			}
 		}.bind( this ) );
-	},
-
-	onScrollPinTools: function() {
-		const editor = this._editor;
-		if ( ! editor || this.props.mode === 'html' ) {
-			return;
-		}
-
-		const container = editor.getContainer();
-		const rect = container.getBoundingClientRect();
-
-		let newPinned;
-		if ( ! this._pinned && rect.top < 46 && viewport.isWithinBreakpoint( '>660px' ) ) {
-			newPinned = true;
-		} else if ( this._pinned && window.pageYOffset < 164 ) {
-			newPinned = false;
-		} else {
-			return;
-		}
-
-		this._pinned = newPinned;
-		editor.dom.toggleClass( editor.getContainer(), 'is-pinned', newPinned );
 	},
 
 	toggleEditor: function( options = { autofocus: true } ) {

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -151,8 +151,7 @@ module.exports = React.createClass( {
 		tabIndex: React.PropTypes.number,
 		isNew: React.PropTypes.bool,
 		onTextEditorChange: React.PropTypes.func,
-		onKeyUp: React.PropTypes.func,
-		onTogglePin: React.PropTypes.func
+		onKeyUp: React.PropTypes.func
 	},
 
 	contextTypes: {
@@ -362,9 +361,6 @@ module.exports = React.createClass( {
 
 		this._pinned = newPinned;
 		editor.dom.toggleClass( editor.getContainer(), 'is-pinned', newPinned );
-		if ( this.props.onTogglePin ) {
-			this.props.onTogglePin( newPinned ? 'pin' : 'unpin' );
-		}
 	},
 
 	toggleEditor: function( options = { autofocus: true } ) {

--- a/client/components/tinymce/plugins/toolbar-pin/plugin.js
+++ b/client/components/tinymce/plugins/toolbar-pin/plugin.js
@@ -47,10 +47,10 @@ function toolbarPin( editor ) {
 			return;
 		}
 
-		if ( isPinned && window.scrollY < container.offsetTop ) {
+		if ( isPinned && window.pageYOffset < container.offsetTop ) {
 			// Scroll doesn't reach container top and should be unpinned
 			togglePinned( false );
-		} else if ( ! isPinned && window.scrollY > container.offsetTop ) {
+		} else if ( ! isPinned && window.pageYOffset > container.offsetTop ) {
 			// Scroll exceeds container top and should be pinned
 			togglePinned( true );
 		}

--- a/client/components/tinymce/plugins/toolbar-pin/plugin.js
+++ b/client/components/tinymce/plugins/toolbar-pin/plugin.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce/tinymce';
+import throttle from 'lodash/throttle';
+
+/**
+ * Internal dependencies
+ */
+import { isWithinBreakpoint } from 'lib/viewport';
+
+/**
+ * TinyMCE plugin for toggling an `is-pinned` class on the editor container
+ * when the viewport scroll position exceeds the top edge of the container.
+ *
+ * @param {Object} editor TinyMCE editor instance
+ */
+function toolbarPin( editor ) {
+	let isMonitoringScroll = false,
+		isPinned = false,
+		container;
+
+	/**
+	 * Assigns the container top-level variable to the current container.
+	 */
+	function setContainer() {
+		container = editor.getContainer();
+	}
+
+	/**
+	 * Checks whether the current pinned state of the editor should change,
+	 * toggling the class as determined by the current viewport compared to the
+	 * top edge of the container.
+	 *
+	 * @type Function
+	 */
+	const pinToolbarOnScroll = throttle( () => {
+		if ( ! container ) {
+			return;
+		}
+
+		if ( isPinned && window.scrollY < container.offsetTop ) {
+			// Scroll doesn't reach container top and should be unpinned
+			isPinned = false;
+		} else if ( ! isPinned && window.scrollY > container.offsetTop ) {
+			// Scroll exceeds container top and should be pinned
+			isPinned = true;
+		} else {
+			// If we've reached this point, assume that no change is necessary
+			return;
+		}
+
+		editor.dom.toggleClass( container, 'is-pinned', isPinned );
+	}, 50 );
+
+	/**
+	 * Binds or unbinds the scroll event from the global window object, since
+	 * pinning behavior is restricted to larger viewports whilst the visual
+	 * editing mode is active.
+	 *
+	 * @type Function
+	 */
+	const maybeBindScroll = throttle( ( event ) => {
+		const isVisual = ! editor.isHidden();
+		const shouldBind = 'remove' !== event.type && isVisual && isWithinBreakpoint( '>660px' );
+
+		if ( shouldBind === isMonitoringScroll ) {
+			// Window event binding already matches expectation, so skip
+			return;
+		}
+
+		const eventBindFn = ( shouldBind ? 'add' : 'remove' ) + 'EventListener';
+		window[ eventBindFn ]( 'scroll', pinToolbarOnScroll );
+
+		isMonitoringScroll = shouldBind;
+		if ( isMonitoringScroll ) {
+			setContainer();
+		}
+	}, 200 );
+
+	editor.on( 'init show hide remove', maybeBindScroll );
+	window.addEventListener( 'resize', maybeBindScroll );
+}
+
+export default function() {
+	tinymce.PluginManager.add( 'wpcom/toolbarpin', toolbarPin );
+}

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -42,8 +42,14 @@
 		&:after {
 			position: fixed;
 				top: 47px;
-			border-left-width: 0px;
-			border-right-width: 0px;
+			border-top-width: 0;
+			border-left-width: 0;
+			border-right-width: 0;
+		}
+
+		& > .mce-toolbar-grp > .mce-container-body > .mce-container {
+			padding-left: 1px;
+			padding-right: 1px;
 		}
 
 		& > .mce-toolbar-grp {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -5,7 +5,6 @@ const ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:post-editor' ),
 	page = require( 'page' ),
-	classnames = require( 'classnames' ),
 	debounce = require( 'lodash/debounce' ),
 	throttle = require( 'lodash/throttle' ),
 	assign = require( 'lodash/assign' );
@@ -311,19 +310,13 @@ const PostEditor = React.createClass( {
 			isInvalidURL = this.state.loadingError,
 			isPage,
 			isTrashed,
-			hasAutosave,
-			headerClass;
+			hasAutosave;
 
 		if ( this.state.post ) {
 			isPage = utils.isPage( this.state.post );
 			isTrashed = this.state.post.status === 'trash';
 			hasAutosave = ( this.state.post.meta && this.state.post.meta.data && this.state.post.meta.data.autosave );
 		}
-
-		headerClass = classnames( 'editor__header', {
-			'is-pinned': this.state.pinned
-		} );
-
 		return (
 			<div className="post-editor">
 				<div className="post-editor__inner">
@@ -344,7 +337,7 @@ const PostEditor = React.createClass( {
 								post={ this.state.post }
 								maxWidth={ 1462 } />
 							{ this.renderNotice() }
-							<div className={ headerClass }>
+							<div className="editor__header">
 								<EditorTitleContainer
 									onChange={ this.debouncedAutosave }
 									tabIndex={ 1 } />
@@ -380,8 +373,7 @@ const PostEditor = React.createClass( {
 								onChange={ this.onEditorContentChange }
 								onKeyUp={ this.debouncedSaveRawContent }
 								onFocus={ this.onEditorFocus }
-								onTextEditorChange={ this.onEditorContentChange }
-								onTogglePin={ this.onTogglePin } />
+								onTextEditorChange={ this.onEditorContentChange } />
 						</div>
 						<EditorWordCount />
 						{ this.iframePreviewEnabled()
@@ -489,12 +481,6 @@ const PostEditor = React.createClass( {
 	onNoticeClick: function( event ) {
 		event.preventDefault();
 		this.setState( { notice: false } );
-	},
-
-	onTogglePin: function( state ) {
-		this.setState( {
-			pinned: state === 'pin'
-		} );
 	},
 
 	onEditedPostChange: function() {

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -128,10 +128,6 @@
 .editor__header {
 	position: relative;
 	padding-bottom: 27px;
-
-	&.is-pinned {
-		visibility: none;
-	}
 }
 
 .editor__switch-mode {


### PR DESCRIPTION
Fixes #337
Fixes #4792

This pull request seeks to improve the behavior of editor toolbar pinning by removing reliance on hard-coded offset thresholds. Further, it removes a complex pinning flow for applying an unnecessary modifier class to the editor header, and may improve performance by throttling the bound scroll event. Finally, the pinning logic has been extracted from the `<TinyMCE />` component and implemented as a standalone plugin.

Notably, this resolves an issue where the pinning behavior of the toolbar would not behave as expected when a featured image was assigned to the post.

Before|After
---|---
![before](https://cloud.githubusercontent.com/assets/1779930/14609134/7e1eb394-0556-11e6-8f69-8006cfea0287.gif)|![after](https://cloud.githubusercontent.com/assets/1779930/14609133/7e1a07ea-0556-11e6-9a9e-f072d44c920c.gif)

__Testing instructions:__

Verify that toolbar is pinned as expected whilst you scroll the editor page. Toolbar pinning is only available for larger viewports, and mobile usage should remain unaffected.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Enter enough content (e.g. [Lorem ipsum](http://lipsum.com/feed)) or shrink the vertical height of your browser for scroll to appear
4. Note that when the master bar reaches the top edge of the editor, the toolbar becomes pinned (or unpinned while scrolling upwards)

Try a variety of more complex cases:
- Viewport resizing
- Toggling between HTML and Visual modes
- Featured image assigned