### PR TITLE
Redux: enable Terms in global state tree.

### DIFF
--- a/client/components/data/query-terms/index.jsx
+++ b/client/components/data/query-terms/index.jsx
@@ -31,7 +31,7 @@ class QueryTerms extends Component {
 			return;
 		}
 
-		props.requestSiteTerms( props.siteId, props.taxonomy );
+		props.requestSiteTerms( props.siteId, props.taxonomy, props.query );
 	}
 
 	shouldComponentUpdate() {

--- a/client/state/index.js
+++ b/client/state/index.js
@@ -27,6 +27,7 @@ import sites from './sites/reducer';
 import siteSettings from './site-settings/reducer';
 import stats from './stats/reducer';
 import support from './support/reducer';
+import terms from './terms/reducer';
 import themes from './themes/reducer';
 import ui from './ui/reducer';
 import users from './users/reducer';
@@ -55,6 +56,7 @@ export const reducer = combineReducers( {
 	siteSettings,
 	stats,
 	support,
+	terms,
 	themes,
 	ui,
 	users

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -16,14 +16,16 @@ import {
  * @param  {Number} siteId   Site ID
  * @param  {String} taxonomy Taxonomy Slug
  * @param  {Array}  terms    An array of term objects
+ * @param  {Object} query    Query Options
  * @return {Object}          Action object
  */
-export function receiveTerms( siteId, taxonomy, terms ) {
+export function receiveTerms( siteId, taxonomy, terms, query = {} ) {
 	return {
 		type: TERMS_RECEIVE,
 		siteId,
 		taxonomy,
-		terms
+		terms,
+		query
 	};
 }
 
@@ -46,7 +48,7 @@ export function requestSiteTerms( siteId, taxonomy, query = {} ) {
 		} );
 
 		return wpcom.site( siteId ).taxonomy( taxonomy ).termsList( query ).then( ( data ) => {
-			dispatch( receiveTerms( siteId, taxonomy, data.terms ) );
+			dispatch( receiveTerms( siteId, taxonomy, data.terms, query ) );
 			dispatch( {
 				type: TERMS_REQUEST_SUCCESS,
 				siteId,

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -19,7 +19,7 @@ import {
  * @param  {Object} query    Query Options
  * @return {Object}          Action object
  */
-export function receiveTerms( siteId, taxonomy, terms, query = {} ) {
+export function receiveTerms( siteId, taxonomy, terms, query ) {
 	return {
 		type: TERMS_RECEIVE,
 		siteId,

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -70,6 +70,10 @@ export function queryRequests( state = {}, action ) {
 export function queries( state = {}, action ) {
 	switch ( action.type ) {
 		case TERMS_RECEIVE:
+			if ( ! action.query ) {
+				return state;
+			}
+
 			const serializedQuery = getSerializedTermsQuery( action.query );
 			return merge( {}, state, {
 				[ action.siteId ]: {

--- a/client/state/terms/schema.js
+++ b/client/state/terms/schema.js
@@ -17,8 +17,7 @@ export const termsSchema = {
 								description: { type: 'string' },
 								post_count: { type: 'number' },
 								parent: { type: 'number' }
-							},
-							additionalProperties: false
+							}
 						}
 					},
 					additionalProperties: false

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -49,7 +49,7 @@ describe( 'actions', () => {
 				siteId: siteId,
 				taxonomy: taxonomyName,
 				terms: testTerms,
-				query: {}
+				query: undefined
 			} );
 		} );
 

--- a/client/state/terms/test/actions.js
+++ b/client/state/terms/test/actions.js
@@ -48,7 +48,20 @@ describe( 'actions', () => {
 				type: TERMS_RECEIVE,
 				siteId: siteId,
 				taxonomy: taxonomyName,
-				terms: testTerms
+				terms: testTerms,
+				query: {}
+			} );
+		} );
+
+		it( 'should return an action object with query if passed', () => {
+			const action = receiveTerms( siteId, taxonomyName, testTerms, { search: 'foo' } );
+
+			expect( action ).to.eql( {
+				type: TERMS_RECEIVE,
+				siteId: siteId,
+				taxonomy: taxonomyName,
+				terms: testTerms,
+				query: { search: 'foo' }
 			} );
 		} );
 	} );
@@ -86,7 +99,8 @@ describe( 'actions', () => {
 					type: TERMS_RECEIVE,
 					siteId: siteId,
 					taxonomy: taxonomyName,
-					terms: testTerms
+					terms: testTerms,
+					query: {}
 				} );
 			} );
 		} );

--- a/client/state/terms/test/reducer.js
+++ b/client/state/terms/test/reducer.js
@@ -195,6 +195,32 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		it( 'should ignore actions without a query object', () => {
+			const original = deepFreeze( {
+				2916284: {
+					categories: {
+						'{"search":"ribs"}': [ 111 ]
+					}
+				}
+			} );
+
+			const state = queries( original, {
+				type: TERMS_RECEIVE,
+				siteId: 2916284,
+				found: 1,
+				terms: [ { ID: 7878, name: 'Kentucky Fried Chicken' } ],
+				taxonomy: 'categories'
+			} );
+
+			expect( state ).to.eql( {
+				2916284: {
+					categories: {
+						'{"search":"ribs"}': [ 111 ]
+					}
+				}
+			} );
+		} );
+
 		it( 'should accumulate query request success', () => {
 			const original = deepFreeze( {
 				2916284: {


### PR DESCRIPTION
Small follow up to #5350.  This branch adds the terms reducer to the global state tree making it available for usage in #5366.  Additionally discovered a bug where the query object was not being passed along in `<QueryTerms />` nor in the `TERMS_RECEIVE` action.

__To Test__
Ensure the terms tests pass by running `npm run test-client -- --grep "state terms"`

/cc @aduth 