### PR TITLE
Build: add script to easily get the calypso-string artifact url

### DIFF
--- a/bin/get-circle-string-artifact-url
+++ b/bin/get-circle-string-artifact-url
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+// This script will return a url of the calypso-string.php file generated in our latest master build.
+// eg: node bin/get-circle-string-artifact-url | xargs curl
+
+const https = require('https');
+const path = '/api/v1/project/Automattic/wp-calypso/latest/artifacts?branch=master&filter=successful&circle-token=' + process.env.CIRCLE_CI_TOKEN;
+
+const options = {
+	host: 'circleci.com',
+	port: 443,
+	path: path,
+	headers: {
+		'Accept': 'application/json'
+	}
+};
+
+https.get( options, ( response ) => {
+	var body = '';
+	response.on( 'data', function( data ) {
+		body += data;
+	} );
+
+	response.on( 'end', () => {
+		const artifacts = JSON.parse( body );
+		const artifact = artifacts.filter( ( artifact ) => artifact.pretty_path === '$CIRCLE_ARTIFACTS/translate/calypso-strings.php' ).shift();
+		if( ! artifact ) {
+			console.error( 'failed to get latest build artifact information from circle ci', artifacts );
+			process.exit( 1 );
+		}
+		console.log( artifact.url );
+	} );
+
+} ).on( 'error', (e) => {
+	console.error( 'failed to get latest build artifact information from circle ci', e );
+	process.exit( 1 );
+} );


### PR DESCRIPTION
This PR adds a script to easily get the calypso-strings artifact generated by our master builds. This is prep work to simplify our i18n sync process to wpcom, which was broken in our upgrade to node v5

## Testing
- No changes to calypso
- Create a circle-ci token https://circleci.com/account/api
- export your token as the env variable `CIRCLE_CI_TOKEN `
- running `node bin/get-circle-string-artifact-url` returns the latest calypso string artifact url from https://circleci.com/gh/Automattic/wp-calypso/tree/master
- running `node bin/get-circle-string-artifact-url | xargs curl` returns the expected calypso-strings

cc @rralian @blowery @deBhal @akirk 

pMz3w-4A4-p2 pMz3w-5vb-p2