### PR TITLE
Signup: Footer links should be aligned left

### DIFF
--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -30,9 +30,8 @@
 	font-family: $sans;
 	font-size: 14px;
 	line-height: 21px;
-	padding: 16px 0 16px 0;
+	padding: 16px 24px;
 	cursor: pointer;
-	text-align: center;
 
 	&:last-child {
 		border-bottom: none;


### PR DESCRIPTION
Links below the signup forms should be aligned left with the form, not centered.

Brought them in line with the login form footer links.

This is a fix for #5390 where the links were center-aligned.

**Update:**

Testing instructions: 
1. Checkout PR/branch
2. Run local Calypso
3. Open browser at: `http://calypso.localhost:3000/start/account/user`

Before: 
<img width="407" alt="screen shot 2016-05-24 at 12 10 14" src="https://cloud.githubusercontent.com/assets/184938/15498918/4040428e-21aa-11e6-9f7a-f7c014e1d0f6.png">

After:
<img width="405" alt="screen shot 2016-05-24 at 12 19 45" src="https://cloud.githubusercontent.com/assets/184938/15498924/48569d7e-21aa-11e6-8efd-1b5a5c5d60a6.png">