### PR TITLE
Jetpack connect: New first step specific for jetpack.com installs

### DIFF
--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -32,6 +32,8 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
+		page( '/jetpack/install', jetpackConnectController.install );
+		page( '/jetpack/connect', jetpackConnectController.connect );
 		page(
 			'/jetpack/connect/authorize/:locale?',
 			jetpackConnectController.redirectWithoutLocaleifLoggedIn,

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -39,6 +39,24 @@ const sites = sitesFactory();
 const debug = new Debug( 'calypso:jetpack-connect:controller' );
 const userModule = userFactory();
 
+const jetpackConnectFirstStep = ( context, isInstall ) => {
+	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+	context.store.dispatch( setSection( 'jetpackConnect', {
+		hasSidebar: false
+	} ) );
+
+	renderWithReduxStore(
+		React.createElement( JetpackConnect, {
+			path: context.path,
+			context: context,
+			isInstall: isInstall,
+			locale: context.params.lang
+		} ),
+		document.getElementById( 'primary' ),
+		context.store
+	);
+};
+
 export default {
 	redirectWithoutLocaleifLoggedIn( context, next ) {
 		if ( userModule.get() && i18nUtils.getLocaleFromPath( context.path ) ) {
@@ -71,22 +89,12 @@ export default {
 		next();
 	},
 
-	connect( context ) {
-		ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
-		context.store.dispatch( setSection( 'jetpackConnect', {
-			hasSidebar: false
-		} ) );
+	install( context ) {
+		jetpackConnectFirstStep( context, true );
+	},
 
-		renderWithReduxStore(
-			React.createElement( JetpackConnect, {
-				path: context.path,
-				context: context,
-				locale: context.params.locale,
-				userModule: userModule
-			} ),
-			document.getElementById( 'primary' ),
-			context.store
-		);
+	connect( context ) {
+		jetpackConnectFirstStep( context, false );
 	},
 
 	authorizeForm( context ) {

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -41,6 +41,9 @@ const userModule = userFactory();
 
 const jetpackConnectFirstStep = ( context, isInstall ) => {
 	ReactDom.unmountComponentAtNode( document.getElementById( 'secondary' ) );
+
+	userModule.fetch();
+
 	context.store.dispatch( setSection( 'jetpackConnect', {
 		hasSidebar: false
 	} ) );
@@ -50,6 +53,7 @@ const jetpackConnectFirstStep = ( context, isInstall ) => {
 			path: context.path,
 			context: context,
 			isInstall: isInstall,
+			userModule: userModule,
 			locale: context.params.lang
 		} ),
 		document.getElementById( 'primary' ),

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -172,7 +172,10 @@ const JetpackConnectMain = React.createClass( {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">{ this.translate( 'Install Jetpack Manually' ) }</LoggedOutFormLinkItem>
-				<LoggedOutFormLinkItem href="/start">{ this.translate( 'Start a new site on WordPress.com' ) }</LoggedOutFormLinkItem>
+				{ this.props.isInstall
+					? null
+					: <LoggedOutFormLinkItem href="/start">{ this.translate( 'Start a new site on WordPress.com' ) }</LoggedOutFormLinkItem>
+				}
 			</LoggedOutFormLinks>
 		);
 	},
@@ -190,7 +193,8 @@ const JetpackConnectMain = React.createClass( {
 					onClick={ this.onURLEnter }
 					onDismissClick={ this.onDismissClick }
 					isError={ this.getStatus() }
-					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() } />
+					isFetching={ this.isCurrentUrlFetching() || this.isRedirecting() }
+					isInstall={ this.props.isInstall } />
 			</Card>
 		);
 	},
@@ -211,8 +215,29 @@ const JetpackConnectMain = React.createClass( {
 			<Main className="jetpack-connect">
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
-					<ConnectHeader headerText={ this.translate( 'Connect a self-hosted WordPress' ) }
+					<ConnectHeader
+						showLogo={ false }
+						headerText={ this.translate( 'Connect a self-hosted WordPress' ) }
 						subHeaderText={ this.translate( 'We\'ll be installing the Jetpack plugin so WordPress.com can connect to your self-hosted WordPress site.' ) }
+						step={ 1 }
+						steps={ 3 } />
+
+					{ this.renderSiteInput( status ) }
+					{ this.renderFooter() }
+				</div>
+			</Main>
+		);
+	},
+
+	renderSiteEntryInstall() {
+		const status = this.getStatus();
+		return (
+			<Main className="jetpack-connect">
+				<div className="jetpack-connect__site-url-entry-container">
+					<ConnectHeader
+						showLogo={ false }
+						headerText={ this.translate( 'Install Jetpack' ) }
+						subHeaderText={ this.translate( 'Installing Jetpack is easy. Please start by typing your site address below and then click "Start Installation"' ) }
 						step={ 1 }
 						steps={ 3 } />
 
@@ -228,7 +253,9 @@ const JetpackConnectMain = React.createClass( {
 			<Main className="jetpack-connect-wide">
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__install">
-					<ConnectHeader headerText={ this.translate( 'Ready for installation' ) }
+					<ConnectHeader
+						showLogo={ false }
+						headerText={ this.translate( 'Ready for installation' ) }
 						subHeaderText={ this.translate( 'We\'ll need to send you to your site dashboard for a few manual steps' ) }
 						step={ 1 }
 						steps={ 3 } />
@@ -254,7 +281,8 @@ const JetpackConnectMain = React.createClass( {
 			<Main className="jetpack-connect-wide">
 				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__install">
-					<ConnectHeader headerText={ this.translate( 'Ready for installation' ) }
+					<ConnectHeader showLogo={ false }
+						headerText={ this.translate( 'Ready for installation' ) }
 						subHeaderText={ this.translate( 'We\'ll need to send you to your site dashboard for a few manual steps' ) }
 						step={ 1 }
 						steps={ 3 } />
@@ -279,6 +307,9 @@ const JetpackConnectMain = React.createClass( {
 		}
 		if ( status === 'notActiveJetpack' && ! this.props.jetpackConnectSite.isDismissed ) {
 			return this.renderActivateInstructions();
+		}
+		if ( this.props.isInstall ) {
+			return this.renderSiteEntryInstall();
 		}
 		return this.renderSiteEntry();
 	}

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -260,14 +260,17 @@ const JetpackConnectMain = React.createClass( {
 						step={ 1 }
 						steps={ 3 } />
 					<div className="jetpack-connect__install-steps">
-						<JetpackInstallStep title={ this.translate( '1. Install Jetpack' ) }
-							text={ this.translate( 'You will be redirected to the Jetpack plugin page on your site\'s dashboard to install Jetpack. Click the blue install button.' ) }
+						<JetpackInstallStep title={ this.translate( '1. Install' ) }
+							text={ this.props.isInstall
+									? this.translate( 'You will be redirected to your site\'s dashboard to install Jetpack. Click the blue "Install Now" button' )
+									: this.translate( 'You will be redirected to the Jetpack plugin page on your site\'s dashboard to install Jetpack. Click the blue install button.' )
+							}
 							example={ <JetpackExampleInstall url={ this.state.currentUrl } /> } />
 						<JetpackInstallStep title={ this.translate( '2. Activate Jetpack' ) }
-							text={ this.translate( 'Once the plugin is installed, you\'ll need to click this tiny blue \'Activate\' link from your plugins list page.' ) }
+							text={ this.translate( 'You\'ll then need to click the small blue "Activate Plugin" link to activate Jetpack.' ) }
 							example={ <JetpackExampleActivate url={ this.state.currentUrl } /> } />
 						<JetpackInstallStep title={ this.translate( '3. Connect Jetpack' ) }
-							text={ this.translate( 'Once the plugin is activated you\'ll click this green \'Connect\' button to complete the connection.' ) }
+							text={ this.translate( 'Finally, just click the green "Connect to WordPress.com" button to finish the process.' ) }
 							example={ <JetpackExampleConnect url={ this.state.currentUrl } /> } />
 					</div>
 					<Button onClick={ this.installJetpack } primary>{ this.translate( 'Install Jetpack' ) }</Button>
@@ -291,7 +294,7 @@ const JetpackConnectMain = React.createClass( {
 							text={ this.translate( 'You need to click this tiny blue \'Activate\' link from your plugins list page.' ) }
 							example={ <JetpackExampleActivate url={ this.state.currentUrl } /> } />
 						<JetpackInstallStep title={ this.translate( '2. Connect Jetpack' ) }
-							text={ this.translate( 'Once the plugin is activated you\'ll click this green \'Connect\' button to complete the connection.' ) }
+							text={ this.translate( 'Finally, just click the green "Connect to WordPress.com" button to finish the process.' ) }
 							example={ <JetpackExampleConnect url={ this.state.currentUrl } /> } />
 					</div>
 					<Button onClick={ this.activateJetpack } primary>{ this.translate( 'Activate Jetpack' ) }</Button>

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -30,7 +30,10 @@ export default React.createClass( {
 
 	renderButtonLabel() {
 		if ( ! this.props.isFetching ) {
-			return( this.translate( 'Connect Now' ) );
+			if ( ! this.props.isInstall ) {
+				return( this.translate( 'Connect Now' ) );
+			}
+			return this.translate( 'Start Installation' );
 		}
 		return( this.translate( 'Connecting…' ) );
 	},


### PR DESCRIPTION
For new installs from jetpack.com, we want some specific texts & layouts in jetpack connect. This PR adds the route `/jetpack/install` that works exactly the same than `/jetpack/connect`, but is customised for users that arrive from jetpack.com:

![image](https://cloud.githubusercontent.com/assets/1554855/15220983/d3c57e4c-1869-11e6-9f19-bb81e7d92cef.png)


how to test
=========
1. Go to http://calypso.localhost:3000/jetpack/install
2. Connect a jetpack site and make sure it works the same that /jetpack/connect

ping @richardmuscat @rickybanister 