### PR TITLE
Framework: Make sure `devmodules` chunk is not generated for production env

### DIFF
--- a/client/boot/index.js
+++ b/client/boot/index.js
@@ -127,7 +127,7 @@ function setUpContext( reduxStore ) {
 }
 
 function loadDevModulesAndBoot() {
-	if ( config.isEnabled( 'render-visualizer' ) ) {
+	if ( process.env.NODE_ENV === 'development' && config.isEnabled( 'render-visualizer' ) ) {
 		// Use Webpack's code splitting feature to put the render visualizer in a separate fragment.
 		// This way it won't get downloaded unless this feature is enabled.
 		// Since loading this fragment is asynchronous and we need to inject this mixin into all React classes,


### PR DESCRIPTION
I found out that we always create `devmodules` chunk when generating WebPack output. Given that client configuration uses `process.env.NODE_ENV` as an alias to config `env`:

```js
new webpack.DefinePlugin( {
	'process.env': {
		NODE_ENV: JSON.stringify( config( 'env' ) )
	}
} ),
```
we can use it to disable this chunk in production build.

It looks like we could replace also all `config( 'env' )` calls inside `client` code to take advantage of WebPack plugins to limit code that needs to be parsed by WebPack. See in how many places we use it in an unoptimized way:
![screen shot 2016-05-23 at 10 08 49](https://cloud.githubusercontent.com/assets/699132/15464263/8aa9d754-20ce-11e6-9668-185d3f9fbcf8.png)

@blowery @mtias @nb: does it make sense? I have no prior experience with WebPack :)
