### PR TITLE
Editor: Port inline text patterns from WordPress 4.5 to Calypso

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,3 @@ docs/
 public/
 
 server/devdocs/search-index.js
-client/components/tinymce/plugins/wptextpattern/plugin.js

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -20,9 +20,6 @@ require( 'tinymce/plugins/paste/plugin.js' );
 require( 'tinymce/plugins/tabfocus/plugin.js' );
 require( 'tinymce/plugins/textcolor/plugin.js' );
 
-// TinyMCE plugins copied from .org
-require( './plugins/wptextpattern/plugin.js' );
-
 // TinyMCE plugins that we've forked or written ourselves
 import wpcomPlugin from './plugins/wpcom/plugin.js';
 import wpcomAutoresizePlugin from './plugins/wpcom-autoresize/plugin.js';
@@ -40,6 +37,7 @@ import editorButtonAnalyticsPlugin from './plugins/editor-button-analytics/plugi
 import calypsoAlertPlugin from './plugins/calypso-alert/plugin';
 import contactFormPlugin from './plugins/contact-form/plugin';
 import afterTheDeadlinePlugin from './plugins/after-the-deadline/plugin';
+import wptextpatternPlugin from './plugins/wptextpattern/plugin';
 
 [
 	wpcomPlugin,
@@ -57,7 +55,8 @@ import afterTheDeadlinePlugin from './plugins/after-the-deadline/plugin';
 	editorButtonAnalyticsPlugin,
 	calypsoAlertPlugin,
 	contactFormPlugin,
-	afterTheDeadlinePlugin
+	afterTheDeadlinePlugin,
+	wptextpatternPlugin
 ].forEach( ( initializePlugin ) => initializePlugin() );
 
 /**

--- a/client/components/tinymce/plugins/wptextpattern/plugin.js
+++ b/client/components/tinymce/plugins/wptextpattern/plugin.js
@@ -1,5 +1,5 @@
 /**
- * Adapted from the WordPress wplink TinyMCE plugin.
+ * Adapted from the WordPress wptextpattern TinyMCE plugin.
  *
  * @copyright 2015 by the WordPress contributors.
  * @license See CREDITS.md.
@@ -15,169 +15,290 @@
  * If the transformation in unwanted, the user can undo the change by pressing backspace,
  * using the undo shortcut, or the undo button in the toolbar.
  */
-( function( tinymce, setTimeout ) {
-	tinymce.PluginManager.add( 'wptextpattern', function( editor ) {
-		var VK = tinymce.util.VK,
-			spacePatterns = [
-				{ regExp: /^[*-]\s/, cmd: 'InsertUnorderedList' },
-				{ regExp: /^1[.)]\s/, cmd: 'InsertOrderedList' }
-			],
-			enterPatterns = [
-				{ start: '##', format: 'h2' },
-				{ start: '###', format: 'h3' },
-				{ start: '####', format: 'h4' },
-				{ start: '#####', format: 'h5' },
-				{ start: '######', format: 'h6' },
-				{ start: '>', format: 'blockquote' }
-			],
-			canUndo, refNode, refPattern;
 
-		editor.on( 'selectionchange', function() {
-			canUndo = null;
-		} );
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce/tinymce';
 
-		editor.on( 'keydown', function( event ) {
-			if ( ( canUndo && event.keyCode === 27 /* ESCAPE */ ) || ( canUndo === 'space' && event.keyCode === VK.BACKSPACE ) ) {
-				editor.undoManager.undo();
-				event.preventDefault();
-				event.stopImmediatePropagation();
-			}
+function wptextpattern( editor ) {
+	var VK = tinymce.util.VK;
 
-			if ( event.keyCode === VK.ENTER && ! VK.modifierPressed( event ) ) {
-				watchEnter();
-			}
-		}, true );
+	var spacePatterns = [
+		{ regExp: /^[*-]\s/, cmd: 'InsertUnorderedList' },
+		{ regExp: /^1[.)]\s/, cmd: 'InsertOrderedList' }
+	];
 
-		editor.on( 'keyup', function( event ) {
-			if ( event.keyCode === VK.SPACEBAR && ! event.ctrlKey && ! event.metaKey && ! event.altKey ) {
-				space();
-			} else if ( event.keyCode === VK.ENTER && ! VK.modifierPressed( event ) ) {
-				enter();
+	var enterPatterns = [
+		{ start: '##', format: 'h2' },
+		{ start: '###', format: 'h3' },
+		{ start: '####', format: 'h4' },
+		{ start: '#####', format: 'h5' },
+		{ start: '######', format: 'h6' },
+		{ start: '>', format: 'blockquote' },
+		{ regExp: /^(-){3,}$/, element: 'hr' }
+	];
+
+	var inlinePatterns = [
+		{ start: '`', end: '`', format: 'code' }
+	];
+
+	var canUndo;
+	var chars = [];
+
+	tinymce.each( inlinePatterns, function( pattern ) {
+		tinymce.each( ( pattern.start + pattern.end ).split( '' ), function( c ) {
+			if ( tinymce.inArray( chars, c ) === -1 ) {
+				chars.push( c );
 			}
 		} );
+	} );
 
-		function firstTextNode( node ) {
-			var parent = editor.dom.getParent( node, 'p' ),
-				child;
+	editor.on( 'selectionchange', function() {
+		canUndo = null;
+	} );
 
-			if ( ! parent ) {
+	editor.on( 'keydown', function( event ) {
+		if ( ( canUndo && event.keyCode === 27 /* ESCAPE */ ) || ( canUndo === 'space' && event.keyCode === VK.BACKSPACE ) ) {
+			editor.undoManager.undo();
+			event.preventDefault();
+			event.stopImmediatePropagation();
+		}
+
+		if ( event.keyCode === VK.ENTER && ! VK.modifierPressed( event ) ) {
+			enter();
+		}
+	}, true );
+
+	editor.on( 'keyup', function( event ) {
+		if ( event.keyCode === VK.SPACEBAR && ! event.ctrlKey && ! event.metaKey && ! event.altKey ) {
+			space();
+		} else if ( event.keyCode > 47 && ! ( event.keyCode >= 91 && event.keyCode <= 93 ) ) {
+			inline();
+		}
+	} );
+
+	function inline() {
+		var rng = editor.selection.getRng();
+		var node = rng.startContainer;
+		var offset = rng.startOffset;
+		var startOffset;
+		var endOffset;
+		var pattern;
+		var format;
+		var zero;
+
+		if ( ! node || node.nodeType !== 3 || ! node.data.length || ! offset ) {
+			return;
+		}
+
+		if ( tinymce.inArray( chars, node.data.charAt( offset - 1 ) ) === -1 ) {
+			return;
+		}
+
+		function findStart( node ) {
+			var i = inlinePatterns.length;
+			var offset;
+
+			while ( i-- ) {
+				pattern = inlinePatterns[ i ];
+				offset = node.data.indexOf( pattern.end );
+
+				if ( offset !== -1 ) {
+					return offset;
+				}
+			}
+		}
+
+		startOffset = findStart( node );
+		endOffset = node.data.lastIndexOf( pattern.end );
+
+		if ( startOffset === endOffset || endOffset === -1 ) {
+			return;
+		}
+
+		if ( endOffset - startOffset <= pattern.start.length ) {
+			return;
+		}
+
+		if ( node.data.slice( startOffset + pattern.start.length, endOffset ).indexOf( pattern.start.slice( 0, 1 ) ) !== -1 ) {
+			return;
+		}
+
+		format = editor.formatter.get( pattern.format );
+
+		if ( format && format[0].inline ) {
+			editor.undoManager.add();
+
+			editor.undoManager.transact( function() {
+				node.insertData( offset, '\u200b' );
+
+				node = node.splitText( startOffset );
+				zero = node.splitText( offset - startOffset );
+
+				node.deleteData( 0, pattern.start.length );
+				node.deleteData( node.data.length - pattern.end.length, pattern.end.length );
+
+				editor.formatter.apply( pattern.format, {}, node );
+
+				editor.selection.setCursorLocation( zero, 1 );
+			} );
+
+			// We need to wait for native events to be triggered.
+			setTimeout( function() {
+				canUndo = 'space';
+
+				editor.once( 'selectionchange', function() {
+					var offset;
+
+					if ( zero ) {
+						offset = zero.data.indexOf( '\u200b' );
+
+						if ( offset !== -1 ) {
+							zero.deleteData( offset, offset + 1 );
+						}
+					}
+				} );
+			} );
+		}
+	}
+
+	function firstTextNode( node ) {
+		var parent = editor.dom.getParent( node, 'p' ),
+			child;
+
+		if ( ! parent ) {
+			return;
+		}
+
+		while ( child = parent.firstChild ) { // eslint-disable-line no-cond-assign
+			if ( child.nodeType !== 3 ) {
+				parent = child;
+			} else {
+				break;
+			}
+		}
+
+		if ( ! child ) {
+			return;
+		}
+
+		if ( ! child.data ) {
+			if ( child.nextSibling && child.nextSibling.nodeType === 3 ) {
+				child = child.nextSibling;
+			} else {
+				child = null;
+			}
+		}
+
+		return child;
+	}
+
+	function space() {
+		var rng = editor.selection.getRng(),
+			node = rng.startContainer,
+			parent,
+			text;
+
+		if ( ! node || firstTextNode( node ) !== node ) {
+			return;
+		}
+
+		parent = node.parentNode;
+		text = node.data;
+
+		tinymce.each( spacePatterns, function( pattern ) {
+			var match = text.match( pattern.regExp );
+
+			if ( ! match || rng.startOffset !== match[0].length ) {
 				return;
 			}
 
-			while ( child = parent.firstChild ) {
-				if ( child.nodeType !== 3 ) {
-					parent = child;
-				} else {
+			editor.undoManager.add();
+
+			editor.undoManager.transact( function() {
+				node.deleteData( 0, match[0].length );
+
+				if ( ! parent.innerHTML ) {
+					parent.appendChild( document.createElement( 'br' ) );
+				}
+
+				editor.selection.setCursorLocation( parent );
+				editor.execCommand( pattern.cmd );
+			} );
+
+			// We need to wait for native events to be triggered.
+			setTimeout( function() {
+				canUndo = 'space';
+			} );
+
+			return false;
+		} );
+	}
+
+	function enter() {
+		var rng = editor.selection.getRng(),
+			start = rng.startContainer,
+			node = firstTextNode( start ),
+			i = enterPatterns.length,
+			text, pattern, parent;
+
+		if ( ! node ) {
+			return;
+		}
+
+		text = node.data;
+
+		while ( i-- ) {
+			if ( enterPatterns[ i ].start ) {
+				if ( text.indexOf( enterPatterns[ i ].start ) === 0 ) {
+					pattern = enterPatterns[ i ];
+					break;
+				}
+			} else if ( enterPatterns[ i ].regExp ) {
+				if ( enterPatterns[ i ].regExp.test( text ) ) {
+					pattern = enterPatterns[ i ];
 					break;
 				}
 			}
-
-			if ( ! child ) {
-				return;
-			}
-
-			if ( ! child.data ) {
-				if ( child.nextSibling && child.nextSibling.nodeType === 3 ) {
-					child = child.nextSibling;
-				} else {
-					child = null;
-				}
-			}
-
-			return child;
 		}
 
-		function space() {
-			var rng = editor.selection.getRng(),
-				node = rng.startContainer,
-				parent,
-				text;
+		if ( ! pattern ) {
+			return;
+		}
 
-			if ( ! node || firstTextNode( node ) !== node ) {
-				return;
-			}
+		if ( node === start && tinymce.trim( text ) === pattern.start ) {
+			return;
+		}
 
-			parent = node.parentNode;
-			text = node.data;
+		editor.once( 'keyup', function() {
+			editor.undoManager.add();
 
-			tinymce.each( spacePatterns, function( pattern ) {
-				var match = text.match( pattern.regExp );
+			editor.undoManager.transact( function() {
+				if ( pattern.format ) {
+					editor.formatter.apply( pattern.format, {}, node );
+					node.replaceData( 0, node.data.length, ltrim( node.data.slice( pattern.start.length ) ) );
+				} else if ( pattern.element ) {
+					parent = node.parentNode && node.parentNode.parentNode;
 
-				if ( ! match || rng.startOffset !== match[0].length ) {
-					return;
-				}
-
-				editor.undoManager.add();
-
-				editor.undoManager.transact( function() {
-					node.deleteData( 0, match[0].length );
-
-					if ( ! parent.innerHTML ) {
-						parent.appendChild( document.createElement( 'br' ) );
+					if ( parent ) {
+						parent.replaceChild( document.createElement( pattern.element ), node.parentNode );
 					}
-
-					editor.selection.setCursorLocation( parent );
-					editor.execCommand( pattern.cmd );
-				} );
-
-				// We need to wait for native events to be triggered.
-				setTimeout( function() {
-					canUndo = 'space';
-				} );
-
-				return false;
+				}
 			} );
-		}
 
-		function watchEnter() {
-			var rng = editor.selection.getRng(),
-				start = rng.startContainer,
-				node = firstTextNode( start ),
-				i = enterPatterns.length,
-				text, pattern;
+			// We need to wait for native events to be triggered.
+			setTimeout( function() {
+				canUndo = 'enter';
+			} );
+		} );
+	}
 
-			if ( ! node ) {
-				return;
-			}
+	function ltrim( text ) {
+		return text ? text.replace( /^\s+/, '' ) : '';
+	}
+}
 
-			text = node.data;
-
-			while ( i-- ) {
-				 if ( text.indexOf( enterPatterns[ i ].start ) === 0 ) {
-				 	pattern = enterPatterns[ i ];
-				 	break;
-				 }
-			}
-
-			if ( ! pattern ) {
-				return;
-			}
-
-			if ( node === start && tinymce.trim( text ) === pattern.start ) {
-				return;
-			}
-
-			refNode = node;
-			refPattern = pattern;
-		}
-
-		function enter() {
-			if ( refNode ) {
-				editor.undoManager.add();
-
-				editor.undoManager.transact( function() {
-					editor.formatter.apply( refPattern.format, {}, refNode );
-					refNode.replaceData( 0, refNode.data.length, tinymce.trim( refNode.data.slice( refPattern.start.length ) ) );
-				} );
-
-				// We need to wait for native events to be triggered.
-				setTimeout( function() {
-					canUndo = 'enter';
-				} );
-			}
-
-			refNode = null;
-			refPattern = null;
-		}
-	} );
-} )( window.tinymce, window.setTimeout );
+export default function() {
+	tinymce.PluginManager.add( 'wptextpattern', wptextpattern );
+}


### PR DESCRIPTION
Closes #3512

This pull request seeks to update the `wptextpattern` plugin to include formatting shortcut changes from the [WordPress 4.5 release](https://wordpress.org/news/2016/04/coleman/).

![shortcuts](https://cloud.githubusercontent.com/assets/1779930/14614818/d0257b18-0570-11e6-9396-f462b2e641bf.gif)

__Implementation notes:__

The changes aren't as substantial as they may appear. In the process of updating the plugin, I forked it to better adapt to our standards of avoiding the window global TinyMCE object. ~~It's suggested you add a `?w=1` query parameter to the changed files tab while reviewing, to ignore whitespace changes.~~ (Tip doesn't seem to help 😞 )

__Testing instructions:__

Verify that formatting shortcuts behave as expected, including preexisting shortcuts.

[See WordPress Codex formatting shortcuts documentation](https://codex.wordpress.org/Keyboard_Shortcuts#Formatting_Shortcuts)

__Follow-up tasks:__

- Include help documentation for formatting shortcuts in Calypso (#4829)