### PR TITLE
Reader: fixes styling regression

### DIFF
--- a/client/reader/post-options/_style.scss
+++ b/client/reader/post-options/_style.scss
@@ -54,7 +54,7 @@
 	}
 }
 
-.popover__menu {
+.popover__menu .follow-button {
 
 	.gridicon {
 		height: 24px;


### PR DESCRIPTION
Fixes styling regression from #5256 on /pages dropdown
Before:
<img width="291" alt="screen shot 2016-05-13 at 4 15 34 pm" src="https://cloud.githubusercontent.com/assets/1270189/15264493/64490f88-1928-11e6-90cb-d1d724d5a4be.png">
After:
<img width="262" alt="screen shot 2016-05-13 at 4 33 53 pm" src="https://cloud.githubusercontent.com/assets/1270189/15264503/87467458-1928-11e6-997b-7f9cf8f46d55.png">

cc @BandonRandon @jancavan @blowery 
