### PR TITLE
Plans: remove unused feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -114,7 +114,6 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/paypal": true,
 		"upgrades/premium-themes": true,
-		"upgrades/product-nudge-success": true,
 		"vip": false,
 		"vip/backups": true,
 		"vip/billing": true,


### PR DESCRIPTION
A feature flag `upgrades/product-nudge-success` was added in #4592, but we were never actually checking it. We probably decided last minute to just launch it to production and missed that we should have removed the feature flag in the PR. Meetup project, whattayagonnado?

/cc @rodrigoi @roundhill 