### PR TITLE
Reader: Fix how we detect Discover posts

### DIFF
--- a/client/reader/discover/helper.jsx
+++ b/client/reader/discover/helper.jsx
@@ -18,7 +18,7 @@ module.exports = {
 	},
 
 	isDiscoverPost: function( post ) {
-		return !! ( post.discover_metadata || post.site_ID == config( 'discover_blog_id' ) ); //eslint-disable-line eqeqeq
+		return !! ( post.discover_metadata || post.site_ID === config( 'discover_blog_id' ) );
 	},
 
 	isDiscoverSitePick: function( post ) {

--- a/client/reader/discover/helper.jsx
+++ b/client/reader/discover/helper.jsx
@@ -3,7 +3,8 @@
 // External dependencies
 var find = require( 'lodash/find' ),
 	get = require( 'lodash/get' ),
-	url = require( 'url' );
+	url = require( 'url' ),
+	config = require( 'config' );
 
 /**
  * Internal Dependencies
@@ -17,11 +18,11 @@ module.exports = {
 	},
 
 	isDiscoverPost: function( post ) {
-		return !! post.discover_metadata;
+		return !! ( post.discover_metadata || post.site_ID == config( 'discover_blog_id' ) ); //eslint-disable-line eqeqeq
 	},
 
 	isDiscoverSitePick: function( post ) {
-		return !! find( post.discover_metadata.discover_fp_post_formats, { slug: 'site-pick' } );
+		return !! ( post.discover_metadata && find( post.discover_metadata.discover_fp_post_formats, { slug: 'site-pick' } ) );
 	},
 
 	isInternalDiscoverPost: function( post ) {

--- a/client/reader/following-stream/post.jsx
+++ b/client/reader/following-stream/post.jsx
@@ -436,7 +436,7 @@ const Post = React.createClass( {
 					? <PostImages postImages={ post.content_images || [] } />
 					: null }
 
-				{ ( isDiscoverPost && ! isDiscoverSitePick ) ? <DiscoverPostAttribution attribution={ post.discover_metadata.attribution } siteUrl={ discoverSiteUrl } /> : null }
+				{ ( isDiscoverPost && post.discover_metadata && ! isDiscoverSitePick ) ? <DiscoverPostAttribution attribution={ post.discover_metadata.attribution } siteUrl={ discoverSiteUrl } /> : null }
 				{ ( isDiscoverSitePick ) ? <DiscoverSiteAttribution attribution={ post.discover_metadata.attribution } siteUrl={ discoverSiteUrl } /> : null }
 
 				{ this.props.xPostedTo


### PR DESCRIPTION
Prevents the Block option from appearing on Discover posts that don't have discover_metadata.