### PR TITLE
Jetpack connect: check users sites before fetching info from the api

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -17,7 +17,7 @@ import Main from 'components/main';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
 import { dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation, checkUrl } from 'state/jetpack-connect/actions';
-import { isUrlInSites } from 'state/sites/selectors';
+import { getSiteByUrl } from 'state/sites/selectors';
 import JetpackExampleInstall from './exampleComponents/jetpack-install';
 import JetpackExampleActivate from './exampleComponents/jetpack-activate';
 import JetpackExampleConnect from './exampleComponents/jetpack-connect';
@@ -81,14 +81,10 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	onURLEnter() {
-<<<<<<< 1f10439420e9b897a7d541714a4696f9268580c0
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
 			jetpack_url: this.state.currentUrl
 		} );
-		this.props.checkUrl( this.state.currentUrl );
-=======
-		this.props.checkUrl( this.state.currentUrl, this.props.isUrlInSites( this.state.currentUrl ) );
->>>>>>> Jetpack connect: check users sites before fetching info from the api
+		this.props.checkUrl( this.state.currentUrl, !! this.props.getSiteByUrl( this.state.currentUrl ) );
 	},
 
 	installJetpack() {
@@ -289,11 +285,11 @@ const JetpackConnectMain = React.createClass( {
 export default connect(
 	state => {
 		const checkUrlInSites = ( url ) => {
-			return isUrlInSites( state, url );
+			return getSiteByUrl( state, url );
 		};
 		return {
 			jetpackConnectSite: state.jetpackConnect.jetpackConnectSite,
-			isUrlInSites: checkUrlInSites
+			getSiteByUrl: checkUrlInSites
 		};
 	},
 	dispatch => bindActionCreators( { recordTracksEvent, checkUrl, dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation }, dispatch )

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -17,6 +17,7 @@ import Main from 'components/main';
 import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
 import { dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation, checkUrl } from 'state/jetpack-connect/actions';
+import { isUrlInSites } from 'state/sites/selectors';
 import JetpackExampleInstall from './exampleComponents/jetpack-install';
 import JetpackExampleActivate from './exampleComponents/jetpack-activate';
 import JetpackExampleConnect from './exampleComponents/jetpack-connect';
@@ -80,10 +81,14 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	onURLEnter() {
+<<<<<<< 1f10439420e9b897a7d541714a4696f9268580c0
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
 			jetpack_url: this.state.currentUrl
 		} );
 		this.props.checkUrl( this.state.currentUrl );
+=======
+		this.props.checkUrl( this.state.currentUrl, this.props.isUrlInSites( this.state.currentUrl ) );
+>>>>>>> Jetpack connect: check users sites before fetching info from the api
 	},
 
 	installJetpack() {
@@ -155,6 +160,9 @@ const JetpackConnectMain = React.createClass( {
 		if ( ! this.checkProperty( 'isJetpackConnected' ) ) {
 			return 'notConnectedJetpack';
 		}
+		if ( this.checkProperty( 'userOwnsSite' ) ) {
+			return 'alreadyOwned';
+		}
 		if ( this.checkProperty( 'isJetpackConnected' ) ) {
 			return 'alreadyConnected';
 		}
@@ -175,7 +183,7 @@ const JetpackConnectMain = React.createClass( {
 		return (
 			<Card className="jetpack-connect__site-url-input-container">
 				{ ! this.isCurrentUrlFetching() && this.isCurrentUrlFetched() && ! this.props.jetpackConnectSite.isDismissed && status
-					? <JetpackConnectNotices noticeType={ status } onDismissClick={ this.dismissUrl } />
+					? <JetpackConnectNotices noticeType={ status } onDismissClick={ this.dismissUrl } url={ this.state.currentUrl } />
 					: null
 				}
 
@@ -280,8 +288,12 @@ const JetpackConnectMain = React.createClass( {
 
 export default connect(
 	state => {
+		const checkUrlInSites = ( url ) => {
+			return isUrlInSites( state, url );
+		};
 		return {
-			jetpackConnectSite: state.jetpackConnect.jetpackConnectSite
+			jetpackConnectSite: state.jetpackConnect.jetpackConnectSite,
+			isUrlInSites: checkUrlInSites
 		};
 	},
 	dispatch => bindActionCreators( { recordTracksEvent, checkUrl, dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation }, dispatch )

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -18,6 +18,7 @@ import JetpackConnectNotices from './jetpack-connect-notices';
 import SiteURLInput from './site-url-input';
 import { dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation, checkUrl } from 'state/jetpack-connect/actions';
 import { getSiteByUrl } from 'state/sites/selectors';
+import { requestSites } from 'state/sites/actions';
 import JetpackExampleInstall from './exampleComponents/jetpack-install';
 import JetpackExampleActivate from './exampleComponents/jetpack-activate';
 import JetpackExampleConnect from './exampleComponents/jetpack-connect';
@@ -42,6 +43,7 @@ const JetpackConnectMain = React.createClass( {
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: from
 		} );
+		this.props.requestSites();
 	},
 
 	getInitialState() {
@@ -84,7 +86,7 @@ const JetpackConnectMain = React.createClass( {
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
 			jetpack_url: this.state.currentUrl
 		} );
-		this.props.checkUrl( this.state.currentUrl, !! this.props.getSiteByUrl( this.state.currentUrl ) );
+		this.props.checkUrl( this.state.currentUrl, !! this.props.getJetpackSiteByUrl( this.state.currentUrl ) );
 	},
 
 	installJetpack() {
@@ -284,13 +286,17 @@ const JetpackConnectMain = React.createClass( {
 
 export default connect(
 	state => {
-		const checkUrlInSites = ( url ) => {
-			return getSiteByUrl( state, url );
+		const getJetpackSiteByUrl = ( url ) => {
+			const site = getSiteByUrl( state, url );
+			if ( site && ! site.jetpack ) {
+				return false;
+			}
+			return site;
 		};
 		return {
 			jetpackConnectSite: state.jetpackConnect.jetpackConnectSite,
-			getSiteByUrl: checkUrlInSites
+			getJetpackSiteByUrl
 		};
 	},
-	dispatch => bindActionCreators( { recordTracksEvent, checkUrl, dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation }, dispatch )
+	dispatch => bindActionCreators( { recordTracksEvent, checkUrl, dismissUrl, requestSites, goToRemoteAuth, goToPluginInstall, goToPluginActivation }, dispatch )
 )( JetpackConnectMain );

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -78,7 +78,7 @@ export default React.createClass( {
 		if ( this.props.noticeType === 'alreadyOwned' ) {
 			noticeValues.status = 'is-success';
 			noticeValues.icon = 'status';
-			noticeValues.text = this.translate( 'You already have connected {{a}}this site!{{/a}}', {
+			noticeValues.text = this.translate( '{{a}}Your site{{/a}} is already connected', {
 				components: {
 					a: <a href={ '/stats/day/' + url } />
 				}

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -16,7 +16,7 @@ export default React.createClass( {
 		siteUrl: PropTypes.string
 	},
 
-	getNoticeValues() {
+	getNoticeValues( url ) {
 		let noticeValues = {
 			icon: 'trash',
 			status: 'is-warning',
@@ -75,6 +75,16 @@ export default React.createClass( {
 			noticeValues.text = this.translate( 'This site is already connected!' );
 			return noticeValues;
 		}
+		if ( this.props.noticeType === 'alreadyOwned' ) {
+			noticeValues.status = 'is-success';
+			noticeValues.icon = 'status';
+			noticeValues.text = this.translate( 'You already have connected {{a}}this site!{{/a}}', {
+				components: {
+					a: <a href={ '/stats/day/' + url } />
+				}
+			} );
+			return noticeValues;
+		}
 		if ( this.props.noticeType === 'wordpress.com' ) {
 			noticeValues.text = this.translate( 'I think that\'s us ¯\\_(ツ)_/¯' );
 			noticeValues.status = 'is-warning';
@@ -97,7 +107,8 @@ export default React.createClass( {
 	},
 
 	render() {
-		const values = this.getNoticeValues();
+		const urlSlug = this.props.url.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+		const values = this.getNoticeValues( urlSlug );
 		if ( values ) {
 			return (
 				<div className="jetpack-connect__notices-container">

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -56,9 +56,25 @@ export default {
 		};
 	},
 
-	checkUrl( url ) {
+	checkUrl( url, isUrlOnSites ) {
 		return ( dispatch ) => {
 			if ( _fetching[ url ] ) {
+				return;
+			}
+
+			if ( isUrlOnSites ) {
+				dispatch( {
+					type: JETPACK_CONNECT_CHECK_URL,
+					url: url,
+				} );
+				setTimeout( () => {
+					dispatch( {
+						type: JETPACK_CONNECT_CHECK_URL_RECEIVE,
+						url: url,
+						data: { exists: true, isWordPress: true, hasJetpack: true, isJetpackActive: true, isJetpackConnected: true, isWordPressDotCom: false, userOwnsSite: true },
+						error: null
+					} );
+				} );
 				return;
 			}
 			_fetching[ url ] = true;

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -102,3 +102,20 @@ export function getSiteSlug( state, siteId ) {
 export function isRequestingSites( state ) {
 	return !! state.sites.fetchingItems.all;
 }
+
+/**
+ * Returns true if an url is already in the current site list
+ * @param {Object}	state Global state tree
+ * @return {Boolean}
+ */
+export function isUrlInSites( state, url ) {
+	for ( let siteId in state.sites.items ) {
+		const site = state.sites.items[ siteId ];
+		const siteUrlSansProtocol = site.URL.replace( /^https?:\/\//, '' );
+		const urlSansProtocol = url.replace( /^https?:\/\//, '' );
+		if ( siteUrlSansProtocol === urlSansProtocol ) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -108,14 +108,14 @@ export function isRequestingSites( state ) {
  * @param {Object}	state Global state tree
  * @return {Boolean}
  */
-export function isUrlInSites( state, url ) {
+export function getSiteByUrl( state, url ) {
 	for ( let siteId in state.sites.items ) {
 		const site = state.sites.items[ siteId ];
 		const siteUrlSansProtocol = site.URL.replace( /^https?:\/\//, '' );
 		const urlSansProtocol = url.replace( /^https?:\/\//, '' );
 		if ( siteUrlSansProtocol === urlSansProtocol ) {
-			return true;
+			return site;
 		}
 	}
-	return false;
+	return null;
 }

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -110,11 +110,10 @@ export function isRequestingSites( state ) {
  */
 export function getSiteByUrl( state, url ) {
 	for ( let siteId in state.sites.items ) {
-		const site = state.sites.items[ siteId ];
-		const siteUrlSansProtocol = site.URL.replace( /^https?:\/\//, '' );
-		const urlSansProtocol = url.replace( /^https?:\/\//, '' );
-		if ( siteUrlSansProtocol === urlSansProtocol ) {
-			return site;
+		const siteSlug = getSiteSlug( state, siteId );
+		const urlSlug = url.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+		if ( siteSlug === urlSlug ) {
+			return state.sites.items[ siteId ];
 		}
 	}
 	return null;


### PR DESCRIPTION
Right now, we are hitting the API to check if a site is already connected. We don't need to do this if the site is connected by this same user, because we already have it in the users sites list.

This PR avoids fetching info from the API when a site is already connected to the current user

![image](https://cloud.githubusercontent.com/assets/1554855/15160237/02b3c726-16f9-11e6-9735-b71037ac952d.png)

how to test
========
1. Go to calypso.localhost:3000/jetpack/connect
2. Enter the url of a site you have already connected
3. You should see the notice up there

ping for reviews, @roccotripaldi  @ryelle @rickybanister 