### PR TITLE
Jetpack Connect: Fix timer to use miliseconds instead of seconds

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -180,7 +180,7 @@ const LoggedInForm = React.createClass( {
 		const site = this.props.jetpackConnectAuthorize.queryObject.site.replace( /.*?:\/\//g, '' );
 		if ( this.props.jetpackConnectSessions && this.props.jetpackConnectSessions[ site ] ) {
 			const currentTime = ( new Date() ).getTime();
-			const oneDay = 24 * 60 * 60;
+			const oneDay = 24 * 60 * 60 * 1000;
 			return ( currentTime - this.props.jetpackConnectSessions[ site ] < oneDay );
 		}
 		return false;


### PR DESCRIPTION
Dumbest PR ever because I don't know how Javascript Date lib works :D

I was using seconds for this comparison instead of milliseconds



