### PR TITLE
i18n: Update RTLCSS to 2.0.5

### DIFF
--- a/.rtlcssrc
+++ b/.rtlcssrc
@@ -1,10 +1,6 @@
 {
-    "options": {
-        "preserveComments": true,
-        "preserveDirectives": false,
-        "swapLeftRightInUrl": true,
-        "swapLtrRtlInUrl": true,
-        "swapWestEastInUrl": false,
-        "autoRename": false
-    }
+	"options": {
+		"processUrls": { "atrule": true, "decl": false }
+	}
 }
+

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -81,6 +81,7 @@
 	text-align: right;
 }
 
+/*rtl:begin:ignore*/
 .post-trends__scroll-left {
 	left: 0px;
 }
@@ -88,6 +89,7 @@
 .post-trends__scroll-right {
 	right: 0px;
 }
+/*rtl:end:ignore*/
 
 .post-trends__month {
 	font-size: 0;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3183,16 +3183,16 @@
       "version": "1.0.0"
     },
     "rtlcss": {
-      "version": "1.6.1",
+      "version": "2.0.5",
       "dependencies": {
         "minimist": {
           "version": "0.0.8"
         },
         "mkdirp": {
-          "version": "0.5.0"
+          "version": "0.5.1"
         },
         "postcss": {
-          "version": "4.1.16"
+          "version": "5.0.21"
         },
         "source-map": {
           "version": "0.4.4"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "react-tap-event-plugin": "0.2.1",
     "redux": "3.0.4",
     "redux-thunk": "1.0.0",
-    "rtlcss": "1.6.1",
+    "rtlcss": "2.0.5",
     "sanitize-html": "1.11.1",
     "semver": "5.1.0",
     "source-map": "0.1.39",


### PR DESCRIPTION
The most significant change is the support for `calc`, but settings have also been changed/renamed.