### PR TITLE
Purchases: change wording for Edit Payment Method in unsubscribed purchases

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -466,10 +466,12 @@ const ManagePurchase = React.createClass( {
 		if ( canEditPaymentDetails( purchase ) ) {
 			const path = paths.editCardDetails( this.props.selectedSite.slug, purchase.id );
 
+			const text = isRenewing( purchase )
+				? this.translate( 'Edit Payment Method' )
+				: this.translate( 'Add Payment Method' );
+
 			return (
-				<CompactCard href={ path }>
-					{ this.translate( 'Edit Payment Method' ) }
-				</CompactCard>
+				<CompactCard href={ path }>{ text }</CompactCard>
 			);
 		}
 

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -20,6 +20,7 @@ import formState from 'lib/form-state';
 import forOwn from 'lodash/forOwn';
 import HeaderCake from 'components/header-cake' ;
 import { getPurchase, goToManagePurchase, isDataLoading, recordPageView } from 'me/purchases/utils';
+import { isRenewing } from 'lib/purchases';
 import kebabCase from 'lodash/kebabCase';
 import Main from 'components/main';
 import mapKeys from 'lodash/mapKeys';
@@ -246,11 +247,11 @@ const EditCardDetails = React.createClass( {
 			);
 		}
 
+		const title = isRenewing( getPurchase( this.props ) ) ? titles.editCardDetails : titles.addCardDetails;
+
 		return (
 			<Main className="edit-card-details">
-				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>
-					{ titles.editCardDetails }
-				</HeaderCake>
+				<HeaderCake onClick={ goToManagePurchase.bind( null, this.props ) }>{ title }</HeaderCake>
 
 				<form onSubmit={ this.onSubmit }>
 					<Card className="edit-card-details__content">

--- a/client/me/purchases/payment/edit-card-details/loading-placeholder.jsx
+++ b/client/me/purchases/payment/edit-card-details/loading-placeholder.jsx
@@ -16,7 +16,7 @@ import titles from 'me/purchases/titles';
 
 const EditCardDetailsLoadingPlaceholder = () => {
 	return (
-		<LoadingPlaceholder title={ titles.editCardDetails }>
+		<LoadingPlaceholder title={ titles.addCardDetails }>
 			<Card className="edit-card-details__content">
 				<div className="credit-card-form">
 					<div className="credit-card-form__field">

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -12,6 +12,7 @@ export default {
 	cancelPurchase: i18n.translate( 'Cancel Purchase', options ),
 	confirmCancelDomain: i18n.translate( 'Cancel Domain', options ),
 	editCardDetails: i18n.translate( 'Edit Card Details', Object.assign( {}, options, { comment: 'Credit card' } ) ),
+	addCardDetails: i18n.translate( 'Add Card Details', Object.assign( {}, options, { comment: 'Credit card' } ) ),
 	editPaymentMethod: i18n.translate( 'Edit Payment Method', options ),
 	managePurchase: i18n.translate( 'Manage Purchase', options ),
 	purchases: i18n.translate( 'Purchases', options )


### PR DESCRIPTION
Fixes #5153.

To test, check that purchase details page shows "Add Payment Method" instead of "Edit Payment Method" for subscription with auto renew turned off.