### PR TITLE
client/boot: Replace `?sb`/`?sp` qs redirection by a `page.redirect()`

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -211,14 +211,19 @@ function reduxStoreReady( reduxStore ) {
 	}
 
 	// If `?sb` or `?sp` are present on the path set the focus of layout
-	// This needs to be done before the page.js router is started and can be removed when the legacy version is retired
-	if ( window && [ '?sb', '?sp' ].indexOf( window.location.search ) !== -1 ) {
-		layoutSection = ( window.location.search === '?sb' ) ? 'sidebar' : 'sites';
-		layoutFocus.set( layoutSection );
-		window.history.replaceState( null, document.title, window.location.pathname );
-	}
+	// This can be removed when the legacy version is retired.
+	page( '*', function( context, next ) {
+		if ( [ 'sb', 'sp' ].indexOf( context.querystring ) !== -1 ) {
+			layoutSection = ( context.querystring === 'sb' ) ? 'sidebar' : 'sites';
+			layoutFocus.set( layoutSection );
+			page.redirect( context.pathname );
+		}
+
+		next();
+	} );
 
 	setUpContext( reduxStore );
+
 	page( '*', require( 'lib/route/normalize' ) );
 
 	// warn against navigating from changed, unsaved forms


### PR DESCRIPTION
Instead of using `window.location` and `window.history`, use `page.js`'s `context.querystring` and `page.redirect()`, respectively. This allows for more flexibility, as we'll now be able to invoke other `page` middleware even before that. 

To test:
* Navigate to any Calypso url with `?sb` attached
* Verify that you're redirected to the same url without `?sb`
* Verify that the sidebar is highlighted
* Same for `?sp` (expands and highlights the list pages)