### PR TITLE
Plans: only show monthly breakdown for plans

### DIFF
--- a/client/my-sites/upgrades/cart/cart-item.jsx
+++ b/client/my-sites/upgrades/cart/cart-item.jsx
@@ -12,7 +12,8 @@ import {
 	isCredits,
 	isDomainProduct,
 	isGoogleApps,
-	isTheme
+	isTheme,
+	isPlan
 } from 'lib/products-values';
 import * as upgradesActions from 'lib/upgrades/actions';
 import { abtest } from 'lib/abtest';
@@ -59,6 +60,10 @@ export default React.createClass( {
 		const { cost, currency } = this.props.cartItem;
 
 		if ( typeof cost === 'undefined' ) {
+			return null;
+		}
+
+		if ( ! isPlan( this.props.cartItem ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
This PR fixes #5373 We accidentally displayed monthly pricing not only for plans, but also for any add on items like domains or premium themes.

Before:
![68747470733a2f2f636c6475702e636f6d2f59744e6e516376346d6f2e706e67](https://cloud.githubusercontent.com/assets/1270189/15262631/7c532e16-1918-11e6-871a-f2d7f84ab12b.png)

After:
<img width="265" alt="screen shot 2016-05-13 at 2 22 58 pm" src="https://cloud.githubusercontent.com/assets/1270189/15262642/83d2dbe6-1918-11e6-941e-f67cfa47d84e.png">
...
<img width="257" alt="screen shot 2016-05-13 at 2 33 36 pm" src="https://cloud.githubusercontent.com/assets/1270189/15262646/8e30137e-1918-11e6-971e-46a20a1abd93.png">

## Testing Instructions
- Make sure you run the monthly plan pricing test via: `localStorage.setItem('ABTests','{"planPricing_20160426":"monthly"}')`
- Add a plan to cart, add a premium theme to cart
- Cart item breaks down the plan but not the theme
- Empty cart
- Add a custom domain without a plan
- Add a different premium theme
- Both items should not break down price

cc @rralian @lizthefair @artpi @retrofox 