### PR TITLE
Reader: handle AFK posts with a featured image

### DIFF
--- a/client/reader/following-stream/_style.scss
+++ b/client/reader/following-stream/_style.scss
@@ -178,7 +178,9 @@
 		.reader__full-post-content,
 		.reader-post-byline__tag,
 		.reader-post-byline__date,
+		.reader__post-featured-image,
 		.reader__post-footer,
+		.post-excerpt,
 		.site__info {
 			display: none;
 		}


### PR DESCRIPTION
AFK posts are intended to be limited to a single line title in post streams.

@ebinnion noticed in #5202 that, when his post included a featured image, both the image and part of the excerpt were displayed in the stream:

![2a7b64f6-1174-11e6-8007-d2b94c0d2d61](https://cloud.githubusercontent.com/assets/17325/15008822/c6818766-11da-11e6-9901-d0d97f783773.png)


This PR makes sure featured images and excerpts are always hidden for AFK posts in the stream.

Fixes #5202.