### PR TITLE
Media: trigger the correct analytics event for media storage errors

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -211,7 +211,7 @@ const MediaLibraryContent = React.createClass( {
 			<NoticeAction
 				external={ true }
 				href={ upgradeNudgeFeature ? `/plans/features/${ upgradeNudgeFeature }/${ this.props.siteSlug }` : `/plans/${ this.props.siteSlug }` }
-				onClick={ this.recordPlansNavigation.bind( this, 'plan-media-storage-error', eventProperties ) }>
+				onClick={ this.recordPlansNavigation.bind( this, 'calypso_upgrade_nudge_cta_click', eventProperties ) }>
 				{ this.translate( 'Upgrade Plan' ) }
 				<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
 			</NoticeAction>


### PR DESCRIPTION
The analytics event was accidentally changed here in a previous PR. Note that we need to prefix any tracks events with calypso, or they will not be recorded.

<img width="823" alt="error" src="https://cloud.githubusercontent.com/assets/1270189/14895527/fb66c34e-0d2d-11e6-9282-6e220040aadc.png">

Getting a media error, should give us an impression event like:
<img width="1058" alt="screen shot 2016-04-28 at 10 38 48 am" src="https://cloud.githubusercontent.com/assets/1270189/14895550/1469ab54-0d2e-11e6-9aea-9fa1e0a05579.png">

And clicking on the action should record:
<img width="1065" alt="screen shot 2016-04-28 at 10 39 13 am" src="https://cloud.githubusercontent.com/assets/1270189/14895563/24578662-0d2e-11e6-98a4-05876a046c12.png">

cc @artpi @rralian 