### PR TITLE
Testing: Enable passing directory root to test runner

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -33,6 +33,9 @@ Example for client:
 > npm run test-server server/config/test/parser.js
 > # run single test suite from test folder
 > npm run test-test test/helpers/use-nock/test/index.js
+> # run test suite for all files in a specific folder
+> npm run test-client client/state
+> npm run test-client client/state/posts/test
 ```
 
 ### How to run specified suite or test-case

--- a/test/runner.js
+++ b/test/runner.js
@@ -10,7 +10,8 @@ const debug = require( 'debug' )( 'test-runner' ),
 	glob = require( 'glob' ),
 	Mocha = require( 'mocha' ),
 	path = require( 'path' ),
-	program = require( 'commander' );
+	program = require( 'commander' ),
+	chalk = require( 'chalk' );
 
 /**
  * Internal dependencies
@@ -50,6 +51,13 @@ mocha.suite.afterAll( boot.after );
 
 files = program.args.length ? program.args : [ process.env.TEST_ROOT ];
 files = files.reduce( ( memo, filePath ) => {
+	if ( ! filePath.startsWith( process.env.TEST_ROOT ) ) {
+		console.log(
+			chalk.red.bold( 'WARNING:' ),
+			chalk.yellow( 'Invalid arguments passed to test runner (files with mismatched test root)' )
+		);
+	}
+
 	if ( /\.jsx?$/i.test( filePath ) ) {
 		return memo.concat( filePath );
 	}

--- a/test/runner.js
+++ b/test/runner.js
@@ -54,10 +54,13 @@ files = program.args.length ? program.args : [ process.env.TEST_ROOT ];
 files = files.reduce( ( memo, filePath ) => {
 	// Validate test root matches specified file paths
 	if ( ! filePath.startsWith( process.env.TEST_ROOT ) ) {
-		console.log(
+		console.warn(
 			chalk.red.bold( 'WARNING:' ),
-			chalk.yellow( 'Invalid arguments passed to test runner (files with mismatched test root)' )
+			chalk.yellow( 'Invalid argument passed to test runner. Paths must match test root `' + process.env.TEST_ROOT + '`.' )
 		);
+		console.warn( ' - ' + filePath + '\n' );
+
+		return memo;
 	}
 
 	// Append individual file argument


### PR DESCRIPTION
This pull request seeks to enhance the test runner by enabling a developer to pass a directory root for which tests should be sought and run.

__Testing instructions:__

Existing test behavior should remain unaffected. Specifically, run variations of test commands, including the entire test suite, test suites specific to directories (`client`, `server`, `test`), and specifying a single file.

Next, ensure that you can also use the test runner to run tests within a specific directory. For example:

```
npm run test-client client/state/post-types
```

...should run all test files in `client/state/post-types`, including those in `client/state/post-types/test` and in `client/state/post-types/taxonomies/test`

/cc @gziolo @blowery 