### PR TITLE
Jetpack connect: Add TOS link

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -171,6 +171,11 @@ const JetpackConnectMain = React.createClass( {
 
 	clearUrl() {
 		this.dismissUrl();
+
+	},
+
+	handleOnClickTos() {
+		this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
 	},
 
 	renderFooter() {
@@ -194,6 +199,7 @@ const JetpackConnectMain = React.createClass( {
 				}
 
 				<SiteURLInput ref="siteUrlInputRef"
+					onTosClick={ this.handleOnClickTos }
 					onChange={ this.onURLChange }
 					onClick={ this.onURLEnter }
 					onDismissClick={ this.onDismissClick }

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -12,6 +12,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
 import Spinner from 'components/spinner';
 import untrailingslashit from 'lib/route/untrailingslashit';
+import i18n from 'lib/mixins/i18n';
 
 export default React.createClass( {
 	displayName: 'JetpackConnectSiteURLInput',
@@ -44,6 +45,28 @@ export default React.createClass( {
 		}
 	},
 
+	getTermsOfServiceUrl() {
+		return 'https://' + i18n.getLocaleSlug() + '.wordpress.com/tos/';
+	},
+
+	renderTermsOfServiceLink() {
+		return (
+			<p className="jetpack-connect__tos_link">{
+				this.translate(
+					'By clicking this button you agree to our {{a}}fascinating Terms of Service{{/a}}.',
+					{
+						components: {
+							a: <a
+								href={ this.getTermsOfServiceUrl() }
+								onClick={ this.props.handleOnClickTos }
+								target="_blank" />
+						}
+					}
+				)
+			}</p>
+		);
+	},
+
 	render() {
 		return (
 			<div>
@@ -53,7 +76,7 @@ export default React.createClass( {
 						size={ 24 }
 						icon="globe" />
 					<FormTextInput
-						onChange={ this.onChange }
+						onChange={ this.props.onTosClick }
 						disabled={ this.props.isFetching }
 						placeholder={ this.translate( 'http://www.yoursite.com' ) }
 						onKeyUp={ this.handleKeyPress } />
@@ -64,6 +87,8 @@ export default React.createClass( {
 				<Button primary
 					disabled={ ( ! this.state.value || this.props.isFetching ) }
 					onClick={ this.props.onClick }>{ this.renderButtonLabel() }</Button>
+
+				{ this.renderTermsOfServiceLink() }
 			</div>
 		);
 	}

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -52,12 +52,13 @@ export default React.createClass( {
 
 	renderTermsOfServiceLink() {
 		return (
-			<p className="jetpack-connect__tos_link">{
+			<p className="jetpack-connect__tos-link">{
 				this.translate(
 					'By connecting your site you agree to our fascinating {{a}}Terms of Service{{/a}}.',
 					{
 						components: {
 							a: <a
+								className="jetpack-connect__tos-link-text"
 								href={ this.getTermsOfServiceUrl() }
 								onClick={ this.props.handleOnClickTos }
 								target="_blank" />
@@ -85,7 +86,7 @@ export default React.createClass( {
 						? ( <Spinner duration={ 30 } /> )
 						: null }
 				</div>
-				<Card className="jetpack-connect__connect_button_card">
+				<Card className="jetpack-connect__connect-button-card">
 					{ this.renderTermsOfServiceLink() }
 					<Button primary
 						disabled={ ( ! this.state.value || this.props.isFetching ) }

--- a/client/signup/jetpack-connect/site-url-input.jsx
+++ b/client/signup/jetpack-connect/site-url-input.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import Button from 'components/button';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
@@ -53,7 +54,7 @@ export default React.createClass( {
 		return (
 			<p className="jetpack-connect__tos_link">{
 				this.translate(
-					'By clicking this button you agree to our {{a}}fascinating Terms of Service{{/a}}.',
+					'By connecting your site you agree to our fascinating {{a}}Terms of Service{{/a}}.',
 					{
 						components: {
 							a: <a
@@ -76,7 +77,7 @@ export default React.createClass( {
 						size={ 24 }
 						icon="globe" />
 					<FormTextInput
-						onChange={ this.props.onTosClick }
+						onChange={ this.onChange }
 						disabled={ this.props.isFetching }
 						placeholder={ this.translate( 'http://www.yoursite.com' ) }
 						onKeyUp={ this.handleKeyPress } />
@@ -84,11 +85,12 @@ export default React.createClass( {
 						? ( <Spinner duration={ 30 } /> )
 						: null }
 				</div>
-				<Button primary
-					disabled={ ( ! this.state.value || this.props.isFetching ) }
-					onClick={ this.props.onClick }>{ this.renderButtonLabel() }</Button>
-
-				{ this.renderTermsOfServiceLink() }
+				<Card className="jetpack-connect__connect_button_card">
+					{ this.renderTermsOfServiceLink() }
+					<Button primary
+						disabled={ ( ! this.state.value || this.props.isFetching ) }
+						onClick={ this.props.onClick }>{ this.renderButtonLabel() }</Button>
+				</Card>
 			</div>
 		);
 	}

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -215,3 +215,9 @@
 		margin-top: 8px;
 	}
 }
+
+.jetpack-connect__tos_link {
+	font-size: 11px;
+   	margin: 8px 0 0px 0;
+    text-align: center;
+}

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -216,22 +216,26 @@
 	}
 }
 
-.jetpack-connect__tos_link {
+.jetpack-connect__tos-link {
 	font-size: 11px;
-   	margin: 4px 0 8px 0;
+   	margin: 0 0 16px 0;
     text-align: center;
 }
 
-.jetpack-connect__connect_button_card {
+.jetpack-connect__tos-link-text {
+	white-space: nowrap;
+}
+
+.jetpack-connect__connect-button-card {
 	background: lighten( $gray, 34% );
 	border-top: 1px solid lighten( $gray, 30% );
 	box-shadow: none;
-	margin: 0 -16px -16px -16px;
+	margin: 16px -16px -16px -16px;
 	padding: 16px;
 
 	@include breakpoint( ">480px" ) {
-		margin: 16px -24px -24px -24px;
-		padding: 8px 24px 24px;
+		margin: 24px -24px -24px -24px;
+		padding: 24px;
 	}
 
 	.button.is-primary {

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -218,6 +218,23 @@
 
 .jetpack-connect__tos_link {
 	font-size: 11px;
-   	margin: 8px 0 0px 0;
+   	margin: 4px 0 8px 0;
     text-align: center;
+}
+
+.jetpack-connect__connect_button_card {
+	background: lighten( $gray, 34% );
+	border-top: 1px solid lighten( $gray, 30% );
+	box-shadow: none;
+	margin: 0 -16px -16px -16px;
+	padding: 16px;
+
+	@include breakpoint( ">480px" ) {
+		margin: 16px -24px -24px -24px;
+		padding: 8px 24px 24px;
+	}
+
+	.button.is-primary {
+		margin: 0;
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/5174

This PR adds a ToS link to the first step of jetpack connect:
![image](https://cloud.githubusercontent.com/assets/1554855/15390951/f5f883ec-1dbe-11e6-950f-fce85864e10a.png)

How to test
=========
1. Go to http://calypso.dev:3000/jetpack/connect
2. Check the link is there and it works :D