### PR TITLE
Stats: Replace PostListStore by the QueryPosts in the PostPerformanceComponent

### DIFF
--- a/client/my-sites/stats/controller.js
+++ b/client/my-sites/stats/controller.js
@@ -5,7 +5,8 @@ var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
 	store = require( 'store' ),
 	page = require( 'page' ),
-	get = require( 'lodash/get' );
+	get = require( 'lodash/get' ),
+	ReactRedux = require( 'react-redux' );
 
 /**
  * Internal Dependencies
@@ -188,21 +189,23 @@ module.exports = {
 		analytics.pageView.record( basePath, analyticsPageTitle + ' > Insights' );
 
 		ReactDom.render(
-			React.createElement( StatsComponent, {
-				site: site,
-				followList: followList,
-				streakList: streakList,
-				allTimeList: allTimeList,
-				statSummaryList: statSummaryList,
-				insightsList: insightsList,
-				commentsList: commentsList,
-				tagsList: tagsList,
-				publicizeList: publicizeList,
-				wpcomFollowersList: wpcomFollowersList,
-				emailFollowersList: emailFollowersList,
-				commentFollowersList: commentFollowersList,
-				summaryDate: summaryDate
-			} ),
+			React.createElement( ReactRedux.Provider, { store: context.store },
+				React.createElement( StatsComponent, {
+					site: site,
+					followList: followList,
+					streakList: streakList,
+					allTimeList: allTimeList,
+					statSummaryList: statSummaryList,
+					insightsList: insightsList,
+					commentsList: commentsList,
+					tagsList: tagsList,
+					publicizeList: publicizeList,
+					wpcomFollowersList: wpcomFollowersList,
+					emailFollowersList: emailFollowersList,
+					commentFollowersList: commentFollowersList,
+					summaryDate: summaryDate
+				} )
+			),
 			document.getElementById( 'primary' )
 		);
 	},


### PR DESCRIPTION
This just replaces the use of the PostListStore (flux store) by the QueryPosts Redux based component. So to make this work I had to add the ReduxProvider to the statsInsights page.
This is the first step in my way to resolve this https://github.com/Automattic/wp-calypso/pull/5008

While making the change, I've also noticed that the `isLoading` flag hides the post summary and the stats even if we have a cached version (and the request updating those results is on going), is this the desired behavior ?

The next step would be to move the `PostStatsStore` to the redux global state