### PR TITLE
Header Cake: updated for consistency

### DIFF
--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
  */
 import ObserveWindowSizeMixin from 'lib/mixins/observe-window-resize';
 import Gridicon from 'components/gridicon';
+import Button from 'components/button';
 import i18n from 'lib/mixins/i18n';
 import viewport from 'lib/viewport';
 
@@ -63,13 +64,10 @@ export default React.createClass( {
 		} );
 
 		return (
-			<a className={ linkClasses } href={ href } onClick={ onClick }>
-				<Gridicon icon="chevron-left" size={ 18 } />
-				{
-					! this.hideText( text ) &&
-					<span className="header-cake__back-text">{ text }</span>
-				}
-			</a>
+			<Button compact borderless className={ linkClasses } href={ href } onClick={ onClick }>
+				<Gridicon icon="arrow-left" size={ 18 } />
+				{ ! this.hideText( text ) && text }
+			</Button>
 		);
 	},
 

--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -10,7 +10,8 @@
 	align-items: center;
 	font-size: 14px;
 	line-height: 18px;
-	padding: 0;
+	padding-top: 11px;
+	padding-bottom: 11px;
 
 	&::after {
 		display: none;
@@ -25,18 +26,9 @@
 	flex: none;
 	display: block;
 	max-width: 33.333%;
-	padding: 16px;
-	color: darken( $gray, 20% );
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	cursor: pointer;
-
-	.gridicon {
-		display: inline-block;
-		vertical-align: middle;
-		opacity: 0.6;
-	}
 
 	&.is-spacer {
 		opacity: 0;
@@ -44,19 +36,13 @@
 	}
 }
 
-.header-cake__back-text {
-	font-size: 11px;
-	font-weight: 600;
-	text-transform: uppercase;
-}
-
 .header-cake__title {
 	flex: 1 1 auto;
-	padding: 16px 0;
-	color: darken( $gray, 20% );
+	color: $gray;
 	text-align: center;
 	word-break: break-word;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	padding: 0 8px;
 }

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -54,10 +54,6 @@
 		text-align: left;
 		padding: 16px;
 		width: 100%;
-
-		.gridicon {
-			margin-right: 4px;
-		}
 	}
 
 	@include breakpoint( "<660px" ) {


### PR DESCRIPTION
* Switched to using compact borderless button as we do in the picker
* Switched to using the arrow-left gridicon as we do in the picker
* Switched headerCake title font style to match sectionHeader since they are similar
* Switched to using native card padding so headerCake matches the cards that come after it
* Nudged the arrow-left gridicon up 1px in site picker and in headerCake

**Before:** 

<img width="762" alt="screen shot 2016-05-19 at 1 29 00 pm" src="https://cloud.githubusercontent.com/assets/437258/15403286/36f5f1d4-1dc6-11e6-88df-f48a1f885462.png">

<img width="269" alt="screen shot 2016-05-19 at 1 29 06 pm" src="https://cloud.githubusercontent.com/assets/437258/15403287/36f7d422-1dc6-11e6-8e5c-a72239d94dbd.png">

**After:**

<img width="275" alt="screen shot 2016-05-19 at 1 28 39 pm" src="https://cloud.githubusercontent.com/assets/437258/15403294/41c1ed84-1dc6-11e6-96da-b5d6bc79c14c.png">

<img width="690" alt="screen shot 2016-05-19 at 1 28 55 pm" src="https://cloud.githubusercontent.com/assets/437258/15403293/41c1ce12-1dc6-11e6-9aaf-589e76c20d61.png">

cc @drw158 @mtias 