### PR TITLE
Jetpack SSO: Use jetpackSSOSessions for auto authorize

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -123,7 +123,7 @@ const LoggedInForm = React.createClass( {
 	componentWillMount() {
 		const { autoAuthorize, queryObject } = this.props.jetpackConnectAuthorize;
 		debug( 'Checking for auto-auth on mount', autoAuthorize );
-		if ( autoAuthorize || this.props.calypsoStartedConnection ) {
+		if ( autoAuthorize || this.props.calypsoStartedConnection || this.props.isSSO ) {
 			this.props.authorize( queryObject );
 		}
 	},
@@ -315,6 +315,16 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		return false;
 	},
 
+	isSSO() {
+		const site = this.props.jetpackConnectAuthorize.queryObject.site.replace( /.*?:\/\//g, '' );
+		if ( this.props.jetpackSSOSessions && this.props.jetpackSSOSessions[ site ] ) {
+			const currentTime = ( new Date() ).getTime();
+			return ( currentTime - this.props.jetpackSSOSessions[ site ] < JETPACK_CONNECT_TTL );
+		}
+
+		return false;
+	},
+
 	renderForm() {
 		const { userModule } = this.props;
 		let user = userModule.get();
@@ -323,8 +333,16 @@ const JetpackConnectAuthorizeForm = React.createClass( {
 		} );
 		return (
 			( user )
-				? <LoggedInForm { ...props } calypsoStartedConnection={ this.isCalypsoStartedConnection() } />
-				: <LoggedOutForm { ...props } calypsoStartedConnection={ this.isCalypsoStartedConnection() } />
+				? <LoggedInForm
+					{ ...props }
+					calypsoStartedConnection={ this.isCalypsoStartedConnection() }
+					isSSO={ this.isSSO() }
+					/>
+				: <LoggedOutForm
+					{ ...props }
+					calypsoStartedConnection={ this.isCalypsoStartedConnection() }
+					isSSO={ this.isSSO() }
+					/>
 		);
 	},
 	render() {
@@ -342,7 +360,8 @@ export default connect(
 	state => {
 		return {
 			jetpackConnectAuthorize: state.jetpackConnect.jetpackConnectAuthorize,
-			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions
+			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions,
+			jetpackSSOSessions: state.jetpackConnect.jetpackSSOSessions
 		};
 	},
 	dispatch => bindActionCreators( { authorize, createAccount, activateManage, goBackToWpAdmin }, dispatch )

--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -52,9 +52,6 @@ export function jetpackConnectSessions( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_STORE_SESSION:
 			return Object.assign( {}, state, buildNoProtocolUrlObj( action.url ) );
-		case JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS:
-			const parsedUrl = urlModule.parse( action.ssoUrl );
-			return Object.assign( {}, state, buildNoProtocolUrlObj( parsedUrl.hostname ) );
 		case SERIALIZE:
 		case DESERIALIZE:
 			return state;
@@ -150,9 +147,22 @@ export function jetpackSSO( state = {}, action ) {
 	return state;
 }
 
+export function jetpackSSOSessions( state = {}, action ) {
+	switch ( action.type ) {
+		case JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS:
+			const parsedUrl = urlModule.parse( action.ssoUrl );
+			return Object.assign( {}, state, buildNoProtocolUrlObj( parsedUrl.hostname ) );
+		case SERIALIZE:
+		case DESERIALIZE:
+			return state;
+	}
+	return state;
+}
+
 export default combineReducers( {
 	jetpackConnectSite,
 	jetpackConnectAuthorize,
 	jetpackSSO,
 	jetpackConnectSessions,
+	jetpackSSOSessions
 } );

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -18,9 +18,9 @@ import {
 	SERIALIZE,
 } from 'state/action-types';
 import reducer, {
-	jetpackConnectSessions,
 	jetpackConnectAuthorize,
-	jetpackSSO
+	jetpackSSO,
+	jetpackSSOSessions
 } from '../reducer';
 
 describe( 'reducer', () => {
@@ -29,11 +29,12 @@ describe( 'reducer', () => {
 			'jetpackConnectSite',
 			'jetpackConnectAuthorize',
 			'jetpackConnectSessions',
-			'jetpackSSO'
+			'jetpackSSO',
+			'jetpackSSOSessions'
 		] );
 	} );
 
-	describe( '#jetpackConnectSessions()', () => {
+	describe( '#jetpackSSOSessions()', () => {
 		it( 'should default to an empty object', () => {
 			const state = jetpackConnectAuthorize( undefined, {} );
 			expect( state ).to.eql( {} );
@@ -41,7 +42,7 @@ describe( 'reducer', () => {
 
 		it( 'should store an integer timestamp when creating new session', () => {
 			const nowTime = ( new Date() ).getTime();
-			const state = jetpackConnectSessions( undefined, {
+			const state = jetpackSSOSessions( undefined, {
 				type: JETPACK_CONNECT_SSO_AUTHORIZE_SUCCESS,
 				ssoUrl: 'https://website.com?action=jetpack-sso&result=success&sso_nonce={$nonce}&user_id={$user_id}'
 			} );


### PR DESCRIPTION
Previously, we were using `jetpackConnectSessions` to handle the auto-authorize functionality. The issue with this is that [that store is used to autoAuthorize as well as keep users in Calypso](https://github.com/Automattic/wp-calypso/blob/1352a61dc4f89afc35f7de94e1c618d812f68bd0/client/signup/jetpack-connect/authorize-form.jsx#L143-L151). This meant that after SSO, users weren't getting redirect back to Jetpack.

To fix this, I created a separate `jetpackSSOSessions` store to be used explicitly for our SSO needs.

To test:
- Checkout `update/jetpack-connect-sso-sessions` branch
- Run tests with: `npm run test-client -- --grep="state jetpack-connect"`
- <strike>Checkout Automattic/jetpack#3789 to your Jetpack site</strike>
- Attempt to SSO with a user that is not already connected to WP.com (Also, you'll need to be in the testers array on WPCOM. Ping me for details).
- Go to `/wp-admin` on your site
- Click "Log in with WordPress.com` button
- You should land on `/jetpack/sso` and be asked to "Log in"
- Click that button
- You should be auto-authorized and eventually land in the `wp-admin` of your site.

cc @lezama for review.

