### PR TITLE
WIP: Add "insert items" menu item to editor

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -39,6 +39,7 @@ import contactFormPlugin from './plugins/contact-form/plugin';
 import afterTheDeadlinePlugin from './plugins/after-the-deadline/plugin';
 import wptextpatternPlugin from './plugins/wptextpattern/plugin';
 import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
+import insertMenuPlugin from './plugins/insert-menu/plugin';
 
 [
 	wpcomPlugin,
@@ -49,6 +50,7 @@ import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
 	wpcomSourcecode,
 	wpeditimagePlugin,
 	wplinkPlugin,
+	insertMenuPlugin,
 	mediaPlugin,
 	advancedPlugin,
 	wpcomTabindexPlugin,
@@ -110,6 +112,7 @@ const PLUGINS = [
 	'wplink',
 	'AtD',
 	'wpcom/autoresize',
+	'wpcom/insertmenu',
 	'wpcom/media',
 	'wpcom/advanced',
 	'wpcom/help',
@@ -284,7 +287,7 @@ module.exports = React.createClass( {
 			// future, we should calculate from the rendered editor bounds.
 			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
 
-			toolbar1: 'wpcom_add_media,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_add_contact_form,wpcom_advanced',
+			toolbar1: 'wpcom_add_media,wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced',
 			toolbar2: 'strikethrough,underline,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
 			toolbar3: '',
 			toolbar4: '',

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -287,7 +287,7 @@ module.exports = React.createClass( {
 			// future, we should calculate from the rendered editor bounds.
 			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
 
-			toolbar1: 'wpcom_add_media,wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced',
+			toolbar1: 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced',
 			toolbar2: 'strikethrough,underline,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
 			toolbar3: '',
 			toolbar4: '',

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -287,7 +287,9 @@ module.exports = React.createClass( {
 			// future, we should calculate from the rendered editor bounds.
 			autoresize_min_height: Math.max( document.documentElement.clientHeight - 300, 300 ),
 
-			toolbar1: 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced',
+			toolbar1: config.isEnabled( 'post-editor/insert-menu' )
+				? 'wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_advanced'
+				: 'wpcom_add_media,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,wpcom_add_contact_form,wpcom_advanced',
 			toolbar2: 'strikethrough,underline,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
 			toolbar3: '',
 			toolbar4: '',

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Gridicon from 'components/gridicon';
 import SocialLogo from 'components/social-logo';
+import i18n from 'lib/mixins/i18n';
 
 const GridiconButton = ( { icon, label } ) => (
 	<div>
@@ -21,13 +22,13 @@ export default [
 	{
 		name: 'insert_media_item',
 		icon: 'add-image',
-		item: <GridiconButton icon="image-multiple" label={ 'Add Media' } />,
+		item: <GridiconButton icon="image-multiple" label={ i18n.translate( 'Add Media' ) } />,
 		cmd: 'wpcomAddMedia'
 	},
 	{
 		name: 'insert_contact_form',
 		icon: 'mention',
-		item: <GridiconButton icon="mention" label={ 'Add Contact Form' } />,
+		item: <GridiconButton icon="mention" label={ i18n.translate( 'Add Contact Form' ) } />,
 		cmd: 'wpcomContactForm'
 	}
 ];

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import Gridicon from 'components/gridicon';
+import SocialLogo from 'components/social-logo';
+
+const GridiconButton = ( { icon, label } ) => (
+	<div>
+		<Gridicon className="wpcom-insert-menu__menu-icon" icon={ icon } />
+		<span className="wpcom-insert-menu__menu-label">{ label }</span>
+	</div>
+);
+
+const SocialLogoButton = ( { icon, label } ) => (
+	<div>
+		<SocialLogo className="wpcom-insert-menu__menu-icon" icon={ icon } />
+		<span className="wpcom-insert-menu__menu-label">{ label }</span>
+	</div>
+);
+
+export default [
+	{
+		name: 'insert_media_item',
+		icon: 'add-image',
+		item: <GridiconButton icon="image-multiple" label={ 'Add Media' } />
+	},
+	{
+		name: 'insert_contact_form',
+		icon: 'mention',
+		item: <GridiconButton icon="mention" label={ 'Add Contact Form' } />,
+		cmd: 'wpcomContactForm'
+	},
+	{
+		name: 'insert_instragram_item',
+		icon: 'instagram',
+		item: <SocialLogoButton icon="instagram" label={ 'Instagram Widget' } />
+	}
+];

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -21,17 +21,13 @@ export default [
 	{
 		name: 'insert_media_item',
 		icon: 'add-image',
-		item: <GridiconButton icon="image-multiple" label={ 'Add Media' } />
+		item: <GridiconButton icon="image-multiple" label={ 'Add Media' } />,
+		cmd: 'wpcomAddMedia'
 	},
 	{
 		name: 'insert_contact_form',
 		icon: 'mention',
 		item: <GridiconButton icon="mention" label={ 'Add Contact Form' } />,
 		cmd: 'wpcomContactForm'
-	},
-	{
-		name: 'insert_instragram_item',
-		icon: 'instagram',
-		item: <SocialLogoButton icon="instagram" label={ 'Instagram Widget' } />
 	}
 ];

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -21,13 +21,11 @@ const SocialLogoButton = ( { icon, label } ) => (
 export default [
 	{
 		name: 'insert_media_item',
-		icon: 'add-image',
 		item: <GridiconButton icon="image-multiple" label={ i18n.translate( 'Add Media' ) } />,
 		cmd: 'wpcomAddMedia'
 	},
 	{
 		name: 'insert_contact_form',
-		icon: 'mention',
 		item: <GridiconButton icon="mention" label={ i18n.translate( 'Add Contact Form' ) } />,
 		cmd: 'wpcomContactForm'
 	}

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import tinymce from 'tinymce/tinymce';
+import { renderToString } from 'react-dom/server';
+
+import Gridicon from 'components/gridicon';
+
+import menuItems from './menu-items';
+
+const initialize = editor => {
+	menuItems.forEach( item =>
+		editor.addMenuItem( item.name, {
+			classes: 'wpcom-insert-menu__menu-item',
+			cmd: item.cmd,
+			onPostRender() {
+				this.innerHtml( renderToString( item.item ) )
+			}
+		} )
+	);
+
+	editor.addButton( 'wpcom_insert_menu', {
+		type: 'menubutton',
+		title: 'Insert content',
+		classes: 'btn wpcom-insert-menu insert-menu',
+		menu: menuItems.map( ( { name } ) => editor.menuItems[ name ] ),
+		onPostRender() {
+			const parentNode = this.$el[0].children[0];
+			const oldNode = parentNode.children[0];
+			const newNode = document.createElement( 'span' );
+
+			ReactDOM.render(
+				<Gridicon icon={ menuItems[0].icon } />,
+				newNode
+			);
+
+			parentNode.replaceChild( newNode, oldNode );
+		}
+	} );
+};
+
+export default () => {
+	tinymce.PluginManager.add( 'wpcom/insertmenu', initialize );
+};

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -13,15 +13,16 @@ const initialize = editor => {
 			classes: 'wpcom-insert-menu__menu-item',
 			cmd: item.cmd,
 			onPostRender() {
-				this.innerHtml( renderToString( item.item ) )
+				this.innerHtml( renderToString( item.item ) );
 			}
 		} )
 	);
 
 	editor.addButton( 'wpcom_insert_menu', {
-		type: 'menubutton',
+		type: 'splitbutton',
 		title: 'Insert content',
 		classes: 'btn wpcom-insert-menu insert-menu',
+		cmd: menuItems[0].cmd,
 		menu: menuItems.map( ( { name } ) => editor.menuItems[ name ] ),
 		onPostRender() {
 			const parentNode = this.$el[0].children[0];

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -4,6 +4,7 @@ import tinymce from 'tinymce/tinymce';
 import { renderToString } from 'react-dom/server';
 
 import Gridicon from 'components/gridicon';
+import i18n from 'lib/mixins/i18n';
 
 import menuItems from './menu-items';
 
@@ -20,7 +21,7 @@ const initialize = editor => {
 
 	editor.addButton( 'wpcom_insert_menu', {
 		type: 'splitbutton',
-		title: 'Insert content',
+		title: i18n.translate( 'Insert content' ),
 		classes: 'btn wpcom-insert-menu insert-menu',
 		cmd: menuItems[0].cmd,
 		menu: menuItems.map( ( { name } ) => editor.menuItems[ name ] ),

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -26,16 +26,10 @@ const initialize = editor => {
 		cmd: menuItems[0].cmd,
 		menu: menuItems.map( ( { name } ) => editor.menuItems[ name ] ),
 		onPostRender() {
-			const parentNode = this.$el[0].children[0];
-			const oldNode = parentNode.children[0];
-			const newNode = document.createElement( 'span' );
-
 			ReactDOM.render(
 				<Gridicon icon={ menuItems[0].icon } />,
-				newNode
+				this.$el[0].children[0]
 			);
-
-			parentNode.replaceChild( newNode, oldNode );
 		}
 	} );
 };

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -4,6 +4,7 @@ import tinymce from 'tinymce/tinymce';
 import { renderToString } from 'react-dom/server';
 
 import Gridicon from 'components/gridicon';
+import config from 'config';
 import i18n from 'lib/mixins/i18n';
 
 import menuItems from './menu-items';
@@ -27,7 +28,7 @@ const initialize = editor => {
 		menu: menuItems.map( ( { name } ) => editor.menuItems[ name ] ),
 		onPostRender() {
 			ReactDOM.render(
-				<Gridicon icon={ menuItems[0].icon } />,
+				<Gridicon icon="add-image" />,
 				this.$el[0].children[0]
 			);
 		}
@@ -35,5 +36,9 @@ const initialize = editor => {
 };
 
 export default () => {
+	if ( ! config.isEnabled( 'post-editor/insert-menu' ) ) {
+		return;
+	}
+
 	tinymce.PluginManager.add( 'wpcom/insertmenu', initialize );
 };

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -1,9 +1,33 @@
-.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu button {
-	padding-right: 20px;
+.post-editor,
+.mce-inline-toolbar-grp {
+
+	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu:hover,
+	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu:focus {
+		border-color: lighten( $gray, 20%);
+	}
+	
+	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu {
+		margin: 4px 2px;
+		border-right: 1px solid lighten( $gray, 30% );
+	}
 }
 
-.mce-container .mce-wpcom-insert-menu .mce-caret {
-	padding-left: 12px;
+.mce-toolbar .mce-btn.mce-insert-menu button:first-child {
+	padding: 2px 4px;
+}
+
+.mce-splitbtn.mce-insert-menu .mce-open.mce-active {
+	background-color: $white;
+	outline: 0;
+}
+
+.mce-btn.mce-insert-menu span {
+	padding-left: 0;
+}
+
+.mce-toolbar .mce-btn.mce-insert-menu .mce-open {
+	padding-right: 10px;
+	padding-left: 8px;
 }
 
 .wpcom-insert-menu__menu-icon {
@@ -18,7 +42,7 @@
 	color: darken( $gray, 30% );
 	display: inline-block;
 	font-family: $sans;
-	margin-left: 4px;
+	margin-left: 8px;
 	margin-top: 2px;
 
 	&:hover {

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -5,10 +5,9 @@
 	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu:focus {
 		border-color: lighten( $gray, 20%);
 	}
-	
+
 	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu {
-		margin: 4px 2px;
-		border-right: 1px solid lighten( $gray, 30% );
+		margin: 4px;
 	}
 }
 
@@ -46,13 +45,13 @@
 	padding: 9px 16px;
 	margin: none;
 	border: none;
-	
+
 	&:hover {
-		
+
 		.wpcom-insert-menu__menu-label {
 			color: $blue-medium;
 		}
-		
+
 		.wpcom-insert-menu__menu-icon {
 			fill: $blue-medium;
 		}

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -30,31 +30,31 @@
 	padding-left: 8px;
 }
 
-.wpcom-insert-menu__menu-icon {
-	fill: $gray;
-
-	&:hover {
-		fill: $blue-medium;
-	}
-}
-
 .mce-container .wpcom-insert-menu__menu-label {
 	color: darken( $gray, 30% );
 	display: inline-block;
 	font-family: $sans;
 	margin-left: 8px;
 	margin-top: 2px;
-
-	&:hover {
-		color: $blue-medium;
-	}
 }
 
-.mce-container.mce-menu .mce-container-body {
-	padding: 0 16px;
-	box-sizing: border-box;
+.wpcom-insert-menu__menu-icon {
+	fill: $gray;
 }
 
 .mce-container.mce-menu .mce-container-body .mce-wpcom-insert-menu__menu-item {
-	padding: 9px 0;
+	padding: 9px 16px;
+	margin: none;
+	border: none;
+	
+	&:hover {
+		
+		.wpcom-insert-menu__menu-label {
+			color: $blue-medium;
+		}
+		
+		.wpcom-insert-menu__menu-icon {
+			fill: $blue-medium;
+		}
+	}
 }

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -50,6 +50,11 @@
 	}
 }
 
+.mce-container.mce-menu .mce-container-body {
+	padding: 0 16px;
+	box-sizing: border-box;
+}
+
 .mce-container.mce-menu .mce-container-body .mce-wpcom-insert-menu__menu-item {
-	margin-left: -6px;
+	padding: 9px 0;
 }

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -1,0 +1,31 @@
+.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu button {
+	padding-right: 20px;
+}
+
+.mce-container .mce-wpcom-insert-menu .mce-caret {
+	padding-left: 12px;
+}
+
+.wpcom-insert-menu__menu-icon {
+	fill: $gray;
+
+	&:hover {
+		fill: $blue-medium;
+	}
+}
+
+.mce-container .wpcom-insert-menu__menu-label {
+	color: darken( $gray, 30% );
+	display: inline-block;
+	font-family: $sans;
+	margin-left: 4px;
+	margin-top: 2px;
+
+	&:hover {
+		color: $blue-medium;
+	}
+}
+
+.mce-container.mce-menu .mce-container-body .mce-wpcom-insert-menu__menu-item {
+	margin-left: -6px;
+}

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -1,18 +1,21 @@
 .post-editor,
 .mce-inline-toolbar-grp {
 
-	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu:hover,
-	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu:focus {
-		border-color: lighten( $gray, 20%);
-	}
-
 	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu {
-		margin: 4px;
+		margin: 0;
+	}
+}
+
+.post-editor,
+.mce-inline-toolbar-grp {
+
+	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu .mce-open:hover i.mce-caret {
+		color: $gray-dark;
 	}
 }
 
 .mce-toolbar .mce-btn.mce-insert-menu button:first-child {
-	padding: 2px 4px;
+	padding: 6px 6px 6px 6px;
 }
 
 .mce-splitbtn.mce-insert-menu .mce-open.mce-active {
@@ -25,8 +28,7 @@
 }
 
 .mce-toolbar .mce-btn.mce-insert-menu .mce-open {
-	padding-right: 10px;
-	padding-left: 8px;
+	padding: 8px 12px 8px 12px;
 }
 
 .mce-container .wpcom-insert-menu__menu-label {

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -15,7 +15,7 @@
 }
 
 .mce-toolbar .mce-btn.mce-insert-menu button:first-child {
-	padding: 6px 6px 6px 6px;
+	padding: 6px;
 }
 
 .mce-splitbtn.mce-insert-menu .mce-open.mce-active {
@@ -28,7 +28,7 @@
 }
 
 .mce-toolbar .mce-btn.mce-insert-menu .mce-open {
-	padding: 8px 12px 8px 12px;
+	padding: 8px 12px;
 }
 
 .mce-container .wpcom-insert-menu__menu-label {
@@ -48,7 +48,8 @@
 	margin: 0;
 	border: none;
 
-	&:hover {
+	&:hover,
+	&:focus {
 
 		.wpcom-insert-menu__menu-label {
 			color: $blue-medium;

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -3,14 +3,26 @@
 
 	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu {
 		margin: 0;
-	}
-}
-
-.post-editor,
-.mce-inline-toolbar-grp {
-
-	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu .mce-open:hover i.mce-caret {
-		color: $gray-dark;
+		
+		&:hover .mce-open i.mce-caret,
+		&:focus .mce-open i.mce-caret {
+			color: lighten( $gray, 20% );
+		}
+		
+		&:hover .gridicons-add-image,
+		&:focus .gridicons-add-image {
+			fill: lighten( $gray, 20% );
+		}
+		
+		.mce-open:hover i.mce-caret,
+		.mce-open:focus i.mce-caret {
+			color: $gray-dark;
+		}
+		
+		.gridicons-add-image:hover,
+		.gridicons-add-image:focus {
+			fill: $gray-dark;
+		}
 	}
 }
 

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -45,7 +45,7 @@
 
 .mce-container.mce-menu .mce-container-body .mce-wpcom-insert-menu__menu-item {
 	padding: 9px 16px;
-	margin: none;
+	margin: 0;
 	border: none;
 
 	&:hover {

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -3,27 +3,33 @@
 
 	.mce-toolbar .mce-btn-group .mce-btn.mce-insert-menu {
 		margin: 0;
-		
+
 		&:hover .mce-open i.mce-caret,
 		&:focus .mce-open i.mce-caret {
 			color: lighten( $gray, 10% );
 		}
-		
+
 		&:hover .gridicons-add-image,
 		&:focus .gridicons-add-image {
 			fill: lighten( $gray, 10% );
 		}
-		
+
 		.mce-open:hover i.mce-caret,
 		.mce-open:focus i.mce-caret {
 			color: $gray-dark;
 		}
-		
+
 		.gridicons-add-image:hover,
 		.gridicons-add-image:focus {
 			fill: $gray-dark;
 		}
 	}
+}
+
+.post-editor .mce-toolbar .mce-btn.mce-insert-menu .gridicon,
+.wpcom-insert-menu__menu-icon.gridicon {
+	height: 24px;
+	width: 24px;
 }
 
 .mce-toolbar .mce-btn.mce-insert-menu button:first-child {

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -6,12 +6,12 @@
 		
 		&:hover .mce-open i.mce-caret,
 		&:focus .mce-open i.mce-caret {
-			color: lighten( $gray, 20% );
+			color: lighten( $gray, 10% );
 		}
 		
 		&:hover .gridicons-add-image,
 		&:focus .gridicons-add-image {
-			fill: lighten( $gray, 20% );
+			fill: lighten( $gray, 10% );
 		}
 		
 		.mce-open:hover i.mce-caret,

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -1,5 +1,6 @@
 @import 'plugins/wplink/style';
 @import 'plugins/calypso-alert/style';
+@import 'plugins/insert-menu/style';
 @import 'plugins/wpcom-help/style';
 @import 'plugins/wpcom-charmap/style';
 @import 'plugins/contact-form/style';

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -96,11 +96,13 @@
 		margin: 0 2px 0 0;
 		padding: 0 8px;
 		vertical-align: top;
+		border-left: 1px solid lighten( $gray, 30% );
 		border-right: 1px solid lighten( $gray, 30% );
 		height: 36px;
 
 		@include breakpoint( "<660px" ) {
 			border-right-color: $white;
+			border-left-color: $white;
 			padding: 2px 0;
 		}
 	}
@@ -221,7 +223,6 @@
 
 .mce-toolbar .mce-btn-group .mce-wpcom-icon-button.mce-media button {
 	@include breakpoint( ">660px" ) {
-		border-right: 1px solid lighten( $gray, 30% );
 		font-size: 13px;
 	}
 }
@@ -591,7 +592,9 @@ div.mce-path {
 	}
 }
 
-.mce-toolbar-grp:not( .mce-inline-toolbar-grp ) .mce-btn-group .mce-btn.mce-first {
+// [TODO]: Selector `:not( .mce-wpcom-insert-menu )` unnecessary when
+// `post-editor/insert-menu` feature enabled in all environments
+.mce-toolbar-grp:not( .mce-inline-toolbar-grp ) .mce-btn-group .mce-btn.mce-first:not( .mce-wpcom-insert-menu ) {
 	margin-left: 4px;
 }
 
@@ -728,10 +731,12 @@ div.mce-path {
 
 .post-editor .mce-toolbar .mce-btn-group .mce-btn.mce-listbox:hover {
 	background-image: none;
+	border-left-color: lighten( $gray, 30% );
 	border-right-color: lighten( $gray, 30% );
 
 	@include breakpoint( "<660px" ) {
 		border-right-color: $white;
+		border-left-color: $white;
 	}
 
 	i.mce-caret {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -1004,7 +1004,7 @@ div.mce-menu .mce-menu-item-sep,
 .mce-toolbar .mce-btn:hover .mce-open,
 .mce-toolbar .mce-btn:focus .mce-open,
 .mce-toolbar .mce-btn.mce-active .mce-open {
-	border-left-color: lighten( $gray, 20% );
+	border-left-color: lighten( $gray, 30% );
 }
 
 i.mce-i-bold,

--- a/config/development.json
+++ b/config/development.json
@@ -99,6 +99,7 @@
 		"phone_signup": true,
 		"post-editor-github-link": false,
 		"post-editor/image-editor": false,
+		"post-editor/insert-menu": true,
 		"post-editor/media-advanced": true,
 		"press-this": true,
 		"reader": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -68,6 +68,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"phone_signup": false,
+		"post-editor/insert-menu": true,
 		"press-this": true,
 		"reader": true,
 		"resume-editing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -65,6 +65,7 @@
 		"olark": true,
 		"perfmon": true,
 		"persist-redux": true,
+		"post-editor/insert-menu": true,
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -81,7 +81,6 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/search": true,
 		"reader/recommendations/posts": true,
 		"reader/search": true,
 		"reader/tags-with-elasticsearch": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -77,6 +77,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"phone_signup": true,
+		"post-editor/insert-menu": true,
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -81,6 +81,7 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
+		"reader/search": true,
 		"reader/recommendations/posts": true,
 		"reader/search": true,
 		"reader/tags-with-elasticsearch": true,


### PR DESCRIPTION
Part of #5070

Adds an "insert item" menu bar to the editor toolbar to allow inserting various types of media or embeds into a post, similar to how the insert menus in mainstream applications work.

![artboard1](https://cloud.githubusercontent.com/assets/5431237/14875734/72a65c6a-0cc2-11e6-9e43-915999e507a8.png)

This PR's goal is to add in the empty shell on the editor toolbar which will make it easy to add other modules or embeds.

**Testing**
 - Load the editor
 - Check for the new dropdown on the top left of the toolbar

**Questions**
 - [ ] There's something pretty strange about the way this code replaces the top HTML in the split button. It's deeply coupled into the DOM structure of what the TinyMCE menu creates. I would appreciate some advice on a better or more idiomatic way to do this.
 - [x] <del>The toolbar button initialization and runtime code is tightly coupled to TinyMCE's API. This is making it hard to abstract the buttons and actions; for example, it's not possible to simply add the existing media plugin into the new dropdown menu. Our options are to **refactor the existing TinyMCE plugins** or to provide an adapter interface to mock the TinyMCE API and pass through the appropriate calls to the actual TinyMCE. None of this feels like the "right way to do it" so if anyone can offer some wisdom that would help us keep the code clean.</del> As long as the other plugins create a new TinyMCE command, we can use that command in the insert menu without having to rewire anything else.

cc: @dan @aduth @drw158 @rodrigoi 