### PR TITLE
Jetpack-connect: final redirect link

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -25,13 +25,12 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
 import i18n from 'lib/mixins/i18n';
-import { getSiteSlug } from 'state/sites/selectors';
 
 /**
  * Constants
  */
 
-const STATS_PAGE = 'stats/insights/';
+const STATS_PAGE = '/stats/insights/';
 
 /**
  * Module variables
@@ -197,7 +196,7 @@ const LoggedInForm = React.createClass( {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
 		if ( this.isCalypsoStartedConnection() ) {
 			const site = this.props.jetpackConnectAuthorize.queryObject.site;
-			const siteSlug =  site.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+			const siteSlug = site.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
 			return STATS_PAGE + siteSlug;
 		}
 

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -25,6 +25,13 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
 import i18n from 'lib/mixins/i18n';
+import { getSiteSlug } from 'state/sites/selectors';
+
+/**
+ * Constants
+ */
+
+const STATS_PAGE = 'stats/insights/';
 
 /**
  * Module variables
@@ -186,6 +193,17 @@ const LoggedInForm = React.createClass( {
 		return false;
 	},
 
+	getRedirectionTarget() {
+		const { queryObject } = this.props.jetpackConnectAuthorize;
+		if ( this.isCalypsoStartedConnection() ) {
+			const site = this.props.jetpackConnectAuthorize.queryObject.site;
+			const siteSlug =  site.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+			return STATS_PAGE + siteSlug;
+		}
+
+		return queryObject.redirect_after_auth;
+	},
+
 	renderFooterLinks() {
 		const { queryObject, authorizeSuccess, isAuthorizing } = this.props.jetpackConnectAuthorize;
 		const loginUrl = config( 'login_url' ) + '?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) + '&_wp_nonce=' + encodeURIComponent( queryObject._wp_nonce );
@@ -197,7 +215,7 @@ const LoggedInForm = React.createClass( {
 		if ( authorizeSuccess ) {
 			return (
 				<LoggedOutFormLinks>
-					<LoggedOutFormLinkItem href={ queryObject.redirect_after_auth }>
+					<LoggedOutFormLinkItem href={ this.getRedirectionTarget() }>
 						{ this.translate( 'I\'m not interested in upgrades' ) }
 					</LoggedOutFormLinkItem>
 				</LoggedOutFormLinks>


### PR DESCRIPTION
This PR makes the 'Im not interested' link take the users to their site stats page in case they started the connection flow in calypso, instead of taking them back to their wp-admin

![image](https://cloud.githubusercontent.com/assets/1554855/14732595/7967a92e-085c-11e6-963a-2f124b92d6d2.png)

How to test:
========
1. Go to http://calypso.localhost:3000/jetpack/connect
2. Enter an url of a site running an unconnected jetpack 4.0
3. Wait for all the connection process to happen. At the then, the "I'm not interested" link at the bottom of the page should take you to your site calypso stats


@roccotripaldi