### PR TITLE
Add/more search stats

### DIFF
--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -69,7 +69,7 @@ const EVENTS = {
 			analytics.tracks.recordEvent( 'calypso_domain_search_results_mapping_button_click', { section } );
 		},
 
-		searchFormSubmit( searchBoxValue, section ) {
+		searchFormSubmit( searchBoxValue, section, timeDiffFromLastSearch, searchCount ) {
 			analytics.ga.recordEvent(
 				'Domain Search',
 				'Submitted Search Form',
@@ -81,6 +81,56 @@ const EVENTS = {
 				'calypso_domain_search',
 				{
 					search_box_value: searchBoxValue,
+					seconds_from_last_search: timeDiffFromLastSearch,
+					search_count: searchCount,
+					section
+				}
+			);
+		},
+
+		searchFormView( section ) {
+			analytics.ga.recordEvent(
+				'Domain Search',
+				'Landed on Search'
+			);
+
+			analytics.tracks.recordEvent( 'calypso_domain_search_pageview', { section } );
+		},
+
+		searchResultsReceive( searchQuery, searchResults, responseTimeInMs, resultCount, section ) {
+			analytics.ga.recordEvent(
+				'Domain Search',
+				'Receive Results',
+				'Response Time',
+				responseTimeInMs
+			);
+
+			analytics.tracks.recordEvent(
+				'calypso_domain_search_results_suggestions_receive',
+				{
+					search_query: searchQuery,
+					results: searchResults.join( ';' ),
+					response_time_ms: responseTimeInMs,
+					result_count: resultCount,
+					section
+				}
+			);
+		},
+
+		domainAvailabilityReceive( searchQuery, availableStatus, responseTimeInMs, section ) {
+			analytics.ga.recordEvent(
+				'Domain Search',
+				'Domain Availability Result',
+				'Domain Available Status',
+				availableStatus
+			);
+
+			analytics.tracks.recordEvent(
+				'calypso_domain_search_results_availability_receive',
+				{
+					search_query: searchQuery,
+					available_status: availableStatus,
+					response_time: responseTimeInMs,
 					section
 				}
 			);


### PR DESCRIPTION
Adds more stats (search pageview, search results receive, availability check receive) to domain search.

Testing:
- Open network tab 
- Go to domain search
- Look for `t.gif` call that includes: `calypso_domain_search_pageview`
- Search for something.com (ensure endswith .com)
- Wait for a result
- Look for `t.gif` calls that include: `calypso_domain_search_results_availability_receive` and `_en=calypso_domain_search_results_suggestions_receive`

/cc: @klimeryk 