### PR TITLE
Media: Fix spacing on edit screen

### DIFF
--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -8,7 +8,7 @@
 }
 
 .editor-media-modal-detail .header-cake__title {
-	padding: 6px 0;
+	padding: 6px;
 }
 
 .editor-media-modal-detail .editor-media-modal-detail__title-input {

--- a/client/post-editor/media-modal/detail/_style.scss
+++ b/client/post-editor/media-modal/detail/_style.scss
@@ -1,4 +1,7 @@
 .editor-media-modal-detail .header-cake.card {
+	padding-top: 0;
+	padding-bottom: 0;
+
 	@include breakpoint( "<660px" ) {
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
Noticed some spacing inconsistencies when I went to edit a photo yesterday. Zoomed in on the effected area:

Before:
<img width="994" alt="screen shot 2016-05-24 at 2 34 40 pm" src="https://cloud.githubusercontent.com/assets/5835847/15519557/4bd0c942-21bf-11e6-8624-e35fe317f73d.png">

![screen shot 2016-05-24 at 2 47 55 pm](https://cloud.githubusercontent.com/assets/5835847/15519528/2c4d07e8-21bf-11e6-9cb5-deb72ebae905.png)

After:
![screen shot 2016-05-24 at 2 47 40 pm](https://cloud.githubusercontent.com/assets/5835847/15519520/22a59b06-21bf-11e6-8b4f-c0495bed5e7e.png)

(I was comparing to the screenshot below that I took soon after we launched media)
<img width="565" alt="screen shot 2016-05-24 at 2 51 31 pm" src="https://cloud.githubusercontent.com/assets/5835847/15519610/871ceda0-21bf-11e6-8828-5b14624ea317.png">
