### PR TITLE
GuidedTours: fix viewport resizing/scrolling

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import debounce from 'lodash/debounce';
 
 /**
  * Internal dependencies
@@ -22,7 +23,7 @@ import {
 class GuidedTours extends Component {
 	constructor() {
 		super();
-		this.bind( 'next', 'quit', 'finish' );
+		this.bind( 'next', 'quit', 'finish', 'onWindowResize' );
 	}
 
 	bind( ...methods ) {
@@ -32,6 +33,8 @@ class GuidedTours extends Component {
 	componentDidMount() {
 		const { stepConfig } = this.props.tourState;
 		this.updateTarget( stepConfig );
+		this._handleWindowResize = debounce( this.onWindowResize, 100 );
+		global.window.addEventListener( 'resize', this._handleWindowResize );
 	}
 
 	shouldComponentUpdate( nextProps ) {
@@ -41,6 +44,14 @@ class GuidedTours extends Component {
 	componentWillUpdate( nextProps ) {
 		const { stepConfig } = nextProps.tourState;
 		this.updateTarget( stepConfig );
+	}
+
+	componentWillUnmount() {
+		global.window.removeEventListener( 'resize', this._handleWindowResize );
+	}
+
+	onWindowResize() {
+		this.forceUpdate();
 	}
 
 	updateTarget( step ) {

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -87,7 +87,6 @@ export function getStepPosition( { placement = 'center', targetSlug } ) {
 		: global.window.document.body.getBoundingClientRect();
 	const position = dialogPositioners[ validatePlacement( placement, target ) ]( rect, scrollDiff );
 
-	console.log( target, scrollDiff, rect, position );
 	return {
 		x: position.x,
 		y: position.y - scrollDiff +

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -81,6 +81,7 @@ export function getStepPosition( { placement = 'center', targetSlug } ) {
 		: global.window.document.body.getBoundingClientRect();
 	const position = dialogPositioners[ validatePlacement( placement, target ) ]( rect );
 
+	console.log( position );
 	return {
 		x: position.x,
 		y: position.y - scrollDiff +

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -12,19 +12,25 @@ const MASTERBAR_HEIGHT = 48;
 
 const middle = ( a, b ) => Math.abs( b - a ) / 2;
 
-const wouldBeOffscreen = pos =>
+const wouldBeOffscreen = ( pos, dimension = 'width' ) =>
 	pos < 0 || ( pos + DIALOG_PADDING + DIALOG_WIDTH ) >
-		document.documentElement.clientWidth;
+		( dimension === 'width'
+			? document.documentElement.clientWidth
+			: document.documentElement.clientHeight );
 
-const fitOnScreen = pos =>
-	Math.max( 0, pos - DIALOG_PADDING - DIALOG_WIDTH ) / 2;
+const fitOnScreen = ( pos, dimension = 'width' ) =>
+	Math.max( 0, pos - DIALOG_PADDING -
+												( dimension === 'width' ? DIALOG_WIDTH : DIALOG_HEIGHT )
+					) / dimension === 'width' ? 2 : 16;
 
 const dialogPositioners = {
-	below: ( { left, bottom } ) => ( {
+	below: ( { left, bottom }, scrollDiff ) => ( {
 		x: wouldBeOffscreen( left )
 			? fitOnScreen( document.documentElement.clientWidth )
 			: left + DIALOG_PADDING,
-		y: bottom + DIALOG_PADDING,
+		y: wouldBeOffscreen( bottom, 'height' ) && scrollDiff === 0
+			? fitOnScreen( bottom, 'height' )
+			: bottom + DIALOG_PADDING
 	} ),
 	beside: ( { left, right, top } ) => ( {
 		x: wouldBeOffscreen( right )
@@ -79,9 +85,9 @@ export function getStepPosition( { placement = 'center', targetSlug } ) {
 	const rect = target && target.getBoundingClientRect
 		? target.getBoundingClientRect()
 		: global.window.document.body.getBoundingClientRect();
-	const position = dialogPositioners[ validatePlacement( placement, target ) ]( rect );
+	const position = dialogPositioners[ validatePlacement( placement, target ) ]( rect, scrollDiff );
 
-	console.log( position );
+	console.log( target, scrollDiff, rect, position );
 	return {
 		x: position.x,
 		y: position.y - scrollDiff +


### PR DESCRIPTION
When resizing the browser window, tour steps don't gracefully adjust. This PR attempts to fix this. 

_Edit by @ehg_

There are two problems to solve:
- When the window is resized, we need to reposition the steps. I've done this using a `forceUpdate` on the `resize` event. Not pretty, but it works. 57f2877
- When we move from desktop -> mobile, some `right` positioned steps are forced into `below` steps, and they get the height wrong. 65549b4 attempts to solve this.

To test:
1. Go to http://calypso.localhost:3000/design?tour=main
2. Resize the window at each step, making sure the positioning looks sane through mobile and desktop breakpoints, and that steps are always visible. 