### PR TITLE
Settings: add delete site tracking

### DIFF
--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -12,6 +12,13 @@ import DeleteSiteWarningDialog from 'my-sites/site-settings/delete-site-warning-
 import PurchasesStore from 'lib/purchases/store';
 import notices from 'notices';
 import config from 'config';
+import { tracks } from 'lib/analytics';
+
+const trackDeleteSiteOption = ( option ) => {
+	tracks.recordEvent( 'calypso_settings_delete_site_options', {
+		option: option
+	} );
+};
 
 module.exports = React.createClass( {
 	displayName: 'DeleteSite',
@@ -40,7 +47,7 @@ module.exports = React.createClass( {
 		const changeAddressLink = `/domains/manage/${selectedSite.slug}`;
 		const startOverLink = `/settings/start-over/${selectedSite.slug}`;
 		const deleteSiteLink = `/settings/delete-site/${selectedSite.slug}`;
-		const changeAddressLinkText = this.translate( 'Register a new domain or change your site\'s address.' );
+		let changeAddressLinkText = this.translate( 'Register a new domain or change your site\'s address.' );
 		const strings = {
 			changeSiteAddress: this.translate( 'Change Site Address' ),
 			startOver: this.translate( 'Start Over' ),
@@ -103,7 +110,16 @@ module.exports = React.createClass( {
 		);
 	},
 
+	trackChangeAddress() {
+		trackDeleteSiteOption( 'change-address' );
+	},
+
+	trackStartOver() {
+		trackDeleteSiteOption( 'start-over' );
+	},
+
 	checkForSubscriptions( event ) {
+		trackDeleteSiteOption( 'delete-site' );
 		const activeSubscriptions = filter( this.props.purchases.data, 'active' );
 
 		if ( ! activeSubscriptions.length ) {

--- a/client/my-sites/site-settings/delete-site-options/index.jsx
+++ b/client/my-sites/site-settings/delete-site-options/index.jsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	filter = require( 'lodash/filter' );
+import React from 'react';
+import filter from 'lodash/filter';
 
 /**
  * Internal dependencies
  */
-var CompactCard = require( 'components/card/compact' ),
-	DeleteSiteWarningDialog = require( 'my-sites/site-settings/delete-site-warning-dialog' ),
-	PurchasesStore = require( 'lib/purchases/store' ),
-	notices = require( 'notices' ),
-	config = require( 'config' );
+import CompactCard from 'components/card/compact';
+import DeleteSiteWarningDialog from 'my-sites/site-settings/delete-site-warning-dialog';
+import PurchasesStore from 'lib/purchases/store';
+import notices from 'notices';
+import config from 'config';
 
 module.exports = React.createClass( {
 	displayName: 'DeleteSite',
@@ -21,7 +21,7 @@ module.exports = React.createClass( {
 		site: React.PropTypes.object.isRequired
 	},
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			showDialog: false,
 			showStartOverDialog: false,
@@ -29,21 +29,19 @@ module.exports = React.createClass( {
 		};
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentWillReceiveProps( nextProps ) {
 		if ( nextProps.purchases.error ) {
 			notices.error( nextProps.purchases.error );
 		}
 	},
 
-	render: function() {
-		var selectedSite = this.props.site,
-			changeAddressLink = '/domains/manage/' + selectedSite.slug,
-			startOverLink = '/settings/start-over/' + selectedSite.slug,
-			deleteSiteLink = '/settings/delete-site/' + selectedSite.slug,
-			changeAddressLinkText = this.translate( 'Register a new domain or change your site\'s address.' ),
-			strings;
-
-		strings = {
+	render() {
+		const selectedSite = this.props.site;
+		const changeAddressLink = `/domains/manage/${selectedSite.slug}`;
+		const startOverLink = `/settings/start-over/${selectedSite.slug}`;
+		const deleteSiteLink = `/settings/delete-site/${selectedSite.slug}`;
+		const changeAddressLinkText = this.translate( 'Register a new domain or change your site\'s address.' );
+		const strings = {
 			changeSiteAddress: this.translate( 'Change Site Address' ),
 			startOver: this.translate( 'Start Over' ),
 			deleteSite: this.translate( 'Delete Site' )
@@ -59,7 +57,10 @@ module.exports = React.createClass( {
 
 		return (
 			<div className="delete-site-options">
-				<CompactCard href={ changeAddressLink } className="delete-site-options__link">
+				<CompactCard
+					href={ changeAddressLink }
+					onClick={ this.trackChangeAddress }
+					className="delete-site-options__link">
 					<div className="delete-site-options__content">
 						<h2 className="delete-site-options__section-title">{ strings.changeSiteAddress }</h2>
 						<p className="delete-site-options__section-desc">{ changeAddressLinkText }</p>
@@ -70,13 +71,19 @@ module.exports = React.createClass( {
 						} ) }</p>
 					</div>
 				</CompactCard>
-				<CompactCard href={ startOverLink } className="delete-site-options__link">
+				<CompactCard
+					href={ startOverLink }
+					onClick={ this.trackStartOver }
+					className="delete-site-options__link">
 					<div className="delete-site-options__content">
 						<h2 className="delete-site-options__section-title">{ strings.startOver }</h2>
 						<p className="delete-site-options__section-desc">{ this.translate( 'Keep your URL and site active, but remove the content.' ) }</p>
 					</div>
 				</CompactCard>
-				<CompactCard href={ deleteSiteLink } onClick={ this.checkForSubscriptions } className="delete-site-options__link">
+				<CompactCard
+					href={ deleteSiteLink }
+					onClick={ this.checkForSubscriptions }
+					className="delete-site-options__link">
 					<div className="delete-site-options__content">
 						<h2 className="delete-site-options__section-title">{ strings.deleteSite }</h2>
 						<p className="delete-site-options__section-desc">{ this.translate( 'All your posts, images, data, and this site\'s address ({{siteAddress /}}) will be gone forever.', {
@@ -96,8 +103,8 @@ module.exports = React.createClass( {
 		);
 	},
 
-	checkForSubscriptions: function( event ) {
-		var activeSubscriptions = filter( this.props.purchases.data, 'active' );
+	checkForSubscriptions( event ) {
+		const activeSubscriptions = filter( this.props.purchases.data, 'active' );
 
 		if ( ! activeSubscriptions.length ) {
 			return true;
@@ -107,7 +114,7 @@ module.exports = React.createClass( {
 		this.setState( { showDialog: true } );
 	},
 
-	closeDialog: function() {
+	closeDialog() {
 		this.setState( { showDialog: false } );
 	}
 } );


### PR DESCRIPTION
This adds some tracking to the delete site options in the general settings page. I promised to do this a while ago, finally getting to it. This should not result in any functional changes... just tracking the clicks on the three common reasons for requesting to delete a site.

![delete site options](https://cloudup.com/c8wQzA0YYNn+)

## Testing
1. Go to http://calypso.localhost:3000/
2. In your browser's console, type `localStorage.setItem( 'debug', 'calypso:analytics' );`
3. Type this into the address bar http://calypso.localhost:3000/settings/general
4. Select a site.
5. Click any of the three items at the bottom of the page.
6. You should see an event is triggered with the name `calypso_settings_delete_site_options`. It will have  an `option` node with one of three values: `change-address`, `start-over` and `delete-site`.

/cc @dbspringer 