### PR TITLE
Purchases: Display the correct refund amount in `CancelPurchaseButton`

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -47,7 +47,7 @@ const CancelPurchaseButton = React.createClass( {
 	},
 
 	renderCancelConfirmationDialog() {
-		const { domain, priceText } = this.props.purchase,
+		const { domain, refundText } = this.props.purchase,
 			purchaseName = getName( this.props.purchase ),
 			buttons = [
 				{
@@ -83,7 +83,7 @@ const CancelPurchaseButton = React.createClass( {
 							args: {
 								purchaseName,
 								domain,
-								priceText
+								priceText: refundText
 							},
 							components: {
 								em: <em />


### PR DESCRIPTION
Currently, the dialog displayed by `CancelPurchaseButton` displays the "price text" of a purchase, which is the cost of a product, instead of the refund text, which is the amount the user will actually be refunded. This PR updates this component to display the refund text.

**Testing**
- Visit `/plans` and purchase a premium plan.
- Visit `/plans` for the same site and purchase a business plan at a discount.
- Visit `/purchases` and click on the business plan.
- Click 'Cancel Subscription and Refund'.
- Assert that the amount to be refunded in [green text](https://cloudup.com/cCr1ZHGX1Qd) at the bottom of the page is the same as the amount in [the dialog](https://cloudup.com/caR8Bp1V4bU) after clicking the primary cancel button

- [x] Code review
- [x] Product review