### PR TITLE
Editor/CPT: Omit post format and featured image accordions if post type lacks support

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -139,6 +139,10 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderFeaturedImage: function() {
+		if ( ! this.currentPostTypeSupports( 'thumbnail' ) ) {
+			return;
+		}
+
 		return (
 			<Accordion
 				title={ this.translate( 'Featured Image' ) }

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -114,7 +114,8 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderPostFormats: function() {
-		if ( ! this.props.site || ! this.props.post ) {
+		if ( ! this.props.site || ! this.props.post ||
+				! this.currentPostTypeSupports( 'post-formats' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This pull request seeks to update the editor sidebar to exclude the featured image and post formats accordion items if the current post type does not support these features.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/14687818/63ecf536-070d-11e6-836a-cfd5219123eb.png)|![After](https://cloud.githubusercontent.com/assets/1779930/14687756/22643dc2-070d-11e6-9084-ada8233d7d14.png)

__Testing instructions:__

Verify that featured image and post format accordion presence matches support of the current post type (all types on WordPress.com support both, except Testimonials lacking post format support).

If you have a Jetpack site handy, you can quickly test support by installing the following plugin from zip: https://cloudup.com/files/i1uX4SkJwwq/download

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Note that sidebar accordions match expected post type support

__Follow-up tasks:__

- Post types can lack support for titles and/or the editor. These may be more involved to exclude from the page.