### PR TITLE
Editor: Update pending toggle logic to respond to user action

### DIFF
--- a/client/lib/posts/test/utils.js
+++ b/client/lib/posts/test/utils.js
@@ -67,6 +67,20 @@ describe( 'utils', function() {
 		} );
 	} );
 
+	describe( '#isPending', function() {
+		it( 'should return undefined when no post is supplied', function() {
+			assert( postUtils.isPending() === undefined );
+		} );
+
+		it( 'should return true when post.status is pending', function() {
+			assert( postUtils.isPending( { status: 'pending' } ) );
+		} );
+
+		it( 'should return false when post.status is not pending', function() {
+			assert( ! postUtils.isPending( { status: 'draft' } ) );
+		} );
+	} );
+
 	describe( '#isBackDatedPublished', function() {
 		it( 'should return false when no post is supplied', function() {
 			assert( ! postUtils.isBackDatedPublished() );

--- a/client/lib/posts/utils.js
+++ b/client/lib/posts/utils.js
@@ -69,6 +69,10 @@ var utils = {
 		return post && ( 'private' === post.status );
 	},
 
+	isPending: function( post ) {
+		return post && ( 'pending' === post.status );
+	},
+
 	getEditedTime: function( post ) {
 		if ( ! post ) {
 			return;

--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -25,7 +25,7 @@ const actions = require( 'lib/posts/actions' ),
 import {
 	toggleStickyStatus,
 	togglePendingStatus
-} from 'state/ui/editor/post/actions'
+} from 'state/ui/editor/post/actions';
 
 const EditPostStatus = React.createClass( {
 	propTypes: {
@@ -51,7 +51,7 @@ const EditPostStatus = React.createClass( {
 			showTZTooltip: false,
 			showPostSchedulePopover: false,
 			onDateChange: noop
-		}
+		};
 	},
 
 	toggleStickyStatus: function() {
@@ -107,9 +107,7 @@ const EditPostStatus = React.createClass( {
 
 		if ( this.props.post ) {
 			isSticky = this.props.post.sticky;
-			isPending = this.props.savedPost.status === 'pending' || (
-				this.props.savedPost.status === 'draft' &&
-				this.props.post.status === 'pending' );
+			isPending = postUtils.isPending( this.props.post );
 			isPublished = this.props.savedPost.status === 'publish';
 			isScheduled = this.props.savedPost.status === 'future';
 			canPublish = siteUtils.userCan( 'publish_posts', this.props.site );
@@ -123,7 +121,7 @@ const EditPostStatus = React.createClass( {
 			( postUtils.getEditedTime( this.props.post ) || new Date() ),
 			siteUtils.timezone( this.props.site ),
 			siteUtils.gmtOffset( this.props.site )
-		).format( 'll LT' )
+		).format( 'll LT' );
 
 		return (
 			<div className="edit-post-status">


### PR DESCRIPTION
This is meant to fix #4285. Currently, we're using two checks to determine if the pending toggle should be active:

1. `this.props.savedPost.status === 'pending'`
2. `this.props.savedPost.status === 'draft' && this.props.post.status === 'pending'`

As noted in the original report, the issue pops up when a post is saved as pending (thus `this.props.savedPost.status==='pending'`) but the user wants to toggle pending off. The user has to toggle the option but an update to the toggle is only shown after save when the saved post is set back to another status.

This updates the comparison to set `isPending` to `true` if either:

1. `this.props.savedPost.status === 'pending' && this.props.post.status === 'pending'`
2. `this.props.savedPost.status === 'draft' && this.props.post.status === 'pending'`

Now, when a post is set to pending and a user toggles it off, `this.props.post.status` won't equal pending so the toggle responds correctly.

Note: Reference to `this.props.savedPost` in these comparisons was introduced back in 9196-gh-calypso-pre-oss to avoid showing UI changes optimistically.

Note 2: In the bug report, the question of "Should the auto-save kick in when this toggle is changed either direction?" was asked. Currently, `this.debouncedAutosave()` is only triggered when [the title changes](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/post-editor.jsx#L349) or [post content is updated](https://github.com/Automattic/wp-calypso/blob/master/client/post-editor/post-editor.jsx#L536). I'm not sure if we want to, but I didn't address that here.

## Testing
1. Fire up this branch
2. Open a new post
3. Type in some content. 
4. Toggle "Pending" on and save the post. The toggle should appear checked.
5. Toggle "Pending" off. The toggle should appear unchecked immediately instead of requiring a save.

## GIF
![pending](https://cloud.githubusercontent.com/assets/7240478/15396135/e6c7c1a2-1d97-11e6-9ae6-c220b758a7ad.gif)

ESLint was throwing some errors so I also updated so semicolons.