### PR TITLE
Abtest: Update test dates for domainsWithPlans only

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -94,7 +94,7 @@ module.exports = {
 		allowAnyLocale: true
 	},
 	domainsWithPlansOnly: {
-		datestamp: '20200101',
+		datestamp: '20160427',
 		variations: {
 			original: 50,
 			plansOnly: 50


### PR DESCRIPTION
Here we go.

Starts domains with plans only a/b test. (_drumroll_)

/cc: @klimeryk 