### PR TITLE
WPCOM Plugins: Navigation Exceptions

### DIFF
--- a/client/lib/plugins/store.js
+++ b/client/lib/plugins/store.js
@@ -206,7 +206,7 @@ PluginsStore = {
 			return [];
 		}
 
-		if ( plugins.filter && !! pluginFilter ) {
+		if ( plugins.filter && !! pluginFilter && _filters[ pluginFilter ] ) {
 			plugins = plugins.filter( _filters[ pluginFilter ] );
 		}
 		return plugins;

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -146,7 +146,7 @@ function renderProvisionPlugins() {
 
 controller = {
 	validateFilters: function( filter, context, next ) {
-		const wpcomFilters = [ 'standard', 'business', 'premium' ];
+		const wpcomFilter = 'standard';
 		const siteUrl = route.getSiteFragment( context.path );
 		const site = sites.getSelectedSite();
 		const appliedFilter = ( filter ? filter : context.params.plugin ).toLowerCase();
@@ -164,10 +164,10 @@ controller = {
 		 * if no site URL is provided, bail if a WordPress.com filter was provided.
 		 * Only Jetpack plugins should work when no URL is provided.
 		 */
-		if ( siteUrl && ( ( ! site.jetpack && ! includes( [ 'all' ].concat( wpcomFilters ), appliedFilter ) ) || ( site.jetpack && includes( wpcomFilters, appliedFilter ) ) ) ) {
+		if ( siteUrl && ( ( ! site.jetpack && ! includes( [ 'all', wpcomFilter ], appliedFilter ) ) || ( site.jetpack && appliedFilter === wpcomFilter ) ) ) {
 			page.redirect( '/plugins/' + siteUrl );
 			return;
-		} else if ( ! siteUrl && includes( wpcomFilters, appliedFilter ) ) {
+		} else if ( ! siteUrl && appliedFilter === wpcomFilter ) {
 			page.redirect( '/plugins' );
 			return;
 		}

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -5,6 +5,7 @@ var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	page = require( 'page' ),
 	some = require( 'lodash/some' ),
+	includes = require( 'lodash/includes' ),
 	capitalize = require( 'lodash/capitalize' );
 
 /**
@@ -147,7 +148,16 @@ controller = {
 
 	plugins: function( filter, context ) {
 		var basePath = route.sectionify( context.path ),
-			siteUrl = route.getSiteFragment( context.path );
+			siteUrl = route.getSiteFragment( context.path ),
+			site = sites.getSelectedSite();
+
+		if ( siteUrl && ( ( site.jetpack && ! includes( jetpackFilters, filter ) ) || ( ! site.jetpack && ! includes( wpcomFilters, filter ) ) ) ) {
+			page.redirect( '/plugins/' + siteUrl );
+			return;
+		} else if ( ! siteUrl && ! includes( jetpackFilters, filter ) ) {
+			page.redirect( '/plugins/' );
+			return;
+		}
 
 		context.params.pluginFilter = filter;
 		basePath = basePath.replace( '/' + filter, '' );
@@ -156,10 +166,16 @@ controller = {
 	},
 
 	plugin: function( context ) {
-		var siteUrl = route.getSiteFragment( context.path );
+		var siteUrl = route.getSiteFragment( context.path ),
+			site = sites.getSelectedSite();
 
 		if ( siteUrl && context.params.plugin && context.params.plugin === siteUrl.toString() ) {
 			controller.plugins( 'all', context );
+			return;
+		}
+
+		if ( siteUrl && ! site.jetpack ) {
+			page.redirect( '/plugins/' + siteUrl );
 			return;
 		}
 

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -149,10 +149,10 @@ controller = {
 		const wpcomFilters = [ 'standard', 'business', 'premium' ];
 		const siteUrl = route.getSiteFragment( context.path );
 		const site = sites.getSelectedSite();
-		filter || ( filter = context.params.plugin );
+		const appliedFilter = ( filter ? filter : context.params.plugin ).toLowerCase();
 
 		// bail if /plugins/:site_id?
-		if ( siteUrl && filter.toLowerCase() === siteUrl.toString().toLowerCase() ) {
+		if ( siteUrl && appliedFilter === siteUrl.toString().toLowerCase() ) {
 			next();
 			return;
 		}
@@ -164,10 +164,10 @@ controller = {
 		 * if no site URL is provided, bail if a WordPress.com filter was provided.
 		 * Only Jetpack plugins should work when no URL is provided.
 		 */
-		if ( siteUrl && ( ( ! site.jetpack && ! includes( [ 'all' ].concat( wpcomFilters ), filter.toLowerCase() ) ) || ( site.jetpack && includes( wpcomFilters, filter.toLowerCase() ) ) ) ) {
+		if ( siteUrl && ( ( ! site.jetpack && ! includes( [ 'all' ].concat( wpcomFilters ), appliedFilter ) ) || ( site.jetpack && includes( wpcomFilters, appliedFilter ) ) ) ) {
 			page.redirect( '/plugins/' + siteUrl );
 			return;
-		} else if ( ! siteUrl && includes( wpcomFilters, filter.toLowerCase() ) ) {
+		} else if ( ! siteUrl && includes( wpcomFilters, appliedFilter ) ) {
 			page.redirect( '/plugins' );
 			return;
 		}

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -10,13 +10,6 @@ var controller = require( 'my-sites/controller' ),
 	config = require( 'config' ),
 	pluginsController = require( './controller' );
 
-/**
- * Module variables
- */
-var pluginFilters = config.isEnabled( 'manage/plugins/wpcom' )
-	? [ 'active', 'inactive', 'updates', 'standard', 'premium', 'business' ]
-	: [ 'active', 'inactive', 'updates' ];
-
 module.exports = function() {
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
 		page( '/plugins/setup', controller.siteSelection, controller.navigation, pluginsController.setupPlugins );
@@ -29,7 +22,7 @@ module.exports = function() {
 
 		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
 
-		pluginFilters.forEach( function( filter ) {
+		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {
 			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
 		} );
 

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -20,12 +20,12 @@ module.exports = function() {
 		page( '/plugins/browse/:category/:site', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 		page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 
-		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
+		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.validateFilters.bind( null, 'all' ), pluginsController.plugins.bind( null, 'all' ) );
 
 		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {
-			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
+			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.validateFilters.bind( null, filter ), pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
 		} );
 
-		page( '/plugins/:plugin/:business_plugin?/:site_id?', controller.siteSelection, controller.navigation, pluginsController.plugin );
+		page( '/plugins/:plugin/:business_plugin?/:site_id?', controller.siteSelection, controller.navigation, pluginsController.validateFilters.bind( null, null ), pluginsController.plugin );
 	}
 };

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -10,6 +10,13 @@ var controller = require( 'my-sites/controller' ),
 	config = require( 'config' ),
 	pluginsController = require( './controller' );
 
+/**
+ * Module variables
+ */
+var pluginFilters = config.isEnabled( 'manage/plugins/wpcom' )
+	? [ 'active', 'inactive', 'updates', 'standard', 'premium', 'business' ]
+	: [ 'active', 'inactive', 'updates' ];
+
 module.exports = function() {
 	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
 		page( '/plugins/setup', controller.siteSelection, controller.navigation, pluginsController.setupPlugins );
@@ -22,7 +29,7 @@ module.exports = function() {
 
 		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
 
-		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {
+		pluginFilters.forEach( function( filter ) {
 			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
 		} );
 


### PR DESCRIPTION
Part of #4572 

Manages exceptions when triggering navigation to and from plugin lists or details page.

Tested scenarios:

| From | To |
| --- | --- |
| WordPress.com Site All Plugins Page | All Sites |
| WordPress.com Site All Plugins Page | Jetpack Site |
| WordPress.com Site All Plugins Page | WordPress.com Site |
| WordPress.com Site Stardard Plugins Page | All Sites |
| WordPress.com Site Stardard Plugins Page | Jetpack Site |
| WordPress.com Site Stardard Plugins Page | WordPress.com Site |
| Jetpack Site All Plugins Page | All Sites |
| Jetpack Site All Plugins Page | Jetpack Site |
| Jetpack Site All Plugins Page | WordPress.com Site |
| Jetpack Site Filtered Plugins Page | All Sites |
| Jetpack Site Filtered Plugins Page | Jetpack Site |
| Jetpack Site Filtered Plugins Page | WordPress.com Site |
| Jetpack Site Plugin Details Page | All Sites |
| Jetpack Site Plugin Details Page | Jetpack Site |
| Jetpack Site Plugin Details Page | WordPress.com Site |