### PR TITLE
Themes: added Support tab to sheet

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
+import { isPremium } from 'my-sites/themes/helpers';
 
 /**
  * Internal dependencies
@@ -54,17 +55,13 @@ const ThemeSheet = React.createClass( {
 		page.back();
 	},
 
-	isPremium() {
-		return this.props.price.value > 0;
-	},
-
 	onPrimaryClick() {
 		// TODO: if active -> customize (could use theme slug from selected site)
 
 		if ( ! this.props.isLoggedIn ) {
 			this.props.dispatch( signup( this.props ) );
 		// TODO: use site picker if no selected site
-		} else if ( this.isPremium() ) {
+		} else if ( isPremium( this.props ) ) {
 			// TODO: check theme is not already purchased
 			this.props.dispatch( purchase( this.props, this.props.selectedSite, 'showcase-sheet' ) );
 		} else {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -21,6 +21,7 @@ import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import Card from 'components/card';
+import Gridicon from 'components/gridicon';
 import { signup, purchase, activate } from 'state/themes/actions';
 import i18n from 'lib/mixins/i18n';
 import { getSelectedSite } from 'state/ui/selectors';
@@ -69,20 +70,6 @@ const ThemeSheet = React.createClass( {
 		} else {
 			this.props.dispatch( activate( this.props, this.props.selectedSite, 'showcase-sheet' ) );
 		}
-	},
-
-	getContentElement( section ) {
-		return {
-			overview: <div dangerouslySetInnerHTML={ { __html: this.props.descriptionLong } } />,
-			setup: <div dangerouslySetInnerHTML={ { __html: this.props.supportDocumentation } } />,
-			support: <div>Visit the support forum</div>,
-		}[ section ];
-	},
-
-	getDangerousElements( section ) {
-		const priceElement = <span className="themes__sheet-action-bar-cost" dangerouslySetInnerHTML={ { __html: this.props.price } } />;
-		const themeContentElement = this.getContentElement( section );
-		return { priceElement, themeContentElement };
 	},
 
 	getValidSections() {
@@ -150,7 +137,53 @@ const ThemeSheet = React.createClass( {
 		);
 	},
 
-	renderFeatures() {
+	renderSectionContent( section ) {
+		return {
+			overview: this.renderOverviewTab(),
+			setup: this.renderSetupTab(),
+			support: this.renderSupportTab(),
+		}[ section ];
+	},
+
+	renderOverviewTab() {
+		return <div>
+				<Card className="themes__sheet-content">
+					<div dangerouslySetInnerHTML={ { __html: this.props.descriptionLong } } />
+				</Card>
+				{ this.renderFeaturesCard() }
+			</div>;
+	},
+
+	renderSetupTab() {
+		return <div>
+				<Card className="themes__sheet-content">
+					<div dangerouslySetInnerHTML={ { __html: this.props.supportDocumentation } } />
+				</Card>
+			</div>;
+	},
+
+	renderSupportTab() {
+		return <div>
+				<Card className="themes__sheet-card-support">
+					<Gridicon icon="comment" size="48" />
+					<div className="themes__sheet-card-support-details">
+						{ i18n.translate( 'Need extra help?' ) }
+						<small>{ i18n.translate( 'Visit the theme support forum' ) }</small>
+					</div>
+					<Button primary="true" href="#undefined">Visit forum</Button>
+				</Card>
+				<Card className="themes__sheet-card-support">
+					<Gridicon icon="briefcase" size="48" />
+					<div className="themes__sheet-card-support-details">
+						{ i18n.translate( 'Need CSS help? ' ) }
+						<small>{ i18n.translate( 'Visit the CSS customization forum' ) }</small>
+					</div>
+					<Button href="//en.forums.wordpress.com/forum/css-customization">Visit forum</Button>
+				</Card>
+			</div>;
+	},
+
+	renderFeaturesCard() {
 		const themeFeatures = this.props.taxonomies && this.props.taxonomies.features instanceof Array
 		? this.props.taxonomies.features.map( function( item, i ) {
 			return ( <li key={ 'theme-features-item-' + i++ }><span>{ item.name }</span></li> );
@@ -177,7 +210,7 @@ const ThemeSheet = React.createClass( {
 		}
 
 		const section = this.validateSection( this.props.section );
-		const { themeContentElement, priceElement } = this.getDangerousElements( section );
+		const priceElement = <span className="themes__sheet-action-bar-cost" dangerouslySetInnerHTML={ { __html: this.props.price } } />;
 
 		return (
 			<Main className="themes__sheet">
@@ -194,8 +227,8 @@ const ThemeSheet = React.createClass( {
 						</HeaderCake>
 						<div className="themes__sheet-content">
 							{ this.renderSectionNav( section ) }
-							<Card className="themes__sheet-content">{ themeContentElement }</Card>
-							{ this.renderFeatures() }
+							{ this.renderSectionContent( section ) }
+							<div className="footer__line"><Gridicon icon="my-sites" /></div>
 						</div>
 					</div>
 					<div className="themes__sheet-column-right">

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -145,24 +145,29 @@ const ThemeSheet = React.createClass( {
 	},
 
 	renderOverviewTab() {
-		return <div>
+		return (
+			<div>
 				<Card className="themes__sheet-content">
 					<div dangerouslySetInnerHTML={ { __html: this.props.descriptionLong } } />
 				</Card>
 				{ this.renderFeaturesCard() }
-			</div>;
+			</div>
+		);
 	},
 
 	renderSetupTab() {
-		return <div>
+		return (
+			<div>
 				<Card className="themes__sheet-content">
 					<div dangerouslySetInnerHTML={ { __html: this.props.supportDocumentation } } />
 				</Card>
-			</div>;
+			</div>
+		);
 	},
 
 	renderSupportTab() {
-		return <div>
+		return (
+			<div>
 				<Card className="themes__sheet-card-support">
 					<Gridicon icon="comment" size={ 48 } />
 					<div className="themes__sheet-card-support-details">
@@ -179,7 +184,8 @@ const ThemeSheet = React.createClass( {
 					</div>
 					<Button href="//en.forums.wordpress.com/forum/css-customization">Visit forum</Button>
 				</Card>
-			</div>;
+			</div>
+		);
 	},
 
 	renderFeaturesCard() {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -27,6 +27,7 @@ import { signup, purchase, activate } from 'state/themes/actions';
 import i18n from 'lib/mixins/i18n';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
+import Helpers from 'my-sites/themes/helpers';
 
 const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
@@ -168,7 +169,7 @@ const ThemeSheet = React.createClass( {
 						{ i18n.translate( 'Need extra help?' ) }
 						<small>{ i18n.translate( 'Visit the theme support forum' ) }</small>
 					</div>
-					<Button primary="true" href="#undefined">Visit forum</Button>
+					<Button primary="true" href={ Helpers.getForumUrl( this.props ) }>Visit forum</Button>
 				</Card>
 				<Card className="themes__sheet-card-support">
 					<Gridicon icon="briefcase" size="48" />

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -41,6 +41,7 @@ const ThemeSheet = React.createClass( {
 		descriptionLong: React.PropTypes.string,
 		supportDocumentation: React.PropTypes.string,
 		taxonomies: React.PropTypes.object,
+		stylesheet: React.PropTypes.string,
 		isLoggedIn: React.PropTypes.bool,
 		// Connected props
 		selectedSite: React.PropTypes.object,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -164,15 +164,15 @@ const ThemeSheet = React.createClass( {
 	renderSupportTab() {
 		return <div>
 				<Card className="themes__sheet-card-support">
-					<Gridicon icon="comment" size="48" />
+					<Gridicon icon="comment" size={ 48 } />
 					<div className="themes__sheet-card-support-details">
 						{ i18n.translate( 'Need extra help?' ) }
 						<small>{ i18n.translate( 'Visit the theme support forum' ) }</small>
 					</div>
-					<Button primary="true" href={ Helpers.getForumUrl( this.props ) }>Visit forum</Button>
+					<Button primary={ true } href={ Helpers.getForumUrl( this.props ) }>Visit forum</Button>
 				</Card>
 				<Card className="themes__sheet-card-support">
-					<Gridicon icon="briefcase" size="48" />
+					<Gridicon icon="briefcase" size={ 48 } />
 					<div className="themes__sheet-card-support-details">
 						{ i18n.translate( 'Need CSS help? ' ) }
 						<small>{ i18n.translate( 'Visit the CSS customization forum' ) }</small>

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -243,7 +243,7 @@
 		flex: 0 0 auto;
 
 		@include breakpoint( "<660px" ) {
-			flex: 0 0 100%;
+			flex: 1 1 100%;
 			margin-top: 20px;
 			text-align: center;
 		}

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -252,7 +252,7 @@
 
 .themes__sheet-card-support-details {
 	flex: 1 1 20px;
-	padding-left: 20px;
+	padding: 0 20px;
 
 	small {
 		display: block;

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -222,6 +222,56 @@
 	}
 }
 
+.themes__sheet-card-support {
+	display: flex;
+	align-items: center;
+
+	&:not(:last-child) {
+		margin-bottom: 0;
+	}
+
+	@include breakpoint( "<660px" ) {
+		flex-wrap: wrap;
+	}
+
+	.gridicon {
+		color: lighten( $gray, 20% );
+		flex: 0 0 auto;
+	}
+
+	.button {
+		flex: 0 0 auto;
+
+		@include breakpoint( "<660px" ) {
+			flex: 0 0 100%;
+			margin-top: 20px;
+			text-align: center;
+		}
+	}
+}
+
+.themes__sheet-card-support-details {
+	flex: 1 1 20px;
+	padding-left: 20px;
+
+	small {
+		display: block;
+		color: $gray;
+	}
+}
+
+.footer__line {
+	color: lighten( $gray, 20% );
+	border-top: 1px solid lighten( $gray, 20% );
+	margin: 32px 0 20px;
+
+	.gridicon {
+		display: block;
+		margin: -12px auto 0;
+		background: $gray-light;
+	}
+}
+
 @include breakpoint( "<660px" ) {
 	.themes__sheet-columns {
 		flex-direction: column-reverse;

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -54,14 +54,14 @@ export function fetchThemes( site ) {
 				dispatch( receiveThemes( themes, site, queryParams, responseTime ) );
 			} )
 			.catch( error => receiveServerError( error ) );
-	}
+	};
 }
 
 export function fetchNextPage( site ) {
 	return dispatch => {
 		dispatch( incrementThemesPage( site ) );
 		dispatch( fetchThemes( site ) );
-	}
+	};
 }
 
 export function query( params ) {
@@ -75,7 +75,7 @@ export function incrementThemesPage( site ) {
 	return {
 		type: THEMES_INCREMENT_PAGE,
 		site: site
-	}
+	};
 }
 
 export function fetchCurrentTheme( site ) {
@@ -89,7 +89,7 @@ export function fetchCurrentTheme( site ) {
 					themeId: theme.id,
 					themeName: theme.name,
 					themeCost: theme.cost
-				} )
+				} );
 			} ); // TODO: add .catch() error handler
 	};
 }
@@ -99,12 +99,12 @@ export function fetchThemeDetails( id ) {
 		wpcom.undocumented().themeDetails( id )
 			.then( themeDetails => {
 				debug( 'Received theme details', themeDetails );
-				dispatch( receiveThemeDetails( themeDetails ) )
+				dispatch( receiveThemeDetails( themeDetails ) );
 			} )
 			.catch( error => {
-				dispatch( receiveServerError( error ) )
+				dispatch( receiveServerError( error ) );
 			} );
-	}
+	};
 }
 
 export function receiveThemeDetails( theme ) {
@@ -119,8 +119,9 @@ export function receiveThemeDetails( theme ) {
 		themeDescriptionLong: theme.description_long,
 		themeSupportDocumentation: theme.extended ? theme.extended.support_documentation : undefined,
 		themeTaxonomies: theme.taxonomies,
+		themeStylesheet: theme.stylesheet,
 	};
-};
+}
 
 export function receiveServerError( error ) {
 	return {
@@ -162,7 +163,7 @@ export function receiveThemes( data, site, queryParams, responseTime ) {
 			: themeAction;
 
 		dispatch( action );
-	}
+	};
 }
 
 export function activate( theme, site, source = 'unknown' ) {
@@ -180,7 +181,7 @@ export function activate( theme, site, source = 'unknown' ) {
 			.catch( error => {
 				dispatch( receiveServerError( error ) );
 			} );
-	}
+	};
 }
 
 export function activated( theme, site, source = 'unknown', purchased = false ) {
@@ -212,14 +213,14 @@ export function activated( theme, site, source = 'unknown', purchased = false ) 
 
 			dispatch( withAnalytics( trackThemeActivation, action ) );
 		} );
-	}
-};
+	};
+}
 
 export function clearActivated() {
 	return {
 		type: THEME_CLEAR_ACTIVATED
 	};
-};
+}
 
 export function signup( theme ) {
 	return dispatch => {
@@ -233,7 +234,7 @@ export function signup( theme ) {
 		// `ThemeHelpers.navigateTo` uses `page()` here, which messes with `pushState`,
 		// which we don't want here, since we're navigating away from Calypso.
 		window.location = signupUrl;
-	}
+	};
 }
 
 // Might be obsolete, since in my-sites/themes, we're using `getUrl()` for Details
@@ -247,8 +248,8 @@ export function details( theme, site ) {
 		} );
 
 		ThemeHelpers.navigateTo( detailsUrl, site.jetpack );
-	}
-};
+	};
+}
 
 // Might be obsolete, since in my-sites/themes, we're using `getUrl()` for Support
 export function support( theme, site ) {
@@ -261,8 +262,8 @@ export function support( theme, site ) {
 		} );
 
 		ThemeHelpers.navigateTo( supportUrl, site.jetpack );
-	}
-};
+	};
+}
 
 export function preview( theme, site ) {
 	return dispatch => {
@@ -274,7 +275,7 @@ export function preview( theme, site ) {
 		} );
 
 		ThemeHelpers.navigateTo( previewUrl, site.jetpack );
-	}
+	};
 }
 
 export function customize( theme, site ) {
@@ -287,8 +288,8 @@ export function customize( theme, site ) {
 		} );
 
 		ThemeHelpers.navigateTo( customizeUrl, site.jetpack );
-	}
-};
+	};
+}
 
 export function purchase( theme, site, source = 'unknown' ) {
 	const CartActions = require( 'lib/upgrades/actions' );
@@ -306,5 +307,5 @@ export function purchase( theme, site, source = 'unknown' ) {
 				site: site
 			} );
 		} );
-	}
+	};
 }

--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -26,6 +26,7 @@ export default ( state = Map(), action ) => {
 					descriptionLong: action.themeDescriptionLong,
 					supportDocumentation: action.themeSupportDocumentation,
 					taxonomies: action.themeTaxonomies,
+					stylesheet: action.themeStylesheet,
 				} ) );
 		case DESERIALIZE:
 			return Map();

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -34,6 +34,7 @@ describe( 'reducer', () => {
 			themeDescription: 'the best theme ever invented',
 			themeDescriptionLong: 'the plato form of a theme',
 			themeSupportDocumentation: 'support comes from within',
+			themeStylesheet: 'premium/mood',
 			themeTaxonomies: {
 				features: [ {
 					term_id: null,
@@ -58,6 +59,7 @@ describe( 'reducer', () => {
 			description: 'the best theme ever invented',
 			descriptionLong: 'the plato form of a theme',
 			supportDocumentation: 'support comes from within',
+			stylesheet: 'premium/mood',
 			taxonomies: {
 				features: [ {
 					term_id: null,


### PR DESCRIPTION
![screen shot 2016-05-09 at 13 24 04](https://cloud.githubusercontent.com/assets/4389/15111749/5b4c5346-15e9-11e6-8675-3d6879018523.png)


This PR does:

1. Add Support page layout (React + CSS)
2. Refactoring: moved tab code to individual render calls + cleanup of the logic
3. Added footer line item (ready to be a component, but might be too much).

### Still Todo

1. ~~The correct URL for the Theme Forum~~
2. ~~A visual glitch on the mobile size on IE11.~~

### To test

1. Open My Sites → Themes
2. Tap any theme's ••• → Details
3. Check the theme sheet page for the Support tab (and the closing footer (W) line) at multiple breakpoints.

