### PR TITLE
Jetpack Connect: Link additional user

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -79,6 +79,10 @@ const JetpackConnectMain = React.createClass( {
 		this.props.goToPluginActivation( this.state.currentUrl );
 	},
 
+	linkAdditionalUser() {
+		this.props.goToRemoteAuth( this.state.currentUrl );
+	},
+
 	checkProperty( propName ) {
 		return this.state.currentUrl &&
 			this.props.jetpackConnectSite &&
@@ -148,6 +152,7 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	renderSiteInput( status ) {
+		const onClickCallback = ( 'alreadyConnected' === status ) ? this.linkAdditionalUser : this.onURLEnter;
 		return (
 			<Card className="jetpack-connect__site-url-input-container">
 				{ ! this.isCurrentUrlFetching() && this.isCurrentUrlFetched() && ! this.props.jetpackConnectSite.isDismissed && status
@@ -157,9 +162,9 @@ const JetpackConnectMain = React.createClass( {
 
 				<SiteURLInput ref="siteUrlInputRef"
 					onChange={ this.onURLChange }
-					onClick={ this.onURLEnter }
+					onClick={ onClickCallback }
 					onDismissClick={ this.onDismissClick }
-					isError={ this.getStatus() }
+					status={ status }
 					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() } />
 			</Card>
 		);

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -70,9 +70,9 @@ export default React.createClass( {
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'alreadyConnected' ) {
-			noticeValues.status = 'is-success';
+			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'status';
-			noticeValues.text = this.translate( 'This site is already connected!' );
+			noticeValues.text = this.translate( 'This site is already connected, would you like to link an other user?' );
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'wordpress.com' ) {

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -29,6 +29,9 @@ export default React.createClass( {
 	},
 
 	renderButtonLabel() {
+		if ( 'alreadyConnected' === this.props.status ) {
+			return( this.translate( 'Link Additional User' ) );
+		}
 		if ( ! this.props.isFetching ) {
 			return( this.translate( 'Connect Now' ) );
 		}


### PR DESCRIPTION
Provides a way for Jetpack sites that are already connected to link additional users.

If you try to connect an already-connected Jetpack site, you will now see this:
![screen shot 2016-05-06 at 9 01 13 am](https://cloud.githubusercontent.com/assets/2694219/15073782/7bc6a4aa-1369-11e6-9d63-946ee02f6248.png)

Note: that if you login, or are already logged in, on the remote site as an already-connected user, you will see this:

![screen shot 2016-05-06 at 9 01 31 am](https://cloud.githubusercontent.com/assets/2694219/15073807/97fb7c22-1369-11e6-8303-6d39e5c9af73.png)


To test:
- Ensure that you have a Jetpack site running the latest master with at least one connected user
- log out of your Jetpack site
- checkout this branch and go to calypso.localhost:3000/jetpack/connect
- enter your Jetpack site's URL, and click 'Link Additional User'
- log in to your Jetpack site as a non-connected user ( Note: user should have an a8c email )
- boom! you should get an other user connected.

cc: @johnHackworth  for code review
cc: @rickybanister  for design review
