### PR TITLE
CPT: Infinite scrolling for posts list screen

### DIFF
--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -1,60 +1,77 @@
 /**
  * External dependencies
  */
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import isEqual from 'lodash/isEqual';
 
 /**
  * Internal dependencies
  */
 import QueryPosts from 'components/data/query-posts';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import {
-	isRequestingSitePostsForQuery,
-	getSitePostsForQueryIgnoringPage
-} from 'state/posts/selectors';
-import PostTypeListPost from './post';
-import PostTypeListPostPlaceholder from './post-placeholder';
-import PostTypeListEmptyContent from './empty-content';
+import PostTypeListList from './list';
 
-function PostTypeList( { query, siteId, posts, requesting } ) {
-	return (
-		<div className="post-type-list">
-			<QueryPosts
-				siteId={ siteId }
-				query={ query } />
-			{ posts && ! posts.length && ! requesting && (
-				<PostTypeListEmptyContent
-					type={ query.type }
-					status={ query.status } />
-			) }
-			<ul className="post-type-list__posts">
-				{ requesting && (
-					<li><PostTypeListPostPlaceholder /></li>
-				) }
-				{ posts && posts.map( ( post ) => (
-					<li key={ post.global_ID }>
-						<PostTypeListPost globalId={ post.global_ID } />
-					</li>
-				) ) }
-			</ul>
-		</div>
-	);
+/**
+ * Constants
+ */
+const POSTS_PER_PAGE = 10;
+
+class PostTypeList extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.boundSetNextPage = this.setNextPage.bind( this );
+
+		this.state = PostTypeList.initialState;
+	}
+
+	getQuery() {
+		return Object.assign( {}, this.props.query, {
+			page: this.state.page,
+			number: POSTS_PER_PAGE
+		} );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! isEqual( nextProps.query, this.props.query ) ) {
+			this.setState( PostTypeList.initialState );
+		}
+	}
+
+	setNextPage() {
+		this.setState( {
+			page: this.state.page + 1
+		} );
+	}
+
+	render() {
+		const query = this.getQuery();
+
+		return (
+			<div className="post-type-list">
+				<QueryPosts
+					siteId={ this.props.siteId }
+					query={ query } />
+				<PostTypeListList
+					query={ query }
+					requestNextPage={ this.boundSetNextPage } />
+			</div>
+		);
+	}
 }
+
+PostTypeList.initialState = {
+	page: 1
+};
 
 PostTypeList.propTypes = {
 	query: PropTypes.object,
-	siteId: PropTypes.number,
-	posts: PropTypes.array,
-	requesting: PropTypes.bool
+	siteId: PropTypes.number
 };
 
-export default connect( ( state, ownProps ) => {
-	const siteId = getSelectedSiteId( state );
-
+export default connect( ( state ) => {
 	return {
-		siteId,
-		posts: getSitePostsForQueryIgnoringPage( state, siteId, ownProps.query ),
-		requesting: isRequestingSitePostsForQuery( state, siteId, ownProps.query )
+		siteId: getSelectedSiteId( state )
 	};
 } )( PostTypeList );

--- a/client/my-sites/post-type-list/list.jsx
+++ b/client/my-sites/post-type-list/list.jsx
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import omit from 'lodash/omit';
+
+/**
+ * Internal dependencies
+ */
+import InfiniteList from 'components/infinite-list';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	isRequestingSitePostsForQuery,
+	isSitePostsLastPageForQuery,
+	getSitePostsForQueryIgnoringPage
+} from 'state/posts/selectors';
+import PostTypeListPost from './post';
+import PostTypeListPostPlaceholder from './post-placeholder';
+import PostTypeListEmptyContent from './empty-content';
+
+/**
+ * Constants
+ */
+const GUESSED_POST_HEIGHT = 86;
+
+class PostTypeListList extends Component {
+	getListKey() {
+		const { siteId, query } = this.props;
+		return [ siteId, JSON.stringify( omit( query, 'page' ) ) ].join();
+	}
+
+	getPostItemRef( post ) {
+		return post.global_ID;
+	}
+
+	renderPostItem( post ) {
+		return (
+			<PostTypeListPost
+				key={ post.global_ID }
+				globalId={ post.global_ID } />
+		);
+	}
+
+	renderLoadingPlaceholder() {
+		return (
+			<PostTypeListPostPlaceholder key="placeholder" />
+		);
+	}
+
+	render() {
+		const { query, posts, lastPage, requesting, requestNextPage } = this.props;
+
+		return (
+			<div className="post-type-list__list">
+				{ posts && ! posts.length && ! requesting && (
+					<PostTypeListEmptyContent
+						type={ query.type }
+						status={ query.status } />
+				) }
+				<InfiniteList
+					key={ this.getListKey() }
+					items={ posts || [] }
+					lastPage={ !! lastPage }
+					fetchingNextPage={ requesting }
+					guessedItemHeight={ GUESSED_POST_HEIGHT }
+					fetchNextPage={ requestNextPage }
+					getItemRef={ this.getPostItemRef }
+					renderItem={ this.renderPostItem }
+					renderLoadingPlaceholders={ this.renderLoadingPlaceholder }
+					className="post-type-list__posts" />
+			</div>
+		);
+	}
+}
+
+PostTypeListList.propTypes = {
+	query: PropTypes.object,
+	siteId: PropTypes.number,
+	posts: PropTypes.array,
+	lastPage: PropTypes.bool,
+	requesting: PropTypes.bool,
+	requestNextPage: PropTypes.func
+};
+
+export default connect( ( state, ownProps ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+		posts: getSitePostsForQueryIgnoringPage( state, siteId, ownProps.query ),
+		lastPage: isSitePostsLastPageForQuery( state, siteId, ownProps.query ),
+		requesting: isRequestingSitePostsForQuery( state, siteId, ownProps.query )
+	};
+} )( PostTypeListList );

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -33,7 +33,11 @@ import {
 	getSerializedPostsQueryWithoutPage
 } from './utils';
 import { DEFAULT_POST_QUERY } from './constants';
-import { itemsSchema, queriesSchema } from './schema';
+import {
+	itemsSchema,
+	queriesSchema,
+	queriesLastPageSchema
+} from './schema';
 import { isValidStateWithSchema } from 'state/utils';
 
 /**
@@ -161,10 +165,14 @@ export function queriesLastPage( state = {}, action ) {
 				[ serializedQuery ]: Math.max( lastPage, 1 )
 			} );
 
-		case SERIALIZE:
 		case DESERIALIZE:
+			if ( isValidStateWithSchema( state, queriesLastPageSchema ) ) {
+				return state;
+			}
+
 			return {};
 	}
+
 	return state;
 }
 

--- a/client/state/posts/schema.js
+++ b/client/state/posts/schema.js
@@ -65,3 +65,14 @@ export const queriesSchema = {
 	},
 	additionalProperties: false
 };
+
+export const queriesLastPageSchema = {
+	type: 'object',
+	patternProperties: {
+		// Queries are JSON strings, optionally prepended by a site ID
+		'^(\\d+:)?\\{[^\\}]*\\}$': {
+			type: 'number'
+		}
+	},
+	additionalProperties: false
+};

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -116,7 +116,7 @@ export function isSitePostsLastPageForQuery( state, siteId, query = {} ) {
 		return lastPage;
 	}
 
-	return lastPage === ( query.page || DEFAULT_POST_QUERY.page );
+	return ( query.page || DEFAULT_POST_QUERY.page ) >= lastPage;
 }
 
 /**

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -406,19 +406,30 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		it( 'never persists state', () => {
+		it( 'should persist state', () => {
 			const original = deepFreeze( {
 				'2916284:{"search":"hello"}': 1
 			} );
 			const state = queriesLastPage( original, { type: SERIALIZE } );
-			expect( state ).to.eql( {} );
+
+			expect( state ).to.eql( original );
 		} );
 
-		it( 'never loads persisted state', () => {
+		it( 'should load valid persisted state', () => {
 			const original = deepFreeze( {
 				'2916284:{"search":"hello"}': 1
 			} );
 			const state = queriesLastPage( original, { type: DESERIALIZE } );
+
+			expect( state ).to.eql( original );
+		} );
+
+		it( 'should not load invalid persisted state', () => {
+			const original = deepFreeze( {
+				'2916284:{"search":"hello"}': 'bad'
+			} );
+			const state = queriesLastPage( original, { type: DESERIALIZE } );
+
 			expect( state ).to.eql( {} );
 		} );
 	} );

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -263,6 +263,18 @@ describe( 'selectors', () => {
 
 			expect( isLastPage ).to.be.true;
 		} );
+
+		it( 'should return true if the query value is greater than the last page', () => {
+			const isLastPage = isSitePostsLastPageForQuery( {
+				posts: {
+					queriesLastPage: {
+						'2916284:{"search":"hello"}': 4
+					}
+				}
+			}, 2916284, { search: 'Hello', page: 6 } );
+
+			expect( isLastPage ).to.be.true;
+		} );
 	} );
 
 	describe( '#getSitePostsForQueryIgnoringPage()', () => {


### PR DESCRIPTION
This pull request seeks to implement infinite scroll for the custom post types listing screen.

It also introduces two changes to posts state to better accommodate this use-case:
- Persist post queries last page state. I'm not sure the reasoning behind this original choice, but due to [the implementation of `getSitePostsForQueryIgnoringPage`](https://github.com/Automattic/wp-calypso/blob/8abb152ee8a73b29208eee78c4751693d36ac082/client/state/posts/selectors.js#L114-L117), no posts will be shown on page load until the last page is re-requested.
 - This affects the post selector in the post editor link dialog, so ensure that no regressions occur there. This should be an enhancement in that we can show results from the last page session. Currently, only the loading placeholder is ever shown on the initial dialog shown.
- Consider a query containing a page greater than the last known page as "last".
 - While developing, I encountered this several times, causing `lastPage` to never be passed as true to `<InfiniteList />` if attempting to request a page greater than the last known. While this was a bug in my initial implementation of the list rendering, it still seems reasonable and safer to assume a page greater than the last known is considered last.

__Testing instructions:__

Verify that all posts are revealed on the custom post types list screen, requested ten at a time infinitely until the last known page. When changing filters, note that the same behavior applies to the new filter. Note between page refreshes and tab changing that persisted state is respected (i.e. last known results shown while querying new results).

1. Navigate to [My Sites](http://calypso.localhost:3000/stats/insights)
2. Select a site where at least one custom post type is enabled
3. Choose the custom post type navigation link in the sidebar
4. Note that a loading placeholder or, if persisted state exists, the past results are immediately shown
5. Note that posts are revealed ten at a time
6. Note that as you scroll, more posts are loaded until all pages have been exhausted

Due to the nature of `<InfiniteScroll />`, it may be wise to monitor the network tab of your browser's developer tools to ensure that requests are not being made infinitely.