### PR TITLE
jetpack-connect: Open jetpack connect on wpcalypso and staging

### DIFF
--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -30,7 +30,7 @@ module.exports = function() {
 		page( '/log-in/:lang?', controller.login );
 	}
 
-	if ( config.isEnabled( 'jetpack/calypso-first-signup-flow' ) ) {
+	if ( config.isEnabled( 'jetpack/connect' ) ) {
 		page( '/jetpack/connect', jetpackConnectController.connect );
 		page(
 			'/jetpack/connect/authorize',

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -58,7 +58,7 @@ export default React.createClass( {
 				<StepHeader
 					headerText={ this.headerText() }
 					subHeaderText={ this.subHeaderText() }>
-					{ config.isEnabled( 'jetpack/calypso-first-signup-flow' )
+					{ config.isEnabled( 'jetpack/connect' )
 						? ( this.props.headerButton )
 						: null }
 				</StepHeader>

--- a/config/development.json
+++ b/config/development.json
@@ -36,7 +36,7 @@
 		"devdocs/redirect-loggedout-homepage": true,
 		"guidestours": true,
 		"help": true,
-		"jetpack/calypso-first-signup-flow": true,
+		"jetpack/connect": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"login": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,6 +19,7 @@
 		"community-translator": true,
 		"desktop-promo": true,
 		"help": true,
+		"jetpack/connect": true,
 		"jetpack_core_inline_update": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,

--- a/config/test.json
+++ b/config/test.json
@@ -34,7 +34,7 @@
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
 		"help": true,
-		"jetpack/calypso-first-signup-flow": true,
+		"jetpack/connect": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"login": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -21,6 +21,7 @@
 		"devdocs/redirect-loggedout-homepage": false,
 		"guidestours": true,
 		"help": true,
+		"jetpack/connect": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"login": false,


### PR DESCRIPTION
This pr changes the name of the feature flag to reflect the 'new' feature name and opens it in staging & wpcalypso so we can test it without running just in localhost

@roccotripaldi