### PR TITLE
Tests: Add translate directly to component prototypes

### DIFF
--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -23,13 +23,13 @@ xdescribe( 'Domain Suggestion', function() {
 	beforeEach( function() {
 		DomainSuggestion = require( 'components/domains/domain-suggestion' );
 		DomainProductPrice = require( 'components/domains/domain-product-price' );
-		DomainSuggestion.prototype.__reactAutoBindMap.translate = sinon.stub();
-		DomainProductPrice.prototype.__reactAutoBindMap.translate = sinon.stub();
+		DomainSuggestion.prototype.translate = sinon.stub();
+		DomainProductPrice.prototype.translate = sinon.stub();
 	} );
 
 	afterEach( function() {
-		delete DomainSuggestion.prototype.__reactAutoBindMap.translate;
-		delete DomainProductPrice.prototype.__reactAutoBindMap.translate;
+		delete DomainSuggestion.prototype.translate;
+		delete DomainProductPrice.prototype.translate;
 	} );
 
 	describe( 'added domain', function() {

--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -15,7 +15,7 @@ describe( 'index', function() {
 	require( 'test/helpers/use-fake-dom' )( '<html><body><div id="container"></div></body></html>' );
 
 	before( function() {
-		DropZone.prototype.__reactAutoBindMap.translate = sinon.stub().returnsArg( 0 );
+		DropZone.prototype.translate = sinon.stub().returnsArg( 0 );
 		container = document.getElementById( 'container' );
 		window.MutationObserver = sinon.stub().returns( {
 			observe: sinon.stub(),
@@ -27,7 +27,7 @@ describe( 'index', function() {
 		if ( global.window && global.window.MutationObserver ) {
 			delete global.window.MutationObserver;
 		}
-		delete DropZone.prototype.__reactAutoBindMap.translate;
+		delete DropZone.prototype.translate;
 	} );
 
 	beforeEach( function() {

--- a/client/my-sites/upgrades/cart/test/cart-buttons.js
+++ b/client/my-sites/upgrades/cart/test/cart-buttons.js
@@ -17,12 +17,12 @@ describe( 'cart-buttons', function() {
 
 	beforeEach( function() {
 		this.CartButtons = require( '../cart-buttons.jsx' );
-		this.CartButtons.prototype.__reactAutoBindMap.translate = sinon.stub();
+		this.CartButtons.prototype.translate = sinon.stub();
 		this.recordStub = this.CartButtons.prototype.__reactAutoBindMap.recordEvent = sinon.stub();
 	} );
 
 	afterEach( function() {
-		delete this.CartButtons.prototype.__reactAutoBindMap.translate;
+		delete this.CartButtons.prototype.translate;
 		delete this.CartButtons.prototype.__reactAutoBindMap.recondEvent;
 	} );
 

--- a/client/my-sites/upgrades/components/domain-warnings/index.jsx
+++ b/client/my-sites/upgrades/components/domain-warnings/index.jsx
@@ -13,7 +13,6 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import purchasesPaths from 'me/purchases/paths';
 import domainConstants from 'lib/domains/constants';
-import i18n from 'lib/mixins/i18n';
 import support from 'lib/url/support';
 import paths from 'my-sites/upgrades/paths';
 
@@ -22,9 +21,7 @@ const debug = _debug( 'calypso:domain-warnings' );
 
 const allAboutDomainsLink = <a href={ support.ALL_ABOUT_DOMAINS } target="_blank"/>,
 	domainsLink = <a href={ support.DOMAINS } target="_blank" />,
-	pNode = <p />,
-	renewLinkSingle = <a href={ purchasesPaths.list() }>{ i18n.translate( 'Renew it now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>,
-	renewLinkPlural = <a href={ purchasesPaths.list() }>{ i18n.translate( 'Renew them now.', { context: 'Call to action link for renewing an expiring/expired domain' } ) }</a>;
+	pNode = <p />;
 
 export default React.createClass( {
 	displayName: 'DomainWarnings',
@@ -36,6 +33,21 @@ export default React.createClass( {
 			React.PropTypes.object,
 			React.PropTypes.bool
 		] ).isRequired
+	},
+
+	renewLink( count ) {
+		return(
+			<a href={ purchasesPaths.list() }>
+				{ this.translate(
+					'Renew it now.',
+					'Renew them now.',
+					{
+						count,
+						context: 'Call to action link for renewing an expiring/expired domain'
+					}
+				) }
+			</a>
+		);
 	},
 
 	getPipe() {
@@ -66,13 +78,12 @@ export default React.createClass( {
 				context: 'Expired domain notice',
 				comment: '%(timeSince)s is something like "a year ago"'
 			} );
-			renewLink = renewLinkSingle;
 		} else {
 			text = this.translate( 'Some of your domains have expired.', {
 				context: 'Expired domain notice'
 			} );
-			renewLink = renewLinkPlural;
 		}
+		renewLink = this.renewLink( expiredDomains.length );
 		return <Notice status="is-error" showDismiss={ false } key="expired-domains">{ text } { renewLink }</Notice>;
 	},
 
@@ -89,13 +100,12 @@ export default React.createClass( {
 				context: 'Expiring soon domain notice',
 				comment: '%(timeUntil)s is something like "in a week"'
 			} );
-			renewLink = renewLinkSingle;
 		} else {
 			text = this.translate( 'Some of your domains are expiring soon.', {
 				context: 'Expiring domain notice'
 			} );
-			renewLink = renewLinkPlural;
 		}
+		renewLink = this.renewLink( expiringDomains.length );
 		return <Notice status="is-error" showDismiss={ false } key="expiring-domains">{ text } { renewLink }</Notice>;
 	},
 

--- a/client/my-sites/upgrades/components/domain-warnings/test/index.js
+++ b/client/my-sites/upgrades/components/domain-warnings/test/index.js
@@ -25,13 +25,13 @@ describe( 'index', () => {
 		translateFn = i18n.translate;
 		i18n.translate = identity;
 		DomainWarnings = require( '../' );
-		DomainWarnings.prototype.__reactAutoBindMap.translate = identity;
-		Notice.prototype.__reactAutoBindMap.translate = identity;
+		DomainWarnings.prototype.translate = identity;
+		Notice.prototype.translate = identity;
 	} );
 
 	afterEach( () => {
-		delete DomainWarnings.prototype.__reactAutoBindMap.translate;
-		delete Notice.prototype.__reactAutoBindMap.translate;
+		delete DomainWarnings.prototype.translate;
+		delete Notice.prototype.translate;
 		i18n.translate = translateFn;
 	} );
 
@@ -45,7 +45,7 @@ describe( 'index', () => {
 
 		const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
 
-		expect( ReactDom.findDOMNode( component ) ).to.be.a( 'null' )
+		expect( ReactDom.findDOMNode( component ) ).to.be.a( 'null' );
 	} );
 
 	it( 'should render new warning notice if the domain is new', () => {

--- a/client/my-sites/upgrades/components/domain-warnings/test/index.js
+++ b/client/my-sites/upgrades/components/domain-warnings/test/index.js
@@ -11,20 +11,16 @@ import TestUtils from 'react-addons-test-utils';
 /**
  * Internal dependencies
  */
-import i18n from 'lib/mixins/i18n';
 import Notice from 'components/notice';
 import { type as domainTypes } from 'lib/domains/constants';
 import useFakeDom from 'test/helpers/use-fake-dom';
 
 describe( 'index', () => {
-	let DomainWarnings, translateFn;
+	let DomainWarnings = require( '../' );
 
 	useFakeDom();
 
 	beforeEach( () => {
-		translateFn = i18n.translate;
-		i18n.translate = identity;
-		DomainWarnings = require( '../' );
 		DomainWarnings.prototype.translate = identity;
 		Notice.prototype.translate = identity;
 	} );
@@ -32,7 +28,6 @@ describe( 'index', () => {
 	afterEach( () => {
 		delete DomainWarnings.prototype.translate;
 		delete Notice.prototype.translate;
-		i18n.translate = translateFn;
 	} );
 
 	it( 'should not render anything if there\'s no need', () => {

--- a/client/post-editor/editor-discussion/test/index.jsx
+++ b/client/post-editor/editor-discussion/test/index.jsx
@@ -43,7 +43,7 @@ describe( 'EditorDiscussion', function() {
 			recordStat: noop
 		} );
 		EditorDiscussion = require( '../' ).WrappedComponent;
-		EditorDiscussion.prototype.__reactAutoBindMap.translate = sinon.stub().returnsArg( 0 );
+		EditorDiscussion.prototype.translate = sinon.stub().returnsArg( 0 );
 	} );
 
 	beforeEach( function() {
@@ -51,7 +51,7 @@ describe( 'EditorDiscussion', function() {
 	} );
 
 	after( function() {
-		delete EditorDiscussion.prototype.__reactAutoBindMap.translate;
+		delete EditorDiscussion.prototype.translate;
 	} );
 
 	describe( '#getDiscussionSetting()', function() {

--- a/client/post-editor/editor-ground-control/test/index.jsx
+++ b/client/post-editor/editor-ground-control/test/index.jsx
@@ -45,12 +45,12 @@ describe( 'EditorGroundControl', function() {
 		mockery.registerMock( 'components/post-schedule', EmptyComponent );
 		EditorGroundControl = require( '../' ).WrappedComponent;
 
-		EditorGroundControl.prototype.__reactAutoBindMap.translate = i18n.translate;
+		EditorGroundControl.prototype.translate = i18n.translate;
 		EditorGroundControl.prototype.__reactAutoBindMap.moment = i18n.moment;
 	} );
 
 	after( function() {
-		delete EditorGroundControl.prototype.__reactAutoBindMap.translate;
+		delete EditorGroundControl.prototype.translate;
 		delete EditorGroundControl.prototype.__reactAutoBindMap.moment;
 	} );
 

--- a/client/post-editor/editor-taxonomies/test/accordion.jsx
+++ b/client/post-editor/editor-taxonomies/test/accordion.jsx
@@ -32,7 +32,7 @@ describe( 'EditorTaxonomiesAccordion', function() {
 		i18n = require( 'lib/mixins/i18n' );
 
 		TaxonomiesAccordion = require( 'post-editor/editor-taxonomies/accordion' );
-		TaxonomiesAccordion.prototype.__reactAutoBindMap.translate = i18n.translate;
+		TaxonomiesAccordion.prototype.translate = i18n.translate;
 
 		common.dispatchReceiveCategoryTerms();
 		common.dispatchReceiveTagTerms();

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -56,7 +56,7 @@ describe( 'EditorMediaModal', function() {
 		mockery.registerMock( 'lib/media/actions', { delete: deleteMedia } );
 
 		EditorMediaModal = require( '../' );
-		EditorMediaModal.prototype.__reactAutoBindMap.translate = i18n.translate;
+		EditorMediaModal.prototype.translate = i18n.translate;
 	} );
 
 	it( 'should prompt to delete a single item from the list view', function( done ) {

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -67,7 +67,7 @@ describe( 'PostEditor', function() {
 		SitesList = require( 'lib/sites-list/list' );
 		PostEditStore = require( 'lib/posts/post-edit-store' );
 		PostEditor = require( '../post-editor' );
-		PostEditor.prototype.__reactAutoBindMap.translate = ( string ) => string;
+		PostEditor.prototype.translate = ( string ) => string;
 	} );
 
 	afterEach( function() {

--- a/test/test/helpers/use-i18n/README.md
+++ b/test/test/helpers/use-i18n/README.md
@@ -27,6 +27,6 @@ describe( 'component', () => {
 
 ```js
 before( () => {
-	MyComponent.prototype.__reactAutoBindMap.translate = ( string ) => string;	
+	MyComponent.prototype.translate = ( string ) => string;	
 } );
 ```


### PR DESCRIPTION
Instead as previously to `prototype.__reactAutoBindMap`. The latter is an
implementation detail that is going away in React 15. (-> #5116)

This also necessitated some fixes to the way `DomainWarnings` did `i18n`.

Other prototype-enhancing stubs than `translate()` are a bit more involved, and will be tackled in a follow-up PR.

To test -- run `npm test`.

/cc @seear @gziolo @aduth