### PR TITLE
Framework: update wpcom to `4.9.12`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -197,7 +197,7 @@
           "version": "0.8.40"
         },
         "source-map": {
-          "version": "0.5.5"
+          "version": "0.5.6"
         },
         "source-map-support": {
           "version": "0.2.10",
@@ -742,7 +742,7 @@
           "version": "4.0.0"
         },
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.1.0"
         }
       }
     },
@@ -1056,7 +1056,7 @@
           "version": "3.0.0"
         },
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.1.0"
         },
         "optionator": {
           "version": "0.6.0"
@@ -1082,7 +1082,7 @@
           "version": "4.1.1"
         },
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.1.0"
         }
       }
     },
@@ -1182,7 +1182,7 @@
       "version": "1.2.4",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.1.0"
         }
       }
     },
@@ -1274,6 +1274,395 @@
     "fs-readdir-recursive": {
       "version": "0.1.2"
     },
+    "fsevents": {
+      "version": "1.0.12",
+      "dependencies": {
+        "ansi": {
+          "version": "0.3.1"
+        },
+        "ansi-regex": {
+          "version": "2.0.0"
+        },
+        "ansi-styles": {
+          "version": "2.2.1"
+        },
+        "are-we-there-yet": {
+          "version": "1.1.2"
+        },
+        "asn1": {
+          "version": "0.2.3"
+        },
+        "assert-plus": {
+          "version": "0.2.0"
+        },
+        "async": {
+          "version": "1.5.2"
+        },
+        "aws-sign2": {
+          "version": "0.6.0"
+        },
+        "aws4": {
+          "version": "1.3.2",
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.0.1",
+              "dependencies": {
+                "pseudomap": {
+                  "version": "1.0.2"
+                },
+                "yallist": {
+                  "version": "2.0.0"
+                }
+              }
+            }
+          }
+        },
+        "bl": {
+          "version": "1.0.3"
+        },
+        "block-stream": {
+          "version": "0.0.8"
+        },
+        "boom": {
+          "version": "2.10.1"
+        },
+        "caseless": {
+          "version": "0.11.0"
+        },
+        "chalk": {
+          "version": "1.1.3"
+        },
+        "combined-stream": {
+          "version": "1.0.5"
+        },
+        "commander": {
+          "version": "2.9.0"
+        },
+        "core-util-is": {
+          "version": "1.0.2"
+        },
+        "cryptiles": {
+          "version": "2.0.5"
+        },
+        "dashdash": {
+          "version": "1.13.0",
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0"
+        },
+        "deep-extend": {
+          "version": "0.4.1"
+        },
+        "delayed-stream": {
+          "version": "1.0.0"
+        },
+        "delegates": {
+          "version": "1.0.0"
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5"
+        },
+        "extend": {
+          "version": "3.0.0"
+        },
+        "extsprintf": {
+          "version": "1.0.2"
+        },
+        "forever-agent": {
+          "version": "0.6.1"
+        },
+        "form-data": {
+          "version": "1.0.0-rc4"
+        },
+        "fstream": {
+          "version": "1.0.8"
+        },
+        "fstream-ignore": {
+          "version": "1.0.3",
+          "dependencies": {
+            "minimatch": {
+              "version": "3.0.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.3",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "gauge": {
+          "version": "1.2.7"
+        },
+        "generate-function": {
+          "version": "2.0.0"
+        },
+        "generate-object-property": {
+          "version": "1.2.0"
+        },
+        "graceful-fs": {
+          "version": "4.1.3"
+        },
+        "graceful-readlink": {
+          "version": "1.0.1"
+        },
+        "har-validator": {
+          "version": "2.0.6"
+        },
+        "has-ansi": {
+          "version": "2.0.0"
+        },
+        "has-unicode": {
+          "version": "2.0.0"
+        },
+        "hawk": {
+          "version": "3.1.3"
+        },
+        "hoek": {
+          "version": "2.16.3"
+        },
+        "http-signature": {
+          "version": "1.1.1"
+        },
+        "inherits": {
+          "version": "2.0.1"
+        },
+        "ini": {
+          "version": "1.3.4"
+        },
+        "is-my-json-valid": {
+          "version": "2.13.1"
+        },
+        "is-property": {
+          "version": "1.0.2"
+        },
+        "is-typedarray": {
+          "version": "1.0.0"
+        },
+        "isarray": {
+          "version": "1.0.0"
+        },
+        "isstream": {
+          "version": "0.1.2"
+        },
+        "jodid25519": {
+          "version": "1.0.2"
+        },
+        "jsbn": {
+          "version": "0.1.0"
+        },
+        "json-schema": {
+          "version": "0.2.2"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1"
+        },
+        "jsonpointer": {
+          "version": "2.0.0"
+        },
+        "jsprim": {
+          "version": "1.2.2"
+        },
+        "lodash.pad": {
+          "version": "4.1.0"
+        },
+        "lodash.padend": {
+          "version": "4.2.0"
+        },
+        "lodash.padstart": {
+          "version": "4.2.0"
+        },
+        "lodash.repeat": {
+          "version": "4.0.0"
+        },
+        "lodash.tostring": {
+          "version": "4.1.2"
+        },
+        "mime-db": {
+          "version": "1.22.0"
+        },
+        "mime-types": {
+          "version": "2.1.10"
+        },
+        "minimist": {
+          "version": "0.0.8"
+        },
+        "mkdirp": {
+          "version": "0.5.1"
+        },
+        "ms": {
+          "version": "0.7.1"
+        },
+        "node-pre-gyp": {
+          "version": "0.6.25",
+          "dependencies": {
+            "nopt": {
+              "version": "3.0.6",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.7"
+                }
+              }
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7"
+        },
+        "npmlog": {
+          "version": "2.0.3"
+        },
+        "oauth-sign": {
+          "version": "0.8.1"
+        },
+        "once": {
+          "version": "1.3.3"
+        },
+        "pinkie": {
+          "version": "2.0.4"
+        },
+        "pinkie-promise": {
+          "version": "2.0.0"
+        },
+        "process-nextick-args": {
+          "version": "1.0.6"
+        },
+        "qs": {
+          "version": "6.0.2"
+        },
+        "rc": {
+          "version": "1.1.6",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0"
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.0.6"
+        },
+        "request": {
+          "version": "2.69.0"
+        },
+        "rimraf": {
+          "version": "2.5.2",
+          "dependencies": {
+            "glob": {
+              "version": "7.0.3",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1"
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.3",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.1.0"
+        },
+        "sntp": {
+          "version": "1.0.9"
+        },
+        "sshpk": {
+          "version": "1.7.4"
+        },
+        "string_decoder": {
+          "version": "0.10.31"
+        },
+        "stringstream": {
+          "version": "0.0.5"
+        },
+        "strip-ansi": {
+          "version": "3.0.1"
+        },
+        "strip-json-comments": {
+          "version": "1.0.4"
+        },
+        "supports-color": {
+          "version": "2.0.0"
+        },
+        "tar": {
+          "version": "2.2.1"
+        },
+        "tar-pack": {
+          "version": "3.1.3"
+        },
+        "tough-cookie": {
+          "version": "2.2.2"
+        },
+        "tunnel-agent": {
+          "version": "0.4.2"
+        },
+        "tweetnacl": {
+          "version": "0.14.3"
+        },
+        "uid-number": {
+          "version": "0.0.6"
+        },
+        "util-deprecate": {
+          "version": "1.0.2"
+        },
+        "verror": {
+          "version": "1.3.6"
+        },
+        "wrappy": {
+          "version": "1.0.1"
+        },
+        "xtend": {
+          "version": "4.0.1"
+        }
+      }
+    },
     "fstream": {
       "version": "1.0.8"
     },
@@ -1332,7 +1721,7 @@
           "version": "5.0.15"
         },
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.1.0"
         },
         "pinkie": {
           "version": "1.0.0"
@@ -1467,10 +1856,10 @@
       "version": "0.4.0",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.1.0"
         },
         "source-map": {
-          "version": "0.5.5"
+          "version": "0.5.6"
         }
       }
     },
@@ -1603,7 +1992,7 @@
           "version": "2.7.0"
         },
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.1.0"
         }
       }
     },
@@ -1871,7 +2260,7 @@
       "version": "0.2.14",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.1.0"
         }
       }
     },
@@ -2046,7 +2435,7 @@
       "version": "3.7.0",
       "dependencies": {
         "object-assign": {
-          "version": "4.0.1"
+          "version": "4.1.0"
         }
       }
     },
@@ -2471,10 +2860,10 @@
       "version": "2.0.1"
     },
     "postcss": {
-      "version": "5.0.20",
+      "version": "5.0.21",
       "dependencies": {
         "source-map": {
-          "version": "0.5.5"
+          "version": "0.5.6"
         }
       }
     },
@@ -3303,7 +3692,7 @@
           "version": "0.2.10"
         },
         "source-map": {
-          "version": "0.5.5"
+          "version": "0.5.6"
         },
         "window-size": {
           "version": "0.1.0"
@@ -3459,7 +3848,7 @@
       "version": "1.2.0"
     },
     "wpcom": {
-      "version": "4.9.7",
+      "version": "4.9.12",
       "dependencies": {
         "babel": {
           "version": "5.8.38"
@@ -3474,7 +3863,7 @@
           "version": "3.10.1"
         },
         "source-map": {
-          "version": "0.5.5"
+          "version": "0.5.6"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "walk": "2.3.4",
     "webpack": "1.12.15",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom": "4.9.7",
+    "wpcom": "4.9.12",
     "wpcom-proxy-request": "1.0.5",
     "wpcom-xhr-request": "0.5.0",
     "xgettext-js": "0.3.0"


### PR DESCRIPTION
Update `wpcom` dependency to `4.9.12`.

### Testing

Test the whole app ( :-o ). Keep in mind that the previous version is `4.9.7`. The main changes between these versions are:

* Enable support for post types taxonomies endpoint
* Use `js` files instead of `json`files to export runtime methods
* Add `Plans` class to handle `/plans` endpoints.

Also in `development` environment you can use the wpcom global var in the client-side and make some simple tests, for instance get the current version of wpcom:

```cli
> wpcom.__version
```

![image](https://cloud.githubusercontent.com/assets/77539/14963736/5ea9c30c-107b-11e6-9282-d5dfa3dd6b9c.png)

.... or for instance the new post-type implementation

```js
wpcom
.site( 'es.blog.wordpress.com' )
.postType( 'post' )
.taxonomiesList( { fileds: 'name' } ).
.then( list => console.log( list ) );
```

![image](https://cloud.githubusercontent.com/assets/77539/14835925/051f305c-0be3-11e6-8bc0-914ca090274e.png)

cc @aduth cc @timmyc 

I close #5034 in favor of this one.