### PR TITLE
Framework: Use frontend filtering in getSiteQueryPosts Selector

### DIFF
--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -114,34 +114,6 @@ export function queryRequests( state = {}, action ) {
 }
 
 /**
- * Returns the updated post query state after an action has been dispatched.
- * The state reflects a mapping of serialized query key to an array of post
- * global IDs for the query, if a query response was successfully received.
- *
- * @param  {Object} state  Current state
- * @param  {Object} action Action payload
- * @return {Object}        Updated state
- */
-export function queries( state = {}, action ) {
-	switch ( action.type ) {
-		case POSTS_REQUEST_SUCCESS:
-			const serializedQuery = getSerializedPostsQuery( action.query, action.siteId );
-			return Object.assign( {}, state, {
-				[ serializedQuery ]: action.posts.map( ( post ) => post.global_ID )
-			} );
-
-		case DESERIALIZE:
-			if ( isValidStateWithSchema( state, queriesSchema ) ) {
-				return state;
-			}
-
-			return {};
-	}
-
-	return state;
-}
-
-/**
  * Returns the updated post query last page state after an action has been
  * dispatched. The state reflects a mapping of serialized query to last known
  * page number.
@@ -222,7 +194,6 @@ export default combineReducers( {
 	items,
 	siteRequests,
 	queryRequests,
-	queries,
 	queriesLastPage,
 	edits
 } );

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -13,7 +13,8 @@ import merge from 'lodash/merge';
 import TreeConvert from 'lib/tree-convert';
 import {
 	getSerializedPostsQuery,
-	getSerializedPostsQueryWithoutPage
+	getSerializedPostsQueryWithoutPage,
+	applyQueryToPostsList
 } from './utils';
 import { DEFAULT_POST_QUERY } from './constants';
 
@@ -63,14 +64,9 @@ export const getSitePost = createSelector(
  * @return {?Array}         Posts for the post query
  */
 export function getSitePostsForQuery( state, siteId, query ) {
-	const serializedQuery = getSerializedPostsQuery( query, siteId );
-	if ( ! state.posts.queries[ serializedQuery ] ) {
-		return null;
-	}
+	const sitePosts = getSitePosts( state, siteId );
 
-	return state.posts.queries[ serializedQuery ].map( ( globalId ) => {
-		return getPost( state, globalId );
-	} ).filter( Boolean );
+	return applyQueryToPostsList( sitePosts, query );
 }
 
 /**

--- a/client/state/posts/test/reducer.js
+++ b/client/state/posts/test/reducer.js
@@ -45,7 +45,6 @@ describe( 'reducer', () => {
 			'items',
 			'siteRequests',
 			'queryRequests',
-			'queries',
 			'queriesLastPage',
 			'edits'
 		] );
@@ -236,83 +235,6 @@ describe( 'reducer', () => {
 			} );
 
 			const state = queryRequests( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {} );
-		} );
-	} );
-
-	describe( '#queries()', () => {
-		it( 'should default to an empty object', () => {
-			const state = queries( undefined, {} );
-
-			expect( state ).to.eql( {} );
-		} );
-
-		it( 'should track post query request success', () => {
-			const state = queries( undefined, {
-				type: POSTS_REQUEST_SUCCESS,
-				siteId: 2916284,
-				query: { search: 'Hello' },
-				found: 1,
-				posts: [
-					{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-				]
-			} );
-
-			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-			} );
-		} );
-
-		it( 'should accumulate query request success', () => {
-			const original = deepFreeze( {
-				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-			} );
-			const state = queries( original, {
-				type: POSTS_REQUEST_SUCCESS,
-				siteId: 2916284,
-				query: { search: 'Hello W' },
-				posts: [
-					{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-				]
-			} );
-
-			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
-				'2916284:{"search":"hello w"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-			} );
-		} );
-
-		it( 'should persist state', () => {
-			const original = deepFreeze( {
-				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-			} );
-
-			const state = queries( original, { type: SERIALIZE } );
-
-			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-			} );
-		} );
-
-		it( 'should load persisted state', () => {
-			const original = deepFreeze( {
-				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-			} );
-
-			const state = queries( original, { type: DESERIALIZE } );
-
-			expect( state ).to.eql( {
-				'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-			} );
-		} );
-
-		it( 'should not load invalid persisted state', () => {
-			const original = deepFreeze( {
-				2916284: [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
-			} );
-
-			const state = queries( original, { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {} );
 		} );

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -92,30 +92,27 @@ describe( 'selectors', () => {
 	} );
 
 	describe( '#getSitePostsForQuery()', () => {
-		it( 'should return null if the site query is not tracked', () => {
+		it( 'should return an empty array if no posts items', () => {
 			const sitePosts = getSitePostsForQuery( {
 				posts: {
-					queries: {}
+					items: {}
 				}
 			}, 2916284, { search: 'Hello' } );
 
-			expect( sitePosts ).to.be.null;
+			expect( sitePosts ).to.eql( [] );
 		} );
 
 		it( 'should return an array of the known queried posts', () => {
 			const sitePosts = getSitePostsForQuery( {
 				posts: {
 					items: {
-						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
-					},
-					queries: {
-						'2916284:{"search":"hello"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ]
+						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World', parent: 100 }
 					}
 				}
-			}, 2916284, { search: 'Hello' } );
+			}, 2916284, { parent_id: 100 } );
 
 			expect( sitePosts ).to.eql( [
-				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World', parent: 100 }
 			] );
 		} );
 
@@ -283,15 +280,11 @@ describe( 'selectors', () => {
 						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
 						'6c831c187ffef321eb43a67761a525a3': { ID: 413, site_ID: 2916284, global_ID: '6c831c187ffef321eb43a67761a525a3', title: 'Ribs & Chicken' }
 					},
-					queries: {
-						'2916284:{"number":1}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
-						'2916284:{"number":1,"page":2}': [ '6c831c187ffef321eb43a67761a525a3' ]
-					},
 					queriesLastPage: {
-						'2916284:{"number":1}': 2
+						'2916284:{"order":"asc","order_by":"title","number":1}': 2
 					}
 				}
-			}, 2916284, { search: '', number: 1 } );
+			}, 2916284, { order: 'ASC', order_by: 'title', number: 1 } );
 
 			expect( sitePosts ).to.eql( [
 				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' },
@@ -324,15 +317,15 @@ describe( 'selectors', () => {
 						'f0cb4eb16f493c19b627438fdc18d57c': { ID: 120, site_ID: 2916284, global_ID: 'f0cb4eb16f493c19b627438fdc18d57c', title: 'Steak & Eggs', parent: { ID: 413 } } // eslint-disable-line
 					},
 					queries: {
-						'2916284:{"number":1}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
-						'2916284:{"number":1,"page":2}': [ '6c831c187ffef321eb43a67761a525a3' ],
-						'2916284:{"number":1,"page":3}': [ 'f0cb4eb16f493c19b627438fdc18d57c' ]
+						'2916284:{"number":1,"order_by":"title","order":"asc"}': [ '3d097cb7c5473c169bba0eb8e3c6cb64' ],
+						'2916284:{"number":1,"order_by":"title","order":"asc","page":2}': [ '6c831c187ffef321eb43a67761a525a3' ],
+						'2916284:{"number":1,"order_by":"title","order":"asc","page":3}': [ 'f0cb4eb16f493c19b627438fdc18d57c' ]
 					},
 					queriesLastPage: {
-						'2916284:{"number":1}': 3
+						'2916284:{"number":1,"order_by":"title","order":"asc"}': 3
 					}
 				}
-			}, 2916284, { search: '', number: 1 } );
+			}, 2916284, { search: '', number: 1, order_by: 'title', order: 'asc' } );
 
 			expect( sitePosts ).to.eql( [
 				{ ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World', parent: 0 },

--- a/client/state/posts/test/utils.js
+++ b/client/state/posts/test/utils.js
@@ -9,7 +9,8 @@ import { expect } from 'chai';
 import {
 	getNormalizedPostsQuery,
 	getSerializedPostsQuery,
-	getSerializedPostsQueryWithoutPage
+	getSerializedPostsQueryWithoutPage,
+	applyQueryToPostsList
 } from '../utils';
 
 describe( 'utils', () => {
@@ -79,6 +80,223 @@ describe( 'utils', () => {
 			}, 2916284 );
 
 			expect( serializedQuery ).to.equal( '2916284:{"search":"hello"}' );
+		} );
+	} );
+
+	describe( '#applyQueryToPostsList()', () => {
+		const post1 = {
+			ID: 841,
+			site_ID: 2916284,
+			global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64',
+			title: 'Hello World',
+			date: '2016-03-25T15:47:33-04:00',
+			modified: '2016-04-29T11:53:53-04:00',
+			tags: {
+				Tagged: {
+					ID: 17695,
+					name: 'Tagged!',
+					slug: 'tagged'
+				}
+			},
+			categories: {
+				'Categorized!': {
+					ID: 5519,
+					name: 'Categorized!',
+					slug: 'categorized'
+				}
+			},
+			type: 'post',
+			parent: 100,
+			sticky: true,
+			discussion: {
+				comment_count: 0
+			}
+		};
+		const post2 = {
+			ID: 413,
+			site_ID: 2916284,
+			global_ID: '6c831c187ffef321eb43a67761a525a3',
+			title: 'Ribs & Chicken',
+			date: '2016-04-25T15:47:33-04:00',
+			modified: '2016-05-29T11:53:53-04:00',
+			tags: {
+				Tagged2: {
+					ID: 17695,
+					name: 'Tagged2!',
+					slug: 'tagged2'
+				}
+			},
+			categories: {
+				Categorized2: {
+					ID: 5519,
+					name: 'Categorized2!',
+					slug: 'categorized2'
+				}
+			},
+			type: 'page',
+			author: {
+				ID: 73705554,
+				login: 'testonesite2014'
+			},
+			status: 'publish',
+			discussion: {
+				comment_count: 1
+			}
+		};
+		const originalPosts = [ post1, post2 ];
+
+		it( 'should return the specified number of posts', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				number: 1,
+				page: 1
+			} );
+			expect( posts ).to.eql( [post2] );
+		} );
+
+		it( 'should take the page parameter into account', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				number: 1,
+				page: 2
+			} );
+			expect( posts ).to.eql( [post1] );
+		} );
+
+		it( 'should take the offset parameter into account', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				number: 1,
+				offset: 1
+			} );
+			expect( posts ).to.eql( [post1] );
+		} );
+
+		it( 'should take the ord parameter into account before pagination', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				number: 1,
+				offset: 1,
+				order: 'DESC',
+				order_by: 'date'
+			} );
+			expect( posts ).to.eql( [post1] );
+		} );
+
+		it( 'should order by title', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				number: 1,
+				order: 'DESC',
+				order_by: 'title'
+			} );
+			expect( posts ).to.eql( [post2] );
+		} );
+
+		it( 'should order by comment_count', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				number: 1,
+				order: 'DESC',
+				order_by: 'comment_count'
+			} );
+			expect( posts ).to.eql( [post2] );
+		} );
+
+		it( 'should order by modified', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				number: 1,
+				order: 'DESC',
+				order_by: 'modified'
+			} );
+			expect( posts ).to.eql( [post2] );
+		} );
+
+		it( 'should order by ID', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				number: 1,
+				order: 'DESC',
+				order_by: 'ID'
+			} );
+			expect( posts ).to.eql( [post1] );
+		} );
+
+		it( 'should filter after date', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				after: '2016-03-26T15:47:33-04:00'
+			} );
+			expect( posts ).to.eql( [post2] );
+		} );
+
+		it( 'should filter before date', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				before: '2016-03-26T15:47:33-04:00'
+			} );
+			expect( posts ).to.eql( [post1] );
+		} );
+
+		it( 'should filter after modification date', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				modified_after: '2016-04-30T11:53:53-04:00'
+			} );
+			expect( posts ).to.eql( [post2] );
+		} );
+
+		it( 'should filter before modification date', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				modified_before: '2016-04-30T11:53:53-04:00'
+			} );
+			expect( posts ).to.eql( [post1] );
+		} );
+
+		it( 'should filter by tag', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				tag: 'tagged2'
+			} );
+			expect( posts ).to.eql( [post2] );
+		} );
+
+		it( 'should filter by category', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				category: 'categorized'
+			} );
+			expect( posts ).to.eql( [post1] );
+		} );
+
+		it( 'should filter by type', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				type: 'page'
+			} );
+			expect( posts ).to.eql( [post2] );
+		} );
+
+		it( 'should filter by parent', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				parent_id: 100
+			} );
+			expect( posts ).to.eql( [post1] );
+		} );
+
+		it( 'should exclude post ids', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				exclude: 841
+			} );
+			expect( posts ).to.eql( [post2] );
+		} );
+
+		it( 'should filter by sticky flag', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				sticky: 'require'
+			} );
+			expect( posts ).to.eql( [post1] );
+		} );
+
+		it( 'should filter by author', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				author: 73705554
+			} );
+			expect( posts ).to.eql( [post2] );
+		} );
+
+		it( 'should filter by status', () => {
+			const posts = applyQueryToPostsList( originalPosts, {
+				status: 'publish'
+			} );
+			expect( posts ).to.eql( [post2] );
 		} );
 	} );
 } );

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
+import moment from 'moment';
+import get from 'lodash/get';
+import includes from 'lodash/includes';
 import omit from 'lodash/omit';
 import omitBy from 'lodash/omitBy';
+import some from 'lodash/some';
 
 /**
  * Internal dependencies
@@ -49,4 +53,214 @@ export function getSerializedPostsQuery( query = {}, siteId ) {
  */
 export function getSerializedPostsQueryWithoutPage( query, siteId ) {
 	return getSerializedPostsQuery( omit( query, 'page' ), siteId );
+}
+
+/**
+ * Taks a query key name and returns a function that takes a post and a filterValue
+ * and returns a Boolean Whether the post match the query value or not
+ * The query key can be one of (after, before, modified_after, modified_before)
+ *
+ * @param  {String} key Query Key
+ * @return {Function}   Post filtering function
+ */
+function doPostMatchDate( key ) {
+	return ( post, value ) => {
+		const queryDate = moment( value, moment.ISO_8601 );
+		const comparison = /after$/.test( key ) ? 'isAfter' : 'isBefore';
+		const field = /^modified_/.test( key ) ? 'modified' : 'date';
+		return queryDate.isValid() && moment( post[ field ] )[ comparison ]( queryDate );
+	};
+}
+
+/**
+ * Taks a query key name and returns a function that takes a post and a filterValue
+ * and returns a Boolean Whether the post match the query value or not
+ * The query key can be one of (tag, category)
+ *
+ * @param  {String} key Query Key
+ * @return {Function}   Post filtering function
+ */
+function doPostMatchTagCategory( key ) {
+	return ( post, value ) => {
+		const search = new RegExp( `^${ value }$`, 'i' );
+		const field = 'tag' === key ? 'tags' : 'categories';
+		return some( post[ field ], ( { name, slug } ) => {
+			return search.test( name ) || search.test( slug );
+		} );
+	};
+}
+
+/**
+ * Takes a post and checks Whether the post match the type
+ *
+ * @param  {Object} post  Post object
+ * @param  {string} value Post Type
+ * @return {Boolean}      Whether the post has value as type
+ */
+function doPostMatchType( post, value ) {
+	return 'any' === value || value === post.type;
+}
+
+/**
+ * Takes a post and check if he has value as parent
+ *
+ * @param  {Object} post  Post object
+ * @param  {string} value Post ID
+ * @return {Boolean}      Whether the post has value as parent
+ */
+function doPostMatchParent( post, value ) {
+	return value === post.parent;
+}
+
+/**
+ * Checkes Whether the post is excluded
+ *
+ * @param  {Object} post  Post object
+ * @param  {Array} value  Post Ids
+ * @return {Boolean}      Whether the post is excluded
+ */
+function doPostMatchExclude( post, value ) {
+	if ( Array.isArray( value ) ) {
+		return ! includes( value, post.ID );
+	}
+
+	return value !== post.ID;
+}
+
+/**
+ * Check if the post is excluded from query
+ * based on the value of the sticky filter
+ *
+ * @param  {Object} post  Post object
+ * @param  {string} value Sticky filter value
+ * @return {Boolean}      Whether the post is excluded
+ */
+function doPostMatchSticky( post, value ) {
+	if ( 'require' === value ) {
+		return post.sticky;
+	} else if ( 'exclude' === value ) {
+		return ! post.sticky;
+	}
+
+	return true;
+}
+
+/**
+ * Checks if the post author matchs the provided value
+ *
+ * @param  {Object} post  Post object
+ * @param  {Number} value Author ID
+ * @return {Boolean}      Whether the post has the provided author
+ */
+function doPostMatchAuthor( post, value ) {
+	return get( post, 'author.ID', post.author ) === value;
+}
+
+/**
+ * Checks if the post status matchs the provided value
+ *
+ * @param  {Object} post  Post object
+ * @param  {Number} value Post status
+ * @return {Boolean}      Whether the post has the provided status
+ */
+function doPostMatchStatus( post, value ) {
+	return value === post.status;
+}
+
+const matchingFunctions = {
+	after: doPostMatchDate( 'after' ),
+	before: doPostMatchDate( 'before' ),
+	modified_after: doPostMatchDate( 'modified_after' ),
+	modified_before: doPostMatchDate( 'modified_before' ),
+	tag: doPostMatchTagCategory( 'tag' ),
+	category: doPostMatchTagCategory( 'category' ),
+	type: doPostMatchType,
+	parent_id: doPostMatchParent,
+	exclude: doPostMatchExclude,
+	sticky: doPostMatchSticky,
+	author: doPostMatchAuthor,
+	status: doPostMatchStatus
+};
+
+/**
+ * Checks Whether the post matchs the provided query key
+ *
+ * @param  {Object} post  Post object
+ * @param  {Object} query Posts query object
+ * @param  {String} key   Query key
+ * @return {Boolean}      Whether the post matchs the query key
+ */
+function doPostMatchQueryKey( post, query, key ) {
+	const doMatch = matchingFunctions[key];
+	return ! ( key in query ) || doMatch( post, query[key] );
+}
+
+/**
+ * Checks Whether the post matchs the provided query
+ *
+ * @param  {Object} post  Post object
+ * @param  {Object} query Posts query object
+ * @return {Boolean}      Whether the post matchs the query
+ */
+export function doPostMatchQuery( post, query ) {
+	return Object.keys( matchingFunctions )
+		.every( key => doPostMatchQueryKey( post, query, key ) );
+}
+
+/**
+ * Sort Compare Function based on a query object
+ *
+ * @param  {Object} query  Posts query object
+ * @param  {Object} postA  Post object
+ * @param  {Object} postB  Post object
+ * @return {Number}        Whether postA is greater/lower or equal to postB
+ */
+function comparePostsByQuery( query, postA, postB ) {
+	let order;
+
+	switch ( query.order_by ) {
+		case 'ID':
+			order = postA.ID - postB.ID;
+			break;
+
+		case 'comment_count':
+			order = postA.discussion.comment_count - postB.discussion.comment_count;
+			break;
+
+		case 'title':
+			order = postA.title.localeCompare( postB.title );
+			break;
+
+		case 'modified':
+			order = moment( postA.modified ).diff( postB.modified );
+			break;
+
+		case 'date':
+		default:
+			order = moment( postA.date ).diff( postB.date );
+	}
+
+	// Default to descending order, opposite sign of ordered result
+	if ( ! query.order || /^desc$/i.test( query.order ) ) {
+		order *= -1;
+	}
+
+	return order || 0;
+}
+
+/**
+ * Apply query filtering, pagination and sorting to a post list
+ *
+ * @param  {Array} posts  Posts list
+ * @param  {Object} query Posts query object
+ * @return {Array}        Posts for the post query
+ */
+export function applyQueryToPostsList( posts, query ) {
+	const { number = 20, offset = 0, page } = query,
+		startAt = page ? ( page - 1 * number ) : offset;
+
+	return posts
+		.filter( post => doPostMatchQuery( post, query ) )
+		.sort( ( postA, postB ) => comparePostsByQuery( query, postA, postB ) )
+		.splice( startAt, number );
 }


### PR DESCRIPTION
This is an experiment to implement the getSiteQueryPosts redux selector by applying the query filters client-side. Instead of relying on backend results and storing them in the redux global state while fetching posts, we apply the same backend filters on the client. This have some pros and cons as well.

**Pros**
 - If the posts are updated by any other action in the redux state (delete, update etc...), the query result is immediately reflected on the different views (no need to trigger a refresh).

**Cons**
 - Unfortunately all the backend filters can not be reproduced on the client side (search for example or metadata are not so obvious to implement). It also requires the two filtering algorithms to be in sync.

---
This is an alternative approach to the solution proposed here https://github.com/Automattic/wp-calypso/pull/5135. The two use client filters to update the results : The selector approach is full frontend while the `QueryManager` is a mixed approach (rely on the backend for the initial loading and update those results each time there's an action that alters them).

I think the more we replace the Flux Stores by The redux global store, the more we would need a solution for this.

**Questions :**
I also think the selector is a good one if we limit the used query filters to the ones that can be reproduced in front. Are those filters sufficient for all calypso's use cases ? 
If not, we could keep the `queries` reducer and have two selectors, one auto-updated using the frontend filters and another one (manually refreshed) that relies on the `queries` reducer.

@aduth 