### PR TITLE
CPT: add private label for post-type-filter

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -57,6 +57,12 @@ const PostTypeFilter = React.createClass( {
 					} );
 					break;
 
+				case 'private':
+					label = this.translate( 'Private', {
+						context: 'Filter label for posts list'
+					} );
+					break;
+
 				case 'future':
 					label = this.translate( 'Scheduled', {
 						context: 'Filter label for posts list'

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -57,6 +57,12 @@ const PostTypeFilter = React.createClass( {
 					} );
 					break;
 
+				case 'pending':
+					label = this.translate( 'Pending', {
+						context: 'Filter label for posts list'
+					} );
+					break;
+
 				case 'private':
 					label = this.translate( 'Private', {
 						context: 'Filter label for posts list'


### PR DESCRIPTION
While testing #5135 I had an empty label in the nav items above the post type list:

__Before__
![posts_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/15123480/e5217a62-15d8-11e6-9944-a06597adad75.png)

__After__
![posts_ _testingtimmy2_wordpress_com_ _wordpress_com](https://cloud.githubusercontent.com/assets/22080/15123501/f6b3a624-15d8-11e6-8072-f56c4847df11.png)

__To Test__
- View a post type list at http://calypso.localhost:3000/types/post, for a site that has private posts
- Validate the label for private shows up properly