### PR TITLE
WPCOM Plugins: Title Pluralization Bugs

### DIFF
--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -115,14 +115,15 @@ const SinglePlugin = React.createClass( {
 	},
 
 	updatePageTitle() {
-		const pageTitle = upperFirst( this.state.plugin ? this.state.plugin.name : this.props.pluginSlug );
+		const pageTitle = this.state.plugin ? this.state.plugin.name : this.props.pluginSlug;
 		if ( _currentPageTitle === pageTitle ) {
 			return;
 		}
 		_currentPageTitle = pageTitle;
 		this.pluginRefreshTimeout = setTimeout( () => {
-			this.props.onPluginRefresh( this.translate( '%(pluginName)s Plugin', {
-				args: { pluginName: _currentPageTitle },
+			this.props.onPluginRefresh( this.translate( '%(pluginName)s Plugin', '%(pluginName)s Plugins', {
+				count: pageTitle.toLowerCase() !== 'standard' | 0,
+				args: { pluginName: upperFirst( _currentPageTitle ) },
 				textOnly: true,
 				context: 'Page title: Plugin detail'
 			} ) );

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -36,13 +36,13 @@ import WpcomPluginsList from 'my-sites/plugins-wpcom/plugins-list';
  */
 const debug = debugModule( 'calypso:my-sites:plugin' );
 
-let _currentPageTitle = null;
-
 const SinglePlugin = React.createClass( {
 
 	displayName: 'SinglePlugin',
 
 	_DEFAULT_PLUGINS_BASE_PATH: 'http://wordpress.org/plugins/',
+
+	_currentPageTitle: null,
 
 	mixins: [ PluginNotices ],
 
@@ -116,14 +116,15 @@ const SinglePlugin = React.createClass( {
 
 	updatePageTitle() {
 		const pageTitle = this.state.plugin ? this.state.plugin.name : this.props.pluginSlug;
-		if ( _currentPageTitle === pageTitle ) {
+		if ( this._currentPageTitle === pageTitle ) {
 			return;
 		}
-		_currentPageTitle = pageTitle;
+
+		this._currentPageTitle = pageTitle;
 		this.pluginRefreshTimeout = setTimeout( () => {
 			this.props.onPluginRefresh( this.translate( '%(pluginName)s Plugin', '%(pluginName)s Plugins', {
 				count: pageTitle.toLowerCase() !== 'standard' | 0,
-				args: { pluginName: upperFirst( _currentPageTitle ) },
+				args: { pluginName: upperFirst( this._currentPageTitle ) },
 				textOnly: true,
 				context: 'Page title: Plugin detail'
 			} ) );


### PR DESCRIPTION
Pluralizes the page title when the showing the list of standard plugins for WordPress.com sites and prevents to wrong page title to show between pagesviews or when refreshing the page.

cc @drw158 @roundhill @dmsnell

Fixes #5019