### PR TITLE
Framework: throttle serialization of the redux tree

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -3,12 +3,13 @@
  */
 import debugModule from 'debug';
 import pick from 'lodash/pick';
+import throttle from 'lodash/throttle';
 
 /**
  * Internal dependencies
  */
 import { createReduxStore, reducer } from 'state';
-import { SERIALIZE, DESERIALIZE, SERVER_DESERIALIZE } from 'state/action-types'
+import { SERIALIZE, DESERIALIZE, SERVER_DESERIALIZE } from 'state/action-types';
 import localforage from 'lib/localforage';
 import { isSupportUserSession } from 'lib/user/support-user-interop';
 import config from 'config';
@@ -20,6 +21,7 @@ const debug = debugModule( 'calypso:state' );
 
 const DAY_IN_HOURS = 24;
 const HOUR_IN_MS = 3600000;
+export const SERIALIZE_THROTTLE = 500;
 export const MAX_AGE = 7 * DAY_IN_HOURS * HOUR_IN_MS;
 
 function getInitialServerState() {
@@ -64,8 +66,7 @@ function loadInitialStateFailed( error ) {
 
 export function persistOnChange( reduxStore, serializeState = serialize ) {
 	let state;
-
-	reduxStore.subscribe( function() {
+	reduxStore.subscribe( throttle( function() {
 		const nextState = reduxStore.getState();
 		if ( state && nextState === state ) {
 			return;
@@ -77,7 +78,7 @@ export function persistOnChange( reduxStore, serializeState = serialize ) {
 			.catch( ( setError ) => {
 				debug( 'failed to set redux-store state', setError );
 			} );
-	} );
+	}, SERIALIZE_THROTTLE, { leading: false, trailing: true } ) );
 
 	return reduxStore;
 }


### PR DESCRIPTION
Following up on an earlier conversation, this PR throttles redux store serialization to indexedDB. If a flurry of events are triggered, we'll update at most every 500ms. Throttle is also set to trailing, because the most recent events are more interesting.

## Testing Instructions
- No functional changes
- test pass with `npm run test-client client/state/test/*.js`
- With debug `localStorage.setItem( 'debug', 'calypso:state' );`
- `redux-state` in our indexedDB calypso db updates
- Refreshing the page loads persisted state

cc @aduth @blowery @dmsnell 