### PR TITLE
Plugins (wpcom) fix google-analytics plugin link

### DIFF
--- a/client/my-sites/plans/plan-feature/google-analytics.js
+++ b/client/my-sites/plans/plan-feature/google-analytics.js
@@ -41,6 +41,8 @@ import PlanFeatureFooter from './footer';
 const sites = sitesList();
 
 export default function( context ) {
+	window.scrollTo( 0, 0 );
+
 	const site = sites.getSelectedSite();
 	const planSlug = ( site && site.ID ) ? getSitePlanSlug( site.ID ) : PLAN_FREE;
 

--- a/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
+++ b/client/my-sites/plugins-wpcom/plugin-types/business-plugin.jsx
@@ -29,7 +29,7 @@ export const BusinessPlugin = React.createClass( {
 			descriptionLink,
 		} = this.props;
 
-		const target = hasHttpProtocol( descriptionLink ) ? '_blank' : '_self';
+		const target = hasHttpProtocol( descriptionLink ) ? '_blank' : null;
 
 		return (
 			<div className="wpcom-plugins__plugin-item">


### PR DESCRIPTION
[Fix 4993](https://github.com/Automattic/wp-calypso/issues/4993)

The problem here is if we add `target` `<a>` html attribute page.js doesn't handle rightly the link when the user does the click beyond that its value is `_self`.

Please read the [issue description](https://github.com/Automattic/wp-calypso/issues/4993#issue-150954562) to understand the problem and to test this solution.

cc @drw158 @adambbecker 
