### PR TITLE
GuidedTours: Remove highlight overlay

### DIFF
--- a/client/layout/guided-tours/steps.js
+++ b/client/layout/guided-tours/steps.js
@@ -118,7 +118,6 @@ class ActionStep extends Component {
 		if ( onNext && target.addEventListener ) {
 			target.addEventListener( 'click', onNext );
 		}
-		target && target.classList.add( 'guided-tours__overlay' );
 	}
 
 	removeTargetListener() {
@@ -128,7 +127,6 @@ class ActionStep extends Component {
 		if ( onNext && target.removeEventListener ) {
 			target.removeEventListener( 'click', onNext );
 		}
-		target && target.classList.remove( 'guided-tours__overlay' );
 	}
 
 	render() {

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -136,34 +136,3 @@ $zoom-scale: 5; // the multiplier determining the size of the animated rings
 .guided-tours__bullseye-ring:after {
 	animation-delay: #{ $animation-speed / 4 };
 }
-
-// the overlay with animation present when showing a bullseye
-@keyframes guided-tours__overlay-animation {
-	0%, 100% {
-		opacity: 0.4;
-	}
-
-	50% {
-		opacity: 0.7
-	}
-}
-
-.guided-tours__overlay,
-.guided-tours__overlay:hover,
-.guided-tours__overlay:focus,
-.guided-tours__overlay:visited,
-.guided-tours__overlay:active {
-	box-shadow: 0 0 0 9999px rgba( $gray-light, 0.8 );
-	transition: box-shadow 300ms ease-in-out;
-	z-index: z-index( 'root', '.guided-tours__overlay' );
-}
-
-.guided-tours__overlay:before {
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	content: " ";
-	margin-left: -15px;
-	animation: guided-tours__overlay-animation 3s ease-in-out 300ms infinite;
-	opacity: 0.4;
-}


### PR DESCRIPTION
Only affects the `ActionStep`, remove until we can find a better solution that works for all targets and steps.

Before:
![screen shot 2016-05-24 at 11 17 01](https://cloud.githubusercontent.com/assets/215074/15500552/18f7da74-21a1-11e6-89a0-2b86c239cfb0.png)

After:
![screen shot 2016-05-24 at 11 16 34](https://cloud.githubusercontent.com/assets/215074/15501287/98d8dfa6-21a4-11e6-9511-954567ceb5e9.png)


To test:
1. http://calypso.localhost:3000?tour=main
2. Check no overlay appears on the my-sites step