### PR TITLE
Navigation Link: made nav link use a compact borderless button

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -207,9 +207,16 @@ button {
 			height: 18px;
 			top: 5px;
 		}
+
+		//arrows sit 1px low in their svg bounding box, need a nudge
 		.gridicons-arrow-left {
 			top: 4px;
 			margin-right: 4px;
+		}
+
+		.gridicons-arrow-right {
+			top: 4px;
+			margin-left: 4px;
 		}
 	}
 }

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -8,6 +8,7 @@ import find from 'lodash/find';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import Button from 'components/button';
 import Gridicon from 'components/gridicon';
 import { submitSignupStep } from 'lib/signup/actions';
 import signupUtils from 'signup/utils';
@@ -72,23 +73,21 @@ const NavigationLink = React.createClass( {
 		let backGridicon, forwardGridicon, text;
 
 		if ( this.props.direction === 'back' ) {
-			backGridicon = <Gridicon icon="chevron-left" size={ 18 } />;
+			backGridicon = <Gridicon icon="arrow-left" size={ 18 } />;
 			text = this.translate( 'Back' );
 		}
 
 		if ( this.props.direction === 'forward' ) {
-			forwardGridicon = <Gridicon icon="chevron-right" size={ 18 } />;
+			forwardGridicon = <Gridicon icon="arrow-right" size={ 18 } />;
 			text = this.translate( 'Skip for now' );
 		}
 
 		return (
-			<a className="navigation-link" href={ this.getBackUrl() } onClick={ this.handleClick }>
-				<span className="navigation-link__label">
-					{ backGridicon }
-					{ text }
-					{ forwardGridicon }
-				</span>
-			</a>
+			<Button compact borderless className="navigation-link" href={ this.getBackUrl() } onClick={ this.handleClick }>
+				{ backGridicon }
+				{ text }
+				{ forwardGridicon }
+			</Button>
 		);
 	}
 } );

--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -1,31 +1,6 @@
 .navigation-link {
 	cursor: pointer;
 	display: inline-block;
-	margin: 20px auto;
+	margin: 24px auto;
 	text-align: center;
-
-	.gridicon {
-		color: darken( $gray, 20% );
-	    margin-top: -2px;
-		opacity: 0.6;
-	    vertical-align: middle;
-	}
-}
-
-.navigation-link__label {
-	color: darken( $gray, 20% );
-	font-size: 11px;
-	font-weight: 600;
-	padding: 0 10px;
-	text-transform: uppercase;
-}
-
-/*rtl:ignore*/
-.rtl {
-	.navigation-link {
-		.gridicon {
-			margin-top: -3px;
-			transform: scaleX(-1);
-		}
-	}
 }


### PR DESCRIPTION
Mostly was able to remove css from this single-use component. This was the last 'back' button that hadn't been converted to using the button component. I was able to remove an RTL hack as well. Now that we're using `button` we can make any RTL adjustments upstream and get the fix everywhere.

Related to #5494 and #5466 (all back button looking things are now standardized)

**Before:**
<img width="193" alt="screen shot 2016-05-20 at 4 15 15 pm" src="https://cloud.githubusercontent.com/assets/437258/15440925/189ab7de-1ea6-11e6-939e-b5c4a44f1c02.png">

<img width="157" alt="screen shot 2016-05-20 at 4 15 24 pm" src="https://cloud.githubusercontent.com/assets/437258/15440924/189a0eb0-1ea6-11e6-9d77-d15d423c9600.png">

**After:**
<img width="309" alt="screen shot 2016-05-20 at 4 09 30 pm" src="https://cloud.githubusercontent.com/assets/437258/15440888/edbd4a40-1ea5-11e6-8327-9da6c2ee1e2e.png">

<img width="360" alt="screen shot 2016-05-20 at 4 09 39 pm" src="https://cloud.githubusercontent.com/assets/437258/15440889/edbf9c78-1ea5-11e6-9ddd-fe3e2a54f32e.png">

cc @folletto @shaunandrews @drw158 
