### PR TITLE
Domains: Fix duplicated notices for new domains

### DIFF
--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -39,7 +39,7 @@ export default React.createClass( {
 	},
 
 	getPipe() {
-		let allRules = [ this.expiredDomains, this.expiringDomains, this.newDomainsWithPrimary, this.newDomains, this.unverifiedDomains ],
+		let allRules = [ this.expiredDomains, this.expiringDomains, this.newDomains, this.unverifiedDomains ],
 			rules;
 		if ( ! this.props.ruleWhiteList ) {
 			rules = allRules;
@@ -99,56 +99,10 @@ export default React.createClass( {
 		return <Notice status="is-error" showDismiss={ false } key="expiring-domains">{ text } { renewLink }</Notice>;
 	},
 
-	newDomainsWithPrimary() {
-		debug( 'Rendering newDomainsWithPrimary' );
-		let newDomains = this.getDomains().filter( ( domain ) =>
-			domain.registrationMoment && moment( domain.registrationMoment ).add( 3, 'days' ).isAfter( moment() ) && domain.type === domainTypes.REGISTERED ),
-			hasNewPrimaryDomain = newDomains.some( ( domain ) => this.props.selectedSite.domain === domain.name ),
-			text;
-
-		if ( ! hasNewPrimaryDomain || newDomains.length === 0 ) {
-			return null;
-		}
-
-		if ( newDomains.length > 1 ) {
-			// Multiple new domains, one is primary
-			text = this.translate( '{{pNode}}We are setting up your new domains for you. They should start working immediately, ' +
-				'but may be unreliable during the first 72 hours.{{/pNode}}' +
-				'{{pNode}}If you are unable to access your site at %(primaryDomain)s, try setting the primary domain to a domain ' +
-				'you know is working. {{domainsLink}}Learn more{{/domainsLink}} about setting the primary domain.{{/pNode}}',
-				{
-					args: { primaryDomain: this.props.selectedSite.domain },
-					components: {
-						pNode,
-						domainsLink
-					}
-				}
-			);
-		} else {
-			// One new domain and is primary
-			let domain = newDomains[0];
-			text = this.translate( '{{pNode}}We are setting up %(domainName)s for you. It should start working immediately, ' +
-				'but may be unreliable during the first 72 hours.{{/pNode}}' +
-				'{{pNode}}If you are unable to access your site at %(domainName)s, try setting the primary domain to a domain you' +
-				' know is working. {{domainsLink}}Learn more{{/domainsLink}} about setting the primary domain, or ' +
-				'{{tryNowLink}}try %(domainName)s now.{{/tryNowLink}}{{/pNode}}',
-				{
-					args: { domainName: domain.name },
-					components: {
-						domainsLink,
-						pNode,
-						tryNowLink: <a href={ `http://${domain.name}` } target="_blank"/>
-					}
-				}
-			);
-		}
-
-		return <Notice status="is-warning" showDismiss={ false } key="new-domains-with-primary">{ text }</Notice>;
-	},
-
 	newDomains() {
 		let newDomains = this.getDomains().filter( ( domain ) =>
-			domain.registrationMoment && moment( domain.registrationMoment ).add( 3, 'days' ).isAfter( moment() ) && domain.type === domainTypes.REGISTERED ),
+				domain.registrationMoment && moment( domain.registrationMoment ).add( 3, 'days' ).isAfter( moment() ) && domain.type === domainTypes.REGISTERED ),
+			hasNewPrimaryDomain = newDomains.some( ( domain ) => this.props.selectedSite.domain === domain.name ),
 			text;
 
 		if ( newDomains.length === 0 ) {
@@ -156,23 +110,56 @@ export default React.createClass( {
 		}
 
 		if ( newDomains.length > 1 ) {
-			text = this.translate( 'We are setting up your new domains for you. They should start working immediately, ' +
-				'but may be unreliable during the first 72 hours. ' +
-				'{{allAboutDomainsLink}}Learn more{{/allAboutDomainsLink}}.', { components: { allAboutDomainsLink } } );
-		} else {
-			let domain = newDomains[0];
-			text = this.translate( 'We are setting up %(domainName)s for you. It should start working immediately, ' +
-				'but may be unreliable during the first 72 hours. ' +
-				'{{allAboutDomainsLink}}Learn more{{/allAboutDomainsLink}} about your new domain, or {{tryNowLink}} try it now{{/tryNowLink}}.',
-				{
-					args: { domainName: domain.name },
-					components: {
-						allAboutDomainsLink,
-						tryNowLink: <a href={ `http://${domain.name}` } target="_blank"/>
+			if ( hasNewPrimaryDomain ) {
+				text = this.translate( '{{pNode}}We are setting up your new domains for you. They should start working immediately, ' +
+					'but may be unreliable during the first 72 hours.{{/pNode}}' +
+					'{{pNode}}If you are unable to access your site at %(primaryDomain)s, try setting the primary domain to a domain ' +
+					'you know is working. {{domainsLink}}Learn more{{/domainsLink}} about setting the primary domain.{{/pNode}}',
+					{
+						args: { primaryDomain: this.props.selectedSite.domain },
+						components: {
+							pNode,
+							domainsLink
+						}
 					}
-				}
-			);
+				);
+			} else {
+				text = this.translate( 'We are setting up your new domains for you. They should start working immediately, ' +
+					'but may be unreliable during the first 72 hours. ' +
+					'{{allAboutDomainsLink}}Learn more{{/allAboutDomainsLink}}.', { components: { allAboutDomainsLink } } );
+			}
+		} else {
+			const domain = newDomains[0];
+			if ( hasNewPrimaryDomain ) {
+				text = this.translate( '{{pNode}}We are setting up %(domainName)s for you. It should start working immediately, ' +
+					'but may be unreliable during the first 72 hours.{{/pNode}}' +
+					'{{pNode}}If you are unable to access your site at %(domainName)s, try setting the primary domain to a domain you' +
+					' know is working. {{domainsLink}}Learn more{{/domainsLink}} about setting the primary domain, or ' +
+					'{{tryNowLink}}try %(domainName)s now.{{/tryNowLink}}{{/pNode}}',
+					{
+						args: { domainName: domain.name },
+						components: {
+							domainsLink,
+							pNode,
+							tryNowLink: <a href={ `http://${domain.name}` } target="_blank"/>
+						}
+					}
+				);
+			} else {
+				text = this.translate( 'We are setting up %(domainName)s for you. It should start working immediately, ' +
+					'but may be unreliable during the first 72 hours. ' +
+					'{{allAboutDomainsLink}}Learn more{{/allAboutDomainsLink}} about your new domain, or {{tryNowLink}} try it now{{/tryNowLink}}.',
+					{
+						args: { domainName: domain.name },
+						components: {
+							allAboutDomainsLink,
+							tryNowLink: <a href={ `http://${domain.name}` } target="_blank"/>
+						}
+					}
+				);
+			}
 		}
+
 		return <Notice status="is-warning" showDismiss={ false } key="new-domains">{ text }</Notice>;
 	},
 

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -51,7 +51,7 @@ export default React.createClass( {
 	},
 
 	getDomains() {
-		return this.props.domains || [ this.props.domain ]
+		return this.props.domains || [ this.props.domain ];
 	},
 
 	expiredDomains() {
@@ -73,7 +73,7 @@ export default React.createClass( {
 			} );
 			renewLink = renewLinkPlural;
 		}
-		return <Notice status="is-error" showDismiss={ false } key="expired-domains">{ text } { renewLink }</Notice>
+		return <Notice status="is-error" showDismiss={ false } key="expired-domains">{ text } { renewLink }</Notice>;
 	},
 
 	expiringDomains() {


### PR DESCRIPTION
Before, we had two separate cases for new domains - a new domain and a new domain that was set as a primary address for the site. This could lead to a situation where the user is presented with two, very similar warning notices about setting up their domain.
I merged the two cases (`newDomains` and `newDomainsWithPrimary`) into one. Suggestions for better organisation of this new method are more than welcome - there's _some_ overlapping of the strings, but not enough to warrant adding extra logic to deduplicate it further.

#### Before:
<img width="749" alt="screen shot 2016-04-25 at 02 00 20" src="https://cloud.githubusercontent.com/assets/3392497/14771385/ce1155d6-0a89-11e6-993a-46add296e13e.png">

<img width="753" alt="screen shot 2016-04-25 at 01 55 01" src="https://cloud.githubusercontent.com/assets/3392497/14771387/d42f99a0-0a89-11e6-86c7-d3273865bfd8.png">

#### After:
<img width="753" alt="screen shot 2016-04-25 at 02 06 22" src="https://cloud.githubusercontent.com/assets/3392497/14771403/59eedcae-0a8a-11e6-95c3-32d9e8a877c9.png">

<img width="743" alt="screen shot 2016-04-25 at 01 53 17" src="https://cloud.githubusercontent.com/assets/3392497/14771396/0a6f816a-0a8a-11e6-9b00-a96f98ea051a.png">

Fixes #4978

/cc @aidvu @umurkontaci 