### PR TITLE
GuidedTours: Support multiple tours

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -6,113 +6,121 @@
 import React from 'react';
 import i18n from 'i18n-calypso';
 
-function get( site ) {
-	return {
-		init: {
-			text: i18n.translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, and give you some ideas for what to do next.", {
-				components: {
-					strong: <strong />,
-				}
-			} ),
-			type: 'FirstStep',
-			placement: 'right',
-			next: 'my-sites',
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+
+function get( tour = 'main' ) {
+	const tours = {
+		main: {
+			version: '20160601',
+			init: {
+				text: i18n.translate( "{{strong}}Need a hand?{{/strong}} We'd love to show you around the place, and give you some ideas for what to do next.", {
+					components: {
+						strong: <strong />,
+					}
+				} ),
+				type: 'FirstStep',
+				placement: 'right',
+				next: 'my-sites',
+			},
+			'my-sites': {
+				target: 'my-sites',
+				arrow: 'top-left',
+				type: 'ActionStep',
+				icon: 'my-sites',
+				placement: 'below',
+				text: i18n.translate( "{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing your site's content and design.", {
+					components: {
+						strong: <strong />,
+					}
+				} ),
+				next: 'sidebar',
+			},
+			sidebar: {
+				text: i18n.translate( 'This menu lets you navigate around, and will adapt to give you the tools you need when you need them.' ),
+				type: 'BasicStep',
+				target: 'sidebar',
+				arrow: 'left-middle',
+				placement: 'beside',
+				next: 'click-preview',
+			},
+			'click-preview': {
+				target: 'site-card-preview',
+				arrow: 'top-left',
+				type: 'ActionStep',
+				iconText: i18n.translate( "your site's name", {
+					context: "Click your site's name to continue.",
+				} ),
+				placement: 'below',
+				showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
+				text: i18n.translate( "This shows your currently {{strong}}selected site{{/strong}}'s name and address.", {
+					components: {
+						strong: <strong />,
+					}
+				} ),
+				next: 'in-preview',
+			},
+			'in-preview': {
+				text: i18n.translate( "This is your site's {{strong}}Preview{{/strong}}. From here you can see how your site looks to others.", {
+					components: {
+						strong: <strong />,
+					}
+				} ),
+				type: 'BasicStep',
+				placement: 'center',
+				showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
+				next: 'close-preview',
+			},
+			'close-preview': {
+				target: 'web-preview__close',
+				arrow: 'left-top',
+				type: 'ActionStep',
+				placement: 'beside',
+				icon: 'cross-small',
+				text: i18n.translate( 'Take a look at your site — and then close the site preview. You can come back here anytime.' ),
+				showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_previewable,
+				next: 'themes',
+			},
+			themes: {
+				text: i18n.translate( "Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} your theme's colors, fonts, and more.", {
+					components: {
+						strong: <strong />,
+					}
+				} ),
+				type: 'BasicStep',
+				target: 'themes',
+				arrow: 'top-left',
+				placement: 'below',
+				showInContext: state => getSelectedSite( state ) && getSelectedSite( state ).is_customizable,
+				next: 'finish',
+			},
+			finish: {
+				placement: 'center',
+				text: i18n.translate( "{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.", {
+					components: {
+						strong: <strong />,
+					}
+				} ),
+				type: 'FinishStep',
+				linkLabel: i18n.translate( 'Learn more about WordPress.com' ),
+				linkUrl: 'https://learn.wordpress.com',
+			},
 		},
-		'my-sites': {
-			target: 'my-sites',
-			arrow: 'top-left',
-			type: 'ActionStep',
-			icon: 'my-sites',
-			placement: 'below',
-			text: i18n.translate( "{{strong}}First things first.{{/strong}} Up here, you'll find tools for managing your site's content and design.", {
-				components: {
-					strong: <strong />,
-				}
-			} ),
-			next: 'sidebar',
-		},
-		sidebar: {
-			text: i18n.translate( 'This menu lets you navigate around, and will adapt to give you the tools you need when you need them.' ),
-			type: 'BasicStep',
-			target: 'sidebar',
-			arrow: 'left-middle',
-			placement: 'beside',
-			next: ( ( () => {
-				if ( site && site.is_previewable ) {
-					return 'click-preview';
-				}
-				if ( site && site.is_customizable ) {
-					return 'themes';
-				}
-				return 'finish';
-			} )() ),
-		},
-		'click-preview': {
-			target: 'site-card-preview',
-			arrow: 'top-left',
-			type: 'ActionStep',
-			iconText: i18n.translate( "your site's name", {
-				context: "Click your site's name to continue.",
-			} ),
-			placement: 'below',
-			text: i18n.translate( "This shows your currently {{strong}}selected site{{/strong}}'s name and address.", {
-				components: {
-					strong: <strong />,
-				}
-			} ),
-			next: 'in-preview',
-		},
-		'in-preview': {
-			text: i18n.translate( "This is your site's {{strong}}Preview{{/strong}}. From here you can see how your site looks to others.", {
-				components: {
-					strong: <strong />,
-				}
-			} ),
-			type: 'BasicStep',
-			placement: 'center',
-			next: 'close-preview',
-		},
-		'close-preview': {
-			target: 'web-preview__close',
-			arrow: 'left-top',
-			type: 'ActionStep',
-			placement: 'beside',
-			icon: 'cross-small',
-			text: i18n.translate( 'Take a look at your site—and then close the site preview. You can come back here anytime.' ),
-			next: ( () => {
-				if ( site && site.is_customizable ) {
-					return 'themes';
-				}
-				return 'finish';
-			} )(),
-		},
-		themes: {
-			text: i18n.translate( "Change your {{strong}}Theme{{/strong}} to choose a new layout, or {{strong}}Customize{{/strong}} your theme's colors, fonts, and more.", {
-				components: {
-					strong: <strong />,
-				}
-			} ),
-			type: 'BasicStep',
-			target: 'themes',
-			arrow: 'top-left',
-			placement: 'below',
-			next: 'finish',
-		},
-		finish: {
-			placement: 'center',
-			text: i18n.translate( "{{strong}}That's it!{{/strong}} Now that you know a few of the basics, feel free to wander around.", {
-				components: {
-					strong: <strong />,
-				}
-			} ),
-			type: 'FinishStep',
-			linkLabel: i18n.translate( 'Learn more about WordPress.com' ),
-			linkUrl: 'https://learn.wordpress.com',
+		test: {
+			version: '20160516',
+			init: {
+				description: 'Testing multi tour support',
+				text: i18n.translate( 'Single step tour!' ),
+				type: 'FinishStep',
+			},
 		}
 	};
+
+	return tours[ tour ] || tours.main;
 }
 
 export default {
 	get,
-	version: '20160601',
 };

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import scrollTo from 'lib/scroll-to';
-import { getSelectedSite } from 'state/ui/selectors';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { nextGuidedTourStep, quitGuidedTour } from 'state/ui/guided-tours/actions';
 import { errorNotice } from 'state/notices/actions';
@@ -107,6 +106,7 @@ class GuidedTours extends Component {
 
 	render() {
 		const { stepConfig } = this.props.tourState;
+		debug( 'GuidedTours#render() tourState', this.props.tourState );
 
 		if ( ! stepConfig ) {
 			return null;
@@ -134,7 +134,6 @@ class GuidedTours extends Component {
 }
 
 export default connect( ( state ) => ( {
-	selectedSite: getSelectedSite( state ),
 	tourState: getGuidedTourState( state ),
 } ), {
 	nextGuidedTourStep,

--- a/client/state/ui/guided-tours/actions.js
+++ b/client/state/ui/guided-tours/actions.js
@@ -28,7 +28,7 @@ export function showGuidedTour( { shouldShow, shouldDelay = false, tour = 'main'
 	};
 
 	const trackEvent = recordTracksEvent( 'calypso_guided_tours_show', {
-		tour_version: guidedToursConfig.version,
+		tour_version: guidedToursConfig.get( tour ).version,
 		tour,
 	} );
 
@@ -47,7 +47,7 @@ export function quitGuidedTour( { tour = 'main', stepName, finished, error } ) {
 
 	const trackEvent = recordTracksEvent( `calypso_guided_tours_${ finished ? 'finished' : 'quit' }`, {
 		step: stepName,
-		tour_version: guidedToursConfig.version,
+		tour_version: guidedToursConfig.get( tour ).version,
 		tour,
 		error,
 	} );
@@ -62,7 +62,7 @@ export function nextGuidedTourStep( { tour = 'main', stepName } ) {
 
 	const trackEvent = recordTracksEvent( 'calypso_guided_tours_next_step', {
 		step: stepName,
-		tour_version: guidedToursConfig.version,
+		tour_version: guidedToursConfig.get( tour ).version,
 		tour,
 	} );
 

--- a/client/state/ui/guided-tours/selectors.js
+++ b/client/state/ui/guided-tours/selectors.js
@@ -11,7 +11,7 @@ import { isSectionLoading, getSelectedSite } from 'state/ui/selectors';
 import createSelector from 'lib/create-selector';
 import guidedToursConfig from 'layout/guided-tours/config';
 
-const getToursConfig = memoize( ( site ) => guidedToursConfig.get( site ) );
+const getToursConfig = memoize( ( tour ) => guidedToursConfig.get( tour ) );
 
 /**
  * Returns the current state for Guided Tours.
@@ -28,10 +28,21 @@ const getRawGuidedTourState = state => get( state, 'ui.guidedTour', false );
 export const getGuidedTourState = createSelector(
 	state => {
 		const tourState = getRawGuidedTourState( state );
-		const site = getSelectedSite( state );
-		const { shouldReallyShow, stepName = '' } = tourState;
-		const stepConfig = getToursConfig( site )[ stepName ] || false;
-		const nextStepConfig = getToursConfig( site )[ stepConfig.next ] || false;
+		const { shouldReallyShow, stepName = '', tour } = tourState;
+		const tourConfig = getToursConfig( tour );
+
+		const getStepConfig = name => {
+			const step = tourConfig[ name ] || false;
+			const shouldSkip = !! (
+				step &&
+				( step.showInContext && ! step.showInContext( state ) ) ||
+				( step.continueIf && step.continueIf( state ) )
+			);
+			return shouldSkip ? getStepConfig( step.next ) : step;
+		};
+
+		const stepConfig = getStepConfig( stepName ) || false;
+		const nextStepConfig = getStepConfig( stepConfig.next ) || false;
 
 		const shouldShow = !! (
 			! isSectionLoading( state ) &&


### PR DESCRIPTION
Allow multiple tours to be specified in the config.

- Config's `get()` now takes an optional `tour` param
- Individual tours are now accessible via the `tour` qarg
- Shift tour version into the tour object
- Skip steps in main getGuidedTourState selector, based on step config's
 `continueIf` and `showInContext`
- Modify config to use `showInContext` for preview/theme steps

To test:
1. Check main tour still works
2. Check that preview isn't shown for URLs like `http://calypso.localhost:3000/stats/day?tour=main`
3. Check that themes step isn't shown when there's no permission to customize

TODO:
- [ ] ~~Document how to write a tour, including definitions of step types, placement etc~~