### PR TITLE
Reader: make the default `sizingFunction` percentage-aware

### DIFF
--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -706,7 +706,7 @@ normalizePost.content = {
 		// hosts that we trust that don't work in a sandboxed iframe
 		const iframeNoSandbox = [
 			'spotify.com'
-		]
+		];
 
 		embeds = filter( embeds, function( iframe ) {
 			const iframeSrc = iframe.src && url.parse( iframe.src ).hostname.toLowerCase();
@@ -718,7 +718,7 @@ normalizePost.content = {
 		post.content_embeds = map( embeds, function( iframe ) {
 			var node = iframe,
 				embedType = null,
-				aspectRatio = 0,
+				aspectRatio,
 				width, height,
 				matches;
 
@@ -737,7 +737,15 @@ normalizePost.content = {
 			if ( iframe.width && iframe.height ) {
 				width = Number( iframe.width );
 				height = Number( iframe.height );
-				aspectRatio = Number( iframe.width ) / Number( iframe.height );
+				if ( ! isNaN( width ) && ! isNaN( height ) ) {
+					aspectRatio = width / height;
+				}
+				if ( isNaN( width ) ) {
+					width = iframe.width;
+				}
+				if ( isNaN( height ) ) {
+					height = iframe.height;
+				}
 			}
 
 			const embedUrl = iframe.getAttribute( 'data-wpcom-embed-url' );
@@ -777,7 +785,7 @@ normalizePost.content = {
 				post.content_embeds.push( {
 					type: 'special-' + type,
 					content: node.outerHTML
-				} )
+				} );
 			} );
 		} );
 

--- a/client/reader/embed-helper.jsx
+++ b/client/reader/embed-helper.jsx
@@ -1,11 +1,25 @@
-
 var embedsConfig = {
-	default: {
+	'default': {
 		sizingFunction: function defaultEmbedSizingFunction( embed, availableWidth ) {
-			var aspectRatio = embed.aspectRatio || 1;
+			let { aspectRatio, width, height } = embed;
+
+			if ( ! isNaN( aspectRatio ) ) {
+				// width and height were numbers, so grab the aspect ratio
+				// and scale to the `availableWidth`
+				width = availableWidth;
+				height = availableWidth / aspectRatio;
+			}
+			if ( isPercentage( width ) ) {
+				// if `width` is a percentage, then scale based on `availableWidth`
+				width = availableWidth * ( parseInt( width, 10 ) / 100 );
+			}
+			if ( isPercentage( height ) ) {
+				// if `height` is a percentage, then scale based on the calculated `width`
+				height = width * ( parseInt( height, 10 ) / 100 );
+			}
 			return {
-				width: availableWidth + 'px',
-				height: Math.floor( availableWidth / aspectRatio ) + 'px'
+				width: `${ width | 0 }px`,
+				height: `${ height | 0 }px`
 			};
 		}
 	},
@@ -44,15 +58,6 @@ var embedsConfig = {
 		},
 		urlRegex: /\/\/w\.soundcloud\.com\/player/
 	},
-	bandcamp: {
-		sizingFunction( embed, availableWidth ) {
-			return {
-				width: availableWidth + 'px',
-				height: embed.height + 'px'
-			};
-		},
-		urlRegex: /\/\/bandcamp\.com\/EmbeddedPlayer/
-	}
 };
 
 function extractUrlFromIframe( iframeHtml ) {
@@ -85,6 +90,10 @@ function resolveEmbedConfig( embed ) {
 	}
 
 	return embedsConfig.default;
+}
+
+function isPercentage( val ) {
+	return 'string' === typeof val && '%' === val[ val.length - 1 ];
 }
 
 module.exports = {

--- a/client/reader/embed-helper.jsx
+++ b/client/reader/embed-helper.jsx
@@ -1,3 +1,8 @@
+import percentageFactory from 'percentage-regex';
+
+const percentageRegex = percentageFactory({ exact: true });
+const isPercentage = (val) => percentageRegex.test(val);
+
 var embedsConfig = {
 	'default': {
 		sizingFunction: function defaultEmbedSizingFunction( embed, availableWidth ) {
@@ -90,10 +95,6 @@ function resolveEmbedConfig( embed ) {
 	}
 
 	return embedsConfig.default;
-}
-
-function isPercentage( val ) {
-	return 'string' === typeof val && '%' === val[ val.length - 1 ];
 }
 
 module.exports = {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2433,6 +2433,9 @@
     "pbkdf2-compat": {
       "version": "2.0.1"
     },
+    "percentage-regex": {
+      "version": "3.0.0"
+    },
     "performance-now": {
       "version": "0.1.4"
     },

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "node-sass": "3.4.2",
     "page": "1.6.4",
     "path-parser": "1.0.2",
+    "percentage-regex": "3.0.0",
     "phone": "git+https://github.com/Automattic/node-phone.git#1.0.4-11",
     "photon": "2.0.0",
     "postcss-cli": "2.5.1",


### PR DESCRIPTION
So now, an IFRAME with `width="100%" height="120"` have the sizes correctly computed without having to write another custom sizing function for it.

The custom `bandcamp` formatter from #5399 has been removed as it is no longer needed at this point.