### PR TITLE
Invites: Store invite_accepted optimistically for logged out invites

### DIFF
--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -49,6 +49,11 @@ export function redirectWithoutLocaleifLoggedIn( context, next ) {
 }
 
 export function acceptInvite( context ) {
+	titleActions.setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) );
+
+	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
+
 	const acceptedInvite = store.get( 'invite_accepted' );
 	if ( acceptedInvite ) {
 		debug( 'invite_accepted is set in localStorage' );
@@ -69,15 +74,10 @@ export function acceptInvite( context ) {
 				debug( 'Accepted invite and redirecting to:  ' + redirect );
 				page( redirect );
 			}
-		}
+		};
 		acceptInviteAction( acceptedInvite, acceptInviteCallback )( context.store.dispatch );
 		return;
 	}
-
-	titleActions.setTitle( i18n.translate( 'Accept Invite', { textOnly: true } ) );
-
-	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-	context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 
 	renderWithReduxStore(
 		React.createElement(

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -6,6 +6,7 @@ import React from 'react';
 import store from 'store';
 import page from 'page';
 import get from 'lodash/get';
+import debugModule from 'debug';
 
 /**
  * Internal Dependencies
@@ -27,6 +28,7 @@ import isEmpty from 'lodash/isEmpty';
  * Module variables
  */
 const user = _user();
+const debug = debugModule( 'calypso:invite-accept:controller' );
 
 function getLocale( parameters ) {
 	const paths = [ 'site_id', 'invitation_key', 'activation_key', 'auth_key', 'locale' ];
@@ -49,17 +51,23 @@ export function redirectWithoutLocaleifLoggedIn( context, next ) {
 export function acceptInvite( context ) {
 	const acceptedInvite = store.get( 'invite_accepted' );
 	if ( acceptedInvite ) {
+		debug( 'invite_accepted is set in localStorage' );
 		if ( user.get().email === acceptedInvite.sentTo ) {
+			debug( 'Setting email_verified in user object' );
 			user.set( { email_verified: true } );
 		}
 		store.remove( 'invite_accepted' );
 		const acceptInviteCallback = error => {
 			if ( error ) {
+				debug( 'Accept invite error: ' + JSON.stringify( error ) );
 				page( window.location.href );
 			} else if ( get( acceptedInvite, 'site.is_vip' ) ) {
+				debug( 'Accepted invite for VIP sites' );
 				window.location.href = getRedirectAfterAccept( acceptedInvite );
 			} else {
-				page( getRedirectAfterAccept( acceptedInvite ) );
+				const redirect = getRedirectAfterAccept( acceptedInvite );
+				debug( 'Accepted invite and redirecting to:  ' + redirect );
+				page( redirect );
 			}
 		}
 		acceptInviteAction( acceptedInvite, acceptInviteCallback )( context.store.dispatch );

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import store from 'store';
+import debugModule from 'debug';
 
 /**
  * Internal dependencies
@@ -20,6 +21,11 @@ import analytics from 'lib/analytics';
 import { errorNotice } from 'state/notices/actions';
 import Card from 'components/card';
 import FormButton from 'components/forms/form-button';
+
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:invite-accept:logged-out' );
 
 let InviteAcceptLoggedOut = React.createClass( {
 
@@ -47,12 +53,17 @@ let InviteAcceptLoggedOut = React.createClass( {
 
 	submitForm( form, userData ) {
 		this.setState( { submitting: true } );
+		debug( 'Storing invite_accepted: ' + JSON.stringify( this.props.invite ) );
+		store.set( 'invite_accepted', this.props.invite );
 
 		const createAccountCallback = ( error, bearerToken ) => {
+			debug( 'Create account error: ' + JSON.stringify( error ) );
+			debug( 'Create account bearerToken: ' + bearerToken );
+
 			if ( error ) {
+				store.remove( 'invite_accepted' );
 				this.setState( { submitting: false } );
 			} else if ( bearerToken ) {
-				store.set( 'invite_accepted', this.props.invite );
 				this.setState( { bearerToken, userData } );
 			}
 		};
@@ -77,7 +88,7 @@ let InviteAcceptLoggedOut = React.createClass( {
 				log={ userData.username }
 				authorization={ 'Bearer ' + bearerToken }
 				redirectTo={ window.location.href } />
-		)
+		);
 	},
 
 	subscribeUserByEmailOnly() {


### PR DESCRIPTION
After looking into #5169, I believe that we may be running into some sort of race condition. For logged out invites, here's what happens. I wasn't able to reproduce myself after 6-8 different invites, so perhaps @alisterscott can help test that this PR solves the issue.

One the user [submits the form](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/invites/invite-accept-logged-out/index.jsx#L48-L65), we:

- Attempt to create an account
- If successful, we store the current invite in `localStorage`
- We update state with `userData` and `bearerToken`
- Then we use the [WPcomLoginForm component to log the user in](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/invites/invite-accept-logged-out/index.jsx#L73-L81). This component actually redirects the user to WordPress.com to login and then redirects the user back to Calypso. Which is why we needed to store the invite in `localStorage`.
- Once we return from logging in, we check to [see if invite_accept is in localStorage](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/invites/controller.js#L50-L67).
- If it is, *then* we accept the invite and log the user in

So, with all of that in mind. I think what's happening in the reported case is that we're logging the user in, but we're not actually accepting the invite.

Also, this layout is no good.

![new user additional dialog](https://cloud.githubusercontent.com/assets/128826/14971122/bd12dfea-1112-11e6-99fe-36695e997aac.png)

It looks like for some reason, the layout isn't being changed to not have a sidebar. Because of that, I'm going to go ahead and move the no sidebar layout to the top of that method.

@alisterscott – I added several debug statements. If you use `localStorage.setItem( 'debug', 'calypso:invite-accept:*' )` you should be able to take advantage of them. Is there any way that we can get that information from the automated tests that you're creating? 