### PR TITLE
Update/redux latest post summary

### DIFF
--- a/client/components/data/query-post-stats/README.md
+++ b/client/components/data/query-post-stats/README.md
@@ -1,0 +1,52 @@
+Query Post Types
+================
+
+`<QueryPostStats />` is a React component used in managing network requests for post stats.
+
+## Usage
+
+Render the component, passing `siteId`, `postId` and `stat`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import QueryPostStats from 'components/data/query-post-stats';
+import MyPostStatItem from './stat-item';
+
+export default function MyPostStatItem( { statValue } ) {
+	return (
+		<div>
+			<QueryPostStats siteId={ 3584907 } postId={ 4533 } stat="views" />
+			<div>{ statValue }</div>
+		</div>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+The site ID for which the post stat should be requested.
+
+### `postId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+The post ID for which the stat should be requested.
+
+### `stat`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+The stat key being requested.

--- a/client/components/data/query-post-stats/index.jsx
+++ b/client/components/data/query-post-stats/index.jsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingPostStat } from 'state/stats/posts/selectors';
+import { requestPostStat } from 'state/stats/posts/actions';
+
+class QueryPostStats extends Component {
+	componentWillMount() {
+		if ( !this.props.requestingPostStat &&
+			this.props.siteId &&
+			this.props.postId &&
+			this.props.stat ) {
+			this.props.requestPostStat( this.props.stat, this.props.siteId, this.props.postId );
+		}
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if (
+			! ( this.props.siteId && this.props.postId && this.props.stat ) ||
+			( this.props.siteId === nextProps.siteId &&
+				this.props.postId === nextProps.postId &&
+				this.props.stat === nextProps.stat )
+			) {
+			return;
+		}
+
+		nextProps.requestPostStat( nextProps.stat, nextProps.siteId, nextProps.postId );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryPostStats.propTypes = {
+	siteId: PropTypes.number,
+	postId: PropTypes.number,
+	stat: PropTypes.string,
+	requestingPostStat: PropTypes.bool,
+	requestPostStat: PropTypes.func
+};
+
+QueryPostStats.defaultProps = {
+	requestPostStat: () => {}
+};
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			requestingPostStat: isRequestingPostStat(
+				state, ownProps.stat, ownProps.siteId, ownProps.postId
+			)
+		};
+	},
+	( dispatch ) => {
+		return bindActionCreators( {
+			requestPostStat
+		}, dispatch );
+	}
+)( QueryPostStats );

--- a/client/components/data/query-post-stats/index.jsx
+++ b/client/components/data/query-post-stats/index.jsx
@@ -13,20 +13,19 @@ import { requestPostStat } from 'state/stats/posts/actions';
 
 class QueryPostStats extends Component {
 	componentWillMount() {
-		if ( !this.props.requestingPostStat &&
-			this.props.siteId &&
-			this.props.postId &&
-			this.props.stat ) {
-			this.props.requestPostStat( this.props.stat, this.props.siteId, this.props.postId );
+		const { requestingPostStat, siteId, postId, stat } = this.props;
+		if ( ! requestingPostStat && siteId && postId && stat ) {
+			this.props.requestPostStat( stat, siteId, postId );
 		}
 	}
 
 	componentWillReceiveProps( nextProps ) {
+		const { siteId, postId, stat } = this.props;
 		if (
-			! ( this.props.siteId && this.props.postId && this.props.stat ) ||
-			( this.props.siteId === nextProps.siteId &&
-				this.props.postId === nextProps.postId &&
-				this.props.stat === nextProps.stat )
+			! ( siteId && postId && stat ) ||
+			( siteId === nextProps.siteId &&
+				postId === nextProps.postId &&
+				stat === nextProps.stat )
 			) {
 			return;
 		}

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -24,7 +24,7 @@ const StatsPostPerformance = React.createClass( {
 	displayName: 'StatsPostPerformance',
 
 	propTypes: {
-		countViews: PropTypes.number,
+		viewCount: PropTypes.number,
 		site: PropTypes.oneOfType( [
 			PropTypes.bool,
 			PropTypes.object
@@ -36,14 +36,14 @@ const StatsPostPerformance = React.createClass( {
 	},
 
 	buildTabs( summaryUrl ) {
-		const { countViews, post, loading } = this.props;
+		const { viewCount, post, loading } = this.props;
 		const tabClassName = 'is-post-summary';
 
 		const tabs = [
 			{
 				label: this.translate( 'Views' ),
 				gridicon: 'visible',
-				value: countViews,
+				value: viewCount,
 				href: summaryUrl,
 				className: tabClassName,
 				loading: loading
@@ -129,12 +129,12 @@ export default connect( ( state, ownProps ) => {
 	const query = { status: 'published' };
 	const posts = site ? getSitePostsForQuery( state, site.ID, query ) : null;
 	const post = posts && posts.length ? posts[ 0 ] : null;
-	const countViews = post && site ? getPostStat( state, 'views', site.ID, post.ID ) : null;
+	const viewCount = post && site ? getPostStat( state, 'views', site.ID, post.ID ) : null;
 
 	return {
-		countViews,
+		viewCount,
 		query,
 		post,
-		loading: !site || !posts || countViews === null
+		loading: ! site || ! posts || viewCount === null
 	};
 } )( StatsPostPerformance );

--- a/client/my-sites/stats/post-performance/index.jsx
+++ b/client/my-sites/stats/post-performance/index.jsx
@@ -9,29 +9,22 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Card from 'components/card';
-import PostStatsStore from 'lib/post-stats/store';
 import StatsTabs from '../stats-tabs';
 import StatsTab from '../stats-tabs/tab';
 import Emojify from 'components/emojify';
 import SectionHeader from 'components/section-header';
 import QueryPosts from 'components/data/query-posts';
-import {
-	getSitePostsForQuery,
-	isRequestingSitePostsForQuery
-} from 'state/posts/selectors';
+import QueryPostStats from 'components/data/query-post-stats';
+import { getSitePostsForQuery } from 'state/posts/selectors';
+import { getPostStat } from 'state/stats/posts/selectors';
 import { decodeEntities } from 'lib/formatting';
-
-function getPostState( post ) {
-	return {
-		views: post ? PostStatsStore.getItem( 'totalViews', post.site_ID, post.ID ) : String.fromCharCode( 8211 )
-	};
-}
 
 const StatsPostPerformance = React.createClass( {
 
 	displayName: 'StatsPostPerformance',
 
 	propTypes: {
+		countViews: PropTypes.number,
 		site: PropTypes.oneOfType( [
 			PropTypes.bool,
 			PropTypes.object
@@ -42,66 +35,15 @@ const StatsPostPerformance = React.createClass( {
 		loading: PropTypes.bool
 	},
 
-	componentWillMount() {
-		const post = this.props.post;
-		if ( post ) {
-			this.updatePostViews( post );
-		}
-		PostStatsStore.on( 'change', this.onViewsChange );
-	},
-
-	componentWillUnmount() {
-		PostStatsStore.off( 'change', this.onViewsChange );
-	},
-
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.post !== this.props.post ) {
-			this.updatePostViews( nextProps.post );
-		}
-	},
-
-	getInitialState() {
-		return {
-			views: null
-		};
-	},
-
-	updatePostViews( post ) {
-		const postState = getPostState( post );
-
-		this.setState( postState );
-	},
-
-	onViewsChange() {
-		const views = this.getTotalViews();
-
-		if ( this.state.views !== views ) {
-			this.setState( {
-				views: views
-			} );
-		}
-	},
-
-	getTotalViews() {
-		let views;
-
-		if ( this.props.post ) {
-			views = PostStatsStore.getItem( 'totalViews', this.props.site.ID, this.props.post.ID );
-		}
-
-		return views;
-	},
-
 	buildTabs( summaryUrl ) {
-		const { views } = this.state;
-		const { post, loading } = this.props;
+		const { countViews, post, loading } = this.props;
 		const tabClassName = 'is-post-summary';
 
 		const tabs = [
 			{
 				label: this.translate( 'Views' ),
 				gridicon: 'visible',
-				value: views,
+				value: countViews,
 				href: summaryUrl,
 				className: tabClassName,
 				loading: loading
@@ -148,10 +90,8 @@ const StatsPostPerformance = React.createClass( {
 
 		return (
 			<div>
-				{ site
-					? <QueryPosts siteId={ site.ID } query={ query } />
-					: null
-				}
+				{ site ? <QueryPosts siteId={ site.ID } query={ query } /> : null }
+				{ site && post ? <QueryPostStats siteId= { site.ID } postId={ post.ID } stat="views" /> : null }
 				<SectionHeader label={ this.translate( 'Latest Post Summary' ) } href={ summaryUrl } />
 				<Card className={ cardClass }>
 					<div className="module-content-text">
@@ -189,9 +129,12 @@ export default connect( ( state, ownProps ) => {
 	const query = { status: 'published' };
 	const posts = site ? getSitePostsForQuery( state, site.ID, query ) : null;
 	const post = posts && posts.length ? posts[ 0 ] : null;
+	const countViews = post && site ? getPostStat( state, 'views', site.ID, post.ID ) : null;
+
 	return {
+		countViews,
 		query,
 		post,
-		loading: isRequestingSitePostsForQuery( state, site.ID, query )
+		loading: !site || !posts || countViews === null
 	};
 } )( StatsPostPerformance );

--- a/client/state/stats/posts/reducer.js
+++ b/client/state/stats/posts/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import get from 'lodash/get';
+import merge from 'lodash/merge';
 
 /**
  * Internal dependencies
@@ -31,12 +31,12 @@ export function requesting( state = {}, action ) {
 		case POST_STATS_REQUEST:
 		case POST_STATS_REQUEST_SUCCESS:
 		case POST_STATS_REQUEST_FAILURE:
-			return Object.assign( {}, state, {
-				[ action.siteId ]: Object.assign( {}, get( state, [ action.siteId ], {} ), {
-					[ action.postId ]: Object.assign( {}, get( state, [ action.siteId, action.postId ], {} ), {
+			return merge( {}, state, {
+				[ action.siteId ]: {
+					[ action.postId ]: {
 						[ action.stat ]: POST_STATS_REQUEST === action.type
-					} )
-				} )
+					}
+				}
 			} );
 
 		case SERIALIZE:
@@ -58,12 +58,12 @@ export function requesting( state = {}, action ) {
 export function items( state = {}, action ) {
 	switch ( action.type ) {
 		case POST_STATS_RECEIVE:
-			return Object.assign( {}, state, {
-				[ action.siteId ]: Object.assign( {}, get( state, [ action.siteId ], {} ), {
-					[ action.postId ]: Object.assign( {}, get( state, [ action.siteId, action.postId ], {} ), {
+			return merge( {}, state, {
+				[ action.siteId ]: {
+					[ action.postId ]: {
 						[ action.stat ]: action.value
-					} )
-				} )
+					}
+				}
 			} );
 
 		case DESERIALIZE:


### PR DESCRIPTION
Cherry-picks from https://github.com/Automattic/wp-calypso/pull/5025

In this PR, I've added a new `QueryPostStats` component to trigger loading of required post stats.
The component accepts a siteId, a postId and a stat key. It then triggers the redux actions responsible of providing the stat.

I also use this component in the PostPerformanceComponent (Last post summary) to get rid of the `PostStatsStore` dependency and use the redux approach instead.

The last change is setting the loading flag on data availability instead of request status (to display the stats immediately if a cached version is available)

cc @timmyc @mdawaffe  