### PR TITLE
State: Port reader posts into redux state

### DIFF
--- a/client/reader/start/post-preview.jsx
+++ b/client/reader/start/post-preview.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 // Internal dependencies
 import Gravatar from 'components/gravatar';
 import PostExcerpt from 'components/post-excerpt';
-import { decodeEntities } from 'lib/formatting';
 import page from 'page';
 import { getPostBySiteAndId } from 'state/reader/posts/selectors';
 
@@ -25,12 +24,15 @@ const StartPostPreview = React.createClass( {
 
 	render() {
 		const post = this.props.post;
+		if ( ! post ) {
+			return null;
+		}
 		return (
 			<article className="reader-start-post-preview">
-				<h1><a href={ this.getFullPostUrl() } onClick={ this.showFullPost } className="reader-start-post-preview__title">{ decodeEntities( post.title ) }</a></h1>
+				<h1><a href={ this.getFullPostUrl() } onClick={ this.showFullPost } className="reader-start-post-preview__title">{ post.title }</a></h1>
 				<div className="reader-start-post-preview__byline">
 					<Gravatar user={ post.author } size={ 20 } />
-					<span className="reader-start-post-preview__author">by { decodeEntities( post.author.name ) }</span>
+					<span className="reader-start-post-preview__author">by { post.author.name }</span>
 				</div>
 				<PostExcerpt maxLength={ 160 } content={ post.excerpt } className="reader-start-post-preview__excerpt" />
 			</article>

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -1,9 +1,19 @@
 /**
+ * External Dependencies
+ */
+import forEach from 'lodash/forEach';
+import map from 'lodash/map';
+import isUndefined from 'lodash/isUndefined';
+import reject from 'lodash/reject';
+
+/**
  * Internal dependencies
  */
 import {
 	READER_POSTS_RECEIVE
 } from 'state/action-types';
+
+import { runFastRules, runSlowRules } from './normalization-rules';
 
 /**
  * Returns an action object to signal that post objects have been received.
@@ -12,8 +22,27 @@ import {
  * @return {Object} Action object
  */
 export function receivePosts( posts ) {
-	return {
-		type: READER_POSTS_RECEIVE,
-		posts
+	if ( ! posts ) {
+		return Promise.resolve( [] );
+	}
+	return function( dispatch ) {
+		const withoutUndefined = reject( posts, isUndefined );
+		const normalizedPosts = map( withoutUndefined, runFastRules );
+
+		forEach( map( normalizedPosts, runSlowRules ), slowPromise => {
+			slowPromise.then( post => {
+				dispatch( {
+					type: READER_POSTS_RECEIVE,
+					posts: [ post ]
+				} );
+			} );
+		} );
+
+		dispatch( {
+			type: READER_POSTS_RECEIVE,
+			posts: normalizedPosts
+		} );
+
+		return Promise.resolve( normalizedPosts );
 	};
 }

--- a/client/state/reader/posts/display-types.js
+++ b/client/state/reader/posts/display-types.js
@@ -1,0 +1,18 @@
+/**
+ * Feed post display types
+ * @type {Object} Types of post for display
+ */
+module.exports = {
+	UNCLASSIFIED: 0,
+	PHOTO_ONLY: 1,
+	LARGE_BANNER: 2,
+	ONE_LINER: 4,
+	LANDSCAPE_BANNER: 8,
+	PORTRAIT_BANNER: 16,
+	GALLERY: 32,
+	VIDEO: 64,
+	THUMBNAIL: 128,
+	CANONICAL_IN_CONTENT: 256,
+	FEATURED_VIDEO: 512,
+	X_POST: 1024
+};

--- a/client/state/reader/posts/normalization-rules.js
+++ b/client/state/reader/posts/normalization-rules.js
@@ -1,0 +1,173 @@
+/**
+ * External Dependencies
+ */
+import find from 'lodash/find';
+import flow from 'lodash/flow';
+import forEach from 'lodash/forEach';
+import url from 'url';
+import matches from 'lodash/matches';
+
+/**
+ * Internal Dependencies
+ */
+import resizeImageUrl from 'lib/resize-image-url';
+import DISPLAY_TYPES from './display-types';
+
+/**
+ * Rules
+ */
+import createBetterExcerpt from 'lib/post-normalizer/rule-create-better-excerpt';
+import detectEmbeds from 'lib/post-normalizer/rule-content-detect-embeds';
+import detectPolls from 'lib/post-normalizer/rule-content-detect-polls';
+import makeEmbedsSecure from 'lib/post-normalizer/rule-content-make-embeds-secure';
+import removeStyles from 'lib/post-normalizer/rule-content-remove-styles';
+import safeImages from 'lib/post-normalizer/rule-content-safe-images';
+import wordCount from 'lib/post-normalizer/rule-content-word-count';
+import { disableAutoPlayOnMedia, disableAutoPlayOnEmbeds} from 'lib/post-normalizer/rule-content-disable-autoplay';
+import decodeEntities from 'lib/post-normalizer/rule-decode-entities';
+import firstPassCanonicalImage from 'lib/post-normalizer/rule-first-pass-canonical-image';
+import makeSiteIdSafeForApi from 'lib/post-normalizer/rule-make-site-id-safe-for-api';
+import pickPrimaryTag from 'lib/post-normalizer/rule-pick-primary-tag';
+import preventWidows from 'lib/post-normalizer/rule-prevent-widows';
+import safeImageProperties from 'lib/post-normalizer/rule-safe-image-properties';
+import stripHtml from 'lib/post-normalizer/rule-strip-html';
+import withContentDom from 'lib/post-normalizer/rule-with-content-dom';
+import keepValidImages from 'lib/post-normalizer/rule-keep-valid-images';
+import pickCanonicalImage from 'lib/post-normalizer/rule-pick-canonical-image';
+import waitForImagesToLoad from 'lib/post-normalizer/rule-wait-for-images-to-load';
+
+/**
+ * Module vars
+ */
+const READER_CONTENT_WIDTH = 720,
+	DISCOVER_FULL_BLEED_WIDTH = 1082,
+	PHOTO_ONLY_MIN_WIDTH = READER_CONTENT_WIDTH * 0.8,
+	ONE_LINER_THRESHOLD = ( 20 * 10 ), // roughly 10 lines of words
+	DISCOVER_BLOG_ID = 53424024;
+
+function discoverFullBleedImages( post, dom ) {
+	if ( post.site_ID === DISCOVER_BLOG_ID ) {
+		const images = dom.querySelectorAll( '.fullbleed img, img.fullbleed' );
+		forEach( images, function( image ) {
+			const newSrc = resizeImageUrl( image.src, { w: DISCOVER_FULL_BLEED_WIDTH } );
+			let oldImageObject = find( post.content_images, { src: image.src } );
+			oldImageObject.src = newSrc;
+			image.src = newSrc;
+		} );
+	}
+	return post;
+}
+
+/**
+ * Attempt to classify the post into a display type
+ * @param  {object}   post     A post to classify
+ * @return {object}            The classified post
+ */
+function classifyPost( post ) {
+	var displayType = DISPLAY_TYPES.UNCLASSIFIED,
+		canonicalImage = post.canonical_image,
+		canonicalAspect;
+
+	if ( post.images && post.images.length === 1 && post.images[0].naturalWidth >= PHOTO_ONLY_MIN_WIDTH && post.word_count < 100 ) {
+		displayType ^= DISPLAY_TYPES.PHOTO_ONLY;
+	}
+
+	if ( canonicalImage ) {
+		if ( canonicalImage.width >= 600 ) {
+			displayType ^= DISPLAY_TYPES.LARGE_BANNER;
+		}
+
+		if ( canonicalImage.height && canonicalImage.width ) {
+			canonicalAspect = canonicalImage.width / canonicalImage.height;
+
+			if ( canonicalAspect >= 2 && canonicalImage.width >= 600 ) {
+				displayType ^= DISPLAY_TYPES.LANDSCAPE_BANNER;
+			} else if ( canonicalAspect < 1 && canonicalImage.height > 160 ) {
+				displayType ^= DISPLAY_TYPES.PORTRAIT_BANNER;
+			} else if ( canonicalAspect > 0.7 && canonicalAspect < 1.3 && canonicalImage.width < 200 ) {
+				displayType ^= DISPLAY_TYPES.THUMBNAIL;
+			}
+		}
+
+		const canonicalImageUrl = url.parse( canonicalImage.uri, true, true ),
+			canonicalImageUrlImportantParts = {
+				hostname: canonicalImageUrl.hostname,
+				pathname: canonicalImageUrl.pathname,
+				query: canonicalImageUrl.query
+			},
+			matcher = matches( canonicalImageUrlImportantParts );
+		if ( find( post.content_images, ( img ) => {
+			const imgUrl = url.parse( img.src, true, true );
+			return matcher( imgUrl );
+		} ) ) {
+			displayType ^= DISPLAY_TYPES.CANONICAL_IN_CONTENT;
+		}
+	}
+
+	if ( post.content_embeds && post.content_embeds.length >= 1 ) {
+		if ( ! canonicalImage || post.content_embeds.length === 1 ) {
+			displayType ^= DISPLAY_TYPES.FEATURED_VIDEO;
+		}
+	}
+
+	if ( post.word_count <= ONE_LINER_THRESHOLD &&
+			( ! post.content_images || post.content_images.length === 0 ) &&
+			( ! post.content_embeds || post.content_embeds.length === 0 ) ) {
+		displayType ^= DISPLAY_TYPES.ONE_LINER;
+	}
+
+	if ( post.content_images && post.content_images.length > 2 ) {
+		displayType ^= DISPLAY_TYPES.GALLERY;
+	}
+
+	if ( post.tags && post.tags[ 'p2-xpost' ] ) {
+		displayType ^= DISPLAY_TYPES.X_POST;
+	}
+
+	post.display_type = displayType;
+
+	return post;
+}
+
+const fastPostNormalizationRules = flow( [
+	decodeEntities,
+	stripHtml,
+	preventWidows,
+	makeSiteIdSafeForApi,
+	pickPrimaryTag,
+	safeImageProperties( READER_CONTENT_WIDTH ),
+	firstPassCanonicalImage,
+	withContentDom( [
+		removeStyles,
+		safeImages( READER_CONTENT_WIDTH ),
+		discoverFullBleedImages,
+		makeEmbedsSecure,
+		disableAutoPlayOnEmbeds,
+		disableAutoPlayOnMedia,
+		detectEmbeds,
+		detectPolls,
+		wordCount
+	] ),
+	createBetterExcerpt,
+	classifyPost
+] );
+
+export function runFastRules( post ) {
+	if ( ! post ) {
+		return post;
+	}
+	post = Object.assign( {}, post );
+	fastPostNormalizationRules( post );
+	return post;
+}
+
+const slowSyncRules = flow( [
+	keepValidImages( 144, 72 ),
+	pickCanonicalImage,
+	classifyPost
+] );
+
+export function runSlowRules( post ) {
+	post = Object.assign( {}, post );
+	return waitForImagesToLoad( post ).then( slowSyncRules );
+}

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -26,8 +26,9 @@ import { isValidStateWithSchema } from 'state/utils';
  */
 export function items( state = {}, action ) {
 	switch ( action.type ) {
-		case READER_POSTS_RECEIVE:
-			return Object.assign( {}, state, keyBy( omitBy( action.posts, isUndefined ), 'global_ID' ) );
+		case READER_POSTS_RECEIVE: {
+			return Object.assign( {}, state, keyBy( action.posts, 'global_ID' ) );
+		}
 		case SERIALIZE:
 			return state;
 		case DESERIALIZE:

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -27,12 +27,12 @@ describe( 'actions', () => {
 
 	describe( '#receivePosts()', () => {
 		it( 'should return an action object', () => {
-			const posts = {};
-			const action = receivePosts( posts );
-
-			expect( action ).to.eql( {
-				type: READER_POSTS_RECEIVE,
-				posts
+			const posts = [];
+			return receivePosts( posts )( spy ).then( () => {
+				expect( spy ).to.have.been.calledWith( {
+					type: READER_POSTS_RECEIVE,
+					posts
+				} );
 			} );
 		} );
 	} );

--- a/client/state/reader/start/actions.js
+++ b/client/state/reader/start/actions.js
@@ -48,18 +48,19 @@ export function requestRecommendations() {
 				const sites = map( data.recommendations, property( 'meta.data.site' ) );
 				const posts = map( data.recommendations, property( 'meta.data.post' ) );
 				dispatch( updateSites( sites ) );
-				dispatch( receivePosts( posts ) );
 
-				// Trim meta off before receiving recommendations
-				const recommendations = map( data.recommendations, ( recommendation ) => {
-					return omit( recommendation, 'meta' );
-				} );
+				return dispatch( receivePosts( posts ) ).then( () => {
+					// Trim meta off before receiving recommendations
+					const recommendations = map( data.recommendations, ( recommendation ) => {
+						return omit( recommendation, 'meta' );
+					} );
 
-				dispatch( receiveRecommendations( recommendations ) );
+					dispatch( receiveRecommendations( recommendations ) );
 
-				dispatch( {
-					type: READER_START_RECOMMENDATIONS_REQUEST_SUCCESS,
-					data
+					dispatch( {
+						type: READER_START_RECOMMENDATIONS_REQUEST_SUCCESS,
+						data
+					} );
 				} );
 			},
 			( error ) => {


### PR DESCRIPTION
This brings post normalization ala the `feed-post-store` to the redux reader/posts state area. This fixes all the things we need to fix on posts to make them displayable inside Calypso.

To test, make sure tests pass and make sure http://calypso.localhost:3000/read/start works as expected. No other user-facing changes.