### PR TITLE
Plans: fix pricing labels when loading

### DIFF
--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -55,7 +55,9 @@ const PlanPrice = React.createClass( {
 			return <div className="plan-price is-placeholder" />;
 		}
 
-		if ( abtest( 'planPricing' ) === 'monthly' && plan.raw_price !== 0 ) {
+		if ( ! plan ) {
+			periodLabel = this.translate( 'Loading' );
+		} else if ( abtest( 'planPricing' ) === 'monthly' && plan.raw_price !== 0 ) {
 			periodLabel = this.translate( 'per month, billed yearly' );
 		} else {
 			periodLabel = hasDiscount ? this.translate( 'due today when you upgrade' ) : plan.bill_period_label;

--- a/client/components/plans/plan-price/index.jsx
+++ b/client/components/plans/plan-price/index.jsx
@@ -56,8 +56,8 @@ const PlanPrice = React.createClass( {
 		}
 
 		if ( ! plan ) {
-			periodLabel = this.translate( 'Loading' );
-		} else if ( abtest( 'planPricing' ) === 'monthly' && plan.raw_price !== 0 ) {
+			periodLabel = '';
+		} else if ( abtest( 'planPricing' ) === 'monthly' && plan.raw_price > 0 ) {
 			periodLabel = this.translate( 'per month, billed yearly' );
 		} else {
 			periodLabel = hasDiscount ? this.translate( 'due today when you upgrade' ) : plan.bill_period_label;

--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -57,6 +57,11 @@ export default React.createClass( {
 
 	monthlyPrice: function() {
 		const { cost, currency } = this.props.cartItem;
+
+		if ( typeof cost === 'undefined' ) {
+			return this.translate( 'Loading price' );
+		}
+
 		if ( abtest( 'planPricing' ) === 'annual' || cost === 0 ) {
 			return null;
 		}

--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -59,10 +59,10 @@ export default React.createClass( {
 		const { cost, currency } = this.props.cartItem;
 
 		if ( typeof cost === 'undefined' ) {
-			return this.translate( 'Loading price' );
+			return null;
 		}
 
-		if ( abtest( 'planPricing' ) === 'annual' || cost === 0 ) {
+		if ( abtest( 'planPricing' ) === 'annual' || cost <= 0 ) {
 			return null;
 		}
 


### PR DESCRIPTION
Fixes #5044 This PR adds text loading placeholders when plan pricing is loading in a cart item, or in the plans compare page.

<img width="332" alt="screen shot 2016-04-27 at 8 46 22 am" src="https://cloud.githubusercontent.com/assets/1270189/14858718/01007ae4-0c56-11e6-953e-6a2e26c57686.png">

cc @scruffian @rralian