### PR TITLE
i18n: Hacky fix for &nbsp; issue.

### DIFF
--- a/client/lib/mixins/i18n/index.js
+++ b/client/lib/mixins/i18n/index.js
@@ -171,6 +171,9 @@ function numberFormat( number ) {
 		decPoint = options.decPoint || i18nState.numberFormatSettings.decimal_point || '.',
 		thousandsSep = options.thousandsSep || i18nState.numberFormatSettings.thousands_sep || ',';
 
+	// quick fix for &nbsp; issue
+	thousandsSep = thousandsSep === '&nbsp;' ? ' ' : thousandsSep;
+
 	return numberFormatPHPJS( number, decimals, decPoint, thousandsSep );
 }
 


### PR DESCRIPTION
Glot press is currently returning `&nbsp;` for the thousands separator.  We should fix this in the translation files generated by glotpress itself, but this hacky work around also fixes the issue in `numberFormat()`.

Fixes #4981 and Fixes #5002

__To Test__
Follow the steps in #4981 