### PR TITLE
Plugins: Don‘t run only this one test in the new `plugins-list` tests

### DIFF
--- a/client/my-sites/plugins/plugins-list/test/index.jsx
+++ b/client/my-sites/plugins/plugins-list/test/index.jsx
@@ -43,7 +43,7 @@ describe( 'PluginsList', () => {
 		PluginsList = require( '../' );
 	} );
 
-	describe.only( 'rendering bulk actions', function() {
+	describe( 'rendering bulk actions', function() {
 		let renderedPluginsList, plugins, props;
 
 		before( () => {


### PR DESCRIPTION
We had an accidental `describe.only`.