### PR TITLE
State: Persist state via localforage only when changed

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -62,13 +62,23 @@ function loadInitialStateFailed( error ) {
 	return createReduxStore();
 }
 
-function persistOnChange( reduxStore ) {
+export function persistOnChange( reduxStore, serializeState = serialize ) {
+	let state;
+
 	reduxStore.subscribe( function() {
-		localforage.setItem( 'redux-state', serialize( reduxStore.getState() ) )
+		const nextState = reduxStore.getState();
+		if ( state && nextState === state ) {
+			return;
+		}
+
+		state = nextState;
+
+		localforage.setItem( 'redux-state', serializeState( state ) )
 			.catch( ( setError ) => {
 				debug( 'failed to set redux-store state', setError );
 			} );
 	} );
+
 	return reduxStore;
 }
 


### PR DESCRIPTION
This pull request seeks to enhance state persistence to eliminate unnecessary saves. Specifically, we subscribe to the store, but we do not check to ensure that state has changed before persisting state via `localforage`. For example, we may load persisted state that includes the current user ID, and when [`setCurrentUserId` is dispatched during boot](https://github.com/Automattic/wp-calypso/blob/b8d1232811086993b9108a1e1b0e94ac7d9e1853/client/boot/index.js#L181), we unnecessarily persist state, even though the current user ID has not changed.

Note that the return value of `combineReducers` is such that if none of the reducer key function results include a changed value, the original state is returned, thereby enabling us to compare state strictly ([source](https://github.com/reactjs/redux/blob/f02e8251212e0b90c522e4ae308cd6feb882fa0b/src/combineReducers.js#L123-L138)).

See included test cases for clarification on the expected behavior of `persistOnChange` when a dispatch occurs.

__Testing instructions:__

Ensure tests pass by running `npm run test-client`

Verify that state persistence continues to behave as expected in your browser. In particular, enable debugging via `localStorage.debug = 'calypso:state`;` and note that the state persistence continues to behave as expected by examining the restored state after page refreshes.

/cc @gwwar