### PR TITLE
Invites: Use dynamic key for role select on invite form

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -82,7 +82,7 @@ const InvitePeople = React.createClass( {
 		if ( sendInvitesSuccess ) {
 			this.setState( this.resetState() );
 			analytics.tracks.recordEvent( 'calypso_invite_people_form_refresh_initial' );
-			debug( 'Submit successful. Resetting form.' )
+			debug( 'Submit successful. Resetting form.' );
 		} else {
 			const sendInvitesErrored = InvitesSentStore.getErrors( this.state.formId );
 			const errors = get( sendInvitesErrored, 'errors', {} );
@@ -335,7 +335,7 @@ const InvitePeople = React.createClass( {
 						<RoleSelect
 							id="role"
 							name="role"
-							key="role"
+							key={ this.props.site.ID }
 							includeFollower
 							siteId={ this.props.site.ID }
 							onChange={ this.onRoleChange }


### PR DESCRIPTION
It was reported by @hoverduck and @alisterscott that the role select was sometimes "stale" when on the invite form and switching sites.

For example:
- Go to `/people/new/$site1` where `$site1` is a public site
- In the site selector, select `$site2`, which is a private site
- Note that the role selector "likely" says "Follower" instead of "Viewer"

In my testing, it seems that the role select component simply wasn't updating when it should. To address this, we now add a key to the role select that consists of the site's ID. This should ensure that the role select updates each time the site changes.

To test, follow the same instructions above and note that the role says "Viewer" after switching sites.

cc @lezama for code review and @alisterscott to see if this fixes the issue.