### PR TITLE
Jetpack Connect: Back button

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -26,6 +26,7 @@ import JetpackInstallStep from './install-step';
 import versionCompare from 'lib/version-compare';
 import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
+import Gridicon from 'components/gridicon';
 
 /**
  * Constants
@@ -168,6 +169,10 @@ const JetpackConnectMain = React.createClass( {
 		return false;
 	},
 
+	clearUrl() {
+		this.dismissUrl();
+	},
+
 	renderFooter() {
 		return (
 			<LoggedOutFormLinks>
@@ -243,9 +248,21 @@ const JetpackConnectMain = React.createClass( {
 							text={ this.translate( 'Once the plugin is activated you\'ll click this green \'Connect\' button to complete the connection.' ) }
 							example={ <JetpackExampleConnect url={ this.state.currentUrl } /> } />
 					</div>
+					{ this.renderBackButton() }
 					<Button onClick={ this.installJetpack } primary>{ this.translate( 'Install Jetpack' ) }</Button>
 				</div>
 			</Main>
+		);
+	},
+
+	renderBackButton() {
+		return (
+			<a className="navigation-link jetpack-connect__back-button" onClick={ this.clearUrl }>
+				<span className="navigation-link__label">
+					<Gridicon icon="chevron-left" size={ 18 } />
+					{ this.translate( 'Back' ) }
+				</span>
+			</a>
 		);
 	},
 
@@ -266,6 +283,7 @@ const JetpackConnectMain = React.createClass( {
 							text={ this.translate( 'Once the plugin is activated you\'ll click this green \'Connect\' button to complete the connection.' ) }
 							example={ <JetpackExampleConnect url={ this.state.currentUrl } /> } />
 					</div>
+					{ this.renderBackButton() }
 					<Button onClick={ this.activateJetpack } primary>{ this.translate( 'Activate Jetpack' ) }</Button>
 				</div>
 			</Main>

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -248,8 +248,10 @@ const JetpackConnectMain = React.createClass( {
 							text={ this.translate( 'Once the plugin is activated you\'ll click this green \'Connect\' button to complete the connection.' ) }
 							example={ <JetpackExampleConnect url={ this.state.currentUrl } /> } />
 					</div>
-					{ this.renderBackButton() }
 					<Button onClick={ this.installJetpack } primary>{ this.translate( 'Install Jetpack' ) }</Button>
+					<div className="jetpack-connect__navigation">
+						{ this.renderBackButton() }
+					</div>
 				</div>
 			</Main>
 		);
@@ -259,7 +261,7 @@ const JetpackConnectMain = React.createClass( {
 		return (
 			<a className="navigation-link jetpack-connect__back-button" onClick={ this.clearUrl }>
 				<span className="navigation-link__label">
-					<Gridicon icon="chevron-left" size={ 18 } />
+					<Gridicon icon="arrow-left" size={ 18 } />
 					{ this.translate( 'Back' ) }
 				</span>
 			</a>

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -215,3 +215,8 @@
 		margin-top: 8px;
 	}
 }
+
+.jetpack-connect__back-button {
+	position: absolute;
+	transform: translateX(-96px) translateY(4px);
+}

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -215,8 +215,3 @@
 		margin-top: 8px;
 	}
 }
-
-.jetpack-connect__back-button {
-	position: absolute;
-	transform: translateX(-96px) translateY(4px);
-}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/5131;

This PR adds a back button that allows the user to return to the first step in jetpack connect flow when they are in the install or activation instructions screen:

![image](https://cloud.githubusercontent.com/assets/1554855/14981687/4672ebb8-1131-11e6-9c67-57802520bec2.png)

How to test:
=========
1. Go to http://calypso.localhost:3000/jetpack/connect
2. Enter the url of a site where jetpack is inactive or not installed at all
3. In the next step, click back button, you should be back at the start of the flow

ping @rickybanister  (Rick, I've done certain creative css styles, you may want to review them)