### PR TITLE
Test: Move client/auth test to single test runner

### DIFF
--- a/client/auth/Makefile
+++ b/client/auth/Makefile
@@ -1,7 +1,0 @@
-REPORTER ?= spec
-MOCHA ?= ../../node_modules/.bin/mocha
-
-test:
-	@NODE_ENV=test NODE_PATH=test:../../client $(MOCHA) --compilers jsx:babel/register --reporter $(REPORTER)
-
-.PHONY: test

--- a/client/tests.json
+++ b/client/tests.json
@@ -1,4 +1,7 @@
 {
+	"auth": {
+		"test": [ "login" ]
+	},
 	"components": {
 		"count": {
 			"test": [ "index" ]


### PR DESCRIPTION
Last piece of #3942!

This one was a bit problematic, but I wanted to get rid it out of the migration list asap :)

When executing I see this warning:
> Warning: ReactDOMComponent: Do not access .props of a DOM node; instead, recreate the props as `render` did originally or read the DOM properties/attributes directly from this node (e.g., this.refs.box.className). This DOM node was rendered by `Button`.

It would be nice to fix it, but it's not essential this week :) We could also refactor it to use enzyme, which would most likely solve it, but I had issues with React loading several times when I played with `mount` helper.

### Testing
* `npm run test-client`
* `npm run test-client client/auth/test/login.jsx -- -w`

/cc @aduth @blowery @umurkontaci