### PR TITLE
Refactored WordPress.com plugins page purchase links

### DIFF
--- a/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/business-plugins-panel.jsx
@@ -10,8 +10,8 @@ export const BusinessPluginsPanel = React.createClass( {
 	render() {
 		const {
 			isActive = false,
-			plugins = [],
-			slug
+			purchaseLink,
+			plugins = []
 		} = this.props;
 
 		const cardClasses = classNames( 'wpcom-plugins__business-panel', {
@@ -21,7 +21,7 @@ export const BusinessPluginsPanel = React.createClass( {
 		return (
 			<div>
 				<SectionHeader label={ this.translate( 'Business Plan Upgrades' ) }>
-					<PurchaseButton { ...{ isActive, slug } } />
+					<PurchaseButton { ...{ isActive, href: purchaseLink } } />
 				</SectionHeader>
 
 				<Card className={ cardClasses }>
@@ -39,6 +39,8 @@ export const BusinessPluginsPanel = React.createClass( {
 } );
 
 BusinessPluginsPanel.propTypes = {
+	isActive: PropTypes.bool,
+	purchaseLink: PropTypes.string.isRequired,
 	plugins: PropTypes.array
 };
 

--- a/client/my-sites/plugins-wpcom/plugin-panel.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-panel.jsx
@@ -46,6 +46,7 @@ export const PluginPanel = React.createClass( {
 		} = this.props;
 
 		const standardPluginsLink = `/plugins/standard/${ siteSlug }`;
+		const purchaseLink = `/plans/${ siteSlug }`;
 
 		const hasBusiness = isBusiness( plan ) || isEnterprise( plan );
 		const hasPremium = hasBusiness || isPremium( plan );
@@ -66,8 +67,8 @@ export const PluginPanel = React.createClass( {
 					{ this.translate( 'View all standard plugins' ) }
 				</Card>
 
-				<PremiumPluginsPanel plugins={ premiumPlugins } isActive={ hasPremium } slug={ siteSlug } />
-				<BusinessPluginsPanel plugins={ businessPlugins } isActive={ hasBusiness } slug={ siteSlug } />
+				<PremiumPluginsPanel plugins={ premiumPlugins } isActive={ hasPremium } { ...{ purchaseLink } } />
+				<BusinessPluginsPanel plugins={ businessPlugins } isActive={ hasBusiness } { ...{ purchaseLink } } />
 			</div>
 		);
 	}

--- a/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
+++ b/client/my-sites/plugins-wpcom/premium-plugins-panel.jsx
@@ -10,8 +10,8 @@ export const PremiumPluginsPanel = React.createClass( {
 	render() {
 		const {
 			isActive = false,
-			plugins = [],
-			slug
+			purchaseLink,
+			plugins = []
 		} = this.props;
 
 		const cardClasses = classNames( 'wpcom-plugins__premium-panel', {
@@ -21,7 +21,7 @@ export const PremiumPluginsPanel = React.createClass( {
 		return (
 			<div>
 				<SectionHeader label={ this.translate( 'Premium Plan Upgrades' ) }>
-					<PurchaseButton { ...{ isActive, slug } } />
+					<PurchaseButton { ...{ isActive, href: purchaseLink } } />
 				</SectionHeader>
 
 				<Card className={ cardClasses }>
@@ -39,6 +39,8 @@ export const PremiumPluginsPanel = React.createClass( {
 } );
 
 PremiumPluginsPanel.propTypes = {
+	isActive: PropTypes.bool,
+	purchaseLink: PropTypes.string.isRequired,
 	plugins: PropTypes.array
 };
 

--- a/client/my-sites/plugins-wpcom/purchase-button.jsx
+++ b/client/my-sites/plugins-wpcom/purchase-button.jsx
@@ -2,16 +2,13 @@ import React, { PropTypes } from 'react';
 
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
-import page from 'page';
 
 export const PurchaseButton = React.createClass( {
-	showPlansPage() {
-		const { slug } = this.props;
-		page( `/plans/${ slug }` );
-	},
-
 	render() {
-		const { isActive } = this.props;
+		const {
+			href,
+			isActive
+		} = this.props;
 
 		if ( isActive ) {
 			return (
@@ -21,11 +18,16 @@ export const PurchaseButton = React.createClass( {
 			);
 		}
 
-		return <Button compact primary onClick={ this.showPlansPage }>{ this.translate( 'Purchase' ) }</Button>;
+		return (
+			<Button compact primary { ...{ href } }>
+				{ this.translate( 'Purchase' ) }
+			</Button>
+		);
 	}
 } );
 
 PurchaseButton.propTypes = {
+	href: PropTypes.string.isRequired,
 	isActive: PropTypes.bool.isRequired
 };
 


### PR DESCRIPTION
Previously after some changes to the purchase links in the WordPress.com
plugins page, we introduced some tight data coupling between different
React components.

This patch introduces some refactorings to remove those tight couplings
as a response to post-merge feedback in the PR (#4873)

There are no visual changes here.

**Testing**
Navigate to **My Sites** > [some WordPress.com site] > **Plugins** and look for the premium and business panels listing plugins. If the purchase button is active and clickable, it should take you to the plans page for the selected site.