### PR TITLE
Purchases: Fix broken Edit payment method link

### DIFF
--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -40,13 +40,6 @@ export default function() {
 	);
 
 	page(
-		paths.editSpecificCardDetails(),
-		meController.sidebar,
-		controller.noSitesMessage,
-		controller.editCardDetails
-	);
-
-	page(
 		paths.list(),
 		meController.sidebar,
 		controller.noSitesMessage,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -199,7 +199,7 @@ const ManagePurchase = React.createClass( {
 								},
 								components: {
 									a: canEditPaymentDetails( purchase )
-										? <a href={ paths.editCardDetails( this.props.selectedSite.slug, id, creditCard.id ) } />
+										? <a href={ paths.editCardDetails( this.props.selectedSite.slug, id ) } />
 										: <span />
 								}
 							}
@@ -336,11 +336,9 @@ const ManagePurchase = React.createClass( {
 			);
 		}
 
-		const { id, payment: { creditCard } } = purchase;
-
 		return (
 			<li>
-				<a href={ paths.editCardDetails( this.props.selectedSite.slug, id, creditCard.id ) }>
+				<a href={ paths.editCardDetails( this.props.selectedSite.slug, purchase.id ) }>
 					{ paymentDetails }
 				</a>
 			</li>
@@ -459,19 +457,15 @@ const ManagePurchase = React.createClass( {
 	},
 
 	renderEditPaymentMethodNavItem() {
-		const purchase = getPurchase( this.props ),
-			{ id, payment } = purchase;
-
 		if ( ! getSelectedSite( this.props ) ) {
 			return null;
 		}
 
-		let path = paths.editCardDetails( this.props.selectedSite.slug, id );
-		if ( isPaidWithCreditCard( purchase ) ) {
-			path = paths.editSpecificCardDetails( this.props.selectedSite.slug, id, payment.creditCard.id );
-		}
+		const purchase = getPurchase( this.props );
 
 		if ( canEditPaymentDetails( purchase ) ) {
+			const path = paths.editCardDetails( this.props.selectedSite.slug, purchase.id );
+
 			return (
 				<CompactCard href={ path }>
 					{ this.translate( 'Edit Payment Method' ) }

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -26,10 +26,6 @@ function editCardDetails( siteName, purchaseId ) {
 	return editPaymentMethod( siteName, purchaseId ) + `/edit`;
 }
 
-function editSpecificCardDetails( siteName, purchaseId, cardId = ':cardId' ) {
-	return editPaymentMethod( siteName, purchaseId ) + `/edit/${ cardId }`;
-}
-
 function editPaymentMethod( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/payment';
 }
@@ -40,7 +36,6 @@ export default {
 	confirmCancelDomain,
 	editCardDetails,
 	editPaymentMethod,
-	editSpecificCardDetails,
 	list,
 	listNotice,
 	managePurchase


### PR DESCRIPTION
### Issue

When users visit their payments page, and attempt to edit the payment information, they hit a weird redirect loop where they are taken back to the main payments page, and seem to be unable to edit the payment information. It happens when user removes stored credit card info.

### Solution
I removed stored credit card id param from the link, in that case we won’t have redirect when stored card was removed. It turned out `editSpecificCardDetails` path is no longer in use so I removed related logic. I'm sure we could remove more logic, but I decided to keep it because of this related issue - https://github.com/Automattic/wp-calypso/issues/193#issuecomment-159915208.

### Testing
1. Checkout `fix/broken-edit-payment-method-link`.
2. Execute `make run`.
3. Go to http://calypso.localhost:3000/.
4. Purchase something that can be renewed using credit card.
5. Go to `Billing History` (http://calypso.localhost:3000/me/billing).
6. Delete used Credit Card from the list of stored cards.
7. Go to `Purchases` (http://calypso.localhost:3000/purchases).
8. Click on your purchase.
9. Click on `Edit Payment Method` link.
10. `Edit Card Details` page should load normally and you should be able to save new card details.

/cc @janm6k @eoigal @fabianapsimoes @stephanethomas 