### PR TITLE
Themes: ES6ify all the things

### DIFF
--- a/client/my-sites/customize/actions.js
+++ b/client/my-sites/customize/actions.js
@@ -10,7 +10,7 @@ import Dispatcher from 'dispatcher';
 import page from 'page';
 import wpcom from 'lib/wp';
 import { addItem } from 'lib/upgrades/actions/cart';
-import ThemeHelper from '../themes/helpers';
+import { trackClick } from '../themes/helpers';
 import { themeItem } from 'lib/cart-values/cart-items';
 
 var CustomizeActions = {
@@ -27,7 +27,7 @@ var CustomizeActions = {
 	purchase: function( id, site ) {
 		addItem( themeItem( id, 'customizer' ) );
 
-		ThemeHelper.trackClick( 'customizer', 'purchase' );
+		trackClick( 'customizer', 'purchase' );
 
 		defer( function() {
 			page( '/checkout/' + site.slug );
@@ -45,7 +45,7 @@ var CustomizeActions = {
 	// but directly imported and dispatch()ed from inside `activated()`,
 	// which needs to be turned into a Redux thunk.
 	activated: function( id, site, themeActivated ) {
-		ThemeHelper.trackClick( 'customizer', 'activate' );
+		trackClick( 'customizer', 'activate' );
 
 		page( '/design/' + site.slug );
 
@@ -60,7 +60,7 @@ var CustomizeActions = {
 
 	close: function( previousPath ) {
 		if ( previousPath.indexOf( '/design' ) > -1 ) {
-			ThemeHelper.trackClick( 'customizer', 'close' );
+			trackClick( 'customizer', 'close' );
 		}
 
 		Dispatcher.handleViewAction( {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -27,8 +27,7 @@ import { signup, purchase, activate, clearActivated } from 'state/themes/actions
 import i18n from 'lib/mixins/i18n';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import Helpers from 'my-sites/themes/helpers';
-import { isPremium } from 'my-sites/themes/helpers';
+import { isPremium, getForumUrl } from 'my-sites/themes/helpers';
 import ActivatingTheme from 'components/data/activating-theme';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 
@@ -179,7 +178,7 @@ const ThemeSheet = React.createClass( {
 						{ i18n.translate( 'Need extra help?' ) }
 						<small>{ i18n.translate( 'Visit the theme support forum' ) }</small>
 					</div>
-					<Button primary={ true } href={ Helpers.getForumUrl( this.props ) }>Visit forum</Button>
+					<Button primary={ true } href={ getForumUrl( this.props ) }>Visit forum</Button>
 				</Card>
 				<Card className="themes__sheet-card-support">
 					<Gridicon icon="briefcase" size={ 48 } />

--- a/client/my-sites/themes/current-theme/index.jsx
+++ b/client/my-sites/themes/current-theme/index.jsx
@@ -1,21 +1,27 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	Helpers = require( '../helpers' ),
-	CurrentThemeButton = require( './button' );
+import Card from 'components/card';
+import CurrentThemeButton from './button';
+import {
+	getCustomizeUrl,
+	getDetailsUrl,
+	getSupportUrl,
+	isPremium,
+	trackClick
+} from '../helpers';
 
 /**
  * Show current active theme for a site, with
  * related actions.
  */
-var CurrentTheme = React.createClass( {
+const CurrentTheme = React.createClass( {
 
 	propTypes: {
 		currentTheme: React.PropTypes.object,
@@ -26,14 +32,13 @@ var CurrentTheme = React.createClass( {
 		canCustomize: React.PropTypes.bool.isRequired
 	},
 
-	trackClick: Helpers.trackClick.bind( null, 'current theme' ),
+	trackClick: trackClick.bind( null, 'current theme' ),
 
-	render: function() {
-		var currentTheme = this.props.currentTheme,
+	render() {
+		const { currentTheme, site } = this.props,
 			placeholderText = <span className="current-theme__placeholder">loading...</span>,
 			text = currentTheme ? currentTheme.name : placeholderText,
-			site = this.props.site,
-			displaySupportButton = Helpers.isPremium( currentTheme ) && ! site.jetpack;
+			displaySupportButton = isPremium( currentTheme ) && ! site.jetpack;
 
 		return (
 			<Card className="current-theme">
@@ -52,17 +57,17 @@ var CurrentTheme = React.createClass( {
 					<CurrentThemeButton name="customize"
 						label={ this.translate( 'Customize' ) }
 						noticon="paintbrush"
-						href={ this.props.canCustomize ? Helpers.getCustomizeUrl( null, site ) : null }
+						href={ this.props.canCustomize ? getCustomizeUrl( null, site ) : null }
 						onClick={ this.trackClick } />
 					<CurrentThemeButton name="details"
 						label={ this.translate( 'Details' ) }
 						noticon="info"
-						href={ currentTheme ? Helpers.getDetailsUrl( currentTheme, site ) : null }
+						href={ currentTheme ? getDetailsUrl( currentTheme, site ) : null }
 						onClick={ this.trackClick } />
 					{ displaySupportButton && <CurrentThemeButton name="support"
 						label={ this.translate( 'Support' ) }
 						noticon="help"
-						href={ currentTheme ? Helpers.getSupportUrl( currentTheme, site ) : null }
+						href={ currentTheme ? getSupportUrl( currentTheme, site ) : null }
 						onClick={ this.trackClick } /> }
 				</div>
 			</Card>
@@ -70,4 +75,4 @@ var CurrentTheme = React.createClass( {
 	}
 } );
 
-module.exports = CurrentTheme;
+export default CurrentTheme;

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -1,38 +1,38 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	connect = require( 'react-redux' ).connect,
-	pickBy = require( 'lodash/pickBy' ),
-	merge = require( 'lodash/merge' );
+import React from 'react';
+import { connect } from 'react-redux';
+import pickBy from 'lodash/pickBy';
+import merge from 'lodash/merge';
 
 /**
  * Internal dependencies
  */
-var Main = require( 'components/main' ),
-	Action = require( 'state/themes/actions' ),
-	ThemePreview = require( './theme-preview' ),
-	ThemesSelection = require( './themes-selection' ),
-	ThemeHelpers = require( './helpers' ),
-	actionLabels = require( './action-labels' ),
-	ThemesListSelectors = require( 'state/themes/themes-list/selectors' );
+import Main from 'components/main';
+import { signup } from 'state/themes/actions' ;
+import ThemePreview from './theme-preview';
+import ThemesSelection from './themes-selection';
+import { getSignupUrl, getDetailsUrl, getSupportUrl, isPremium, addTracking } from './helpers';
+import actionLabels from './action-labels';
+import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
 
-var ThemesLoggedOut = React.createClass( {
+const ThemesLoggedOut = React.createClass( {
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			showPreview: false
-		}
+		};
 	},
 
-	togglePreview: function( theme ) {
+	togglePreview( theme ) {
 		this.setState( { showPreview: ! this.state.showPreview, previewingTheme: theme } );
 	},
 
-	getButtonOptions: function() {
+	getButtonOptions() {
 		const buttonOptions = {
 			signup: {
-				getUrl: theme => ThemeHelpers.getSignupUrl( theme ),
+				getUrl: theme => getSignupUrl( theme ),
 			},
 			preview: {
 				action: theme => this.togglePreview( theme ),
@@ -42,12 +42,12 @@ var ThemesLoggedOut = React.createClass( {
 				separator: true
 			},
 			details: {
-				getUrl: theme => ThemeHelpers.getDetailsUrl( theme ),
+				getUrl: theme => getDetailsUrl( theme ),
 			},
 			support: {
-				getUrl: theme => ThemeHelpers.getSupportUrl( theme ),
+				getUrl: theme => getSupportUrl( theme ),
 				// Free themes don't have support docs.
-				hideForTheme: theme => ! ThemeHelpers.isPremium( theme )
+				hideForTheme: theme => ! isPremium( theme )
 			},
 		};
 		return merge( {}, buttonOptions, actionLabels );
@@ -56,12 +56,12 @@ var ThemesLoggedOut = React.createClass( {
 	onPreviewButtonClick( theme ) {
 		this.setState( { showPreview: false },
 			() => {
-				this.props.dispatch( Action.signup( theme ) );
+				this.props.dispatch( signup( theme ) );
 			} );
 	},
 
-	render: function() {
-		var buttonOptions = this.getButtonOptions();
+	render() {
+		const buttonOptions = this.getButtonOptions();
 
 		return (
 			<Main className="themes">
@@ -84,7 +84,7 @@ var ThemesLoggedOut = React.createClass( {
 					} }
 					getOptions={ function( theme ) {
 						return pickBy(
-							ThemeHelpers.addTracking( buttonOptions ),
+							addTracking( buttonOptions ),
 							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
 						); } }
 					trackScrollPage={ this.props.trackScrollPage }
@@ -98,7 +98,7 @@ var ThemesLoggedOut = React.createClass( {
 
 export default connect(
 	state => ( {
-		queryParams: ThemesListSelectors.getQueryParams( state ),
-		themesList: ThemesListSelectors.getThemesList( state )
+		queryParams: getQueryParams( state ),
+		themesList: getThemesList( state )
 	} )
 )( ThemesLoggedOut );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -1,52 +1,52 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	bindActionCreators = require( 'redux' ).bindActionCreators,
-	connect = require( 'react-redux' ).connect,
-	pickBy = require( 'lodash/pickBy' ),
-	merge = require( 'lodash/merge' );
+ import React from 'react';
+ import { bindActionCreators } from 'redux';
+ import { connect } from 'react-redux';
+ import pickBy from 'lodash/pickBy';
+ import merge from 'lodash/merge';
 
 /**
  * Internal dependencies
  */
-var Main = require( 'components/main' ),
-	Action = require( 'state/themes/actions' ),
-	ThemePreview = require( './theme-preview' ),
-	SidebarNavigation = require( 'my-sites/sidebar-navigation' ),
-	ThemesSiteSelectorModal = require( './themes-site-selector-modal' ),
-	ThemesSelection = require( './themes-selection' ),
-	ThemeHelpers = require( './helpers' ),
-	actionLabels = require( './action-labels' ),
-	ThemesListSelectors = require( 'state/themes/themes-list/selectors' ),
-	config = require( 'config' );
+import Main from 'components/main';
+import * as Action from 'state/themes/actions';
+import ThemePreview from './theme-preview';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import ThemesSiteSelectorModal from './themes-site-selector-modal';
+import ThemesSelection from './themes-selection';
+import { getDetailsUrl, getSupportUrl, isPremium, addTracking } from './helpers';
+import actionLabels from './action-labels';
+import { getQueryParams, getThemesList } from 'state/themes/themes-list/selectors';
+import config from 'config';
 
-var ThemesMultiSite = React.createClass( {
+const ThemesMultiSite = React.createClass( {
 
-	getInitialState: function() {
+	getInitialState() {
 		return {
 			selectedTheme: null,
 			selectedAction: null,
 		};
 	},
 
-	showSiteSelectorModal: function( action, theme ) {
+	showSiteSelectorModal( action, theme ) {
 		this.setState( { selectedTheme: theme, selectedAction: action } );
 	},
 
-	togglePreview: function( theme ) {
+	togglePreview( theme ) {
 		this.setState( { showPreview: ! this.state.showPreview, previewingTheme: theme } );
 	},
 
-	hideSiteSelectorModal: function() {
+	hideSiteSelectorModal() {
 		this.showSiteSelectorModal( null, null );
 	},
 
-	isThemeOrActionSet: function() {
+	isThemeOrActionSet() {
 		return this.state.selectedTheme || this.state.selectedAction;
 	},
 
-	getButtonOptions: function() {
+	getButtonOptions() {
 		const buttonOptions = {
 			preview: {
 				action: theme => this.togglePreview( theme ),
@@ -70,12 +70,12 @@ var ThemesMultiSite = React.createClass( {
 				separator: true
 			},
 			details: {
-				getUrl: theme => ThemeHelpers.getDetailsUrl( theme ),
+				getUrl: theme => getDetailsUrl( theme ),
 			},
 			support: {
-				getUrl: theme => ThemeHelpers.getSupportUrl( theme ),
+				getUrl: theme => getSupportUrl( theme ),
 				// Free themes don't have support docs.
-				hideForTheme: theme => ! ThemeHelpers.isPremium( theme )
+				hideForTheme: theme => ! isPremium( theme )
 			},
 		};
 		return merge( {}, buttonOptions, actionLabels );
@@ -88,8 +88,8 @@ var ThemesMultiSite = React.createClass( {
 			} );
 	},
 
-	render: function() {
-		var { dispatch } = this.props,
+	render() {
+		const { dispatch } = this.props,
 			buttonOptions = this.getButtonOptions();
 
 		return (
@@ -114,7 +114,7 @@ var ThemesMultiSite = React.createClass( {
 					} }
 					getOptions={ function( theme ) {
 						return pickBy(
-							ThemeHelpers.addTracking( buttonOptions ),
+							addTracking( buttonOptions ),
 							option => ! ( option.hideForTheme && option.hideForTheme( theme ) )
 						); } }
 					trackScrollPage={ this.props.trackScrollPage }
@@ -136,7 +136,7 @@ var ThemesMultiSite = React.createClass( {
 
 export default connect(
 	state => ( {
-		queryParams: ThemesListSelectors.getQueryParams( state ),
-		themesList: ThemesListSelectors.getThemesList( state )
+		queryParams: getQueryParams( state ),
+		themesList: getThemesList( state )
 	} )
 )( ThemesMultiSite );

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-var React = require( 'react' );
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-var Dialog = require( 'components/dialog' ),
-	PulsingDot = require( 'components/pulsing-dot' ),
-	Helpers = require( './helpers' );
+import Dialog from 'components/dialog';
+import PulsingDot from 'components/pulsing-dot';
+import { getDetailsUrl, getCustomizeUrl, getForumUrl, trackClick } from './helpers';
 
-var ThanksModal = React.createClass( {
-	trackClick: Helpers.trackClick.bind( null, 'current theme' ),
+const ThanksModal = React.createClass( {
+	trackClick: trackClick.bind( null, 'current theme' ),
 
 	propTypes: {
 		clearActivated: React.PropTypes.func.isRequired,
@@ -19,36 +19,36 @@ var ThanksModal = React.createClass( {
 		source: React.PropTypes.oneOf( [ 'details', 'list' ] ).isRequired,
 	},
 
-	onCloseModal: function() {
+	onCloseModal() {
 		this.props.clearActivated();
 		this.setState( { show: false } );
 	},
 
-	visitSite: function() {
+	visitSite() {
 		this.trackClick( 'visit site' );
 		window.open( this.props.site.URL );
 	},
 
-	goBack: function() {
+	goBack() {
 		this.trackClick( 'go back' );
 		this.onCloseModal();
 	},
 
-	onLinkClick: function( link ) {
+	onLinkClick( link ) {
 		return this.trackClick.bind( null, link, 'click' );
 	},
 
-	renderWpcomInfo: function() {
+	renderWpcomInfo() {
 		const features = this.translate( "Discover this theme's {{a}}awesome features.{{/a}}", {
 			components: {
-				a: <a href={ Helpers.getDetailsUrl( this.props.currentTheme, this.props.site ) }
+				a: <a href={ getDetailsUrl( this.props.currentTheme, this.props.site ) }
 					target="_blank"
 					onClick={ this.onLinkClick( 'features' ) }/>
 			}
 		} );
 		const customize = this.translate( '{{a}}Customize{{/a}} this design.', {
 			components: {
-				a: <a href={ Helpers.getCustomizeUrl( this.props.currentTheme, this.props.site ) }
+				a: <a href={ getCustomizeUrl( this.props.currentTheme, this.props.site ) }
 					target="_blank"
 					onClick={ this.onLinkClick( 'customize' ) }/>
 			}
@@ -61,7 +61,7 @@ var ThanksModal = React.createClass( {
 			<li>
 				{ this.translate( 'Have questions? Stop by our {{a}}support forums.{{/a}}', {
 					components: {
-						a: <a href={ Helpers.getForumUrl( this.props.currentTheme ) }
+						a: <a href={ getForumUrl( this.props.currentTheme ) }
 							target="_blank"
 							onClick={ this.onLinkClick( 'support' ) }/>
 					}
@@ -71,7 +71,7 @@ var ThanksModal = React.createClass( {
 		);
 	},
 
-	renderWporgThemeInfo: function( themeUri ) {
+	renderWporgThemeInfo( themeUri ) {
 		if ( themeUri ) {
 			return (
 				<li>
@@ -87,7 +87,7 @@ var ThanksModal = React.createClass( {
 		}
 	},
 
-	renderWporgAuthorInfo: function( authorUri ) {
+	renderWporgAuthorInfo( authorUri ) {
 		if ( authorUri ) {
 			return (
 				<li>
@@ -103,7 +103,7 @@ var ThanksModal = React.createClass( {
 		}
 	},
 
-	renderWporgForumInfo: function() {
+	renderWporgForumInfo() {
 		return (
 			<li>
 				{ this.translate( 'If you need support, visit the WordPress.org {{a}}Themes forum{{/a}}.', {
@@ -117,9 +117,11 @@ var ThanksModal = React.createClass( {
 		);
 	},
 
-	renderJetpackInfo: function() {
-		const themeUri = this.props.currentTheme.theme_uri;
-		const authorUri = this.props.currentTheme.author_uri;
+	renderJetpackInfo() {
+		const {
+			theme_uri: themeUri,
+			author_uri: authorUri
+		} = this.props.currentTheme;
 
 		return (
 			<ul>
@@ -130,29 +132,30 @@ var ThanksModal = React.createClass( {
 		);
 	},
 
-	renderContent: function() {
+	renderContent() {
+		const {
+			name: themeName,
+			author: themeAuthor
+		} = this.props.currentTheme;
+
 		return (
 			<div>
 				<h1>
 					{ this.translate( 'Thanks for choosing {{br/}} %(themeName)s {{br/}} by %(themeAuthor)s', {
-						args: {
-							themeName: this.props.currentTheme.name,
-							themeAuthor: this.props.currentTheme.author
-						},
+						args: { themeName, themeAuthor },
 						components: {
 							br: <br />
 						}
 					} ) }
 				</h1>
 				<ul>
-
 					{ this.props.site.jetpack ? this.renderJetpackInfo() : this.renderWpcomInfo() }
 				</ul>
 			</div>
 		);
 	},
 
-	renderLoading: function() {
+	renderLoading() {
 		return (
 			<div>
 				<PulsingDot active={ true } />
@@ -160,10 +163,8 @@ var ThanksModal = React.createClass( {
 		);
 	},
 
-	render: function() {
-		var buttons;
-
-		buttons = [
+	render() {
+		const buttons = [
 			{ action: 'back', label: this.translate( 'Back to themes' ), onClick: this.goBack },
 			{ action: 'visitSite', label: this.translate( 'Visit site' ), isPrimary: true, onClick: this.visitSite },
 		];
@@ -176,4 +177,4 @@ var ThanksModal = React.createClass( {
 	},
 } );
 
-module.exports = ThanksModal;
+export default ThanksModal;

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -82,11 +82,11 @@ const ThemesSearchCard = React.createClass( {
 						{ isPremiumThemesEnabled && <hr className="section-nav__hr" /> }
 
 						{ isPremiumThemesEnabled && <NavItem
-														path={ getExternalThemesUrl( this.props.site ) }
-														onClick={ this.onMore }
-														isExternalLink={ true }>
-														{ this.translate( 'More' ) + ' ' }
-													</NavItem> }
+							path={ getExternalThemesUrl( this.props.site ) }
+							onClick={ this.onMore }
+							isExternalLink={ true }>
+							{ this.translate( 'More' ) + ' ' }
+						</NavItem> }
 					</NavTabs>
 
 					<Search

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -1,23 +1,23 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	find = require( 'lodash/find' ),
-	debounce = require( 'lodash/debounce' );
+import React from 'react';
+import find from 'lodash/find';
+import debounce from 'lodash/debounce';
 
 /**
  * Internal dependencies
  */
-var Search = require( 'components/search' ),
-	ThemesSelectDropdown = require( './select-dropdown' ),
-	SectionNav = require( 'components/section-nav' ),
-	NavTabs = require( 'components/section-nav/tabs' ),
-	NavItem = require( 'components/section-nav/item' ),
-	Helper = require( '../helpers' ),
-	config = require( 'config' ),
-	isMobile = require( 'lib/viewport' ).isMobile;
+import Search from 'components/search';
+import ThemesSelectDropdown from './select-dropdown';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import { getExternalThemesUrl, trackClick } from '../helpers';
+import config from 'config';
+import { isMobile } from 'lib/viewport';
 
-var ThemesSearchCard = React.createClass( {
+const ThemesSearchCard = React.createClass( {
 	propTypes: {
 		tier: React.PropTypes.string.isRequired,
 		select: React.PropTypes.func.isRequired,
@@ -29,7 +29,7 @@ var ThemesSearchCard = React.createClass( {
 		search: React.PropTypes.string
 	},
 
-	trackClick: Helper.trackClick.bind( null, 'search bar' ),
+	trackClick: trackClick.bind( null, 'search bar' ),
 
 	componentWillMount() {
 		this.onResize = debounce( () => {
@@ -82,7 +82,7 @@ var ThemesSearchCard = React.createClass( {
 						{ isPremiumThemesEnabled && <hr className="section-nav__hr" /> }
 
 						{ isPremiumThemesEnabled && <NavItem
-														path={ Helper.getExternalThemesUrl( this.props.site ) }
+														path={ getExternalThemesUrl( this.props.site ) }
 														onClick={ this.onMore }
 														isExternalLink={ true }>
 														{ this.translate( 'More' ) + ' ' }
@@ -133,7 +133,7 @@ var ThemesSearchCard = React.createClass( {
 										options={ tiers }
 										onSelect={ this.props.select } /> }
 				{ isPremiumThemesEnabled && <a className="button more"
-												href={ Helper.getExternalThemesUrl( this.props.site ) }
+												href={ getExternalThemesUrl( this.props.site ) }
 												target="_blank"
 												onClick={ this.onMore }>
 
@@ -144,4 +144,4 @@ var ThemesSearchCard = React.createClass( {
 	}
 } );
 
-module.exports = ThemesSearchCard;
+export default ThemesSearchCard;

--- a/client/my-sites/themes/themes-search-card/select-dropdown.jsx
+++ b/client/my-sites/themes/themes-search-card/select-dropdown.jsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' );
+import React from 'react';
+import ReactDom from 'react-dom';
 
 /**
  * Internal dependencies
  */
-var SelectDropdown = require( 'components/select-dropdown' );
+import SelectDropdown from 'components/select-dropdown';
 
 /**
  * Constants
@@ -16,7 +16,7 @@ var SelectDropdown = require( 'components/select-dropdown' );
 // Needed so that computed width more or less matches actual width :/
 const WIDTH_CORRECTION = 2.5;
 
-var ThemesSelectDropdown = React.createClass( {
+const ThemesSelectDropdown = React.createClass( {
 	propTypes: {
 		tier: React.PropTypes.string.isRequired,
 		options: React.PropTypes.array.isRequired,
@@ -53,5 +53,4 @@ var ThemesSelectDropdown = React.createClass( {
 	}
 } );
 
-module.exports = ThemesSelectDropdown;
-
+export default ThemesSelectDropdown;

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -8,7 +8,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import Helper from './helpers';
+import { getPreviewUrl, trackClick } from './helpers';
 import ThemesSearchCard from './themes-search-card';
 import ThemesData from 'components/data/themes-list-fetcher';
 import ThemesList from 'components/themes-list';
@@ -70,12 +70,12 @@ const ThemesSelection = React.createClass( {
 		const siteId = this.props.siteId ? `/${this.props.siteId}` : '';
 		const url = `/design/type/${tier}${siteId}`;
 		this.setState( { tier } );
-		Helper.trackClick( 'search bar filter', tier );
+		trackClick( 'search bar filter', tier );
 		page( buildUrl( url, this.props.search ) );
 	},
 
 	onScreenshotClick( theme, resultsRank ) {
-		Helper.trackClick( 'theme', 'screenshot' );
+		trackClick( 'theme', 'screenshot' );
 		if ( ! theme.active ) {
 			this.recordSearchResultsClick( theme, resultsRank );
 		}
@@ -105,7 +105,7 @@ const ThemesSelection = React.createClass( {
 					<ThemesList getButtonOptions={ this.props.getOptions }
 						onMoreButtonClick={ this.onMoreButtonClick }
 						onScreenshotClick={ this.onScreenshotClick }
-						getScreenshotUrl={ site ? partialRight( Helper.getPreviewUrl, site ) : null }
+						getScreenshotUrl={ site ? partialRight( getPreviewUrl, site ) : null }
 						getActionLabel={ this.props.getActionLabel } />
 				</ThemesData>
 			</div>

--- a/client/my-sites/themes/themes-site-selector-modal.jsx
+++ b/client/my-sites/themes/themes-site-selector-modal.jsx
@@ -10,7 +10,7 @@ import defer from 'lodash/defer';
  */
 import Theme from 'components/theme';
 import SiteSelectorModal from 'components/site-selector-modal';
-import Helper from './helpers';
+import { trackClick } from './helpers';
 
 const ThemesSiteSelectorModal = React.createClass( {
 	propTypes: {
@@ -28,7 +28,7 @@ const ThemesSiteSelectorModal = React.createClass( {
 		 * changes are enqueued, e.g. setSelectedTheme.
 		 */
 		defer( () => {
-			Helper.trackClick( 'site selector', this.props.name );
+			trackClick( 'site selector', this.props.name );
 			page( '/design/' + site.slug );
 			this.props.action( this.props.selectedTheme, site );
 		} );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -27,7 +27,7 @@ import {
 	THEMES_RECEIVE,
 	THEMES_RECEIVE_SERVER_ERROR,
 } from '../action-types';
-import ThemeHelpers from 'my-sites/themes/helpers';
+import { getSignupUrl, getCustomizeUrl, navigateTo } from 'my-sites/themes/helpers';
 import { getCurrentTheme } from './current-theme/selectors';
 import {
 	recordTracksEvent,
@@ -222,14 +222,14 @@ export function clearActivated() {
 
 export function signup( theme ) {
 	return dispatch => {
-		const signupUrl = ThemeHelpers.getSignupUrl( theme );
+		const signupUrl = getSignupUrl( theme );
 
 		dispatch( {
 			type: THEME_SIGNUP_WITH,
 			theme
 		} );
 
-		// `ThemeHelpers.navigateTo` uses `page()` here, which messes with `pushState`,
+		// `navigateTo` uses `page()` here, which messes with `pushState`,
 		// which we don't want here, since we're navigating away from Calypso.
 		window.location = signupUrl;
 	};
@@ -237,14 +237,14 @@ export function signup( theme ) {
 
 export function customize( theme, site ) {
 	return dispatch => {
-		const customizeUrl = ThemeHelpers.getCustomizeUrl( theme, site );
+		const customizeUrl = getCustomizeUrl( theme, site );
 
 		dispatch( {
 			type: THEME_CUSTOMIZE,
 			site: site.id
 		} );
 
-		ThemeHelpers.navigateTo( customizeUrl, site.jetpack );
+		navigateTo( customizeUrl, site.jetpack );
 	};
 }
 


### PR DESCRIPTION
This ES6ifies most if not all of `my-sites/themes`, and then some. Main objective is more granular imports of `helpers` (no more `this` references), and generally better ease-of-use (e.g. to also replace `signup` and `customize` actions by their `get...Url()` counterparts further down the road, cf #5284).

This is a change that touches a lot of files, so be sure to give it a thorough testing (try different flows in the theme showcase, be sure to cover all possible actions; use e2e tests!)