### PR TITLE
Framework: Fix errors on transition from themes to signup by re-rendering layout

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -161,15 +161,30 @@ function boot() {
 	createReduxStoreFromPersistedInitialState( reduxStoreReady );
 }
 
+function renderLayout( reduxStore ) {
+	let props = { focus: layoutFocus };
+
+	if ( user.get() ) {
+		Object.assign( props, {}, { user, sites, nuxWelcome, translatorInvitation } );
+	}
+
+	Layout = require( 'layout' );
+	renderWithReduxStore(
+		React.createElement( Layout, props ),
+		document.getElementById( 'wpcom' ),
+		reduxStore
+	);
+
+	debug( 'Main layout rendered.' );
+}
+
 function reduxStoreReady( reduxStore ) {
-	let layoutSection, layoutElement, validSections = [];
+	let layoutSection, validSections = [];
 
 	bindWpLocaleState( reduxStore );
 	bindTitleToStore( reduxStore );
 
 	supportUser.setReduxStore( reduxStore );
-
-	Layout = require( 'layout' );
 
 	if ( user.get() ) {
 		// When logged in the analytics module requires user and superProps objects
@@ -179,18 +194,8 @@ function reduxStoreReady( reduxStore ) {
 		// Set current user in Redux store
 		reduxStore.dispatch( receiveUser( user.get() ) );
 		reduxStore.dispatch( setCurrentUserId( user.get().ID ) );
-
-		// Create layout instance with current user prop
-		layoutElement = React.createElement( Layout, {
-			user: user,
-			sites: sites,
-			focus: layoutFocus,
-			nuxWelcome: nuxWelcome,
-			translatorInvitation: translatorInvitation
-		} );
 	} else {
 		analytics.setSuperProps( superProps );
-		layoutElement = React.createElement( Layout, { focus: layoutFocus } );
 	}
 
 	if ( config.isEnabled( 'perfmon' ) ) {
@@ -202,13 +207,7 @@ function reduxStoreReady( reduxStore ) {
 		require( 'lib/network-connection' ).init( reduxStore );
 	}
 
-	renderWithReduxStore(
-		layoutElement,
-		document.getElementById( 'wpcom' ),
-		reduxStore
-	);
-
-	debug( 'Main layout rendered.' );
+	renderLayout( reduxStore );
 
 	// If `?sb` or `?sp` are present on the path set the focus of layout
 	// This can be removed when the legacy version is retired.

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -12,7 +12,7 @@ var React = require( 'react' ),
 	url = require( 'url' ),
 	qs = require( 'querystring' ),
 	injectTapEventPlugin = require( 'react-tap-event-plugin' ),
-	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default;
+	isEmpty = require( 'lodash/isEmpty' );
 
 /**
  * Internal dependencies
@@ -47,8 +47,8 @@ var config = require( 'config' ),
 	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
 	bindWpLocaleState = require( 'lib/wp/localization' ).bindState,
 	supportUser = require( 'lib/user/support-user-interop' ),
-	isIsomorphicRoute = require( 'controller' ).isIsomorphicRoute,
-	previousLayoutIsSingleTree = require( 'controller' ).previousLayoutIsSingleTree,
+	isSectionIsomorphic = require( 'state/ui/selectors' ).isSectionIsomorphic,
+	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default,
 	// The following components require the i18n mixin, so must be required after i18n is initialized
 	Layout;
 
@@ -369,7 +369,12 @@ function reduxStoreReady( reduxStore ) {
 	 * TODO (@seear): React 15's new reconciliation algo may make this unnecessary
 	 */
 	page( '*', function( context, next ) {
-		if ( ! isIsomorphicRoute( context.path ) && previousLayoutIsSingleTree() ) {
+		const sectionNotIsomorphic = ! isSectionIsomorphic( context.store.getState() );
+		const previousLayoutIsSingleTree = ! isEmpty(
+			document.getElementsByClassName( 'wp-singletree-layout' )
+		);
+
+		if ( sectionNotIsomorphic && previousLayoutIsSingleTree ) {
 			debug( 'Re-rendering multi-tree layout' );
 			renderLayout( context.store );
 		}

--- a/client/controller.js
+++ b/client/controller.js
@@ -6,20 +6,15 @@ import ReactDom from 'react-dom';
 import { Provider as ReduxProvider } from 'react-redux';
 import { setSection as setSectionAction } from 'state/ui/actions';
 import noop from 'lodash/noop';
-import page from 'page';
-import isEmpty from 'lodash/isEmpty';
-import pathToRegexp from 'path-to-regexp';
-import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
+import page from 'page';
 import LayoutLoggedOut from 'layout/logged-out';
+import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:controller' );
-
-let routes = [];
-let routeMatcher = pathToRegexp( routes );
 
 /**
  * @param { object } context -- Middleware context
@@ -38,7 +33,7 @@ export function makeLoggedOutLayout( context, next ) {
 		</ReduxProvider>
 	);
 	next();
-}
+};
 
 /**
  * Isomorphic routing helper, client side
@@ -55,8 +50,6 @@ export function makeLoggedOutLayout( context, next ) {
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	routes.push( route );
-	routeMatcher = pathToRegexp( routes );
 	page( route, ...[ ...middlewares, render ] );
 }
 
@@ -65,7 +58,7 @@ export function setSection( section ) {
 		context.store.dispatch( setSectionAction( section ) );
 
 		next();
-	};
+	}
 }
 
 function render( context ) {
@@ -109,12 +102,4 @@ function renderSecondary( context ) {
 			document.getElementById( 'secondary' )
 		);
 	}
-}
-
-export function isIsomorphicRoute( path ) {
-	return routeMatcher.exec( path );
-}
-
-export function previousLayoutIsSingleTree() {
-	return ! isEmpty( document.getElementsByClassName( 'wp-singletree-layout' ) );
 }

--- a/client/controller.js
+++ b/client/controller.js
@@ -6,15 +6,20 @@ import ReactDom from 'react-dom';
 import { Provider as ReduxProvider } from 'react-redux';
 import { setSection as setSectionAction } from 'state/ui/actions';
 import noop from 'lodash/noop';
+import page from 'page';
+import isEmpty from 'lodash/isEmpty';
+import pathToRegexp from 'path-to-regexp';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
-import page from 'page';
 import LayoutLoggedOut from 'layout/logged-out';
-import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:controller' );
+
+let routes = [];
+let routeMatcher = pathToRegexp( routes );
 
 /**
  * @param { object } context -- Middleware context
@@ -33,7 +38,7 @@ export function makeLoggedOutLayout( context, next ) {
 		</ReduxProvider>
 	);
 	next();
-};
+}
 
 /**
  * Isomorphic routing helper, client side
@@ -50,6 +55,8 @@ export function makeLoggedOutLayout( context, next ) {
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
+	routes.push( route );
+	routeMatcher = pathToRegexp( routes );
 	page( route, ...[ ...middlewares, render ] );
 }
 
@@ -58,7 +65,7 @@ export function setSection( section ) {
 		context.store.dispatch( setSectionAction( section ) );
 
 		next();
-	}
+	};
 }
 
 function render( context ) {
@@ -102,4 +109,12 @@ function renderSecondary( context ) {
 			document.getElementById( 'secondary' )
 		);
 	}
+}
+
+export function isIsomorphicRoute( path ) {
+	return routeMatcher.exec( path );
+}
+
+export function previousLayoutIsSingleTree() {
+	return ! isEmpty( document.getElementsByClassName( 'wp-singletree-layout' ) );
 }

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -22,7 +22,8 @@ const LayoutLoggedOut = ( {
 		[ 'is-group-' + section.group ]: !! section,
 		[ 'is-section-' + section.name ]: !! section,
 		'focus-content': true,
-		'has-no-sidebar': true // Logged-out never has a sidebar
+		'has-no-sidebar': true, // Logged-out never has a sidebar
+		'wp-singletree-layout': !! primary,
 	} );
 
 	return (

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -52,3 +52,15 @@ export function getSectionName( state ) {
 export function isSectionLoading( state ) {
 	return state.ui.isLoading;
 }
+
+/*
+ * Returns true if the current section is isomorphic.
+ *
+ * @param  {Object}  state Global state tree
+ * @return {bool}    True if current section is isomorphic
+ *
+ * @see client/sections
+ */
+export function isSectionIsomorphic( state ) {
+	return get( state.ui.section, 'isomorphic', false );
+}

--- a/client/state/ui/test/selectors.js
+++ b/client/state/ui/test/selectors.js
@@ -10,6 +10,7 @@ import {
 	getSelectedSite,
 	getSelectedSiteId,
 	getSectionName,
+	isSectionIsomorphic,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -87,6 +88,36 @@ describe( 'selectors', () => {
 			} );
 
 			expect( sectionName ).to.equal( 'post-editor' );
+		} );
+	} );
+
+	describe( '#isSectionIsomorphic()', () => {
+		it( 'should return false if there is no section currently selected', () => {
+			const selected = isSectionIsomorphic( {
+				ui: {
+					section: false
+				}
+			} );
+
+			expect( selected ).to.be.false;
+		} );
+
+		it( 'should return true if current section is isomorphic', () => {
+			const section = {
+				enableLoggedOut: true,
+				group: 'sites',
+				isomorphic: true,
+				module: 'my-sites/themes',
+				name: 'themes',
+				paths: [ '/design' ],
+				secondary: false
+			};
+
+			const selected = isSectionIsomorphic( {
+				ui: { section }
+			} );
+
+			expect( selected ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
All legacy routes in Calypso use multiple react mount points, where components are mounted to #primary and #secondary divs in an existing layout.

Routes that need to render both server- and client-side cannot use this technique, and need to render a complete layout tree into the parent #wpcom div.

Unfortunately these two approaches are incompatible, since React cannot properly reconcile the DOM when the mount points are switching around.

This change does the necessary re-rendering of an empty multi-tree layout when transitioning away from a single-tree-layout route.

**To Test**
* Logged-out, go to http://calypso.localhost:3000/design
* From any theme's ... button, click _Choose this design_
* Check that there are no errors as the signup page loads

Previous errors:
<img width="885" alt="screen shot 2016-04-15 at 17 04 09" src="https://cloud.githubusercontent.com/assets/7767559/14567485/31772674-032c-11e6-9d17-746084c7a4ae.png">