### PR TITLE
Non-visual indicator for auto-save

### DIFF
--- a/client/post-editor/editor-status-label/index.jsx
+++ b/client/post-editor/editor-status-label/index.jsx
@@ -72,6 +72,8 @@ export default React.createClass( {
 				ref="statusLabel"
 				aria-label={ this.translate( 'Show advanced status details' ) }
 				aria-pressed={ !! this.props.advancedStatus }
+				role="alert"
+				aria-live="polite"
 			>
 				<Gridicon icon="cog" size={ 16 } />
 				{ this.renderLabel() }


### PR DESCRIPTION
This PR aims to fix  the issue raised in #2005 and provide a non-visual indicator to VoiceOvers users. 

I've added `role="alert" aria-live="assertive"` to the main button in the post editor's publish module.

Further testing on VoiceOver is needed.
