### PR TITLE
State: Jetpack Connect query params

### DIFF
--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -105,7 +105,7 @@ export function jetpackConnectAuthorize( state = {}, action ) {
 			return Object.assign( {}, state, { isActivating: false, manageActivated: true, manageActivatedError: error, activateManageSecret: false } );
 		case JETPACK_CONNECT_QUERY_SET:
 			const queryObject = Object.assign( {}, action.queryObject );
-			return Object.assign( {}, defaultAuthorizeState, state, { queryObject: queryObject } );
+			return Object.assign( {}, defaultAuthorizeState, { queryObject: queryObject } );
 		case JETPACK_CONNECT_QUERY_UPDATE:
 			return Object.assign( {}, state, { queryObject: Object.assign( {}, state.queryObject, { [ action.property ]: action.value } ) } );
 		case JETPACK_CONNECT_CREATE_ACCOUNT:


### PR DESCRIPTION
When we receive a new set of query params, we should reset every thing else in the jetpackConnectAuthorize state. This is somewhat of an edge case, as it only happens in connections initiated from wp-admin. But the issue does illustrate that we need to be more diligent with state management.

To recreate the issue:
- go to wp-admin of an un-connected Jetpack site running the latest master
- connect with a user with an a8c email address to enter the flow on wordpress.com/jetpack/connect/authorize
- finish the connect, and you should get back to the site.
- disconnect, and reconnect
- you should land in wordpress.com/jetpack/connect/authorize, and the screen should be stuck in waiting state FOREVER
- clear your indexDB redux state
- go back to wp-admin, and try to reconnect
- the connection should complete, but you should get redirected to 0.0.0.1!

- PHEW

To fix:
- Run this patch at calypso.localhost:3000
- On your jetpack site replace this block of code in class.jetpack.php:
```
if ( isset( $_GET['calypso_env'] ) ) {
			$url = add_query_arg( 'calypso_env', sanitize_key( $_GET['calypso_env'] ), $url );
		}
```
with
```
$url = add_query_arg( 'calypso_env', sanitize_key( 'development' ), $url );
```
to force yourself into calypso.localhost:3000
- repeat the steps to ensure the error is gone.

PHEW!
cc: @johnHackworth @dereksmart 