### PR TITLE
Plans: check if selectedSite exists before checking for domain credit

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -92,7 +92,7 @@ const SiteNotice = React.createClass( {
 
 export default connect( ( state, ownProps ) => {
 	return {
-		hasDomainCredit: hasDomainCredit( state, ownProps.site.ID )
+		hasDomainCredit: !! ownProps.site && hasDomainCredit( state, ownProps.site.ID )
 	};
 }, ( dispatch ) => {
 	return {

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -335,7 +335,7 @@ export const List = React.createClass( {
 
 export default connect( ( state, ownProps ) => {
 	return {
-		hasDomainCredit: hasDomainCredit( state, ownProps.selectedSite.ID )
+		hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, ownProps.selectedSite.ID )
 	};
 }, ( dispatch ) => {
 	return {


### PR DESCRIPTION
Potential fix for #5084. This adds bulletproofing before we check if a site has domain credits.

I wasn't able to reproduce the original issue, but we should handle this case anyway.

cc @fabianapsimoes @stephanethomas @rralian 