### PR TITLE
Jetpack-connect: Remove trailing backlash

### DIFF
--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -22,8 +22,9 @@ export default React.createClass( {
 	},
 
 	onChange( event ) {
+		const url = event.target.value;
 		this.setState( {
-			value: event.target.value
+			value: url.replace(/\/$/, "")
 		}, this.props.onChange );
 	},
 

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -11,6 +11,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
 import Spinner from 'components/spinner';
+import untrailingslashit from 'lib/route/untrailingslashit';
 
 export default React.createClass( {
 	displayName: 'JetpackConnectSiteURLInput',
@@ -18,13 +19,12 @@ export default React.createClass( {
 	getInitialState() {
 		return {
 			value: ''
-		}
+		};
 	},
 
 	onChange( event ) {
-		const url = event.target.value;
 		this.setState( {
-			value: url.replace(/\/$/, "")
+			value: untrailingslashit( event.target.value )
 		}, this.props.onChange );
 	},
 
@@ -32,7 +32,7 @@ export default React.createClass( {
 		if ( ! this.props.isFetching ) {
 			return( this.translate( 'Connect Now' ) );
 		}
-		return( this.translate( 'Connecting…' ) )
+		return( this.translate( 'Connecting…' ) );
 	},
 
 	handleKeyPress( event ) {


### PR DESCRIPTION
Right now, if you enter an url ending in a backslash, the redirection url to your wp-admin gets messed up, and you end in a loop of the login screen of your site.

This PR removes the trailing backslash of the urls before storing them in the state, so this don't happens anymore.

how to test
=========

1. go to http://calypso.localhost:3000/jetpack/connect 
2. enter an url of a 4.0 jetpack site, not connected (or a WP site without jetpack), and make sure that ends on a backslash
3. You should be able to keep going with the connected process, without getting stuck in the login screen

/cc @beaulebens