### PR TITLE
Framework: update wpcom to 4.9.11

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3990,26 +3990,7 @@
       "version": "1.2.0"
     },
     "wpcom": {
-      "version": "4.9.7",
-      "dependencies": {
-        "babel": {
-          "version": "5.8.38",
-          "dependencies": {
-            "commander": {
-              "version": "2.9.0"
-            },
-            "glob": {
-              "version": "5.0.15"
-            },
-            "lodash": {
-              "version": "3.10.1"
-            },
-            "source-map": {
-              "version": "0.5.3"
-            }
-          }
-        }
-      }
+      "version": "4.9.11"
     },
     "wpcom-proxy-request": {
       "version": "1.0.5"

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "walk": "2.3.4",
     "webpack": "1.12.15",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom": "4.9.7",
+    "wpcom": "4.9.11",
     "wpcom-proxy-request": "1.0.5",
     "wpcom-xhr-request": "0.5.0",
     "xgettext-js": "0.3.0"


### PR DESCRIPTION
Update `wpcom` dependency to `4.9.11`.

### Testing

Test the whole app ( :-o ). Keep in mind that the previous version is `4.9.7`. The main changes between these versions are

* Enable support for post types taxonomies endpoint
* Use `js` files instead of `json`files to export runtime methods

Also in `development` environment you can use the wpcom global var in the client-side and make some simple tests, for instance get the current version of wpcom:

```cli
> wpcom.__version
```

![image](https://cloud.githubusercontent.com/assets/77539/14835923/f462b982-0be2-11e6-96dc-7b951009e57c.png)

.... or for instance the new post-type implementation

```js
wpcom
.site( 'es.blog.wordpress.com' )
.postType( 'post' )
.taxonomiesList( { fileds: 'name' } ).
.then( list => console.log( list ) );
```

![image](https://cloud.githubusercontent.com/assets/77539/14835925/051f305c-0be3-11e6-8bc0-914ca090274e.png)

cc @aduth 