### PR TITLE
Reader: whitelist bandcamp embeds

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -699,7 +699,8 @@ normalizePost.content = {
 			'soundcloud.com',
 			'8tracks.com',
 			'spotify.com',
-			'me.sh'
+			'me.sh',
+			'bandcamp.com'
 		];
 
 		// hosts that we trust that don't work in a sandboxed iframe

--- a/client/reader/embed-helper.jsx
+++ b/client/reader/embed-helper.jsx
@@ -52,7 +52,7 @@ var embedsConfig = {
 			};
 		},
 		urlRegex: /\/\/bandcamp\.com\/EmbeddedPlayer/
-  }
+	}
 };
 
 function extractUrlFromIframe( iframeHtml ) {

--- a/client/reader/embed-helper.jsx
+++ b/client/reader/embed-helper.jsx
@@ -43,7 +43,16 @@ var embedsConfig = {
 			};
 		},
 		urlRegex: /\/\/w\.soundcloud\.com\/player/
-	}
+	},
+	bandcamp: {
+		sizingFunction( embed, availableWidth ) {
+			return {
+				width: availableWidth + 'px',
+				height: embed.height + 'px'
+			};
+		},
+		urlRegex: /\/\/bandcamp\.com\/EmbeddedPlayer/
+  }
 };
 
 function extractUrlFromIframe( iframeHtml ) {


### PR DESCRIPTION
This is the _cheap_ fix: add an explicit sizing function for bandcamp embeds, assuming a width of 100%.

A more ideal fix would be to make the `default` sizing function be percentage-aware. Right now the `width` on the embed object is `null` from the 100% value, causing the aspect ratio to end up as 1:1.

I will look into this more ideal solution before we merge or supersede this one.