### PR TITLE
Jetpack Plans: fixed plans page feature list margins 

### DIFF
--- a/client/my-sites/plans/jetpack-plan-details/index.jsx
+++ b/client/my-sites/plans/jetpack-plan-details/index.jsx
@@ -13,7 +13,7 @@ const JetpackPlanDetails = ( { plan } ) => {
 		<div>
 			<p>{ plan.description }</p>
 
-			<ul>
+			<ul className="plan__plan-details-list">
 				<li className="plan__plan-details-item"><Gridicon icon="checkmark" size={ 18 } />{ plan.feature_1 }</li>
 				<li className="plan__plan-details-item"><Gridicon icon="checkmark" size={ 18 } />{ plan.feature_2 }</li>
 				<li className="plan__plan-details-item"><Gridicon icon="checkmark" size={ 18 } />{ plan.feature_3 }</li>

--- a/client/my-sites/plans/jetpack-plan-details/index.jsx
+++ b/client/my-sites/plans/jetpack-plan-details/index.jsx
@@ -3,15 +3,20 @@
  */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
 const JetpackPlanDetails = ( { plan } ) => {
 	return (
 		<div>
 			<p>{ plan.description }</p>
 
 			<ul>
-				<li>{ plan.feature_1 }</li>
-				<li>{ plan.feature_2 }</li>
-				<li>{ plan.feature_3 }</li>
+				<li className="plan__plan-details-item"><Gridicon icon="checkmark" size={ 18 } />{ plan.feature_1 }</li>
+				<li className="plan__plan-details-item"><Gridicon icon="checkmark" size={ 18 } />{ plan.feature_2 }</li>
+				<li className="plan__plan-details-item"><Gridicon icon="checkmark" size={ 18 } />{ plan.feature_3 }</li>
 			</ul>
 		</div>
 	);

--- a/client/my-sites/plans/jetpack-plan-details/style.scss
+++ b/client/my-sites/plans/jetpack-plan-details/style.scss
@@ -1,5 +1,5 @@
-.jetpack_premium .plan__plan-details ul,
-.jetpack_business .plan__plan-details ul {
+.jetpack_premium .plan__plan-details .plan__plan-details-list,
+.jetpack_business .plan__plan-details .plan__plan-details-list {
 	margin: 8px 0;
 }
 

--- a/client/my-sites/plans/jetpack-plan-details/style.scss
+++ b/client/my-sites/plans/jetpack-plan-details/style.scss
@@ -1,12 +1,16 @@
-.jetpack_premium .plan__plan-details ul, .jetpack_business .plan__plan-details ul {
-	margin: 10px 0 10px 10px;
+.jetpack_premium .plan__plan-details ul,
+.jetpack_business .plan__plan-details ul {
+	margin: 8px 0;
 }
 
-.jetpack_premium .plan__plan-details li, .jetpack_business .plan__plan-details li {
+.jetpack_premium .plan__plan-details .plan__plan-details-item,
+.jetpack_business .plan__plan-details .plan__plan-details-item {
 	opacity: 1.0;
+	padding: 4px 0;
 
-	&:before {
-		@include noticon( '\f418', 16px );
-		vertical-align: middle;
+	.gridicons-checkmark {
+		color: $alert-green;
+		vertical-align: top;
+		margin-right: 4px;
 	}
 }


### PR DESCRIPTION
* The padding/margin of the list items was very strange before, also caused problems at narrow widths
* And and swapped noticons for gridicons
* Also used classnames instead of targeting elements

To test, visit the plans page on any Jetpack site
Or 
Go through the Jetpack Connect flow and hit the plans step

**Before:**
<img width="781" alt="screen shot 2016-05-24 at 12 21 48 pm" src="https://cloud.githubusercontent.com/assets/437258/15511767/fb417814-21aa-11e6-85e9-13a16306dcc9.png">

**After:**
<img width="682" alt="screen shot 2016-05-24 at 12 20 59 pm" src="https://cloud.githubusercontent.com/assets/437258/15511772/01f7069c-21ab-11e6-98c3-e33ef999e246.png">

cc @johnHackworth @richardmuscat 
