### PR TITLE
Framework: add QueryPlans data component

### DIFF
--- a/client/components/data/query-plans/index.jsx
+++ b/client/components/data/query-plans/index.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingPlans } from 'state/plans/selectors';
+import { requestPlans } from 'state/plans/actions';
+
+class QueryPlans extends Component {
+	componentWillMount() {
+		if ( ! this.props.requestingPlans ) {
+			this.props.requestPlans();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QueryPlans.propTypes = {
+	requestingPlans: PropTypes.bool,
+	requestPlans: PropTypes.func
+};
+
+QueryPlans.defaultProps = {
+	requestPlans: () => {}
+};
+
+export default connect(
+	state => {
+		return {
+			requestingPlans: isRequestingPlans( state )
+		};
+	},
+	{ requestPlans }
+)( QueryPlans );

--- a/client/components/plans/plan-list/index.jsx
+++ b/client/components/plans/plan-list/index.jsx
@@ -23,18 +23,18 @@ const PlanList = React.createClass( {
 	},
 
 	render() {
-		const isLoadingSitePlans = ! this.props.isInSignup && ! this.props.sitePlans.hasLoadedFromServer,
-			site = this.props.site;
+		const isLoadingSitePlans = ! this.props.isInSignup && ! this.props.sitePlans.hasLoadedFromServer;
+		const { site, hideFreePlan, plans, showJetpackFreePlan } = this.props;
 
 		let className = '',
-			plans = this.props.plans,
-			numberOfPlaceholders = 3,
-			plansList;
+			numberOfPlaceholders = 3;
 
-		if ( this.props.hideFreePlan || ( site && site.jetpack ) ) {
-			numberOfPlaceholders = this.props.showJetpackFreePlan ? 3 : 2;
+		if ( hideFreePlan || ( site && site.jetpack ) ) {
+			numberOfPlaceholders = showJetpackFreePlan ? 3 : 2;
 			className = 'jetpack';
 		}
+
+		let plansList;
 
 		if ( plans.length === 0 || isLoadingSitePlans ) {
 			plansList = times( numberOfPlaceholders, ( n ) => {
@@ -75,15 +75,15 @@ const PlanList = React.createClass( {
 		}
 
 		if ( plans.length > 0 ) {
-			plans = filterPlansBySiteAndProps( plans, site, this.props.hideFreePlan, this.props.showJetpackFreePlan );
+			const filteredPlans = filterPlansBySiteAndProps( plans, site, hideFreePlan, showJetpackFreePlan );
 
-			plansList = plans.map( ( plan ) => {
+			plansList = filteredPlans.map( plan => {
 				return (
 					<Plan
 						plan={ plan }
 						sitePlans={ this.props.sitePlans }
 						comparePlansUrl={ this.props.comparePlansUrl }
-						hideDiscountMessage={ this.props.hideFreePlan }
+						hideDiscountMessage={ hideFreePlan }
 						isInSignup={ this.props.isInSignup }
 						key={ plan.product_id }
 						open={ plan.product_id === this.state.openPlan }

--- a/client/components/plans/plan/index.jsx
+++ b/client/components/plans/plan/index.jsx
@@ -203,9 +203,17 @@ const Plan = React.createClass( {
 
 	render() {
 		return (
-			<Card className={ this.getClassNames() } key={ this.getProductSlug() } onClick={ this.showDetails }>
+			<Card
+				className={ this.getClassNames() }
+				key={ this.getProductSlug() }
+				onClick={ this.showDetails }
+			>
 				{ this.getPlanDiscountMessage() }
-				<PlanHeader onClick={ this.showDetails } text={ this.getProductName() } isPlaceholder={ this.isPlaceholder() }>
+				<PlanHeader
+					onClick={ this.showDetails }
+					text={ this.getProductName() }
+					isPlaceholder={ this.isPlaceholder() }
+				>
 					{ this.getBadge() }
 
 					<p className="plan__plan-tagline">{ this.getPlanTagline() }</p>
@@ -213,6 +221,7 @@ const Plan = React.createClass( {
 					{ this.getImagePlanAction() }
 					{ this.getPlanPrice() }
 				</PlanHeader>
+
 				<div className="plan__plan-expand">
 					<div className="plan__plan-details">
 						{ this.getDescription() }

--- a/client/components/plans/plans-compare/index.jsx
+++ b/client/components/plans/plans-compare/index.jsx
@@ -15,6 +15,7 @@ import analytics from 'lib/analytics';
 import Card from 'components/card';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { filterPlansBySiteAndProps, shouldFetchSitePlans } from 'lib/plans';
+import { getPlans } from 'state/plans/selectors';
 import { getPlansBySite } from 'state/sites/plans/selectors';
 import Gridicon from 'components/gridicon';
 import HeaderCake from 'components/header-cake';
@@ -28,11 +29,10 @@ import PlanPrice from 'components/plans/plan-price';
 import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
+import QueryPlans from 'components/data/query-plans';
 
 const PlansCompare = React.createClass( {
-	mixins: [
-		observe( 'features', 'plans' )
-	],
+	mixins: [ observe( 'features' ) ],
 
 	componentWillReceiveProps( nextProps ) {
 		this.props.fetchSitePlans( nextProps.sitePlans, nextProps.selectedSite );
@@ -140,7 +140,7 @@ const PlansCompare = React.createClass( {
 
 	getPlans() {
 		return filterPlansBySiteAndProps(
-			this.props.plans.get(),
+			this.props.plans,
 			this.props.selectedSite,
 			this.props.hideFreePlan
 		);
@@ -393,6 +393,7 @@ const PlansCompare = React.createClass( {
 
 		return (
 			<div className={ classes }>
+				<QueryPlans />
 				{
 					this.props.isInSignup
 					? null
@@ -413,6 +414,7 @@ const PlansCompare = React.createClass( {
 export default connect(
 	( state, props ) => {
 		return {
+			plans: getPlans( state ),
 			sitePlans: getPlansBySite( state, props.selectedSite )
 		};
 	},

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -11,7 +11,6 @@ import ReactDom from 'react-dom';
 import analytics from 'lib/analytics';
 import config from 'config';
 import i18n from 'lib/mixins/i18n';
-import plansFactory from 'lib/plans-list';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import route from 'lib/route';
 import sitesFactory from 'lib/sites-list';
@@ -19,7 +18,6 @@ import titleActions from 'lib/screen-title/actions';
 import get from 'lodash/get';
 import { isValidFeatureKey } from 'lib/plans';
 
-const plans = plansFactory();
 const sites = sitesFactory();
 
 export default {
@@ -69,7 +67,6 @@ export default {
 			<CheckoutData>
 				<Plans
 					sites={ sites }
-					plans={ plans }
 					context={ context }
 					destinationType={ context.params.destinationType } />
 			</CheckoutData>,
@@ -110,7 +107,6 @@ export default {
 				<CheckoutData>
 					<PlansCompare
 						selectedSite={ site }
-						plans={ plans }
 						features={ features }
 						selectedFeature={ context.params.feature }
 						productsList={ productsList } />

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -10,8 +10,9 @@ import React from 'react';
  */
 import analytics from 'lib/analytics';
 import { fetchSitePlans } from 'state/sites/plans/actions';
-import { getCurrentPlan } from 'lib/plans';
 import { getPlansBySite } from 'state/sites/plans/selectors';
+import { getCurrentPlan } from 'lib/plans';
+import { getPlans } from 'state/plans/selectors';
 import Gridicon from 'components/gridicon';
 import { isJpphpBundle } from 'lib/products-values';
 import Main from 'components/main';
@@ -24,15 +25,16 @@ import { shouldFetchSitePlans } from 'lib/plans';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { SUBMITTING_WPCOM_REQUEST } from 'lib/store-transactions/step-types';
 import UpgradesNavigation from 'my-sites/upgrades/navigation';
+import QueryPlans from 'components/data/query-plans';
 
 const Plans = React.createClass( {
-	mixins: [ observe( 'sites', 'plans' ) ],
+	mixins: [ observe( 'sites' ) ],
 
 	propTypes: {
 		cart: React.PropTypes.object.isRequired,
 		context: React.PropTypes.object.isRequired,
 		destinationType: React.PropTypes.string,
-		plans: React.PropTypes.object.isRequired,
+		plans: React.PropTypes.array.isRequired,
 		fetchSitePlans: React.PropTypes.func.isRequired,
 		sites: React.PropTypes.object.isRequired,
 		sitePlans: React.PropTypes.object.isRequired,
@@ -74,7 +76,7 @@ const Plans = React.createClass( {
 			compareString = this.translate( 'Compare Options' );
 		}
 
-		if ( this.props.plans.get().length <= 0 ) {
+		if ( this.props.plans.length <= 0 ) {
 			return '';
 		}
 
@@ -140,9 +142,11 @@ const Plans = React.createClass( {
 							cart={ this.props.cart }
 							selectedSite={ selectedSite } />
 
+						<QueryPlans />
+
 						<PlanList
 							site={ selectedSite }
-							plans={ this.props.plans.get() }
+							plans={ this.props.plans }
 							sitePlans={ this.props.sitePlans }
 							onOpen={ this.openPlan }
 							cart={ this.props.cart }
@@ -159,10 +163,12 @@ const Plans = React.createClass( {
 export default connect(
 	( state, props ) => {
 		return {
+			plans: getPlans( state ),
 			sitePlans: getPlansBySite( state, props.sites.getSelectedSite() )
 		};
 	},
-	( dispatch ) => {
+
+	dispatch => {
 		return {
 			fetchSitePlans( sitePlans, site ) {
 				if ( shouldFetchSitePlans( sitePlans, site ) ) {

--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -81,7 +81,7 @@ export const requestPlans = () => {
 
 		return wpcom
 			.plans()
-			.list()
+			.list( { apiVersion: '1.2' } )
 			.then( data => {
 				dispatch( plansRequestSuccessAction() );
 				dispatch( plansReceiveAction( getValidDataFromResponse( data ) ) );

--- a/client/state/plans/test/actions.js
+++ b/client/state/plans/test/actions.js
@@ -65,7 +65,7 @@ describe( 'actions', () => {
 		before( () => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( `/rest/v1.1/plans` )
+				.get( `/rest/v1.2/plans` )
 				.reply( 200, wpcomResponse );
 		} );
 


### PR DESCRIPTION
This PR adds `<QueryPlans />` data component and implements it in plans pages trying to remove the previous implementation.


### Testing

Check plans page: http://calypso.localhost:3000/plans/<testing-site>
and compare plans page http://calypso.localhost:3000/plans/compare/google-analytics/<testing-site> . Everything should be ok.

You can clean the persistent data using chrome tool to be sure that the plans will be requested from server-side.

![image](https://cloud.githubusercontent.com/assets/77539/15371978/8c9757fc-1d14-11e6-9b51-97f0d33a0358.png)
