### PR TITLE
Domains: decrease search delay to 1000

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -182,7 +182,7 @@ var RegisterDomainStep = React.createClass( {
 					placeholder={ this.translate( 'Enter a domain or keyword', { textOnly: true } ) }
 					autoFocus={ true }
 					delaySearch={ true }
-					delayTimeout={ 2000 }
+					delayTimeout={ 1000 }
 				/>
 			</div>
 		);


### PR DESCRIPTION
Now that we are using two APIs for domain search, we can increase the number of requests we do.

To test:
1. Go to domains/add/site
2. Search for a domain. It should work slightly faster than before.