### PR TITLE
state: rename QueryPlans to QuerySitePlans

### DIFF
--- a/client/components/data/domain-management/index.jsx
+++ b/client/components/data/domain-management/index.jsx
@@ -12,7 +12,7 @@ import DomainsStore from 'lib/domains/store';
 import CartStore from 'lib/cart/store';
 import observe from 'lib/mixins/data-observe';
 import * as upgradesActions from 'lib/upgrades/actions';
-import QueryPlans from 'components/data/query-plans';
+import QuerySitePlans from 'components/data/query-site-plans';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 
 const stores = [
@@ -74,7 +74,7 @@ const DomainManagementData = React.createClass( {
 					context={ this.props.context } />
 				{
 					selectedSite &&
-					<QueryPlans siteId={ selectedSite.ID } />
+					<QuerySitePlans siteId={ selectedSite.ID } />
 				}
 			</div>
 		);

--- a/client/components/data/query-plans/README.md
+++ b/client/components/data/query-plans/README.md
@@ -1,8 +1,0 @@
-Query Plans
-===========================
-
-`<QueryPlans />` is a React component used in managing network requests for sites/plans.
-
-## Usage
-
-Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page.

--- a/client/components/data/query-site-plans/README.md
+++ b/client/components/data/query-site-plans/README.md
@@ -1,0 +1,8 @@
+Query Site Plans
+================
+
+`<QuerySitePlans />` is a React component used in managing network requests for sites/plans.
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page.

--- a/client/components/data/query-site-plans/index.jsx
+++ b/client/components/data/query-site-plans/index.jsx
@@ -11,7 +11,7 @@ import { bindActionCreators } from 'redux';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 
-class QueryPlans extends Component {
+class QuerySitePlans extends Component {
 
 	constructor( props ) {
 		super( props );
@@ -42,13 +42,13 @@ class QueryPlans extends Component {
 	}
 }
 
-QueryPlans.propTypes = {
+QuerySitePlans.propTypes = {
 	siteId: PropTypes.number,
 	requestingPlans: PropTypes.bool,
 	fetchSitePlans: PropTypes.func
 };
 
-QueryPlans.defaultProps = {
+QuerySitePlans.defaultProps = {
 	fetchSitePlans: () => {}
 };
 
@@ -63,4 +63,4 @@ export default connect(
 			fetchSitePlans
 		}, dispatch );
 	}
-)( QueryPlans );
+)( QuerySitePlans );

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -13,7 +13,7 @@ import NoticeAction from 'components/notice/notice-action';
 import paths from 'my-sites/upgrades/paths';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import QueryPlans from 'components/data/query-plans';
+import QuerySitePlans from 'components/data/query-site-plans';
 import { abtest } from 'lib/abtest';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
@@ -90,7 +90,7 @@ const SiteNotice = React.createClass( {
 		return (
 			<div className="site__notices">
 				{ this.getSiteRedirectNotice( site ) }
-				<QueryPlans siteId={ site.ID } />
+				<QuerySitePlans siteId={ site.ID } />
 				{ this.domainCreditNotice() }
 			</div>
 		);


### PR DESCRIPTION
I did this PR to rename the current `QueryPlans` query to `QuerySitePlans`. Reasons: 

* This query component depends directly of `siteId` property. In other words this component won't work without this property.
* This component uses `fetchSiteDomains` action function to get site domains. It hits to `/sites/$site/plans` endpoint to get data from REST-API.
* `fetchSiteDomains` function is located in `./client/state/sites/plans/` directory.

* On another hand I've created this PR #5253 to redux `Plans`. The action `fetchWordPressPlans` function hits to `/plans` endpoint. No siteId here.

* This component is located in `./client/state/plans/`.

* I'll work in `QueryPlans` component once this stuff is merged / updated.

### Testing

Test the app where the QuerySitePlans is used such as site plans page: http://calypso.localhost:3000/plans/<your-testing-site>

### State tree
![image](https://cloud.githubusercontent.com/assets/77539/15112613/b06ca192-15c5-11e6-82ab-f953528fe1ba.png)

cc @gwwar @aduth 