### PR TITLE
Jetpack Plans: Persist the plugins status, display message if install is interrupted

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -15,6 +15,7 @@ import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { canCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
+import { isFinished as isJetpackPluginsFinished } from 'state/plugins/premium/selectors';
 import { abtest } from 'lib/abtest';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
@@ -83,6 +84,24 @@ const SiteNotice = React.createClass( {
 		);
 	},
 
+	jetpackPluginsSetupNotice() {
+		if ( ! this.props.pausedJetpackPluginsSetup || this.props.site.plan.product_slug === 'jetpack_free' ) {
+			return null;
+		}
+
+		return (
+			<Notice isCompact status="is-info" icon="plugins">
+				{ this.translate(
+					'Your %(plan)s plan needs setting up!',
+					{ args: { plan: this.props.site.plan.product_name_short } }
+				) }
+				<NoticeAction href={ `/plugins/setup/${ this.props.site.slug }` } >
+					{ this.translate( 'Finish' ) }
+				</NoticeAction>
+			</Notice>
+		);
+	},
+
 	render() {
 		const { site } = this.props;
 		if ( ! site ) {
@@ -93,6 +112,7 @@ const SiteNotice = React.createClass( {
 				{ this.getSiteRedirectNotice( site ) }
 				<QuerySitePlans siteId={ site.ID } />
 				{ this.domainCreditNotice() }
+				{ this.jetpackPluginsSetupNotice() }
 			</div>
 		);
 	}
@@ -102,7 +122,8 @@ export default connect( ( state, ownProps ) => {
 	const siteId = ownProps.site && ownProps.site.ID ? ownProps.site.ID : null;
 	return {
 		hasDomainCredit: hasDomainCredit( state, siteId ),
-		canManageOptions: canCurrentUser( state, siteId, 'manage_options' )
+		canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
+		pausedJetpackPluginsSetup: ! isJetpackPluginsFinished( state, siteId )
 	};
 }, ( dispatch ) => {
 	return {

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -79,9 +79,14 @@ const PlansSetup = React.createClass( {
 	},
 
 	componentDidMount() {
+		window.addEventListener( 'beforeunload', this.warnIfNotFinished );
 		if ( this.props.siteId ) {
 			this.fetchInstallInstructions();
 		}
+	},
+
+	componentWillUnmount() {
+		window.removeEventListener( 'beforeunload', this.warnIfNotFinished );
 	},
 
 	componentWillReceiveProps( props ) {
@@ -100,6 +105,15 @@ const PlansSetup = React.createClass( {
 		) {
 			this.startNextPlugin( this.props.nextPlugin );
 		}
+	},
+
+	warnIfNotFinished( event ) {
+		if ( this.props.isFinished ) {
+			return;
+		}
+		const beforeUnloadText = this.translate( 'We haven\'t finished installing your plugins.' );
+		( event || window.event ).returnValue = beforeUnloadText;
+		return beforeUnloadText;
 	},
 
 	startNextPlugin( plugin ) {

--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -2,6 +2,7 @@
 * External dependencies
 */
 import { combineReducers } from 'redux';
+import forEach from 'lodash/forEach';
 
 /**
  * Internal dependencies
@@ -17,6 +18,8 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from 'state/action-types';
+import { pluginInstructionSchema } from './schema';
+import { isValidStateWithSchema } from 'state/utils';
 
 /*
  * Tracks the requesting state for premium plugin "instructions" (the list
@@ -72,7 +75,22 @@ export function plugins( state = {}, action ) {
 			}
 			return state;
 		case SERIALIZE:
+			let processedState = {};
+			// Save the error state as a string message.
+			forEach( state, ( pluginList, key ) => {
+				processedState[ key ] = pluginList.map( ( item ) => {
+					if ( item.error !== null ) {
+						return Object.assign( {}, item, { error: item.error.toString() } );
+					}
+					return item;
+				} );
+			} );
+			return processedState;
 		case DESERIALIZE:
+			if ( ! isValidStateWithSchema( state, pluginInstructionSchema ) ) {
+				return {};
+			}
+			return state;
 		default:
 			return state;
 	}

--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -73,7 +73,6 @@ export function plugins( state = {}, action ) {
 			return state;
 		case SERIALIZE:
 		case DESERIALIZE:
-			return {};
 		default:
 			return state;
 	}

--- a/client/state/plugins/premium/schema.js
+++ b/client/state/plugins/premium/schema.js
@@ -1,0 +1,20 @@
+export const pluginInstructionSchema = {
+	type: 'object',
+	patternProperties: {
+		//be careful to escape regexes properly
+		'^[0-9]+$': {
+			type: 'array',
+			items: {
+				required: [ 'slug', 'key' ],
+				properties: {
+					name: { type: 'string' },
+					slug: { type: 'string' },
+					key: { type: 'string' },
+					status: { type: 'string' },
+					error: { type: [ 'object', 'string', 'null' ] },
+				}
+			}
+		}
+	},
+	additionalProperties: false
+};

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -28,7 +28,7 @@ const getPluginsForSite = function( state, siteId ) {
 const isFinished = function( state, siteId ) {
 	let pluginList = getPluginsForSite( state, siteId );
 	if ( pluginList.length === 0 ) {
-		return false;
+		return true;
 	}
 	pluginList = filter( pluginList, ( item ) => {
 		return ( ( 'done' !== item.status ) && ( item.error === null ) );

--- a/client/state/plugins/premium/test/selectors.js
+++ b/client/state/plugins/premium/test/selectors.js
@@ -63,8 +63,8 @@ describe( 'Premium Plugin Selectors', function() {
 	} );
 
 	describe( 'isFinished', function() {
-		it( 'Should get `false` if the requested site is not in the current state', function() {
-			assert.equal( selectors.isFinished( state, 'no.site' ), false );
+		it( 'Should get `true` if the requested site is not in the current state', function() {
+			assert.equal( selectors.isFinished( state, 'no.site' ), true );
 		} );
 
 		it( 'Should get `false` if there is a plugin installing on the requested site', function() {


### PR DESCRIPTION
A user can close the install screen/navigate away mid-install, and the process won't continue behind the scenes. This adds a `SiteNotice` telling the user they need to continue the install, with a link to the setup page.

Since the plugin status is tracked in the redux state, we'll persist that - then we can use the `isFinished` selector to see if the site was interrupted. Once the user goes back to the page, it refreshes the plugin instructions state, and runs the rest of the install process.

This PR also fixes a few issues with loading wp.com sites, and ensuring we can update files before attempting the install.

To test:

- Visit the auto-install screen, either by buying a plan and going through the flow, or by visiting `plugins/setup/$site` for an existing JP Premium or Business plan
- Try to close the tab, or click away to the Reader
- You should get a pop-up confirmation asking if you want to leave the page
- If you do confirm and leave, you should see a notice under the site asking you to finish the installation, like so:

![screen shot 2016-06-07 at 4 52 30 pm](https://cloud.githubusercontent.com/assets/541093/15874421/118886c2-2cd1-11e6-98dc-8cef07d6cfd9.png)
