### PR TITLE
Jetpack connect add tracks steps 3 & 4

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -28,7 +28,6 @@ import i18n from 'lib/mixins/i18n';
 import Gridicon from 'components/gridicon';
 import LocaleSuggestions from 'signup/locale-suggestions';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getCurrentUser } from 'state/current-user/selectors';
 
 /**
  * Constants
@@ -147,9 +146,7 @@ const LoggedInForm = React.createClass( {
 		const { autoAuthorize, queryObject } = this.props.jetpackConnectAuthorize;
 		debug( 'Checking for auto-auth on mount', autoAuthorize );
 		if ( autoAuthorize || this.props.calypsoStartedConnection || this.props.isSSO ) {
-			this.props.recordTracksEvent( 'jpc_auth_view', {
-				user: this.props.userId
-			} );
+			this.props.recordTracksEvent( 'jpc_auth_view' );
 			this.props.authorize( queryObject );
 		}
 	},
@@ -384,12 +381,10 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 
 export default connect(
 	state => {
-		const user = getCurrentUser( state );
 		return {
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
-			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions,
 			jetpackSSOSessions: state.jetpackConnect.jetpackSSOSessions,
-			userId: user ? user.ID : null
+			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions
 		};
 	},
 	dispatch => bindActionCreators( { recordTracksEvent, authorize, createAccount, activateManage, goBackToWpAdmin }, dispatch )

--- a/client/state/jetpack-connect/actions.js
+++ b/client/state/jetpack-connect/actions.js
@@ -46,6 +46,7 @@ const tracksEvent = ( dispatch, eventName, props ) => {
 		dispatch( recordTracksEvent( eventName, props ) );
 	}, 1 );
 };
+
 export default {
 	dismissUrl( url ) {
 		return ( dispatch ) => {
@@ -220,7 +221,10 @@ export default {
 				return wpcom.undocumented().jetpackAuthorize( client_id, data.code, state, redirect_uri, secret );
 			} )
 			.then( ( data ) => {
-				tracksEvent( dispatch, 'calypso_jpc_authorize_success' );
+				tracksEvent( dispatch, 'calypso_jpc_authorize_success', {
+					site: client_id
+				} );
+
 				debug( 'Jetpack authorize complete. Updating sites list.', data );
 				dispatch( {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
@@ -233,6 +237,9 @@ export default {
 				return wpcom.me().sites( { site_visibility: 'all' } );
 			} )
 			.then( ( data ) => {
+				tracksEvent( dispatch, 'jpc_auth_sitesrefresh', {
+					site: client_id
+				} );
 				debug( 'Sites list updated!', data );
 				dispatch( {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE_SITE_LIST,
@@ -244,8 +251,15 @@ export default {
 				} );
 			} )
 			.catch( ( error ) => {
+				tracksEvent( dispatch, 'jpc_auth_error', {
+					error: error,
+					site: client_id
+				} );
 				debug( 'Authorize error', error );
-				tracksEvent( dispatch, 'calypso_jpc_authorize_error', { error: error.code } );
+				tracksEvent( dispatch, 'calypso_jpc_authorize_error', {
+					error: error.code,
+					site: client_id
+				} );
 				dispatch( {
 					type: JETPACK_CONNECT_AUTHORIZE_RECEIVE,
 					siteId: client_id,
@@ -306,6 +320,7 @@ export default {
 			} );
 			wpcom.undocumented().activateManage( blogId, state, secret )
 			.then( ( data ) => {
+				tracksEvent( dispatch, 'jpc_activate_manage_success' );
 				debug( 'Manage activated!', data );
 				dispatch( {
 					type: JETPACK_CONNECT_ACTIVATE_MANAGE_RECEIVE,
@@ -314,6 +329,7 @@ export default {
 				} );
 			} )
 			.catch( ( error ) => {
+				tracksEvent( dispatch, 'jpc_activate_manage_error', { error: error.code } );
 				debug( 'Manage activation error', error );
 				dispatch( {
 					type: JETPACK_CONNECT_ACTIVATE_MANAGE_RECEIVE,


### PR DESCRIPTION
MOAR ANALYTICS!

![](http://24.media.tumblr.com/3607c65173b2eeb98ca56003f66a9d11/tumblr_mr930qWvzs1qz5nl8o1_500.gif)

This PR adds analytics to the authorization step of jetpack connect: Not a lot to see but in your dev console.

How to test
=========
1. Go to http://calypso.localhost:3000/jetpack/connect
2. Open the developer tools of your browser of choice and activate the analytics debug writing `localStorage.debug = 'calypso:analytics'`
3. Use jetpack connect and check the events are launched when they should looking at your console

@richardmuscat 