### PR TITLE
Add 'data-domain' attribute to domain suggestion button

### DIFF
--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -32,7 +32,7 @@ var DomainSuggestion = React.createClass( {
 			buttonContent = abtest( 'domainsWithPlansOnly' ) === 'plansOnly' && ! this.props.price ? this.translate( 'Select' ) : this.props.buttonLabel;
 		}
 		return (
-			<button ref="button" className={ 'button domain-suggestion__select-button ' + this.props.buttonClasses } onClick={ this.props.onButtonClick } data-domain={ this.props.domain }>
+			<button ref="button" className={ 'button domain-suggestion__select-button ' + this.props.buttonClasses } onClick={ this.props.onButtonClick } data-e2e-domain={ this.props.domain }>
 				{ buttonContent }
 			</button>
 		);

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -32,7 +32,7 @@ var DomainSuggestion = React.createClass( {
 			buttonContent = abtest( 'domainsWithPlansOnly' ) === 'plansOnly' && ! this.props.price ? this.translate( 'Select' ) : this.props.buttonLabel;
 		}
 		return (
-			<button ref="button" className={ 'button ' + this.props.buttonClasses } onClick={ this.props.onButtonClick }>
+			<button ref="button" className={ 'button ' + this.props.buttonClasses } onClick={ this.props.onButtonClick } data-domain={ this.props.domain }>
 				{ buttonContent }
 			</button>
 		);

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -32,7 +32,7 @@ var DomainSuggestion = React.createClass( {
 			buttonContent = abtest( 'domainsWithPlansOnly' ) === 'plansOnly' && ! this.props.price ? this.translate( 'Select' ) : this.props.buttonLabel;
 		}
 		return (
-			<button ref="button" className={ 'button ' + this.props.buttonClasses } onClick={ this.props.onButtonClick } data-domain={ this.props.domain }>
+			<button ref="button" className={ 'button domain-suggestion__select-button ' + this.props.buttonClasses } onClick={ this.props.onButtonClick } data-domain={ this.props.domain }>
 				{ buttonContent }
 			</button>
 		);

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -2,49 +2,56 @@
  * External Dependencies
  */
 import { expect } from 'chai';
-import sinon from 'sinon';
-import ReactDom from 'react-dom';
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import { shallow } from 'enzyme';
+import noop from 'lodash/noop';
+
 /**
  * Internal Dependencies
  */
 import useFakeDom from 'test/helpers/use-fake-dom';
 import useMockery from 'test/helpers/use-mockery';
+import useI18n from 'test/helpers/use-i18n';
 
-xdescribe( 'Domain Suggestion', function() {
-	let DomainSuggestion,
-		DomainProductPrice;
+describe( 'Domain Suggestion', function() {
+
+	let DomainSuggestion;
+
 	useFakeDom();
-	useMockery( mockery => {
-		mockery.registerMock( 'components/plans/premium-popover', () => {} );
+	useMockery( ( mockery ) => {
+		mockery.registerMock( 'components/plans/premium-popover', noop );
 	} );
+	useI18n();
 
-	beforeEach( function() {
+	before( () => {
 		DomainSuggestion = require( 'components/domains/domain-suggestion' );
-		DomainProductPrice = require( 'components/domains/domain-product-price' );
-		DomainSuggestion.prototype.translate = sinon.stub();
-		DomainProductPrice.prototype.translate = sinon.stub();
 	} );
 
-	afterEach( function() {
-		delete DomainSuggestion.prototype.translate;
-		delete DomainProductPrice.prototype.translate;
+	describe( 'has attributes', () => {
+		it( 'should have data-domain attribute for integration testing', () => {
+			const domainSuggestion = shallow( <DomainSuggestion
+				domain="example.com" isAdded={ false }/> );
+			const domainSuggestionButton = domainSuggestion.find( '.domain-suggestion__select-button[data-domain]' );
+			expect( domainSuggestionButton.length ).to.equal( 1 );
+			expect( domainSuggestionButton.props()[ 'data-domain' ] ).to.equal( 'example.com' )
+		} );
 	} );
 
 	describe( 'added domain', function() {
 		it( 'should show a checkbox when in cart', function() {
-			var suggestionComponent = TestUtils.renderIntoDocument( <DomainSuggestion isAdded={ true } /> );
-
-			expect( suggestionComponent.refs.checkmark ).to.exist;
+			const domainSuggestion = shallow( <DomainSuggestion isAdded={ true } /> );
+			const domainSuggestionButton = domainSuggestion.find( '.domain-suggestion__select-button' );
+			expect( domainSuggestionButton.children().props().icon ).to.equal( 'checkmark' );
 		} );
 
 		it( 'should show the button label when not in cart', function() {
-			var buttonLabel = 'Hello',
-				suggestionComponent = TestUtils.renderIntoDocument(
+			const buttonLabel = 'Hello';
+			const domainSuggestion = shallow(
 					<DomainSuggestion isAdded={ false } buttonLabel={ buttonLabel } />
 				);
-			expect( ReactDom.findDOMNode( suggestionComponent.refs.button ).textContent ).to.equal( buttonLabel );
+			const domainSuggestionButton = domainSuggestion.find( '.domain-suggestion__select-button' );
+			expect( domainSuggestionButton.text() ).to.equal( buttonLabel );
 		} );
 	} );
+
 } );

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -27,12 +27,12 @@ describe( 'Domain Suggestion', function() {
 	} );
 
 	describe( 'has attributes', () => {
-		it( 'should have data-domain attribute for e2e testing', () => {
+		it( 'should have data-e2e-domain attribute for e2e testing', () => {
 			const domainSuggestion = shallow( <DomainSuggestion
 				domain="example.com" isAdded={ false }/> );
-			const domainSuggestionButton = domainSuggestion.find( '.domain-suggestion__select-button[data-domain]' );
+			const domainSuggestionButton = domainSuggestion.find( `.domain-suggestion__select-button` );
 			expect( domainSuggestionButton.length ).to.equal( 1 );
-			expect( domainSuggestionButton.props()[ 'data-domain' ] ).to.equal( 'example.com' );
+			expect( domainSuggestionButton.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' );
 		} );
 	} );
 

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -27,7 +27,7 @@ describe( 'Domain Suggestion', function() {
 	} );
 
 	describe( 'has attributes', () => {
-		it( 'should have data-domain attribute for integration testing', () => {
+		it( 'should have data-domain attribute for e2e testing', () => {
 			const domainSuggestion = shallow( <DomainSuggestion
 				domain="example.com" isAdded={ false }/> );
 			const domainSuggestionButton = domainSuggestion.find( '.domain-suggestion__select-button[data-domain]' );

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -14,7 +14,6 @@ import useMockery from 'test/helpers/use-mockery';
 import useI18n from 'test/helpers/use-i18n';
 
 describe( 'Domain Suggestion', function() {
-
 	let DomainSuggestion;
 
 	useFakeDom();
@@ -33,7 +32,7 @@ describe( 'Domain Suggestion', function() {
 				domain="example.com" isAdded={ false }/> );
 			const domainSuggestionButton = domainSuggestion.find( '.domain-suggestion__select-button[data-domain]' );
 			expect( domainSuggestionButton.length ).to.equal( 1 );
-			expect( domainSuggestionButton.props()[ 'data-domain' ] ).to.equal( 'example.com' )
+			expect( domainSuggestionButton.props()[ 'data-domain' ] ).to.equal( 'example.com' );
 		} );
 	} );
 
@@ -53,5 +52,4 @@ describe( 'Domain Suggestion', function() {
 			expect( domainSuggestionButton.text() ).to.equal( buttonLabel );
 		} );
 	} );
-
 } );


### PR DESCRIPTION
The upgrade to React 15 will mean all elements will no longer have data-react attributes, which we were relying on for end-to-end tests to identify elements.

This PR adds a `data-domain` attribute to domain results buttons so the e2e tests can easily locate the correct button.

It also adds a unit test to ensure this data-domain attribute is present (so that nobody inadvertently removes it).

It also fixes the two existing unit tests for this component - thanks @gwwar 