### PR TITLE
Editor: Add error notice when post trashing fails

### DIFF
--- a/client/post-editor/editor-delete-post/index.jsx
+++ b/client/post-editor/editor-delete-post/index.jsx
@@ -45,10 +45,10 @@ const EditorDeletePost = React.createClass( {
 
 		const handleTrashingPost = function( error ) {
 			if ( error ) {
-				return this.setState( { isTrashing: false } );
+				this.setState( { isTrashing: false } );
 			}
 
-			this.props.onTrashingPost();
+			this.props.onTrashingPost( error );
 		}.bind( this );
 
 		if ( utils.userCan( 'delete_post', this.props.post ) ) {

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -66,6 +66,9 @@ const messages = {
 		publishFailure: function() {
 			return i18n.translate( 'Publishing of post failed.' );
 		},
+		trashFailure: function() {
+			return i18n.translate( 'Trashing of post failed.' );
+		},
 		editTitle: function() {
 			return i18n.translate( 'Edit Post', { textOnly: true } );
 		},
@@ -118,6 +121,9 @@ const messages = {
 	page: {
 		publishFailure: function() {
 			return i18n.translate( 'Publishing of page failed.' );
+		},
+		trashFailure: function() {
+			return i18n.translate( 'Trashing of page failed.' );
 		},
 		editTitle: function() {
 			return i18n.translate( 'Edit Page', { textOnly: true } );
@@ -606,12 +612,22 @@ const PostEditor = React.createClass( {
 		return path;
 	},
 
-	onTrashingPost: function() {
+	onTrashingPost: function( error ) {
 		var isPage = utils.isPage( this.state.post );
-		stats.recordStat( isPage ? 'page_trashed' : 'post_trashed' );
-		stats.recordEvent( isPage ? 'Clicked Trash Page Button' : 'Clicked Trash Post Button' );
-		this.markSaved();
-		this.onClose();
+
+		if ( error ) {
+			this.setState( {
+				notice: {
+					type: 'error',
+					text: this.getMessage( 'trashFailure' )
+				}
+			} );
+		} else {
+			stats.recordStat( isPage ? 'page_trashed' : 'post_trashed' );
+			stats.recordEvent( isPage ? 'Clicked Trash Page Button' : 'Clicked Trash Post Button' );
+			this.markSaved();
+			this.onClose();
+		}
 	},
 
 	onSaveTrashed: function( status, callback ) {


### PR DESCRIPTION
This is meant to address #5082. We already [capture an error message](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/editor-delete-post/index.jsx#L46) when trashing a post fails. This PR adds a call to `this.props.onTrashingPost` passing in the error when the trashing fails. Then, if `error` exists [when we call `onTrashingPost`](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/post-editor.jsx#L609), it throws the appropriate error message for either a post or page.

**Steps to Test**
The easiest way to test this is by checking out the branch and then:
1. Start a new post or page.
2. Type some content and click the "Save" button so that the Trash icon appears in the top right-hand corner.
3. Turn off your Wi-Fi so the post trashing will fail. (That's the only way I could make it fail.)
4. Click the Trash icon. You should get an error message on this branch.

**Screenshot**
<img width="1280" alt="failure" src="https://cloud.githubusercontent.com/assets/7240478/15307414/fa385116-1b8f-11e6-8042-a993ec657a8c.png">

On a related note, there's some work going on in #5032 to refactor how we approach notices.