### PR TITLE
Framework: update node to v6.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN     apt-get -y update && apt-get -y install \
           make \
           build-essential
 
-ENV NODE_VERSION 5.10.1
+ENV NODE_VERSION 5.11.0
 
 RUN     wget https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz && \
           tar -zxf node-v$NODE_VERSION-linux-x64.tar.gz -C /usr/local && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN     apt-get -y update && apt-get -y install \
           make \
           build-essential
 
-ENV NODE_VERSION 5.11.0
+ENV NODE_VERSION 6.0.0
 
 RUN     wget https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz && \
           tar -zxf node-v$NODE_VERSION-linux-x64.tar.gz -C /usr/local && \

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "xgettext-js": "0.3.0"
   },
   "engines": {
-    "node": "5.11.0",
+    "node": "6.0.0",
     "npm": "3.8.6"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -118,8 +118,8 @@
     "xgettext-js": "0.3.0"
   },
   "engines": {
-    "node": "5.10.1",
-    "npm": "3.8.3"
+    "node": "5.11.0",
+    "npm": "3.8.6"
   },
   "scripts": {
     "test": "npm run test-client && npm run test-server && npm run test-test",


### PR DESCRIPTION
This updates Calypso to the latest node, v6.0.0. [Changelog](https://github.com/nodejs/node/blob/v6.0.0/CHANGELOG.md)
https://nodejs.org/en/blog/announcements/v6-release/

## Testing Instructions

### Local Dev
- Switch to node version 6.0.0 (npm 3.8.6)
- `make distclean`
- `make run`
- No functional changes to Calypso

### Local Docker Image
- Follow image instructions at: PCYsg-5XR-p2

### Desktop
- Clone the wp-desktop project
- Follow install instructions
- In the calypso submodule checkout this branch
- Desktop behaves normally

cc @rralian @blowery @aduth