### PR TITLE
Plans: Domains: Deploy plansOnly variation

### DIFF
--- a/client/components/domains/example-domain-suggestions/index.jsx
+++ b/client/components/domains/example-domain-suggestions/index.jsx
@@ -55,7 +55,7 @@ module.exports = React.createClass( {
 		if ( cost && domainsWithPlansOnlyTestEnabled ) {
 			return (
 				<span className="example-domain-suggestions__premium-price" ref="premiumPrice">
-					{ this.translate( 'Included in Premium Plan' ) }
+					{ this.translate( 'Included in WordPress.com Premium' ) }
 					<PremiumPopover
 						context={ this.refs && this.refs.premiumPrice }
 						position="bottom left"

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -92,13 +92,14 @@ module.exports = {
 		allowAnyLocale: true
 	},
 	domainsWithPlansOnly: {
-		datestamp: '20200101', // was 20160427
+		datestamp: '20160517', // was 20160427
 		variations: {
-			original: 50,
-			plansOnly: 50
+			original: 0,
+			plansOnly: 100
 		},
 		defaultVariation: 'original',
-		allowExistingUsers: false
+		allowExistingUsers: false,
+		allowAnyLocale: true
 	},
 	planPricing: {
 		datestamp: '20160426',

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -13,6 +13,7 @@ import { cartItems } from 'lib/cart-values';
 import { isDomainMapping, isDomainRegistration, isPlan } from 'lib/products-values';
 import { abtest } from 'lib/abtest';
 import SitesList from 'lib/sites-list';
+import CartStore from 'lib/cart/store';
 const sitesList = SitesList();
 
 // We need to load the CartStore to make sure the store is registered with the
@@ -55,7 +56,8 @@ function addItems( items ) {
 	let shouldBundleWithPremium = items.some( item => isDomainRegistration( item ) || isDomainMapping( item ) ) && ! freeTrialsEnabled && domainsWithPlansOnlyTestEnabled;
 
 	if ( selectedSite ) {
-		shouldBundleWithPremium = shouldBundleWithPremium && ! isPlan( selectedSite.plan );
+		const cart = CartStore.get();
+		shouldBundleWithPremium = shouldBundleWithPremium && ! isPlan( selectedSite.plan ) && ! cartItems.hasPlan( cart );
 	}
 
 	if ( shouldBundleWithPremium ) {


### PR DESCRIPTION
This PR deploys the "Domains with plans only" variation to all new users on WordPress.com.

We're keeping it as A/B variation for now.


Everything is copied from the original PR #5000 but we should test it again.

### Screenshots
![image](https://cloud.githubusercontent.com/assets/991022/14803379/d56f077c-0b0d-11e6-9b8a-2d7efc1af14e.png)

_text changed to "Included in WordPress.com Premium"_
![screen shot 2016-04-25 at 5 54 35 pm](https://cloud.githubusercontent.com/assets/991022/14803498/de7c2600-0b0e-11e6-9529-bd00c33e5d3e.png)

### Enabling the test
`localStorage.setItem('ABTests','{"domainsWithPlansOnly_20170517":"plansOnly"}')`

### Flows to test:
- NUX flow (/start) (Registration and Mapping)
- Domain Management -> Domain Search (Registration and Mapping)

### Notes:
- You should not see any price details for a domain / mapping, only Premium plan information.
- Any time you add a domain registration / mapping to your cart, Premium plan should be automatically added.
- Any time you remove Premium Plan from your cart, domain registrations / mappings should be removed as well.
- The test should not change the behaviour when it is not active.
- The test should not change the behaviour if you already have a plan.

### Tests & Checks (mark them as you test, anyone can test)
#### NUX
- [x] Did not see any individual domain / mapping price
- [x] Premium Plan was auto added when adding a domain registration
- [x] Premium Plan was auto added when adding a domain mapping
- [x] The flow did not change when the test was disabled
- [x] Removing the Premium Plan from the cart removed the domain product
- [ ] Hovering / clicking on the price information text (Included in Premium) showed plan information
- [x] Plan information popup should show monthly pricing
- [ ] Design looks good
- [ ] Nothing seems broken

#### Domain Management -> Domain Search
- [x] Did not see any individual domain / mapping price
- [x] Premium Plan was auto added when adding a domain registration
- [x] Premium Plan was auto added when adding a domain mapping
- [x] The flow did not change when the test is disabled
- [x] Removing the Premium Plan from the cart removed the domain product
- [ ] Hovering / clicking on the price information text (Included in Premium) showed plan information
- [x] In a site with a paid plan, adding a domain did not Premium plan to cart.
- [x] In a site with a paid plan, with the domain credit unused, the domain price was displayed correctly.
- [x] In a site with a paid plan, with the domain credit *used*, the domain price was displayed correctly.
- [ ] Design looks good
- [ ] Nothing seems broken


/cc: @breezyskies @p3ob7o @klimeryk @wensco @lucasartoni @aidvu @meremagee 

