### PR TITLE
Plugins: Use wpcom.js plugins stuff instead of wpcom-undocumened

### DIFF
--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -9,7 +9,7 @@ var debug = require( 'debug' )( 'calypso:my-sites:plugins:actions' ),
 var analytics = require( 'lib/analytics' ),
 	Dispatcher = require( 'dispatcher' ),
 	utils = require( 'lib/site/utils' ),
-	wpcom = require( 'lib/wp' ).undocumented();
+	wpcom = require( 'lib/wp' );
 
 var _actionsQueueBySite = {},
 	PluginsActions;
@@ -49,7 +49,7 @@ function queueSitePluginAction( action, siteId, pluginId, callback ) {
 		nextAction = _actionsQueueBySite[ siteId ].shift();
 
 		if ( nextAction ) {
-			nextAction.action( nextAction.siteId, nextAction.pluginId, next.bind( this, nextAction.callback ) );
+			nextAction.action( next.bind( this, nextAction.callback ) );
 		} else {
 			delete _actionsQueueBySite[ siteId ];
 		}
@@ -64,9 +64,49 @@ function queueSitePluginAction( action, siteId, pluginId, callback ) {
 		} );
 	} else {
 		_actionsQueueBySite[ siteId ] = [];
-		action( siteId, pluginId, next.bind( this, callback ) );
+		action( next.bind( this, callback ) );
 	}
 }
+
+/**
+ * Return plugin id depending if the site is a jetpack site
+ *
+ * @param {Object} site - site object
+ * @param {Object} plugin - plugin object
+ * @return {String} plugin if
+ */
+const getPluginId = ( site, plugin ) => {
+	return site.jetpack ? plugin.id : plugin.slug;
+};
+
+/**
+ * Return a SitePlugin instance used to handle the plugin
+ *
+ * @param {Object} site - site object
+ * @param {String} pluginId - plugin identifier
+ * @return {SitePlugin} SitePlugin instance
+ */
+const getPluginHandler = ( site, pluginId ) => {
+	const siteHandler = wpcom.site( site.ID );
+	const pluginHandler = site.jetpack
+		? siteHandler.plugin( pluginId )
+		: siteHandler.wpcomPlugin( pluginId );
+
+	return pluginHandler;
+};
+
+/**
+ * Return the bound plugin method
+ *
+ * @param {Object} site - site object
+ * @param {String} pluginId - plugin identifier
+ * @param {String} method - plugin method to bind
+ * @return {Function} bound function
+ */
+const getPluginBoundMethod = ( site, pluginId, method ) => {
+	const handler = getPluginHandler( site, pluginId );
+	return handler[ method ].bind( handler );
+};
 
 function recordEvent( eventType, plugin, site, error ) {
 	if ( error ) {
@@ -113,9 +153,11 @@ function autoupdatePlugin( site, plugin ) {
 		site: site.ID,
 		plugin: plugin.slug
 	} );
+
 	analytics.mc.bumpStat( 'calypso_plugin_update_automatic' );
 
-	queueSitePluginAction( wpcom.pluginsUpdate.bind( wpcom ), site.ID, plugin.id, function( error, data ) {
+	const boundEnableAU = getPluginBoundMethod( site, plugin.id, 'enableAutoupdate' );
+	queueSitePluginAction( boundEnableAU, site.ID, plugin.id, ( error, data ) => {
 		Dispatcher.handleServerAction( {
 			type: 'RECEIVE_AUTOUPDATE_PLUGIN',
 			action: 'AUTOUPDATE_PLUGIN',
@@ -148,8 +190,8 @@ PluginsActions = {
 
 			return;
 		}
-		const endpoint = site.jetpack ? wpcom.plugins : wpcom.wpcomPlugins;
-		endpoint.call( wpcom, site.ID, ( error, data ) => {
+
+		const receivePluginsDispatcher = ( error, data ) => {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_PLUGINS',
 				action: 'RECEIVE_PLUGINS',
@@ -160,7 +202,13 @@ PluginsActions = {
 			if ( ! error ) {
 				processAutoupdates( site, data.plugins );
 			}
-		} );
+		};
+
+		if ( site.jetpack ) {
+			wpcom.site( site.ID ).pluginsList( receivePluginsDispatcher );
+		} else {
+			wpcom.site( site.ID ).wpcomPluginsList( receivePluginsDispatcher );
+		}
 	},
 
 	updatePlugin: function( site, plugin ) {
@@ -183,7 +231,8 @@ PluginsActions = {
 			plugin: plugin
 		} );
 
-		queueSitePluginAction( wpcom.pluginsUpdate.bind( wpcom ), site.ID, plugin.id, function( error, data ) {
+		const boundUpdate = getPluginBoundMethod( site, plugin.id, 'updateVersion' );
+		queueSitePluginAction( boundUpdate, site.ID, plugin.id, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_UPDATED_PLUGIN',
 				action: 'UPDATE_PLUGIN',
@@ -197,33 +246,38 @@ PluginsActions = {
 	},
 
 	installPlugin: function( site, plugin ) {
-		var install, update, activate, autoupdate, dispatchMessage, manageError, manageSuccess;
-
 		if ( ! site.canUpdateFiles ) {
-			return getRejectedPromise( 'Error: Can\'t update files on the site' )
+			return getRejectedPromise( 'Error: Can\'t update files on the site' );
 		}
 
 		if ( ! utils.userCan( 'manage_options', site ) ) {
-			return getRejectedPromise( 'Error: User can\'t manage the site' )
+			return getRejectedPromise( 'Error: User can\'t manage the site' );
 		}
 
-		install = function() {
-			return queueSitePluginActionAsPromise( wpcom.pluginsInstall.bind( wpcom ), site.ID, plugin.slug );
+		const install = () => {
+			const bound = getPluginBoundMethod( site, plugin.id, 'install' );
+			return queueSitePluginActionAsPromise( bound, site.ID, plugin.slug );
 		};
 
-		update = function( pluginData ) {
-			return queueSitePluginActionAsPromise( wpcom.pluginsUpdate.bind( wpcom ), site.ID, pluginData.id );
+		const update = pluginData => {
+			const { id } = pluginData;
+			const bound = getPluginBoundMethod( site, id, 'updateVersion' );
+			return queueSitePluginActionAsPromise( bound, site.ID, id );
 		};
 
-		activate = function( pluginData ) {
-			return queueSitePluginActionAsPromise( wpcom.pluginsActivate.bind( wpcom ), site.ID, pluginData.id );
+		const activate = pluginData => {
+			const { id } = pluginData;
+			const bound = getPluginBoundMethod( site, id, 'activate' );
+			return queueSitePluginActionAsPromise( bound, site.ID, id );
 		};
 
-		autoupdate = function( pluginData ) {
-			return queueSitePluginActionAsPromise( wpcom.enableAutoupdates.bind( wpcom ), site.ID, pluginData.id );
+		const autoupdate = pluginData => {
+			const { id } = pluginData;
+			const bound = getPluginBoundMethod( site, id, 'enableAutoupdate' );
+			return queueSitePluginActionAsPromise( bound, site.ID, pluginData.id );
 		};
 
-		dispatchMessage = function( type, responseData, error ) {
+		const dispatchMessage = function( type, responseData, error ) {
 			var message = {
 				type: type,
 				action: 'INSTALL_PLUGIN',
@@ -236,16 +290,17 @@ PluginsActions = {
 				Dispatcher.handleViewAction( message );
 				return;
 			}
+
 			Dispatcher.handleServerAction( message );
 			recordEvent( 'calypso_plugin_installed', plugin, site, error );
 		};
 
-		manageSuccess = function( responseData ) {
+		const manageSuccess = function( responseData ) {
 			dispatchMessage( 'RECEIVE_INSTALLED_PLUGIN', responseData );
 			return responseData;
 		};
 
-		manageError = function( error ) {
+		const manageError = function( error ) {
 			if ( error.name === 'PluginAlreadyInstalledError' ) {
 				if ( site.isMainNetworkSite() ) {
 					return update( plugin )
@@ -269,7 +324,7 @@ PluginsActions = {
 
 			dispatchMessage( 'RECEIVE_INSTALLED_PLUGIN', null, error );
 			return error;
-		}
+		};
 
 		dispatchMessage( 'INSTALL_PLUGIN' );
 
@@ -279,6 +334,7 @@ PluginsActions = {
 				.then( manageSuccess )
 				.catch( manageError );
 		}
+
 		return install()
 			.then( activate )
 			.then( autoupdate )
@@ -287,11 +343,10 @@ PluginsActions = {
 	},
 
 	removePlugin: function( site, plugin ) {
-		var remove, deactivate, disableAutoupdate, dispatchMessage;
-
 		if ( ! site.canUpdateFiles || ! utils.userCan( 'manage_options', site ) ) {
 			return;
 		}
+
 		Dispatcher.handleViewAction( {
 			type: 'REMOVE_PLUGIN',
 			action: 'REMOVE_PLUGIN',
@@ -299,8 +354,8 @@ PluginsActions = {
 			plugin: plugin
 		} );
 
-		dispatchMessage = function( type, responseData, error ) {
-			var message = {
+		const dispatchMessage = ( type, responseData, error ) => {
+			const message = {
 				type: type,
 				action: 'REMOVE_PLUGIN',
 				site: site,
@@ -313,20 +368,26 @@ PluginsActions = {
 			recordEvent( 'calypso_plugin_removed', plugin, site, error );
 		};
 
-		remove = function( pluginData ) {
-			return queueSitePluginActionAsPromise( wpcom.pluginsDelete.bind( wpcom ), site.ID, pluginData.id );
+		const remove = pluginData => {
+			const { id } = pluginData;
+			const bound = getPluginBoundMethod( site, id, 'delete' );
+			return queueSitePluginActionAsPromise( bound, site.ID, id );
 		};
 
-		deactivate = function( pluginData ) {
+		const deactivate = pluginData => {
 			if ( pluginData.active ) {
-				return queueSitePluginActionAsPromise( wpcom.pluginsDeactivate .bind( wpcom ), site.ID, pluginData.id );
+				const { id } = pluginData;
+				const bound = getPluginBoundMethod( site, id, 'deactivate' );
+				return queueSitePluginActionAsPromise( bound, site.ID, id );
 			}
 			return getSolvedPromise( pluginData );
 		};
 
-		disableAutoupdate = function( pluginData ) {
+		const disableAutoupdate = pluginData => {
 			if ( pluginData.autoupdate ) {
-				return queueSitePluginActionAsPromise( wpcom.disableAutoupdates.bind( wpcom ), site.ID, pluginData.id );
+				const { id } = pluginData;
+				const bound = getPluginBoundMethod( site, id, 'disableAutoupdate' );
+				return queueSitePluginActionAsPromise( bound, site.ID, id );
 			}
 			return getSolvedPromise( pluginData );
 		};
@@ -339,9 +400,6 @@ PluginsActions = {
 	},
 
 	activatePlugin: function( site, plugin ) {
-		var endpoint = site.jetpack ? wpcom.pluginsActivate : wpcom.activateWpcomPlugin,
-			pluginId = site.jetpack ? plugin.id : plugin.slug;
-
 		Dispatcher.handleViewAction( {
 			type: 'ACTIVATE_PLUGIN',
 			action: 'ACTIVATE_PLUGIN',
@@ -349,7 +407,11 @@ PluginsActions = {
 			plugin: plugin
 		} );
 
-		queueSitePluginAction( endpoint.bind( wpcom ), site.ID, pluginId, function( error, data ) {
+		const pluginId = getPluginId( site, plugin );
+		const pluginHandler = getPluginHandler( site, pluginId );
+		const activate = pluginHandler.activate.bind( pluginHandler );
+
+		queueSitePluginAction( activate, site.ID, pluginId, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_ACTIVATED_PLUGIN',
 				action: 'ACTIVATE_PLUGIN',
@@ -359,9 +421,14 @@ PluginsActions = {
 				error: error
 			} );
 
-			// Sometime data can be empty or the plugin always return the active state even when the error is empty.
+			// Sometime data can be empty or the plugin always
+			// return the active state even when the error is empty.
 			// Activation error is ok, because it means the plugin is already active
-			if ( ( error && error.error !== 'activation_error' ) || ( ! ( data && data.active ) && ! error ) ) {
+			if (
+				( error && error.error !== 'activation_error' ) ||
+				( ! ( data && data.active ) &&
+				! error )
+			) {
 				analytics.mc.bumpStat( 'calypso_plugin_activated', 'failed' );
 				analytics.tracks.recordEvent( 'calypso_plugin_activated_error', {
 					error: error && error.error ? error.error : 'Undefined activation error',
@@ -371,6 +438,7 @@ PluginsActions = {
 
 				return;
 			}
+
 			analytics.mc.bumpStat( 'calypso_plugin_activated', 'succeeded' );
 			analytics.tracks.recordEvent( 'calypso_plugin_activated_success', {
 				site: site.ID,
@@ -380,9 +448,6 @@ PluginsActions = {
 	},
 
 	deactivatePlugin: function( site, plugin ) {
-		var endpoint = site.jetpack ? wpcom.pluginsDeactivate : wpcom.deactivateWpcomPlugin,
-			pluginId = site.jetpack ? plugin.id : plugin.slug;
-
 		Dispatcher.handleViewAction( {
 			type: 'DEACTIVATE_PLUGIN',
 			action: 'DEACTIVATE_PLUGIN',
@@ -390,8 +455,12 @@ PluginsActions = {
 			plugin: plugin
 		} );
 
+		const pluginId = getPluginId( site, plugin );
+		const pluginHandler = getPluginHandler( site, pluginId );
+		const deactivate = pluginHandler.deactivate.bind( pluginHandler );
+
 		// make the API Request
-		queueSitePluginAction( endpoint.bind( wpcom ), site.ID, pluginId, function( error, data ) {
+		queueSitePluginAction( deactivate, site.ID, pluginId, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_DEACTIVATED_PLUGIN',
 				action: 'DEACTIVATE_PLUGIN',
@@ -400,7 +469,9 @@ PluginsActions = {
 				data: data,
 				error: error
 			} );
-			// Sometime data can be empty or the plugin always return the active state even when the error is empty.
+
+			// Sometime data can be empty or the plugin always
+			// return the active state even when the error is empty.
 			// Activation error is ok, because it means the plugin is already active
 			if ( error && error.error !== 'deactivation_error' ) {
 				analytics.mc.bumpStat( 'calypso_plugin_deactivated', 'failed' );
@@ -444,7 +515,8 @@ PluginsActions = {
 			plugin: plugin
 		} );
 
-		queueSitePluginAction( wpcom.enableAutoupdates.bind( wpcom ), site.ID, plugin.id, function( error, data ) {
+		const boundEnableAU = getPluginBoundMethod( site, plugin.id, 'enableAutoupdate' );
+		queueSitePluginAction( boundEnableAU, site.ID, plugin.id, ( error, data ) => {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_ENABLED_AUTOUPDATE_PLUGIN',
 				action: 'ENABLE_AUTOUPDATE_PLUGIN',
@@ -465,6 +537,7 @@ PluginsActions = {
 		if ( ! utils.userCan( 'manage_options', site ) || ! site.canAutoupdateFiles ) {
 			return;
 		}
+
 		Dispatcher.handleViewAction( {
 			type: 'DISABLE_AUTOUPDATE_PLUGIN',
 			action: 'DISABLE_AUTOUPDATE_PLUGIN',
@@ -473,7 +546,8 @@ PluginsActions = {
 		} );
 
 		// make the API Request
-		queueSitePluginAction( wpcom.disableAutoupdates.bind( wpcom ), site.ID, plugin.id, function( error, data ) {
+		const disableAA = getPluginBoundMethod( site, plugin.id, 'disableAutoupdate' );
+		queueSitePluginAction( disableAA, site.ID, plugin.id, function( error, data ) {
 			Dispatcher.handleServerAction( {
 				type: 'RECEIVE_DISABLED_AUTOUPDATE_PLUGIN',
 				action: 'DISABLE_AUTOUPDATE_PLUGIN',

--- a/client/lib/plugins/test/mocks/wpcom.js
+++ b/client/lib/plugins/test/mocks/wpcom.js
@@ -6,7 +6,77 @@ var pluginsInstallCalls = 0,
 	pluginsRemoveCalls = 0,
 	lastRequestParams = null,
 	deactivatedCallbacks = false,
+
+	wpcomPluginMock = {
+		deactivate: function( callback ) {
+			pluginsDeactivateCalls++;
+			callback();
+		},
+
+		delete: function( site, plugin, callback ) {
+			pluginsRemoveCalls++;
+			callback();
+		},
+
+	},
+
+	pluginMock = {
+		activate: function( callback ) {
+			pluginsActivateCalls++;
+			callback();
+		},
+
+		deactivate: function( callback ) {
+			pluginsDeactivateCalls++;
+			callback();
+		},
+
+		enableAutoupdate: function( callback ) {
+			pluginsAutoupdateCalls++;
+			callback();
+		},
+
+		disableAutoupdate: function( callback ) {
+			pluginsDisableAutoupdateCalls++;
+			callback();
+		},
+
+		delete: function( site, plugin, callback ) {
+			pluginsRemoveCalls++;
+			callback();
+		},
+
+		install: function( callback ) {
+			pluginsInstallCalls++;
+
+			if ( ! deactivatedCallbacks ) {
+				callback( null, {
+					code: 200,
+					headers: [ { name: 'Content-Type', value: 'application/json' } ],
+					body: {}
+				} );
+			}
+		}
+	},
+
+	siteMock = {
+		plugin: function( pluginId ) {
+			console.log( 'Create %s plugin', pluginId );
+			return pluginMock;
+		},
+
+		wpcomPlugin: function( pluginId ) {
+			console.log( 'Create %s wpcom plugin', pluginId );
+			return wpcomPluginMock;
+		}
+	},
+
 	mock = {
+		site: function( siteId ) {
+			console.log( 'Create %s site', siteId );
+			return siteMock;
+		},
+
 		reset: function() {
 			pluginsAutoupdateCalls = 0;
 			pluginsActivateCalls = 0;
@@ -30,54 +100,9 @@ var pluginsInstallCalls = 0,
 			};
 		},
 
-		pluginsInstall: function( site, plugin, callback ) {
-			pluginsInstallCalls++;
-			lastRequestParams = {
-				site: site,
-				plugin: plugin
-			};
-			if ( ! deactivatedCallbacks ) {
-				callback( null, {
-					code: 200,
-					headers: [ { name: 'Content-Type', value: 'application/json' } ],
-					body: {}
-				} );
-			}
-		},
-
-		pluginsActivate: function( site, plugin, callback ) {
-			pluginsActivateCalls++;
-			callback();
-		},
-
-		enableAutoupdates: function( site, plugin, callback ) {
-			pluginsAutoupdateCalls++;
-			callback();
-		},
-
-		pluginsDeactivate: function( site, plugin, callback ) {
-			pluginsDeactivateCalls++;
-			callback();
-		},
-
-		disableAutoupdates: function( site, plugin, callback ) {
-			pluginsDisableAutoupdateCalls++;
-			callback();
-		},
-
-		deactivateWpcomPlugin: function() {
-			pluginsDeactivateCalls++;
-		},
-
-		pluginsDelete: function( site, plugin, callback ) {
-			pluginsRemoveCalls++;
-			callback();
-		},
-
 		undocumented: function() {
 			return mock;
 		}
-
 	};
 
 module.exports = mock;

--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -47,7 +47,9 @@ if ( config.isEnabled( 'support-user' ) ) {
 
 // expose wpcom global var only in development
 if ( 'development' === config( 'env' ) ) {
+	let wpcomPKG = require( 'wpcom/package' );
 	window.wpcom = wpcom;
+	window.wpcom.__version = wpcomPKG.version;
 }
 
 // Inject localization helpers to `wpcom` instance

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -58,48 +58,6 @@ Undocumented.prototype.mailingList = function( category ) {
 };
 
 /*
- * Plugins data from the site with id siteId
- *
- * @param {int} [siteId]
- * @param {Function} fn
- * @api public
- */
-Undocumented.prototype.plugins = function( siteId, fn ) {
-	debug( '/sites/:site_id:/plugins query' );
-	this.wpcom.req.get( '/sites/' + siteId + '/plugins', fn );
-};
-
-/*
- * Activate the plugin with pluginSlug on the site with id siteId
- *
- * @param {int} [siteId]
- * @param {string} [pluginSlug]
- * @param {Function} fn
- * @api public
- */
-Undocumented.prototype.pluginsActivate = function( siteId, pluginSlug, fn ) {
-	debug( '/sites/:site_id:/plugins/:plugin_slug query' );
-	this.wpcom.req.post( { path: '/sites/' + siteId + '/plugins/' + encodeURIComponent( pluginSlug ) }, {}, {
-		active: true
-	}, fn );
-};
-
-/*
- * Deactivate the plugin with pluginSlug on the site with id siteId
- *
- * @param {int} [siteId]
- * @param {string} [pluginSlug]
- * @param {Function} fn
- * @api public
- */
-Undocumented.prototype.pluginsDeactivate = function( siteId, pluginSlug, fn ) {
-	debug( '/sites/:site_id:/plugins/:plugin_slug query' );
-	this.wpcom.req.post( { path: '/sites/' + siteId + '/plugins/' + encodeURIComponent( pluginSlug ) }, {}, {
-		active: false
-	}, fn );
-};
-
-/*
  * Jetpack modules data from the site with id siteId
  *
  * @param {int} [siteId]
@@ -147,79 +105,6 @@ Undocumented.prototype.jetpackModulesDeactivate = function( siteId, moduleSlug, 
 Undocumented.prototype.updateWordPressCore = function( siteId, fn ) {
 	debug( '/sites/:site_id:/core/update query' );
 	this.wpcom.req.post( { path: '/sites/' + siteId + '/core/update' }, fn );
-};
-
-/**
- * Update the plugin with the pluginSlug on the site with id siteId
- *
- * @param {int} [siteId] The site ID
- * @param {string} [pluginSlug] The slug for the plugin
- * @param {Function} fn The callback function
- * @api public
- */
-Undocumented.prototype.pluginsUpdate = function( siteId, pluginSlug, fn ) {
-	debug( '/sites/:site_id:/plugins/:plugin_slug/update query' );
-	this.wpcom.req.post( { path: '/sites/' + siteId + '/plugins/' + encodeURIComponent( pluginSlug ) + '/update' }, fn );
-};
-
-/**
- * Install the plugin with the pluginSlug on the site with id siteId
- *
- * @param {int} [siteId] The site ID
- * @param {string} [pluginSlug] The slug for the plugin
- * @param {Function} fn The callback function
- * @api public
- */
-Undocumented.prototype.pluginsInstall = function( siteId, pluginSlug, fn ) {
-	debug( '/sites/:site_id:/plugins/:plugin_slug/install query' );
-	this.wpcom.req.post( {
-		path: '/sites/' + siteId + '/plugins/' + encodeURIComponent( pluginSlug ) + '/install',
-		method: 'post'
-	}, fn );
-};
-
-/**
- * Remove the plugin with the pluginSlug on the site with id siteId
- *
- * @param {int} [siteId] The Site ID
- * @param {string} [pluginSlug] The slug for the plugin
- * @param {Function} fn The callback function
- * @api public
- */
-Undocumented.prototype.pluginsDelete = function( siteId, pluginSlug, fn ) {
-	debug( '/sites/:site_id:/plugins/:plugin_slug/delete query' );
-	this.wpcom.req.post( {
-		path: '/sites/' + siteId + '/plugins/' + encodeURIComponent( pluginSlug ) + '/delete',
-		method: 'post'
-	}, fn );
-};
-
-/**
- * Enable autoupdates on plugin with pluginSlug on the site with siteId
- * @param {int} [siteId] The site ID
- * @param {string} [pluginSlug] The slug for the plugin
- * @param {Function} fn The callback function
- * @api public
- */
-Undocumented.prototype.enableAutoupdates = function( siteId, pluginSlug, fn ) {
-	debug( '/sites/:site_id:/plugins/:plugin_slug query' );
-	this.wpcom.req.post( { path: '/sites/' + siteId + '/plugins/' + encodeURIComponent( pluginSlug ) }, {}, {
-		autoupdate: true
-	}, fn );
-};
-
-/**
- * Disable autoupdates on plugin with pluginSlug on the site with siteId
- * @param {int} [siteId] The site ID
- * @param {string} [pluginSlug] The slug for the plugin
- * @param {Function} fn The callback function
- * @api public
- */
-Undocumented.prototype.disableAutoupdates = function( siteId, pluginSlug, fn ) {
-	debug( '/sites/:site_id:/plugins/:plugin_slug query' );
-	this.wpcom.req.post( { path: '/sites/' + siteId + '/plugins/' + encodeURIComponent( pluginSlug ) }, {}, {
-		autoupdate: false
-	}, fn );
 };
 
 /**
@@ -1528,46 +1413,6 @@ Undocumented.prototype.activateTheme = function( theme, siteId, fn ) {
 	}, fn );
 };
 
-/*
- * Retrieve plugins data from the .com site with id siteId
- *
- * @param {int} [siteId]
- * @param {Function} fn
- * @api public
- */
-Undocumented.prototype.wpcomPlugins = function( siteId, fn ) {
-	debug( '/sites/:site_id:/wpcom-plugins query' );
-	this.wpcom.req.get( '/sites/' + siteId + '/wpcom-plugins', fn );
-};
-
-/*
- * Activate the .com plugin for the given site.
- *
- * @param {int} [siteId]
- * @param {string} [pluginSlug]
- * @param {Function} fn
- * @api public
- */
-Undocumented.prototype.activateWpcomPlugin = function( siteId, pluginSlug, fn ) {
-	debug( '/sites/:site_id:/wpcom-plugins/:plugin_slug query' );
-	this.wpcom.req.post( { path: '/sites/' + siteId + '/wpcom-plugins/' + encodeURIComponent( pluginSlug ) },
-		{}, { active: true }, fn );
-};
-
-/*
- * Deactivate the .com plugin for the given site.
- *
- * @param {int} [siteId]
- * @param {string} [pluginSlug]
- * @param {Function} fn
- * @api public
- */
-Undocumented.prototype.deactivateWpcomPlugin = function( siteId, pluginSlug, fn ) {
-	debug( '/sites/:site_id:/wpcom-plugins/:plugin_slug query' );
-	this.wpcom.req.post( { path: '/sites/' + siteId + '/wpcom-plugins/' + encodeURIComponent( pluginSlug ) },
-		{}, { active: false }, fn );
-};
-
 Undocumented.prototype.emailForwards = function( domain, callback ) {
 	this.wpcom.req.get( '/domains/' + domain + '/email', function( error, response ) {
 		if ( error ) {
@@ -1654,7 +1499,7 @@ Undocumented.prototype.deleteDns = function( domain, record, fn ) {
 };
 
 Undocumented.prototype.fetchWapiDomainInfo = function( domainName, fn ) {
-	this.wpcom.req.get( '/domains/' + domainName + '/status', fn )
+	this.wpcom.req.get( '/domains/' + domainName + '/status', fn );
 };
 
 Undocumented.prototype.requestTransferCode = function( options, fn ) {
@@ -1942,7 +1787,7 @@ Undocumented.prototype.getExport = function( siteId, exportId, fn ) {
 		apiVersion: '1.1',
 		path: `/sites/${ siteId }/exports/${ exportId }`
 	}, fn );
-}
+};
 
 Undocumented.prototype.timezones = function( params, fn ) {
 	if ( typeof params === 'function' ) {
@@ -1952,7 +1797,7 @@ Undocumented.prototype.timezones = function( params, fn ) {
 
 	let query = Object.assign( {}, params, { apiNamespace: 'wpcom/v2' } );
 	return this.wpcom.req.get( '/timezones', query, fn );
-}
+};
 
 /**
  * Check different info about WordPress and Jetpack status on a url
@@ -1974,7 +1819,7 @@ Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters ) {
 	}
 
 	return this.wpcom.req.get( `${ endpointUrl }`, params );
-}
+};
 
 /**
  * Post an url to be stored under user's settings,
@@ -1987,7 +1832,7 @@ Undocumented.prototype.storeJetpackConnectUrl = function( targetUrl ) {
 	return this.wpcom.req.post( { path: '/me/settings' }, {}, {
 		jetpack_connect: targetUrl
 	} );
-}
+};
 
 /**
  * Exports the user's Reader feed as an OPML XML file.

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -17,8 +17,7 @@ var Site = require( './site' ),
 	Me = require( './me' ),
 	MailingList = require( './mailing-list' ),
 	config = require( 'config' ),
-	i18n = require( 'lib/i18n-utils' ),
-	moment = require( 'moment' );
+	i18n = require( 'lib/i18n-utils' );
 
 /**
  * Some endpoints are restricted by OAuth client IDs and secrets
@@ -1978,10 +1977,11 @@ Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters ) {
 }
 
 /**
- * Post an url to be stored under user's settings, so we can know that they have started a jetpack-connect flow for that site
+ * Post an url to be stored under user's settings,
+ * so we can know that they have started a jetpack-connect flow for that site
  *
  * @param {String} targetUrl          The url of the site to store
- * @returns {Promise}
+ * @returns {Promise} Promise
  */
 Undocumented.prototype.storeJetpackConnectUrl = function( targetUrl ) {
 	return this.wpcom.req.post( { path: '/me/settings' }, {}, {


### PR DESCRIPTION
After bump `wpcom@4.9.7` we can start to remove plugins methods defined in wpcom-undocument internal library.
This PR removes `wpcom-undocumented` plugins methods used to make requests to WP.com and uses directly methods defined in `wpcom.js`.

### Testing

1) Go to jetpack testing site

2) Make the following plugin actions:
  * Install
  * Remove
  * Activate
  * Deactivate
  * EnableAutoupdate
  * DisableAutoUpdate

Uses batch process

3) Run plugins test

```cli
cd client/lib/plugins
make
```