### PR TITLE
Jetpack connect: Activate instructions back button fixed

### DIFF
--- a/client/signup/jetpack-connect/index.jsx
+++ b/client/signup/jetpack-connect/index.jsx
@@ -171,7 +171,6 @@ const JetpackConnectMain = React.createClass( {
 
 	clearUrl() {
 		this.dismissUrl();
-
 	},
 
 	handleOnClickTos() {
@@ -320,8 +319,10 @@ const JetpackConnectMain = React.createClass( {
 							text={ this.translate( 'Finally, just click the green "Connect to WordPress.com" button to finish the process.' ) }
 							example={ <JetpackExampleConnect url={ this.state.currentUrl } /> } />
 					</div>
-					{ this.renderBackButton() }
 					<Button onClick={ this.activateJetpack } primary>{ this.translate( 'Activate Jetpack' ) }</Button>
+					<div className="jetpack-connect__navigation">
+						{ this.renderBackButton() }
+					</div>
 				</div>
 			</Main>
 		);


### PR DESCRIPTION
The back button in the activate instructions screen was being added before the main action button instead of behind it, so the layout was kind of broken for that case.

Before:
![image](https://cloud.githubusercontent.com/assets/1554855/15501059/d66e3990-21ab-11e6-9508-5e0711b94266.png)


After:
![image](https://cloud.githubusercontent.com/assets/1554855/15501033/b0dfe84a-21ab-11e6-886f-284f66d16a23.png)


ping @rickybanister 