### PR TITLE
Reader: add feature check to /read/a8c

### DIFF
--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -50,5 +50,7 @@ module.exports = function() {
 		page.exit( '/read/blogs/:blog/posts/:post', controller.resetTitle );
 	}
 
-	page( '/read/a8c', controller.updateLastRoute, controller.removePost, controller.sidebar, forceTeamA8C, controller.readA8C );
+	if ( config.isEnabled( 'reader/a8c' ) ) {
+		page( '/read/a8c', controller.updateLastRoute, controller.removePost, controller.sidebar, forceTeamA8C, controller.readA8C );
+	}
 };

--- a/client/reader/sidebar/reader-sidebar-teams/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/index.jsx
@@ -9,6 +9,8 @@ import map from 'lodash/map';
  */
 import ReaderSidebarTeamsListItem from './list-item';
 
+var config = require( 'config' );
+
 const ReaderSidebarTeams = React.createClass( {
 
 	propTypes: {
@@ -19,9 +21,11 @@ const ReaderSidebarTeams = React.createClass( {
 	renderItems() {
 		const { path } = this.props;
 		return map( this.props.teams, function( team ) {
-			return (
-				<ReaderSidebarTeamsListItem key={ team.slug } team={ team } path={ path } />
-			);
+			if ( config.isEnabled( 'reader/' + team.slug ) ) {
+				return (
+					<ReaderSidebarTeamsListItem key={ team.slug } team={ team } path={ path } />
+				);
+			}
 		} );
 	},
 

--- a/config/development.json
+++ b/config/development.json
@@ -98,6 +98,7 @@
 		"post-editor/media-advanced": true,
 		"press-this": true,
 		"reader": true,
+		"reader/a8c": true,
 		"reader/full-errors": true,
 		"reader/list-management": true,
 		"reader/search": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -77,6 +77,7 @@
 		"post-editor/live-image-updates": true,
 		"press-this": true,
 		"reader": true,
+		"reader/a8c": true,
 		"reader/full-errors": true,
 		"reader/search": true,
 		"resume-editing": true,


### PR DESCRIPTION
Separated out from PR: https://github.com/Automattic/wp-calypso/pull/5166

Performs a feature check for /read/a8c. Allows other features in the `ReaderSidebarTeams` subcomponent to be turned on/off.