### PR TITLE
Sidebar: use the "preview" layoutFocus to preview the current site

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -151,6 +151,7 @@ Layout = React.createClass( {
 				<DesignPreview
 					className="layout__preview"
 					showPreview={ this.props.focus.getCurrent() === 'preview' }
+					defaultViewportDevice="computer"
 				/>
 			);
 		}

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -104,8 +104,9 @@ module.exports = React.createClass( {
 		);
 	},
 
-	trackHomepageClick: function() {
+	previewSite: function( event ) {
 		analytics.ga.recordEvent( 'Sidebar', 'Clicked View Site' );
+		this.props.onClick && this.props.onClick( event );
 	},
 
 	render: function() {
@@ -151,7 +152,8 @@ module.exports = React.createClass( {
 						homeLink={ true }
 						enableActions={ true }
 						externalLink={ true }
-						onSelect={ this.trackHomepageClick }
+						onClick={ this.previewSite }
+						onSelect={ this.previewSite }
 						ref="site" />
 					: <AllSites sites={ this.props.sites.get() } />
 				}

--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -6,6 +6,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import noop from 'lodash/noop';
 import debugFactory from 'debug';
+import url from 'url';
 
 /**
  * Internal dependencies
@@ -146,6 +147,21 @@ const DesignPreview = React.createClass( {
 		// TODO: if the href is on the current site, load the href as a preview and fetch markup for that url
 	},
 
+	getPreviewUrl( site ) {
+		if ( ! site ) {
+			return null;
+		}
+
+		const parsed = url.parse( site.URL, true );
+		parsed.query.iframe = true;
+		parsed.query.theme_preview = true;
+		if ( site.options && site.options.frame_nonce ) {
+			parsed.query['frame-nonce'] = site.options.frame_nonce;
+		}
+		delete parsed.search;
+		return url.format( parsed );
+	},
+
 	render() {
 		const useEndpoint = config.isEnabled( 'preview-endpoint' );
 
@@ -156,7 +172,7 @@ const DesignPreview = React.createClass( {
 		return (
 			<WebPreview
 				className={ this.props.className }
-				previewUrl={ useEndpoint ? null : this.props.selectedSite.URL }
+				previewUrl={ useEndpoint ? null : this.getPreviewUrl( this.props.selectedSite ) }
 				showExternal={ true }
 				showClose={ this.props.showClose }
 				showPreview={ this.props.showPreview }
@@ -174,12 +190,14 @@ const DesignPreview = React.createClass( {
 function mapStateToProps( state ) {
 	const selectedSite = getSelectedSite( state );
 	const selectedSiteId = getSelectedSiteId( state );
+
 	if ( ! state.preview || ! state.preview[ selectedSiteId ] ) {
 		return {
 			selectedSite,
 			selectedSiteId,
 		};
 	}
+
 	const { previewMarkup, customizations, isUnsaved } = state.preview[ selectedSiteId ];
 	return {
 		selectedSite,

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -53,6 +53,13 @@ module.exports = React.createClass( {
 		window.scrollTo( 0, 0 );
 	},
 
+	onPreviewSite( event ) {
+		if ( config.isEnabled( 'preview-layout' ) ) {
+			event.preventDefault();
+			this.props.layoutFocus.set( 'preview' );
+		}
+	},
+
 	itemLinkClass: function( paths, existingClasses ) {
 		var classSet = {};
 
@@ -703,6 +710,7 @@ module.exports = React.createClass( {
 				<CurrentSite
 					sites={ this.props.sites }
 					siteCount={ this.props.user.get().visible_site_count }
+					onClick={ this.onPreviewSite }
 				/>
 				<SidebarMenu>
 					<ul>

--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -8,6 +8,7 @@ import noop from 'lodash/noop';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import SiteIcon from 'components/site-icon';
 import Gridicon from 'components/gridicon';
 import SiteIndicator from 'my-sites/site-indicator';
@@ -218,15 +219,18 @@ export default React.createClass( {
 							href={ this.props.homeLink ? site.URL : this.props.href }
 							target={ this.props.externalLink && ! this.state.showMoreActions && '_blank' }
 							title={ this.props.homeLink
-								? this.translate( 'Visit "%(title)s"', { args: { title: site.title } } )
+								? this.translate( 'View "%(title)s"', { args: { title: site.title } } )
 								: site.title
 							}
 							onTouchTap={ this.onSelect }
 							onClick={ this.props.onClick }
 							onMouseEnter={ this.props.onMouseEnter }
 							onMouseLeave={ this.props.onMouseLeave }
-							aria-label={
-								this.translate( 'Open site %(domain)s in new tab', {
+							aria-label={ this.props.homeLink && config.isEnabled( 'preview-layout' )
+								? this.translate( 'Open site %(domain)s in a preview', {
+									args: { domain: site.domain }
+								} )
+								: this.translate( 'Open site %(domain)s in new tab', {
 									args: { domain: site.domain }
 								} )
 							}


### PR DESCRIPTION
Uses the `preview` layoutFocus to preview the current site when clicking it in the sidebar:

![preview-card](https://cloud.githubusercontent.com/assets/215074/15504120/54fe8bf8-21b5-11e6-89f9-059c6306f96a.gif)

To test:
- Try clicking the site card on different sites (including Jetpack sites), check it works
- Try cold refreshes
- Make sure switching sites works OK
- `DISABLE_FEATURES=preview-layout make run` — check behaviour is the same as `master`