### PR TITLE
Posts: display recent-drafts at the top of default view.

### DIFF
--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -8,6 +8,8 @@
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
 
+	@include clear-fix;
+
 	@include breakpoint( ">480px" ) {
 		margin-bottom: 16px;
 		padding: 24px;

--- a/client/components/card/style.scss
+++ b/client/components/card/style.scss
@@ -8,8 +8,6 @@
 	box-shadow: 0 0 0 1px transparentize( lighten( $gray, 20% ), .5 ),
 		0 1px 2px lighten( $gray, 30% );
 
-	@include clear-fix;
-
 	@include breakpoint( ">480px" ) {
 		margin-bottom: 16px;
 		padding: 24px;

--- a/client/components/section-nav/item.jsx
+++ b/client/components/section-nav/item.jsx
@@ -27,7 +27,8 @@ var NavItem = React.createClass( {
 		onClick: React.PropTypes.func,
 		isExternalLink: React.PropTypes.bool,
 		disabled: React.PropTypes.bool,
-		count: React.PropTypes.number
+		count: React.PropTypes.number,
+		className: React.PropTypes.string
 	},
 
 	render: function() {
@@ -43,7 +44,7 @@ var NavItem = React.createClass( {
 			};
 
 		itemClasses[ 'section-nav-' + itemClassPrefix ] = true;
-		itemClassName = classNames( itemClasses );
+		itemClassName = classNames( this.props.className, itemClasses );
 
 		if ( this.props.isExternalLink ) {
 			target = '_blank';

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -142,10 +142,11 @@ export default class QueryManager {
 
 	/**
 	 * Returns items tracked by the instance. If a query is specified, returns
-	 * items specific to that query.
+	 * items specific to that query, or null if no items have been received for
+	 * the query.
 	 *
-	 * @param  {?Object} query Optional query object
-	 * @return {Object[]}      Items tracked
+	 * @param  {?Object}       query Optional query object
+	 * @return {Object[]|null}       Items tracked, if known
 	 */
 	getItems( query ) {
 		if ( ! query ) {

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -152,6 +152,11 @@ module.exports = React.createClass( {
 			imageUrl = '//' + image.hostname + image.pathname + '?w=680px';
 		}
 
+		if ( post && post.canonical_image ) {
+			image = url.parse( post.canonical_image.uri, true );
+			imageUrl = '//' + image.hostname + image.pathname + '?w=680px';
+		}
+
 		classes = [
 			'draft',
 			{

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -2,7 +2,7 @@
 .draft__title {
 	display: inline-block;
 	font-family: $serif;
-	font-weight: bold;
+	font-weight: 400;
 	font-size: 14px;
 	white-space: nowrap;
 	overflow: hidden;

--- a/client/my-sites/posts/controller.js
+++ b/client/my-sites/posts/controller.js
@@ -5,8 +5,9 @@ var page = require( 'page' ),
 	ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	debug = require( 'debug' )( 'calypso:my-sites:posts' ),
-	i18n = require( 'i18n-calypso' ),
-	ReactRedux = require( 'react-redux' );
+	i18n = require( 'i18n-calypso' );
+
+import { Provider } from 'react-redux';
 
 /**
  * Internal Dependencies
@@ -77,7 +78,7 @@ module.exports = {
 		analytics.pageView.record( baseAnalyticsPath, analyticsPageTitle );
 
 		ReactDom.render(
-			React.createElement( ReactRedux.Provider, { store: context.store },
+			React.createElement( Provider, { store: context.store },
 				React.createElement( Posts, {
 					context: context,
 					siteID: siteID,

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -45,7 +45,7 @@ const PostsMain = React.createClass( {
 					siteId={ site && site.ID }
 					query={ this.props.draftsQuery } />
 				{ this.props.drafts &&
-					<SectionHeader label={ this.translate( 'Most Recent Drafts' ) } />
+					<SectionHeader label={ this.translate( 'Drafts' ) } />
 				}
 				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
 			</div>
@@ -65,9 +65,11 @@ const PostsMain = React.createClass( {
 		return (
 			<Main className="posts">
 				<SidebarNavigation />
-				<PostsNavigation { ...this.props } />
-				{ path === '/posts' && this.mostRecentDrafts() }
-				<PostList { ...this.props } />
+				<div className="posts__primary">
+					<PostsNavigation { ...this.props } />
+					<PostList { ...this.props } />
+				</div>
+				{ this.mostRecentDrafts() }
 			</Main>
 		);
 	},
@@ -90,7 +92,7 @@ export default connect( ( state ) => {
 		type: 'post',
 		lastPage: true,
 		status: 'draft',
-		number: 3,
+		number: 10,
 		order_by: 'modified'
 	};
 

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -55,7 +55,9 @@ const PostsMain = React.createClass( {
 						{ this.translate( 'Drafts' ) }
 						{ this.props.draftCount ? <Count count={ this.props.draftCount } /> : null }
 					</span>
-					<Button borderless><Gridicon icon="plus" /></Button>
+					<Button disabled={ ! site } borderless href={ `/post/${ site.slug }` }>
+						<Gridicon icon="plus" />
+					</Button>
 				</Card>
 				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
 				{ this.props.loadingDrafts && <Draft isPlaceholder /> }
@@ -98,7 +100,7 @@ const PostsMain = React.createClass( {
 
 export default connect( ( state ) => {
 	const selectedSite = getSelectedSite( state );
-	const siteId = selectedSite.ID;
+	const siteId = selectedSite && selectedSite.ID;
 	const draftsQuery = {
 		type: 'post',
 		lastPage: true,

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -52,7 +52,7 @@ const PostsMain = React.createClass( {
 			<div className="posts__recent-drafts">
 				{ site &&
 					<QueryPosts
-						siteId={ site && site.ID }
+						siteId={ site.ID }
 						query={ this.props.draftsQuery } />
 				}
 				{ site && <QueryPostCounts siteId={ site.ID } type="post" /> }

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -60,7 +60,7 @@ const PostsMain = React.createClass( {
 					</Button>
 				</Card>
 				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
-				{ this.props.loadingDrafts && <Draft isPlaceholder /> }
+				{ ! this.props.drafts && this.props.loadingDrafts && <Draft isPlaceholder /> }
 			</div>
 		);
 	},

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -22,6 +22,7 @@ import {
 	isRequestingSitePostsForQuery
 } from 'state/posts/selectors';
 import SectionHeader from 'components/section-header';
+import { sectionify } from 'lib/route/path';
 
 const PostsMain = React.createClass( {
 	mixins: [ observe( 'sites' ) ],
@@ -36,6 +37,21 @@ const PostsMain = React.createClass( {
 		this.setWarning( selectedSite );
 	},
 
+	mostRecentDrafts() {
+		const site = this.props.sites.getSelectedSite();
+		return (
+			<div className="posts__recent-drafts">
+				<QueryPosts
+					siteId={ site && site.ID }
+					query={ this.props.draftsQuery } />
+				{ this.props.drafts &&
+					<SectionHeader label={ this.translate( 'Most Recent Drafts' ) } />
+				}
+				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
+			</div>
+		);
+	},
+
 	renderDraft( draft ) {
 		if ( ! draft ) {
 			return null;
@@ -45,20 +61,12 @@ const PostsMain = React.createClass( {
 	},
 
 	render() {
-		const site = this.props.sites.getSelectedSite();
+		const path = sectionify( this.props.context.path );
 		return (
 			<Main className="posts">
 				<SidebarNavigation />
 				<PostsNavigation { ...this.props } />
-				<div className="posts__recent-drafts">
-					<QueryPosts
-						siteId={ site && site.ID }
-						query={ this.props.query } />
-					{ this.props.drafts &&
-						<SectionHeader label={ this.translate( 'Most Recent Drafts' ) } />
-					}
-					{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
-				</div>
+				{ path === '/posts' && this.mostRecentDrafts() }
 				<PostList { ...this.props } />
 			</Main>
 		);
@@ -78,7 +86,7 @@ const PostsMain = React.createClass( {
 export default connect( ( state ) => {
 	const selectedSite = getSelectedSite( state );
 	const siteId = selectedSite.ID;
-	const query = {
+	const draftsQuery = {
 		type: 'post',
 		lastPage: true,
 		status: 'draft',
@@ -87,8 +95,8 @@ export default connect( ( state ) => {
 	};
 
 	return {
-		drafts: getSitePostsForQueryIgnoringPage( state, siteId, query ),
-		loading: isRequestingSitePostsForQuery( state, siteId, query ),
-		query: query
+		drafts: getSitePostsForQueryIgnoringPage( state, siteId, draftsQuery ),
+		loadingDrafts: isRequestingSitePostsForQuery( state, siteId, draftsQuery ),
+		draftsQuery: draftsQuery
 	};
 } )( PostsMain );

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -1,20 +1,19 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-var PostsNavigation = require( './posts-navigation' ),
-	observe = require( 'lib/mixins/data-observe' ),
-	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	PostList = require( './post-list' ),
-	config = require( 'config' ),
-	Main = require( 'components/main' ),
-	notices = require( 'notices' );
-
+import PostsNavigation from './posts-navigation';
+import observe from 'lib/mixins/data-observe';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import PostList from './post-list';
+import config from 'config';
+import Main from 'components/main';
+import notices from 'notices';
 import QueryPosts from 'components/data/query-posts';
 import Draft from 'my-sites/draft';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -25,22 +24,19 @@ import {
 import SectionHeader from 'components/section-header';
 
 const PostsMain = React.createClass( {
-
-	displayName: 'Posts',
-
 	mixins: [ observe( 'sites' ) ],
 
-	componentWillMount: function() {
-		var selectedSite = this.props.sites.getSelectedSite();
-		this._setWarning( selectedSite );
+	componentWillMount() {
+		const selectedSite = this.props.sites.getSelectedSite();
+		this.setWarning( selectedSite );
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
-		var selectedSite = nextProps.sites.getSelectedSite();
-		this._setWarning( selectedSite );
+	componentWillReceiveProps( nextProps ) {
+		const selectedSite = nextProps.sites.getSelectedSite();
+		this.setWarning( selectedSite );
 	},
 
-	renderDraft: function( draft ) {
+	renderDraft( draft ) {
 		if ( ! draft ) {
 			return null;
 		}
@@ -48,7 +44,7 @@ const PostsMain = React.createClass( {
 		return <Draft key={ draft.global_ID } post={ draft } sites={ this.props.sites } />;
 	},
 
-	render: function() {
+	render() {
 		const site = this.props.sites.getSelectedSite();
 		return (
 			<Main className="posts">
@@ -68,7 +64,7 @@ const PostsMain = React.createClass( {
 		);
 	},
 
-	_setWarning: function( selectedSite ) {
+	setWarning( selectedSite ) {
 		if ( selectedSite && selectedSite.jetpack && ! selectedSite.hasMinimumJetpackVersion ) {
 			notices.warning(
 				this.translate( 'Jetpack %(version)s is required to take full advantage of all post editing features.', { args: { version: config( 'jetpack_min_version' ) } } ),

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -68,6 +68,11 @@ const PostsMain = React.createClass( {
 				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
 				{ isLoading && <Draft isPlaceholder /> }
 				{ this.props.draftCount === 0 && <NoResults text={ this.translate( 'You have no drafts at the moment.' ) } /> }
+				{ site && this.props.draftCount > 50 &&
+					<Button compact borderless href={ `/posts/drafts/${ site.slug }` }>
+						{ this.translate( 'See all drafts' ) }
+					</Button>
+				}
 			</div>
 		);
 	},

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -15,6 +15,7 @@ import config from 'config';
 import Main from 'components/main';
 import notices from 'notices';
 import QueryPosts from 'components/data/query-posts';
+import QueryPostCounts from 'components/data/query-post-counts';
 import Draft from 'my-sites/draft';
 import { getSelectedSite } from 'state/ui/selectors';
 import {
@@ -25,6 +26,8 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import { sectionify } from 'lib/route/path';
+import Count from 'components/count';
+import { getAllPostCount } from 'state/posts/counts/selectors';
 
 const PostsMain = React.createClass( {
 	mixins: [ observe( 'sites' ) ],
@@ -46,9 +49,13 @@ const PostsMain = React.createClass( {
 				<QueryPosts
 					siteId={ site && site.ID }
 					query={ this.props.draftsQuery } />
+				<QueryPostCounts siteId={ site && site.ID } type="post" />
 				{ this.props.drafts &&
 					<Card compact className="posts__drafts-header">
-						{ this.translate( 'Drafts' ) }
+						<span>
+							{ this.translate( 'Drafts' ) }
+							{ this.props.draftCount ? <Count count={ this.props.draftCount } /> : null }
+						</span>
 						<Button borderless><Gridicon icon="plus" /></Button>
 					</Card>
 				}
@@ -104,6 +111,7 @@ export default connect( ( state ) => {
 	return {
 		drafts: getSitePostsForQueryIgnoringPage( state, siteId, draftsQuery ),
 		loadingDrafts: isRequestingSitePostsForQuery( state, siteId, draftsQuery ),
-		draftsQuery: draftsQuery
+		draftsQuery: draftsQuery,
+		draftCount: getAllPostCount( state, siteId, 'post', 'draft' )
 	};
 } )( PostsMain );

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -21,7 +21,9 @@ import {
 	getSitePostsForQueryIgnoringPage,
 	isRequestingSitePostsForQuery
 } from 'state/posts/selectors';
-import SectionHeader from 'components/section-header';
+import Button from 'components/button';
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
 import { sectionify } from 'lib/route/path';
 
 const PostsMain = React.createClass( {
@@ -45,7 +47,10 @@ const PostsMain = React.createClass( {
 					siteId={ site && site.ID }
 					query={ this.props.draftsQuery } />
 				{ this.props.drafts &&
-					<SectionHeader label={ this.translate( 'Drafts' ) } />
+					<Card compact className="posts__drafts-header">
+						{ this.translate( 'Drafts' ) }
+						<Button borderless><Gridicon icon="plus" /></Button>
+					</Card>
 				}
 				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
 			</div>

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -50,16 +50,15 @@ const PostsMain = React.createClass( {
 					siteId={ site && site.ID }
 					query={ this.props.draftsQuery } />
 				<QueryPostCounts siteId={ site && site.ID } type="post" />
-				{ this.props.drafts &&
-					<Card compact className="posts__drafts-header">
-						<span>
-							{ this.translate( 'Drafts' ) }
-							{ this.props.draftCount ? <Count count={ this.props.draftCount } /> : null }
-						</span>
-						<Button borderless><Gridicon icon="plus" /></Button>
-					</Card>
-				}
+				<Card compact className="posts__drafts-header">
+					<span>
+						{ this.translate( 'Drafts' ) }
+						{ this.props.draftCount ? <Count count={ this.props.draftCount } /> : null }
+					</span>
+					<Button borderless><Gridicon icon="plus" /></Button>
+				</Card>
 				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
+				{ this.props.loadingDrafts && <Draft isPlaceholder /> }
 			</div>
 		);
 	},
@@ -104,7 +103,6 @@ export default connect( ( state ) => {
 		type: 'post',
 		lastPage: true,
 		status: 'draft',
-		number: 10,
 		order_by: 'modified'
 	};
 

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -24,9 +24,10 @@ import {
 } from 'state/posts/selectors';
 import Button from 'components/button';
 import Card from 'components/card';
-import Gridicon from 'components/gridicon';
-import { sectionify } from 'lib/route/path';
 import Count from 'components/count';
+import Gridicon from 'components/gridicon';
+import NoResults from 'my-sites/no-results';
+import { sectionify } from 'lib/route/path';
 import { getAllPostCount } from 'state/posts/counts/selectors';
 
 const PostsMain = React.createClass( {
@@ -44,6 +45,8 @@ const PostsMain = React.createClass( {
 
 	mostRecentDrafts() {
 		const site = this.props.sites.getSelectedSite();
+		const isLoading = this.props.draftCount !== 0 && this.props.loadingDrafts;
+
 		return (
 			<div className="posts__recent-drafts">
 				<QueryPosts
@@ -60,7 +63,8 @@ const PostsMain = React.createClass( {
 					</Button>
 				</Card>
 				{ this.props.drafts && this.props.drafts.map( this.renderDraft, this ) }
-				{ ! this.props.drafts && this.props.loadingDrafts && <Draft isPlaceholder /> }
+				{ isLoading && <Draft isPlaceholder /> }
+				{ this.props.draftCount === 0 && <NoResults text="You have no drafts at the moment." /> }
 			</div>
 		);
 	},

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -167,10 +167,10 @@ export default React.createClass( {
 					selectedCount = count;
 				}
 			}
-			console.log(this.props);
 
 			statusItems.push(
 				<NavItem
+					className={ 'is-' + status }
 					key={ 'statusTabs' + path }
 					path={ path }
 					count={ null === this.props.sites.selected || isJetpackSite ?

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -167,6 +167,7 @@ export default React.createClass( {
 					selectedCount = count;
 				}
 			}
+			console.log(this.props);
 
 			statusItems.push(
 				<NavItem

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -1,6 +1,11 @@
 .posts.main {
-	display: flex;
-	max-width: 1040px;
+	display: block;
+	max-width: 720px;
+
+	@include breakpoint( ">1040px" ) {
+		display: flex;
+		max-width: 1040px;
+	}
 }
 
 .posts__primary {
@@ -471,6 +476,11 @@
 	flex-grow: 1;
 	margin: 0 0 24px 24px;
 	max-width: 296px;
+	display: none;
+
+	@include breakpoint( ">1040px" ) {
+		display: block;
+	}
 }
 
 .posts__recent-drafts .posts__drafts-header.card.is-compact {
@@ -479,11 +489,17 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	padding: 4px 16px;
+	padding: 3px 16px;
 	color: $gray-dark;
 	font-size: 14px;
 
 	.count {
 		margin-left: 8px;
+	}
+}
+
+.posts .section-nav-tab.is-draft {
+	@include breakpoint( ">1040px" ) {
+		display: none;
 	}
 }

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -472,3 +472,14 @@
 	margin: 0 0 24px 24px;
 	max-width: 296px;
 }
+
+.posts__recent-drafts .posts__drafts-header.card.is-compact {
+	border-bottom: 2px solid $alert-yellow;
+	margin-bottom: 16px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 4px 16px;
+	color: $gray-dark;
+	font-size: 14px;
+}

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -482,4 +482,8 @@
 	padding: 4px 16px;
 	color: $gray-dark;
 	font-size: 14px;
+
+	.count {
+		margin-left: 8px;
+	}
 }

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -5,6 +5,7 @@
 	@include breakpoint( ">1040px" ) {
 		display: flex;
 		max-width: 1040px;
+		justify-content: center;
 	}
 }
 

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -9,6 +9,7 @@
 }
 
 .posts__primary {
+	flex-grow: 1;
 	max-width: 720px;
 }
 
@@ -492,6 +493,10 @@
 	padding: 3px 16px;
 	color: $gray-dark;
 	font-size: 14px;
+
+	&::after {
+		display: none;
+	}
 
 	.count {
 		margin-left: 8px;

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -482,6 +482,10 @@
 	@include breakpoint( ">1040px" ) {
 		display: block;
 	}
+
+	.draft__actions {
+		display: none;
+	}
 }
 
 .posts__recent-drafts .posts__drafts-header.card.is-compact {

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -457,3 +457,7 @@
 	margin-left: 6px;
 	vertical-align: middle;
 }
+
+.posts__recent-drafts {
+	margin: 0 0 24px;
+}

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -1,3 +1,12 @@
+.posts.main {
+	display: flex;
+	max-width: 1040px;
+}
+
+.posts__primary {
+	max-width: 720px;
+}
+
 .posts__list {
 
 	.post {
@@ -459,5 +468,7 @@
 }
 
 .posts__recent-drafts {
-	margin: 0 0 24px;
+	flex-grow: 1;
+	margin: 0 0 24px 24px;
+	max-width: 296px;
 }

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -508,3 +508,9 @@
 		display: none;
 	}
 }
+
+.posts__recent-drafts .no-results {
+	color: $gray;
+	font-size: 14px;
+	margin-left: 16px;
+}

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -31,6 +31,23 @@ export function getPost( state, globalId ) {
 }
 
 /**
+ * Returns a normalized post object by its global ID.
+ *
+ * @param  {Object} state    Global state tree
+ * @param  {String} globalId Post global ID
+ * @return {Object}          Post object
+ */
+export const getNormalizedPost = createSelector(
+	( state, globalId ) => {
+		const post = getPost( state, globalId );
+		firstPassCanonicalImage( post );
+		decodeEntities( post );
+		return post;
+	},
+	( state ) => state.posts.items
+);
+
+/**
  * Returns an array of post objects by site ID.
  *
  * @param  {Object} state  Global state tree
@@ -154,9 +171,7 @@ export function getSitePostsForQueryIgnoringPage( state, siteId, query ) {
 	}
 
 	return posts.getItemsIgnoringPage( query ).map( ( post ) => {
-		firstPassCanonicalImage( post );
-		decodeEntities( post );
-		return post;
+		return getNormalizedPost( state, post.global_ID );
 	} );
 }
 

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -16,6 +16,7 @@ import {
 	getSerializedPostsQueryWithoutPage
 } from './utils';
 import { DEFAULT_POST_QUERY } from './constants';
+import { runFastRules } from 'lib/feed-post-store/normalization-rules';
 
 /**
  * Returns a post object by its global ID.
@@ -150,7 +151,15 @@ export function getSitePostsForQueryIgnoringPage( state, siteId, query ) {
 		return null;
 	}
 
-	return state.posts.queries[ siteId ].getItemsIgnoringPage( query );
+	let posts = state.posts.queries[ siteId ].getItemsIgnoringPage( query );
+
+	// Normalize each post object
+	const normalizedPosts = posts.map( ( post ) => {
+		const normalizedPost = runFastRules( post );
+		return Object.assign( {}, normalizedPost );
+	} );
+
+	return normalizedPosts;
 }
 
 /**

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -170,11 +170,16 @@ export function isSitePostsLastPageForQuery( state, siteId, query = {} ) {
  */
 export function getSitePostsForQueryIgnoringPage( state, siteId, query ) {
 	const posts = state.posts.queries[ siteId ];
-	if ( ! posts || ! posts.getItemsIgnoringPage( query ) ) {
+	if ( ! posts ) {
 		return null;
 	}
 
-	return posts.getItemsIgnoringPage( query ).map( ( post ) => {
+	const itemsIgnoringPage = posts.getItemsIgnoringPage( query );
+	if ( ! itemsIgnoringPage ) {
+		return null;
+	}
+
+	return itemsIgnoringPage.map( ( post ) => {
 		return getNormalizedPost( state, post.global_ID );
 	} );
 }

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -41,13 +41,17 @@ export function getPost( state, globalId ) {
  * @return {Object}          Post object
  */
 export const getNormalizedPost = createSelector(
-	( state, globalId ) => {
-		return flow( [
+	( () => {
+		// Cache normalize flow in immediately-invoked closure so to avoid
+		// regenerating same flow on each call to this selector
+		const normalize = flow( [
 			firstPassCanonicalImage,
 			decodeEntities,
 			stripHtml
-		] )( cloneDeep( getPost( state, globalId ) ) );
-	},
+		] );
+
+		return ( state, globalId ) => normalize( cloneDeep( getPost( state, globalId ) ) );
+	} )(),
 	( state ) => state.posts.items
 );
 

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -52,8 +52,8 @@ describe( 'selectors', () => {
 				posts: {
 					items: {
 						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' },
-						'0fcb4eb16f493c19b627438fdc18d57c': { ID: 120, site_ID: 77203074, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak & Eggs' }
+						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs &amp; Chicken' },
+						'0fcb4eb16f493c19b627438fdc18d57c': { ID: 120, site_ID: 77203074, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak &amp; Eggs' }
 					}
 				}
 			};
@@ -82,13 +82,13 @@ describe( 'selectors', () => {
 					posts: {
 						items: {
 							'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-							'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' },
-							'0fcb4eb16f493c19b627438fdc18d57c': { ID: 120, site_ID: 77203074, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak & Eggs' }
+							'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs &amp; Chicken' },
+							'0fcb4eb16f493c19b627438fdc18d57c': { ID: 120, site_ID: 77203074, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak &amp; Eggs' }
 						}
 					}
 				}, 2916284, 413 );
 
-				expect( post ).to.eql( { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' } );
+				expect( post ).to.eql( { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs &amp; Chicken' } );
 			} );
 		} );
 	} );
@@ -370,13 +370,13 @@ describe( 'selectors', () => {
 				posts: {
 					items: {
 						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
+						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs &amp; Chicken' }
 					},
 					queries: {
 						2916284: new PostQueryManager( {
 							items: {
 								841: { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-								413: { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
+								413: { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs &amp; Chicken' }
 							},
 							queries: {
 								'[]': {
@@ -401,15 +401,15 @@ describe( 'selectors', () => {
 				posts: {
 					items: {
 						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' },
-						f0cb4eb16f493c19b627438fdc18d57c: { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak & Eggs', parent: { ID: 413 } }
+						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs &amp; Chicken' },
+						f0cb4eb16f493c19b627438fdc18d57c: { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak &amp; Eggs', parent: { ID: 413 } }
 					},
 					queries: {
 						2916284: new PostQueryManager( {
 							items: {
 								841: { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
-								413: { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' },
-								120: { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak & Eggs', parent: { ID: 413 } }
+								413: { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs &amp; Chicken' },
+								120: { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak &amp; Eggs', parent: { ID: 413 } }
 							},
 							queries: {
 								'[]': {
@@ -498,14 +498,14 @@ describe( 'selectors', () => {
 					edits: {
 						2916284: {
 							'': {
-								title: 'Ribs & Chicken'
+								title: 'Ribs &amp; Chicken'
 							}
 						}
 					}
 				}
 			}, 2916284 );
 
-			expect( editedPost ).to.eql( { title: 'Ribs & Chicken' } );
+			expect( editedPost ).to.eql( { title: 'Ribs &amp; Chicken' } );
 		} );
 
 		it( 'should return revisions for a draft if the original is unknown', () => {

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -365,6 +365,33 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSitePostsForQueryIgnoringPage()', () => {
+		it( 'should return null if the query is not tracked', () => {
+			const sitePosts = getSitePostsForQueryIgnoringPage( {
+				posts: {
+					items: {},
+					queries: {}
+				}
+			}, 2916284, { search: '', number: 1 } );
+
+			expect( sitePosts ).to.be.null;
+		} );
+
+		it( 'should return null if the query manager has not received items for query', () => {
+			const sitePosts = getSitePostsForQueryIgnoringPage( {
+				posts: {
+					items: {},
+					queries: {
+						2916284: new PostQueryManager( {
+							items: {},
+							queries: {}
+						} )
+					}
+				}
+			}, 2916284, { search: '', number: 1 } );
+
+			expect( sitePosts ).to.be.null;
+		} );
+
 		it( 'should return a concatenated array of all site posts ignoring page', () => {
 			const sitePosts = getSitePostsForQueryIgnoringPage( {
 				posts: {

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -8,6 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getPost,
+	getNormalizedPost,
 	getSitePosts,
 	getSitePost,
 	getSitePostsForQuery,
@@ -24,6 +25,13 @@ import {
 import PostQueryManager from 'lib/query-manager/post';
 
 describe( 'selectors', () => {
+	beforeEach( () => {
+		getSitePosts.memoizedSelector.cache.clear();
+		getSitePost.memoizedSelector.cache.clear();
+		getSitePostsHierarchyForQueryIgnoringPage.memoizedSelector.cache.clear();
+		getNormalizedPost.memoizedSelector.cache.clear();
+	} );
+
 	describe( '#getPost()', () => {
 		it( 'should return the object for the post global ID', () => {
 			const post = getPost( {
@@ -39,10 +47,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSitePosts()', () => {
-		beforeEach( () => {
-			getSitePosts.memoizedSelector.cache.clear();
-		} );
-
 		it( 'should return an array of post objects for the site', () => {
 			const state = {
 				posts: {
@@ -62,11 +66,6 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSitePost()', () => {
-		beforeEach( () => {
-			getSitePosts.memoizedSelector.cache.clear();
-			getSitePost.memoizedSelector.cache.clear();
-		} );
-
 		describe( '#getSitePost()', () => {
 			it( 'should return null if the post is not known for the site', () => {
 				const post = getSitePost( {
@@ -369,6 +368,10 @@ describe( 'selectors', () => {
 		it( 'should return a concatenated array of all site posts ignoring page', () => {
 			const sitePosts = getSitePostsForQueryIgnoringPage( {
 				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
+						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
+					},
 					queries: {
 						2916284: new PostQueryManager( {
 							items: {
@@ -393,13 +396,14 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSitePostsHierarchyForQueryIgnoringPage()', () => {
-		beforeEach( () => {
-			getSitePostsHierarchyForQueryIgnoringPage.memoizedSelector.cache.clear();
-		} );
-
 		it( 'should return a concatenated array of all site posts ignoring page, preserving hierarchy', () => {
 			const sitePosts = getSitePostsHierarchyForQueryIgnoringPage( {
 				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
+						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' },
+						f0cb4eb16f493c19b627438fdc18d57c: { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak & Eggs', parent: { ID: 413 } }
+					},
 					queries: {
 						2916284: new PostQueryManager( {
 							items: {


### PR DESCRIPTION
Adds a panel on large screens showing a list of drafts for quick and easy access. Drafts collapse into a filter in section nav on smaller viewports.

![image](https://cloud.githubusercontent.com/assets/548849/16045155/87bb7914-3247-11e6-8677-a7714e4b0613.png)
