### PR TITLE
Jetpack SSO: Allow Jetpack SSO in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -23,6 +23,7 @@
 		"guided-tours": true,
 		"help": true,
 		"jetpack/connect": true,
+		"jetpack/sso": true,
 		"jetpack_core_inline_update": true,
 		"keyboard-shortcuts": true,
 		"login": false,


### PR DESCRIPTION
The `/jetpack/sso` route is still a bit rough, but having it in `wpcalypso` will allow us to more easily test the  SSO functionality in the Jetpack alpha. We'll continue to refine while in `wpcalypso` before pushing to `staging` and `production`.

cc @lezama for review

To test:

- Checkout `update/jetpack-sso-to-wpcalypso` branch
- Set `wpcom_user_bootstrap` in `config/wpcalypso.json` to `false`
- In terminal, run `CALYPSO_ENV=wpcalypso make run`
- Go to `/jetpack/sso`
- You should see a Drake message like this:
