### PR TITLE
Purchases: Add refund/cancellation survey.

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -3,10 +3,13 @@
  */
 import page from 'page';
 import React from 'react';
+import shuffle from 'lodash/shuffle';
 
 /**
  * Internal dependencies
  */
+import wpcom from 'lib/wp';
+import config from 'config';
 import CompactCard from 'components/card/compact';
 import Dialog from 'components/dialog';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
@@ -16,6 +19,13 @@ import { isDomainRegistration, isPlan, isGoogleApps } from 'lib/products-values'
 import notices from 'notices';
 import purchasePaths from '../paths';
 import { removePurchase } from 'lib/upgrades/actions';
+import FormSectionHeading from 'components/forms/form-section-heading';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLegend from 'components/forms/form-legend';
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextarea from 'components/forms/form-textarea';
 
 const RemovePurchase = React.createClass( {
 	propTypes: {
@@ -29,9 +39,34 @@ const RemovePurchase = React.createClass( {
 	},
 
 	getInitialState() {
+		// shuffle reason order, but keep anotherReasonOne last
+		const questionOneOrder = shuffle( [
+			'couldNotInstall',
+			'tooHard',
+			'didNotInclude',
+			'onlyNeedFree'
+		] );
+		questionOneOrder.push( 'anotherReasonOne' );
+
+		const questionTwoOrder = shuffle( [
+			'stayingHere',
+			'otherWordPress',
+			'differentService',
+			'noNeed'
+		] );
+		questionTwoOrder.push( 'anotherReasonTwo' );
+
 		return {
 			isDialogVisible: false,
-			isRemoving: false
+			isRemoving: false,
+			surveyStep: 1,
+			questionOneRadio: null,
+			questionOneText: '',
+			questionOneOrder: questionOneOrder,
+			questionTwoRadio: null,
+			questionTwoText: '',
+			questionTwoOrder: questionTwoOrder,
+			questionThreeText: ''
 		};
 	},
 
@@ -45,11 +80,40 @@ const RemovePurchase = React.createClass( {
 		this.setState( { isDialogVisible: true } );
 	},
 
+	changeSurveyStep() {
+		this.setState( {
+			surveyStep: this.state.surveyStep === 1 ? 2 : 1,
+		} );
+	},
+
 	removePurchase( closeDialog ) {
 		this.setState( { isRemoving: true } );
 
 		const purchase = getPurchase( this.props ),
 			{ selectedSite, user } = this.props;
+
+		if ( ! isDomainRegistration( purchase ) && config.isEnabled( 'upgrades/removal-survey' ) ) {
+			const survey = wpcom.marketing().survey( 'calypso-remove-purchase', this.props.selectedSite.ID );
+			survey.addResponses( {
+				'why-cancel': {
+					response: this.state.questionOneRadio,
+					text: this.state.questionOneText
+				},
+				'next-adventure': {
+					response: this.state.questionTwoRadio,
+					text: this.state.questionTwoText
+				},
+				'what-better': { text: this.state.questionThreeText }
+			} );
+
+			survey.submit()
+				.then( res => {
+					if ( ! res.success ) {
+						notices.error( res.err );
+					}
+				} )
+				.catch( err => console.error( err ) ); // shouldn't get here
+		}
 
 		removePurchase( purchase.id, user.ID, success => {
 			if ( success ) {
@@ -83,6 +147,38 @@ const RemovePurchase = React.createClass( {
 		} );
 	},
 
+	handleRadioOne( event ) {
+		this.setState( {
+			questionOneRadio: event.currentTarget.value,
+			questionOneText: ''
+		} );
+	},
+
+	handleTextOne( event ) {
+		this.setState( {
+			questionOneText: event.currentTarget.value
+		} );
+	},
+
+	handleRadioTwo( event ) {
+		this.setState( {
+			questionTwoRadio: event.currentTarget.value,
+			questionTwoText: ''
+		} );
+	},
+
+	handleTextTwo( event ) {
+		this.setState( {
+			questionTwoText: event.currentTarget.value
+		} );
+	},
+
+	handleTextThree( event ) {
+		this.setState( {
+			questionThreeText: event.currentTarget.value
+		} );
+	},
+
 	renderCard() {
 		const productName = getName( getPurchase( this.props ) );
 
@@ -96,7 +192,7 @@ const RemovePurchase = React.createClass( {
 		);
 	},
 
-	renderDialog() {
+	renderDomainDialog() {
 		const buttons = [ {
 				action: 'cancel',
 				disabled: this.state.isRemoving,
@@ -117,68 +213,384 @@ const RemovePurchase = React.createClass( {
 				className="remove-purchase__dialog"
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }>
-				<h1>{ this.translate( 'Remove %(productName)s', { args: { productName } } ) }</h1>
-				{ this.renderDialogText() }
+				<FormSectionHeading>{ this.translate( 'Remove %(productName)s', { args: { productName } } ) }</FormSectionHeading>
+				{ this.renderDomainDialogText() }
 			</Dialog>
 		);
 	},
 
-	renderDialogText() {
+	renderDomainDialogText() {
 		const purchase = getPurchase( this.props ),
 			productName = getName( purchase );
 
-		if ( isDomainRegistration( purchase ) ) {
-			return (
-				<p>
-					{
-						this.translate( 'This will remove %(domain)s from your account.', {
-							args: { domain: productName }
-						} )
-					}
-					{ ' ' }
-					{ this.translate( 'By removing, you are canceling the domain registration. This may stop you from using it again, even with another service.' ) }
-				</p>
-			);
+		return (
+			<p>
+				{
+					this.translate(
+						'This will remove %(domain)s from your account. By removing, ' +
+							'you are canceling the domain registration. This may stop ' +
+							'you from using it again, even with another service.',
+						{ args: { domain: productName } }
+					)
+				}
+			</p>
+		);
+	},
+
+	renderPlanDialogs() {
+		const buttons = {
+				cancel: {
+					action: 'cancel',
+					disabled: this.state.isRemoving,
+					label: this.translate( 'Cancel' )
+				},
+				next: {
+					action: 'next',
+					disabled: this.state.isRemoving || this.state.questionOneRadio == null || this.state.questionTwoRadio == null,
+					label: this.translate( 'Next' ),
+					onClick: this.changeSurveyStep
+				},
+				prev: {
+					action: 'prev',
+					disabled: this.state.isRemoving,
+					label: this.translate( 'Previous' ),
+					onClick: this.changeSurveyStep
+				},
+				remove: {
+					action: 'remove',
+					disabled: this.state.isRemoving,
+					isPrimary: true,
+					label: this.translate( 'Remove' ),
+					onClick: this.removePurchase
+				}
+			},
+			productName = getName( getPurchase( this.props ) ),
+			inStepOne = this.state.surveyStep === 1;
+
+		let buttonsArr, dialogContent;
+		if ( ! config.isEnabled( 'upgrades/removal-survey' ) ) {
+			buttonsArr = [ buttons.cancel, buttons.remove ];
+			dialogContent = this.renderPlanDialogsText();
+		} else {
+			buttonsArr = ( inStepOne ) ? [ buttons.cancel, buttons.next ] : [ buttons.cancel, buttons.prev, buttons.remove ];
+			dialogContent = ( inStepOne ) ? this.renderDialogContentOne() : this.renderDialogContentTwo();
 		}
 
-		let includedDomainText;
+		return (
+			<div>
+				<Dialog
+					buttons={ buttonsArr }
+					className="remove-purchase__dialog"
+					isVisible={ this.state.isDialogVisible }
+					onClose={ this.closeDialog }>
+					<FormSectionHeading>{ this.translate( 'Remove %(productName)s', { args: { productName } } ) }</FormSectionHeading>
+					{ dialogContent }
+				</Dialog>
+			</div>
+		);
+	},
 
-		if ( isPlan( purchase ) && hasIncludedDomain( purchase ) ) {
+	renderPlanDialogsText() {
+		const purchase = getPurchase( this.props ),
+			productName = getName( purchase ),
 			includedDomainText = (
 				<p>
 					{
 						this.translate(
-							'The domain associated with this plan, {{domain/}}, will not be removed. It will remain active on your site, unless also removed.',
-							{
-								components: { domain: <em>{ getIncludedDomain( purchase ) }</em> }
-							}
+							'The domain associated with this plan, {{domain/}}, will not be removed. ' +
+								'It will remain active on your site, unless also removed.',
+							{ components: { domain: <em>{ getIncludedDomain( purchase ) }</em> } }
 						)
 					}
 				</p>
 			);
-		}
 
 		return (
 			<div>
 				<p>
 					{
-						this.translate( 'Are you sure you want to remove %(productName)s from {{siteName/}}?', {
-							args: { productName },
-							components: { siteName: <em>{ this.props.selectedSite.slug }</em> }
-						} )
+						this.translate(
+							'Are you sure you want to remove %(productName)s from {{siteName/}}?',
+							{
+								args: { productName },
+								components: { siteName: <em>{ this.props.selectedSite.slug }</em> }
+							}
+						)
 					}
 					{ ' ' }
 					{ isGoogleApps( purchase )
-						? this.translate( 'Your Google Apps account will continue working without interruption. ' +
-						'You will be able to manage your Google Apps billing directly through Google.'
-					)
-						: this.translate( 'You will not be able to reuse it again without purchasing a new subscription.', {
-							comment: "'it' refers to a product purchased by a user"
-						} )
+						? this.translate(
+							'Your Google Apps account will continue working without interruption. ' +
+								'You will be able to manage your Google Apps billing directly through Google.'
+						)
+						: this.translate(
+							'You will not be able to reuse it again without purchasing a new subscription.',
+							{ comment: "'it' refers to a product purchased by a user" }
+						)
 					}
+
 				</p>
 
-				{ includedDomainText }
+				{ ( isPlan( purchase ) && hasIncludedDomain( purchase ) ) && includedDomainText }
+			</div>
+		);
+	},
+
+	renderQuestionOne() {
+		const reasons = {};
+
+		const couldNotInstallInput = (
+			<FormTextInput
+				className="remove-purchase__reason-input"
+				name="couldNotInstallInput"
+				id="couldNotInstallInput"
+				value={ this.state.questionOneText }
+				onChange={ this.handleTextOne }
+				placeholder={ this.translate( 'What plugin/theme were you trying to install?' ) } />
+		);
+		reasons.couldNotInstall = (
+			<FormLabel key="couldNotInstall">
+				<FormRadio
+					name="couldNotInstall"
+					value="couldNotInstall"
+					checked={ 'couldNotInstall' === this.state.questionOneRadio }
+					onChange={ this.handleRadioOne } />
+				<span>{ this.translate( 'I couldn\'t install a plugin/theme I wanted.' ) }</span>
+				{ 'couldNotInstall' === this.state.questionOneRadio && couldNotInstallInput }
+			</FormLabel>
+		);
+
+		const tooHardInput = (
+			<FormTextInput
+				className="remove-purchase__reason-input"
+				name="tooHardInput"
+				id="tooHardInput"
+				value={ this.state.questionOneText }
+				onChange={ this.handleTextOne }
+				placeholder={ this.translate( 'Where did you run into problems?' ) } />
+		);
+		reasons.tooHard = (
+			<FormLabel key="tooHard">
+				<FormRadio
+					name="tooHard"
+					value="tooHard"
+					checked={ 'tooHard' === this.state.questionOneRadio }
+					onChange={ this.handleRadioOne } />
+				<span>{ this.translate( 'It was too hard to set up my site.' ) }</span>
+				{ 'tooHard' === this.state.questionOneRadio && tooHardInput }
+			</FormLabel>
+		);
+
+		const didNotIncludeInput = (
+			<FormTextInput
+				className="remove-purchase__reason-input"
+				name="didNotIncludeInput"
+				id="didNotIncludeInput"
+				value={ this.state.questionOneText }
+				onChange={ this.handleTextOne }
+				placeholder={ this.translate( 'What are we missing that you need?' ) } />
+		);
+		reasons.didNotInclude = (
+			<FormLabel key="didNotInclude">
+				<FormRadio
+					name="didNotInclude"
+					value="didNotInclude"
+					checked={ 'didNotInclude' === this.state.questionOneRadio }
+					onChange={ this.handleRadioOne } />
+				<span>{ this.translate( 'This upgrade didn\'t include what I needed.' ) }</span>
+				{ 'didNotInclude' === this.state.questionOneRadio && didNotIncludeInput }
+			</FormLabel>
+		);
+
+		const onlyNeedFreeInput = (
+			<FormTextInput
+				className="remove-purchase__reason-input"
+				name="onlyNeedFreeInput"
+				id="onlyNeedFreeInput"
+				value={ this.state.questionOneText }
+				onChange={ this.handleTextOne }
+				placeholder={ this.translate( 'How can we improve our upgrades?' ) } />
+		);
+		reasons.onlyNeedFree = (
+			<FormLabel key="onlyNeedFree">
+				<FormRadio
+					name="onlyNeedFree"
+					value="onlyNeedFree"
+					checked={ 'onlyNeedFree' === this.state.questionOneRadio }
+					onChange={ this.handleRadioOne } />
+				<span>{ this.translate( 'All I need is the free plan.' ) }</span>
+				{ 'onlyNeedFree' === this.state.questionOneRadio && onlyNeedFreeInput }
+			</FormLabel>
+		);
+
+		const anotherReasonOneInput = (
+			<FormTextInput
+				className="remove-purchase__reason-input"
+				name="anotherReasonOneInput"
+				value={ this.state.questionOneText }
+				onChange={ this.handleTextOne }
+				id="anotherReasonOneInput" />
+		);
+		reasons.anotherReasonOne = (
+			<FormLabel key="anotherReasonOne">
+				<FormRadio
+					name="anotherReasonOne"
+					value="anotherReasonOne"
+					checked={ 'anotherReasonOne' === this.state.questionOneRadio }
+					onChange={ this.handleRadioOne } />
+				<span>{ this.translate( 'Another reason…' ) }</span>
+				{ 'anotherReasonOne' === this.state.questionOneRadio && anotherReasonOneInput }
+			</FormLabel>
+		);
+
+		const { questionOneOrder } = this.state,
+			orderedReasons = questionOneOrder.map( question => reasons[ question ] );
+
+		return (
+			<div>
+				<FormLegend>{ this.translate( 'Please tell us why you are canceling:' ) }</FormLegend>
+				{ orderedReasons }
+			</div>
+		);
+	},
+
+	renderQuestionTwo() {
+		const reasons = {};
+
+		reasons.stayingHere = (
+			<FormLabel key="stayingHere">
+				<FormRadio
+					name="stayingHere"
+					value="stayingHere"
+					checked={ 'stayingHere' === this.state.questionTwoRadio }
+					onChange={ this.handleRadioTwo } />
+				<span>{ this.translate( 'I\'m staying here and using the free plan.' ) }</span>
+			</FormLabel>
+		);
+
+		const otherWordPressInput = (
+			<FormTextInput
+				className="remove-purchase__reason-input"
+				name="otherWordPressInput"
+				id="otherWordPressInput"
+				value={ this.state.questionTwoText }
+				onChange={ this.handleTextTwo }
+				placeholder={ this.translate( 'Mind telling us where?' ) } />
+		);
+		reasons.otherWordPress = (
+			<FormLabel key="otherWordPress">
+				<FormRadio
+					name="otherWordPress"
+					value="otherWordPress"
+					checked={ 'otherWordPress' === this.state.questionTwoRadio }
+					onChange={ this.handleRadioTwo } />
+				<span>{ this.translate( 'I\'m going to use WordPress somewhere else.' ) }</span>
+				{ 'otherWordPress' === this.state.questionTwoRadio && otherWordPressInput }
+			</FormLabel>
+		);
+
+		const differentServiceInput = (
+			<FormTextInput
+				className="remove-purchase__reason-input"
+				name="differentServiceInput"
+				id="differentServiceInput"
+				value={ this.state.questionTwoText }
+				onChange={ this.handleTextTwo }
+				placeholder={ this.translate( 'Mind telling us which one?' ) } />
+		);
+		reasons.differentService = (
+			<FormLabel key="differentService">
+				<FormRadio
+					name="differentService"
+					value="differentService"
+					checked={ 'differentService' === this.state.questionTwoRadio }
+					onChange={ this.handleRadioTwo } />
+				<span>{ this.translate( 'I\'m going to use a different service for my website or blog.' ) }</span>
+				{ 'differentService' === this.state.questionTwoRadio && differentServiceInput }
+			</FormLabel>
+		);
+
+		const noNeedInput = (
+			<FormTextInput
+				className="remove-purchase__reason-input"
+				name="noNeedInput"
+				id="noNeedInput"
+				value={ this.state.questionTwoText }
+				onChange={ this.handleTextTwo }
+				placeholder={ this.translate( 'What will you do instead?' ) } />
+		);
+		reasons.noNeed = (
+			<FormLabel key="noNeed">
+				<FormRadio
+					name="noNeed"
+					value="noNeed"
+					checked={ 'noNeed' === this.state.questionTwoRadio }
+					onChange={ this.handleRadioTwo } />
+				<span>{ this.translate( 'I no longer need a website or blog.' ) }</span>
+				{ 'noNeed' === this.state.questionTwoRadio && noNeedInput }
+			</FormLabel>
+		);
+
+		const anotherReasonTwoInput = (
+			<FormTextInput
+				className="remove-purchase__reason-input"
+				name="anotherReasonTwoInput"
+				value={ this.state.questionTwoText }
+				onChange={ this.handleTextTwo }
+				id="anotherReasonTwoInput" />
+		);
+		reasons.anotherReasonTwo = (
+			<FormLabel key="anotherReasonTwo">
+				<FormRadio
+					name="anotherReasonTwo"
+					value="anotherReasonTwo"
+					checked={ 'anotherReasonTwo' === this.state.questionTwoRadio }
+					onChange={ this.handleRadioTwo } />
+				<span>{ this.translate( 'Another reason…' ) }</span>
+				{ 'anotherReasonTwo' === this.state.questionTwoRadio && anotherReasonTwoInput }
+			</FormLabel>
+		);
+
+		const { questionTwoOrder } = this.state,
+			orderedReasons = questionTwoOrder.map( question => reasons[ question ] );
+
+		return (
+			<div>
+				<FormLegend>{ this.translate( 'Where is your next adventure taking you?' ) }</FormLegend>
+				{ orderedReasons }
+			</div>
+		);
+	},
+
+	renderFreeformQuestion() {
+		return (
+			<FormFieldset>
+				<FormLabel>
+					{ this.translate( 'What\'s one thing we could have done better? (optional)' ) }
+					<FormTextarea
+						name="improvementInput"
+						id="improvementInput"
+						value={ this.state.questionThreeText }
+						onChange={ this.handleTextThree } />
+				</FormLabel>
+			</FormFieldset>
+		);
+	},
+
+	renderDialogContentOne() {
+		return (
+			<div>
+				{ this.renderQuestionOne() }
+				{ this.renderQuestionTwo() }
+			</div>
+		);
+	},
+
+	renderDialogContentTwo() {
+		return (
+			<div>
+				{ this.renderFreeformQuestion() }
+				{ this.renderPlanDialogsText() }
 			</div>
 		);
 	},
@@ -189,7 +601,6 @@ const RemovePurchase = React.createClass( {
 		}
 
 		const purchase = getPurchase( this.props );
-
 		if ( ! isRemovable( purchase ) ) {
 			return null;
 		}
@@ -197,7 +608,7 @@ const RemovePurchase = React.createClass( {
 		return (
 			<span>
 				{ this.renderCard() }
-				{ this.renderDialog() }
+				{ isDomainRegistration( purchase ) ? this.renderDomainDialog() : this.renderPlanDialogs() }
 			</span>
 		);
 	}

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -19,3 +19,8 @@
 		text-overflow: ellipsis;
 	}
 }
+
+.remove-purchase__dialog .remove-purchase__reason-input {
+	margin: 4px 0 0 24px;
+	width: calc( 100% - 24px );
+}

--- a/config/development.json
+++ b/config/development.json
@@ -129,6 +129,7 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
+		"upgrades/removal-survey": true,
 		"vip": false,
 		"vip/backups": true,
 		"vip/billing": true,


### PR DESCRIPTION
This PR adds the customer survey onto the `RemovePurchase` flow. We were previously not gaining any insight as to why our customers were cancelling their purchases, so this short, mandatory survey has been prepended to the cancellation action. This update fully utilizes the existing `RemovePurchase` components with a reshuffling of the dialogs and a new call to `wpcom.marketing().survey().submit()`.

### /purchases/:site/:purchase
Nothing has changed on the surface here.
<img width="1169" alt="screen shot 2016-06-22 at 10 15 46 am" src="https://cloud.githubusercontent.com/assets/273708/16276395/04aad1e2-3863-11e6-80aa-4014eb6938c0.png">

### Remove \<product>
#### `isEnabled( 'upgrades/removal-survey' )` == true
Clicking the remove link will bring up the first page of the survey dialog. None of the options are selected by default and their order (minus 'another reason...') is randomized. 'Next' does not activate until both questions are answered.

<img width="645" alt="screen shot 2016-06-22 at 10 28 20 am" src="https://cloud.githubusercontent.com/assets/273708/16276635/196a7712-3864-11e6-9c44-3b3bc640a65c.png">

Selecting an answer opens up an additional optional field with a further question.

<img width="529" alt="screen shot 2016-06-22 at 10 31 06 am" src="https://cloud.githubusercontent.com/assets/273708/16276731/78faa454-3864-11e6-9726-7e9ae7ceb3df.png">

Second dialog after clicking 'Next' brings up final optional question and the rest of the original remove product dialog. Clicking 'Remove' is the original remove `removePurchase()` action with the additional action of submitting the responses to the `wpcom.marketing()` endpoint.

<img width="664" alt="screen shot 2016-06-22 at 10 33 32 am" src="https://cloud.githubusercontent.com/assets/273708/16276865/20773d50-3865-11e6-9670-72d9cbd19436.png">

#### `isEnabled( 'upgrades/removal-survey' )` == false
Original dialog is presented, survey is not sent.

<img width="930" alt="screen shot 2016-06-22 at 10 41 34 am" src="https://cloud.githubusercontent.com/assets/273708/16277039/fdd80d00-3865-11e6-9173-d0f41c29dd04.png">


## Testing

With `"upgrades/removal-survey": true,` set in development.json go to http://calypso.localhost:3000/purchases/ and select a site with a product to remove.

<img width="1243" alt="screen shot 2016-06-22 at 10 45 12 am" src="https://cloud.githubusercontent.com/assets/273708/16277138/84d1ad16-3866-11e6-931b-5e381e5b957b.png">

Then click on 'Remove \<product>' to bring the survey up.

<img width="792" alt="screen shot 2016-06-22 at 10 47 21 am" src="https://cloud.githubusercontent.com/assets/273708/16277205/c55e808e-3866-11e6-8e2e-12a3ac7edfb2.png">

~~I've struggled with testing the `isDomainRegistration( purchase )` path, since I don't know how to add a domain to a site without also adding a Plan. Some input in that regard would be welcome.~~

---
_Original info below_

We are looking into bringing in refund questionnaires into Calypso. Following the design by @breezyskies.

**Old Design**
<img width="935" alt="screen shot 2016-04-18 at 2 02 10 pm" src="https://cloud.githubusercontent.com/assets/273708/14619815/2cde193a-056e-11e6-9ec6-6b2f518191d1.png">

**New Design**
<img width="670" alt="screen shot 2016-04-18 at 2 01 17 pm" src="https://cloud.githubusercontent.com/assets/273708/14619783/0af37586-056e-11e6-9a6f-9a975224b5fb.png">
