### PR TITLE
State: state: export `domains` instead of the default value

### DIFF
--- a/client/state/sites/domains/reducer.js
+++ b/client/state/sites/domains/reducer.js
@@ -100,7 +100,7 @@ export const errors = ( state = {}, action ) => {
 	return state;
 };
 
-export default combineReducers( {
+export const domains = combineReducers( {
 	items,
 	requesting,
 	errors

--- a/client/state/sites/domains/test/reducer.js
+++ b/client/state/sites/domains/test/reducer.js
@@ -7,7 +7,8 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import domainsReducer, {
+import {
+	domains as domainsReducer,
 	items as itemsReducer,
 	requesting as requestReducer,
 	errors as errorsReducer


### PR DESCRIPTION
it changes the way that the site-domains reducer can be required.

**before**
```es6
import domains from './domains/reducer';
```

**after**
```es6
import { domains } from './domains/reducer';
```

It attempts to be consisten with other reducer implementations.