### PR TITLE
GuidedTours: Remove duplicate actions

### DIFF
--- a/client/state/ui/actions.js
+++ b/client/state/ui/actions.js
@@ -4,16 +4,7 @@
 import {
 	SELECTED_SITE_SET,
 	SET_SECTION,
-	GUIDED_TOUR_SHOW,
-	GUIDED_TOUR_UPDATE,
 } from 'state/action-types';
-
-import {
-	withAnalytics,
-	recordTracksEvent,
-} from 'state/analytics/actions';
-
-import guidedToursConfig from 'layout/guided-tours/config';
 
 /**
  * Returns an action object to be used in signalling that a site has been set
@@ -49,59 +40,4 @@ export function setSection( section, options = {} ) {
 	}
 	options.hasSidebar = ( options.hasSidebar === false ) ? false : true;
 	return options;
-}
-
-/**
- * Returns an action object which will be used to hide or show a specific tour.
- *
- * @param {Object} options Options object, see fn signature.
- * @return {Object} Action object
- */
-export function showGuidedTour( { shouldShow, shouldDelay = false, tour = 'main' } ) {
-	const showAction = {
-		type: GUIDED_TOUR_SHOW,
-		shouldShow,
-		shouldDelay,
-		tour,
-	};
-
-	const trackEvent = recordTracksEvent( 'calypso_guided_tours_show', {
-		tour_version: guidedToursConfig.version,
-		tour,
-	} );
-
-	return withAnalytics( trackEvent, showAction );
-}
-
-export function quitGuidedTour( { tour = 'main', stepName, finished } ) {
-	const quitAction = {
-		type: GUIDED_TOUR_UPDATE,
-		shouldShow: false,
-		shouldReallyShow: false,
-		shouldDelay: false,
-		tour,
-		stepName,
-	};
-
-	const trackEvent = recordTracksEvent( `calypso_guided_tours_${ finished ? 'finished' : 'quit' }`, {
-		step: stepName,
-		tour_version: guidedToursConfig.version,
-		tour,
-	} );
-
-	return withAnalytics( trackEvent, quitAction );
-}
-export function nextGuidedTourStep( { tour = 'main', stepName } ) {
-	const nextAction = {
-		type: GUIDED_TOUR_UPDATE,
-		stepName,
-	};
-
-	const trackEvent = recordTracksEvent( 'calypso_guided_tours_next_step', {
-		step: stepName,
-		tour_version: guidedToursConfig.version,
-		tour,
-	} );
-
-	return withAnalytics( trackEvent, nextAction );
 }


### PR DESCRIPTION
Somehow these actions were left over from the move to a separate directory. Removing them here.

To test:
- http://calypso.localhost:3000?tour=main — make sure the tour still works
- Check for console/webpack errors