### PR TITLE
Jetpack SSO: Fixes failing SSO redirect

### DIFF
--- a/client/signup/jetpack-connect/sso.jsx
+++ b/client/signup/jetpack-connect/sso.jsx
@@ -48,7 +48,7 @@ const JetpackSSOForm = React.createClass( {
 			// we land in the same development environment.
 			const redirect = addQueryArgs( { calypso_env: config( 'env' ) }, nextProps.ssoUrl );
 			debug( 'Redirecting to: ' + redirect );
-			window.location.href = addQueryArgs( redirect );
+			window.location.href = redirect;
 		}
 	},
 


### PR DESCRIPTION
Previously, we were calling addQueryArgs() incorrectly, which was causing the redirect back to the remote site to fail.

Since we already generated the redirect in order to pass it to debug(), there was no need to call addQueryArgs() again.

cc @lezama for review

To test:
- Checkout `update/jetpack-sso-redirect`
- Add yourself as a Calypso SSO flow tester. Ping me for details.
- Click "Log in with WordPress.com" button
- When using a WordPress.com user that has not approved for the remote site yet, you should land at `/jetpack/sso`
- Click "Log in"
- You should automatically be redirected to the remote Jetpack site