### PR TITLE
GuidedTours: Enable in production

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -83,7 +83,7 @@ module.exports = {
 		defaultVariation: 'original'
 	},
 	guidedTours: {
-		datestamp: '20160418',
+		datestamp: '20160427',
 		variations: {
 			original: 96,
 			guided: 2,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -83,7 +83,7 @@ module.exports = {
 		defaultVariation: 'original'
 	},
 	guidedTours: {
-		datestamp: '20160427',
+		datestamp: '20160428',
 		variations: {
 			original: 96,
 			guided: 2,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -18,6 +18,7 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"devdocs": false,
+		"guided-tours": true,
 		"help": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -16,6 +16,7 @@
 		"code-splitting": true,
 		"community-translator": true,
 		"desktop-promo": true,
+		"guided-tours": true,
 		"help": true,
 		"mailing-lists/unsubscribe": true,
 		"manage/add-people": true,


### PR DESCRIPTION
Change AB test date to 20160427, and enable in production.

~~Depends on 23-gh-trampoline~~