### PR TITLE
Framework: Replace `click-outside` by `react-click-outside`

### DIFF
--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -3,7 +3,7 @@
  */
 var ReactDom = require( 'react-dom' ),
 	React = require( 'react' ),
-	clickOutside = require( 'click-outside' ),
+	withClickOutside = require( 'react-click-outside' ),
 	closest = require( 'component-closest' ),
 	noop = require( 'lodash/noop' ),
 	classnames = require( 'classnames' );
@@ -14,6 +14,18 @@ var ReactDom = require( 'react-dom' ),
 var closeOnEsc = require( 'lib/mixins/close-on-esc' ),
 	Card = require( 'components/card' ),
 	trapFocus = require( 'lib/mixins/trap-focus' );
+
+// Subclass <Card> component to extend with "click outside" behavior.".
+var DialogBaseCard = withClickOutside( React.createClass( {
+
+	render: function() {
+		return <Card {...this.props} />
+	},
+
+	handleClickOutside: function( event ) {
+		this.props.onClickOutside( event );
+	}
+} ) );
 
 var DialogBase = React.createClass( {
 	mixins: [ closeOnEsc( '_close' ), trapFocus ],
@@ -37,8 +49,6 @@ var DialogBase = React.createClass( {
 			if ( this.props.autoFocus ) {
 				ReactDom.findDOMNode( this.refs.content ).focus();
 			}
-
-			this._unbindClickHandler = clickOutside( ReactDom.findDOMNode( this.refs.dialog ), this._onBackgroundClick );
 		}.bind( this ), 10 );
 		document.documentElement.classList.add( 'no-scroll' );
 	},
@@ -49,10 +59,6 @@ var DialogBase = React.createClass( {
 			this._focusTimeout = false;
 		}
 
-		if ( this._unbindClickHandler ) {
-			this._unbindClickHandler();
-			this._unbindClickHandler = null;
-		}
 		document.documentElement.classList.remove( 'no-scroll' );
 	},
 
@@ -72,12 +78,12 @@ var DialogBase = React.createClass( {
 
 		return (
 			<div className={ backdropClassName } ref="backdrop">
-				<Card className={ dialogClassName } role="dialog" ref="dialog">
+				<DialogBaseCard className={ dialogClassName } role="dialog" onClickOutside={ this._onBackgroundClick }>
 					<div className={ classnames( this.props.className, contentClassName ) } ref="content" tabIndex="-1">
 						{ this.props.children }
 					</div>
 					{ this._renderButtonsBar() }
-				</Card>
+				</DialogBaseCard>
 			</div>
 		);
 	},

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -27,7 +27,7 @@ var Content = withClickOutside( React.createClass( {
 
 	handleClickOutside( event ) {
 		this.props.onClickOutside( event );
-  },
+	},
 
 	_close: function() {
 		this.props.onClose();

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import clickOutside from 'click-outside';
+import withClickOutside from 'react-click-outside';
 import defer from 'lodash/defer';
 import ReactDom from 'react-dom';
 import React from 'react';
@@ -15,7 +15,8 @@ import { Provider as ReduxProvider } from 'react-redux';
 import closeOnEsc from 'lib/mixins/close-on-esc';
 import warn from 'lib/warn';
 
-var Content = React.createClass( {
+// Create <Content> component and extend with "click outside" behavior.
+var Content = withClickOutside( React.createClass( {
 	mixins: [ closeOnEsc( '_close' ) ],
 
 	render: function() {
@@ -24,10 +25,14 @@ var Content = React.createClass( {
 		);
 	},
 
+	handleClickOutside( event ) {
+		this.props.onClickOutside( event );
+  },
+
 	_close: function() {
 		this.props.onClose();
 	}
-} );
+} ) );
 
 var Popover = React.createClass( {
 	propTypes: {
@@ -57,11 +62,6 @@ var Popover = React.createClass( {
 	},
 
 	componentWillUnmount: function() {
-		clearTimeout( this._clickOutsideTimeout );
-		if ( this._unbindClickOutside ) {
-			this._unbindClickOutside();
-			this._unbindClickOutside = null;
-		}
 		this._tip.remove();
 		ReactDom.unmountComponentAtNode( this._container );
 		this._container = null;
@@ -71,89 +71,101 @@ var Popover = React.createClass( {
 		return null;
 	},
 
-	_showOrHideTip: function( prevProps ) {
-		if ( ! this._tip ) {
-			this._tip = new Tip( '' );
-			this._tip.classname = this.props.className;
-			this._container = this._tip.inner;
+	_initTip: function() {
+		this._tip = new Tip( '' );
+		this._tip.classname = this.props.className;
+		this._container = this._tip.inner;
+	},
+
+	_renderTip: function() {
+		let content = <Content { ...omit( this.props, 'className' ) } onClickOutside={ this._onClickOutside } onClose={ this._close } />;
+
+		// Context is lost when creating a new render hierarchy, so ensure
+		// that we preserve the context that we care about
+		if ( this.context.store ) {
+			content = (
+				<ReduxProvider store={ this.context.store }>
+					{ content }
+				</ReduxProvider>
+			);
 		}
 
-		if ( this.props.isVisible && this.props.context ) {
-			let content = <Content { ...omit( this.props, 'className' ) } onClose={ this._close } />;
+		// this schedules a render, but does not actually render the content
+		ReactDom.render( content, this._container );
+	},
 
-			// Context is lost when creating a new render hierarchy, so ensure
-			// that we preserve the context that we care about
-			if ( this.context.store ) {
-				content = (
-					<ReduxProvider store={ this.context.store }>
-						{ content }
-					</ReduxProvider>
+	_showTip: function() {
+		// defer showing the content to give it a chance to render
+		defer( () => {
+			const contextNode = ReactDom.findDOMNode( this.props.context );
+			if ( contextNode.nodeType !== Node.ELEMENT_NODE || contextNode.nodeName.toLowerCase() === 'svg' ) {
+				warn(
+					'Popover is attached to a %s element (nodeType %d).  ' +
+					'This causes problems in IE11 - see 12168-gh-calypso-pre-oss.',
+					contextNode.nodeName,
+					contextNode.nodeType
 				);
 			}
 
-			// this schedules a render, but does not actually render the content
-			ReactDom.render( content, this._container );
+			this._tip.position( this.props.position, { auto: true } );
+			this._tip.show( contextNode );
 
+			if ( this.props.onShow ) {
+				this.props.onShow();
+			}
+		} );
+	},
+
+	_hideTip: function() {
+		ReactDom.unmountComponentAtNode( this._container );
+		this._tip.hide();
+	},
+
+	_showOrHideTip: function( prevProps ) {
+		if ( ! this._tip ) {
+			this._initTip();
+		}
+		if ( this.props.isVisible && this.props.context ) {
+			this._renderTip();
 			if ( ! prevProps.isVisible ) {
-				// defer showing the content to give it a chance to render
-				defer( () => {
-					const contextNode = ReactDom.findDOMNode( this.props.context );
-					if ( contextNode.nodeType !== Node.ELEMENT_NODE || contextNode.nodeName.toLowerCase() === 'svg' ) {
-						warn(
-							'Popover is attached to a %s element (nodeType %d).  ' +
-							'This causes problems in IE11 - see 12168-gh-calypso-pre-oss.',
-							contextNode.nodeName,
-							contextNode.nodeType
-						);
-					}
-
-					this._tip.position( this.props.position, { auto: true } );
-					this._tip.show( contextNode );
-
-					if ( this.props.onShow ) {
-						this.props.onShow();
-					}
-				} );
-
-				this._setupClickOutside();
+				this._showTip();
 			}
 		} else {
-			ReactDom.unmountComponentAtNode( this._container );
-			this._tip.hide();
-
-			if ( this._unbindClickOutside ) {
-				this._unbindClickOutside();
-				this._unbindClickOutside = null;
-			}
+			this._hideTip();
 		}
 	},
 
-	_setupClickOutside: function() {
-		if ( this._unbindClickOutside ) {
-			this._unbindClickOutside();
+	_onClickOutside: function( event ) {
+		let shouldClose = true;
+
+		if ( this.props.ignoreContext ) {
+			const ignoreContext = ReactDom.findDOMNode( this.props.ignoreContext );
+			shouldClose = ignoreContext && ignoreContext.contains && ! ignoreContext.contains( event.target );
 		}
 
-		// have to setup clickOutside after a short delay, otherwise it counts the current
-		// click to show the tip and the tip will never be shown
-		this._clickOutsideTimeout = setTimeout( function() {
-			this._unbindClickOutside = clickOutside( this._container, function( event ) {
-				const contextNode = ReactDom.findDOMNode( this.props.context );
-				let shouldClose = ( contextNode && contextNode.contains && ! contextNode.contains( event.target ) );
-
-				if ( this.props.ignoreContext && shouldClose ) {
-					const ignoreContext = ReactDom.findDOMNode( this.props.ignoreContext );
-					shouldClose = shouldClose && ( ignoreContext && ignoreContext.contains && ! ignoreContext.contains( event.target ) );
-				}
-
-				if ( shouldClose ) {
-					this._close( event );
-				}
-			}.bind( this ) );
-		}.bind( this ), 10 );
+		if ( shouldClose ) {
+			// Defer execution of `_close` to prevent "double event" when Popover's
+			// content is visible AND clicking outside of its content AND on its
+			// toggle/open element.
+			// Problem: With synchronous execution, react-click-outside will register
+			// a `click` event on the <Content> element before it registers on the
+			// containing <Popover> element. This bubbling click event will allow
+			// `_close` to be called moments before `_showOrHideTip` which will now
+			// see the component as closed and reopen it.
+			// Solution: By removing the call to `_close` from the call stack with
+			// `defer`, the toggle inside of `_showOrHideTip` behaves as expected
+			// and when the duplicative call is executed, it can be ignored with a
+			// simple check of `this.props.isVisible`.
+			defer( () => this._close( event ) );
+		}
 	},
 
 	_close: function( event ) {
-		this.props.onClose( event );
+		// This check prevents a duplicate call to `this.props.onClose` when the
+		// popover is closed using the toggle.
+		if ( this.props.isVisible ) {
+			this.props.onClose( event );
+		}
 	}
 } );
 

--- a/client/my-sites/upgrades/cart/cart-items.jsx
+++ b/client/my-sites/upgrades/cart/cart-items.jsx
@@ -25,8 +25,8 @@ var CartItems = React.createClass({
 		event.preventDefault();
 
 		// If we call setState here directly, it would remove the expander from DOM,
-		// and then click-outside from Popover would consider it as an outside click,
-		// and it would close the Popover cart.
+		// and then react-click-outside from Popover would consider it as an outside
+		// click, and it would close the Popover cart.
 		// event.stopPropagation() does not help.
 		setTimeout( this.setState.bind( this, { isCollapsed: false } ), 0 );
 	},

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -473,17 +473,6 @@
     "cli-width": {
       "version": "1.1.1"
     },
-    "click-outside": {
-      "version": "1.0.4",
-      "dependencies": {
-        "babel-runtime": {
-          "version": "4.7.4"
-        },
-        "core-js": {
-          "version": "0.6.1"
-        }
-      }
-    },
     "clipboard": {
       "version": "1.5.3"
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "char-spinner": "1.0.1",
     "chrono-node": "^1.0.6",
     "classnames": "1.1.1",
-    "click-outside": "1.0.4",
     "clipboard": "1.5.3",
     "commander": "2.3.0",
     "component-closest": "0.1.4",


### PR DESCRIPTION
Per #5181, replaced `click-outside` with `react-click-outside` in `Popover` and `DialogBase` components.

/cc @apeatling @aduth @nb