### PR TITLE
GuidedTours: Only undelayGuidedTour when in guided abtest

### DIFF
--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -13,6 +13,7 @@ import React from 'react';
  */
 import { activated } from 'state/themes/actions';
 import analytics from 'lib/analytics';
+import abtest from 'lib/abtest';
 import BusinessPlanDetails from './business-plan-details';
 import Card from 'components/card';
 import ChargebackDetails from './chargeback-details';
@@ -75,7 +76,9 @@ const CheckoutThankYou = React.createClass( {
 	},
 
 	componentDidMount() {
-		config.isEnabled( 'guided-tours' ) && defer( () => this.props.undelayGuidedTour() );
+		if ( config.isEnabled( 'guided-tours' ) && abtest( 'guidedTours' === 'guided' ) ) {
+			defer( () => this.props.undelayGuidedTour() );
+		}
 		this.redirectIfThemePurchased();
 
 		if ( this.props.receipt.hasLoadedFromServer && this.hasPlanOrDomainProduct() ) {

--- a/client/my-sites/upgrades/checkout-thank-you/index.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/index.jsx
@@ -13,7 +13,7 @@ import React from 'react';
  */
 import { activated } from 'state/themes/actions';
 import analytics from 'lib/analytics';
-import abtest from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 import BusinessPlanDetails from './business-plan-details';
 import Card from 'components/card';
 import ChargebackDetails from './chargeback-details';
@@ -76,7 +76,7 @@ const CheckoutThankYou = React.createClass( {
 	},
 
 	componentDidMount() {
-		if ( config.isEnabled( 'guided-tours' ) && abtest( 'guidedTours' === 'guided' ) ) {
+		if ( config.isEnabled( 'guided-tours' ) && abtest( 'guidedTours' ) === 'guided' ) {
 			defer( () => this.props.undelayGuidedTour() );
 		}
 		this.redirectIfThemePurchased();

--- a/client/state/ui/guided-tours/actions.js
+++ b/client/state/ui/guided-tours/actions.js
@@ -32,7 +32,7 @@ export function showGuidedTour( { shouldShow, shouldDelay = false, tour = 'main'
 		tour,
 	} );
 
-	return withAnalytics( trackEvent, showAction );
+	return shouldDelay ? showAction : withAnalytics( trackEvent, showAction );
 }
 
 export function quitGuidedTour( { tour = 'main', stepName, finished } ) {


### PR DESCRIPTION
This wouldn't have _actually_ shown the tour, but was firing the `…_SHOW` track event. We want clean data.

To test:
- Sandbox store
- Signup logged out with plan purchase. Remember to:
 - `localStorage.setItem( 'ABTests', '{"guidedTours_20160428":"guided"}' );`
 - `localStorage.setItem( 'debug', 'calypso:analytics' )`
- Make sure we're sending a single `…SHOW` event
- Sign up again logged out with plan purchase. Remember to:
 - `localStorage.setItem( 'debug', 'calypso:analytics' )`
- Make sure we're not sending any GuidedTour events