### PR TITLE
Update node-phone version to 1.0.4-11

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2843,8 +2843,8 @@
       "version": "0.1.4"
     },
     "phone": {
-      "version": "1.0.4-10",
-      "resolved": "git+https://github.com/Automattic/node-phone.git#1.0.4-10"
+      "version": "1.0.4-11",
+      "resolved": "git+https://github.com/Automattic/node-phone.git#1.0.4-11"
     },
     "photon": {
       "version": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "node-sass": "3.4.2",
     "page": "1.6.4",
     "path-parser": "1.0.2",
-    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-10",
+    "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-11",
     "photon": "2.0.0",
     "postcss-cli": "2.5.1",
     "q": "1.0.1",


### PR DESCRIPTION
## Summary
Prior to 1.0.4-11, node-phone had missed some of area codes of Brazil and thus caused some Brazil users couldn't turn on two-step authentication by phone. Bumping up the version to 1.0.4-11 fixes the problem.

## How to test
According to https://en.wikipedia.org/wiki/List_of_dialling_codes_in_Brazil, the format is an area code followed by nnnn-nnnn ( 8-digit number ) or by 9-nnnn-nnnn ( 9-digit number ). The area code missed in the previous version are: 42, 46, 49, 63, 64, 66, 87, 88, 89, 93, 94, 97, 99. Thus,

1. visit http://calypso.localhost:3000/me/security/two-step
1. Choose Brazil as the nation.
1. Put a synthesized phone number according to the above format, it should be validated successfully. Make sure both the newly-added area codes and those already there can be validated.
1. Anything other than that should be invalidated.
![image](https://cloud.githubusercontent.com/assets/1842898/15037459/060c5ae8-12ce-11e6-93ee-03a3581cf98b.png)

