### PR TITLE
Notices: Make links white instead of blue

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -76,6 +76,7 @@
 	}
 
 	a {
+		color: $white;
 		text-decoration: underline;
 	}
 


### PR DESCRIPTION
Before:
<img width="737" alt="screen shot 2016-04-27 at 5 42 00 pm" src="https://cloud.githubusercontent.com/assets/5835847/14871449/78908d12-0c9f-11e6-8ce0-5f56e8db604b.png">

After:
<img width="735" alt="screen shot 2016-04-27 at 5 42 36 pm" src="https://cloud.githubusercontent.com/assets/5835847/14871452/7db2294a-0c9f-11e6-86f9-17fd7a76f3d6.png">

(domain blocked out)

To test: Add a domain to a site and view the notice that appears.

cc: @umurkontaci @MichaelArestad 