### PR TITLE
Fix/signup abtest overlap

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -24,8 +24,9 @@ module.exports = {
 	freeTrialsInSignup: {
 		datestamp: '20160328',
 		variations: {
-			disabled: 85,
-			enabled: 15
+			disabled: 40,
+			enabled: 15,
+			notTested: 45
 		},
 		defaultVariation: 'disabled'
 	},
@@ -95,9 +96,9 @@ module.exports = {
 	triforce: {
 		datestamp: '20160421',
 		variations: {
-			original: 30,
-			triforce: 30,
-			notTested: 40
+			original: 45,
+			triforce: 45,
+			notTested: 10
 		},
 		defaultVariation: 'original'
 	}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -8,7 +8,7 @@ import reject from 'lodash/reject';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
+import { abtest, getABTestVariation } from 'lib/abtest';
 import config from 'config';
 import { isOutsideCalypso } from 'lib/url';
 import plansPaths from 'my-sites/plans/paths';
@@ -241,7 +241,7 @@ function filterFlowName( flowName ) {
 		return 'free-trial';
 	}
 
-	if ( includes( defaultFlows, flowName ) && 'triforce' === abtest( 'triforce' ) ) {
+	if ( includes( defaultFlows, flowName ) && 'notTested' === getABTestVariation( 'freeTrialsInSignup' ) && 'triforce' === abtest( 'triforce' ) ) {
 		return 'layout';
 	}
 


### PR DESCRIPTION
The Triforce AB test was merged with taking users from the `disabled` control variation of the free trials test. This PR shaves off a `notTested` variation for use by the Triforce test instead.