### PR TITLE
Domain Management: Only show 'Change Primary Domain' button with at least 2 domains

### DIFF
--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -222,6 +222,10 @@ export const List = React.createClass( {
 	},
 
 	changePrimaryButton() {
+		if ( ! this.props.domains.list || this.props.domains.list.length < 2 ) {
+			return null;
+		}
+
 		return (
 			<Button
 				compact

--- a/client/my-sites/upgrades/domain-management/list/test/index.js
+++ b/client/my-sites/upgrades/domain-management/list/test/index.js
@@ -186,5 +186,25 @@ describe( 'index', function() {
 				} );
 			} );
 		} );
+
+		describe( 'when less than 2 domains', () => {
+			beforeEach( () => {
+				const oneDomain = deepFreeze( {
+					domains: {
+						hasLoadedFromServer: true,
+						list: [
+							{ name: 'example.com', isPrimary: true }
+						]
+					}
+				} );
+				const propsWithOneDomain = deepFreeze( Object.assign( {}, defaultProps, oneDomain ) );
+				component = renderWithProps( propsWithOneDomain );
+			} );
+
+			it( 'should not show "Change Primary Domain" button', () => {
+				const button = ReactDom.findDOMNode( component ).querySelector( '.domain-management-list__change-primary-button' );
+				assert( button === null );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
Addresses #4739 

Changed the behavior of the "Change Primary" domain button to not render by default and only render when there are at least 2 domains.

Before:
<img width="742" alt="screen shot 2016-05-11 at 1 33 46 am" src="https://cloud.githubusercontent.com/assets/8526652/15174870/8f5c38c4-1718-11e6-8c7e-6f594c435ffa.png">
After:
<img width="736" alt="screen shot 2016-05-11 at 1 34 00 am" src="https://cloud.githubusercontent.com/assets/8526652/15174881/94cfc9e2-1718-11e6-9e4a-229e7149e32e.png">

cc @akirk from #4739 
cc @umurkontaci from last commit