### PR TITLE
Settings: adds new markdown toggles for posts/comments

### DIFF
--- a/client/my-sites/site-settings/form-discussion.jsx
+++ b/client/my-sites/site-settings/form-discussion.jsx
@@ -52,7 +52,9 @@ module.exports = React.createClass( {
 		'comment_max_links',
 		'moderation_keys',
 		'blacklist_keys',
-		'admin_url'
+		'admin_url',
+		'wpcom_publish_comments_with_markdown',
+		'markdown_supported',
 	],
 
 	getSettingsFromSite: function( siteInstance ) {
@@ -115,6 +117,7 @@ module.exports = React.createClass( {
 	},
 
 	otherCommentSettings: function() {
+		const markdownSupported = this.state.markdown_supported;
 		return (
 			<FormFieldset className="has-divider">
 				<FormLabel>{ this.translate( 'Other comment settings' ) }</FormLabel>
@@ -218,6 +221,20 @@ module.exports = React.createClass( {
 						} )
 						}</span>
 				</FormLabel>
+				{ markdownSupported &&
+					<FormLabel>
+						<FormCheckbox
+							name="wpcom_publish_comments_with_markdown"
+							checkedLink={ this.linkState( 'wpcom_publish_comments_with_markdown' ) }
+							disabled={ this.state.fetchingSettings }
+							onClick={ this.recordEvent.bind( this, 'Clicked Markdown for Comments Checkbox' ) } />
+						<span>{ this.translate( 'Enable Markdown for comments. {{a}}Learn more about markdown{{/a}}.', {
+								components: {
+									a: <a href="http://en.support.wordpress.com/markdown-quick-reference/" target="_blank" />
+								}
+							} ) }</span>
+					</FormLabel>
+				}
 				<FormLabel>
 					<span>{
 						this.translate( 'Comments should be displayed with the {{olderOrNewer /}} comments at the top of each page', {

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -16,6 +16,7 @@ import PressThisLink from './press-this-link';
 import dirtyLinkedState from 'lib/mixins/dirty-linked-state';
 import FormSelect from 'components/forms/form-select';
 import FormFieldset from 'components/forms/form-fieldset';
+import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
 import SectionHeader from 'components/section-header';
 import Card from 'components/card';
@@ -30,7 +31,9 @@ const SiteSettingsFormWriting = React.createClass( {
 		var writingAttributes = [
 				'default_category',
 				'post_categories',
-				'default_post_format'
+				'default_post_format',
+				'wpcom_publish_posts_with_markdown',
+				'markdown_supported',
 			],
 			settings = {};
 
@@ -83,6 +86,7 @@ const SiteSettingsFormWriting = React.createClass( {
 	},
 
 	render: function() {
+		const markdownSupported = this.state.markdown_supported;
 		return (
 			<form id="site-settings" onSubmit={ this.submitForm } onChange={ this.markChanged }>
 				<SectionHeader label={ this.translate( 'Writing Settings' ) }>
@@ -139,6 +143,25 @@ const SiteSettingsFormWriting = React.createClass( {
 							recordEvent={ this.recordEvent }
 							className="has-divider is-top-only" />
 					) }
+					{ markdownSupported &&
+						<FormFieldset className="has-divider is-top-only">
+							<FormLabel>
+								{ this.translate( 'Markdown' ) }
+							</FormLabel>
+							<FormLabel>
+								<FormCheckbox
+									name="wpcom_publish_posts_with_markdown"
+									checkedLink={ this.linkState( 'wpcom_publish_posts_with_markdown' ) }
+									disabled={ this.state.fetchingSettings }
+									onClick={ this.recordEvent.bind( this, 'Clicked Markdown for Posts Checkbox' ) } />
+								<span>{ this.translate( 'Use markdown for posts and pages. {{a}}Learn more about markdown{{/a}}.', {
+										components: {
+											a: <a href="http://en.support.wordpress.com/markdown-quick-reference/" target="_blank" />
+										}
+									} ) }</span>
+							</FormLabel>
+						</FormFieldset>
+					}
 
 					{ config.isEnabled( 'press-this' ) &&
 						<FormFieldset className="has-divider is-top-only">


### PR DESCRIPTION
These new fields require an accompanying change to the API that is undergoing review separately in D1871-code.

## Testing
Once you have the API patch enabled (or it's been merged), you can see the new settings in the `/settings/writing` and `/settings/discussion` pages, but _only for wpcom sites_.

![screen shot 2016-05-22 at 12 48 15 pm](https://cloud.githubusercontent.com/assets/134044/15455506/87f79c8e-201b-11e6-9036-3974c2425b3f.png)

--------------------------

![screen shot 2016-05-22 at 12 47 23 pm](https://cloud.githubusercontent.com/assets/134044/15455507/91798506-201b-11e6-8129-e9a9c52e0d01.png)

---------------------

Ensure they do not appear for jetpack sites.

These settings are analogous to the markdown settings in wp-admin under `Settings->Writing` and `Settings->Discussion`. Test first by making sure these values correspond to the values in those screens. Then try changing the values (and saving them) in calypso and making sure they persist and are reflected in the wp-admin pages.

cc @roundhill @apeatling @dllh @southp 