### PR TITLE
Jetpack connect: Restore rebase-deleted code

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -195,7 +195,7 @@ const LoggedInForm = React.createClass( {
 
 	getRedirectionTarget() {
 		const { queryObject } = this.props.jetpackConnectAuthorize;
-		if ( this.isCalypsoStartedConnection() ) {
+		if ( this.props.calypsoStartedConnection ) {
 			const site = this.props.jetpackConnectAuthorize.queryObject.site;
 			const siteSlug = site.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
 			return STATS_PAGE + siteSlug;
@@ -283,8 +283,8 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		} );
 		return (
 			( user )
-				? <LoggedInForm { ...props } />
-				: <LoggedOutForm { ...props } />
+				? <LoggedInForm { ...props } calypsoStartedConnection={ this.isCalypsoStartedConnection() } />
+				: <LoggedOutForm { ...props } calypsoStartedConnection={ this.isCalypsoStartedConnection() } />
 		);
 	},
 	render() {

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencis
+ */
+ import isEmpty from 'lodash/isEmpty';
+
+/**
  * Internal dependencies
  */
 import {
@@ -30,7 +35,7 @@ export function jetpackConnectSessions( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_STORE_SESSION:
 			const noProtocolUrl = action.url.replace( /.*?:\/\//g, '' );
-			return Object.assign( {}, state, { [ noProtocolUrl ]:  ( new Date() ).getTime() } );
+			return Object.assign( {}, state, { [ noProtocolUrl ]: ( new Date() ).getTime() } );
 		case SERIALIZE:
 		case DESERIALIZE:
 			return state;
@@ -69,7 +74,7 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_AUTHORIZE:
 			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false } );
 		case JETPACK_CONNECT_AUTHORIZE_RECEIVE:
-			if ( ! action.error ) {
+			if ( isEmpty( action.error ) ) {
 				const { plans_url } = action.data;
 				return Object.assign( {}, state, { authorizeError: false, authorizeSuccess: true, autoAuthorize: false, plansURL: plans_url, siteReceived: false } );
 			}
@@ -84,7 +89,7 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 		case JETPACK_CONNECT_CREATE_ACCOUNT:
 			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false, autoAuthorize: true } );
 		case JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE:
-			if ( action.error ) {
+			if ( ! isEmpty( action.error ) ) {
 				return Object.assign( {}, state, { isAuthorizing: false, authorizeSuccess: false, authorizeError: true, autoAuthorize: false } );
 			}
 			return Object.assign( {}, state, { isAuthorizing: true, authorizeSuccess: false, authorizeError: false, autoAuthorize: true, userData: action.userData, bearerToken: action.data.bearer_token } );


### PR DESCRIPTION
I've done like a million merges & rebases today, and in one of them, some new code was removed. This is making one of the promises in the auth process to crash, because it's trying to access to a method that is not there. 

This PR restores the missing code and makes everything work fine.

![](https://randomwelfare.files.wordpress.com/2015/03/anigif_enhanced-buzz-4919-1386099167-19.gif)

how to test:
========
1. Go to http://calypso.localhost:3000/jetpack/connect/
2. Connect a site that is still not connected
3. you should be able to connect it without getting an error

ping @roccotripaldi @ryelle @oskosk 