### PR TITLE
Jetpack-connect: Automatically authorize a connection when the flow is calypso-started

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -178,7 +178,7 @@ const LoggedInForm = React.createClass( {
 
 	isCalypsoStartedConnection() {
 		const site = this.props.jetpackConnectAuthorize.queryObject.site.replace( /.*?:\/\//g, '' );
-		if ( this.props.jetpackConnectSessions[ site ] ) {
+		if ( this.props.jetpackConnectSessions && this.props.jetpackConnectSessions[ site ] ) {
 			const currentTime = ( new Date() ).getTime();
 			const oneDay = 24 * 60 * 60;
 			return ( currentTime - this.props.jetpackConnectSessions[ site ] < oneDay );

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -66,7 +66,7 @@ const LoggedOutForm = React.createClass( {
 				authorization={ 'Bearer ' + bearerToken }
 				extraFields={ extraFields }
 				redirectTo={ window.location.href } />
-		)
+		);
 	},
 
 	renderFooterLink() {
@@ -82,7 +82,7 @@ const LoggedOutForm = React.createClass( {
 
 	render() {
 		const { userData } = this.props.jetpackConnectAuthorize;
-		const { site } = this.props.jetpackConnectAuthorize.queryObject
+		const { site } = this.props.jetpackConnectAuthorize.queryObject;
 		return (
 			<div>
 				{ renderFormHeader( site ) }
@@ -106,7 +106,7 @@ const LoggedInForm = React.createClass( {
 	componentWillMount() {
 		const { autoAuthorize, queryObject } = this.props.jetpackConnectAuthorize;
 		debug( 'Checking for auto-auth on mount', autoAuthorize );
-		if ( autoAuthorize ) {
+		if ( autoAuthorize || this.isCalypsoStartedConnection() ) {
 			this.props.authorize( queryObject );
 		}
 	},
@@ -176,6 +176,16 @@ const LoggedInForm = React.createClass( {
 		return text;
 	},
 
+	isCalypsoStartedConnection() {
+		const site = this.props.jetpackConnectAuthorize.queryObject.site.replace( /.*?:\/\//g, '' );
+		if ( this.props.jetpackConnectSessions[ site ] ) {
+			const currentTime = ( new Date() ).getTime();
+			const oneDay = 24 * 60 * 60;
+			return ( currentTime - this.props.jetpackConnectSessions[ site ] < oneDay );
+		}
+		return false;
+	},
+
 	renderFooterLinks() {
 		const { queryObject, authorizeSuccess, isAuthorizing } = this.props.jetpackConnectAuthorize;
 		const loginUrl = config( 'login_url' ) + '?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) + '&_wp_nonce=' + encodeURIComponent( queryObject._wp_nonce );
@@ -208,7 +218,7 @@ const LoggedInForm = React.createClass( {
 
 	render() {
 		const { authorizeSuccess } = this.props.jetpackConnectAuthorize;
-		const { site } = this.props.jetpackConnectAuthorize.queryObject
+		const { site } = this.props.jetpackConnectAuthorize.queryObject;
 		return (
 			<div className="jetpack-connect-logged-in-form">
 				{ renderFormHeader( site, authorizeSuccess ) }
@@ -234,10 +244,12 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		let user = userModule.get();
 		const props = Object.assign( {}, this.props, {
 			user: user
-		} )
-		return ( user )
-			? <LoggedInForm { ...props } />
-			: <LoggedOutForm { ...props } />
+		} );
+		return (
+			( user )
+				? <LoggedInForm { ...props } />
+				: <LoggedOutForm { ...props } />
+		);
 	},
 	render() {
 		return (
@@ -253,7 +265,8 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 export default connect(
 	state => {
 		return {
-			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize
+			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
+			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions
 		};
 	},
 	dispatch => bindActionCreators( { authorize, createAccount }, dispatch )


### PR DESCRIPTION
~~Requires https://github.com/Automattic/wp-calypso/pull/4919 to be merged (and rebased into this) to work~~

This PR changes the authorization screen so if a user have started the connection flow from calypso, the confirmation button in the connection screen is skipped and the connection is created right away:

![untitled screencast 9](https://cloud.githubusercontent.com/assets/1554855/14707104/f5f8ec72-07c2-11e6-8d86-85db4ce788a8.gif)

(That gif is broken as hell, take a look at the video: https://cloudup.com/cxCDXlPv1OL )

how to test
=========
~~0. Wait until #4919 is merged :D (or rebase that branch into this one in your localhost for testing)~~
1. Go to http://calypso.localhost:3000/jetpack/connect 
2. Enter an url of a site with an unconnected jetpack (which is running jetpack master branch)
3. Watch the magic happens :magic:


![magic](http://24.media.tumblr.com/c580a26d7117c438280fdb26be4c9007/tumblr_mkdgleZKgY1rfvrjbo4_250.gif)


hey @rickybanister @roccotripaldi !