### PR TITLE
Settings: fixes console errors in delete site flow

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -28,6 +28,9 @@ const SiteNotice = React.createClass( {
 	},
 
 	getSiteRedirectNotice: function( site ) {
+		if ( ! site ) {
+			return null;
+		}
 		if ( ! ( site.options && site.options.is_redirect ) ) {
 			return null;
 		}
@@ -80,10 +83,14 @@ const SiteNotice = React.createClass( {
 	},
 
 	render() {
+		const { site } = this.props;
+		if ( ! site ) {
+			return <div className="site__notices" />;
+		}
 		return (
 			<div className="site__notices">
-				{ this.getSiteRedirectNotice( this.props.site ) }
-				<QueryPlans siteId={ this.props.site.ID } />
+				{ this.getSiteRedirectNotice( site ) }
+				<QueryPlans siteId={ site.ID } />
 				{ this.domainCreditNotice() }
 			</div>
 		);


### PR DESCRIPTION
Addresses #5084 and #4444. You should no longer see a console error when deleting a site. I can't vouch for unrelated console errors, however. In particular, I consistently get a webpack error when viewing any page for a single-site-user. I will open a separate issue to track that. It looks like this, fwiw:

![single-site-user](https://cloudup.com/cB3r5bpPDZP+)

So if you see that, it's _not_ an issue related to this PR.

## Testing
There are two cases to test. One is a user that only has one site and deletes it. The other is a user with multiple sites that deletes one of them. The difference is that the user who deletes their only site should get redirected to a screen saying they don't have any sites. The user with multiple sites will get redirected to `/stats`.

There is still an issue that the "success" notice a user sees after deleting a site is removed once the user is redirected to another page, which automatically happens. That's a known issue (#158) that should be addressed separately.

/cc @fabianapsimoes @gwwar 