### PR TITLE
Pass locale slug to back URLs on signup.

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -11,6 +11,7 @@ import analytics from 'lib/analytics';
 import Gridicon from 'components/gridicon';
 import { submitSignupStep } from 'lib/signup/actions';
 import signupUtils from 'signup/utils';
+import i18n from 'lib/mixins/i18n';
 
 const NavigationLink = React.createClass( {
 	propTypes: {
@@ -35,7 +36,7 @@ const NavigationLink = React.createClass( {
 		const previousStepName = signupUtils.getPreviousStepName( this.props.flowName, this.props.stepName ),
 			{ stepSectionName } = find( this.props.signupProgressStore, { stepName: previousStepName } );
 
-		return signupUtils.getStepUrl( this.props.flowName, previousStepName, stepSectionName );
+		return signupUtils.getStepUrl( this.props.flowName, previousStepName, stepSectionName, i18n.getLocaleSlug() );
 	},
 
 	handleClick() {

--- a/client/signup/previous-step-button/index.jsx
+++ b/client/signup/previous-step-button/index.jsx
@@ -9,6 +9,7 @@ import find from 'lodash/find';
  */
 import analytics from 'lib/analytics';
 import signupUtils from 'signup/utils';
+import i18n from 'lib/mixins/i18n';
 
 export default React.createClass( {
 	displayName: 'PreviousStepButton',
@@ -29,7 +30,7 @@ export default React.createClass( {
 		const previousStepName = signupUtils.getPreviousStepName( this.props.flowName, this.props.stepName ),
 			{ stepSectionName } = find( this.props.signupProgressStore, { stepName: previousStepName } );
 
-		return signupUtils.getStepUrl( this.props.flowName, previousStepName, stepSectionName );
+		return signupUtils.getStepUrl( this.props.flowName, previousStepName, stepSectionName, i18n.getLocaleSlug() );
 	},
 
 	recordClick() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -17,7 +17,8 @@ var StepWrapper = require( 'signup/step-wrapper' ),
 	GoogleApps = require( 'components/upgrades/google-apps' ),
 	Notice = require( 'components/notice' ),
 	abtest = require( 'lib/abtest' ).abtest,
-	signupUtils = require( 'signup/utils' );
+	signupUtils = require( 'signup/utils' ),
+	i18n = require( 'lib/mixins/i18n' );
 
 const domainsWithPlansOnlyTestEnabled = abtest( 'domainsWithPlansOnly' ) === 'plansOnly';
 
@@ -229,7 +230,7 @@ module.exports = React.createClass( {
 	render: function() {
 		let content;
 		const backUrl = this.props.stepSectionName ?
-			signupUtils.getStepUrl( this.props.flowName, this.props.stepName ) :
+			signupUtils.getStepUrl( this.props.flowName, this.props.stepName, undefined, i18n.getLocaleSlug() ) :
 			undefined;
 
 		if ( 'mapping' === this.props.stepSectionName ) {


### PR DESCRIPTION
Now when you click on the “back” button during signup, locale information is preserved on the URL, so that even if you refresh the page you'll remain on the same locale.

This fixes issue #2692.

cc @bisko @michaeldcain