### PR TITLE
Stats: Encode Post Title on the Post Stats Detail page

### DIFF
--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -13,6 +13,7 @@ import SummaryChart from '../stats-summary-chart';
 import PostMonths from '../stats-detail-months';
 import PostWeeks from '../stats-detail-weeks';
 import HeaderCake from 'components/header-cake';
+import { decodeEntities } from 'lib/formatting';
 
 export default React.createClass( {
 	displayName: 'StatsPostDetail',
@@ -44,7 +45,7 @@ export default React.createClass( {
 
 		if ( postOnRecord ) {
 			if ( typeof post.post_title === 'string' && post.post_title.length ) {
-				title = <Emojify>{ post.post_title }</Emojify>;
+				title = <Emojify>{ decodeEntities( post.post_title ) }</Emojify>;
 			}
 		}
 


### PR DESCRIPTION
I've noticed a small bug in the post stats details page : The post title is not encoded correctly.

Before  
<img width="729" alt="capture d ecran 2016-04-28 a 23 32 20" src="https://cloud.githubusercontent.com/assets/272444/14902267/331bddc6-0d9a-11e6-8413-39ccb4a1a242.png">

After
<img width="728" alt="capture d ecran 2016-04-28 a 23 32 53" src="https://cloud.githubusercontent.com/assets/272444/14902274/3c8c66d2-0d9a-11e6-8a25-75b6024c0e47.png">

cc @timmyc Similar to what I had in the Last Post Summary

Thanks