### PR TITLE
CPT: Use translated labels from type object for empty content

### DIFF
--- a/client/my-sites/post-type-list/empty-content.jsx
+++ b/client/my-sites/post-type-list/empty-content.jsx
@@ -20,15 +20,11 @@ function PostTypeListEmptyContent( { siteId, translate, status, typeObject, edit
 	if ( 'draft' === status ) {
 		title = translate( 'You don\'t have any drafts.' );
 	} else if ( typeObject ) {
-		title = translate( 'You don\'t have any %s.', {
-			args: [ typeObject.label.toLocaleLowerCase() ]
-		} );
+		title = typeObject.labels.not_found;
 	}
 
 	if ( typeObject ) {
-		action = translate( 'Start a %s', {
-			args: [ typeObject.labels.singular_name ]
-		} );
+		action = typeObject.labels.add_new_item;
 	}
 
 	return (

--- a/client/my-sites/post-type-list/empty-content.jsx
+++ b/client/my-sites/post-type-list/empty-content.jsx
@@ -34,7 +34,6 @@ function PostTypeListEmptyContent( { siteId, translate, status, typeObject, edit
 			) }
 			<EmptyContent
 				title={ title }
-				line={ translate( 'Would you like to create one?' ) }
 				action={ action }
 				actionURL={ editPath }
 				illustration="/calypso/images/pages/illustration-pages.svg"


### PR DESCRIPTION
This pull request seeks to use the exact labels as provided from the [post types REST API endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/post-types/) when there are no posts to be shown on the custom post types list screen. This is to address localization concerns for languages where the context of the post type as used in the sentence could alter its translation.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15195959/2ee8d6ac-1798-11e6-982d-773f385796e4.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15195952/27898bae-1798-11e6-9f21-bc63178704e6.png)

__Open questions:__

- Are there better labels we can use that apply generally to all post types? See drafts as example, "You don't have any drafts." applies to all post types and works well across languages.

__Testing instructions:__

Verify that post type labels are shown when there is no content to be displayed on the custom post types list screen.

1. Navigate to the [custom post types list screen](https://wpcalypso.wordpress.com/types/post)
2. Select a site
3. In the address bar, change add a status after `/post` where posts do not exist (e.g. `/post/pending` or `/post/private`)
4. Note that the empty content warning is appropriately localized with correct labels

/cc @ockham @mcsf 