### PR TITLE
Terms: add request tracking to terms and QueryTerms component.

### DIFF
--- a/client/components/data/query-terms/README.md
+++ b/client/components/data/query-terms/README.md
@@ -1,0 +1,59 @@
+Query Terms
+================
+
+`<QueryTerms />` is a React component used in managing network requests for terms for a given site and taxonomy pair.
+
+## Usage
+
+Render the component, passing `siteId` and `taxonomy`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import QueryTerms from 'components/data/query-terms';
+
+export default function AmazingListOfTerms( { terms } ) {
+	return (
+		<ul>
+			<QueryTerms
+				siteId={ 3584907 }
+				taxonomy="category" />
+			{ terms.map( ( term ) => {
+				return (
+					<li key={ term.ID }>
+						{ term.name }
+					</li>
+				);
+			} }
+		</ul>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site ID for which terms should be requested.
+
+### `taxonomy`
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The taxonomy for which terms should be requested.
+
+### `query`
+
+<table>
+	<tr><th>Type</th><td>Object</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+</table>
+
+Query object to be used for pagination, and search.

--- a/client/components/data/query-terms/index.jsx
+++ b/client/components/data/query-terms/index.jsx
@@ -9,7 +9,7 @@ import shallowEqual from 'react-pure-render/shallowEqual';
  * Internal dependencies
  */
 import { requestSiteTerms } from 'state/terms/actions';
-import { isRequestingSiteTaxonomyTermsForQuery } from 'state/terms/selectors';
+import { isRequestingTermsForQuery } from 'state/terms/selectors';
 
 class QueryTerms extends Component {
 	componentWillMount() {
@@ -58,7 +58,7 @@ QueryTerms.defaultProps = {
 export default connect(
 	( state, ownProps ) => {
 		return {
-			requesting: isRequestingSiteTaxonomyTermsForQuery( state, ownProps.siteId, ownProps.taxonomy, ownProps.query )
+			requesting: isRequestingTermsForQuery( state, ownProps.siteId, ownProps.taxonomy, ownProps.query )
 		};
 	},
 	{

--- a/client/components/data/query-terms/index.jsx
+++ b/client/components/data/query-terms/index.jsx
@@ -3,12 +3,13 @@
  */
 import { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import shallowEqual from 'react-pure-render/shallowEqual';
 
 /**
  * Internal dependencies
  */
 import { requestSiteTerms } from 'state/terms/actions';
-import { isRequestingSiteTaxonomyTerms } from 'state/terms/selectors';
+import { isRequestingSiteTaxonomyTermsForQuery } from 'state/terms/selectors';
 
 class QueryTerms extends Component {
 	componentWillMount() {
@@ -17,7 +18,8 @@ class QueryTerms extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.props.siteId === nextProps.siteId &&
-				this.props.taxonomy === nextProps.taxonomy ) {
+				this.props.taxonomy === nextProps.taxonomy &&
+				shallowEqual( this.props.query, nextProps.query ) ) {
 			return;
 		}
 
@@ -49,10 +51,14 @@ QueryTerms.propTypes = {
 	requestSiteTerms: PropTypes.func.isRequired
 };
 
+QueryTerms.defaultProps = {
+	query: {}
+};
+
 export default connect(
 	( state, ownProps ) => {
 		return {
-			requesting: isRequestingSiteTaxonomyTerms( state, ownProps.siteId, ownProps.taxonomy )
+			requesting: isRequestingSiteTaxonomyTermsForQuery( state, ownProps.siteId, ownProps.taxonomy, ownProps.query )
 		};
 	},
 	{

--- a/client/components/data/query-terms/index.jsx
+++ b/client/components/data/query-terms/index.jsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestSiteTerms } from 'state/terms/actions';
+import { isRequestingSiteTaxonomyTerms } from 'state/terms/selectors';
+
+class QueryTerms extends Component {
+	componentWillMount() {
+		this.request( this.props );
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( this.props.siteId === nextProps.siteId &&
+				this.props.taxonomy === nextProps.taxonomy ) {
+			return;
+		}
+
+		this.request( nextProps );
+	}
+
+	request( props ) {
+		if ( props.requesting ) {
+			return;
+		}
+
+		props.requestSiteTerms( props.siteId, props.taxonomy );
+	}
+
+	shouldComponentUpdate() {
+		return false;
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryTerms.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	taxonomy: PropTypes.string.isRequired,
+	query: PropTypes.object,
+	requesting: PropTypes.bool.isRequired,
+	requestSiteTerms: PropTypes.func.isRequired
+};
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			requesting: isRequestingSiteTaxonomyTerms( state, ownProps.siteId, ownProps.taxonomy )
+		};
+	},
+	{
+		requestSiteTerms
+	}
+)( QueryTerms );

--- a/client/state/terms/constants.js
+++ b/client/state/terms/constants.js
@@ -1,0 +1,11 @@
+export const DEFAULT_TERMS_QUERY = {
+	context: 'display',
+	http_envelope: false,
+	pretty: false,
+	number: 100,
+	offset: 0,
+	page: 1,
+	order: 'DESC',
+	order_by: 'name',
+	search: ''
+};

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -19,7 +19,7 @@ import {
 import { isValidStateWithSchema } from 'state/utils';
 
 import {
-	getSerializedTaxonomyTermsQuery
+	getSerializedTermsQuery
 } from './utils';
 
 import {
@@ -41,7 +41,7 @@ export function queryRequests( state = {}, action ) {
 		case TERMS_REQUEST:
 		case TERMS_REQUEST_SUCCESS:
 		case TERMS_REQUEST_FAILURE:
-			const serializedQuery = getSerializedTaxonomyTermsQuery( action.query, action.taxonomy, action.siteId );
+			const serializedQuery = getSerializedTermsQuery( action.query, action.taxonomy, action.siteId );
 			return Object.assign( {}, state, {
 				[ serializedQuery ]: TERMS_REQUEST === action.type
 			} );
@@ -65,8 +65,8 @@ export function queryRequests( state = {}, action ) {
  */
 export function queries( state = {}, action ) {
 	switch ( action.type ) {
-		case TERMS_REQUEST_SUCCESS:
-			const serializedQuery = getSerializedTaxonomyTermsQuery( action.query, action.taxonomy, action.siteId );
+		case TERMS_RECEIVE:
+			const serializedQuery = getSerializedTermsQuery( action.query, action.taxonomy, action.siteId );
 			return Object.assign( {}, state, {
 				[ serializedQuery ]: action.terms.map( ( term ) => term.ID )
 			} );

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -42,8 +42,10 @@ export function queryRequests( state = {}, action ) {
 		case TERMS_REQUEST_SUCCESS:
 		case TERMS_REQUEST_FAILURE:
 			const serializedQuery = getSerializedTermsQuery( action.query, action.taxonomy, action.siteId );
-			return Object.assign( {}, state, {
-				[ serializedQuery ]: TERMS_REQUEST === action.type
+			return merge( {}, state, {
+				[ action.siteId ]: {
+					[ serializedQuery ]: TERMS_REQUEST === action.type
+				}
 			} );
 
 		case SERIALIZE:
@@ -66,9 +68,11 @@ export function queryRequests( state = {}, action ) {
 export function queries( state = {}, action ) {
 	switch ( action.type ) {
 		case TERMS_RECEIVE:
-			const serializedQuery = getSerializedTermsQuery( action.query, action.taxonomy, action.siteId );
-			return Object.assign( {}, state, {
-				[ serializedQuery ]: action.terms.map( ( term ) => term.ID )
+			const serializedQuery = getSerializedTermsQuery( action.query, action.taxonomy );
+			return merge( {}, state, {
+				[ action.siteId ]: {
+					[ serializedQuery ]: action.terms.map( ( term ) => term.ID )
+				}
 			} );
 
 		case DESERIALIZE:

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -9,13 +9,45 @@ import keyBy from 'lodash/keyBy';
  * Internal dependencies
  */
 import {
+	DESERIALIZE,
 	TERMS_RECEIVE,
-	DESERIALIZE
+	TERMS_REQUEST,
+	TERMS_REQUEST_FAILURE,
+	TERMS_REQUEST_SUCCESS,
+	SERIALIZE
 } from 'state/action-types';
 import { isValidStateWithSchema } from 'state/utils';
 import {
 	termsSchema
 } from './schema';
+
+/**
+ * Returns the updated requests state after an action has been dispatched. The
+ * state is a mapping of site ID to taxonomy to whether a request for that
+ * taxonomy is in progress.
+ *
+ * @param  {Object} state  Current state
+ * @param  {Object} action Action payload
+ * @return {Object}        Updated state
+ */
+export function requesting( state = {}, action ) {
+	switch ( action.type ) {
+		case TERMS_REQUEST:
+		case TERMS_REQUEST_SUCCESS:
+		case TERMS_REQUEST_FAILURE:
+			return merge( {}, state, {
+				[ action.siteId ]: {
+					[ action.taxonomy ]: TERMS_REQUEST === action.type
+				}
+			} );
+
+		case SERIALIZE:
+		case DESERIALIZE:
+			return {};
+	}
+
+	return state;
+}
 
 /**
  * Returns the updated terms state after an action has been dispatched.
@@ -46,5 +78,6 @@ export function items( state = {}, action ) {
 }
 
 export default combineReducers( {
-	items
+	items,
+	requesting
 } );

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -41,10 +41,12 @@ export function queryRequests( state = {}, action ) {
 		case TERMS_REQUEST:
 		case TERMS_REQUEST_SUCCESS:
 		case TERMS_REQUEST_FAILURE:
-			const serializedQuery = getSerializedTermsQuery( action.query, action.taxonomy, action.siteId );
+			const serializedQuery = getSerializedTermsQuery( action.query );
 			return merge( {}, state, {
 				[ action.siteId ]: {
-					[ serializedQuery ]: TERMS_REQUEST === action.type
+					[ action.taxonomy ]: {
+						[ serializedQuery ]: TERMS_REQUEST === action.type
+					}
 				}
 			} );
 
@@ -68,10 +70,12 @@ export function queryRequests( state = {}, action ) {
 export function queries( state = {}, action ) {
 	switch ( action.type ) {
 		case TERMS_RECEIVE:
-			const serializedQuery = getSerializedTermsQuery( action.query, action.taxonomy );
+			const serializedQuery = getSerializedTermsQuery( action.query );
 			return merge( {}, state, {
 				[ action.siteId ]: {
-					[ serializedQuery ]: action.terms.map( ( term ) => term.ID )
+					[ action.taxonomy ]: {
+						[ serializedQuery ]: action.terms.map( ( term ) => term.ID )
+					}
 				}
 			} );
 

--- a/client/state/terms/schema.js
+++ b/client/state/terms/schema.js
@@ -33,13 +33,19 @@ export const termsSchema = {
 export const queriesSchema = {
 	type: 'object',
 	patternProperties: {
-		// Queries are JSON strings, prepended by a site ID and taxonomy slug
-		'^(\\d+:)([A-Za-z0-9-_]+:)\\{[^\\}]*\\}$': {
-			type: 'array',
-			items: {
-				type: 'number'
-			}
-		}
+		'^\\d+$': {
+			type: 'object',
+			patternProperties: {
+				// Queries are JSON strings, prepended by a site ID and taxonomy slug
+				'^([A-Za-z0-9-_]+:)\\{[^\\}]*\\}$': {
+					type: 'array',
+					items: {
+						type: 'number'
+					}
+				}
+			},
+			additionalProperties: false
+		},
 	},
 	additionalProperties: false
 };

--- a/client/state/terms/schema.js
+++ b/client/state/terms/schema.js
@@ -36,16 +36,21 @@ export const queriesSchema = {
 		'^\\d+$': {
 			type: 'object',
 			patternProperties: {
-				// Queries are JSON strings, prepended by a site ID and taxonomy slug
-				'^([A-Za-z0-9-_]+:)\\{[^\\}]*\\}$': {
-					type: 'array',
-					items: {
-						type: 'number'
-					}
+				'^[A-Za-z0-9-_]+$': {
+					type: 'object',
+					patternProperties: {
+						'^\\{[^\\}]*\\}$': {
+							type: 'array',
+							items: {
+								type: 'number'
+							}
+						}
+					},
+					additionalProperties: false
 				}
 			},
 			additionalProperties: false
-		},
+		}
 	},
 	additionalProperties: false
 };

--- a/client/state/terms/schema.js
+++ b/client/state/terms/schema.js
@@ -29,3 +29,17 @@ export const termsSchema = {
 	},
 	additionalProperties: false
 };
+
+export const queriesSchema = {
+	type: 'object',
+	patternProperties: {
+		// Queries are JSON strings, prepended by a site ID and taxonomy slug
+		'^(\\d+:)([A-Za-z0-9-_]+:)\\{[^\\}]*\\}$': {
+			type: 'array',
+			items: {
+				type: 'number'
+			}
+		}
+	},
+	additionalProperties: false
+};

--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -23,7 +23,7 @@ import {
  */
 export function isRequestingTermsForQuery( state, siteId, taxonomy, query ) {
 	const serializedQuery = getSerializedTermsQuery( query );
-	return !! get( state.terms, [ 'queryRequests', siteId, taxonomy, serializedQuery ] );
+	return !! get( state.terms.queryRequests, [ siteId, taxonomy, serializedQuery ] );
 }
 
 /**
@@ -38,7 +38,7 @@ export function isRequestingTermsForQuery( state, siteId, taxonomy, query ) {
  */
 export function getTermsForQuery( state, siteId, taxonomy, query ) {
 	const serializedQuery = getSerializedTermsQuery( query );
-	const queryResults = get( state.terms, [ 'queries', siteId, taxonomy, serializedQuery ] );
+	const queryResults = get( state.terms.queries, [ siteId, taxonomy, serializedQuery ] );
 	if ( ! queryResults ) {
 		return null;
 	}

--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -5,20 +5,49 @@ import get from 'lodash/get';
 import values from 'lodash/values';
 
 /**
- * Returns true if a network request is in-progress for the specified site ID,
- * taxonomy pair, or false otherwise.
+ * Internal dependencies
+ */
+import {
+	getSerializedTaxonomyTermsQuery
+} from './utils';
+
+/**
+ * Returns true if currently requesting terms for the taxonomies query, or false
+ * otherwise.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @param  {String}  taxonomy Taxonomy slug
+ * @param  {Object}  query  Taxonomy query object
+ * @return {Boolean}        Whether terms are being requested
+ */
+export function isRequestingSiteTaxonomyTermsForQuery( state, siteId, taxonomy, query ) {
+	const serializedQuery = getSerializedTaxonomyTermsQuery( query, taxonomy, siteId );
+	return !! state.terms.queryRequests[ serializedQuery ];
+}
+
+/**
+ * Returns an array of terms for the taxonomies query, or null if no terms have been
+ * received.
  *
  * @param  {Object}  state    Global state tree
  * @param  {Number}  siteId   Site ID
- * @param  {String}  taxonomy Taxonomy Slug
- * @return {Boolean}          Whether request is in-progress
+ * @param  {String}  taxonomy Taxonomy slug
+ * @param  {Object}  query    Post query object
+ * @return {?Array}           Posts for the post query
  */
-export function isRequestingSiteTaxonomyTerms( state, siteId, taxonomy ) {
-	if ( ! state.terms ) {
-		return false;
+export function getSiteTaxonomyTermsForQuery( state, siteId, taxonomy, query ) {
+	const serializedQuery = getSerializedTaxonomyTermsQuery( query, taxonomy, siteId );
+	if ( ! state.terms.queries[ serializedQuery ] ) {
+		return null;
 	}
 
-	return get( state.terms.requesting, [ siteId, taxonomy ], false );
+	const taxonomyTerms = getSiteTaxonomyTerms( state, siteId, taxonomy );
+	const matchingTerms = state.terms.queries[ serializedQuery ];
+
+	return taxonomyTerms.filter( ( term ) => {
+		return matchingTerms.indexOf( term.ID ) >= 0;
+	} );
 }
 
 /**

--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -5,6 +5,23 @@ import get from 'lodash/get';
 import values from 'lodash/values';
 
 /**
+ * Returns true if a network request is in-progress for the specified site ID,
+ * taxonomy pair, or false otherwise.
+ *
+ * @param  {Object}  state    Global state tree
+ * @param  {Number}  siteId   Site ID
+ * @param  {String}  taxonomy Taxonomy Slug
+ * @return {Boolean}          Whether request is in-progress
+ */
+export function isRequestingSiteTaxonomyTerms( state, siteId, taxonomy ) {
+	if ( ! state.terms ) {
+		return false;
+	}
+
+	return get( state.terms.requesting, [ siteId, taxonomy ], false );
+}
+
+/**
  * Returns terms for a site, filtered by taxonomy.
  *
  * @param  {Object} state    Global state tree

--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -8,7 +8,7 @@ import values from 'lodash/values';
  * Internal dependencies
  */
 import {
-	getSerializedTaxonomyTermsQuery
+	getSerializedTermsQuery
 } from './utils';
 
 /**
@@ -22,7 +22,7 @@ import {
  * @return {Boolean}        Whether terms are being requested
  */
 export function isRequestingSiteTaxonomyTermsForQuery( state, siteId, taxonomy, query ) {
-	const serializedQuery = getSerializedTaxonomyTermsQuery( query, taxonomy, siteId );
+	const serializedQuery = getSerializedTermsQuery( query, taxonomy, siteId );
 	return !! state.terms.queryRequests[ serializedQuery ];
 }
 
@@ -37,17 +37,19 @@ export function isRequestingSiteTaxonomyTermsForQuery( state, siteId, taxonomy, 
  * @return {?Array}           Posts for the post query
  */
 export function getSiteTaxonomyTermsForQuery( state, siteId, taxonomy, query ) {
-	const serializedQuery = getSerializedTaxonomyTermsQuery( query, taxonomy, siteId );
+	const serializedQuery = getSerializedTermsQuery( query, taxonomy, siteId );
 	if ( ! state.terms.queries[ serializedQuery ] ) {
 		return null;
 	}
 
-	const taxonomyTerms = getSiteTaxonomyTerms( state, siteId, taxonomy );
-	const matchingTerms = state.terms.queries[ serializedQuery ];
+	return state.terms.queries[ serializedQuery ].reduce( ( memo, termId ) => {
+		const term = get( state.terms.items, [ siteId, taxonomy, termId ] );
+		if ( term ) {
+			memo.push( term );
+		}
 
-	return taxonomyTerms.filter( ( term ) => {
-		return matchingTerms.indexOf( term.ID ) >= 0;
-	} );
+		return memo;
+	}, [] );
 }
 
 /**

--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -22,8 +22,8 @@ import {
  * @return {Boolean}        Whether terms are being requested
  */
 export function isRequestingTermsForQuery( state, siteId, taxonomy, query ) {
-	const serializedQuery = getSerializedTermsQuery( query, taxonomy );
-	return !! get( state.terms.queryRequests, [ siteId, serializedQuery ] );
+	const serializedQuery = getSerializedTermsQuery( query );
+	return !! get( state.terms, [ 'queryRequests', siteId, taxonomy, serializedQuery ] );
 }
 
 /**
@@ -37,14 +37,14 @@ export function isRequestingTermsForQuery( state, siteId, taxonomy, query ) {
  * @return {?Array}           Posts for the post query
  */
 export function getTermsForQuery( state, siteId, taxonomy, query ) {
-	const serializedQuery = getSerializedTermsQuery( query, taxonomy );
-	const queryResults = get( state.terms.queries, [ siteId, serializedQuery ] );
+	const serializedQuery = getSerializedTermsQuery( query );
+	const queryResults = get( state.terms, [ 'queries', siteId, taxonomy, serializedQuery ] );
 	if ( ! queryResults ) {
 		return null;
 	}
 
 	return queryResults.reduce( ( memo, termId ) => {
-		const term = get( state.terms.items, [ siteId, taxonomy, termId ] );
+		const term = get( state.terms, [ 'items', siteId, taxonomy, termId ] );
 		if ( term ) {
 			memo.push( term );
 		}

--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -21,7 +21,7 @@ import {
  * @param  {Object}  query  Taxonomy query object
  * @return {Boolean}        Whether terms are being requested
  */
-export function isRequestingSiteTaxonomyTermsForQuery( state, siteId, taxonomy, query ) {
+export function isRequestingTermsForQuery( state, siteId, taxonomy, query ) {
 	const serializedQuery = getSerializedTermsQuery( query, taxonomy );
 	return !! get( state.terms.queryRequests, [ siteId, serializedQuery ] );
 }
@@ -36,7 +36,7 @@ export function isRequestingSiteTaxonomyTermsForQuery( state, siteId, taxonomy, 
  * @param  {Object}  query    Post query object
  * @return {?Array}           Posts for the post query
  */
-export function getSiteTaxonomyTermsForQuery( state, siteId, taxonomy, query ) {
+export function getTermsForQuery( state, siteId, taxonomy, query ) {
 	const serializedQuery = getSerializedTermsQuery( query, taxonomy );
 	const queryResults = get( state.terms.queries, [ siteId, serializedQuery ] );
 	if ( ! queryResults ) {
@@ -61,7 +61,7 @@ export function getSiteTaxonomyTermsForQuery( state, siteId, taxonomy, query ) {
  * @param  {String} taxonomy Taxonomy slug
  * @return {Array}           Terms
  */
-export function getSiteTaxonomyTerms( state, siteId, taxonomy ) {
+export function getTerms( state, siteId, taxonomy ) {
 	const terms = get( state.terms, [ 'items', siteId, taxonomy ] );
 
 	if ( ! terms ) {

--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -22,8 +22,8 @@ import {
  * @return {Boolean}        Whether terms are being requested
  */
 export function isRequestingSiteTaxonomyTermsForQuery( state, siteId, taxonomy, query ) {
-	const serializedQuery = getSerializedTermsQuery( query, taxonomy, siteId );
-	return !! state.terms.queryRequests[ serializedQuery ];
+	const serializedQuery = getSerializedTermsQuery( query, taxonomy );
+	return !! get( state.terms.queryRequests, [ siteId, serializedQuery ] );
 }
 
 /**
@@ -37,12 +37,13 @@ export function isRequestingSiteTaxonomyTermsForQuery( state, siteId, taxonomy, 
  * @return {?Array}           Posts for the post query
  */
 export function getSiteTaxonomyTermsForQuery( state, siteId, taxonomy, query ) {
-	const serializedQuery = getSerializedTermsQuery( query, taxonomy, siteId );
-	if ( ! state.terms.queries[ serializedQuery ] ) {
+	const serializedQuery = getSerializedTermsQuery( query, taxonomy );
+	const queryResults = get( state.terms.queries, [ siteId, serializedQuery ] );
+	if ( ! queryResults ) {
 		return null;
 	}
 
-	return state.terms.queries[ serializedQuery ].reduce( ( memo, termId ) => {
+	return queryResults.reduce( ( memo, termId ) => {
 		const term = get( state.terms.items, [ siteId, taxonomy, termId ] );
 		if ( term ) {
 			memo.push( term );

--- a/client/state/terms/test/reducer.js
+++ b/client/state/terms/test/reducer.js
@@ -150,7 +150,7 @@ describe( 'reducer', () => {
 
 		it( 'should track term query request success', () => {
 			const state = queries( undefined, {
-				type: TERMS_REQUEST_SUCCESS,
+				type: TERMS_RECEIVE,
 				siteId: 2916284,
 				query: { search: 'Ribs' },
 				found: 2,
@@ -168,7 +168,7 @@ describe( 'reducer', () => {
 				'2916284:categories:{"search":"ribs"}': [ 111 ]
 			} );
 			const state = queries( original, {
-				type: TERMS_REQUEST_SUCCESS,
+				type: TERMS_RECEIVE,
 				siteId: 2916284,
 				query: { search: 'And Chicken' },
 				found: 1,

--- a/client/state/terms/test/reducer.js
+++ b/client/state/terms/test/reducer.js
@@ -70,7 +70,9 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				2916284: {
-					'categories:{"search":"ribs"}': true
+					categories: {
+						'{"search":"ribs"}': true
+					}
 				}
 			} );
 		} );
@@ -78,7 +80,9 @@ describe( 'reducer', () => {
 		it( 'should accumulate queries', () => {
 			const original = deepFreeze( {
 				2916284: {
-					'categories:{"search":"ribs"}': true
+					categories: {
+						'{"search":"ribs"}': true
+					}
 				}
 			} );
 
@@ -91,8 +95,10 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				2916284: {
-					'categories:{"search":"ribs"}': true,
-					'categories:{"search":"and chicken"}': true
+					categories: {
+						'{"search":"ribs"}': true,
+						'{"search":"and chicken"}': true
+					}
 				}
 			} );
 		} );
@@ -109,7 +115,9 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				2916284: {
-					'categories:{"search":"ribs"}': false
+					categories: {
+						'{"search":"ribs"}': false
+					}
 				}
 			} );
 		} );
@@ -125,7 +133,9 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				2916284: {
-					'categories:{"search":"ribs"}': false
+					categories: {
+						'{"search":"ribs"}': false
+					}
 				}
 			} );
 		} );
@@ -133,7 +143,9 @@ describe( 'reducer', () => {
 		it( 'should never persist state', () => {
 			const original = deepFreeze( {
 				2916284: {
-					'categories:{"search":"ribs"}': false
+					categories: {
+						'{"search":"ribs"}': false
+					}
 				}
 			} );
 
@@ -145,7 +157,9 @@ describe( 'reducer', () => {
 		it( 'should never load persisted state', () => {
 			const original = deepFreeze( {
 				2916284: {
-					'categories:{"search":"ribs"}': false
+					categories: {
+						'{"search":"ribs"}': false
+					}
 				}
 			} );
 
@@ -174,7 +188,9 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				2916284: {
-					'categories:{"search":"ribs"}': [ 111, 123 ]
+					categories: {
+						'{"search":"ribs"}': [ 111, 123 ]
+					}
 				}
 			} );
 		} );
@@ -182,7 +198,9 @@ describe( 'reducer', () => {
 		it( 'should accumulate query request success', () => {
 			const original = deepFreeze( {
 				2916284: {
-					'categories:{"search":"ribs"}': [ 111 ]
+					categories: {
+						'{"search":"ribs"}': [ 111 ]
+					}
 				}
 			} );
 			const state = queries( original, {
@@ -196,8 +214,10 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				2916284: {
-					'categories:{"search":"ribs"}': [ 111 ],
-					'categories:{"search":"and chicken"}': [ 777 ]
+					categories: {
+						'{"search":"ribs"}': [ 111 ],
+						'{"search":"and chicken"}': [ 777 ]
+					}
 				}
 			} );
 		} );
@@ -205,7 +225,9 @@ describe( 'reducer', () => {
 		it( 'should persist state', () => {
 			const original = deepFreeze( {
 				2916284: {
-					'categories:{"search":"ribs"}': [ 111 ]
+					categories: {
+						'{"search":"ribs"}': [ 111 ]
+					}
 				}
 			} );
 
@@ -213,7 +235,9 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				2916284: {
-					'categories:{"search":"ribs"}': [ 111 ]
+					categories: {
+						'{"search":"ribs"}': [ 111 ]
+					}
 				}
 			} );
 		} );
@@ -221,7 +245,9 @@ describe( 'reducer', () => {
 		it( 'should load persisted state', () => {
 			const original = deepFreeze( {
 				2916284: {
-					'categories:{"search":"ribs"}': [ 111 ]
+					categories: {
+						'{"search":"ribs"}': [ 111 ]
+					}
 				}
 			} );
 
@@ -229,7 +255,9 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				2916284: {
-					'categories:{"search":"ribs"}': [ 111 ]
+					categories: {
+						'{"search":"ribs"}': [ 111 ]
+					}
 				}
 			} );
 		} );

--- a/client/state/terms/test/reducer.js
+++ b/client/state/terms/test/reducer.js
@@ -69,13 +69,17 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:categories:{"search":"ribs"}': true
+				2916284: {
+					'categories:{"search":"ribs"}': true
+				}
 			} );
 		} );
 
 		it( 'should accumulate queries', () => {
 			const original = deepFreeze( {
-				'2916284:categories:{"search":"ribs"}': true
+				2916284: {
+					'categories:{"search":"ribs"}': true
+				}
 			} );
 
 			const state = queryRequests( original, {
@@ -86,8 +90,10 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:categories:{"search":"ribs"}': true,
-				'2916284:categories:{"search":"and chicken"}': true
+				2916284: {
+					'categories:{"search":"ribs"}': true,
+					'categories:{"search":"and chicken"}': true
+				}
 			} );
 		} );
 
@@ -102,7 +108,9 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:categories:{"search":"ribs"}': false
+				2916284: {
+					'categories:{"search":"ribs"}': false
+				}
 			} );
 		} );
 
@@ -116,13 +124,17 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:categories:{"search":"ribs"}': false
+				2916284: {
+					'categories:{"search":"ribs"}': false
+				}
 			} );
 		} );
 
 		it( 'should never persist state', () => {
 			const original = deepFreeze( {
-				'2916284:categories:{"search":"ribs"}': true
+				2916284: {
+					'categories:{"search":"ribs"}': false
+				}
 			} );
 
 			const state = queryRequests( original, { type: SERIALIZE } );
@@ -132,7 +144,9 @@ describe( 'reducer', () => {
 
 		it( 'should never load persisted state', () => {
 			const original = deepFreeze( {
-				'2916284:categories:{"search":"ribs"}': true
+				2916284: {
+					'categories:{"search":"ribs"}': false
+				}
 			} );
 
 			const state = queryRequests( original, { type: DESERIALIZE } );
@@ -159,13 +173,17 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:categories:{"search":"ribs"}': [ 111, 123 ]
+				2916284: {
+					'categories:{"search":"ribs"}': [ 111, 123 ]
+				}
 			} );
 		} );
 
 		it( 'should accumulate query request success', () => {
 			const original = deepFreeze( {
-				'2916284:categories:{"search":"ribs"}': [ 111 ]
+				2916284: {
+					'categories:{"search":"ribs"}': [ 111 ]
+				}
 			} );
 			const state = queries( original, {
 				type: TERMS_RECEIVE,
@@ -177,32 +195,42 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
-				'2916284:categories:{"search":"ribs"}': [ 111 ],
-				'2916284:categories:{"search":"and chicken"}': [ 777 ]
+				2916284: {
+					'categories:{"search":"ribs"}': [ 111 ],
+					'categories:{"search":"and chicken"}': [ 777 ]
+				}
 			} );
 		} );
 
 		it( 'should persist state', () => {
 			const original = deepFreeze( {
-				'2916284:categories:{"search":"ribs"}': [ 111 ]
+				2916284: {
+					'categories:{"search":"ribs"}': [ 111 ]
+				}
 			} );
 
 			const state = queries( original, { type: SERIALIZE } );
 
 			expect( state ).to.eql( {
-				'2916284:categories:{"search":"ribs"}': [ 111 ]
+				2916284: {
+					'categories:{"search":"ribs"}': [ 111 ]
+				}
 			} );
 		} );
 
 		it( 'should load persisted state', () => {
 			const original = deepFreeze( {
-				'2916284:categories:{"search":"ribs"}': [ 111 ]
+				2916284: {
+					'categories:{"search":"ribs"}': [ 111 ]
+				}
 			} );
 
 			const state = queries( original, { type: DESERIALIZE } );
 
 			expect( state ).to.eql( {
-				'2916284:categories:{"search":"ribs"}': [ 111 ]
+				2916284: {
+					'categories:{"search":"ribs"}': [ 111 ]
+				}
 			} );
 		} );
 

--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -7,74 +7,118 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	isRequestingSiteTaxonomyTerms,
-	getSiteTaxonomyTerms
+	getSiteTaxonomyTerms,
+	getSiteTaxonomyTermsForQuery,
+	isRequestingSiteTaxonomyTermsForQuery
 } from '../selectors';
 
 describe( 'selectors', () => {
-	describe( '#isRequestingSiteTaxonomyTerms()', () => {
-		it( 'should return false if state tree is empty', () => {
-			const isRequesting = isRequestingSiteTaxonomyTerms( {}, 2916284, 'category' );
-
-			expect( isRequesting ).to.be.false;
-		} );
-
-		it( 'should return false if no request has been made for site and taxonomy combo', () => {
-			const isRequesting = isRequestingSiteTaxonomyTerms( {
+	describe( 'isRequestingSiteTaxonomyTermsForQuery()', () => {
+		it( 'should return false if no request exists', () => {
+			const requesting = isRequestingSiteTaxonomyTermsForQuery( {
 				terms: {
-					requesting: {}
+					queryRequests: {}
 				}
-			}, 2916284, 'category' );
+			}, 2916284, 'categories', {} );
 
-			expect( isRequesting ).to.be.false;
+			expect( requesting ).to.be.false;
 		} );
 
-		it( 'should return false if no request has been made for site and taxonomy', () => {
-			const isRequesting = isRequestingSiteTaxonomyTerms( {
+		it( 'should return false if query is not requesting', () => {
+			const requesting = isRequestingSiteTaxonomyTermsForQuery( {
 				terms: {
-					requesting: {
-						2916284: {
-							'random-taxonomy': true
-						}
+					queryRequests: {
+						'2916284:categories:{"search":"ribs"}': false
 					}
 				}
-			}, 2916284, 'category' );
+			}, 2916284, 'categories', { search: 'ribs' } );
 
-			expect( isRequesting ).to.be.false;
+			expect( requesting ).to.be.false;
 		} );
 
-		it( 'should return false if request has finished for site taxonomy combo', () => {
-			const isRequesting = isRequestingSiteTaxonomyTerms( {
+		it( 'should return true if query is in progress', () => {
+			const requesting = isRequestingSiteTaxonomyTermsForQuery( {
 				terms: {
-					requesting: {
-						2916284: {
-							'random-taxonomy': false,
-							category: false
-						}
+					queryRequests: {
+						'2916284:categories:{"search":"ribs"}': true
 					}
 				}
-			}, 2916284, 'random-taxonomy' );
+			}, 2916284, 'categories', { search: 'ribs' } );
 
-			expect( isRequesting ).to.be.false;
-		} );
-
-		it( 'should return true if requesting for site taxonomy combo', () => {
-			const isRequesting = isRequestingSiteTaxonomyTerms( {
-				terms: {
-					requesting: {
-						2916284: {
-							'random-taxonomy': false,
-							category: true
-						}
-					}
-				}
-			}, 2916284, 'category' );
-
-			expect( isRequesting ).to.be.true;
+			expect( requesting ).to.be.true;
 		} );
 	} );
 
-	describe( '#getSiteTaxonomyTerms()', () => {
+	describe( 'getSiteTaxonomyTermsForQuery()', () => {
+		it( 'should return null if no matching query results exist', () => {
+			const requesting = getSiteTaxonomyTermsForQuery( {
+				terms: {
+					queries: {}
+				}
+			}, 2916284, 'categories', {} );
+
+			expect( requesting ).to.be.null;
+		} );
+
+		it( 'should return an empty array if no matches exist', () => {
+			const requesting = getSiteTaxonomyTermsForQuery( {
+				terms: {
+					queries: {
+						'2916284:categories:{"search":"ribs"}': []
+					},
+					items: {
+						2916284: {
+							categories: {
+								111: {
+									ID: 111,
+									name: 'Chicken and a biscuit'
+								},
+								112: {
+									ID: 112,
+									name: 'Ribs'
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'categories', { search: 'ribs' } );
+
+			expect( requesting ).to.eql( [] );
+		} );
+
+		it( 'should return matching terms', () => {
+			const requesting = getSiteTaxonomyTermsForQuery( {
+				terms: {
+					queries: {
+						'2916284:categories:{"search":"ribs"}': [ 111 ]
+					},
+					items: {
+						2916284: {
+							categories: {
+								111: {
+									ID: 111,
+									name: 'Chicken and a biscuit'
+								},
+								112: {
+									ID: 112,
+									name: 'Ribs'
+								}
+							}
+						}
+					}
+				}
+			}, 2916284, 'categories', { search: 'ribs' } );
+
+			expect( requesting ).to.eql( [
+				{
+					ID: 111,
+					name: 'Chicken and a biscuit'
+				}
+			] );
+		} );
+	} );
+
+	describe( 'getSiteTaxonomyTerms()', () => {
 		it( 'should return null if no site exists', () => {
 			const terms = getSiteTaxonomyTerms( {}, 2916284, 'jetpack-portfolio' );
 

--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -7,15 +7,15 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
-	getSiteTaxonomyTerms,
-	getSiteTaxonomyTermsForQuery,
-	isRequestingSiteTaxonomyTermsForQuery
+	getTerms,
+	getTermsForQuery,
+	isRequestingTermsForQuery
 } from '../selectors';
 
 describe( 'selectors', () => {
-	describe( 'isRequestingSiteTaxonomyTermsForQuery()', () => {
+	describe( 'isRequestingTermsForQuery()', () => {
 		it( 'should return false if no request exists', () => {
-			const requesting = isRequestingSiteTaxonomyTermsForQuery( {
+			const requesting = isRequestingTermsForQuery( {
 				terms: {
 					queryRequests: {}
 				}
@@ -25,7 +25,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return false if query is not requesting', () => {
-			const requesting = isRequestingSiteTaxonomyTermsForQuery( {
+			const requesting = isRequestingTermsForQuery( {
 				terms: {
 					queryRequests: {
 						2916284: {
@@ -39,7 +39,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return true if query is in progress', () => {
-			const requesting = isRequestingSiteTaxonomyTermsForQuery( {
+			const requesting = isRequestingTermsForQuery( {
 				terms: {
 					queryRequests: {
 						2916284: {
@@ -53,9 +53,9 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getSiteTaxonomyTermsForQuery()', () => {
+	describe( 'getTermsForQuery()', () => {
 		it( 'should return null if no matching query results exist', () => {
-			const terms = getSiteTaxonomyTermsForQuery( {
+			const terms = getTermsForQuery( {
 				terms: {
 					queries: {}
 				}
@@ -65,7 +65,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return an empty array if no matches exist', () => {
-			const terms = getSiteTaxonomyTermsForQuery( {
+			const terms = getTermsForQuery( {
 				terms: {
 					queries: {
 						2916284: {
@@ -93,7 +93,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return matching terms', () => {
-			const terms = getSiteTaxonomyTermsForQuery( {
+			const terms = getTermsForQuery( {
 				terms: {
 					queries: {
 						2916284: {
@@ -126,15 +126,15 @@ describe( 'selectors', () => {
 		} );
 	} );
 
-	describe( 'getSiteTaxonomyTerms()', () => {
+	describe( 'getTerms()', () => {
 		it( 'should return null if no site exists', () => {
-			const terms = getSiteTaxonomyTerms( {}, 2916284, 'jetpack-portfolio' );
+			const terms = getTerms( {}, 2916284, 'jetpack-portfolio' );
 
 			expect( terms ).to.be.null;
 		} );
 
 		it( 'should return null if no taxonomies exist for site', () => {
-			const terms = getSiteTaxonomyTerms( {
+			const terms = getTerms( {
 				terms: {
 					items: {
 						2916284: {
@@ -153,7 +153,7 @@ describe( 'selectors', () => {
 		} );
 
 		it( 'should return array of matching terms for site taxonomy combo', () => {
-			const terms = getSiteTaxonomyTerms( {
+			const terms = getTerms( {
 				terms: {
 					items: {
 						2916284: {

--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -7,10 +7,73 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import {
+	isRequestingSiteTaxonomyTerms,
 	getSiteTaxonomyTerms
 } from '../selectors';
 
 describe( 'selectors', () => {
+	describe( '#isRequestingSiteTaxonomyTerms()', () => {
+		it( 'should return false if state tree is empty', () => {
+			const isRequesting = isRequestingSiteTaxonomyTerms( {}, 2916284, 'category' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return false if no request has been made for site and taxonomy combo', () => {
+			const isRequesting = isRequestingSiteTaxonomyTerms( {
+				terms: {
+					requesting: {}
+				}
+			}, 2916284, 'category' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return false if no request has been made for site and taxonomy', () => {
+			const isRequesting = isRequestingSiteTaxonomyTerms( {
+				terms: {
+					requesting: {
+						2916284: {
+							'random-taxonomy': true
+						}
+					}
+				}
+			}, 2916284, 'category' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return false if request has finished for site taxonomy combo', () => {
+			const isRequesting = isRequestingSiteTaxonomyTerms( {
+				terms: {
+					requesting: {
+						2916284: {
+							'random-taxonomy': false,
+							category: false
+						}
+					}
+				}
+			}, 2916284, 'random-taxonomy' );
+
+			expect( isRequesting ).to.be.false;
+		} );
+
+		it( 'should return true if requesting for site taxonomy combo', () => {
+			const isRequesting = isRequestingSiteTaxonomyTerms( {
+				terms: {
+					requesting: {
+						2916284: {
+							'random-taxonomy': false,
+							category: true
+						}
+					}
+				}
+			}, 2916284, 'category' );
+
+			expect( isRequesting ).to.be.true;
+		} );
+	} );
+
 	describe( '#getSiteTaxonomyTerms()', () => {
 		it( 'should return null if no site exists', () => {
 			const terms = getSiteTaxonomyTerms( {}, 2916284, 'jetpack-portfolio' );

--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -29,7 +29,9 @@ describe( 'selectors', () => {
 				terms: {
 					queryRequests: {
 						2916284: {
-							'categories:{"search":"ribs"}': false
+							categories: {
+								'{"search":"ribs"}': false
+							}
 						}
 					}
 				}
@@ -43,7 +45,9 @@ describe( 'selectors', () => {
 				terms: {
 					queryRequests: {
 						2916284: {
-							'categories:{"search":"ribs"}': true
+							categories: {
+								'{"search":"ribs"}': true
+							}
 						}
 					}
 				}
@@ -69,7 +73,9 @@ describe( 'selectors', () => {
 				terms: {
 					queries: {
 						2916284: {
-							'categories:{"search":"ribs"}': []
+							categories: {
+								'{"search":"ribs"}': []
+							}
 						}
 					},
 					items: {
@@ -97,7 +103,9 @@ describe( 'selectors', () => {
 				terms: {
 					queries: {
 						2916284: {
-							'categories:{"search":"ribs"}': [ 111 ]
+							categories: {
+								'{"search":"ribs"}': [ 111 ]
+							}
 						}
 					},
 					items: {

--- a/client/state/terms/test/selectors.js
+++ b/client/state/terms/test/selectors.js
@@ -28,7 +28,9 @@ describe( 'selectors', () => {
 			const requesting = isRequestingSiteTaxonomyTermsForQuery( {
 				terms: {
 					queryRequests: {
-						'2916284:categories:{"search":"ribs"}': false
+						2916284: {
+							'categories:{"search":"ribs"}': false
+						}
 					}
 				}
 			}, 2916284, 'categories', { search: 'ribs' } );
@@ -40,7 +42,9 @@ describe( 'selectors', () => {
 			const requesting = isRequestingSiteTaxonomyTermsForQuery( {
 				terms: {
 					queryRequests: {
-						'2916284:categories:{"search":"ribs"}': true
+						2916284: {
+							'categories:{"search":"ribs"}': true
+						}
 					}
 				}
 			}, 2916284, 'categories', { search: 'ribs' } );
@@ -51,20 +55,22 @@ describe( 'selectors', () => {
 
 	describe( 'getSiteTaxonomyTermsForQuery()', () => {
 		it( 'should return null if no matching query results exist', () => {
-			const requesting = getSiteTaxonomyTermsForQuery( {
+			const terms = getSiteTaxonomyTermsForQuery( {
 				terms: {
 					queries: {}
 				}
 			}, 2916284, 'categories', {} );
 
-			expect( requesting ).to.be.null;
+			expect( terms ).to.be.null;
 		} );
 
 		it( 'should return an empty array if no matches exist', () => {
-			const requesting = getSiteTaxonomyTermsForQuery( {
+			const terms = getSiteTaxonomyTermsForQuery( {
 				terms: {
 					queries: {
-						'2916284:categories:{"search":"ribs"}': []
+						2916284: {
+							'categories:{"search":"ribs"}': []
+						}
 					},
 					items: {
 						2916284: {
@@ -83,14 +89,16 @@ describe( 'selectors', () => {
 				}
 			}, 2916284, 'categories', { search: 'ribs' } );
 
-			expect( requesting ).to.eql( [] );
+			expect( terms ).to.eql( [] );
 		} );
 
 		it( 'should return matching terms', () => {
-			const requesting = getSiteTaxonomyTermsForQuery( {
+			const terms = getSiteTaxonomyTermsForQuery( {
 				terms: {
 					queries: {
-						'2916284:categories:{"search":"ribs"}': [ 111 ]
+						2916284: {
+							'categories:{"search":"ribs"}': [ 111 ]
+						}
 					},
 					items: {
 						2916284: {
@@ -109,7 +117,7 @@ describe( 'selectors', () => {
 				}
 			}, 2916284, 'categories', { search: 'ribs' } );
 
-			expect( requesting ).to.eql( [
+			expect( terms ).to.eql( [
 				{
 					ID: 111,
 					name: 'Chicken and a biscuit'

--- a/client/state/terms/test/utils.js
+++ b/client/state/terms/test/utils.js
@@ -8,8 +8,7 @@ import { expect } from 'chai';
  */
 import {
 	getNormalizedTermsQuery,
-	getSerializedTaxonomyTermsQuery,
-	getSerializedTaxonomyTermsQueryWithoutPage
+	getSerializedTermsQuery
 } from '../utils';
 
 describe( 'utils', () => {
@@ -26,9 +25,9 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe( 'getSerializedTaxonomyTermsQuery()', () => {
+	describe( 'getSerializedTermsQuery()', () => {
 		it( 'should return a JSON string of a normalized query', () => {
-			const serializedQuery = getSerializedTaxonomyTermsQuery( {
+			const serializedQuery = getSerializedTermsQuery( {
 				search: 'ribs',
 				page: 1,
 			}, 'categories', 2916284 );
@@ -37,32 +36,12 @@ describe( 'utils', () => {
 		} );
 
 		it( 'should lowercase the result', () => {
-			const serializedQuery = getSerializedTaxonomyTermsQuery( {
+			const serializedQuery = getSerializedTermsQuery( {
 				search: 'Chicken',
 				page: '2'
 			}, 'categories', 2916284 );
 
 			expect( serializedQuery ).to.equal( '2916284:categories:{"search":"chicken","page":"2"}' );
-		} );
-	} );
-
-	describe( 'getSerializedTaxonomyTermsQueryWithoutPage()', () => {
-		it( 'should return a JSON string of a normalized query omitting page', () => {
-			const serializedQuery = getSerializedTaxonomyTermsQueryWithoutPage( {
-				search: 'ribs',
-				page: 2
-			}, 'tags', 2916284 );
-
-			expect( serializedQuery ).to.equal( '2916284:tags:{"search":"ribs"}' );
-		} );
-
-		it( 'should lowercase the result', () => {
-			const serializedQuery = getSerializedTaxonomyTermsQueryWithoutPage( {
-				search: 'ChiCKEN',
-				page: 2
-			}, 'tags', 2916284 );
-
-			expect( serializedQuery ).to.equal( '2916284:tags:{"search":"chicken"}' );
 		} );
 	} );
 } );

--- a/client/state/terms/test/utils.js
+++ b/client/state/terms/test/utils.js
@@ -30,18 +30,18 @@ describe( 'utils', () => {
 			const serializedQuery = getSerializedTermsQuery( {
 				search: 'ribs',
 				page: 1,
-			}, 'categories', 2916284 );
+			}, 'categories' );
 
-			expect( serializedQuery ).to.equal( '2916284:categories:{"search":"ribs"}' );
+			expect( serializedQuery ).to.equal( 'categories:{"search":"ribs"}' );
 		} );
 
 		it( 'should lowercase the result', () => {
 			const serializedQuery = getSerializedTermsQuery( {
 				search: 'Chicken',
 				page: '2'
-			}, 'categories', 2916284 );
+			}, 'categories' );
 
-			expect( serializedQuery ).to.equal( '2916284:categories:{"search":"chicken","page":"2"}' );
+			expect( serializedQuery ).to.equal( 'categories:{"search":"chicken","page":"2"}' );
 		} );
 	} );
 } );

--- a/client/state/terms/test/utils.js
+++ b/client/state/terms/test/utils.js
@@ -30,18 +30,18 @@ describe( 'utils', () => {
 			const serializedQuery = getSerializedTermsQuery( {
 				search: 'ribs',
 				page: 1,
-			}, 'categories' );
+			} );
 
-			expect( serializedQuery ).to.equal( 'categories:{"search":"ribs"}' );
+			expect( serializedQuery ).to.equal( '{"search":"ribs"}' );
 		} );
 
 		it( 'should lowercase the result', () => {
 			const serializedQuery = getSerializedTermsQuery( {
 				search: 'Chicken',
 				page: '2'
-			}, 'categories' );
+			} );
 
-			expect( serializedQuery ).to.equal( 'categories:{"search":"chicken","page":"2"}' );
+			expect( serializedQuery ).to.equal( '{"search":"chicken","page":"2"}' );
 		} );
 	} );
 } );

--- a/client/state/terms/test/utils.js
+++ b/client/state/terms/test/utils.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getNormalizedTermsQuery,
+	getSerializedTaxonomyTermsQuery,
+	getSerializedTaxonomyTermsQueryWithoutPage
+} from '../utils';
+
+describe( 'utils', () => {
+	describe( 'getNormalizedTermsQuery()', () => {
+		it( 'should exclude default values', () => {
+			const query = getNormalizedTermsQuery( {
+				page: 2,
+				number: 100
+			} );
+
+			expect( query ).to.eql( {
+				page: 2
+			} );
+		} );
+	} );
+
+	describe( 'getSerializedTaxonomyTermsQuery()', () => {
+		it( 'should return a JSON string of a normalized query', () => {
+			const serializedQuery = getSerializedTaxonomyTermsQuery( {
+				search: 'ribs',
+				page: 1,
+			}, 'categories', 2916284 );
+
+			expect( serializedQuery ).to.equal( '2916284:categories:{"search":"ribs"}' );
+		} );
+
+		it( 'should lowercase the result', () => {
+			const serializedQuery = getSerializedTaxonomyTermsQuery( {
+				search: 'Chicken',
+				page: '2'
+			}, 'categories', 2916284 );
+
+			expect( serializedQuery ).to.equal( '2916284:categories:{"search":"chicken","page":"2"}' );
+		} );
+	} );
+
+	describe( 'getSerializedTaxonomyTermsQueryWithoutPage()', () => {
+		it( 'should return a JSON string of a normalized query omitting page', () => {
+			const serializedQuery = getSerializedTaxonomyTermsQueryWithoutPage( {
+				search: 'ribs',
+				page: 2
+			}, 'tags', 2916284 );
+
+			expect( serializedQuery ).to.equal( '2916284:tags:{"search":"ribs"}' );
+		} );
+
+		it( 'should lowercase the result', () => {
+			const serializedQuery = getSerializedTaxonomyTermsQueryWithoutPage( {
+				search: 'ChiCKEN',
+				page: 2
+			}, 'tags', 2916284 );
+
+			expect( serializedQuery ).to.equal( '2916284:tags:{"search":"chicken"}' );
+		} );
+	} );
+} );

--- a/client/state/terms/utils.js
+++ b/client/state/terms/utils.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import omit from 'lodash/omit';
+import omitBy from 'lodash/omitBy';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_TERMS_QUERY } from './constants';
+
+/**
+ * Returns a normalized terms query, excluding any values which match the
+ * default terms query.
+ *
+ * @param  {Object} query Posts query
+ * @return {Object}       Normalized terms query
+ */
+export function getNormalizedTermsQuery( query ) {
+	return omitBy( query, ( value, key ) => DEFAULT_TERMS_QUERY[ key ] === value );
+}
+
+/**
+ * Returns a serialized terms query, used as the key in the
+ * `state.terms.queries` state object.
+ *
+ * @param  {Object} query    Terms query
+ * @param  {String} taxonomy Taxonomy slug
+ * @param  {Number} siteId   Site ID
+ * @return {String}          Serialized terms query
+ */
+export function getSerializedTaxonomyTermsQuery( query = {}, taxonomy, siteId ) {
+	const normalizedQuery = getNormalizedTermsQuery( query );
+	const serializedQuery = JSON.stringify( normalizedQuery ).toLocaleLowerCase();
+
+	return [ siteId, taxonomy, serializedQuery ].join( ':' );
+}
+
+/**
+ * Returns a serialized terms query, excluding any page parameter, used as the
+ * key in the `state.terms.queriesLastPage` state object.
+ *
+ * @param  {Object} query    Terms query
+ * @param  {String} taxonomy Taxonomy slug
+ * @param  {Number} siteId   Site ID
+ * @return {String}          Serialized terms query
+ */
+export function getSerializedTaxonomyTermsQueryWithoutPage( query, taxonomy, siteId ) {
+	return getSerializedTaxonomyTermsQuery( omit( query, 'page' ), taxonomy, siteId );
+}

--- a/client/state/terms/utils.js
+++ b/client/state/terms/utils.js
@@ -29,22 +29,9 @@ export function getNormalizedTermsQuery( query ) {
  * @param  {Number} siteId   Site ID
  * @return {String}          Serialized terms query
  */
-export function getSerializedTaxonomyTermsQuery( query = {}, taxonomy, siteId ) {
+export function getSerializedTermsQuery( query = {}, taxonomy, siteId ) {
 	const normalizedQuery = getNormalizedTermsQuery( query );
 	const serializedQuery = JSON.stringify( normalizedQuery ).toLocaleLowerCase();
 
 	return [ siteId, taxonomy, serializedQuery ].join( ':' );
-}
-
-/**
- * Returns a serialized terms query, excluding any page parameter, used as the
- * key in the `state.terms.queriesLastPage` state object.
- *
- * @param  {Object} query    Terms query
- * @param  {String} taxonomy Taxonomy slug
- * @param  {Number} siteId   Site ID
- * @return {String}          Serialized terms query
- */
-export function getSerializedTaxonomyTermsQueryWithoutPage( query, taxonomy, siteId ) {
-	return getSerializedTaxonomyTermsQuery( omit( query, 'page' ), taxonomy, siteId );
 }

--- a/client/state/terms/utils.js
+++ b/client/state/terms/utils.js
@@ -24,12 +24,9 @@ export function getNormalizedTermsQuery( query ) {
  * `state.terms.queries` state object.
  *
  * @param  {Object} query    Terms query
- * @param  {String} taxonomy Taxonomy slug
  * @return {String}          Serialized terms query
  */
-export function getSerializedTermsQuery( query = {}, taxonomy ) {
+export function getSerializedTermsQuery( query = {} ) {
 	const normalizedQuery = getNormalizedTermsQuery( query );
-	const serializedQuery = JSON.stringify( normalizedQuery ).toLocaleLowerCase();
-
-	return [ taxonomy, serializedQuery ].join( ':' );
+	return JSON.stringify( normalizedQuery ).toLocaleLowerCase();
 }

--- a/client/state/terms/utils.js
+++ b/client/state/terms/utils.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import omit from 'lodash/omit';
 import omitBy from 'lodash/omitBy';
 
 /**
@@ -26,12 +25,11 @@ export function getNormalizedTermsQuery( query ) {
  *
  * @param  {Object} query    Terms query
  * @param  {String} taxonomy Taxonomy slug
- * @param  {Number} siteId   Site ID
  * @return {String}          Serialized terms query
  */
-export function getSerializedTermsQuery( query = {}, taxonomy, siteId ) {
+export function getSerializedTermsQuery( query = {}, taxonomy ) {
 	const normalizedQuery = getNormalizedTermsQuery( query );
 	const serializedQuery = JSON.stringify( normalizedQuery ).toLocaleLowerCase();
 
-	return [ siteId, taxonomy, serializedQuery ].join( ':' );
+	return [ taxonomy, serializedQuery ].join( ':' );
 }


### PR DESCRIPTION
For #3697.  This branch adds in a query component for terms ( `<QueryTerms />` ) and associated request tracking for the `terms` state tree.  This portion of the state tree is still in active development, and as such there are no visual impacts to test with this branch.  Instead you can ensure the terms tests pass by running: `npm run test-client -- --grep "state terms"`

__Notes__
I have added in a propType for `query` to `QueryTerms`.  Currently support for this has yet to be added but figured it wouldn't hurt to add now.