### PR TITLE
Editor: focus category name when adding new category.

### DIFF
--- a/client/my-sites/category-selector/add-category.jsx
+++ b/client/my-sites/category-selector/add-category.jsx
@@ -65,6 +65,12 @@ module.exports = React.createClass( {
 		this.setState( {
 			showDialog: true,
 			selectedParent: []
+		}, () => {
+			// much like components/dialog/dialog-base.jsx
+			// we need a short timeout here to wait for css transitions to finish
+			setTimeout( () => {
+				ReactDom.findDOMNode( this.refs.categoryName ).focus();
+			}, 20 );
 		} );
 	},
 
@@ -128,8 +134,12 @@ module.exports = React.createClass( {
 		return ! error;
 	},
 
-	validateInput: function() {
-		this.isValid();
+	validateInput: function( event ) {
+		if ( 13 === event.keyCode ) {
+			this.saveCategory();
+		} else {
+			this.isValid();
+		}
 	},
 
 	saveCategory: function() {

--- a/client/my-sites/category-selector/add-category.jsx
+++ b/client/my-sites/category-selector/add-category.jsx
@@ -65,12 +65,6 @@ module.exports = React.createClass( {
 		this.setState( {
 			showDialog: true,
 			selectedParent: []
-		}, () => {
-			// much like components/dialog/dialog-base.jsx
-			// we need a short timeout here to wait for css transitions to finish
-			setTimeout( () => {
-				ReactDom.findDOMNode( this.refs.categoryName ).focus();
-			}, 20 );
 		} );
 	},
 
@@ -180,10 +174,20 @@ module.exports = React.createClass( {
 				<Button borderless compact={ true } onClick={ this.openDialog }>
 					<Gridicon icon="folder" /> { addCategoryString }
 				</Button>
-				<Dialog isVisible={ this.state.showDialog } buttons={ buttons } onClose={ this.closeDialog } additionalClassNames="category-selector__add-category-dialog">
+				<Dialog
+					autoFocus={ false }
+					isVisible={ this.state.showDialog }
+					buttons={ buttons }
+					onClose={ this.closeDialog }
+					additionalClassNames="category-selector__add-category-dialog">
 					<FormSectionHeading>{ addCategoryString }</FormSectionHeading>
 					<FormFieldset>
-						<FormTextInput placeholder={ this.translate( 'New category name' ) } ref="categoryName" isError={ isError } onKeyUp={ this.validateInput } />
+						<FormTextInput
+							autoFocus={ this.state.showDialog }
+							placeholder={ this.translate( 'New category name' ) }
+							ref="categoryName"
+							isError={ isError }
+							onKeyUp={ this.validateInput } />
 						{ isError ? <FormInputValidation isError={ true } text={ this.state.error } /> : null }
 					</FormFieldset>
 					<FormFieldset>

--- a/client/my-sites/category-selector/add-category.jsx
+++ b/client/my-sites/category-selector/add-category.jsx
@@ -22,7 +22,8 @@ var Dialog = require( 'components/dialog' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	InfoPopover = require( 'components/info-popover' ),
 	FormLegend = require( 'components/forms/form-legend' ),
-	FormFieldset = require( 'components/forms/form-fieldset' );
+	FormFieldset = require( 'components/forms/form-fieldset' ),
+	viewport = require( 'lib/viewport' );
 
 /**
  * Component
@@ -183,7 +184,7 @@ module.exports = React.createClass( {
 					<FormSectionHeading>{ addCategoryString }</FormSectionHeading>
 					<FormFieldset>
 						<FormTextInput
-							autoFocus={ this.state.showDialog }
+							autoFocus={ this.state.showDialog && ! viewport.isMobile() }
 							placeholder={ this.translate( 'New category name' ) }
 							ref="categoryName"
 							isError={ isError }


### PR DESCRIPTION
Fixes #3449

Currently when adding a new category from the editor sidebar, the category name field in the modal is not focused - which adds an additional step to this flow.  I believe @aduth originally reported this ( though could not find where ) - additionally he mentioned it would be nice if when you pressed enter when typing in a new category name, the form would submit - so that has also been addressed in this branch.

__To Test__
- Open up the editor
- Expand the _Categories & Tags_ accordion
- Click "Add New Category"
- Note that the category name input is focused in the modal
- Type in a category name and press enter - note the modal closes
- Verify your new category has been added and is selected in the sidebar