### PR TITLE
Plans: Fix bug for grandfathered sites 

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -7,6 +7,7 @@ import moment from 'moment';
 import get from 'lodash/get';
 import includes from 'lodash/includes';
 import invoke from 'lodash/invoke';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -17,10 +18,19 @@ import {
 	isFreeJetpackPlan,
 	isJetpackPlan
 } from 'lib/products-values';
-import { featuresList, plansList } from './constants';
-import { PLAN_FREE } from 'lib/plans/constants';
+import {
+	featuresList,
+	plansList,
+	PLAN_FREE
+} from 'lib/plans/constants';
+import { createSitePlanObject } from 'state/sites/plans/assembler';
 import SitesList from 'lib/sites-list';
+
+/**
+ * Module vars
+ */
 const sitesList = SitesList();
+const debug = debugFactory( 'calypso:plans' );
 
 export function getPlan( plan ) {
 	return plansList[ plan ];
@@ -67,7 +77,18 @@ export function addCurrentPlanToCartAndRedirect( sitePlans, selectedSite ) {
 }
 
 export function getCurrentPlan( plans ) {
-	return find( plans, { currentPlan: true } );
+	const currentPlan = find( plans, { currentPlan: true } );
+
+	if ( currentPlan ) {
+		debug( 'current plan: %o', currentPlan );
+		return currentPlan;
+	}
+
+	// get Site plan from the `site` data
+	const site = sitesList.getSelectedSite();
+	const plan = createSitePlanObject( site.plan );
+	debug( 'current plan: %o', plan );
+	return plan;
 }
 
 export function getCurrentTrialPeriodInDays( plan ) {

--- a/client/state/sites/plans/actions.js
+++ b/client/state/sites/plans/actions.js
@@ -62,7 +62,7 @@ export function cancelSitePlanTrial( siteId, planId ) {
 				}
 			} );
 		} );
-	}
+	};
 }
 
 /**
@@ -110,7 +110,7 @@ export function fetchSitePlans( siteId ) {
 				resolve();
 			} );
 		} );
-	}
+	};
 }
 
 /**
@@ -141,5 +141,5 @@ export function refreshSitePlans( siteId ) {
 	return ( dispatch ) => {
 		dispatch( clearSitePlans( siteId ) );
 		dispatch( fetchSitePlans( siteId ) );
-	}
+	};
 }

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -28,4 +28,4 @@ const createSitePlanObject = ( plan ) => {
 
 export default {
 	createSitePlanObject
-}
+};

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -2,11 +2,20 @@
  * External dependencies
  */
 import find from 'lodash/find';
+import get from 'lodash/get';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import { initialSiteState } from './reducer';
+import { getSite } from 'state/sites/selectors';
+import { createSitePlanObject } from './assembler';
+
+/**
+ * Module dependencies
+ */
+const debug = debugFactory( 'calypso:state:sites:plans:selectors' );
 
 export function getPlansBySite( state, site ) {
 	if ( ! site ) {
@@ -22,13 +31,31 @@ export function getPlansBySiteId( state, siteId ) {
 	return state.sites.plans[ siteId ] || initialSiteState;
 }
 
-export function hasDomainCredit( state, siteId ) {
+export const getCurrentPlan = ( state, siteId ) => {
 	const plans = getPlansBySiteId( state, siteId );
 	if ( plans.data ) {
 		const currentPlan = find( plans.data, 'currentPlan' );
-		return currentPlan.hasDomainCredit;
+
+		if ( currentPlan ) {
+			debug( 'current plan: %o', currentPlan );
+			return currentPlan;
+		}
+
+		const site = getSite( state, siteId );
+		const plan = createSitePlanObject( site.plan );
+		debug( 'current plan: %o', plan );
+		return plan;
 	}
+
 	return null;
+};
+
+export function hasDomainCredit( state, siteId ) {
+	if ( ! siteId ) {
+		return initialSiteState;
+	}
+	const currentPlan = getCurrentPlan( state, siteId );
+	return get( currentPlan, 'hasDomainCredit', null );
 }
 
 export function isRequestingSitePlans( state, siteId ) {


### PR DESCRIPTION
Some grandfathered sites belong to `Enterprise` plan and we aren't handling this case rightly. It produces a bug in calypso and breaks the whole application.

![image](https://cloud.githubusercontent.com/assets/77539/14970413/0b398cb0-109f-11e6-9b5a-3e4366274069.png)

The user can't change the page clicking in the sidebar or whatever.

When the site doesn't have defined its current plan from its plans list then get the current plan from its properties (`site.plan`).