### PR TITLE
Fix #5464 wrong apiVersion of `/plans` request.

### DIFF
--- a/client/lib/plans-list/index.js
+++ b/client/lib/plans-list/index.js
@@ -76,7 +76,9 @@ PlansList.prototype.get = function() {
  */
 PlansList.prototype.fetch = function() {
 	debug( 'getting PlansList from api' );
-	wpcom.plans().list( function( error, data ) {
+	wpcom
+	.plans()
+	.list( { apiVersion: '1.2' }, function( error, data ) {
 		if ( error ) {
 			debug( 'error fetching PlansList from api', error );
 			return;


### PR DESCRIPTION
We have to set apiVersion to `1.2` since the default value for this request is `1.1`
This PR fix #5464 