### PR TITLE
Media: fix uploads with # or ? in filename

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -137,8 +137,6 @@ MediaActions.add = function( siteId, files ) {
 				URL: fileUrl,
 				guid: fileUrl,
 				file: fileName,
-				extension: MediaUtils.getFileExtension( fileName ),
-				mime_type: MediaUtils.getMimeType( fileName ),
 				title: path.basename( fileName ),
 				// Size is not an API media property, though can be useful for
 				// validation purposes if known

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -96,12 +96,36 @@ describe( 'MediaUtils', function() {
 			expect( MediaUtils.getFileExtension( 'example.gif' ) ).to.equal( 'gif' );
 		} );
 
+		it( 'should handle reserved url characters in filename', function() {
+			expect( MediaUtils.getFileExtension( 'example#?#?.gif' ) ).to.equal( 'gif' );
+		} );
+
+		it( 'should ignore invalid filenames', function() {
+			expect( MediaUtils.getFileExtension( 'example#?#?.gif?w=100' ) ).to.equal( '' );
+		} );
+
 		it( 'should ignore querystring parameters', function() {
 			expect( MediaUtils.getFileExtension( 'example.gif?w=100' ) ).to.equal( 'gif' );
 		} );
 
+		it( 'should detect extension from HTML5 File object type', function() {
+			expect( MediaUtils.getFileExtension( new window.File( [''], 'example.wrong', { type: 'image/gif' } ) ) ).to.equal( 'gif' );
+		} );
+
 		it( 'should detect extension from HTML5 File object', function() {
 			expect( MediaUtils.getFileExtension( new window.File( [''], 'example.gif' ) ) ).to.equal( 'gif' );
+		} );
+
+		it( 'should detect extension from HTML5 File object with reserved url chars', function() {
+			expect( MediaUtils.getFileExtension( new window.File( [''], 'example#?#?.gif' ) ) ).to.equal( 'gif' );
+		} );
+
+		it( 'should detect extension from HTML5 Blob object', function() {
+			expect( MediaUtils.getFileExtension( new window.Blob( [''], { type: 'image/gif' } ) ) ).to.equal( 'gif' );
+		} );
+
+		it( 'should detect extension from Blob wrapper', function() {
+			expect( MediaUtils.getFileExtension( { fileName: 'example#?#?.gif', fileContents: new window.Blob( [''], { type: 'image/gif' } ) } ) ).to.equal( 'gif' );
 		} );
 
 		it( 'should detect extension from object file property', function() {
@@ -146,6 +170,14 @@ describe( 'MediaUtils', function() {
 
 		it( 'should detect mime type from string extension', function() {
 			expect( MediaUtils.getMimeType( 'example.gif' ) ).to.equal( 'image/gif' );
+		} );
+
+		it( 'should detect mime type with reserved url characters in filename', function() {
+			expect( MediaUtils.getMimeType( 'example#?#?.gif' ) ).to.equal( 'image/gif' );
+		} );
+
+		it( 'should ignore invalid filenames', function() {
+			expect( MediaUtils.getMimeType( 'example#?#?.gif?w=100' ) ).to.be.undefined;
 		} );
 
 		it( 'should ignore querystring parameters', function() {


### PR DESCRIPTION
Fixes the regression introduced in #5218 Closes #4726 

## Testing Instructions
- Navigate to /post or /page
- Click Add Media button in editor
- Try to upload file with # or ? in the filename

cc @aduth @robobot3000 @rralian @BandonRandon 