### PR TITLE
WIP: Add/instagram shortcode wizard

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -40,6 +40,7 @@ import afterTheDeadlinePlugin from './plugins/after-the-deadline/plugin';
 import wptextpatternPlugin from './plugins/wptextpattern/plugin';
 import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
 import insertMenuPlugin from './plugins/insert-menu/plugin';
+import wpcomAddInstagramShortcodePlugin from './plugins/insert-menu/add-instagram-shortcode';
 
 [
 	wpcomPlugin,
@@ -60,7 +61,8 @@ import insertMenuPlugin from './plugins/insert-menu/plugin';
 	contactFormPlugin,
 	afterTheDeadlinePlugin,
 	wptextpatternPlugin,
-	toolbarPinPlugin
+	toolbarPinPlugin,
+	wpcomAddInstagramShortcodePlugin
 ].forEach( ( initializePlugin ) => initializePlugin() );
 
 /**
@@ -125,6 +127,7 @@ const PLUGINS = [
 	'wpcom/toolbarpin',
 	'wpcom/contactform',
 	'wpcom/sourcecode',
+	'wpcom/instagramshortcode',
 ];
 
 if ( config.isEnabled( 'post-editor/insert-menu' ) ) {

--- a/client/components/tinymce/plugins/insert-menu/add-instagram-shortcode.jsx
+++ b/client/components/tinymce/plugins/insert-menu/add-instagram-shortcode.jsx
@@ -1,0 +1,12 @@
+import menuItemPlugin from './menu-item-plugin';
+
+import InstagramShortcodeWizard from 'post-editor/wizards/instagram';
+
+export const InstagramShortCodePlugin = menuItemPlugin( {
+	Wizard: InstagramShortcodeWizard,
+	buttonName: 'wpcom_add_instagram',
+	commandName: 'wpcomAddInstagramShortcode',
+	pluginSlug: 'wpcom/instagramshortcode',
+} );
+
+export default InstagramShortCodePlugin;

--- a/client/components/tinymce/plugins/insert-menu/menu-item-plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-item-plugin.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import tinymce from 'tinymce/tinymce';
+import { Provider } from 'react-redux';
+
+const menuItemPlugin = props => editor => {
+	let node;
+	const store = editor.getParam( 'redux_store' );
+	const { commandName, Wizard } = props;
+	const focusEditor = () => editor.focus();
+	const updateContent = newContent => editor.execCommand( 'mceInsertContent', false, newContent );
+
+	editor.on( 'init', () => {
+		node = editor.getContainer().appendChild(
+			document.createElement( 'div' )
+		);
+	} );
+
+	editor.on( 'remove', () => {
+		ReactDOM.unmountComponentAtNode( node );
+		node.parentNode.removeChild( node );
+		node = null;
+	} );
+
+	editor.addCommand( commandName, content => {
+		ReactDOM.render(
+			<Provider store={ store }>
+				<Wizard
+					content={ content }
+					onClose={ focusEditor }
+					onUpdateContent={ updateContent }
+				/>
+			</Provider>,
+			node
+		);
+	} );
+};
+
+export default props => () => {
+	tinymce.PluginManager.add( props.pluginSlug, menuItemPlugin( props ) );
+}

--- a/client/components/tinymce/plugins/insert-menu/menu-item-plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-item-plugin.jsx
@@ -6,36 +6,55 @@ import { Provider } from 'react-redux';
 const menuItemPlugin = props => editor => {
 	let node;
 	const store = editor.getParam( 'redux_store' );
-	const { commandName, Wizard } = props;
+	const {
+		Wizard,
+		buttonName,
+		commandName,
+	} = props;
+
 	const focusEditor = () => editor.focus();
 	const updateContent = newContent => editor.execCommand( 'mceInsertContent', false, newContent );
 
-	editor.on( 'init', () => {
-		node = editor.getContainer().appendChild(
-			document.createElement( 'div' )
-		);
-	} );
+	const closeWizard = () => {
+		if ( ! node ) {
+			return focusEditor();
+		}
 
-	editor.on( 'remove', () => {
 		ReactDOM.unmountComponentAtNode( node );
 		node.parentNode.removeChild( node );
 		node = null;
-	} );
 
-	editor.addCommand( commandName, content => {
+		focusEditor();
+	};
+
+	const openWizard = () => {
+		node = editor.getContainer().appendChild(
+			document.createElement( 'div' )
+		);
+
 		ReactDOM.render(
 			<Provider store={ store }>
 				<Wizard
-					content={ content }
-					onClose={ focusEditor }
+					content={ editor.getContent() }
+					onClose={ closeWizard }
 					onUpdateContent={ updateContent }
 				/>
 			</Provider>,
 			node
 		);
+	};
+
+	editor.on( 'remove', closeWizard );
+
+	editor.addCommand( commandName, openWizard );
+
+	editor.addButton( buttonName, {
+		cmd: commandName,
+		title: 'Button',
+		icon: 'unlink'
 	} );
 };
 
 export default props => () => {
 	tinymce.PluginManager.add( props.pluginSlug, menuItemPlugin( props ) );
-}
+};

--- a/client/post-editor/wizards/instagram.jsx
+++ b/client/post-editor/wizards/instagram.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import Dialog from 'components/dialog';
+
+export const InstagramShortcodeWizard = React.createClass( {
+	insertShortcode( closeDialog ) {
+		const {
+			onUpdateContent
+		} = this.props;
+
+		const shortcode = `[instagram url=${ this.urlInput.value } width=${ this.widthInput.value } /]`;
+
+		onUpdateContent( shortcode );
+
+		closeDialog();
+	},
+
+	render() {
+		const buttons = [
+			{ action: 'insert', label: 'Insert', onClick: this.insertShortcode },
+			{ action: 'cancel', label: 'Cancel', onClick: close => close() }
+		];
+
+		return (
+			<Dialog isVisible={ true } buttons={ buttons } onClose={ this.props.onClose }>
+				<h1>Add an Instagram link!</h1>
+				<p>URL: <input ref={ r => ( this.urlInput = r ) } type="text" /></p>
+				<p>Width: <input ref={ r => ( this.widthInput = r ) } type="text" /></p>
+			</Dialog>
+		);
+	}
+} );
+
+InstagramShortcodeWizard.displayName = 'InstagramShortcodeWizard';
+
+export default InstagramShortcodeWizard;


### PR DESCRIPTION
Follows #5070 and #5071 

Related: #1729

This PR is mainly about the new shortcode wizard infrastructure being added to the editor. It includes an Instagram shortcode "wizard" as a demonstration of how to hook into the _plugin generator_.

The purpose of this new code is to enable creating a series of wizard-style modals for the editor without needing to mix a bunch of TinyMCE-specific code into them.

As this is still a work-in-progress and a demonstration PR, **please ignore the ugly button on the left side of the TinyMCE toolbar**. It depends on #5071 and will end up being a menu item on the dropdown in there.

**Questions**
 - [ ] How can we get the shortcode to be replaced by the embedded area and then provide the hover/tap edit/delete buttons?
 - [ ] Is the given API robust enough for the types of embeds/widgets/shortcodes we want to create?
 - [ ] Is the level of modularity/separation of concerns appropriate for the tasks at hand? As designed, the wizard modals can be tested in isolation without mocking.

**Testing**
Open the editor and try to mess around with the new embed. Please look at the code and suggest any recommendations you might have.

Thanks!

cc: @rodrigoi @aduth @blowery 