### PR TITLE
Jetpack SSO: Show EmptyContent when going directly to /jetpack/sso with no query args

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -75,7 +75,7 @@ const JetpackSSOForm = React.createClass( {
 	maybeValidateSSO() {
 		const { ssoNonce, siteId, nonceValid, isAuthorizing, isValidating } = this.props;
 
-		if ( ! nonceValid && ! isAuthorizing && ! isValidating ) {
+		if ( ssoNonce && siteId && ! nonceValid && ! isAuthorizing && ! isValidating ) {
 			this.props.validateSSONonce( siteId, ssoNonce );
 		}
 	},

--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -22,6 +22,7 @@ import { errorNotice } from 'state/notices/actions';
 import { validateSSONonce, authorizeSSO } from 'state/jetpack-connect/actions';
 import addQueryArgs from 'lib/route/add-query-args';
 import config from 'config';
+import EmptyContent from 'components/empty-content';
 
 /*
  * Module variables
@@ -79,8 +80,36 @@ const JetpackSSOForm = React.createClass( {
 		}
 	},
 
+	renderNoQueryArgsError() {
+		return (
+			<Main>
+				<EmptyContent
+					illustration="/calypso/images/drake/drake-whoops.svg"
+					title={ this.translate(
+						'Oops, this URL should not be accessed directly'
+					) }
+					line={ this.translate(
+						'Please click the {{em}}Log in with WordPress.com button{{/em}} on your Jetpack site.',
+						{
+							components: {
+								em: <em />
+							}
+						}
+					) }
+					action={ this.translate( 'Read Single Sign-On Documentation' ) }
+					actionURL="https://jetpack.com/support/sso/"
+				/>
+			</Main>
+		);
+	},
+
 	render() {
 		const user = this.props.userModule.get();
+		const { ssoNonce, siteId } = this.props;
+
+		if ( ! ssoNonce || ! siteId ) {
+			return this.renderNoQueryArgsError();
+		}
 
 		return (
 			<Main className="jetpack-connect">


### PR DESCRIPTION
Because we require certain query args be present for Jetpack SSO and for the Jetpack connect flow, we should show some UI when those args aren't present.

Related - #5109.

Here's a first pass:

![screen shot 2016-05-13 at 1 31 44 pm](https://cloud.githubusercontent.com/assets/1126811/15258323/88394b6e-1910-11e6-9840-cb770a88b19d.png)

cc @rickybanister for a design/wording review. Note, that in this context, we have no information. If a user lands on `/jetpack/sso` with no query args, we don't which sites the user was trying to SSO in to. In that case, I thought it best to remind the user to click the button from their remote Jetpack site login page.

To test:
- Checkout `update/jetpack-sso-no-args` branch
- Go to `/jetpack/sso`.
- See the above

Note, that until #5364 is in, this means that we will not show the user profile and "Log in" button that were  you can see after #5305. So, we should probably get #5364 in and then we can review/merge this PR.