### PR TITLE
Signup: remove survey steps from `app` and `desktop` flows

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -184,14 +184,14 @@ const flows = {
 	},
 
 	desktop: {
-		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'themes', 'domains', 'plans', 'user' ],
 		destination: getPostsDestination,
 		description: 'Signup flow for desktop app',
 		lastModified: '2016-05-03'
 	},
 
 	app: {
-		steps: [ 'survey', 'themes', 'domains', 'plans', 'survey-user' ],
+		steps: [ 'themes', 'domains', 'plans', 'user' ],
 		destination: getPostsDestination,
 		description: 'Used as a web-based control to test the "desktop" flow',
 		lastModified: '2016-05-11'


### PR DESCRIPTION
Remove survey steps from `app` and `desktop` flow for homepage app download test. Desktop app Calypso build doesn't have the steps, and we need an identical control.