### PR TITLE
State: Refactor and test getSiteByUrl selector

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -7,6 +7,7 @@ import map from 'lodash/map';
 import filter from 'lodash/filter';
 import some from 'lodash/some';
 import includes from 'lodash/includes';
+import find from 'lodash/find';
 
 /**
  * Internal dependencies
@@ -104,17 +105,21 @@ export function isRequestingSites( state ) {
 }
 
 /**
- * Returns true if an url is already in the current site list
- * @param {Object}	state Global state tree
- * @return {Boolean}
+ * Returns a site object by its URL.
+ *
+ * @param  {Object}  state Global state tree
+ * @param  {String}  url   Site URL
+ * @return {?Object}       Site object
  */
 export function getSiteByUrl( state, url ) {
-	for ( let siteId in state.sites.items ) {
-		const siteSlug = getSiteSlug( state, siteId );
-		const urlSlug = url.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
-		if ( siteSlug === urlSlug ) {
-			return state.sites.items[ siteId ];
-		}
+	const slug = url.replace( /^https?:\/\//, '' ).replace( /\//g, '::' );
+	const site = find( state.sites.items, ( item, siteId ) => {
+		return getSiteSlug( state, siteId ) === slug;
+	} );
+
+	if ( ! site ) {
+		return null;
 	}
-	return null;
+
+	return site;
 }

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -12,7 +12,8 @@ import {
 	isSiteConflicting,
 	isJetpackSite,
 	getSiteSlug,
-	isRequestingSites
+	isRequestingSites,
+	getSiteByUrl
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -251,6 +252,50 @@ describe( 'selectors', () => {
 			expect( isRequestingSites( state ) ).to.equal( true );
 			expect( isRequestingSites( emptyState ) ).to.equal( false );
 			expect( isRequestingSites( falseState ) ).to.equal( false );
+		} );
+	} );
+
+	describe( '#getSiteByUrl()', () => {
+		it( 'should return null if a site cannot be found', () => {
+			const site = getSiteByUrl( {
+				sites: {
+					items: {}
+				}
+			}, 'https://testtwosites2014.wordpress.com' );
+
+			expect( site ).to.be.null;
+		} );
+
+		it( 'should return a matched site', () => {
+			const state = {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://testtwosites2014.wordpress.com'
+						}
+					}
+				}
+			};
+			const site = getSiteByUrl( state, 'https://testtwosites2014.wordpress.com' );
+
+			expect( site ).to.equal( state.sites.items[ 77203199 ] );
+		} );
+
+		it( 'should return a matched site with nested path', () => {
+			const state = {
+				sites: {
+					items: {
+						77203199: {
+							ID: 77203199,
+							URL: 'https://testtwosites2014.wordpress.com/path/to/site'
+						}
+					}
+				}
+			};
+			const site = getSiteByUrl( state, 'https://testtwosites2014.wordpress.com/path/to/site' );
+
+			expect( site ).to.equal( state.sites.items[ 77203199 ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
This pull request seeks to refactor the `getSiteByUrl` method in `client/state/sites/selectors`, with the following in mind:

- Include missing tests
- Provide accurate docblock documentation
- Generate slug from URL argument a single time per function call
- Use [Lodash `_.find`](https://lodash.com/docs#find) for finding site in set of items

__Testing instructions:__

Repeat testing instructions from #5325.

Ensure Mocha tests pass:

```
npm run test-client
```

/cc @johnHackworth @mtias 