### PR TITLE
Media: Fix uploads where file name contains ? or #

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -111,6 +111,8 @@ MediaActions.add = function( siteId, files ) {
 		const transientMedia = {
 			ID: id,
 			'transient': true,
+			extension: MediaUtils.getFileExtension( file ),
+			mime_type: MediaUtils.getMimeType( file ),
 			// Assign a date such that the first item will be the oldest at the
 			// time of upload, as this is expected order when uploads finish
 			date: new Date( baseTime - ( files.length - i ) ).toISOString()
@@ -120,8 +122,6 @@ MediaActions.add = function( siteId, files ) {
 			// Generate from string
 			assign( transientMedia, {
 				file: file,
-				extension: MediaUtils.getFileExtension( file ),
-				mime_type: MediaUtils.getMimeType( file ),
 				title: path.basename( file )
 			} );
 		} else {
@@ -131,8 +131,6 @@ MediaActions.add = function( siteId, files ) {
 				URL: fileUrl,
 				guid: fileUrl,
 				file: file.name,
-				extension: MediaUtils.getFileExtension( file.name ),
-				mime_type: MediaUtils.getMimeType( file.name ),
 				title: path.basename( file.name ),
 				// Size is not an API media property, though can be useful for
 				// validation purposes if known

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -4,7 +4,6 @@
 var debug = require( 'debug' )( 'calypso:media' ),
 	assign = require( 'lodash/assign' ),
 	uniqueId = require( 'lodash/uniqueId' ),
-	isPlainObject = require( 'lodash/isPlainObject' ),
 	path = require( 'path' );
 
 /**
@@ -158,7 +157,7 @@ MediaActions.add = function( siteId, files ) {
 
 		// Assign parent ID if currently editing post
 		const post = PostEditStore.get();
-		if ( post && post.ID && ! isPlainObject( file ) ) {
+		if ( post && post.ID ) {
 			file = {
 				parent_id: post.ID,
 				[ isUrl ? 'url' : 'file' ]: file

--- a/client/lib/media/test/actions.js
+++ b/client/lib/media/test/actions.js
@@ -216,15 +216,6 @@ describe( 'MediaActions', function() {
 			} );
 		} );
 
-		it( 'should accept a plain object file descriptor', function() {
-			var file = { file: DUMMY_UPLOAD, parent_id: 300 };
-			sandbox.stub( PostEditStore, 'get' ).returns( { ID: 200 } );
-
-			return MediaActions.add( DUMMY_SITE_ID, file ).then( () => {
-				expect( mediaAdd ).to.have.been.calledWithMatch( {}, file );
-			} );
-		} );
-
 		it( 'should call to the WordPress.com REST API', function() {
 			return MediaActions.add( DUMMY_SITE_ID, DUMMY_UPLOAD ).then( () => {
 				expect( mediaAdd ).to.have.been.calledWithMatch( {}, DUMMY_UPLOAD );

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -152,6 +152,10 @@ describe( 'MediaUtils', function() {
 			expect( MediaUtils.getMimeType( 'example.gif?w=100' ) ).to.equal( 'image/gif' );
 		} );
 
+		it( 'should detect mime type from HTML5 File object', function() {
+			expect( MediaUtils.getMimeType( new window.File( [ '' ], 'example.gif', { type: 'image/gif' } ) ) ).to.equal( 'image/gif' );
+		} );
+
 		it( 'should detect mime type from object file property', function() {
 			expect( MediaUtils.getMimeType( { file: 'example.gif' } ) ).to.equal( 'image/gif' );
 		} );


### PR DESCRIPTION
Fixes #4726 
Related: #3923

This pull request seeks to resolve an issue where files cannot be uploaded if the file name contains either `?` or `#` characters. This is because in generating the extension for the transient image object, we were passing the file name to [the `getFileExtension` utility method](https://github.com/Automattic/wp-calypso/blob/90cfaf183d580d865138c3f0c0c0f7d472a08d34/client/lib/media/utils.js#L73-L106), not the file object itself. By doing so, it was treated as a URL, and was considering the `?` and `#` as query and hash parameters of a URL. Because `getFileExtension` supports extracting the extension from a file object, we can pass this object directly to retrieve the correct extension.

__Implementation notes:__

`getMimeType` is similarly capable of handling an incoming file object and has also been updated here.

Making these changes in test breakage for unused usage of `MediaActions.add` in adding an object file descriptor. This support was included in anticipation of adding media outside the context of the post editor, but is not currently in use (ref: 8924-gh-calypso-pre-oss).

__Testing instructions:__

Repeat steps to reproduce in #4726, verifying that media with special characters in the file name upload correctly. Verify also that other media upload paths are unaffected.

Ensure Mocha tests pass:

```
npm run test-client
```