### PR TITLE
Reader: Use embed-container to render Slideshow gallery

### DIFF
--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -9,8 +9,9 @@ import filter from 'lodash/filter';
 import forEach from 'lodash/forEach';
 import forOwn from 'lodash/forOwn';
 import noop from 'lodash/noop';
+import assign from 'lodash/assign';
 
-import { loadScript } from 'lib/load-script';
+import { loadScript, loadjQueryDependentScript } from 'lib/load-script';
 
 import debugFactory from 'debug';
 
@@ -20,7 +21,15 @@ const embedsToLookFor = {
 	'blockquote[class^="instagram-"]': embedInstagram,
 	'blockquote[class^="twitter-"]': embedTwitter,
 	'fb\\\:post, [class^=fb-]': embedFacebook,
-	'[class^=tumblr-]': embedTumblr
+	'[class^=tumblr-]': embedTumblr,
+	'.jetpack-slideshow': embedSlideshow
+};
+
+const SLIDESHOW_URLS = {
+	CSS: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/css/slideshow-shortcode.css',
+	CYCLE_JS: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/jquery.cycle.js',
+	JS: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/slideshow-shortcode.js',
+	SPINNER: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/img/slideshow-loader.gif'
 };
 
 function processEmbeds( domNode ) {
@@ -37,6 +46,16 @@ function nodeNeedsProcessing( domNode ) {
 
 	domNode.setAttribute( 'data-wpcom-embed-processed', '1' );
 	return true;
+}
+
+function loadCSS( cssUrl ) {
+	const link = assign( document.createElement( 'link' ), {
+		rel: 'stylesheet',
+		type: 'text/css',
+		href: cssUrl
+	} );
+
+	document.head.appendChild( link );
 }
 
 let loaders = {};
@@ -110,6 +129,56 @@ function embedTumblr( domNode ) {
 	setTimeout( function() {
 		loadScript( 'https://secure.assets.tumblr.com/post.js', removeScript );
 	}, 30 );
+}
+
+function triggerJQueryLoadEvent() {
+	// force JetpackSlideshow to initialize, in case navigation hasn't caused ready event on document
+	window.jQuery( 'body' ).trigger( 'post-load' );
+}
+
+function createSlideshow() {
+	if ( window.JetpackSlideshow ) {
+		triggerJQueryLoadEvent();
+	}
+
+	loadAndRun( SLIDESHOW_URLS.JS, () => {
+		triggerJQueryLoadEvent();
+	} );
+}
+
+function embedSlideshow( domNode ) {
+	debug( 'processing slideshow for', domNode );
+
+	// set global variable required by JetpackSlideshow
+	window.jetpackSlideshowSettings = {
+		spinner: SLIDESHOW_URLS.SPINNER
+	};
+
+	// load CSS if it isn't alread there
+	if ( ! document.head.querySelector( `link[href="${ SLIDESHOW_URLS.CSS }"]` ) ) {
+		loadCSS( SLIDESHOW_URLS.CSS );
+	}
+
+	// Remove no JS warning so user doesn't have to look at it while several scripts load
+	const warningElements = domNode.parentNode.getElementsByClassName( 'jetpack-slideshow-noscript' );
+	forEach( warningElements, ( el ) => {
+		el.classList.add( 'hidden' );
+	} );
+
+	if ( window.jQuery && ! window.jQuery.prototype.cycle ) {
+		// Only jQuery exists
+		loadAndRun( SLIDESHOW_URLS.CYCLE_JS, ()=> {
+			createSlideshow();
+		} );
+	} else if ( window.jQuery && window.jQuery.prototype.cycle ) {
+		// jQuery and cylcejs exist
+		createSlideshow();
+	} else {
+		// Neither exist
+		loadjQueryDependentScript( SLIDESHOW_URLS.CYCLE_JS, () => {
+			createSlideshow();
+		} );
+	}
 }
 
 export default React.createClass( {

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -146,6 +146,8 @@ function createSlideshow() {
 	} );
 }
 
+let slideshowCSSPresent = false;
+
 function embedSlideshow( domNode ) {
 	debug( 'processing slideshow for', domNode );
 
@@ -154,8 +156,8 @@ function embedSlideshow( domNode ) {
 		spinner: SLIDESHOW_URLS.SPINNER
 	};
 
-	// load CSS if it isn't alread there
-	if ( ! document.head.querySelector( `link[href="${ SLIDESHOW_URLS.CSS }"]` ) ) {
+	if ( ! slideshowCSSPresent ) {
+		slideshowCSSPresent = true;
 		loadCSS( SLIDESHOW_URLS.CSS );
 	}
 
@@ -165,14 +167,14 @@ function embedSlideshow( domNode ) {
 		el.classList.add( 'hidden' );
 	} );
 
-	if ( window.jQuery && ! window.jQuery.prototype.cycle ) {
+	if ( window.jQuery && window.jQuery.prototype.cycle ) {
+		// jQuery and cylcejs exist
+		createSlideshow();
+	} else if ( window.jQuery && ! window.jQuery.prototype.cycle ) {
 		// Only jQuery exists
 		loadAndRun( SLIDESHOW_URLS.CYCLE_JS, ()=> {
 			createSlideshow();
 		} );
-	} else if ( window.jQuery && window.jQuery.prototype.cycle ) {
-		// jQuery and cylcejs exist
-		createSlideshow();
 	} else {
 		// Neither exist
 		loadjQueryDependentScript( SLIDESHOW_URLS.CYCLE_JS, () => {

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -25,11 +25,13 @@ const embedsToLookFor = {
 	'.jetpack-slideshow': embedSlideshow
 };
 
+const cacheBustQuery = `?v=${ Math.floor( new Date().getTime() / ( 1000 * 60 * 60 * 24 * 10 ) ) }`; // A new query every 10 days
+
 const SLIDESHOW_URLS = {
-	CSS: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/css/slideshow-shortcode.css',
-	CYCLE_JS: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/jquery.cycle.js',
-	JS: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/slideshow-shortcode.js',
-	SPINNER: 'https://s0.wp.com/wp-content/mu-plugins/shortcodes/img/slideshow-loader.gif'
+	CSS: `https://s0.wp.com/wp-content/mu-plugins/shortcodes/css/slideshow-shortcode.css${cacheBustQuery}`,
+	CYCLE_JS: `https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/jquery.cycle.js${cacheBustQuery}`,
+	JS: `https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/slideshow-shortcode.js${cacheBustQuery}`,
+	SPINNER: `https://s0.wp.com/wp-content/mu-plugins/shortcodes/img/slideshow-loader.gif${cacheBustQuery}`
 };
 
 function processEmbeds( domNode ) {

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -146,7 +146,7 @@ function createSlideshow() {
 	} );
 }
 
-let slideshowCSSPresent = false;
+let slideshowCSSPresent = document.head.querySelector( `link[href="${ SLIDESHOW_URLS.CSS }"]` );
 
 function embedSlideshow( domNode ) {
 	debug( 'processing slideshow for', domNode );

--- a/client/reader/full-post/index.jsx
+++ b/client/reader/full-post/index.jsx
@@ -517,7 +517,7 @@ FullPostContainer = React.createClass( {
 } );
 
 export default connect(
-	( state, ownProps ) => ( {
+	( state ) => ( {
 		isVisible: state.ui.reader.fullpost.isVisible
 	} ),
 	( dispatch ) => bindActionCreators( {


### PR DESCRIPTION
**Issue**
The slideshow doesn't render on Reader
<img width="426" alt="screen shot 2016-05-14 at 12 05 31 am" src="https://cloud.githubusercontent.com/assets/1922453/15247352/c93e23e4-1967-11e6-9a20-7633a22c9f52.png">

But does render in the WYSIWYG editor in My Sites. More details on how to reproduce in https://github.com/Automattic/wp-calypso/issues/766

**Problem**
In Reader, a post's content is a string of html that is ```dangerouslySetInnerHTML```'ed. Included is an empty div whose data attributes contain the information required to create a slideshow, but no javascript is ever included to make that happen.

**Solution**
Use ```EmbedContainer``` Component to check if rendered content contains a slideshow. If so, pull in the required scripts and css:
* jQuery
* [slideshow-shortcode.js](https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/js/slideshow-shortcode.js)
* [slideshow-shortcode.css](https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/css/slideshow-shortcode.css)
* [jQuery's cylcejs](https://s0.wp.com/wp-content/mu-plugins/shortcodes/js/jquery.cycle.js)


cc @blowery @bluefuton 

