### PR TITLE
Jetpack connect: working routes for both logged in and logged out

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -373,8 +373,8 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
-		app.get( '/jetpack/connect', setUpLoggedOutRoute, serverRender );
-		app.get( '/jetpack/connect/authorize', setUpLoggedOutRoute, serverRender );
+		app.get( '/jetpack/connect', setUpRoute, serverRender );
+		app.get( '/jetpack/connect/authorize', setUpRoute, serverRender );
 	}
 
 	app.get( '/start/:flowName?/:stepName?/:stepSectionName?/:lang?', setUpRoute, serverRender );


### PR DESCRIPTION
When I set up the logged-out routes for jetpack connect, I used the logged out routes method thinking that the logged-in ones would be handled by the default  catchall in line 413, but it's not the case :)

This PR (should) make '/jetpack/connect' work both logged in and out.