### PR TITLE
Upgrades: Use enzyme for CartButtons test, use `localize` for CartButtons

### DIFF
--- a/client/my-sites/upgrades/cart/cart-buttons.jsx
+++ b/client/my-sites/upgrades/cart/cart-buttons.jsx
@@ -25,7 +25,7 @@ var CartButtons = React.createClass( {
 	render: function() {
 		return (
 			<div className="cart-buttons">
-				<button ref="checkoutButton" className="cart-checkout-button button is-primary"
+				<button className="cart-checkout-button button is-primary"
 						onClick={ this.goToCheckout }>
 					{ this.translate( 'Checkout', { context: 'Cart button' } ) }
 				</button>
@@ -41,7 +41,7 @@ var CartButtons = React.createClass( {
 		}
 
 		return (
-			<button ref="keepSearchingButton" className="cart-keep-searching-button button"
+			<button className="cart-keep-searching-button button"
 					onClick={ this.onKeepSearchingClick }>
 				{ this.translate( 'Keep Searching' ) }
 			</button>

--- a/client/my-sites/upgrades/cart/cart-buttons.jsx
+++ b/client/my-sites/upgrades/cart/cart-buttons.jsx
@@ -9,6 +9,7 @@ import page from 'page';
  * Internal dependencies
  */
 import AnalyticsMixin from 'lib/mixins/analytics';
+import localize from 'lib/mixins/i18n/localize';
 
 export const CartButtons = React.createClass( {
 	mixins: [ AnalyticsMixin( 'popupCart' ) ],
@@ -17,7 +18,8 @@ export const CartButtons = React.createClass( {
 		selectedSite: React.PropTypes.oneOfType( [
 			React.PropTypes.object,
 			React.PropTypes.bool
-		] ).isRequired
+		] ).isRequired,
+		translate: React.PropTypes.func.isRequired
 	},
 
 	getDefaultProps() {
@@ -29,7 +31,7 @@ export const CartButtons = React.createClass( {
 			<div className="cart-buttons">
 				<button className="cart-checkout-button button is-primary"
 						onClick={ this.goToCheckout }>
-					{ this.translate( 'Checkout', { context: 'Cart button' } ) }
+					{ this.props.translate( 'Checkout', { context: 'Cart button' } ) }
 				</button>
 
 				{ this.optionalKeepSearching() }
@@ -45,7 +47,7 @@ export const CartButtons = React.createClass( {
 		return (
 			<button className="cart-keep-searching-button button"
 					onClick={ this.onKeepSearchingClick }>
-				{ this.translate( 'Keep Searching' ) }
+				{ this.props.translate( 'Keep Searching' ) }
 			</button>
 		);
 	},
@@ -67,4 +69,4 @@ export const CartButtons = React.createClass( {
 	}
 } );
 
-export default CartButtons;
+export default localize( CartButtons );

--- a/client/my-sites/upgrades/cart/cart-buttons.jsx
+++ b/client/my-sites/upgrades/cart/cart-buttons.jsx
@@ -1,14 +1,16 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	isFunction = require( 'lodash/isFunction' ),
-	page = require( 'page' );
+import React from 'react';
+import isFunction from 'lodash/isFunction';
+import page from 'page';
 
-/** Internal dependencies **/
-var AnalyticsMixin = require( 'lib/mixins/analytics' );
+/**
+ * Internal dependencies
+ */
+import AnalyticsMixin from 'lib/mixins/analytics';
 
-var CartButtons = React.createClass( {
+export const CartButtons = React.createClass( {
 	mixins: [ AnalyticsMixin( 'popupCart' ) ],
 
 	propTypes: {
@@ -18,11 +20,11 @@ var CartButtons = React.createClass( {
 		] ).isRequired
 	},
 
-	getDefaultProps: function() {
+	getDefaultProps() {
 		return { showKeepSearching: false };
 	},
 
-	render: function() {
+	render() {
 		return (
 			<div className="cart-buttons">
 				<button className="cart-checkout-button button is-primary"
@@ -35,7 +37,7 @@ var CartButtons = React.createClass( {
 		);
 	},
 
-	optionalKeepSearching: function() {
+	optionalKeepSearching() {
 		if ( ! this.props.showKeepSearching ) {
 			return;
 		}
@@ -48,7 +50,7 @@ var CartButtons = React.createClass( {
 		);
 	},
 
-	onKeepSearchingClick: function( event ) {
+	onKeepSearchingClick( event ) {
 		event.preventDefault();
 		this.recordEvent( 'keepSearchButtonClick' );
 		if ( isFunction( this.props.onKeepSearchingClick ) ) {
@@ -56,7 +58,7 @@ var CartButtons = React.createClass( {
 		}
 	},
 
-	goToCheckout: function( event ) {
+	goToCheckout( event ) {
 		event.preventDefault();
 
 		this.recordEvent( 'checkoutButtonClick' );
@@ -65,4 +67,4 @@ var CartButtons = React.createClass( {
 	}
 } );
 
-module.exports = CartButtons;
+export default CartButtons;

--- a/client/my-sites/upgrades/cart/cart-buttons.jsx
+++ b/client/my-sites/upgrades/cart/cart-buttons.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import identity from 'lodash/identity';
 import isFunction from 'lodash/isFunction';
 import page from 'page';
 
@@ -23,7 +24,10 @@ export const CartButtons = React.createClass( {
 	},
 
 	getDefaultProps() {
-		return { showKeepSearching: false };
+		return {
+			showKeepSearching: false,
+			translate: identity
+		};
 	},
 
 	render() {

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -10,7 +10,7 @@ var React = require( 'react' ),
  */
 var CartBody = require( './cart-body' ),
 	CartMessagesMixin = require( './cart-messages-mixin' ),
-	CartButtons = require( './cart-buttons' ),
+	CartButtons = require( './cart-buttons' ).default,
 	Popover = require( 'components/popover' ),
 	CartEmpty = require( './cart-empty' ),
 	CartPlanAd = require( './cart-plan-ad' ),

--- a/client/my-sites/upgrades/cart/popover-cart.jsx
+++ b/client/my-sites/upgrades/cart/popover-cart.jsx
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-var React = require( 'react' ),
-	reject = require( 'lodash/reject' ),
-	classNames = require( 'classnames' );
+import React from 'react';
+import reject from 'lodash/reject';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-var CartBody = require( './cart-body' ),
-	CartMessagesMixin = require( './cart-messages-mixin' ),
-	CartButtons = require( './cart-buttons' ).default,
-	Popover = require( 'components/popover' ),
-	CartEmpty = require( './cart-empty' ),
-	CartPlanAd = require( './cart-plan-ad' ),
-	CartTrialAd = require( './cart-trial-ad' ),
-	isCredits = require( 'lib/products-values' ).isCredits,
-	Gridicon = require( 'components/gridicon' );
+import CartBody from './cart-body';
+import CartMessagesMixin from './cart-messages-mixin';
+import CartButtons from './cart-buttons';
+import Popover from 'components/popover';
+import CartEmpty from './cart-empty';
+import CartPlanAd from './cart-plan-ad';
+import CartTrialAd from './cart-trial-ad';
+import { isCredits } from 'lib/products-values';
+import Gridicon from 'components/gridicon';
 
 var PopoverCart = React.createClass( {
 	propTypes: {

--- a/client/my-sites/upgrades/cart/test/cart-buttons.js
+++ b/client/my-sites/upgrades/cart/test/cart-buttons.js
@@ -1,65 +1,77 @@
 /**
  * External Dependencies
  */
-const sinon = require( 'sinon' ),
-	ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
-	TestUtils = require( 'react-addons-test-utils' ),
-	{ expect } = require( 'chai' );
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
 
 /**
  * Internal dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
+import useMockery from 'test/helpers/use-mockery';
+import { useSandbox } from 'test/helpers/use-sinon';
 
 describe( 'cart-buttons', function() {
+	let recordStub, onKeepSearchingClickStub, CartButtons;
+
+	useSandbox( ( sandbox ) => {
+		recordStub = sandbox.stub();
+		onKeepSearchingClickStub = sandbox.stub();
+	} );
+
+	const AnalyticsMixinStub = () => ( {
+		recordEvent: recordStub
+	} );
+
 	useFakeDom();
 
+	useMockery( mockery => {
+		mockery.registerMock( 'lib/mixins/analytics', AnalyticsMixinStub );
+		CartButtons = require( '../cart-buttons.jsx' );
+	} );
+
 	beforeEach( function() {
-		this.CartButtons = require( '../cart-buttons.jsx' );
-		this.CartButtons.prototype.translate = sinon.stub();
-		this.recordStub = this.CartButtons.prototype.__reactAutoBindMap.recordEvent = sinon.stub();
+		CartButtons.prototype.translate = sinon.stub();
 	} );
 
 	afterEach( function() {
-		delete this.CartButtons.prototype.translate;
-		delete this.CartButtons.prototype.__reactAutoBindMap.recondEvent;
+		delete CartButtons.prototype.translate;
 	} );
 
 	describe( 'Click on Keep Searching Button', function() {
 		beforeEach( function() {
-			this.onKeepSearchingClick = sinon.stub();
-			this.cartButtonsComponent = TestUtils.renderIntoDocument(
-				<this.CartButtons
+			this.cartButtonsComponent = mount(
+				<CartButtons
 					selectedSite={ {slug: 'example.com'} }
 					showKeepSearching={ true }
-					onKeepSearchingClick={ this.onKeepSearchingClick }
+					onKeepSearchingClick={ onKeepSearchingClickStub }
 					/>
 			);
 		} );
 
 		it( 'should track "keepSearchButtonClick" event', function() {
-			TestUtils.Simulate.click( ReactDom.findDOMNode( this.cartButtonsComponent.refs.keepSearchingButton ) );
-			expect( this.recordStub ).to.have.been.calledWith( 'keepSearchButtonClick' );
+			this.cartButtonsComponent.find( '.cart-keep-searching-button' ).simulate( 'click' );
+			expect( recordStub ).to.have.been.calledWith( 'keepSearchButtonClick' );
 		} );
 
 		it( 'call props.onKeepSearchingClick', function() {
-			TestUtils.Simulate.click( ReactDom.findDOMNode( this.cartButtonsComponent.refs.keepSearchingButton ) );
-			expect( this.onKeepSearchingClick ).to.have.been.called;
+			this.cartButtonsComponent.find( '.cart-keep-searching-button' ).simulate( 'click' );
+			expect( onKeepSearchingClickStub ).to.have.been.called;
 		} );
 	} );
 	describe( 'Click on Checkout Button', function() {
 		beforeEach( function() {
-			this.cartButtonsComponent = TestUtils.renderIntoDocument(
-				<this.CartButtons
+			this.cartButtonsComponent = mount(
+				<CartButtons
 					selectedSite={ {slug: 'example.com'} }
 					/>
 			);
 		} );
 
 		it( 'should track "checkoutButtonClick" event', function() {
-			TestUtils.Simulate.click( ReactDom.findDOMNode( this.cartButtonsComponent.refs.checkoutButton ) );
-			expect( this.recordStub ).to.have.been.calledWith( 'checkoutButtonClick' );
+			this.cartButtonsComponent.find( '.cart-checkout-button' ).simulate( 'click' );
+			expect( recordStub ).to.have.been.calledWith( 'checkoutButtonClick' );
 		} );
 	} );
 } );

--- a/client/my-sites/upgrades/cart/test/cart-buttons.js
+++ b/client/my-sites/upgrades/cart/test/cart-buttons.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
+import identity from 'lodash/identity';
 
 /**
  * Internal dependencies
@@ -28,15 +29,7 @@ describe( 'cart-buttons', function() {
 
 	useMockery( mockery => {
 		mockery.registerMock( 'lib/mixins/analytics', AnalyticsMixinStub );
-		CartButtons = require( '../cart-buttons.jsx' );
-	} );
-
-	beforeEach( function() {
-		CartButtons.prototype.translate = sinon.stub();
-	} );
-
-	afterEach( function() {
-		delete CartButtons.prototype.translate;
+		CartButtons = require( '../cart-buttons.jsx' ).CartButtons;
 	} );
 
 	describe( 'Click on Keep Searching Button', function() {
@@ -46,6 +39,7 @@ describe( 'cart-buttons', function() {
 					selectedSite={ {slug: 'example.com'} }
 					showKeepSearching={ true }
 					onKeepSearchingClick={ onKeepSearchingClickStub }
+					translate={ identity }
 					/>
 			);
 		} );
@@ -65,6 +59,7 @@ describe( 'cart-buttons', function() {
 			this.cartButtonsComponent = mount(
 				<CartButtons
 					selectedSite={ {slug: 'example.com'} }
+					translate={ identity }
 					/>
 			);
 		} );


### PR DESCRIPTION
Rationale here is to fix the `CartButtons` test to no longer rely on `__reactAutoBindMap`, which is going away with React 15 (see #5116). This is the last occurrence of `__reactAutoBindMap`, but also the trickiest to get rid of.

This PR:
* Mocks `AnalyticsMixin` to stub `recordEvent`, instead of indirectly adding `recordEvent` to `CartButtons.prototype.__reactAutoBindMap`.
* Uses enzyme for `CartButtons` tests, to easily find components by class attributes instead of `ref`s.
* Drops `ref`s defined in `cart-buttons.jsx`, which were only used in the test, and, after stubbing `recordEvent`, were giving me [this error](https://fb.me/react-refs-must-have-owner).
* ES6ifies `CartButtons`.
* Wraps `CartButtons` in [`localize()`](https://github.com/Automattic/wp-calypso/tree/master/client/lib/mixins/i18n/localize) for i18n, as `CartButton` tests would otherwise interfere with others, causing them to break.

Code QA instructions:
* Verify that the `ref`s previously defined in `cart-buttons.jsx` aren't referenced anywhere anymore.
* Verify that `CartButtons` is imported correctly everywhere.
* Verify that tests pass :-)

Testing instructions:
* Verify that the `CartButtons` component still works correctly -- especially that strings are translated. To see that component, add stuff to your cart for 'yoursite' and hit 'Back' from checkout flow. Then, navigate to http://calypso.localhost:3000/domains/manage/<yoursite>, and click on the little cart icon in the upper right.

/cc @gwwar @aduth for review