### PR TITLE
Signup: Fix oveflow bug on processing screen

### DIFF
--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -2,6 +2,7 @@
 	margin: 0 auto;
 	min-width: 200px;
 	max-width: 450px;
+	min-height: 140px + 48px;
 	padding-left: 188px;
 	position: relative;
 


### PR DESCRIPTION
Adding a min-height to the processing step card to ensure there’s always enough room for the illustration.

Here's the bug in action on `master`:

<img width="489" alt="68747470733a2f2f636c6f756475702e636f6d2f63595f52577a6b392d38592b" src="https://cloud.githubusercontent.com/assets/191598/14645997/d88d7dc2-0625-11e6-8741-834071dcf554.png">

This PR sets a min-height on the `.card` element to avoid it.

Fixes #4857 