### PR TITLE
Build: make calypso-strings artifact available on builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,3 +22,4 @@ test:
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/ && find . -type f -regex  "./test-results.*\.xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;:
         parallel: true
+    - if [[ $CIRCLE_BRANCH == "master" ]]; then make translate; mkdir $CIRCLE_ARTIFACTS/translate; cp calypso-strings.php $CIRCLE_ARTIFACTS/translate/calypso-strings.php; fi;


### PR DESCRIPTION
This PR calls `make translate` on master builds, and makes the calypso-string file available as an artifact on the build.
<img width="865" alt="screen shot 2016-04-21 at 11 51 13 am" src="https://cloud.githubusercontent.com/assets/1270189/14720901/842eb018-07b8-11e6-83e2-06ccc08f9bfe.png">

We can use this with the [Circle CI API](https://circleci.com/docs/api/#build-artifacts) to sync this file to wpcom.

For an example of what the results look like, see:
https://circleci.com/gh/Automattic/wp-calypso/14030
https://circle-artifacts.com/gh/Automattic/wp-calypso/14030/artifacts/0/tmp/circle-artifacts.b4rFvFm/translate/calypso-strings.php

On development branches, a normal build should look like:
https://circleci.com/gh/Automattic/wp-calypso/14032

cc @rralian @blowery 