### PR TITLE
Fix plans only test interference

### DIFF
--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -29,7 +29,7 @@ module.exports = {
 				cartItem.extra = Object.assign( cartItem.extra || {}, {
 					context: 'signup',
 					// no boolean below, they are casted to strings somewhere down the line
-					withPlansOnly: abtest( 'domainsWithPlansOnly' ) === 'plansOnly' ? 'yes' : ''
+					withPlansOnly: abtest( 'domainsWithPlansOnly' ) === 'plansOnly' && abtest( 'freeTrialsInSignup' ) !== 'enabled' ? 'yes' : ''
 				} );
 				const addFunction = cartItems.add( cartItem );
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -47,7 +47,7 @@ function addDomainItemsToCart( callback, dependencies, { domainItem, googleAppsC
 			let newCartItems = [];
 
 			if ( domainItem ) {
-				if ( abtest( 'domainsWithPlansOnly' ) === 'plansOnly' ) {
+				if ( abtest( 'domainsWithPlansOnly' ) === 'plansOnly' && abtest( 'freeTrialsInSignup' ) !== 'enabled' ) {
 					newCartItems = [ ...newCartItems, domainItem, cartItems.premiumPlan( 'value_bundle', { isFreeTrial: false } ) ];
 				} else {
 					newCartItems = [ ...newCartItems, domainItem ];

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -50,20 +50,21 @@ function addItem( item ) {
 
 function addItems( items ) {
 	const domainsWithPlansOnlyTestEnabled = abtest( 'domainsWithPlansOnly' ) === 'plansOnly',
+		freeTrialsEnabled = abtest( 'freeTrialsInSignup' ) === 'enabled',
 		selectedSite = sitesList.getSelectedSite();
-	let hasItemRequiresBundle = items.some( item => isDomainRegistration( item ) || isDomainMapping( item ) );
+	let shouldBundleWithPremium = items.some( item => isDomainRegistration( item ) || isDomainMapping( item ) ) && ! freeTrialsEnabled && domainsWithPlansOnlyTestEnabled;
 
 	if ( selectedSite ) {
-		hasItemRequiresBundle = hasItemRequiresBundle && ! isPlan( selectedSite.plan );
+		shouldBundleWithPremium = shouldBundleWithPremium && ! isPlan( selectedSite.plan );
 	}
 
-	if ( hasItemRequiresBundle && domainsWithPlansOnlyTestEnabled ) {
+	if ( shouldBundleWithPremium ) {
 		items = [ cartItems.premiumPlan( 'value_bundle', { isFreeTrial: false } ) ].concat( items );
 	}
 	const extendedItems = items.map( ( item ) => {
 		const extra = assign( {}, item.extra, {
 			context: 'calypstore',
-			withPlansOnly: domainsWithPlansOnlyTestEnabled ? 'yes' : ''
+			withPlansOnly: domainsWithPlansOnlyTestEnabled && ! freeTrialsEnabled ? 'yes' : ''
 		} );
 
 		return assign( {}, item, { extra } );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -247,14 +247,16 @@ const Signup = React.createClass( {
 		var flowSteps = flows.getFlow( this.props.flowName ).steps,
 			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
 			nextStepName = flowSteps[ currentStepIndex + 1 ],
-			nextStepSection = this.state.progress[ currentStepIndex + 1 ] ?
-				this.state.progress[ currentStepIndex + 1 ].stepSectionName :
-				'';
+			nextProgressItem = this.state.progress[ currentStepIndex + 1 ],
+			nextStepSection = nextProgressItem && nextProgressItem.stepSectionName || '';
+		this.goToStep( nextStepName, nextStepSection );
+	},
 
+	goToStep( stepName, stepSection ) {
 		clearInterval( this.windowScroller );
 
-		if ( ! this.isEveryStepSubmitted() && nextStepName ) {
-			page( utils.getStepUrl( this.props.flowName, nextStepName, nextStepSection, this.props.locale ) );
+		if ( ! this.isEveryStepSubmitted() && stepName ) {
+			page( utils.getStepUrl( this.props.flowName, stepName, stepSection, this.props.locale ) );
 		} else if ( this.isEveryStepSubmitted() ) {
 			this.goToFirstInvalidStep();
 		}
@@ -311,8 +313,10 @@ const Signup = React.createClass( {
 					<CurrentComponent
 						path={ this.props.path }
 						step={ currentStepProgress }
+						steps={ flows.getFlow( this.props.flowName ).steps }
 						stepName={ this.props.stepName }
 						goToNextStep={ this.goToNextStep }
+						goToStep={ this.goToStep }
 						flowName={ this.props.flowName }
 						signupProgressStore={ this.state.progress }
 						signupDependencies={ this.state.dependencies }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -111,11 +111,20 @@ module.exports = React.createClass( {
 			stepSectionName: this.props.stepSectionName
 		}, this.getThemeArgs() ), [], { domainItem } );
 
-		if ( domainsWithPlansOnlyTestEnabled && isPurchasingItem ) {
+		if ( domainsWithPlansOnlyTestEnabled && isPurchasingItem && abtest( 'freeTrialsInSignup' ) !== 'enabled' ) {
 			this.submitPlansStepWithPremium();
-		}
+			const plansIndex = this.props.steps.indexOf( 'plans' );
+			if ( plansIndex === this.props.steps.length - 1 || plansIndex === -1 ) {
+				// if plans is the last step or not in the flow, this'll finish the flow
+				this.props.goToNextStep();
+			} else {
+				// skip plans step
 
-		this.props.goToNextStep();
+				this.props.goToStep( this.props.steps[ plansIndex + 1 ] );
+			}
+		} else {
+			this.props.goToNextStep();
+		}
 	},
 
 	submitPlansStepWithPremium() {
@@ -143,7 +152,7 @@ module.exports = React.createClass( {
 			stepSectionName: this.props.stepSectionName
 		}, this.getThemeArgs() ) );
 
-		if ( domainsWithPlansOnlyTestEnabled ) {
+		if ( domainsWithPlansOnlyTestEnabled && abtest( 'freeTrialsInSignup' ) !== 'enabled' ) {
 			this.submitPlansStepWithPremium();
 		}
 


### PR DESCRIPTION
Plans Only Tests had some interference with Free Trials in Signup test; this PR fixes it.

## Testing
### Free Trials and Plans Only tests enabled at the same time
- 
`localStorage.clear() && localStorage.setItem('ABTests','{"freeTrialsInSignup_20160328":"enabled","domainsWithPlansOnly_20160427":"plansOnly"}')`
- Logged out, go through the signup flow with domain registration, domain mapping and free .wordpress.com.
- At no stage you Premium Plan should be added to your cart
- Signup should complete w/o errors

### Plans Only enabled
- `localStorage.clear() && localStorage.setItem('ABTests','{"domainsWithPlansOnly_20160427":"plansOnly"}')`
- Logged out, go through the signup flow with domain registration - domain mapping.
- Premium Plan should be added to your cart
- Removing Premium Plan should remove domain item from your cart.
- Signup should complete w/o errors

//cc: @klimeryk @rralian @aidvu 