### PR TITLE
Jetpack Connect: Add localization support for /jetpack/connect route

### DIFF
--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -31,9 +31,15 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
-		page( '/jetpack/connect', jetpackConnectController.connect );
 		page(
-			'/jetpack/connect/authorize',
+			'/jetpack/connect/:locale?',
+			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
+			jetpackConnectController.connect
+		);
+
+		page(
+			'/jetpack/connect/authorize/:locale?',
+			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
 			jetpackConnectController.saveQueryObject,
 			jetpackConnectController.authorizeForm
 		);

--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -32,16 +32,16 @@ module.exports = function() {
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
 		page(
-			'/jetpack/connect/:locale?',
-			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
-			jetpackConnectController.connect
-		);
-
-		page(
 			'/jetpack/connect/authorize/:locale?',
 			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
 			jetpackConnectController.saveQueryObject,
 			jetpackConnectController.authorizeForm
+		);
+
+		page(
+			'/jetpack/connect/:locale?',
+			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
+			jetpackConnectController.connect
 		);
 	}
 

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -26,6 +26,7 @@ import CompactCard from 'components/card/compact';
 import Gravatar from 'components/gravatar';
 import i18n from 'lib/mixins/i18n';
 import Gridicon from 'components/gridicon';
+import LocaleSuggestions from 'signup/locale-suggestions';
 
 /**
  * Constants
@@ -86,6 +87,16 @@ const LoggedOutForm = React.createClass( {
 		);
 	},
 
+	renderLocaleSuggestions() {
+		if ( ! this.props.locale ) {
+			return;
+		}
+
+		return (
+			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+		);
+	},
+
 	renderFooterLink() {
 		const loginUrl = config( 'login_url' ) + '?redirect_to=' + encodeURIComponent( window.location.href );
 		return (
@@ -102,6 +113,7 @@ const LoggedOutForm = React.createClass( {
 		const { site } = this.props.jetpackConnectAuthorize.queryObject;
 		return (
 			<div>
+				{ this.renderLocaleSuggestions() }
 				{ renderFormHeader( site ) }
 				<SignupForm
 					getRedirectToAfterLoginUrl={ window.location.href }

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -20,6 +20,7 @@ import {
 } from 'state/action-types';
 import userFactory from 'lib/user';
 import jetpackSSOForm from './sso';
+import i18nUtils from 'lib/i18n-utils';
 
 /**
  * Module variables
@@ -28,6 +29,15 @@ const debug = new Debug( 'calypso:jetpack-connect:controller' );
 const userModule = userFactory();
 
 export default {
+	redirectWithoutLocaleifLoggedIn( context, next ) {
+		if ( userModule.get() && i18nUtils.getLocaleFromPath( context.path ) ) {
+			let urlWithoutLocale = i18nUtils.removeLocaleFromPath( context.path );
+			return page.redirect( urlWithoutLocale );
+		}
+
+		next();
+	},
+
 	saveQueryObject( context, next ) {
 		if ( ! isEmpty( context.query ) && context.query.redirect_uri ) {
 			debug( 'set initial query object', context.query );

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -64,7 +64,8 @@ export default {
 			React.createElement( JetpackConnect, {
 				path: context.path,
 				context: context,
-				locale: context.params.lang
+				locale: context.params.locale,
+				userModule: userModule
 			} ),
 			document.getElementById( 'primary' ),
 			context.store
@@ -82,7 +83,7 @@ export default {
 		renderWithReduxStore(
 			React.createElement( jetpackConnectAuthorizeForm, {
 				path: context.path,
-				locale: context.params.lang,
+				locale: context.params.locale,
 				userModule: userModule
 			} ),
 			document.getElementById( 'primary' ),

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -166,7 +166,7 @@ const JetpackConnectMain = React.createClass( {
 		);
 	},
 
-	localeSuggestions() {
+	renderLocaleSuggestions() {
 		if ( this.props.userModule.get() || ! this.props.locale ) {
 			return;
 		}
@@ -180,7 +180,7 @@ const JetpackConnectMain = React.createClass( {
 		const status = this.getStatus();
 		return (
 			<Main className="jetpack-connect">
-				{ this.localeSuggestions() }
+				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
 					<ConnectHeader headerText={ this.translate( 'Connect a self-hosted WordPress' ) }
 						subHeaderText={ this.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect to your self-hosted WordPress site.' ) }
@@ -197,7 +197,7 @@ const JetpackConnectMain = React.createClass( {
 	renderInstallInstructions() {
 		return (
 			<Main className="jetpack-connect-wide">
-				{ this.localeSuggestions() }
+				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__install">
 					<ConnectHeader headerText={ this.translate( 'Ready for installation' ) }
 						subHeaderText={ this.translate( 'We\'ll need to send you to your site dashboard for a few manual steps' ) }
@@ -223,7 +223,7 @@ const JetpackConnectMain = React.createClass( {
 	renderActivateInstructions() {
 		return (
 			<Main className="jetpack-connect-wide">
-				{ this.localeSuggestions() }
+				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__install">
 					<ConnectHeader headerText={ this.translate( 'Ready for installation' ) }
 						subHeaderText={ this.translate( 'We\'ll need to send you to your site dashboard for a few manual steps' ) }

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -22,6 +22,7 @@ import JetpackExampleActivate from './exampleComponents/jetpack-activate';
 import JetpackExampleConnect from './exampleComponents/jetpack-connect';
 import JetpackInstallStep from './install-step';
 import versionCompare from 'lib/version-compare';
+import LocaleSuggestions from 'signup/locale-suggestions';
 
 /**
  * Constants
@@ -165,10 +166,21 @@ const JetpackConnectMain = React.createClass( {
 		);
 	},
 
+	localeSuggestions() {
+		if ( this.props.userModule.get() || ! this.props.locale ) {
+			return;
+		}
+
+		return (
+			<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+		);
+	},
+
 	renderSiteEntry() {
 		const status = this.getStatus();
 		return (
 			<Main className="jetpack-connect">
+				{ this.localeSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
 					<ConnectHeader headerText={ this.translate( 'Connect a self-hosted WordPress' ) }
 						subHeaderText={ this.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect to your self-hosted WordPress site.' ) }
@@ -185,6 +197,7 @@ const JetpackConnectMain = React.createClass( {
 	renderInstallInstructions() {
 		return (
 			<Main className="jetpack-connect-wide">
+				{ this.localeSuggestions() }
 				<div className="jetpack-connect__install">
 					<ConnectHeader headerText={ this.translate( 'Ready for installation' ) }
 						subHeaderText={ this.translate( 'We\'ll need to send you to your site dashboard for a few manual steps' ) }
@@ -210,6 +223,7 @@ const JetpackConnectMain = React.createClass( {
 	renderActivateInstructions() {
 		return (
 			<Main className="jetpack-connect-wide">
+				{ this.localeSuggestions() }
 				<div className="jetpack-connect__install">
 					<ConnectHeader headerText={ this.translate( 'Ready for installation' ) }
 						subHeaderText={ this.translate( 'We\'ll need to send you to your site dashboard for a few manual steps' ) }
@@ -230,7 +244,6 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	render() {
-		const status = this.getStatus();
 		if ( status === 'notJetpack' && ! this.props.jetpackConnectSite.isDismissed ) {
 			return this.renderInstallInstructions();
 		}

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -244,6 +244,7 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	render() {
+		const status = this.getStatus();
 		if ( status === 'notJetpack' && ! this.props.jetpackConnectSite.isDismissed ) {
 			return this.renderInstallInstructions();
 		}

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -374,8 +374,8 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
-		app.get( '/jetpack/connect', setUpRoute, serverRender );
-		app.get( '/jetpack/connect/authorize', setUpRoute, serverRender );
+		app.get( '/jetpack/connect/:locale?', setUpRoute, serverRender );
+		app.get( '/jetpack/connect/authorize/:locale?', setUpRoute, serverRender );
 	}
 
 	app.get( '/start/:flowName?/:stepName?/:stepSectionName?/:lang?', setUpRoute, serverRender );


### PR DESCRIPTION
Adds localization support for Jetpack connect to the `/jetpack/connect` and `/jetpack/connect/authorize` routes.

To test:
- Checkout Automattic/jetpack#3717 to your Jetpack site
- Set Jetpack site language to something like Spanish
- Make sure site is not connected to WP.com
- Checkout `update/jetpack-connect-localization` branch within Calypso
- Go to `/jetpack/connect/es`. You should see Spanish.
- Enter your site's URL
- Note that you should be redirected to site and then immediately back to `/jetpack/connect/authorize/{$locale}`. You should see Spanish again.
