### PR TITLE
DesignPreview: Refresh iframe the second time the preview is accessed

### DIFF
--- a/client/my-sites/design-preview/index.js
+++ b/client/my-sites/design-preview/index.js
@@ -22,6 +22,7 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 const debug = debugFactory( 'calypso:design-preview' );
 
 const DesignPreview = React.createClass( {
+	previewCounter: 0,
 
 	propTypes: {
 		// Any additional classNames to set on this wrapper
@@ -44,6 +45,12 @@ const DesignPreview = React.createClass( {
 		selectedSiteId: React.PropTypes.number,
 	},
 
+	getInitialState() {
+		return {
+			previewCount: 0
+		};
+	},
+
 	getDefaultProps() {
 		return {
 			showPreview: false,
@@ -54,6 +61,20 @@ const DesignPreview = React.createClass( {
 			isUnsaved: false,
 			onLoad: noop,
 		};
+	},
+
+	componentWillReceiveProps( nextProps ) {
+		if ( ! config.isEnabled( 'preview-endpoint' ) ) {
+			if ( this.props.selectedSiteId && this.props.selectedSiteId !== nextProps.selectedSiteId ) {
+				this.previewCounter = 0;
+			}
+
+			if ( ! this.props.showPreview && nextProps.showPreview ) {
+				debug( 'forcing refresh' );
+				this.previewCounter > 0 && this.setState( { previewCount: this.previewCounter } );
+				this.previewCounter += 1;
+			}
+		}
 	},
 
 	componentDidMount() {
@@ -159,7 +180,7 @@ const DesignPreview = React.createClass( {
 			parsed.query['frame-nonce'] = site.options.frame_nonce;
 		}
 		delete parsed.search;
-		return url.format( parsed );
+		return url.format( parsed ) + '&' + this.state.previewCount;
 	},
 
 	render() {


### PR DESCRIPTION
Since we can't access the iframe to do a `.reload()`, or change the `src`, changing the URL seems to be the only way of refreshing the iframe.

- Add a 'view' counter to `DesignPreview`, which is incremented if a refresh is needed, and reset on site change

Ideally we'd be able to tell `WebPreview` to refresh the URL _somehow_, and get rid of the qarg.

TODO:
- [x] Rebase to a branch with `getPreviewUrl` code
- [x] Add counter to `getPreviewUrl` as a qarg 

To test:
- Open calypso, open the preview (click the site card in the sites list)
- Close the preview
- Add a post/change theme
- Open the preview