### PR TITLE
Jetpack Scan: fix missing space in translated string, Security settings page

### DIFF
--- a/client/my-sites/site-settings/form-jetpack-scan.jsx
+++ b/client/my-sites/site-settings/form-jetpack-scan.jsx
@@ -282,10 +282,10 @@ module.exports = React.createClass( {
 					disabled={ this.disableForm() } />
 
 				<FormSettingExplanation>
-					{ this.translate( 'Password is not required if you use public key authentication.' ) }
-					<a onClick={ this._onShowDialog } href="#">
-						{ this.translate( 'Get your public key string.' ) }
-					</a>
+					{ this.translate(
+						'Password is not required if you use public key authentication. {{a}}Get your public key string.{{/a}}',
+						{ components: { a: <a onClick={ this._onShowDialog } href="#" /> } }
+					) }
 				</FormSettingExplanation>
 				{ footerContents }
 			</form>


### PR DESCRIPTION
<img width="347" alt="screen shot 2016-04-21 at 15 48 36" src="https://cloud.githubusercontent.com/assets/66797/14727402/681529ee-07df-11e6-9137-1ea9c0742223.png">

<img width="1114" alt="screen shot 2016-04-21 at 16 39 38" src="https://cloud.githubusercontent.com/assets/66797/14727432/aa8baabe-07df-11e6-9f94-7d7a9f8e5f7e.png">

To test:

1. Connect a Jetpack site.
2. Go to the site's settings page, and click "Security", like https://wordpress.com/settings/security/example.myjetpacksite.com
3. Activate Jetpack Scan there
4. Look for the message `Password is not required if you use public key authentication.Get your public key string.` — note the missing space.
5. Switch branch to this pull request, see if space is now there correctly, and link still works.