### PR TITLE
Export during Site Delete: Link to page that shows Guided Transfer

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -74,7 +74,7 @@ module.exports = React.createClass( {
 	render: function() {
 		var site = this.state.site,
 			adminURL = site.options && site.options.admin_url ? site.options.admin_url : '',
-			exportLink = config.isEnabled( 'manage/export' ) ? '/settings/export/' + site.slug : adminURL + 'export.php',
+			exportLink = config.isEnabled( 'manage/export' ) ? '/settings/export/' + site.slug : adminURL + 'tools.php?page=export-choices',
 			exportTarget = config.isEnabled( 'manage/export' ) ? undefined : '_blank',
 			deleteDisabled = ( typeof this.state.confirmDomain !== 'string' || this.state.confirmDomain.replace( /\s/g, '' ) !== site.domain ),
 			deleteButtons, strings;


### PR DESCRIPTION
When a user starts the process to delete a site, we tell them to go and export their content first. Ideally we'd have a better flow here to let them know that we could do a Guided Transfer for them, but at the very least, this change makes it so that they are linked to the interim page where they can choose a GT instead of just exporting and doing it themselves.

![screen shot 2016-04-28 at 7 16 25 pm](https://cloud.githubusercontent.com/assets/108942/14906179/caaffd36-0d75-11e6-82e6-5268322ec897.png)

Fixes #5105 