### PR TITLE
Jetpack SSO: Adds jetpack/sso route

### DIFF
--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -38,4 +38,8 @@ module.exports = function() {
 			jetpackConnectController.authorizeForm
 		);
 	}
+
+	if ( config.isEnabled( 'jetpack/sso' ) ) {
+		page( '/jetpack/sso', jetpackConnectController.saveQueryObject, jetpackConnectController.sso );
+	}
 };

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -14,8 +14,12 @@ import JetpackConnect from './index';
 import jetpackConnectAuthorizeForm from './authorize-form';
 import { setSection } from 'state/ui/actions';
 import { renderWithReduxStore } from 'lib/react-helpers';
-import { JETPACK_CONNECT_QUERY_SET, JETPACK_CONNECT_QUERY_UPDATE } from 'state/action-types';
+import {
+	JETPACK_CONNECT_QUERY_SET,
+	JETPACK_CONNECT_QUERY_UPDATE,
+} from 'state/action-types';
 import userFactory from 'lib/user';
+import jetpackSSOForm from './sso';
 
 /**
  * Module variables
@@ -67,6 +71,25 @@ export default {
 
 		renderWithReduxStore(
 			React.createElement( jetpackConnectAuthorizeForm, {
+				path: context.path,
+				locale: context.params.lang,
+				userModule: userModule
+			} ),
+			document.getElementById( 'primary' ),
+			context.store
+		);
+	},
+
+	sso( context ) {
+		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+		context.store.dispatch( setSection( 'jetpackConnect', {
+			hasSidebar: false
+		} ) );
+
+		userModule.fetch();
+
+		renderWithReduxStore(
+			React.createElement( jetpackSSOForm, {
 				path: context.path,
 				locale: context.params.lang,
 				userModule: userModule

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import debugModule from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import ConnectHeader from './connect-header';
+import observe from 'lib/mixins/data-observe';
+import Card from 'components/card';
+import Gravatar from 'components/gravatar';
+import Button from 'components/button';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import { errorNotice } from 'state/notices/actions';
+
+/*
+ * Module variables
+ */
+const debug = debugModule( 'calypso:jetpack-connect:sso' );
+
+const JetpackSSOForm = React.createClass( {
+	displayName: 'JetpackSSOForm',
+
+	mixins: [ observe( 'userModule' ) ],
+
+	onApproveSSO( event ) {
+		event.preventDefault();
+		debug( 'Approving sso' );
+		this.props.errorNotice( 'Jetpack SSO is currently in development.' );
+	},
+
+	onCancelClick( event ) {
+		event.preventDefault();
+		debug( 'Clicked return to site link' );
+		this.props.errorNotice( 'Jetpack SSO is currently in development.' );
+	},
+
+	render() {
+		const user = this.props.userModule.get();
+
+		return (
+			<Main className="jetpack-connect">
+				<div className="jetpack-connect__sso">
+					<ConnectHeader
+						headerText="Connect with WordPress.com"
+						subHeaderText="To use Single Sign-On, WordPress.com needs to be able to connect to your account on {$site}"
+					/>
+
+					<Card>
+						<div className="jetpack-connect__sso__user-profile">
+							<Gravatar user={ user } size={ 120 } imgSize={ 400 } />
+							<h3 className="jetpack-connect__sso__user-profile-name">
+								{ this.translate(
+									'Log in as {{strong}}%s{{/strong}}',
+									{
+										args: user.display_name,
+										components: {
+											strong: <strong />
+										}
+									}
+								) }
+							</h3>
+							<div className="jetpack-connect__sso__user-email">
+								{ user.email }
+							</div>
+						</div>
+
+						<div className="jetpack-connect__sso__actions">
+							<Button
+								primary
+								onClick={ this.onApproveSSO }
+								disabled={ false }>
+								{ this.translate( 'Log in' ) }
+							</Button>
+						</div>
+					</Card>
+
+					<LoggedOutFormLinks>
+						<LoggedOutFormLinkItem onClick={ this.onCancelClick } >
+							{ this.translate( 'Return to %(siteName)s', {
+								args: {
+									siteName: '{$site}'
+								}
+							} ) }
+						</LoggedOutFormLinkItem>
+					</LoggedOutFormLinks>
+				</div>
+			</Main>
+		);
+	}
+} );
+
+export default connect(
+	null,
+	dispatch => bindActionCreators( { errorNotice }, dispatch )
+)( JetpackSSOForm );

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -173,3 +173,31 @@
 	font-size: 12px;
 	color: $gray;
 }
+
+.jetpack-connect__sso__user-profile {
+	margin-bottom: 16px;
+}
+
+.jetpack-connect__sso__user-profile .gravatar {
+	display: block;
+	margin: 0 auto 16px;
+}
+
+.jetpack-connect__sso__user-profile-name {
+	font-family: $sans;
+	font-size: 21px;
+	font-weight: 300;
+	text-align: center;
+}
+
+.jetpack-connect__sso__user-email {
+	color: lighten( $gray, 10% );
+	font-weight: 400;
+	text-align: center;
+}
+
+.jetpack-connect__sso__actions .button {
+	display: block;
+	text-align: center;
+	width: 100%;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -38,6 +38,7 @@
 		"guided-tours": true,
 		"help": true,
 		"jetpack/connect": true,
+		"jetpack/sso": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"login": true,


### PR DESCRIPTION
The PR factors out the code needed to create the `/jetpack/sso` route as well as provide a first pass at a UI. This PR is very much a work in progress and will require some further design, which I would prefer to knock out in smaller blocks. cc @rickybanister to provide suggestions.

To test:
- Checkout `add/jetpack-sso-route` branch
- Do a fresh `make run` to pick up config changes
- Go to `/jetpack/sso`
- Ensure that there are no JS errors
- Does the design look OK for a first pass? 
- Click the "Log in" button or the "Return to site" link. Do you get an error notice. Good. 

First pass looks like this:

![screen shot 2016-05-09 at 5 58 45 pm](https://cloud.githubusercontent.com/assets/1126811/15130705/21ce9b5c-1610-11e6-9e42-c5462aea5b6b.png)
