### PR TITLE
Jetpack connect: Allow linked accounts

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -163,7 +163,7 @@ const LoggedInForm = React.createClass( {
 	},
 
 	handleSubmit() {
-		const { queryObject, siteReceived, manageActivated, activateManageSecret, plansUrl, authorizeError, authorizeSuccess } = this.props.jetpackConnectAuthorize;
+		const { queryObject, siteReceived, manageActivated, activateManageSecret, plansUrl, authorizeError } = this.props.jetpackConnectAuthorize;
 		if ( ! this.props.isAlreadyOnSitesList &&
 			queryObject.already_authorized ) {
 			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
@@ -171,8 +171,8 @@ const LoggedInForm = React.createClass( {
 			this.activateManage();
 		} else if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_missing' ) >= 0 ) {
 			window.location.href = queryObject.site + authUrl;
-		} else if ( this.props.isAlreadyOnSitesList || ( siteReceived && plansURL ) ) {
-			page( plansURL );
+		} else if ( this.props.isAlreadyOnSitesList || ( siteReceived && plansUrl ) ) {
+			page( plansUrl );
 		} else {
 			this.props.authorize( queryObject );
 		}

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -28,6 +28,7 @@ import i18n from 'lib/mixins/i18n';
 import Gridicon from 'components/gridicon';
 import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSiteByUrl } from 'state/sites/selectors';
 
 /**
  * Module variables
@@ -137,8 +138,9 @@ const LoggedInForm = React.createClass( {
 	componentWillMount() {
 		const { autoAuthorize, queryObject } = this.props.jetpackConnectAuthorize;
 		debug( 'Checking for auto-auth on mount', autoAuthorize );
-		if ( autoAuthorize || this.props.calypsoStartedConnection || this.props.isSSO ) {
-			this.props.recordTracksEvent( 'jpc_auth_view' );
+		this.props.recordTracksEvent( 'jpc_auth_view' );
+		if ( ! this.props.isAlreadyOnSitesList &&
+			( autoAuthorize || this.props.calypsoStartedConnection || this.props.isSSO ) ) {
 			this.props.authorize( queryObject );
 		}
 	},
@@ -160,13 +162,16 @@ const LoggedInForm = React.createClass( {
 	},
 
 	handleSubmit() {
-		const { queryObject, manageActivated, activateManageSecret, plansUrl, authorizeError, authorizeSuccess } = this.props.jetpackConnectAuthorize;
-		if ( activateManageSecret && ! manageActivated ) {
+		const { queryObject, siteReceived, manageActivated, activateManageSecret, plansUrl, authorizeError, authorizeSuccess } = this.props.jetpackConnectAuthorize;
+		if ( ! this.props.isAlreadyOnSitesList &&
+			queryObject.already_authorized ) {
+			this.props.goBackToWpAdmin( queryObject.redirect_after_auth );
+		} else if ( activateManageSecret && ! manageActivated ) {
 			this.activateManage();
 		} else if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_missing' ) >= 0 ) {
 			window.location.href = queryObject.site + authUrl;
-		} else if ( authorizeSuccess && plansUrl ) {
-			page.redirect( plansUrl );
+		} else if ( this.props.isAlreadyOnSitesList || ( siteReceived && plansURL ) ) {
+			page( plansURL );
 		} else {
 			this.props.authorize( queryObject );
 		}
@@ -183,11 +188,16 @@ const LoggedInForm = React.createClass( {
 
 	isAuthorizing() {
 		const { isAuthorizing, isActivating } = this.props.jetpackConnectAuthorize;
-		return ( isAuthorizing || isActivating );
+		return ( ! this.props.isAlreadyOnSitesList && ( isAuthorizing || isActivating ) );
 	},
 
 	renderNotices() {
 		const { authorizeError, queryObject } = this.props.jetpackConnectAuthorize;
+
+		if ( queryObject.already_authorized && ! this.props.isAlreadyOnSitesList ) {
+			return <JetpackConnectNotices noticeType="alreadyConnectedByOtherUser" />;
+		}
+
 		if ( ! authorizeError ) {
 			return null;
 		}
@@ -201,13 +211,18 @@ const LoggedInForm = React.createClass( {
 	},
 
 	getButtonText() {
-		const { isAuthorizing, authorizeSuccess, isRedirectingToWpAdmin, siteReceived, authorizeError } = this.props.jetpackConnectAuthorize;
+		const { queryObject, isAuthorizing, authorizeSuccess, isRedirectingToWpAdmin, siteReceived, authorizeError } = this.props.jetpackConnectAuthorize;
+
+		if ( ! this.props.isAlreadyOnSitesList &&
+			queryObject.already_authorized ) {
+			return this.translate( 'Go to your site' );
+		}
 
 		if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_missing' ) >= 0 ) {
 			return this.translate( 'Try again' );
 		}
 
-		if ( siteReceived ) {
+		if ( this.props.isAlreadyOnSitesList || siteReceived ) {
 			return this.translate( 'Browse Available Upgrades' );
 		}
 
@@ -376,7 +391,8 @@ export default connect(
 		return {
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
 			jetpackSSOSessions: state.jetpackConnect.jetpackSSOSessions,
-			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions
+			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions,
+			isAlreadyOnSitesList: getSiteByUrl( state, state.jetpackConnect.jetpackConnectAuthorize.queryObject.site )
 		};
 	},
 	dispatch => bindActionCreators( { recordTracksEvent, authorize, createAccount, activateManage, goBackToWpAdmin }, dispatch )

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -140,6 +140,7 @@ const LoggedInForm = React.createClass( {
 		debug( 'Checking for auto-auth on mount', autoAuthorize );
 		this.props.recordTracksEvent( 'jpc_auth_view' );
 		if ( ! this.props.isAlreadyOnSitesList &&
+			! queryObject.already_authorized &&
 			( autoAuthorize || this.props.calypsoStartedConnection || this.props.isSSO ) ) {
 			this.props.authorize( queryObject );
 		}
@@ -193,7 +194,6 @@ const LoggedInForm = React.createClass( {
 
 	renderNotices() {
 		const { authorizeError, queryObject } = this.props.jetpackConnectAuthorize;
-
 		if ( queryObject.already_authorized && ! this.props.isAlreadyOnSitesList ) {
 			return <JetpackConnectNotices noticeType="alreadyConnectedByOtherUser" />;
 		}
@@ -215,7 +215,7 @@ const LoggedInForm = React.createClass( {
 
 		if ( ! this.props.isAlreadyOnSitesList &&
 			queryObject.already_authorized ) {
-			return this.translate( 'Go to your site' );
+			return this.translate( 'Return to your site' );
 		}
 
 		if ( authorizeError && authorizeError.message.indexOf( 'verify_secrets_missing' ) >= 0 ) {
@@ -248,7 +248,7 @@ const LoggedInForm = React.createClass( {
 			components: { strong: <strong /> }
 		} );
 
-		if ( authorizeSuccess ) {
+		if ( authorizeSuccess || this.props.isAlreadyOnSitesList ) {
 			text = this.translate( 'Connected as {{strong}}%(user)s{{/strong}}', {
 				args: { user: this.props.user.display_name },
 				components: { strong: <strong /> }
@@ -388,11 +388,14 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 export default connect(
 	state => {
+		const site = state.jetpackConnect.jetpackConnectAuthorize && state.jetpackConnect.jetpackConnectAuthorize.queryObject
+			? getSiteByUrl( state, state.jetpackConnect.jetpackConnectAuthorize.queryObject.site )
+			: null;
 		return {
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
 			jetpackSSOSessions: state.jetpackConnect.jetpackSSOSessions,
 			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions,
-			isAlreadyOnSitesList: getSiteByUrl( state, state.jetpackConnect.jetpackConnectAuthorize.queryObject.site )
+			isAlreadyOnSitesList: !! site
 		};
 	},
 	dispatch => bindActionCreators( { recordTracksEvent, authorize, createAccount, activateManage, goBackToWpAdmin }, dispatch )

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -104,8 +104,8 @@ export default React.createClass( {
 			return noticeValues;
 		}
 		if ( this.props.noticeType === 'alreadyConnectedByOtherUser' ) {
-			noticeValues.text = this.translate( 'This site is already connected to a different WordPress.com user' );
-			noticeValues.status = 'is-error';
+			noticeValues.text = this.translate( 'This site is already connected to a different WordPress.com user, you need to disconnect that user before you can connect your current one' );
+			noticeValues.status = 'is-warning';
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}

--- a/client/signup/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/signup/jetpack-connect/jetpack-connect-notices.jsx
@@ -103,6 +103,13 @@ export default React.createClass( {
 			noticeValues.icon = 'notice';
 			return noticeValues;
 		}
+		if ( this.props.noticeType === 'alreadyConnectedByOtherUser' ) {
+			noticeValues.text = this.translate( 'This site is already connected to a different WordPress.com user' );
+			noticeValues.status = 'is-error';
+			noticeValues.icon = 'notice';
+			return noticeValues;
+		}
+
 		return;
 	},
 

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -90,7 +90,6 @@ export default {
 				wpcom.undocumented().getSiteConnectInfo( url, 'isWordPress' ),
 				wpcom.undocumented().getSiteConnectInfo( url, 'hasJetpack' ),
 				wpcom.undocumented().getSiteConnectInfo( url, 'isJetpackActive' ),
-				wpcom.undocumented().getSiteConnectInfo( url, 'isJetpackConnected' ),
 				wpcom.undocumented().getSiteConnectInfo( url, 'isWordPressDotCom' ),
 			] ).then( ( data, error ) => {
 				_fetching[ url ] = null;


### PR DESCRIPTION
This PR removes the 'already connected' check in the first step of jetpack connect and defers that logic to the authorization step.

Until know, if a site was already connected to .com, in anyway, we didn't allow the user to go further the first step of jetpack connect. that way we didn't allow to connect secondary accounts.

With this PR, that restriction is lifted. Once the user enters an url and we do the roundtrip to their wp-admin, `authorize-form` will look if the site is already on the users sites list and will look for an additional parameter added by jetpack that indicates if the site is already connected or not (until know, jetpack would show an error instead of redirecting user back to calypso anyways in that case). This are the combinations that can happen:

- Site not in sites-list, no 'already_authorized' param => normal authorization process
- Site already in sites-list => directly to the last step of jetpack-connect (plans?) (since this .com user already have this site connected, we don't need to do anything)
- Site not in sites-list, existent 'already_authorized' param => The user/site are already connected to a different WordPress.com account, so we warn the user about it and give them a link to their wp-admin to fix it:
![image](https://cloud.githubusercontent.com/assets/1554855/15187000/92264ea0-179f-11e6-8587-190e7edc71f5.png)


How to test
========

1. You need a jetpack site with a jetpack running https://github.com/Automattic/jetpack/pull/3788
2. Go to http://calypso.localhost:3000/jetpack/connect and connect a site that you already have connected with this same .com user. You should be taken directly to the last step of jetpack connect (the link to the plans page, right now)
3. Login with a different .com user and try to connect the same site/user that you already connected in 2) . You should see the warning telling you that the site is already connected to other use and a button linking you to your wp-admin
4. Login in your 3rd party site with a different user (remember to use one that has a automattic.com email address) and connect the site using http://calypso.localhost:3000/jetpack/connect . Everything should work fine, even if another user is already connected

ping @roccotripaldi @rickybanister 