### PR TITLE
Domain Management: DNS: Allow root A records to be updated (part 2)

### DIFF
--- a/client/lib/domains/dns/index.js
+++ b/client/lib/domains/dns/index.js
@@ -1,9 +1,15 @@
 /**
  * External dependencies
  */
-const includes = require( 'lodash/includes' ),
-	mapValues = require( 'lodash/mapValues' ),
-	endsWith = require( 'lodash/endsWith' );
+import endsWith from 'lodash/endsWith';
+import filter from 'lodash/filter';
+import find from 'lodash/find';
+import includes from 'lodash/includes';
+import mapValues from 'lodash/mapValues';
+import startsWith from 'lodash/startsWith';
+import without from 'lodash/without';
+import matches from 'lodash/matches';
+import negate from 'lodash/negate';
 
 function validateAllFields( fieldValues, domainName ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {
@@ -89,7 +95,7 @@ function getNormalizedName( name, type, selectedDomainName ) {
 	const endsWithDomain = endsWith( name, '.' + selectedDomainName );
 
 	if ( isRootDomain( name, selectedDomainName ) && canBeRootDomain( type ) ) {
-		return '';
+		return selectedDomainName + '.';
 	}
 
 	if ( endsWithDomain ) {
@@ -118,7 +124,7 @@ function isRootDomain( name, domainName ) {
 }
 
 function canBeRootDomain( type ) {
-	return includes( [ 'MX', 'SRV', 'TXT' ], type );
+	return includes( [ 'A', 'MX', 'SRV', 'TXT' ], type );
 }
 
 function getFieldWithDot( field ) {
@@ -126,7 +132,50 @@ function getFieldWithDot( field ) {
 	return ( typeof field === 'string' && field.match( /^([a-z0-9-_]+\.)+\.?[a-z]+$/i ) ) ? field + '.' : field;
 }
 
-module.exports = {
-	validateAllFields,
-	getNormalizedData
+function isWpcomRecord( record ) {
+	return startsWith( record.id, 'wpcom:' );
+}
+
+function isRootARecord( domain ) {
+	return matches( {
+		type: 'A',
+		name: `${domain}.`
+	} );
+}
+
+function removeDuplicateWpcomRecords( domain, records ) {
+	const rootARecords = filter( records, isRootARecord( domain ) ),
+		wpcomARecord = find( rootARecords, isWpcomRecord ),
+		customARecord = find( rootARecords, negate( isWpcomRecord ) );
+
+	if ( wpcomARecord && customARecord ) {
+		return without( records, wpcomARecord );
+	}
+
+	return records;
+}
+
+function addMissingWpcomRecords( domain, records ) {
+	const rootARecords = filter( records, isRootARecord( domain ) );
+
+	if ( rootARecords.length === 0 ) {
+		const defaultRootARecord = {
+			domain,
+			id: `wpcom:A:${domain}.:${domain}`,
+			name: `${domain}.`,
+			protected_field: true,
+			type: 'A'
+		};
+
+		return records.concat( [ defaultRootARecord ] );
+	}
+
+	return records;
+}
+
+export {
+	addMissingWpcomRecords,
+	getNormalizedData,
+	removeDuplicateWpcomRecords,
+	validateAllFields
 };

--- a/client/lib/domains/dns/test/data/index.js
+++ b/client/lib/domains/dns/test/data/index.js
@@ -1,9 +1,9 @@
 export const DOMAIN_NAME = 'dummy.com';
 
 export const RECORD_A = {
-	data: '12.34.56.78',
+	data: '',
 	id: '23466069',
-	name: 'test',
+	name: 'dummy.com.',
 	type: 'A'
 };
 

--- a/client/lib/domains/dns/test/reducer.js
+++ b/client/lib/domains/dns/test/reducer.js
@@ -35,7 +35,7 @@ describe( 'reducer', () => {
 	it( 'should return state without record passed in the delete action', () => {
 		const state = deepFreeze( {
 				[ DOMAIN_NAME ]: {
-					records: [ RECORD_TXT ]
+					records: [ RECORD_A, RECORD_TXT ]
 				}
 			} ),
 			payload = {
@@ -48,14 +48,14 @@ describe( 'reducer', () => {
 
 		const result = reducer( state, payload );
 
-		expect( result ).to.be.eql( { [ DOMAIN_NAME ]: { records: [] } } );
+		expect( result ).to.be.eql( { [ DOMAIN_NAME ]: { records: [ RECORD_A ] } } );
 	} );
 
 	it( 'should return state without record (having no id) passed in the delete action', () => {
 		const RECORD_TXT_WITHOUT_ID = pick( RECORD_TXT, [ 'data', 'name', 'type' ] ),
 			state = deepFreeze( {
 				[ DOMAIN_NAME ]: {
-					records: [ RECORD_TXT_WITHOUT_ID ]
+					records: [ RECORD_A, RECORD_TXT_WITHOUT_ID ]
 				}
 			} ),
 			payload = {
@@ -68,6 +68,6 @@ describe( 'reducer', () => {
 
 		const result = reducer( state, payload );
 
-		expect( result ).to.be.eql( { [ DOMAIN_NAME ]: { records: [] } } );
+		expect( result ).to.be.eql( { [ DOMAIN_NAME ]: { records: [ RECORD_A ] } } );
 	} );
 } );

--- a/client/lib/upgrades/actions/domain-management.js
+++ b/client/lib/upgrades/actions/domain-management.js
@@ -244,7 +244,9 @@ function addDns( domainName, record, onComplete ) {
 		record
 	} );
 
-	wpcom.addDns( domainName, record, ( error ) => {
+	const dns = DnsStore.getByDomainName( domainName );
+
+	wpcom.updateDns( domainName, dns.records, ( error ) => {
 		const type = ! error ? ActionTypes.DNS_ADD_COMPLETED : ActionTypes.DNS_ADD_FAILED;
 		Dispatcher.handleServerAction( {
 			type,
@@ -260,10 +262,12 @@ function deleteDns( domainName, record, onComplete ) {
 	Dispatcher.handleServerAction( {
 		type: ActionTypes.DNS_DELETE,
 		domainName,
-		record,
+		record
 	} );
 
-	wpcom.deleteDns( domainName, record, ( error ) => {
+	const dns = DnsStore.getByDomainName( domainName );
+
+	wpcom.updateDns( domainName, dns.records, ( error ) => {
 		const type = ! error ? ActionTypes.DNS_DELETE_COMPLETED : ActionTypes.DNS_DELETE_FAILED;
 
 		Dispatcher.handleServerAction( {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -8,7 +8,8 @@ var debug = require( 'debug' )( 'calypso:wpcom-undocumented:undocumented' ),
 	camelCase = require( 'lodash/camelCase' ),
 	snakeCase = require( 'lodash/snakeCase' ),
 	pick = require( 'lodash/pick' ),
-	url = require( 'url' );
+	url = require( 'url' ),
+	reject = require( 'lodash/reject' );
 
 /**
  * Internal dependencies.
@@ -1523,12 +1524,11 @@ Undocumented.prototype.fetchDns = function( domainName, fn ) {
 	this.wpcom.req.get( '/domains/' + domainName + '/dns', fn );
 };
 
-Undocumented.prototype.addDns = function( domain, record, fn ) {
-	this.wpcom.req.post( '/domains/' + domain + '/dns/add', {}, record, fn );
-};
+Undocumented.prototype.updateDns = function( domain, records, fn ) {
+	var filtered = reject( records, 'isBeingDeleted' ),
+		body = { dns: JSON.stringify( filtered ) };
 
-Undocumented.prototype.deleteDns = function( domain, record, fn ) {
-	this.wpcom.req.post( '/domains/' + domain + '/dns/delete', {}, record, fn );
+	this.wpcom.req.post( '/domains/' + domain + '/dns', body, fn );
 };
 
 Undocumented.prototype.fetchWapiDomainInfo = function( domainName, fn ) {

--- a/client/my-sites/upgrades/domain-management/dns/a-record.jsx
+++ b/client/my-sites/upgrades/domain-management/dns/a-record.jsx
@@ -45,7 +45,7 @@ const ARecord = React.createClass( {
 					<FormLabel>{ this.translate( 'Name', { context: 'Dns Record' } ) }</FormLabel>
 					<FormTextInputWithAffixes
 						name="name"
-						placeholder={ this.translate( 'Enter subdomain (required)', { context: 'Placeholder shown when entering the required subdomain part of a new DNS record' } ) }
+						placeholder={ this.translate( 'Enter subdomain (optional)', { context: 'Placeholder shown when entering the required subdomain part of a new DNS record' } ) }
 						isError={ ! isNameValid }
 						onChange={ onChange }
 						value={ fieldValues.name }


### PR DESCRIPTION
**StoreP2 Post: p2MSmN-4VC-p2**

This is a follow-up to an earlier PR, #3711, that had to be reverted due to a bug with the server-side changes that were included.

This is the same code as the previous PR with an additional commit that replaces the use of the `POST /domains/%s/dns/add` and `POST /domains/%s/dns/delete` endpoints with the single `POST /domains/%s/dns` endpoint.

Using this endpoint over the other ones has some nice advantages:

- It means this PR no longer needs any server-side changes to work.
- We can keep the logic for adding and removing the root WPCOM records on the client without duplicating it on the server (it always has to *at least* be on the client for optimistic updates).
- It's easy to know exactly what records are being set by looking at the request.

This seems like a good way to solve the problem while also allowing for more flexibility in the future.

![dns](https://cloud.githubusercontent.com/assets/11401/13443525/3b67b9d0-dfb6-11e5-8725-a1aea2f5218e.gif)