### PR TITLE
Signup: Properly align logged out links below the signup form

### DIFF
--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -30,12 +30,9 @@
 	font-family: $sans;
 	font-size: 14px;
 	line-height: 21px;
-	padding: 16px 0 16px 16px;
+	padding: 16px 0 16px 0;
 	cursor: pointer;
-
-	@include breakpoint( ">480px" ) {
-		padding-left: 24px;
-	}
+	text-align: center;
 
 	&:last-child {
 		border-bottom: none;

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -1,5 +1,18 @@
 .jetpack-connect {
 	max-width: 400px;
+
+	.logged-out-form__links {
+		max-width: 100%;
+
+		.logged-out-form__link-item {
+			.gridicon {
+				position: relative;
+				top: 4px;
+			}
+		}
+
+	}
+
 }
 
 .jetpack-connect-wide {
@@ -67,18 +80,6 @@
 		margin-top: 16px;
 		word-wrap: nowrap;
 	}
-}
-
-.logged-out-form__links {
-	max-width: 100%;
-
-	.logged-out-form__link-item {
-		.gridicon {
-			position: relative;
-			top: 4px;
-		}
-	}
-
 }
 
 .jetpack-connect__authorize-form {


### PR DESCRIPTION
This is a fix for #5376

Links below the signup form were not properly aligned, because of conflicting CSS with Jetpack Connect.

Fixed Jetpack Connect CSS to have proper scope.

Improved padding of the links for wider resolutions, because the links were still misaligned by few pixels.


cc @meremagee @michaeldcain @coreh 