### PR TITLE
WPCOM Plugins: All My Sites view for users with only WordPress.com sites.

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -190,9 +190,14 @@ const controller = {
 		next();
 	},
 
-	plugins( filter, context ) {
+	plugins( filter, context, next ) {
 		const siteUrl = route.getSiteFragment( context.path );
 		const basePath = route.sectionify( context.path ).replace( '/' + filter, '' );
+
+		// bail if no site is selected and the user has no Jetpack sites.
+		if ( ! siteUrl && sites.getJetpack().length === 0 ) {
+			return next();
+		}
 
 		context.params.pluginFilter = filter;
 		notices.clearNotices( 'notices' );

--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -20,7 +20,7 @@ module.exports = function() {
 		page( '/plugins/browse/:category/:site', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 		page( '/plugins/browse/:siteOrCategory?', controller.siteSelection, controller.navigation, pluginsController.browsePlugins );
 
-		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.validateFilters.bind( null, 'all' ), pluginsController.plugins.bind( null, 'all' ) );
+		page( '/plugins', controller.siteSelection, controller.navigation, pluginsController.validateFilters.bind( null, 'all' ), pluginsController.plugins.bind( null, 'all' ), controller.sites );
 
 		[ 'active', 'inactive', 'updates' ].forEach( function( filter ) {
 			page( '/plugins/' + filter + '/:site_id?', controller.siteSelection, controller.navigation, pluginsController.validateFilters.bind( null, filter ), pluginsController.jetpackCanUpdate.bind( null, filter ), pluginsController.plugins.bind( null, filter ) );


### PR DESCRIPTION
Fixes #5090 

By design, the _Plugins_ page only works for _All My Sites_ when the user has one or more Jetpack connected sites. This is because the _Plugins_ page does not support multiple WordPress.com sites. It can only show content for multiple sites when the user has at least one Jetpack site.

To provide a better user experience for users with only WordPress.com sites, the plugins page now displays the site selector if the user has no Jetpack sites. This is the pattern all the _My Sites_ section follow for _All My Sites_ when the view only supports one site.

![site-selector](https://cloud.githubusercontent.com/assets/233601/15059686/b84b5dfe-12fa-11e6-97a5-6099eabff076.png)

Tested with users with:
- Only WordPress.com sites.
- Mixed WordPress.com and Jetpack sites.
- Only Jetpack sites.

A good options to create hosted WordPress sites is [OpenShift](https://openshift.redhat.com)

cc @drw158 @dmsnell 