### PR TITLE
Domains: Change domain suggestion parameter name

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -300,7 +300,7 @@ const RegisterDomainStep = React.createClass( {
 					const query = {
 						query: domain,
 						quantity: SUGGESTION_QUANTITY,
-						includeWordPressDotCom: this.props.includeWordPressDotCom,
+						include_wordpressdotcom: this.props.includeWordPressDotCom,
 						vendor: abtest( 'domainSuggestionVendor' )
 					};
 


### PR DESCRIPTION
d1da81db6c992b37265c91734c7ef14bad881cf5 broke domain suggestions.
Bad parameter, signup never returned wordpress.com