### PR TITLE
Jetpack connect: User different image example when activate only

### DIFF
--- a/client/signup/jetpack-connect/exampleComponents/jetpack-activate.jsx
+++ b/client/signup/jetpack-connect/exampleComponents/jetpack-activate.jsx
@@ -28,7 +28,11 @@ export default React.createClass( {
 					</div>
 
 				</div>
-				<img src="/calypso/images/jetpack/jetpack-connect-activate.png" />
+				{
+					this.props.isInstall
+						? <img src="/calypso/images/jetpack/jetpack-connect-activate.png" />
+						: <img src="/calypso/images/jetpack/jetpack-connect-activate-from-plugins.png" />
+				}
 			</div>
 		);
 	}

--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -171,7 +171,6 @@ const JetpackConnectMain = React.createClass( {
 
 	clearUrl() {
 		this.dismissUrl();
-
 	},
 
 	handleOnClickTos() {
@@ -279,7 +278,7 @@ const JetpackConnectMain = React.createClass( {
 							example={ <JetpackExampleInstall url={ this.state.currentUrl } /> } />
 						<JetpackInstallStep title={ this.translate( '2. Activate Jetpack' ) }
 							text={ this.translate( 'You\'ll then need to click the small blue "Activate Plugin" link to activate Jetpack.' ) }
-							example={ <JetpackExampleActivate url={ this.state.currentUrl } /> } />
+							example={ <JetpackExampleActivate url={ this.state.currentUrl } /> } isInstall={ true } />
 						<JetpackInstallStep title={ this.translate( '3. Connect Jetpack' ) }
 							text={ this.translate( 'Finally, just click the green "Connect to WordPress.com" button to finish the process.' ) }
 							example={ <JetpackExampleConnect url={ this.state.currentUrl } /> } />
@@ -315,7 +314,7 @@ const JetpackConnectMain = React.createClass( {
 					<div className="jetpack-connect__install-steps">
 						<JetpackInstallStep title={ this.translate( '1. Activate Jetpack' ) }
 							text={ this.translate( 'You need to click this tiny blue \'Activate\' link from your plugins list page.' ) }
-							example={ <JetpackExampleActivate url={ this.state.currentUrl } /> } />
+							example={ <JetpackExampleActivate url={ this.state.currentUrl } isInstall={ false } /> } />
 						<JetpackInstallStep title={ this.translate( '2. Connect Jetpack' ) }
 							text={ this.translate( 'Finally, just click the green "Connect to WordPress.com" button to finish the process.' ) }
 							example={ <JetpackExampleConnect url={ this.state.currentUrl } /> } />


### PR DESCRIPTION
This PR makes the activate jetpack instructions screen use a different example png that the one being used for the activation when an install is required. Until now, we were using the same image for both cases, but jetpack is activated in different sections of your wp-admin depending on if it's already installed but inactive or it's not installed at all.

Before:
![image](https://cloud.githubusercontent.com/assets/1554855/15500466/22222570-21a9-11e6-9431-aba84cbb8d27.png)

After:
![image](https://cloud.githubusercontent.com/assets/1554855/15500439/fed7fa90-21a8-11e6-90fc-3651867544ff.png)

How to test
=========
1. Go to http://calypso.localhost:3000/jetpack/connect
2. Enter a site that has jetpack installed but inactive
3. You should see the provided example

ping @roccotripaldi @rickybanister 