### PR TITLE
Framework: remove fetchDomainSuggestions

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -73,7 +73,7 @@ function enqueueSearch( search ) {
 	searchStackTimer = window.setTimeout( processSearchQueue, 10000 );
 }
 
-var RegisterDomainStep = React.createClass( {
+const RegisterDomainStep = React.createClass( {
 	mixins: [ analytics ],
 
 	propTypes: {
@@ -314,7 +314,8 @@ var RegisterDomainStep = React.createClass( {
 						callback( error, domainSuggestions );
 					} );
 				}
-			], ( error, result ) => {
+			],
+			( error, result ) => {
 				if ( ! this.state.loadingResults || domain !== this.state.lastDomainSearched ) {
 					// this callback is irrelevant now, a newer search has been made or the results were cleared
 					return;
@@ -383,11 +384,13 @@ var RegisterDomainStep = React.createClass( {
 			},
 			suggestions = reject( this.state.searchResults, isSearchedDomain ),
 			availableDomain = find( this.state.searchResults, isSearchedDomain ),
-			onAddMapping = this.props.onAddMapping ?
-				domain => {
-					return this.props.onAddMapping( domain, this.state );
-				} :
-				undefined;
+			onAddMapping;
+
+		if ( this.props.onAddMapping ) {
+			onAddMapping = ( domain ) => {
+				return this.props.onAddMapping( domain, this.state );
+			};
+		}
 
 		if ( suggestions.length === 0 && ! this.state.loadingResults ) {
 			// the search returned no results

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1,36 +1,38 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	extend = require( 'lodash/extend' ),
-	async = require( 'async' ),
-	flatten = require( 'lodash/flatten' ),
-	reject = require( 'lodash/reject' ),
-	find = require( 'lodash/find' ),
-	uniqBy = require( 'lodash/uniqBy' ),
-	times = require( 'lodash/times' ),
-	compact = require( 'lodash/compact' ),
-	noop = require( 'lodash/noop' ),
-	startsWith = require( 'lodash/startsWith' ),
-	page = require( 'page' ),
-	qs = require( 'qs' );
+import React from 'react';
+import async from 'async';
+import extend from 'lodash/extend';
+import flatten from 'lodash/flatten';
+import reject from 'lodash/reject';
+import find from 'lodash/find';
+import uniqBy from 'lodash/uniqBy';
+import times from 'lodash/times';
+import compact from 'lodash/compact';
+import noop from 'lodash/noop';
+import startsWith from 'lodash/startsWith';
+import page from 'page';
+import qs from 'qs';
 
 /**
  * Internal dependencies
  */
-var wpcom = require( 'lib/wp' ).undocumented(),
-	Notice = require( 'components/notice' ),
-	{ getFixedDomainSearch, canRegister } = require( 'lib/domains' ),
-	SearchCard = require( 'components/search-card' ),
-	DomainRegistrationSuggestion = require( 'components/domains/domain-registration-suggestion' ),
-	DomainMappingSuggestion = require( 'components/domains/domain-mapping-suggestion' ),
-	DomainSearchResults = require( 'components/domains/domain-search-results' ),
-	ExampleDomainSuggestions = require( 'components/domains/example-domain-suggestions' ),
-	analyticsMixin = require( 'lib/mixins/analytics' ),
-	upgradesActions = require( 'lib/upgrades/actions' ),
-	{ isPlan } = require( 'lib/products-values' ),
-	cartItems = require( 'lib/cart-values/cart-items' ),
-	abtest = require( 'lib/abtest' ).abtest;
+import wpcom from 'lib/wp';
+import Notice from 'components/notice';
+import { getFixedDomainSearch, canRegister } from 'lib/domains';
+import SearchCard from 'components/search-card';
+import DomainRegistrationSuggestion from 'components/domains/domain-registration-suggestion';
+import DomainMappingSuggestion from 'components/domains/domain-mapping-suggestion';
+import DomainSearchResults from 'components/domains/domain-search-results';
+import ExampleDomainSuggestions from 'components/domains/example-domain-suggestions';
+import analyticsMixin from 'lib/mixins/analytics';
+import * as upgradesActions from 'lib/upgrades/actions';
+import { isPlan } from 'lib/products-values';
+import cartItems from 'lib/cart-values/cart-items';
+import { abtest } from 'lib/abtest';
+
+const undocumented = wpcom.undocumented();
 
 // max amount of domain suggestions we should fetch/display
 const SUGGESTION_QUANTITY = 10,
@@ -151,8 +153,7 @@ var RegisterDomainStep = React.createClass( {
 		}
 
 		initialQuery = this.props.selectedSite.domain.split( '.' )[ 0 ];
-
-		wpcom.fetchDomainSuggestions( initialQuery, { quantity: SUGGESTION_QUANTITY, vendor: abtest( 'domainSuggestionVendor' ) }, function( error, suggestions ) {
+		undocumented.fetchDomainSuggestions( initialQuery, { quantity: SUGGESTION_QUANTITY, vendor: abtest( 'domainSuggestionVendor' ) }, function( error, suggestions ) {
 			if ( ! this.isMounted() ) {
 				return;
 			}
@@ -300,7 +301,7 @@ var RegisterDomainStep = React.createClass( {
 						vendor: abtest( 'domainSuggestionVendor' )
 					};
 
-					wpcom.fetchDomainSuggestions( domain, params, ( error, domainSuggestions ) => {
+					undocumented.fetchDomainSuggestions( domain, params, ( error, domainSuggestions ) => {
 						if ( error && error.statusCode === 503 ) {
 							return this.props.onDomainsAvailabilityChange( false );
 						} else if ( error && error.error ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -882,31 +882,6 @@ Undocumented.prototype.paypalExpressUrl = function( data, fn ) {
 };
 
 /**
- * GET domain suggestions
- *
- * @param {int|string} searchQuery The domain name to search
- * @param {object} functionParams Parameters for the endpoint
- * @param {Function} fn The callback function
- * @api public
- */
-Undocumented.prototype.fetchDomainSuggestions = function( searchQuery, functionParams, fn ) {
-	var query = {
-		query: searchQuery,
-		quantity: functionParams.quantity,
-		include_wordpressdotcom: functionParams.includeWordPressDotCom,
-		vendor: functionParams.vendor,
-	};
-
-	this.wpcom.req.get( '/domains/suggestions', query, function( error, response ) {
-		if ( error ) {
-			return fn( error );
-		}
-
-		fn( null, response );
-	} );
-};
-
-/**
  * GET example domain suggestions
  *
  * @param {Function} fn - The callback funtion


### PR DESCRIPTION
Some tidying in preparation for domain tips. This PR removes an unneeded client method, fetchDomainSuggestions from wpcom.undocumented, and uses wpcom.domains.suggestions instead. I'll have a few redux PRs for domain suggestions as a follow up.

## Testing Instructions
No functional changes.
- Navigate to http://calypso.localhost:3000/domains/add
- Select a site if prompted
- 2 initial suggestions display
- Type in the search box
- Up to 10 suggestions should display
- You can add a domain normally.

cc @retrofox @rralian @umurkontaci @drewblaisdell 