### PR TITLE
Customizer: Fix premium theme purchases

### DIFF
--- a/client/my-sites/customize/actions.js
+++ b/client/my-sites/customize/actions.js
@@ -9,7 +9,7 @@ import defer from 'lodash/defer';
 import Dispatcher from 'dispatcher';
 import page from 'page';
 import wpcom from 'lib/wp';
-import CartActions from 'lib/upgrades/actions';
+import { addItem } from 'lib/upgrades/actions/cart';
 import ThemeHelper from '../themes/helpers';
 import { themeItem } from 'lib/cart-values/cart-items';
 
@@ -25,7 +25,7 @@ var CustomizeActions = {
 	},
 
 	purchase: function( id, site ) {
-		CartActions.addItem( themeItem( id, 'customizer' ) );
+		addItem( themeItem( id, 'customizer' ) );
 
 		ThemeHelper.trackClick( 'customizer', 'purchase' );
 


### PR DESCRIPTION
The flow for purchasing premium themes that are first previewed in the Customizer is broken and maybe has been for some time.

To test:

1. Pick a site in My Sites (that doesn't have an unlimited themes upgrade)
2. Click Themes
3. Preview a premium theme you don't own
4. Click the "Try & Customize" button
5. In the Customizer, click "Purchase ($n)"

In master, we just get an error and no action because `addItem` isn't being imported properly. This PR fixes that and everything works again.