### PR TITLE
Push Notifications: Remove device registration when users unsubscribe

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1874,6 +1874,18 @@ Undocumented.prototype.registerDevice = function( registration, deviceFamily, de
 };
 
 /**
+ * Removes a Push Notification registration for the device
+ *
+ * @param {int}        deviceId       The device ID for the registration to be removed
+ * @param {Function}   fn             The callback function
+ * @returns {XMLHttpRequest}          The XHR instance
+ */
+Undocumented.prototype.unregisterDevice = function( deviceId, fn ) {
+	debug( '/devices/:device_id/delete' );
+	return this.wpcom.req.post( { path: `/devices/${ deviceId }/delete` }, fn );
+};
+
+/**
  * Expose `Undocumented` module
  */
 module.exports = Undocumented;


### PR DESCRIPTION
This pull request is to remove the server-side device registration for [browser-based push notifications](Desktop push notifications) when a user unsubscribes from them.

###### Testing

This change in the library is easiest to test in the context of #4987, using those testing instructions, with the following additions:

1. Merge these changes into the aforementioned PR: `git merge fix/push-notification-unsubscribe`
2. [Patch the notice prompt file](https://gist.github.com/jeherve/1c64cb27c40375220c107a02d37ff0cb) to surface the unsubscribe ui
3. Hit subscribe, and confirm that you see the id of the subscription in the debug log, and that it was saved.
4. Hit unsubscribe and confirm in the debug log that the subscription with the same id has been deleted.

![screen shot 2016-05-11 at 11 50 13 am](https://cloud.githubusercontent.com/assets/1017839/15177866/a2b10878-1772-11e6-8749-e513c164ccfa.png)