### PR TITLE
Editor: Change selected featured image when clicking the edit button

### DIFF
--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -46,7 +46,7 @@ module.exports = React.createClass( {
 		};
 	},
 
-	shouldComponentUpdate: function( nextProps, nextState ) {
+	shouldComponentUpdate: function( nextProps ) {
 		return ! ( nextProps.media === this.props.media &&
 			nextProps.scale === this.props.scale &&
 			nextProps.maxImageWidth === this.props.maxImageWidth &&

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -241,7 +241,7 @@ module.exports = React.createClass( {
 	},
 
 	editItem: function( item ) {
-		const { site, mediaLibrarySelectedItems } = this.props;
+		const { site, mediaLibrarySelectedItems, single } = this.props;
 		if ( ! site ) {
 			return;
 		}
@@ -249,7 +249,11 @@ module.exports = React.createClass( {
 		// Append item to set of selected items if not already selected.
 		let items = mediaLibrarySelectedItems;
 		if ( ! items.some( ( selected ) => selected.ID === item.ID ) ) {
-			items = items.concat( item );
+			if ( single ) {
+				items = [ item ];
+			} else {
+				items = items.concat( item );
+			}
 			MediaActions.setLibrarySelectedItems( site.ID, items );
 		}
 


### PR DESCRIPTION
Fixes #4791 

Currently a bug exists where clicking on the "edit" icon when selecting a featured image from the media-list checks multiple images to be set for a featured image.  Initially I tried to fix this by adding some logic to [editItem](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/media-modal/index.jsx#L243) in the post editor media modal, but that led to some issues with a media item not being selected which is required for the detail view.

~~In lieu of this approach, I opted to make the edit button display dependent upon a new prop in the `list-item`.  This mimics the existing approach taken with `showGalleryHelp` so it felt like a good solution.~~

After feedback I did implement a solution in `editItem` that only allows a single item to be selected when the `single` prop is truthy.

/cc @aduth 

__To Test__
- Open a post in the editor ( new or draft )
- Click set featured image from the sidebar
- Select an image from your library, note the checkmark will be shown on the selected image
- Now hover over other images in the library and verify that the image edit button is not shown
- Also validate the "normal" use of the media library to select images to insert to a post is not affected by this change.  As in open the medial modal via the editor toolbar, select an image or two, and note that all images hovered still show the edit icon.