### PR TITLE
Exporter: More consistent loading placeholders

### DIFF
--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -145,6 +145,13 @@ var FormFields = React.createClass( {
 							<option>3</option>
 							<option>4</option>
 						</FormSelect>
+						<FormSelect id="select-disabled" disabled>
+							<option>Disabled</option>
+						</FormSelect>
+						<br />
+						<FormSelect id="select-error" className="is-error">
+							<option>Error</option>
+						</FormSelect>
 					</FormFieldset>
 
 					<FormFieldset>

--- a/client/components/forms/form-select/style.scss
+++ b/client/components/forms/form-select/style.scss
@@ -9,6 +9,10 @@
 		border-color: darken( $alert-red, 10 );
 	}
 
+	&:disabled {
+		color: lighten( $gray, 10% );
+	}
+
 	&:focus {
 		&.is-error {
 			box-shadow: 0 0 0 2px lighten( $alert-red, 35 );

--- a/client/my-sites/exporter/post-type-options.jsx
+++ b/client/my-sites/exporter/post-type-options.jsx
@@ -77,14 +77,14 @@ const PostTypeOptions = React.createClass( {
 		};
 
 		const placeholderLabels = get( {
-			page: [
+			post: [
 				this.translate( 'Author…' ),
 				this.translate( 'Status…' ),
 				this.translate( 'Start Date…' ),
 				this.translate( 'End Date…' ),
 				this.translate( 'Category…' )
 			],
-			post: [
+			page: [
 				this.translate( 'Author…' ),
 				this.translate( 'Status…' ),
 				this.translate( 'Start Date…' ),

--- a/client/my-sites/exporter/post-type-options.jsx
+++ b/client/my-sites/exporter/post-type-options.jsx
@@ -4,6 +4,7 @@
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import { connect } from 'react-redux';
+import { times } from 'lodash/util';
 
 /**
  * Internal dependencies
@@ -43,9 +44,9 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 } );
 
 /**
- * Displays a list of select menus with a checkbox legend
+ * Displays a list of select menus with a radio option legend
  *
- * Displays a field group with a checkbox legend and optionally
+ * Displays a field group with a radio legend and optionally
  * a list of select menus, or a description to appear beneath the
  * legend.
  */
@@ -61,27 +62,42 @@ const PostTypeOptions = React.createClass( {
 		legend: PropTypes.string.isRequired,
 	},
 
-	renderPlaceholders() {
-		return (
-			<div className="exporter__option-fieldset-fields">
-				<div className="exporter__placeholder-text">
-					{ this.translate( 'Loading options…' ) }
-				</div>
-			</div>
-		);
-	},
-
 	renderFields() {
 		const {
 			fields,
-			postType,
-			siteId,
 			fieldValues,
+			postType,
+			shouldShowPlaceholders,
+			siteId,
 		} = this.props;
+
+		const Placeholder = () => {
+			return (
+				<div className="exporter__placeholder-text">
+					{ this.translate( 'Loading options…' ) }
+				</div>
+			);
+		};
+
+		if ( shouldShowPlaceholders ) {
+			let placeholderCount = 0;
+			if ( postType === 'post' ) {
+				placeholderCount = 5;
+			}
+			if ( postType === 'page' ) {
+				placeholderCount = 4;
+			}
+
+			return (
+				<div className="exporter__option-fieldset-fields">
+					{ times( placeholderCount, ( i ) => <Placeholder key={ i } /> ) }
+				</div>
+			);
+		}
 
 		const Field = ( props ) => {
 			if ( ! props.options ) {
-				// This should be replaced with `return null` in React >= 0.15
+				// This can be replaced with `return null` in React >= 0.15
 				return <span/>;
 			}
 
@@ -115,7 +131,6 @@ const PostTypeOptions = React.createClass( {
 			onSelect,
 			legend,
 			description,
-			shouldShowPlaceholders
 		} = this.props;
 
 		return (
@@ -134,7 +149,7 @@ const PostTypeOptions = React.createClass( {
 					</p>
 				}
 
-				{ shouldShowPlaceholders ? this.renderPlaceholders() : this.renderFields() }
+				{ this.renderFields() }
 			</div>
 		);
 	}

--- a/client/my-sites/exporter/post-type-options.jsx
+++ b/client/my-sites/exporter/post-type-options.jsx
@@ -63,52 +63,25 @@ const PostTypeOptions = React.createClass( {
 		legend: PropTypes.string.isRequired,
 	},
 
-	renderPlaceholders() {
-		const { postType } = this.props;
-
-		const Placeholder = ( props ) => {
-			return (
-				<Select
-				className="exporter__placeholder-select"
-				defaultLabel={ props.label }
-				options={ [] }
-				disabled={ true } />
-			);
-		};
-
-		const placeholderLabels = get( {
-			post: [
-				this.translate( 'Author…' ),
-				this.translate( 'Status…' ),
-				this.translate( 'Start Date…' ),
-				this.translate( 'End Date…' ),
-				this.translate( 'Category…' )
-			],
-			page: [
-				this.translate( 'Author…' ),
-				this.translate( 'Status…' ),
-				this.translate( 'Start Date…' ),
-				this.translate( 'End Date…' ),
-			],
-		}, postType, [] );
-
-		return (
-			<div className="exporter__option-fieldset-fields">
-				{ map( placeholderLabels, ( label, i ) => <Placeholder key={ i } label={ label } /> ) }
-			</div>
-		);
-	},
-
 	renderFields() {
 		const {
 			fields,
 			fieldValues,
 			postType,
+			shouldShowPlaceholders,
 			siteId,
 		} = this.props;
 
+		const fieldsForPostType = get( {
+			'post': [ 'author', 'status', 'start_date', 'end_date', 'category' ],
+			'page': [ 'author', 'status', 'start_date', 'end_date' ],
+		}, postType, [] );
+
 		const Field = ( props ) => {
-			if ( ! props.options ) {
+			const options = get( fields, props.options, [] );
+
+			// Should the field be displayed for this post type?
+			if ( fieldsForPostType.indexOf( props.fieldName ) < 0 ) {
 				// This can be replaced with `return null` in React >= 0.15
 				return <span/>;
 			}
@@ -118,21 +91,22 @@ const PostTypeOptions = React.createClass( {
 			};
 
 			return <Select
+				className={ shouldShowPlaceholders ? 'exporter__placeholder-select' : '' }
 				onChange={ setFieldValue }
 				key={ props.defaultLabel }
 				defaultLabel={ props.defaultLabel }
-				options={ props.options }
+				options={ options }
 				value={ fieldValues[ props.fieldName ] }
-				disabled={ ! this.props.isEnabled } />;
+				disabled={ shouldShowPlaceholders || ! this.props.isEnabled } />;
 		};
 
 		return (
 			<div className="exporter__option-fieldset-fields">
-				<Field defaultLabel={ this.translate( 'Author…' ) } fieldName="author" options={ fields.authors } />
-				<Field defaultLabel={ this.translate( 'Status…' ) } fieldName="status" options={ fields.statuses } />
-				<Field defaultLabel={ this.translate( 'Start Date…' ) } fieldName="start_date" options={ fields.dates } />
-				<Field defaultLabel={ this.translate( 'End Date…' ) } fieldName="end_date" options={ fields.dates } />
-				<Field defaultLabel={ this.translate( 'Category…' ) } fieldName="category" options={ fields.categories } />
+				<Field defaultLabel={ this.translate( 'Author…' ) } fieldName="author" options="authors" />
+				<Field defaultLabel={ this.translate( 'Status…' ) } fieldName="status" options="statuses" />
+				<Field defaultLabel={ this.translate( 'Start Date…' ) } fieldName="start_date" options="dates" />
+				<Field defaultLabel={ this.translate( 'End Date…' ) } fieldName="end_date" options="dates" />
+				<Field defaultLabel={ this.translate( 'Category…' ) } fieldName="category" options="categories" />
 			</div>
 		);
 	},
@@ -143,7 +117,6 @@ const PostTypeOptions = React.createClass( {
 			onSelect,
 			legend,
 			description,
-			shouldShowPlaceholders,
 		} = this.props;
 
 		return (
@@ -162,7 +135,7 @@ const PostTypeOptions = React.createClass( {
 					</p>
 				}
 
-				{ shouldShowPlaceholders ? this.renderPlaceholders() : this.renderFields() }
+				{ this.renderFields() }
 			</div>
 		);
 	}

--- a/client/my-sites/exporter/post-type-options.jsx
+++ b/client/my-sites/exporter/post-type-options.jsx
@@ -4,7 +4,7 @@
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import { connect } from 'react-redux';
-import { times } from 'lodash/util';
+import { map } from 'lodash/collection';
 import { get } from 'lodash/object';
 
 /**
@@ -66,19 +66,35 @@ const PostTypeOptions = React.createClass( {
 	renderPlaceholders() {
 		const { postType } = this.props;
 
-		const Placeholder = () => {
+		const Placeholder = ( props ) => {
 			return (
-				<div className="exporter__placeholder-text">
-					{ this.translate( 'Loading options…' ) }
-				</div>
+				<Select
+				className="exporter__placeholder-select"
+				defaultLabel={ props.label }
+				options={ [] }
+				disabled={ true } />
 			);
 		};
 
-		const placeholderCount = get( { page: 4, post: 5 }, postType, 0 );
+		const placeholderLabels = get( {
+			page: [
+				this.translate( 'Author…' ),
+				this.translate( 'Status…' ),
+				this.translate( 'Start Date…' ),
+				this.translate( 'End Date…' ),
+				this.translate( 'Category…' )
+			],
+			post: [
+				this.translate( 'Author…' ),
+				this.translate( 'Status…' ),
+				this.translate( 'Start Date…' ),
+				this.translate( 'End Date…' ),
+			],
+		}, postType, [] );
 
 		return (
 			<div className="exporter__option-fieldset-fields">
-				{ times( placeholderCount, ( i ) => <Placeholder key={ i } /> ) }
+				{ map( placeholderLabels, ( label, i ) => <Placeholder key={ i } label={ label } /> ) }
 			</div>
 		);
 	},

--- a/client/my-sites/exporter/post-type-options.jsx
+++ b/client/my-sites/exporter/post-type-options.jsx
@@ -5,6 +5,7 @@ import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-pure-render/mixin';
 import { connect } from 'react-redux';
 import { times } from 'lodash/util';
+import { get } from 'lodash/object';
 
 /**
  * Internal dependencies
@@ -62,14 +63,8 @@ const PostTypeOptions = React.createClass( {
 		legend: PropTypes.string.isRequired,
 	},
 
-	renderFields() {
-		const {
-			fields,
-			fieldValues,
-			postType,
-			shouldShowPlaceholders,
-			siteId,
-		} = this.props;
+	renderPlaceholders() {
+		const { postType } = this.props;
 
 		const Placeholder = () => {
 			return (
@@ -79,21 +74,22 @@ const PostTypeOptions = React.createClass( {
 			);
 		};
 
-		if ( shouldShowPlaceholders ) {
-			let placeholderCount = 0;
-			if ( postType === 'post' ) {
-				placeholderCount = 5;
-			}
-			if ( postType === 'page' ) {
-				placeholderCount = 4;
-			}
+		const placeholderCount = get( { page: 4, post: 5 }, postType, 0 );
 
-			return (
-				<div className="exporter__option-fieldset-fields">
-					{ times( placeholderCount, ( i ) => <Placeholder key={ i } /> ) }
-				</div>
-			);
-		}
+		return (
+			<div className="exporter__option-fieldset-fields">
+				{ times( placeholderCount, ( i ) => <Placeholder key={ i } /> ) }
+			</div>
+		);
+	},
+
+	renderFields() {
+		const {
+			fields,
+			fieldValues,
+			postType,
+			siteId,
+		} = this.props;
 
 		const Field = ( props ) => {
 			if ( ! props.options ) {
@@ -131,6 +127,7 @@ const PostTypeOptions = React.createClass( {
 			onSelect,
 			legend,
 			description,
+			shouldShowPlaceholders,
 		} = this.props;
 
 		return (
@@ -149,7 +146,7 @@ const PostTypeOptions = React.createClass( {
 					</p>
 				}
 
-				{ this.renderFields() }
+				{ shouldShowPlaceholders ? this.renderPlaceholders() : this.renderFields() }
 			</div>
 		);
 	}

--- a/client/my-sites/exporter/select.jsx
+++ b/client/my-sites/exporter/select.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -16,7 +15,7 @@ export default class Select extends Component {
 		} );
 
 		return (
-			<FormSelect { ...this.props } className={ classNames( 'exporter__option-fieldset-select', this.props.className ) }>
+			<FormSelect { ...this.props }>
 				<option value="">{ this.props.defaultLabel }</option>
 				{ options }
 			</FormSelect>

--- a/client/my-sites/exporter/select.jsx
+++ b/client/my-sites/exporter/select.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -15,7 +16,7 @@ export default class Select extends Component {
 		} );
 
 		return (
-			<FormSelect { ...this.props }>
+			<FormSelect { ...this.props } className={ classNames( 'exporter__option-fieldset-select', this.props.className ) }>
 				<option value="">{ this.props.defaultLabel }</option>
 				{ options }
 			</FormSelect>

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -59,10 +59,6 @@
 	}
 }
 
-.exporter__option-fieldset-select:disabled {
-	color: lighten( $gray, 10% );
-}
-
 // The following specificity is required to override the form-label selector:
 // .form-label input[type="checkbox"] + span { font-weight: normal }
 .exporter__option-fieldset-legend .exporter__option-fieldset-legend-text {

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -24,15 +24,15 @@
 	float: right;
 }
 
-.exporter__placeholder-text {
-	padding-left: 24px;
-	padding-right: 24px;
-	margin-bottom: 24px;
-	height: 32px;
 
-	color: transparent;
-	background-color: lighten( $gray, 30% );
-	animation: loading-fade 1.6s ease-in-out infinite;
+.exporter__placeholder-select {
+	animation: exporter__placeholder-select-fade 1.6s ease-in-out infinite;
+
+	@keyframes exporter__placeholder-select-fade {
+		0% { opacity: .2; }
+		50% { opacity: .8; }
+		100% { opacity: .2; }
+	}
 }
 
 .exporter__advanced-settings {

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -24,15 +24,8 @@
 	float: right;
 }
 
-
 .exporter__placeholder-select {
-	animation: exporter__placeholder-select-fade 1.6s ease-in-out infinite;
-
-	@keyframes exporter__placeholder-select-fade {
-		0% { opacity: .2; }
-		50% { opacity: .8; }
-		100% { opacity: .2; }
-	}
+	animation: loading-fade 1.6s ease-in-out infinite;
 }
 
 .exporter__advanced-settings {
@@ -64,6 +57,10 @@
 		margin-top: inherit;
 		flex: 1;
 	}
+}
+
+.exporter__option-fieldset-select:disabled {
+	color: lighten( $gray, 10% );
 }
 
 // The following specificity is required to override the form-label selector:


### PR DESCRIPTION
This changes the loading placeholders for the Exporter's advanced settings to match the number of dropdowns, for a less jarring experience when the data arrives.

| Before  | After |
| ------------- | ------------- |
| ![export-placeholders-before](https://cloud.githubusercontent.com/assets/416133/15414792/2fdf4538-1e81-11e6-9d1c-fac990063850.gif)  | ![export-placeholders-after](https://cloud.githubusercontent.com/assets/416133/15414796/3d353ed6-1e81-11e6-815c-ca657bd26f38.gif)  |

### Testing instructions

1. Open **My Sites -> Settings**
2. Using Chrome's throttling tools on the Network tab, set to simulate the worst connection
3. Click the **Export** tab, then the down chevron
4. Notice the pulsing placeholders match the number of dropdowns that appear later