### PR TITLE
Notifications: Make the cache buster a little more aggressive

### DIFF
--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -213,7 +213,7 @@ var Notifications = React.createClass({
 		widgetURL += '?locale=' + localeSlug;
 
 		// cache buster
-		widgetURL += '&' + now.getFullYear() + ( now.getMonth() + 1 ) + now.getDate();
+		widgetURL += '&' + now.getFullYear() + ( now.getMonth() + 1 ) + now.getDate() + now.getHours();
 
 		if ( this.state.widescreen && this.props.visible ) {
 			frameClasses.push( 'widescreen' );


### PR DESCRIPTION
Now we don't have to wait a day if something breaks with the notifications client. Only an hour. Hmm.

/cc @dmsnell