### PR TITLE
Plans: define and expose plan constants

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -18,6 +18,8 @@ var activeTests = require( './active-tests' ),
 	wpcom = require( 'lib/wp' ),
 	sites = require( 'lib/sites-list' )();
 
+import { PLAN_FREE } from 'lib/plans/constants';
+
 function ABTest( name ) {
 	if ( ! ( this instanceof ABTest ) ) {
 		return new ABTest( name );
@@ -116,7 +118,7 @@ ABTest.prototype.isEligibleForAbTest = function() {
 		return false;
 	}
 
-	if ( this.excludeSitesWithPaidPlan && selectedSite && selectedSite.plan.product_slug !== 'free_plan' ) {
+	if ( this.excludeSitesWithPaidPlan && selectedSite && selectedSite.plan.product_slug !== PLAN_FREE ) {
 		debug( '%s: Site with paid plan detected when excludeSitesWithPaidPlan is set to true', this.experimentId );
 		return false;
 	}
@@ -165,7 +167,7 @@ ABTest.prototype.hasBeenInPreviousSeriesTest = function() {
 
 ABTest.prototype.hasRegisteredBeforeTestBegan = function() {
 	return user.get() && i18n.moment( user.get().date ).isBefore( this.startDate );
-}
+};
 
 ABTest.prototype.getSavedVariation = function() {
 	return getSavedVariations()[ this.experimentId ] || null;

--- a/client/lib/media/validation-store.js
+++ b/client/lib/media/validation-store.js
@@ -14,6 +14,7 @@ import emitter from 'lib/mixins/emitter';
 import Sites from 'lib/sites-list';
 import MediaUtils from './utils';
 import { ValidationErrors as MediaValidationErrors } from './constants';
+import { PLAN_FREE } from 'lib/plans/constants';
 
 /**
  * Module variables
@@ -59,7 +60,7 @@ function validateItem( siteId, item ) {
 	}
 
 	if ( ! MediaUtils.isSupportedFileTypeForSite( item, site ) ) {
-		if ( get( site, 'plan.product_slug' ) === 'free_plan' && MediaUtils.isSupportedFileTypeInPremium( item, site ) ) {
+		if ( get( site, 'plan.product_slug' ) === PLAN_FREE && MediaUtils.isSupportedFileTypeInPremium( item, site ) ) {
 			itemErrors.push( MediaValidationErrors.FILE_TYPE_NOT_IN_PLAN );
 		} else {
 			itemErrors.push( MediaValidationErrors.FILE_TYPE_UNSUPPORTED );
@@ -118,7 +119,7 @@ function receiveServerError( siteId, itemId, errors ) {
 					return MediaValidationErrors.NOT_ENOUGH_SPACE;
 				}
 				if ( error.message.indexOf( 'You have used your space quota' ) === 0 ) {
-					return MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT
+					return MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT;
 				}
 				return MediaValidationErrors.SERVER_ERROR;
 			default:

--- a/client/lib/plans-list/index.js
+++ b/client/lib/plans-list/index.js
@@ -1,20 +1,30 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:plans-list' ),
-	reject = require( 'lodash/reject' ),
-	store = require( 'store' );
+import debugFactory from 'debug';
+import reject from 'lodash/reject';
+import store from 'store';
 
 /**
  * Internal dependencies
  */
-var wpcom = require( 'lib/wp' ),
-	Emitter = require( 'lib/mixins/emitter' );
+import wpcom from 'lib/wp';
+import Emitter from 'lib/mixins/emitter';
+import {
+	PLAN_FREE,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS
+} from 'lib/plans/constants';
+
+/**
+ * Module vars
+ */
+const debug = debugFactory( 'calypso:plans-list' );
 
 /**
  * PlansList component
  *
- * @api public
+ * @return { PlansList } PlansList instance
  */
 function PlansList() {
 	if ( ! ( this instanceof PlansList ) ) {
@@ -32,15 +42,17 @@ Emitter( PlansList.prototype );
 /**
  * Set up a mapping from product_slug to a pretty path
  */
-var pathToSlugMapping = {
-	'beginner': 'free_plan',
-	'premium':  'value_bundle',
-	'business': 'business-bundle'
+const pathToSlugMapping = {
+	beginner: PLAN_FREE,
+	premium: PLAN_PREMIUM,
+	business: PLAN_BUSINESS
 };
 
 /**
  * Get list of plans from current object or store,
  * trigger fetch on first request to update stale data
+ *
+ * @return {Object} list of plans object
  */
 PlansList.prototype.get = function() {
 	var data;
@@ -84,12 +96,13 @@ PlansList.prototype.fetch = function() {
 
 		this.emit( 'change' );
 		store.set( 'PlansList', plans );
-
 	}.bind( this ) );
 };
 
 /**
  * Initialize data with Plan objects
+ *
+ * @param {Object} plans - plans data object
  **/
 PlansList.prototype.initialize = function( plans ) {
 	this.data = plans;
@@ -108,13 +121,18 @@ PlansList.prototype.parse = function( data ) {
 
 /**
  * Update plans list
- **/
+ *
+ * @param {Object} plans - plans data object
+ */
 PlansList.prototype.update = function( plans ) {
 	this.data = plans;
 };
 
 /**
  * Map the plan path to the product_slug
+ *
+ * @param {String} path - plan path
+ * @return {String} plan
  */
 PlansList.prototype.getSlugFromPath = function( path ) {
 	return pathToSlugMapping[ path ];
@@ -122,6 +140,9 @@ PlansList.prototype.getSlugFromPath = function( path ) {
 
 /**
  * Map the product_slug to the plan path
+ *
+ * @param {String} slug - product path
+ * @return {String} plan
  */
 PlansList.prototype.getPathFromSlug = function( slug ) {
 	return Object.keys( pathToSlugMapping ).filter( function( path ) {
@@ -131,14 +152,16 @@ PlansList.prototype.getPathFromSlug = function( slug ) {
 	} );
 };
 
-// Save the plans to memory to save them being fetched from the store every time the user switches sites
-var _plans;
+// Save the plans to memory to save them being fetched
+// from the store every time the user switches sites
+let _plans;
 
 /**
  * Expose `PlansList`
+ *
+ * @return {PlansList} plans list instance
  */
 module.exports = function() {
-
 	if ( ! _plans ) {
 		_plans = new PlansList();
 	}

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -1,58 +1,86 @@
 import i18n from 'lib/mixins/i18n';
 
+// plans constants
+export const PLAN_BUSINESS = 'business-bundle';
+export const PLAN_PREMIUM = 'value_bundle';
+export const PLAN_FREE = 'free_plan';
+export const PLAN_JETPACK_FREE = 'jetpack_free';
+export const PLAN_JETPACK_PREMIUM = 'jetpack_premium';
+export const PLAN_JETPACK_BUSINESS = 'jetpack_business';
+
+// features constants
+export const FEATURE_CUSTOM_DESIGN = 'custom-design';
+export const FEATURE_CUSTOM_DOMAIN = 'custom-domain';
+export const FEATURE_GOOGLE_ANALYTICS = 'google-analytics';
+export const FEATURE_LIVE_CHAT_SUPPORT = 'live-chat-support';
+export const FEATURE_NO_ADS = 'no-ads';
+export const FEATURE_UNLIMITED_PREMIUM_THEMES = 'unlimited-premium-themes';
+export const FEATURE_UNLIMITED_STORAGE = 'unlimited-storage';
+export const FEATURE_VIDEO_UPLOADS = 'video-upload';
+
 export const plansList = {
-	'free_plan': {
+	[ PLAN_FREE ]: {
 		getTitle: () => i18n.translate( 'Free' ),
 		getPriceTitle: () => i18n.translate( 'Free for life' )
 	},
-	'value_bundle': {
+
+	[ PLAN_PREMIUM ]: {
 		getTitle: () => i18n.translate( 'Premium' ),
 		getPriceTitle: () => i18n.translate( '$99 per year' )
 	},
-	'business-bundle': {
+
+	[ PLAN_BUSINESS ]: {
 		getTitle: () => i18n.translate( 'Business' ),
 		getPriceTitle: () => i18n.translate( '$299 per year' )
 	},
-	'jetpack_free': {},
-	'jetpack_business': {}
+
+	[ PLAN_JETPACK_FREE ]: {},
+	[ PLAN_JETPACK_BUSINESS ]: {}
 };
 
 const allPaidPlans = [
-	'value_bundle',
-	'business-bundle'
+	PLAN_PREMIUM,
+	PLAN_BUSINESS
 ];
 
 export const featuresList = {
-	'google-analytics': {
+	[ FEATURE_GOOGLE_ANALYTICS ]: {
 		getTitle: () => i18n.translate( 'Google Analytics' ),
-		plans: [ 'business-bundle' ]
+		plans: [ PLAN_BUSINESS ]
 	},
-	'unlimited-storage': {
+
+	[ FEATURE_UNLIMITED_STORAGE ]: {
 		getTitle: () => i18n.translate( 'Unlimited Storage' ),
-		plans: [ 'business-bundle' ]
+		plans: [ PLAN_BUSINESS ]
 	},
-	'custom-domain': {
+
+	[ FEATURE_CUSTOM_DOMAIN ]: {
 		getTitle: () => i18n.translate( 'Custom Domain' ),
 		plans: allPaidPlans
 	},
-	'unlimited-premium-themes': {
+
+	[ FEATURE_UNLIMITED_PREMIUM_THEMES ]: {
 		getTitle: () => i18n.translate( 'Unlimited Premium Themes' ),
-		plans: [ 'business-bundle' ]
+		plans: [ PLAN_BUSINESS ]
 	},
-	'video-upload': {
+
+	[ FEATURE_VIDEO_UPLOADS ]: {
 		getTitle: () => i18n.translate( 'VideoPress' ),
 		plans: allPaidPlans
 	},
-	'custom-design': {
+
+	[ FEATURE_CUSTOM_DESIGN ]: {
 		getTitle: () => i18n.translate( 'Custom Design' ),
 		plans: allPaidPlans
 	},
-	'no-ads': {
+
+	[ FEATURE_NO_ADS ]: {
 		getTitle: () => i18n.translate( 'No Ads' ),
 		plans: allPaidPlans
 	},
-	'live-chat-support': {
+
+	[ FEATURE_LIVE_CHAT_SUPPORT ]: {
 		getTitle: () => i18n.translate( 'Live Chat Support' ),
-		plans: [ 'business-bundle' ]
+		plans: [ PLAN_BUSINESS ]
 	}
 };

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -18,6 +18,7 @@ import {
 	isJetpackPlan
 } from 'lib/products-values';
 import { featuresList, plansList } from './constants';
+import { PLAN_FREE } from 'lib/plans/constants';
 import SitesList from 'lib/sites-list';
 const sitesList = SitesList();
 
@@ -77,34 +78,34 @@ export function getCurrentTrialPeriodInDays( plan ) {
 	}
 
 	return userFacingExpiryMoment.diff( subscribedDayMoment, 'days' );
-};
+}
 
 export function getDayOfTrial( plan ) {
 	const { subscribedDayMoment } = plan;
 
 	// we return the difference plus one day so that the first day is day 1 instead of day 0
 	return moment().startOf( 'day' ).diff( subscribedDayMoment, 'days' ) + 1;
-};
+}
 
 export function getDaysUntilUserFacingExpiry( plan ) {
 	const { userFacingExpiryMoment } = plan;
 
 	return userFacingExpiryMoment.diff( moment().startOf( 'day' ), 'days' );
-};
+}
 
 export function getDaysUntilExpiry( plan ) {
 	const { expiryMoment } = plan;
 
 	return expiryMoment.diff( moment().startOf( 'day' ), 'days' );
-};
+}
 
 export function isInGracePeriod( plan ) {
 	return getDaysUntilUserFacingExpiry( plan ) <= 0;
-};
+}
 
 export function shouldFetchSitePlans( sitePlans, selectedSite ) {
 	return ! sitePlans.hasLoadedFromServer && ! sitePlans.isRequesting && selectedSite;
-};
+}
 
 export function filterPlansBySiteAndProps( plans, site, hideFreePlan ) {
 	return plans.filter( function( plan ) {
@@ -112,10 +113,10 @@ export function filterPlansBySiteAndProps( plans, site, hideFreePlan ) {
 			return isJetpackPlan( plan ) && ! isFreeJetpackPlan( plan );
 		}
 
-		if ( hideFreePlan && 'free_plan' === plan.product_slug ) {
+		if ( hideFreePlan && PLAN_FREE === plan.product_slug ) {
 			return false;
 		}
 
 		return ! isJetpackPlan( plan );
 	} );
-};
+}

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -16,6 +16,7 @@ const user = require( 'lib/user' )();
 import { getSavedVariations } from 'lib/abtest';
 import SignupCart from 'lib/signup/cart';
 import { startFreeTrial } from 'lib/upgrades/actions';
+import { PLAN_PREMIUM } from 'lib/plans/constants';
 
 function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsCartItem, isPurchasingItem, siteUrl, themeSlug, themeItem } ) {
 	wpcom.undocumented().sitesNew( {
@@ -88,7 +89,7 @@ function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsC
 function startFreePremiumTrial( callback, dependencies, data ) {
 	const { siteId } = dependencies;
 
-	startFreeTrial( siteId, cartItems.planItem( 'value_bundle' ), ( error ) => {
+	startFreeTrial( siteId, cartItems.planItem( PLAN_PREMIUM ), ( error ) => {
 		if ( error ) {
 			callback( error, dependencies );
 		} else {

--- a/client/my-sites/plans/plan-feature/google-analytics.js
+++ b/client/my-sites/plans/plan-feature/google-analytics.js
@@ -16,12 +16,25 @@ import PlanCompareCard from 'my-sites/plan-compare-card';
 import PlanCompareCardItem from 'my-sites/plan-compare-card/item';
 import i18n from 'lib/mixins/i18n';
 import sitesList from 'lib/sites-list';
+
+import {
+	PLAN_BUSINESS,
+	FEATURE_CUSTOM_DESIGN,
+	FEATURE_CUSTOM_DOMAIN,
+	FEATURE_LIVE_CHAT_SUPPORT,
+	FEATURE_NO_ADS,
+	FEATURE_UNLIMITED_PREMIUM_THEMES,
+	FEATURE_UNLIMITED_STORAGE,
+	FEATURE_VIDEO_UPLOADS
+} from 'lib/plans/constants';
+
 import {
 	getFeatureTitle,
 	getSitePlanSlug,
 	planHasFeature,
 	getPlan
 } from 'lib/plans';
+
 import PlanFeatureFooter from './footer';
 
 const sites = sitesList();
@@ -48,17 +61,17 @@ export default function( context ) {
 	}
 
 	const featuresToShow = [
-		'unlimited-storage',
-		'unlimited-premium-themes',
-		'live-chat-support',
-		'custom-domain',
-		'no-ads',
-		'custom-design',
-		'video-upload'
+		FEATURE_UNLIMITED_STORAGE,
+		FEATURE_UNLIMITED_PREMIUM_THEMES,
+		FEATURE_LIVE_CHAT_SUPPORT,
+		FEATURE_CUSTOM_DOMAIN,
+		FEATURE_NO_ADS,
+		FEATURE_CUSTOM_DESIGN,
+		FEATURE_VIDEO_UPLOADS
 	];
 
 	let comparisonCard;
-	if ( planSlug === 'business-bundle' ) {
+	if ( planSlug === PLAN_BUSINESS ) {
 		comparisonCard = ( <Card href={ '/settings/analytics/' + site.slug }>{ i18n.translate( 'Configure Google Analytics' ) }</Card> );
 	} else if ( site.jetpack ) {
 		comparisonCard = ( <Card href={ site.URL + '/wp-admin' }>{ i18n.translate( 'Your site is a Jetpack site hosted on your own server. Most likely you can configure Google Analytics in your admin panel.' ) }</Card> );
@@ -84,8 +97,8 @@ export default function( context ) {
 					}
 				</PlanCompareCard>
 				<PlanCompareCard
-					title={ getPlan( 'business-bundle' ).getTitle() }
-					line={ getPlan( 'business-bundle' ).getPriceTitle() }
+					title={ getPlan( PLAN_BUSINESS ).getTitle() }
+					line={ getPlan( PLAN_BUSINESS ).getPriceTitle() }
 					buttonName={ i18n.translate( 'Upgrade' ) }
 					onClick={ checkoutBusinessPlan }
 					currentPlan={ false }

--- a/client/my-sites/plans/plan-feature/google-analytics.js
+++ b/client/my-sites/plans/plan-feature/google-analytics.js
@@ -18,6 +18,7 @@ import i18n from 'lib/mixins/i18n';
 import sitesList from 'lib/sites-list';
 
 import {
+	PLAN_FREE,
 	PLAN_BUSINESS,
 	FEATURE_CUSTOM_DESIGN,
 	FEATURE_CUSTOM_DOMAIN,
@@ -41,7 +42,7 @@ const sites = sitesList();
 
 export default function( context ) {
 	const site = sites.getSelectedSite();
-	const planSlug = ( site && site.ID ) ? getSitePlanSlug( site.ID ) : 'free_plan';
+	const planSlug = ( site && site.ID ) ? getSitePlanSlug( site.ID ) : PLAN_FREE;
 
 	const svgLogo = '<svg width="84" height="84" viewBox="0 0 84 84" xmlns="http://www.w3.org/2000/svg" style="overflow: visible;"><title>icon - google analytics</title><g fill="none" fill-rule="evenodd"><rect fill-opacity=".27" fill="#C8D7E1" x="4" y="4" width="80" height="80" rx="6"/><rect fill="#FFF" width="80" height="80" rx="6"/><path d="M45.16 49.896a8 8 0 1 1-14.137 4.477l-11.036-6.117A7.966 7.966 0 0 1 15 50c-.57 0-1.124-.06-1.66-.172L0 62.71v11.293A5.997 5.997 0 0 0 5.997 80h68.006A5.997 5.997 0 0 0 80 74.003V33.75l-12.512-8.127A7.963 7.963 0 0 1 63 27c-.76 0-1.495-.106-2.19-.304l-15.65 23.2z" stroke="#F05824" stroke-width="2" fill-opacity=".62" fill="#F05824"/><path d="M39.847 47.044A7.97 7.97 0 0 0 33.707 49l-10.773-5.97A8 8 0 1 0 8.292 46.36L0 54.37V5.996A5.997 5.997 0 0 1 5.997 0h68.006A5.997 5.997 0 0 1 80 5.997v20.597l-9.168-5.954a8 8 0 1 0-14.764 2.356l-16.22 24.048z" stroke="#F79A1F" stroke-width="2" fill-opacity=".68" fill="#F79A1F"/></g></svg>';
 

--- a/client/my-sites/upgrades/cart/cart-plan-ad.jsx
+++ b/client/my-sites/upgrades/cart/cart-plan-ad.jsx
@@ -11,11 +11,12 @@ import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
 import { isPlan } from 'lib/products-values';
 import * as upgradesActions from 'lib/upgrades/actions';
+import { PLAN_PREMIUM } from 'lib/plans/constants';
 
 const CartPlanAd = React.createClass( {
 	addToCartAndRedirect( event ) {
 		event.preventDefault();
-		upgradesActions.addItem( cartItems.premiumPlan( 'value_bundle', { isFreeTrial: false } ) );
+		upgradesActions.addItem( cartItems.premiumPlan( PLAN_PREMIUM, { isFreeTrial: false } ) );
 		page( '/checkout/' + this.props.selectedSite.slug );
 	},
 	shouldDisplayAd() {

--- a/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/free-trial-nudge.jsx
@@ -19,11 +19,10 @@ import {
 } from 'lib/products-values';
 import paths from 'my-sites/plans/paths';
 import PurchaseDetail from 'components/purchase-detail';
-import {
-	refreshSitePlans
-} from 'state/sites/plans/actions';
+import { refreshSitePlans } from 'state/sites/plans/actions';
 import { startFreeTrial } from 'lib/upgrades/actions';
 import * as upgradesNotices from 'lib/upgrades/notices';
+import { PLAN_PREMIUM } from 'lib/plans/constants';
 
 const FreeTrialNudge = React.createClass( {
 	propTypes: {
@@ -46,7 +45,7 @@ const FreeTrialNudge = React.createClass( {
 
 		this.setState( { isSubmitting: true } );
 
-		startFreeTrial( this.props.selectedSite.ID, cartItems.planItem( 'value_bundle' ), ( error ) => {
+		startFreeTrial( this.props.selectedSite.ID, cartItems.planItem( PLAN_PREMIUM ), ( error ) => {
 			if ( error ) {
 				this.setState( { isSubmitting: false } );
 


### PR DESCRIPTION
The goal in this PR is encourage to use plan constants instead of using directly strings.

### Incorrectly

```es6
const upgradeLink = `/plans/features/google-analytics/${ this.props.site.domain }`;
```

### Right way
```es6
import { FEATURE_GOOGLE_ANALYTICS } from 'lib/plans/constants';
const upgradeLink = `/plans/features/${ FEATURE_GOOGLE_ANALYTICS }/${ this.props.site.domain }`;
```

![](http://www.milenio.com/hey/cine/Jared_leto-Oscar-party_oscar-fiesta_oscar-vanity_fair_oscar_MILIMA20150223_0377_3.jpg)

#### Testing

Test all pages that are using these constants.