### PR TITLE
Fix: add missing react key in InfiniteList

### DIFF
--- a/client/my-sites/posts/post-list.jsx
+++ b/client/my-sites/posts/post-list.jsx
@@ -240,7 +240,7 @@ var Posts = React.createClass( {
 
 		if ( index === 2 && this.props.sites.getSelectedSite() && ! this.props.statusSlug ) {
 			return (
-				<div>
+				<div key={ post.global_ID }>
 					<UpgradeNudge
 						title={ this.translate( 'No Ads with WordPress.com Premium' ) }
 						message={ this.translate( 'Prevent ads from showing on your site.' ) }


### PR DESCRIPTION
PR #5205 introduced warning in React infinitelist component :

```
warning.js:45 Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `InfiniteList`. See https://fb.me/react-warning-keys for more information
```

This was my bad.

This adds missing key

CC @aduth @mtias @rralian 