### PR TITLE
Signup: Remove Homepage Layout A/B Test i2

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -109,15 +109,6 @@ module.exports = {
 		defaultVariation: 'original',
 		allowExistingUsers: false
 	},
-	triforce: {
-		datestamp: '20160421',
-		variations: {
-			original: 45,
-			triforce: 45,
-			notTested: 10
-		},
-		defaultVariation: 'original'
-	},
 	planPricing: {
 		datestamp: '20160426',
 		variations: {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -8,7 +8,7 @@ import reject from 'lodash/reject';
 /**
  * Internal dependencies
  */
-import { abtest, getABTestVariation } from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 import config from 'config';
 import { isOutsideCalypso } from 'lib/url';
 import plansPaths from 'my-sites/plans/paths';
@@ -236,10 +236,6 @@ function filterFlowName( flowName ) {
 
 	if ( includes( defaultFlows, flowName ) && abtest( 'domainsWithPlansOnly' ) === 'plansOnly' ) {
 		return 'domains-with-premium';
-	}
-
-	if ( includes( defaultFlows, flowName ) && 'notTested' === getABTestVariation( 'freeTrialsInSignup' ) && 'triforce' === abtest( 'triforce' ) ) {
-		return 'layout';
 	}
 
 	return flowName;


### PR DESCRIPTION
The test was enabled in #4536, and it needs to be removed on May 9th, 2016.