### PR TITLE
Editor: fix permalink URL on pages set as homepage

### DIFF
--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -308,6 +308,7 @@ const PostEditor = React.createClass( {
 		var site = this.props.sites.getSelectedSite() || undefined,
 			mode = this.getEditorMode(),
 			isInvalidURL = this.state.loadingError,
+			siteURL = site ? site.URL + '/' : null,
 			isPage,
 			isTrashed,
 			hasAutosave;
@@ -344,11 +345,11 @@ const PostEditor = React.createClass( {
 								{ this.state.post && isPage && site
 									? <EditorPageSlug
 										slug={ this.state.post.slug }
-										path={ this.state.post.URL && ( this.state.post.URL !== site.URL + '/' )
+										path={ this.state.post.URL && ( this.state.post.URL !== siteURL )
 											? utils.getPagePath( this.state.post )
-											: site.URL + '/'
+											: siteURL
 										}
-									/>
+										/>
 									: null
 								}
 								<SegmentedControl className="editor__switch-mode" compact={ true }>

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -344,7 +344,10 @@ const PostEditor = React.createClass( {
 								{ this.state.post && isPage && site
 									? <EditorPageSlug
 										slug={ this.state.post.slug }
-										path={ this.state.post.URL ? utils.getPagePath( this.state.post ) : site.URL + '/' }
+										path={ this.state.post.URL && ( this.state.post.URL !== site.URL + '/' )
+											? utils.getPagePath( this.state.post )
+											: site.URL + '/'
+										}
 									/>
 									: null
 								}


### PR DESCRIPTION
Fixes #3563 

Currently when editing a page which is set as the homepage, the permalink logic incorrectly displays the base path of the URL:

__Before__
![edit_page_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/14756756/32998446-08a1-11e6-9906-04e075ad98a7.png)

This branch checks to see if the `post.URL === site.URL` to prevent this from happening:

__After__
![edit_page_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/14756764/536d3280-08a1-11e6-893f-941afbdd3be1.png)

Even though the permalink in this scenario will redirect to the homepage of the site, having the slug shown/editable still seems prudent.

__To Test__
- Set the homepage to be a certain page via the customizer
- Open that page in the editor and verify the permalink and slug is shown correctly