### PR TITLE
Framework: Introduce AsyncLoad for asynchronous rendering by code splitting

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -9,6 +9,7 @@
 @import 'auth/style';
 @import 'components/accordion/style';
 @import 'components/app-promo/style';
+@import 'components/async-load/style';
 @import 'components/author-selector/style';
 @import 'components/bulk-select/style';
 @import 'components/button/style';

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, PropTypes } from 'react';
 import omit from 'lodash/omit';
 
-export default class CodeSplitRender extends Component {
+export default class AsyncLoad extends Component {
 	constructor() {
 		super( ...arguments );
 
@@ -33,7 +33,7 @@ export default class CodeSplitRender extends Component {
 	}
 }
 
-CodeSplitRender.propTypes = {
+AsyncLoad.propTypes = {
 	require: PropTypes.func.isRequired,
 	placeholder: PropTypes.node
 };

--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -29,7 +29,7 @@ export default class AsyncLoad extends Component {
 			return this.props.placeholder;
 		}
 
-		return null;
+		return <div className="async-load" />;
 	}
 }
 

--- a/client/components/async-load/style.scss
+++ b/client/components/async-load/style.scss
@@ -1,0 +1,8 @@
+.async-load {
+	background: lighten( $gray, 22% );
+	content: '';
+	display: block;
+	height: 8px;
+	margin: 16px;
+	animation: pulse-light 0.8s ease-in-out infinite;
+}

--- a/client/components/async-load/style.scss
+++ b/client/components/async-load/style.scss
@@ -1,5 +1,6 @@
 .async-load {
 	background: lighten( $gray, 22% );
+	border-radius: 20px;
 	content: '';
 	display: block;
 	height: 8px;

--- a/client/components/async-load/style.scss
+++ b/client/components/async-load/style.scss
@@ -3,6 +3,7 @@
 	content: '';
 	display: block;
 	height: 8px;
-	margin: 16px;
+	width: 80px;
+	margin: 0 16px;
 	animation: pulse-light 0.8s ease-in-out infinite;
 }

--- a/client/components/code-split-render/index.jsx
+++ b/client/components/code-split-render/index.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React, { Component, PropTypes } from 'react';
+import omit from 'lodash/omit';
+
+export default class CodeSplitRender extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			component: null
+		};
+	}
+
+	componentWillMount() {
+		this.props.require( ( component ) => {
+			this.setState( { component } );
+		} );
+	}
+
+	render() {
+		if ( this.state.component ) {
+			const props = omit( this.props, Object.keys( this.constructor.propTypes ) );
+			return <this.state.component { ...props } />;
+		}
+
+		if ( this.props.placeholder ) {
+			return this.props.placeholder;
+		}
+
+		return null;
+	}
+}
+
+CodeSplitRender.propTypes = {
+	require: PropTypes.func.isRequired,
+	placeholder: PropTypes.node
+};

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -16,10 +16,11 @@ const actions = require( 'lib/posts/actions' ),
 	Popover = require( 'components/popover' ),
 	InfoPopover = require( 'components/info-popover' ),
 	Tooltip = require( 'components/tooltip' ),
-	PostSchedule = require( 'components/post-schedule' ),
 	postScheduleUtils = require( 'components/post-schedule/utils' ),
 	siteUtils = require( 'lib/site/utils' ),
 	stats = require( 'lib/posts/stats' );
+
+import AsyncLoad from 'components/async-load';
 
 export default React.createClass( {
 	displayName: 'EditPostStatus',
@@ -190,12 +191,15 @@ export default React.createClass( {
 				onClose={ this.togglePostSchedulePopover }
 			>
 				<div className="edit-post-status__post-schedule">
-					<PostSchedule
+					<AsyncLoad
+						require={ function( callback ) {
+							require( [ 'components/post-schedule' ], callback );
+						} }
 						selectedDay={ selectedDay }
 						timezone={ tz }
 						gmtOffset={ gmt }
-						onDateChange={ this.props.onDateChange }>
-					</PostSchedule>
+						onDateChange={ this.props.onDateChange }
+					/>
 				</div>
 			</Popover>
 		);

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -76,4 +76,9 @@
 	display: block;
 	padding: 0 16px;
 	width: 237px;
+
+	.async-load {
+		margin: 16px 0;
+		width: auto;
+	}
 }

--- a/client/post-editor/editor-action-bar/index.jsx
+++ b/client/post-editor/editor-action-bar/index.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import EditorAuthor from 'post-editor/editor-author';
 import EditorDeletePost from 'post-editor/editor-delete-post';
 import EditorPostType from 'post-editor/editor-post-type';
 import EditorSticky from 'post-editor/editor-sticky';
@@ -16,6 +15,7 @@ import utils from 'lib/posts/utils';
 import Tooltip from 'components/tooltip';
 import Button from 'components/button';
 import EditorActionBarViewLabel from './view-label';
+import AsyncLoad from 'components/async-load';
 
 export default React.createClass( {
 
@@ -58,7 +58,7 @@ export default React.createClass( {
 		};
 
 		return (
-			<EditorVisibility {...props} />
+			<EditorVisibility { ...props } />
 		);
 	},
 
@@ -68,7 +68,15 @@ export default React.createClass( {
 		return (
 			<div className="editor-action-bar">
 				<div className="editor-action-bar__first-group">
-					{ multiUserSite && <EditorAuthor post={ this.props.post } isNew={ this.props.isNew } /> }
+					{ multiUserSite &&
+						<AsyncLoad
+							require={ function( callback ) {
+								require( [ 'post-editor/editor-author' ], callback );
+							} }
+							post={ this.props.post }
+							isNew={ this.props.isNew }
+						/>
+					}
 				</div>
 				<EditorPostType />
 				<div className="editor-action-bar__last-group">

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -39,3 +39,8 @@
 		color: darken( $gray, 10% );
 	}
 }
+
+.editor-action-bar .async-load {
+	max-width: 30%;
+	margin-top: 6px;
+}

--- a/client/post-editor/editor-drawer/categories-and-tags.jsx
+++ b/client/post-editor/editor-drawer/categories-and-tags.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CategoryListData from 'components/data/category-list-data';
+import CategoriesTagsAccordion from 'post-editor/editor-categories-tags/accordion';
+import TagListData from 'components/data/tag-list-data';
+
+const EditorDrawerCategoriesAndTags = React.createClass( {
+
+	propTypes: {
+		site: React.PropTypes.object,
+		post: React.PropTypes.object
+	},
+
+	render() {
+		if ( ! this.props.site ) {
+			return;
+		}
+
+		return (
+			<CategoryListData siteId={ this.props.site.ID }>
+				<TagListData siteId={ this.props.site.ID }>
+					<CategoriesTagsAccordion
+						site={ this.props.site }
+						post={ this.props.post } />
+				</TagListData>
+			</CategoryListData>
+		);
+	}
+} );
+
+export default EditorDrawerCategoriesAndTags;

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -12,9 +12,9 @@ import Accordion from 'components/accordion';
 import AccordionSection from 'components/accordion/section';
 import Gridicon from 'components/gridicon';
 import CategoriesTagsAccordion from 'post-editor/editor-categories-tags/accordion';
+import CodeSplitRender from 'components/code-split-render';
 import CategoryListData from 'components/data/category-list-data';
 import TagListData from 'components/data/tag-list-data';
-import EditorSharingAccordion from 'post-editor/editor-sharing/accordion';
 import FormTextarea from 'components/forms/form-textarea';
 import PostFormatsData from 'components/data/post-formats-data';
 import PostFormatsAccordion from 'post-editor/editor-post-formats/accordion';
@@ -164,7 +164,10 @@ const EditorDrawer = React.createClass( {
 
 	renderSharing: function() {
 		return (
-			<EditorSharingAccordion
+			<CodeSplitRender
+				require={ function( callback ) {
+					require( [ 'post-editor/editor-sharing/accordion' ], callback );
+				} }
 				site={ this.props.site }
 				post={ this.props.post }
 				isNew={ this.props.isNew } />

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -11,10 +11,7 @@ import { connect } from 'react-redux';
 import Accordion from 'components/accordion';
 import AccordionSection from 'components/accordion/section';
 import Gridicon from 'components/gridicon';
-import CategoriesTagsAccordion from 'post-editor/editor-categories-tags/accordion';
 import AsyncLoad from 'components/async-load';
-import CategoryListData from 'components/data/category-list-data';
-import TagListData from 'components/data/tag-list-data';
 import FormTextarea from 'components/forms/form-textarea';
 import PageParent from 'post-editor/editor-page-parent';
 import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
@@ -106,38 +103,27 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderTaxonomies: function() {
-		var element;
+		return (
+			<EditorDrawerTaxonomies
+				postTerms={ this.props.post && this.props.post.terms }
+			/>
+		);
+	},
 
-		if ( config.isEnabled( 'manage/custom-post-types' ) &&
-				! includes( [ 'post', 'page' ], this.props.type ) ) {
-			return (
-				<EditorDrawerTaxonomies
-					postTerms={ this.props.post && this.props.post.terms }
-				/>
-			);
-		}
-
+	renderCategoriesAndTags: function() {
 		if ( ! this.currentPostTypeSupports( 'tags' ) ) {
 			return;
 		}
 
-		element = (
-			<CategoriesTagsAccordion
+		return (
+			<AsyncLoad
+				require={ function( callback ) {
+					require( [ 'post-editor/editor-drawer/categories-and-tags' ], callback );
+				} }
 				site={ this.props.site }
-				post={ this.props.post } />
+				post={ this.props.post }
+			/>
 		);
-
-		if ( this.props.site ) {
-			element = (
-				<CategoryListData siteId={ this.props.site.ID }>
-					<TagListData siteId={ this.props.site.ID }>
-						{ element }
-					</TagListData>
-				</CategoryListData>
-			);
-		}
-
-		return element;
 	},
 
 	renderPostFormats: function() {
@@ -186,7 +172,7 @@ const EditorDrawer = React.createClass( {
 	},
 
 	renderExcerpt: function() {
-		var excerpt;
+		let excerpt;
 
 		if ( ! this.currentPostTypeSupports( 'excerpt' ) ) {
 			return;
@@ -245,7 +231,7 @@ const EditorDrawer = React.createClass( {
 			return;
 		}
 
-		return(
+		return (
 			<AccordionSection>
 				<AsyncLoad
 					require={ function( callback ) {
@@ -317,7 +303,7 @@ const EditorDrawer = React.createClass( {
 			<Accordion
 				title={ this.translate( 'Page Options' ) }
 				icon={ <Gridicon icon="pages" /> }>
-				{ this.props.site && this.props.post ?
+				{ this.props.site && this.props.post &&
 					<div>
 						<PageParent siteId={ this.props.site.ID }
 							postId={ this.props.post.ID }
@@ -327,7 +313,7 @@ const EditorDrawer = React.createClass( {
 							<PageTemplates post={ this.props.post } />
 						</PageTemplatesData>
 					</div>
-				: null }
+				}
 				<PageOrder menuOrder={ this.props.post ? this.props.post.menu_order : 0 } />
 			</Accordion>
 		);
@@ -341,7 +327,10 @@ const EditorDrawer = React.createClass( {
 				{ site && ! this.hasHardCodedPostTypeSupports( type ) && (
 					<QueryPostTypes siteId={ site.ID } />
 				) }
-				{ this.renderTaxonomies() }
+				{ config.isEnabled( 'manage/custom-post-types' ) &&	! includes( [ 'post', 'page' ], this.props.type )
+					? this.renderTaxonomies()
+					: this.renderCategoriesAndTags()
+				}
 				{ this.renderFeaturedImage() }
 				{ this.renderPageOptions() }
 				{ this.renderSharing() }

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -18,10 +18,7 @@ import TagListData from 'components/data/tag-list-data';
 import FormTextarea from 'components/forms/form-textarea';
 import PostFormatsData from 'components/data/post-formats-data';
 import PostFormatsAccordion from 'post-editor/editor-post-formats/accordion';
-import Location from 'post-editor/editor-location';
-import Discussion from 'post-editor/editor-discussion';
 import PageParent from 'post-editor/editor-page-parent';
-import SeoAccordion from 'post-editor/editor-seo-accordion';
 import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
 import InfoPopover from 'components/info-popover';
 import PageTemplatesData from 'components/data/page-templates-data';
@@ -39,7 +36,6 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import config from 'config';
-import EditorDrawerFeaturedImage from './featured-image';
 import EditorDrawerTaxonomies from './taxonomies';
 
 /**
@@ -180,9 +176,13 @@ const EditorDrawer = React.createClass( {
 		}
 
 		return (
-			<EditorDrawerFeaturedImage
+			<AsyncLoad
+				require={ function( callback ) {
+					require( [ './featured-image' ], callback );
+				} }
 				site={ this.props.site }
-				post={ this.props.post } />
+				post={ this.props.post }
+			/>
 		);
 	},
 
@@ -231,7 +231,12 @@ const EditorDrawer = React.createClass( {
 		return (
 			<AccordionSection>
 				<span className="editor-drawer__label-text">{ this.translate( 'Location' ) }</span>
-				<Location coordinates={ PostMetadata.geoCoordinates( this.props.post ) } />
+				<AsyncLoad
+					require={ function( callback ) {
+						require( [ 'post-editor/editor-location' ], callback );
+					} }
+					coordinates={ PostMetadata.geoCoordinates( this.props.post ) }
+				/>
 			</AccordionSection>
 		);
 	},
@@ -243,7 +248,10 @@ const EditorDrawer = React.createClass( {
 
 		return(
 			<AccordionSection>
-				<Discussion
+				<AsyncLoad
+					require={ function( callback ) {
+						require( [ 'post-editor/editor-discussion' ], callback );
+					} }
 					site={ this.props.site }
 					post={ this.props.post }
 					isNew={ this.props.isNew }
@@ -264,7 +272,12 @@ const EditorDrawer = React.createClass( {
 		}
 
 		return (
-			<SeoAccordion metaDescription={ PostMetadata.metaDescription( this.props.post ) } />
+			<AsyncLoad
+				require={ function( callback ) {
+					require( [ 'post-editor/editor-seo-accordion' ], callback );
+				} }
+				metaDescription={ PostMetadata.metaDescription( this.props.post ) }
+			/>
 		);
 	},
 

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -12,7 +12,7 @@ import Accordion from 'components/accordion';
 import AccordionSection from 'components/accordion/section';
 import Gridicon from 'components/gridicon';
 import CategoriesTagsAccordion from 'post-editor/editor-categories-tags/accordion';
-import CodeSplitRender from 'components/code-split-render';
+import AsyncLoad from 'components/async-load';
 import CategoryListData from 'components/data/category-list-data';
 import TagListData from 'components/data/tag-list-data';
 import FormTextarea from 'components/forms/form-textarea';
@@ -164,7 +164,7 @@ const EditorDrawer = React.createClass( {
 
 	renderSharing: function() {
 		return (
-			<CodeSplitRender
+			<AsyncLoad
 				require={ function( callback ) {
 					require( [ 'post-editor/editor-sharing/accordion' ], callback );
 				} }

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -16,8 +16,6 @@ import AsyncLoad from 'components/async-load';
 import CategoryListData from 'components/data/category-list-data';
 import TagListData from 'components/data/tag-list-data';
 import FormTextarea from 'components/forms/form-textarea';
-import PostFormatsData from 'components/data/post-formats-data';
-import PostFormatsAccordion from 'post-editor/editor-post-formats/accordion';
 import PageParent from 'post-editor/editor-page-parent';
 import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
 import InfoPopover from 'components/info-popover';
@@ -149,12 +147,13 @@ const EditorDrawer = React.createClass( {
 		}
 
 		return (
-			<PostFormatsData siteId={ this.props.site.ID }>
-				<PostFormatsAccordion
-					site={ this.props.site }
-					post={ this.props.post }
-					className="editor-drawer__accordion" />
-			</PostFormatsData>
+			<AsyncLoad
+				require={ function( callback ) {
+					require( [ 'post-editor/editor-drawer/post-formats' ], callback );
+				} }
+				site={ this.props.site }
+				post={ this.props.post }
+			/>
 		);
 	},
 

--- a/client/post-editor/editor-drawer/post-formats.jsx
+++ b/client/post-editor/editor-drawer/post-formats.jsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PostFormatsData from 'components/data/post-formats-data';
+import PostFormatsAccordion from 'post-editor/editor-post-formats/accordion';
+
+function EditorDrawerPostFormats( { site, post } ) {
+	return (
+		<PostFormatsData siteId={ site.ID }>
+			<PostFormatsAccordion
+				site={ site }
+				post={ post }
+				className="editor-drawer__accordion" />
+		</PostFormatsData>
+	);
+}
+
+EditorDrawerPostFormats.propTypes = {
+	site: PropTypes.object,
+	post: PropTypes.object
+};
+
+export default EditorDrawerPostFormats;

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -78,3 +78,8 @@
 		left: 0;
 		right: 0;
 }
+
+.editor-drawer .async-load {
+	margin: 16px;
+	width: auto;
+}

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -17,11 +17,12 @@ const Card = require( 'components/card' ),
 	StatusLabel = require( 'post-editor/editor-status-label' ),
 	postUtils = require( 'lib/posts/utils' ),
 	siteUtils = require( 'lib/site/utils' ),
-	PostSchedule = require( 'components/post-schedule' ),
 	postActions = require( 'lib/posts/actions' ),
 	Tooltip = require( 'components/tooltip' ),
 	PostListFetcher = require( 'components/post-list-fetcher' ),
 	stats = require( 'lib/posts/stats' );
+
+import AsyncLoad from 'components/async-load';
 
 export default React.createClass( {
 	displayName: 'EditorGroundControl',
@@ -247,13 +248,16 @@ export default React.createClass( {
 				: null;
 
 		return (
-			<PostSchedule
+			<AsyncLoad
+				require={ function( callback ) {
+					require( [ 'components/post-schedule' ], callback );
+				} }
 				selectedDay={ postDate }
 				timezone={ tz }
 				gmtOffset={ gmtOffset }
 				onDateChange={ this.setPostDate }
-				onMonthChange={ this.setCurrentMonth }>
-			</PostSchedule>
+				onMonthChange={ this.setCurrentMonth }
+			/>
 		);
 	},
 

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -69,6 +69,11 @@
 	display: block;
 	padding: 0 16px;
 	width: 237px;
+
+	.async-load {
+		margin: 16px 0;
+		width: auto;
+	}
 }
 
 .editor-ground-control .edit-post-status {

--- a/client/post-editor/editor-sidebar/header.jsx
+++ b/client/post-editor/editor-sidebar/header.jsx
@@ -18,7 +18,7 @@ import { getEditorPostId, isEditorDraftsVisible } from 'state/ui/editor/selector
 import { toggleEditorDraftsVisible } from 'state/ui/editor/actions';
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
-import DraftsButton from 'post-editor/drafts-button';
+import AsyncLoad from 'components/async-load';
 
 function EditorSidebarHeader( { translate, type, showDrafts, toggleDrafts, allPostsUrl, toggleSidebar } ) {
 	const className = classnames( 'editor-sidebar__header', {
@@ -52,9 +52,14 @@ function EditorSidebarHeader( { translate, type, showDrafts, toggleDrafts, allPo
 					{ closeLabel }
 				</Button>
 			) }
-			{ type === 'post' && (
-				<DraftsButton onClick={ toggleDrafts } />
-			) }
+			{ type === 'post' &&
+				<AsyncLoad
+					require={ function( callback ) {
+						require( [ 'post-editor/drafts-button' ], callback );
+					} }
+					onClick={ toggleDrafts }
+				/>
+			}
 			<Button
 				onClick={ toggleSidebar }
 				className="editor-sidebar__toggle-sidebar">

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -33,7 +33,6 @@ const actions = require( 'lib/posts/actions' ),
 	EditorMobileNavigation = require( 'post-editor/editor-mobile-navigation' ),
 	layoutFocus = require( 'lib/layout-focus' ),
 	observe = require( 'lib/mixins/data-observe' ),
-	DraftList = require( 'my-sites/drafts/draft-list' ),
 	InvalidURLDialog = require( 'post-editor/invalid-url-dialog' ),
 	RestorePostDialog = require( 'post-editor/restore-post-dialog' ),
 	VerifyEmailDialog = require( 'post-editor/verify-email-dialog' ),
@@ -54,6 +53,7 @@ import EditorForbidden from 'post-editor/editor-forbidden';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 import QueryPreferences from 'components/data/query-preferences';
+import AsyncLoad from 'components/async-load';
 
 const messages = {
 	post: {
@@ -387,7 +387,11 @@ const PostEditor = React.createClass( {
 							allPostsUrl={ this.getAllPostsUrl() }
 							toggleSidebar={ this.toggleSidebar } />
 						{ this.props.showDrafts
-							? <DraftList { ...this.props }
+							? <AsyncLoad
+								require={ function( callback ) {
+									require( [ 'my-sites/drafts/draft-list' ], callback );
+								} }
+								{ ...this.props }
 								onTitleClick={ this.toggleSidebar }
 								showAllActionsMenu={ false }
 								siteID={ site ? site.ID : null }


### PR DESCRIPTION
Prompted by discussion for more granular code splitting, this pull request seeks to try an approach for rendering components with dependencies loaded on-demand by introducing new a component which facilitates rendering via asynchronous `require`.

This pull request is a proof-of-concept and should not be merged as-is. The loading experience could be improved to load the contents of the accordion asynchronously by user intent (e.g. hover accordion heading), not whenever the page is loaded. Further, in the case that the bundle is not loaded yet when the user tries to access its content, we should display some placeholder.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15215902/c3060abe-1822-11e6-94c0-041d88a27dc5.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15215890/b47ed0e8-1822-11e6-8507-eca3e8d37ec0.png)

Note in the screenshot above that the `post-editor` chunk has decreased from 3.47MB to 3.36MB, a difference of 0.11MB (110kB).

__Testing instructions:__

Note that the sharing accordion still renders correctly when visiting the post editor.

/cc @mtias 