### PR TITLE
Site Indicator: Don't display errors when fetching updates fail

### DIFF
--- a/client/lib/site/jetpack.js
+++ b/client/lib/site/jetpack.js
@@ -68,10 +68,6 @@ JetpackSite.prototype.fetchAvailableUpdates = function() {
 	wpcom.undocumented().getAvailableUpdates( this.ID, function( error, data ) {
 		if ( error ) {
 			debug( 'error fetching Updates data from api', error );
-			// 403 is returned when the user does not have manage capabilities.
-			if ( 403 !== error.statusCode && ! ( this.update instanceof Object ) ) {
-				this.set( { update: 'error', unreachable: true } );
-			}
 			return;
 		}
 		this.set( { update: data } );

--- a/client/my-sites/site-indicator/site-indicator.jsx
+++ b/client/my-sites/site-indicator/site-indicator.jsx
@@ -42,9 +42,6 @@ export default React.createClass( {
 		if ( site.unreachable ) {
 			return true;
 		}
-		if ( site.hasMinimumJetpackVersion && site.update === 'error' ) {
-			return true;
-		}
 		return false;
 	},
 


### PR DESCRIPTION
We are displaying this message whenever fetching updates for a file fails:

![image](https://cloud.githubusercontent.com/assets/104869/14960637/011164b6-106c-11e6-96d4-1440cadf73f5.png)

This PR removes the message as it is really confusing for users under low-end/bad hosting plans where the `updates` request happens to fail a lot.

**To test**

* checkout `remove/site-indicator-error-message`
* check that you don't get error icons where it shouldn't ¯\_(ツ)_/¯