### PR TITLE
Redux: add query-site-domains data component

### DIFF
--- a/client/components/data/query-site-domains/README.md
+++ b/client/components/data/query-site-domains/README.md
@@ -1,0 +1,32 @@
+Query SiteDomains
+===========================
+
+`<QuerySiteDomains />` is a React component used in managing network requests for sites/%s/domains.
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page.
+
+```es6
+import QuerySiteDomains from 'components/data/query-site-domains';
+
+const MyReactComponent = React.createClass( {
+	render() {
+	const { site, domains } = this.props;
+
+		return (
+			<div>
+				<QuerySiteDomains siteId={ site.ID } />
+				<ul>
+				{
+					domains.map( domain => {
+						return ( <li>{ domain.domain }</li> );
+					} )
+				}
+				</ul>
+			</div>
+		);
+	}
+} );
+```
+

--- a/client/components/data/query-site-domains/index.jsx
+++ b/client/components/data/query-site-domains/index.jsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingSiteDomains } from 'state/sites/domains/selectors';
+import { fetchSiteDomains } from 'state/sites/domains/actions';
+
+class QuerySiteDomains extends Component {
+	constructor( props ) {
+		super( props );
+		this.requestSiteDomains = this.requestSiteDomains.bind( this );
+	}
+
+	componentWillMount() {
+		this.requestSiteDomains();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.requestingSiteDomains ||
+			! nextProps.siteId ||
+			( this.props.siteId === nextProps.siteId ) ) {
+			return;
+		}
+		this.requestSiteDomains( nextProps );
+	}
+
+	requestSiteDomains( props = this.props ) {
+		if ( ! props.requestingSiteDomains && props.siteId ) {
+			props.fetchSiteDomains( props.siteId );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QuerySiteDomains.propTypes = {
+	siteId: PropTypes.number,
+	requestingSiteDomains: PropTypes.bool,
+	fetchSiteDomains: PropTypes.func
+};
+
+QuerySiteDomains.defaultProps = {
+	fetchSiteDomains: () => {}
+};
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			requestingSiteDomains: isRequestingSiteDomains( state, ownProps.siteId )
+		};
+	},
+	dispatch => {
+		return bindActionCreators( { fetchSiteDomains }, dispatch );
+	}
+)( QuerySiteDomains );

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -11,6 +11,7 @@ import page from 'page';
 import sitesFactory from 'lib/sites-list';
 import route from 'lib/route';
 import i18n from 'lib/mixins/i18n';
+import { renderWithReduxStore } from 'lib/react-helpers';
 import config from 'config';
 import analytics from 'lib/analytics';
 import titlecase from 'to-title-case';
@@ -85,7 +86,7 @@ module.exports = {
 			}
 		}
 
-		ReactDom.render(
+		renderWithReduxStore(
 			<SitePurchasesData>
 				<SiteSettingsComponent
 					context={ context }
@@ -93,7 +94,8 @@ module.exports = {
 					section={ context.params.section }
 					path={ context.path } />
 			</SitePurchasesData>,
-			document.getElementById( 'primary' )
+			document.getElementById( 'primary' ),
+			context.store
 		);
 
 		// analytics tracking

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { connect } from 'react-redux';
 import Card from 'components/card';
 import Button from 'components/button';
 import formBase from './form-base';
@@ -26,9 +27,10 @@ import FormRadio from 'components/forms/form-radio';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import TimezoneDropdown from 'components/timezone-dropdown';
+import QuerySiteDomains from 'query-components/site-domains';
+import { getDomainsBySite } from 'state/sites/domains/selectors';
 
-module.exports = React.createClass( {
-
+const FormGeneral = React.createClass( {
 	displayName: 'SiteSettingsFormGeneral',
 
 	mixins: [ dirtyLinkedState, protectForm.mixin, formBase ],
@@ -426,6 +428,7 @@ module.exports = React.createClass( {
 
 		return (
 			<div className={ this.state.fetchingSettings ? 'is-loading' : '' }>
+				{ site && <QuerySiteDomains siteId={ site.ID } /> }
 				<SectionHeader label={ this.translate( 'Site Profile' ) }>
 					<Button
 						compact={ true }
@@ -541,3 +544,12 @@ module.exports = React.createClass( {
 		}
 	}
 } );
+
+// connect exposing `domains` props
+export default connect( ( state, ownProps ) => {
+	const { site } = ownProps;
+
+	return {
+		domains: getDomainsBySite( state, site )
+	};
+} )( FormGeneral );

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -27,7 +27,7 @@ import FormRadio from 'components/forms/form-radio';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import TimezoneDropdown from 'components/timezone-dropdown';
-import QuerySiteDomains from 'query-components/site-domains';
+import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDomainsBySite } from 'state/sites/domains/selectors';
 
 const FormGeneral = React.createClass( {

--- a/client/state/sites/plans/reducer.js
+++ b/client/state/sites/plans/reducer.js
@@ -92,4 +92,4 @@ export function plans( state = {}, action ) {
 	}
 
 	return state;
-};
+}

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -80,9 +80,9 @@ export function fetchingItems( state = {}, action ) {
 }
 
 export default combineReducers( {
-	items,
 	domains,
 	fetchingItems,
+	items,
 	mediaStorage,
 	plans
 } );

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -9,7 +9,7 @@ import keyBy from 'lodash/keyBy';
  * Internal dependencies
  */
 import { plans } from './plans/reducer';
-import { domains } from './domains/reducer';
+import domains from './domains/reducer';
 
 import mediaStorage from './media-storage/reducer';
 import {

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -10,6 +10,7 @@ import keyBy from 'lodash/keyBy';
  */
 import { plans } from './plans/reducer';
 import { domains } from './domains/reducer';
+
 import mediaStorage from './media-storage/reducer';
 import {
 	SITE_RECEIVE,

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -29,6 +29,7 @@ describe( 'reducer', () => {
 
 	it( 'should export expected reducer keys', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'domains',
 			'fetchingItems',
 			'items',
 			'mediaStorage',


### PR DESCRIPTION
This PR adds the `query-site-domains` component. This [query-component](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#query-components) handles site domains data.

`domains` property is present in the state tree:

![image](https://cloud.githubusercontent.com/assets/77539/15017573/725aad9a-11ec-11e6-86ef-b4ddc6c00065.png)

I've connected domains query component with general form of site-settings page. In this way `domains` is present in the `this.props` object.

![image](https://cloud.githubusercontent.com/assets/77539/15017518/469f0688-11ec-11e6-937a-ad3c12d53923.png)
