### PR TITLE
Invites: Fix JS error caused from polling sites

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -330,8 +330,7 @@ if ( config.isEnabled( 'accept-invite' ) ) {
 		name: 'accept-invite',
 		paths: [ '/accept-invite' ],
 		module: 'my-sites/invites',
-		enableLoggedOut: true,
-		group: 'sites'
+		enableLoggedOut: true
 	} );
 }
 


### PR DESCRIPTION
Today, I noticed that a JS error was occurring for logged out invites.
![screen shot 2016-05-06 at 4 54 02 pm](https://cloud.githubusercontent.com/assets/1126811/15087561/81ba79b8-13af-11e6-9f01-39855b379fb6.png)

To reproduce:
- Go to `/people/new/$site` where `$site` is a WP.com site
- Send an invite to a non-user
- Click link in your email
- Check console

After digging in, it looks like the error was coming from this line:

https://github.com/Automattic/wp-calypso/blob/master/client/layout/index.jsx#L62

Specifically, trying to add a poller to `this.props.sites` even when the user is logged out. To fix this, I simply removed the `accept-invite` path from the `sites` group.

I tested accepting invites afterward, and it worked. But frankly, I'm not sure if this will cause issues with chunking or anything else. I did notice several other sections did not have groups set, so my guess is no. All the same, pining @mtias who has a better idea.

To test:
- Checkout `fix/invites-poller-js-error` branch
- Go to `/people/new/$site` where `$site` is a WP.com site
- Send an invite to a non-user
- Get link from email and replace `wordpress.com` with `calypso.localhost:3000`
- Check console

Error on production:
![screen shot 2016-05-06 at 5 21 22 pm](https://cloud.githubusercontent.com/assets/1126811/15087628/1b799cfa-13b0-11e6-962d-ea646d9ac531.png)

No error with this branch in development:
![screen shot 2016-05-06 at 5 21 25 pm](https://cloud.githubusercontent.com/assets/1126811/15087633/22c6c5f0-13b0-11e6-84d1-75379d56de0c.png)


cc @lezama for code review.