### PR TITLE
Tests: Drop rewire dependency

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -21,8 +21,9 @@ var Dispatcher = require( 'dispatcher' ),
 /**
  * Module variables
  */
-var MediaActions = {},
-	_fetching = {};
+const MediaActions = {
+	_fetching: {}
+};
 
 /**
  * Constants
@@ -39,11 +40,11 @@ MediaActions.setQuery = function( siteId, query ) {
 
 MediaActions.fetch = function( siteId, itemId ) {
 	var fetchKey = [ siteId, itemId ].join();
-	if ( _fetching[ fetchKey ] ) {
+	if ( MediaActions._fetching[ fetchKey ] ) {
 		return;
 	}
 
-	_fetching[ fetchKey ] = true;
+	MediaActions._fetching[ fetchKey ] = true;
 	Dispatcher.handleViewAction( {
 		type: 'FETCH_MEDIA_ITEM',
 		siteId: siteId,
@@ -59,7 +60,7 @@ MediaActions.fetch = function( siteId, itemId ) {
 			data: data
 		} );
 
-		delete _fetching[ fetchKey ];
+		delete MediaActions._fetching[ fetchKey ];
 	} );
 };
 
@@ -110,7 +111,7 @@ MediaActions.add = function( siteId, files ) {
 		const id = uniqueId( 'media-' );
 		const transientMedia = {
 			ID: id,
-			transient: true,
+			'transient': true,
 			// Assign a date such that the first item will be the oldest at the
 			// time of upload, as this is expected order when uploads finish
 			date: new Date( baseTime - ( files.length - i ) ).toISOString()

--- a/client/lib/media/library-selected-store.js
+++ b/client/lib/media/library-selected-store.js
@@ -13,24 +13,25 @@ var MediaStore = require( './store' ),
 /**
  * Module variables
  */
-var _media = {},
-	MediaLibrarySelectedStore = {};
+const MediaLibrarySelectedStore = {
+	_media: {}
+};
 
 function ensureSelectedItemsForSiteId( siteId ) {
-	if ( siteId in _media ) {
+	if ( siteId in MediaLibrarySelectedStore._media ) {
 		return;
 	}
 
-	_media[ siteId ] = [];
+	MediaLibrarySelectedStore._media[ siteId ] = [];
 }
 
 function setSelectedItems( siteId, items ) {
-	_media[ siteId ] = map( items, 'ID' );
+	MediaLibrarySelectedStore._media[ siteId ] = map( items, 'ID' );
 }
 
 function addSingle( siteId, item ) {
 	ensureSelectedItemsForSiteId( siteId );
-	_media[ siteId ].push( item.ID );
+	MediaLibrarySelectedStore._media[ siteId ].push( item.ID );
 }
 
 function receiveSingle( siteId, item, itemId ) {
@@ -40,17 +41,17 @@ function receiveSingle( siteId, item, itemId ) {
 		itemId = item.ID;
 	}
 
-	if ( ! itemId || ! ( siteId in _media ) ) {
+	if ( ! itemId || ! ( siteId in MediaLibrarySelectedStore._media ) ) {
 		return;
 	}
 
-	index = _media[ siteId ].indexOf( itemId );
+	index = MediaLibrarySelectedStore._media[ siteId ].indexOf( itemId );
 	if ( -1 === index ) {
 		return;
 	}
 
 	// Replace existing index if one exists
-	_media[ siteId ].splice( index, 1, item.ID );
+	MediaLibrarySelectedStore._media[ siteId ].splice( index, 1, item.ID );
 }
 
 function receiveMany( siteId, items ) {
@@ -62,13 +63,13 @@ function receiveMany( siteId, items ) {
 function removeSingle( siteId, item ) {
 	var index;
 
-	if ( ! ( siteId in _media ) ) {
+	if ( ! ( siteId in MediaLibrarySelectedStore._media ) ) {
 		return;
 	}
 
-	index = _media[ siteId ].indexOf( item.ID );
+	index = MediaLibrarySelectedStore._media[ siteId ].indexOf( item.ID );
 	if ( -1 !== index ) {
-		_media[ siteId ].splice( index, 1 );
+		MediaLibrarySelectedStore._media[ siteId ].splice( index, 1 );
 	}
 }
 
@@ -79,11 +80,11 @@ MediaLibrarySelectedStore.get = function( siteId, itemId ) {
 };
 
 MediaLibrarySelectedStore.getAll = function( siteId ) {
-	if ( ! ( siteId in _media ) ) {
+	if ( ! ( siteId in MediaLibrarySelectedStore._media ) ) {
 		return [];
 	}
 
-	return _media[ siteId ].map( function( itemId ) {
+	return MediaLibrarySelectedStore._media[ siteId ].map( function( itemId ) {
 		return MediaStore.get( siteId, itemId );
 	} );
 };

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -13,35 +13,36 @@ var Dispatcher = require( 'dispatcher' ),
 /**
  * Module variables
  */
-var MediaStore = {},
-	_media = {},
-	_pointers = {};
+const MediaStore = {
+	_media: {},
+	_pointers: {}
+};
 
 emitter( MediaStore );
 
 function receiveSingle( siteId, item, itemId ) {
-	if ( ! ( siteId in _media ) ) {
-		_media[ siteId ] = {};
+	if ( ! ( siteId in MediaStore._media ) ) {
+		MediaStore._media[ siteId ] = {};
 	}
 
 	if ( itemId ) {
-		if ( ! ( siteId in _pointers ) ) {
-			_pointers[ siteId ] = {};
+		if ( ! ( siteId in MediaStore._pointers ) ) {
+			MediaStore._pointers[ siteId ] = {};
 		}
 
-		_pointers[ siteId ][ itemId ] = item.ID;
-		delete _media[ siteId ][ itemId ];
+		MediaStore._pointers[ siteId ][ itemId ] = item.ID;
+		delete MediaStore._media[ siteId ][ itemId ];
 	}
 
-	_media[ siteId ][ item.ID ] = item;
+	MediaStore._media[ siteId ][ item.ID ] = item;
 }
 
 function removeSingle( siteId, item ) {
-	if ( ! ( siteId in _media ) ) {
+	if ( ! ( siteId in MediaStore._media ) ) {
 		return;
 	}
 
-	delete _media[ siteId ][ item.ID ];
+	delete MediaStore._media[ siteId ][ item.ID ];
 }
 
 function receivePage( siteId, items ) {
@@ -51,23 +52,23 @@ function receivePage( siteId, items ) {
 }
 
 MediaStore.get = function( siteId, postId ) {
-	if ( ! ( siteId in _media ) ) {
+	if ( ! ( siteId in MediaStore._media ) ) {
 		return;
 	}
 
-	if ( siteId in _pointers && postId in _pointers[ siteId ] ) {
-		return MediaStore.get( siteId, _pointers[ siteId ][ postId ] );
+	if ( siteId in MediaStore._pointers && postId in MediaStore._pointers[ siteId ] ) {
+		return MediaStore.get( siteId, MediaStore._pointers[ siteId ][ postId ] );
 	}
 
-	return _media[ siteId ][ postId ];
+	return MediaStore._media[ siteId ][ postId ];
 };
 
 MediaStore.getAll = function( siteId ) {
-	if ( ! ( siteId in _media ) ) {
+	if ( ! ( siteId in MediaStore._media ) ) {
 		return;
 	}
 
-	return values( _media[ siteId ] );
+	return values( MediaStore._media[ siteId ] );
 };
 
 MediaStore.dispatchToken = Dispatcher.register( function( payload ) {

--- a/client/lib/media/test/actions.js
+++ b/client/lib/media/test/actions.js
@@ -3,7 +3,6 @@
  */
 import sinon from 'sinon';
 import { expect } from 'chai';
-import rewire from 'rewire';
 import assign from 'lodash/assign';
 import isPlainObject from 'lodash/isPlainObject';
 import mockery from 'mockery';
@@ -65,7 +64,7 @@ describe( 'MediaActions', function() {
 						return {
 							get: mediaGet.bind( [ siteId, mediaId ].join() ),
 							update: mediaUpdate.bind( [ siteId, mediaId ].join() ),
-							delete: mediaDelete.bind( [ siteId, mediaId ].join() )
+							'delete': mediaDelete.bind( [ siteId, mediaId ].join() )
 						};
 					}
 				};
@@ -84,7 +83,7 @@ describe( 'MediaActions', function() {
 			return isPlainObject( obj );
 		} );
 
-		MediaActions = rewire( '../actions' );
+		MediaActions = require( '../actions' );
 	} );
 
 	beforeEach( function() {
@@ -97,7 +96,7 @@ describe( 'MediaActions', function() {
 		mediaAddUrls = sandbox.stub().returns( Promise.resolve( DUMMY_API_RESPONSE ) );
 		mediaUpdate = sandbox.stub().callsArgWithAsync( 1, null, DUMMY_API_RESPONSE );
 		mediaDelete = sandbox.stub().callsArgWithAsync( 0, null, DUMMY_API_RESPONSE );
-		MediaActions.__set__( '_fetching', {} );
+		MediaActions._fetching = {};
 		window.FileList = function() {};
 		window.URL = { createObjectURL: sandbox.stub() };
 	} );
@@ -129,7 +128,7 @@ describe( 'MediaActions', function() {
 		it( 'should call to the WordPress.com REST API', function( done ) {
 			Dispatcher.handleViewAction.restore();
 			sandbox.stub( Dispatcher, 'handleViewAction', function() {
-				expect( MediaActions.__get__( '_fetching' ) ).to.have.all.keys( [ [ DUMMY_SITE_ID, DUMMY_ITEM.ID ].join() ] );
+				expect( MediaActions._fetching ).to.have.all.keys( [ [ DUMMY_SITE_ID, DUMMY_ITEM.ID ].join() ] );
 			} );
 
 			MediaActions.fetch( DUMMY_SITE_ID, DUMMY_ITEM.ID );
@@ -246,7 +245,7 @@ describe( 'MediaActions', function() {
 				data: {
 					ID: 'media-1',
 					file: DUMMY_UPLOAD.name,
-					transient: true
+					'transient': true
 				}
 			} );
 		} );

--- a/client/lib/media/test/library-selected-store.js
+++ b/client/lib/media/test/library-selected-store.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import rewire from 'rewire';
 import assign from 'lodash/assign';
 import sinon from 'sinon';
 
@@ -37,12 +36,12 @@ describe( 'MediaLibrarySelectedStore', function() {
 				return DUMMY_OBJECTS[ itemId ];
 			}
 		} );
-		MediaLibrarySelectedStore = rewire( '../library-selected-store' );
+		MediaLibrarySelectedStore = require( '../library-selected-store' );
 		handler = Dispatcher.register.lastCall.args[ 0 ];
 	} );
 
 	beforeEach( function() {
-		MediaLibrarySelectedStore.__set__( '_media', {} );
+		MediaLibrarySelectedStore._media = {};
 	} );
 
 	after( function() {
@@ -133,7 +132,7 @@ describe( 'MediaLibrarySelectedStore', function() {
 			dispatchSetLibrarySelectedItems();
 			dispatchRemoveMediaItem();
 
-			expect( MediaLibrarySelectedStore.__get__( '_media' )[ DUMMY_SITE_ID ] ).to.be.empty;
+			expect( MediaLibrarySelectedStore._media[ DUMMY_SITE_ID ] ).to.be.empty;
 		} );
 	} );
 } );

--- a/client/lib/media/test/store.js
+++ b/client/lib/media/test/store.js
@@ -2,14 +2,13 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import rewire from 'rewire';
 import sinon from 'sinon';
 
 /**
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
-import Dispatcher from 'dispatcher';
+import useMockery from 'test/helpers/use-mockery';
 
 var DUMMY_SITE_ID = 1,
 	DUMMY_MEDIA_ID = 10,
@@ -20,22 +19,25 @@ var DUMMY_SITE_ID = 1,
 	};
 
 describe( 'MediaStore', function() {
-	var sandbox, MediaStore, handler;
+	let Dispatcher, sandbox, MediaStore, handler;
 
 	useFakeDom();
+	useMockery();
 
 	before( function() {
+		Dispatcher = require( 'dispatcher' );
+
 		sandbox = sinon.sandbox.create();
 		sandbox.spy( Dispatcher, 'register' );
 		sandbox.stub( Dispatcher, 'waitFor' ).returns( true );
 
-		MediaStore = rewire( '../store' );
+		MediaStore = require( '../store' );
 		handler = Dispatcher.register.lastCall.args[ 0 ];
 	} );
 
 	beforeEach( function() {
-		MediaStore.__set__( '_media', {} );
-		MediaStore.__set__( '_pointers', {} );
+		MediaStore._media = {};
+		MediaStore._pointers = {};
 	} );
 
 	after( function() {
@@ -86,16 +88,16 @@ describe( 'MediaStore', function() {
 		} );
 
 		it( 'should resolve a pointer to another image item', function() {
-			MediaStore.__set__( '_media', {
+			MediaStore._media = {
 				[ DUMMY_SITE_ID ]: {
 					[ DUMMY_MEDIA_ID ]: DUMMY_MEDIA_OBJECT
 				}
-			} );
-			MediaStore.__set__( '_pointers', {
+			};
+			MediaStore._pointers = {
 				[ DUMMY_SITE_ID ]: {
 					[ DUMMY_MEDIA_ID + 1 ]: DUMMY_MEDIA_ID
 				}
-			} );
+			};
 
 			expect( MediaStore.get( DUMMY_SITE_ID, DUMMY_MEDIA_ID + 1 ) ).to.equal( DUMMY_MEDIA_OBJECT );
 		} );

--- a/client/lib/media/test/validation-store.js
+++ b/client/lib/media/test/validation-store.js
@@ -3,7 +3,6 @@
  */
 import { expect } from 'chai';
 import assign from 'lodash/assign';
-import rewire from 'rewire';
 import mockery from 'mockery';
 import sinon from 'sinon';
 
@@ -47,12 +46,12 @@ describe( 'MediaValidationStore', function() {
 		} );
 
 		// Load store
-		MediaValidationStore = rewire( '../validation-store' );
+		MediaValidationStore = require( '../validation-store' );
 		handler = Dispatcher.register.lastCall.args[ 0 ];
 	} );
 
 	beforeEach( function() {
-		MediaValidationStore.__set__( '_errors', {} );
+		MediaValidationStore._errors = {};
 	} );
 
 	after( function() {
@@ -94,19 +93,19 @@ describe( 'MediaValidationStore', function() {
 		var validateItem;
 
 		before( function() {
-			validateItem = MediaValidationStore.__get__( 'validateItem' );
+			validateItem = MediaValidationStore.validateItem;
 		} );
 
 		it( 'should have no effect for a valid file', function() {
 			validateItem( DUMMY_SITE_ID, Object.assign( {}, DUMMY_MEDIA_OBJECT, { extension: 'gif' } ) );
 
-			expect( MediaValidationStore.__get__( '_errors' ) ).to.eql( {} );
+			expect( MediaValidationStore._errors ).to.eql( {} );
 		} );
 
 		it( 'should set an error array for an invalid file', function() {
 			validateItem( DUMMY_SITE_ID, DUMMY_MEDIA_OBJECT );
 
-			expect( MediaValidationStore.__get__( '_errors' ) ).to.eql( {
+			expect( MediaValidationStore._errors ).to.eql( {
 				[ DUMMY_SITE_ID ]: {
 					[ DUMMY_MEDIA_OBJECT.ID ]: [ MediaValidationErrors.FILE_TYPE_UNSUPPORTED ]
 				}
@@ -116,7 +115,7 @@ describe( 'MediaValidationStore', function() {
 		it( 'should set an error array for a file exceeding acceptable size', function() {
 			validateItem( DUMMY_SITE_ID, Object.assign( {}, DUMMY_MEDIA_OBJECT, { size: 2048, extension: 'gif' } ) );
 
-			expect( MediaValidationStore.__get__( '_errors' ) ).to.eql( {
+			expect( MediaValidationStore._errors ).to.eql( {
 				[ DUMMY_SITE_ID ]: {
 					[ DUMMY_MEDIA_OBJECT.ID ]: [ MediaValidationErrors.EXCEEDS_MAX_UPLOAD_SIZE ]
 				}
@@ -126,7 +125,7 @@ describe( 'MediaValidationStore', function() {
 		it( 'should accumulate multiple validation errors', function() {
 			validateItem( DUMMY_SITE_ID, Object.assign( {}, DUMMY_MEDIA_OBJECT, { size: 2048 } ) );
 
-			expect( MediaValidationStore.__get__( '_errors' ) ).to.eql( {
+			expect( MediaValidationStore._errors ).to.eql( {
 				[ DUMMY_SITE_ID ]: {
 					[ DUMMY_MEDIA_OBJECT.ID ]: [
 						MediaValidationErrors.FILE_TYPE_UNSUPPORTED,
@@ -141,7 +140,7 @@ describe( 'MediaValidationStore', function() {
 		var clearValidationErrors;
 
 		before( function() {
-			clearValidationErrors = MediaValidationStore.__get__( 'clearValidationErrors' );
+			clearValidationErrors = MediaValidationStore.clearValidationErrors;
 		} );
 
 		it( 'should remove validation errors for a single item on a given site', function() {
@@ -149,7 +148,7 @@ describe( 'MediaValidationStore', function() {
 
 			clearValidationErrors( DUMMY_SITE_ID, DUMMY_MEDIA_OBJECT.ID );
 
-			expect( MediaValidationStore.__get__( '_errors' ) ).to.eql( {
+			expect( MediaValidationStore._errors ).to.eql( {
 				[ DUMMY_SITE_ID ]: {}
 			} );
 		} );
@@ -159,7 +158,7 @@ describe( 'MediaValidationStore', function() {
 
 			clearValidationErrors( DUMMY_SITE_ID );
 
-			expect( MediaValidationStore.__get__( '_errors' ) ).to.eql( {} );
+			expect( MediaValidationStore._errors ).to.eql( {} );
 		} );
 	} );
 
@@ -167,7 +166,7 @@ describe( 'MediaValidationStore', function() {
 		var clearValidationErrorsByType;
 
 		before( function() {
-			clearValidationErrorsByType = MediaValidationStore.__get__( 'clearValidationErrorsByType' );
+			clearValidationErrorsByType = MediaValidationStore.clearValidationErrorsByType;
 		} );
 
 		it( 'should remove errors for all items containing that error type on a given site', function() {
@@ -180,7 +179,7 @@ describe( 'MediaValidationStore', function() {
 
 			clearValidationErrorsByType( DUMMY_SITE_ID, MediaValidationErrors.FILE_TYPE_UNSUPPORTED );
 
-			expect( MediaValidationStore.__get__( '_errors' ) ).to.eql( {
+			expect( MediaValidationStore._errors ).to.eql( {
 				[ DUMMY_SITE_ID ]: {}
 			} );
 		} );


### PR DESCRIPTION
Part of #1515.

As part of upgrade to Babel 6 we need to drop `rewire` dependency. It no longer works with new Babel version.

This is work in progress, so far I refactored the following folders:
* [x] `client/lib/media`

@aduth: Feel free to continue work on this one, most likely I won't get back to it until Monday. 

### Testing
* `npm run client-test` should still pass
* Media part of Calypso should work as before (though I don't know how to test properly)

### Further changes in another PR(s)
* [ ] `client/lib/post-formats`
* [ ] `client/lib/posts`
* [ ] `client/lib/shortcode`
* [ ] `client/lib/terms`
* [ ] `client/lib/wp/localization`
* [ ] `client/signup`