### PR TITLE
Fix global notice key warning

### DIFF
--- a/client/components/global-notices/index.jsx
+++ b/client/components/global-notices/index.jsx
@@ -77,9 +77,8 @@ const NoticesList = React.createClass( {
 		//needs to be updated.
 		noticesList = noticesList.concat( this.props.storeNotices.map( function( notice, index ) {
 			return (
-				<div className='global-notices__notice'>
+				<div className='global-notices__notice' key={ 'notice-' + index }>
 					<Notice
-						key={ 'notice-' + index }
 						status={ notice.status }
 						duration = { notice.duration || null }
 						showDismiss={ notice.showDismiss }


### PR DESCRIPTION
The problem: currently global notices that are generated from the redux store generate the following warning:

```
Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of `NoticesList`.
```

To reproduce with Calypso master, go to any page that has global notices powered by the redux store. For example, `/me/notifications/comments` and change a setting and press save. Observe that a success notice appears but you get the following warning in your console:

![image](https://cloud.githubusercontent.com/assets/260253/15450206/cb25a586-1f4a-11e6-9a4f-110e6f64e1b0.png)

Note: I couldn't get the warning to appear in non-development environments. Does Calypso suppress warnings in production/staging?

The fix is to apply the unique key to the containing div rather than to the notice, which I have done in this PR.

To test: follow the same steps as above and notice no warning is generated.

cc @MichaelArestad @rickybanister @aduth -- this was previously brought up here: https://github.com/Automattic/wp-calypso/pull/3910#discussion_r58777946

Note that I did test removing the surrounding div completely instead, but that resulted in notices stacking side by side rather than one below each other.

Related: https://github.com/Automattic/woocommerce-connect-client/pull/350