### PR TITLE
Domains: Add character limit for address fields during domain registration

### DIFF
--- a/client/my-sites/upgrades/checkout/domain-details-form.jsx
+++ b/client/my-sites/upgrades/checkout/domain-details-form.jsx
@@ -216,11 +216,12 @@ export default React.createClass( {
 					{ ...fieldProps( 'country-code' ) }/>
 
 				{ this.needsFax() && <Input label={ this.translate( 'Fax', { textOnly } ) } { ...fieldProps( 'fax' ) }/> }
-				<Input label={ this.translate( 'Address', { textOnly } ) } { ...fieldProps( 'address-1' ) }/>
+				<Input label={ this.translate( 'Address', { textOnly } ) } maxLength={ 40 } { ...fieldProps( 'address-1' ) }/>
 
 				<HiddenInput
 					label={ this.translate( 'Address Line 2', { textOnly } ) }
 					text={ this.translate( '+ Add Address Line 2', { textOnly } ) }
+					maxLength={ 40 }
 					{ ...fieldProps( 'address-2' ) }/>
 
 				<Input label={ this.translate( 'City', { textOnly } ) } { ...fieldProps( 'city' ) }/>

--- a/client/my-sites/upgrades/components/form/input.jsx
+++ b/client/my-sites/upgrades/components/form/input.jsx
@@ -84,6 +84,7 @@ export default React.createClass( {
 					ref="input"
 					autofocus={ this.props.autofocus }
 					disabled={ this.props.disabled }
+					maxLength={ this.props.maxLength }
 					onChange={ this.props.onChange }
 					onClick={ this.recordFieldClick }
 					isError={ this.props.isError } />


### PR DESCRIPTION
To improve user experience during checkout, this adds a 40 characters limit to the address fields (`address1` and `address2`). This will mean that the user doesn't have to wait for the server-side validation of this constraint. Related server-side change: `D1682-code`.

/cc @aidvu @umurkontaci 