### PR TITLE
GuidedTours: Add tour version to tracks events

### DIFF
--- a/client/guidestours/config.js
+++ b/client/guidestours/config.js
@@ -68,4 +68,5 @@ function get() {
 
 export default {
 	get,
+	version: '20160421',
 };

--- a/client/state/ui/actions.js
+++ b/client/state/ui/actions.js
@@ -13,6 +13,8 @@ import {
 	recordTracksEvent,
 } from 'state/analytics/actions';
 
+import guidesConfig from 'guidestours/config';
+
 /**
  * Returns an action object to be used in signalling that a site has been set
  * as selected.
@@ -64,6 +66,7 @@ export function showGuidesTour( { shouldShow, shouldDelay = false, tour = 'main'
 	};
 
 	const trackEvent = recordTracksEvent( 'calypso_guided_tours_show', {
+		tour_version: guidesConfig.version,
 		tour,
 	} );
 
@@ -82,6 +85,7 @@ export function quitGuidesTour( { tour = 'main', stepName, finished } ) {
 
 	const trackEvent = recordTracksEvent( `calypso_guided_tours_${ finished ? 'finished' : 'quit' }`, {
 		step: stepName,
+		tour_version: guidesConfig.version,
 		tour,
 	} );
 
@@ -95,6 +99,7 @@ export function nextGuidesTourStep( { tour = 'main', stepName } ) {
 
 	const trackEvent = recordTracksEvent( 'calypso_guided_tours_next_step', {
 		step: stepName,
+		tour_version: guidesConfig.version,
 		tour,
 	} );
 


### PR DESCRIPTION
Very simple for now, we'll want to revisit this when we do multitours.

To test:

- `localStorage.setItem('debug', 'calypso:analytics');`
- http://calypso.localhost:3000/?tour=main
- Check start/next step/quit/finish events for `tour_version` prop