### PR TITLE
Themes: 'Thanks' modal on activation from Theme Sheet

### DIFF
--- a/client/components/data/activating-theme/index.js
+++ b/client/components/data/activating-theme/index.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/components/empty-component/README.md
+++ b/client/components/empty-component/README.md
@@ -1,0 +1,18 @@
+EmptyComponent
+==============
+
+Useful for stubbing out components that will not build on the server when rendering server-side.
+
+#### How to use:
+
+In the webpack server [config file](/webpack.config.node.js):
+```js
+plugins: [
+  ...
+	new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ) // Depends on BOM
+],
+```
+In the above example, on the server build, any occurrences of `/my-sites/themes/thanks-modal` will be replaced with the empty component.
+	
+NOTE: You will also need to add the replaced component to the list of ignored modules in the [SSR pragma checker](/server/pragma-checker/index.js).
+	

--- a/client/components/empty-component/index.jsx
+++ b/client/components/empty-component/index.jsx
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+export default () => <div/>;

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -227,7 +227,7 @@ const ThemeSheet = React.createClass( {
 				<ActivatingTheme siteId={ siteID }>
 					<ThanksModal
 						site={ this.props.selectedSite }
-						topLink={ 'customize' }
+						source={ 'details' }
 						clearActivated={ bindActionCreators( clearActivated, this.props.dispatch ) }/>
 				</ActivatingTheme>
 				<div className="themes__sheet-columns">

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -227,6 +227,7 @@ const ThemeSheet = React.createClass( {
 				<ActivatingTheme siteId={ siteID }>
 					<ThanksModal
 						site={ this.props.selectedSite }
+						topLink={ 'customize' }
 						clearActivated={ bindActionCreators( clearActivated, this.props.dispatch ) }/>
 				</ActivatingTheme>
 				<div className="themes__sheet-columns">

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -8,6 +8,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import page from 'page';
 import { isPremium } from 'my-sites/themes/helpers';
 
@@ -23,11 +24,13 @@ import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
-import { signup, purchase, activate } from 'state/themes/actions';
+import { signup, purchase, activate, clearActivated } from 'state/themes/actions';
 import i18n from 'lib/mixins/i18n';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import Helpers from 'my-sites/themes/helpers';
+import ActivatingTheme from 'components/data/activating-theme';
+import ThanksModal from 'my-sites/themes/thanks-modal';
 
 const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
@@ -216,10 +219,16 @@ const ThemeSheet = React.createClass( {
 
 		const section = this.validateSection( this.props.section );
 		const priceElement = <span className="themes__sheet-action-bar-cost" dangerouslySetInnerHTML={ { __html: this.props.price } } />;
+		const siteID = this.props.selectedSite && this.props.selectedSite.ID;
 
 		return (
 			<Main className="themes__sheet">
 				{ this.renderBar() }
+				<ActivatingTheme siteId={ siteID }>
+					<ThanksModal
+						site={ this.props.selectedSite }
+						clearActivated={ bindActionCreators( clearActivated, this.props.dispatch ) }/>
+				</ActivatingTheme>
 				<div className="themes__sheet-columns">
 					<div className="themes__sheet-column-left">
 						<HeaderCake className="themes__sheet-action-bar" onClick={ this.onBackClick }>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -10,7 +10,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import page from 'page';
-import { isPremium } from 'my-sites/themes/helpers';
 
 /**
  * Internal dependencies
@@ -29,6 +28,7 @@ import i18n from 'lib/mixins/i18n';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import Helpers from 'my-sites/themes/helpers';
+import { isPremium } from 'my-sites/themes/helpers';
 import ActivatingTheme from 'components/data/activating-theme';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -8,7 +8,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import page from 'page';
 
 /**
@@ -64,13 +63,13 @@ const ThemeSheet = React.createClass( {
 		// TODO: if active -> customize (could use theme slug from selected site)
 
 		if ( ! this.props.isLoggedIn ) {
-			this.props.dispatch( signup( this.props ) );
+			this.props.signup( this.props );
 		// TODO: use site picker if no selected site
 		} else if ( isPremium( this.props ) ) {
 			// TODO: check theme is not already purchased
-			this.props.dispatch( purchase( this.props, this.props.selectedSite, 'showcase-sheet' ) );
+			this.props.purchase( this.props, this.props.selectedSite, 'showcase-sheet' );
 		} else {
-			this.props.dispatch( activate( this.props, this.props.selectedSite, 'showcase-sheet' ) );
+			this.props.activate( this.props, this.props.selectedSite, 'showcase-sheet' );
 		}
 	},
 
@@ -228,7 +227,7 @@ const ThemeSheet = React.createClass( {
 					<ThanksModal
 						site={ this.props.selectedSite }
 						source={ 'details' }
-						clearActivated={ bindActionCreators( clearActivated, this.props.dispatch ) }/>
+						clearActivated={ this.props.clearActivated }/>
 				</ActivatingTheme>
 				<div className="themes__sheet-columns">
 					<div className="themes__sheet-column-left">
@@ -256,8 +255,11 @@ const ThemeSheet = React.createClass( {
 	}
 } );
 
-export default connect( ( state ) => {
-	const selectedSite = getSelectedSite( state );
-	const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
-	return { selectedSite, siteSlug };
-} )( ThemeSheet );
+export default connect(
+	( state ) => {
+		const selectedSite = getSelectedSite( state );
+		const siteSlug = selectedSite ? getSiteSlug( state, selectedSite.ID ) : '';
+		return { selectedSite, siteSlug };
+	},
+	{ signup, purchase, activate, clearActivated }
+)( ThemeSheet );

--- a/client/my-sites/themes/single-site.jsx
+++ b/client/my-sites/themes/single-site.jsx
@@ -150,6 +150,7 @@ var ThemesSingleSite = React.createClass( {
 				<ActivatingTheme siteId={ site.ID } >
 					<ThanksModal
 						site={ site }
+						source={ 'list' }
 						clearActivated={ bindActionCreators( Action.clearActivated, this.props.dispatch ) } />
 				</ActivatingTheme>
 				<CurrentThemeData site={ site }>

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -14,7 +14,15 @@ var ThanksModal = React.createClass( {
 	trackClick: Helpers.trackClick.bind( null, 'current theme' ),
 
 	propTypes: {
-		clearActivated: React.PropTypes.func.isRequired
+		clearActivated: React.PropTypes.func.isRequired,
+		// First link to show for wpcom themes
+		topLink: React.PropTypes.oneOf( [ 'features', 'customize' ] ),
+	},
+
+	getDefaultProps: function() {
+		return {
+			topLink: 'features',
+		};
 	},
 
 	onCloseModal: function() {
@@ -33,14 +41,20 @@ var ThanksModal = React.createClass( {
 	},
 
 	renderWpcomInfo: function() {
+		const features = this.translate( "Discover this theme's {{a}}awesome features.{{/a}}", {
+			components: {
+				a: <a href={ Helpers.getDetailsUrl( this.props.currentTheme, this.props.site ) } target="_blank" />
+			}
+		} );
+		const customize = this.translate( '{{a}}Customize{{/a}} this design.', {
+			components: {
+				a: <a href={ Helpers.getCustomizeUrl( this.props.currentTheme, this.props.site ) } target="_blank" />
+			}
+		} );
 		return (
 			<ul>
 				<li>
-					{ this.translate( "Discover this theme's {{a}}awesome features.{{/a}}", {
-						components: {
-							a: <a href={ Helpers.getDetailsUrl( this.props.currentTheme, this.props.site ) } target="_blank" />
-						}
-					} ) }
+					{ this.props.topLink === 'features' ? features : customize }
 				</li>
 			<li>
 				{ this.translate( 'Have questions? Stop by our {{a}}support forums.{{/a}}', {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/jsx-no-bind */
+
 /**
  * External dependencies
  */
@@ -37,12 +39,16 @@ var ThanksModal = React.createClass( {
 	renderWpcomInfo: function() {
 		const features = this.translate( "Discover this theme's {{a}}awesome features.{{/a}}", {
 			components: {
-				a: <a href={ Helpers.getDetailsUrl( this.props.currentTheme, this.props.site ) } target="_blank" />
+				a: <a href={ Helpers.getDetailsUrl( this.props.currentTheme, this.props.site ) }
+					target="_blank"
+					onClick={ this.trackClick.bind( null, 'features' ) }/>
 			}
 		} );
 		const customize = this.translate( '{{a}}Customize{{/a}} this design.', {
 			components: {
-				a: <a href={ Helpers.getCustomizeUrl( this.props.currentTheme, this.props.site ) } target="_blank" />
+				a: <a href={ Helpers.getCustomizeUrl( this.props.currentTheme, this.props.site ) }
+					target="_blank"
+					onClick={ this.trackClick.bind( null, 'customize' ) }/>
 			}
 		} );
 		return (
@@ -53,7 +59,9 @@ var ThanksModal = React.createClass( {
 			<li>
 				{ this.translate( 'Have questions? Stop by our {{a}}support forums.{{/a}}', {
 					components: {
-						a: <a href={ Helpers.getForumUrl( this.props.currentTheme ) } target="_blank" />
+						a: <a href={ Helpers.getForumUrl( this.props.currentTheme ) }
+							target="_blank"
+							onClick={ this.trackClick.bind( null, 'support' ) }/>
 					}
 				} ) }
 			</li>
@@ -67,7 +75,9 @@ var ThanksModal = React.createClass( {
 				<li>
 					{ this.translate( 'Learn more about this {{a}}awesome theme{{/a}}.', {
 						components: {
-							a: <a href={ themeUri } target="_blank" />
+							a: <a href={ themeUri }
+								target="_blank"
+								onClick={ this.trackClick.bind( null, 'org theme' ) }/>
 						}
 					} ) }
 				</li>
@@ -81,7 +91,9 @@ var ThanksModal = React.createClass( {
 				<li>
 					{ this.translate( 'Have questions? {{a}}Contact the theme author.{{/a}}', {
 						components: {
-							a: <a href={ authorUri } target="_blank" />
+							a: <a href={ authorUri }
+								target="_blank"
+								onClick={ this.trackClick.bind( null, 'org author' ) }/>
 						}
 					} ) }
 				</li>
@@ -94,7 +106,9 @@ var ThanksModal = React.createClass( {
 			<li>
 				{ this.translate( 'If you need support, visit the WordPress.org {{a}}Themes forum{{/a}}.', {
 					components: {
-						a: <a href="https://wordpress.org/support/forum/themes-and-templates" target="_blank" />
+						a: <a href="https://wordpress.org/support/forum/themes-and-templates"
+							target="_blank"
+							onClick={ this.trackClick.bind( null, 'org forum' ) }/>
 					}
 				} ) }
 			</li>

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -15,14 +15,8 @@ var ThanksModal = React.createClass( {
 
 	propTypes: {
 		clearActivated: React.PropTypes.func.isRequired,
-		// First link to show for wpcom themes
-		topLink: React.PropTypes.oneOf( [ 'features', 'customize' ] ),
-	},
-
-	getDefaultProps: function() {
-		return {
-			topLink: 'features',
-		};
+		// Where is the modal being used?
+		source: React.PropTypes.oneOf( [ 'details', 'list' ] ).isRequired,
 	},
 
 	onCloseModal: function() {
@@ -54,7 +48,7 @@ var ThanksModal = React.createClass( {
 		return (
 			<ul>
 				<li>
-					{ this.props.topLink === 'features' ? features : customize }
+					{ this.props.source === 'list' ? features : customize }
 				</li>
 			<li>
 				{ this.translate( 'Have questions? Stop by our {{a}}support forums.{{/a}}', {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/jsx-no-bind */
-
 /**
  * External dependencies
  */
@@ -36,19 +34,23 @@ var ThanksModal = React.createClass( {
 		this.onCloseModal();
 	},
 
+	onLinkClick: function( link ) {
+		return this.trackClick.bind( null, link, 'click' );
+	},
+
 	renderWpcomInfo: function() {
 		const features = this.translate( "Discover this theme's {{a}}awesome features.{{/a}}", {
 			components: {
 				a: <a href={ Helpers.getDetailsUrl( this.props.currentTheme, this.props.site ) }
 					target="_blank"
-					onClick={ this.trackClick.bind( null, 'features' ) }/>
+					onClick={ this.onLinkClick( 'features' ) }/>
 			}
 		} );
 		const customize = this.translate( '{{a}}Customize{{/a}} this design.', {
 			components: {
 				a: <a href={ Helpers.getCustomizeUrl( this.props.currentTheme, this.props.site ) }
 					target="_blank"
-					onClick={ this.trackClick.bind( null, 'customize' ) }/>
+					onClick={ this.onLinkClick( 'customize' ) }/>
 			}
 		} );
 		return (
@@ -61,7 +63,7 @@ var ThanksModal = React.createClass( {
 					components: {
 						a: <a href={ Helpers.getForumUrl( this.props.currentTheme ) }
 							target="_blank"
-							onClick={ this.trackClick.bind( null, 'support' ) }/>
+							onClick={ this.onLinkClick( 'support' ) }/>
 					}
 				} ) }
 			</li>
@@ -77,7 +79,7 @@ var ThanksModal = React.createClass( {
 						components: {
 							a: <a href={ themeUri }
 								target="_blank"
-								onClick={ this.trackClick.bind( null, 'org theme' ) }/>
+								onClick={ this.onLinkClick( 'org theme' ) }/>
 						}
 					} ) }
 				</li>
@@ -93,7 +95,7 @@ var ThanksModal = React.createClass( {
 						components: {
 							a: <a href={ authorUri }
 								target="_blank"
-								onClick={ this.trackClick.bind( null, 'org author' ) }/>
+								onClick={ this.onLinkClick( 'org author' ) }/>
 						}
 					} ) }
 				</li>
@@ -108,7 +110,7 @@ var ThanksModal = React.createClass( {
 					components: {
 						a: <a href="https://wordpress.org/support/forum/themes-and-templates"
 							target="_blank"
-							onClick={ this.trackClick.bind( null, 'org forum' ) }/>
+							onClick={ this.onLinkClick( 'org forum' ) }/>
 					}
 				} ) }
 			</li>

--- a/server/pragma-checker/index.js
+++ b/server/pragma-checker/index.js
@@ -18,6 +18,7 @@ var IGNORED_MODULES = [
 	'lib/upgrades/actions', // nooped on the server as it still uses the singleton Flux architecture
 	'lib/mixins/i18n', // ignore this until we make it work properly on the server
 	'lib/mixins/i18n/localize', // ignore this until we make it work properly on the server
+	'my-sites/themes/thanks-modal', // stubbed on the server until we develop an isomorphic version
 ];
 
 function PragmaCheckPlugin( options ) {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -82,7 +82,8 @@ module.exports = {
 		new webpack.BannerPlugin( 'require( "source-map-support" ).install();', { raw: true, entryOnly: false } ),
 		new webpack.NormalModuleReplacementPlugin( /^lib\/analytics$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib\/upgrades\/actions$/, 'lodash/noop' ), // Uses Flux dispatcher
-		new webpack.NormalModuleReplacementPlugin( /^lib\/route$/, 'lodash/noop' ) // Depends too much on page.js
+		new webpack.NormalModuleReplacementPlugin( /^lib\/route$/, 'lodash/noop' ), // Depends too much on page.js
+		new webpack.NormalModuleReplacementPlugin( /^my-sites\/themes\/thanks-modal$/, 'components/empty-component' ) // Depends on BOM
 	],
 	externals: getExternals()
 };


### PR DESCRIPTION
Acknowledge activation of a theme from the theme sheet with the existing 'Thanks' modal dialog.

![screen shot 2016-05-06 at 13 55 06](https://cloud.githubusercontent.com/assets/7767559/15073578/31372cc4-1392-11e6-9bef-049ac5fe9d09.png)

Currently only works when a site is selected. A site selector for the sheet is coming soon.

**To Test**
* Go to http://calypso.localhost:3000/design and choose a site
* Click on the ... button for a theme and select __Details__
* Click the __Pick this design__ button
Expected: The modal should display
Expected: The first link in the modal should be to the customizer
* Check that the links in the modal work as expected
