### PR TITLE
Framework: Upgrade react-redux to 4.4.5

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -272,7 +272,7 @@
       "version": "1.0.2"
     },
     "balanced-match": {
-      "version": "0.3.0"
+      "version": "0.4.1"
     },
     "base62": {
       "version": "0.1.1"
@@ -333,7 +333,7 @@
       "version": "0.0.4"
     },
     "block-stream": {
-      "version": "0.0.8"
+      "version": "0.0.9"
     },
     "bluebird": {
       "version": "2.10.2"
@@ -356,7 +356,7 @@
       "version": "1.0.5"
     },
     "brace-expansion": {
-      "version": "1.1.3"
+      "version": "1.1.4"
     },
     "braces": {
       "version": "1.8.4"
@@ -2063,10 +2063,10 @@
       "version": "1.3.4"
     },
     "mime-db": {
-      "version": "1.22.0"
+      "version": "1.23.0"
     },
     "mime-types": {
-      "version": "2.1.10"
+      "version": "2.1.11"
     },
     "minimatch": {
       "version": "2.0.10"
@@ -2471,7 +2471,7 @@
       "version": "2.0.1"
     },
     "postcss": {
-      "version": "5.0.19",
+      "version": "5.0.20",
       "dependencies": {
         "source-map": {
           "version": "0.5.5"
@@ -2619,7 +2619,7 @@
       "version": "1.0.2"
     },
     "react-redux": {
-      "version": "4.0.1"
+      "version": "4.4.5"
     },
     "react-side-effect": {
       "version": "1.0.2",
@@ -3033,7 +3033,7 @@
       "version": "1.0.0"
     },
     "sshpk": {
-      "version": "1.8.2",
+      "version": "1.8.3",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-dom": "0.14.3",
     "react-helmet": "2.2.0",
     "react-pure-render": "1.0.2",
-    "react-redux": "4.0.1",
+    "react-redux": "4.4.5",
     "react-tap-event-plugin": "0.2.1",
     "redux": "3.0.4",
     "redux-thunk": "1.0.0",


### PR DESCRIPTION
Mainly in preparation for React 15.

Changelog at https://github.com/reactjs/react-redux/releases

No visual changes. To test -- check that Calypso works as before.