### PR TITLE
Themes: Add live preview to sheet

### DIFF
--- a/client/components/web-preview/index.jsx
+++ b/client/components/web-preview/index.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */

--- a/client/lib/touch-detect/index.js
+++ b/client/lib/touch-detect/index.js
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * Module exports.
  */
@@ -15,6 +17,6 @@ module.exports = {
 	 */
 	hasTouch: function() {
 		/* global DocumentTouch:true */
-		return ( ( 'ontouchstart' in window ) || window.DocumentTouch && document instanceof DocumentTouch );
+		return window && ( ( 'ontouchstart' in window ) || window.DocumentTouch && document instanceof DocumentTouch );
 	}
 };

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -143,7 +143,7 @@ const ThemeSheet = React.createClass( {
 		return (
 			<div className="themes__sheet-screenshot">
 				<a className="themes__sheet-preview-link" onClick={ this.togglePreview } >
-					<Gridicon icon="external" />
+					<Gridicon icon="external" size="18" />
 					<span className="themes__sheet-preview-link-text">{ i18n.translate( 'Live Preview' ) }</span>
 				</a>
 				{ this.props.screenshot && img }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -35,6 +35,7 @@ import ThemesSiteSelectorModal from 'my-sites/themes/themes-site-selector-modal'
 import actionLabels from 'my-sites/themes/action-labels';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import EmptyContentComponent from 'components/empty-content';
+import ThemePreview from 'my-sites/themes/theme-preview';
 
 const ThemeSheet = React.createClass( {
 	displayName: 'ThemeSheet',
@@ -110,6 +111,10 @@ const ThemeSheet = React.createClass( {
 			return this.getValidSections()[0];
 		}
 		return section;
+	},
+
+	togglePreview() {
+		this.setState( { showPreview: ! this.state.showPreview } );
 	},
 
 	renderBar() {
@@ -299,6 +304,12 @@ const ThemeSheet = React.createClass( {
 						{ ! this.isActive() && priceElement }
 					</Button>
 				</HeaderCake>
+				{ this.state.showPreview && <ThemePreview showPreview={ this.state.showPreview }
+					theme={ this.props }
+					onClose={ this.togglePreview }
+					buttonLabel= { 'temp' }
+					onButtonClick={ this.togglePreview } />
+				}
 				<div className="themes__sheet-columns">
 					<div className="themes__sheet-column-left">
 						<div className="themes__sheet-content">
@@ -308,6 +319,10 @@ const ThemeSheet = React.createClass( {
 						</div>
 					</div>
 					<div className="themes__sheet-column-right">
+						<a className="themes__sheet-preview-link" onClick={ this.togglePreview } >
+							<Gridicon icon="external" />
+							{ i18n.translate( 'Live Preview' ) }
+						</a>
 						{ this.renderScreenshot() }
 					</div>
 				</div>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -142,6 +142,10 @@ const ThemeSheet = React.createClass( {
 		const img = <img className="themes__sheet-img" src={ this.props.screenshot + '?=w680' } />;
 		return (
 			<div className="themes__sheet-screenshot">
+				<a className="themes__sheet-preview-link" onClick={ this.togglePreview } >
+					<Gridicon icon="external" />
+					<span className="themes__sheet-preview-link-text">{ i18n.translate( 'Live Preview' ) }</span>
+				</a>
 				{ this.props.screenshot && img }
 			</div>
 		);
@@ -315,6 +319,7 @@ const ThemeSheet = React.createClass( {
 					action={ this.props[ this.state.selectedAction ] }
 					sourcePath={ `/theme/${ this.props.id }/${ section }` }
 				/> }
+				{ this.state.showPreview && this.renderPreview() }
 				<HeaderCake className="themes__sheet-action-bar"
 							backHref={ this.props.backPath }
 							backText={ i18n.translate( 'All Themes' ) }>
@@ -323,7 +328,6 @@ const ThemeSheet = React.createClass( {
 						{ ! this.isActive() && priceElement }
 					</Button>
 				</HeaderCake>
-				{ this.state.showPreview && this.renderPreview() }
 				<div className="themes__sheet-columns">
 					<div className="themes__sheet-column-left">
 						<div className="themes__sheet-content">
@@ -333,10 +337,6 @@ const ThemeSheet = React.createClass( {
 						</div>
 					</div>
 					<div className="themes__sheet-column-right">
-						<a className="themes__sheet-preview-link" onClick={ this.togglePreview } >
-							<Gridicon icon="external" />
-							{ i18n.translate( 'Live Preview' ) }
-						</a>
 						{ this.renderScreenshot() }
 					</div>
 				</div>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -143,7 +143,7 @@ const ThemeSheet = React.createClass( {
 		return (
 			<div className="themes__sheet-screenshot">
 				<a className="themes__sheet-preview-link" onClick={ this.togglePreview } >
-					<Gridicon icon="external" size="18" />
+					<Gridicon icon="external" size={ 18 } />
 					<span className="themes__sheet-preview-link-text">{ i18n.translate( 'Live Preview' ) }</span>
 				</a>
 				{ this.props.screenshot && img }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -90,6 +90,14 @@ const ThemeSheet = React.createClass( {
 		}
 	},
 
+	onPreviewButtonClick() {
+		if ( ! this.props.isLoggedIn ) {
+			this.props.signup( this.props );
+		} else {
+			this.selectSiteAndDispatch( 'customize' );
+		}
+	},
+
 	selectSiteAndDispatch( action ) {
 		if ( this.props.selectedSite ) {
 			this.props[ action ]( this.props, this.props.selectedSite, 'showcase-sheet' );
@@ -246,6 +254,17 @@ const ThemeSheet = React.createClass( {
 		return <ThemeDownloadCard theme={ this.props.id } href={ this.props.download } />;
 	},
 
+	renderPreview() {
+		const buttonLabel = this.props.isLoggedIn ? i18n.translate( 'Try & Customize' ) : i18n.translate( 'Pick this design' );
+		return(
+			<ThemePreview showPreview={ this.state.showPreview }
+				theme={ this.props }
+				onClose={ this.togglePreview }
+				buttonLabel= { buttonLabel }
+				onButtonClick={ this.onPreviewButtonClick } />
+		);
+	},
+
 	renderError() {
 		const emptyContentTitle = i18n.translate( 'Looking for great WordPress designs?', {
 			comment: 'Message displayed when requested theme was not found',
@@ -304,12 +323,7 @@ const ThemeSheet = React.createClass( {
 						{ ! this.isActive() && priceElement }
 					</Button>
 				</HeaderCake>
-				{ this.state.showPreview && <ThemePreview showPreview={ this.state.showPreview }
-					theme={ this.props }
-					onClose={ this.togglePreview }
-					buttonLabel= { 'temp' }
-					onButtonClick={ this.togglePreview } />
-				}
+				{ this.state.showPreview && this.renderPreview() }
 				<div className="themes__sheet-columns">
 					<div className="themes__sheet-column-left">
 						<div className="themes__sheet-content">

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -8,7 +8,6 @@
 		width: 100%;
 	}
 
-
 	h1 {
 		display: block;
 		font-weight: 300;
@@ -388,18 +387,42 @@
 }
 
 .themes__sheet-preview-link {
+	display: flex;
 	position: absolute;
-		top: -30px;
-	color: $white;
-	text-transform: uppercase;
+		top: -28px;
+	color: lighten( $gray, 30% );
 	cursor: pointer;
+	transition: all ease-in-out 100ms;
+
+	&:hover {
+		color: $white;
+	}
+
+	.gridicon {
+		margin: 0 8px 0 -4px;
+	}
+
+	.themes__sheet-preview-link-text {
+		font-size: 12px;
+		margin-top: 2px;
+		text-transform: uppercase;
+	}
 
 	@include breakpoint( "<660px" ) {
 		color: transparentize( $gray, 0.2 );
 		top: 90%;
 		margin-left: 30px;
 
-		span.themes__sheet-preview-link-text {
+		&:hover {
+			color: $gray-dark;
+		}
+
+		.gridicon {
+			width: 24px;
+			height: 24px;
+		}
+
+		.themes__sheet-preview-link-text {
 			display: none;
 		}
 	}

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -387,6 +387,13 @@
 	}
 }
 
+.themes__sheet-preview-link {
+	position: absolute;
+		top: 60px;
+	color: rgba(255, 255, 255, 0.6);
+	text-transform: uppercase;
+}
+
 .footer__line {
 	color: lighten( $gray, 20% );
 	border-top: 1px solid lighten( $gray, 20% );

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -389,9 +389,20 @@
 
 .themes__sheet-preview-link {
 	position: absolute;
-		top: 60px;
-	color: rgba(255, 255, 255, 0.6);
+		top: -30px;
+	color: $white;
 	text-transform: uppercase;
+	cursor: pointer;
+
+	@include breakpoint( "<660px" ) {
+		color: transparentize( $gray, 0.2 );
+		top: 90%;
+		margin-left: 30px;
+
+		span.themes__sheet-preview-link-text {
+			display: none;
+		}
+	}
 }
 
 .footer__line {

--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -1,3 +1,5 @@
+/** @ssr-ready **/
+
 /**
  * External dependencies
  */
@@ -38,4 +40,4 @@ export default React.createClass( {
 			</WebPreview>
 		);
 	}
-} )
+} );

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -133,6 +133,7 @@ export function receiveThemeDetails( theme ) {
 		themeDownload: theme.download_uri || undefined,
 		themeTaxonomies: theme.taxonomies,
 		themeStylesheet: theme.stylesheet,
+		themeDemoUri: theme.demo_uri,
 	};
 }
 

--- a/client/state/themes/theme-details/reducer.js
+++ b/client/state/themes/theme-details/reducer.js
@@ -29,6 +29,7 @@ export default ( state = Map(), action ) => {
 					download: action.themeDownload,
 					taxonomies: action.themeTaxonomies,
 					stylesheet: action.themeStylesheet,
+					demo_uri: action.themeDemoUri,
 				} ) );
 		case THEME_DETAILS_RECEIVE_FAILURE:
 			return state.set( action.themeId, Map( { error: action.error } ) );

--- a/client/state/themes/theme-details/test/reducer.js
+++ b/client/state/themes/theme-details/test/reducer.js
@@ -36,6 +36,7 @@ describe( 'reducer', () => {
 			themeSupportDocumentation: 'support comes from within',
 			themeStylesheet: 'premium/mood',
 			themeDownload: 'mood.zip',
+			themeDemoUri: 'https://mooddemo.wordpress.com/',
 			themeTaxonomies: {
 				features: [ {
 					term_id: null,
@@ -62,6 +63,7 @@ describe( 'reducer', () => {
 			supportDocumentation: 'support comes from within',
 			stylesheet: 'premium/mood',
 			download: 'mood.zip',
+			demo_uri: 'https://mooddemo.wordpress.com/',
 			taxonomies: {
 				features: [ {
 					term_id: null,


### PR DESCRIPTION
Addresses #3162

**To Test**
* Go to http://calypso.localhost:3000/theme/{theme} both logged-in and logged-out
* e.g: http://calypso.localhost:3000/theme/twentysixteen

Expected
* Clicking the LIVE PREVIEW link brings up the preview overlay
* the button on the preview should perform the appropriate action


![screen shot 2016-05-26 at 18 26 25](https://cloud.githubusercontent.com/assets/7767559/15583839/723267c4-236f-11e6-9f3e-75dd6cc1a0ac.png)
![screen shot 2016-05-26 at 18 26 47](https://cloud.githubusercontent.com/assets/7767559/15583843/740b03b2-236f-11e6-9088-0c725fc717d1.png)
![screen shot 2016-05-26 at 18 27 00](https://cloud.githubusercontent.com/assets/7767559/15583845/76b91b26-236f-11e6-8522-e70dc0615eff.png)