### PR TITLE
Create TinyMCE command for adding media

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -281,28 +281,28 @@ function mediaButton( editor ) {
 		renderDropZone( { visible: event.type === 'dragend' } );
 	}
 
+	editor.addCommand( 'wpcom_add_media', () => {
+		var selectedSite = sites.getSelectedSite();
+		if ( selectedSite ) {
+			MediaActions.clearValidationErrors( selectedSite.ID );
+		}
+
+		renderModal( {
+			visible: true,
+			initialActiveView: MediaModalViews.LIST
+		} );
+	} );
+
 	editor.addButton( 'wpcom_add_media', {
 		classes: 'btn wpcom-icon-button media',
-
+		cmd: 'wpcom_add_media',
 		title: i18n.translate( 'Add Media' ),
-
 		onPostRender: function() {
 			this.innerHtml( ReactDomServer.renderToStaticMarkup(
 				<button type="button" role="presentation" tabIndex="-1">
 					<Gridicon icon="image-multiple" size={ 20 } nonStandardSize />
 				</button>
 			) );
-		},
-		onclick: function() {
-			var selectedSite = sites.getSelectedSite();
-			if ( selectedSite ) {
-				MediaActions.clearValidationErrors( selectedSite.ID );
-			}
-
-			renderModal( {
-				visible: true,
-				initialActiveView: MediaModalViews.LIST
-			} );
 		}
 	} );
 

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -281,7 +281,7 @@ function mediaButton( editor ) {
 		renderDropZone( { visible: event.type === 'dragend' } );
 	}
 
-	editor.addCommand( 'wpcom_add_media', () => {
+	editor.addCommand( 'wpcomAddMedia', () => {
 		var selectedSite = sites.getSelectedSite();
 		if ( selectedSite ) {
 			MediaActions.clearValidationErrors( selectedSite.ID );
@@ -295,7 +295,7 @@ function mediaButton( editor ) {
 
 	editor.addButton( 'wpcom_add_media', {
 		classes: 'btn wpcom-icon-button media',
-		cmd: 'wpcom_add_media',
+		cmd: 'wpcomAddMedia',
 		title: i18n.translate( 'Add Media' ),
 		onPostRender: function() {
 			this.innerHtml( ReactDomServer.renderToStaticMarkup(


### PR DESCRIPTION
The "add media" dialog appears after clicking on the "add media" icon in
the TinyMCE toolbar.

Previously, this occurred as a direct result of the `onclick` handler in
`editor.addButton()`. Because this meant that adding media was dependent
on clicking the button, it prevented being able to do so in other ways,
such as is the goal in #5071

This patch moves the code to cause the media dialog to appear into a new
command, which the button then calls when it's clicked.

**Testing**

There are no visual or functional changes here. Try to edit a post and add media. Click on the "add media" button. Test any other existing ways you know of to add media into a post to make sure this doesn't introduce any regressions.

**Questions**
 - [x] <del>Is it wrong to name the action the same thing as the button? Do they live in different namespaces or will we inadvertently cause collisions by doing this?</del> - I have renamed the command based on a suggestion from @rodrigoi - it is now `wpcomAddMedia`

cc: @aduth 