### PR TITLE
Checkbox: refactored Checkbox component to meet component standards

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -15,6 +15,7 @@
 @import 'components/button-group/style';
 @import 'components/card/style';
 @import 'components/chart/style';
+@import 'components/checkbox/style';
 @import 'components/clipboard-button-input/style';
 @import 'components/comment-button/style';
 @import 'components/count/style';

--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -72,7 +72,6 @@ input[type="search"],
 input[type="email"],
 input[type="number"],
 input[type="password"],
-input[type=checkbox],
 input[type=radio],
 input[type="tel"],
 input[type="url"],
@@ -99,7 +98,6 @@ label {
 
 /*Checkbooms*/
 
-input[type=checkbox],
 input[type=radio] {
 	clear: none;
 	cursor: pointer;
@@ -117,29 +115,9 @@ input[type=radio] {
 	appearance: none;
 }
 
-input[type=checkbox] + span,
 input[type=radio] + span {
 	display: block;
 	margin-left: 24px;
-}
-
-input[type=checkbox] {
-	&:checked:before {
-		@extend %clear-text;
-
-		content: '\f418';
-		margin: -4px 0 0 -5px;
-		float: left;
-		display: inline-block;
-		vertical-align: middle;
-		width: 16px;
-		font: 400 23px/1 Noticons;
-		speak: none;
-		color: $blue-medium;
-	}
-	&:disabled:checked:before {
-		color: lighten( $gray, 10% );
-	}
 }
 
 input[type=radio] {
@@ -179,22 +157,6 @@ input[type=radio] {
 		transform: scale(1);
 	}
 }
-
-@keyframes grow {
-	0% {
-		transform: scale(0.3);
-	}
-
-	60% {
-		transform: scale(1.15);
-	}
-
-	100% {
-		transform: scale(1);
-	}
-}
-
-/* end checkbooms */
 
 
 select {

--- a/client/components/accordion/docs/example.jsx
+++ b/client/components/accordion/docs/example.jsx
@@ -8,6 +8,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var Accordion = require( 'components/accordion' ),
+	Checkbox = require( 'components/checkbox' ),
 	Gridicon = require( 'components/gridicon' );
 
 module.exports = React.createClass( {
@@ -36,11 +37,10 @@ module.exports = React.createClass( {
 
 				<div style={ { paddingBottom: '10px' } }>
 					<label>
-						<input
-							type="checkbox"
+						<Checkbox
 							checked={ this.state.showSubtitles }
 							onChange={ this._toggleShowSubtitles }
-						/>
+							/>
 						Show subtitles
 					</label>
 				</div>

--- a/client/components/accordion/docs/example.jsx
+++ b/client/components/accordion/docs/example.jsx
@@ -9,6 +9,7 @@ var React = require( 'react' ),
  */
 var Accordion = require( 'components/accordion' ),
 	Checkbox = require( 'components/checkbox' ),
+	FormLabel = require( 'components/forms/form-label' ),
 	Gridicon = require( 'components/gridicon' );
 
 module.exports = React.createClass( {
@@ -36,13 +37,13 @@ module.exports = React.createClass( {
 				</h2>
 
 				<div style={ { paddingBottom: '10px' } }>
-					<label>
+					<FormLabel>
 						<Checkbox
 							checked={ this.state.showSubtitles }
 							onChange={ this._toggleShowSubtitles }
 							/>
 						Show subtitles
-					</label>
+					</FormLabel>
 				</div>
 
 				<div style={ { maxWidth: '300px' } }>

--- a/client/components/bulk-select/docs/example.jsx
+++ b/client/components/bulk-select/docs/example.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import Card from 'components/card';
+import Checkbox from 'components/checkbox';
 import BulkSelect from 'components/bulk-select';
 
 module.exports = React.createClass( {
@@ -43,7 +44,10 @@ module.exports = React.createClass( {
 			}.bind( this );
 			return (
 				<label key={ index }>
-					<input type="checkbox" onClick={ onClick } checked={ element.selected } readOnly />
+					<Checkbox
+						onClick={ onClick }
+						checked={ element.selected }
+						readOnly />
 					{ element.title }
 				</label>
 			);

--- a/client/components/bulk-select/docs/example.jsx
+++ b/client/components/bulk-select/docs/example.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import Card from 'components/card';
 import Checkbox from 'components/checkbox';
 import BulkSelect from 'components/bulk-select';
+import FormLabel from 'components/forms/form-label';
 
 module.exports = React.createClass( {
 	displayName: 'BulkSelects',
@@ -43,13 +44,13 @@ module.exports = React.createClass( {
 				this.forceUpdate();
 			}.bind( this );
 			return (
-				<label key={ index }>
+				<FormLabel key={ index }>
 					<Checkbox
 						onClick={ onClick }
 						checked={ element.selected }
 						readOnly />
 					{ element.title }
-				</label>
+				</FormLabel>
 			);
 		} );
 	},

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -28,7 +28,7 @@ export default React.createClass( {
 	},
 
 	hasAllElementsSelected() {
-		return this.props.selectedElements && this.props.selectedElements === this.props.totalElements;
+		return !! ( this.props.selectedElements && this.props.selectedElements === this.props.totalElements );
 	},
 
 	hasSomeElementsSelected() {

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Count from 'components/count';
+import Checkbox from 'components/checkbox';
 import Gridicon from 'components/gridicon';
 
 export default React.createClass( {
@@ -47,7 +48,10 @@ export default React.createClass( {
 		return (
 			<span className="bulk-select" onClick={ this.handleToggleAll }>
 				<span className="bulk-select__container">
-					<input type="checkbox" className={ inputClasses } checked={ isChecked } readOnly />
+					<Checkbox
+						className={ inputClasses }
+						checked={ isChecked }
+						readOnly />
 					<Count count={ this.props.selectedElements } />
 					{ this.getStateIcon() }
 				</span>

--- a/client/components/chart/legend.jsx
+++ b/client/components/chart/legend.jsx
@@ -9,6 +9,8 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 
+var Checkbox = require( 'components/checkbox' );
+
 var LegendItem = React.createClass( {
 	displayName: 'ModuleChartLegendItem',
 
@@ -29,7 +31,10 @@ var LegendItem = React.createClass( {
 		return (
 			<li className="chart__legend-option">
 				<label htmlFor="checkbox" className="chart__legend-label is-selectable" onClick={ this.clickHandler } >
-					<input type="checkbox" className="chart__legend-checkbox" checked={ this.props.checked } onChange={ function(){} } />
+					<Checkbox
+						className="chart__legend-checkbox"
+						checked={ this.props.checked }
+						onChange={ function(){} } />
 					<span className={ this.props.className }></span>{ this.props.label }
 				</label>
 			</li>

--- a/client/components/checkbox/README.md
+++ b/client/components/checkbox/README.md
@@ -1,0 +1,21 @@
+Checkbox
+=========
+
+This component is used to implement some nifty checkboxes.
+
+#### How to use:
+
+```js
+var Checkbox = require( 'components/checkbox' );
+
+render: function() {
+	return (
+		<Checkbox compact primary disabled={ this.props.disabled } />
+	);
+}
+```
+
+#### Props
+
+* `checked`: (bool) whether the checkbox should be in the checked state.
+* `disabled`: (bool) whether the checkbox should be in the disabled state.

--- a/client/components/checkbox/docs/example.jsx
+++ b/client/components/checkbox/docs/example.jsx
@@ -1,0 +1,47 @@
+/**
+* External dependencies
+*/
+var React = require( 'react' ),
+	PureRenderMixin = require( 'react-pure-render/mixin' );
+
+/**
+ * Internal dependencies
+ */
+var Checkbox = require( 'components/checkbox' ),
+	Card = require( 'components/card' ),
+	FormLabel = require( 'components/forms/form-label' );
+
+var Checkboxes = React.createClass( {
+
+	displayName: 'Checkboxes',
+
+	mixins: [ PureRenderMixin ],
+
+	getInitialState: function() {
+		return {
+			compactButtons: false
+		};
+	},
+
+	render: function() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/design/checkboxes">Checkbox</a>
+				</h2>
+				{ this.renderButtons() }
+			</div>
+		);
+	},
+
+	renderButtons: function() {
+		return (
+			<Card>
+				<div><Checkbox /><span>Checkbox</span></div>
+				<div><Checkbox disabled /><span>disabled Checkbox</span></div>
+			</Card>
+		);
+	}
+} );
+
+module.exports = Checkboxes;

--- a/client/components/checkbox/docs/example.jsx
+++ b/client/components/checkbox/docs/example.jsx
@@ -37,8 +37,12 @@ var Checkboxes = React.createClass( {
 	renderButtons: function() {
 		return (
 			<Card>
-				<div><Checkbox /><span>Checkbox</span></div>
-				<div><Checkbox disabled /><span>disabled Checkbox</span></div>
+				<FormLabel>
+					<Checkbox /><span>Checkbox</span>
+				</FormLabel>
+				<FormLabel>
+					<Checkbox disabled /><span>disabled Checkbox</span>
+				</FormLabel>
 			</Card>
 		);
 	}

--- a/client/components/checkbox/index.jsx
+++ b/client/components/checkbox/index.jsx
@@ -7,13 +7,24 @@ var React = require( 'react' ),
 
 module.exports = React.createClass( {
 
-	displayName: 'FormInputCheckbox',
+	displayName: 'Checkbox',
+
+	propTypes: {
+		disabled: React.PropTypes.bool,
+		checked: React.PropTypes.bool
+	},
+
+	getDefaultProps() {
+		return {
+			disabled: false
+		};
+	},
 
 	render: function() {
 		var otherProps = omit( this.props, [ 'className', 'type' ] );
 
 		return (
-			<input { ...otherProps } type="checkbox" className={ classnames( this.props.className, 'form-checkbox' ) } />
+			<input { ...otherProps } type="checkbox" className={ classnames( this.props.className, 'checkbox' ) } />
 		);
 	}
 } );

--- a/client/components/checkbox/style.scss
+++ b/client/components/checkbox/style.scss
@@ -1,0 +1,71 @@
+// ==========================================================================
+// Checkboxes
+// ==========================================================================
+
+.checkbox {
+	display: inline-block;
+	box-sizing: border-box;
+	margin: 2px 0 0;
+	padding: 7px 14px;
+	width: 16px;
+	height: 16px;
+	float: left;
+	outline: 0;
+	padding: 0;
+	background-color: $white;
+	border: 1px solid lighten( $gray, 20% );
+	color: $gray-dark;
+	font-size: 16px;
+	line-height: 0;
+	text-align: center;
+	vertical-align: middle;
+	appearance: none;
+	transition: all .15s ease-in-out;
+	clear: none;
+	cursor: pointer;
+
+	&:hover {
+		border-color: lighten( $gray, 10% );
+	}
+
+	&:focus {
+		border-color: $blue-wordpress;
+		outline: none;
+		box-shadow: 0 0 0 2px $blue-light;
+	}
+
+	&:disabled {
+		background: $gray-light;
+		border-color: lighten( $gray, 30% );
+		color: lighten( $gray, 10% );
+
+		&:hover {
+			cursor: default;
+		}
+	}
+
+	// I would like to remove this, but might break things - MJA
+	+ span {
+		display: block;
+		margin-left: 24px;
+	}
+}
+
+input[type=checkbox] {
+	&:checked:before {
+		content: '\f418';
+		margin: -4px 0 0 -5px;
+		float: left;
+		display: inline-block;
+		vertical-align: middle;
+		width: 16px;
+		font: 400 23px/1 Noticons;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		speak: none;
+		color: $blue-medium;
+	}
+	&:disabled:checked:before {
+		color: lighten( $gray, 10% );
+	}
+}

--- a/client/components/checkbox/style.scss
+++ b/client/components/checkbox/style.scss
@@ -24,6 +24,24 @@
 	clear: none;
 	cursor: pointer;
 
+	&:checked:before {
+		content: '\f418';
+		margin: -4px 0 0 -5px;
+		float: left;
+		display: inline-block;
+		vertical-align: middle;
+		width: 16px;
+		font: 400 23px/1 Noticons;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		speak: none;
+		color: $blue-medium;
+	}
+
+	&:disabled:checked:before {
+		color: lighten( $gray, 10% );
+	}
+
 	&:hover {
 		border-color: lighten( $gray, 10% );
 	}
@@ -48,24 +66,5 @@
 	+ span {
 		display: block;
 		margin-left: 24px;
-	}
-}
-
-input[type=checkbox] {
-	&:checked:before {
-		content: '\f418';
-		margin: -4px 0 0 -5px;
-		float: left;
-		display: inline-block;
-		vertical-align: middle;
-		width: 16px;
-		font: 400 23px/1 Noticons;
-		-webkit-font-smoothing: antialiased;
-		-moz-osx-font-smoothing: grayscale;
-		speak: none;
-		color: $blue-medium;
-	}
-	&:disabled:checked:before {
-		color: lighten( $gray, 10% );
 	}
 }

--- a/client/components/forms/README.md
+++ b/client/components/forms/README.md
@@ -8,7 +8,6 @@ The following form components were created as an effort to minimize duplication 
 
 - form-button
 - form-buttons-bar
-- form-checkbox
 - form-fieldset
 - form-label
 - form-legend

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -11,7 +11,7 @@ var countriesList = require( 'lib/countries-list' ).forSms(),
 	Card = require( 'components/card' ),
 	FormButton = require( 'components/forms/form-button' ),
 	FormButtonsBar = require( 'components/forms/form-buttons-bar' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
+	Checkbox = require( 'components/checkbox' ),
 	FormCountrySelect = require( 'components/forms/form-country-select' ),
 	FormFieldset = require( 'components/forms/form-fieldset' ),
 	FormInputValidation = require( 'components/forms/form-input-validation' ),
@@ -78,7 +78,7 @@ var FormFields = React.createClass( {
 					<FormFieldset>
 						<FormLegend>Form Checkbox</FormLegend>
 						<FormLabel>
-							<FormCheckbox id="comment_like_notification" name="comment_like_notification" />
+							<Checkbox id="comment_like_notification" name="comment_like_notification" />
 							<span>Email me when someone Likes one of my comments.</span>
 						</FormLabel>
 					</FormFieldset>

--- a/client/components/forms/form-label/style.scss
+++ b/client/components/forms/form-label/style.scss
@@ -5,7 +5,7 @@
 	margin-bottom: 5px;
 }
 
-.form-label input[type="checkbox"] + span,
+.form-label .checkbox + span,
 .form-label input[type="radio"] + span {
 	font-weight: normal;
 }

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -4,6 +4,11 @@
 var React = require( 'react' ),
 	classNames = require( 'classnames' );
 
+/**
+ * Internal dependencies
+ */
+var Checkbox = require( 'components/checkbox' );
+
 var idNum = 0;
 
 module.exports = React.createClass( {
@@ -44,9 +49,8 @@ module.exports = React.createClass( {
 
 		return (
 			<span>
-				<input
+				<Checkbox
 					className={ classNames( this.props.className, toggleClasses ) }
-					type="checkbox"
 					checked={ this.props.checked }
 					readOnly={ true }
 					disabled={ this.props.disabled }

--- a/client/components/forms/multi-checkbox/index.jsx
+++ b/client/components/forms/multi-checkbox/index.jsx
@@ -5,6 +5,11 @@ var React = require( 'react' ),
 	omit = require( 'lodash/omit' ),
 	debug = require( 'debug' )( 'calypso:forms:multi-checkbox' );
 
+/**
+ * Internal dependencies
+ */
+import Checkbox from 'components/checkbox';
+
 var MultiCheckbox = module.exports = React.createClass({
 	displayName: 'MultiCheckbox',
 
@@ -53,7 +58,12 @@ var MultiCheckbox = module.exports = React.createClass({
 
 			return (
 				<label key={ option.value }>
-					<input name={ this.props.name + '[]' } type="checkbox" value={ option.value } checked={ isChecked } onChange={ this.handleChange } disabled={ this.props.disabled } />
+					<Checkbox
+						name={ this.props.name + '[]' }
+						value={ option.value }
+						checked={ isChecked }
+						onChange={ this.handleChange }
+						disabled={ this.props.disabled } />
 					{ option.label }
 				</label>
 			);

--- a/client/components/global-notices/docs/example.jsx
+++ b/client/components/global-notices/docs/example.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
  */
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import notices from 'notices';
 import { createNotice } from 'state/notices/actions';
 
@@ -47,7 +47,7 @@ class GlobalNotices extends Component {
 					<a href="/devdocs/design/global-notices">Global Notices</a>
 				</h2>
 				<label>
-					<FormCheckbox
+					<Checkbox
 						onChange={ this.toggleUseState }
 						checked={ this.state.useState } />
 					Use global application state

--- a/client/components/tinymce/plugins/contact-form/dialog/field.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field.jsx
@@ -13,7 +13,7 @@ import FoldableCard from 'components/foldable-card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import FormTextValidation from 'components/forms/form-input-validation';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import SelectDropdown from 'components/select-dropdown';
@@ -103,7 +103,7 @@ export default React.createClass( {
 
 				<FormFieldset>
 					<FormLabel>
-						<FormCheckbox
+						<Checkbox
 							checked={ this.props.required }
 							onChange={ () => this.props.onUpdate( { required: ! this.props.required } ) } />
 						{ this.translate( 'Required' ) }

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal dependecies
  */
+import Checkbox from 'components/checkbox';
 import PreviewFieldset from './preview-fieldset';
 import PreviewLegend from './preview-legend';
 import PreviewRequired from './preview-required';
@@ -26,7 +27,7 @@ const textarea = ( field, index ) => (
 
 const checkbox = ( field, index ) => (
 	<PreviewFieldset key={ 'contact-form-field-' + index }>
-		<label><input type="checkbox" />{ field.label }<PreviewRequired required={ field.required } /></label>
+		<label><Checkbox />{ field.label }<PreviewRequired required={ field.required } /></label>
 	</PreviewFieldset>
 );
 

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -14,7 +14,7 @@ import MediaStore from 'lib/media/store';
 import MediaUtils from 'lib/media/utils';
 import Dialog from 'components/dialog';
 import FormTextInput from 'components/forms/form-text-input';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -330,7 +330,7 @@ var LinkDialog = React.createClass( {
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel>
-						<FormCheckbox onChange={ this.setNewWindow } checked={ this.state.newWindow } />
+						<Checkbox onChange={ this.setNewWindow } checked={ this.state.newWindow } />
 						<span>{ this.translate( 'Open link in a new window/tab' ) }</span>
 					</FormLabel>
 				</FormFieldset>

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -17,6 +17,7 @@ import SearchDemo from 'components/search/docs/example';
 import Notices from 'components/notice/docs/example';
 import GlobalNotices from 'components/global-notices/docs/example';
 import Buttons from 'components/button/docs/example';
+import Checkboxes from 'components/checkbox/docs/example';
 import ButtonGroups from 'components/button-group/docs/example';
 import Gridicons from 'components/gridicon/docs/example';
 import Accordions from 'components/accordion/docs/example';
@@ -99,6 +100,7 @@ let DesignAssets = React.createClass( {
 					<BulkSelect />
 					<ButtonGroups />
 					<Buttons componentUsageStats={ componentsUsageStats.button } />
+					<Checkboxes />
 					<Cards />
 					<ClipboardButtonInput />
 					<ClipboardButtons />

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -9,6 +9,7 @@ var React = require( 'react' ),
  */
 var translator = require( 'lib/translator-jumpstart' ),
 	localStorageHelper = require( 'store' ),
+	Checkbox = require( 'components/checkbox' ),
 	Dialog = require( 'components/dialog' ),
 	analytics = require( 'lib/analytics' );
 
@@ -81,7 +82,7 @@ module.exports = React.createClass( {
 					<h1>{ this.translate( 'Community Translator' ) }</h1>
 					<p>{ this.translate( 'You have now enabled the translator.  Right click highlighted text to translate it.' ) }</p>
 					<p>
-						<label><input type="checkbox" onClick={ this.toggleInfoCheckbox } /><span>{ this.translate( "Don't show again" ) }</span></label>
+						<label><Checkbox onClick={ this.toggleInfoCheckbox } /><span>{ this.translate( "Don't show again" ) }</span></label>
 					</p>
 				</Dialog>
 				<div id='translator-launcher' className={ launcherClasses }>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -24,7 +24,7 @@ import config from 'config';
 import Card from 'components/card';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextValidation from 'components/forms/form-input-validation';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
@@ -117,7 +117,7 @@ const Account = React.createClass( {
 				<FormFieldset>
 					<FormLegend>{ this.translate( 'Community Translator' ) }</FormLegend>
 					<FormLabel>
-						<FormCheckbox
+						<Checkbox
 							checkedLink={ this.valueLink( 'enable_translator' ) }
 							disabled={ this.getDisabledState() }
 							id="enable_translator"
@@ -264,7 +264,7 @@ const Account = React.createClass( {
 			<FormFieldset>
 				<FormLegend>{ this.translate( 'Holiday Snow' ) }</FormLegend>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						checkedLink={ this.valueLink( 'holidaysnow' ) }
 						disabled={ this.getDisabledState() }
 						id="holidaysnow"

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -12,7 +12,7 @@ import protectForm from 'lib/mixins/protect-form';
 import formBase from 'me/form-base';
 import Card from 'components/card';
 import Navigation from 'me/notification-settings/navigation';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
@@ -83,7 +83,7 @@ module.exports = React.createClass( {
 						<FormFieldset>
 							<FormLegend>{ this.translate( 'Jabber Subscription Delivery' ) }</FormLegend>
 							<FormLabel>
-								<FormCheckbox
+								<Checkbox
 									checkedLink={ this.valueLink( 'subscription_delivery_jabber_default' ) }
 									disabled={ this.getDisabledState() }
 									id="subscription_delivery_jabber_default"
@@ -152,7 +152,7 @@ module.exports = React.createClass( {
 						<FormFieldset>
 							<FormLegend>{ this.translate( 'Block Emails' ) }</FormLegend>
 							<FormLabel>
-								<FormCheckbox
+								<Checkbox
 									checkedLink={ this.valueLink( 'subscription_delivery_email_blocked' ) }
 									disabled={ this.getDisabledState() }
 									id="subscription_delivery_email_blocked"

--- a/client/me/notification-settings/settings-form/stream-options.jsx
+++ b/client/me/notification-settings/settings-form/stream-options.jsx
@@ -9,7 +9,7 @@ import Immutable from 'immutable';
  * Internal dependencies
  */
 import { NOTIFICATIONS_EXCEPTIONS } from './constants';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 
 export default React.createClass( {
 	displayName: 'NotificationSettingsFormStreamOptions',
@@ -37,7 +37,7 @@ export default React.createClass( {
 					const isException = this.props.stream in NOTIFICATIONS_EXCEPTIONS && NOTIFICATIONS_EXCEPTIONS[this.props.stream].indexOf( setting ) >= 0;
 
 					return ( <li className="notification-settings-form-stream-options__item" key={ index }>
-						{ isException ? null : <FormCheckbox checked={ this.props.settings.get( setting ) } onChange={ () => {
+						{ isException ? null : <Checkbox checked={ this.props.settings.get( setting ) } onChange={ () => {
 							this.props.onToggle( this.props.blogId, this.props.stream, setting );
 						} } /> }
 					</li> );

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -14,7 +14,7 @@ import twoStepAuthorization from 'lib/two-step-authorization';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import Navigation from '../navigation';
 import Card from 'components/card';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormLabel from 'components/forms/form-label';
@@ -77,7 +77,7 @@ const WPCOMNotifications = React.createClass( {
 				<FormFieldset>
 					<FormLegend>{ this.translate( 'Suggestions' ) }</FormLegend>
 					<FormLabel>
-						<FormCheckbox checked={ this.state.settings.get( options.marketing ) } onChange={ this.toggleSetting.bind( this, options.marketing ) }/>
+						<Checkbox checked={ this.state.settings.get( options.marketing ) } onChange={ this.toggleSetting.bind( this, options.marketing ) }/>
 						<span>{ this.translate( 'Tips for getting the most out of WordPress.com.' ) }</span>
 					</FormLabel>
 				</FormFieldset>
@@ -85,7 +85,7 @@ const WPCOMNotifications = React.createClass( {
 				<FormFieldset>
 					<FormLegend>{ this.translate( 'Research' ) }</FormLegend>
 					<FormLabel>
-						<FormCheckbox checked={ this.state.settings.get( options.research ) } onChange={ this.toggleSetting.bind( this, options.research ) }/>
+						<Checkbox checked={ this.state.settings.get( options.research ) } onChange={ this.toggleSetting.bind( this, options.research ) }/>
 						<span>{ this.translate( 'Opportunities to participate in WordPress.com research & surveys.' ) }</span>
 					</FormLabel>
 				</FormFieldset>
@@ -93,7 +93,7 @@ const WPCOMNotifications = React.createClass( {
 				<FormFieldset>
 					<FormLegend>{ this.translate( 'Community' ) }</FormLegend>
 					<FormLabel>
-						<FormCheckbox checked={ this.state.settings.get( options.community ) } onChange={ this.toggleSetting.bind( this, options.community ) }/>
+						<Checkbox checked={ this.state.settings.get( options.community ) } onChange={ this.toggleSetting.bind( this, options.community ) }/>
 						<span>{ this.translate( 'Information on WordPress.com courses and events (online & in-person).' ) }</span>
 					</FormLabel>
 				</FormFieldset>

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -8,6 +8,7 @@ var React = require( 'react' );
  */
 var config = require( 'config' ),
 	FormButton = require( 'components/forms/form-button' ),
+	Checkbox = require( 'components/checkbox' ),
 	Notice = require( 'components/notice' ),
 	Site = require( 'my-sites/site' ),
 	sites = require( 'lib/sites-list' )(),
@@ -138,9 +139,8 @@ module.exports = React.createClass( {
 
 				return (
 					<li key={ site.ID } className="profile-links-add-wordpress__item" onClick={ this.recordCheckboxEvent( 'Add WordPress Site' ) }>
-						<input
+						<Checkbox
 							className="profile-links-add-wordpress__checkbox"
-							type="checkbox"
 							name={ inputName }
 							onChange={ this.handleCheckedChanged }
 							checked={ checkedState } />

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -14,7 +14,7 @@ import Card from 'components/card';
 import ConfirmCancelDomainLoadingPlaceholder from './loading-placeholder';
 import { connect } from 'react-redux';
 import FormButton from 'components/forms/form-button';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import FormLabel from 'components/forms/form-label';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormTextarea from 'components/forms/form-textarea';
@@ -170,7 +170,7 @@ const ConfirmCancelDomain = React.createClass( {
 		return (
 			<div className="confirm-cancel-domain__confirm-container">
 				<FormLabel>
-					<FormCheckbox checked={ this.state.confirmed } onChange={ this.onConfirmationChange } />
+					<Checkbox checked={ this.state.confirmed } onChange={ this.onConfirmationChange } />
 					<span>
 						{ this.translate(
 							'I understand that canceling means that I may {{strong}}lose this domain forever{{/strong}}.', {

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -12,7 +12,7 @@ var Dialog = require( 'components/dialog' ),
 	FormFieldset = require( 'components/forms/form-fieldset' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormTelInput = require( 'components/forms/form-tel-input' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
+	Checkbox = require( 'components/checkbox' ),
 	FormButton = require( 'components/forms/form-button' ),
 	FormButtonsBar = require( 'components/forms/form-buttons-bar' ),
 	FormInputValidation = require( 'components/forms/form-input-validation' ),
@@ -195,7 +195,7 @@ module.exports = React.createClass( {
 
 					<FormFieldset>
 						<FormLabel>
-							<FormCheckbox
+							<Checkbox
 								checkedLink={ this.linkState( 'remember2fa' ) }
 								id="remember2fa"
 								name="remember2fa"

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -10,7 +10,7 @@ var React = require( 'react' ),
 var	FormButton = require( 'components/forms/form-button' ),
 	analytics = require( 'lib/analytics' ),
 	FormButtonBar = require( 'components/forms/form-buttons-bar' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
+	Checkbox = require( 'components/checkbox' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	config = require( 'config' ),
 	Notice = require( 'components/notice' );
@@ -197,7 +197,7 @@ module.exports = React.createClass( {
 
 				<FormButtonBar>
 					<FormLabel className="security-2fa-backup-codes-list__print-agreement">
-						<FormCheckbox
+						<Checkbox
 							defaultChecked={ this.state.userAgrees }
 							onChange={ this.onUserAgreesChange }
 						/>

--- a/client/my-sites/ads/form-settings.jsx
+++ b/client/my-sites/ads/form-settings.jsx
@@ -18,7 +18,7 @@ var Card = require( 'components/card' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	FormLegend = require( 'components/forms/form-legend' ),
 	FormRadio = require( 'components/forms/form-radio' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
+	Checkbox = require( 'components/checkbox' ),
 	FormSelect = require( 'components/forms/form-select' ),
 	FormTextInput = require( 'components/forms/form-text-input' ),
 	WordadsActions = require( 'lib/ads/actions' ),
@@ -228,7 +228,7 @@ module.exports = React.createClass( {
 			<FormFieldset>
 				<FormLegend>{ this.translate( 'Additional Ads' ) }</FormLegend>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						name="optimized_ads"
 						checkedLink={ this.linkState( 'optimized_ads' ) }
 						disabled={ this.state.isLoading } />
@@ -271,7 +271,7 @@ module.exports = React.createClass( {
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel>
-						<FormCheckbox
+						<Checkbox
 							name="us_resident"
 							checked={ this.state.us_checked }
 							disabled={ this.state.isLoading }
@@ -360,7 +360,7 @@ module.exports = React.createClass( {
 		return (
 			<FormFieldset className="wordads-tos__fieldset">
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						name="tos"
 						checkedLink={ this.linkState( 'tos' ) }
 						disabled={ this.state.isLoading || 'signed' === this.state.tos } />

--- a/client/my-sites/category-selector/add-category.jsx
+++ b/client/my-sites/category-selector/add-category.jsx
@@ -18,7 +18,7 @@ var Dialog = require( 'components/dialog' ),
 	FormInputValidation = require( 'components/forms/form-input-validation' ),
 	FormTextInput = require( 'components/forms/form-text-input' ),
 	FormSectionHeading = require( 'components/forms/form-section-heading' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
+	Checkbox = require( 'components/checkbox' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	InfoPopover = require( 'components/info-popover' ),
 	FormLegend = require( 'components/forms/form-legend' ),
@@ -204,7 +204,7 @@ module.exports = React.createClass( {
 							</InfoPopover>
 						</FormLegend>
 						<FormLabel>
-							<FormCheckbox ref="topLevel" checked={ this.state.isTopLevel } onChange={ this.onTopLevelChange } />
+							<Checkbox ref="topLevel" checked={ this.state.isTopLevel } onChange={ this.onTopLevelChange } />
 							{ this.translate( 'Top level category', { context: 'Categories: New category being created is top level i.e. has no parent' } ) }
 						</FormLabel>
 						<CategoryList siteId={ this.props.siteId } search={ this.state.searchTerm } categoryStoreId="parent" >

--- a/client/my-sites/category-selector/index.jsx
+++ b/client/my-sites/category-selector/index.jsx
@@ -16,6 +16,7 @@ var ReactDom = require( 'react-dom' ),
  * Internal dependencies
  */
 var NoResults = require( './no-results' ),
+	Checkbox = require( 'components/checkbox' ),
 	analytics = require( 'lib/analytics' ),
 	Search = require( './search' );
 
@@ -125,7 +126,6 @@ module.exports = React.createClass( {
 		var itemId = item.ID,
 			name = unescapeString( item.name ) || this.translate( 'Untitled' ),
 			checked = ( -1 !== this.state.selectedIds.indexOf( item.ID ) ),
-			inputType = this.props.multiple ? 'checkbox' : 'radio',
 			domId = camelCase( this.props.analyticsPrefix ) + '-option-' + itemId,
 			disabled,
 			input;
@@ -136,13 +136,26 @@ module.exports = React.createClass( {
 			disabled = true;
 		}
 
-		input = (
-			<input id={ domId } type={ inputType } name='categories'
-				value={ itemId }
-				onChange={ this.props.onChange.bind( null, item ) }
-				disabled={ disabled }
-				checked={ checked } />
-		);
+		if ( !this.props.multple ) {
+			input = (
+				<Checkbox id={ domId }
+					name="categories"
+					value={ itemId }
+					onChange={ this.props.onChange.bind( null, item ) }
+					disabled={ disabled }
+					checked={ checked } />
+			);
+		} else {
+			input = (
+				<input id={ domId }
+					type="radio"
+					name="categories"
+					value={ itemId }
+					onChange={ this.props.onChange.bind( null, item ) }
+					disabled={ disabled }
+					checked={ checked } />
+			);
+		}
 
 		return (
 			<li key={ 'category-' + itemId }>

--- a/client/my-sites/menus/menu-editable-item.jsx
+++ b/client/my-sites/menus/menu-editable-item.jsx
@@ -18,6 +18,7 @@ var siteMenus = require( 'lib/menu-data' ),
 	PostList = require( './item-options/post-list' ),
 	MenuPanelBackButton = require( './menu-panel-back-button' ),
 	analytics = require( 'lib/analytics' ),
+	Checkbox = require( 'components/checkbox' ),
 	Gridicon = require( 'components/gridicon' );
 
 import { isInjectedNewPageItem } from 'lib/menu-data/menu-data';
@@ -201,7 +202,10 @@ var MenuEditableItem = React.createClass( {
 				<MenuPanelBackButton label={ itemType.label } onClick={ this.showLeftPanel } />
 				<label className="menu-item-form-label">{ this.translate( 'Link address (URL)' ) }</label>
 				<input className="menu-item-form-address" type="text" value={ this.state.item.url } onChange={ this.updateUrlValue } />
-				<input id="menu-flag-open-in-new-window" type="checkbox" defaultChecked={ this.state.item.link_target } onChange={ this.toggleUrlTarget } />
+				<Checkbox
+					id="menu-flag-open-in-new-window"
+					defaultChecked={ this.state.item.link_target }
+					onChange={ this.toggleUrlTarget } />
 				<label htmlFor="menu-flag-open-in-new-window">{ this.translate( 'Open link in new window/tab' ) }</label>
 			</div>
 		);

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -14,6 +14,7 @@ var CompactCard = require( 'components/card/compact' ),
 	PluginsActions = require( 'lib/plugins/actions' ),
 	PluginActivateToggle = require( 'my-sites/plugins/plugin-activate-toggle' ),
 	PluginAutoupdateToggle = require( 'my-sites/plugins/plugin-autoupdate-toggle' ),
+	Checkbox = require( 'components/checkbox' ),
 	Count = require( 'components/count' ),
 	Notice = require( 'components/notice' ),
 	PluginNotices = require( 'lib/plugins/notices' ),
@@ -265,9 +266,8 @@ module.exports = React.createClass( {
 				<CompactCard className="plugin-item">
 					{ ! this.props.isSelectable
 						? null
-						: <input className="plugin-item__checkbox"
+						: <Checkbox className="plugin-item__checkbox"
 								id={ plugin.slug }
-								type="checkbox"
 								onClick={ this.props.onClick }
 								checked={ this.props.isSelected }
 								readOnly={ true } />

--- a/client/my-sites/post-selector/docs/example.jsx
+++ b/client/my-sites/post-selector/docs/example.jsx
@@ -10,6 +10,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import PostSelector from '../';
 import observe from 'lib/mixins/data-observe';
 import sites from 'lib/sites-list';
+import Checkbox from 'components/checkbox';
 import FormLabel from 'components/forms/form-label';
 
 const PostSelectorExample = React.createClass( {
@@ -31,8 +32,7 @@ const PostSelectorExample = React.createClass( {
 				</h2>
 				<div style={ { width: 300 } }>
 					<FormLabel>
-						<input
-							type="checkbox"
+						<Checkbox
 							checked={ this.state.showTypeLabels }
 							onChange={ () => this.setState( { showTypeLabels: ! this.state.showTypeLabels } ) } />
 						Show Type Labels

--- a/client/my-sites/sharing/buttons/appearance.jsx
+++ b/client/my-sites/sharing/buttons/appearance.jsx
@@ -9,6 +9,7 @@ var React = require( 'react' );
 var ButtonsPreview = require( './preview' ),
 	ButtonsPreviewPlaceholder = require( './preview-placeholder' ),
 	ButtonsStyle = require( './style' ),
+	Checkbox = require( 'components/checkbox' ),
 	analytics = require( 'lib/analytics' );
 
 module.exports = React.createClass( {
@@ -68,7 +69,9 @@ module.exports = React.createClass( {
 		if ( ! this.props.site.jetpack ) {
 			return (
 				<label>
-					<input name="disabled_reblogs" type="checkbox" checked={ '' === this.props.values.disabled_reblogs || false === this.props.values.disabled_reblogs } onChange={ this.onReblogsLikesCheckboxClicked } disabled={ ! this.props.initialized } />
+					<Checkbox
+						name="disabled_reblogs"
+						checked={ '' === this.props.values.disabled_reblogs || false === this.props.values.disabled_reblogs } onChange={ this.onReblogsLikesCheckboxClicked } disabled={ ! this.props.initialized } />
 					<span>{ this.translate( 'Show reblog button', { context: 'Sharing options: Checkbox label' } ) }</span>
 				</label>
 			);
@@ -84,7 +87,9 @@ module.exports = React.createClass( {
 					</legend>
 					{ this.getReblogOptionElement() }
 					<label>
-						<input name="disabled_likes" type="checkbox" checked={ '' === this.props.values.disabled_likes || false === this.props.values.disabled_likes } onChange={ this.onReblogsLikesCheckboxClicked } disabled={ ! this.props.initialized } />
+						<Checkbox
+							name="disabled_likes"
+							checked={ '' === this.props.values.disabled_likes || false === this.props.values.disabled_likes } onChange={ this.onReblogsLikesCheckboxClicked } disabled={ ! this.props.initialized } />
 						<span>{ this.translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }</span>
 					</label>
 				</fieldset>

--- a/client/my-sites/sharing/buttons/options.jsx
+++ b/client/my-sites/sharing/buttons/options.jsx
@@ -9,6 +9,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var MultiCheckbox = require( 'components/forms/multi-checkbox' ),
+	Checkbox = require( 'components/checkbox' ),
 	analytics = require( 'lib/analytics' );
 
 module.exports = React.createClass( {
@@ -140,7 +141,7 @@ module.exports = React.createClass( {
 					{ this.translate( 'Comment Likes', { context: 'Sharing options: Header' } ) }
 				</legend>
 				<label>
-					<input name="jetpack_comment_likes_enabled" type="checkbox" checked={ this.props.values.jetpack_comment_likes_enabled } onChange={ this.handleChange } disabled={ ! this.props.initialized } />
+					<Checkbox name="jetpack_comment_likes_enabled" checked={ this.props.values.jetpack_comment_likes_enabled } onChange={ this.handleChange } disabled={ ! this.props.initialized } />
 					<span>{ this.translate( 'On for all posts', { context: 'Sharing options: Comment Likes' } ) }</span>
 				</label>
 			</fieldset>

--- a/client/my-sites/sharing/connections/connection.jsx
+++ b/client/my-sites/sharing/connections/connection.jsx
@@ -8,6 +8,7 @@ var React = require( 'react' ),
  * Internal dependencies
  */
 var analytics = require( 'lib/analytics' ),
+	Checkbox = require( 'components/checkbox' ),
 	serviceConnections = require( './service-connections' );
 
 module.exports = React.createClass( {
@@ -131,7 +132,7 @@ module.exports = React.createClass( {
 		}
 
 		if ( userCanUpdate ) {
-			content.push( <input key="checkbox" type="checkbox" checked={ this.isConnectionShared() } onChange={ this.toggleSitewideConnection } readOnly={ this.state.isSavingSitewide } /> );
+			content.push( <Checkbox key="checkbox" checked={ this.isConnectionShared() } onChange={ this.toggleSitewideConnection } readOnly={ this.state.isSavingSitewide } /> );
 		}
 
 		if ( userCanUpdate || this.props.connection.shared ) {

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -15,7 +15,7 @@ var formBase = require( './form-base' ),
 	FormLegend = require( 'components/forms/form-legend' ),
 	FormTextarea = require( 'components/forms/form-textarea' ),
 	FormTextInput = require( 'components/forms/form-text-input' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
+	Checkbox = require( 'components/checkbox' ),
 	FormSelect = require( 'components/forms/form-select' ),
 	FormSettingExplanation = require( 'components/forms/form-setting-explanation' ),
 	Card = require( 'components/card' ),
@@ -86,7 +86,7 @@ module.exports = React.createClass( {
 			<FormFieldset>
 				<FormLegend>{ this.translate( 'Default article settings' ) }</FormLegend>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						name="default_pingback_flag"
 						checkedLink={ this.linkState( 'default_pingback_flag' ) }
 						disabled={ this.state.fetchingSettings }
@@ -94,7 +94,7 @@ module.exports = React.createClass( {
 					<span>{ this.translate( 'Attempt to notify any blogs linked to from the article' ) }</span>
 				</FormLabel>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						name="default_ping_status"
 						checkedLink={ this.linkState( 'default_ping_status' ) }
 						disabled={ this.state.fetchingSettings }
@@ -102,7 +102,7 @@ module.exports = React.createClass( {
 					<span>{ this.translate( 'Allow link notifications from other blogs (pingbacks and trackbacks)' ) }</span>
 				</FormLabel>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						name="default_comment_status"
 						checkedLink={ this.linkState( 'default_comment_status' ) }
 						disabled={ this.state.fetchingSettings }
@@ -122,7 +122,7 @@ module.exports = React.createClass( {
 			<FormFieldset className="has-divider">
 				<FormLabel>{ this.translate( 'Other comment settings' ) }</FormLabel>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						name="require_name_email"
 						checkedLink={ this.linkState( 'require_name_email' ) }
 						disabled={ this.state.fetchingSettings }
@@ -130,7 +130,7 @@ module.exports = React.createClass( {
 					<span>{ this.translate( 'Comment author must fill out name and e-mail' ) }</span>
 				</FormLabel>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						name="comment_registration"
 						checkedLink={ this.linkState( 'comment_registration' ) }
 						disabled={ this.state.fetchingSettings }
@@ -138,7 +138,7 @@ module.exports = React.createClass( {
 					<span>{ this.translate( 'Users must be registered and logged in to comment' ) }</span>
 				</FormLabel>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						name="close_comments_for_old_posts"
 						checkedLink={ this.linkState( 'close_comments_for_old_posts' ) }
 						disabled={ this.state.fetchingSettings }
@@ -165,7 +165,7 @@ module.exports = React.createClass( {
 						}</span>
 				</FormLabel>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						name="thread_comments"
 						checkedLink={ this.linkState( 'thread_comments' ) }
 						disabled={ this.state.fetchingSettings }
@@ -188,7 +188,7 @@ module.exports = React.createClass( {
 						}</span>
 				</FormLabel>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						name="page_comments"
 						id="page_comments"
 						checkedLink={ this.linkState( 'page_comments' ) }
@@ -261,7 +261,7 @@ module.exports = React.createClass( {
 			<FormFieldset>
 				<FormLegend>{ this.translate( 'E-mail me whenever' ) }</FormLegend>
 				<FormLabel className="short-settings">
-					<FormCheckbox
+					<Checkbox
 						name="comments_notify"
 						checkedLink={ this.linkState( 'comments_notify' ) }
 						disabled={ this.state.fetchingSettings }
@@ -269,7 +269,7 @@ module.exports = React.createClass( {
 					<span>{ this.translate( 'Anyone posts a comment' ) }</span>
 				</FormLabel>
 				<FormLabel className="short-settings">
-					<FormCheckbox
+					<Checkbox
 						name="moderation_notify"
 						checkedLink={ this.linkState( 'moderation_notify' ) }
 						disabled={ this.state.fetchingSettings }
@@ -291,7 +291,7 @@ module.exports = React.createClass( {
 
 		return (
 			<FormLabel className="short-settings">
-				<FormCheckbox
+				<Checkbox
 					name="social_notifications_like"
 					checkedLink={ this.linkState( 'social_notifications_like' ) }
 					disabled={ this.state.fetchingSettings }
@@ -309,7 +309,7 @@ module.exports = React.createClass( {
 
 		return (
 			<FormLabel className="short-settings">
-				<FormCheckbox
+				<Checkbox
 					name="social_notifications_reblog"
 					checkedLink={ this.linkState( 'social_notifications_reblog' ) }
 					disabled={ this.state.fetchingSettings }
@@ -327,7 +327,7 @@ module.exports = React.createClass( {
 
 		return (
 			<FormLabel className="short-settings">
-				<FormCheckbox
+				<Checkbox
 					name="social_notifications_subscribe"
 					checkedLink={ this.linkState( 'social_notifications_subscribe' ) }
 					disabled={ this.state.fetchingSettings }
@@ -342,7 +342,7 @@ module.exports = React.createClass( {
 			<FormFieldset>
 				<FormLegend>{ this.translate( 'Before a comment appears' ) }</FormLegend>
 				<FormLabel className="short-settings">
-					<FormCheckbox
+					<Checkbox
 						name="comment_moderation"
 						checkedLink={ this.linkState( 'comment_moderation' ) }
 						disabled={ this.state.fetchingSettings }
@@ -350,7 +350,7 @@ module.exports = React.createClass( {
 					<span>{ this.translate( 'Comment must be manually approved' ) }</span>
 				</FormLabel>
 				<FormLabel className="short-settings">
-					<FormCheckbox
+					<Checkbox
 						name="comment_whitelist"
 						checkedLink={ this.linkState( 'comment_whitelist' ) }
 						disabled={ this.state.fetchingSettings }

--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -223,7 +223,7 @@ module.exports = React.createClass( {
 				</FormLabel>
 				{ markdownSupported &&
 					<FormLabel>
-						<FormCheckbox
+						<Checkbox
 							name="wpcom_publish_comments_with_markdown"
 							checkedLink={ this.linkState( 'wpcom_publish_comments_with_markdown' ) }
 							disabled={ this.state.fetchingSettings }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -24,7 +24,7 @@ import FormInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import TimezoneDropdown from 'components/timezone-dropdown';
 import QuerySiteDomains from 'components/data/query-site-domains';
@@ -311,13 +311,13 @@ const FormGeneral = React.createClass( {
 						<ul id="settings-reading-relatedposts-customize" className={ 1 === parseInt( this.state.jetpack_relatedposts_enabled, 10 ) ? null : 'disabled-block' }>
 							<li>
 								<FormLabel>
-									<FormCheckbox name="jetpack_relatedposts_show_headline" checkedLink={ this.linkState( 'jetpack_relatedposts_show_headline' ) }/>
+									<Checkbox name="jetpack_relatedposts_show_headline" checkedLink={ this.linkState( 'jetpack_relatedposts_show_headline' ) }/>
 									<span>{ this.translate( 'Show a "Related" header to more clearly separate the related section from posts' ) }</span>
 								</FormLabel>
 							</li>
 							<li>
 								<FormLabel>
-									<FormCheckbox name="jetpack_relatedposts_show_thumbnails" checkedLink={ this.linkState( 'jetpack_relatedposts_show_thumbnails' ) }/>
+									<Checkbox name="jetpack_relatedposts_show_thumbnails" checkedLink={ this.linkState( 'jetpack_relatedposts_show_thumbnails' ) }/>
 									<span>{ this.translate( 'Use a large and visually striking layout' ) }</span>
 								</FormLabel>
 							</li>
@@ -339,7 +339,7 @@ const FormGeneral = React.createClass( {
 					<ul id="settings-jetpack" className="settings-jetpack">
 						<li>
 							<FormLabel>
-								<FormCheckbox name="jetpack_sync_non_public_post_stati" checkedLink={ this.linkState( 'jetpack_sync_non_public_post_stati' ) }/>
+								<Checkbox name="jetpack_sync_non_public_post_stati" checkedLink={ this.linkState( 'jetpack_sync_non_public_post_stati' ) }/>
 								<span>{ this.translate( 'Allow synchronization of Posts and Pages with non-public post statuses' ) }</span>
 								<FormSettingExplanation className="is-indented">
 									{ this.translate( '(e.g. drafts, scheduled, private, etc\u2026)' ) }
@@ -392,7 +392,7 @@ const FormGeneral = React.createClass( {
 				<ul>
 					<li>
 						<FormLabel>
-							<FormCheckbox name="holidaysnow" checkedLink={ this.linkState( 'holidaysnow' ) }/>
+							<Checkbox name="holidaysnow" checkedLink={ this.linkState( 'holidaysnow' ) }/>
 							<span>{ this.translate( 'Show falling snow on my blog until January 4th.' ) }</span>
 						</FormLabel>
 					</li>

--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -10,7 +10,7 @@ var React = require( 'react' ),
 var config = require( 'config' ),
 	protectForm = require( 'lib/mixins/protect-form' ),
 	Card = require( 'components/card' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
+	Checkbox = require( 'components/checkbox' ),
 	FormLabel = require( 'components/forms/form-label' ),
 	formBase = require( './form-base' ),
 	notices = require( 'notices' ),
@@ -100,7 +100,7 @@ module.exports = React.createClass( {
 			<div>
 				<p>{ this.translate( "Jetpack is currently monitoring your site's uptime." ) }</p>
 				<FormLabel>
-					<FormCheckbox
+					<Checkbox
 						disabled={ this.disableForm() }
 						onClick={ this.recordEvent.bind( this, 'Clicked on Monitor email checkbox' ) }
 						id="jetpack_monitor_email"

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -16,7 +16,7 @@ import PressThisLink from './press-this-link';
 import dirtyLinkedState from 'lib/mixins/dirty-linked-state';
 import FormSelect from 'components/forms/form-select';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import FormLabel from 'components/forms/form-label';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
@@ -149,7 +149,7 @@ const SiteSettingsFormWriting = React.createClass( {
 								{ this.translate( 'Markdown' ) }
 							</FormLabel>
 							<FormLabel>
-								<FormCheckbox
+								<Checkbox
 									name="wpcom_publish_posts_with_markdown"
 									checkedLink={ this.linkState( 'wpcom_publish_posts_with_markdown' ) }
 									disabled={ this.state.fetchingSettings }

--- a/client/my-sites/upgrades/checkout/privacy-protection.jsx
+++ b/client/my-sites/upgrades/checkout/privacy-protection.jsx
@@ -9,6 +9,7 @@ var React = require( 'react' );
 var cartItems = require( 'lib/cart-values' ).cartItems,
 	PrivacyProtectionDialog = require( './privacy-protection-dialog' ),
 	Card = require( 'components/card' ),
+	Checkbox = require( 'components/checkbox' ),
 	Gridicon = require( 'components/gridicon' ),
 	abtest = require( 'lib/abtest' ).abtest;
 
@@ -80,7 +81,7 @@ module.exports = React.createClass( {
 			return (
 				<div>
 					<Card className="checkout__privacy-protection-checkbox">
-						<input type="checkbox" onChange={ this.props.onCheckboxChange } checked={ this.props.isChecked } />
+						<Checkbox onChange={ this.props.onCheckboxChange } checked={ this.props.isChecked } />
 						<div className="privacy-protection-checkbox__description">
 							<strong className="checkout__privacy-protection-checkbox-heading">{ this.translate( 'Please keep my information private.', { textOnly: true } ) }</strong>
 							<p className="checkout__privacy-protection-checkbox-text">{ priceForPrivacyText }</p>

--- a/client/my-sites/upgrades/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/upgrades/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 var Toggle = require( 'components/forms/form-toggle' ),
+	Checkbox = require( 'components/checkbox' ),
 	support = require( 'lib/url/support' );
 import analyticsMixin from 'lib/mixins/analytics';
 
@@ -30,7 +31,6 @@ const NameserversToggle = React.createClass( {
 						id="wp-nameservers"
 						name="wp-nameservers"
 						onChange={ this.handleToggle }
-						type="checkbox"
 						checked={ this.props.enabled }
 						value="active"/>
 				</form>

--- a/client/post-editor/editor-discussion/index.jsx
+++ b/client/post-editor/editor-discussion/index.jsx
@@ -8,7 +8,7 @@ const React = require( 'react' ),
  * Internal dependencies
  */
 const EditorFieldset = require( 'post-editor/editor-fieldset' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
+	Checkbox = require( 'components/checkbox' ),
 	PostActions = require( 'lib/posts/actions' ),
 	InfoPopover = require( 'components/info-popover' ),
 	stats = require( 'lib/posts/stats' );
@@ -84,7 +84,7 @@ export default React.createClass( {
 		return (
 			<EditorFieldset legend={ this.translate( 'Discussion' ) }>
 				<label>
-					<FormCheckbox
+					<Checkbox
 						name="comment_status"
 						checked={ statusToBoolean( discussion.comment_status ) }
 						disabled={ ! this.props.post }
@@ -97,7 +97,7 @@ export default React.createClass( {
 					</span>
 				</label>
 				<label>
-					<FormCheckbox
+					<Checkbox
 						name="ping_status"
 						checked={ statusToBoolean( discussion.ping_status ) }
 						disabled={ ! this.props.post }

--- a/client/post-editor/editor-sharing/publicize-connection.jsx
+++ b/client/post-editor/editor-sharing/publicize-connection.jsx
@@ -7,7 +7,7 @@ import includes from 'lodash/includes';
 /**
  * Internal dependencies
  */
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import PostMetadata from 'lib/post-metadata';
 import PostActions from 'lib/posts/actions';
 import * as PostStats from 'lib/posts/stats';
@@ -95,7 +95,7 @@ export default React.createClass( {
 		return (
 			<div className="editor-sharing__publicize-connection">
 				<label>
-					<FormCheckbox
+					<Checkbox
 						checked={ ! this.isConnectionSkipped() }
 						disabled={ this.isDisabled() }
 						onChange={ this.onChange } />

--- a/client/post-editor/editor-sharing/sharing-like-options.jsx
+++ b/client/post-editor/editor-sharing/sharing-like-options.jsx
@@ -7,7 +7,7 @@ const React = require( 'react' );
  * Internal dependencies
  */
 const EditorFieldset = require( 'post-editor/editor-fieldset' ),
-	FormCheckbox = require( 'components/forms/form-checkbox' ),
+	Checkbox = require( 'components/checkbox' ),
 	PostActions = require( 'lib/posts/actions' ),
 	stats = require( 'lib/posts/stats' );
 
@@ -53,7 +53,7 @@ export default React.createClass( {
 
 		return (
 			<label>
-				<FormCheckbox
+				<Checkbox
 					name='sharing_enabled'
 					checked={ this.isShowingSharingButtons() }
 					onChange={ this.onChange } />
@@ -69,7 +69,7 @@ export default React.createClass( {
 
 		return (
 				<label>
-					<FormCheckbox
+					<Checkbox
 						name='likes_enabled'
 						checked={ this.isShowingLikeButton() }
 						onChange={ this.onChange } />

--- a/client/post-editor/media-modal/gallery-help.jsx
+++ b/client/post-editor/media-modal/gallery-help.jsx
@@ -10,7 +10,7 @@ import PureRenderMixin from 'react-pure-render/mixin';
 import { isMobile } from 'lib/viewport';
 import Popover from 'components/popover';
 import Gridicon from 'components/gridicon';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import Button from 'components/button';
 
 export default React.createClass( {
@@ -86,7 +86,7 @@ export default React.createClass( {
 					</div>
 					<div className="editor-media-modal__gallery-help-actions">
 						<label className="editor-media-modal__gallery-help-remember-dismiss">
-							<FormCheckbox checked={ this.state.rememberDismiss } onChange={ this.toggleRememberDismiss } />
+							<Checkbox checked={ this.state.rememberDismiss } onChange={ this.toggleRememberDismiss } />
 							<span onClick={ this.toggleRememberDismiss }>
 								{ this.translate( 'Don\'t show again' ) }
 							</span>

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -14,7 +14,7 @@ import fromPairs from 'lodash/fromPairs';
 import EditorMediaModalFieldset from '../fieldset';
 import SelectDropdown from 'components/select-dropdown';
 import SelectDropdownItem from 'components/select-dropdown/item';
-import FormCheckbox from 'components/forms/form-checkbox';
+import Checkbox from 'components/checkbox';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'lib/media/constants';
 
 export default React.createClass( {
@@ -139,7 +139,7 @@ export default React.createClass( {
 
 		return (
 			<EditorMediaModalFieldset legend={ this.translate( 'Random Order' ) }>
-				<FormCheckbox onChange={ this.updateRandomOrder } checked={ settings.orderBy === 'rand' } />
+				<Checkbox onChange={ this.updateRandomOrder } checked={ settings.orderBy === 'rand' } />
 			</EditorMediaModalFieldset>
 		);
 	},


### PR DESCRIPTION
There should be no visual changes. This will require a bit of testing.

* It was originally `components/forms/form-checkbox`
* Now it is `components/checkbox`
* All styles have been extracted into classes (way better for, say, using Calypso as a framework)
* README.md has been added
* devdocs have been added
* Checkbox has been implemented everywhere I could find a checkbox

Related to https://github.com/Automattic/wp-calypso/issues/5322