### PR TITLE
Add a context to tracks post like events

### DIFF
--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -338,7 +338,7 @@ FullPostDialog = React.createClass( {
 			buttons.push( <PostOptions key="post-options" position="bottom left" post={ post } site={ site } onBlock={ this.props.onClose } /> );
 
 			if ( shouldShowLikes ) {
-				buttons.push( <LikeButton key="like-button" siteId={ post.site_ID } postId={ post.ID } tagName="div" forceCounter={ true } /> );
+				buttons.push( <LikeButton key="like-button" siteId={ post.site_ID } postId={ post.ID } fullPost={ true } tagName="div" forceCounter={ true } /> );
 			}
 
 			if ( shouldShowComments ) {

--- a/client/reader/like-button/index.jsx
+++ b/client/reader/like-button/index.jsx
@@ -1,19 +1,20 @@
-var React = require( 'react' );
-var postStore = require( 'lib/feed-post-store' );
+const React = require( 'react' );
 
-var LikeButtonContainer = require( 'components/like-button' ),
+const postStore = require( 'lib/feed-post-store' );
+
+const LikeButtonContainer = require( 'components/like-button' ),
 	stats = require( 'reader/stats' );
 
-var ReaderLikeButton = React.createClass( {
+const ReaderLikeButton = React.createClass( {
 
 	recordLikeToggle: function( liked ) {
-		var post = postStore.get( {
+		const post = postStore.get( {
 			blogId: this.props.siteId,
 			postId: this.props.postId
 		} );
 		stats.recordAction( liked ? 'liked_post' : 'unliked_post' );
 		stats.recordGaEvent( liked ? 'Clicked Like Post' : 'Clicked Unlike Post' );
-		stats.recordTrackForPost( liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked', post );
+		stats.recordTrackForPost( liked ? 'calypso_reader_article_liked' : 'calypso_reader_article_unliked', post, { context: this.props.fullPost ? 'full-post' : 'card' } );
 	},
 
 	render: function() {


### PR DESCRIPTION
We show two types of like buttons, ones on a post card in a feed view and one
on a single post expanded view. This adds a context to the like event so that
it's easier to tell where the user liked the post from.