### PR TITLE
Jetpack connect: avoid showing a generic error message

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -135,8 +135,11 @@ const LoggedInForm = React.createClass( {
 
 	renderNotices() {
 		const { authorizeError } = this.props.jetpackConnectAuthorize;
-		if ( authorizeError ) {
+		if ( authorizeError && authorizeError.message.indexOf( 'already_connected' ) < 0 ) {
 			return <JetpackConnectNotices noticeType="authorizeError" />;
+		}
+		if ( authorizeError && authorizeError.message.indexOf( 'already_connected' ) >= 0 ) {
+			return <JetpackConnectNotices noticeType="alreadyConnected" />;
 		}
 		return null;
 	},


### PR DESCRIPTION
If we are have just authorized a jetpack site, and we reload the page (or just go to the next screen and the go back to the authorization screen), right now we are going to see a "unknown error" message. 
![image](https://cloud.githubusercontent.com/assets/1554855/14821640/d612dde8-0bcb-11e6-8b25-eea6b10423d5.png)

This is because we are trying to authorize the site again, and the API is returning an "already authorized" message, which is not controlled so it defaults to the default generic error message.

This PR changes this, so we can show an "already authorized" message:
![image](https://cloud.githubusercontent.com/assets/1554855/14821631/cf10f7dc-0bcb-11e6-8cb0-4b3ed1f006c7.png)

How to test
========
1. Go to http://calypso.localhost:3000/jetpack/connect/ and enter an unconnected jetpack site url
2. Wait until your site is connected, by then you should be at http://calypso.localhost:3000/jetpack/connect/authorize
3. Reload the page (or go to the plans page and the click browser's back button). You  should see a message telling you tha te site is already connected, not an error message

@roccotripaldi @rickybanister 