### PR TITLE
ABTest: Domains: Disable domainsWithPlansOnly test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -101,7 +101,7 @@ module.exports = {
 		allowAnyLocale: true
 	},
 	domainsWithPlansOnly: {
-		datestamp: '20160427',
+		datestamp: '20200101', // was 20160427
 		variations: {
 			original: 50,
 			plansOnly: 50


### PR DESCRIPTION
Ending the test a day early since we reached MSS.

I'm setting the date to future without changing the code. We'll see which way to go after the analysis.

Testing:
1. Go through My Domains -> Add Domain flow. You should see individual domain prices; once you add a domain to your cart, Premium Plan should *not* be automatically added to your cart.
2. If you add Premium Plan manually while having a domain in your cart, removing Premium Plan from the cart should *not* remove the domain. (However, if you have added a Premium Plan while in the test and remove it outside of the test, it will still remove the domains along with it – won't fix)
3. With a new user, go to /start. You should see individual domain item prices and selecting a custom domain should not add a Premium plan to your cart (i.e. you should see the plans page after selecting a custom domain and selecting Free Plan should result in a cart that only contains the domain.)



/cc: (Crowded cc list as we're ending it early) @klimeryk @breezyskies @rralian @lucasartoni @meremagee @p3ob7o 