### PR TITLE
Site Settings SEO: Improved Error Message Design

### DIFF
--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -387,7 +387,7 @@ export const SeoForm = React.createClass( {
 		return (
 			<FormInputValidation isError={ true } text={
 				isPasteError
-					? this.translate( 'Verification code should be copied and pasted in.' )
+					? this.translate( 'Verification code should be copied and pasted into this field.' )
 					: this.translate( 'Invalid site verification tag.' )
 			} />
 		);

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -369,9 +369,9 @@ export const SeoForm = React.createClass( {
 									onChange={ event => this.handleVerificationCodeChange( event, 'yandex' ) } />
 							</FormFieldset>
 							{ showPasteError &&
-								<div className="verification-code-error">
-									{ this.translate( 'Verification tag should be copied and pasted in.' ) }
-								</div>
+								<FormInputValidation
+									isError={ true }
+									text={ this.translate( 'Verification tag should be copied and pasted in.' ) } />
 							}
 
 						</FormFieldset>

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -120,7 +120,10 @@ export const SeoForm = React.createClass( {
 
 		// Show an error if the user types into the field
 		if ( event.target.value.length === 1 ) {
-			this.setState( { showPasteError: true } );
+			this.setState( {
+				showPasteError: true,
+				invalidCodes: [ serviceName ]
+			} );
 			return;
 		}
 
@@ -204,6 +207,7 @@ export const SeoForm = React.createClass( {
 
 		const isSitePrivate = parseInt( blog_public, 10 ) !== 1;
 		const isDisabled = isSitePrivate || isSubmittingForm;
+		const isSaveDisabled = isDisabled || isSubmittingForm || ( ! showPasteError && invalidCodes.length > 0 );
 
 		const sitemapUrl = `https://${ slug }/sitemap.xml`;
 		const generalTabUrl = getGeneralTabUrl( slug );
@@ -245,7 +249,7 @@ export const SeoForm = React.createClass( {
 						onClick={ this.submitSeoForm }
 						primary={ true }
 						type="submit"
-						disabled={ isDisabled || isSubmittingForm }
+						disabled={ isSaveDisabled }
 					>
 						{ isSubmittingForm
 							? this.translate( 'Saving…' )
@@ -328,6 +332,7 @@ export const SeoForm = React.createClass( {
 									isError={ hasError( 'google' ) }
 									placeholder={ getMetaTag( 'google', placeholderTagContent ) }
 									onChange={ event => this.handleVerificationCodeChange( event, 'google' ) } />
+								{ hasError( 'google' ) && this.getVerificationError( showPasteError ) }
 							</FormFieldset>
 
 							<FormFieldset>
@@ -341,6 +346,7 @@ export const SeoForm = React.createClass( {
 									isError={ hasError( 'bing' ) }
 									placeholder={ getMetaTag( 'bing', placeholderTagContent ) }
 									onChange={ event => this.handleVerificationCodeChange( event, 'bing' ) } />
+								{ hasError( 'bing' ) && this.getVerificationError( showPasteError ) }
 							</FormFieldset>
 
 							<FormFieldset>
@@ -354,6 +360,7 @@ export const SeoForm = React.createClass( {
 									isError={ hasError( 'pinterest' ) }
 									placeholder={ getMetaTag( 'pinterest', placeholderTagContent ) }
 									onChange={ event => this.handleVerificationCodeChange( event, 'pinterest' ) } />
+								{ hasError( 'pinterest' ) && this.getVerificationError( showPasteError ) }
 							</FormFieldset>
 
 							<FormFieldset>
@@ -367,17 +374,22 @@ export const SeoForm = React.createClass( {
 									isError={ hasError( 'yandex' ) }
 									placeholder={ getMetaTag( 'yandex', placeholderTagContent ) }
 									onChange={ event => this.handleVerificationCodeChange( event, 'yandex' ) } />
+								{ hasError( 'yandex' ) && this.getVerificationError( showPasteError ) }
 							</FormFieldset>
-							{ showPasteError &&
-								<FormInputValidation
-									isError={ true }
-									text={ this.translate( 'Verification tag should be copied and pasted in.' ) } />
-							}
-
 						</FormFieldset>
 					</form>
 				</Card>
 			</div>
+		);
+	},
+
+	getVerificationError( isPasteError ) {
+		return (
+			<FormInputValidation isError={ true } text={
+				isPasteError
+					? this.translate( 'Verification code should be copied and pasted in.' )
+					: this.translate( 'Invalid site verification tag.' )
+			} />
 		);
 	}
 } );


### PR DESCRIPTION
Use `FormInputValidation` component for copy/paste error message.

**To test:** Try and type in one of the site verification fields, you should see this error:

<img width="693" alt="screen shot 2016-05-24 at 10 22 20 am" src="https://cloud.githubusercontent.com/assets/789137/15513579/0eb25690-219a-11e6-813a-cdfb0914e74d.png">

@drw158 needs review! I think you mentioned doing the error inline, but it doesn't look like the text input with affixes component supports errors at this time.

Fixes #5498