### PR TITLE
Eslint:  improve `quote-props` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,7 +74,7 @@ module.exports = {
 			':': 'before'
 		} } ],
 		'padded-blocks': [ 1, 'never' ],
-		'quote-props': [ 1, 'as-needed' ],
+		'quote-props': [ 1, 'as-needed', { 'keywords': true } ],
 		'quotes': [ 1, 'single', 'avoid-escape' ],
 		'semi': 1,
 		'semi-spacing': 1,


### PR DESCRIPTION
Language keywords should be quoted as properties.

```es6
const object = {
  name: 'Finn',
  'class': 'Human'
};
```

`class` property must be quoted because it's a reserved word in javascript.

* Eslint quote-props rule -> http://eslint.org/docs/rules/quote-props#as-needed
* Comment about this -> https://github.com/Automattic/wp-calypso/pull/4970#discussion_r60797515


### Before
![image](https://cloud.githubusercontent.com/assets/77539/14790090/1b28ce88-0ae6-11e6-808d-084efb92a837.png)


### After
![image](https://cloud.githubusercontent.com/assets/77539/14790071/fba6092c-0ae5-11e6-9ec6-4e9de14f640c.png)


cc @rralian 