### PR TITLE
Theme Showcase: Adding styles for theme sheets

### DIFF
--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -222,54 +222,54 @@
 	}
 
 	h2 {
-	  color: #87a6bc; /* $gray */
-	  font-size: 14px;
-	  font-weight: 400;
+		color: #87a6bc; /* $gray */
+		font-size: 14px;
+		font-weight: 400;
 
-	  margin: -20px -20px 20px;
-	  padding: 15px 20px 15px;
-	  border-bottom: 1px solid #dce5eb;
+		margin: -20px -20px 20px;
+		padding: 15px 20px 15px;
+		border-bottom: 1px solid #dce5eb;
 
 		&:nth-child(n+2) {
 			// Everything except the first
-		  border-top: 1px solid #dce5eb;
-		  margin: 20px -20px 20px;
-		  padding: 15px 20px 15px;
+			border-top: 1px solid #dce5eb;
+			margin: 20px -20px 20px;
+			padding: 15px 20px 15px;
 
 			&:before {
 				// The "fake" Card separation
-			  content: "";
-			  display: block;
-			  height: 15px;
-			  margin: -15px -21px 15px;
-			  border-bottom: 1px solid #dce5eb;
-			  background: #f3f6f8;
+				content: "";
+				display: block;
+				height: 15px;
+				margin: -15px -21px 15px;
+				border-bottom: 1px solid #dce5eb;
+				background: #f3f6f8;
 			}
 		}
 	}
 
 	h3 {
-	  font-size: 20px;
-	  font-weight: 200;
-	  margin: 40px 0 10px;
+		font-size: 20px;
+		font-weight: 200;
+		margin: 40px 0 10px;
 	}
 
 	h4 {
-	  font-size: 18px;
-	  font-weight: 200;
-	  margin: 40px 0 10px;
+		font-size: 18px;
+		font-weight: 200;
+		margin: 40px 0 10px;
 	}
 
 	h5 {
-	  font-size: 16px;
-	  font-weight: 200;
-	  margin: 40px 0 10px;
+		font-size: 16px;
+		font-weight: 200;
+		margin: 40px 0 10px;
 	}
 
 	h6 {
-	  font-size: 14px;
-	  font-weight: 200;
-	  margin: 40px 0 10px;
+		font-size: 14px;
+		font-weight: 200;
+		margin: 40px 0 10px;
 	}
 
 	pre {
@@ -283,38 +283,36 @@
 	}
 
 	.notes {
-	  background: $gray-light;
-	  margin: 40px -20px -20px;
-	  border-top: 1px solid #e9eff3;
-	  padding: 20px;
+		background: $gray-light;
+		margin: 40px -20px -20px;
+		border-top: 1px solid #e9eff3;
+		padding: 20px;
 
-	  font-size: 13px;
-	  line-height: 21px;
+		font-size: 13px;
+		line-height: 21px;
 
 		&>p:first-child {
-		  color: $gray;
-		  font-weight: 600;
-		  margin: 0 0 14px;
+			color: $gray;
+			font-weight: 600;
+			margin: 0 0 14px;
 		}
 
 		ol {
-		  margin-left: 20px;
+			margin-left: 20px;
 		}
 
 		code {
-		  font-size: 11px;
-		  background: #ffffff;
-		  padding: 2px 4px;
-		  border-radius: 4px;
+			font-size: 11px;
+			background: #ffffff;
+			padding: 2px 4px;
+			border-radius: 4px;
 		}
 
 		:last-child {
-		  margin-bottom: 5px;
+			margin-bottom: 5px;
 		}
 	}
 }
-
-
 
 .themes__sheet-placeholder {
 	color: transparent;

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -276,6 +276,12 @@
 		white-space: pre-wrap;
 	}
 
+	blockquote {
+		padding: 30px;
+		margin: 0 -20px;
+		border-left: 2px solid $gray;
+	}
+
 	.notes {
 	  background: $gray-light;
 	  margin: 40px -20px -20px;

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -186,14 +186,113 @@
 
 .themes__sheet-content {
 	padding: 20px;
-	// whilst loading
-	min-height: 900px;
+	font-size: 14px;
+
+	min-height: 900px; // whilst loading
 
 	div {
-		// override inline style in content markup
-		width: auto !important;
+		width: auto !important; // override inline style in content markup
+	}
+
+	p:last-child {
+  	margin-bottom: 0;
+	}
+
+	img {
+  	margin: 0 -20px;
+  	max-width: calc(100% + 40px);
+
+		&.aligncenter {
+			display: block;
+		  margin: 20px auto;
+		  border: 1px solid $gray-light;
+		}
+	}
+
+	h2 {
+	  color: #87a6bc; /* $gray */
+	  font-size: 14px;
+	  font-weight: 400;
+
+	  margin: -20px -20px 20px;
+	  padding: 15px 20px 15px;
+	  border-bottom: 1px solid #dce5eb;
+
+		&:nth-child(n+2) {
+			// Everything except the first
+		  border-top: 1px solid #dce5eb;
+		  margin: 20px -20px 20px;
+		  padding: 15px 20px 15px;
+
+			&:before {
+				// The "fake" Card separation
+			  content: "";
+			  display: block;
+			  height: 15px;
+			  margin: -15px -21px 15px;
+			  border-bottom: 1px solid #dce5eb;
+			  background: #f3f6f8;
+			}
+		}
+	}
+
+	h3 {
+	  font-size: 20px;
+	  font-weight: 200;
+	  margin: 40px 0 10px;
+	}
+
+	h4 {
+	  font-size: 18px;
+	  font-weight: 200;
+	  margin: 40px 0 10px;
+	}
+
+	h5 {
+	  font-size: 16px;
+	  font-weight: 200;
+	  margin: 40px 0 10px;
+	}
+
+	h6 {
+	  font-size: 14px;
+	  font-weight: 200;
+	  margin: 40px 0 10px;
+	}
+
+	.notes {
+	  background: $gray-light;
+	  margin: 40px -20px -20px;
+	  border-top: 1px solid #e9eff3;
+	  padding: 20px;
+
+	  font-size: 13px;
+	  line-height: 21px;
+
+		&>p:first-child {
+		  color: $gray;
+		  font-weight: 600;
+		  margin: 0 0 14px;
+		}
+
+		ol {
+		  margin-left: 20px;
+		}
+
+		code {
+		  font-size: 11px;
+		  background: #ffffff;
+		  padding: 2px 4px;
+		  border-radius: 4px;
+		}
+
+		:last-child {
+		  margin-bottom: 5px;
+		}
 	}
 }
+
+
 
 .themes__sheet-placeholder {
 	color: transparent;

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -199,13 +199,25 @@
 	}
 
 	img {
-  	margin: 0 -20px;
-  	max-width: calc(100% + 40px);
-
 		&.aligncenter {
+			max-width: 100%;
 			display: block;
-		  margin: 20px auto;
-		  border: 1px solid $gray-light;
+			margin: 20px auto;
+			border: 1px solid $gray-light;
+		}
+
+		&.alignright,
+		&.alignleft {
+			max-width: 100%;
+			margin: 20px 0;
+		}
+
+		&.alignright {
+			float: right;
+		}
+
+		&.alignleft {
+			float: left;
 		}
 	}
 

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -272,6 +272,10 @@
 	  margin: 40px 0 10px;
 	}
 
+	pre {
+		white-space: pre-wrap;
+	}
+
 	.notes {
 	  background: $gray-light;
 	  margin: 40px -20px -20px;


### PR DESCRIPTION
Implementing #5470. 

This PR implements the styling of the content body coming of the theme details and setup:

* font size normalized
* `h2` is converted to Calypso Card titles-alike
* `h3` and others marked, but should be reviewed theme-by-theme
* `img` are made edge-to-edge
* "Quick Specs" have their own blocks

#### How to test

1. Open http://calypso.localhost:3000/theme/mood
2. Check the first column of the page, both Overview and Setup
3. Check all the styling, and give feedback on how it looks

_Note: in some instances the markup/content should be reviewed, so it might not be a style problem but a markup content._

/cc @kathrynwp 