### PR TITLE
Framework: add query plans component

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -1,22 +1,21 @@
 /**
  * External dependencies
  */
-var connect = require( 'react-redux' ).connect,
-	React = require( 'react' );
+import { connect } from 'react-redux';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var StoreConnection = require( 'components/data/store-connection' ),
-	DomainsStore = require( 'lib/domains/store' ),
-	CartStore = require( 'lib/cart/store' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	upgradesActions = require( 'lib/upgrades/actions' ),
-	fetchSitePlans = require( 'state/sites/plans/actions' ).fetchSitePlans,
-	shouldFetchSitePlans = require( 'lib/plans' ).shouldFetchSitePlans,
-	getPlansBySite = require( 'state/sites/plans/selectors' ).getPlansBySite;
+import StoreConnection from 'components/data/store-connection';
+import DomainsStore from 'lib/domains/store';
+import CartStore from 'lib/cart/store';
+import observe from 'lib/mixins/data-observe';
+import * as upgradesActions from 'lib/upgrades/actions';
+import QueryPlans from 'components/data/query-plans';
+import { getPlansBySite } from 'state/sites/plans/selectors';
 
-var stores = [
+const stores = [
 	DomainsStore,
 	CartStore
 ];
@@ -33,7 +32,7 @@ function getStateFromStores( props ) {
 	};
 }
 
-var DomainManagementData = React.createClass( {
+const DomainManagementData = React.createClass( {
 	propTypes: {
 		context: React.PropTypes.object.isRequired,
 		productsList: React.PropTypes.object.isRequired,
@@ -47,7 +46,6 @@ var DomainManagementData = React.createClass( {
 	componentWillMount: function() {
 		if ( this.props.sites.getSelectedSite() ) {
 			upgradesActions.fetchDomains( this.props.sites.getSelectedSite().ID );
-			this.props.fetchSitePlans( this.props.sitePlans, this.props.sites.getSelectedSite() );
 		}
 
 		this.prevSelectedSite = this.props.sites.getSelectedSite();
@@ -56,40 +54,37 @@ var DomainManagementData = React.createClass( {
 	componentWillUpdate: function() {
 		if ( this.prevSelectedSite !== this.props.sites.getSelectedSite() ) {
 			upgradesActions.fetchDomains( this.props.sites.getSelectedSite().ID );
-			this.props.fetchSitePlans( this.props.sitePlans, this.props.sites.getSelectedSite() );
 		}
 
 		this.prevSelectedSite = this.props.sites.getSelectedSite();
 	},
 
 	render: function() {
+		const selectedSite = this.props.sites.getSelectedSite();
 		return (
-			<StoreConnection
-				component={ this.props.component }
-				stores={ stores }
-				getStateFromStores={ getStateFromStores }
-				products={ this.props.productsList.get() }
-				selectedDomainName={ this.props.selectedDomainName }
-				selectedSite={ this.props.sites.getSelectedSite() }
-				sitePlans={ this.props.sitePlans }
-				context={ this.props.context } />
+			<div>
+				<StoreConnection
+					component={ this.props.component }
+					stores={ stores }
+					getStateFromStores={ getStateFromStores }
+					products={ this.props.productsList.get() }
+					selectedDomainName={ this.props.selectedDomainName }
+					selectedSite={ this.props.sites.getSelectedSite() }
+					sitePlans={ this.props.sitePlans }
+					context={ this.props.context } />
+				{
+					selectedSite &&
+					<QueryPlans siteId={ selectedSite.ID } />
+				}
+			</div>
 		);
 	}
 } );
 
-module.exports = connect(
+export default connect(
 	function( state, props ) {
 		return {
 			sitePlans: getPlansBySite( state, props.sites.getSelectedSite() )
-		}
-	},
-	function( dispatch ) {
-		return {
-			fetchSitePlans: ( sitePlans, site ) => {
-				if ( shouldFetchSitePlans( sitePlans, site ) ) {
-					dispatch( fetchSitePlans( site.ID ) );
-				}
-			}
-		}
+		};
 	}
 )( DomainManagementData );

--- a/client/components/data/query-plans/README.md
+++ b/client/components/data/query-plans/README.md
@@ -1,0 +1,8 @@
+Query Plans
+===========================
+
+`<QueryPlans />` is a React component used in managing network requests for sites/plans.
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page.

--- a/client/components/data/query-plans/index.jsx
+++ b/client/components/data/query-plans/index.jsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingSitePlans } from 'state/sites/plans/selectors';
+import { fetchSitePlans } from 'state/sites/plans/actions';
+
+class QueryPlans extends Component {
+
+	constructor( props ) {
+		super( props );
+		this.requestPlans = this.requestPlans.bind( this );
+	}
+
+	requestPlans( props = this.props ) {
+		if ( ! props.requestingSitePlans && props.siteId ) {
+			props.fetchSitePlans( props.siteId );
+		}
+	}
+
+	componentWillMount() {
+		this.requestPlans();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.requestingSitePlans ||
+			! nextProps.siteId ||
+			( this.props.siteId === nextProps.siteId ) ) {
+			return;
+		}
+		this.requestPlans( nextProps );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryPlans.propTypes = {
+	siteId: PropTypes.number,
+	requestingPlans: PropTypes.bool,
+	fetchSitePlans: PropTypes.func
+};
+
+QueryPlans.defaultProps = {
+	fetchSitePlans: () => {}
+};
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			requestingSitePlans: isRequestingSitePlans( state, ownProps.siteId )
+		};
+	},
+	( dispatch ) => {
+		return bindActionCreators( {
+			fetchSitePlans
+		}, dispatch );
+	}
+)( QueryPlans );

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -30,3 +30,8 @@ export function hasDomainCredit( state, siteId ) {
 	}
 	return null;
 }
+
+export function isRequestingSitePlans( state, siteId ) {
+	const plans = getPlansBySiteId( state, siteId );
+	return plans.isRequesting;
+}

--- a/client/state/sites/plans/test/selectors.js
+++ b/client/state/sites/plans/test/selectors.js
@@ -9,7 +9,8 @@ import { expect } from 'chai';
 import {
 	getPlansBySite,
 	getPlansBySiteId,
-	hasDomainCredit
+	hasDomainCredit,
+	isRequestingSitePlans
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -48,7 +49,7 @@ describe( 'selectors', () => {
 		} );
 	} );
 	describe( '#hasDomainCredit()', () => {
-		it( 'should return if plan has domain credit', () => {
+		it( 'should return true if plan has domain credit', () => {
 			const state = {
 				sites: {
 					plans: {
@@ -65,6 +66,33 @@ describe( 'selectors', () => {
 
 			expect( hasDomainCredit( state, 77203074 ) ).to.equal( true );
 			expect( hasDomainCredit( state, 2916284 ) ).to.equal( false );
+		} );
+	} );
+	describe( '#isRequestingSitePlans()', () => {
+		it( 'should return true if we are fetching plans', () => {
+			const state = {
+				sites: {
+					plans: {
+						2916284: {
+							data: null,
+							error: null,
+							hasLoadedFromServer: false,
+							isRequesting: true
+						},
+						77203074: {
+							data: null,
+							error: null,
+							hasLoadedFromServer: false,
+							isRequesting: false
+						}
+
+					}
+				}
+			};
+
+			expect( isRequestingSitePlans( state, 2916284 ) ).to.equal( true );
+			expect( isRequestingSitePlans( state, 77203074 ) ).to.equal( false );
+			expect( isRequestingSitePlans( state, 'unknown' ) ).to.equal( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
This PR adds a [query component](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#query-components) for the state/sites/plans tree, and updates an example usage in domains

## Testing
- navigate to calypso.localhost:3000/domains
- select a site
- confirm that the sites/plans tree is still populated

cc @mtias @rralian @aduth