### PR TITLE
Discover: check that we have discover_metadata before grabbing the attribution details in full post view

### DIFF
--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -149,7 +149,7 @@ FullPostView = React.createClass( {
 			discoverSiteUrl,
 			discoverSiteName;
 
-		if ( isDiscoverPost ) {
+		if ( isDiscoverPost && post.discover_metadata ) {
 			discoverSiteUrl = DiscoverHelper.getSiteUrl( post );
 			discoverSiteName = post.discover_metadata.attribution.blog_name;
 		}
@@ -212,7 +212,7 @@ FullPostView = React.createClass( {
 					}
 
 					{ shouldShowExcerptOnly && ! isDiscoverPost ? <PostExcerptLink siteName={ siteName } postUrl={ post.URL } /> : null }
-					{ isDiscoverPost ? <DiscoverVisitLink siteName={ discoverSiteName } siteUrl={ discoverSiteUrl } /> : null }
+					{ discoverSiteName && discoverSiteUrl ? <DiscoverVisitLink siteName={ discoverSiteName } siteUrl={ discoverSiteUrl } /> : null }
 					{ this.props.shouldShowComments ? <PostCommentList ref="commentList" post={ post } onCommentsUpdate={ this.checkForCommentAnchor } /> : null }
 				</article>
 			</div>


### PR DESCRIPTION
We changed the way Discover posts are detected recently in #4833. `DiscoverHelper.isDiscoverPost( post )` now returns for true for all posts that match the Discover site ID, including those without discover metadata on the post.

Meanwhile, the Reader full post view assumed that we could access `discover_metadata` for all Discover posts. This broke the full post view for Discover feature posts, which don't carry any metadata.

This PR adds a check for `discover_metadata` before attempting to access attribution details for Discover posts.