### PR TITLE
Media: Restore validity of media with varied mime types

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -111,8 +111,6 @@ MediaActions.add = function( siteId, files ) {
 		const transientMedia = {
 			ID: id,
 			'transient': true,
-			extension: MediaUtils.getFileExtension( file ),
-			mime_type: MediaUtils.getMimeType( file ),
 			// Assign a date such that the first item will be the oldest at the
 			// time of upload, as this is expected order when uploads finish
 			date: new Date( baseTime - ( files.length - i ) ).toISOString()
@@ -122,11 +120,13 @@ MediaActions.add = function( siteId, files ) {
 			// Generate from string
 			assign( transientMedia, {
 				file: file,
-				title: path.basename( file )
+				title: path.basename( file ),
+				extension: MediaUtils.getFileExtension( file ),
+				mime_type: MediaUtils.getMimeType( file )
 			} );
 		} else {
-			//handle the case where a an object has been passed that wraps a
-			//Blob and contains a fileName
+			// Handle the case where a an object has been passed that wraps a
+			// Blob and contains a fileName
 			const fileContents = file.fileContents || file;
 			const fileName = file.fileName || file.name;
 
@@ -138,6 +138,8 @@ MediaActions.add = function( siteId, files ) {
 				guid: fileUrl,
 				file: fileName,
 				title: path.basename( fileName ),
+				extension: MediaUtils.getFileExtension( fileContents ),
+				mime_type: MediaUtils.getMimeType( fileContents ),
 				// Size is not an API media property, though can be useful for
 				// validation purposes if known
 				size: fileContents.size

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -100,18 +100,6 @@ describe( 'MediaUtils', function() {
 			expect( MediaUtils.getFileExtension( 'example#?#?.gif' ) ).to.equal( 'gif' );
 		} );
 
-		it( 'should ignore invalid filenames', function() {
-			expect( MediaUtils.getFileExtension( 'example#?#?.gif?w=100' ) ).to.equal( '' );
-		} );
-
-		it( 'should ignore querystring parameters', function() {
-			expect( MediaUtils.getFileExtension( 'example.gif?w=100' ) ).to.equal( 'gif' );
-		} );
-
-		it( 'should detect extension from HTML5 File object type', function() {
-			expect( MediaUtils.getFileExtension( new window.File( [''], 'example.wrong', { type: 'image/gif' } ) ) ).to.equal( 'gif' );
-		} );
-
 		it( 'should detect extension from HTML5 File object', function() {
 			expect( MediaUtils.getFileExtension( new window.File( [''], 'example.gif' ) ) ).to.equal( 'gif' );
 		} );
@@ -170,10 +158,6 @@ describe( 'MediaUtils', function() {
 
 		it( 'should ignore invalid filenames', function() {
 			expect( MediaUtils.getMimeType( 'example#?#?.gif?w=100' ) ).to.be.undefined;
-		} );
-
-		it( 'should ignore querystring parameters', function() {
-			expect( MediaUtils.getMimeType( 'example.gif?w=100' ) ).to.equal( 'image/gif' );
 		} );
 
 		it( 'should detect mime type from HTML5 File object', function() {

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -123,6 +123,10 @@ describe( 'MediaUtils', function() {
 		it( 'should detect extension from object guid property', function() {
 			expect( MediaUtils.getFileExtension( { guid: 'example.gif' } ) ).to.equal( 'gif' );
 		} );
+
+		it( 'should detect extension from URL string with query parameters', function() {
+			expect( MediaUtils.getFileExtension( 'https://example.com/example.gif?w=110' ) ).to.equal( 'gif' );
+		} );
 	} );
 
 	describe( '#getMimePrefix()', function() {
@@ -174,6 +178,10 @@ describe( 'MediaUtils', function() {
 
 		it( 'should ignore query string parameters', function() {
 			expect( MediaUtils.getMimeType( { URL: 'example.gif?w=110' } ) ).to.equal( 'image/gif' );
+		} );
+
+		it( 'should ignore query string parameters in URL strings', function() {
+			expect( MediaUtils.getMimeType( 'https://example.com/example.gif?w=110' ) ).to.equal( 'image/gif' );
 		} );
 
 		it( 'should detect mime type from object guid property', function() {

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -120,14 +120,6 @@ describe( 'MediaUtils', function() {
 			expect( MediaUtils.getFileExtension( new window.File( [''], 'example#?#?.gif' ) ) ).to.equal( 'gif' );
 		} );
 
-		it( 'should detect extension from HTML5 Blob object', function() {
-			expect( MediaUtils.getFileExtension( new window.Blob( [''], { type: 'image/gif' } ) ) ).to.equal( 'gif' );
-		} );
-
-		it( 'should detect extension from Blob wrapper', function() {
-			expect( MediaUtils.getFileExtension( { fileName: 'example#?#?.gif', fileContents: new window.Blob( [''], { type: 'image/gif' } ) } ) ).to.equal( 'gif' );
-		} );
-
 		it( 'should detect extension from object file property', function() {
 			expect( MediaUtils.getFileExtension( { file: 'example.gif' } ) ).to.equal( 'gif' );
 		} );

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -7,6 +7,7 @@ import photon from 'photon';
 import includes from 'lodash/includes';
 import omitBy from 'lodash/omitBy';
 import findKey from 'lodash/findKey';
+import { isUri } from 'valid-url';
 
 /**
  * Internal dependencies
@@ -26,7 +27,6 @@ import Shortcode from 'lib/shortcode';
  * Module variables
  */
 const REGEXP_VIDEOPRESS_GUID = /^[a-z\d]+$/i;
-const REGEXP_EXTENSION = /\.([a-z]+)$/i;
 
 const MediaUtils = {
 	/**
@@ -91,21 +91,18 @@ const MediaUtils = {
 			return;
 		}
 
-		const isUrl = 'string' === typeof media;
+		const isString = 'string' === typeof media;
 		const isFileObject = 'File' in window && media instanceof window.File;
 
-		if ( isUrl ) {
-			// Check if we have a plain filename
-			const match = REGEXP_EXTENSION.exec( media );
-			if ( match && match.length >= 2 ) {
-				extension = match[ 1 ];
+		if ( isString ) {
+			let filePath;
+			if ( isUri( media ) ) {
+				filePath = url.parse( media ).pathname;
 			} else {
-				const filePath = url.parse( media ).pathname;
-				extension = path.extname( filePath ).slice( 1 );
+				filePath = media;
 			}
-			} else {
-				extension = this.getFileExtension( media.fileName || fileContents.name );
-			}
+
+			extension = path.extname( filePath ).slice( 1 );
 		} else if ( isFileObject ) {
 			extension = path.extname( media.name ).slice( 1 );
 		} else if ( media.extension ) {

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -93,8 +93,6 @@ const MediaUtils = {
 
 		const isUrl = 'string' === typeof media;
 		const isFileObject = 'File' in window && media instanceof window.File;
-		const isBlobObject = 'Blob' in window && media instanceof window.Blob;
-		const isBlobWrapper = media.fileName && media.fileContents;
 
 		if ( isUrl ) {
 			// Check if we have a plain filename
@@ -105,13 +103,11 @@ const MediaUtils = {
 				const filePath = url.parse( media ).pathname;
 				extension = path.extname( filePath ).slice( 1 );
 			}
-		} else if ( isFileObject || isBlobObject || isBlobWrapper ) {
-			const fileContents = media.fileContents || media;
-			if ( fileContents.type ) {
-				extension = this.getFileExtensionFromMimeType( fileContents.type );
 			} else {
 				extension = this.getFileExtension( media.fileName || fileContents.name );
 			}
+		} else if ( isFileObject ) {
+			extension = path.extname( media.name ).slice( 1 );
 		} else if ( media.extension ) {
 			extension = media.extension;
 		} else {


### PR DESCRIPTION
Fixes #5435

This pull request seeks to resolve the issue described in #5435, where it is not currently possible to upload mp3 or m4v files (and presumably others).

__Implementation notes:__

- Removes handling of blob wrappers from `MediaUtils`, instead imposes that the file object passed is already a reference the original file.
- Changes behavior of URL string handling to check for validity of URL using `valid-url` dependency before parsing as URL. Non-URLs are parsed as file paths.

__Testing instructions:__

Ensure Mocha tests pass:

```
npm run test-client
```

Verify that file uploads continue to succeed for (a) media not historically with any uploading issues, (b) media with special characters in their names, and (c) media with varied mime types.

__Open questions:__

- Should we improve `getFileExtensionFromMimeType` to account for these cases? Currently, it's not very reliable. Additionally, perhaps we should return a value more indicative of a failing case, like `null` or `undefined`, rather than an empty string.
- Is there a case where we'd expect the name to be defined on a blob wrapper at `file.fileName`, but not available from the original raw object `file.fileContents` ?

/cc @gwwar @robobot3000 