### PR TITLE
Domains: better error handling for initial domains suggestion search

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -169,9 +169,11 @@ const RegisterDomainStep = React.createClass( {
 		} ).catch( error => {
 			if ( error && error.statusCode === 503 ) {
 				return this.props.onDomainsAvailabilityChange( false );
-			} else if ( error ) {
-				throw error;
+			} else if ( error && error.error ) {
+				error.code = error.error;
+				this.showValidationErrorMessage( initialQuery, error );
 			}
+			this.setState( { defaultSuggestions: [] } );
 		} );
 	},
 


### PR DESCRIPTION
This PR adds better error handling when we cannot find any default domain suggestions. We normally shouldn't hit this case, but we may see this when we encounter timeouts on WWD.

Before:
<img width="1020" alt="screen shot 2016-05-04 at 12 17 15 pm" src="https://cloud.githubusercontent.com/assets/1270189/15029934/ac9886cc-1204-11e6-88c0-425b11f96670.png">

After:
<img width="761" alt="screen shot 2016-05-04 at 2 26 10 pm" src="https://cloud.githubusercontent.com/assets/1270189/15029941/b2f03498-1204-11e6-8a96-cdc0edcfd6f9.png">

cc @umurkontaci @rralian @aidvu 
