### PR TITLE
Editor: Resolve error when tracking stats of excerpt changed

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -30,7 +30,7 @@ import PageOrder from 'post-editor/editor-page-order';
 import PostMetadata from 'lib/post-metadata';
 import TrackInputChanges from 'components/track-input-changes';
 import actions from 'lib/posts/actions';
-import stats from 'lib/posts/stats';
+import * as stats from 'lib/posts/stats';
 import siteUtils from 'lib/site/utils';
 import { setExcerpt } from 'state/ui/editor/post/actions';
 import QueryPostTypes from 'components/data/query-post-types';


### PR DESCRIPTION
Regression introduced in #3336 (4049db8823596936a3b8124fbb5ebce67bab89c4)

This pull request seeks to resolve an issue where we're not using the correct `import` syntax when importing from `lib/posts/stats` (which exports several functions), causing an error to be logged occur when a new value is entered in the post editor excerpt field. It does not appear that this error has prevented excerpts from being assigned to a post.

__Testing instructions:__

Verify that no error occurs when assigning a value to Excerpt (under More Options) in the [post editor](http://calypso.localhost:3000/post). Further, you may want to ensure that the stats are in-fact tracked by setting `localStorage.debug = 'calypso:analytics';` and refreshing the page before following the same steps.