### PR TITLE
Editor: Allow title to split onto multiple lines

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -111,6 +111,7 @@
 @import 'components/spinner-line/style';
 @import 'components/stat-update-indicator/style';
 @import 'components/sticky-panel/style';
+@import 'components/textarea-autosize/style';
 @import 'components/theme/style';
 @import 'components/themes-list/style';
 @import 'components/tinymce/style';

--- a/client/components/textarea-autosize/README.md
+++ b/client/components/textarea-autosize/README.md
@@ -1,0 +1,24 @@
+Textarea Autosize
+=================
+
+`<TextareaAutosize />` is a drop-in replacement for a `<textarea />` element which automatically grows or shrinks to accommodate its content.
+
+## Usage
+
+Since it is a drop-in replacement, use as you would a regular `<textarea />` element.
+
+```jsx
+import TextareaAutosize from 'components/textarea-autosize';
+
+export default function MyForm( { onTextareaChange } ) {
+	return (
+		<TextareaAutosize
+			onChange={ onTextareaChange }
+			rows="1" />
+	);
+}
+```
+
+## Props
+
+This component passes all props to the rendered `<textarea />` and does not accept any additional props of its own.

--- a/client/components/textarea-autosize/index.jsx
+++ b/client/components/textarea-autosize/index.jsx
@@ -20,8 +20,12 @@ export default class TextareaAutosize extends Component {
 
 	componentDidUpdate( prevProps ) {
 		if ( this.props.value !== prevProps.value ) {
-			autosize.update( this.refs.textarea );
+			this.resize();
 		}
+	}
+
+	resize() {
+		autosize.update( this.refs.textarea );
 	}
 
 	render() {

--- a/client/components/textarea-autosize/index.jsx
+++ b/client/components/textarea-autosize/index.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import classnames from 'classnames';
+import autosize from 'autosize';
+
+export default class TextareaAutosize extends Component {
+	static propTypes = {
+		className: PropTypes.string
+	};
+
+	componentDidMount() {
+		autosize( this.refs.textarea );
+	}
+
+	componentWillUnmount() {
+		autosize.destroy( this.refs.textarea );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.value !== prevProps.value ) {
+			autosize.update( this.refs.textarea );
+		}
+	}
+
+	render() {
+		const classes = classnames( 'textarea-autosize', this.props.className );
+
+		return (
+			<textarea
+				ref="textarea"
+				{ ...this.props }
+				className={ classes } />
+		);
+	}
+}

--- a/client/components/textarea-autosize/style.scss
+++ b/client/components/textarea-autosize/style.scss
@@ -1,0 +1,4 @@
+.textarea-autosize {
+	// Important because otherwise autosize height calculation is incorrect in Safari
+	transition: none !important;
+}

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -18,6 +18,11 @@ import TextareaAutosize from 'components/textarea-autosize';
 import { isMobile } from 'lib/viewport';
 import * as stats from 'lib/posts/stats';
 
+/**
+ * Constants
+ */
+const REGEXP_NEWLINES = /[\r\n]+/g;
+
 export default React.createClass( {
 	displayName: 'EditorTitle',
 
@@ -47,32 +52,6 @@ export default React.createClass( {
 			const input = ReactDom.findDOMNode( this.refs.titleInput );
 			input.focus();
 		}
-
-		// If value updated via paste, restore caret location
-		if ( this.selectionStart ) {
-			this.setSelectionTimeout = setTimeout( this.setSelection, 0 );
-		}
-	},
-
-	componentWillUnmount() {
-		clearTimeout( this.setSelectionTimeout );
-		delete this.setSelectionTimeout;
-		delete this.selectionStart;
-	},
-
-	setSelection() {
-		if ( ! this.selectionStart ) {
-			return;
-		}
-
-		const input = ReactDom.findDOMNode( this.refs.titleInput );
-		input.setSelectionRange( this.selectionStart, this.selectionStart );
-		delete this.selectionStart;
-	},
-
-	setTitle( title ) {
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		PostActions.edit( { title } );
 	},
 
 	onChange( event ) {
@@ -80,7 +59,10 @@ export default React.createClass( {
 			return;
 		}
 
-		this.setTitle( event.target.value );
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
+		PostActions.edit( {
+			title: event.target.value.replace( REGEXP_NEWLINES, ' ' )
+		} );
 		this.props.onChange( event );
 	},
 
@@ -92,37 +74,6 @@ export default React.createClass( {
 
 	onBlur( event ) {
 		this.onChange( event );
-	},
-
-	stripPasteNewlines( event ) {
-		// `window.clipboardData` deprecated as of Microsoft Edge
-		// See: https://msdn.microsoft.com/library/ms535220(v=vs.85).aspx
-		const clipboard = event.clipboardData || window.clipboardData;
-		if ( ! clipboard ) {
-			return;
-		}
-
-		event.preventDefault();
-
-		let text = clipboard.getData( 'Text' ) || clipboard.getData( 'text/plain' );
-		if ( ! text ) {
-			return;
-		}
-
-		// Replace any newline characters with a single space
-		text = text.replace( /[\r\n]+/g, ' ' );
-
-		// Splice trimmed text into current title selection
-		const { value, selectionStart, selectionEnd } = event.target;
-		const valueChars = value.split( '' );
-		valueChars.splice( selectionStart, selectionEnd - selectionStart, text );
-		const newTitle = valueChars.join( '' );
-
-		// To preserve caret location, we track intended selection point to be
-		// restored after next render pass
-		this.selectionStart = selectionStart + text.length;
-
-		this.setTitle( newTitle );
 	},
 
 	preventEnterKeyPress( event ) {
@@ -154,7 +105,6 @@ export default React.createClass( {
 						placeholder={ this.translate( 'Title' ) }
 						onChange={ this.onChange }
 						onBlur={ this.onBlur }
-						onPaste={ this.stripPasteNewlines }
 						onKeyPress={ this.preventEnterKeyPress }
 						autoFocus={ isNew && ! isMobile() }
 						value={ post ? post.title : '' }

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import React, { PropTypes } from 'react';
+import ReactDom from 'react-dom';
 import classNames from 'classnames';
-import omit from 'lodash/omit';
+import { omit, get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,7 +14,7 @@ import PostUtils from 'lib/posts/utils';
 import SiteUtils from 'lib/site/utils';
 import EditorPermalink from 'post-editor/editor-permalink';
 import TrackInputChanges from 'components/track-input-changes';
-import FormTextInput from 'components/forms/form-text-input';
+import TextareaAutosize from 'components/textarea-autosize';
 import { isMobile } from 'lib/viewport';
 import * as stats from 'lib/posts/stats';
 
@@ -27,12 +28,6 @@ export default React.createClass( {
 		onChange: PropTypes.func
 	},
 
-	getInitialState() {
-		return {
-			isFocused: false
-		};
-	},
-
 	getDefaultProps() {
 		return {
 			isNew: true,
@@ -40,20 +35,16 @@ export default React.createClass( {
 		};
 	},
 
-	componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		if ( isMobile() ) {
 			return;
 		}
 
 		// If next post is new, or the next site is different, focus title
-		if ( nextProps.isNew && ! this.props.isNew ||
-			( nextProps.isNew && ( this.props.site && nextProps.site ) && ( this.props.site.ID !== nextProps.site.ID ) )
-		) {
-			this.setState( {
-				isFocused: true
-			}, () => {
-				this.refs.titleInput.focus();
-			} );
+		const { isNew, site } = this.props;
+		if ( ( isNew && ! prevProps.isNew ) ||
+				( isNew && get( prevProps.site, 'ID' ) !== get( site, 'ID' ) ) ) {
+			ReactDom.findDOMNode( this.refs.titleInput ).focus();
 		}
 	},
 
@@ -79,19 +70,7 @@ export default React.createClass( {
 	},
 
 	onBlur( event ) {
-		this.setState( {
-			isFocused: false
-		} );
-
 		this.onChange( event );
-
-		event.target.scrollLeft = 0;
-	},
-
-	onFocus() {
-		this.setState( {
-			isFocused: true
-		} );
 	},
 
 	render() {
@@ -99,7 +78,6 @@ export default React.createClass( {
 		const isPermalinkEditable = SiteUtils.isPermalinkEditable( site );
 
 		const classes = classNames( 'editor-title', {
-			'is-focused': this.state.isFocused,
 			'is-loading': ! post
 		} );
 
@@ -112,17 +90,17 @@ export default React.createClass( {
 						isEditable={ isPermalinkEditable } />
 				}
 				<TrackInputChanges onNewValue={ this.recordChangeStats }>
-					<FormTextInput
+					<TextareaAutosize
 						{ ...omit( this.props, Object.keys( this.constructor.propTypes ) ) }
 						className="editor-title__input"
 						placeholder={ this.translate( 'Title' ) }
 						onChange={ this.onChange }
 						onBlur={ this.onBlur }
-						onFocus={ this.onFocus }
 						autoFocus={ isNew && ! isMobile() }
 						value={ post ? post.title : '' }
 						aria-label={ this.translate( 'Edit title' ) }
-						ref="titleInput" />
+						ref="titleInput"
+						rows="1" />
 				</TrackInputChanges>
 			</div>
 		);

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -44,23 +44,44 @@ export default React.createClass( {
 		const { isNew, site } = this.props;
 		if ( ( isNew && ! prevProps.isNew ) ||
 				( isNew && get( prevProps.site, 'ID' ) !== get( site, 'ID' ) ) ) {
-			ReactDom.findDOMNode( this.refs.titleInput ).focus();
+			const input = ReactDom.findDOMNode( this.refs.titleInput );
+			input.focus();
+		}
+
+		// If value updated via paste, restore caret location
+		if ( this.selectionStart ) {
+			this.setSelectionTimeout = setTimeout( this.setSelection, 0 );
 		}
 	},
 
-	onChange( event ) {
-		const { post, onChange } = this.props;
+	componentWillUnmount() {
+		clearTimeout( this.setSelectionTimeout );
+		delete this.setSelectionTimeout;
+		delete this.selectionStart;
+	},
 
-		if ( ! post ) {
+	setSelection() {
+		if ( ! this.selectionStart ) {
 			return;
 		}
 
-		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-		PostActions.edit( {
-			title: event.target.value
-		} );
+		const input = ReactDom.findDOMNode( this.refs.titleInput );
+		input.setSelectionRange( this.selectionStart, this.selectionStart );
+		delete this.selectionStart;
+	},
 
-		onChange( event );
+	setTitle( title ) {
+		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
+		PostActions.edit( { title } );
+	},
+
+	onChange( event ) {
+		if ( ! this.props.post ) {
+			return;
+		}
+
+		this.setTitle( event.target.value );
+		this.props.onChange( event );
 	},
 
 	recordChangeStats() {
@@ -71,6 +92,43 @@ export default React.createClass( {
 
 	onBlur( event ) {
 		this.onChange( event );
+	},
+
+	stripPasteNewlines( event ) {
+		// `window.clipboardData` deprecated as of Microsoft Edge
+		// See: https://msdn.microsoft.com/library/ms535220(v=vs.85).aspx
+		const clipboard = event.clipboardData || window.clipboardData;
+		if ( ! clipboard ) {
+			return;
+		}
+
+		event.preventDefault();
+
+		let text = clipboard.getData( 'Text' ) || clipboard.getData( 'text/plain' );
+		if ( ! text ) {
+			return;
+		}
+
+		// Replace any newline characters with a single space
+		text = text.replace( /[\r\n]+/g, ' ' );
+
+		// Splice trimmed text into current title selection
+		const { value, selectionStart, selectionEnd } = event.target;
+		const valueChars = value.split( '' );
+		valueChars.splice( selectionStart, selectionEnd - selectionStart, text );
+		const newTitle = valueChars.join( '' );
+
+		// To preserve caret location, we track intended selection point to be
+		// restored after next render pass
+		this.selectionStart = selectionStart + text.length;
+
+		this.setTitle( newTitle );
+	},
+
+	preventEnterKeyPress( event ) {
+		if ( 'Enter' === event.key || 13 === event.charCode ) {
+			event.preventDefault();
+		}
 	},
 
 	render() {
@@ -96,6 +154,8 @@ export default React.createClass( {
 						placeholder={ this.translate( 'Title' ) }
 						onChange={ this.onChange }
 						onBlur={ this.onBlur }
+						onPaste={ this.stripPasteNewlines }
+						onKeyPress={ this.preventEnterKeyPress }
 						autoFocus={ isNew && ! isMobile() }
 						value={ post ? post.title : '' }
 						aria-label={ this.translate( 'Edit title' ) }

--- a/client/post-editor/editor-title/index.jsx
+++ b/client/post-editor/editor-title/index.jsx
@@ -66,6 +66,14 @@ export default React.createClass( {
 		this.props.onChange( event );
 	},
 
+	resizeAfterNewlineInput( event ) {
+		const title = event.target.value;
+		if ( REGEXP_NEWLINES.test( title ) ) {
+			event.target.value = title.replace( REGEXP_NEWLINES, ' ' );
+			this.refs.titleInput.resize();
+		}
+	},
+
 	recordChangeStats() {
 		const isPage = PostUtils.isPage( this.props.post );
 		stats.recordStat( isPage ? 'page_title_changed' : 'post_title_changed' );
@@ -74,12 +82,6 @@ export default React.createClass( {
 
 	onBlur( event ) {
 		this.onChange( event );
-	},
-
-	preventEnterKeyPress( event ) {
-		if ( 'Enter' === event.key || 13 === event.charCode ) {
-			event.preventDefault();
-		}
 	},
 
 	render() {
@@ -104,8 +106,8 @@ export default React.createClass( {
 						className="editor-title__input"
 						placeholder={ this.translate( 'Title' ) }
 						onChange={ this.onChange }
+						onInput={ this.resizeAfterNewlineInput }
 						onBlur={ this.onBlur }
-						onKeyPress={ this.preventEnterKeyPress }
 						autoFocus={ isNew && ! isMobile() }
 						value={ post ? post.title : '' }
 						aria-label={ this.translate( 'Edit title' ) }

--- a/client/post-editor/editor-title/style.scss
+++ b/client/post-editor/editor-title/style.scss
@@ -42,6 +42,7 @@
 	color: $gray-dark;
 	font-weight: 600;
 	resize: none;
+	-ms-overflow-y: hidden !important;
 
 	&:focus {
 		box-shadow: none;

--- a/client/post-editor/editor-title/style.scss
+++ b/client/post-editor/editor-title/style.scss
@@ -1,10 +1,6 @@
 .editor-title {
 	position: relative;
 
-	&:not( .is-focused ):not( .is-loading )::after {
-		@include long-content-fade( $color: $white );
-	}
-
 	&.is-loading::before {
 		content: '';
 		position: absolute;
@@ -36,7 +32,8 @@
 	}
 }
 
-.editor-title__input[type="text"] {
+.editor-title__input {
+	min-height: 0;
 	padding-left: 10px; /* Intentionally non-standard to align editor body margin (10px) */
 	padding-right: 10px;
 	border: none;
@@ -44,6 +41,7 @@
 	font-size: 28px;
 	color: $gray-dark;
 	font-weight: 600;
+	resize: none;
 
 	&:focus {
 		box-shadow: none;
@@ -54,6 +52,6 @@
 	}
 }
 
-.editor-title.is-loading .editor-title__input[type="text"] {
+.editor-title.is-loading .editor-title__input {
 	color: transparent;
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -126,7 +126,7 @@
       "version": "6.3.5"
     },
     "autosize": {
-      "version": "3.0.7"
+      "version": "3.0.15"
     },
     "aws-sign2": {
       "version": "0.6.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "async": "0.9.0",
     "atob": "1.1.2",
     "autoprefixer": "6.3.5",
-    "autosize": "3.0.7",
+    "autosize": "3.0.15",
     "babel-core": "6.9.1",
     "babel-loader": "6.2.4",
     "babel-plugin-add-module-exports": "0.2.1",


### PR DESCRIPTION
~~Blocked by #4824~~
Closes #1059
Fixes #1679

This pull request seeks to allow the editor post title to split onto multiple lines, rather than obscuring it with a long-content fade when the input loses focus.

It also introduces a new `<TextareaAutosize />` component to serve as a drop-in replacement for `<textarea />` in order to facilitate in this use-case.

Before|After
---|---
![before](https://cloud.githubusercontent.com/assets/1779930/14613941/cc785cc8-056c-11e6-9540-9dd893afc253.png)|![after](https://cloud.githubusercontent.com/assets/1779930/14613924/ba7623a2-056c-11e6-933f-90d643308710.png)

__Implementation notes:__

While the implementation does use [`autosize`](https://github.com/jackmoore/autosize), a third-party library, note that this is already used in the editor for the HTML editing tab, so the change in editor bundle size should be negligible if anything. A follow-up task may be to consider whether the HTML tab textarea can be updated to use this component instead.

__Testing instructions:__

Verify in a large and small viewport size that the editor title resizes to accommodate multiple lines as needed. Ensure that existing behavior remains unaffected (notably, focusing the input for a new post, including when navigating from an existing post to a new post).

1. Navigate to the [Reader](http://calypso.localhost:3000/post)
2. Start a new post using the New Post masterbar button
3. Note that the title field is auto-focused for your new post
4. Enter text into the title area
5. Note that the textarea expands to allow multiple line entry