### PR TITLE
Revert "Framework: Don't render layout for isomorphic sections in `client/boot`"

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -27,7 +27,6 @@ var config = require( 'config' ),
 	receiveUser = require( 'state/users/actions' ).receiveUser,
 	setCurrentUserId = require( 'state/current-user/actions' ).setCurrentUserId,
 	showGuidesTour = require( 'state/ui/actions' ).showGuidesTour,
-	isSectionIsomorphic = require( 'state/ui/selectors' ).isSectionIsomorphic,
 	sites = require( 'lib/sites-list' )(),
 	superProps = require( 'lib/analytics/super-props' ),
 	i18n = require( 'lib/mixins/i18n' ),
@@ -102,6 +101,7 @@ function setUpContext( reduxStore ) {
 		}
 
 		// set `context.query`
+		// debugger
 		const querystringStart = context.canonicalPath.indexOf( '?' );
 		if ( querystringStart !== -1 ) {
 			context.query = qs.parse( context.canonicalPath.substring( querystringStart + 1 ) );
@@ -161,8 +161,7 @@ function boot() {
 }
 
 function reduxStoreReady( reduxStore ) {
-	let layoutSection, layoutElement, validSections = [],
-		isIsomorphic = isSectionIsomorphic( reduxStore.getState() );
+	let layoutSection, layoutElement, validSections = [];
 
 	bindWpLocaleState( reduxStore );
 	bindTitleToStore( reduxStore );
@@ -181,6 +180,12 @@ function reduxStoreReady( reduxStore ) {
 		analytics.setSuperProps( superProps );
 	}
 
+	Layout = require( 'controller' ).ReduxWrappedLayout;
+
+	layoutElement = React.createElement( Layout, {
+		store: reduxStore
+	} );
+
 	if ( config.isEnabled( 'perfmon' ) ) {
 		// Record time spent watching slowly-flashing divs
 		perfmon();
@@ -190,25 +195,12 @@ function reduxStoreReady( reduxStore ) {
 		require( 'lib/network-connection' ).init( reduxStore );
 	}
 
-	// Render Layout only for non-isomorphic sections, unless logged-in.
-	// Isomorphic sections will take care of rendering their Layout last themselves,
-	// unless in logged-in mode, where we can't do that yet.
-	// TODO: Remove the ! user.get() check once isomorphic sections render their
-	// Layout themselves when logged in.
-	if ( ! isIsomorphic || user.get() ) {
-		Layout = require( 'controller' ).ReduxWrappedLayout;
+	ReactDom.render(
+		layoutElement,
+		document.getElementById( 'wpcom' )
+	);
 
-		layoutElement = React.createElement( Layout, {
-			store: reduxStore
-		} );
-
-		ReactDom.render(
-			layoutElement,
-			document.getElementById( 'wpcom' )
-		);
-
-		debug( 'Main layout rendered.' );
-	}
+	debug( 'Main layout rendered.' );
 
 	// If `?sb` or `?sp` are present on the path set the focus of layout
 	// This can be removed when the legacy version is retired.

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -74,7 +74,7 @@ export const ReduxWrappedLayout = ( { store, primary, secondary, tertiary } ) =>
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	page( route, ...middlewares, render );
+	page( route, ...[ ...middlewares, render ] );
 }
 
 function render( context ) {

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -51,18 +51,6 @@ export function getSectionName( state ) {
 }
 
 /**
- * Returns true if the current section is isomorphic.
- *
- * @param  {Object}  state Global state tree
- * @return {bool}    True if current section is isomorphic
- *
- * @see client/sections
- */
-export function isSectionIsomorphic( state ) {
-	return get( state.ui.section, 'isomorphic', false );
-}
-
-/**
  * Returns the current state for Guided Tours.
  *
  * This includes the raw state from state/ui/guidesTour, but also the available

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -10,7 +10,6 @@ import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSectionName,
-	isSectionIsomorphic,
 	getGuidesTourState,
 } from '../selectors';
 import guidesToursConfig from 'guidestours/config';
@@ -91,36 +90,6 @@ describe( 'selectors', () => {
 			} );
 
 			expect( sectionName ).to.equal( 'post-editor' );
-		} );
-	} );
-
-	describe( '#isSectionIsomorphic()', () => {
-		it( 'should return false if there is no section currently selected', () => {
-			const selected = isSectionIsomorphic( {
-				ui: {
-					section: false
-				}
-			} );
-
-			expect( selected ).to.be.false;
-		} );
-
-		it( 'should return true if current section is isomorphic', () => {
-			const section = {
-				enableLoggedOut: true,
-				group: 'sites',
-				isomorphic: true,
-				module: 'my-sites/themes',
-				name: 'themes',
-				paths: [ '/design' ],
-				secondary: false
-			};
-
-			const selected = isSectionIsomorphic( {
-				ui: { section }
-			} );
-
-			expect( selected ).to.be.true;
 		} );
 	} );
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#4836