### PR TITLE
Reader: enable ESC key navigation on close following-search

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -88,7 +88,6 @@ $z-layers: (
 		'.search': 22,
 		'#translator-launcher': 99,
 		'.author-selector__popover.popover': 100,
-		'.search.is-pinned': 170,
 		'.select-dropdown.is-open .select-dropdown__container': 170,
 		'.accessible-focus .select-dropdown.is-open .select-dropdown__container': 170,
 		'.sites-dropdown.is-open .sites-dropdown__wrapper' : 170,

--- a/client/components/search/README.md
+++ b/client/components/search/README.md
@@ -25,8 +25,11 @@ Use this prop to delay the `onSearch` callback until after the user has stopped 
 ### delayTimeout (optional) number ( default 300 )
 If `delaySearch` is true, this prop can be used to control the number of milliseconds used to determine when the user has stopped typing. It's a good idea to leave this at its default value unless there's a specific reason to change the timeout (e.g., a very expensive search may benefit from a longer timeout).
 
-### pinned (optional)
-Whether to display the search input from collapsed by default and pinned to the right of its container. If not set, the search input will show as already expanded.
+### pinned (optional) bool ( default false )
+Whether to display the search input from collapsed by default. If not set, the search input will show as already expanded.
+
+### fitsContainer (optional) bool ( default false )
+Position search absolutely, taking the height of the containing element and anchor to the right side.
 
 ### placeholder (optional)
 The label to place inside the search field if/when empty. Defaults to a translated version of "Search…".

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import ReactDom from 'react-dom';
-import React from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import debounce from 'lodash/debounce';
 import noop from 'lodash/noop';
@@ -32,24 +32,25 @@ const Search = React.createClass( {
 	},
 
 	propTypes: {
-		additionalClasses: React.PropTypes.string,
-		initialValue: React.PropTypes.string,
-		placeholder: React.PropTypes.string,
-		pinned: React.PropTypes.bool,
-		delaySearch: React.PropTypes.bool,
-		delayTimeout: React.PropTypes.number,
-		onSearch: React.PropTypes.func.isRequired,
-		onSearchChange: React.PropTypes.func,
-		onSearchClose: React.PropTypes.func,
-		analyticsGroup: React.PropTypes.string,
-		autoFocus: React.PropTypes.bool,
-		disabled: React.PropTypes.bool,
-		onKeyDown: React.PropTypes.func,
-		disableAutocorrect: React.PropTypes.bool,
-		onBlur: React.PropTypes.func,
-		searching: React.PropTypes.bool,
-		isOpen: React.PropTypes.bool,
-		dir: React.PropTypes.string
+		additionalClasses: PropTypes.string,
+		initialValue: PropTypes.string,
+		placeholder: PropTypes.string,
+		pinned: PropTypes.bool,
+		delaySearch: PropTypes.bool,
+		delayTimeout: PropTypes.number,
+		onSearch: PropTypes.func.isRequired,
+		onSearchChange: PropTypes.func,
+		onSearchClose: PropTypes.func,
+		analyticsGroup: PropTypes.string,
+		autoFocus: PropTypes.bool,
+		disabled: PropTypes.bool,
+		onKeyDown: PropTypes.func,
+		disableAutocorrect: PropTypes.bool,
+		onBlur: PropTypes.func,
+		searching: PropTypes.bool,
+		isOpen: PropTypes.bool,
+		dir: PropTypes.string,
+		fitsContainer: PropTypes.bool
 	},
 
 	getInitialState: function() {
@@ -72,7 +73,8 @@ const Search = React.createClass( {
 			disableAutocorrect: false,
 			searching: false,
 			isOpen: false,
-			dir: undefined
+			dir: undefined,
+			fitsContainer: false
 		};
 	},
 
@@ -175,15 +177,13 @@ const Search = React.createClass( {
 	},
 
 	closeSearch: function( event ) {
-		var input;
-
 		event.preventDefault();
 
 		if ( this.props.disabled ) {
 			return;
 		}
 
-		input = ReactDom.findDOMNode( this.refs.searchInput );
+		const input = ReactDom.findDOMNode( this.refs.searchInput );
 
 		this.setState( {
 			keyword: '',
@@ -203,7 +203,7 @@ const Search = React.createClass( {
 	},
 
 	keyUp: function( event ) {
-		if ( event.which === 13 && isMobile() ) {
+		if ( event.key === 'Enter' && isMobile() ) {
 			//dismiss soft keyboards
 			this.blur();
 		}
@@ -252,7 +252,7 @@ const Search = React.createClass( {
 		};
 
 		searchClass = classNames( this.props.additionalClasses, {
-			'is-pinned': this.props.pinned,
+			'is-expanded-to-container': this.props.fitsContainer,
 			'is-open': isOpenUnpinnedOrQueried,
 			'is-searching': this.props.searching,
 			rtl: this.props.dir === 'rtl',

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -85,12 +85,12 @@
 
 // Position collapsed search-button to the right
 // of the container element
-.search.is-pinned {
+.search.is-expanded-to-container {
 	margin-bottom: 0;
 	height: auto;
 	position: absolute;
-		bottom: 0;
-		top: 0;
+	bottom: 0;
+	top: 0;
 
 	&:not(.ltr) {
 		right: 0;
@@ -99,9 +99,6 @@
 	&.ltr {
 		right: 0 #{"/*rtl:ignore*/"};
 	}
-
-	// matching dropdown-selector
-	z-index: z-index( 'root', '.search.is-pinned' );
 
 	.search-open__icon {
 		&:not(.ltr) {

--- a/client/components/section-nav/README.md
+++ b/client/components/section-nav/README.md
@@ -43,7 +43,8 @@ module.exports = React.createClass( {
 				</NavSegmented>
 				
 				<Search
-					pinned={ true }
+					pinned
+					fitsContainer
 					onSearch={ this.doSearch }
 					initialValue={ this.props.search }
 					placeholder="Search Published..."

--- a/client/components/section-nav/docs/example.jsx
+++ b/client/components/section-nav/docs/example.jsx
@@ -141,7 +141,8 @@ var SectionNavigation = React.createClass( {
 					</NavSegmented>
 
 					<Search
-						pinned={ true }
+						pinned
+						fitsContainer
 						onSearch={ this.demoSearch }
 						placeholder={ 'Search ' + this.getSelectedText( 'siblingTabs' ) + '...' }
 					/>

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -370,7 +370,7 @@
 // -------- Search --------
 .section-nav {
 	@include breakpoint( "<480px" ) {
-		.search.is-pinned {
+		.search.is-expanded-to-container {
 			height: 46px;
 		}
 	}

--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -113,7 +113,8 @@ module.exports = React.createClass( {
 				{ ! this.props.filterRequiresUpgrade &&
 					<Search
 						analyticsGroup="Media"
-						pinned={ true }
+						pinned
+						fitsContainer
 						onSearch={ this.props.onSearch }
 						initialValue={ this.props.search }
 						placeholder={ this.getSearchPlaceholderText() }

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -72,7 +72,8 @@ module.exports = React.createClass( {
 						{ this.getNavItems( filterStrings, status ) }
 					</NavTabs>
 					<Search
-						pinned={ true }
+						pinned
+						fitsContainer
 						onSearch={ this.doSearch }
 						initialValue={ this.props.search }
 						placeholder={ searchStrings[ status ] }

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -23,6 +23,7 @@ let PeopleSearch = React.createClass( {
 		return (
 			<Search
 				pinned
+				fitsContainer
 				onSearch={ this.doSearch }
 				initialValue={ this.props.search }
 				ref="url-search"

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -393,6 +393,7 @@ const PluginsMain = React.createClass( {
 
 					<Search
 						pinned
+						fitsContainer
 						onSearch={ this.doSearch }
 						initialValue={ this.props.search }
 						ref="url-search"

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -162,8 +162,9 @@ module.exports = React.createClass( {
 		if ( pinned ) {
 			return (
 				<Search
+					pinned
+					fitsContainer
 					onSearch={ this.doSearch }
-					pinned={ pinned }
 					initialValue={ this.props.search }
 					placeholder={ this.translate( 'Search Plugins' ) }
 					delaySearch={ true }

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -127,7 +127,8 @@ const PostTypeFilter = React.createClass( {
 						</NavTabs>,
 						<Search
 							key="search"
-							pinned={ true }
+							pinned
+							fitsContainer
 							onSearch={ this.doSearch }
 							placeholder={ this.translate( 'Search…' ) }
 							delaySearch={ true } />

--- a/client/my-sites/posts/posts-navigation.jsx
+++ b/client/my-sites/posts/posts-navigation.jsx
@@ -128,7 +128,8 @@ export default React.createClass( {
 					authorSegmented.element : null
 				}
 				<Search
-					pinned={ true }
+					pinned
+					fitsContainer
 					onSearch={ this.doSearch }
 					initialValue={ this.props.search }
 					placeholder={ 'Search ' + statusTabs.selectedText + '...' }

--- a/client/my-sites/themes/themes-search-card/index.jsx
+++ b/client/my-sites/themes/themes-search-card/index.jsx
@@ -90,7 +90,8 @@ const ThemesSearchCard = React.createClass( {
 					</NavTabs>
 
 					<Search
-						pinned={ true }
+						pinned
+						fitsContainer
 						onSearch={ this.props.onSearch }
 						initialValue={ this.props.search }
 						ref="url-search"

--- a/client/reader/following-edit/index.jsx
+++ b/client/reader/following-edit/index.jsx
@@ -57,7 +57,7 @@ const FollowingEdit = React.createClass( {
 	getDefaultProps: function() {
 		return {
 			initialFollowUrl: ''
-		}
+		};
 	},
 
 	smartSetState: smartSetState,
@@ -134,7 +134,7 @@ const FollowingEdit = React.createClass( {
 		}
 
 		return subscriptions.sortBy( function( subscription ) {
-			return subscription.get( 'date_subscribed' )
+			return subscription.get( 'date_subscribed' );
 		} ).reverse();
 	},
 
@@ -495,7 +495,7 @@ const FollowingEdit = React.createClass( {
 		// the following stream was processed
 		if ( subscriptions ) {
 			subscriptionsToDisplay = subscriptions.filter( function( subscription ) {
-				return subscription.has( 'ID' )
+				return subscription.has( 'ID' );
 			} ).toArray();
 		}
 
@@ -550,6 +550,7 @@ const FollowingEdit = React.createClass( {
 
 				{ ! hasNoSubscriptions ? <SearchCard
 					isOpen={ true }
+					pinned={ true }
 					key="existingFeedSearch"
 					autoFocus={ false }
 					additionalClasses="following-edit__existing-feed-search"

--- a/client/vip/vip-logs/index.jsx
+++ b/client/vip/vip-logs/index.jsx
@@ -186,7 +186,8 @@ module.exports = React.createClass( {
 						<NavItem path={ '/vip/logs/notice' + siteFilter } selected={ statusSlug === 'notice' } >{ filterStrings.notice }</NavItem>
 					</NavTabs>
 					<Search
-						pinned={ true }
+						pinned
+						fitsContainer
 						onSearch={ this.doSearch }
 						initialValue={ this.props.search }
 						placeholder={ searchPlaceholder }


### PR DESCRIPTION
**Issue**
Keyboard navigation on "ESC" does not close following-search box in Reader.

<img width="518" alt="screen shot 2016-05-19 at 9 48 05 pm" src="https://cloud.githubusercontent.com/assets/1922453/15389513/6fca5dfc-1e0b-11e6-99dc-722ec4643d91.png">

**Steps to Reproduce**
* navigate to ```http://calypso.localhost:3000/following/edit```
* click the second magnifying glass to search the sites you follow
<img width="481" alt="screen shot 2016-05-19 at 9 49 34 pm" src="https://cloud.githubusercontent.com/assets/1922453/15389567/b346180a-1e0b-11e6-8ca4-d0eff4c9d1a4.png">
* enter text
* press "Escape" key

**What does happen**
* search query is cleared and all the blogs followed return below

**What should happen**
* it should additionally return to original menu

**Problem**
 ```props.pinned``` was designated to denote a search box that was always open, and included styles involving its position. It also controlled logic around the component's ```state.isOpen```. This caused multiple sources of truth.

The easy fix would have been to set ```pinned: { true }``` and override the styles and pass the buck. 

**Fix**
* Use ```props.isOpen``` as the single method of dictating the component's state from outside.
* Allow ```onSearchClose``` to always be available.

@bluefuton 