### PR TITLE
Accessibility: Add a focus style to borderless button

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -169,6 +169,7 @@ button {
 
 	&:focus {
 		box-shadow: none;
+		color: $gray-dark;
 	}
 
 	.gridicon {

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -163,10 +163,7 @@ button {
 	padding-left: 0;
 	padding-right: 0;
 
-	&:hover {
-		color: $gray-dark;
-	}
-
+	&:hover,
 	&:focus {
 		box-shadow: none;
 		color: $gray-dark;


### PR DESCRIPTION
The non-scary borderless button didn't have a :focus style. Notice the lack of indication when tabbing through:

![borderless](https://cloud.githubusercontent.com/assets/5835847/15090109/d8a2bfc0-13d6-11e6-8700-d1dc492772f0.gif)
Before

The scary borderless button uses the hover color for its style. I did the same for this one.

![borderless after](https://cloud.githubusercontent.com/assets/5835847/15090119/274e0a44-13d7-11e6-9a0b-d0d23faa6a43.gif)
After

Ping @MichaelArestad or @mtias for review.