### PR TITLE
Premium dops plugins: open in staging and wpcalypso

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -40,7 +40,7 @@
 		"manage/plans": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
-		"manage/plugins/setup": false,
+		"manage/plugins/setup": true,
 		"manage/plugins/wpcom": true,
 		"manage/posts": true,
 		"manage/security": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -47,7 +47,7 @@
 		"manage/plans": true,
 		"manage/plugins": true,
 		"manage/plugins/cache": false,
-		"manage/plugins/setup": false,
+		"manage/plugins/setup": true,
 		"manage/plugins/wpcom": true,
 		"manage/posts": true,
 		"manage/security": true,


### PR DESCRIPTION
We forgot to open the feature flags to test premium dops plugins in staging :D

