### PR TITLE
ThemesList: Use localize()

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	times = require( 'lodash/times' ),
-	isEqual = require( 'lodash/isEqual' );
+import React from 'react';
+import times from 'lodash/times';
+import isEqual from 'lodash/isEqual';
 
 /**
  * Internal dependencies
  */
-var Theme = require( 'components/theme' ),
-	EmptyContent = require( 'components/empty-content' ),
-	InfiniteScroll = require( 'lib/mixins/infinite-scroll' ),
-	PER_PAGE = require( 'state/themes/themes-list/constants' ).PER_PAGE;
+import Theme from 'components/theme';
+import EmptyContent from 'components/empty-content';
+import InfiniteScroll from 'lib/mixins/infinite-scroll';
+import { PER_PAGE } from 'state/themes/themes-list/constants';
 
 /**
  * Component
  */
-var ThemesList = React.createClass( {
+const ThemesList = React.createClass( {
 
 	mixins: [ InfiniteScroll( 'fetchNextPage' ) ],
 
@@ -31,30 +31,30 @@ var ThemesList = React.createClass( {
 		getActionLabel: React.PropTypes.func
 	},
 
-	fetchNextPage: function( options ) {
+	fetchNextPage( options ) {
 		this.props.fetchNextPage( options );
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return {
 			loading: false,
 			themes: [],
-			fetchNextPage: function() {},
-			optionsGenerator: function() {
+			fetchNextPage() {},
+			optionsGenerator() {
 				return [];
 			},
-			getActionLabel: function() {
+			getActionLabel() {
 				return '';
 			}
 		};
 	},
 
-	shouldComponentUpdate: function( nextProps ) {
+	shouldComponentUpdate( nextProps ) {
 		return this.props.loading !== nextProps.loading ||
 			! isEqual( this.props.themes, nextProps.themes );
 	},
 
-	renderTheme: function( theme, index ) {
+	renderTheme( theme, index ) {
 		return <Theme
 			key={ 'theme-' + theme.id }
 			buttonContents={ this.props.getButtonOptions( theme ) }
@@ -66,21 +66,21 @@ var ThemesList = React.createClass( {
 			theme={ theme } />;
 	},
 
-	renderLoadingPlaceholders: function() {
+	renderLoadingPlaceholders() {
 		return times( PER_PAGE, function( i ) {
 			return <Theme key={ 'placeholder-' + i } theme={ { id: 'placeholder-' + i, name: 'Loading…' } } isPlaceholder={ true } />;
 		} );
 	},
 
 	// Invisible trailing items keep all elements same width in flexbox grid.
-	renderTrailingItems: function() {
+	renderTrailingItems() {
 		const NUM_SPACERS = 8; // gives enough spacers for a theoretical 9 column layout
 		return times( NUM_SPACERS, function( i ) {
 			return <div className="themes-list--spacer" key={ 'themes-list--spacer-' + i } />;
 		} );
 	},
 
-	renderEmpty: function() {
+	renderEmpty() {
 		return this.props.emptyContent ||
 			<EmptyContent
 				title={ this.translate( 'Sorry, no themes found.' ) }
@@ -88,7 +88,7 @@ var ThemesList = React.createClass( {
 				/>;
 	},
 
-	render: function() {
+	render() {
 		if ( ! this.props.loading && this.props.themes.length === 0 ) {
 			return this.renderEmpty();
 		}
@@ -103,4 +103,4 @@ var ThemesList = React.createClass( {
 	}
 } );
 
-module.exports = ThemesList;
+export default ThemesList;

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -12,11 +12,12 @@ import Theme from 'components/theme';
 import EmptyContent from 'components/empty-content';
 import InfiniteScroll from 'lib/mixins/infinite-scroll';
 import { PER_PAGE } from 'state/themes/themes-list/constants';
+import localize from 'lib/mixins/i18n/localize';
 
 /**
  * Component
  */
-const ThemesList = React.createClass( {
+export const ThemesList = React.createClass( {
 
 	mixins: [ InfiniteScroll( 'fetchNextPage' ) ],
 
@@ -28,7 +29,9 @@ const ThemesList = React.createClass( {
 		getButtonOptions: React.PropTypes.func,
 		onScreenshotClick: React.PropTypes.func.isRequired,
 		onMoreButtonClick: React.PropTypes.func,
-		getActionLabel: React.PropTypes.func
+		getActionLabel: React.PropTypes.func,
+		// i18n function provided by localize()
+		translate: React.PropTypes.func
 	},
 
 	fetchNextPage( options ) {
@@ -83,8 +86,8 @@ const ThemesList = React.createClass( {
 	renderEmpty() {
 		return this.props.emptyContent ||
 			<EmptyContent
-				title={ this.translate( 'Sorry, no themes found.' ) }
-				line={ this.translate( 'Try a different search or more filters?' ) }
+				title={ this.props.translate( 'Sorry, no themes found.' ) }
+				line={ this.props.translate( 'Try a different search or more filters?' ) }
 				/>;
 	},
 
@@ -103,4 +106,4 @@ const ThemesList = React.createClass( {
 	}
 } );
 
-export default ThemesList;
+export default localize( ThemesList );

--- a/client/components/themes-list/test/index.jsx
+++ b/client/components/themes-list/test/index.jsx
@@ -19,16 +19,10 @@ describe( 'ThemesList', function() {
 		TestUtils = require( 'react-addons-test-utils' );
 
 		mockery.registerMock( './more-button', React.createClass( { render: () => <div/> } ) );
-		ThemesList = require( '../' );
-	} );
-
-	after( function() {
-		delete ThemesList.prototype.__reactAutoBindMap.translate;
+		ThemesList = require( '../' ).ThemesList;
 	} );
 
 	beforeEach( function() {
-		ThemesList.prototype.__reactAutoBindMap.translate = this.sandbox.stub().returnsArg( 0 );
-
 		this.props = {
 			themes: [
 				{
@@ -46,7 +40,8 @@ describe( 'ThemesList', function() {
 			loading: false,
 			fetchNextPage: noop,
 			getButtonOptions: noop,
-			onScreenshotClick: noop
+			onScreenshotClick: noop,
+			translate: x => x // Mock translate()
 		};
 
 		this.themesList = React.createElement( ThemesList, this.props );

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	noop = require( 'lodash/noop' );
+import React from 'react';
+import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'lib/analytics' ),
-	SignupActions = require( 'lib/signup/actions' ),
-	ThemesList = require( 'components/themes-list' ),
-	StepWrapper = require( 'signup/step-wrapper' ),
-	Button = require( 'components/button' );
+import analytics from 'lib/analytics';
+import SignupActions from 'lib/signup/actions';
+import ThemesList from 'components/themes-list';
+import StepWrapper from 'signup/step-wrapper';
+import Button from 'components/button';
 
 module.exports = React.createClass( {
 	displayName: 'ThemeSelection',
@@ -69,7 +69,7 @@ module.exports = React.createClass( {
 					id: theme.slug,
 					name: theme.name,
 					screenshot: 'https://i1.wp.com/s0.wp.com/wp-content/themes/pub/' + theme.slug + '/screenshot.png?w=660'
-				}
+				};
 			} );
 		return (
 			<ThemesList


### PR DESCRIPTION
This is remotely related to the React 15 update, #5116.

The trouble with using a higher-order component here is that it adds another level so that shallow rendering will no longer work as before. (See https://github.com/airbnb/enzyme/issues/242 for Enzyme's take on this kind of issue.) My strategy here is to also export the non-wrapped `ThemesList`, and to pass identity as `translate` in the test. CCing @aduth and @gziolo for a review of that strategy, and suggestions for possible alternatives.

(The signup step ES6ification is mainly so that we don't have to `require( 'components/themes-list' ).default` there, which would be ugly.)

To test -- check that `/design` works as before.