### PR TITLE
Media: Fix truncated Upload via URL button in Safari

### DIFF
--- a/client/my-sites/media-library/upload-url.scss
+++ b/client/my-sites/media-library/upload-url.scss
@@ -9,6 +9,7 @@
 
 .media-library__upload-url-button-group {
 	display: flex;
+	flex-shrink: 0;
 	padding-left: 8px;
 }
 


### PR DESCRIPTION
Fixes #4911 

This pull request seeks to resolve an issue where the "Upload" button is truncated in the media modal header when uploading a media item via URL.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15401043/d1e09b5a-1dbb-11e6-90c0-a5630d9e79a7.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15401029/c336a612-1dbb-11e6-8cf3-f1da60eda430.png)

__Testing instructions:__

Verify in Safari and your primary browser that the Upload button is not truncated.

1. Navigate to the [post editor](http://calypso.localhost:3000/post)
2. Select a site, if prompted
3. Click Add Media in the editor toolbar
4. Click Add via URL
5. Verify that the Upload and cancel buttons are fully visible

/cc @drw158, @designsimply 