### PR TITLE
Jetpack connect: Add correct manual install link

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -141,7 +141,7 @@ const JetpackConnectMain = React.createClass( {
 	renderFooter() {
 		return (
 			<LoggedOutFormLinks>
-				<LoggedOutFormLinkItem href="http://jetpack.com">{ this.translate( 'Install Jetpack Manually' ) }</LoggedOutFormLinkItem>
+				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">{ this.translate( 'Install Jetpack Manually' ) }</LoggedOutFormLinkItem>
 				<LoggedOutFormLinkItem href="/start">{ this.translate( 'Start a new site on WordPress.com' ) }</LoggedOutFormLinkItem>
 			</LoggedOutFormLinks>
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/5140

We weren't pointing to the correct install page in the manual install link. This PR fixes it

/cc @jeherve 