### PR TITLE
Adjust the drop shadow for the GuidedTours steps to the proper value

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -3,7 +3,7 @@
 	max-width: 410px;
 	z-index: z-index( 'root', '.guidestours__step' );
 	border: 1px solid lighten( $gray, 10 );
-	box-shadow: 1px 2px 3px 0px rgba( $gray-dark, 0.3 );
+	box-shadow: 0px 2px 4px 0px rgba( $gray-dark, 0.15 );
 	border-radius: 4px;
 	padding-top: 19px;
 	margin-left: 5px;


### PR DESCRIPTION
... as suggested by @drw158 [here](https://github.com/Automattic/wp-calypso/commit/d84b0ad09697d4bbb07e278c1e95df5c45690a97#commitcomment-17104421) (thanks!). 