### PR TITLE
Jetpack Plans: Link to the automatic setup flow from the checkout receipt

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -90,7 +90,14 @@ const PlansSetup = React.createClass( {
 
 	componentDidUpdate() {
 		const site = this.props.selectedSite;
-		if ( site && site.canManage() && this.allPluginsHaveWporgData() && ! this.props.isInstalling && this.props.nextPlugin ) {
+		if ( site &&
+			site.jetpack &&
+			site.canUpdateFiles &&
+			site.canManage() &&
+			this.allPluginsHaveWporgData() &&
+			! this.props.isInstalling &&
+			this.props.nextPlugin
+		) {
 			this.startNextPlugin( this.props.nextPlugin );
 		}
 	},
@@ -122,6 +129,15 @@ const PlansSetup = React.createClass( {
 			<JetpackManageErrorPage
 				site={ this.props.selectedSite }
 				title={ this.translate( 'Oh no! You need to select a jetpack site to be able to setup your plan' ) }
+				illustration={ '/calypso/images/jetpack/jetpack-manage.svg' } />
+		);
+	},
+
+	renderCantInstallPlugins() {
+		return (
+			<JetpackManageErrorPage
+				site={ this.props.selectedSite }
+				title={ this.translate( 'Oh no! We can\'t install plugins on this site.' ) }
 				illustration={ '/calypso/images/jetpack/jetpack-manage.svg' } />
 		);
 	},
@@ -158,7 +174,7 @@ const PlansSetup = React.createClass( {
 							{ plugin.name }
 						</div>
 						{ hidden
-							? <Notice isCompact={ true } showDismiss={ false } icon="plugins" text={ this.translate( 'Waiting to install' ) } />
+							? <Notice key={ 0 } isCompact={ true } showDismiss={ false } icon="plugins" text={ this.translate( 'Waiting to install' ) } />
 							: this.renderStatus( plugin )
 						}
 					</span>
@@ -273,6 +289,10 @@ const PlansSetup = React.createClass( {
 
 		if ( ! site || ! site.jetpack ) {
 			return this.renderNoJetpackSiteSelected();
+		}
+
+		if ( ! site.canUpdateFiles ) {
+			return this.renderCantInstallPlugins();
 		}
 
 		if ( site &&

--- a/client/my-sites/upgrades/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/jetpack-plan-details.jsx
@@ -10,19 +10,34 @@ import i18n from 'lib/mixins/i18n';
 import PurchaseDetail from 'components/purchase-detail';
 import userFactory from 'lib/user';
 
+var config = require( 'config' );
+
 const user = userFactory();
 
-const JetpackPlanDetails = () => {
+var JetpackPlanDetails = ( { selectedSite } ) => {
+	const props = {
+		icon: 'cog',
+		title: i18n.translate( 'Set up your VaultPress and Akismet accounts' ),
+		description: i18n.translate(
+			'We emailed you at %(email)s with information for setting up Akismet and VaultPress on your site. Follow the instructions in the email to get started.',
+			{ args: { email: user.get().email } }
+		),
+	};
+
+	if ( config.isEnabled( 'manage/plugins/setup' ) ) {
+		props.title = null;
+		props.description = i18n.translate(
+			'We are about to install Akismet and VaultPress for your site, which will automatically protect your site from spam and data loss. If you have any questions along the way, we\'re here to help! You can also perform a manual installation by following {{a}}these instructions{{/a}}.',
+			{ components: {
+				a: <a target="_blank" href="https://en.support.wordpress.com/setting-up-premium-services/" />
+			} }
+		);
+		props.buttonText = i18n.translate( 'Set up your plan' );
+		props.href = `/plugins/setup/${selectedSite.slug}`;
+	}
+
 	return (
-		<PurchaseDetail
-			icon="cog"
-			title={ i18n.translate( 'Set up your VaultPress and Akismet accounts' ) }
-			description={
-				i18n.translate(
-					'We emailed you at %(email)s with information for setting up Akismet and VaultPress on your site. Follow the instructions in the email to get started.',
-					{ args: { email: user.get().email } }
-				)
-			} />
+		<PurchaseDetail { ...props }/>
 	);
 };
 

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -25,12 +25,12 @@ const _fetching = {};
 
 const normalizePluginInstructions = ( data ) => {
 	const _plugins = data.keys;
-	return keys( _plugins ).map( ( key ) => {
-		const plugin = _plugins[key];
+	return keys( _plugins ).map( ( slug ) => {
+		const apiKey = _plugins[slug];
 		return {
-			slug: plugin.slug || key,
-			name: plugin.name || key,
-			key: plugin.key || plugin,
+			slug: slug,
+			name: slug,
+			key: apiKey,
 			status: 'wait',
 			error: null,
 		};


### PR DESCRIPTION
Switch the `JetpackPlanDetails` shown on the receipt page if automatic plugins setup is enabled (which it is for development, stage, test, & wpcalypso). It should show new copy, and a link leading to the automatic setup. The copy could also use review :)

Once the plugins setup is launched, the logic can be removed and this'll just be a straightforward component again.

cc @rickybanister @johnHackworth 