### PR TITLE
Framework: Don't render layout for isomorphic sections in `client/boot`

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -101,7 +101,6 @@ function setUpContext( reduxStore ) {
 		}
 
 		// set `context.query`
-		// debugger
 		const querystringStart = context.canonicalPath.indexOf( '?' );
 		if ( querystringStart !== -1 ) {
 			context.query = qs.parse( context.canonicalPath.substring( querystringStart + 1 ) );

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -74,7 +74,7 @@ export const ReduxWrappedLayout = ( { store, primary, secondary, tertiary } ) =>
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	page( route, ...[ ...middlewares, render ] );
+	page( route, ...middlewares, render );
 }
 
 function render( context ) {

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -51,6 +51,18 @@ export function getSectionName( state ) {
 }
 
 /**
+ * Returns true if the current section is isomorphic.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {bool}    True if current section is isomorphic
+ *
+ * @see client/sections
+ */
+export function isSectionIsomorphic( state ) {
+	return get( state.ui.section, 'isomorphic', false );
+}
+
+/**
  * Returns the current state for Guided Tours.
  *
  * This includes the raw state from state/ui/guidesTour, but also the available

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -10,6 +10,7 @@ import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSectionName,
+	isSectionIsomorphic,
 	getGuidesTourState,
 } from '../selectors';
 import guidesToursConfig from 'guidestours/config';
@@ -90,6 +91,36 @@ describe( 'selectors', () => {
 			} );
 
 			expect( sectionName ).to.equal( 'post-editor' );
+		} );
+	} );
+
+	describe( '#isSectionIsomorphic()', () => {
+		it( 'should return false if there is no section currently selected', () => {
+			const selected = isSectionIsomorphic( {
+				ui: {
+					section: false
+				}
+			} );
+
+			expect( selected ).to.be.false;
+		} );
+
+		it( 'should return true if current section is isomorphic', () => {
+			const section = {
+				enableLoggedOut: true,
+				group: 'sites',
+				isomorphic: true,
+				module: 'my-sites/themes',
+				name: 'themes',
+				paths: [ '/design' ],
+				secondary: false
+			};
+
+			const selected = isSectionIsomorphic( {
+				ui: { section }
+			} );
+
+			expect( selected ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
Isomorphic sections render `LayoutLoggedOut` themselves (when logged-out) -- that includes server-side. Hence, this PR disables rendering `Layout` in `client/boot` for isomorphic sections, when logged out.

This means no more reconciliation errors for logged-out http://calypso.localhost:3000/theme/rowling/details. Reconc errors will be furthermore reduced with #4668.

To this end, this PR also introduces an `isSectionIsomorphic` selector, along with tests.

A future iteration will require isomorphic sections to render `Layout` themselves when logged-in, too, and will consequently also disable rendering `Layout` for isomorphic sections in `client/boot` when logged in.

No visual changes. To test -- make sure the theme showcase still works as before.

Fixes part of #2299.