### PR TITLE
Jetpack connect: Change install route

### DIFF
--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -32,7 +32,7 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
-		page( '/jetpack/install', jetpackConnectController.install );
+		page( '/jetpack/connect/install', jetpackConnectController.install );
 		page( '/jetpack/connect', jetpackConnectController.connect );
 		page(
 			'/jetpack/connect/authorize/:locale?',
@@ -45,6 +45,12 @@ module.exports = function() {
 			'/jetpack/connect/:locale?',
 			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
 			jetpackConnectController.connect
+		);
+
+		page(
+			'/jetpack/connect/install/:locale?',
+			jetpackConnectController.redirectWithoutLocaleifLoggedIn,
+			jetpackConnectController.install
 		);
 
 		page(

--- a/client/signup/index.js
+++ b/client/signup/index.js
@@ -32,7 +32,6 @@ module.exports = function() {
 	}
 
 	if ( config.isEnabled( 'jetpack/connect' ) ) {
-		page( '/jetpack/connect/install', jetpackConnectController.install );
 		page( '/jetpack/connect', jetpackConnectController.connect );
 		page(
 			'/jetpack/connect/authorize/:locale?',

--- a/client/signup/jetpack-connect/controller.js
+++ b/client/signup/jetpack-connect/controller.js
@@ -54,7 +54,7 @@ const jetpackConnectFirstStep = ( context, isInstall ) => {
 			context: context,
 			isInstall: isInstall,
 			userModule: userModule,
-			locale: context.params.lang
+			locale: context.params.locale
 		} ),
 		document.getElementById( 'primary' ),
 		context.store
@@ -131,7 +131,7 @@ export default {
 		renderWithReduxStore(
 			React.createElement( jetpackSSOForm, {
 				path: context.path,
-				locale: context.params.lang,
+				locale: context.params.locale,
 				userModule: userModule
 			} ),
 			document.getElementById( 'primary' ),

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -244,6 +244,7 @@ const JetpackConnectMain = React.createClass( {
 		const status = this.getStatus();
 		return (
 			<Main className="jetpack-connect">
+				{ this.renderLocaleSuggestions() }
 				<div className="jetpack-connect__site-url-entry-container">
 					<ConnectHeader
 						showLogo={ false }

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -171,7 +171,6 @@ const JetpackConnectMain = React.createClass( {
 
 	clearUrl() {
 		this.dismissUrl();
-
 	},
 
 	handleOnClickTos() {


### PR DESCRIPTION
Dumb PR to change the route used for the install version of jetpack connect, due conflicts with already existing routes in WordPress.com

ping @roccotripaldi @ebinnion 