### PR TITLE
i18n: Localize HoC testing and docs improvements

### DIFF
--- a/client/lib/mixins/i18n/localize/README.md
+++ b/client/lib/mixins/i18n/localize/README.md
@@ -1,13 +1,13 @@
 Localize
 ========
 
-`localize` is a higher-order component which, when invoked as a function with a component, returns a new component class. The new component wraps the original component, passing all original props plus props to assist in localization (`translate`, `moment`, and `numberFormat`). The advantage of using a higher-order component instead of calling translate directly from the `lib/i18n/mixins` module is that the latter does not properly account for change events which may be emitted by the state emitter object.
+`localize` is a [higher-order component](https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750#.35mnb3b22) which, when invoked as a function with a component, returns a new component class. The new component wraps the original component, passing all original props plus props to assist in localization (`translate`, `moment`, and `numberFormat`). The advantage of using a higher-order component instead of calling translate directly from the `lib/i18n/mixins` module is that the latter does not properly account for change events which may be emitted by the state emitter object.
 
 It should act as a substitute to the existing i18n mixin which provides the `this.translate`, `this.moment`, and `this.numberFormat` functions. Notably, the higher-order component can be used for components which do not support mixins, including those inheriting the `Component` class or stateless function components.
 
 ## Usage
 
-Typically, you'd wrap your exported function with `localize`:
+Typically, you'd wrap your exported component with `localize`:
 
 ```jsx
 // greeting.jsx
@@ -25,7 +25,7 @@ function Greeting( { translate, className } ) {
 export default localize( Greeting );
 ```
 
-When the wrapped component is rendered, the render behavior of the original component is used, but with access to localization props.
+When the wrapped component is rendered, the render behavior of the original component is used, with access to localization props.
 
 ```jsx
 // index.jsx

--- a/client/lib/mixins/i18n/localize/test/index.jsx
+++ b/client/lib/mixins/i18n/localize/test/index.jsx
@@ -3,17 +3,14 @@
  */
 import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 /**
  * Internal dependencies
  */
-import useFakeDom from 'test/helpers/use-fake-dom';
 import localize from '../';
 
 describe( '#localize()', () => {
-	useFakeDom();
-
 	it( 'should be named using the variable name of the composed component', () => {
 		const MyComponent = React.createClass( {
 			render: () => null
@@ -26,14 +23,14 @@ describe( '#localize()', () => {
 
 	it( 'should be named using the displayName of the composed component', () => {
 		const MyComponent = React.createClass( {
-			displayName: 'MyComponent',
+			displayName: 'MyRenamedComponent',
 
 			render: () => null
 		} );
 
 		const LocalizedComponent = localize( MyComponent );
 
-		expect( LocalizedComponent.displayName ).to.equal( 'LocalizedMyComponent' );
+		expect( LocalizedComponent.displayName ).to.equal( 'LocalizedMyRenamedComponent' );
 	} );
 
 	it( 'should be named using the name of the composed function component', () => {
@@ -50,7 +47,7 @@ describe( '#localize()', () => {
 		} );
 		const LocalizedComponent = localize( MyComponent );
 
-		const mounted = mount( <LocalizedComponent /> );
+		const mounted = shallow( <LocalizedComponent /> );
 		const props = mounted.find( MyComponent ).props();
 
 		expect( props.translate ).to.be.a( 'function' );


### PR DESCRIPTION
This pull request includes minor revisions to the `localize` higher-order component documentation and tests. It removes reliance on the fake DOM by using shallow rendering, and clarifies usage in the documentation.

__Testing instructions:__

Verify Mocha tests pass:

```
npm run test-client
```