### PR TITLE
Site Settings: standardized heading font styles

### DIFF
--- a/client/my-sites/exporter/advanced-settings.jsx
+++ b/client/my-sites/exporter/advanced-settings.jsx
@@ -68,7 +68,7 @@ const AdvancedSettings = React.createClass( {
 				<h1 className="exporter__advanced-settings-title">
 					{ this.translate( 'Select specific content to export' ) }
 				</h1>
-				<p>
+				<p className="exporter__advanced-settings-description">
 					{ this.translate(
 						'Use the options below to select a specific content ' +
 						'type to download. You can select Posts, Pages, ' +

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -40,11 +40,14 @@
 }
 
 .exporter__advanced-settings-title {
-	margin-bottom: 0.5em;
-
-	font-size: 22px;
-	font-weight: 200;
+	font-size: 21px;
+	font-weight: 300;
 	color: $gray-dark;
+	margin-bottom: 16px;
+}
+
+.exporter__advanced-settings-description {
+	font-size: 14px;
 }
 
 .exporter__advanced-settings-row {
@@ -70,7 +73,7 @@
 }
 
 .exporter__option-fieldset-description {
-	font-size: smaller;
+	font-size: 14px;
 	color: $gray;
 	padding-left: 24px;
 	padding-right: 24px;

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -3,17 +3,15 @@
 }
 
 .exporter__title {
-	margin-bottom: 0.5em;
-
-	font-size: 24px;
+	font-size: 21px;
 	font-weight: 300;
 	color: $gray-dark;
-
+	margin-bottom: 16px;
 	clear: left;
 }
 
 .exporter__subtitle {
-	font-size: 11px;
+	font-size: 14px;
 	color: $gray-dark;
 }
 

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -11,11 +11,11 @@
 }
 
 .importer__section-title {
-	margin-bottom: 1em;
-
-	font-size: 24px;
-	font-weight: 200;
+	font-size: 21px;
+	font-weight: 300;
+	line-height: 24px;
 	color: $gray-dark;
+	margin-bottom: 16px;
 }
 
 .importer__section-description {
@@ -42,7 +42,7 @@
 	&.medium {
 		background-color: #00AB6C;
 	}
-	
+
 	@include breakpoint(">960px") {
 		width: 56px;
 		height: 56px;
@@ -58,7 +58,7 @@
 
 .importer__service-title {
 	font-size: 21px;
-	font-weight: 200;
+	font-weight: 300;
 	color: $gray;
 
 	@include breakpoint(">480px") {


### PR DESCRIPTION
Across the General, Import, and Export settings we had three or four different heading styles for h1, some other things for h2, and different sizes for descriptive text.

I made them all the same as the site deletion stuff.

**Before:**
<img width="759" alt="screen shot 2016-04-19 at 4 02 05 pm" src="https://cloud.githubusercontent.com/assets/437258/14653843/f68bc73e-0648-11e6-92cd-c01d59c73c82.png">
<img width="736" alt="screen shot 2016-04-19 at 4 02 17 pm" src="https://cloud.githubusercontent.com/assets/437258/14653845/f6919ede-0648-11e6-9b70-2d0dd493b327.png">
<img width="765" alt="screen shot 2016-04-19 at 4 03 14 pm" src="https://cloud.githubusercontent.com/assets/437258/14653844/f68fcb90-0648-11e6-90ab-df5d0f71649d.png">

**After:**
<img width="759" alt="screen shot 2016-04-19 at 4 02 05 pm" src="https://cloud.githubusercontent.com/assets/437258/14653858/07110880-0649-11e6-9a86-646da3b70307.png">
<img width="746" alt="screen shot 2016-04-19 at 4 07 14 pm" src="https://cloud.githubusercontent.com/assets/437258/14653860/07238ffa-0649-11e6-84c9-13dfea4b6c0b.png">
<img width="744" alt="screen shot 2016-04-19 at 4 07 22 pm" src="https://cloud.githubusercontent.com/assets/437258/14653859/0714574c-0649-11e6-8ae8-d62e763602a5.png">