### PR TITLE
Webpack: Move common modules in children into new common async chunk

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ var webpack = require( 'webpack' ),
  * Internal dependencies
  */
 var config = require( './server/config' ),
+	sections = require( './client/sections' ),
 	ChunkFileNamePlugin = require( './server/bundler/plugin' ),
 	PragmaCheckPlugin = require( 'server/pragma-checker' );
 
@@ -19,6 +20,8 @@ var config = require( './server/config' ),
 var CALYPSO_ENV = process.env.CALYPSO_ENV || 'development',
 	jsLoader,
 	webpackConfig;
+
+const sectionCount = sections.length;
 
 webpackConfig = {
 	cache: true,
@@ -93,8 +96,8 @@ if ( CALYPSO_ENV === 'desktop' || CALYPSO_ENV === 'desktop-mac-app-store' ) {
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( 'vendor', '[name].[hash].js' ) );
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( {
 		children: true,
-		minChunks: 5,
-		name: 'build-' + CALYPSO_ENV
+		minChunks: Math.floor( sectionCount * 0.25 ),
+		async: true
 	} ) );
 	webpackConfig.plugins.push( new ChunkFileNamePlugin() );
 	// jquery is only needed in the build for the desktop app

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,6 +91,11 @@ if ( CALYPSO_ENV === 'desktop' || CALYPSO_ENV === 'desktop-mac-app-store' ) {
 } else {
 	webpackConfig.entry.vendor = [ 'react', 'store', 'page', 'wpcom', 'jed', 'debug' ];
 	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( 'vendor', '[name].[hash].js' ) );
+	webpackConfig.plugins.push( new webpack.optimize.CommonsChunkPlugin( {
+		children: true,
+		minChunks: 5,
+		name: 'build-' + CALYPSO_ENV
+	} ) );
 	webpackConfig.plugins.push( new ChunkFileNamePlugin() );
 	// jquery is only needed in the build for the desktop app
 	// see electron bug: https://github.com/atom/electron/issues/254


### PR DESCRIPTION
Before:
```
                                        Asset     Size  Chunks             Chunk Names
                   me.e472e3b3b23fd3bfdf5c.js   109 kB      20  [emitted]  me
                  ads.606752b421394dd69afe.js  86.6 kB      22  [emitted]  ads
                 help.359357ba1e62728be0cf.js   204 kB      16  [emitted]  help
                media.966c5ccc443ac623784e.js   309 kB      13  [emitted]  media
                menus.c0db4a9923df8971c7ee.js   286 kB      14  [emitted]  menus
                plans.e7bdc9bd0844d612b764.js   240 kB      15  [emitted]  plans
                stats.eb87921d178b4efeb065.js   466 kB       8  [emitted]  stats
                theme.22f3a68df278078e0d1c.js   288 kB       2  [emitted]  theme
               people.7dc7de88210ca8d21335.js   339 kB      11  [emitted]  people
               reader.e9b30fc463d08f24326a.js   869 kB       0  [emitted]  reader
               signup.7623631fbcc7ad8f51d0.js   510 kB       1  [emitted]  signup
               vendor.3e5ebb5de2fcc51da904.js   927 kB      25  [emitted]  vendor
              account.4bb5d9fd67c2cf4846be.js   165 kB      19  [emitted]  account
              billing.b2e428c74185b0825cef.js   192 kB      17  [emitted]  billing
              plugins.3d4b2be68d3fe571d2d2.js   552 kB       6  [emitted]  plugins
              sharing.3800cd55ec6e5235c68e.js   282 kB      18  [emitted]  sharing
             security.57706613dd093c51ad07.js   368 kB       9  [emitted]  security
             settings.cc7da2f63fbb6e4e47ae.js   486 kB       7  [emitted]  settings
             upgrades.b4597d6d8aa0bfb94708.js   765 kB       5  [emitted]  upgrades
            customize.f06020e7df45f11f01d1.js  47.7 kB      23  [emitted]  customize
            purchases.0520f9d7181454491789.js   347 kB      10  [emitted]  purchases
           devmodules.167a0961ffdfc0b1f215.js  7.97 kB      26  [emitted]  devmodules
          post-editor.e9ea21a55a9c1489875a.js  2.94 MB       4  [emitted]  post-editor
          posts-pages.61ca5f78f7333a07aed1.js   323 kB       3  [emitted]  posts-pages
        accept-invite.93f20881cb724fd9bfa7.js   132 kB      21  [emitted]  accept-invite
        mailing-lists.697d864a7b49e2d364c5.js  10.8 kB      24  [emitted]  mailing-lists
     build-production.3e5ebb5de2fcc51da904.js  2.83 MB      27  [emitted]  build-production
notification-settings.06898c8646bfa3b7a0ad.js   277 kB      12  [emitted]  notification-settings
```

After:
```
                    0.9081fbc2a41d0d5395c0.js   258 kB       0  [emitted]
                   me.313406e59e3e09f2b1e9.js   1.9 kB      25  [emitted]  me
                  ads.de08eecaddcdb890a07b.js  47.7 kB      22  [emitted]  ads
                 help.dc1e4230b624079c7bef.js  69.1 kB      19  [emitted]  help
                media.cffbc677f8e1e70647f6.js   175 kB      16  [emitted]  media
                menus.d1af84be719ea49b227e.js   225 kB      12  [emitted]  menus
                plans.ddbc87e69b8b93806b8c.js   191 kB      13  [emitted]  plans
                stats.e084d05bbeb7d47bdb7c.js   381 kB       9  [emitted]  stats
                theme.a605a8073ba4afd7ec97.js   227 kB       3  [emitted]  theme
               people.210290c596b3dbe3c27b.js   232 kB      10  [emitted]  people
               reader.20711253e130b13c27cc.js   714 kB       1  [emitted]  reader
               signup.6f2add3b798c8ea1a324.js   437 kB       2  [emitted]  signup
               vendor.96dd8a31340bf2ecde59.js   927 kB      26  [emitted]  vendor
              account.d7e5c80d3a735ab7f26a.js  45.5 kB      23  [emitted]  account
              billing.13b8f4bf908efe8a496d.js  47.6 kB      20  [emitted]  billing
              plugins.79a5f645261461b9d9b5.js   493 kB       7  [emitted]  plugins
              sharing.bd2827d6ac72a2d851b8.js   239 kB      15  [emitted]  sharing
             security.c4072b5e3b70f399222a.js   227 kB      11  [emitted]  security
             settings.155d3cb2725984b71e41.js   378 kB       8  [emitted]  settings
             upgrades.91f0c9443ce4f48bbdde.js   696 kB       6  [emitted]  upgrades
            customize.93815a862394c8122fd1.js  39.7 kB      21  [emitted]  customize
            purchases.4df0590896ba08aef430.js   197 kB      14  [emitted]  purchases
           devmodules.79ef1f15a2adb43577a5.js  7.97 kB      27  [emitted]  devmodules
          post-editor.c841462720a63aff35cf.js  2.79 MB       5  [emitted]  post-editor
          posts-pages.2bb4d07ccbe95f45f15e.js   173 kB       4  [emitted]  posts-pages
        accept-invite.ce33b933fdbd0c27099d.js   127 kB      18  [emitted]  accept-invite
        mailing-lists.adc5554fe41a1d88f388.js  10.8 kB      24  [emitted]  mailing-lists
     build-production.96dd8a31340bf2ecde59.js  2.84 MB      28  [emitted]  build-production
notification-settings.bc4aeec0cca209859ff3.js  88.6 kB      17  [emitted]  notification-settings
```