### PR TITLE
Inline SVGs

### DIFF
--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -3,15 +3,10 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
 
-/**
- * Module variables
- */
-var Spinner;
-
-Spinner = React.createClass( {
+const Spinner = React.createClass( {
 	propTypes: {
 		className: React.PropTypes.string,
 		size: React.PropTypes.number,
@@ -56,7 +51,7 @@ Spinner = React.createClass( {
 	},
 
 	renderFallback: function() {
-		var style = {
+		const style = {
 			width: this.props.size,
 			height: this.props.size
 		};
@@ -70,7 +65,7 @@ Spinner = React.createClass( {
 	},
 
 	render: function() {
-		var instanceId = parseInt( this.state.instanceId, 10 );
+		const instanceId = parseInt( this.state.instanceId, 10 );
 
 		if ( ! this.isSVGCSSAnimationSupported() ) {
 			return this.renderFallback();

--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -76,48 +76,41 @@ Spinner = React.createClass( {
 			return this.renderFallback();
 		}
 
-		// We're using `dangerouslySetInnerHTML` for the SVG, as React unfortunately doesn't support
-		// SVG's `mask` attribute, see https://github.com/facebook/react/issues/1657#issuecomment-63209488
-		// The only variable we're using inside is `instanceId`, which is an (integer) counter
-		// we generate ourselves, so we're fine.
-		/*eslint-disable react/no-danger*/
 		return (
 			<div className={ this.getClassName() }>
 				<svg className="spinner__image"
 					width={ this.props.size }
 					height={ this.props.size }
-					viewBox="0 0 100 100"
-					dangerouslySetInnerHTML={ { __html: `
+					viewBox="0 0 100 100">
 					<defs>
-						<mask id="maskBorder${ instanceId }">
+						<mask id={ `maskBorder${ instanceId }` }>
 							<rect x="0" y="0" width="100%" height="100%" fill="white" />
 							<circle r="46%" cx="50%" cy="50%" fill="black" />
 						</mask>
-						<mask id="maskDonut${ instanceId }">
+						<mask id={ `maskDonut${ instanceId }` }>
 							<rect x="0" y="0" width="100%" height="100%" fill="black" />
 							<circle r="46%" cx="50%" cy="50%" fill="white" />
 							<circle r="30%" cx="50%" cy="50%" fill="black" />
 						</mask>
-						<mask id="maskLeft${ instanceId }">
+						<mask id={ `maskLeft${ instanceId }` }>
 							<rect x="0" y="0" width="50%" height="100%" fill="white" />
 						</mask>
-						<mask id="maskRight${ instanceId }">
+						<mask id={ `maskRight${ instanceId }` }>
 							<rect x="50%" y="0" width="50%" height="100%" fill="white" />
 						</mask>
 					</defs>
-					<circle class="spinner__border" r="50%" cx="50%" cy="50%" mask="url( #maskBorder${ instanceId } )" />
-					<g mask="url( #maskDonut${ instanceId } )">
-						<g mask="url( #maskLeft${ instanceId } )">
-							<rect class="spinner__progress is-left" x="0" y="0" width="50%" height="100%" />
+					<circle className="spinner__border" r="50%" cx="50%" cy="50%" mask={ `url( #maskBorder${ instanceId } )` } />
+					<g mask={ `url( #maskDonut${ instanceId } )` }>
+						<g mask={ `url( #maskLeft${ instanceId } )` }>
+							<rect className="spinner__progress is-left" x="0" y="0" width="50%" height="100%" />
 						</g>
-						<g mask="url( #maskRight${ instanceId } )">
-							<rect class="spinner__progress is-right" x="50%" y="0" width="50%" height="100%" />
+						<g mask={ `url( #maskRight${ instanceId } )` }>
+							<rect className="spinner__progress is-right" x="50%" y="0" width="50%" height="100%" />
 						</g>
 					</g>
-				` } } />
+				</svg>
 			</div>
 		);
-		/*eslint-enable react/no-danger*/
 	}
 } );
 

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -37,8 +37,194 @@ const PushNotificationSettings = React.createClass( {
 	},
 
 	getBlockedInstruction: function() {
-		const svgAddressBar = '<svg width="206px" height="206px" viewBox="0 0 206 206" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><!-- Generator: Sketch 3.7.2 (28276) - http://www.bohemiancoding.com/sketch --><title>address-bar</title><desc>Created with Sketch.</desc><defs><circle id="path-1" cx="99" cy="99" r="99"></circle><mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-4" y="-4" width="206" height="206"><rect x="-4" y="-4" width="206" height="206" fill="white"></rect><use xlink:href="#path-1" fill="black"></use></mask><circle id="path-3" cx="99" cy="99" r="99"></circle><rect id="path-5" x="0" y="0" width="488" height="361" rx="4"></rect><mask id="mask-6" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-4" y="-4" width="496" height="369"><rect x="-4" y="-4" width="496" height="369" fill="white"></rect><use xlink:href="#path-5" fill="black"></use></mask><rect id="path-7" x="93" y="6" width="334" height="28" rx="4"></rect><mask id="mask-8" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-1" y="-1" width="336" height="30"><rect x="92" y="5" width="336" height="30" fill="white"></rect><use xlink:href="#path-7" fill="black"></use></mask><path d="M97.25,40 L71.0028524,40 C69.3442117,40 68,41.3470833 68,43.0087948 L68,340.991205 C68,342.661303 69.3444228,344 71.0028524,344 L451.997148,344 C453.655788,344 455,342.652917 455,340.991205 L455,43.0087948 C455,41.3386965 453.655577,40 451.997148,40 L121.75,40 L109.5,28 L97.25,40 Z" id="path-9"></path><filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-10"><feMorphology radius="1" operator="dilate" in="SourceAlpha" result="shadowSpreadOuter1"></feMorphology><feOffset dx="0" dy="4" in="shadowSpreadOuter1" result="shadowOffsetOuter1"></feOffset><feGaussianBlur stdDeviation="8" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur><feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"></feComposite><feColorMatrix values="0 0 0 0 0.180392157   0 0 0 0 0.266666667   0 0 0 0 0.325490196  0 0 0 0.3 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix></filter><mask id="mask-11" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-1" y="-1" width="389" height="318"><rect x="67" y="27" width="389" height="318" fill="white"></rect><use xlink:href="#path-9" fill="black"></use></mask></defs><g id="Enable-Notifications" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="address-bar"><g id="Group-15-Copy" transform="translate(4.000000, 4.000000)"><g id="Oval-2"><use fill="#F3F6F8" fill-rule="evenodd" xlink:href="#path-1"></use><use stroke="#C8D7E1" mask="url(#mask-2)" stroke-width="8" xlink:href="#path-1"></use></g><g id="Group-11-Copy"><mask id="mask-4" fill="white"><use xlink:href="#path-3"></use></mask><g id="Mask"></g><g mask="url(#mask-4)"><g transform="translate(10.000000, 42.000000)"><g id="Rectangle-64" fill="none"><use fill="#FFFFFF" fill-rule="evenodd" xlink:href="#path-5"></use><use stroke="#E9EFF3" mask="url(#mask-6)" stroke-width="8" xlink:href="#path-5"></use></g><rect id="Rectangle-64-Copy" fill="#F3F6F8" fill-rule="evenodd" x="0" y="0" width="488" height="40" rx="4"></rect><g id="Rectangle-69" fill="none"><use fill="#FFFFFF" fill-rule="evenodd" xlink:href="#path-7"></use><use stroke="#E9EFF3" mask="url(#mask-8)" stroke-width="2" xlink:href="#path-7"></use></g><text id="https://wordpress.co" fill="none" font-family="SFUIText-Regular, SF UI Text" font-size="13" font-weight="normal"><tspan x="122.245605" y="24" fill="#C8D7E1">https://wordpress.com</tspan></text><rect id="Rectangle-66" fill="#E9EFF3" fill-rule="evenodd" x="0" y="40" width="488" height="4"></rect><g id="Group" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(13.000000, 8.000000)"><rect id="Rectangle-path" x="0" y="0" width="24" height="24"></rect><polygon id="Shape" fill="#C8D7E1" points="20 11 7.83 11 13.42 5.41 12 4 4 12 12 20 13.41 18.59 7.83 13 20 13"></polygon></g><g id="Group" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(53.000000, 8.000000)"><rect id="Rectangle-path" x="0" y="0" width="24" height="24"></rect><polygon id="Shape" fill="#C8D7E1" points="12 4 10.59 5.41 16.17 11 4 11 4 13 16.17 13 10.59 18.59 12 20 20 12"></polygon></g><g id="Group" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(101.000000, 11.000000)"><rect id="Rectangle-path" x="0" y="0" width="16" height="16"></rect><path d="M12,5.33333333 L11.3333333,5.33333333 L11.3333333,4.66666667 C11.3333333,2.82866667 9.838,1.33333333 8,1.33333333 C6.162,1.33333333 4.66666667,2.82866667 4.66666667,4.66666667 L4.66666667,5.33333333 L4,5.33333333 C3.26333333,5.33333333 2.66666667,5.93 2.66666667,6.66666667 L2.66666667,13.3333333 C2.66666667,14.07 3.26333333,14.6666667 4,14.6666667 L12,14.6666667 C12.7366667,14.6666667 13.3333333,14.07 13.3333333,13.3333333 L13.3333333,6.66666667 C13.3333333,5.93 12.7366667,5.33333333 12,5.33333333 L12,5.33333333 Z M6,4.66666667 C6,3.564 6.89733333,2.66666667 8,2.66666667 C9.10266667,2.66666667 10,3.564 10,4.66666667 L10,5.33333333 L6,5.33333333 L6,4.66666667 L6,4.66666667 Z M8.66666667,10.482 L8.66666667,12 L7.33333333,12 L7.33333333,10.482 C6.93666667,10.2513333 6.66666667,9.826 6.66666667,9.33333333 C6.66666667,8.59666667 7.26333333,8 8,8 C8.73666667,8 9.33333333,8.59666667 9.33333333,9.33333333 C9.33333333,9.82533333 9.06333333,10.2506667 8.66666667,10.482 L8.66666667,10.482 Z" id="Shape" fill="#A8BECE"></path></g><g id="Combined-Shape" fill="none"><use fill="black" fill-opacity="1" filter="url(#filter-10)" xlink:href="#path-9"></use><use fill="#FFFFFF" fill-rule="evenodd" xlink:href="#path-9"></use><use stroke="#C8D7E1" mask="url(#mask-11)" stroke-width="2" xlink:href="#path-9"></use></g><rect id="Rectangle-70" fill="#C8D7E1" fill-rule="evenodd" x="83" y="55" width="161" height="18"></rect><rect id="Rectangle-70-Copy-2" fill="#C8D7E1" fill-rule="evenodd" x="83" y="113" width="151" height="14"></rect><rect id="Rectangle-70-Copy-3" fill="#E9EFF3" fill-rule="evenodd" x="113" y="143" width="151" height="14"></rect><rect id="Rectangle-70-Copy" fill="#E9EFF3" fill-rule="evenodd" x="83" y="77" width="121" height="14"></rect></g></g></g></g></g></g></svg>';
-		const svgAlwaysAllow = '<svg width="206px" height="206px" viewBox="0 0 206 206" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><!-- Generator: Sketch 3.7.2 (28276) - http://www.bohemiancoding.com/sketch --><title>always-allow</title><desc>Created with Sketch.</desc><defs><circle id="path-1" cx="99" cy="99" r="99"></circle><mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-4" y="-4" width="206" height="206"><rect x="-4" y="-4" width="206" height="206" fill="white"></rect><use xlink:href="#path-1" fill="black"></use></mask><circle id="path-3" cx="99" cy="99" r="99"></circle><rect id="path-5" x="0" y="0" width="392" height="290" rx="4"></rect><mask id="mask-6" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-4" y="-4" width="400" height="298"><rect x="-4" y="-4" width="400" height="298" fill="white"></rect><use xlink:href="#path-5" fill="black"></use></mask><path d="M78.505814,31.6455696 L58.0031305,31.6455696 C56.3525752,31.6455696 55,32.9893356 55,34.6469549 L55,272.998615 C55,274.655708 56.3445473,276 58.0031305,276 L362.99687,276 C364.647425,276 366,274.656234 366,272.998615 L366,34.6469549 C366,32.9898616 364.655453,31.6455696 362.99687,31.6455696 L98.1944444,31.6455696 L88.3501292,22 L78.505814,31.6455696 Z" id="path-7"></path><filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-8"><feMorphology radius="1" operator="dilate" in="SourceAlpha" result="shadowSpreadOuter1"></feMorphology><feOffset dx="0" dy="4" in="shadowSpreadOuter1" result="shadowOffsetOuter1"></feOffset><feGaussianBlur stdDeviation="8" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur><feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"></feComposite><feColorMatrix values="0 0 0 0 0.180392157   0 0 0 0 0.266666667   0 0 0 0 0.325490196  0 0 0 0.3 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix></filter><mask id="mask-9" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-1" y="-1" width="313" height="256"><rect x="54" y="21" width="313" height="256" fill="white"></rect><use xlink:href="#path-7" fill="black"></use></mask><rect id="path-10" x="0" y="0" width="153" height="55" rx="4"></rect><filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-11"><feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset><feGaussianBlur stdDeviation="7" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur><feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"></feComposite><feColorMatrix values="0 0 0 0 0.180392157   0 0 0 0 0.266666667   0 0 0 0 0.325490196  0 0 0 0.2 0" type="matrix" in="shadowBlurOuter1"></feColorMatrix></filter><mask id="mask-12" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="153" height="55" fill="white"><use xlink:href="#path-10"></use></mask></defs><g id="Enable-Notifications" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="always-allow"><g id="Group-14-Copy" transform="translate(4.000000, 4.000000)"><g id="Oval-2-Copy"><use fill="#F3F6F8" fill-rule="evenodd" xlink:href="#path-1"></use><use stroke="#C8D7E1" mask="url(#mask-2)" stroke-width="8" xlink:href="#path-1"></use></g><g id="Group-13"><mask id="mask-4" fill="white"><use xlink:href="#path-3"></use></mask><use id="Mask" fill="#F3F6F8" xlink:href="#path-3"></use><g mask="url(#mask-4)"><g transform="translate(-39.000000, -46.000000)"><g id="Rectangle-64" fill="none"><use fill="#FFFFFF" fill-rule="evenodd" xlink:href="#path-5"></use><use stroke="#E9EFF3" mask="url(#mask-6)" stroke-width="8" xlink:href="#path-5"></use></g><g id="Combined-Shape" fill="none"><use fill="black" fill-opacity="1" filter="url(#filter-8)" xlink:href="#path-7"></use><use fill="#FFFFFF" fill-rule="evenodd" xlink:href="#path-7"></use><use stroke="#C8D7E1" mask="url(#mask-9)" stroke-width="2" xlink:href="#path-7"></use></g><rect id="Rectangle-70" fill="#C8D7E1" fill-rule="evenodd" x="67" y="44" width="129" height="14"></rect><rect id="Rectangle-70-Copy-2" fill="#C8D7E1" fill-rule="evenodd" x="67" y="91" width="121" height="11"></rect><rect id="Rectangle-70-Copy-3" fill="#E9EFF3" fill-rule="evenodd" x="91" y="115" width="121" height="11"></rect><rect id="Rectangle-70-Copy-5" fill="#E9EFF3" fill-rule="evenodd" x="91" y="163" width="121" height="11"></rect><rect id="Rectangle-70-Copy-6" fill="#E9EFF3" fill-rule="evenodd" x="91" y="187" width="121" height="11"></rect><rect id="Rectangle-70-Copy" fill="#E9EFF3" fill-rule="evenodd" x="67" y="62" width="97" height="11"></rect><text id="Notifications:-Ask-b" fill="none" font-family="SFUIText-Regular, SF UI Text" font-size="10.442623" font-weight="normal"><tspan x="91" y="148" fill="#3D596D">Notifications: Ask by default</tspan></text><g id="Group-12" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(236.000000, 139.000000)"><polyline id="Shape" fill="#C8D7E1" points="0 2.86363636 3 0 6 2.86363636 5.46975 3.36978409 3 1.01229545 0.53025 3.36978409"></polyline><polyline id="Shape" fill="#C8D7E1" points="6 5.87546591 3 8.73910227 0 5.87546591 0.53025 5.36931818 3 7.72680682 5.46975 5.36931818"></polyline></g><polygon id="Path-24" fill="#C8D7E1" fill-rule="evenodd" points="67.8235294 139 80.1764706 139 81 139.8 81 147 80.1764706 147.8 73.5882353 147.8 70.2941176 151 70.2941176 147 67.8235294 147 67 146.2 67 139.8"></polygon><g id="Group-11" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(158.000000, 124.000000)"><g id="Rectangle-88"><use fill="black" fill-opacity="1" filter="url(#filter-11)" xlink:href="#path-10"></use><use stroke="#C8D7E1" mask="url(#mask-12)" stroke-width="2" fill="#F3F6F8" fill-rule="evenodd" xlink:href="#path-10"></use></g><text id="Always-allow-on-this" font-family="SFUIText-Regular, SF UI Text" font-size="9.56521739" font-weight="normal" fill="#3D596D"><tspan x="26.434555" y="20.1594203">Always allow on this site</tspan></text><rect id="Rectangle-89" fill="#C8D7E1" opacity="0.5" x="26.434555" y="32.6811594" width="98.5287958" height="11.1594203"></rect></g><polyline id="Shape" fill="#2E4453" fill-rule="evenodd" points="171.109251 144 168 140.675235 168.655506 139.974294 171.109251 142.598116 176.344494 137 177 137.700942"></polyline></g></g></g></g></g></g></svg>';
+		const SvgAddressBar = () => (
+			<svg width="206px" height="206px" viewBox="0 0 206 206" version="1.1" xmlns="http://www.w3.org/2000/svg">
+				{ /* Generator: Sketch 3.7.2 (28276) - http://www.bohemiancoding.com/sketch */ }
+				<title>address-bar</title>
+				<desc>Created with Sketch.</desc>
+				<defs>
+					<circle id="path-1" cx="99" cy="99" r="99"/>
+					<mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-4" y="-4" width="206" height="206">
+						<rect x="-4" y="-4" width="206" height="206" fill="white"/>
+						<use xlinkHref="#path-1" fill="black"/>
+					</mask>
+					<circle id="path-3" cx="99" cy="99" r="99"/>
+					<rect id="path-5" x="0" y="0" width="488" height="361" rx="4"/>
+					<mask id="mask-6" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-4" y="-4" width="496" height="369">
+						<rect x="-4" y="-4" width="496" height="369" fill="white"/>
+						<use xlinkHref="#path-5" fill="black"/>
+					</mask>
+					<rect id="path-7" x="93" y="6" width="334" height="28" rx="4"/>
+					<mask id="mask-8" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-1" y="-1" width="336" height="30">
+						<rect x="92" y="5" width="336" height="30" fill="white"/>
+						<use xlinkHref="#path-7" fill="black"/>
+					</mask>
+					<path d="M97.25,40 L71.0028524,40 C69.3442117,40 68,41.3470833 68,43.0087948 L68,340.991205 C68,342.661303 69.3444228,344 71.0028524,344 L451.997148,344 C453.655788,344 455,342.652917 455,340.991205 L455,43.0087948 C455,41.3386965 453.655577,40 451.997148,40 L121.75,40 L109.5,28 L97.25,40 Z" id="path-9"/>
+					<filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-10">
+						<feMorphology radius="1" operator="dilate" in="SourceAlpha" result="shadowSpreadOuter1"/>
+						<feOffset dx="0" dy="4" in="shadowSpreadOuter1" result="shadowOffsetOuter1"/>
+						<feGaussianBlur stdDeviation="8" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+						<feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"/>
+						<feColorMatrix values="0 0 0 0 0.180392157   0 0 0 0 0.266666667   0 0 0 0 0.325490196  0 0 0 0.3 0" type="matrix" in="shadowBlurOuter1"/>
+					</filter>
+					<mask id="mask-11" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-1" y="-1" width="389" height="318">
+						<rect x="67" y="27" width="389" height="318" fill="white"/>
+						<use xlinkHref="#path-9" fill="black"/>
+					</mask>
+				</defs>
+				<g id="Enable-Notifications" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+					<g id="address-bar">
+						<g id="Group-15-Copy" transform="translate(4.000000, 4.000000)">
+							<g id="Oval-2">
+								<use fill="#F3F6F8" fillRule="evenodd" xlinkHref="#path-1"/>
+								<use stroke="#C8D7E1" mask="url(#mask-2)" strokeWidth="8" xlinkHref="#path-1"/>
+							</g>
+							<g id="Group-11-Copy">
+								<mask id="mask-4" fill="white">
+									<use xlinkHref="#path-3"/>
+								</mask>
+								<g id="Mask"></g>
+								<g mask="url(#mask-4)">
+									<g transform="translate(10.000000, 42.000000)">
+										<g id="Rectangle-64" fill="none">
+											<use fill="#FFFFFF" fillRule="evenodd" xlinkHref="#path-5"/>
+											<use stroke="#E9EFF3" mask="url(#mask-6)" strokeWidth="8" xlinkHref="#path-5"/>
+										</g>
+										<rect id="Rectangle-64-Copy" fill="#F3F6F8" fillRule="evenodd" x="0" y="0" width="488" height="40" rx="4"/>
+										<g id="Rectangle-69" fill="none">
+											<use fill="#FFFFFF" fillRule="evenodd" xlinkHref="#path-7"/>
+											<use stroke="#E9EFF3" mask="url(#mask-8)" strokeWidth="2" xlinkHref="#path-7"/>
+										</g>
+										<text id="https://wordpress.com" fill="none" fontFamily="SFUIText-Regular, SF UI Text" fontSize="13" fontWeight="normal">
+											<tspan x="122.245605" y="24" fill="#C8D7E1">https://wordpress.com</tspan>
+										</text>
+										<rect id="Rectangle-66" fill="#E9EFF3" fillRule="evenodd" x="0" y="40" width="488" height="4"/>
+										<g id="Group" strokeWidth="1" fill="none" fillRule="evenodd" transform="translate(13.000000, 8.000000)">
+											<rect id="Rectangle-path" x="0" y="0" width="24" height="24"/>
+											<polygon id="Shape" fill="#C8D7E1" points="20 11 7.83 11 13.42 5.41 12 4 4 12 12 20 13.41 18.59 7.83 13 20 13"/>
+										</g>
+										<g id="Group" strokeWidth="1" fill="none" fillRule="evenodd" transform="translate(53.000000, 8.000000)">
+											<rect id="Rectangle-path" x="0" y="0" width="24" height="24"/>
+											<polygon id="Shape" fill="#C8D7E1" points="12 4 10.59 5.41 16.17 11 4 11 4 13 16.17 13 10.59 18.59 12 20 20 12"/>
+										</g>
+										<g id="Group" strokeWidth="1" fill="none" fillRule="evenodd" transform="translate(101.000000, 11.000000)">
+											<rect id="Rectangle-path" x="0" y="0" width="16" height="16"/>
+											<path d="M12,5.33333333 L11.3333333,5.33333333 L11.3333333,4.66666667 C11.3333333,2.82866667 9.838,1.33333333 8,1.33333333 C6.162,1.33333333 4.66666667,2.82866667 4.66666667,4.66666667 L4.66666667,5.33333333 L4,5.33333333 C3.26333333,5.33333333 2.66666667,5.93 2.66666667,6.66666667 L2.66666667,13.3333333 C2.66666667,14.07 3.26333333,14.6666667 4,14.6666667 L12,14.6666667 C12.7366667,14.6666667 13.3333333,14.07 13.3333333,13.3333333 L13.3333333,6.66666667 C13.3333333,5.93 12.7366667,5.33333333 12,5.33333333 L12,5.33333333 Z M6,4.66666667 C6,3.564 6.89733333,2.66666667 8,2.66666667 C9.10266667,2.66666667 10,3.564 10,4.66666667 L10,5.33333333 L6,5.33333333 L6,4.66666667 L6,4.66666667 Z M8.66666667,10.482 L8.66666667,12 L7.33333333,12 L7.33333333,10.482 C6.93666667,10.2513333 6.66666667,9.826 6.66666667,9.33333333 C6.66666667,8.59666667 7.26333333,8 8,8 C8.73666667,8 9.33333333,8.59666667 9.33333333,9.33333333 C9.33333333,9.82533333 9.06333333,10.2506667 8.66666667,10.482 L8.66666667,10.482 Z" id="Shape" fill="#A8BECE"/>
+										</g>
+										<g id="Combined-Shape" fill="none">
+											<use fill="black" fillOpacity="1" filter="url(#filter-10)" xlinkHref="#path-9"/>
+											<use fill="#FFFFFF" fillRule="evenodd" xlinkHref="#path-9"/>
+											<use stroke="#C8D7E1" mask="url(#mask-11)" strokeWidth="2" xlinkHref="#path-9"/>
+										</g>
+										<rect id="Rectangle-70" fill="#C8D7E1" fillRule="evenodd" x="83" y="55" width="161" height="18"/>
+										<rect id="Rectangle-70-Copy-2" fill="#C8D7E1" fillRule="evenodd" x="83" y="113" width="151" height="14"/>
+										<rect id="Rectangle-70-Copy-3" fill="#E9EFF3" fillRule="evenodd" x="113" y="143" width="151" height="14"/>
+										<rect id="Rectangle-70-Copy" fill="#E9EFF3" fillRule="evenodd" x="83" y="77" width="121" height="14"/>
+									</g>
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</svg>
+		);
+
+		const SvgAlwaysAllow = () => (
+			<svg width="206px" height="206px" viewBox="0 0 206 206" version="1.1" xmlns="http://www.w3.org/2000/svg">
+				{ /* Generator: Sketch 3.7.2 (28276) - http://www.bohemiancoding.com/sketch */ }
+				<title>always-allow</title>
+				<desc>Created with Sketch.</desc>
+				<defs>
+					<circle id="path-1" cx="99" cy="99" r="99"/>
+					<mask id="mask-2" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-4" y="-4" width="206" height="206">
+						<rect x="-4" y="-4" width="206" height="206" fill="white"/>
+						<use xlinkHref="#path-1" fill="black"/>
+					</mask>
+					<circle id="path-3" cx="99" cy="99" r="99"/>
+					<rect id="path-5" x="0" y="0" width="392" height="290" rx="4"/>
+					<mask id="mask-6" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-4" y="-4" width="400" height="298">
+						<rect x="-4" y="-4" width="400" height="298" fill="white"/>
+						<use xlinkHref="#path-5" fill="black"/>
+					</mask>
+					<path d="M78.505814,31.6455696 L58.0031305,31.6455696 C56.3525752,31.6455696 55,32.9893356 55,34.6469549 L55,272.998615 C55,274.655708 56.3445473,276 58.0031305,276 L362.99687,276 C364.647425,276 366,274.656234 366,272.998615 L366,34.6469549 C366,32.9898616 364.655453,31.6455696 362.99687,31.6455696 L98.1944444,31.6455696 L88.3501292,22 L78.505814,31.6455696 Z" id="path-7"/>
+					<filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-8">
+						<feMorphology radius="1" operator="dilate" in="SourceAlpha" result="shadowSpreadOuter1"/>
+						<feOffset dx="0" dy="4" in="shadowSpreadOuter1" result="shadowOffsetOuter1"/>
+						<feGaussianBlur stdDeviation="8" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+						<feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"/>
+						<feColorMatrix values="0 0 0 0 0.180392157   0 0 0 0 0.266666667   0 0 0 0 0.325490196  0 0 0 0.3 0" type="matrix" in="shadowBlurOuter1"/>
+					</filter>
+					<mask id="mask-9" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="-1" y="-1" width="313" height="256">
+						<rect x="54" y="21" width="313" height="256" fill="white"/>
+						<use xlinkHref="#path-7" fill="black"/>
+					</mask>
+					<rect id="path-10" x="0" y="0" width="153" height="55" rx="4"/>
+					<filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-11">
+						<feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"/>
+						<feGaussianBlur stdDeviation="7" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+						<feComposite in="shadowBlurOuter1" in2="SourceAlpha" operator="out" result="shadowBlurOuter1"/>
+						<feColorMatrix values="0 0 0 0 0.180392157   0 0 0 0 0.266666667   0 0 0 0 0.325490196  0 0 0 0.2 0" type="matrix" in="shadowBlurOuter1"/>
+					</filter>
+					<mask id="mask-12" maskContentUnits="userSpaceOnUse" maskUnits="objectBoundingBox" x="0" y="0" width="153" height="55" fill="white">
+						<use xlinkHref="#path-10"/>
+					</mask>
+				</defs>
+				<g id="Enable-Notifications" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+					<g id="always-allow">
+						<g id="Group-14-Copy" transform="translate(4.000000, 4.000000)">
+							<g id="Oval-2-Copy">
+								<use fill="#F3F6F8" fillRule="evenodd" xlinkHref="#path-1"/>
+								<use stroke="#C8D7E1" mask="url(#mask-2)" strokeWidth="8" xlinkHref="#path-1"/>
+							</g>
+							<g id="Group-13">
+								<mask id="mask-4" fill="white">
+									<use xlinkHref="#path-3"/>
+								</mask>
+								<use id="Mask" fill="#F3F6F8" xlinkHref="#path-3"/>
+								<g mask="url(#mask-4)">
+									<g transform="translate(-39.000000, -46.000000)">
+										<g id="Rectangle-64" fill="none">
+											<use fill="#FFFFFF" fillRule="evenodd" xlinkHref="#path-5"/>
+											<use stroke="#E9EFF3" mask="url(#mask-6)" strokeWidth="8" xlinkHref="#path-5"/>
+										</g>
+										<g id="Combined-Shape" fill="none">
+											<use fill="black" fillOpacity="1" filter="url(#filter-8)" xlinkHref="#path-7"/>
+											<use fill="#FFFFFF" fillRule="evenodd" xlinkHref="#path-7"/>
+											<use stroke="#C8D7E1" mask="url(#mask-9)" strokeWidth="2" xlinkHref="#path-7"/>
+										</g>
+										<rect id="Rectangle-70" fill="#C8D7E1" fillRule="evenodd" x="67" y="44" width="129" height="14"/>
+										<rect id="Rectangle-70-Copy-2" fill="#C8D7E1" fillRule="evenodd" x="67" y="91" width="121" height="11"/>
+										<rect id="Rectangle-70-Copy-3" fill="#E9EFF3" fillRule="evenodd" x="91" y="115" width="121" height="11"/>
+										<rect id="Rectangle-70-Copy-5" fill="#E9EFF3" fillRule="evenodd" x="91" y="163" width="121" height="11"/>
+										<rect id="Rectangle-70-Copy-6" fill="#E9EFF3" fillRule="evenodd" x="91" y="187" width="121" height="11"/>
+										<rect id="Rectangle-70-Copy" fill="#E9EFF3" fillRule="evenodd" x="67" y="62" width="97" height="11"/>
+										<text id="Notifications:-Ask-b" fill="none" fontFamily="SFUIText-Regular, SF UI Text" fontSize="10.442623" fontWeight="normal">
+											<tspan x="91" y="148" fill="#3D596D">Notifications: Ask by default</tspan>
+										</text>
+										<g id="Group-12" strokeWidth="1" fill="none" fillRule="evenodd" transform="translate(236.000000, 139.000000)">
+											<polyline id="Shape" fill="#C8D7E1" points="0 2.86363636 3 0 6 2.86363636 5.46975 3.36978409 3 1.01229545 0.53025 3.36978409"/>
+											<polyline id="Shape" fill="#C8D7E1" points="6 5.87546591 3 8.73910227 0 5.87546591 0.53025 5.36931818 3 7.72680682 5.46975 5.36931818"/>
+										</g>
+										<polygon id="Path-24" fill="#C8D7E1" fillRule="evenodd" points="67.8235294 139 80.1764706 139 81 139.8 81 147 80.1764706 147.8 73.5882353 147.8 70.2941176 151 70.2941176 147 67.8235294 147 67 146.2 67 139.8"/>
+										<g id="Group-11" strokeWidth="1" fill="none" fillRule="evenodd" transform="translate(158.000000, 124.000000)">
+											<g id="Rectangle-88">
+												<use fill="black" fillOpacity="1" filter="url(#filter-11)" xlinkHref="#path-10"/>
+												<use stroke="#C8D7E1" mask="url(#mask-12)" strokeWidth="2" fill="#F3F6F8" fillRule="evenodd" xlinkHref="#path-10"/>
+											</g>
+											<text id="Always-allow-on-this" fontFamily="SFUIText-Regular, SF UI Text" fontSize="9.56521739" fontWeight="normal" fill="#3D596D">
+												<tspan x="26.434555" y="20.1594203">Always allow on this site</tspan>
+											</text>
+											<rect id="Rectangle-89" fill="#C8D7E1" opacity="0.5" x="26.434555" y="32.6811594" width="98.5287958" height="11.1594203"/>
+										</g>
+										<polyline id="Shape" fill="#2E4453" fillRule="evenodd" points="171.109251 144 168 140.675235 168.655506 139.974294 171.109251 142.598116 176.344494 137 177 137.700942"/>
+									</g>
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</svg>
+		);
 
 		return (
 			<Dialog isVisible={ this.props.showDialog } className=".notification-settings-push-notification-settings__instruction-dialog" onClose={ this.props.toggleUnblockInstructions }>
@@ -46,13 +232,15 @@ const PushNotificationSettings = React.createClass( {
 					<div>
 						<div className="notification-settings-push-notification-settings__instruction-title">{ this.translate( 'Enable Browser Notifications' ) }</div>
 						<div className="notification-settings-push-notification-settings__instruction-step">
-							{ /*eslint-disable react/no-danger*/ }
-							<div className="notification-settings-push-notification-settings__instruction-image" dangerouslySetInnerHTML={ { __html: svgAddressBar } } />
+							<div className="notification-settings-push-notification-settings__instruction-image">
+								<SvgAddressBar />
+							</div>
 							<p>{ this.translate( 'Click the lock icon in your address bar.' ) }</p>
 						</div>
 						<div className="notification-settings-push-notification-settings__instruction-step">
-							{ /*eslint-disable react/no-danger*/ }
-							<div className="notification-settings-push-notification-settings__instruction-image" dangerouslySetInnerHTML={ { __html: svgAlwaysAllow } } />
+							<div className="notification-settings-push-notification-settings__instruction-image">
+								<SvgAlwaysAllow />
+							</div>
 							<p>{ this.translate(
 								'Click {{strong}}Notifications{{/strong}} and choose {{em}}Always allow{{/em}}.', {
 									components: {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -66,9 +66,8 @@ class PlanFeaturesHeader extends Component {
 	}
 
 	getFreePlanSvg() {
-		/*eslint-disable react/no-danger*/
 		return (
-			<svg viewBox="0 0 200 200" dangerouslySetInnerHTML={ { __html: `
+			<svg viewBox="0 0 200 200">
 				<path fill="#D3DEE6" d="M133.4,7.6v98.3h-0.2c-9.1,0-16.5-7.4-16.5-16.5v0.2c0,9.1-7.4,16.5-16.5,16.5h-0.3
 					c-9.1,0-16.5-7.4-16.5-16.5v-0.2c0,9.1-7.6,16.5-16.7,16.5V7.6C29.2,21.2,2.4,57.1,2.4,99.3c0,53.9,43.7,97.6,97.6,97.6
 					c53.9,0,97.6-43.7,97.6-97.6C197.6,57.1,170.8,21.2,133.4,7.6z"/>
@@ -83,24 +82,22 @@ class PlanFeaturesHeader extends Component {
 					V3.2C111.3,2.2,105.7,1.7,100,1.7z"/>
 				<path fill="#B1C6D4" d="M83.3,89.4V3.2c-5.7,1-11.3,2.5-16.7,4.4v98.3C75.8,105.9,83.3,98.5,83.3,89.4z"/>
 				<path fill="#485567" d="M116.7,89.4c0,9.1,7.4,16.5,16.5,16.5h0.2V7.6c-5.4-1.9-10.9-3.4-16.7-4.4V89.4z"/>
-			` } } ></svg>
+			</svg>
 		);
-		/*eslint-enable react/no-danger*/
 	}
 
 	getPremiumPlanSvg() {
-		/*eslint-disable react/no-danger*/
 		return (
-			<svg viewBox="0 0 124 127.1" enableBackground="new 0 0 124 127.1" dangerouslySetInnerHTML={ { __html: `
+			<svg viewBox="0 0 124 127.1" enableBackground="new 0 0 124 127.1">
 				<circle fill="#D3DEE6" cx="62" cy="63.1" r="62"/>
 				<g>
 					<defs>
 						<circle id="SVGID_3_" cx="62" cy="63.1" r="62"/>
 					</defs>
 					<clipPath id="SVGID_4_">
-						<use xlink:href="#SVGID_3_"  overflow="visible"/>
+						<use xlinkHref="#SVGID_3_" overflow="visible"/>
 					</clipPath>
-					<g clip-path="url(#SVGID_4_)">
+					<g clipPath="url(#SVGID_4_)">
 						<path fill="#FFFFFF" d="M61.9,67.3H41l13.7,24.7c0-4,3.2-7.2,7.2-7.2h0.1c4,0,7.2,3.2,7.2,7.2L62,105.3l21-37.9H62.1H61.9z"/>
 						<polygon fill="#485567" points="54.7,92.1 62,105.3 54.7,92.1 		"/>
 						<polygon fill="#485567" points="54.7,92.1 62,105.3 69.3,92.1 		"/>
@@ -131,9 +128,9 @@ class PlanFeaturesHeader extends Component {
 						<circle id="SVGID_1_" cx="62" cy="63" r="62"/>
 					</defs>
 					<clipPath id="SVGID_5_">
-						<use xlink:href="#SVGID_1_"  overflow="visible"/>
+						<use xlinkHref="#SVGID_1_" overflow="visible"/>
 					</clipPath>
-					<g clip-path="url(#SVGID_5_)">
+					<g clipPath="url(#SVGID_5_)">
 						<path fill="none" d="M85.2,70.9c0-9.4-5.6-17.4-13.5-21.1V37.8H52.4v12.1c-8,3.7-13.5,11.7-13.5,21.1c0,4.9,1.5,9.4,4.1,13.1h0
 							c15.4,22.4,15.4,22.4,17,24.8H64c1.6-2.4,1.6-2.4,17-24.8h0C83.6,80.3,85.2,75.8,85.2,70.9z"/>
 						<path fill="#FFFFFF" d="M57.4,74.8c0-2.5,2-4.6,4.6-4.6V37.8h-9.6v12.1c-8,3.7-13.5,11.7-13.5,21.1c0,4.9,1.5,9.4,4.1,13.1h0
@@ -157,9 +154,9 @@ class PlanFeaturesHeader extends Component {
 						<circle id="SVGID_2_" cx="62" cy="63" r="62"/>
 					</defs>
 					<clipPath id="SVGID_6_">
-						<use xlink:href="#SVGID_2_"  overflow="visible"/>
+						<use xlinkHref="#SVGID_2_" overflow="visible"/>
 					</clipPath>
-					<g clip-path="url(#SVGID_6_)">
+					<g clipPath="url(#SVGID_6_)">
 						<g>
 							<path fill="none" d="M85.3-2c-0.1,0.7-0.1,1.4-0.2,2.1C85.2-0.6,85.3-1.3,85.3-2z"/>
 							<path fill="none" d="M43,35.2c-0.6-4.8-1.2-10-1.9-15.5C41.7,25.2,42.4,30.3,43,35.2z"/>
@@ -285,24 +282,22 @@ class PlanFeaturesHeader extends Component {
 							c0.1-0.9,0.2-1.9,0.3-2.8c0-0.4,0.1-0.9,0.1-1.3H62V37.2z"/>
 					</g>
 				</g>
-			` } } ></svg>
+			</svg>
 		);
-		/*eslint-enable react/no-danger*/
 	}
 
 	getBusinessPlanSvg() {
-		/*eslint-disable react/no-danger*/
 		return (
-			<svg viewBox="0 0 124 127.1" enableBackground="new 0 0 124 127.1" dangerouslySetInnerHTML={ { __html: `
+			<svg viewBox="0 0 124 127.1" enableBackground="new 0 0 124 127.1">
 				<circle fill="#D3DEE6" cx="62" cy="63.1" r="62"/>
 				<g>
 					<defs>
 						<circle id="SVGID_3_" cx="62" cy="63.1" r="62"/>
 					</defs>
 					<clipPath id="SVGID_2_">
-						<use xlink:href="#SVGID_3_"  overflow="visible"/>
+						<use xlinkHref="#SVGID_3_" overflow="visible"/>
 					</clipPath>
-					<g clip-path="url(#SVGID_2_)">
+					<g clipPath="url(#SVGID_2_)">
 						<path fill="#FFFFFF" d="M61.9,67.3H41l13.7,24.7c0-4,3.2-7.2,7.2-7.2h0.1c4,0,7.2,3.2,7.2,7.2L62,105.3l21-37.9H62.1H61.9z"/>
 						<polygon fill="#485567" points="54.7,92.1 62,105.3 54.7,92.1 		"/>
 						<polygon fill="#485567" points="54.7,92.1 62,105.3 69.3,92.1 		"/>
@@ -333,9 +328,9 @@ class PlanFeaturesHeader extends Component {
 						<circle id="SVGID_1_" cx="62" cy="63" r="62"/>
 					</defs>
 					<clipPath id="SVGID_4_">
-						<use xlink:href="#SVGID_1_"  overflow="visible"/>
+						<use xlinkHref="#SVGID_1_" overflow="visible"/>
 					</clipPath>
-					<g clip-path="url(#SVGID_4_)">
+					<g clipPath="url(#SVGID_4_)">
 						<path fill="none" d="M85.2,70.9c0-9.4-5.6-17.4-13.5-21.1V37.8H52.4v12.1c-8,3.7-13.5,11.7-13.5,21.1c0,4.9,1.5,9.4,4.1,13.1h0
 							c15.4,22.4,15.4,22.4,17,24.8H64c1.6-2.4,1.6-2.4,17-24.8h0C83.6,80.3,85.2,75.8,85.2,70.9z"/>
 						<path fill="#FFFFFF" d="M57.4,74.8c0-2.5,2-4.6,4.6-4.6V37.8h-9.6v12.1c-8,3.7-13.5,11.7-13.5,21.1c0,4.9,1.5,9.4,4.1,13.1h0
@@ -353,9 +348,8 @@ class PlanFeaturesHeader extends Component {
 						<rect x="62" y="-4.6" fill="#485567" width="0" height="44.7"/>
 					</g>
 				</g>
-			` } } ></svg>
+			</svg>
 		);
-		/*eslint-enable react/no-danger*/
 	}
 }
 

--- a/client/my-sites/plans/plan-feature/google-analytics.js
+++ b/client/my-sites/plans/plan-feature/google-analytics.js
@@ -46,9 +46,63 @@ export default function( context ) {
 	const site = sites.getSelectedSite();
 	const planSlug = ( site && site.ID ) ? getSitePlanSlug( site.ID ) : PLAN_FREE;
 
-	const svgLogo = '<svg width="84" height="84" viewBox="0 0 84 84" xmlns="http://www.w3.org/2000/svg" style="overflow: visible;"><title>icon - google analytics</title><g fill="none" fill-rule="evenodd"><rect fill-opacity=".27" fill="#C8D7E1" x="4" y="4" width="80" height="80" rx="6"/><rect fill="#FFF" width="80" height="80" rx="6"/><path d="M45.16 49.896a8 8 0 1 1-14.137 4.477l-11.036-6.117A7.966 7.966 0 0 1 15 50c-.57 0-1.124-.06-1.66-.172L0 62.71v11.293A5.997 5.997 0 0 0 5.997 80h68.006A5.997 5.997 0 0 0 80 74.003V33.75l-12.512-8.127A7.963 7.963 0 0 1 63 27c-.76 0-1.495-.106-2.19-.304l-15.65 23.2z" stroke="#F05824" stroke-width="2" fill-opacity=".62" fill="#F05824"/><path d="M39.847 47.044A7.97 7.97 0 0 0 33.707 49l-10.773-5.97A8 8 0 1 0 8.292 46.36L0 54.37V5.996A5.997 5.997 0 0 1 5.997 0h68.006A5.997 5.997 0 0 1 80 5.997v20.597l-9.168-5.954a8 8 0 1 0-14.764 2.356l-16.22 24.048z" stroke="#F79A1F" stroke-width="2" fill-opacity=".68" fill="#F79A1F"/></g></svg>';
+	const SvgLogo = () => (
+		<svg width="84" height="84" viewBox="0 0 84 84" xmlns="http://www.w3.org/2000/svg" style="overflow: visible;">
+			<title>icon - google analytics</title>
+			<g fill="none" fillRule="evenodd">
+				<rect fillOpacity=".27" fill="#C8D7E1" x="4" y="4" width="80" height="80" rx="6"/>
+				<rect fill="#FFF" width="80" height="80" rx="6"/>
+				<path d="M45.16 49.896a8 8 0 1 1-14.137 4.477l-11.036-6.117A7.966 7.966 0 0 1 15 50c-.57 0-1.124-.06-1.66-.172L0 62.71v11.293A5.997 5.997 0 0 0 5.997 80h68.006A5.997 5.997 0 0 0 80 74.003V33.75l-12.512-8.127A7.963 7.963 0 0 1 63 27c-.76 0-1.495-.106-2.19-.304l-15.65 23.2z" stroke="#F05824" strokeWidth="2" fillOpacity=".62" fill="#F05824"/><path d="M39.847 47.044A7.97 7.97 0 0 0 33.707 49l-10.773-5.97A8 8 0 1 0 8.292 46.36L0 54.37V5.996A5.997 5.997 0 0 1 5.997 0h68.006A5.997 5.997 0 0 1 80 5.997v20.597l-9.168-5.954a8 8 0 1 0-14.764 2.356l-16.22 24.048z" stroke="#F79A1F" strokeWidth="2" fillOpacity=".68" fill="#F79A1F"/>
+			</g>
+		</svg>
+	);
 
-	const svgIllustration = '<svg width="720" height="168" viewBox="0 0 720 168" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><title>figure</title><defs><path id="a" d="M0 0h720v168H0z"/><path id="c" d="M3.958 95.457l64.13 10.647 64.447-30.737 63.947 15.8 62.526-45.334 64.804-26.5 64.646 12.724 63.263 35.09 64.463-21.06L580.333.87l64.178 18.397 63.95 52.7 64.12 23.122v50.48H.48"/></defs><g fill="none" fill-rule="evenodd"><mask id="b" fill="#fff"><use xlink:href="#a"/></mask><use xlink:href="#a"/><g mask="url(#b)"><g transform="translate(-24 -22)"><g transform="translate(0 61)"><mask id="d" fill="#fff"><use xlink:href="#c"/></mask><use xlink:href="#c"/><g mask="url(#d)" fill-opacity=".05" fill="#44B963"><path d="M20 98h31v39H20zM84-31h31v177H84zM142-31h31v177h-31zM200-31h31v177h-31zM258-31h31v177h-31zM316-31h31v177h-31zM374-31h31v177h-31zM432-31h31v177h-31zM490-31h31v177h-31zM548-31h31v177h-31zM606-31h31v177h-31zM664-31h31v177h-31zM724-31h31v177h-31z"/></g></g><path d="M4.958 159.457l64.13 10.647 64.447-30.737 63.947 15.8 62.526-45.334 64.804-26.5 64.646 12.724 63.263 35.09 64.463-21.06 64.15-45.218 64.178 18.397 63.95 52.7 64.12 23.122" stroke-opacity=".12" stroke="#44B963" stroke-width="4"/><path d="M3.958 156.457l64.13 10.647 64.447-30.737 63.947 15.8 62.526-45.334 64.804-26.5 64.646 12.724 63.263 35.09 64.463-21.06 64.15-45.218 64.178 18.397 63.95 52.7 64.12 23.122v50.48H.48" stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill-opacity=".05" fill="#44B963"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="68" cy="167" r="4"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="132" cy="137" r="4"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="196" cy="152" r="4"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="259" cy="107" r="4"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="324" cy="80" r="4"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="388" cy="93" r="4"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="452" cy="128" r="4"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="516" cy="107" r="4"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="580" cy="62" r="4"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="644" cy="80" r="4"/><circle stroke-opacity=".62" stroke="#44B963" stroke-width="2" fill="#FFF" cx="708" cy="133" r="4"/></g><path d="M541 6.005c0-1.107.888-2.005 2-2.005h35c1.104 0 2 .897 2 2.005v19.99A1.997 1.997 0 0 1 578 28h-13.657l-4.053 3-4.018-3h-13.275A2 2 0 0 1 541 25.995V6.005z" fill-opacity=".27" fill="#C8D7E1"/><path d="M537 2.005C537 .898 537.888 0 539 0h35c1.104 0 2 .897 2 2.005v19.99A1.997 1.997 0 0 1 574 24h-13.657l-4.053 3-4.018-3h-13.275A2 2 0 0 1 537 21.995V2.005z" stroke="#C8D7E1" fill="#FFF"/><text font-family="AppleColorEmoji, Apple Color Emoji" font-size="14" fill="#000" transform="translate(537)"><tspan x="12" y="17">🎉</tspan></text></g></g></svg>';
+	const SvgIllustration = () => (
+		<svg width="720" height="168" viewBox="0 0 720 168" xmlns="http://www.w3.org/2000/svg">
+			<title>figure</title>
+			<defs>
+				<path id="a" d="M0 0h720v168H0z"/>
+				<path id="c" d="M3.958 95.457l64.13 10.647 64.447-30.737 63.947 15.8 62.526-45.334 64.804-26.5 64.646 12.724 63.263 35.09 64.463-21.06L580.333.87l64.178 18.397 63.95 52.7 64.12 23.122v50.48H.48"/>
+			</defs>
+			<g fill="none" fillRule="evenodd">
+				<mask id="b" fill="#fff">
+					<use xlinkHref="#a"/>
+				</mask>
+				<use xlinkHref="#a"/>
+				<g mask="url(#b)">
+					<g transform="translate(-24 -22)">
+						<g transform="translate(0 61)">
+							<mask id="d" fill="#fff">
+								<use xlinkHref="#c"/>
+							</mask>
+							<use xlinkHref="#c"/>
+							<g mask="url(#d)" fillOpacity=".05" fill="#44B963">
+								<path d="M20 98h31v39H20zM84-31h31v177H84zM142-31h31v177h-31zM200-31h31v177h-31zM258-31h31v177h-31zM316-31h31v177h-31zM374-31h31v177h-31zM432-31h31v177h-31zM490-31h31v177h-31zM548-31h31v177h-31zM606-31h31v177h-31zM664-31h31v177h-31zM724-31h31v177h-31z"/>
+							</g>
+						</g>
+						<path d="M4.958 159.457l64.13 10.647 64.447-30.737 63.947 15.8 62.526-45.334 64.804-26.5 64.646 12.724 63.263 35.09 64.463-21.06 64.15-45.218 64.178 18.397 63.95 52.7 64.12 23.122" strokeOpacity=".12" stroke="#44B963" strokeWidth="4"/>
+						<path d="M3.958 156.457l64.13 10.647 64.447-30.737 63.947 15.8 62.526-45.334 64.804-26.5 64.646 12.724 63.263 35.09 64.463-21.06 64.15-45.218 64.178 18.397 63.95 52.7 64.12 23.122v50.48H.48" strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fillOpacity=".05" fill="#44B963"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="68" cy="167" r="4"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="132" cy="137" r="4"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="196" cy="152" r="4"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="259" cy="107" r="4"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="324" cy="80" r="4"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="388" cy="93" r="4"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="452" cy="128" r="4"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="516" cy="107" r="4"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="580" cy="62" r="4"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="644" cy="80" r="4"/>
+						<circle strokeOpacity=".62" stroke="#44B963" strokeWidth="2" fill="#FFF" cx="708" cy="133" r="4"/>
+					</g>
+					<path d="M541 6.005c0-1.107.888-2.005 2-2.005h35c1.104 0 2 .897 2 2.005v19.99A1.997 1.997 0 0 1 578 28h-13.657l-4.053 3-4.018-3h-13.275A2 2 0 0 1 541 25.995V6.005z" fillOpacity=".27" fill="#C8D7E1"/>
+					<path d="M537 2.005C537 .898 537.888 0 539 0h35c1.104 0 2 .897 2 2.005v19.99A1.997 1.997 0 0 1 574 24h-13.657l-4.053 3-4.018-3h-13.275A2 2 0 0 1 537 21.995V2.005z" stroke="#C8D7E1" fill="#FFF"/>
+					<text fontFamily="AppleColorEmoji, Apple Color Emoji" fontSize="14" fill="#000" transform="translate(537)">
+						<tspan x="12" y="17">🎉</tspan>
+					</text>
+				</g>
+			</g>
+		</svg>
+	);
 
 	function goBack() {
 		const fallback = '/plans/' + ( context.params.domain || '' );
@@ -123,14 +177,16 @@ export default function( context ) {
 		<Main>
 			<HeaderCake onClick={ goBack }>{ i18n.translate( 'Google Analytics' ) }</HeaderCake>
 			<Card compact>
-				{ /*eslint-disable react/no-danger*/ }
-				<div className="plan-feature__logo" dangerouslySetInnerHTML={ { __html: svgLogo } } />
+				<div className="plan-feature__logo">
+					<SvgLogo />
+				</div>
 				<h1 className="plan-feature__title">{ i18n.translate( 'Use Google Analytics with Business' ) }</h1>
-				{ /*eslint-disable react/no-danger*/ }
 				<span className="plan-feature__description">
 					{ i18n.translate( 'Upgrade to Business to use your own Google Analytics, get a custom domain, and much more.' ) }
 				</span>
-				<div className="plan-feature__ilustration" dangerouslySetInnerHTML={ { __html: svgIllustration } } />
+				<div className="plan-feature__ilustration">
+					<SvgIllustration />
+				</div>
 			</Card>
 			{ comparisonCard }
 			<PlanFeatureFooter />


### PR DESCRIPTION
**If I @mentioned you, please take a minute to verify that the SVG(s) next to your GitHub username still look(s) as before with this PR (if you don't know which one(s) I mean, check the diff), and tick the corresponding box!**

React 15 [enables all SVG attributes](https://facebook.github.io/react/blog/2016/04/07/react-v15.html#improved-svg-support). This allows us to get rid of some instances of `__dangerouslySetInnerHTML`, which is what this PR does. Note that as with all things React, SVG elements and attributes are `camelCased`.

SVGs to test:
- [x] Spinner component (http://calypso.localhost:3000/devdocs/design/spinner) @ockham
- [x] "Enable Browser Notifications" instructive SVGs (http://calypso.localhost:3000/me/notifications) @jonathansadowski @jblz
- [x] Plan Features Header @gwwar @rralian 
- [x] Google Analytics Plan Feature @gwwar @rralian 
