### PR TITLE
Upgrades: Data-Driven stats Like nudge

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -65,6 +65,15 @@ module.exports = {
 		defaultVariation: 'drake',
 		allowExistingUsers: true,
 	},
+	statsTabsLikesNudge: {
+		datestamp: '20160427',
+		variations: {
+			dataInformedBelowChart: 10,
+			noNudge: 90
+		},
+		defaultVariation: 'noNudge',
+		allowExistingUsers: true
+	},
 	swapButtonsMySiteSidebar: {
 		datestamp: '20160414',
 		variations: {

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -15,6 +15,9 @@ import analytics from 'lib/analytics';
 import observe from 'lib/mixins/data-observe';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import Card from 'components/card';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
+import { abtest } from 'lib/abtest';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 export default React.createClass( {
 	displayName: 'StatModuleChartTabs',
@@ -210,6 +213,25 @@ export default React.createClass( {
 		return chartData;
 	},
 
+	renderNudge: function() {
+		if ( abtest( 'statsTabsLikesNudge' ) === 'dataInformedBelowChart' ) {
+			return (
+				<UpgradeNudge
+					title={ this.translate( 'Sites with Premium get 31% more likes' ) }
+					message={ this.translate( 'Premium plan owners get a domain, custom design, and on avarage 31% more likes!' ) }
+					event={ 'stats_likes_31_more' }
+				/>
+			);
+		} else {
+			return (
+				<TrackComponentView
+					eventName={ 'calypso_upgrade_nudge_hide' }
+					eventProperties={ { cta_name: 'stats_likes_31_more' } }
+				/>
+			);
+		}
+	},
+
 	render: function() {
 		var data = this.buildChartData(),
 			activeTab = this.getActiveTab(),
@@ -237,12 +259,15 @@ export default React.createClass( {
 		}
 
 		return (
-			<Card className={ classNames.apply( null, classes ) }>
-				<Legend tabs={ this.props.charts } activeTab={ activeTab } availableCharts={ availableCharts } activeCharts={ this.state.activeLegendCharts } clickHandler={ this.onLegendClick } />
-				<StatsModulePlaceholder className="is-chart" isLoading={ activeTabLoading } />
-				<ElementChart loading={ activeTabLoading } data={ data } barClick={ this.props.barClick } />
-				<StatTabs dataList={ visitsList } tabs={ this.props.charts } switchTab={ this.props.switchTab } selectedTab={ this.props.chartTab } activeIndex={ this.props.queryDate } activeKey="period" />
-			</Card>
+			<div>
+				<Card className={ classNames.apply( null, classes ) }>
+					<Legend tabs={ this.props.charts } activeTab={ activeTab } availableCharts={ availableCharts } activeCharts={ this.state.activeLegendCharts } clickHandler={ this.onLegendClick } />
+					<StatsModulePlaceholder className="is-chart" isLoading={ activeTabLoading } />
+					<ElementChart loading={ activeTabLoading } data={ data } barClick={ this.props.barClick } />
+					<StatTabs dataList={ visitsList } tabs={ this.props.charts } switchTab={ this.props.switchTab } selectedTab={ this.props.chartTab } activeIndex={ this.props.queryDate } activeKey="period" />
+				</Card>
+				{ this.props.chartTab === 'likes' && this.renderNudge() }
+			</div>
 		);
 	}
 } );

--- a/client/my-sites/upgrade-nudge/style.scss
+++ b/client/my-sites/upgrade-nudge/style.scss
@@ -11,6 +11,10 @@
 	.button {
 		margin-left: auto;
 	}
+
+	&.is-no-margin {
+		margin: 0;
+	}
 }
 
 .upgrade-nudge__icon {


### PR DESCRIPTION
## Based on true data

Implements #4888

Updated visuals (25.04):  

![zrzut ekranu 2016-04-25 o 18 09 47](https://cloud.githubusercontent.com/assets/3775068/14790618/42bb29f6-0b12-11e6-882b-feaa7ebc5c10.png)


### Testing

- Put yourself in a test: `localStorage.setItem('ABTests','{"statsTabsLikesNudge_20160424":"dataInformedBelowChart"}')`
- http://calypso.localhost:3000/stats/year/artpitesting.wordpress.com?tab=likes

CC @mtias @rralian @gwwar @adambbecker @retrofox