### PR TITLE
Posts: Fix meta icon alignment

### DIFF
--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -19,23 +19,27 @@ module.exports = React.createClass( {
 		post: React.PropTypes.object.isRequired,
 		includeNonDraftStatuses: React.PropTypes.bool,
 		link: React.PropTypes.string,
-		target: React.PropTypes.string
+		target: React.PropTypes.string,
+		iconSize: React.PropTypes.oneOf( [ 18, 24 ] ),
 	},
 
 	getDefaultProps: function() {
 		return {
 			includeNonDraftStatuses: false,
 			link: null,
-			target: null
+			target: null,
+			iconSize: 18
 		};
 	},
 
 	getRelativeTimeText: function() {
-		const status = this.props.post.status;
+		var status = this.props.post.status,
+			iconSize = this.props.iconSize,
+			time, timeReference;
 
-		let time;
 		if ( status === 'draft' || status === 'pending' ) {
 			time = this.props.post.modified;
+			timeReference = ( <small style={ { marginLeft: 2 } }>{ this.translate( ' (last-modified)' ) }</small> );
 		} else if ( status !== 'new' ) {
 			time = this.props.post.date;
 		}
@@ -45,10 +49,10 @@ module.exports = React.createClass( {
 		}
 
 		return (
-			<span className="post-relative-time-status__time">
-				<Gridicon icon="time" size={ 18 } />
-				<span className="post-relative-time-status__time-text">
-					{ this.moment( time ).fromNow() }
+			<span className="time">
+				<Gridicon icon="time" size={ iconSize } />
+				<span className="time-text">
+					{ this.moment( time ).fromNow() }{ timeReference }
 				</span>
 			</span>
 		);
@@ -56,7 +60,8 @@ module.exports = React.createClass( {
 
 	getStatusText: function() {
 		var status = this.props.post.status,
-			statusClassName = 'post-relative-time-status__status',
+			iconSize = this.props.iconSize,
+			statusClassName = 'status',
 			statusIcon = 'aside',
 			statusText;
 
@@ -88,10 +93,8 @@ module.exports = React.createClass( {
 		if ( statusText ) {
 			return (
 				<span className={ statusClassName }>
-					<Gridicon icon={ statusIcon } size={ 18 } />
-					<span className="post-relative-time-status__status-text">
-						{ statusText }
-					</span>
+					<Gridicon icon={ statusIcon } size={ iconSize } />
+					<span className="status-text">{ statusText }</span>
 				</span>
 			);
 		}

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -1,8 +1,26 @@
 .post-relative-time-status {
+	display: flex;
+	flex-wrap: wrap;
+
+	.time,
+	.status {
+		display: inline-flex;
+		align-items: center;
+		margin-right: (11 / 12) * 1em;
+	}
+
+	.time .time-text {
+		&::first-letter {
+			text-transform: capitalize;
+		}
+	}
+
+	.status .status-text {
+		text-transform: capitalize;
+	}
+
 	.gridicon {
-		display: inline-block;
-		margin: -4px 8px 0 0;
-		vertical-align: middle;
+		margin-right: 8px;
 	}
 
 	// Apply colors on /posts/* cards

--- a/client/my-sites/posts/post-total-views.jsx
+++ b/client/my-sites/posts/post-total-views.jsx
@@ -21,11 +21,18 @@ var PostTotalViews = React.createClass( {
 	propTypes: {
 		post: PropTypes.object.isRequired,
 		viewCount: PropTypes.number,
+		iconSize: PropTypes.oneOf( [ 18, 24 ] ),
 		clickHandler: PropTypes.func
 	},
 
+	getDefaultProps() {
+		return {
+			iconSize: 24
+		};
+	},
+
 	render() {
-		const { viewCount, post } = this.props,
+		const { viewCount, post, iconSize } = this.props,
 			postId = post.ID,
 			siteId = post.site_ID;
 		let viewsCountDisplay = '',
@@ -54,7 +61,7 @@ var PostTotalViews = React.createClass( {
 				title={ viewsTitle }
 				onClick={ this.props.clickHandler }>
 				<QueryPostStats siteId= { siteId } postId={ postId } stat="views" />
-				<Gridicon icon="visible" size={ 24 } />
+				<Gridicon icon="visible" size={ iconSize } />
 				<StatUpdateIndicator updateOn={ viewsCountDisplay }>{ viewsCountDisplay }</StatUpdateIndicator>
 			</a>
 		);

--- a/client/my-sites/posts/post.jsx
+++ b/client/my-sites/posts/post.jsx
@@ -24,6 +24,8 @@ import config from 'config';
 import Comments from 'reader/comments';
 import PostShare from './post-share';
 
+const META_ICON_SIZE = 24; // size used for meta icons (views, comments, & likes)
+
 function recordEvent( eventAction ) {
 	analytics.ga.recordEvent( 'Posts', eventAction );
 }
@@ -267,7 +269,7 @@ module.exports = React.createClass( {
 						title={ commentTitle }
 						onClick={ this.toggleComments }
 					>
-					<Gridicon icon="comment" size={ 24 } />
+					<Gridicon icon="comment" size={ META_ICON_SIZE } />
 
 					<span>{ commentCountDisplay }</span></a>
 				);
@@ -303,7 +305,7 @@ module.exports = React.createClass( {
 						title={ likeTitle }
 						onClick={ this.analyticsEvents.likeIconClick }
 					>
-					<Gridicon icon="star" size={ 24 } />
+					<Gridicon icon="star" size={ META_ICON_SIZE } />
 					<span>{ likeCountDisplay }</span></a>
 				);
 				metaItems.push( likeMeta );
@@ -313,7 +315,10 @@ module.exports = React.createClass( {
 		// If the user can see stats, show how many total views this post has received
 		if ( showStats ) {
 			metaItems.push( (
-				<PostTotalViews post={ post } clickHandler={ this.analyticsEvents.viewStats } />
+				<PostTotalViews
+					post={ post }
+					iconSize={ META_ICON_SIZE }
+					clickHandler={ this.analyticsEvents.viewStats } />
 			) );
 		}
 
@@ -334,7 +339,7 @@ module.exports = React.createClass( {
 		if ( metaItems.length ) {
 			footerMetaItems = metaItems.map( function( item, i ) {
 				const itemKey = 'meta-' + postId + '-' + i;
-				return ( <li key={ itemKey }><span>{ item }</span></li> );
+				return ( <li key={ itemKey }>{ item }</li> );
 			}, this );
 
 			return ( <ul className="post__meta">{ footerMetaItems }</ul> );
@@ -388,7 +393,12 @@ module.exports = React.createClass( {
 					{ this.getPostImage() }
 					{ this.getContent() }
 					<footer className="post__info">
-						<PostRelativeTimeStatus post={ this.props.post } link={ this.getContentLinkURL() } target={ this.getContentLinkTarget() } onClick={ this.analyticsEvents.dateClick }/>
+						<PostRelativeTimeStatus
+							post={ this.props.post }
+							link={ this.getContentLinkURL() }
+							target={ this.getContentLinkTarget() }
+							iconSize={ META_ICON_SIZE }
+							onClick={ this.analyticsEvents.dateClick } />
 						{
 							// Only show meta items for non-drafts
 							( this.props.post.status === 'draft' ) ? null : this.getMeta()

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -185,6 +185,9 @@
 	}
 
 	.post__info {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
 		width: 100%;
 		font-size: (14 / 15) * 1em;
 		padding-top: (16 / 10) * 1rem;
@@ -193,12 +196,10 @@
 		overflow: hidden;
 		@include breakpoint( ">660px" ) {
 			padding-top: (20 / 10) * 1rem;
-			padding-bottom: (20 / 10) * 1rem;
 		}
 	}
 
 	.post-relative-time-status {
-		float: left;
 		margin: 0;
 		.noticon {
 			font-size: (16 / 14) * 1em;
@@ -214,7 +215,6 @@
 	}
 
 	.post__meta {
-		float: right;
 		margin: 0;
 		list-style: none;
 		box-sizing: border-box;
@@ -223,13 +223,14 @@
 			overflow: hidden;
 			white-space: nowrap;
 			text-overflow: ellipsis;
-			margin-left: (15 / 14) * 1em;
+			margin-right: (15 / 14) * 1em;
 			color: $gray;
-			vertical-align: top;
-			&:first-child {
-				margin-left: 0;
+			&:last-child {
+				margin-right: 0;
 			}
 			a {
+				display: flex;
+				align-items: center;
 				color: inherit;
 				&:before {
 					@extend %noticon;
@@ -241,17 +242,9 @@
 						color: lighten( $gray, 20% );
 					}
 				}
-				.gridicon{
-					position: relative;
-					top: 6px;
-				}
 				&:hover {
 					color: $blue-medium;
 				}
-			}
-			span {
-				display: inline-block;
-				margin: (1 / 14) * 1em 0 0 (3 / 14) * 1em;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes an issue on the `/posts/*` cards where the post date & meta info (stat counters) had become misaligned.

| Before | After |
| --- | --- |
| [![screen shot 2016-05-24 at 4 48 10 pm](https://cloud.githubusercontent.com/assets/1427136/15519732/d09cfe32-21d0-11e6-836b-9b346a156b9f.png)](https://cloud.githubusercontent.com/assets/1427136/15519732/d09cfe32-21d0-11e6-836b-9b346a156b9f.png) | [![screen shot 2016-05-24 at 3 52 06 pm](https://cloud.githubusercontent.com/assets/1427136/15519747/ebcc8f6a-21d0-11e6-8dae-b512592e64cd.png)](https://cloud.githubusercontent.com/assets/1427136/15519747/ebcc8f6a-21d0-11e6-8dae-b512592e64cd.png) |

While adjusting the alignment, I noticed that it felt odd to have different icon sizes for the stat counters & date, so now everything uses the same icon & text sizing. The technique has also been altered to use flexbox instead of small margin & positioning adjustments to make it easier for alterations.

/cc @rickybanister, @mtias 
