### PR TITLE
Adds page-view tracking to list of all standard wpcom plugins

### DIFF
--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 
 import HeaderCake from 'components/header-cake';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 
@@ -17,6 +18,7 @@ export const PluginsList = React.createClass( {
 
 		return (
 			<div className="wpcom-plugin-panel wpcom-plugins-expanded">
+				<PageViewTracker path="/plugins/standard/:site" title="Plugins > WPCOM Site > Standard Plugins" />
 				<HeaderCake backHref={ backHref } onClick={ noop }>Standard Plugins</HeaderCake>
 				<StandardPluginsPanel plugins={ defaultStandardPlugins } />
 			</div>


### PR DESCRIPTION
Previously, only the main plugins page for WordPress.com sites recorded
page views. If someone clicked on "See all standard plugins" then no
page view got recorded.

This has been added via the `<PageViewTracker />` component.

**This isn't tested yet**, as we are waiting for the routing to properly send the user to this page.

**Open Questions**
 - Is this the appropriate name for the analytics message?