### PR TITLE
Editor/CPT: Display accordions for custom taxonomies available for post type

### DIFF
--- a/client/components/data/query-taxonomies/README.md
+++ b/client/components/data/query-taxonomies/README.md
@@ -1,0 +1,50 @@
+Query Taxonomies
+================
+
+`<QueryTaxonomies />` is a React component used in managing network requests for post type taxonomies.
+
+## Usage
+
+Render the component, passing `siteId` and `postType`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import QueryTaxonomies from 'components/data/query-taxonomies';
+
+export default function MyTaxonomiesList( { taxonomies } ) {
+	return (
+		<ul>
+			<QueryTaxonomies
+				siteId={ 3584907 }
+				postType="post" />
+			{ taxonomies.map( ( taxonomy ) => {
+				return (
+					<li key={ taxonomy.name }>
+						{ taxonomy.label }
+					</li>
+				);
+			} }
+		</ul>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site ID for which taxonomies should be requested.
+
+### `postType`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The post type for which taxonomies should be requested.

--- a/client/components/data/query-taxonomies/index.jsx
+++ b/client/components/data/query-taxonomies/index.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestPostTypeTaxonomies } from 'state/post-types/taxonomies/actions';
+import { isRequestingPostTypeTaxonomies } from 'state/post-types/taxonomies/selectors';
+
+class QueryTaxonomies extends Component {
+	componentWillMount() {
+		this.request( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.siteId === nextProps.siteId &&
+				this.props.postType === nextProps.postType ) {
+			return;
+		}
+
+		this.request( nextProps );
+	}
+
+	request( props ) {
+		if ( props.requesting ) {
+			return;
+		}
+
+		props.requestPostTypeTaxonomies( props.siteId, props.postType );
+	}
+
+	shouldComponentUpdate() {
+		return false;
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryTaxonomies.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	postType: PropTypes.string.isRequired,
+	requesting: PropTypes.bool.isRequired,
+	requestPostTypeTaxonomies: PropTypes.func.isRequired
+};
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			requesting: isRequestingPostTypeTaxonomies( state, ownProps.siteId, ownProps.postType )
+		};
+	},
+	{
+		requestPostTypeTaxonomies
+	}
+)( QueryTaxonomies );

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import get from 'lodash/get';
+import includes from 'lodash/includes';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -36,7 +37,9 @@ import { setExcerpt } from 'state/ui/editor/post/actions';
 import QueryPostTypes from 'components/data/query-post-types';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getPostTypes } from 'state/post-types/selectors';
+import config from 'config';
 import EditorDrawerFeaturedImage from './featured-image';
+import EditorDrawerTaxonomies from './taxonomies';
 
 const EditorDrawer = React.createClass( {
 	propTypes: {
@@ -89,6 +92,11 @@ const EditorDrawer = React.createClass( {
 
 	renderTaxonomies: function() {
 		var element;
+
+		if ( config.isEnabled( 'manage/custom-post-types' ) &&
+				! includes( [ 'post', 'page' ], this.props.type ) ) {
+			return <EditorDrawerTaxonomies />;
+		}
 
 		if ( ! this.currentPostTypeSupports( 'tags' ) ) {
 			return;

--- a/client/post-editor/editor-drawer/taxonomies.jsx
+++ b/client/post-editor/editor-drawer/taxonomies.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import map from 'lodash/map';
+
+/**
+ * Internal dependencies
+ */
+import QueryTaxonomies from 'components/data/query-taxonomies';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
+import { getPostTypeTaxonomies } from 'state/post-types/taxonomies/selectors';
+import Accordion from 'components/accordion';
+import Gridicon from 'components/gridicon';
+
+function EditorDrawerTaxonomies( { siteId, postType, taxonomies } ) {
+	return (
+		<div className="editor-drawer__taxonomies">
+			{ siteId && postType && (
+				<QueryTaxonomies { ...{ siteId, postType } } />
+			) }
+			{ map( taxonomies, ( taxonomy ) => {
+				if ( 'post_format' === taxonomy.name ) {
+					// Post format has its own dedicated accordion
+					return;
+				}
+
+				return (
+					<Accordion
+						key={ taxonomy.name }
+						title={ taxonomy.label }
+						icon={ <Gridicon icon="tag" /> }>
+						Work in Progress
+					</Accordion>
+				);
+			} ).filter( Boolean ) }
+		</div>
+	);
+}
+
+EditorDrawerTaxonomies.propTypes = {
+	siteId: PropTypes.number,
+	postType: PropTypes.string,
+	taxonomies: PropTypes.array
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const postType = getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' );
+
+	return {
+		siteId,
+		postType,
+		taxonomies: getPostTypeTaxonomies( state, siteId, postType )
+	};
+} )( EditorDrawerTaxonomies );

--- a/client/state/post-types/taxonomies/selectors.js
+++ b/client/state/post-types/taxonomies/selectors.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import get from 'lodash/get';
+import values from 'lodash/values';
+
+/**
+ * Returns true if a network request is in-progress for the specified site ID,
+ * post type pair, or false otherwise.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {String}  postType Post type
+ * @return {Boolean}          Whether request is in-progress
+ */
+export function isRequestingPostTypeTaxonomies( state, siteId, postType ) {
+	return get( state.postTypes.taxonomies.requesting, [ siteId, postType ], false );
+}
+
+/**
+ * Returns taxonomies for the given post type on a site, or null if the
+ * taxonomies are not known.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {String}  postType Post type
+ * @return {Array?}           Post type taxonomies
+ */
+export function getPostTypeTaxonomies( state, siteId, postType ) {
+	const taxonomies = get( state.postTypes.taxonomies.items, [ siteId, postType ] );
+	if ( ! taxonomies ) {
+		return null;
+	}
+
+	return values( taxonomies );
+}

--- a/client/state/post-types/taxonomies/test/selectors.js
+++ b/client/state/post-types/taxonomies/test/selectors.js
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isRequestingPostTypeTaxonomies,
+	getPostTypeTaxonomies
+} from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'isRequestingPostTypeTaxonomies()', () => {
+		it( 'should return false if no request has been made for site', () => {
+			const isRequesting = isRequestingPostTypeTaxonomies( {
+				postTypes: {
+					taxonomies: {
+						requesting: {}
+					}
+				}
+			}, 2916284, 'post' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return false if no request has been made for site post type', () => {
+			const isRequesting = isRequestingPostTypeTaxonomies( {
+				postTypes: {
+					taxonomies: {
+						requesting: {
+							2916284: {
+								page: true
+							}
+						}
+					}
+				}
+			}, 2916284, 'post' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return false if request has finished for site post type', () => {
+			const isRequesting = isRequestingPostTypeTaxonomies( {
+				postTypes: {
+					taxonomies: {
+						requesting: {
+							2916284: {
+								page: true,
+								post: false
+							}
+						}
+					}
+				}
+			}, 2916284, 'post' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return true if requesting for site post type', () => {
+			const isRequesting = isRequestingPostTypeTaxonomies( {
+				postTypes: {
+					taxonomies: {
+						requesting: {
+							2916284: {
+								page: true,
+								post: true
+							}
+						}
+					}
+				}
+			}, 2916284, 'post' );
+
+			expect( isRequesting ).to.be.true;
+		} );
+	} );
+
+	describe( 'getPostTypeTaxonomies()', () => {
+		it( 'should return null if taxonomies are not known', () => {
+			const taxonomies = getPostTypeTaxonomies( {
+				postTypes: {
+					taxonomies: {
+						items: {}
+					}
+				}
+			}, 2916284, 'post' );
+
+			expect( taxonomies ).to.be.null;
+		} );
+
+		it( 'should return an array of known taxonomies', () => {
+			const taxonomies = getPostTypeTaxonomies( {
+				postTypes: {
+					taxonomies: {
+						items: {
+							2916284: {
+								post: {
+									category: {
+										name: 'category',
+										label: 'Categories'
+									},
+									post_tag: {
+										name: 'post_tag',
+										label: 'Tags'
+									}
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'post' );
+
+			expect( taxonomies ).to.eql( [
+				{ name: 'category', label: 'Categories' },
+				{ name: 'post_tag', label: 'Tags' }
+			] );
+		} );
+	} );
+} );

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import get from 'lodash/get';
 import range from 'lodash/range';
 import createSelector from 'lib/create-selector';
 import filter from 'lodash/filter';
@@ -209,4 +210,17 @@ export function getEditedPost( state, siteId, postId ) {
 	}
 
 	return merge( {}, post, edits );
+}
+
+/**
+ * Returns the assigned value for the edited post by field key.
+ *
+ * @param  {Object} state  Global state tree
+ * @param  {Number} siteId Site ID
+ * @param  {Number} postId Post ID
+ * @param  {String} field  Field value to retrieve
+ * @return {*}             Field value
+ */
+export function getEditedPostValue( state, siteId, postId, field ) {
+	return get( getEditedPost( state, siteId, postId ), field );
 }

--- a/client/state/posts/test/selectors.js
+++ b/client/state/posts/test/selectors.js
@@ -17,7 +17,8 @@ import {
 	getSitePostsForQueryIgnoringPage,
 	getSitePostsHierarchyForQueryIgnoringPage,
 	isRequestingSitePost,
-	getEditedPost
+	getEditedPost,
+	getEditedPostValue
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -476,6 +477,59 @@ describe( 'selectors', () => {
 			}, 2916284, 841 );
 
 			expect( editedPost ).to.eql( { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', discussion: { comments_open: true, pings_open: true } } );
+		} );
+	} );
+
+	describe( 'getEditedPostValue()', () => {
+		it( 'should return undefined if the post does not exist', () => {
+			const editedPostValue = getEditedPostValue( {
+				posts: {
+					items: {},
+					edits: {}
+				}
+			}, 2916284, 841, 'title' );
+
+			expect( editedPostValue ).to.be.undefined;
+		} );
+
+		it( 'should return the assigned post value', () => {
+			const editedPostValue = getEditedPostValue( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', title: 'Hello World' }
+					},
+					edits: {
+						2916284: {
+							841: {
+								title: 'Hello World!'
+							}
+						}
+					}
+				}
+			}, 2916284, 841, 'title' );
+
+			expect( editedPostValue ).to.equal( 'Hello World!' );
+		} );
+
+		it( 'should return the assigned nested post value', () => {
+			const editedPostValue = getEditedPostValue( {
+				posts: {
+					items: {
+						'3d097cb7c5473c169bba0eb8e3c6cb64': { ID: 841, site_ID: 2916284, global_ID: '3d097cb7c5473c169bba0eb8e3c6cb64', discussion: { comments_open: true } }
+					},
+					edits: {
+						2916284: {
+							841: {
+								discussion: {
+									pings_open: true
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 841, 'discussion.pings_open' );
+
+			expect( editedPostValue ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to display a single editor sidebar accordion for each custom taxonomy available for the custom post type.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15125874/2e07aeee-15fd-11e6-8f4e-36886c7e8ae6.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15125886/38568e38-15fd-11e6-85d2-0948344479f5.png)

_Example shows portfolio custom post type_

__Implementation notes:__

Includes additional post type taxonomies and edited post selectors for retrieving available taxonomies, and a `<QueryTaxonomies />` [query component](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#query-components) for requesting post type taxonomies.

__Testing instructions:__

Verify that post type taxonomy accordions are displayed, only for custom post types, and only when the custom post types feature flag is enabled. Since editor routes are not defined for custom post types when  the feature flag is disabled, it should not be possible to reach the editor at all for these post types.

1. Navigate to My Sites
2. Switch to a site where at least one custom post type is available
3. Click Add next to a post type in the sidebar navigation
4. Note that...
 - For "post" post type, only the Categories & Tags accordion is shown
 - For "page" post type, no taxonomy accordions are shown
 - For any other post type, an accordion is shown for each available taxonomy

__Caveats:__

- The accordion content is currently a placeholder and will be fleshed out in subsequent pull requests