### PR TITLE
Invites: Fixes ESLint warnings in controller and logged in/out components

### DIFF
--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -75,6 +75,7 @@ export function acceptInvite( context ) {
 				page( redirect );
 			}
 		};
+
 		acceptInviteAction( acceptedInvite, acceptInviteCallback )( context.store.dispatch );
 		return;
 	}

--- a/client/my-sites/invites/invite-accept-logged-in/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-in/index.jsx
@@ -23,7 +23,7 @@ import analytics from 'lib/analytics';
 let InviteAcceptLoggedIn = React.createClass( {
 
 	getInitialState() {
-		return { submitting: false }
+		return { submitting: false };
 	},
 
 	accept() {

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -166,7 +166,7 @@ let InviteAcceptLoggedOut = React.createClass( {
 					disableEmailExplanation={ this.translate( 'This invite is only valid for %(email)s.', { args: { email: this.props.invite.sentTo } } ) } />
 				{ this.state.userData && this.loginUser() }
 			</div>
-		)
+		);
 	}
 
 } );


### PR DESCRIPTION
Fixes a few ESLint warnings that I found while looking through invites code.

To test:
- Checkout `update/invites-controller-eslint-fix` branch
- Go to `/people/new/$site` where `$site` is a WP.com site
- Send a few invites out for logged in and logged out
- Make sure nothing breaks

cc @lezama for review