### PR TITLE
CurrentPlan: display purchase details like expiration date.

### DIFF
--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -3,20 +3,55 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import PlanIcon from 'components/plans/plan-icon';
 import HappinessSupport from 'components/happiness-support';
+import Button from 'components/button';
+import Card from 'components/card';
 
-export default ( {
+export default localize( ( {
 	selectedSite,
 	title,
 	tagLine,
-	isPlaceholder = false
+	isPlaceholder = false,
+	currentPlanSlug,
+	currentPlan,
+	isExpiring,
+	translate
 } ) => {
-	const currentPlan = selectedSite.plan.product_slug;
+	function getPurchaseInfo() {
+		if ( ! currentPlan ) {
+			return null;
+		}
+
+		const hasAutoRenew = currentPlan.auto_renew;
+		const classes = classNames( 'current-plan__header-purchase-info', {
+			'is-expiring': isExpiring
+		} );
+
+		return (
+			<div className={ classes }>
+				<span className="current-plan__header-expires-in">
+					{ hasAutoRenew
+						? translate( 'Set to Auto Renew on %s.', { args: currentPlan.userFacingExpiryMoment.format( 'LL' ) } )
+						: translate( 'Expires on %s.', { args: currentPlan.userFacingExpiryMoment.format( 'LL' ) } )
+					}
+				</span>
+				{ currentPlan.userIsOwner &&
+				<Button compact href={ `/purchases/${ selectedSite.slug }/${ currentPlan.id }` }>
+					{ hasAutoRenew
+						? translate( 'Manage Payment' )
+						: translate( 'Renew Now' )
+					}
+				</Button>
+				}
+			</div>
+		);
+	}
 
 	return (
 		<div className="current-plan__header">
@@ -24,8 +59,8 @@ export default ( {
 				<div className="current-plan__header-item-content">
 					<div className="current-plan__header-icon">
 						{
-							currentPlan &&
-							<PlanIcon plan={ currentPlan } />
+							currentPlanSlug &&
+							<PlanIcon plan={ currentPlanSlug } />
 						}
 					</div>
 					<div className="current-plan__header-copy">
@@ -45,6 +80,9 @@ export default ( {
 							{ tagLine }
 						</h2>
 					</div>
+					<Card compact>
+						{ getPurchaseInfo() }
+					</Card>
 				</div>
 			</div>
 
@@ -58,4 +96,4 @@ export default ( {
 			</div>
 		</div>
 	);
-};
+} );

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -1,99 +1,140 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
+import React, { Component, PropTypes } from 'react';
 
 /**
  * Internal dependencies
  */
-import PlanIcon from 'components/plans/plan-icon';
-import HappinessSupport from 'components/happiness-support';
 import Button from 'components/button';
 import Card from 'components/card';
+import HappinessSupport from 'components/happiness-support';
+import PlanIcon from 'components/plans/plan-icon';
+import {
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_JETPACK_FREE,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+	PLAN_PERSONAL
+} from 'lib/plans/constants';
 
-export default localize( ( {
-	selectedSite,
-	title,
-	tagLine,
-	isPlaceholder = false,
-	currentPlanSlug,
-	currentPlan,
-	isExpiring,
-	translate
-} ) => {
-	function getPurchaseInfo() {
-		if ( ! currentPlan ) {
+class CurrentPlanHeader extends Component {
+	static propTypes = {
+		selectedSite: PropTypes.object,
+		title: PropTypes.string,
+		tagLine: PropTypes.string,
+		isPlaceholder: PropTypes.bool,
+		currentPlanSlug: React.PropTypes.oneOf( [
+			PLAN_PREMIUM,
+			PLAN_BUSINESS,
+			PLAN_JETPACK_FREE,
+			PLAN_JETPACK_BUSINESS,
+			PLAN_JETPACK_BUSINESS_MONTHLY,
+			PLAN_JETPACK_PREMIUM,
+			PLAN_JETPACK_PREMIUM_MONTHLY,
+			PLAN_PERSONAL
+		] ).isRequired,
+		currentPlan: PropTypes.object,
+		isExpiring: PropTypes.bool,
+		translate: PropTypes.func
+	};
+
+	renderPurchaseInfo() {
+		const {
+			currentPlan,
+			currentPlanSlug,
+			selectedSite,
+			isExpiring,
+			translate
+		} = this.props;
+
+		if ( ! currentPlan || currentPlanSlug === PLAN_JETPACK_FREE ) {
 			return null;
 		}
 
-		const hasAutoRenew = currentPlan.auto_renew;
+		const hasAutoRenew = currentPlan.autoRenew;
 		const classes = classNames( 'current-plan__header-purchase-info', {
 			'is-expiring': isExpiring
 		} );
 
 		return (
-			<div className={ classes }>
-				<span className="current-plan__header-expires-in">
-					{ hasAutoRenew
-						? translate( 'Set to Auto Renew on %s.', { args: currentPlan.userFacingExpiryMoment.format( 'LL' ) } )
-						: translate( 'Expires on %s.', { args: currentPlan.userFacingExpiryMoment.format( 'LL' ) } )
+			<Card className="current-plan__header-purchase-info-wrapper" compact>
+				<div className={ classes }>
+					<span className="current-plan__header-expires-in">
+						{ hasAutoRenew
+							? translate( 'Set to Auto Renew on %s.', { args: currentPlan.userFacingExpiryMoment.format( 'LL' ) } )
+							: translate( 'Expires on %s.', { args: currentPlan.userFacingExpiryMoment.format( 'LL' ) } )
+						}
+					</span>
+					{ currentPlan.userIsOwner &&
+					<Button compact href={ `/purchases/${ selectedSite.slug }/${ currentPlan.id }` }>
+						{ hasAutoRenew
+							? translate( 'Manage Payment' )
+							: translate( 'Renew Now' )
+						}
+					</Button>
 					}
-				</span>
-				{ currentPlan.userIsOwner &&
-				<Button compact href={ `/purchases/${ selectedSite.slug }/${ currentPlan.id }` }>
-					{ hasAutoRenew
-						? translate( 'Manage Payment' )
-						: translate( 'Renew Now' )
-					}
-				</Button>
-				}
-			</div>
+				</div>
+			</Card>
 		);
 	}
 
-	return (
-		<div className="current-plan__header">
-			<div className="current-plan__header-item">
-				<div className="current-plan__header-item-content">
-					<div className="current-plan__header-icon">
-						{
-							currentPlanSlug &&
-							<PlanIcon plan={ currentPlanSlug } />
-						}
-					</div>
-					<div className="current-plan__header-copy">
-						<h1 className={
-							classNames( 'current-plan__header-heading', {
-								'is-placeholder': isPlaceholder
-							} )
-						} >
-							{ title }
-						</h1>
+	render() {
+		const {
+			currentPlanSlug,
+			isPlaceholder,
+			title,
+			tagLine,
+			selectedSite
+		} = this.props;
 
-						<h2 className={
-							classNames( 'current-plan__header-text', {
-								'is-placeholder': isPlaceholder
-							} )
-						} >
-							{ tagLine }
-						</h2>
+		return (
+			<div className="current-plan__header">
+				<div className="current-plan__header-item">
+					<div className="current-plan__header-item-content">
+						<div className="current-plan__header-icon">
+							{
+								currentPlanSlug &&
+								<PlanIcon plan={ currentPlanSlug } />
+							}
+						</div>
+						<div className="current-plan__header-copy">
+							<h1 className={
+								classNames( 'current-plan__header-heading', {
+									'is-placeholder': isPlaceholder
+								} )
+							} >
+								{ title }
+							</h1>
+
+							<h2 className={
+								classNames( 'current-plan__header-text', {
+									'is-placeholder': isPlaceholder
+								} )
+							} >
+								{ tagLine }
+							</h2>
+						</div>
+						{ this.renderPurchaseInfo() }
 					</div>
-					<Card compact>
-						{ getPurchaseInfo() }
-					</Card>
+				</div>
+
+				<div className="current-plan__header-item">
+					<div className="current-plan__header-item-content">
+						<HappinessSupport
+							isJetpack={ !! selectedSite.jetpack }
+							isPlaceholder={ isPlaceholder }
+						/>
+					</div>
 				</div>
 			</div>
+		);
+	}
+}
 
-			<div className="current-plan__header-item">
-				<div className="current-plan__header-item-content">
-					<HappinessSupport
-						isJetpack={ !! selectedSite.jetpack }
-						isPlaceholder={ isPlaceholder }
-					/>
-				</div>
-			</div>
-		</div>
-	);
-} );
+export default localize( CurrentPlanHeader );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -9,7 +9,11 @@ import { localize } from 'i18n-calypso';
  * Internal Dependencies
  */
 import Main from 'components/main';
-import { getPlansBySite } from 'state/sites/plans/selectors';
+import {
+	getPlansBySite,
+	getCurrentPlan,
+	isCurrentPlanExpiring
+} from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlansNavigation from 'my-sites/upgrades/navigation';
@@ -62,7 +66,9 @@ class CurrentPlan extends Component {
 			selectedSite,
 			selectedSiteId,
 			sitePlans,
-			context
+			context,
+			currentPlan,
+			isExpiring
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug,
@@ -87,6 +93,9 @@ class CurrentPlan extends Component {
 						isPlaceholder={ isLoading }
 						title={ title }
 						tagLine={ tagLine }
+						currentPlanSlug={ currentPlanSlug }
+						currentPlan={ currentPlan }
+						isExpiring={ isExpiring }
 					/>
 					<ProductPurchaseFeaturesList
 						plan={ currentPlanSlug }
@@ -110,7 +119,9 @@ export default connect(
 			selectedSite,
 			selectedSiteId: getSelectedSiteId( state ),
 			sitePlans: getPlansBySite( state, selectedSite ),
-			context: ownProps.context
+			context: ownProps.context,
+			currentPlan: getCurrentPlan( state, getSelectedSiteId( state ) ),
+			isExpiring: isCurrentPlanExpiring( state, getSelectedSiteId( state ) )
 		};
 	}
 )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -89,3 +89,19 @@
 		}
 	}
 }
+
+.current-plan__header-purchase-info {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	&.is-expiring {
+		.current-plan__expires-in {
+			color: $alert-red;
+		}
+	}
+}
+
+.current-plan__header-expires-in {
+	color: $gray;
+}

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -90,6 +90,10 @@
 	}
 }
 
+.current-plan__header-purchase-info-wrapper {
+	margin-top: 20px;
+}
+
 .current-plan__header-purchase-info {
 	display: flex;
 	justify-content: space-between;

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -9,6 +9,7 @@ const createSitePlanObject = ( plan ) => {
 	}
 
 	return {
+		auto_renew: Boolean( plan.auto_renew ),
 		canStartTrial: Boolean( plan.can_start_trial ),
 		currentPlan: Boolean( plan.current_plan ),
 		currencyCode: plan.currency_code,

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -9,13 +9,13 @@ const createSitePlanObject = ( plan ) => {
 	}
 
 	return {
-		auto_renew: Boolean( plan.auto_renew ),
+		autoRenew: Boolean( plan.auto_renew ), // Always true for plans paid with credits.
 		canStartTrial: Boolean( plan.can_start_trial ),
 		currentPlan: Boolean( plan.current_plan ),
 		currencyCode: plan.currency_code,
 		discountReason: plan.discount_reason,
 		expiry: plan.expiry,
-		expiryMoment: moment( plan.expiry ).startOf( 'day' ),
+		expiryMoment: plan.expiry ? moment( plan.expiry ).startOf( 'day' ) : null,
 		formattedDiscount: plan.formatted_discount,
 		formattedPrice: plan.formatted_price,
 		freeTrial: Boolean( plan.free_trial ),
@@ -29,7 +29,9 @@ const createSitePlanObject = ( plan ) => {
 		subscribedDate: plan.subscribed_date,
 		subscribedDayMoment: moment( plan.subscribed_date ).startOf( 'day' ),
 		userFacingExpiry: plan.user_facing_expiry,
-		userFacingExpiryMoment: moment( plan.user_facing_expiry ).startOf( 'day' ),
+		userFacingExpiryMoment: plan.user_facing_expiry
+			? moment( plan.user_facing_expiry ).startOf( 'day' )
+			: null,
 		userIsOwner: Boolean( plan.user_is_owner )
 	};
 };

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -4,6 +4,7 @@
 import find from 'lodash/find';
 import get from 'lodash/get';
 import debugFactory from 'debug';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -99,4 +100,10 @@ export function hasDomainCredit( state, siteId ) {
 export function isRequestingSitePlans( state, siteId ) {
 	const plans = getPlansBySiteId( state, siteId );
 	return plans.isRequesting;
+}
+
+export function isCurrentPlanExpiring( state, siteId ) {
+	const currentPlan = getCurrentPlan( state, siteId );
+	const expiration = get( currentPlan, 'userFacingExpiryMoment', null );
+	return expiration < moment().add( 30, 'days' );
 }


### PR DESCRIPTION
This PR adds relevant information on plan management to the new current-plan section.

To-dos:

- [x] Display expiration date of current plan with color changing based on date proximity.
- [x] Display auto-renew information instead of expiration if enabled.
- [x] Link to `/purchase/$id` (needs to expose id from API)

![image](https://cloud.githubusercontent.com/assets/548849/15507086/660f3c48-21ca-11e6-8d76-8920018b369a.png)
