### PR TITLE
Jetpack connect tracks step 1 & 2

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -34,12 +34,12 @@ const MINIMUM_JETPACK_VERSION = '3.9.6';
 const JetpackConnectMain = React.createClass( {
 	displayName: 'JetpackConnectSiteURLStep',
 
-	componetDidMount() {
+	componentDidMount() {
 		let from = 'direct';
 		if ( this.props.isInstall ) {
 			from = 'jpdotcom';
 		}
-		recordTracksEvent( 'jpc_url_view', {
+		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: from,
 			user: this.props.userId
 		} );
@@ -82,7 +82,7 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	onURLEnter() {
-		recordTracksEvent( 'jpc_url_submit', {
+		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
 			jetpack_funnel: this.state.currentUrl,
 			user: this.props.userId
 		} );
@@ -90,7 +90,7 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	installJetpack() {
-		recordTracksEvent( 'jpc_instructions_click', {
+		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
 			jetpack_funnel: this.state.currentUrl,
 			user: this.props.userId,
 			type: 'install_jetpack'
@@ -100,7 +100,7 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	activateJetpack() {
-		recordTracksEvent( 'jpc_instructions_click', {
+		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
 			jetpack_funnel: this.state.currentUrl,
 			user: this.props.userId,
 			type: 'activate_jetpack'

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -23,6 +23,8 @@ import JetpackExampleConnect from './exampleComponents/jetpack-connect';
 import JetpackInstallStep from './install-step';
 import versionCompare from 'lib/version-compare';
 import LocaleSuggestions from 'signup/locale-suggestions';
+import analytics from 'lib/analytics';
+import { getCurrentUser } from 'state/current-user/selectors';
 
 /**
  * Constants
@@ -31,6 +33,17 @@ const MINIMUM_JETPACK_VERSION = '3.9.6';
 
 const JetpackConnectMain = React.createClass( {
 	displayName: 'JetpackConnectSiteURLStep',
+
+	componetDidMount() {
+		let from = 'direct';
+		if ( this.props.isInstall ) {
+			from = 'jpdotcom';
+		}
+		analytics.tracks.recordEvent( 'jpc_url_view', {
+			jpc_from: from,
+			user: this.props.userId
+		} );
+	},
 
 	getInitialState() {
 		return {
@@ -69,6 +82,10 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	onURLEnter() {
+		analytics.tracks.recordEvent( 'jpc_url_submit', {
+			jetpack_funnel: this.state.currentUrl,
+			user: this.props.userId
+		} );
 		this.props.checkUrl( this.state.currentUrl );
 	},
 
@@ -257,8 +274,10 @@ const JetpackConnectMain = React.createClass( {
 
 export default connect(
 	state => {
+		const user = getCurrentUser( state );
 		return {
-			jetpackConnectSite: state.jetpackConnect.jetpackConnectSite
+			jetpackConnectSite: state.jetpackConnect.jetpackConnectSite,
+			userId: user ? user.ID : null
 		};
 	},
 	dispatch => bindActionCreators( { checkUrl, dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation }, dispatch )

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -24,7 +24,6 @@ import JetpackInstallStep from './install-step';
 import versionCompare from 'lib/version-compare';
 import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getCurrentUser } from 'state/current-user/selectors';
 
 /**
  * Constants
@@ -40,8 +39,7 @@ const JetpackConnectMain = React.createClass( {
 			from = 'jpdotcom';
 		}
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
-			jpc_from: from,
-			user: this.props.userId
+			jpc_from: from
 		} );
 	},
 
@@ -83,8 +81,7 @@ const JetpackConnectMain = React.createClass( {
 
 	onURLEnter() {
 		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
-			jetpack_funnel: this.state.currentUrl,
-			user: this.props.userId
+			jetpack_url: this.state.currentUrl
 		} );
 		this.props.checkUrl( this.state.currentUrl );
 	},
@@ -92,7 +89,6 @@ const JetpackConnectMain = React.createClass( {
 	installJetpack() {
 		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
 			jetpack_funnel: this.state.currentUrl,
-			user: this.props.userId,
 			type: 'install_jetpack'
 		} );
 
@@ -102,7 +98,6 @@ const JetpackConnectMain = React.createClass( {
 	activateJetpack() {
 		this.props.recordTracksEvent( 'calypso_jpc_instructions_click', {
 			jetpack_funnel: this.state.currentUrl,
-			user: this.props.userId,
 			type: 'activate_jetpack'
 		} );
 		this.props.goToPluginActivation( this.state.currentUrl );
@@ -285,10 +280,8 @@ const JetpackConnectMain = React.createClass( {
 
 export default connect(
 	state => {
-		const user = getCurrentUser( state );
 		return {
-			jetpackConnectSite: state.jetpackConnect.jetpackConnectSite,
-			userId: user ? user.ID : null
+			jetpackConnectSite: state.jetpackConnect.jetpackConnectSite
 		};
 	},
 	dispatch => bindActionCreators( { recordTracksEvent, checkUrl, dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation }, dispatch )

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -90,10 +90,21 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	installJetpack() {
+		analytics.tracks.recordEvent( 'jpc_instructions_click', {
+			jetpack_funnel: this.state.currentUrl,
+			user: this.props.userId,
+			type: 'install_jetpack'
+		} );
+
 		this.props.goToPluginInstall( this.state.currentUrl );
 	},
 
 	activateJetpack() {
+		analytics.tracks.recordEvent( 'jpc_instructions_click', {
+			jetpack_funnel: this.state.currentUrl,
+			user: this.props.userId,
+			type: 'activate_jetpack'
+		} );
 		this.props.goToPluginActivation( this.state.currentUrl );
 	},
 

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -23,7 +23,7 @@ import JetpackExampleConnect from './exampleComponents/jetpack-connect';
 import JetpackInstallStep from './install-step';
 import versionCompare from 'lib/version-compare';
 import LocaleSuggestions from 'signup/locale-suggestions';
-import analytics from 'lib/analytics';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 
 /**
@@ -39,7 +39,7 @@ const JetpackConnectMain = React.createClass( {
 		if ( this.props.isInstall ) {
 			from = 'jpdotcom';
 		}
-		analytics.tracks.recordEvent( 'jpc_url_view', {
+		recordTracksEvent( 'jpc_url_view', {
 			jpc_from: from,
 			user: this.props.userId
 		} );
@@ -82,7 +82,7 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	onURLEnter() {
-		analytics.tracks.recordEvent( 'jpc_url_submit', {
+		recordTracksEvent( 'jpc_url_submit', {
 			jetpack_funnel: this.state.currentUrl,
 			user: this.props.userId
 		} );
@@ -90,7 +90,7 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	installJetpack() {
-		analytics.tracks.recordEvent( 'jpc_instructions_click', {
+		recordTracksEvent( 'jpc_instructions_click', {
 			jetpack_funnel: this.state.currentUrl,
 			user: this.props.userId,
 			type: 'install_jetpack'
@@ -100,7 +100,7 @@ const JetpackConnectMain = React.createClass( {
 	},
 
 	activateJetpack() {
-		analytics.tracks.recordEvent( 'jpc_instructions_click', {
+		recordTracksEvent( 'jpc_instructions_click', {
 			jetpack_funnel: this.state.currentUrl,
 			user: this.props.userId,
 			type: 'activate_jetpack'
@@ -291,5 +291,5 @@ export default connect(
 			userId: user ? user.ID : null
 		};
 	},
-	dispatch => bindActionCreators( { checkUrl, dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation }, dispatch )
+	dispatch => bindActionCreators( { recordTracksEvent, checkUrl, dismissUrl, goToRemoteAuth, goToPluginInstall, goToPluginActivation }, dispatch )
 )( JetpackConnectMain );

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -43,7 +43,7 @@ const activateURL = '/wp-admin/plugins.php';
 const userModule = userFactory();
 const tracksEvent = ( dispatch, eventName, props ) => {
 	setTimeout( () => {
-		dispatch( recordTracksEvent( 'calypso_' + eventName, props ) );
+		dispatch( recordTracksEvent( eventName, props ) );
 	}, 1 );
 };
 export default {
@@ -89,16 +89,16 @@ export default {
 				let errorCode = null;
 				let instructionsType = null;
 				if ( data && data.isWordPressDotCom ) {
-					errorCode = 'jpc_error_wpdotcomsite';
+					errorCode = 'calypso_jpc_error_wpdotcomsite';
 				} else if ( data && ! data.exists ) {
-					errorCode = 'jpc_error_notexists';
+					errorCode = 'calypso_jpc_error_notexists';
 				} else if ( data && ! data.isWordPress ) {
-					errorCode = 'jpc_error_notwpsite';
+					errorCode = 'calypso_jpc_error_notwpsite';
 				} else if ( data && ! data.hasJetpack ) {
-					errorCode = 'jpc_instructions_view';
+					errorCode = 'calypso_jpc_instructions_view';
 					instructionsType = 'not_jetpack';
 				} else if ( data && ! data.isJetpackActive ) {
-					errorCode = 'jpc_instructions_view';
+					errorCode = 'calypso_jpc_instructions_view';
 					instructionsType = 'inactive_jetpack';
 				}
 
@@ -116,7 +116,7 @@ export default {
 						url: url
 					} );
 				} else {
-					tracksEvent( dispatch, 'jpc_error_other', {
+					tracksEvent( dispatch, 'calypso_jpc_error_other', {
 						url: url
 					} );
 				}
@@ -138,7 +138,7 @@ export default {
 				type: JETPACK_CONNECT_REDIRECT,
 				url: url
 			} );
-			tracksEvent( dispatch, 'jpc_success_redirect', {
+			tracksEvent( dispatch, 'calypso_jpc_success_redirect', {
 				url: url,
 				type: 'remote_auth'
 			} );
@@ -151,7 +151,7 @@ export default {
 				type: JETPACK_CONNECT_REDIRECT,
 				url: url
 			} );
-			tracksEvent( dispatch, 'jpc_success_redirect', {
+			tracksEvent( dispatch, 'calypso_jpc_success_redirect', {
 				url: url,
 				type: 'plugin_install'
 			} );
@@ -164,7 +164,7 @@ export default {
 				type: JETPACK_CONNECT_REDIRECT,
 				url: url
 			} );
-			tracksEvent( dispatch, 'jpc_success_redirect', {
+			tracksEvent( dispatch, 'calypso_jpc_success_redirect', {
 				url: url,
 				type: 'plugin_activation'
 			} );
@@ -181,7 +181,7 @@ export default {
 	},
 	createAccount( userData ) {
 		return ( dispatch ) => {
-			tracksEvent( dispatch, 'jetpack_connect_create_account', {} );
+			tracksEvent( dispatch, 'calypso_jpc_create_account', {} );
 
 			dispatch( {
 				type: JETPACK_CONNECT_CREATE_ACCOUNT,
@@ -191,9 +191,9 @@ export default {
 				userData,
 				( error, data ) => {
 					if ( error ) {
-						tracksEvent( dispatch, 'jetpack_connect_create_account_error', { error: error.code } );
+						tracksEvent( dispatch, 'calypso_jpc_create_account_error', { error: error.code } );
 					} else {
-						tracksEvent( dispatch, 'jetpack_connect_create_account_success', {} );
+						tracksEvent( dispatch, 'calypso_jpc_create_account_success', {} );
 					}
 					dispatch( {
 						type: JETPACK_CONNECT_CREATE_ACCOUNT_RECEIVE,
@@ -209,7 +209,7 @@ export default {
 		return ( dispatch ) => {
 			const { _wp_nonce, client_id, redirect_uri, scope, secret, state } = queryObject;
 			debug( 'Trying Jetpack login.', _wp_nonce, redirect_uri, scope, state );
-			tracksEvent( dispatch, 'jetpack_connect_authorize' );
+			tracksEvent( dispatch, 'calypso_jpc_authorize' );
 			dispatch( {
 				type: JETPACK_CONNECT_AUTHORIZE,
 				queryObject: queryObject
@@ -220,7 +220,7 @@ export default {
 				return wpcom.undocumented().jetpackAuthorize( client_id, data.code, state, redirect_uri, secret );
 			} )
 			.then( ( data ) => {
-				tracksEvent( dispatch, 'jetpack_connect_authorize_success' );
+				tracksEvent( dispatch, 'calypso_jpc_authorize_success' );
 				debug( 'Jetpack authorize complete. Updating sites list.', data );
 				dispatch( {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
@@ -245,7 +245,7 @@ export default {
 			} )
 			.catch( ( error ) => {
 				debug( 'Authorize error', error );
-				tracksEvent( dispatch, 'jetpack_connect_authorize_error', { error: error.code } );
+				tracksEvent( dispatch, 'calypso_jpc_authorize_error', { error: error.code } );
 				dispatch( {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
 					siteId: client_id,

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -43,7 +43,7 @@ const activateURL = '/wp-admin/plugins.php';
 const userModule = userFactory();
 const tracksEvent = ( dispatch, eventName, props ) => {
 	setTimeout( () => {
-		dispatch( recordTracksEvent( eventName, props ) )
+		dispatch( recordTracksEvent( eventName, props ) );
 	}, 1 );
 };
 export default {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -103,6 +103,7 @@ export default {
 		return ( dispatch ) => {
 			dispatch( {
 				type: JETPACK_CONNECT_REDIRECT,
+				redirectType: 'remote_auth',
 				url: url
 			} );
 			window.location = url + authURL;
@@ -112,6 +113,7 @@ export default {
 		return ( dispatch ) => {
 			dispatch( {
 				type: JETPACK_CONNECT_REDIRECT,
+				redirectType: 'plugin_install',
 				url: url
 			} );
 			window.location = url + installURL;
@@ -121,6 +123,7 @@ export default {
 		return ( dispatch ) => {
 			dispatch( {
 				type: JETPACK_CONNECT_REDIRECT,
+				redirectType: 'plugin_activation',
 				url: url
 			} );
 			window.location = url + activateURL;

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -43,7 +43,7 @@ const activateURL = '/wp-admin/plugins.php';
 const userModule = userFactory();
 const tracksEvent = ( dispatch, eventName, props ) => {
 	setTimeout( () => {
-		dispatch( recordTracksEvent( eventName, props ) );
+		dispatch( recordTracksEvent( 'calypso_' + eventName, props ) );
 	}, 1 );
 };
 export default {

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -77,22 +77,23 @@ export default {
 				wpcom.undocumented().getSiteConnectInfo( url, 'isWordPressDotCom' ),
 			] ).then( ( data, error ) => {
 				_fetching[ url ] = null;
+				data = data ? Object.assign.apply( Object, data ) : null;
 				debug( 'jetpack-connect state checked for url', url, error, data );
 				dispatch( {
 					type: JETPACK_CONNECT_CHECK_URL_RECEIVE,
 					url: url,
-					data: data ? Object.assign.apply( Object, data ) : null,
+					data: data,
 					error: error
 				} );
 
 				let errorCode = null;
 				let instructionsType = null;
-				if ( data && ! data.exists ) {
+				if ( data && data.isWordPressDotCom ) {
+					errorCode = 'jpc_error_wpdotcomsite';
+				} else if ( data && ! data.exists ) {
 					errorCode = 'jpc_error_notexists';
 				} else if ( data && ! data.isWordPress ) {
 					errorCode = 'jpc_error_notwpsite';
-				} else if ( data && ! data.isWordPressDotCom ) {
-					errorCode = 'jpc_error_wpdotcomsite';
 				} else if ( data && ! data.hasJetpack ) {
 					errorCode = 'jpc_instructions_view';
 					instructionsType = 'not_jetpack';

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -48,11 +48,6 @@ function buildNoProtocolUrlObj( url ) {
 	return { [ noProtocolUrl ]: ( new Date() ).getTime() };
 }
 
-const getCurrentUserId = ( state ) => {
-	const user = getCurrentUser( state );
-	return user ? user.ID : null;
-};
-
 export function jetpackConnectSessions( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_STORE_SESSION:

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -76,18 +76,25 @@ export function jetpackConnectSite( state = {}, action ) {
 		case JETPACK_CONNECT_CHECK_URL_RECEIVE:
 			if ( action.url === state.url ) {
 				let errorCode = null;
+				let instructionsType = null;
 				if ( ! action.data.exists ) {
 					errorCode = 'jpc_error_notexists';
-				}
-				if ( ! action.data.isWordPress ) {
+				} else if ( ! action.data.isWordPress ) {
 					errorCode = 'jpc_error_notwpsite';
-				}
-				if ( ! action.data.isWordPressDotCom ) {
+				} else if ( ! action.data.isWordPressDotCom ) {
 					errorCode = 'jpc_error_wpdotcomsite';
+				} else if ( ! action.data.hasJetpack ) {
+					errorCode = 'jpc_instructions_view';
+					instructionsType = 'not_jetpack';
+				} else if ( ! action.data.isJetpackActive ) {
+					errorCode = 'jpc_instructions_view';
+					instructionsType = 'inactive_jetpack';
 				}
+
 				if ( errorCode ) {
 					analytics.tracks.recordEvent( errorCode, {
 						url: action.url,
+						type: instructionsType,
 						user: getCurrentUserId( state )
 					} );
 				}

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -35,8 +35,6 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
-import analytics from 'lib/analytics';
-import { getCurrentUser } from 'state/current-user/selectors';
 
 const defaultAuthorizeState = {
 	queryObject: {},
@@ -75,30 +73,6 @@ export function jetpackConnectSite( state = {}, action ) {
 			return Object.assign( {}, { url: action.url, isFetching: true, isFetched: false, isDismissed: false, data: {} } );
 		case JETPACK_CONNECT_CHECK_URL_RECEIVE:
 			if ( action.url === state.url ) {
-				let errorCode = null;
-				let instructionsType = null;
-				if ( ! action.data.exists ) {
-					errorCode = 'jpc_error_notexists';
-				} else if ( ! action.data.isWordPress ) {
-					errorCode = 'jpc_error_notwpsite';
-				} else if ( ! action.data.isWordPressDotCom ) {
-					errorCode = 'jpc_error_wpdotcomsite';
-				} else if ( ! action.data.hasJetpack ) {
-					errorCode = 'jpc_instructions_view';
-					instructionsType = 'not_jetpack';
-				} else if ( ! action.data.isJetpackActive ) {
-					errorCode = 'jpc_instructions_view';
-					instructionsType = 'inactive_jetpack';
-				}
-
-				if ( errorCode ) {
-					analytics.tracks.recordEvent( errorCode, {
-						url: action.url,
-						type: instructionsType,
-						user: getCurrentUserId( state )
-					} );
-				}
-
 				return Object.assign( {}, state, { isFetching: false, isFetched: true, data: action.data } );
 			}
 			return state;
@@ -109,11 +83,6 @@ export function jetpackConnectSite( state = {}, action ) {
 			return state;
 		case JETPACK_CONNECT_REDIRECT:
 			if ( action.url === state.url ) {
-				analytics.tracks.recordEvent( 'jpc_success_redirect', {
-					url: action.url,
-					type: action.redirectType,
-					user: getCurrentUserId( state )
-				} );
 				return Object.assign( {}, state, { isRedirecting: true } );
 			}
 			return state;

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -18,8 +18,6 @@ import {
 	SERIALIZE,
 } from 'state/action-types';
 
-import useFakeDom from 'test/helpers/use-fake-dom';
-
 import reducer, {
 	jetpackConnectSessions,
 	jetpackConnectAuthorize,
@@ -27,9 +25,6 @@ import reducer, {
 } from '../reducer';
 
 describe( 'reducer', () => {
-
-	useFakeDom();
-
 	it( 'should export expected reducer keys', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'jetpackConnectSite',

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -17,6 +17,9 @@ import {
 	JETPACK_CONNECT_SSO_VALIDATION_ERROR,
 	SERIALIZE,
 } from 'state/action-types';
+
+import useFakeDom from 'test/helpers/use-fake-dom';
+
 import reducer, {
 	jetpackConnectSessions,
 	jetpackConnectAuthorize,
@@ -24,6 +27,9 @@ import reducer, {
 } from '../reducer';
 
 describe( 'reducer', () => {
+
+	useFakeDom();
+
 	it( 'should export expected reducer keys', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'jetpackConnectSite',


### PR DESCRIPTION
This PR adds tracking to Jetpack Connect. Not a lot to see here.

![](https://media4.giphy.com/media/Yl5aO3gdVfsQ0/200_s.gif)

How to test
=========
1. Go to http://calypso.localhost:3000/jetpack/connect
2. Open the developer tools of your browser of choice and activate the analytics debug writing `localStorage.debug = 'calypso:analytics'`
3. Use jetpack connect and check the events are launched when they should looking at your console

![image](https://cloud.githubusercontent.com/assets/1554855/15286596/3c388d88-1b5e-11e6-8b93-0f386d026f40.png)

@richardmuscat 