### PR TITLE
Tests: Remove better-assert dependency and replace it with assert

### DIFF
--- a/client/lib/posts/test/post-edit-store.js
+++ b/client/lib/posts/test/post-edit-store.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import assert from 'better-assert';
+import assert from 'assert';
 import assign from 'lodash/assign';
 import isEqual from 'lodash/isEqual';
 import { spy } from 'sinon';

--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-var assert = require( 'better-assert' );
+import assert from 'assert';
 
 /**
 * Internal dependencies

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -298,9 +298,6 @@
     "benchmark": {
       "version": "1.0.0"
     },
-    "better-assert": {
-      "version": "1.0.2"
-    },
     "big.js": {
       "version": "3.1.3"
     },

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
   },
   "devDependencies": {
     "babel-eslint": "4.1.8",
-    "better-assert": "1.0.2",
     "blanket": "1.1.6",
     "chai": "2.0.0",
     "deep-freeze": "0.0.1",


### PR DESCRIPTION
Like I mentioned in #5412 we use `better-assert` only in two test files, and it can be replaced with `assert` without any further changes. That's why I think we should remove that dependency to avoid confusion.

@gwwar I removed this dependency manually, because I had some issues with `shonkwrap`. I tested it according to https://github.com/Automattic/wp-calypso/blob/master/docs/shrinkwrap.md#testing which is:

* Run `make distclean` to delete local `node_modules`
* Run `npm install`
* Verify that Calypso works as expected and that tests pass (requires `make run`)
* Verify that all tests pass - run `make test`

/cc @aduth @blowery 