### PR TITLE
Reader: Make following-edit search keyboard accessible

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -38,11 +38,13 @@
 	font-size: 14px;
 }
 
-.section-header__actions .button {
-	float: left;
-	margin-right: 8px;
+.section-header__actions {
+	.button {
+		float: left;
+		margin-right: 8px;
+	}
 
-	&:last-child {
+	& > .button:last-child {
 		margin-right: 0;
 	}
 }

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -33,6 +33,7 @@ import FollowingExportButton from './export-button';
 import FollowingImportButton from './import-button';
 import FeedDisplayHelper from 'reader/lib/feed-display-helper';
 import SectionHeader from 'components/section-header';
+import Button from 'components/button';
 const stats = require( 'reader/stats' );
 
 const initialLoadFeedCount = 20;
@@ -57,7 +58,7 @@ const FollowingEdit = React.createClass( {
 	getDefaultProps: function() {
 		return {
 			initialFollowUrl: ''
-		}
+		};
 	},
 
 	smartSetState: smartSetState,
@@ -134,7 +135,7 @@ const FollowingEdit = React.createClass( {
 		}
 
 		return subscriptions.sortBy( function( subscription ) {
-			return subscription.get( 'date_subscribed' )
+			return subscription.get( 'date_subscribed' );
 		} ).reverse();
 	},
 
@@ -495,7 +496,7 @@ const FollowingEdit = React.createClass( {
 		// the following stream was processed
 		if ( subscriptions ) {
 			subscriptionsToDisplay = subscriptions.filter( function( subscription ) {
-				return subscription.has( 'ID' )
+				return subscription.has( 'ID' );
 			} ).toArray();
 		}
 
@@ -544,7 +545,13 @@ const FollowingEdit = React.createClass( {
 							? <FollowingEditSortControls onSelectChange={ this.handleSortOrderChange } sortOrder={ this.state.sortOrder } />
 							: null }
 					{ ! hasNoSubscriptions
-							? <Gridicon icon="search" className="following-edit__search" onClick={ this.toggleSearching } />
+							? <Button
+								borderless
+								className="following-edit__search"
+								aria-label={ this.translate( 'Open Search', { context: 'button label' } ) }
+								onClick={ this.toggleSearching }>
+								<Gridicon icon="search" />
+							  </Button>
 							: null }
 				</SectionHeader>
 

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -53,7 +53,6 @@
 		color: $gray;
 		font-weight: 600;
 		font-size: 12px;
-		margin-right: 8px;
 		text-transform: capitalize;
 	}
 
@@ -109,8 +108,20 @@
 }
 
 .following-edit__search {
-	color: $blue-wordpress;
-	cursor: pointer;
+	margin-right: 0;
+	padding: 0;
+
+	.gridicons-search {
+		color: $blue-wordpress;
+	}
+
+	&.button.is-borderless .gridicons-search {
+		top: 4px;
+	}
+
+	&:focus .gridicons-search {
+		color: $blue-light;
+	}
 }
 
 


### PR DESCRIPTION
**Issue**
In Reader's following/edit screen, the search icon is not reachable by keyboard TAB navigation or ENTER key. More info in https://github.com/Automattic/wp-calypso/issues/5347

**Before**
![tabindex_not_working](https://cloud.githubusercontent.com/assets/1922453/15286812/1a183078-1bb3-11e6-96fb-76643e29f544.gif)

**After**
![tabindex](https://cloud.githubusercontent.com/assets/1922453/15286715/b2a35d3c-1bb2-11e6-8024-5f49c532ad5d.gif)

**Fix**
I wrapped the icon in a ```Button``` Component to make use of the rendered native ```button```'s accessibility.

**Notes**
* The focused style is my own best guess, I'll seek feedback on that.
* In order to avoid a CSS specificity war to overwrite the ```margin: 8px``` on the last child of the ```.section-header__actions```, I needed to change the rule to direct children only. I made [a jsFiddle to illustrate what was happening](https://jsfiddle.net/b0m96k5e/).

cc @apeatling @TooTallNate 