### PR TITLE
Jetpack-connect: Add server route

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -372,6 +372,11 @@ module.exports = function() {
 		app.get( '/log-in/:lang?', setUpLoggedOutRoute, serverRender );
 	}
 
+	if ( config.isEnabled( 'jetpack/connect' ) ) {
+		app.get( '/jetpack/connect', setUpLoggedOutRoute, serverRender );
+		app.get( '/jetpack/connect/authorize', setUpLoggedOutRoute, serverRender );
+	}
+
 	app.get( '/start/:flowName?/:stepName?/:stepSectionName?/:lang?', setUpRoute, serverRender );
 
 	app.get( '/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',


### PR DESCRIPTION
Right now the jetpack connect routes doesn't work at all in production, they always request you to log in. They work well in calypso.localhost, so this is an attempt to make them work also when server side rendering is active.