### PR TITLE
DropZone: ES6ify (preparing for React 15 upgrade)

### DIFF
--- a/client/components/drop-zone/README.md
+++ b/client/components/drop-zone/README.md
@@ -10,26 +10,26 @@ Drop Zone is a React component which can be used to illustrate areas on the page
 Render the component in the context of a parent element which is assigned a `relative` position style, or specify the `fullScreen` to occupy the entire page.
 
 ```jsx
-var React = require( 'react' ),
-	DropZone = require( 'components/drop-zone' );
+import React, { Component } from 'react';
+import DropZone from 'components/drop-zone';
 
-module.exports = React.createClass( {
-	displayName: 'MyComponent',
-
-	onFilesDrop: function( files ) {
+class MyComponent extends Component {
+	onFilesDrop( files ) {
 		console.log( 'You dropped some files: %s', files.map( function( file ) {
 			return file.name;
 		}.join( ', ' ) );
-	},
+	}
 
-	render: function() {
+	render() {
 		return (
 			<div className="my-component">
 				<DropZone onFilesDrop={ this.onFilesDrop } />
 			</div>
 		);
 	}
-} );
+};
+
+export default MyComponent;
 ```
 
 ## Props

--- a/client/components/drop-zone/docs/example.jsx
+++ b/client/components/drop-zone/docs/example.jsx
@@ -1,35 +1,36 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	PureRenderMixin = require( 'react-pure-render/mixin' );
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
 
 /**
  * Internal dependencies
  */
-var Card = require( 'components/card' ),
-	DropZone = require( 'components/drop-zone' );
+import Card from 'components/card';
+import DropZone from 'components/drop-zone';
 
-module.exports = React.createClass( {
+export default React.createClass( {
 	displayName: 'DropZones',
 
 	mixins: [ PureRenderMixin ],
 
-	getInitialState: function() {
+	getInitialState() {
 		return {};
 	},
 
-	onFilesDrop: function( files ) {
+	onFilesDrop( files ) {
 		this.setState( {
 			lastDroppedFiles: files
 		} );
 	},
 
-	renderContainerContent: function() {
-		var style = {
+	renderContainerContent() {
+		const style = {
 			lineHeight: '100px',
 			textAlign: 'center'
-		}, fileNames;
+		};
+		let fileNames;
 
 		if ( this.state.lastDroppedFiles ) {
 			fileNames = this.state.lastDroppedFiles.map( function( file ) {
@@ -39,15 +40,15 @@ module.exports = React.createClass( {
 
 		return (
 			<Card style={ style }>
-				{ fileNames ?
-					this.translate( 'You dropped: %s', { args: fileNames } ) :
-					this.translate( 'This is a droppable area' ) }
+				{ fileNames
+					? this.translate( 'You dropped: %s', { args: fileNames } )
+					: this.translate( 'This is a droppable area' ) }
 			</Card>
 		);
 	},
 
-	renderContainer: function() {
-		var style = {
+	renderContainer() {
+		const style = {
 			position: 'relative',
 			height: '150px'
 		};
@@ -60,7 +61,7 @@ module.exports = React.createClass( {
 		);
 	},
 
-	render: function() {
+	render() {
 		return (
 			<div className="design-assets__group">
 				<h2>

--- a/client/components/drop-zone/index.jsx
+++ b/client/components/drop-zone/index.jsx
@@ -1,48 +1,38 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	createFragment = require( 'react-addons-create-fragment' ),
-	without = require( 'lodash/without' ),
-	includes = require( 'lodash/includes' ),
-	classNames = require( 'classnames' ),
-	noop = require( 'lodash/noop' );
+import ReactDom from 'react-dom';
+import React, { Component, PropTypes } from 'react';
+import createFragment from 'react-addons-create-fragment';
+import without from 'lodash/without';
+import includes from 'lodash/includes';
+import classNames from 'classnames';
+import noop from 'lodash/noop';
+import identity from 'lodash/identity';
 
 /**
  * Internal dependencies
  */
-var RootChild = require( 'components/root-child' );
+import RootChild from 'components/root-child';
+import localize from 'lib/mixins/i18n/localize';
 
-module.exports = React.createClass( {
-	displayName: 'DropZone',
+export class DropZone extends Component {
+	constructor( props ) {
+		super( props );
 
-	propTypes: {
-		onDrop: React.PropTypes.func,
-		onVerifyValidTransfer: React.PropTypes.func,
-		onFilesDrop: React.PropTypes.func,
-		fullScreen: React.PropTypes.bool,
-		icon: React.PropTypes.string
-	},
-
-	getInitialState: function() {
-		return {
+		this.state = {
 			isDraggingOverDocument: false,
 			isDraggingOverElement: false
 		};
-	},
 
-	getDefaultProps: function() {
-		return {
-			onDrop: noop,
-			onVerifyValidTransfer: () => true,
-			onFilesDrop: noop,
-			fullScreen: false,
-			icon: 'dashicons dashicons-admin-media'
-		};
-	},
+		// Bind listeners found in componentDidMount(), except for the ones whose
+		// implementation doesn't refer to `this`.
+		this.onDrop = this.onDrop.bind( this );
+		this.toggleDraggingOverDocument = this.toggleDraggingOverDocument.bind( this );
+		this.resetDragState = this.resetDragState.bind( this );
+	}
 
-	componentDidMount: function() {
+	componentDidMount() {
 		this.dragEnterNodes = [];
 
 		window.addEventListener( 'dragover', this.preventDefault );
@@ -50,32 +40,32 @@ module.exports = React.createClass( {
 		window.addEventListener( 'dragenter', this.toggleDraggingOverDocument );
 		window.addEventListener( 'dragleave', this.toggleDraggingOverDocument );
 		window.addEventListener( 'mouseup', this.resetDragState );
-	},
+	}
 
-	componentDidUpdate: function( prevProps, prevState ) {
+	componentDidUpdate( prevProps, prevState ) {
 		if ( prevState.isDraggingOverDocument !== this.state.isDraggingOverDocument ) {
 			this.toggleMutationObserver();
 		}
-	},
+	}
 
-	componentWillUnmount: function() {
+	componentWillUnmount() {
 		window.removeEventListener( 'dragover', this.preventDefault );
 		window.removeEventListener( 'drop', this.onDrop );
 		window.removeEventListener( 'dragenter', this.toggleDraggingOverDocument );
 		window.removeEventListener( 'dragleave', this.toggleDraggingOverDocument );
 		window.removeEventListener( 'mouseup', this.resetDragState );
 		this.disconnectMutationObserver();
-	},
+	}
 
-	resetDragState: function() {
+	resetDragState() {
 		if ( ! ( this.state.isDraggingOverDocument || this.state.isDraggingOverElement ) ) {
 			return;
 		}
 
 		this.setState( this.getInitialState() );
-	},
+	}
 
-	toggleMutationObserver: function() {
+	toggleMutationObserver() {
 		this.disconnectMutationObserver();
 
 		if ( this.state.isDraggingOverDocument ) {
@@ -85,18 +75,18 @@ module.exports = React.createClass( {
 				subtree: true
 			} );
 		}
-	},
+	}
 
-	disconnectMutationObserver: function() {
+	disconnectMutationObserver() {
 		if ( ! this.observer ) {
 			return;
 		}
 
 		this.observer.disconnect();
 		delete this.observer;
-	},
+	}
 
-	detectNodeRemoval: function( mutations ) {
+	detectNodeRemoval( mutations ) {
 		mutations.forEach( ( mutation ) => {
 			if ( ! mutation.removedNodes.length ) {
 				return;
@@ -104,10 +94,10 @@ module.exports = React.createClass( {
 
 			this.dragEnterNodes = without( this.dragEnterNodes, Array.from( mutation.removedNodes ) );
 		} );
-	},
+	}
 
-	toggleDraggingOverDocument: function( event ) {
-		var isDraggingOverDocument, detail, isValidDrag;
+	toggleDraggingOverDocument( event ) {
+		let isDraggingOverDocument, detail, isValidDrag;
 
 		// Track nodes that have received a drag event. So long as nodes exist
 		// in the set, we can assume that an item is being dragged on the page.
@@ -139,14 +129,14 @@ module.exports = React.createClass( {
 			// from tracked nodes since another "real" event will be triggered.
 			this.dragEnterNodes = without( this.dragEnterNodes, window );
 		}
-	},
+	}
 
-	preventDefault: function( event ) {
+	preventDefault( event ) {
 		event.preventDefault();
-	},
+	}
 
-	isWithinZoneBounds: function( x, y ) {
-		var rect;
+	isWithinZoneBounds( x, y ) {
+		let rect;
 
 		if ( ! this.refs.zone ) {
 			return false;
@@ -161,9 +151,9 @@ module.exports = React.createClass( {
 
 		return x >= rect.left && x <= rect.right &&
 			y >= rect.top && y <= rect.bottom;
-	},
+	}
 
-	onDrop: function( event ) {
+	onDrop( event ) {
 		// This seemingly useless line has been shown to resolve a Safari issue
 		// where files dragged directly from the dock are not recognized
 		event.dataTransfer && event.dataTransfer.files.length;
@@ -189,10 +179,10 @@ module.exports = React.createClass( {
 
 		event.stopPropagation();
 		event.preventDefault();
-	},
+	}
 
-	renderContent: function() {
-		var content;
+	renderContent() {
+		let content;
 
 		if ( this.props.children ) {
 			content = this.props.children;
@@ -201,24 +191,24 @@ module.exports = React.createClass( {
 				icon: <span className={ classNames( 'drop-zone__content-icon', this.props.icon ) } />,
 				text: (
 					<span className="drop-zone__content-text">
-						{ this.translate( 'Drop files to upload' ) }
+						{ this.props.translate( 'Drop files to upload' ) }
 					</span>
 				)
 			} );
 		}
 
 		return <div className="drop-zone__content">{ content }</div>;
-	},
+	}
 
-	render: function() {
-		var classes = classNames( 'drop-zone', {
+	render() {
+		const classes = classNames( 'drop-zone', {
 			'is-active': this.state.isDraggingOverDocument || this.state.isDraggingOverElement,
 			'is-dragging-over-document': this.state.isDraggingOverDocument,
 			'is-dragging-over-element': this.state.isDraggingOverElement,
 			'is-full-screen': this.props.fullScreen
-		} ), element;
+		} );
 
-		element = (
+		const element = (
 			<div ref="zone" className={ classes }>
 				{ this.renderContent() }
 			</div>
@@ -226,8 +216,27 @@ module.exports = React.createClass( {
 
 		if ( this.props.fullScreen ) {
 			return <RootChild>{ element }</RootChild>;
-		} else {
-			return element;
 		}
+		return element;
 	}
-} );
+}
+
+DropZone.propTypes = {
+	onDrop: PropTypes.func,
+	onVerifyValidTransfer: PropTypes.func,
+	onFilesDrop: PropTypes.func,
+	fullScreen: PropTypes.bool,
+	icon: PropTypes.string,
+	translate: PropTypes.func,
+};
+
+DropZone.defaultProps = {
+	onDrop: noop,
+	onVerifyValidTransfer: () => true,
+	onFilesDrop: noop,
+	fullScreen: false,
+	icon: 'dashicons dashicons-admin-media',
+	translate: identity,
+};
+
+export default localize( DropZone );

--- a/client/components/drop-zone/test/index.jsx
+++ b/client/components/drop-zone/test/index.jsx
@@ -1,21 +1,21 @@
-var expect = require( 'chai' ).expect,
-	ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	TestUtils = require( 'react-addons-test-utils' ),
-	sinon = require( 'sinon' ),
-	DropZone = require( '../' ),
-	Wrapper = React.createClass( {
-		render: function() {
-			return <div>{ this.props.children }</div>;
-		}
-	} );
+import { expect } from 'chai';
+import ReactDom from 'react-dom';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import sinon from 'sinon';
+import { DropZone } from '../';
+
+const Wrapper = React.createClass( {
+	render: function() {
+		return <div>{ this.props.children }</div>;
+	}
+} );
 
 describe( 'index', function() {
 	var container, sandbox;
 	require( 'test/helpers/use-fake-dom' )( '<html><body><div id="container"></div></body></html>' );
 
 	before( function() {
-		DropZone.prototype.translate = sinon.stub().returnsArg( 0 );
 		container = document.getElementById( 'container' );
 		window.MutationObserver = sinon.stub().returns( {
 			observe: sinon.stub(),
@@ -27,7 +27,6 @@ describe( 'index', function() {
 		if ( global.window && global.window.MutationObserver ) {
 			delete global.window.MutationObserver;
 		}
-		delete DropZone.prototype.translate;
 	} );
 
 	beforeEach( function() {
@@ -135,7 +134,7 @@ describe( 'index', function() {
 	it( 'should further highlight the drop zone when dragging over the element', function() {
 		var tree, dragEnterEvent;
 
-		sandbox.stub( DropZone.prototype.__reactAutoBindMap, 'isWithinZoneBounds' ).returns( true );
+		sandbox.stub( DropZone.prototype, 'isWithinZoneBounds' ).returns( true );
 
 		tree = ReactDom.render( React.createElement( DropZone ), container );
 

--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -1,16 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	noop = require( 'lodash/noop' );
+import React from 'react';
+import noop from 'lodash/noop';
 
 /**
  * Internal dependencies
  */
-var analytics = require( 'lib/analytics' ),
-	DropZone = require( 'components/drop-zone' ),
-	MediaActions = require( 'lib/media/actions' ),
-	userCan = require( 'lib/site/utils' ).userCan;
+import analytics from 'lib/analytics';
+import DropZone from 'components/drop-zone';
+import MediaActions from 'lib/media/actions';
+import { userCan } from 'lib/site/utils';
 
 module.exports = React.createClass( {
 	displayName: 'MediaLibraryDropZone',


### PR DESCRIPTION
Motivation is to turn it into an ES6 class, which allows us to drop
`__reactAutoBindMap` in the test and stub prototype methods directly.
Required for the React 15 upgrade which drops `__reactAutoBindMap`.
(See #5116 for the upgrade PR.)

To test -- check that the `DropZone`component works as before (try http://calypso.localhost:3000/devdocs/design/dropzones). Also, make sure that all `require( './drop-zone' )` instances now have `.default` attached, due to the ES6 export. (I only found one occurrence, in `MediaDropZone`.)

/cc @aduth for review