### PR TITLE
Framework: Don't render layout for isomorphic sections in `client/boot`

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -181,7 +181,8 @@ function renderLayout( reduxStore ) {
 }
 
 function reduxStoreReady( reduxStore ) {
-	let layoutSection, validSections = [];
+	let layoutSection, validSections = [],
+		isIsomorphic = isSectionIsomorphic( reduxStore.getState() );
 
 	bindWpLocaleState( reduxStore );
 	bindTitleToStore( reduxStore );
@@ -209,7 +210,14 @@ function reduxStoreReady( reduxStore ) {
 		require( 'lib/network-connection' ).init( reduxStore );
 	}
 
-	renderLayout( reduxStore );
+	// Render Layout only for non-isomorphic sections, unless logged-in.
+	// Isomorphic sections will take care of rendering their Layout last themselves,
+	// unless in logged-in mode, where we can't do that yet.
+	// TODO: Remove the ! user.get() check once isomorphic sections render their
+	// Layout themselves when logged in.
+	if ( ! isIsomorphic || user.get() ) {
+		renderLayout( reduxStore );
+	}
 
 	// If `?sb` or `?sp` are present on the path set the focus of layout
 	// This can be removed when the legacy version is retired.

--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -104,7 +104,6 @@ function setUpContext( reduxStore ) {
 		}
 
 		// set `context.query`
-		// debugger
 		const querystringStart = context.canonicalPath.indexOf( '?' );
 		if ( querystringStart !== -1 ) {
 			context.query = qs.parse( context.canonicalPath.substring( querystringStart + 1 ) );

--- a/client/controller.js
+++ b/client/controller.js
@@ -50,7 +50,7 @@ export function makeLoggedOutLayout( context, next ) {
  * divs.
  */
 export function clientRouter( route, ...middlewares ) {
-	page( route, ...[ ...middlewares, render ] );
+	page( route, ...middlewares, render );
 }
 
 export function setSection( section ) {

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -29,5 +29,5 @@ const routes = Object.assign( {},
 export default function( router ) {
 	Object.keys( routes ).forEach( route => {
 		router( route, ...routes[ route ] );
-	} )
-};
+	} );
+}

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import config from 'config';
-import userFactory from 'lib/user';;
+import userFactory from 'lib/user';
 import { makeLoggedOutLayout } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { singleSite, multiSite, loggedOut, details } from './controller';
@@ -34,10 +34,10 @@ const themesRoutes = isLoggedIn
 const routes = Object.assign( {},
 	config.isEnabled( 'manage/themes' ) ? designRoutes : {},
 	config.isEnabled( 'manage/themes/details' ) ? themesRoutes : {}
-)
+);
 
 export default function( router ) {
 	Object.keys( routes ).forEach( route => {
 		router( route, ...routes[ route ] );
-	} )
-};
+	} );
+}

--- a/client/state/ui/selectors.js
+++ b/client/state/ui/selectors.js
@@ -53,7 +53,7 @@ export function isSectionLoading( state ) {
 	return state.ui.isLoading;
 }
 
-/*
+/**
  * Returns true if the current section is isomorphic.
  *
  * @param  {Object}  state Global state tree

--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -9,7 +9,7 @@ For an example of isomorphic routing, see `client/my-sites/themes`.
 In order to enable isomorphic routing for a section, set `isomorphic: true`
 for that section in `client/sections.js`.
 
-The constraints required for isomporphic routing are:
+The constraints required for isomorphic routing are:
 * In `client/mysection/index.js`, export a default function that accepts
 `router` as an argument. Instead of defining routes by invoking `page`, use
 `router`, e.g.
@@ -26,7 +26,7 @@ by either the client or the server render, as appropriate. (This is clearly
 different from the previous client-side-only routing approach where you'd have
 to render to `#primary`/`#secondary`/`#tertiary` DOM elements.)
 
-To faciliate that, you can (but don't have to) use the `makeLoggedOutLayout`
+To facilitate that, you can (but don't have to) use the `makeLoggedOutLayout`
 generic middleware found in `client/controller`. So in the above example, the
 details middleware will just create an element in `context.primary` (instead of
 rendering it to the `#primary` DOM element, as previously).


### PR DESCRIPTION
Isomorphic sections render `LayoutLoggedOut` themselves (when logged-out) -- that includes server-side. Hence, this PR disables rendering `Layout` in `client/boot` for isomorphic sections, when logged out.

This means no more reconciliation errors for logged-out http://calypso.localhost:3000/theme/rowling/details. Reconc errors will be furthermore reduced with #4668.

A future iteration will require isomorphic sections to render `Layout` themselves when logged-in, too, and will consequently also disable rendering `Layout` for isomorphic sections in `client/boot` when logged in.

No visual changes. To test -- make sure the theme showcase still works as before.

Fixes part of #2299. This is a redux of #4836, also picking up some pieces from #4820.