### PR TITLE
Plans SEO: Adds New Site Settings SEO Tab

### DIFF
--- a/client/my-sites/site-settings/README.md
+++ b/client/my-sites/site-settings/README.md
@@ -1,7 +1,7 @@
 Site Settings JSX
 =================
 
-Site settings are broken into several different pages; general, writing, discussion, analytics, and security. The settings are dependent on the type and features of the selected site. Because much of the wiring for these components is the same, they all use the mixin `form-base` to declare common methods.
+Site settings are broken into several different pages; general, writing, discussion, analytics, seo, and security. The settings are dependent on the type and features of the selected site. Because much of the wiring for these components is the same, they all use the mixin `form-base` to declare common methods.
 
 Site Security Settings
 ----------------------

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -122,8 +122,19 @@ export default React.createClass( {
 	},
 
 	render() {
-		const { slug = '', settings: { blog_public = 1 } = {}, fetchingSettings } = this.props.site;
-		const { isSubmittingForm, seoMetaDescription, verificationServicesCodes } = this.state;
+		const {
+			slug = '',
+			settings: {
+				blog_public = 1
+			} = {},
+			fetchingSettings
+		} = this.props.site;
+
+		const {
+			isSubmittingForm,
+			seoMetaDescription,
+			verificationServicesCodes
+		} = this.state;
 
 		const isSitePrivate = parseInt( blog_public, 10 ) !== 1;
 		const isDisabled = isSitePrivate || fetchingSettings || isSubmittingForm;

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -85,7 +85,7 @@ export default React.createClass( {
 
 		notices.clearNotices( 'notices' );
 
-		this.setState( { submittingForm: true } );
+		this.setState( { isSubmittingForm: true } );
 
 		const filteredCodes = omitBy( this.state.verificationServicesCodes, isBoolean );
 		const updatedOptions = {
@@ -102,11 +102,11 @@ export default React.createClass( {
 					default:
 						notices.error( this.translate( 'There was a problem saving your changes. Please, try again.' ) );
 				}
-				this.setState( { submittingForm: false } );
+				this.setState( { isSubmittingForm: false } );
 			} else {
 				notices.success( this.translate( 'Settings saved!' ) );
 				this.markSaved();
-				this.setState( { submittingForm: false } );
+				this.setState( { isSubmittingForm: false } );
 
 				site.fetchSettings();
 			}
@@ -121,11 +121,11 @@ export default React.createClass( {
 
 	render() {
 		const { slug = '', settings: { blog_public = 1 } = {}, fetchingSettings } = this.props.site;
-		const { submittingForm, seoMetaDescription, verificationServicesCodes } = this.state;
+		const { isSubmittingForm, seoMetaDescription, verificationServicesCodes } = this.state;
 
 		const isSitePrivate = parseInt( blog_public, 10 ) !== 1;
-		const isDisabled = isSitePrivate || fetchingSettings || submittingForm;
-		const isMetaError = seoMetaDescription && seoMetaDescription.length > 160;
+		const isDisabled = isSitePrivate || fetchingSettings || isSubmittingForm;
+		const hasMetaError = seoMetaDescription && seoMetaDescription.length > 160;
 
 		const sitemapUrl = `https://${ slug }/sitemap.xml`;
 		const generalSettingsUrl = this.getGeneralSettingsUrl( slug );
@@ -137,7 +137,7 @@ export default React.createClass( {
 		const yandexCode = get( verificationServicesCodes, 'yandex' ) || '';
 
 		return (
-			<div className={ this.state.fetchingSettings ? 'is-loading' : '' }>
+			<div className={ fetchingSettings ? 'is-loading' : '' }>
 				<PageViewTracker path="/settings/seo/:site" title="Site Settings > SEO" />
 				{ isSitePrivate &&
 					<Notice status="is-warning" showDismiss={ false } text={ this.translate( 'SEO settings are disabled because the site visibility is not set to Public.' ) }>
@@ -150,9 +150,9 @@ export default React.createClass( {
 						onClick={ this.submitSeoForm }
 						primary={ true }
 						type="submit"
-						disabled={ isDisabled || this.state.submittingForm }
+						disabled={ isDisabled || isSubmittingForm }
 					>
-						{ this.state.submittingForm
+						{ isSubmittingForm
 							? this.translate( 'Saving…' )
 							: this.translate( 'Save Settings' )
 						}
@@ -185,7 +185,7 @@ export default React.createClass( {
 									maxLength="160"
 									acceptableLength={ 159 }
 									onChange={ this.handleMetaChange } />
-								{ isMetaError &&
+								{ hasMetaError &&
 									<FormInputValidation isError={ true } text={ this.translate( 'Description can\'t be longer than 160 characters.' ) } />
 								}
 								<FormSettingExplanation>

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -1,0 +1,279 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import get from 'lodash/get';
+import omitBy from 'lodash/omitBy';
+import isBoolean from 'lodash/isBoolean';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Button from 'components/button';
+import SectionHeader from 'components/section-header';
+import ExternalLink from 'components/external-link';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+import notices from 'notices';
+import protectForm from 'lib/mixins/protect-form';
+import FormInput from 'components/forms/form-text-input-with-affixes';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import CountedTextarea from 'components/forms/counted-textarea';
+import analytics from 'lib/analytics';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+
+export default React.createClass( {
+	displayName: 'SiteSettingsFormSEO',
+
+	mixins: [ protectForm.mixin ],
+
+	getInitialState() {
+		return this.stateForSite( this.props.site );
+	},
+
+	componentWillReceiveProps: function( nextProps ) {
+		if ( get( nextProps, 'site.ID', 0 ) !== get( this.props, 'site.ID', 0 ) ) {
+			if ( get( nextProps, 'site.jetpack' ) ) {
+				// Go back to general settings if switched to a Jetpack site
+				page( this.getGeneralSettingsUrl( get( nextProps, 'site.slug', '' ) ) );
+				return;
+			}
+
+			// Update state when switching sites
+			this.setState( this.stateForSite( nextProps.site ) );
+		}
+	},
+
+	stateForSite: function( site ) {
+		return {
+			seoMetaDescription: get( site, 'options.seo_meta_description', '' ),
+			verificationServicesCodes: {
+				google: get( site, 'options.verification_services_codes.google', '' ),
+				bing: get( site, 'options.verification_services_codes.bing', '' ),
+				pinterest: get( site, 'options.verification_services_codes.pinterest', '' ),
+				yandex: get( site, 'options.verification_services_codes.yandex', '' )
+			}
+		};
+	},
+
+	handleMetaChange( event ) {
+		this.setState( { seoMetaDescription: get( event, 'target.value', '' ) } );
+	},
+
+	handleVerificationCodeChange( event, serviceName ) {
+		const servicesCodes = this.state.verificationServicesCodes;
+		if ( ! servicesCodes.hasOwnProperty( serviceName ) ) {
+			return;
+		}
+
+		servicesCodes[ serviceName ] = get( event, 'target.value', '' );
+
+		this.setState( { verificationServicesCodes: servicesCodes } );
+	},
+
+	submitSeoForm( event ) {
+		const site = this.props.site;
+
+		if ( ! event.isDefaultPrevented() && event.nativeEvent ) {
+			event.preventDefault();
+		}
+
+		notices.clearNotices( 'notices' );
+
+		this.setState( { submittingForm: true } );
+
+		const filteredCodes = omitBy( this.state.verificationServicesCodes, isBoolean );
+		const updatedOptions = {
+			seo_meta_description: this.state.seoMetaDescription,
+			verification_services_codes: filteredCodes
+		};
+
+		site.saveSettings( updatedOptions, error => {
+			if ( error ) {
+				switch ( error.error ) {
+					case 'invalid_ip':
+						notices.error( this.translate( 'One of your IP Addresses was invalid. Please, try again.' ) );
+						break;
+					default:
+						notices.error( this.translate( 'There was a problem saving your changes. Please, try again.' ) );
+				}
+				this.setState( { submittingForm: false } );
+			} else {
+				notices.success( this.translate( 'Settings saved!' ) );
+				this.markSaved();
+				this.setState( { submittingForm: false } );
+
+				site.fetchSettings();
+			}
+		} );
+
+		analytics.tracks.recordEvent( 'calypso_seo_settings_form_submit' );
+	},
+
+	getGeneralSettingsUrl( slug ) {
+		return `/settings/general/${ slug }`;
+	},
+
+	render() {
+		const { slug = '', settings: { blog_public = 1 } = {}, fetchingSettings } = this.props.site;
+		const { submittingForm, seoMetaDescription, verificationServicesCodes } = this.state;
+
+		const isSitePrivate = parseInt( blog_public, 10 ) !== 1;
+		const isDisabled = isSitePrivate || fetchingSettings || submittingForm;
+		const isMetaError = seoMetaDescription && seoMetaDescription.length > 160;
+
+		const sitemapUrl = `https://${ slug }/sitemap.xml`;
+		const generalSettingsUrl = this.getGeneralSettingsUrl( slug );
+
+		// The API returns 'false' for an empty array value, so we force it to an empty string if needed
+		const googleCode = get( verificationServicesCodes, 'google' ) || '';
+		const bingCode = get( verificationServicesCodes, 'bing' ) || '';
+		const pinterestCode = get( verificationServicesCodes, 'pinterest' ) || '';
+		const yandexCode = get( verificationServicesCodes, 'yandex' ) || '';
+
+		return (
+			<div className={ this.state.fetchingSettings ? 'is-loading' : '' }>
+				<PageViewTracker path="/settings/seo/:site" title="Site Settings > SEO" />
+				{ isSitePrivate &&
+					<Notice status="is-warning" showDismiss={ false } text={ this.translate( 'SEO settings are disabled because the site visibility is not set to Public.' ) }>
+						<NoticeAction href={ generalSettingsUrl }>{ this.translate( 'View Settings' ) }</NoticeAction>
+					</Notice>
+				}
+				<SectionHeader label={ this.translate( 'Search Engine Optimization' ) }>
+					<Button
+						compact={ true }
+						onClick={ this.submitSeoForm }
+						primary={ true }
+						type="submit"
+						disabled={ isDisabled || this.state.submittingForm }
+					>
+						{ this.state.submittingForm
+							? this.translate( 'Saving…' )
+							: this.translate( 'Save Settings' )
+						}
+					</Button>
+				</SectionHeader>
+				<Card>
+					<p>
+						{ this.translate(
+							'{{b}}WordPress.com has great SEO{{/b}} out of the box. All of our themes are optimized for search engines, ' +
+							'so you don\'t have to do anything extra. However, you can tweak these settings if you\'d like more advanced control. ' +
+							'Read more about what you can do to {{a}}optimize your site\'s SEO{{/a}}.',
+							{
+								components: {
+									a: <a href={ 'https://en.blog.wordpress.com/2013/03/22/seo-on-wordpress-com/' } />,
+									b: <strong />
+								}
+							}
+						) }
+					</p>
+					<form onChange={ this.markChanged } className="seo-form">
+						<FormFieldset>
+							<FormFieldset className="has-divider is-top-only">
+								<FormLabel htmlFor="seo_meta_description">{ this.translate( 'Front Page Meta Description' ) }</FormLabel>
+								<CountedTextarea
+									name="seo_meta_description"
+									type="text"
+									id="seo_meta_description"
+									value={ seoMetaDescription || '' }
+									disabled={ isDisabled }
+									maxLength="160"
+									acceptableLength={ 159 }
+									onChange={ this.handleMetaChange } />
+								{ isMetaError &&
+									<FormInputValidation isError={ true } text={ this.translate( 'Description can\'t be longer than 160 characters.' ) } />
+								}
+								<FormSettingExplanation>
+									{ this.translate( 'Craft a description of your site in 160 characters or less. This description can be used in search engine results for your site\'s Front Page.' ) }
+								</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset className="has-divider">
+								<FormLabel htmlFor="seo_sitemap">{ this.translate( 'XML Sitemap' ) }</FormLabel>
+								<ExternalLink className="seo-sitemap" icon={ true } href={ sitemapUrl } target={ "_blank" }>{ sitemapUrl }</ExternalLink>
+								<FormSettingExplanation>
+									{ this.translate( 'Your site\'s sitemap is automatically sent to all major search engines for indexing.' ) }
+								</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset>
+								<FormLabel htmlFor="verification_code_google">{ this.translate( 'Site Verification Services' ) }</FormLabel>
+									<p>
+										{ this.translate(
+											'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order' +
+											' for your site to be indexed by search engines. To use these advanced search engine tools' +
+											' and verify your site with a service, paste the HTML Tag code below. Read the' +
+											' {{support}}full instructions{{/support}} if you are having trouble. Supported verification services:' +
+											' {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}},' +
+											' {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',
+											{
+												components: {
+													b: <strong />,
+													support: <a href="https://en.support.wordpress.com/webmaster-tools/" />,
+													google: <ExternalLink icon={ true } href="https://www.google.com/webmasters/tools/" />,
+													bing: <ExternalLink icon={ true } href="https://www.bing.com/webmaster/" />,
+													pinterest: <ExternalLink icon={ true } href="https://pinterest.com/website/verify/" />,
+													yandex: <ExternalLink icon={ true } href="https://webmaster.yandex.com/sites/" />
+												}
+											}
+										) }
+									</p>
+								<FormInput
+									prefix={ this.translate( 'Google' ) }
+									name="verification_code_google"
+									type="text"
+									value={ googleCode }
+									id="verification_code_google"
+									disabled={ isDisabled }
+									placeholder={ '<meta name="google-site-verification" content="1234">' }
+									onChange={ event => this.handleVerificationCodeChange( event, 'google' ) } />
+							</FormFieldset>
+
+							<FormFieldset>
+								<FormInput
+									prefix={ this.translate( 'Bing' ) }
+									name="verification_code_bing"
+									type="text"
+									value={ bingCode }
+									id="verification_code_bing"
+									disabled={ isDisabled }
+									placeholder={ '<meta name="msvalidate.01" content="1234" />' }
+									onChange={ event => this.handleVerificationCodeChange( event, 'bing' ) } />
+							</FormFieldset>
+
+							<FormFieldset>
+								<FormInput
+									prefix={ this.translate( 'Pinterest' ) }
+									name="verification_code_pinterest"
+									type="text"
+									value={ pinterestCode }
+									id="verification_code_pinterest"
+									disabled={ isDisabled }
+									placeholder={ '<meta name="p:domain_verify content="1234" />' }
+									onChange={ event => this.handleVerificationCodeChange( event, 'pinterest' ) } />
+							</FormFieldset>
+
+							<FormFieldset>
+								<FormInput
+									prefix={ this.translate( 'Yandex' ) }
+									name="verification_code_yandex"
+									type="text"
+									value={ yandexCode }
+									id="verification_code_yandex"
+									disabled={ isDisabled }
+									placeholder={ '<meta name="yandex-verification" content="1234" />' }
+									onChange={ event => this.handleVerificationCodeChange( event, 'yandex' ) } />
+							</FormFieldset>
+
+						</FormFieldset>
+					</form>
+				</Card>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -179,8 +179,7 @@ export const SeoForm = React.createClass( {
 			slug = '',
 			settings: {
 				blog_public = 1
-			} = {},
-			fetchingSettings
+			} = {}
 		} = this.props.site;
 
 		const {
@@ -192,7 +191,7 @@ export const SeoForm = React.createClass( {
 		} = this.state;
 
 		const isSitePrivate = parseInt( blog_public, 10 ) !== 1;
-		const isDisabled = isSitePrivate || fetchingSettings || isSubmittingForm;
+		const isDisabled = isSitePrivate || isSubmittingForm;
 		const hasMetaError = seoMetaDescription && seoMetaDescription.length > 160;
 
 		const sitemapUrl = `https://${ slug }/sitemap.xml`;
@@ -223,7 +222,7 @@ export const SeoForm = React.createClass( {
 		const isYandexError = invalidCodes.indexOf( 'yandex' ) > -1;
 
 		return (
-			<div className={ fetchingSettings ? 'is-loading' : '' }>
+			<div>
 				<PageViewTracker path="/settings/seo/:site" title="Site Settings > SEO" />
 				{ isSitePrivate &&
 					<Notice status="is-warning" showDismiss={ false } text={ this.translate( 'SEO settings are disabled because the site visibility is not set to Public.' ) }>

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -3,8 +3,8 @@
  */
 import React from 'react';
 import get from 'lodash/get';
-import omitBy from 'lodash/omitBy';
-import isBoolean from 'lodash/isBoolean';
+import pickBy from 'lodash/pickBy';
+import isString from 'lodash/isString';
 import page from 'page';
 
 /**
@@ -93,7 +93,7 @@ export default React.createClass( {
 
 		this.setState( { isSubmittingForm: true } );
 
-		const filteredCodes = omitBy( this.state.verificationServicesCodes, isBoolean );
+		const filteredCodes = pickBy( this.state.verificationServicesCodes, isString );
 		const updatedOptions = {
 			seo_meta_description: this.state.seoMetaDescription,
 			verification_services_codes: filteredCodes

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -27,6 +27,13 @@ import CountedTextarea from 'components/forms/counted-textarea';
 import analytics from 'lib/analytics';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
+const serviceNames = {
+	google: 'google-site-verification',
+	bing: 'msvalidate.01',
+	pinterest: 'p:domain_verify',
+	yandex: 'yandex-verification'
+};
+
 function getGeneralSettingsUrl( slug ) {
 	return `/settings/general/${ slug }`;
 }
@@ -41,6 +48,19 @@ function stateForSite( site ) {
 			yandex: get( site, 'options.verification_services_codes.yandex', '' )
 		}
 	};
+}
+
+function getMetaTagForService( serviceName = '', content = '' ) {
+	if ( ! content ) {
+		return '';
+	}
+
+	if ( content.indexOf( '<meta' ) !== -1 ) {
+		// We were passed a meta tag already!
+		return content;
+	}
+
+	return `<meta name="${ get( serviceNames, serviceName, '' ) }" content="${ content }" />`;
 }
 
 export default React.createClass( {
@@ -142,12 +162,25 @@ export default React.createClass( {
 
 		const sitemapUrl = `https://${ slug }/sitemap.xml`;
 		const generalSettingsUrl = getGeneralSettingsUrl( slug );
+		const placeholderTagContent = '1234';
 
-		// The API returns 'false' for an empty array value, so we force it to an empty string if needed
-		const googleCode = get( verificationServicesCodes, 'google' ) || '';
-		const bingCode = get( verificationServicesCodes, 'bing' ) || '';
-		const pinterestCode = get( verificationServicesCodes, 'pinterest' ) || '';
-		const yandexCode = get( verificationServicesCodes, 'yandex' ) || '';
+		const googleTag = getMetaTagForService(
+			'google',
+			// The API returns 'false' for an empty array value, so we force it to an empty string if needed
+			get( verificationServicesCodes, 'google' ) || ''
+		);
+		const bingTag = getMetaTagForService(
+			'bing',
+			get( verificationServicesCodes, 'bing' ) || ''
+		);
+		const pinterestTag = getMetaTagForService(
+			'pinterest',
+			get( verificationServicesCodes, 'pinterest' ) || ''
+		);
+		const yandexTag = getMetaTagForService(
+			'yandex',
+			get( verificationServicesCodes, 'yandex' ) || ''
+		);
 
 		return (
 			<div className={ fetchingSettings ? 'is-loading' : '' }>
@@ -240,10 +273,10 @@ export default React.createClass( {
 									prefix={ this.translate( 'Google' ) }
 									name="verification_code_google"
 									type="text"
-									value={ googleCode }
+									value={ googleTag }
 									id="verification_code_google"
 									disabled={ isDisabled }
-									placeholder={ '<meta name="google-site-verification" content="1234">' }
+									placeholder={ getMetaTagForService( 'google', placeholderTagContent ) }
 									onChange={ event => this.handleVerificationCodeChange( event, 'google' ) } />
 							</FormFieldset>
 
@@ -252,10 +285,10 @@ export default React.createClass( {
 									prefix={ this.translate( 'Bing' ) }
 									name="verification_code_bing"
 									type="text"
-									value={ bingCode }
+									value={ bingTag }
 									id="verification_code_bing"
 									disabled={ isDisabled }
-									placeholder={ '<meta name="msvalidate.01" content="1234" />' }
+									placeholder={ getMetaTagForService( 'bing', placeholderTagContent ) }
 									onChange={ event => this.handleVerificationCodeChange( event, 'bing' ) } />
 							</FormFieldset>
 
@@ -264,10 +297,10 @@ export default React.createClass( {
 									prefix={ this.translate( 'Pinterest' ) }
 									name="verification_code_pinterest"
 									type="text"
-									value={ pinterestCode }
+									value={ pinterestTag }
 									id="verification_code_pinterest"
 									disabled={ isDisabled }
-									placeholder={ '<meta name="p:domain_verify content="1234" />' }
+									placeholder={ getMetaTagForService( 'pinterest', placeholderTagContent ) }
 									onChange={ event => this.handleVerificationCodeChange( event, 'pinterest' ) } />
 							</FormFieldset>
 
@@ -276,10 +309,10 @@ export default React.createClass( {
 									prefix={ this.translate( 'Yandex' ) }
 									name="verification_code_yandex"
 									type="text"
-									value={ yandexCode }
+									value={ yandexTag }
 									id="verification_code_yandex"
 									disabled={ isDisabled }
-									placeholder={ '<meta name="yandex-verification" content="1234" />' }
+									placeholder={ getMetaTagForService( 'yandex', placeholderTagContent ) }
 									onChange={ event => this.handleVerificationCodeChange( event, 'yandex' ) } />
 							</FormFieldset>
 

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -6,6 +6,7 @@ import get from 'lodash/get';
 import pickBy from 'lodash/pickBy';
 import isString from 'lodash/isString';
 import page from 'page';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -24,8 +25,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
-import analytics from 'lib/analytics';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const serviceIds = {
 	google: 'google-site-verification',
@@ -73,7 +74,7 @@ function isValidVerificationCode( serviceName = '', content = '' ) {
 	return content.indexOf( serviceIds[ serviceName ] ) > -1;
 }
 
-export default React.createClass( {
+export const SeoForm = React.createClass( {
 	displayName: 'SiteSettingsFormSEO',
 
 	mixins: [ protectForm.mixin ],
@@ -121,7 +122,7 @@ export default React.createClass( {
 	},
 
 	submitSeoForm( event ) {
-		const site = this.props.site;
+		const { site, trackSubmission } = this.props;
 
 		if ( ! event.isDefaultPrevented() && event.nativeEvent ) {
 			event.preventDefault();
@@ -170,7 +171,7 @@ export default React.createClass( {
 			}
 		} );
 
-		analytics.tracks.recordEvent( 'calypso_seo_settings_form_submit' );
+		trackSubmission();
 	},
 
 	render() {
@@ -371,3 +372,9 @@ export default React.createClass( {
 		);
 	}
 } );
+
+const mapDispatchToProps = dispatch => ( {
+	trackSubmission: () => dispatch( recordTracksEvent( 'calypso_seo_settings_form_submit', {} ) )
+} );
+
+export default connect( null, mapDispatchToProps )( SeoForm );

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -53,7 +53,7 @@ export default React.createClass( {
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
-		if ( get( nextProps, 'site.ID', 0 ) !== get( this.props, 'site.ID', 0 ) ) {
+		if ( get( nextProps, 'site.ID' ) !== get( this.props, 'site.ID' ) ) {
 			if ( get( nextProps, 'site.jetpack' ) ) {
 				// Go back to general settings if switched to a Jetpack site
 				page( getGeneralSettingsUrl( get( nextProps, 'site.slug', '' ) ) );
@@ -75,9 +75,11 @@ export default React.createClass( {
 			return;
 		}
 
-		servicesCodes[ serviceName ] = get( event, 'target.value', '' );
-
-		this.setState( { verificationServicesCodes: servicesCodes } );
+		this.setState( {
+			verificationServicesCodes: Object.assign( {}, servicesCodes, {
+				[ serviceName ]: event.target.value
+			} )
+		} );
 	},
 
 	submitSeoForm( event ) {

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -27,38 +27,42 @@ import CountedTextarea from 'components/forms/counted-textarea';
 import analytics from 'lib/analytics';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
+function getGeneralSettingsUrl( slug ) {
+	return `/settings/general/${ slug }`;
+}
+
+function stateForSite( site ) {
+	return {
+		seoMetaDescription: get( site, 'options.seo_meta_description', '' ),
+		verificationServicesCodes: {
+			google: get( site, 'options.verification_services_codes.google', '' ),
+			bing: get( site, 'options.verification_services_codes.bing', '' ),
+			pinterest: get( site, 'options.verification_services_codes.pinterest', '' ),
+			yandex: get( site, 'options.verification_services_codes.yandex', '' )
+		}
+	};
+}
+
 export default React.createClass( {
 	displayName: 'SiteSettingsFormSEO',
 
 	mixins: [ protectForm.mixin ],
 
 	getInitialState() {
-		return this.stateForSite( this.props.site );
+		return stateForSite( this.props.site );
 	},
 
 	componentWillReceiveProps: function( nextProps ) {
 		if ( get( nextProps, 'site.ID', 0 ) !== get( this.props, 'site.ID', 0 ) ) {
 			if ( get( nextProps, 'site.jetpack' ) ) {
 				// Go back to general settings if switched to a Jetpack site
-				page( this.getGeneralSettingsUrl( get( nextProps, 'site.slug', '' ) ) );
+				page( getGeneralSettingsUrl( get( nextProps, 'site.slug', '' ) ) );
 				return;
 			}
 
 			// Update state when switching sites
-			this.setState( this.stateForSite( nextProps.site ) );
+			this.setState( stateForSite( nextProps.site ) );
 		}
-	},
-
-	stateForSite: function( site ) {
-		return {
-			seoMetaDescription: get( site, 'options.seo_meta_description', '' ),
-			verificationServicesCodes: {
-				google: get( site, 'options.verification_services_codes.google', '' ),
-				bing: get( site, 'options.verification_services_codes.bing', '' ),
-				pinterest: get( site, 'options.verification_services_codes.pinterest', '' ),
-				yandex: get( site, 'options.verification_services_codes.yandex', '' )
-			}
-		};
 	},
 
 	handleMetaChange( event ) {
@@ -115,10 +119,6 @@ export default React.createClass( {
 		analytics.tracks.recordEvent( 'calypso_seo_settings_form_submit' );
 	},
 
-	getGeneralSettingsUrl( slug ) {
-		return `/settings/general/${ slug }`;
-	},
-
 	render() {
 		const { slug = '', settings: { blog_public = 1 } = {}, fetchingSettings } = this.props.site;
 		const { isSubmittingForm, seoMetaDescription, verificationServicesCodes } = this.state;
@@ -128,7 +128,7 @@ export default React.createClass( {
 		const hasMetaError = seoMetaDescription && seoMetaDescription.length > 160;
 
 		const sitemapUrl = `https://${ slug }/sitemap.xml`;
-		const generalSettingsUrl = this.getGeneralSettingsUrl( slug );
+		const generalSettingsUrl = getGeneralSettingsUrl( slug );
 
 		// The API returns 'false' for an empty array value, so we force it to an empty string if needed
 		const googleCode = get( verificationServicesCodes, 'google' ) || '';

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -15,6 +15,7 @@ import GeneralSettings from './section-general';
 import WritingSettings from './form-writing';
 import DiscussionSettings from './section-discussion';
 import AnalyticsSettings from './section-analytics';
+import SeoSettings from './section-seo';
 import ImportSettings from './section-import';
 import ExportSettings from './section-export';
 import SiteSecurity from './section-security';
@@ -72,6 +73,7 @@ export class SiteSettingsComponent extends Component {
 			discussion: i18n.translate( 'Discussion', { context: 'settings screen' } ),
 			analytics: i18n.translate( 'Analytics', { context: 'settings screen' } ),
 			security: i18n.translate( 'Security', { context: 'settings screen' } ),
+			seo: i18n.translate( 'SEO', { context: 'settings screen' } ),
 			'import': i18n.translate( 'Import', { context: 'settings screen' } ),
 			'export': i18n.translate( 'Export', { context: 'settings screen' } ),
 		};
@@ -91,6 +93,7 @@ export class SiteSettingsComponent extends Component {
 			discussion: <DiscussionSettings site={ site } />,
 			security: <SiteSecurity site={ site } />,
 			analytics: <AnalyticsSettings site={ site } />,
+			seo: <SeoSettings site={ site } />,
 			'import': <ImportSettings site={ site } />,
 			'export': <ExportSettings site={ site } store={ context.store } />
 		};
@@ -135,6 +138,14 @@ export class SiteSettingsComponent extends Component {
 								selected={ section === 'analytics' } >
 									{ strings.analytics }
 							</NavItem>
+					}
+
+					{ ! site.jetpack && config.isEnabled( 'manage/seo' ) &&
+						<NavItem
+							path={ `/settings/seo/${ site.slug }` }
+							selected={ section === 'seo' } >
+								{ strings.seo }
+						</NavItem>
 					}
 
 					{

--- a/client/my-sites/site-settings/section-seo.jsx
+++ b/client/my-sites/site-settings/section-seo.jsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SeoForm from 'my-sites/site-settings/form-seo';
+
+export default React.createClass( {
+	displayName: 'SiteSettingsSeo',
+
+	render() {
+		return (
+			<SeoForm site={ this.props.site } />
+		);
+	}
+} );

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -101,6 +101,16 @@
 			}
 		}
 	}
+
+	.seo-form .form-text-input-with-affixes__prefix {
+		min-width: 60px;
+		text-align: center;
+	}
+
+	.seo-sitemap {
+		word-wrap: break-word;
+		word-break: break-word;
+	}
 }
 
 .writing-settings,
@@ -213,7 +223,6 @@
 	.jp-relatedposts-post .jp-relatedposts-post-context {
 		opacity: .6;
 	}
-
 }
 
 .jetpack-protect__deactivate,

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -111,6 +111,11 @@
 		word-wrap: break-word;
 		word-break: break-word;
 	}
+
+	.verification-code-error {
+		color: $alert-red;
+		font-weight: bold;
+	}
 }
 
 .writing-settings,

--- a/config/development.json
+++ b/config/development.json
@@ -70,6 +70,7 @@
 		"manage/plugins/wpcom": true,
 		"manage/posts": true,
 		"manage/security": true,
+		"manage/seo": true,
 		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -46,6 +46,7 @@
 		"manage/plugins/wpcom": true,
 		"manage/posts": true,
 		"manage/security": true,
+		"manage/seo": true,
 		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -47,6 +47,7 @@
 		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,
+		"manage/seo": true,
 		"manage/stats": true,
 		"manage/themes": true,
 		"manage/themes-jetpack": true,

--- a/config/test.json
+++ b/config/test.json
@@ -63,6 +63,7 @@
 		"manage/plugins/setup": true,
 		"manage/posts": true,
 		"manage/security": true,
+		"manage/seo": true,
 		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -51,6 +51,7 @@
 		"manage/plugins/wpcom": true,
 		"manage/posts": true,
 		"manage/security": true,
+		"manage/seo": true,
 		"manage/sharing": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/delete-site": true,


### PR DESCRIPTION
Adds a new tab to site settings that allows the user to manage their SEO settings.

They can:
 * Get informed about the SEO work WordPress.com already does for them.
 * Set a custom front page site meta description for search engines.
 * Get a link to their sitemap.
 * Add site verification codes for various services (this was previously in wp-admin under 'Available tools')

**To test**:
Visit settings for a site and modify the fields in the `SEO` tab. You should see your entries in meta tags on the site when you view the source:

For the front page description:
```
<meta name="description" content="The best site on the internet!" />
```

For the verification codes:
```
<meta name="google-site-verification" content="GOOGLE12345" />
<meta name="msvalidate.01" content="BING12345" />
<meta name="p:domain_verify" content="PINTEREST12345" />
<meta name="yandex-verification" content="YANDEX12345" />
```

You should also be able to click on the sitemap link and see the xml code.

You should also see a warning message when you access the SEO tab when the site is set to `private` or to `discourage search engines`.

**Screenshot**
![0r2eoxmkinnaaaaaelftksuqmcc](https://cloud.githubusercontent.com/assets/618551/15329727/60766e9c-1c1f-11e6-89ab-7e756764be7a.png)



Fixes #5308 