### PR TITLE
Site Settings SEO: Fix Jetpack Redirect to General Tab

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -4,7 +4,6 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import page from 'page';
-import endsWith from 'lodash/endsWith';
 
 /**
  * Internal Dependencies
@@ -77,7 +76,7 @@ module.exports = {
 		}
 
 		// redirect seo tab to general for Jetpack sites
-		if ( site.jetpack && endsWith( basePath, 'seo' ) ) {
+		if ( site.jetpack && context.params.section === 'seo' ) {
 			page.redirect( '/settings/general/' + site.slug );
 			return;
 		}

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -4,6 +4,7 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import page from 'page';
+import endsWith from 'lodash/endsWith';
 
 /**
  * Internal Dependencies
@@ -72,6 +73,12 @@ module.exports = {
 		// if user went directly to jetpack settings page, redirect
 		if ( site.jetpack && ! config.isEnabled( 'manage/jetpack' ) ) {
 			window.location.href = '//wordpress.com/manage/' + site.ID;
+			return;
+		}
+
+		// redirect seo tab to general for Jetpack sites
+		if ( site.jetpack && endsWith( basePath, 'seo' ) ) {
+			page.redirect( '/settings/general/' + site.slug );
 			return;
 		}
 

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -84,16 +84,23 @@ export const SeoForm = React.createClass( {
 		return stateForSite( this.props.site );
 	},
 
-	componentWillReceiveProps: function( nextProps ) {
+	componentDidMount() {
+		this.redirectJetpack( this.props.site );
+	},
+
+	componentWillReceiveProps( nextProps ) {
 		if ( get( nextProps, 'site.ID' ) !== get( this.props, 'site.ID' ) ) {
-			if ( get( nextProps, 'site.jetpack' ) ) {
-				// Go back to general settings if switched to a Jetpack site
-				page( getGeneralTabUrl( get( nextProps, 'site.slug', '' ) ) );
-				return;
-			}
+			this.redirectJetpack( get( nextProps, 'site' ) );
 
 			// Update state when switching sites
 			this.setState( stateForSite( nextProps.site ) );
+		}
+	},
+
+	redirectJetpack( site ) {
+		if ( get( site, 'jetpack' ) ) {
+			// Go back to general settings if this is a Jetpack site
+			page( getGeneralTabUrl( get( site, 'slug', '' ) ) );
 		}
 	},
 

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -84,23 +84,10 @@ export const SeoForm = React.createClass( {
 		return stateForSite( this.props.site );
 	},
 
-	componentDidMount() {
-		this.redirectJetpack( this.props.site );
-	},
-
 	componentWillReceiveProps( nextProps ) {
 		if ( get( nextProps, 'site.ID' ) !== get( this.props, 'site.ID' ) ) {
-			this.redirectJetpack( get( nextProps, 'site' ) );
-
 			// Update state when switching sites
 			this.setState( stateForSite( nextProps.site ) );
-		}
-	},
-
-	redirectJetpack( site ) {
-		if ( get( site, 'jetpack' ) ) {
-			// Go back to general settings if this is a Jetpack site
-			page( getGeneralTabUrl( get( site, 'slug', '' ) ) );
 		}
 	},
 


### PR DESCRIPTION
Check if site is Jetpack after the component mounts.

**To test:** visit /settings/seo/`yourjetpackurl.com`. You should be redirected to the general settings. Visiting the same url with a wp.com site should load the SEO tab.

Fixes #5511