### PR TITLE
Reader: basics for recommendations/posts stream

### DIFF
--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -140,6 +140,19 @@ function getStoreForFeatured( storeId ) {
 	} );
 }
 
+function getStoreForWarmstart( storeId ) {
+	var fetcher = function( query, callback ) {
+			wpcomUndoc.readWarmstart( query, callback );
+		};
+
+	return new PagedStream( {
+		id: storeId,
+		fetcher: fetcher,
+		keyMaker: siteKeyMaker,
+		perPage: 5
+	} );
+}
+
 function feedStoreFactory( storeId ) {
 	var store = FeedStreamCache.get( storeId );
 
@@ -170,6 +183,8 @@ function feedStoreFactory( storeId ) {
 			onUpdateFetch: limitSiteParamsForLikes,
 			dateProperty: 'date_liked'
 		} );
+	} else if ( storeId.indexOf( 'warmstart' ) === 0 ) {
+		store = getStoreForWarmstart( storeId );
 	} else if ( storeId.indexOf( 'feed:' ) === 0 ) {
 		store = getStoreForFeed( storeId );
 	} else if ( storeId.indexOf( 'tag:' ) === 0 ) {

--- a/client/lib/feed-stream-store/index.js
+++ b/client/lib/feed-stream-store/index.js
@@ -140,9 +140,9 @@ function getStoreForFeatured( storeId ) {
 	} );
 }
 
-function getStoreForWarmstart( storeId ) {
+function getStoreForRecommendedPosts( storeId ) {
 	var fetcher = function( query, callback ) {
-			wpcomUndoc.readWarmstart( query, callback );
+			wpcomUndoc.readRecommendedPosts( query, callback );
 		};
 
 	return new PagedStream( {
@@ -183,8 +183,8 @@ function feedStoreFactory( storeId ) {
 			onUpdateFetch: limitSiteParamsForLikes,
 			dateProperty: 'date_liked'
 		} );
-	} else if ( storeId.indexOf( 'warmstart' ) === 0 ) {
-		store = getStoreForWarmstart( storeId );
+	} else if ( storeId === 'recommendations_posts' ) {
+		store = getStoreForRecommendedPosts( storeId );
 	} else if ( storeId.indexOf( 'feed:' ) === 0 ) {
 		store = getStoreForFeed( storeId );
 	} else if ( storeId.indexOf( 'tag:' ) === 0 ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -979,6 +979,12 @@ Undocumented.prototype.readTagPosts = function( query, fn ) {
 	this.wpcom.req.get( '/read/tags/' + encodeURIComponent( query.tag ) + '/posts', params, fn );
 };
 
+Undocumented.prototype.readWarmstart = function( query, fn ) {
+	debug( '/read/warmstart' );
+	query.apiVersion = '1.2';
+	this.wpcom.req.get( '/read/recommendations/warm-start', query, fn );
+};
+
 Undocumented.prototype.followReaderTag = function( tag, fn ) {
 	debug( '/read/tags/' + tag + '/mine/new' );
 	this.wpcom.req.post( '/read/tags/' + tag + '/mine/new', fn );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -979,8 +979,8 @@ Undocumented.prototype.readTagPosts = function( query, fn ) {
 	this.wpcom.req.get( '/read/tags/' + encodeURIComponent( query.tag ) + '/posts', params, fn );
 };
 
-Undocumented.prototype.readWarmstart = function( query, fn ) {
-	debug( '/read/warmstart' );
+Undocumented.prototype.readRecommendedPosts = function( query, fn ) {
+	debug( '/recommendations/posts' );
 	query.apiVersion = '1.2';
 	this.wpcom.req.get( '/read/recommendations/warm-start', query, fn );
 };

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -49,3 +49,7 @@ export function trackUpdatesLoaded( key ) {
 export function setPageTitle( title ) {
 	titleActions.setTitle( i18n.translate( '%s ‹ Reader', { args: title } ) );
 }
+
+export function userHasHistory( context ) {
+	return !! context.lastRoute;
+}

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -50,5 +50,7 @@ module.exports = function() {
 		page.exit( '/read/blogs/:blog/posts/:post', controller.resetTitle );
 	}
 
+	// Automattic Employee Posts
 	page( '/read/a8c', controller.updateLastRoute, controller.removePost, controller.sidebar, forceTeamA8C, controller.readA8C );
+
 };

--- a/client/reader/recommendations/controller.js
+++ b/client/reader/recommendations/controller.js
@@ -10,15 +10,11 @@ import ReactDom from 'react-dom';
 import trackScrollPage from 'lib/track-scroll-page';
 import titleActions from 'lib/screen-title/actions';
 import i18n from 'lib/mixins/i18n';
-import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, setPageTitle } from 'reader/controller-helper';
+import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, setPageTitle, userHasHistory } from 'reader/controller-helper';
 import route from 'lib/route';
 import feedStreamFactory from 'lib/feed-stream-store';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
-
-function userHasHistory( context ) {
-	return !! context.lastRoute;
-}
 
 export default {
 	recommendedForYou() {

--- a/client/reader/recommendations/controller.js
+++ b/client/reader/recommendations/controller.js
@@ -10,9 +10,15 @@ import ReactDom from 'react-dom';
 import trackScrollPage from 'lib/track-scroll-page';
 import titleActions from 'lib/screen-title/actions';
 import i18n from 'lib/mixins/i18n';
-import { trackPageLoad } from 'reader/controller-helper';
+import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, setPageTitle } from 'reader/controller-helper';
+import route from 'lib/route';
+import feedStreamFactory from 'lib/feed-stream-store';
 
 const ANALYTICS_PAGE_TITLE = 'Reader';
+
+function userHasHistory( context ) {
+	return !! context.lastRoute;
+}
 
 export default {
 	recommendedForYou() {
@@ -36,5 +42,36 @@ export default {
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 		titleActions.setTitle( i18n.translate( 'Recommended Sites For You ‹ Reader' ) );
+	},
+
+	// Post Recommendations - Used by the Data team to test recommendation algorithms
+	recommendedPosts( context ) {
+		var WarmstartStream = require( 'reader/recommendations/posts' ),
+			basePath = route.sectionify( context.path ),
+			fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Warmstart',
+			warmstartPostsStore = feedStreamFactory( 'warmstart' ),
+			mcKey = 'warmstart';
+
+		ensureStoreLoading( warmstartPostsStore, context );
+
+		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+
+		ReactDom.render(
+			React.createElement( WarmstartStream, {
+				key: 'warmstart',
+				store: warmstartPostsStore,
+				setPageTitle: setPageTitle,
+				trackScrollPage: trackScrollPage.bind(
+					null,
+					basePath,
+					fullAnalyticsPageTitle,
+					ANALYTICS_PAGE_TITLE,
+					mcKey
+				),
+				onUpdatesShown: trackUpdatesLoaded.bind( null, mcKey ),
+				showBack: userHasHistory( context )
+			} ),
+			document.getElementById( 'primary' )
+		);
 	}
 };

--- a/client/reader/recommendations/controller.js
+++ b/client/reader/recommendations/controller.js
@@ -46,20 +46,20 @@ export default {
 
 	// Post Recommendations - Used by the Data team to test recommendation algorithms
 	recommendedPosts( context ) {
-		var WarmstartStream = require( 'reader/recommendations/posts' ),
+		var RecommendedPostsStream = require( 'reader/recommendations/posts' ),
 			basePath = route.sectionify( context.path ),
-			fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Warmstart',
-			warmstartPostsStore = feedStreamFactory( 'warmstart' ),
-			mcKey = 'warmstart';
+			fullAnalyticsPageTitle = ANALYTICS_PAGE_TITLE + ' > Recommended Posts',
+			RecommendedPostsStore = feedStreamFactory( 'recommendations_posts' ),
+			mcKey = 'recommendations_posts';
 
-		ensureStoreLoading( warmstartPostsStore, context );
+		ensureStoreLoading( RecommendedPostsStore, context );
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
 		ReactDom.render(
-			React.createElement( WarmstartStream, {
-				key: 'warmstart',
-				store: warmstartPostsStore,
+			React.createElement( RecommendedPostsStream, {
+				key: 'recommendations_posts',
+				store: RecommendedPostsStore,
 				setPageTitle: setPageTitle,
 				trackScrollPage: trackScrollPage.bind(
 					null,

--- a/client/reader/recommendations/index.js
+++ b/client/reader/recommendations/index.js
@@ -9,7 +9,10 @@ import page from 'page';
 import controller from './controller';
 import readerController from 'reader/controller';
 
-export default function() {
+var config = require( 'config' );
+
+module.exports = function() {
+	// Blog Recommendations
 	page( '/recommendations',
 		readerController.loadSubscriptions,
 		readerController.initAbTests,
@@ -18,4 +21,14 @@ export default function() {
 		readerController.sidebar,
 		controller.recommendedForYou
 	);
+
+	// Post Recommendations - Used by the Data team to test recommendation algorithms
+	if ( config.isEnabled( 'reader/recommendations/posts' ) ) {
+		page( '/recommendations/posts',
+			readerController.loadSubscriptions,
+			readerController.updateLastRoute,
+			readerController.removePost,
+			readerController.sidebar,
+			controller.recommendedPosts );
+	}
 }

--- a/client/reader/recommendations/navigation/index.jsx
+++ b/client/reader/recommendations/navigation/index.jsx
@@ -10,6 +10,7 @@ const RecommendedNavigation = React.createClass( {
 		const current = this.props.selected;
 		const sectionNames = {
 			'for-you': this.translate( 'Recommendations: For You' ),
+			posts: this.translate( 'Recommendations: Posts' ),
 			sites: this.translate( 'Recommendations: Sites' ),
 			tags: this.translate( 'Recommendations: Tags' )
 		};
@@ -18,6 +19,7 @@ const RecommendedNavigation = React.createClass( {
 			<SectionNav selectedText={ sectionNames[ current ]}>
 				<NavTabs>
 					<NavItem path="/recommendations/mine" selected={current === 'for-you'}>{ this.translate( 'For You' )}</NavItem>
+					<NavItem path="/recommendations/posts" selected={current === 'posts'}>{ this.translate( 'Posts' )}</NavItem>
 					<NavItem path="/recommendations" selected={current === 'sites'}>{ this.translate( 'Topics' )}</NavItem>
 					<NavItem path="/tags" selected={current === 'tags'}>{ this.translate( 'Tags' )}</NavItem>
 				</NavTabs>

--- a/client/reader/recommendations/posts/README.md
+++ b/client/reader/recommendations/posts/README.md
@@ -1,0 +1,7 @@
+# Reader Recommended Posts Stream
+
+A stream of posts recommended using your like and comment interactions on WordPress.com
+
+## Props
+
+See `reader/following-stream` for more props

--- a/client/reader/recommendations/posts/empty.jsx
+++ b/client/reader/recommendations/posts/empty.jsx
@@ -1,0 +1,46 @@
+var React = require( 'react' );
+
+var EmptyContent = require( 'components/empty-content' ),
+	stats = require( 'reader/stats' ),
+	discoverHelper = require( 'reader/discover/helper' );
+
+var RecommendedPostsEmptyContent = React.createClass( {
+	shouldComponentUpdate: function() {
+		return false;
+	},
+
+	recordAction: function() {
+		stats.recordAction( 'clicked_following_on_empty_recommended_posts' );
+		stats.recordGaEvent( 'Clicked Following on Empty Recommended Posts Stream' );
+		stats.recordTrack( 'calypso_reader_following_on_empty_Posts_stream_clicked' );
+	},
+
+	recordSecondaryAction: function() {
+		stats.recordAction( 'clicked_discover_on_empty_recommended_posts' );
+		stats.recordGaEvent( 'Clicked Discover on Empty Recommended Posts Stream' );
+		stats.recordTrack( 'calypso_reader_discover_on_empty_Posts_stream_clicked' );
+	},
+
+	render: function() {
+		var action = ( <a
+			className="empty-content__action button is-primary"
+			onClick={ this.recordAction }
+			href="/">{ this.translate( 'Back to Following' ) }</a> ),
+			secondaryAction = discoverHelper.isEnabled()
+			? ( <a
+				className="empty-content__action button"
+				onClick={ this.recordSecondaryAction }
+				href="/discover">{ this.translate( 'Explore Discover' ) }</a> ) : null;
+
+		return ( <EmptyContent
+			title={ this.translate( 'No Post Recommendations yet' ) }
+			line={ this.translate( 'Posts we recommend based on your WordPress.com activity will appear here.' ) }
+			action={ action }
+			secondaryAction={ secondaryAction }
+			illustration={ '/calypso/images/drake/drake-empty-results.svg' }
+			illustrationWidth={ 500 }
+			/> );
+	}
+} );
+
+module.exports = RecommendedPostsEmptyContent;

--- a/client/reader/recommendations/posts/index.jsx
+++ b/client/reader/recommendations/posts/index.jsx
@@ -1,0 +1,26 @@
+var React = require( 'react' );
+
+var FollowingStream = require( 'reader/following-stream' ),
+	EmptyContent = require( './empty' );
+
+var RecommendationPostsStream = React.createClass( {
+
+	render: function() {
+		var title = this.translate( 'Recommended Posts' ),
+			emptyContent = ( <EmptyContent /> );
+
+		if ( this.props.setPageTitle ) {
+			this.props.setPageTitle( title );
+		}
+		return (
+			<FollowingStream { ...this.props }
+				listName = { title }
+				emptyContent = { emptyContent }
+				showFollowInHeader = { true }
+			/>
+		);
+	}
+
+} );
+
+module.exports = RecommendationPostsStream;

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -171,6 +171,19 @@ const ReaderSidebar = React.createClass( {
 						<ReaderSidebarTeams teams={ this.state.teams } path={ this.props.path } />
 
 						{
+							// Post Recommendations - Used by the Data team to test recommendation algorithms
+							config.isEnabled( 'reader/recommendations/posts' ) &&
+							(
+								<li className={ ReaderSidebarHelper.itemLinkClass( '/recommendations/posts', this.props.path, { 'sidebar-streams__post-recommendations': true } ) }>
+									<a href="/recommendations/posts">
+										<Gridicon icon="star" size={ 24 } />
+										<span className="menu-link-text">{ this.translate( 'Recommended Posts (Alpha)' ) }</span>
+									</a>
+								</li>
+							)
+						}
+
+						{
 							discoverHelper.isEnabled()
 							? (
 									<li className={ ReaderSidebarHelper.itemLinkClass( '/discover', this.props.path, { 'sidebar-streams__discover': true } ) }>
@@ -193,7 +206,7 @@ const ReaderSidebar = React.createClass( {
 							)
 						}
 
-						<li className={ ReaderSidebarHelper.itemLinkClassStartsWithOneOf( [ '/recommendations', '/tags' ], this.props.path, { 'sidebar-streams__recommendations': true } ) }>
+						<li className={ ReaderSidebarHelper.itemLinkClass( '/recommendations', this.props.path, { 'sidebar-streams__recommendations': true } ) }>
 							<a href="/recommendations">
 								<Gridicon icon="thumbs-up" size={ 24 } />
 								<span className="menu-link-text">{ this.translate( 'Recommendations' ) }</span>

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -63,6 +63,9 @@ function getLocation() {
 	if ( path.indexOf( '/discover' ) === 0 ) {
 		return 'discover';
 	}
+	if ( path.indexOf( '/read/recommendations/posts' ) === 0 ) {
+		return 'recommended_posts';
+	}
 	return 'unknown';
 }
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -214,15 +214,15 @@ if ( config.isEnabled( 'reader' ) ) {
 	} );
 
 	sections.push( {
-		name: 'reader-recomendations',
-		paths: [ '/recommendations' ],
+		name: 'reader-post-recomendations',
+		paths: [ '/recommendations/posts' ],
 		module: 'reader/recommendations',
 		secondary: true,
 		group: 'reader'
 	} );
 
 	sections.push( {
-		name: 'reader-post-recomendations',
+		name: 'reader-recomendations',
 		paths: [ '/recommendations' ],
 		module: 'reader/recommendations',
 		secondary: true,

--- a/client/sections.js
+++ b/client/sections.js
@@ -222,6 +222,14 @@ if ( config.isEnabled( 'reader' ) ) {
 	} );
 
 	sections.push( {
+		name: 'reader-post-recomendations',
+		paths: [ '/recommendations' ],
+		module: 'reader/recommendations',
+		secondary: true,
+		group: 'reader'
+	} );
+
+	sections.push( {
 		name: 'discover',
 		paths: [ '/discover' ],
 		module: 'reader/discover',

--- a/config/development.json
+++ b/config/development.json
@@ -102,6 +102,7 @@
 		"reader/list-management": true,
 		"reader/search": true,
 		"reader/start": true,
+		"reader/recommendations/posts": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -69,6 +69,7 @@
 		"press-this": true,
 		"reader": true,
 		"reader/full-errors": true,
+		"reader/recommendations/posts": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -80,6 +80,7 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/search": true,
+		"reader/recommendations/posts": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,


### PR DESCRIPTION
A basic page to view streams of recommended posts for testing the Data team's Cold-start and Warm-start algorithms. These algorithms are used to populate the Reader with posts that take into account a user's interactions with WordPress.com.

- Cold-start algorithms = recommend posts for new users (using no information about user interactions (likes/comments/posts) with WordPress.com)
- Warm-start algorithms = recommend posts using user interactions (likes/comments/posts) with WordPress.com