### PR TITLE
Jetpack-connect: url path format changed

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1808,14 +1808,14 @@ Undocumented.prototype.timezones = function( params, fn ) {
  */
 Undocumented.prototype.getSiteConnectInfo = function( targetUrl, filters ) {
 	const parsedUrl = url.parse( targetUrl );
-	const endpointUrl = `/connect/site-info/${ parsedUrl.protocol.slice( 0, -1 ) }/${ parsedUrl.host }`;
+	let endpointUrl = `/connect/site-info/${ parsedUrl.protocol.slice( 0, -1 ) }/${ parsedUrl.host }`;
 	let params = {
 		filters: filters,
 		apiVersion: '1.1',
 	};
 
 	if ( parsedUrl.path && parsedUrl.path !== '/' ) {
-		params.path = parsedUrl.path;
+		endpointUrl += parsedUrl.path.replace( /\//g, '::' );
 	}
 
 	return this.wpcom.req.get( `${ endpointUrl }`, params );


### PR DESCRIPTION
This PR changes the way we send the path of a jetpack-connect url to the API. As pointed by @beaulebens, we were not using the same format that is commonly used through calypso. 

This branch should be merged synchronized with `D1712-code`, since it reflects its changes

how to test
========
1. You need an .com API sandbox running `D1712-code`
2. Go to http://calypso.localhost:3000/jetpack/connect and enter an url of site. You should get the same result that you would get on `master`

ping @roccotripaldi 