### PR TITLE
Reader lists: protect access to private list streams

### DIFF
--- a/client/state/reader/lists/actions.js
+++ b/client/state/reader/lists/actions.js
@@ -50,20 +50,20 @@ export function requestSubscribedLists() {
 
 		return new Promise( ( resolve, reject ) => {
 			wpcom.undocumented().readLists( ( error, data ) => {
-				if ( error ) {
-					dispatch( {
-						type: READER_LISTS_REQUEST_FAILURE,
-						error
-					} );
-					reject();
-				} else {
-					dispatch( receiveLists( data.lists ) );
-					dispatch( {
-						type: READER_LISTS_REQUEST_SUCCESS,
-						data
-					} );
-					resolve();
-				}
+				error ? reject( error ) : resolve( data );
+			} );
+		} )
+		.then( ( data ) => {
+			dispatch( receiveLists( data.lists ) );
+			dispatch( {
+				type: READER_LISTS_REQUEST_SUCCESS,
+				data
+			} );
+		} )
+		.catch( ( error ) => {
+			dispatch( {
+				type: READER_LISTS_REQUEST_FAILURE,
+				error
 			} );
 		} );
 	};
@@ -86,21 +86,19 @@ export function requestList( owner, slug ) {
 
 		return new Promise( ( resolve, reject ) => {
 			wpcom.undocumented().readList( query, ( error, data ) => {
-				if ( error ) {
-					dispatch( {
-						type: READER_LIST_REQUEST_FAILURE,
-						error,
-						owner,
-						slug
-					} );
-					reject();
-				} else {
-					dispatch( {
-						type: READER_LIST_REQUEST_SUCCESS,
-						data
-					} );
-					resolve();
-				}
+				error ? reject( error ) : resolve( data );
+			} );
+		} )
+		.then( ( data ) => {
+			dispatch( {
+				type: READER_LIST_REQUEST_SUCCESS,
+				data
+			} );
+		} )
+		.catch( ( error ) => {
+			dispatch( {
+				type: READER_LIST_REQUEST_FAILURE,
+				error
 			} );
 		} );
 	};
@@ -125,24 +123,20 @@ export function followList( owner, slug ) {
 
 		return new Promise( ( resolve, reject ) => {
 			wpcom.undocumented().followList( query, ( error, data ) => {
-				if ( error || ! ( data && data.following ) ) {
-					dispatch( {
-						type: READER_LISTS_FOLLOW_FAILURE,
-						owner,
-						slug,
-						error
-					} );
-					reject();
-				} else {
-					dispatch( receiveLists( [ data.list ] ) );
-					dispatch( {
-						type: READER_LISTS_FOLLOW_SUCCESS,
-						owner,
-						slug,
-						data
-					} );
-					resolve();
-				}
+				error ? reject( error ) : resolve( data );
+			} );
+		} )
+		.then( ( data ) => {
+			dispatch( receiveLists( [ data.list ] ) );
+			dispatch( {
+				type: READER_LISTS_FOLLOW_SUCCESS,
+				data
+			} );
+		} )
+		.catch( ( error ) => {
+			dispatch( {
+				type: READER_LISTS_FOLLOW_FAILURE,
+				error
 			} );
 		} );
 	};
@@ -167,23 +161,19 @@ export function unfollowList( owner, slug ) {
 
 		return new Promise( ( resolve, reject ) => {
 			wpcom.undocumented().unfollowList( query, ( error, data ) => {
-				if ( error || ! ( data && ! data.following ) ) {
-					dispatch( {
-						type: READER_LISTS_UNFOLLOW_FAILURE,
-						owner,
-						slug,
-						error
-					} );
-					reject();
-				} else {
-					dispatch( {
-						type: READER_LISTS_UNFOLLOW_SUCCESS,
-						owner,
-						slug,
-						data
-					} );
-					resolve();
-				}
+				error ? reject( error ) : resolve( data );
+			} );
+		} )
+		.then( ( data ) => {
+			dispatch( {
+				type: READER_LISTS_UNFOLLOW_SUCCESS,
+				data
+			} );
+		} )
+		.catch( ( error ) => {
+			dispatch( {
+				type: READER_LISTS_UNFOLLOW_FAILURE,
+				error
 			} );
 		} );
 	};

--- a/client/state/reader/lists/actions.js
+++ b/client/state/reader/lists/actions.js
@@ -86,7 +86,16 @@ export function requestList( owner, slug ) {
 
 		return new Promise( ( resolve, reject ) => {
 			wpcom.undocumented().readList( query, ( error, data ) => {
-				error ? reject( error ) : resolve( data );
+				if ( error ) {
+					const errorInfo = {
+						error,
+						owner,
+						slug
+					};
+					reject( errorInfo );
+				} else {
+					resolve( data );
+				}
 			} );
 		} )
 		.then( ( data ) => {
@@ -95,10 +104,12 @@ export function requestList( owner, slug ) {
 				data
 			} );
 		} )
-		.catch( ( error ) => {
+		.catch( ( errorInfo ) => {
 			dispatch( {
 				type: READER_LIST_REQUEST_FAILURE,
-				error
+				error: errorInfo.error,
+				owner: errorInfo.owner,
+				slug: errorInfo.slug
 			} );
 		} );
 	};

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -9,6 +9,7 @@ import filter from 'lodash/filter';
 import get from 'lodash/get';
 import omit from 'lodash/omit';
 import find from 'lodash/find';
+import includes from 'lodash/includes';
 
 /**
  * Internal dependencies
@@ -223,8 +224,8 @@ export function missingLists( state = [], action ) {
 				return action.data.list.owner !== list.owner && action.data.list.slug !== list.slug;
 			} );
 		case READER_LIST_REQUEST_FAILURE:
-			// Add lists that have failed with a 404 to missingLists
-			if ( ! action.error || action.error.statusCode !== 404 ) {
+			// Add lists that have failed with a 403 or 404 to missingLists
+			if ( ! action.error || ! includes( [ 403, 404 ], action.error.statusCode ) ) {
 				return state;
 			}
 			return union( state, [ { owner: action.owner, slug: action.slug } ] );


### PR DESCRIPTION
If a list is marked as private and you do not own it, it should not be possible to view the list stream.

Example list: `supernovia/friends`

This PR treats a 403 from the API the same way as a 404 - so the 'list not found' page is shown to the end user if they try to access a private list they do not own.

I've also reworked the way promises work for list actions, so that we no longer end up with a uncaught exception inside the promise when the API returns an error.

![screen shot 2016-04-27 at 16 00 30](https://cloud.githubusercontent.com/assets/17325/14856782/60366678-0c91-11e6-85ac-5671dda4c9ef.png)

(Note: it's not possible to mark a list private in the current UI, but we have a number of lists where the `public_flag` is set to 0, so it must have existed at some point.)