### PR TITLE
Domains: restart the test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -47,7 +47,7 @@ module.exports = {
 		defaultVariation: 'original'
 	},
 	domainSuggestionVendor: {
-		datestamp: '20160408',
+		datestamp: '20160520',
 		variations: {
 			namegen: 75,
 			domainsbot: 25,


### PR DESCRIPTION
We fixed a bug which impacts the results and we need to start over with the test.

To test:
1. Go to domains/add and search for a domain
2. Make sure you're assigned to a proper variation