### PR TITLE
Customizer: adds panel routing support to customizer

### DIFF
--- a/client/my-sites/customize/controller.js
+++ b/client/my-sites/customize/controller.js
@@ -31,7 +31,8 @@ module.exports = {
 					domain: context.params.domain || '',
 					sites: sites,
 					prevPath: context.prevPath || '',
-					query: context.query
+					query: context.query,
+					panel: context.params.panel
 				} )
 			),
 			document.getElementById( 'primary' )

--- a/client/my-sites/customize/index.js
+++ b/client/my-sites/customize/index.js
@@ -12,7 +12,7 @@ var controller = require( 'my-sites/controller' ),
 
 module.exports = function() {
 	if ( config.isEnabled( 'manage/customize' ) ) {
-		page( '/customize', controller.siteSelection, controller.sites );
-		page( '/customize/:domain', controller.siteSelection, controller.navigation, customizeController.customize );
+		page( '/customize/:panel([^\.]+)?', controller.siteSelection, controller.sites );
+		page( '/customize/:panel?/:domain', controller.siteSelection, controller.navigation, customizeController.customize );
 	}
 };

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -34,6 +34,7 @@ var Customize = React.createClass( {
 		prevPath: React.PropTypes.string,
 		query: React.PropTypes.object,
 		themeActivated: React.PropTypes.func.isRequired,
+		panel: React.PropTypes.string,
 	},
 
 	getDefaultProps: function() {
@@ -196,16 +197,27 @@ var Customize = React.createClass( {
 	},
 
 	buildCustomizerQuery: function() {
-		var protocol = window.location.protocol,
-			host = window.location.host,
-			query = cloneDeep( this.props.query ),
-			site = this.getSite();
+		const { protocol, host } = window.location;
+		const query = cloneDeep( this.props.query );
+		const site = this.getSite();
+		const { panel } = this.props;
 
 		query.return = protocol + '//' + host + this.getPreviousPath();
 		query.calypso = true;
 		query.calypsoOrigin = protocol + '//' + host;
 		if ( site.options && site.options.frame_nonce ) {
 			query['frame-nonce'] = site.options.frame_nonce;
+		}
+
+		// autofocus panels
+		const panels = {
+			widgets: { panel: 'widgets' },
+			fonts: { section: 'jetpack_fonts' },
+			'custom-css': { section: 'jetpack_custom_css' },
+		};
+
+		if ( panels.hasOwnProperty( panel ) ) {
+			query.autofocus = panels[ panel ];
 		}
 
 		return Qs.stringify( query );


### PR DESCRIPTION
This PR adds support for simple routing in the customizer, of the format:
```js
/customize/:panel?/:domain
```
Where `panel` is optional, and is the customizer panel we want to open immediately. The customizer will work normally when the `panel` is omitted. The PR only adds support for the `widgets`, `fonts`, and `custom-css` panels, though others can be added easily.

I have also added support for the route `/customize/:panel` which will load a site-selection screen in order to not break standard calypso behavior. `/customize/:domain` will continue to be recognized separately and continue to work as it always has to load the front page of the customizer.

I am doing this so that we can link directly to particular panels from the [plugins page](https://wordpress.com/plugins). I will have a followup PR to point to widgets and custom-css.

### Testing
Visit the following routes and confirm their behavior.

- https://calypso.localhost:3000/customize --> site-selection route, upon selection loads customizer
- https://calypso.localhost:3000/customize/fonts --> site-selection route, upon selection loads fonts panel
- https://calypso.localhost:3000/customize/custom-css --> site-selection route, upon selection loads custom-css panel
- https://calypso.localhost:3000/customize/widgets --> site-selection route, upon selection loads widgets panel
- `https://calypso.localhost:3000/customize/:domain` --> loads customizer
- `https://calypso.localhost:3000/customize/fonts/:domain` --> loads fonts panel
- `https://calypso.localhost:3000/customize/custom-css/:domain` --> loads custom-css panel
- `https://calypso.localhost:3000/customize/widgets/:domain` --> loads widgets panel


cc @sirbrillig 