### PR TITLE
Framework: Deprecate use of component-file-picker

### DIFF
--- a/client/components/file-picker/index.jsx
+++ b/client/components/file-picker/index.jsx
@@ -6,24 +6,63 @@
 import React from 'react';
 import assign from 'lodash/assign';
 import noop from 'lodash/noop';
-import pick from 'component-file-picker';
 
 export default class FilePicker extends React.Component {
-	constructor( props ) {
-		super( props );
-		this.showPicker = this.showPicker.bind( this );
+
+	getFileAttributes() {
+		return {
+			multiple: this.props.multiple,
+			webkitDirectory: this.props.directory,
+			mozDirectory: this.props.directory,
+			msDirectory: this.props.directory,
+			oDirectory: this.props.directory,
+			directory: this.props.directory,
+			accept: this.props.accept
+		};
 	}
 
-	showPicker() {
-		pick( assign( {}, this.props ), this.props.onPick );
+	// This method is only required until React adds directory to their whitelist.
+	// @see https://github.com/facebook/react/issues/3468
+	// Once it is added, `setFileDirectoryAttribute`, `componentDidMount` and
+	// `componentDidUpdate` methods can be removed.
+	// Note: they are already included in the `getFileAttributes` method.
+	setFileDirectoryAttribute() {
+		if ( this.props.directory ) {
+			// Note: the trailing space is important. It includes the unprefixed
+			// `directory` attribute.
+			'webkit moz ms o '.split( ' ' ).forEach( prefix => {
+				this.refs.fileInput.setAttribute( `${prefix}directory`, '' );
+			} );
+		}
+	}
+
+	componentDidMount() {
+		this.setFileDirectoryAttribute();
+	}
+
+	componentDidUpdate() {
+		this.setFileDirectoryAttribute();
 	}
 
 	render() {
+		const formStyle = {
+			top: '-1000px',
+			position: 'absolute'
+		};
 		return (
-			<span className="file-picker" onClick={ this.showPicker } >
-				{ this.props.children }
+			<span className="file-picker">
+				<span onClick={ () => this.refs.fileInput.click() } >
+					{ this.props.children }
+				</span>
+				<form style={ formStyle } >
+					<input type="file" { ...this.getFileAttributes() } aria-hidden="true" ref="fileInput" onChange={ this.onChange.bind( this ) }  />
+				</form>
 			</span>
 		);
+	}
+
+	onChange( event ) {
+		this.props.onPick( this.refs.fileInput.files );
 	}
 }
 
@@ -33,7 +72,7 @@ FilePicker.propTypes = {
 	multiple: React.PropTypes.bool,
 	directory: React.PropTypes.bool,
 	accept: React.PropTypes.string,
-	onPick: React.PropTypes.func
+	onPick: React.PropTypes.func.isRequired
 };
 
 FilePicker.defaultProps = {

--- a/client/components/file-picker/index.jsx
+++ b/client/components/file-picker/index.jsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import React from 'react';
-import assign from 'lodash/assign';
 import noop from 'lodash/noop';
 
 export default class FilePicker extends React.Component {

--- a/client/components/file-picker/index.jsx
+++ b/client/components/file-picker/index.jsx
@@ -28,11 +28,11 @@ export default class FilePicker extends React.Component {
 	setFileDirectoryAttribute() {
 		if ( this.props.directory ) {
 			const fileInput = this.refs.fileInput;
-			fileInput.setAttribute( `webkitdirectory`, '' );
-			fileInput.setAttribute( `mozdirectory`, '' );
-			fileInput.setAttribute( `msdirectory`, '' );
-			fileInput.setAttribute( `odirectory`, '' );
-			fileInput.setAttribute( `directory`, '' );
+			fileInput.setAttribute( 'webkitdirectory', '' );
+			fileInput.setAttribute( 'mozdirectory', '' );
+			fileInput.setAttribute( 'msdirectory', '' );
+			fileInput.setAttribute( 'odirectory', '' );
+			fileInput.setAttribute( 'directory', '' );
 		}
 	}
 

--- a/client/components/file-picker/index.jsx
+++ b/client/components/file-picker/index.jsx
@@ -27,11 +27,12 @@ export default class FilePicker extends React.Component {
 	// Note: they are already included in the `getFileAttributes` method.
 	setFileDirectoryAttribute() {
 		if ( this.props.directory ) {
-			// Note: the trailing space is important. It includes the unprefixed
-			// `directory` attribute.
-			'webkit moz ms o '.split( ' ' ).forEach( prefix => {
-				this.refs.fileInput.setAttribute( `${prefix}directory`, '' );
-			} );
+			const fileInput = this.refs.fileInput;
+			fileInput.setAttribute( `webkitdirectory`, '' );
+			fileInput.setAttribute( `mozdirectory`, '' );
+			fileInput.setAttribute( `msdirectory`, '' );
+			fileInput.setAttribute( `odirectory`, '' );
+			fileInput.setAttribute( `directory`, '' );
 		}
 	}
 

--- a/client/components/file-picker/index.jsx
+++ b/client/components/file-picker/index.jsx
@@ -46,6 +46,12 @@ export default class FilePicker extends React.Component {
 
 	render() {
 		const formStyle = {
+			position: 'relative',
+			width: '0px',
+			height: '0px',
+			overflow: 'hidden'
+		};
+		const inputStyle = {
 			top: '-1000px',
 			position: 'absolute'
 		};
@@ -55,7 +61,7 @@ export default class FilePicker extends React.Component {
 					{ this.props.children }
 				</span>
 				<form style={ formStyle } >
-					<input type="file" { ...this.getFileAttributes() } aria-hidden="true" ref="fileInput" onChange={ this.onChange.bind( this ) }  />
+					<input type="file" { ...this.getFileAttributes() } style={ inputStyle } aria-hidden="true" ref="fileInput" onChange={ this.onChange.bind( this ) }  />
 				</form>
 			</span>
 		);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -552,9 +552,6 @@
     "component-events": {
       "version": "1.0.10"
     },
-    "component-file-picker": {
-      "version": "0.2.1"
-    },
     "component-indexof": {
       "version": "0.0.3"
     },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "commander": "2.3.0",
     "component-classes": "1.2.6",
     "component-closest": "0.1.4",
-    "component-file-picker": "0.2.1",
     "component-tip": "3.0.3",
     "component-uid": "0.0.2",
     "cookie": "0.1.2",


### PR DESCRIPTION
Per #5418, incorporate functionality of third-party `component-file-picker` into A8c `file-picker`.

I removed the unused ability to pass `accept` configuration as `String` or `Array` and the unused additional arguments `event` and `input` passed to the `this.props.onPick` callback from the third-party module. This is safer and saner.

The `getFileAttributes` method sets up an attribute configuration object to be splatted onto the `<input type="file">` element. Since React whitelists safe attributes and the `directory` attribute and its prefixed variants are not yet allowed, a fallback method `setFileDirectoryAttribute` is called on `componentDidMount` and `componentDidUpdate` to manually set these attributes on the element. Once the white list is updated to include the `directory` attribute, `setFileDirectoryAttribute`, `componentDidMount` and `componentDidUpdate` can safely be removed. No changes will be necessary to `getFileAttributes`.

/cc @TooTallNate @nb