### PR TITLE
DesignPreview: Switch off markup injection from endpoint

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -89,6 +89,7 @@
 		"me/security/checkup": true,
 		"me/trophies": false,
 		"preview-layout": true,
+		"preview-endpoint": false,
 		"muse": true,
 		"network-connection": true,
 		"notifications2beta": true,


### PR DESCRIPTION
Let's load our preview iframes the regular way for now, until the preview endpoint is ready for private sites and Jetpack.

**Remove 5783b1c before merging.**

To test:
1. Load up Calypso with a site selected
2. Click the current side card
3. The site's preview should be shown, and there should be no XHRs to the preview endpoint.
4. Try switching to another site, check the preview has changed.