### PR TITLE
Purchases: Fix Manage purchases says wrong expiration date for auto-renewals with card that expires before renewal

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -443,12 +443,12 @@ const ManagePurchase = React.createClass( {
 			);
 		}
 
-		if ( isRenewing( purchase ) ) {
-			return this.moment( purchase.renewDate ).format( 'LL' );
-		}
-
 		if ( isExpiring( purchase ) || isExpired( purchase ) || creditCardExpiresBeforeSubscription( purchase ) ) {
 			return this.moment( purchase.expiryDate ).format( 'LL' );
+		}
+
+		if ( isRenewing( purchase ) ) {
+			return this.moment( purchase.renewDate ).format( 'LL' );
 		}
 
 		if ( isOneTimePurchase( purchase ) ) {


### PR DESCRIPTION
Fixes #5107 

This PR fixes the expiration date displayed on the Manage Purchase page which is wrong when the following conditions are met:
- Purchase is set to auto-renew
- Card expires before renewal date

There is a mistake in the order the conditions are checked to chose which date to display for this block. The logic is correct for the label so I simply used the same for the date selection.

## Testing Instructions
- Activate sandbox store and set the expiration date of a cc paid purchase after the cc expiration from on SA (internal tool)
- `git checkout fix/5107-expiry-date-cc-expires-before-sub`
- `make run`
- Check that the correct expiration date is displayed (ie it matches the one defined in SA)

![image](https://cloud.githubusercontent.com/assets/230230/15246243/84de6454-190b-11e6-8b2b-3b68a1062fa9.png)

## Reviews
- [x] Product Review
- [x] Code Review
 