### PR TITLE
Plugins: Fixes broken 'Purchase' buttons

### DIFF
--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
-
 import BusinessPlugin from './plugin-types/business-plugin';
 import PurchaseButton from './purchase-button';
 
@@ -11,7 +10,8 @@ export const BusinessPluginsPanel = React.createClass( {
 	render() {
 		const {
 			isActive = false,
-			plugins = []
+			plugins = [],
+			slug
 		} = this.props;
 
 		const cardClasses = classNames( 'wpcom-plugins__business-panel', {
@@ -21,7 +21,7 @@ export const BusinessPluginsPanel = React.createClass( {
 		return (
 			<div>
 				<SectionHeader label={ this.translate( 'Business Plan Upgrades' ) }>
-					<PurchaseButton { ...{ isActive } } />
+					<PurchaseButton { ...{ isActive, slug } } />
 				</SectionHeader>
 
 				<Card className={ cardClasses }>

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -44,7 +44,7 @@ export const PluginPanel = React.createClass( {
 			plan,
 			siteSlug
 		} = this.props;
-		
+
 		const standardPluginsLink = `/plugins/standard/${ siteSlug }`;
 
 		const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
@@ -66,8 +66,8 @@ export const PluginPanel = React.createClass( {
 					{ this.translate( 'View all standard plugins' ) }
 				</Card>
 
-				<PremiumPluginsPanel plugins={ premiumPlugins } isActive={ hasPremium }/>
-				<BusinessPluginsPanel plugins={ businessPlugins } isActive={ hasBusiness }/>
+				<PremiumPluginsPanel plugins={ premiumPlugins } isActive={ hasPremium } slug={ siteSlug } />
+				<BusinessPluginsPanel plugins={ businessPlugins } isActive={ hasBusiness } slug={ siteSlug } />
 			</div>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 
 import Card from 'components/card';
 import SectionHeader from 'components/section-header';
-
 import PremiumPlugin from './plugin-types/premium-plugin';
 import PurchaseButton from './purchase-button';
 
@@ -11,7 +10,8 @@ export const PremiumPluginsPanel = React.createClass( {
 	render() {
 		const {
 			isActive = false,
-			plugins = []
+			plugins = [],
+			slug
 		} = this.props;
 
 		const cardClasses = classNames( 'wpcom-plugins__premium-panel', {
@@ -21,7 +21,7 @@ export const PremiumPluginsPanel = React.createClass( {
 		return (
 			<div>
 				<SectionHeader label={ this.translate( 'Premium Plan Upgrades' ) }>
-					<PurchaseButton { ...{ isActive } } />
+					<PurchaseButton { ...{ isActive, slug } } />
 				</SectionHeader>
 
 				<Card className={ cardClasses }>

--- a/client/my-sites/plugins-wpcom/purchase-button.jsx
+++ b/client/my-sites/plugins-wpcom/purchase-button.jsx
@@ -2,8 +2,14 @@ import React, { PropTypes } from 'react';
 
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
+import page from 'page';
 
 export const PurchaseButton = React.createClass( {
+	showPlansPage() {
+		const { slug } = this.props;
+		page( `/plans/${ slug }` );
+	},
+
 	render() {
 		const { isActive } = this.props;
 
@@ -15,7 +21,7 @@ export const PurchaseButton = React.createClass( {
 			);
 		}
 
-		return <Button compact primary>{ this.translate( 'Purchase' ) }</Button>;
+		return <Button compact primary onClick={ this.showPlansPage }>{ this.translate( 'Purchase' ) }</Button>;
 	}
 } );
 


### PR DESCRIPTION
Pass the site slug to the premium and business panels, and use it to open the plans page for the site.

Refs #4572