### PR TITLE
Upgrades: nudge tracking fix

### DIFF
--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -15,6 +15,7 @@ import analytics from 'lib/analytics';
 import sitesList from 'lib/sites-list';
 import { getValidFeatureKeys, hasFeature } from 'lib/plans';
 import { isFreePlan } from 'lib/products-values';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 const sites = sitesList();
 
@@ -72,19 +73,6 @@ export default React.createClass( {
 		return true;
 	},
 
-	componentDidMount() {
-		const site = sites.getSelectedSite();
-		if (
-			this.shouldDisplay( site ) &&
-			( this.props.event || this.props.feature )
-		) {
-			analytics.tracks.recordEvent( 'calypso_upgrade_nudge_impression', {
-				cta_name: this.props.event,
-				cta_feature: this.props.feature
-			} );
-		}
-	},
-
 	render() {
 		const classes = classNames( this.props.className, 'upgrade-nudge' );
 
@@ -130,6 +118,12 @@ export default React.createClass( {
 						{ this.props.message }
 					</span>
 				</div>
+				{ ( this.props.event || this.props.feature ) &&
+					<TrackComponentView eventName={ 'calypso_upgrade_nudge_impression' } eventProperties={ {
+						cta_name: this.props.event,
+						cta_feature: this.props.feature
+					} } />
+				}
 			</Card>
 		);
 	}

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -56,8 +56,28 @@ export default React.createClass( {
 		this.props.onClick();
 	},
 
+	shouldDisplay( site ) {
+		if ( site && this.props.feature ) {
+			if ( hasFeature( this.props.feature, site.siteID ) ) {
+				return false;
+			}
+		} else if ( site && ! isFreePlan( site.plan ) ) {
+			return false;
+		}
+
+		if ( ! this.props.jetpack && site.jetpack || this.props.jetpack && ! site.jetpack ) {
+			return false;
+		}
+
+		return true;
+	},
+
 	componentDidMount() {
-		if ( this.props.event || this.props.feature ) {
+		const site = sites.getSelectedSite();
+		if (
+			this.shouldDisplay( site ) &&
+			( this.props.event || this.props.feature )
+		) {
 			analytics.tracks.recordEvent( 'calypso_upgrade_nudge_impression', {
 				cta_name: this.props.event,
 				cta_feature: this.props.feature
@@ -71,15 +91,7 @@ export default React.createClass( {
 		const site = sites.getSelectedSite();
 		let href = this.props.href;
 
-		if ( site && this.props.feature ) {
-			if ( hasFeature( this.props.feature, site.siteID ) ) {
-				return null;
-			}
-		} else if ( site && ! isFreePlan( site.plan ) ) {
-			return null;
-		}
-
-		if ( ! this.props.jetpack && site.jetpack || this.props.jetpack && ! site.jetpack ) {
+		if ( ! this.shouldDisplay( site ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
Fixes a problem when we track nudge impression without actually showing the nudge (for users that have certain plan / functionality)

Uses TrackComponentView introduced by @gwwar 

CC @mtias @rralian @gwwar 