### PR TITLE
Jetpack SSO: Authorize and redirect working

### DIFF
--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -17,6 +17,7 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import {
 	JETPACK_CONNECT_QUERY_SET,
 	JETPACK_CONNECT_QUERY_UPDATE,
+	JETPACK_CONNECT_SSO_QUERY_SET
 } from 'state/action-types';
 import userFactory from 'lib/user';
 import jetpackSSOForm from './sso';
@@ -38,6 +39,12 @@ export default {
 		if ( ! isEmpty( context.query ) && context.query.update_nonce ) {
 			debug( 'updating nonce', context.query );
 			context.store.dispatch( { type: JETPACK_CONNECT_QUERY_UPDATE, property: '_wp_nonce', value: context.query.update_nonce } );
+			page.redirect( context.pathname );
+		}
+
+		if ( ! isEmpty( context.query ) && context.query.sso_nonce && context.query.site_id ) {
+			debug( 'updating SSO query', context.query );
+			context.store.dispatch( { type: JETPACK_CONNECT_SSO_QUERY_SET, queryObject: context.query } );
 			page.redirect( context.pathname );
 		}
 

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -41,9 +41,14 @@ const JetpackSSOForm = React.createClass( {
 		this.maybeValidateSSO();
 
 		if ( nextProps.ssoUrl && ! this.props.ssoUrl ) {
+			// After receiving the SSO URL, which will log the user in on remote site,
+			// we redirect user to remote site to be logged in.
+			//
+			// Note: We add `calypso_env` so that when we are redirected back to Calypso,
+			// we land in the same development environment.
 			const redirect = addQueryArgs( { calypso_env: config( 'env' ) }, nextProps.ssoUrl );
 			debug( 'Redirecting to: ' + redirect );
-			window.location.href = addQueryArgs( { calypso_env: config( 'env' ) }, nextProps.ssoUrl );
+			window.location.href = addQueryArgs( redirect );
 		}
 	},
 
@@ -63,7 +68,7 @@ const JetpackSSOForm = React.createClass( {
 
 	isButtonDisabled() {
 		const { nonceValid, isAuthorizing, isValidating, ssoUrl } = this.props;
-		return ! nonceValid || !! isAuthorizing || !! isValidating || !! ssoUrl;
+		return !! ( ! nonceValid | isAuthorizing | isValidating | ssoUrl );
 	},
 
 	maybeValidateSSO() {
@@ -76,7 +81,6 @@ const JetpackSSOForm = React.createClass( {
 
 	render() {
 		const user = this.props.userModule.get();
-		console.log( this.props );
 
 		return (
 			<Main className="jetpack-connect">

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -18,6 +18,7 @@ import {
 	SERIALIZE,
 } from 'state/action-types';
 import reducer, {
+	jetpackConnectSessions,
 	jetpackConnectAuthorize,
 	jetpackSSO
 } from '../reducer';
@@ -32,53 +33,29 @@ describe( 'reducer', () => {
 		] );
 	} );
 
-	describe( '#jetpackConnectAuthorize()', () => {
+	describe( '#jetpackConnectSessions()', () => {
 		it( 'should default to an empty object', () => {
 			const state = jetpackConnectAuthorize( undefined, {} );
 			expect( state ).to.eql( {} );
 		} );
 
-		it( 'should set autoAuthorize to true when SSO authorized', () => {
-			const state = jetpackConnectAuthorize( undefined, {
-				type: JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST
+		it( 'should store an integer timestamp when creating new session', () => {
+			const nowTime = ( new Date() ).getTime();
+			const state = jetpackConnectSessions( undefined, {
+				type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
+				ssoUrl: 'https://website.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}'
 			} );
 
-			expect( state ).to.have.property( 'autoAuthorize', true );
+			expect( state ).to.have.property( 'website.com' )
+				.to.be.a( 'number' )
+				.to.be.at.least( nowTime );
 		} );
+	} );
 
-		it( 'should leave autoAuthorize as true when authorize successful', () => {
-			const original = deepFreeze( {
-				queryObject: {},
-				isAuthorizing: false,
-				authorizeSuccess: false,
-				authorizeError: false,
-				autoAuthorize: true
-			} );
-
-			const state = jetpackConnectAuthorize( original, {
-				type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS
-			} );
-
-			expect( state ).to.have.property( 'autoAuthorize', true );
-		} );
-
-		it( 'should set autoAuthorize to false when authorize errors', () => {
-			const original = deepFreeze( {
-				queryObject: {},
-				isAuthorizing: false,
-				authorizeSuccess: false,
-				authorizeError: false,
-				autoAuthorize: true
-			} );
-
-			const state = jetpackConnectAuthorize( original, {
-				type: JETPACK_CONNECT_SSO_AUTHORIZE_ERROR,
-				error: {
-					statusCode: 400
-				}
-			} );
-
-			expect( state ).to.have.property( 'autoAuthorize', false );
+	describe( '#jetpackConnectAuthorize()', () => {
+		it( 'should default to an empty object', () => {
+			const state = jetpackConnectAuthorize( undefined, {} );
+			expect( state ).to.eql( {} );
 		} );
 	} );
 


### PR DESCRIPTION
This PR is a first pass at making the new Jetpack Connect SSO flow functional! 🎉 

The idea here is that when a user uses Jetpack SSO, that we send the user through this flow at `/jetpack/sso`. Then, after the users completes the SSO flow and logs in to the Jetpack site, we auto-authorize the user. 

To test:

- Checkout Automattic/jetpack#3789 into your Jetpack site
- Checkout `update/jetpack-sso-first-working` branch
- Make sure your site has a connection to WP.com
- With another remote site user and with another WP.com user, attempt to SSO
- First, you should land on `/jetpack/sso` and be prompted to "Log in".
    - Note: We'll tidy up the wording in a future PR
- After you click "Log in", if SSO is successful, you should be redirected back to `/jetpack/connect/authorize`
- And then eventually, you will land in the `wp-admin` for your remote site.

Some known jankiness:

- Currently, if you attempt to SSO and your remote site user's email is not the same as your WP.com user's email, you may see an awkward error notice on the remote site. I will fix in the future. For now, just make sure your remote site user's email is the same