### PR TITLE
Jetpack Connect: Always try to remove sidebar

### DIFF
--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import ReactDom from 'react-dom';
 import React from 'react';
 import isEmpty from 'lodash/isEmpty';
 import page from 'page';
@@ -40,6 +41,7 @@ export default {
 	},
 
 	connect( context ) {
+		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		context.store.dispatch( setSection( 'jetpackConnect', {
 			hasSidebar: false
 		} ) );
@@ -56,6 +58,7 @@ export default {
 	},
 
 	authorizeForm( context ) {
+		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
 		context.store.dispatch( setSection( 'jetpackConnect', {
 			hasSidebar: false
 		} ) );


### PR DESCRIPTION
Fixes #5094

As reported in the above issue, if a user authorizes a site and then goes back in history, then the sidebar is shown. This fixes that by attempting to remove the sidebar each time the Jetpack connect routes are loaded.

To test existence of bug:

Steps to reproduce:
- Go to https://wordpress.com/jetpack/connect
- Enter URL of blog to connect
- Let it authorize
- Let it search for available upgrades
- Click either "Browse available upgrades" or "I'm not interested in upgrades"
- Go back in history (I use the two finger gesture on Mac)
- Notice sidebar is still there 😱 

Also, you can do something similar by:
- Go to https://wordpress.com/jetpack/connect
- Clicking "Reader"
- Going back in history

To test fix:
- Checkout `update/jetpack-connect-sidebar-history` branch
- Complete the above steps
- Does everything work? Sidebar shouldn't show.

cc @johnHackworth for review.