### PR TITLE
Jetpack connect: Skip plans if user is not an admin

### DIFF
--- a/client/signup/jetpack-connect/plans.jsx
+++ b/client/signup/jetpack-connect/plans.jsx
@@ -19,6 +19,7 @@ import { shouldFetchSitePlans } from 'lib/plans';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import * as upgradesActions from 'lib/upgrades/actions';
+import { userCan } from 'lib/site/utils';
 
 const CALYPSO_REDIRECTION_PAGE = '/posts/';
 
@@ -46,6 +47,9 @@ const Plans = React.createClass( {
 	componentWillReceiveProps( props ) {
 		const selectedSite = props.sites.getSelectedSite();
 		if ( this.hasPlan( selectedSite ) ) {
+			page.redirect( CALYPSO_REDIRECTION_PAGE + selectedSite.slug );
+		}
+		if ( ! props.canPurchasePlans ) {
 			page.redirect( CALYPSO_REDIRECTION_PAGE + selectedSite.slug );
 		}
 	},
@@ -93,7 +97,7 @@ const Plans = React.createClass( {
 	render() {
 		const selectedSite = this.props.sites.getSelectedSite();
 
-		if ( this.hasPlan( selectedSite ) ) {
+		if ( ! this.props.canPurchasePlans || this.hasPlan( selectedSite ) ) {
 			return null;
 		}
 
@@ -130,10 +134,12 @@ const Plans = React.createClass( {
 export default connect(
 	( state, props ) => {
 		const user = getCurrentUser( state );
+		const selectedSite = props.sites.getSelectedSite();
 		return {
-			sitePlans: getPlansBySite( state, props.sites.getSelectedSite() ),
+			sitePlans: getPlansBySite( state, selectedSite ),
 			jetpackConnectSessions: state.jetpackConnect.jetpackConnectSessions,
-			userId: user ? user.ID : null
+			userId: user ? user.ID : null,
+			canPurchasePlans: userCan( 'manage_options', selectedSite )
 		};
 	},
 	( dispatch ) => {


### PR DESCRIPTION
closes #5177 

If a user is not an admin on their connected site, it makes no sense for them to buy plans, so we must skip the plans step completely. This PR checks if the remote user have permission to manage site's options, and if they doesn't, skip the plans page entirely.

Video:
https://cloudup.com/cHxpurTlk6Q

How to test
========
1. Go to calypso.localhost:3000/jetpack/connect and enter a site where you are logged with a non-admin user (that has a @automattic.com email address)
2. Complete the connection flow. You should end in the site calypso's /post page without passing through the plans page.

ping @roccotripaldi @lezama 