### PR TITLE
WPCOM Plugins: add horizon for testing

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -43,6 +43,7 @@
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,
+		"manage/plugins/wpcom": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/sharing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,6 +41,7 @@
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
 		"manage/plugins/setup": false,
+		"manage/plugins/wpcom": true,
 		"manage/posts": true,
 		"manage/security": true,
 		"manage/sharing": true,


### PR DESCRIPTION
Enabling wpcom plugins on horizon.

Waiting for #4896 to merge first.