### PR TITLE
Remove the sidebar plan/my-plan split test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -46,15 +46,6 @@ module.exports = {
 		},
 		defaultVariation: 'original'
 	},
-	sidebarPlanLinkMyPlan: {
-		datestamp: '20160101',
-		variations: {
-			plans: 50,
-			'plans/my-plan': 50,
-		},
-		defaultVariation: 'plans',
-		allowExistingUsers: true,
-	},
 	domainSuggestionVendor: {
 		datestamp: '20160408',
 		variations: {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -367,7 +367,6 @@ module.exports = React.createClass( {
 
 		// Show plan details for upgraded sites
 		if (
-			abtest( 'sidebarPlanLinkMyPlan' ) === 'plans/my-plan' &&
 			site &&
 			( isPremium( site.plan ) || isBusiness( site.plan ) )
 		) {
@@ -401,8 +400,7 @@ module.exports = React.createClass( {
 
 	trackUpgradeClick: function() {
 		analytics.tracks.recordEvent( 'calypso_upgrade_nudge_cta_click', {
-			cta_name: 'sidebar_upgrade_default',
-			cta_landing: abtest( 'sidebarPlanLinkMyPlan' )
+			cta_name: 'sidebar_upgrade_default'
 		} );
 		this.onNavigate();
 	},


### PR DESCRIPTION
Remove the test introduced in https://github.com/Automattic/wp-calypso/pull/4783
Test does not show any significant result, but we're going to roll with new version

CC @rralian @mtias 