### PR TITLE
CurrentSite: add "notice" component and display domain notice

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -231,8 +231,8 @@ a.notice__action {
 		flex-shrink: 0;
 		margin: 0 0 0 8px;
 		padding: 0;
-		width: 14px;
-		height: 14px;
+		width: 18px;
+		height: 18px;
 		vertical-align: middle;
 	}
 

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	debug = require( 'debug' )( 'calypso:my-sites:current-site' ),
-	url = require( 'url' );
+	debug = require( 'debug' )( 'calypso:my-sites:current-site' );
 
 /**
  * Internal dependencies
@@ -12,16 +11,12 @@ var AllSites = require( 'my-sites/all-sites' ),
 	analytics = require( 'lib/analytics' ),
 	Button = require( 'components/button' ),
 	Card = require( 'components/card' ),
-	Notice = require( 'components/notice' ),
-	NoticeAction = require( 'components/notice/notice-action' ),
 	layoutFocus = require( 'lib/layout-focus' ),
 	Site = require( 'my-sites/site' ),
 	Gridicon = require( 'components/gridicon' ),
-	config = require( 'config' ),
 	UpgradesActions = require( 'lib/upgrades/actions' ),
 	DomainsStore = require( 'lib/domains/store' ),
-	DomainWarnings = require( 'my-sites/upgrades/components/domain-warnings' ),
-	paths = require( 'my-sites/upgrades/paths' );
+	DomainWarnings = require( 'my-sites/upgrades/components/domain-warnings' );
 
 import SiteNotice from './notice';
 
@@ -90,26 +85,6 @@ module.exports = React.createClass( {
 		return this.props.sites.getSelectedSite();
 	},
 
-	getSiteRedirectNotice: function( site ) {
-		if ( ! ( site.options && site.options.is_redirect ) ) {
-			return null;
-		}
-		const { hostname } = url.parse( site.URL );
-		return (
-			<Notice
-				showDismiss={ false }
-				isCompact={ true }
-				text={ this.translate( 'Redirects to {{a}}%(url)s{{/a}}', {
-					args: { url: hostname },
-					components: { a: <a href={ site.URL }/> }
-				} ) }>
-				<NoticeAction href={ paths.domainManagementList( site.domain ) }>
-					{ this.translate( 'Edit' ) }
-				</NoticeAction>
-			</Notice>
-		);
-	},
-
 	getDomainExpirationNotices: function() {
 		let domainStore = this.state.domainsStore.getBySite( this.getSelectedSite().ID ),
 			domains = domainStore && domainStore.list || [];
@@ -121,11 +96,10 @@ module.exports = React.createClass( {
 		);
 	},
 
-	getSiteNotices: function( site ) {
+	getSiteNotices: function() {
 		return (
 			<div>
 				{ this.getDomainExpirationNotices() }
-				{ this.getSiteRedirectNotice( site ) }
 			</div>
 		);
 	},

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -23,6 +23,8 @@ var AllSites = require( 'my-sites/all-sites' ),
 	DomainWarnings = require( 'my-sites/upgrades/components/domain-warnings' ),
 	paths = require( 'my-sites/upgrades/paths' );
 
+import SiteNotice from './notice';
+
 module.exports = React.createClass( {
 	displayName: 'CurrentSite',
 
@@ -180,6 +182,7 @@ module.exports = React.createClass( {
 					: <AllSites sites={ this.props.sites.get() } />
 				}
 				{ this.getSiteNotices( site ) }
+				<SiteNotice site={ site } />
 			</Card>
 		);
 	}

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import React from 'react';
+import url from 'url';
 
 /**
  * Internal dependencies
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import paths from 'my-sites/upgrades/paths';
 
 export default React.createClass( {
 	displayName: 'SiteNotice',
@@ -21,14 +23,39 @@ export default React.createClass( {
 		};
 	},
 
-	render() {
+	getSiteRedirectNotice: function( site ) {
+		if ( ! ( site.options && site.options.is_redirect ) ) {
+			return null;
+		}
+		const { hostname } = url.parse( site.URL );
 		return (
-			<Notice isCompact status="is-success" icon="info-outline">
-				{ this.translate( 'Unused domain credit' ) }
-				<NoticeAction>
-					Claim
+			<Notice
+				showDismiss={ false }
+				icon="info-outline"
+				isCompact
+			>
+				{ this.translate( 'Redirects to {{a}}%(url)s{{/a}}', {
+					args: { url: hostname },
+					components: { a: <a href={ site.URL }/> }
+				} ) }
+				<NoticeAction href={ paths.domainManagementList( site.domain ) }>
+					{ this.translate( 'Edit' ) }
 				</NoticeAction>
 			</Notice>
+		);
+	},
+
+	render() {
+		return (
+			<div className="site__notices">
+				{ this.getSiteRedirectNotice( this.props.site ) }
+				<Notice isCompact status="is-success" icon="info-outline">
+					{ this.translate( 'Unused domain credit' ) }
+					<NoticeAction>
+						Claim
+					</NoticeAction>
+				</Notice>
+			</div>
 		);
 	}
 } );

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+
+export default React.createClass( {
+	displayName: 'SiteNotice',
+
+	propTypes: {
+		site: React.PropTypes.object
+	},
+
+	getDefaultProps() {
+		return {
+		};
+	},
+
+	render() {
+		return (
+			<Notice isCompact status="is-success" icon="info-outline">
+				{ this.translate( 'Unused domain credit' ) }
+				<NoticeAction>
+					Claim
+				</NoticeAction>
+			</Notice>
+		);
+	}
+} );

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -13,6 +13,7 @@ import NoticeAction from 'components/notice/notice-action';
 import paths from 'my-sites/upgrades/paths';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import QueryPlans from 'components/data/query-plans';
 
 const SiteNotice = React.createClass( {
 	propTypes: {
@@ -68,6 +69,7 @@ const SiteNotice = React.createClass( {
 		return (
 			<div className="site__notices">
 				{ this.getSiteRedirectNotice( this.props.site ) }
+				<QueryPlans siteId={ this.props.site.ID } />
 				{ this.domainCreditNotice() }
 			</div>
 		);

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -14,6 +14,8 @@ import paths from 'my-sites/upgrades/paths';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QueryPlans from 'components/data/query-plans';
+import { abtest } from 'lib/abtest';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 const SiteNotice = React.createClass( {
 	propTypes: {
@@ -52,16 +54,28 @@ const SiteNotice = React.createClass( {
 			return null;
 		}
 
+		if ( abtest( 'domainCreditsInfoNotice' ) === 'showNotice' ) {
+			const eventName = 'calypso_domain_credit_reminder_impression';
+			const eventProperties = { cta_name: 'current_site_domain_notice' };
+			return (
+				<Notice isCompact status="is-success" icon="info-outline">
+					{ this.translate( 'Unused domain credit' ) }
+					<NoticeAction
+						onClick={ this.props.clickClaimDomainNotice }
+						href={ `/domains/add/${ this.props.site.slug }` }
+					>
+						{ this.translate( 'Claim' ) }
+						<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
+					</NoticeAction>
+				</Notice>
+			);
+		}
+
+		//otherwise still track what happens when we don't show a notice
+		const eventName = 'calypso_domain_credit_reminder_no_impression';
+		const eventProperties = { cta_name: 'current_site_domain_notice' };
 		return (
-			<Notice isCompact status="is-success" icon="info-outline">
-				{ this.translate( 'Unused domain credit' ) }
-				<NoticeAction
-					onClick={ this.props.clickClaimDomainNotice }
-					href={ `/domains/add/${ this.props.site.slug }` }
-				>
-					{ this.translate( 'Claim' ) }
-				</NoticeAction>
-			</Notice>
+			<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
 		);
 	},
 

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -76,3 +76,19 @@
 .current-site .site__badge {
 	padding-right: 8px;
 }
+
+.current-site .notice.is-compact {
+	display: flex;
+	margin: 0 -8px;
+	padding: 0 0 0 4px;
+
+	.notice__text {
+		width: 100%;
+		display: flex;
+		line-height: 1.3;
+	}
+
+	.notice__action {
+		margin-left: auto;
+	}
+}

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -82,6 +82,10 @@
 	margin: 0 -8px;
 	padding: 0 0 0 4px;
 
+	@include breakpoint( "<660px" ) {
+		padding: 0 24px;
+	}
+
 	.notice__text {
 		width: 100%;
 		display: flex;


### PR DESCRIPTION
This adds a new subcomponent to `<CurrentSite>` intended to display site related notices. It also adds a notice for when the site has unclaimed domain credits to use.

![image](https://cloud.githubusercontent.com/assets/548849/14713238/9c10da08-07e0-11e6-8028-c30e59c8fa1b.png)

## Testing Instructions
- Turn on analytics debug: `localStorage.setItem('debug', 'calypso:analytics');`
- Upgrade a free site to premium or business
- Click on "My Sites" and select your upgraded site
- Set the testing variant to: `localStorage.setItem('ABTests','{"domainCreditsInfoNotice_20160420":"showNotice"}')`
- Your upgraded site should see the notice, and other sites should not
- The following analytics events should fire:
<img width="828" alt="impression" src="https://cloud.githubusercontent.com/assets/1270189/14658553/7d714ada-0649-11e6-8837-29dadfb7b825.png">
<img width="1180" alt="click" src="https://cloud.githubusercontent.com/assets/1270189/14658576/b4a17f2a-0649-11e6-82ff-3c21bf8b22f8.png">
- Set the testing variant to:
`localStorage.setItem('ABTests','{"domainCreditsInfoNotice_20160420":"original"}')`
- Navigate to "MySites" and select your upgraded site
- Notice does not display, but the following analytics event fires:
<img width="941" alt="screen shot 2016-04-20 at 8 33 20 am" src="https://cloud.githubusercontent.com/assets/1270189/14680561/973da56a-06d2-11e6-8def-c2e71c8c4140.png">
