### PR TITLE
Sites: Allow sites dropdown to overlap surrounding elements

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -92,6 +92,7 @@ $z-layers: (
 		'.search.is-pinned': 170,
 		'.select-dropdown.is-open .select-dropdown__container': 170,
 		'.accessible-focus .select-dropdown.is-open .select-dropdown__container': 170,
+		'.sites-dropdown.is-open .sites-dropdown__wrapper' : 170,
 		'.popover.editor-visibility__popover': 179,
 		'.feature-example__gradient': 179,
 		'.global-notices': 179,

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -31,6 +31,8 @@
 }
 
 .sites-dropdown.is-open .sites-dropdown__wrapper {
+	position: relative;
+	z-index: z-index( 'root', '.sites-dropdown.is-open .sites-dropdown__wrapper' );
 	margin: 0;
 }
 


### PR DESCRIPTION
**Before**
![screen shot 2016-04-22 at 15 02 16](https://cloud.githubusercontent.com/assets/7767559/14743808/5b423114-089b-11e6-8c74-bd8c793004f5.png)

**After**
![screen shot 2016-04-22 at 15 03 03](https://cloud.githubusercontent.com/assets/7767559/14743811/608f2a28-089b-11e6-874e-23ffe8fe459e.png)

Position the component so that z-index comes into play, and add a positive index.

**To Test**
* Check that the Sites Dropdown is fixed as above at http://calypso.localhost:3000/devdocs/app-components
* Some other uses
   - http://calypso.localhost:3000/me/account
   - http://calypso.localhost:3000/design, _activate_ a theme

/cc @mtias