### PR TITLE
Reader: Fix the Manage button under Lists on sidebar

### DIFF
--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -120,6 +120,19 @@
 			.sidebar__menu-item {
 				opacity: 1;
 				transform: translateY( 0 );
+
+				.add-new {
+					background: $white;
+					border: 1px solid lighten( $gray, 20% );
+					border-radius: 3px;
+					color: darken( $gray, 10% );
+					font-size: 11px;
+					padding: 6px 7px;
+					position: absolute;
+						top: 2px;
+						right: 8px;
+					text-transform: none;
+				}
 			}
 		}
 
@@ -142,6 +155,7 @@
 	}
 
 	.sidebar__menu-item {
+
 		a.sidebar__button {
 			margin-top: 5px;
 
@@ -153,10 +167,6 @@
 
 	.sidebar__menu-item-label {
 		padding: 8px 16px 8px 55px;
-
-		@include breakpoint( "<660px" ) {
-			padding: 18px 16px 18px 24px;
-		}
 	}
 
 	.sidebar__menu-add-button {

--- a/client/reader/sidebar/_style.scss
+++ b/client/reader/sidebar/_style.scss
@@ -134,6 +134,33 @@
 					text-transform: none;
 				}
 			}
+
+			.sidebar__menu-list {
+
+				.sidebar__menu-item,
+				.sidebar-dynamic-menu__tag {
+
+					@include breakpoint( "<660px" ) {
+						background: none;
+						border-top: 0;
+					}
+				}
+
+				li {
+
+					&:first-child {
+						@include breakpoint( "<660px" ) {
+							margin-top: -5px;
+						}
+					}
+
+					&:last-child {
+						@include breakpoint( "<660px" ) {
+							border-bottom: 1px solid rgba( 200, 215, 225, .5 );
+						}
+					}
+				}
+			}
 		}
 
 		.is-add-open {
@@ -167,6 +194,27 @@
 
 	.sidebar__menu-item-label {
 		padding: 8px 16px 8px 55px;
+
+		&::after {
+			@include long-content-fade( $color: lighten( $gray, 30% ), $size: 28% );
+			padding-right: 50px;
+		}
+
+		.sidebar__menu-item-listname,
+		.sidebar__menu-item-tagname {
+
+			&::after {
+				@include long-content-fade( $color: lighten( $gray, 30% ), $size: 20% );
+				right: 60px;
+			}
+		}
+
+		.sidebar__menu-item-tagname {
+
+			&::after {
+				right: 20px;
+			}
+		}
 	}
 
 	.sidebar__menu-add-button {
@@ -245,7 +293,7 @@
 		}
 
 		@include breakpoint( "<660px" ) {
-			top: 7px;
+			top: -40px;
 
 			.gridicon {
 				top: 6px;

--- a/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/list-item.jsx
@@ -60,7 +60,9 @@ const ReaderSidebarListsListItem = React.createClass( {
 
 		return (
 			<li className={ classes } key={ list.ID } >
-				<a className="sidebar__menu-item-label" href={ listRelativeUrl }>{ list.title }</a>
+				<a className="sidebar__menu-item-label" href={ listRelativeUrl }>
+					<div className="sidebar__menu-item-listname">{ list.title }</div>
+				</a>
 				{ list.is_owner ? <a href={ listManageUrl } rel={ listRel } className="add-new">{ this.translate( 'Manage' ) }</a> : null }
 			</li>
 		);

--- a/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list-item.jsx
@@ -33,7 +33,7 @@ const ReaderSidebarTagsListItem = React.createClass( {
 		return (
 			<li key={ tag.ID } className={ ReaderSidebarHelper.itemLinkClass( '/tag/' + tag.slug, this.props.path, { 'sidebar-dynamic-menu__tag': true } ) }>
 				<a className="sidebar__menu-item-label" href={ tag.URL }>
-					{ tag.display_name || tag.slug }
+					<div className="sidebar__menu-item-tagname">{ tag.display_name || tag.slug }</div>
 				</a>
 				{ tag.ID !== 'pending' ? <button className="sidebar__menu-action" data-tag-slug={ tag.slug } onClick={ this.props.onUnfollow }>
 					<Gridicon icon="cross-small" />


### PR DESCRIPTION
This fixes the alignment and incorrect button styles of the Manage buttons under Lists on the sidebar:

**Before:**
![screenshot 2016-04-29 16 08 08](https://cloud.githubusercontent.com/assets/4924246/14931969/f7954e8c-0e24-11e6-9ca1-24317e41525b.png)

**After:**
![screenshot 2016-04-29 16 09 18](https://cloud.githubusercontent.com/assets/4924246/14931976/fbf6f930-0e24-11e6-9d6a-95cfba83a6ab.png)

/cc @bluefuton 

