### PR TITLE
Editor: prevent published scheduled posts from auto saving

### DIFF
--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -67,7 +67,7 @@ describe( 'utils', function() {
 		} );
 	} );
 
-	describe( '#isBackDatePublished', function() {
+	describe( '#isBackDatedPublished', function() {
 		it( 'should return false when no post is supplied', function() {
 			assert( ! postUtils.isBackDatedPublished() );
 		} );
@@ -78,14 +78,14 @@ describe( 'utils', function() {
 
 		it( 'should return false when status === future and date is in future', function() {
 			const tenMinutes = 1000 * 60;
-			const postDate = +new Date() + tenMinutes;
+			const postDate = Date.now() + tenMinutes;
 
 			assert( ! postUtils.isBackDatedPublished( { status: 'future', date: postDate } ) );
 		} );
 
 		it( 'should return true when status === future and date is in the past', function() {
 			const tenMinutes = 1000 * 60;
-			const postDate = +new Date() - tenMinutes;
+			const postDate = Date.now() - tenMinutes;
 
 			assert( postUtils.isBackDatedPublished( { status: 'future', date: postDate } ) );
 		} );

--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -67,6 +67,30 @@ describe( 'utils', function() {
 		} );
 	} );
 
+	describe( '#isBackDatePublished', function() {
+		it( 'should return false when no post is supplied', function() {
+			assert( ! postUtils.isBackDatedPublished() );
+		} );
+
+		it( 'should return false when status !== future', function() {
+			assert( ! postUtils.isBackDatedPublished( { status: 'draft' } ) );
+		} );
+
+		it( 'should return false when status === future and date is in future', function() {
+			const tenMinutes = 1000 * 60;
+			const postDate = +new Date() + tenMinutes;
+
+			assert( ! postUtils.isBackDatedPublished( { status: 'future', date: postDate } ) );
+		} );
+
+		it( 'should return true when status === future and date is in the past', function() {
+			const tenMinutes = 1000 * 60;
+			const postDate = +new Date() - tenMinutes;
+
+			assert( postUtils.isBackDatedPublished( { status: 'future', date: postDate } ) );
+		} );
+	} );
+
 	describe( '#removeSlug', function() {
 		it( 'should return undefined when no path is supplied', function() {
 			assert( postUtils.removeSlug() === undefined );

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -62,7 +62,7 @@ var utils = {
 	},
 
 	isPublished: function( post ) {
-		return post && ( post.status === 'publish' || post.status === 'private' );
+		return post && ( post.status === 'publish' || post.status === 'private' || this.isBackDatedPublished( post ) );
 	},
 
 	isPrivate: function( post ) {
@@ -79,6 +79,14 @@ var utils = {
 		}
 
 		return post.modified;
+	},
+
+	isBackDatedPublished: function( post ) {
+		if ( ! post || post.status !== 'future' ) {
+			return false;
+		}
+
+		return moment( post.date ).isBefore( moment() );
 	},
 
 	isFutureDated: function( post ) {

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -110,12 +110,13 @@ const EditorGroundControl = React.createClass( {
 		const buttonState = this.getPrimaryButtonState();
 		const eventString = postUtils.isPage( this.props.post ) ? pageEvents[ buttonState ] : postEvents[ buttonState ];
 		stats.recordEvent( eventString );
-		stats.recordEvent( 'Clicked Primary Button' )
+		stats.recordEvent( 'Clicked Primary Button' );
 	},
 
 	getPrimaryButtonState: function() {
 		if (
 			postUtils.isPublished( this.props.savedPost ) &&
+			! postUtils.isBackDatedPublished( this.props.savedPost ) &&
 			! postUtils.isFutureDated( this.props.post ) ||
 			(
 				this.props.savedPost &&
@@ -184,7 +185,7 @@ const EditorGroundControl = React.createClass( {
 				onDateChange={ this.setPostDate }
 				onMonthChange={ this.setCurrentMonth }>
 			</PostSchedule>
-		)
+		);
 	},
 
 	schedulePostPopover: function() {
@@ -253,7 +254,7 @@ const EditorGroundControl = React.createClass( {
 	isPrimaryButtonEnabled: function() {
 		return ! this.props.isPublishing &&
 			! this.props.isSaveBlocked &&
-			this.props.hasContent
+			this.props.hasContent;
 	},
 
 	toggleAdvancedStatus: function() {
@@ -267,7 +268,9 @@ const EditorGroundControl = React.createClass( {
 			return this.props.onSave( 'future' );
 		}
 
-		if ( postUtils.isPublished( this.props.savedPost ) ) {
+		if ( postUtils.isPublished( this.props.savedPost ) &&
+			! postUtils.isBackDatedPublished( this.props.savedPost )
+		) {
 			return this.props.onSave();
 		}
 

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -181,7 +181,7 @@ describe( 'EditorGroundControl', function() {
 				/>
 			).instance();
 
-			expect( tree.getPrimaryButtonLabel() ).to.equal( 'Publish' );
+			expect( tree.getPrimaryButtonLabel() ).to.equal( 'Update' );
 		} );
 
 		it( 'should return Publish if the post is a draft', function() {
@@ -377,24 +377,24 @@ describe( 'EditorGroundControl', function() {
 			expect( onSave ).to.have.been.calledWith( 'future' );
 		} );
 
-		it( 'should publish a scheduled post dated in past', function() {
+		it( 'should update a scheduled post dated in past', function() {
 			var now = moment( new Date() ),
 				lastMonth = now.month( now.month() - 1 ).format(),
-				onPublish = sinon.spy(),
+				onSave = sinon.spy(),
 				tree;
 
 			tree = shallow(
 				<EditorGroundControl
 					savedPost={ { status: 'future', date: lastMonth } }
 					post={ { title: 'change', status: 'future', date: lastMonth } }
-					onPublish={ onPublish }
+					onSave={ onSave }
 					site={ MOCK_SITE }
 				/>
 			).instance();
 
 			tree.onPrimaryButtonClick();
 
-			expect( onPublish ).to.have.been.called;
+			expect( onSave ).to.have.been.called;
 		} );
 
 		it( 'should update a published post that has changed status', function() {

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -181,7 +181,7 @@ describe( 'EditorGroundControl', function() {
 				/>
 			).instance();
 
-			expect( tree.getPrimaryButtonLabel() ).to.equal( 'Update' );
+			expect( tree.getPrimaryButtonLabel() ).to.equal( 'Publish' );
 		} );
 
 		it( 'should return Publish if the post is a draft', function() {
@@ -377,24 +377,24 @@ describe( 'EditorGroundControl', function() {
 			expect( onSave ).to.have.been.calledWith( 'future' );
 		} );
 
-		it( 'should update a scheduled post dated in past', function() {
+		it( 'should publish a scheduled post dated in past', function() {
 			var now = moment( new Date() ),
 				lastMonth = now.month( now.month() - 1 ).format(),
-				onSave = sinon.spy(),
+				onPublish = sinon.spy(),
 				tree;
 
 			tree = shallow(
 				<EditorGroundControl
 					savedPost={ { status: 'future', date: lastMonth } }
 					post={ { title: 'change', status: 'future', date: lastMonth } }
-					onSave={ onSave }
+					onPublish={ onPublish }
 					site={ MOCK_SITE }
 				/>
 			).instance();
 
 			tree.onPrimaryButtonClick();
 
-			expect( onSave ).to.have.been.called;
+			expect( onPublish ).to.have.been.called;
 		} );
 
 		it( 'should update a published post that has changed status', function() {

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -184,6 +184,22 @@ describe( 'EditorGroundControl', function() {
 			expect( tree.getPrimaryButtonLabel() ).to.equal( 'Publish' );
 		} );
 
+		it( 'should return Update if the post was originally published and is scheduled with date in the past', function() {
+			var now = moment(),
+				lastMonth = now.month( now.month() - 1 ).format(),
+				tree;
+
+			tree = shallow(
+				<EditorGroundControl
+					savedPost={ { status: 'publish', date: lastMonth } }
+					post={ { title: 'change', status: 'future', date: lastMonth } }
+					site={ MOCK_SITE }
+				/>
+			).instance();
+
+			expect( tree.getPrimaryButtonLabel() ).to.equal( 'Update' );
+		} );
+
 		it( 'should return Publish if the post is a draft', function() {
 			var tree = shallow(
 				<EditorGroundControl
@@ -405,6 +421,26 @@ describe( 'EditorGroundControl', function() {
 				<EditorGroundControl
 					savedPost={ { status: 'publish' } }
 					post={ { title: 'change', status: 'draft' } }
+					onSave={ onSave }
+					site={ MOCK_SITE }
+				/>
+			).instance();
+
+			tree.onPrimaryButtonClick();
+
+			expect( onSave ).to.have.been.called;
+		} );
+
+		it( 'should update a published post scheduled in the past', function() {
+			var now = moment( new Date() ),
+				lastMonth = now.month( now.month() - 1 ).format(),
+				onSave = sinon.spy(),
+				tree;
+
+			tree = shallow(
+				<EditorGroundControl
+					savedPost={ { status: 'publish' } }
+					post={ { title: 'change', status: 'future', date: lastMonth } }
 					onSave={ onSave }
 					site={ MOCK_SITE }
 				/>


### PR DESCRIPTION
fixes #310

There is an edge case where if a scheduled post time has lapsed ( e.g. the post is now published ), and the editor window the post was drafted in is still open, the first set of modifications preformed in the "stale" editor window will be auto-saved, and updated to the live post.

After that first false auto-save, the state is properly updated in the post edit store, and no more auto-saves will happen.

This branch seeks to prevent that first false auto-save from firing by seeing if the `post.date` is in the past when `post.status === 'future'`.

__To Test__
- Scheduled a post sometime in the future. Came back to edit the post close to the set publish time. (To reproduce you can just schedule a post a couple minutes into the future.)
- Leave the Editor window open past the scheduled time.
- After publish time has lapsed, make some changes to the post, validate that these changes are not autosaved
- Also create a new post, and ensure no auto-save functionality has changed

__Notes__
Due to this new logic to `isPublished` some tests were failing for ground control.  I have updated the tests in e9614bb to reflect this new logic, but wanted to hear @aduth 's thoughts on the matter.