### PR TITLE
Framework: Add `makeLayout`

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -10,7 +10,6 @@ These are some of the key modules of the application, kept in `client`'s root fo
 * `boot` - the booting file that sets up the application and requires the main sections.
 * `config` - generated configuration settings.
 * `layout` - handles the main React layout, including the masterbar. Notably, it sets #primary and #secondary used to render the different sections.
-* `controller.js` - isomorphic routing helper, see comments in that file.
 * `sections.js` - defines section groups, paths, and main modules. (Used by webpack to generate separate chunks.)
 
 ### Components

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -5,6 +5,7 @@ require( 'lib/local-storage' )();
  * External dependencies
  */
 var React = require( 'react' ),
+	ReactDom = require( 'react-dom' ),
 	store = require( 'store' ),
 	ReactInjection = require( 'react/lib/ReactInjection' ),
 	some = require( 'lodash/some' ),
@@ -38,24 +39,19 @@ var config = require( 'config' ),
 	sites = require( 'lib/sites-list' )(),
 	superProps = require( 'lib/analytics/super-props' ),
 	translatorJumpstart = require( 'lib/translator-jumpstart' ),
-	translatorInvitation = require( 'layout/community-translator/invitation-utils' ),
 	nuxWelcome = require( 'layout/nux-welcome' ),
 	emailVerification = require( 'components/email-verification' ),
 	viewport = require( 'lib/viewport' ),
 	detectHistoryNavigation = require( 'lib/detect-history-navigation' ),
 	pushNotificationsInit = require( 'state/push-notifications/actions' ).init,
-	sections = require( 'sections' ),
 	touchDetect = require( 'lib/touch-detect' ),
 	setRouteAction = require( 'state/ui/actions' ).setRoute,
 	accessibleFocus = require( 'lib/accessible-focus' ),
 	TitleStore = require( 'lib/screen-title/store' ),
 	syncHandler = require( 'lib/wp/sync-handler' ),
-	renderWithReduxStore = require( 'lib/react-helpers' ).renderWithReduxStore,
 	bindWpLocaleState = require( 'lib/wp/localization' ).bindState,
 	supportUser = require( 'lib/user/support-user-interop' ),
-	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default,
-	// The following components require the i18n mixin, so must be required after i18n is initialized
-	Layout;
+	createReduxStoreFromPersistedInitialState = require( 'state/initial-state' ).default;
 
 import { getSelectedSiteId, getSectionName, isSectionIsomorphic } from 'state/ui/selectors';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -179,17 +175,15 @@ function boot() {
 }
 
 function renderLayout( reduxStore ) {
-	const props = {};
+	const Layout = require( 'controller' ).ReduxWrappedLayout;
 
-	if ( user.get() ) {
-		Object.assign( props, { user, sites, nuxWelcome, translatorInvitation } );
-	}
+	const layoutElement = React.createElement( Layout, {
+		store: reduxStore
+	} );
 
-	Layout = require( 'layout' );
-	renderWithReduxStore(
-		React.createElement( Layout, props ),
-		document.getElementById( 'wpcom' ),
-		reduxStore
+	ReactDom.render(
+		layoutElement,
+		document.getElementById( 'wpcom' )
 	);
 
 	debug( 'Main layout rendered.' );
@@ -328,6 +322,7 @@ function reduxStoreReady( reduxStore ) {
 	}
 
 	// Load the application modules for the various sections and features
+	const sections = require( 'sections' );
 	sections.load();
 
 	// delete any lingering local storage data from signup

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -219,12 +219,9 @@ function reduxStoreReady( reduxStore ) {
 		require( 'lib/network-connection' ).init( reduxStore );
 	}
 
-	// Render Layout only for non-isomorphic sections, unless logged-in.
-	// Isomorphic sections will take care of rendering their Layout last themselves,
-	// unless in logged-in mode, where we can't do that yet.
-	// TODO: Remove the ! user.get() check once isomorphic sections render their
-	// Layout themselves when logged in.
-	if ( ! isIsomorphic || user.get() ) {
+	// Render Layout only for non-isomorphic sections.
+	// Isomorphic sections will take care of rendering their Layout last themselves.
+	if ( ! isIsomorphic ) {
 		renderLayout( reduxStore );
 
 		if ( config.isEnabled( 'catch-js-errors' ) ) {

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -423,7 +423,11 @@ function reduxStoreReady( reduxStore ) {
 
 		if ( isMultiTreeLayout && previousLayoutIsSingleTree ) {
 			debug( 'Re-rendering multi-tree layout' );
+
 			renderLayout( context.store );
+		} else if ( ! isMultiTreeLayout && ! previousLayoutIsSingleTree ) {
+			debug( 'Unmounting multi-tree layout' );
+			ReactDom.unmountComponentAtNode( document.getElementById( 'wpcom' ) );
 		}
 		next();
 	} );

--- a/client/controller/README.md
+++ b/client/controller/README.md
@@ -1,0 +1,4 @@
+Isomorphic Routing Helpers
+==========================
+
+See inline comments.

--- a/client/controller/README.md
+++ b/client/controller/README.md
@@ -1,4 +1,15 @@
 Isomorphic Routing Helpers
 ==========================
 
-See inline comments.
+Provides middleware to be used agnostically with either `page.js`, or with
+`express` (through middleware adapters found in `server/`). Since some of the
+middleware needs to function differently on the server than on the client,
+both versions are provided transparently in those cases (by `index.web.js` and
+`index.node.js`, respectively.)
+
+These middlewares include:
+* `makeLayout`: creates a `Layout` (or `LayoutLoggedOut`) component in `context.layout`.
+  Accepts `primary`, `secondary`, and `tertiary` arguments which it will use to
+  populate the corresponding `<div>`s.
+* `clientRouter`: Essentially an alias for `page`, which invokes a client-side
+  `render` middleware after all other middlewares.

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -1,0 +1,56 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { setSection as setSectionAction } from 'state/ui/actions';
+import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import LayoutLoggedOut from 'layout/logged-out';
+import { getCurrentUser } from 'state/current-user/selectors';
+
+export function makeLayoutMiddleware( LayoutComponent ) {
+	return ( context, next ) => {
+		const { store, primary, secondary, tertiary } = context;
+
+		// On server, only render LoggedOutLayout when logged-out.
+		if ( ! context.isServerSide || getCurrentUser( context.store.getState() ) ) {
+			context.layout = (
+				<LayoutComponent store={ store }
+					primary={ primary }
+					secondary={ secondary }
+					tertiary={ tertiary }
+				/>
+			);
+		}
+		next();
+	};
+}
+
+const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, tertiary } ) => (
+	<ReduxProvider store={ store }>
+		<LayoutLoggedOut primary={ primary }
+			secondary={ secondary }
+			tertiary={ tertiary } />
+	</ReduxProvider>
+);
+
+/**
+ * @param { object } context -- Middleware context
+ * @param { function } next -- Call next middleware in chain
+ *
+ * Produce a `LayoutLoggedOut` element in `context.layout`, using
+ * `context.primary`, `context.secondary`, and `context.tertiary` to populate it.
+*/
+export const makeLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );
+
+export function setSection( section ) {
+	return ( context, next = noop ) => {
+		context.store.dispatch( setSectionAction( section ) );
+
+		next();
+	};
+}

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -7,31 +7,13 @@ import { Provider as ReduxProvider } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { makeLayoutMiddleware } from './shared.js';
 import LayoutLoggedOut from 'layout/logged-out';
-import { getCurrentUser } from 'state/current-user/selectors';
 
 /**
  * Re-export
  */
 export { setSection } from './shared.js';
-
-export function makeLayoutMiddleware( LayoutComponent ) {
-	return ( context, next ) => {
-		const { store, primary, secondary, tertiary } = context;
-
-		// On server, only render LoggedOutLayout when logged-out.
-		if ( ! context.isServerSide || getCurrentUser( context.store.getState() ) ) {
-			context.layout = (
-				<LayoutComponent store={ store }
-					primary={ primary }
-					secondary={ secondary }
-					tertiary={ tertiary }
-				/>
-			);
-		}
-		next();
-	};
-}
 
 const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, tertiary } ) => (
 	<ReduxProvider store={ store }>

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -3,14 +3,17 @@
  */
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
-import { setSection as setSectionAction } from 'state/ui/actions';
-import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
  */
 import LayoutLoggedOut from 'layout/logged-out';
 import { getCurrentUser } from 'state/current-user/selectors';
+
+/**
+ * Re-export
+ */
+export { setSection } from './shared.js';
 
 export function makeLayoutMiddleware( LayoutComponent ) {
 	return ( context, next ) => {
@@ -46,11 +49,3 @@ const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, tertiary } ) 
  * `context.primary`, `context.secondary`, and `context.tertiary` to populate it.
 */
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );
-
-export function setSection( section ) {
-	return ( context, next = noop ) => {
-		context.store.dispatch( setSectionAction( section ) );
-
-		next();
-	};
-}

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -13,7 +13,7 @@ import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
 import nuxWelcome from 'layout/nux-welcome';
 import translatorInvitation from 'layout/community-translator/invitation-utils';
-import { makeLayoutMiddleware } from './index.node.js';
+import { makeLayoutMiddleware } from './shared.js';
 import { getCurrentUser } from 'state/current-user/selectors';
 import userFactory from 'lib/user';
 import sitesFactory from 'lib/sites-list';

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -11,7 +11,6 @@ import page from 'page';
  */
 import Layout from 'layout';
 import LayoutLoggedOut from 'layout/logged-out';
-import layoutFocus from 'lib/layout-focus';
 import nuxWelcome from 'layout/nux-welcome';
 import translatorInvitation from 'layout/community-translator/invitation-utils';
 import { makeLayoutMiddleware } from './index.node.js';
@@ -37,14 +36,12 @@ export const ReduxWrappedLayout = ( { store, primary, secondary, tertiary } ) =>
 				tertiary={ tertiary }
 				user={ user }
 				sites={ sites }
-				focus={ layoutFocus }
 				nuxWelcome={ nuxWelcome }
 				translatorInvitation={ translatorInvitation }
 			/>
 			: <LayoutLoggedOut primary={ primary }
 				secondary={ secondary }
-				tertiary={ tertiary }
-				focus={ layoutFocus } />
+				tertiary={ tertiary } />
 		}
 	</ReduxProvider>
 );

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -23,7 +23,7 @@ import debugFactory from 'debug';
 /**
  * Re-export
  */
-export { setSection } from './index.node.js';
+export { setSection } from './shared.js';
 
 const user = userFactory();
 const sites = sitesFactory();

--- a/client/controller/package.json
+++ b/client/controller/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "index.node.js",
+	"browser": "index.web.js"
+}

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -1,5 +1,32 @@
-import { setSection as setSectionAction } from 'state/ui/actions';
+/**
+ * External dependencies
+ */
+import React from 'react';
 import noop from 'lodash/noop';
+
+/**
+ * Internal dependencies
+ */
+import { setSection as setSectionAction } from 'state/ui/actions';
+import { getCurrentUser } from 'state/current-user/selectors';
+
+export function makeLayoutMiddleware( LayoutComponent ) {
+	return ( context, next ) => {
+		const { store, primary, secondary, tertiary } = context;
+
+		// On server, only render LoggedOutLayout when logged-out.
+		if ( ! context.isServerSide || getCurrentUser( context.store.getState() ) ) {
+			context.layout = (
+				<LayoutComponent store={ store }
+					primary={ primary }
+					secondary={ secondary }
+					tertiary={ tertiary }
+				/>
+			);
+		}
+		next();
+	};
+}
 
 export function setSection( section ) {
 	return ( context, next = noop ) => {

--- a/client/controller/shared.js
+++ b/client/controller/shared.js
@@ -1,0 +1,10 @@
+import { setSection as setSectionAction } from 'state/ui/actions';
+import noop from 'lodash/noop';
+
+export function setSection( section ) {
+	return ( context, next = noop ) => {
+		context.store.dispatch( setSectionAction( section ) );
+
+		next();
+	};
+}

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -56,6 +56,22 @@ Layout = React.createClass( {
 
 	_sitesPoller: null,
 
+	propTypes: {
+		primary: React.PropTypes.element,
+		secondary: React.PropTypes.element,
+		tertiary: React.PropTypes.element,
+		sites: React.PropTypes.object,
+		user: React.PropTypes.object,
+		nuxWelcome: React.PropTypes.object,
+		translatorInvitation: React.PropTypes.object,
+		focus: React.PropTypes.object,
+		// connected props
+		isLoading: React.PropTypes.bool,
+		isSupportUser: React.PropTypes.bool,
+		section: React.PropTypes.object,
+		isOffline: React.PropTypes.bool,
+	},
+
 	componentWillUpdate: function( nextProps ) {
 		if ( this.props.section.group !== nextProps.section.group ) {
 			if ( nextProps.section.group === 'sites' ) {
@@ -188,10 +204,16 @@ Layout = React.createClass( {
 					{ this.renderWelcome() }
 					{ this.renderPushNotificationPrompt() }
 					<GlobalNotices id="notices" notices={ notices.list } forcePinned={ 'post' === this.props.section.name } />
-					<div id="primary" className="layout__primary" />
-					<div id="secondary" className="layout__secondary" />
+					<div id="primary" className="layout__primary">
+						{ this.props.primary }
+					</div>
+					<div id="secondary" className="layout__secondary">
+						{ this.props.secondary }
+					</div>
 				</div>
-				<div id="tertiary" />
+				<div id="tertiary">
+					{ this.props.tertiary }
+				</div>
 				<TranslatorLauncher
 					isEnabled={ translator.isEnabled() }
 					isActive={ translator.isActivated() }/>

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -187,7 +187,8 @@ Layout = React.createClass( {
 				`is-section-${this.props.section.name}`,
 				`focus-${this.props.currentLayoutFocus}`,
 				{ 'is-support-user': this.props.isSupportUser },
-				{ 'has-no-sidebar': ! this.props.hasSidebar }
+				{ 'has-no-sidebar': ! this.props.hasSidebar },
+				{ 'wp-singletree-layout': !! this.props.primary }
 			),
 			loadingClass = classnames( {
 				layout__loader: true,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -68,7 +68,10 @@ Layout = React.createClass( {
 		// connected props
 		isLoading: React.PropTypes.bool,
 		isSupportUser: React.PropTypes.bool,
-		section: React.PropTypes.object,
+		section: React.PropTypes.oneOfType( [
+			React.PropTypes.bool,
+			React.PropTypes.object,
+		] ),
 		isOffline: React.PropTypes.bool,
 	},
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -50,14 +50,14 @@ function createNavigation( context ) {
 		basePath = route.sectionify( context.pathname );
 	}
 
-	return React.createElement( ReduxProvider, { store: context.store },
-		React.createElement( NavigationComponent, {
-			path: context.path,
-			allSitesPath: basePath,
-			siteBasePath: basePath,
-			user,
-			sites
-		} )
+	return (
+		<ReduxProvider store={ context.store }>
+			<NavigationComponent path={ context.path }
+				allSitesPath={ basePath }
+				siteBasePath={ basePath }
+				user={ user }
+				sites={ sites } />
+		</ReduxProvider>
 	);
 }
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -39,20 +39,25 @@ const sites = sitesFactory();
 /*
  * The main navigation of My Sites consists of a component with
  * the site selector list and the sidebar section items
+ * @param { object } context - Middleware context
+ * @returns { object } React element containing the site selector and sidebar
  */
-function renderNavigation( context, allSitesPath, siteBasePath ) {
-	// Render the My Sites navigation in #secondary
-	ReactDom.render(
-		React.createElement( ReduxProvider, { store: context.store },
-			React.createElement( NavigationComponent, {
-				path: context.path,
-				allSitesPath,
-				siteBasePath,
-				user,
-				sites
-			} )
-		),
-		document.getElementById( 'secondary' )
+function createNavigation( context ) {
+	const siteFragment = route.getSiteFragment( context.pathname );
+	let basePath = context.pathname;
+
+	if ( siteFragment ) {
+		basePath = route.sectionify( context.pathname );
+	}
+
+	return React.createElement( ReduxProvider, { store: context.store },
+		React.createElement( NavigationComponent, {
+			path: context.path,
+			allSitesPath: basePath,
+			siteBasePath: basePath,
+			user,
+			sites
+		} )
 	);
 }
 
@@ -240,15 +245,17 @@ module.exports = {
 		checkSiteShouldFetch();
 	},
 
-	navigation( context, next ) {
-		const siteFragment = route.getSiteFragment( context.pathname );
-		let basePath = context.pathname;
+	makeNavigation: function( context, next ) {
+		context.secondary = createNavigation( context );
+		next();
+	},
 
-		if ( siteFragment ) {
-			basePath = route.sectionify( context.pathname );
-		}
-
-		renderNavigation( context, basePath, basePath );
+	navigation: function( context, next ) {
+		// Render the My Sites navigation in #secondary
+		ReactDom.render(
+			createNavigation( context ),
+			document.getElementById( 'secondary' )
+		);
 		next();
 	},
 

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -7,14 +7,6 @@ import { makeLayout } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { singleSite, multiSite, loggedOut } from './controller';
 
-// FIXME: These routes will SSR the logged-out Layout even if logged-in.
-// While subsequently replaced by the logged-in Layout on the client-side,
-// we'll want to render it on the server, too.
-
-// `logged-out` middleware isn't SSR-compliant yet, but we can at least render
-// the layout.
-// FIXME: Also create loggedOut/multiSite/singleSite elements, depending on route.
-
 export default function( router ) {
 	const user = userFactory();
 	const isLoggedIn = !! user.get();

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -13,7 +13,7 @@ export default function( router ) {
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( isLoggedIn ) {
-			router( '/design/:tier(free|premium)?', siteSelection, multiSite, makeNavigation, makeLayout );
+			router( '/design/:tier(free|premium)?', multiSite, makeNavigation, makeLayout );
 			router( '/design/:tier(free|premium)?/:site_id', siteSelection, singleSite, makeNavigation, makeLayout );
 			router( '/design/:tier(free|premium)?/filter/:filter', siteSelection, multiSite, makeNavigation, makeLayout );
 			router( '/design/:tier(free|premium)?/filter/:filter/:site_id', siteSelection, singleSite, makeNavigation, makeLayout );

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -4,7 +4,7 @@
 import config from 'config';
 import userFactory from 'lib/user';
 import { makeLayout } from 'controller';
-import { navigation, siteSelection } from 'my-sites/controller';
+import { makeNavigation, siteSelection } from 'my-sites/controller';
 import { singleSite, multiSite, loggedOut } from './controller';
 
 export default function( router ) {
@@ -13,10 +13,10 @@ export default function( router ) {
 
 	if ( config.isEnabled( 'manage/themes' ) ) {
 		if ( isLoggedIn ) {
-			router( '/design/:tier(free|premium)?', multiSite, navigation, siteSelection );
-			router( '/design/:tier(free|premium)?/:site_id', singleSite, navigation, siteSelection );
-			router( '/design/:tier(free|premium)?/filter/:filter', multiSite, navigation, siteSelection );
-			router( '/design/:tier(free|premium)?/filter/:filter/:site_id', singleSite, navigation, siteSelection );
+			router( '/design/:tier(free|premium)?', siteSelection, multiSite, makeNavigation, makeLayout );
+			router( '/design/:tier(free|premium)?/:site_id', siteSelection, singleSite, makeNavigation, makeLayout );
+			router( '/design/:tier(free|premium)?/filter/:filter', siteSelection, multiSite, makeNavigation, makeLayout );
+			router( '/design/:tier(free|premium)?/filter/:filter/:site_id', siteSelection, singleSite, makeNavigation, makeLayout );
 		} else {
 			router( '/design/:tier(free|premium)?', loggedOut, makeLayout );
 			router( '/design/:tier(free|premium)?/filter/:filter', loggedOut, makeLayout );


### PR DESCRIPTION
This PR:

* Has `Layout` accept React element trees as `primary`, `secondary`, and `tertiary` props. 
* Splits `client/controller` into a client and server side version.
*  Changes `makeLayout()` to automatically render `LayoutLoggedOut` in logged-out mode, and `Layout` otherwise.
* Also adds `ReduxWrappedLayout` and `ReduxWrappedLoggedOutLayout` helper components.
* Has `my-sites/controller` expose `makeNavigation` as a middleware that populates `context.secondary` 
* Changes `client/my-sites/themes` to use `makeLayout`

No visual changes.

To test:
* Make sure the theme showcase still works as before.
* Specifically, test landing on (logged-in)  `/design`, and clicking on a theme's screenshot to navigate to its details sheet.

Fixes part of #2299. This is a redux of #4836, also picking up some pieces from #4820.