### PR TITLE
Media: Fix media modal gallery preview vertical scrolling

### DIFF
--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -150,7 +150,6 @@ input.editor-media-modal-gallery__caption[type="text"] {
 	&,
 	& .shortcode-frame {
 		width: 100%;
-		height: 100%;
 	}
 }
 


### PR DESCRIPTION
Fixes #3389 
Regression introduced in 98962b50652d7a3285fe2c30fccb6024b4f0ee0c

This pull request seeks to resolve an issue where a gallery preview cannot be scrolled in the editor media modal.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15127981/3daac4c6-1607-11e6-80eb-28505059d444.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15127994/4c683994-1607-11e6-81f5-7d93e547cf4f.png)

__Testing instructions:__

Verify that gallery previews can be scrolled.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click Add Media in the editor toolbar
4. Select two or more images from the media library
5. Click Continue
6. Note that, if necessary, the gallery can be scrolled to reveal the entire preview