### PR TITLE
Signup: Allow for site name editing after the step has been submitted.

### DIFF
--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -132,13 +132,6 @@ module.exports = React.createClass( {
 
 		this.setState( { submitting: true } );
 
-		if ( this.props.step && 'in-progress' !== this.props.step.status ) {
-			this.resetAnalyticsData();
-
-			this.props.goToNextStep();
-			return;
-		}
-
 		this.formStateController.handleSubmit( function( hasErrors ) {
 			var site = formState.getFieldValue( this.state.form, 'site' );
 
@@ -220,7 +213,7 @@ module.exports = React.createClass( {
 	},
 
 	formFields: function() {
-		var fieldDisabled = this.props.step && 'in-progress' !== this.props.step.status;
+		var fieldDisabled = this.state.submitting;
 
 		return <ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }>
 			<FormLabel htmlFor="site">
@@ -247,7 +240,7 @@ module.exports = React.createClass( {
 			return this.translate( 'Site created - Go to next step' );
 		}
 
-		if ( this.state.submitting || ( this.props.step && 'in-progress' !== this.props.step.status ) ) {
+		if ( this.state.submitting ) {
 			return this.translate( 'Creating your site…' );
 		}
 


### PR DESCRIPTION
This PR aims to fix #3273 .

Site name wasn't editable after submitting the step. There is no reason for that, as the information about the site is submitted at the end of the signup process.

Note: Currently the suggested username remains unchanged after returning to the site name step and submitting the change. Not sure if this should be updated (ref: #5234).

Testing:

* Start user signup at `/start/developer` (logged out, as new user)
* Choose theme
* Type site name
* Submit
* At the username form go back and edit the site name
* Submit
* Fill username information and submit 


cc @scruffian @lancewillett @michaeldcain 