### PR TITLE
Jetpack Connect: switched back link for compact borderless button

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -209,6 +209,10 @@ button {
 			height: 18px;
 			top: 5px;
 		}
+		.gridicons-arrow-left {
+			top: 4px;
+			margin-right: 4px;
+		}
 	}
 }
 

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -289,12 +289,10 @@ const JetpackConnectMain = React.createClass( {
 
 	renderBackButton() {
 		return (
-			<a className="navigation-link jetpack-connect__back-button" onClick={ this.clearUrl }>
-				<span className="navigation-link__label">
-					<Gridicon icon="arrow-left" size={ 18 } />
-					{ this.translate( 'Back' ) }
-				</span>
-			</a>
+			<Button compact borderless className="jetpack-connect__back-button" onClick={ this.clearUrl }>
+				<Gridicon icon="arrow-left" size={ 18 } />
+				{ this.translate( 'Back' ) }
+			</Button>
 		);
 	},
 

--- a/client/signup/jetpack-connect/style.scss
+++ b/client/signup/jetpack-connect/style.scss
@@ -20,11 +20,10 @@
 	text-align: center;
 	margin-bottom: 24px;
 
-	.button {
+	.button.is-primary {
 		width: 320px;
 	}
 }
-
 
 .jetpack-connect__site-url-entry-container {
 	max-width: 400px;
@@ -105,6 +104,10 @@
 	.logged-out-form__links .gridicon {
 		top: 2px;
 	}
+}
+
+.jetpack-connect__back-button {
+	margin-top: 16px;
 }
 
 .jetpack-connect__install-steps {


### PR DESCRIPTION
Also moved icon positioning upstream to the button component's css file since the arrow-left is misaligned everywhere.

If merged this will affect a few other back buttons (the site picker, the header cake once #5466 is merged).

In another PR I will update the NUX to use a compact borderless button instead of a non-component 'navigational-link'.

**Before:**
<img width="379" alt="screen shot 2016-05-20 at 3 48 08 pm" src="https://cloud.githubusercontent.com/assets/437258/15440232/4cf61c8e-1ea2-11e6-8813-39c66af1331a.png">

**After:**
<img width="357" alt="screen shot 2016-05-20 at 3 47 42 pm" src="https://cloud.githubusercontent.com/assets/437258/15440234/52047c98-1ea2-11e6-82ea-cbbe1f817ede.png">

cc @folletto 