### PR TITLE
Update node-phone version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2454,9 +2454,8 @@
       "version": "0.1.4"
     },
     "phone": {
-      "version": "1.0.4-3",
-      "from": "git+https://github.com/Automattic/node-phone.git#8f012b153e968038c2ce758b7f34e5b8d792eb20",
-      "resolved": "git+https://github.com/Automattic/node-phone.git#8f012b153e968038c2ce758b7f34e5b8d792eb20"
+      "version": "1.0.4-10",
+      "resolved": "git+https://github.com/Automattic/node-phone.git#1.0.4-10"
     },
     "photon": {
       "version": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "node-sass": "3.4.2",
     "page": "1.6.4",
     "path-parser": "1.0.2",
-    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-9",
+    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-10",
     "photon": "2.0.0",
     "postcss-cli": "2.5.1",
     "q": "1.0.1",


### PR DESCRIPTION
This is similar to #3368

This time, we need to update our validation for Cameroon.
Current failure:
![2fa_wordpress_cmr](https://cloud.githubusercontent.com/assets/844866/14955265/7c5ba522-1081-11e6-96f4-387477f455c5.png)


**To test:**
Go to http://calypso.localhost:3000/me/security/two-step
Select Cameroon as the country.
Enter invalid phone numbers (e.g. 71234567 or 61111). They should fail.
Enter well-formed phone numbers (9 digits, starting with a 6). They should not show the red validation error.

