### PR TITLE
Push Notifications: add library for dealing with registration of notifications

### DIFF
--- a/client/lib/push-notifications/README.md
+++ b/client/lib/push-notifications/README.md
@@ -1,0 +1,46 @@
+PushNotifications
+==========
+
+This modules provides an abstracted way to deal with registering a push notification subscription via the service worker.
+
+This module exposes the property `state` which is one of:
+ * `unknown`: The browser may not support push notifications, or the state has not yet been determined
+ * `subscribed`: The user has opted into push notifications via a call to `subscribe()`.
+ * `unsubscribed`: The user has either not yet given permissions, or has revoked them via a call to `unsubscribe()`
+ * `denied`: The user denied the push notification via the browser's UI. Futher calls to `subscribe()` will fail. The user must grant permission manually via the browser's UI. We cannot trigger that UI.
+
+It also exposes two methods:
+ * `subscribe( [callback] )`: This method triggers the browser's UI for subscribing to push notifications (if necessary) and takes an optional callback
+ * `unsubscribe( [callback] )`: This method unsubscribes the user from push notifications. There is no native browser UI. Subsequent calls to `subscribe()` will succeed without user intervention so long as the user hasn't manually updated their permissions.
+
+#### How to use
+
+```js
+
+var pushNotifications = require( 'lib/push-notifications' );
+
+/* Inside your component: */
+	componentWillMount: function() {
+		pushNotifications.on( 'change', this.handleChange );
+	},
+
+	componentWillUnmount: function() {
+		pushNotifications.off( 'change', this.handleChange );
+	},
+
+	handleChange: function() {
+		// Alter your UI based on the available states of 'unknown', 'subscribed', 'unsubscribed', or 'denied'
+		var registrationState = pushNotifications.state;
+	},
+
+	subscribeClick: function() {
+		pushNotifications.subscribe( function( state ) {
+			// Callback is optional. You can use it to update your state variable so that you know your UI affected the subscription
+		} );
+	},
+
+	unsubscribeClick: function() {
+		pushNotifications.unsubscribe();
+	}
+
+```

--- a/client/lib/push-notifications/index.js
+++ b/client/lib/push-notifications/index.js
@@ -12,7 +12,7 @@ import store from 'store';
 import config from 'config';
 import wpcom from 'lib/wp';
 
-const daysBeforeForcingRegistrationRefresh = 15,
+const DAYS_BEFORE_FORCING_REGISTRATION_REFRESH = 15,
 	debug = debugFactory( 'calypso:push-notifications' );
 
 let _pushNotifications = false;
@@ -110,7 +110,7 @@ PushNotifications.prototype.saveSubscription = function( subscription ) {
 		age = moment().diff( moment( lastUpdated ), 'days' );
 	}
 
-	if ( oldSub !== sub || ( ! lastUpdated ) || age > daysBeforeForcingRegistrationRefresh ) {
+	if ( oldSub !== sub || ( ! lastUpdated ) || age > DAYS_BEFORE_FORCING_REGISTRATION_REFRESH ) {
 		debug( 'Subscription needed updating.', age );
 		wpcom.undocumented().registerDevice( sub, 'chrome', 'Chrome', function() {
 			store.set( 'push-subscription', sub );

--- a/client/lib/push-notifications/index.js
+++ b/client/lib/push-notifications/index.js
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import Emitter from 'lib/mixins/emitter';
+import debugFactory from 'debug';
+import moment from 'moment';
+import store from 'store';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import wpcom from 'lib/wp';
+
+let _pushNotifications = false;
+
+const debug = debugFactory( 'calypso:push-notifications' );
+
+function initializeState() {
+	// Only continue if the service worker supports notifications
+	if ( ! ( ( 'ServiceWorkerRegistration' in window ) && ( 'showNotification' in window.ServiceWorkerRegistration.prototype ) ) ) {
+		debug( 'Notifications not supported' );
+		return;
+	}
+
+	// If the user denied notifications permission, we cannot prompt again; the user must change the permission
+	if ( ( ! ( 'Notification' in window ) ) || 'denied' === window.Notification.permission ) {
+		debug( 'Permission denied' );
+		this.setState( 'denied' );
+		return;
+	}
+
+	// Only continue if push messaging is supported
+	if ( ! ( 'PushManager' in window ) ) {
+		debug( 'Push messaging not supported' );
+		return;
+	}
+
+	window.navigator.serviceWorker.ready.then( registerServiceWorker.bind( this ) );
+}
+
+function registerServiceWorker( serviceWorkerRegistration ) {
+	debug( 'Registering service worker' );
+	// Grab existing subscription if we have it
+	serviceWorkerRegistration.pushManager.getSubscription().then( ( subscription ) => {
+		if ( ! subscription ) {
+			debug( 'Permission not yet granted' );
+			this.setState( 'unsubscribed' );
+			return;
+		}
+
+		this.setState( 'subscribed' );
+		this.saveSubscription( subscription );
+	} ).catch( ( err ) => {
+		debug( 'Error in getSubscription()', err );
+	} );
+}
+
+/**
+ * PushNotifications component
+ *
+ * @api public
+ */
+
+function PushNotifications() {
+	// state is one of 'unknown', 'subscribed', 'unsubscribed', or 'denied'
+	this.state = 'unknown';
+	this.initialize();
+	return this;
+}
+
+PushNotifications.prototype.initialize = function() {
+	if ( ! config.isEnabled( 'push-notifications' ) ) {
+		return;
+	}
+
+	// Only register the service worker in browsers that support it.
+	if ( 'serviceWorker' in window.navigator ) {
+		window.navigator.serviceWorker.register( '/service-worker.js' ).then( initializeState.bind( this ) ).catch( function( err ) {
+			debug( 'Service worker not supported', err );
+		} );
+	} else {
+		debug( 'Service worker not supported' );
+	}
+};
+
+PushNotifications.prototype.setState = function( state, callback ) {
+	debug( 'Switching state to %s', state );
+	this.state = state;
+	if ( 'function' === typeof callback ) {
+		callback( state );
+	}
+	this.emit( 'change' );
+};
+
+PushNotifications.prototype.deleteSubscription = function() {
+	// @todo: delete the subscription
+	debug( 'Delete subscription' );
+};
+
+PushNotifications.prototype.saveSubscription = function( subscription ) {
+	const sub = JSON.stringify( subscription ),
+		oldSub = store.get( 'push-subscription' ),
+		lastUpdated = store.get( 'push-subscription-updated' );
+
+	var age;
+
+	if ( lastUpdated ) {
+		age = moment().diff( moment( lastUpdated ), 'days' );
+	}
+
+	if ( oldSub !== sub || ( ! lastUpdated ) || age > 15 ) {
+		debug( 'Subscription needed updating.', age );
+		wpcom.undocumented().registerDevice( sub, 'chrome', 'Chrome', function() {
+			store.set( 'push-subscription', sub );
+			store.set( 'push-subscription-updated', moment().format() );
+			debug( 'Saved subscription', subscription );
+		} );
+	} else {
+		debug( 'Subscription did not need updating.', age );
+	}
+};
+
+PushNotifications.prototype.subscribe = function( callback ) {
+	debug( 'Triggering browser UI for permission' );
+	if ( 'serviceWorker' in window.navigator ) {
+		window.navigator.serviceWorker.ready.then( ( serviceWorkerRegistration ) => {
+			serviceWorkerRegistration.pushManager.subscribe( { userVisibleOnly: true } ).then( ( subscription ) => {
+				this.setState( 'subscribed', callback );
+				this.saveSubscription( subscription );
+			} ).catch( ( err ) => {
+				if ( 'denied' === window.Notification.permission ) {
+					debug( 'Permission denied' );
+					this.setState( 'denied', callback );
+				} else {
+					debug( 'Couldn\'t subscribe', err );
+					this.setState( 'unknown', callback );
+				}
+			} );
+		} );
+	}
+};
+
+PushNotifications.prototype.unsubscribe = function( callback ) {
+	if ( 'serviceWorker' in window.navigator ) {
+		window.navigator.serviceWorker.ready.then( ( serviceWorkerRegistration ) => {
+			serviceWorkerRegistration.pushManager.getSubscription().then( ( pushSubscription ) => {
+				if ( ! pushSubscription ) {
+					this.setState( 'unsubscribed', callback );
+					return;
+				}
+
+				this.deleteSubscription();
+
+				pushSubscription.unsubscribe().then( () => {
+					this.setState( 'unsubscribed', callback );
+				} ).catch( ( err ) => {
+					debug( 'Error while unsubscribing', err );
+					this.setState( 'unknown', callback );
+				} );
+			} ).catch( ( err ) => {
+				debug( 'Error while unsubscribing', err );
+				this.setState( 'unknown', callback );
+			} );
+		} );
+	}
+};
+
+/**
+ * Mixins
+ */
+Emitter( PushNotifications.prototype );
+
+module.exports = function() {
+	if ( ! _pushNotifications ) {
+		_pushNotifications = new PushNotifications();
+	}
+	return _pushNotifications;
+};

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1850,6 +1850,24 @@ Undocumented.prototype.importReaderFeed = function( file, fn ) {
 };
 
 /**
+ * Creates a Push Notification registration for the device
+ *
+ * @param {String}     registration   The registration to be stored
+ * @param {String}     deviceFamily   The device family
+ * @param {String}     deviceName     The device name
+ * @param {Function}   fn             The callback function
+ * @returns {XMLHttpRequest}          The XHR instance
+ */
+Undocumented.prototype.registerDevice = function( registration, deviceFamily, deviceName, fn ) {
+	debug( '/devices/new' );
+	return this.wpcom.req.post( { path: '/devices/new' }, {}, {
+		device_token: registration,
+		device_family: deviceFamily,
+		device_name: deviceName
+	}, fn );
+};
+
+/**
  * Expose `Undocumented` module
  */
 module.exports = Undocumented;


### PR DESCRIPTION
This library adds methods for subscribing and unsubscribing from push-notifications. In addition it monitors the current state, and emits a change whenever the registration status changes and stores the registration to the server whenever a change is detected.

To test: see the test-plan on this PR: https://github.com/Automattic/wp-calypso/pull/4987