### PR TITLE
Themes: Fix misaligned buttons on theme selection screen

### DIFF
--- a/client/my-sites/themes/themes-search-card/style.scss
+++ b/client/my-sites/themes/themes-search-card/style.scss
@@ -25,6 +25,11 @@
 		align-self: center;
 	}
 
+	.more {
+		line-height: 18px;
+		padding: 11px 14px 11px;
+	}
+
 	.select-dropdown .select-dropdown__header {
 		pointer-events: none;
 	}


### PR DESCRIPTION
This is a minor tweak to address #5314. I specified a `line-height` that matches the dropdown container and then updated the padding so that the text appears inline with the dropdown as well.

To give it a spin, checkout this branch and get it up and running. You can view the change by visiting http://calypso.localhost:3000/design/site-address).

Here's a quick comparison in screenshots.

Before:

![before](https://cloud.githubusercontent.com/assets/7240478/15259592/5fc19ad4-190f-11e6-9e99-31e95f5647c3.png)

After: 

![after](https://cloud.githubusercontent.com/assets/7240478/15259596/645fa37e-190f-11e6-90e7-ff36b38d19be.png)