### PR TITLE
Editor: Set document title using DocumentHead component

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -18,7 +18,6 @@ var actions = require( 'lib/posts/actions' ),
 	PostEditor = require( './post-editor' ),
 	route = require( 'lib/route' ),
 	i18n = require( 'lib/mixins/i18n' ),
-	titleActions = require( 'lib/screen-title/actions' ),
 	sites = require( 'lib/sites-list' )(),
 	user = require( 'lib/user' )(),
 	analytics = require( 'lib/analytics' );
@@ -124,32 +123,11 @@ module.exports = {
 				return;
 			}
 
-			let titleStrings;
+			let gaTitle;
 			switch ( postType ) {
-				case 'post':
-					titleStrings = {
-						edit: i18n.translate( 'Edit Post', { textOnly: true } ),
-						new: i18n.translate( 'New Post', { textOnly: true } ),
-						ga: 'Post'
-					};
-					break;
-
-				case 'page':
-					titleStrings = {
-						edit: i18n.translate( 'Edit Page', { textOnly: true } ),
-						new: i18n.translate( 'New Page', { textOnly: true } ),
-						ga: 'Page'
-					};
-					break;
-
-				default:
-					// [TODO]: Improve these strings, notably once page query
-					// component is available for assigning title dynamically.
-					titleStrings = {
-						edit: i18n.translate( 'Edit', { textOnly: true } ),
-						new: i18n.translate( 'New', { textOnly: true } ),
-						ga: 'Custom Post Type'
-					};
+				case 'post': gaTitle = 'Post'; break;
+				case 'page': gaTitle = 'Page'; break;
+				default: gaTitle = 'Custom Post Type';
 			}
 
 			// We have everything we need to start loading the post for editing,
@@ -158,8 +136,7 @@ module.exports = {
 			if ( postID ) {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 				actions.startEditingExisting( site, postID );
-				titleActions.setTitle( titleStrings.edit, { siteID: site.ID } );
-				analytics.pageView.record( '/' + postType + '/:blogid/:postid', titleStrings.ga + ' > Edit' );
+				analytics.pageView.record( '/' + postType + '/:blogid/:postid', gaTitle + ' > Edit' );
 			} else {
 				let postOptions = { type: postType };
 
@@ -175,8 +152,7 @@ module.exports = {
 
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 				actions.startEditingNew( site, postOptions );
-				titleActions.setTitle( titleStrings.new, { siteID: site.ID } );
-				analytics.pageView.record( '/' + postType, titleStrings.ga + ' > New' );
+				analytics.pageView.record( '/' + postType, gaTitle + ' > New' );
 			}
 		}
 

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -24,8 +24,8 @@ var actions = require( 'lib/posts/actions' ),
 	analytics = require( 'lib/analytics' );
 import { setEditorPostId } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getEditorPostId, getEditorPath, isEditorNewPost } from 'state/ui/editor/selectors';
-import { editPost, resetPostEdits } from 'state/posts/actions';
+import { getEditorPostId, getEditorPath } from 'state/ui/editor/selectors';
+import { editPost } from 'state/posts/actions';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -223,15 +223,5 @@ module.exports = {
 
 		page.redirect( redirectWithParams );
 		return false;
-	},
-
-	resetNewPostEdits( context, next ) {
-		const state = context.store.getState();
-		if ( isEditorNewPost( state ) ) {
-			const siteId = getSelectedSiteId( state );
-			context.store.dispatch( resetPostEdits( siteId ) )
-		}
-
-		next();
 	}
 };

--- a/client/post-editor/editor-document-head/index.jsx
+++ b/client/post-editor/editor-document-head/index.jsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import localize from 'lib/mixins/i18n/localize';
+import DocumentHead from 'components/data/document-head';
+import QueryPostTypes from 'components/data/query-post-types';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId, isEditorNewPost } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
+import { getPostType } from 'state/post-types/selectors';
+
+function EditorDocumentHead( { translate, siteId, type, typeObject, newPost } ) {
+	let title;
+	if ( 'post' === type ) {
+		if ( newPost ) {
+			title = translate( 'New Post', { textOnly: true } );
+		} else {
+			title = translate( 'Edit Post', { textOnly: true } );
+		}
+	} else if ( 'page' === type ) {
+		if ( newPost ) {
+			title = translate( 'New Page', { textOnly: true } );
+		} else {
+			title = translate( 'Edit Page', { textOnly: true } );
+		}
+	} else if ( newPost ) {
+		if ( typeObject ) {
+			title = typeObject.labels.new_item;
+		} else {
+			title = translate( 'New', { textOnly: true } );
+		}
+	} else if ( typeObject ) {
+		title = typeObject.labels.edit_item;
+	} else {
+		title = translate( 'Edit', { context: 'verb', textOnly: true } );
+	}
+
+	return (
+		<div>
+			{ siteId && 'page' !== type && 'post' !== type && (
+				<QueryPostTypes siteId={ siteId } />
+			) }
+			<DocumentHead title={ title } />
+		</div>
+	);
+}
+
+EditorDocumentHead.propTypes = {
+	translate: PropTypes.func,
+	siteId: PropTypes.number,
+	type: PropTypes.string,
+	typeObject: PropTypes.object,
+	newPost: PropTypes.bool
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const postId = getEditorPostId( state );
+	const type = getEditedPostValue( state, siteId, postId, 'type' );
+
+	return {
+		siteId,
+		type,
+		typeObject: getPostType( state, siteId, type ),
+		newPost: isEditorNewPost( state )
+	};
+} )( localize( EditorDocumentHead ) );

--- a/client/post-editor/index.js
+++ b/client/post-editor/index.js
@@ -14,17 +14,14 @@ module.exports = function() {
 	page( '/post', controller.pressThis, sitesController.siteSelection, sitesController.sites );
 	page( '/post/new', () => page.redirect( '/post' ) ); // redirect from beep-beep-boop
 	page( '/post/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
-	page.exit( '/post/:site?/:post?', controller.resetNewPostEdits );
 
 	page( '/page', sitesController.siteSelection, sitesController.sites );
 	page( '/page/new', () => page.redirect( '/page' ) ); // redirect from beep-beep-boop
 	page( '/page/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
-	page.exit( '/page/:site?/:post?', controller.resetNewPostEdits );
 
 	if ( config.isEnabled( 'manage/custom-post-types' ) ) {
 		page( '/edit/:type', sitesController.siteSelection, sitesController.sites );
 		page( '/edit/:type/new', ( context ) => page.redirect( `/edit/${ context.params.type }` ) );
 		page( '/edit/:type/:site?/:post?', sitesController.siteSelection, sitesController.fetchJetpackSettings, controller.post );
-		page.exit( '/edit/:type/:site?/:post?', controller.resetNewPostEdits );
 	}
 };

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -33,7 +33,6 @@ const actions = require( 'lib/posts/actions' ),
 	SegmentedControlItem = require( 'components/segmented-control/item' ),
 	EditorMobileNavigation = require( 'post-editor/editor-mobile-navigation' ),
 	layoutFocus = require( 'lib/layout-focus' ),
-	titleActions = require( 'lib/screen-title/actions' ),
 	observe = require( 'lib/mixins/data-observe' ),
 	DraftList = require( 'my-sites/drafts/draft-list' ),
 	PreferencesActions = require( 'lib/preferences/actions' ),
@@ -51,6 +50,7 @@ import { isEditorDraftsVisible, getEditorPostId } from 'state/ui/editor/selector
 import { toggleEditorDraftsVisible, setEditorPostId } from 'state/ui/editor/actions';
 import { receivePost, editPost, resetPostEdits } from 'state/posts/actions';
 import EditorSidebarHeader from 'post-editor/editor-sidebar/header';
+import EditorDocumentHead from 'post-editor/editor-document-head';
 
 const messages = {
 	post: {
@@ -59,9 +59,6 @@ const messages = {
 		},
 		trashFailure: function() {
 			return i18n.translate( 'Trashing of post failed.' );
-		},
-		editTitle: function() {
-			return i18n.translate( 'Edit Post', { textOnly: true } );
 		},
 		published: function() {
 			var site = this.props.sites.getSelectedSite();
@@ -115,9 +112,6 @@ const messages = {
 		},
 		trashFailure: function() {
 			return i18n.translate( 'Trashing of page failed.' );
-		},
-		editTitle: function() {
-			return i18n.translate( 'Edit Page', { textOnly: true } );
 		},
 		published: function() {
 			var site = this.props.sites.getSelectedSite();
@@ -295,6 +289,7 @@ const PostEditor = React.createClass( {
 		}
 		return (
 			<div className="post-editor">
+				<EditorDocumentHead />
 				<div className="post-editor__inner">
 					<div className="post-editor__content">
 						<EditorMobileNavigation site={ site } onClose={ this.onClose } />
@@ -806,7 +801,6 @@ const PostEditor = React.createClass( {
 			basePath + '/' + this.props.sites.getSite( post.site_ID ).slug + '/' + post.ID,
 			null, false, false
 		);
-		titleActions.setTitle( this.getMessage( 'editTitle' ), { siteID: this.props.sites.selected } );
 
 		nextState = {
 			isSaving: false,

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -45,9 +45,9 @@ const actions = require( 'lib/posts/actions' ),
 	stats = require( 'lib/posts/stats' ),
 	analytics = require( 'lib/analytics' ),
 	VerifyEmailDialogI18n = require( 'post-editor/verify-email-dialog.i18n' ); // temporary for i18n tools to pick up
-
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { setEditorLastDraft, resetEditorLastDraft } from 'state/ui/editor/last-draft/actions';
-import { isEditorDraftsVisible } from 'state/ui/editor/selectors';
+import { isEditorDraftsVisible, getEditorPostId } from 'state/ui/editor/selectors';
 import { toggleEditorDraftsVisible, setEditorPostId } from 'state/ui/editor/actions';
 import { receivePost, editPost, resetPostEdits } from 'state/posts/actions';
 import EditorSidebarHeader from 'post-editor/editor-sidebar/header';
@@ -227,6 +227,10 @@ const PostEditor = React.createClass( {
 
 	componentWillUnmount: function() {
 		PostEditStore.removeListener( 'change', this.onEditedPostChange );
+
+		// Reset post edits after leaving editor
+		this.props.resetPostEdits( this.props.siteId, this.props.postId );
+
 		// TODO: REDUX - remove flux actions when whole post-editor is reduxified
 		actions.stopEditing();
 
@@ -871,6 +875,8 @@ const PostEditor = React.createClass( {
 export default connect(
 	( state ) => {
 		return {
+			siteId: getSelectedSiteId( state ),
+			postId: getEditorPostId( state ),
 			showDrafts: isEditorDraftsVisible( state )
 		};
 	},

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -48,7 +48,8 @@ const actions = require( 'lib/posts/actions' ),
 
 import { setEditorLastDraft, resetEditorLastDraft } from 'state/ui/editor/last-draft/actions';
 import { isEditorDraftsVisible } from 'state/ui/editor/selectors';
-import { toggleEditorDraftsVisible } from 'state/ui/editor/actions';
+import { toggleEditorDraftsVisible, setEditorPostId } from 'state/ui/editor/actions';
+import { receivePost, editPost, resetPostEdits } from 'state/posts/actions';
 import EditorSidebarHeader from 'post-editor/editor-sidebar/header';
 
 const messages = {
@@ -785,6 +786,17 @@ const PostEditor = React.createClass( {
 			this.props.resetEditorLastDraft();
 		}
 
+		// Reset previous edits, preserving type
+		this.props.resetPostEdits( this.props.siteId );
+		this.props.resetPostEdits( post.site_ID, post.ID );
+		this.props.editPost( { type: this.props.type }, post.site_ID, post.ID );
+
+		// Assign editor post ID to saved value (especially important when
+		// transitioning from an unsaved post to a saved one)
+		if ( post.ID !== this.props.postId ) {
+			this.props.setEditorPostId( post.ID );
+		}
+
 		// make sure the history entry has the post ID in it, but don't dispatch
 		page.replace(
 			basePath + '/' + this.props.sites.getSite( post.site_ID ).slug + '/' + post.ID,
@@ -866,7 +878,11 @@ export default connect(
 		return bindActionCreators( {
 			toggleDrafts: toggleEditorDraftsVisible,
 			setEditorLastDraft,
-			resetEditorLastDraft
+			resetEditorLastDraft,
+			receivePost,
+			editPost,
+			resetPostEdits,
+			setEditorPostId
 		}, dispatch );
 	},
 	null,

--- a/client/post-editor/test/post-editor.jsx
+++ b/client/post-editor/test/post-editor.jsx
@@ -40,6 +40,7 @@ describe( 'PostEditor', function() {
 		mockery.registerMock( 'components/notice', MOCK_COMPONENT );
 		mockery.registerMock( 'components/segmented-control', MOCK_COMPONENT );
 		mockery.registerMock( 'components/segmented-control/item', MOCK_COMPONENT );
+		mockery.registerMock( 'post-editor/editor-document-head', MOCK_COMPONENT );
 		mockery.registerMock( 'post-editor/editor-action-bar', MOCK_COMPONENT );
 		mockery.registerMock( 'post-editor/editor-drawer', MOCK_COMPONENT );
 		mockery.registerMock( 'post-editor/editor-featured-image', MOCK_COMPONENT );


### PR DESCRIPTION
This pull request seeks to assign the title of the post editor screen using the [`<DocumentHead />` component](https://github.com/Automattic/wp-calypso/tree/master/client/components/data/document-head). This will enable accurate titles to be shown when editing custom post types, e.g. "Edit Project" for portfolios instead of "Edit".

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15372709/bc6b173e-1d0f-11e6-923a-e19eea935706.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15372691/a6a1b8a4-1d0f-11e6-9af6-a394f60827b2.png)

__Implementation notes:__

- ~~Removes a few conflicting placeholder Redux actions proposed to be removed already in #5438~~ (merged as part of #5438)
- Fixes issue where the editor post state was not correctly updated to reflect new post ID after save (in production, you can verify that saving a new post does not change the `<EditorPostType />` label from "New Post" to "Post" until after a complete refresh).
- Resets post edits via component unmounting instead of route exit, which is more consistent with the current implementation and prevents an issue where the title briefly changes from "Edit Post" to "Edit" when leaving the editor

__Testing instructions:__

Verify that the post editor title correctly reflects the current status of editing:
- "New Post" for editing a new post
- "Edit Post" for editing an existing post
- "New Page" for editing a new page
- "Edit Page" for editing an existing page
- "New" for editing a new custom post type if the post type labels have not loaded from the REST API
- "Edit" for editing an existing custom post type if the post type labels have not loaded from the REST API
- The custom post type object `labels.new_item` when editing a new custom post type
- The custom post type object `labels.edit_item` when editing an existing custom post type

Ensure that the issue fixed by #4539 in resetting edits upon leaving the editor remains fixed.