### PR TITLE
Domains: Fix domain search error handling

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -274,7 +274,7 @@ const RegisterDomainStep = React.createClass( {
 		async.parallel(
 			[
 				callback => {
-					if ( ! domain.match( /.{3,}\..{2,}/ ) || domain.match( /\.wordpress\.com/i ) ) {
+					if ( ! domain.match( /.{3,}\..{2,}/ ) ) {
 						return callback();
 					}
 
@@ -496,6 +496,22 @@ const RegisterDomainStep = React.createClass( {
 			case 'not_available':
 			case 'not_available_but_mappable':
 				// unavailable domains are displayed in the search results, not as a notice
+				break;
+
+			case 'mappable_but_blacklisted_domain':
+				message = this.translate( 'Domain cannot be mapped to a WordPress.com blog because of blacklisted term.' );
+				break;
+
+			case 'mappable_but_forbidden_subdomain':
+				message = this.translate( 'Subdomains starting with \'www.\' cannot be mapped to a WordPress.com blog' );
+				break;
+
+			case 'mappable_but_mapped_domain':
+				message = this.translate( 'This domain is already mapped to a WordPress.com site.' );
+				break;
+
+			case 'mappable_but_restricted_domain':
+				message = this.translate( 'You cannot map another WordPress.com subdomain - try creating a new site or one of the custom domains below.' );
 				break;
 
 			case 'empty_query':

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -41,10 +41,12 @@ function canRegister( domainName, onComplete ) {
 		var errorCode;
 		if ( serverError ) {
 			errorCode = serverError.error;
-		} else if ( ! data.is_registrable ) {
-			errorCode = 'not_registrable';
 		} else if ( ! data.is_available && data.is_mappable ) {
 			errorCode = 'not_available_but_mappable';
+		} else if ( ! data.is_mappable && data.unmappability_reason ) {
+			errorCode = `mappable_but_${data.unmappability_reason}`;
+		} else if ( ! data.is_registrable ) {
+			errorCode = 'not_registrable';
 		} else if ( ! data.is_available ) {
 			errorCode = 'not_available';
 		}

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -147,7 +147,7 @@ function isRegisteredDomain( domain ) {
 }
 
 function getRegisteredDomains( domains ) {
-	return domains.filter( isRegisteredDomain )
+	return domains.filter( isRegisteredDomain );
 }
 
 function getMappedDomains( domains ) {


### PR DESCRIPTION
Needs `D1774-code`.

* Show a more informative error when trying to map a WordPress.com subdomain (we previously silently ignored such queries, but with the backend optimizations this is no longer needed)
* Properly handle subdomains (it seems there was a regression regarding this?) - show a domain mapping suggestion if the domain is mappable.
* Show more detailed messages when a domain cannot be mapped: try searching for domain mapped already to another site, with a forbidden word (`wordpress`), a `wp.com` subdomain or a `www.` subdomain.

Fixes #859

/cc @aidvu @umurkontaci @dzver for review
/cc @kriskarkoski from #859