### PR TITLE
Domains: Signup Flow domain search during outage

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -277,9 +277,7 @@ const RegisterDomainStep = React.createClass( {
 					}
 
 					canRegister( domain, ( error, result ) => {
-						if ( error && error.code === 'domain_registration_unavailable' ) {
-							return this.props.onDomainsAvailabilityChange( false );
-						} else if ( error ) {
+						if ( error && error.code !== 'domain_registration_unavailable' ) {
 							this.showValidationErrorMessage( domain, error );
 							this.setState( { lastDomainError: error } );
 						} else if ( result ) {


### PR DESCRIPTION
In the signup flow, step 3/4 (Let's find a domain) if a user searches for a term that includes the TLD (.com) while there is a service outage we show the loading screen endlessly. We want to show the wp.com subdomain to the user since they can pick the domain later.