### PR TITLE
Fix: CSS animation now comes from bottom

### DIFF
--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -85,13 +85,15 @@ $theme-info-height: 54px;
 
 		color: $gray;
 		text-transform: uppercase;
-		text-align: center;
 		font-size: 11px;
 		font-weight: 600;
 
 		background: transparentize($white, 0.9);
 
 		span {
+			position: absolute;
+			left: 50%;
+			transform: translate( -50%, 0 ); // center (using translate to allow animation)
 			padding: 6px 9px;
 
 			color: $gray-dark;
@@ -104,8 +106,7 @@ $theme-info-height: 54px;
 
 @keyframes theme__active-focus-label {
 	0% {
-		position: absolute;
-		transform: translate3d( 0, 10px, 0);
+		transform: translate3d( -50%, 10px, 0);
 	}
 }
 


### PR DESCRIPTION
Fixes #5526: "Preview button animations in from the bottom-right corner".

Before (slowed to 25%, with opacity fade removed for clarity):
![cap-](https://cloud.githubusercontent.com/assets/4389/15481875/b39370a2-2124-11e6-8907-7173327380be.gif)


This PR:
![cap-fix](https://cloud.githubusercontent.com/assets/4389/15481887/bd2232e8-2124-11e6-9a81-76818c91356b.gif)

Tested on Chrome, Safari, Firefox, Edge, IE11.

/cc @melchoyce 

### To test

* Open http://calypso.localhost:3000/design
* Hover on any thumbnail
* Check that the animation comes from the bottom not from the right.