### PR TITLE
Plans: add domains tip component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -189,6 +189,7 @@
 @import 'my-sites/category-selector/style';
 @import 'my-sites/current-site/style';
 @import 'my-sites/customize/style';
+@import 'my-sites/domain-tip/style';
 @import 'my-sites/draft/style';
 @import 'my-sites/drafts/style';
 @import 'my-sites/exporter/style';

--- a/client/devdocs/design/app-components.jsx
+++ b/client/devdocs/design/app-components.jsx
@@ -26,6 +26,7 @@ import PlanStorage from 'my-sites/plan-storage/docs/example';
 import UpgradeNudge from 'my-sites/upgrade-nudge/docs/example';
 import PlanCompareCard from 'my-sites/plan-compare-card/docs/example';
 import FeatureComparison from 'my-sites/feature-comparison/docs/example';
+import DomainTip from 'my-sites/domain-tip/docs/example';
 
 export default React.createClass( {
 
@@ -73,6 +74,7 @@ export default React.createClass( {
 					<UpgradeNudge />
 					<PlanCompareCard />
 					<FeatureComparison />
+					<DomainTip />
 				</Collection>
 			</div>
 		);

--- a/client/my-sites/domain-tip/docs/example.jsx
+++ b/client/my-sites/domain-tip/docs/example.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PureRenderMixin from 'react-pure-render/mixin';
+
+/**
+ * Internal dependencies
+ */
+import DomainTip from '../index';
+import sitesList from 'lib/sites-list';
+
+const sites = sitesList();
+const siteId = sites.getPrimary().ID;
+
+export default React.createClass( {
+
+	displayName: 'DomainTip',
+
+	mixins: [ PureRenderMixin ],
+
+	render() {
+		return (
+			<div className="design-assets__group">
+				<h2>
+					<a href="/devdocs/app-components/domain-tip">Domain Tip</a>
+				</h2>
+				<div>
+					<DomainTip siteId={ siteId } />
+				</div>
+			</div>
+		);
+	}
+} );

--- a/client/my-sites/domain-tip/index.jsx
+++ b/client/my-sites/domain-tip/index.jsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import noop from 'lodash/noop';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+import { getSite, getSiteSlug } from 'state/sites/selectors';
+import { getDomainsSuggestions, } from 'state/domains/suggestions/selectors';
+import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
+import { FEATURE_CUSTOM_DOMAIN } from 'lib/plans/constants';
+import { isFreePlan } from 'lib/products-values';
+
+function getQueryObject( site, siteSlug ) {
+	if ( ! site || ! siteSlug ) {
+		return null;
+	}
+	return {
+		query: siteSlug.split( '.' )[ 0 ],
+		quantity: 1,
+		vendor: abtest( 'domainSuggestionVendor' )
+	};
+}
+
+const DomainTip = React.createClass( {
+
+	propTypes: {
+		className: React.PropTypes.string,
+		siteId: React.PropTypes.number.isRequired
+	},
+
+	getDefaultProps() {
+		return {
+			quantity: noop
+		};
+	},
+
+	noticeShouldDisplay() {
+		//bypass some of the upgrade nudge display logic
+		return true;
+	},
+
+	render() {
+		if ( ! this.props.site || this.props.site.jetpack || ! this.props.siteSlug ||
+				abtest( 'domainsWithPlansOnly' ) !== 'plansOnly' || ! isFreePlan( this.props.site.plan ) ) {
+			return null;
+		}
+		const classes = classNames( this.props.className, 'domain-tip' );
+		const { query, quantity, vendor } = getQueryObject( this.props.site, this.props.siteSlug );
+		const suggestion = this.props.suggestions ? this.props.suggestions[0] : null;
+		return (
+			<div className={ classes } >
+				<QueryDomainsSuggestions
+					query={ query }
+					quantity={ quantity }
+					vendor={ vendor } />
+				{
+					suggestion && <UpgradeNudge
+						event="domain-tip"
+						shouldDisplay={ this.noticeShouldDisplay }
+						feature={ FEATURE_CUSTOM_DOMAIN }
+						title={ this.translate( '{{span}}%(domain)s{{/span}} is available!', {
+							args: { domain: suggestion.domain_name },
+							components: {
+								span: <span className="domain-tip__suggestion" />
+							} } ) }
+						message={ this.translate( 'Upgrade your plan to register a domain.' ) }
+						href={ `/domains/add/${ this.props.siteSlug }` }
+					/>
+				}
+			</div>
+		);
+	}
+} );
+
+export default connect( ( state, ownProps ) => {
+	const site = getSite( state, ownProps.siteId );
+	const siteSlug = getSiteSlug( state, ownProps.siteId );
+	const queryObject = getQueryObject( site, siteSlug );
+	return {
+		suggestions: queryObject && getDomainsSuggestions( state, queryObject ),
+		site: site,
+		siteSlug: siteSlug
+	};
+} )( DomainTip );

--- a/client/my-sites/domain-tip/style.scss
+++ b/client/my-sites/domain-tip/style.scss
@@ -1,0 +1,3 @@
+.domain-tip__suggestion {
+	color: $blue-wordpress;
+}

--- a/client/my-sites/upgrade-nudge/docs/example.jsx
+++ b/client/my-sites/upgrade-nudge/docs/example.jsx
@@ -20,7 +20,7 @@ export default React.createClass( {
 				</h2>
 				<div>
 					<UpgradeNudge
-						feature="domain"
+						feature="custom-domain"
 						href="#"
 					/>
 				</div>

--- a/client/my-sites/upgrade-nudge/index.jsx
+++ b/client/my-sites/upgrade-nudge/index.jsx
@@ -34,6 +34,7 @@ export default React.createClass( {
 		jetpack: React.PropTypes.bool,
 		compact: React.PropTypes.bool,
 		feature: React.PropTypes.oneOf( [ false, ...getValidFeatureKeys() ] ),
+		shouldDisplay: React.PropTypes.func
 	},
 
 	getDefaultProps() {
@@ -44,8 +45,9 @@ export default React.createClass( {
 			event: null,
 			jetpack: false,
 			feature: false,
-			compact: false
-		}
+			compact: false,
+			shouldDisplay: null
+		};
 	},
 
 	handleClick() {
@@ -59,7 +61,10 @@ export default React.createClass( {
 	},
 
 	shouldDisplay( site ) {
-		const { feature, jetpack } = this.props;
+		const { feature, jetpack, shouldDisplay } = this.props;
+		if ( shouldDisplay ) {
+			return shouldDisplay();
+		}
 		if ( ! site ) {
 			return false;
 		}

--- a/client/state/domains/suggestions/selectors.js
+++ b/client/state/domains/suggestions/selectors.js
@@ -34,7 +34,7 @@ export function getDomainsSuggestions( state, queryObject ) {
 export function isRequestingDomainsSuggestions( state, queryObject ) {
 	const serializedQuery = getSerializedDomainsSuggestionsQuery( queryObject );
 	if ( serializedQuery ) {
-		return !! state.domains.suggestions.items[ serializedQuery ];
+		return !! state.domains.suggestions.requesting[ serializedQuery ];
 	}
 	return false;
 }

--- a/client/state/domains/suggestions/test/selectors.js
+++ b/client/state/domains/suggestions/test/selectors.js
@@ -51,7 +51,7 @@ describe( 'selectors', () => {
 			const state = {
 				domains: {
 					suggestions: {
-						items: {
+						requesting: {
 							'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': true,
 							'{"query":"foobar","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': false
 						}


### PR DESCRIPTION
This adds a domains tip component which can be viewed from: http://calypso.localhost:3000/devdocs/app-components/domain-tip

![screen shot 2016-05-24 at 1 56 49 pm](https://cloud.githubusercontent.com/assets/1270189/15519665/64fd9a56-21b7-11e6-8593-ddc6c88cd7a9.png)

On page load you should see the following 
![screen shot 2016-05-24 at 1 49 04 pm](https://cloud.githubusercontent.com/assets/1270189/15519560/ee186ad8-21b6-11e6-9f97-ad8d3b2d7355.png)

Clicking on the component should navigate to `/domains/add`

![domains-add](https://cloud.githubusercontent.com/assets/1270189/15519609/2420d0c0-21b7-11e6-9e5d-4400ca3c1542.png)

and fires off the following analytics event:
![screen shot 2016-05-24 at 1 50 06 pm](https://cloud.githubusercontent.com/assets/1270189/15519598/15644c42-21b7-11e6-8428-540ce5f4ad29.png)

Selecting one of the domains takes you to checkout with both a premium plan and your selected domain:
![screen shot 2016-05-24 at 1 50 33 pm](https://cloud.githubusercontent.com/assets/1270189/15519637/427c4428-21b7-11e6-9e7e-99dca3793e1e.png)

## Testing Instructions
- Set your primary site to a site that has a free plan
- Enable nudges, and domains with plans only: `localStorage.setItem('ABTests','{"domainsWithPlansOnly_20160517":"plansOnly", "nudges_20160519":"showAll"}')`
- The sites redux tree currently doesn't auto-populate, so please switch to your primary site before visiting the dev-docs page. I'll spin up a different PR to add support for fetching a single site.
- Navigate to http://calypso.localhost:3000/devdocs/app-components/domain-tip
- Follow steps above

cc @rralian @mtias @artpi @retrofox @drw158 