### PR TITLE
Signup: Improved message on accounts step

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -44,17 +44,7 @@ export default React.createClass( {
 			if ( this.props.subHeaderText ) {
 				return this.props.subHeaderText;
 			}
-
-			let subHeadingText = this.translate( 'Welcome to the best place for your WordPress website.' );
-
-			/**
-			 * Provide a proper subheading in the `account` flow.
-			 */
-			if ( 'account' === this.props.flowName ) {
-				subHeadingText = this.translate( 'Welcome to the wonderful WordPress.com community' );
-			}
-
-			return subHeadingText;
+			return this.translate( 'Welcome to the best place for your WordPress website.' );
 		}
 
 		if ( this.props.fallbackSubHeaderText ) {

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -44,7 +44,17 @@ export default React.createClass( {
 			if ( this.props.subHeaderText ) {
 				return this.props.subHeaderText;
 			}
-			return this.translate( 'Welcome to the best place for your WordPress website.' );
+
+			let subHeadingText = this.translate( 'Welcome to the best place for your WordPress website.' );
+
+			/**
+			 * Provide a proper subheading in the `account` flow.
+			 */
+			if ( 'account' === this.props.flowName ) {
+				subHeadingText = this.translate( 'Welcome to the wonderful WordPress.com community' );
+			}
+
+			return subHeadingText;
 		}
 
 		if ( this.props.fallbackSubHeaderText ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -20,19 +20,25 @@ export default React.createClass( {
 		if ( nextProps.step && 'invalid' === nextProps.step.status ) {
 			this.setState( { submitting: false } );
 		}
+
+		this.setSubHeaderText( nextProps );
 	},
 
 	componentWillMount() {
-		let subHeaderText = this.props.subHeaderText;
+		this.setSubHeaderText( this.props );
+	},
+
+	setSubHeaderText( props )  {
+		let subHeaderText = props.subHeaderText;
 
 		/**
 		 * Update the step sub-header if they only want to create an account, without a site.
 		 */
-		if ( 1 === signupUtils.getFlowSteps( this.props.flowName ).length ) {
+		if ( 1 === signupUtils.getFlowSteps( props.flowName ).length ) {
 			subHeaderText = this.translate( 'Welcome to the wonderful WordPress.com community' );
 		}
 
-		this.setState( Object.assign( {}, this.state, { subHeaderText: subHeaderText } ) );
+		this.setState( { subHeaderText: subHeaderText } );
 	},
 
 	save( form ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -22,6 +22,19 @@ export default React.createClass( {
 		}
 	},
 
+	componentWillMount() {
+		let subHeaderText = this.props.subHeaderText;
+
+		/**
+		 * Update the step sub-header if they only want to create an account, without a site.
+		 */
+		if ( 1 === signupUtils.getFlowSteps( this.props.flowName ).length ) {
+			subHeaderText = this.translate( 'Welcome to the wonderful WordPress.com community' );
+		}
+
+		this.setState( Object.assign( {}, this.state, { subHeaderText: subHeaderText } ) );
+	},
+
 	save( form ) {
 		SignupActions.saveSignupStep( {
 			stepName: this.props.stepName,
@@ -113,7 +126,7 @@ export default React.createClass( {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				headerText={ this.props.headerText }
-				subHeaderText={ this.props.subHeaderText }
+				subHeaderText={ this.state.subHeaderText }
 				positionInFlow={ this.props.positionInFlow }
 				fallbackHeaderText={ this.translate( 'Create your account.' ) }
 				signupProgressStore={ this.props.signupProgressStore }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -21,7 +21,10 @@ export default React.createClass( {
 			this.setState( { submitting: false } );
 		}
 
-		this.setSubHeaderText( nextProps );
+		if ( this.props.flowName !== nextProps.flowName || this.props.subHeaderText !== nextProps.subHeaderText ) {
+			this.setSubHeaderText( nextProps );
+		}
+
 	},
 
 	componentWillMount() {

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -45,7 +45,7 @@ describe( '#signupStep User', () => {
 		User.prototype.translate = ( string ) => string;
 	} );
 
-	it( 'User step as first step in flow', () => {
+	it( 'should show community subheader text if User step is first in the flow', () => {
 		testElement = React.createElement( User, {
 			subHeaderText: 'first subheader message',
 			flowName: 'userAsFirstStepInFlow'
@@ -55,7 +55,7 @@ describe( '#signupStep User', () => {
 		expect( rendered.state.subHeaderText ).to.equal( 'Welcome to the wonderful WordPress.com community' );
 	} );
 
-	it( 'User step as not first step in flow', () => {
+	it( 'should show provided subheader text if User step is not first in the flow', () => {
 		testElement = React.createElement( User, {
 			subHeaderText: 'test subheader message',
 			flowName: 'someOtherFlow'
@@ -65,7 +65,7 @@ describe( '#signupStep User', () => {
 		expect( rendered.state.subHeaderText ).to.equal( 'test subheader message' );
 	} );
 
-	describe( 'Component will update', () => {
+	describe( '#updateComponentProps', () => {
 		let node, spyComponentProps, component;
 
 		beforeEach( () => {
@@ -84,7 +84,7 @@ describe( '#signupStep User', () => {
 			User.prototype.componentWillReceiveProps.restore();
 		} );
 
-		it( 'Change props so User is only step in the flow', () => {
+		it( 'should show community subheader text when new flow has user as first step', () => {
 			let testProps = {
 				subHeaderText: 'My test message',
 				flowName: 'userAsFirstStepInFlow'
@@ -98,7 +98,7 @@ describe( '#signupStep User', () => {
 			expect( component.state.subHeaderText ).to.equal( 'Welcome to the wonderful WordPress.com community' );
 		} );
 
-		it( 'Change props so User is not only step in the flow', () => {
+		it( 'should show provided subheader text when new flow doesn\'t have user as first step', () => {
 			let testProps = {
 				subHeaderText: 'My test message',
 				flowName: 'another test message test'

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -3,11 +3,14 @@ import TestUtils from 'react-addons-test-utils' ;
 import useMockery from 'test/helpers/use-mockery' ;
 
 import React from 'react';
+import ReactDOM from 'react-dom';
+
+import sinon from 'sinon';
 
 import identity from 'lodash/identity';
 import useFakeDom from 'test/helpers/use-fake-dom';
 
-describe.only( '#signupStep User', () => {
+describe( '#signupStep User', () => {
 	let User, testElement, rendered, EMPTY_COMPONENT;
 
 	useFakeDom();
@@ -42,7 +45,7 @@ describe.only( '#signupStep User', () => {
 		User.prototype.translate = ( string ) => string;
 	} );
 
-	it.only( 'User step as first step in flow', () => {
+	it( 'User step as first step in flow', () => {
 		testElement = React.createElement( User, {
 			subHeaderText: 'first subheader message',
 			flowName: 'userAsFirstStepInFlow'
@@ -52,7 +55,7 @@ describe.only( '#signupStep User', () => {
 		expect( rendered.state.subHeaderText ).to.equal( 'Welcome to the wonderful WordPress.com community' );
 	} );
 
-	it.only( 'User step as not first step in flow', () => {
+	it( 'User step as not first step in flow', () => {
 		testElement = React.createElement( User, {
 			subHeaderText: 'test subheader message',
 			flowName: 'someOtherFlow'
@@ -60,5 +63,53 @@ describe.only( '#signupStep User', () => {
 		rendered = TestUtils.renderIntoDocument( testElement );
 
 		expect( rendered.state.subHeaderText ).to.equal( 'test subheader message' );
+	} );
+
+	describe( 'Component will update', () => {
+		let node, spyComponentProps, component;
+
+		beforeEach( () => {
+			node = document.createElement( 'div' );
+
+			spyComponentProps = sinon.spy( User.prototype, 'componentWillReceiveProps' );
+
+			let element = React.createElement( User, {
+				subHeaderText: 'test subheader message',
+				flowName: 'someOtherFlow'
+			} );
+			component = ReactDOM.render( element, node );
+		} );
+
+		afterEach( () => {
+			User.prototype.componentWillReceiveProps.restore();
+		} );
+
+		it( 'Change props so User is only step in the flow', () => {
+			let testProps = {
+				subHeaderText: 'My test message',
+				flowName: 'userAsFirstStepInFlow'
+			};
+
+			expect( spyComponentProps.calledOnce ).to.equal( false );
+
+			ReactDOM.render( React.createElement( User, testProps ), node );
+
+			expect( spyComponentProps.calledOnce ).to.equal( true );
+			expect( component.state.subHeaderText ).to.equal( 'Welcome to the wonderful WordPress.com community' );
+		} );
+
+		it( 'Change props so User is not only step in the flow', () => {
+			let testProps = {
+				subHeaderText: 'My test message',
+				flowName: 'another test message test'
+			};
+
+			expect( spyComponentProps.calledOnce ).to.equal( false );
+
+			ReactDOM.render( React.createElement( User, testProps ), node );
+
+			expect( spyComponentProps.calledOnce ).to.equal( true );
+			expect( component.state.subHeaderText ).to.equal( 'My test message' );
+		} );
 	} );
 } );

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import TestUtils from 'react-addons-test-utils' ;
+import useMockery from 'test/helpers/use-mockery' ;
+
+import React from 'react';
+
+import identity from 'lodash/identity';
+import useFakeDom from 'test/helpers/use-fake-dom';
+
+describe.only( '#signupStep User', () => {
+	let User, testElement, rendered, EMPTY_COMPONENT;
+
+	useFakeDom();
+
+	useMockery( ( mockery ) => {
+		EMPTY_COMPONENT = require( 'test/helpers/react/empty-component' );
+
+		mockery.registerMock( 'lib/analytics', {} );
+		mockery.registerMock( 'components/signup-form', EMPTY_COMPONENT );
+		mockery.registerMock( 'signup/step-wrapper', EMPTY_COMPONENT );
+
+		mockery.registerMock( 'signup/utils', {
+			getFlowSteps: function( flow ) {
+				let flowSteps = null;
+
+				if ( 'userAsFirstStepInFlow' === flow ) {
+					flowSteps = [ 'user' ];
+				} else {
+					flowSteps = [ 'theme', 'domains', 'user' ];
+				}
+
+				return flowSteps;
+			},
+			getNextStepName: identity,
+			getStepUrl: identity,
+			getPreviousStepName: identity
+		} );
+	} );
+
+	before( () => {
+		User = require( '../' );
+		User.prototype.translate = ( string ) => string;
+	} );
+
+	it.only( 'User step as first step in flow', () => {
+		testElement = React.createElement( User, {
+			subHeaderText: 'first subheader message',
+			flowName: 'userAsFirstStepInFlow'
+		} );
+		rendered = TestUtils.renderIntoDocument( testElement );
+
+		expect( rendered.state.subHeaderText ).to.equal( 'Welcome to the wonderful WordPress.com community' );
+	} );
+
+	it.only( 'User step as not first step in flow', () => {
+		testElement = React.createElement( User, {
+			subHeaderText: 'test subheader message',
+			flowName: 'someOtherFlow'
+		} );
+		rendered = TestUtils.renderIntoDocument( testElement );
+
+		expect( rendered.state.subHeaderText ).to.equal( 'test subheader message' );
+	} );
+} );


### PR DESCRIPTION
This is a fix for #5378

Provide a better message for the `accounts` step when only creating an account, without a site. 

cc @meremagee @michaeldcain @coreh 