### PR TITLE
Plans: add 90/10 abtest for monthly vs annual pricing copy

### DIFF
--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import { abtest } from 'lib/abtest';
 import WpcomPlanPrice from 'my-sites/plans/wpcom-plan-price';
 
 const PlanPrice = React.createClass( {
@@ -24,7 +24,7 @@ const PlanPrice = React.createClass( {
 				return this.translate( 'Free', { context: 'Zero cost product price' } );
 			}
 
-			if ( config.isEnabled( 'monthly-plan-pricing' ) ) {
+			if ( abtest( 'planPricing' ) === 'monthly' ) {
 				const monthlyPrice = +( rawPrice / 12 ).toFixed( 2 );
 				formattedPrice = formattedPrice.replace( rawPrice, monthlyPrice );
 			}
@@ -55,10 +55,10 @@ const PlanPrice = React.createClass( {
 			return <div className="plan-price is-placeholder" />;
 		}
 
-		if ( config.isEnabled( 'monthly-plan-pricing' ) && plan.raw_price !== 0 ) {
+		if ( abtest( 'planPricing' ) === 'monthly' && plan.raw_price !== 0 ) {
 			periodLabel = this.translate( 'per month, billed yearly' );
 		} else {
-			periodLabel = hasDiscount ? this.translate( 'due today when you upgrade' ) : plan.bill_period_label
+			periodLabel = hasDiscount ? this.translate( 'due today when you upgrade' ) : plan.bill_period_label;
 		}
 
 		return (

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -101,5 +101,15 @@ module.exports = {
 			notTested: 10
 		},
 		defaultVariation: 'original'
+	},
+	planPricing: {
+		datestamp: '20160426',
+		variations: {
+			monthly: 90,
+			annual: 10
+		},
+		defaultVariation: 'monthly',
+		allowExistingUsers: true,
+		allowAnyLocale: true
 	}
 };

--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -15,7 +15,7 @@ import {
 	isTheme
 } from 'lib/products-values';
 import * as upgradesActions from 'lib/upgrades/actions';
-import config from 'config';
+import { abtest } from 'lib/abtest';
 
 const getIncludedDomain = cartItems.getIncludedDomain;
 
@@ -57,7 +57,7 @@ export default React.createClass( {
 
 	monthlyPrice: function() {
 		const { cost, currency } = this.props.cartItem;
-		if ( ! config.isEnabled( 'monthly-plan-pricing' ) || cost === 0 ) {
+		if ( abtest( 'planPricing' ) === 'annual' || cost === 0 ) {
 			return null;
 		}
 
@@ -93,7 +93,7 @@ export default React.createClass( {
 		if ( isGoogleApps( this.props.cartItem ) && this.props.cartItem.extra.google_apps_users ) {
 			info = this.props.cartItem.extra.google_apps_users.map( user => <div>{ user.email }</div> );
 		} else if ( isCredits( this.props.cartItem ) ) {
-			info = null
+			info = null;
 		} else if ( getIncludedDomain( this.props.cartItem ) ) {
 			info = getIncludedDomain( this.props.cartItem );
 		} else if ( isTheme( this.props.cartItem ) ) {

--- a/config/desktop-mac-app-store.json
+++ b/config/desktop-mac-app-store.json
@@ -55,7 +55,6 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"muse": true,
-		"monthly-plan-pricing": true,
 		"oauth": true,
 		"olark": false,
 		"persist-redux": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -56,7 +56,6 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"muse": true,
-		"monthly-plan-pricing": true,
 		"oauth": true,
 		"olark": true,
 		"persist-redux": true,

--- a/config/development.json
+++ b/config/development.json
@@ -87,7 +87,6 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"muse": true,
-		"monthly-plan-pricing": true,
 		"network-connection": true,
 		"notifications2beta": true,
 		"olark": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -62,7 +62,6 @@
 		"me/security": true,
 		"me/trophies": false,
 		"muse": true,
-		"monthly-plan-pricing": true,
 		"network-connection": true,
 		"notifications2beta": true,
 		"olark": true,

--- a/config/production.json
+++ b/config/production.json
@@ -56,7 +56,6 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"muse": true,
-		"monthly-plan-pricing": true,
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -61,7 +61,6 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"muse": true,
-		"monthly-plan-pricing": true,
 		"notifications2beta": true,
 		"olark": true,
 		"perfmon": true,

--- a/config/test.json
+++ b/config/test.json
@@ -81,7 +81,6 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"muse": true,
-		"monthly-plan-pricing": true,
 		"network-connection": true,
 		"notifications2beta": true,
 		"olark": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -67,7 +67,6 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"muse": true,
-		"monthly-plan-pricing": true,
 		"network-connection": true,
 		"notifications2beta": true,
 		"olark": true,


### PR DESCRIPTION
This PR adds back a 90/10 test to compare monthly vs annual pricing changes. Closes #5026

## Testing Instructions
- Set variant to:
```
localStorage.setItem('ABTests','{"planPricing_20160426":"monthly"}')
```
- Navigate to /plans and select a site if prompted
- Monthly pricing in plans, cart, and checkout is displayed
- Set variant to:
```
localStorage.setItem('ABTests','{"planPricing_20160426":"annual"}')
```
- Navigate to /plans and select a site if prompted
- Annual pricing in plans, cart, and checkout is displayed

cc @rralian @mtias @artpi @retrofox 
 