### PR TITLE
GuidedTours: clean up styles

### DIFF
--- a/client/layout/guided-tours/steps.js
+++ b/client/layout/guided-tours/steps.js
@@ -21,7 +21,7 @@ class BasicStep extends Component {
 		const { text, onNext, onQuit } = this.props;
 		return (
 			<Card className="guided-tours__step" style={ stepCoords } >
-				<p>{ text }</p>
+				<p className="guided-tours__step-text">{ text }</p>
 				<div className="guided-tours__choice-button-row">
 					<Button onClick={ onNext } primary>{ this.props.translate( 'Continue' ) }</Button>
 					<Button onClick={ onQuit } borderless>{ this.props.translate( 'Do this later' ) }</Button>
@@ -39,7 +39,7 @@ class FirstStep extends Component {
 		const { text, onNext, onQuit } = this.props;
 		return (
 			<Card className="guided-tours__step guided-tours__step-first" style={ stepCoords } >
-				<p>{ text }</p>
+				<p className="guided-tours__step-text">{ text }</p>
 				<div className="guided-tours__choice-button-row">
 					<Button onClick={ onNext } primary>{ this.props.translate( "Let's do it!" ) }</Button>
 					<Button onClick={ onQuit } >
@@ -60,7 +60,7 @@ class FinishStep extends Component {
 
 		return (
 			<Card className="guided-tours__step" style={ stepCoords } >
-				<p>{ text }</p>
+				<p className="guided-tours__step-text">{ text }</p>
 				<div className="guided-tours__single-button-row">
 					<Button onClick={ onFinish } primary>{ this.props.translate( "We're all done!" ) }</Button>
 				</div>
@@ -81,7 +81,7 @@ class LinkStep extends Component {
 
 		return (
 			<Card className="guided-tours__step" style={ stepCoords } >
-				<p>{ text }</p>
+				<p className="guided-tours__step-text">{ text }</p>
 				<div className="guided-tours__choice-button-row">
 					<Button onClick={ onNext } primary>{ this.props.translate( 'Continue' ) }</Button>
 					<Button onClick={ onQuit } borderless>{ this.props.translate( 'Do this later' ) }</Button>
@@ -141,16 +141,14 @@ class ActionStep extends Component {
 
 		return (
 			<Card className="guided-tours__step" style={ stepCoords } >
-				<p>{ text }</p>
-				<div className="guided-tours__bullseye-instructions">
-					<p>
-						{ this.props.translate( 'Click the {{gridicon/}} to continue…', {
-							components: {
-								gridicon: <Gridicon icon={ this.props.icon } size={ 24 } />
-							}
-						} ) }
-					</p>
-				</div>
+				<p className="guided-tours__step-text">{ text }</p>
+				<p className="guided-tours__bullseye-instructions">
+					{ this.props.translate( 'Click the {{gridicon/}} to continue…', {
+						components: {
+							gridicon: <Gridicon icon={ this.props.icon } size={ 24 } />
+						}
+					} ) }
+				</p>
 				<Pointer style={ pointerCoords } />
 			</Card>
 		);

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -10,15 +10,9 @@
 	margin-right: 5px;
 	font-size: 14px;
 
-	p {
+	.guided-tours__step-text {
 		color: $gray-dark;
 		margin-bottom: 16px;
-	}
-
-	hr {
-		margin-bottom: 0.5em;
-		color: $gray-light;
-		background-color: $gray-light;
 	}
 
 	.gridicon[height="16"] {
@@ -51,27 +45,25 @@
 }
 
 .guided-tours__choice-button-row {
-	button {
+	.button {
 		width: 48%;
 	}
-	button:nth-child(1) {
+	.button:nth-child(1) {
 		margin-right: 4%;
 	}
 }
 
 .guided-tours__single-button-row {
-	button {
+	.button {
 		width: 100%;
 	}
 }
 
 .guided-tours__external-link,
 .guided-tours__bullseye-instructions {
-	p {
-		color: darken( $gray, 10 );
-		margin-bottom: 0;
-		font-style: italic;
-	}
+	color: darken( $gray, 10 );
+	margin-bottom: 0;
+	font-style: italic;
 
 	.gridicon {
 		position: relative;


### PR DESCRIPTION
As suggested by @mtias, this commit replaces a few remaining generic selectors with CSS classes, bringing things more in line with the rest of the codebase (and possibly making lookups a wee bit cheaper for browsers). 

To test:

- go to http://calypso.localhost:3000/?tour=main
- check whether the steps all work and look the same as on `master`