### PR TITLE
Reader: adjust Recommended Posts GET call to /recommendations/posts

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -982,7 +982,7 @@ Undocumented.prototype.readTagPosts = function( query, fn ) {
 Undocumented.prototype.readRecommendedPosts = function( query, fn ) {
 	debug( '/recommendations/posts' );
 	query.apiVersion = '1.2';
-	this.wpcom.req.get( '/read/recommendations/warm-start', query, fn );
+	this.wpcom.req.get( '/read/recommendations/posts', query, fn );
 };
 
 Undocumented.prototype.followReaderTag = function( tag, fn ) {


### PR DESCRIPTION
Per slack discussions, we should adjust the name of the API endpoint to /recommendations/posts. The previous term 'warm-start' was an internal name and is not informative to anyone outside the Data team.