### PR TITLE
Tweak locale suggestion look

### DIFF
--- a/client/signup/locale-suggestions/index.jsx
+++ b/client/signup/locale-suggestions/index.jsx
@@ -102,7 +102,7 @@ module.exports = React.createClass( {
 
 		return (
 			<div className="locale-suggestions">
-				<Notice status="is-info" showDismiss={ true } onDismissClick={ this.dismiss }>
+				<Notice icon="globe" showDismiss={ true } onDismissClick={ this.dismiss }>
 					<div className="locale-suggestions__list">{ localeMarkup }</div>
 				</Notice>
 			</div>

--- a/client/signup/locale-suggestions/style.scss
+++ b/client/signup/locale-suggestions/style.scss
@@ -1,5 +1,6 @@
 .locale-suggestions {
-	margin-top: 20px;
+	margin: 20px auto 0;
+	max-width: 500px;
 }
 
 .locale-suggestions__list-item {


### PR DESCRIPTION
This has been a pet peeve of mine for a while. The locale suggestion notice has no max-width, so it looks kinda broken on a large monitor.

![screen shot 2016-05-24 at 17 14 45](https://cloud.githubusercontent.com/assets/418473/15518593/09dca988-21d4-11e6-989f-e8bfac012ac7.png)

I've set a max-width for it matching the survey's (500px) and also tentatively added the globe icon, and removed the `is-info` class, that way it doesn't compete as much with the top bar visually.

<img width="541" alt="screen shot 2016-05-24 at 17 19 05" src="https://cloud.githubusercontent.com/assets/418473/15518645/46dde2ca-21d4-11e6-91f3-d76cc152f751.png">

Here's how it looks like on the context of the whole window:

![screen shot 2016-05-24 at 17 14 48](https://cloud.githubusercontent.com/assets/418473/15518683/6d4713aa-21d4-11e6-8faf-ab9749405ac4.png)

