### PR TITLE
WPCOM Plugins: Standard plugin list.

### DIFF
--- a/client/my-sites/plugins-wpcom/plugins-list.jsx
+++ b/client/my-sites/plugins-wpcom/plugins-list.jsx
@@ -8,6 +8,8 @@ import { getSiteSlug } from 'state/sites/selectors';
 
 import StandardPluginsPanel from './standard-plugins-panel';
 
+import { defaultStandardPlugins } from './default-plugins';
+
 export const PluginsList = React.createClass( {
 	render() {
 		const { siteSlug } = this.props;
@@ -16,7 +18,7 @@ export const PluginsList = React.createClass( {
 		return (
 			<div className="wpcom-plugin-panel wpcom-plugins-expanded">
 				<HeaderCake backHref={ backHref } onClick={ noop }>Standard Plugins</HeaderCake>
-				<StandardPluginsPanel />
+				<StandardPluginsPanel plugins={ defaultStandardPlugins } />
 			</div>
 		);
 	}

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -28,40 +28,7 @@ var route = require( 'lib/route' ),
  */
 var lastPluginsListVisited,
 	lastPluginsQuerystring,
-	controller,
-	pluginFilterTitles = {
-		defaultTitle() {
-			return i18n.translate( 'Plugins', { textOnly: true } );
-		},
-		// WordPress.com
-		standard() {
-			return i18n.translate( 'Standard Plugins', { textOnly: true } );
-		},
-		premium() {
-			return i18n.translate( 'Premium Plugins', { textOnly: true } );
-		},
-		business() {
-			return i18n.translate( 'Business Plugins', { textOnly: true } );
-		},
-		// JetPack Sites
-		active() {
-			return i18n.translate( 'Active Plugins', { textOnly: true } );
-		},
-		inactive() {
-			return i18n.translate( 'Inactive Plugins', { textOnly: true } );
-		},
-		updates() {
-			return i18n.translate( 'Plugin Updates', { textOnly: true } );
-		}
-	};
-
-function getTitle( filter ) {
-	if ( pluginFilterTitles.hasOwnProperty( filter ) ) {
-		return pluginFilterTitles[filter];
-	}
-
-	return pluginFilterTitles.defaultTitle;
-}
+	controller;
 
 function renderSinglePlugin( context, siteUrl ) {
 	var pluginSlug = decodeURIComponent( context.params.plugin ),
@@ -110,7 +77,7 @@ function renderPluginList( context, basePath, siteUrl ) {
 
 	lastPluginsListVisited = getPathWithoutSiteSlug( context, site );
 	lastPluginsQuerystring = context.querystring;
-	titleActions.setTitle( getTitle( context.params.pluginFilter )(), { siteID: siteUrl } );
+	titleActions.setTitle( i18n.translate( 'Plugins', { textOnly: true } ), { siteID: siteUrl } );
 
 	renderWithReduxStore(
 		React.createElement( PluginListComponent, {

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -20,12 +20,6 @@ module.exports = function() {
 		page( '/plugins/browse/:category/:site', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 		page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 
-		if ( config.isEnabled( 'manage/plugins/wpcom' ) ) {
-			[ 'standard', 'premium', 'business' ].forEach( function( filter ) {
-				page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );
-			} );
-		}
-
 		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.plugins.bind( null, 'all' ) );
 
 		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import debugModule from 'debug';
 import page from 'page';
 import uniq from 'lodash/uniq';
-import config from 'config';
+import upperFirst from 'lodash/upperFirst';
 
 /**
  * Internal dependencies
@@ -28,7 +28,7 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PluginSections from 'my-sites/plugins/plugin-sections';
 import pluginsAccessControl from 'my-sites/plugins/access-control';
 import EmptyContent from 'components/empty-content';
-import FeatureExample from 'components/feature-example'
+import FeatureExample from 'components/feature-example';
 import WpcomPluginsList from 'my-sites/plugins-wpcom/plugins-list';
 
 /**
@@ -115,7 +115,7 @@ const SinglePlugin = React.createClass( {
 	},
 
 	updatePageTitle() {
-		const pageTitle = this.state.plugin ? this.state.plugin.name : this.props.pluginSlug;
+		const pageTitle = upperFirst( this.state.plugin ? this.state.plugin.name : this.props.pluginSlug );
 		if ( _currentPageTitle === pageTitle ) {
 			return;
 		}


### PR DESCRIPTION
Plugins details page for WordPress.com sites is back.

This PR:

- rolls back https://github.com/Automattic/wp-calypso/pull/4865
- removes `standard`, `premium` and `business` routes that were using the wrong controller.
- fixes the page title for _Standard Plugins_ (https://github.com/Automattic/wp-calypso/pull/4865 original intention)
- loads the default standard plugins on the plugin list.