### PR TITLE
Framework: Fix redirect logged out user to devdocs

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -319,7 +319,7 @@ function reduxStoreReady( reduxStore ) {
 				return startsWith( context.path, validPath );
 			} );
 
-			if ( '/' === context.path && config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
+			if ( '/' === context.pathname && config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) ) {
 				page.redirect( '/devdocs/start' );
 				return;
 			}


### PR DESCRIPTION
The homepage is currently failing to load for logged out users when the path contains a query string such as http://calypso.localhost:3000/?hello=world

This issues only affects development environment since the homepage for logged out users is not handled by calypso at the moment. However it also affects https://calypso.live/ for testing live branches using a query parameter.

This PR should fix the issue.