### PR TITLE
Framework: Introduce utility to check if we are in development env

### DIFF
--- a/server/bundler/test/utils.js
+++ b/server/bundler/test/utils.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { isDevelopment } from '../utils';
+
+describe( 'utils', () => {
+	context( '#isDevelopment', () => {
+		it( 'should return false when no development string provided', () => {
+			expect( isDevelopment( 'test' ) ).to.be.false;
+		} );
+
+		it( 'should return false when string provided does not end with development', () => {
+			expect( isDevelopment( 'development-test' ) ).to.be.false;
+		} );
+
+		it( 'should return true when string provides equals development', () => {
+			expect( isDevelopment( 'development' ) ).to.be.true;
+		} );
+
+		it( 'should return true when string provided ends with development', () => {
+			expect( isDevelopment( 'test-development' ) ).to.be.true;
+		} );
+	} );
+} );

--- a/server/bundler/test/utils.js
+++ b/server/bundler/test/utils.js
@@ -14,16 +14,8 @@ describe( 'utils', () => {
 			expect( isDevelopment( 'test' ) ).to.be.false;
 		} );
 
-		it( 'should return false when string provided does not end with development', () => {
-			expect( isDevelopment( 'development-test' ) ).to.be.false;
-		} );
-
-		it( 'should return true when string provides equals development', () => {
+		it( 'should return true when string provided equals development', () => {
 			expect( isDevelopment( 'development' ) ).to.be.true;
-		} );
-
-		it( 'should return true when string provided ends with development', () => {
-			expect( isDevelopment( 'test-development' ) ).to.be.true;
 		} );
 	} );
 } );

--- a/server/bundler/utils.js
+++ b/server/bundler/utils.js
@@ -1,8 +1,5 @@
-const endsWith = require( 'lodash/endsWith' ),
-	path = require( 'path' );
-
 function getAssets( stats ) {
-	var chunks = stats.chunks;
+	const chunks = stats.chunks;
 
 	return chunks.map( function( chunk ) {
 		var filename = chunk.files[0];
@@ -10,13 +7,13 @@ function getAssets( stats ) {
 			name: chunk.names[0],
 			hash: chunk.hash,
 			file: filename,
-			url: stats.publicPath + filename,
+			url: stats.publicPath + filename
 		};
 	} );
 }
 
 function isDevelopment( env ) {
-	return endsWith( env, 'development' );
+	return env === 'development';
 }
 
 function pathToRegExp( path ) {

--- a/server/bundler/utils.js
+++ b/server/bundler/utils.js
@@ -1,4 +1,5 @@
-var path = require( 'path' );
+const endsWith = require( 'lodash/endsWith' ),
+	path = require( 'path' );
 
 function getAssets( stats ) {
 	var chunks = stats.chunks;
@@ -14,11 +15,16 @@ function getAssets( stats ) {
 	} );
 }
 
+function isDevelopment( env ) {
+	return endsWith( env, 'development' );
+}
+
 function pathToRegExp( path ) {
 	return new RegExp( '^' + path + '(/.*)?$' );
 }
 
 module.exports = {
-	getAssets: getAssets,
-	pathToRegExp: pathToRegExp
+	getAssets,
+	isDevelopment,
+	pathToRegExp
 };

--- a/server/pages/desktop.jade
+++ b/server/pages/desktop.jade
@@ -17,7 +17,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class='is-desktop' + ( isFluidWidth ?
 		if isRTL
 			link(rel='stylesheet', href=urls['style-rtl.css'])
 		else
-			if 'development' === env || isDebug
+			if isDevelopment || isDebug
 				link(rel='stylesheet', href=urls['style-debug.css'])
 			else
 				link(rel='stylesheet', href=urls['style.css'])

--- a/server/pages/index.jade
+++ b/server/pages/index.jade
@@ -50,7 +50,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 		if isRTL
 			link(rel='stylesheet', href=urls['style-rtl.css'])
 		else
-			if 'development' === env || isDebug
+			if isDevelopment || isDebug
 				link(rel='stylesheet', href=urls['style-debug.css'])
 			else
 				link(rel='stylesheet', href=urls['style.css'])
@@ -73,7 +73,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 				if abTestHelper
 					div(class=['environment', 'is-tests'])
 
-		if 'development' !== env
+		if ! isDevelopment
 			script( src=catchJsErrors )
 
 		script.
@@ -120,7 +120,7 @@ html(lang=lang, dir=isRTL ? 'rtl' : 'ltr', class=isFluidWidth ? 'is-fluid-width'
 			script(type='text/javascript')!='var initialReduxState = ' + sanitize.jsonStringifyForHtml( initialReduxState )
 		if i18nLocaleScript
 			script(src=i18nLocaleScript)
-		if 'development' === env || isDebug
+		if isDevelopment || isDebug
 			script(src=urls[ 'vendor' ])
 			script(src=urls[ jsFile + '-' + env ])
 			if chunk

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -144,6 +144,7 @@ function getDefaultContext( request ) {
 		sanitize: sanitize,
 		isRTL: config( 'rtl' ),
 		isDebug: request.query.debug !== undefined ? true : false,
+		isDevelopment: utils.isDevelopment( CALYPSO_ENV ),
 		badge: false,
 		lang: config( 'i18n_default_locale_slug' ),
 		jsFile: 'build',
@@ -157,7 +158,7 @@ function getDefaultContext( request ) {
 	context.app = {
 		// use ipv4 address when is ipv4 mapped address
 		clientIp: request.ip ? request.ip.replace( '::ffff:', '' ) : request.ip,
-		isDebug: context.env === 'development' || context.isDebug,
+		isDebug: context.isDevelopment || context.isDebug,
 		tinymceWpSkin: context.urls[ 'tinymce/skins/wordpress/wp-content.css' ],
 		tinymceEditorCss: context.urls[ 'editor.css' ]
 	};
@@ -181,7 +182,7 @@ function getDefaultContext( request ) {
 		context.faviconURL = '/calypso/images/favicons/favicon-staging.ico';
 	}
 
-	if ( CALYPSO_ENV === 'development' ) {
+	if ( utils.isDevelopment( CALYPSO_ENV ) ) {
 		context.badge = 'dev';
 		context.devDocs = true;
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -144,7 +144,7 @@ function getDefaultContext( request ) {
 		sanitize: sanitize,
 		isRTL: config( 'rtl' ),
 		isDebug: request.query.debug !== undefined ? true : false,
-		isDevelopment: utils.isDevelopment( CALYPSO_ENV ),
+		isDevelopment: utils.isDevelopment( config( 'env' ) ),
 		badge: false,
 		lang: config( 'i18n_default_locale_slug' ),
 		jsFile: 'build',
@@ -182,7 +182,7 @@ function getDefaultContext( request ) {
 		context.faviconURL = '/calypso/images/favicons/favicon-staging.ico';
 	}
 
-	if ( utils.isDevelopment( CALYPSO_ENV ) ) {
+	if ( utils.isDevelopment( config( 'env' ) ) ) {
 		context.badge = 'dev';
 		context.devDocs = true;
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ var webpack = require( 'webpack' ),
  */
 var config = require( './server/config' ),
 	sections = require( './client/sections' ),
+	utils = require( './server/bundler/utils' ),
 	ChunkFileNamePlugin = require( './server/bundler/plugin' ),
 	PragmaCheckPlugin = require( 'server/pragma-checker' );
 
@@ -112,7 +113,7 @@ jsLoader = {
 	loaders: [ 'babel-loader?cacheDirectory&optional[]=runtime' ]
 };
 
-if ( CALYPSO_ENV === 'development' ) {
+if ( utils.isDevelopment( CALYPSO_ENV ) ) {
 	webpackConfig.plugins.push( new PragmaCheckPlugin() );
 	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
 	webpackConfig.entry[ 'build-' + CALYPSO_ENV ] = [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,7 +113,7 @@ jsLoader = {
 	loaders: [ 'babel-loader?cacheDirectory&optional[]=runtime' ]
 };
 
-if ( utils.isDevelopment( CALYPSO_ENV ) ) {
+if ( utils.isDevelopment( config( 'env' ) ) ) {
 	webpackConfig.plugins.push( new PragmaCheckPlugin() );
 	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
 	webpackConfig.entry[ 'build-' + CALYPSO_ENV ] = [


### PR DESCRIPTION
We want to make it easier to fork Calypso and use as a base for another application. To make it possible we need to have a way to add config files that are regonized by Calypso as development env. This PR tackles this use case. When you create new config file which ends with `development`, example: `mc-development.json` it should work the same way as it currently does for `development.json` file.

### Testing
* Run `npm run test-server` to make sure new unit tests pass.
* Run `make run` - it should work as before.
* Copy `development.json` and name it `whatever-development.json`, run `CALYPSO_ENV=whatever-development make run` - it should work exactly the same as development.
* Run any other env to make sure it still works as before.

/cc @janm6k @mtias @nb 