### PR TITLE
Jetpack Connect: improved responsive styles and typography 

### DIFF
--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -5,9 +5,9 @@
 .jetpack-connect-wide {
 	max-width: 100%;
 	text-align: center;
+	margin-bottom: 24px;
 
 	.button {
-		margin-top: 16px;
 		width: 320px;
 	}
 }
@@ -52,7 +52,7 @@
 		}
 
 		.form-text-input {
-			padding-left: 36px;
+			padding-left: 40px;
 		}
 
 		.spinner {
@@ -121,48 +121,34 @@
 	display: flex;
 		flex-direction: column;
 		justify-content: space-between;
-		align-items: center;
-	margin: 0;
-	max-width: 360px;
 	min-width: 320px;
+	text-align: left;
+
+	@include breakpoint( ">480px" ) {
+		max-width: 360px;
+	}
 
 	@include breakpoint( ">660px" ) {
-		margin: 8px;
+		margin: 0 8px 16px 8px;
 	}
 }
 
 .jetpack-connect__install-step-title {
-	font-size: 20px;
-	text-align: left;
-}
-
-.jetpack-connect__install-step-text {
-	color: $gray;
-	font-size: 12px;
-	margin: 8px 0;
-	text-align: left;
-	flex-grow: 2;
-}
-
-
-.jetpack-connect__install-step-title {
 	font-size: 21px;
 	font-weight: 300;
-	text-align: left;
 }
 
 .jetpack-connect__install-step-text {
 	color: $gray;
 	font-size: 12px;
 	margin: 8px 0 16px 0;
-	text-align: left;
+	flex-grow: 2;
 }
 
 .jetpack-connect__browser-chrome {
 	padding: 8px;
 	background-color: lighten( $gray, 30% );
 	border-radius: 8px 8px 0 0;
-	text-align: left;
 }
 
 .jetpack-connect__browser-chrome-dot {


### PR DESCRIPTION
I did some clean up to the breakpoints, margins, typography, removed some duplicate styles. Nothing major.

Would like to have the css vetted a bit perhaps by @MichaelArestad 

To test, just visit /jetpack/connect and type in a site url that does not have Jetpack:
1 installed
2 activated
3 connected

Here's where we're at now:

<img width="768" alt="screen shot 2016-04-29 at 12 50 25 pm" src="https://cloud.githubusercontent.com/assets/437258/14923095/1a295022-0e09-11e6-998b-f2e06917b748.png">

<img width="544" alt="screen shot 2016-04-29 at 12 50 53 pm" src="https://cloud.githubusercontent.com/assets/437258/14923096/1a30cc9e-0e09-11e6-8db5-50c7b8e360e1.png">

<img width="359" alt="screen shot 2016-04-29 at 12 51 06 pm" src="https://cloud.githubusercontent.com/assets/437258/14923097/1a35b574-0e09-11e6-8068-70061e60911b.png">

cc @johnHackworth @roccotripaldi @oskosk 