### PR TITLE
Jetpack Connect: calypso_env for redirect

### DIFF
--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -32,13 +32,12 @@ import {
 	JETPACK_CONNECT_SSO_VALIDATION_ERROR
 } from 'state/action-types';
 import userFactory from 'lib/user';
-import config from 'config';
 
 /**
  *  Local variables;
  */
 let _fetching = {};
-const authURL = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + config( 'env' );
+const authURL = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=' + process.env.NODE_ENV;
 const installURL = '/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 const activateURL = '/wp-admin/plugins.php';
 const userModule = userFactory();


### PR DESCRIPTION
Let's use the config's `hostname` instead of `env` as `env` will produce unexpected results.

This requires a small change to the API, but it can be merged without breaking stuff on staging.

cc: @johnhackworth @ebinnion