### PR TITLE
Theme Component: Turn 'More' button into ES6 class

### DIFF
--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -16,43 +16,28 @@ import { isOutsideCalypso } from 'lib/url';
 /**
  * Component
  */
-const ThemeMoreButton = React.createClass( {
-	propTypes: {
-		// See Theme component propTypes
-		theme: React.PropTypes.object,
-		// Index of theme in results list
-		index: React.PropTypes.number,
-		// Options to populate the popover menu with
-		options: React.PropTypes.objectOf(
-			React.PropTypes.shape( {
-				label: React.PropTypes.string,
-				header: React.PropTypes.string,
-				action: React.PropTypes.func,
-				getUrl: React.PropTypes.func
-			} )
-		).isRequired,
-		active: React.PropTypes.bool
-	},
+class ThemeMoreButton extends React.Component {
 
-	getInitialState() {
-		return {
-			showPopover: false
-		};
-	},
+	constructor( props ) {
+		super( props );
+		this.state = { showPopover: false };
+		this.togglePopover = this.togglePopover.bind( this );
+		this.closePopover = this.closePopover.bind( this );
+	}
 
 	togglePopover() {
 		this.setState( { showPopover: ! this.state.showPopover } );
 		! this.state.showPopover && this.props.onClick( this.props.theme.id, this.props.index );
-	},
+	}
 
 	closePopover( action ) {
 		this.setState( { showPopover: false } );
 		isFunction( action ) && action( this.props.theme );
-	},
+	}
 
 	focus( event ) {
 		event.target.focus();
-	},
+	}
 
 	render() {
 		const classes = classNames(
@@ -103,6 +88,23 @@ const ThemeMoreButton = React.createClass( {
 			</span>
 		);
 	}
-} );
+}
+
+ThemeMoreButton.propTypes = {
+	// See Theme component propTypes
+	theme: React.PropTypes.object,
+	// Index of theme in results list
+	index: React.PropTypes.number,
+	// Options to populate the popover menu with
+	options: React.PropTypes.objectOf(
+		React.PropTypes.shape( {
+			label: React.PropTypes.string,
+			header: React.PropTypes.string,
+			action: React.PropTypes.func,
+			getUrl: React.PropTypes.func
+		} )
+	).isRequired,
+	active: React.PropTypes.bool
+};
 
 export default ThemeMoreButton;

--- a/client/components/theme/test/index.jsx
+++ b/client/components/theme/test/index.jsx
@@ -31,7 +31,7 @@ describe( 'Theme', function() {
 
 		togglePopoverStub = sinon.stub().returnsArg( 0 );
 		let MockMoreButton = require( '../more-button' );
-		MockMoreButton.prototype.__reactAutoBindMap.togglePopover = togglePopoverStub;
+		MockMoreButton.prototype.togglePopover = togglePopoverStub;
 		mockery.registerMock( './more-button', MockMoreButton );
 
 		Theme = require( '../' );


### PR DESCRIPTION
This allows us to get rid of `__reactAutoBindMap` in the test,
which is removed by React 15 (see #5116).

To test -- make sure the theme component still works as before (try `/design`).