### PR TITLE
Editor: Remove added tags from suggestion list

### DIFF
--- a/client/components/token-field/index.jsx
+++ b/client/components/token-field/index.jsx
@@ -4,6 +4,7 @@
 var take = require( 'lodash/take' ),
 	clone = require( 'lodash/clone' ),
 	map = require( 'lodash/map' ),
+	difference = require( 'lodash/difference' ),
 	React = require( 'react' ),
 	PureRenderMixin = require( 'react-pure-render/mixin' ),
 	each = require( 'lodash/each' ),
@@ -369,7 +370,9 @@ var TokenField = React.createClass( {
 			startsWithMatch = [],
 			containsMatch = [];
 
-		if ( match.length > 0 ) {
+		if ( match.length === 0 ) {
+			suggestions = difference( suggestions, this.props.value );
+		} else {
 			match = match.toLocaleLowerCase();
 
 			each( suggestions, function( suggestion ) {
@@ -386,7 +389,7 @@ var TokenField = React.createClass( {
 			suggestions = startsWithMatch.concat( containsMatch );
 		}
 
-		return take( suggestions, this.props.maxSuggestions )
+		return take( suggestions, this.props.maxSuggestions );
 	},
 
 	_getSelectedSuggestion: function() {

--- a/client/components/token-field/test/index.jsx
+++ b/client/components/token-field/test/index.jsx
@@ -138,6 +138,13 @@ describe( 'TokenField', function() {
 			expect( getSuggestionsHTML() ).to.deep.equal( wrapper.state( 'tokenSuggestions' ) );
 		} );
 
+		it( 'should remove already added tags from suggestions', function() {
+			wrapper.setState( {
+				tokens: Object.freeze( [ 'of', 'and' ] )
+			} );
+			expect( getSuggestionsHTML() ).to.not.include.members( getTokensHTML() );
+		} );
+
 		it( 'should suggest partial matches', function() {
 			setText( 't' );
 			expect( getSuggestionsHTML() ).to.deep.equal( fixtures.matchingSuggestions.t );


### PR DESCRIPTION
This is a shot at fixing #2205 by removing tags already added to the post from the suggestion list dropdown. I've been working at this for a bit, but just now got to a working example. 

**How it works**

I wanted to do all of the work in [`components/token-field/index.jsx`](https://github.com/Automattic/wp-calypso/blob/master/client/components/token-field/index.jsx) as I thought this would be a universal need. Items already added to the input field shouldn't appear in the suggestion list. I added a prop to the `SuggestionList` component that accepts the current value of `TokenField`. Then, I ran a check in `_renderSuggestions` when returning the list elements that checks if `this.props.tokenFieldValue.indexOf( suggestion ) === -1`. If so, it returns the item as an `li`.

The main issue I ran into was when all suggestions were added to the post. The `ul` would return empty, but it would still appear. I added another if block in the `render` statement that compares the intersection of `this.props.tokenFieldValue` (the current value of the input) and `this.props.suggestions`. If the length of that intersection is equal to the length of `this.props.suggestions`, the `ul` is removed. 

**To test**

1. Load up this branch and start a new post at http://calypso.localhost:3000/post/
2. Open the tag field. You should see all of your suggestions in the dropdown.
3. Start typing. Suggestion filtering should still work as expected.
4. Click on a tag to add it to your post. It should be removed from the suggestion list.
5. Add all tags in the suggestion dropdown to your post. The `ul` should be removed leaving no trace of a dropdown.
6. Remove tags from the post individually. They should slowly repopulate the tag suggestion dropdown.

**GIF**

![tags](https://cloud.githubusercontent.com/assets/7240478/14771425/d0c0eedc-0a47-11e6-89b9-aaff28789bdf.gif)

I still want to give this another run through, but cc @nylen for early feedback on the approach if you don't mind. My early attempts at doing this in [`post-editor/editor-tags/index.jsx`](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/editor-tags/index.jsx) proved futile.