### PR TITLE
Pages: fixes blog posts placeholder page

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -244,8 +244,9 @@ var Pages = React.createClass({
 			}
 
 			const site = this.props.sites.getSelectedSite();
+			const status = this.props.status || 'published';
 
-			if ( this.props.status === 'published' && get( site, 'options.show_on_front' ) === 'posts' ) {
+			if ( status === 'published' && get( site, 'options.show_on_front' ) === 'posts' ) {
 				rows.push( this.blogPostsPage() );
 			}
 


### PR DESCRIPTION
I noticed while reviewing with @designsimply that the blog-post placeholder page in the pages list was no longer working. It wasn't being shown anymore. Some prior code change (I didn't check too far) had caused the check for status=published to break. The code in general could use a sprucing up, but I made the minimal change to fix the issue.

![blog post page](https://cloudup.com/cdz6t8pCSDi+)

/cc @mtias 