### PR TITLE
Jetpack connect: Change copy of 'searching for available upgrades'

### DIFF
--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -249,7 +249,7 @@ const LoggedInForm = React.createClass( {
 		}
 
 		if ( authorizeSuccess ) {
-			return this.translate( 'Searching Available Upgrades' );
+			return this.translate( 'Finishing up' );
 		}
 
 		if ( isAuthorizing ) {

--- a/client/signup/jetpack-connect/authorize-form.jsx
+++ b/client/signup/jetpack-connect/authorize-form.jsx
@@ -249,7 +249,9 @@ const LoggedInForm = React.createClass( {
 		}
 
 		if ( authorizeSuccess ) {
-			return this.translate( 'Finishing up' );
+			return this.translate( 'Finishing up!', {
+				context: 'Shown during a jetpack authorization process, while we retrieve the info we need to show the last page'
+			} );
 		}
 
 		if ( isAuthorizing ) {


### PR DESCRIPTION
"Searching Available Upgrades" wasn't a good description on what we were doing in that step (pretty much: refreshing sites info so we can show the plans for the newly connected site), so we are changing it for a more generic "finishing up"
![image](https://cloud.githubusercontent.com/assets/1554855/15501796/b4fdd15e-21af-11e6-9adf-804439d5330c.png)

How to test
========
1. Go to http://calypso.localhost:3000/jetpack/connect/ and connect a site that is running latest jetpack's master
2. Once the site is authorized, you should see the "finishing up" message for some seconds