### PR TITLE
Jetpack connect: Add a schema for jetpack connect sessions

### DIFF
--- a/client/state/jetpack-connect/reducer.js
+++ b/client/state/jetpack-connect/reducer.js
@@ -35,6 +35,9 @@ import {
 	DESERIALIZE
 } from 'state/action-types';
 
+import { isValidStateWithSchema } from 'state/utils';
+import { jetpackConnectSessionsSchema } from './schema';
+
 const defaultAuthorizeState = {
 	queryObject: {},
 	isAuthorizing: false,
@@ -42,17 +45,24 @@ const defaultAuthorizeState = {
 	authorizeError: false
 };
 
-function buildNoProtocolUrlObj( url ) {
+function buildNoProtocolUrlObj( url, isInstall ) {
 	const noProtocolUrl = url.replace( /.*?:\/\//g, '' );
-	return { [ noProtocolUrl ]: ( new Date() ).getTime() };
+	const sessionValue = {
+		timestamp: Date.now(),
+		isInstall: !! isInstall
+	};
+	return { [ noProtocolUrl ]: sessionValue };
 }
 
 export function jetpackConnectSessions( state = {}, action ) {
 	switch ( action.type ) {
 		case JETPACK_CONNECT_CHECK_URL:
-			const noProtocolUrl = action.url.replace( /.*?:\/\//g, '' );
-			return Object.assign( {}, state, { [ noProtocolUrl ]: Date.now() } );
+			return Object.assign( {}, state, buildNoProtocolUrlObj( action.url, action.isInstall ) );
 		case DESERIALIZE:
+			if ( isValidStateWithSchema( state, jetpackConnectSessionsSchema ) ) {
+				return state;
+			}
+			return {};
 		case SERIALIZE:
 			return state;
 	}

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -1,0 +1,13 @@
+export const jetpackConnectSessionsSchema = {
+	type: 'object',
+	patternProperties: {
+		'/^[a-z0-9-:]+$/': {
+			type: 'object',
+			required: [ 'timestamp' ],
+			properties: {
+				timestamp: { type: 'number' },
+				isInstall: { type: 'boolean' }
+			}
+		}
+	}
+};

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -9,5 +9,6 @@ export const jetpackConnectSessionsSchema = {
 				isInstall: { type: 'boolean' }
 			}
 		}
-	}
+	},
+	additionalProperties: false
 };

--- a/client/state/jetpack-connect/schema.js
+++ b/client/state/jetpack-connect/schema.js
@@ -1,14 +1,15 @@
 export const jetpackConnectSessionsSchema = {
 	type: 'object',
+	additionalProperties: false,
 	patternProperties: {
-		'/^[a-z0-9-:]+$/': {
+		'^[a-z0-9\.\-\:]+$': {
 			type: 'object',
 			required: [ 'timestamp' ],
 			properties: {
 				timestamp: { type: 'number' },
 				isInstall: { type: 'boolean' }
-			}
+			},
+			additionalProperties: false
 		}
-	},
-	additionalProperties: false
+	}
 };

--- a/client/state/jetpack-connect/selectors.js
+++ b/client/state/jetpack-connect/selectors.js
@@ -4,7 +4,7 @@ const isCalypsoStartedConnection = function( state, siteSlug ) {
 	const site = siteSlug.replace( /.*?:\/\//g, '' );
 	if ( state && state[ site ] ) {
 		const currentTime = ( new Date() ).getTime();
-		return ( currentTime - state[ site ] < JETPACK_CONNECT_TTL );
+		return ( currentTime - state[ site ].timestamp < JETPACK_CONNECT_TTL );
 	}
 
 	return false;

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -49,7 +49,8 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.have.property( 'website.com' )
-				.to.be.a( 'number' )
+				.to.be.a( 'object' );
+			expect( state[ 'website.com' ] ).to.have.property( 'timestamp' )
 				.to.be.at.least( nowTime );
 		} );
 	} );

--- a/client/state/jetpack-connect/test/reducer.js
+++ b/client/state/jetpack-connect/test/reducer.js
@@ -7,6 +7,8 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
+
+import { useSandbox } from 'test/helpers/use-sinon';
 import {
 	JETPACK_CONNECT_SSO_QUERY_SET,
 	JETPACK_CONNECT_SSO_AUTHORIZE_REQUEST,
@@ -28,6 +30,10 @@ import reducer, {
 } from '../reducer';
 
 describe( 'reducer', () => {
+	useSandbox( ( sandbox ) => {
+		sandbox.stub( console, 'warn' );
+	} );
+
 	it( 'should export expected reducer keys', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'jetpackConnectSite',


### PR DESCRIPTION
Adds a (tiny) schema for JetpackConnectSessions subtree. My first redux schema ever \o/

Don't mind the "isInstall" property, not in use yet, but it will be in next PRs 

How to test
=========
1. Functional:

    a) Go to http://calypso.localhost:3000/jetpack/connect/ 

    b) Enter a site with a disconnected jetpack (running latest master from jetpack's github) and make sure the connection process works fine (=== as it does in master)

2. Data:
    a) After you enter some urls, go to your developer tools and check the redux tree to see they are there. Reload the site and check they are still there ;P

ping @roccotripaldi @ebinnion  @gwwar 