### PR TITLE
Framework/State: Opt out of sync local result for posts state requests

### DIFF
--- a/client/lib/wp/browser.js
+++ b/client/lib/wp/browser.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { SyncHandler } from './sync-handler';
+import { SyncHandler, syncOptOut } from './sync-handler';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:wp' );
 
@@ -39,6 +39,10 @@ if ( config.isEnabled( 'oauth' ) ) {
 		}
 		debug( 'Proxy now running in "access all user\'s blogs" mode' );
 	} );
+}
+
+if ( addSyncHandlerWrapper ) {
+	wpcom = syncOptOut( wpcom );
 }
 
 if ( config.isEnabled( 'support-user' ) ) {

--- a/client/lib/wp/sync-handler/README.md
+++ b/client/lib/wp/sync-handler/README.md
@@ -26,7 +26,7 @@ const wpcom = wpcomUndocumented( handler );
 `sync-handler` which allows us to prune records from our local cache. There are
 two methods to invalidate records:
 
-### syncHandler#pruneStaleRecords( [lifetime] );
+#### syncHandler#pruneStaleRecords( [lifetime] );
 Prune records older than the given `lifetime` (milliseconds or [natural
 language](https://github.com/rauchg/ms.js)). By default the value of the lifetime is `2 days`.
 
@@ -42,8 +42,30 @@ syncHandler
 	} );
 ```
 
-### syncHandler.clearAll();
+#### syncHandler.clearAll();
 clearAll the whole sync-handler data.
+
+### Disabling sync handler for single request
+
+To prevent the behavior of sync handler for a single request, a `syncOptOut` function is exported by this module. Passed a wpcom instance, it returns a modified instance including a `skipLocalSyncResult` function which, when called at the beginning of a request chain, will prevent the callback from being called with a local result even if one exists.
+
+```es6
+import { SyncHandler, syncOptOut } from 'lib/wp/sync-handler';
+import wpcomUndocumented from 'lib/wpcom-undocumented';
+import wpcomXHRHandler from 'lib/wpcom-xhr-wrapper';
+
+// wrap the request handler with sync-handler
+const handler = new SyncHandler( wpcomXHRHandler );
+
+// create wpcom instance passing the wrapped handler
+let wpcom = wpcomUndocumented( handler );
+wpcom = syncOptOut( wpcom );
+
+// issue request with sync handler disabled
+wpcom.skipLocalSyncResult().sites( 2916284 ).postsList( ( err, posts ) {
+	// `posts` is guaranteed to be a network response, not local
+} );
+```
 
 ### Testing and Debug
 

--- a/client/lib/wp/sync-handler/test/data/index.js
+++ b/client/lib/wp/sync-handler/test/data/index.js
@@ -18,10 +18,11 @@ export const postListDifferentPageSeriesKey = 'sync-record-5c73482c2934a7f406019
  * Request Parameters
  */
 
+export const postListSiteId = 'bobinprogress.wordpress.com';
 export const postListParams = {
 	apiVersion: '1.1',
 	method: 'GET',
-	path: '/sites/bobinprogress.wordpress.com/posts',
+	path: `/sites/${ postListSiteId }/posts`,
 	query: 'status=publish%2Cprivate&order_by=date&order=DESC&author=6617482&type=post&site_visibility=visible&meta=counts',
 };
 
@@ -29,7 +30,7 @@ export const postListParams = {
 export const postListDifferentOrderParams = {
 	apiVersion: '1.1',
 	method: 'GET',
-	path: '/sites/bobinprogress.wordpress.com/posts',
+	path: `/sites/${ postListSiteId }/posts`,
 	query: 'order_by=date&order=DESC&author=6617482&type=post&site_visibility=visible&meta=counts&status=publish%2Cprivate',
 };
 
@@ -37,7 +38,7 @@ export const postListDifferentOrderParams = {
 export const postListNextPageParams = {
 	apiVersion: '1.1',
 	method: 'GET',
-	path: '/sites/bobinprogress.wordpress.com/posts',
+	path: `/sites/${ postListSiteId }/posts`,
 	query: 'status=publish%2Cprivate&order_by=date&order=DESC&author=6617482&type=post&site_visibility=visible&meta=counts&page_handle=2014-11-24T13%3A39%3A39-08%3A00%26id=1307',
 };
 

--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -54,11 +54,15 @@ export function requestSitePosts( siteId, query = {} ) {
 			query
 		} );
 
-		let source;
+		let source = wpcom;
+		if ( source.skipLocalSyncResult ) {
+			source = source.skipLocalSyncResult();
+		}
+
 		if ( siteId ) {
-			source = wpcom.site( siteId );
+			source = source.site( siteId );
 		} else {
-			source = wpcom.me();
+			source = source.me();
 		}
 
 		return source.postsList( query ).then( ( { found, posts } ) => {


### PR DESCRIPTION
This pull request seeks to enhance the wpcom sync request handler to optionally opt out of responding to a callback with a local result. It also applies said opt-out to the Redux posts state action creator for requesting posts.

It was found that (a) the sync handler always responds to a Promise thenable with stale local results and never the network results if local results exist and (b) Redux state persistence is preferable to local sync handler, rather than having two caching layers.

__Example:__

```js
wpcom.skipLocalSyncResult().sites( 2916284 ).postsList( ( err, posts ) {
	// `posts` is guaranteed to be a network response, not local
} );
```

__Testing instructions:__

Ensure all Mocha tests pass.

```
npm run test-client
```

Verify that existing usages of posts requests remains unaffected, notably either the custom post types list page or the post selector in use by the editor (i.e. link to existing content).

1. Navigate to [CPT listing page](http://calypso.localhost:3000/types/post)
2. Select a site
3. Note that posts are requested and shown without any errors

You may also verify that local sync behavior continues to behave as expected on pages for which this applies ([post listing page](http://calypso.localhost:3000/posts)).

/cc @rralian 