### PR TITLE
Framework: use wpcom.plans() methods instead of wpcom-undocument 

### DIFF
--- a/client/lib/features-list/index.js
+++ b/client/lib/features-list/index.js
@@ -63,7 +63,7 @@ FeaturesList.prototype.get = function() {
  */
 FeaturesList.prototype.fetch = function() {
 	debug( 'getting FeaturesList from api' );
-	wpcom.plans().features( function( error, data ) {
+	wpcom.plans().features( ( error, data ) => {
 		if ( error ) {
 			debug( 'error fetching FeaturesList from api', error );
 			return;
@@ -81,7 +81,7 @@ FeaturesList.prototype.fetch = function() {
 
 		this.emit( 'change' );
 		store.set( 'FeaturesList', features );
-	}.bind( this ) );
+	} );
 };
 
 /**

--- a/client/lib/features-list/index.js
+++ b/client/lib/features-list/index.js
@@ -1,15 +1,20 @@
 /**
  * External dependencies
  */
-var debug = require( 'debug' )( 'calypso:features-list' ),
-	reject = require( 'lodash/reject' ),
-	store = require( 'store' );
+import debugFactory from 'debug';
+import reject from 'lodash/reject';
+import store from 'store';
 
 /**
  * Internal dependencies
  */
-var wpcom = require( 'lib/wp' ),
-	Emitter = require( 'lib/mixins/emitter' );
+import wpcom from 'lib/wp';
+import Emitter from 'lib/mixins/emitter';
+
+/**
+ * Module vars
+ */
+const debug = debugFactory( 'calypso:features-list' );
 
 /**
  * PlansList component
@@ -58,15 +63,13 @@ FeaturesList.prototype.get = function() {
  */
 FeaturesList.prototype.fetch = function() {
 	debug( 'getting FeaturesList from api' );
-	wpcom.undocumented().getPlansFeatures( function( error, data ) {
-		var features;
-
+	wpcom.plans().features( function( error, data ) {
 		if ( error ) {
 			debug( 'error fetching FeaturesList from api', error );
 			return;
 		}
 
-		features = this.parse( data );
+		let features = this.parse( data );
 
 		debug( 'FeaturesList fetched from api:', features );
 

--- a/client/lib/plans-list/index.js
+++ b/client/lib/plans-list/index.js
@@ -76,15 +76,13 @@ PlansList.prototype.get = function() {
  */
 PlansList.prototype.fetch = function() {
 	debug( 'getting PlansList from api' );
-	wpcom.undocumented().getPlans( function( error, data ) {
-		var plans;
-
+	wpcom.plans().list( function( error, data ) {
 		if ( error ) {
 			debug( 'error fetching PlansList from api', error );
 			return;
 		}
 
-		plans = this.parse( data );
+		let plans = this.parse( data );
 
 		debug( 'PlansList fetched from api:', plans );
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -457,35 +457,6 @@ Undocumented.prototype.validateDomainContactInformation = function( contactInfor
 };
 
 /**
- * Get a list of active WordPress.com plans
- *
- * @param {Function} fn The callback function
- * @api public
- */
-Undocumented.prototype.getPlans = function( fn ) {
-	debug( '/plans query' );
-	this._sendRequestWithLocale( {
-		path: '/plans',
-		method: 'get',
-		apiVersion: '1.2'
-	}, fn );
-};
-
-/**
- * Get a list of features for active WordPress.com plans
- *
- * @param {Function} fn The callback function
- * @api public
- */
-Undocumented.prototype.getPlansFeatures = function( fn ) {
-	debug( '/plans/features query' );
-	this._sendRequestWithLocale( {
-		path: '/plans/features',
-		method: 'get'
-	}, fn );
-};
-
-/**
  * Get a list of WordPress.com products
  *
  * @param {Function} fn The callback function


### PR DESCRIPTION
In this PR:

* Remove `.getPlans()` and `. getFeatures()` methods from wpcom-undocumented lib
* Replace those methods by `wpcom.plans().list()` and `wpcom.plans().features()` methods
* Implements ES6ify in features-list
* Fix some Eslint warnings