### PR TITLE
Site Settings SEO: Fix content meta input limit

### DIFF
--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -277,14 +277,14 @@ export const SeoForm = React.createClass( {
 									id="seo_meta_description"
 									value={ seoMetaDescription || '' }
 									disabled={ isDisabled }
-									maxLength="160"
+									maxLength="300"
 									acceptableLength={ 159 }
 									onChange={ this.handleMetaChange } />
 								{ hasHtmlTagError &&
 									<FormInputValidation isError={ true } text={ this.translate( 'HTML tags are not allowed.' ) } />
 								}
 								<FormSettingExplanation>
-									{ this.translate( 'Craft a description of your site in 160 characters or less. This description can be used in search engine results for your site\'s Front Page.' ) }
+									{ this.translate( 'Craft a description of your site in about 160 characters. This description can be used in search engine results for your site\'s Front Page.' ) }
 								</FormSettingExplanation>
 							</FormFieldset>
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -116,6 +116,12 @@
 		color: $alert-red;
 		font-weight: bold;
 	}
+
+	.seo-form .counted-textarea {
+		&.is-exceeding-acceptable-length {
+			background: $alert-yellow;
+		}
+	}
 }
 
 .writing-settings,


### PR DESCRIPTION
Increases the input limit of the meta content input text to 300. You should still see the red warning once you reach 160 characters.

* Updated copy.
* Character limit limited to 300.

Fixes #5541