### PR TITLE
Reader: fix misaligned Follow buttons on list items

### DIFF
--- a/client/components/follow-button/style.scss
+++ b/client/components/follow-button/style.scss
@@ -14,14 +14,6 @@
 		height: 38px;
 	}
 
-	&:first-child {
-		margin-top: 2px;
-	}
-
-	&:last-child {
-		margin-bottom: 2px;
-	}
-
 	&::-moz-focus-inner {
 		border: 0;
 	}

--- a/client/components/follow-button/style.scss
+++ b/client/components/follow-button/style.scss
@@ -15,11 +15,11 @@
 	}
 
 	&:first-child {
-		margin-top: 5px;
+		margin-top: 2px;
 	}
 
 	&:last-child {
-		margin-bottom: 5px;
+		margin-bottom: 2px;
 	}
 
 	&::-moz-focus-inner {

--- a/client/reader/feed-header/style.scss
+++ b/client/reader/feed-header/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	.follow-button {
-		margin-right: 5px;
+		margin: 4px 5px 0 0;
 
 		@include breakpoint( ">480px" ) {
 			margin-right: 15px;

--- a/client/reader/following-edit/style.scss
+++ b/client/reader/following-edit/style.scss
@@ -83,7 +83,6 @@
 	}
 }
 
-
 // Sort Controls
 .following-edit__sort-controls {
 	float: left;

--- a/client/reader/list-item/style.scss
+++ b/client/reader/list-item/style.scss
@@ -67,6 +67,10 @@
 		position: relative;
 			top: 1px;
 	}
+
+	.site-icon {
+		border: 0;
+	}
 }
 
 .reader-list-item__actions {
@@ -84,7 +88,7 @@
 
 	.follow-button {
 		font-size: 16px;
-		margin-right: 15px;
+		margin: 1px 15px 0 0;
 
 		.gridicon {
 			left: 15px;


### PR DESCRIPTION
Small fix for visual bug pointed out here: https://github.com/Automattic/wp-calypso/issues/5118#issuecomment-220588825 /cc @folletto 

> the button is not vertically centered. See current / with tweaks:

**Before:**

In Following edit:
![screenshot 2016-05-20 14 39 57](https://cloud.githubusercontent.com/assets/4924246/15443096/7d4ec7f8-1e9a-11e6-8812-3f2bd0458a71.png)

In Recommendations:
![screenshot 2016-05-20 14 40 14](https://cloud.githubusercontent.com/assets/4924246/15443097/7f8933e6-1e9a-11e6-9300-a98122df8cdb.png)

**After:**

In Following edit:
![screenshot 2016-05-20 14 40 32](https://cloud.githubusercontent.com/assets/4924246/15443104/8df428f0-1e9a-11e6-9588-c4886f9aaee9.png)

In Recommendations:
![screenshot 2016-05-20 14 40 50](https://cloud.githubusercontent.com/assets/4924246/15443108/8f91f0a2-1e9a-11e6-8c8f-c5e1cfcc91a2.png)

> I also noticed that the overall typeface there is a bit bigger than everywhere else in the UI

I think it's fine to make an exception for this button as this is a higher-value action.

Also, just want to mention that the icons within buttons default to `18px`, but we had to make an exception for Reader/Follow/Following (they're using `24px` currently) as assigning the default size doesn't look great. The only place where this is much smaller than desired is on the Authors module on Stats.

More info here: https://github.com/Automattic/gridicons/pull/152#issuecomment-217579472