### PR TITLE
FormPhoneInput: Remove LinkedStateMixin

### DIFF
--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -220,7 +220,7 @@ var FormFields = React.createClass( {
 						<FormLabel>Form Phone Input</FormLabel>
 						<FormPhoneInput
 							initialCountryCode="US"
-							initialPhoneNumber="877-273-3049"
+							initialPhoneNumber="8772733049"
 							countriesList={ countriesList }
 							/>
 					</FormFieldset>

--- a/client/components/forms/form-phone-input/index.jsx
+++ b/client/components/forms/form-phone-input/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 var React = require( 'react' ),
-	LinkedStateMixin = require( 'react-addons-linked-state-mixin' ),
 	noop = require( 'lodash/noop' ),
 	head = require( 'lodash/head' ),
 	filter = require( 'lodash/filter' );
@@ -21,8 +20,6 @@ var CLEAN_REGEX = /^0|[\s.\-()]+/g;
 
 module.exports = React.createClass( {
 	displayName: 'FormPhoneInput',
-
-	mixins: [ LinkedStateMixin ],
 
 	propTypes: {
 		initialCountryCode: React.PropTypes.string,

--- a/client/components/forms/form-tel-input/index.jsx
+++ b/client/components/forms/form-tel-input/index.jsx
@@ -27,7 +27,7 @@ module.exports = React.createClass( {
 			<input
 				{ ...otherProps }
 				type={ 'tel' }
-				pattern={ '[0-9]*'}
+				pattern={ '[0-9]*' }
 				className={ classnames( this.props.className, classes ) } />
 		);
 	}


### PR DESCRIPTION
This is obsolete, since FormPhoneInput doesn't use the `this.linkState()` method provided by the mixin, but instead handles the relavant logic itself in its `countryValueLink` and `phoneValueLink` objects -- very much like the textbook example, https://facebook.github.io/react/docs/two-way-binding-helpers.html#reactlink-without-linkedstatemixin

Also, LinkedStateMixin is [deprecated](https://facebook.github.io/react/blog/2016/04/07/react-v15.html#new-deprecations-introduced-with-a-warning) as of React 15, so it's a good thing to remove it.

Additionally, this PR changes the initial value of the `FormFields` example' `FormPhoneInput` to a valid format (cf p6jOYE-sc-p2).

Code QA:
* Verify that my above claim is true :-) (no reference to `this.linkState()` in `FormPhoneInput`)

To test:
* Go to http://calypso.localhost:3000/devdocs/design/form-fields
* Verify that you can still change the phone number in the phone number field below 'Form Phone Input', and change the country code in the dropdown.