### PR TITLE
Editor: Include comments in hardcoded types support

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -60,13 +60,15 @@ const POST_TYPE_SUPPORTS = {
 		excerpt: true,
 		'post-formats': true,
 		'geo-location': true,
-		tags: true
+		tags: true,
+		comments: true
 	},
 	page: {
 		thumbnail: true,
 		'page-attributes': true,
 		'geo-location': true,
-		excerpt: true
+		excerpt: true,
+		comments: true
 	}
 };
 


### PR DESCRIPTION
Fixes #5522
Regression introduced in #5342

This pull request seeks to resolve an issue where "Discussion" settings may be missing from the editor "More Options" accordion if post types data had not been requested during the session or loaded from persisted Redux state.

__Implementation notes:__

In the editor sidebar, we'd implemented posts as having support for all post type features. In #5342, this was enhanced to include hard-coded values for pages as well, and defined as an object of post type supports (since posts don't support `page-attributes` and pages don't support many post features).

Given the implementation in #5342, the presence of post type data, if requested at any point in the session, or available from the persisted state of a previous session, would cause that object's support to be used instead. This is why it would only intermittently fail to show the discussion settings, as many areas of the application will cause post types to be requested (e.g. Insert Existing Content in the editor, or simply navigating to My Sites).

__Testing instructions:__

Verify that in a new login session with fresh `localStorage` and Redux state, that the Discussions settings are shown when navigating directly to the [post editor](http://calypso.localhost:3000/post). Discussion settings can be found under the "More Options" accordion.

Ensure that `comments` post type supports matches expected values from `GET /sites/%s/post-types` endpoint ([example](https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.com/post-types)).

Ensure that there are no other `currentPostTypeSupports` calls in `<EditorDrawer />` that are not properly accounted for in the `POST_TYPE_SUPPORTS` constant.

/cc @gwwar , @hoverduck 