### PR TITLE
Customizer: account for calypso sidebar in layout

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -15,7 +15,8 @@ sections = [
 		name: 'customize',
 		paths: [ '/customize' ],
 		module: 'my-sites/customize',
-		group: 'sites'
+		group: 'sites',
+		secondary: true,
 	},
 	{
 		name: 'me',


### PR DESCRIPTION
The customizer failure page loads inside Calypso when the wp-admin customizer iframe fails to load, but its section layout does not take into account the sidebar and so it is squashed at smaller widths. This PR makes it aware of the sidebar.

The customizer wp-admin iframe overlays all of calypso anyway, so this should not have any effect on a successfully loaded page.

Fixes #4976 

Before:

<img width="718" alt="screen shot 2016-04-25 at 4 48 05 pm" src="https://cloud.githubusercontent.com/assets/2036909/14798432/900c8e8c-0b05-11e6-9870-9e8075752812.png">

After:

<img width="718" alt="screen shot 2016-04-25 at 4 57 06 pm" src="https://cloud.githubusercontent.com/assets/2036909/14798677/c704fc5c-0b06-11e6-933b-27f11c40fedf.png">


## Testing:

1. Alter line 53 of `client/my-sites/customize/main.jsx` so that it reads `timeoutError: true`
2. Load Calypso (you *must* rebuild this branch if you checked it out while already running `make run`; for some reason this change will not automatically get loaded)
3. Visit `http://calypso.localhost:3000/customize/YOURSITEHERE.wordpress.com` for your site
4. Adjust the window width to about 850px
5. Verify that the text "Sorry, the customizing tools did not load correctly" is not cut off by the sidebar.
6. Revert the changes made in step 1.
7. Load the customize route again (repeat step 3).
8. Verify that the customizer loads full-width.