### PR TITLE
Reader: Make UpdateNotice a proper anchor

### DIFF
--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -47,10 +47,10 @@ var UpdateNotice = React.createClass( {
 		} );
 
 		return (
-			<div className={ counterClasses } onTouchTap={ this.handleClick } >
+			<a className={ counterClasses } onTouchTap={ this.handleClick } >
 				<Gridicon icon="arrow-up" size={ 18 } />
 				{ this.translate( '%s new post', '%s new posts', { args: [ this.countString() ], count: this.props.count } ) }
-			</div>
+			</a>
 		);
 	},
 


### PR DESCRIPTION
`<UpdateNotice />` is rendered as a `div`, when it should be an `a`. This is good practice in general, and is good for accessibility.

No visual change, but navigating the Reader with a screen reader or a keyboard-navigation-enabled browser (_cf._ Vimium, vimprobable, etc.) should reveal that a user can now ask Calypso to show new posts without a cursor click.