### PR TITLE
Editor: ensure the value for Default Post Format is in list of available

### DIFF
--- a/client/post-editor/editor-post-formats/index.jsx
+++ b/client/post-editor/editor-post-formats/index.jsx
@@ -4,6 +4,7 @@
 const React = require( 'react' );
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -33,6 +34,18 @@ const EditorPostFormats = React.createClass( {
 			setPostFormat: () => {},
 			value: 'standard'
 		};
+	},
+
+	getSelectedPostFormat: function() {
+		var validSlugs = this.getPostFormats().map( function( postFormat ) {
+			return postFormat.slug;
+		} );
+
+		if ( includes( validSlugs, this.props.value ) ) {
+			return this.props.value;
+		}
+
+		return 'standard';
 	},
 
 	getPostFormats: function() {
@@ -77,6 +90,8 @@ const EditorPostFormats = React.createClass( {
 	},
 
 	renderPostFormats: function() {
+		var selectedFormat = this.getSelectedPostFormat();
+
 		return this.getPostFormats().map( function( postFormat ) {
 			return (
 				<li key={ postFormat.slug } className="editor-post-formats__format">
@@ -84,11 +99,11 @@ const EditorPostFormats = React.createClass( {
 						<FormRadio
 							name="format"
 							value={ postFormat.slug }
-							checked={ postFormat.slug === this.props.value }
+							checked={ postFormat.slug === selectedFormat }
 							onChange={ this.onChange } />
 						<span className="editor-post-formats__format-label">
 							<span className={ 'editor-post-formats__format-icon' } >
-								<Gridicon icon={ this.getPostFormatIcon( postFormat ) } size={ 20 } />
+								<Gridicon icon={ this.getPostFormatIcon( postFormat ) } size={ 18 } />
 							</span>
 							{ postFormat.label }
 						</span>

--- a/client/post-editor/editor-post-formats/index.jsx
+++ b/client/post-editor/editor-post-formats/index.jsx
@@ -4,7 +4,6 @@
 const React = require( 'react' );
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import includes from 'lodash/includes';
 
 /**
  * Internal dependencies

--- a/client/post-editor/editor-post-formats/index.jsx
+++ b/client/post-editor/editor-post-formats/index.jsx
@@ -108,7 +108,7 @@ const EditorPostFormats = React.createClass( {
 							onChange={ this.onChange } />
 						<span className="editor-post-formats__format-label">
 							<span className={ 'editor-post-formats__format-icon' } >
-								<Gridicon icon={ this.getPostFormatIcon( postFormat ) } size={ 18 } />
+								<Gridicon icon={ this.getPostFormatIcon( postFormat ) } size={ 20 } nonStandardSize />
 							</span>
 							{ postFormat.label }
 						</span>

--- a/client/post-editor/editor-post-formats/index.jsx
+++ b/client/post-editor/editor-post-formats/index.jsx
@@ -37,12 +37,18 @@ const EditorPostFormats = React.createClass( {
 	},
 
 	getSelectedPostFormat: function() {
-		var validSlugs = this.getPostFormats().map( function( postFormat ) {
-			return postFormat.slug;
+		const { value } = this.props;
+
+		if ( 'standard' === value ) {
+			return 'standard';
+		}
+
+		const isSupportedFormat = this.getPostFormats().some( ( postFormat ) => {
+			return postFormat.slug === value;
 		} );
 
-		if ( includes( validSlugs, this.props.value ) ) {
-			return this.props.value;
+		if ( isSupportedFormat ) {
+			return value;
 		}
 
 		return 'standard';


### PR DESCRIPTION
Fixes #1000

Currently you can arrive at a state where the default post format set for a site is not an option in the post format listing in the editor sidebar.  I was able to re-create this issue with the Journalistic Theme by setting my default post format to "Aside".

Aside is not a valid post format for my theme but the option is [hard-coded](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/site-settings/form-writing.jsx#L93-L102) into Site Settings > Writing.  Perhaps that should be re-visited, but regardless, the logic in this branch should still be in place to validate the `default_post_format`.

So by setting my post format to aside, this is how things look in the editor sidebar:

__Before__
<img width="273" alt="new_post_ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/14748336/f00700b4-086d-11e6-92c2-b88b2f85c86c.png">

__After__
<img width="272" alt="new_post_ _trout_bummin_ _wordpress_com" src="https://cloud.githubusercontent.com/assets/22080/14748358/15ba8d12-086e-11e6-829f-29b19f4afb78.png">

__To Test__
- Set your default post format for a site to one that is not supported by your theme, you can surface one by comparing the list in Site Settings -> Writing to what you see in the editor sidebar
- Open a new post in the editor, validate that the default post format is "Standard" and the proper radio button is selected in the accordion