### PR TITLE
Domains: show info notice when user has domain credit

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -82,4 +82,14 @@ module.exports = {
 		defaultVariation: 'original',
 		allowExistingUsers: true,
 	},
+	domainCreditsInfoNotice: {
+		datestamp: '20160420',
+		variations: {
+			showNotice: 90,
+			original: 10
+		},
+		defaultVariation: 'showNotice',
+		allowExistingUsers: true,
+		allowAnyLocale: true
+	}
 };

--- a/client/my-sites/upgrades/domain-management/controller.jsx
+++ b/client/my-sites/upgrades/domain-management/controller.jsx
@@ -49,7 +49,7 @@ module.exports = {
 
 		renderWithReduxStore(
 			<DomainManagementData
-				component={ DomainManagement.List }
+				component={ DomainManagement.List.default }
 				context={ pageContext }
 				productsList={ productsList }
 				sites={ sites } />,

--- a/client/my-sites/upgrades/domain-management/list/test/index.js
+++ b/client/my-sites/upgrades/domain-management/list/test/index.js
@@ -83,7 +83,7 @@ describe( 'upgrades/domain-management/list', function() {
 	}
 
 	beforeEach( function() {
-		DomainList = require( '../' );
+		DomainList = require( '../' ).List;
 	} );
 
 	describe( 'regular cases', function() {

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -1,9 +1,32 @@
+/**
+ * External dependencies
+ */
+import find from 'lodash/find';
+
+/**
+ * Internal dependencies
+ */
 import { initialSiteState } from './reducer';
 
 export function getPlansBySite( state, site ) {
 	if ( ! site ) {
 		return initialSiteState;
 	}
+	return getPlansBySiteId( state, site.ID );
+}
 
-	return state.sites.plans[ site.ID ] || initialSiteState;
+export function getPlansBySiteId( state, siteId ) {
+	if ( ! siteId ) {
+		return initialSiteState;
+	}
+	return state.sites.plans[ siteId ] || initialSiteState;
+}
+
+export function hasDomainCredit( state, siteId ) {
+	const plans = getPlansBySiteId( state, siteId );
+	if ( plans.data ) {
+		const currentPlan = find( plans.data, 'currentPlan' );
+		return currentPlan.hasDomainCredit;
+	}
+	return null;
 }

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getPlansBySite,
+	getPlansBySiteId,
+	hasDomainCredit
+} from '../selectors';
+
+describe( 'selectors', () => {
+	describe( '#getPlansBySite()', () => {
+		it( 'should return plans by site', () => {
+			const plans1 = { data: [ { currentPlan: false }, { currentPlan: false }, { currentPlan: true } ] };
+			const plans2 = { data: [ { currentPlan: true }, { currentPlan: false }, { currentPlan: false } ] };
+			const state = {
+				sites: {
+					plans: {
+						2916284: plans1,
+						77203074: plans2
+					}
+				}
+			};
+			const plans = getPlansBySite( state, { ID: 77203074 } );
+
+			expect( plans ).to.eql( plans2 );
+		} );
+	} );
+	describe( '#getPlansBySiteId()', () => {
+		it( 'should return plans by site id', () => {
+			const plans1 = { data: [ { currentPlan: false }, { currentPlan: false }, { currentPlan: true } ] };
+			const plans2 = { data: [ { currentPlan: true }, { currentPlan: false }, { currentPlan: false } ] };
+			const state = {
+				sites: {
+					plans: {
+						2916284: plans1,
+						77203074: plans2
+					}
+				}
+			};
+			const plans = getPlansBySiteId( state, 2916284 );
+
+			expect( plans ).to.eql( plans1 );
+		} );
+	} );
+	describe( '#hasDomainCredit()', () => {
+		it( 'should return if plan has domain credit', () => {
+			const state = {
+				sites: {
+					plans: {
+						2916284: {
+							data: [ { currentPlan: false }, { currentPlan: false }, { currentPlan: true, hasDomainCredit: false } ]
+						},
+						77203074: {
+							data: [ { currentPlan: false }, { currentPlan: true, hasDomainCredit: true }, { currentPlan: false } ]
+						}
+
+					}
+				}
+			};
+
+			expect( hasDomainCredit( state, 77203074 ) ).to.equal( true );
+			expect( hasDomainCredit( state, 2916284 ) ).to.equal( false );
+		} );
+	} );
+} );

--- a/client/tests.json
+++ b/client/tests.json
@@ -553,7 +553,7 @@
 				"test": [ "actions", "reducer", "selectors" ]
 			},
 			"plans": {
-				"test": [ "actions", "reducer" ]
+				"test": [ "actions", "reducer", "selectors" ]
 			},
 			"test": [ "actions", "reducer", "selectors" ]
 		},


### PR DESCRIPTION
This PR adds an information notice to domains, when a user has purchased a plan upgrade but hasn't yet claimed their custom domain. Part of #4858
<img width="822" alt="reminder" src="https://cloud.githubusercontent.com/assets/1270189/14658496/e7fecd88-0648-11e6-8c35-e71e85b22321.png">

## Testing Instructions
- Turn on analytics debug: `localStorage.setItem('debug', 'calypso:analytics');`
- Upgrade a free site to premium or business
- Navigate to http://calypso.localhost:3000/domains and select your upgraded site
- Set the testing variant to: `localStorage.setItem('ABTests','{"domainCreditsInfoNotice_20160420":"showNotice"}')`
- Your upgraded site should see the notice, and other sites should not
- The following analytics events should fire:
<img width="828" alt="impression" src="https://cloud.githubusercontent.com/assets/1270189/14658553/7d714ada-0649-11e6-8837-29dadfb7b825.png">
<img width="1180" alt="click" src="https://cloud.githubusercontent.com/assets/1270189/14658576/b4a17f2a-0649-11e6-82ff-3c21bf8b22f8.png">
- Set the testing variant to:
`localStorage.setItem('ABTests','{"domainCreditsInfoNotice_20160420":"original"}')`
- Navigate to http://calypso.localhost:3000/domains and select your upgraded site
- Notice does not display, but the following analytics event fires:
<img width="941" alt="screen shot 2016-04-20 at 8 33 20 am" src="https://cloud.githubusercontent.com/assets/1270189/14680561/973da56a-06d2-11e6-8def-c2e71c8c4140.png">


cc @rralian @mtias @dmsnell @artpi @retrofox @adambbecker