### PR TITLE
Jetpack-connect: Add button to go back to your wp-admin

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -51,6 +51,8 @@ const renderFormHeader = ( site, isConnected = false ) => {
 	);
 };
 
+const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 Hour
+
 const LoggedOutForm = React.createClass( {
 	displayName: 'LoggedOutForm',
 
@@ -112,7 +114,7 @@ const LoggedInForm = React.createClass( {
 	componentWillMount() {
 		const { autoAuthorize, queryObject } = this.props.jetpackConnectAuthorize;
 		debug( 'Checking for auto-auth on mount', autoAuthorize );
-		if ( autoAuthorize || this.isCalypsoStartedConnection() ) {
+		if ( autoAuthorize || this.props.calypsoStartedConnection ) {
 			this.props.authorize( queryObject );
 		}
 	},
@@ -185,14 +187,9 @@ const LoggedInForm = React.createClass( {
 		return text;
 	},
 
-	isCalypsoStartedConnection() {
-		const site = this.props.jetpackConnectAuthorize.queryObject.site.replace( /.*?:\/\//g, '' );
-		if ( this.props.jetpackConnectSessions && this.props.jetpackConnectSessions[ site ] ) {
-			const currentTime = ( new Date() ).getTime();
-			const oneDay = 24 * 60 * 60 * 1000;
-			return ( currentTime - this.props.jetpackConnectSessions[ site ] < oneDay );
-		}
-		return false;
+	isWaitingForConfirmation() {
+		const { isAuthorizing, authorizeSuccess, siteReceived } = this.props.jetpackConnectAuthorize;
+		return !( isAuthorizing || authorizeSuccess || siteReceived );
 	},
 
 	getRedirectionTarget() {
@@ -209,6 +206,11 @@ const LoggedInForm = React.createClass( {
 	renderFooterLinks() {
 		const { queryObject, authorizeSuccess, isAuthorizing } = this.props.jetpackConnectAuthorize;
 		const loginUrl = config( 'login_url' ) + '?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) + '&_wp_nonce=' + encodeURIComponent( queryObject._wp_nonce );
+		let backToWpAdminLink = (
+			<LoggedOutFormLinkItem href={ queryObject.redirect_after_auth }>
+				{ this.translate( 'Cancel and go back to my site' ) }
+			</LoggedOutFormLinkItem>
+		);
 
 		if ( isAuthorizing ) {
 			return null;
@@ -217,6 +219,7 @@ const LoggedInForm = React.createClass( {
 		if ( authorizeSuccess ) {
 			return (
 				<LoggedOutFormLinks>
+					{ ! this.props.calypsoStartedConnection && this.isWaitingForConfirmation() ? backToWpAdminLink : null }
 					<LoggedOutFormLinkItem href={ this.getRedirectionTarget() }>
 						{ this.translate( 'I\'m not interested in upgrades' ) }
 					</LoggedOutFormLinkItem>
@@ -226,6 +229,7 @@ const LoggedInForm = React.createClass( {
 
 		return(
 			<LoggedOutFormLinks>
+				{ ! this.props.calypsoStartedConnection && this.isWaitingForConfirmation() ? backToWpAdminLink : null }
 				<LoggedOutFormLinkItem href={ loginUrl }>
 					{ this.translate( 'Sign in as a different user' ) }
 				</LoggedOutFormLinkItem>
@@ -259,6 +263,17 @@ const LoggedInForm = React.createClass( {
 const JetpackConnectAuthorizeForm = React.createClass( {
 	displayName: 'JetpackConnectAuthorizeForm',
 	mixins: [ observe( 'userModule' ) ],
+
+	isCalypsoStartedConnection() {
+		const site = this.props.jetpackConnectAuthorize.queryObject.site.replace( /.*?:\/\//g, '' );
+		if ( this.props.jetpackConnectSessions && this.props.jetpackConnectSessions[ site ] ) {
+			const currentTime = ( new Date() ).getTime();
+			return ( currentTime - this.props.jetpackConnectSessions[ site ] < JETPACK_CONNECT_TTL );
+		}
+
+		return false;
+	},
+
 	renderForm() {
 		const { userModule } = this.props;
 		let user = userModule.get();

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -25,6 +25,7 @@ import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
 import i18n from 'lib/mixins/i18n';
+import Gridicon from 'components/gridicon';
 
 /**
  * Constants
@@ -207,8 +208,8 @@ const LoggedInForm = React.createClass( {
 		const { queryObject, authorizeSuccess, isAuthorizing } = this.props.jetpackConnectAuthorize;
 		const loginUrl = config( 'login_url' ) + '?jetpack_calypso_login=1&redirect_to=' + encodeURIComponent( window.location.href ) + '&_wp_nonce=' + encodeURIComponent( queryObject._wp_nonce );
 		let backToWpAdminLink = (
-			<LoggedOutFormLinkItem href={ queryObject.redirect_after_auth }>
-				{ this.translate( 'Cancel and go back to my site' ) }
+			<LoggedOutFormLinkItem icon={ true } href={ queryObject.redirect_after_auth }>
+				{ this.translate( 'Cancel and go back to my site' ) } <Gridicon size={ 18 } icon="external" />
 			</LoggedOutFormLinkItem>
 		);
 

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -89,4 +89,8 @@
 	.button {
 		width: 100%;
 	}
+
+	.logged-out-form__links .gridicon {
+		top: 2px;
+	}
 }


### PR DESCRIPTION
If I start the connection flow from my wp-admin, when I arrive at the (new) authorization screen, I have no way to say "I don't want to continue" and go back to my dashboard.

This PR introduces a link there to jump out of the flow and go back to your own dashboard:

![image](https://cloud.githubusercontent.com/assets/1554855/14882020/e2489690-0d36-11e6-960c-1a9a95fd1aa7.png)


How to test
=========
1. You need to be on the whitelist of users that see the new authorization screen, talk with @roccotripaldi  about it
2. Go to you site and disconnect and connect jetpack. When you arrive at the authorization screen, you should see the link to send you back to your wp-admin
3. Click it and make sure that it works as expected