### PR TITLE
Jetpack connect: Fixes images width

### DIFF
--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -174,9 +174,14 @@
 	border-radius: 50%;
 }
 
-.jetpack-connect__example .site-address-container {
-	margin-top: 8px;
+.jetpack-connect__example {
+	width: 100%;
+
+	.site-address-container {
+		margin-top: 8px;
+	}
 }
+
 .jetpack-connect__site-url-input-container .site-address-container .jetpack-connect__browser-chrome-url {
 	height: 40px;
 	font-size: 12px;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/5146

The images in the jetpack-connect examples are too big in firefox and IE:

![image](https://cloud.githubusercontent.com/assets/1554855/15040957/cc8ce04a-12b8-11e6-932a-48d743a3f856.png)

This PR makes them fit the container instead of being as big as they can:

![image](https://cloud.githubusercontent.com/assets/1554855/15040967/db17e614-12b8-11e6-962f-2abe0e95c544.png)

How to test
========
1. Open http://calypso.localhost:3000/jetpack/connect in firefox or IE
2. Enter the url of a WordPress site that doesn't have jetpack installed ( or that have it, but inactive)
3. The examples should be the size you can see in the screencap up there

ping @jeherve @rickybanister 