### PR TITLE
Plans: Remove Manage Plan button if user can't manage plan

### DIFF
--- a/client/components/plans/plan-actions/index.jsx
+++ b/client/components/plans/plan-actions/index.jsx
@@ -216,7 +216,7 @@ const PlanActions = React.createClass( {
 	},
 
 	managePlanButton() {
-		if ( this.planHasCost() ) {
+		if ( this.planHasCost() && this.props.sitePlan.userIsOwner ) {
 			const link = purchasesPaths.managePurchase( this.props.site.slug, this.props.sitePlan.id );
 
 			return (

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -22,7 +22,8 @@ const createSitePlanObject = ( plan ) => {
 		subscribedDate: plan.subscribed_date,
 		subscribedDayMoment: moment( plan.subscribed_date ).startOf( 'day' ),
 		userFacingExpiry: plan.user_facing_expiry,
-		userFacingExpiryMoment: moment( plan.user_facing_expiry ).startOf( 'day' )
+		userFacingExpiryMoment: moment( plan.user_facing_expiry ).startOf( 'day' ),
+		userIsOwner: Boolean( plan.user_is_owner )
 	};
 };
 


### PR DESCRIPTION
Small change to address #2522 and remove the Manage Plan button if the user isn't the owner of the plan. This modifies the conditional we look at when the Manage Plan button is rendered so that both `this.planHasCost()` and `this.props.sitePlan.userIsOwner` have to be true in order for the button to be rendered.

#### To test
1. Checkout this branch
2. View calypso.localhost:3000/plans/site-address on a site that has a plan of which you're the owner. You should see a Manage Plan button
3. View the same link under a different WordPress.com that is an Admin but doesn't own the upgrade. You shouldn't see the Manage Plan button

Note: This also works on the Compare Plan page like: wordpress.com/plans/compare/site-address

#### Screenshots:

**Owner**
![owner](https://cloud.githubusercontent.com/assets/7240478/15443481/ef335ff4-1ea5-11e6-9fd8-1a3a698ba0d9.png)

**Not Owner**
![not owner](https://cloud.githubusercontent.com/assets/7240478/15443484/f4e4aea8-1ea5-11e6-9bba-fe675dbdb734.png)

h/t @drewblaisdell for making the change to the API and adding the `user_is_owner` attribute.