### PR TITLE
Signup: Remove the Headstart checks from `filterFlowName`.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -249,17 +249,6 @@ function filterFlowName( flowName ) {
 		return 'free-trial';
 	}
 
-	const locale = getLocaleSlug();
-	// Only allow the `headstart` flow for EN users.
-	if ( 'headstart' === flowName && 'en' !== locale && 'en-gb' !== locale ) {
-		return 'main';
-	}
-
-	// Headstarted "default" flow (`newsite`) with vertical selection for EN users, coming from the homepage single button.
-	if ( 'website' === flowName && ( 'en' === locale || 'en-gb' === locale ) ) {
-		return 'newsite';
-	}
-
 	return flowName;
 }
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -132,13 +132,6 @@ const flows = {
 		lastModified: '2016-01-28'
 	},
 
-	newsite: {
-		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
-		destination: getSiteDestination,
-		description: 'Headstarted flow with verticals for EN users clicking "Create Website" on the homepage.',
-		lastModified: '2016-03-21'
-	},
-
 	blog: {
 		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
 		destination: getSiteDestination,


### PR DESCRIPTION
Headstart is the default on flows now since #4718, and Headstart now includes a check server-side for valid languages.

Would be nice to mop this up so that #4536 can go in cleanly.