### PR TITLE
Jetpack Connect: Improve error message for stale secrets

### DIFF
--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -81,6 +81,12 @@ export default React.createClass( {
 			noticeValues.icon = 'status';
 			return noticeValues;
 		}
+		if ( this.props.noticeType === 'secretExpired' ) {
+			noticeValues.text = this.translate( 'Oops, that took a while. You\'ll have to try again.' );
+			noticeValues.status = 'is-error';
+			noticeValues.icon = 'notice';
+			return noticeValues;
+		}
 		if ( this.props.noticeType === 'authorizeError' ) {
 			noticeValues.text = this.translate( 'Error authorizing your site. Please contact support.' );
 			noticeValues.status = 'is-error';


### PR DESCRIPTION
When Jetpack authorization fails due to a stale secret, show an error message that allows a user to restart the connection flow.
Closes #5060 

![screen shot 2016-04-28 at 8 33 33 pm](https://cloud.githubusercontent.com/assets/2694219/14905636/8578f8f2-0d80-11e6-9591-05f04d93b3a1.png)


To test:
- on a Jetpack site running the latest master, change the 600 to a 0 on this line 
https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L4999
- disconnect jetpack
- run this branch locally and go to calypso.localhost:3000/jetpack/connect
- try to connect, and you should get the above error message

cc: @johnHackworth 