### PR TITLE
Editor: clear pending setTimeout to avoid setState error.

### DIFF
--- a/client/post-editor/editor-permalink/index.jsx
+++ b/client/post-editor/editor-permalink/index.jsx
@@ -41,6 +41,10 @@ var EditorPermalink = React.createClass( {
 		}
 	},
 
+	componentWillUnmount: function() {
+		clearTimeout( this.dismissCopyConfirmation );
+	},
+
 	showPopover: function() {
 		this.setState( {
 			showPopover: ! this.state.showPopover,


### PR DESCRIPTION
Fixes #4868 - this branch adds a simple clearing of a timeout to prevent a `setState` error from happening.

__To Test__
1. Open an existing post in the editor
2. Click the permalink icon next to the title
3. Click "Copy" to copy the link to your clipboard
4. Click on "My Sites" and ensure no errors appear in the console