### PR TITLE
Fix rotated genericons in RTL

### DIFF
--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -21,7 +21,11 @@
 }
 
 /*rtl:ignore*/
-.rtl .gridicon {
-	margin-top: -3px;
-	transform: rotate( 90deg );
+.rtl {
+	.navigation-link {
+		.gridicon {
+			margin-top: -3px;
+			transform: scaleX(-1);
+		}
+	}
 }


### PR DESCRIPTION
Fix over inclusive css rule that caused all RTL genericons to be rotated 90 deg.
Also, use scaleX, since it's better suited for flipping icons in RTL.

Fixes #5276