### PR TITLE
Post Normalizer: Refactor rules into individual files

### DIFF
--- a/client/lib/feed-post-store/normalization-rules.js
+++ b/client/lib/feed-post-store/normalization-rules.js
@@ -52,9 +52,9 @@ const fastPostNormalizationRules = [
 		classifyPost
 	];
 
-function discoverFullBleedImages( post, callback ) {
+function discoverFullBleedImages( post, dom ) {
 	if ( post.site_ID === DISCOVER_BLOG_ID ) {
-		const images = toArray( post.__contentDOM.querySelectorAll( '.fullbleed img, img.fullbleed' ) );
+		const images = dom.querySelectorAll( '.fullbleed img, img.fullbleed' );
 		forEach( images, function( image ) {
 			const newSrc = resizeImageUrl( image.src, { w: DISCOVER_FULL_BLEED_WIDTH } );
 			let oldImageObject = find( post.content_images, { src: image.src } );
@@ -62,7 +62,7 @@ function discoverFullBleedImages( post, callback ) {
 			image.src = newSrc;
 		} );
 	}
-	callback();
+	return post;
 }
 
 /**

--- a/client/lib/post-normalizer/index.js
+++ b/client/lib/post-normalizer/index.js
@@ -1,64 +1,17 @@
 /**
  * External Dependencies
  */
-var assign = require( 'lodash/assign' ),
-	async = require( 'async' ),
+var async = require( 'async' ),
 	debug = require( 'debug' )( 'calypso:post-normalizer' ),
-	cloneDeep = require( 'lodash/cloneDeep' ),
-	every = require( 'lodash/every' ),
-	endsWith = require( 'lodash/endsWith' ),
-	filter = require( 'lodash/filter' ),
-	find = require( 'lodash/find' ),
-	head = require( 'lodash/head' ),
-	forEach = require( 'lodash/forEach' ),
-	forOwn = require( 'lodash/forOwn' ),
-	map = require( 'lodash/map' ),
-	maxBy = require( 'lodash/maxBy' ),
-	pick = require( 'lodash/pick' ),
-	some = require( 'lodash/some' ),
-	srcset = require( 'srcset' ),
-	startsWith = require( 'lodash/startsWith' ),
-	toArray = require( 'lodash/toArray' ),
-	trim = require( 'lodash/trim' ),
-	uniqBy = require( 'lodash/uniqBy' ),
-	url = require( 'url' ),
-	values = require( 'lodash/values' );
-
-import striptags from 'striptags';
-
+	cloneDeep = require( 'lodash/cloneDeep' );
 /**
  * Internal dependencies
  */
-import i18n from 'lib/mixins/i18n';
-import formatting from 'lib/formatting';
-import safeImageURL from 'lib/safe-image-url';
-
-const DEFAULT_PHOTON_QUALITY = 80, // 80 was chosen after some heuristic testing as the best blend of size and quality
-	READING_WORDS_PER_SECOND = 250 / 60; // Longreads says that people can read 250 words per minute. We want the rate in words per second.
-
-const imageScaleFactor = ( typeof window !== 'undefined' && window.devicePixelRatio && window.devicePixelRatio > 1 ) ? 2 : 1,
-	TRANSPARENT_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 function debugForPost( post ) {
 	return function( msg ) {
 		debug( post.global_ID + ': ' + msg );
 	};
-}
-
-function stripAutoPlays( query ) {
-	const keys = Object.keys( query ).filter( function( k ) {
-		k = k.toLowerCase();
-		return k === 'autoplay' || k === 'auto_play';
-	} );
-	keys.forEach( function( key ) {
-		const val = query[ key ].toLowerCase();
-		if ( val === '1' ) {
-			query[ key ] = '0';
-		} else if ( val === 'true' ) {
-			query[ key ] = 'false';
-		}
-	} );
-	return query;
 }
 
 /**
@@ -99,761 +52,81 @@ function normalizePost( post, transforms, callback ) {
 	);
 }
 
-function maxWidthPhotonishURL( imageURL, width ) {
-	if ( ! imageURL ) {
-		return imageURL;
-	}
-
-	let parsedURL = url.parse( imageURL, true, true ), // true, true means allow protocol-less hosts and parse the querystring
-		isGravatar, sizeParam;
-
-	if ( ! parsedURL.host ) {
-		return imageURL;
-	}
-
-	isGravatar = parsedURL.host.indexOf( 'gravatar.com' ) !== -1;
-
-	delete parsedURL.search;
-	// strip other sizing params
-	forEach( [ 'h', 'crop', 'resize', 'fit' ], function( param ) {
-		delete parsedURL.query[ param ];
-	} );
-
-	sizeParam = isGravatar ? 's' : 'w';
-	parsedURL.query[ sizeParam ] = width * imageScaleFactor;
-
-	if ( ! isGravatar ) {
-		// gravatar doesn't support these, only photon / files.wordpress
-		parsedURL.query.quality = DEFAULT_PHOTON_QUALITY;
-		parsedURL.query.strip = 'info'; // strip all exif data, leave ICC intact
-	}
-
-	return url.format( parsedURL );
+function wrapSync( fn ) {
+	return function wrapped( post, callback ) {
+		fn( post );
+		callback();
+	};
 }
 
-function makeImageURLSafe( object, propName, maxWidth, baseURL ) {
-	if ( object && object[ propName ] ) {
-		if ( baseURL && ! url.parse( object[ propName ], true, true ).hostname ) {
-			object[ propName ] = url.resolve( baseURL, object[ propName ] );
-		}
-		object[ propName ] = safeImageURL( object[ propName ] );
+import decodeEntities from './rule-decode-entities';
+normalizePost.decodeEntities = wrapSync( decodeEntities );
 
-		if ( maxWidth ) {
-			object[ propName ] = maxWidthPhotonishURL( object[ propName ], maxWidth );
-		}
-	}
-}
+import stripHtml from './rule-strip-html';
+normalizePost.stripHTML = wrapSync( stripHtml );
 
-function imageForURL( imageUrl ) {
-	var img = new Image();
-	img.src = imageUrl;
-	return img;
-}
+import preventWidows from './rule-prevent-widows';
+normalizePost.preventWidows = wrapSync( preventWidows );
 
-function imageSizeFromAttachments( post, imageUrl ) {
-	var attachments = post.attachments, found;
+import firstPassCanonicalImage from './rule-first-pass-canonical-image';
+normalizePost.firstPassCanonicalImage = wrapSync( firstPassCanonicalImage );
 
-	if ( ! attachments ) {
-		return;
-	}
+import makeSiteIDSafeForAPI from './rule-make-site-id-safe-for-api';
+normalizePost.makeSiteIDSafeForAPI = wrapSync( makeSiteIDSafeForAPI );
 
-	found = find( attachments, function( attachment ) {
-		return attachment.URL === imageUrl;
-	} );
+import pickPrimaryTag from './rule-pick-primary-tag';
+normalizePost.pickPrimaryTag = wrapSync( pickPrimaryTag );
 
-	if ( found ) {
-		return {
-			width: found.width,
-			height: found.height
-		};
-	}
-}
-
-function candidateForCanonicalImage( image ) {
-	if ( ! image ) {
-		return false;
-	}
-
-	if ( image.naturalWidth < 350 ) {
-		debug( ( image && image.src ), ': not wide enough' );
-		return false;
-	}
-
-	if ( ( image.naturalWidth * image.naturalHeight ) < 30000 ) {
-		debug( ( image && image.src ), ': not enough area' );
-		return false;
-	}
-	return true;
-}
-
-function removeUnsafeAttributes( node ) {
-	if ( ! node || ! node.hasAttributes() ) {
-		return;
-	}
-
-	// Have to toArray this because attributes is a live
-	// NodeMap and would node removals would invalidate
-	// the current index as we walked it.
-	forEach( toArray( node.attributes ), function( attr ) {
-		if ( startsWith( attr.name, 'on' ) ) {
-			node.removeAttribute( attr.name );
-		}
-	} );
-}
-
-const excludedContentImageUrlParts = [ 'gravatar.com' ];
-function isCandidateForContentImage( imageUrl ) {
-	return ! imageShouldBeRemovedFromContent( imageUrl ) && every( excludedContentImageUrlParts, function( part ) {
-		return imageUrl && imageUrl.toLowerCase().indexOf( part ) === -1;
-	} );
-}
-
-const bannedUrlParts = [
-	'feeds.feedburner.com',
-	'feeds.wordpress.com/',
-	'.feedsportal.com',
-	'wp-includes',
-	'wp-content/themes',
-	'wp-content/plugins',
-	'stats.wordpress.com',
-	'pixel.wp.com'
-];
-function imageShouldBeRemovedFromContent( imageUrl ) {
-	return some( bannedUrlParts, function( part ) {
-		return imageUrl && imageUrl.toLowerCase().indexOf( part ) !== -1;
-	} );
-}
-
-normalizePost.decodeEntities = function decodeEntities( post, callback ) {
-	forEach( [ 'excerpt', 'title', 'site_name' ], function( prop ) {
-		if ( post[ prop ] ) {
-			post[ prop ] = formatting.decodeEntities( post[ prop ] );
-		}
-	} );
-
-	if ( post.parent && post.parent.title ) {
-		post.parent.title = formatting.decodeEntities( post.parent.title );
-	}
-
-	if ( post.author ) {
-		if ( post.author.name ) {
-			post.author.name = formatting.decodeEntities( post.author.name );
-		}
-		if ( post.author.avatar_URL ) {
-			post.author.avatar_URL = safeImageURL( post.author.avatar_URL );
-		}
-	}
-
-	if ( post.tags ) {
-		// tags is an object
-		forOwn( post.tags, function( tag ) {
-			tag.name = formatting.decodeEntities( tag.name );
-		} );
-	}
-
-	callback();
-};
-
-normalizePost.stripHTML = function stripHTML( post, callback ) {
-	forEach( [ 'excerpt', 'title', 'site_name' ], function( prop ) {
-		if ( post[ prop ] ) {
-			post[ prop ] = formatting.stripHTML( post[ prop ] );
-		}
-	} );
-
-	if ( post.author && post.author.name ) {
-		post.author.name = formatting.stripHTML( post.author.name );
-	}
-
-	callback();
-};
-
-normalizePost.preventWidows = function preventWidows( post, callback ) {
-	forEach( [ 'title', 'excerpt' ], function( prop ) {
-		if ( post[ prop ] ) {
-			post[ prop ] = formatting.preventWidows( post[ prop ], 2 );
-		}
-	} );
-	callback();
-};
-
-normalizePost.firstPassCanonicalImage = function firstPassCanonicalImage( post, callback ) {
-	if ( post.featured_image ) {
-		post.canonical_image = assign( {
-			uri: post.featured_image,
-			type: 'image'
-		}, imageSizeFromAttachments( post.featured_image ) );
-	} else {
-		let candidate = head( filter( post.attachments, function( attachment ) {
-			return startsWith( attachment.mime_type, 'image/' );
-		} ) );
-
-		if ( candidate ) {
-			post.canonical_image = {
-				uri: candidate.URL,
-				width: candidate.width,
-				height: candidate.height,
-				type: 'image'
-			};
-		}
-	}
-
-	callback();
-};
-
-normalizePost.makeSiteIDSafeForAPI = function makeSiteIDSafeForAPI( post, callback ) {
-	if ( post.site_id ) {
-		post.normalized_site_id = ( '' + post.site_id ).replace( /::/g, '/' );
-	}
-
-	callback();
-};
-
-normalizePost.pickPrimaryTag = function assignPrimaryTag( post, callback ) {
-	// if we hand max an invalid or empty array, it returns -Infinity
-	post.primary_tag = maxBy( values( post.tags ), function( tag ) {
-		return tag.post_count;
-	} );
-
-	if ( post.primary_tag === undefined ) {
-		delete post.primary_tag;
-	}
-
-	callback();
-};
-
+import safeImageProperties from './rule-safe-image-properties';
 normalizePost.safeImageProperties = function( maxWidth ) {
-	return function safeImageProperties( post, callback ) {
-		makeImageURLSafe( post.author, 'avatar_URL', maxWidth );
-		makeImageURLSafe( post, 'featured_image', maxWidth, post.URL );
-		if ( post.featured_media && post.featured_media.type === 'image' ) {
-			makeImageURLSafe( post.featured_media, 'uri', maxWidth, post.URL );
-		}
-		if ( post.canonical_image && post.canonical_image.type === 'image' ) {
-			makeImageURLSafe( post.canonical_image, 'uri', maxWidth, post.URL );
-		}
-		if ( post.attachments ) {
-			forOwn( post.attachments, function( attachment ) {
-				if ( startsWith( attachment.mime_type, 'image/' ) ) {
-					makeImageURLSafe( attachment, 'URL', maxWidth, post.URL );
-				}
-			} );
-		}
-
-		callback();
-	};
+	return wrapSync( safeImageProperties( maxWidth ) );
 };
 
-function keepImagesThatLoad( image, acceptCallback ) {
-	if ( image.complete && image.naturalWidth > 0 ) {
-		acceptCallback( true );
-		return; // DO NOT hook up event handlers if we're already complete
-	}
-	image.onload = function() {
-		acceptCallback( true );
-	};
-	image.onerror = function() {
-		acceptCallback( false );
-	};
-}
-
-function convertImageToObject( image ) {
-	return pick( image, [ 'src', 'naturalWidth', 'naturalHeight' ] );
-}
-
-normalizePost.waitForImagesToLoad = function waitForImagesToLoad( post, callback ) {
-	function acceptLoadedImages( images ) {
-		post.images = map( images, convertImageToObject );
-
-		post.content_images = filter( map( post.content_images, function( image ) {
-			return find( post.images, { src: image.src } );
-		} ), Boolean );
-
+import waitForImagesToLoad from './rule-wait-for-images-to-load';
+normalizePost.waitForImagesToLoad = function waitForImagesToLoadAdapter( post, callback ) {
+	waitForImagesToLoad( post ).then( () => {
 		callback();
-	}
-
-	let imagesToCheck = [];
-
-	if ( post.featured_image ) {
-		imagesToCheck.push( imageForURL( post.featured_image ) );
-	}
-
-	forEach( post.content_images, function( image ) {
-		imagesToCheck.push( imageForURL( image.src ) );
+	}, err => {
+		callback( err );
 	} );
-
-	// dedupe the set of images
-	imagesToCheck = uniqBy( imagesToCheck, function( image ) {
-		return image.src;
-	} );
-
-	if ( imagesToCheck.length === 0 ) {
-		callback();
-		return;
-	}
-
-	post.images = imagesToCheck;
-	async.filter( post.images, keepImagesThatLoad, acceptLoadedImages );
 };
 
-function imageHasMinWidthAndHeight( width, height ) {
-	return function( image ) {
-		return image.naturalWidth >= width && image.naturalHeight >= height;
-	};
-}
-
+import keepValidImages from './rule-keep-valid-images';
 normalizePost.keepValidImages = function( minWidth, minHeight ) {
-	return function keepValidImages( post, callback ) {
-		var imageFilter = imageHasMinWidthAndHeight( minWidth, minHeight );
-		if ( post.images ) {
-			post.images = filter( post.images, imageFilter );
-		}
-		if ( post.content_images ) {
-			post.content_images = filter( post.content_images, imageFilter );
-		}
-		callback();
-	};
+	return wrapSync( keepValidImages( minWidth, minHeight ) );
 };
 
-normalizePost.pickCanonicalImage = function pickCanonicalImage( post, callback ) {
-	var canonicalImage;
-	if ( post.images ) {
-		canonicalImage = filter( post.images, candidateForCanonicalImage )[ 0 ];
-		if ( canonicalImage ) {
-			canonicalImage = {
-				uri: canonicalImage.src,
-				width: canonicalImage.naturalWidth,
-				height: canonicalImage.naturalHeight
-			};
-		}
-	} else if ( post.featured_image ) {
-		canonicalImage = {
-			uri: post.featured_image,
-			width: 0,
-			height: 0
-		};
-	}
+import pickCanonicalImage from './rule-pick-canonical-image';
+normalizePost.pickCanonicalImage = wrapSync( pickCanonicalImage );
 
-	if ( canonicalImage ) {
-		post.canonical_image = canonicalImage;
-	}
-	callback();
-};
+import createBetterExcerpt from './rule-create-better-excerpt';
+normalizePost.createBetterExcerpt = wrapSync( createBetterExcerpt );
 
-normalizePost.createBetterExcerpt = function createBetterExcerpt( post, callback ) {
-	if ( ! post || ! post.content ) {
-		callback();
-		return;
-	}
-
-	function removeElement( element ) {
-		element.parentNode && element.parentNode.removeChild( element );
-	}
-
-	let betterExcerpt = striptags( post.content, [ 'p', 'br' ] );
-
-	// Spin up a new DOM for the linebreak markup
-	const dom = document.createElement( 'div' );
-	dom.id = '__better_excerpt__';
-	dom.innerHTML = betterExcerpt;
-
-	// Ditch any photo captions with the wp-caption-text class
-	forEach( dom.querySelectorAll( '.wp-caption-text' ), removeElement );
-
-	// Strip any empty p and br elements from the beginning of the content
-	forEach( dom.querySelectorAll( 'p,br' ), function( element ) {
-		// is this element non-empty? bail on our iteration.
-		if ( element.childNodes.length > 0 && trim( element.textContent ).length > 0 ) {
-			return false;
-		}
-		element.parentNode && element.parentNode.removeChild( element );
-	} );
-
-	// now strip any p's that are empty
-	forEach( dom.querySelectorAll( 'p' ), function( element ) {
-		if ( trim( element.textContent ).length === 0 ) {
-			element.parentNode && element.parentNode.removeChild( element );
-		}
-	} );
-
-	// now limit it to the first three elements
-	forEach( dom.querySelectorAll( '#__better_excerpt__ > p, #__better_excerpt__ > br' ), function( element, index ) {
-		if ( index >= 3 ) {
-			element.parentNode && element.parentNode.removeChild( element );
-		}
-	} );
-
-	post.better_excerpt = trim( dom.innerHTML );
-	dom.innerHTML = '';
-
-	callback();
-},
-
+import withContentDOM from './rule-with-content-dom';
 normalizePost.withContentDOM = function( transforms ) {
-	return function withContentDOM( post, callback ) {
-		if ( ! post || ! post.content || ! transforms ) {
-			callback();
-			return;
-		}
-
-		let postDebug = debugForPost( post );
-
-		postDebug( 'spinning up dom' );
-		// spin up the DOM
-		post.__contentDOM = document.createElement( 'div' );
-		post.__contentDOM.innerHTML = post.content;
-
-		// run the transforms
-		postDebug( 'running dom transforms' );
-		async.eachSeries( transforms, function( transform, transformCallback ) {
-			postDebug( 'running dom transform ' + ( transform.name || 'anonymous' ) );
-			transform( post, transformCallback );
-		}, function( err ) {
-			postDebug( 'done with dom transforms' );
-			// push the new DOM back in, if no error
-			if ( ! err ) {
-				post.content = post.__contentDOM.innerHTML;
-			}
-			// let go of the DOM and let the caller know we're done
-			delete post.__contentDOM;
-			callback( err );
-		} );
+	return function( post, callback ) {
+		withContentDOM( transforms )( post );
+		callback();
 	};
 };
+
+import removeStyles from './rule-content-remove-styles';
+import safeContentImages from './rule-content-safe-images';
+import makeEmbedsSecure from './rule-content-make-embeds-secure';
+import wordCountAndReadingTime from './rule-content-word-count';
+import detectEmbeds from './rule-content-detect-embeds';
+import { disableAutoPlayOnMedia, disableAutoPlayOnEmbeds } from './rule-content-disable-autoplay';
+import detectPolls from './rule-content-detect-polls';
 
 normalizePost.content = {
-
-	removeStyles: function removeContentStyles( post, callback ) {
-		if ( ! post.__contentDOM ) {
-			throw new Error( 'this transform must be used as part of withContentDOM' );
-		}
-
-		// if there are any specials in the post, skip it
-		if ( post.__contentDOM.querySelector( '.gallery, .tiled-gallery, blockquote[class^="instagram-"], blockquote[class^="twitter-"]' ) ) {
-			callback();
-			return;
-		}
-
-		// remove most style attributes
-		let styled = post.__contentDOM.querySelectorAll( '[style]' );
-		forEach( styled, function( element ) {
-			element.removeAttribute( 'style' );
-		} );
-
-		// remove all style elements
-		forEach( post.__contentDOM.querySelectorAll( 'style' ), function( element ) {
-			element.parentNode && element.parentNode.removeChild( element );
-		} );
-
-		callback();
-	},
-
-	safeContentImages: function( maxWidth ) {
-		return function safeContentImages( post, callback ) {
-			var content_images = [],
-				images;
-
-			if ( ! post.__contentDOM ) {
-				throw new Error( 'this transform must be used as part of withContentDOM' );
-			}
-			images = post.__contentDOM.querySelectorAll( 'img[src]' );
-
-			// push everything, including tracking pixels, over to a safe URL
-			forEach( images, function( image ) {
-				let imgSource = image.getAttribute( 'src' ),
-					parsedImgSrc = url.parse( imgSource, false, true ),
-					hostName = parsedImgSrc.hostname;
-
-				let safeSource;
-				// if imgSource is relative, prepend post domain so it isn't relative to calypso
-				if ( ! hostName ) {
-					imgSource = url.resolve( post.URL, imgSource );
-					parsedImgSrc = url.parse( imgSource, false, true );
-				}
-
-				safeSource = safeImageURL( imgSource );
-				if ( ! safeSource && parsedImgSrc.search ) {
-					// we can't make externals with a querystring safe.
-					// try stripping it and retry
-					parsedImgSrc.search = null;
-					parsedImgSrc.query = null;
-					safeSource = safeImageURL( url.format( parsedImgSrc ) );
-				}
-
-				removeUnsafeAttributes( image );
-
-				if ( ! safeSource || imageShouldBeRemovedFromContent( imgSource ) ) {
-					image.parentNode.removeChild( image );
-					// fun fact: removing the node from the DOM will not prevent it from loading. You actually have to
-					// change out the src to change what loads. The following is a 1x1 transparent gif as a data URL
-					image.setAttribute( 'src', TRANSPARENT_GIF );
-					image.removeAttribute( 'srcset' );
-					return;
-				}
-
-				if ( maxWidth ) {
-					safeSource = maxWidthPhotonishURL( safeSource, maxWidth );
-				}
-
-				image.setAttribute( 'src', safeSource );
-
-				if ( image.hasAttribute( 'srcset' ) ) {
-					const imgSrcSet = srcset.parse( image.getAttribute( 'srcset' ) ).map( imgSrc => {
-						if ( ! url.parse( imgSrc.url, false, true ).hostname ) {
-							imgSrc.url = url.resolve( post.URL, imgSrc.url );
-						}
-						imgSrc.url = safeImageURL( imgSrc.url );
-						return imgSrc;
-					} ).filter( imgSrc => imgSrc.url );
-					image.setAttribute( 'srcset', srcset.stringify( imgSrcSet ) );
-				}
-
-				if ( isCandidateForContentImage( imgSource ) ) {
-					content_images.push( {
-						src: safeSource,
-						original_src: imgSource,
-						width: image.width,
-						height: image.height
-					} );
-				}
-			} );
-
-			// grab all of the non-tracking pixels and push them into content_images
-			content_images = filter( content_images, function( image ) {
-				if ( ! image.src ) return false;
-				const edgeLength = image.height + image.width;
-				// if the image size isn't set (0) or is greater than 2, keep it
-				return edgeLength === 0 || edgeLength > 2;
-			} );
-
-			if ( content_images.length ) {
-				post.content_images = content_images;
-			}
-
-			callback();
-		};
-	},
-
-	makeEmbedsSecure: function makeEmbedsSecure( post, callback ) {
-		if ( ! post.__contentDOM ) {
-			throw new Error( 'this transform must be used as part of withContentDOM' );
-		}
-
-		let iframes = post.__contentDOM.querySelectorAll( 'iframe' );
-
-		const badFrames = [];
-
-		forEach( iframes, function( iframe ) {
-			iframe.setAttribute( 'sandbox', '' );
-			if ( ! startsWith( iframe.src, 'http' ) ) {
-				badFrames.push( iframe );
-			} else {
-				iframe.src = iframe.src.replace( /^http:/, 'https:' );
-			}
-		} );
-
-		forEach( badFrames, function( frame ) {
-			frame.parentNode.removeChild( frame );
-		} );
-
-		if ( post.is_external || post.is_jetpack ) {
-			let embeds = post.__contentDOM.querySelectorAll( 'embed,object' );
-
-			forEach( embeds, function( embed ) {
-				embed.parentNode.removeChild( embed );
-			} );
-		}
-
-		callback();
-	},
-
-	wordCountAndReadingTime: function wordCountAndReadingTime( post, callback ) {
-		if ( ! post.__contentDOM ) {
-			throw new Error( 'this transform must be used as part of withContentDOM' );
-		}
-
-		let textContent = post.__contentDOM.textContent.trim();
-
-		post.word_count = ( textContent.replace( /['";:,.?¿\-!¡]+/g, '' ).match( /\S+/g ) || [] ).length;
-
-		if ( post.word_count > 0 ) {
-			post.reading_time = Math.ceil( post.word_count / READING_WORDS_PER_SECOND ); // in seconds
-		}
-
-		callback();
-	},
-
-	detectEmbeds: function detectEmbeds( post, callback ) {
-		if ( ! post.__contentDOM ) {
-			throw new Error( 'this transform must be used as part of withContentDOM' );
-		}
-
-		let embeds = toArray( post.__contentDOM.querySelectorAll( 'iframe' ) );
-
-		const iframeWhitelist = [
-			'youtube.com',
-			'youtube-nocookie.com',
-			'videopress.com',
-			'vimeo.com',
-			'cloudup.com',
-			'soundcloud.com',
-			'8tracks.com',
-			'spotify.com',
-			'me.sh',
-			'bandcamp.com'
-		];
-
-		// hosts that we trust that don't work in a sandboxed iframe
-		const iframeNoSandbox = [
-			'spotify.com'
-		];
-
-		embeds = filter( embeds, function( iframe ) {
-			const iframeSrc = iframe.src && url.parse( iframe.src ).hostname.toLowerCase();
-			return some( iframeWhitelist, function( accepted ) {
-				return endsWith( '.' + iframeSrc, '.' + accepted );
-			} );
-		} );
-
-		post.content_embeds = map( embeds, function( iframe ) {
-			var node = iframe,
-				embedType = null,
-				aspectRatio,
-				width, height,
-				matches;
-
-			const iframeHost = iframe.src && url.parse( iframe.src ).hostname.toLowerCase();
-			const trustedHost = some( iframeNoSandbox, function( accepted ) {
-				return endsWith( '.' + iframeHost, '.' + accepted );
-			} );
-
-			if ( trustedHost ) {
-				iframe.removeAttribute( 'sandbox' );
-			} else {
-				// we allow featured iframes to use a free-er sandbox
-				iframe.setAttribute( 'sandbox', 'allow-same-origin allow-scripts allow-popups' );
-			}
-
-			if ( iframe.width && iframe.height ) {
-				width = Number( iframe.width );
-				height = Number( iframe.height );
-				if ( ! isNaN( width ) && ! isNaN( height ) ) {
-					aspectRatio = width / height;
-				}
-				if ( isNaN( width ) ) {
-					width = iframe.width;
-				}
-				if ( isNaN( height ) ) {
-					height = iframe.height;
-				}
-			}
-
-			const embedUrl = iframe.getAttribute( 'data-wpcom-embed-url' );
-
-			do {
-				if ( ! node.className ) {
-					continue;
-				}
-				matches = node.className.match( /\bembed-([-a-zA-Z0-9_]+)\b/ );
-				if ( matches ) {
-					embedType = matches[ 1 ];
-					break;
-				}
-			} while ( ( node = node.parentNode ) );
-
-			return {
-				type: embedType,
-				src: iframe.src,
-				embedUrl,
-				iframe: iframe.outerHTML,
-				aspectRatio: aspectRatio,
-				width: width,
-				height: height
-			};
-		} );
-
-		const funnyEmbedSelectors = {
-			'blockquote[class^="instagram-"]': 'instagram',
-			'blockquote[class^="twitter-"]': 'twitter',
-			'fb\\\:post': 'facebook',
-			'[class^="fb-"]': 'facebook'
-		};
-
-		forOwn( funnyEmbedSelectors, function( type, selector ) {
-			const funnyEmbeds = toArray( post.__contentDOM.querySelectorAll( selector ) );
-			forEach( funnyEmbeds, function( node ) {
-				post.content_embeds.push( {
-					type: 'special-' + type,
-					content: node.outerHTML
-				} );
-			} );
-		} );
-
-		if ( post.content_embeds.length === 0 ) {
-			delete post.content_embeds;
-		}
-
-		callback();
-	},
-
-	disableAutoPlayOnMedia: function disableAutoPlayOnMedia( post, callback ) {
-		if ( ! post.__contentDOM ) {
-			throw new Error( 'this transform must be used as part of withContentDOM' );
-		}
-
-		let mediaElements = toArray( post.__contentDOM.querySelectorAll( 'audio, video' ) );
-		mediaElements.forEach( function( mediaElement ) {
-			mediaElement.autoplay = false;
-		} );
-
-		callback();
-	},
-
-	disableAutoPlayOnEmbeds: function disableAutoPlayOnEmbeds( post, callback ) {
-		if ( ! post.__contentDOM ) {
-			throw new Error( 'this transform must be used as part of withContentDOM' );
-		}
-
-		let embeds = toArray( post.__contentDOM.querySelectorAll( 'iframe' ) );
-
-		embeds.forEach( function( embed ) {
-			var srcUrl = url.parse( embed.src, true, true );
-			if ( srcUrl.query ) {
-				srcUrl.query = stripAutoPlays( srcUrl.query );
-				srcUrl.search = null;
-				embed.src = url.format( srcUrl );
-			}
-		} );
-
-		callback();
-	},
-
-	// Attempt to find embedded Polldaddy polls - and link to any we find
-	detectPolls( post, callback ) {
-		if ( ! post.__contentDOM ) {
-			throw new Error( 'this transform must be used as part of withContentDOM' );
-		}
-
-		// Polldaddy embed markup isn't very helpfully structured, but we can look for the noscript tag,
-		// which contains the information we need, and replace it with a paragraph.
-		let noscripts = toArray( post.__contentDOM.querySelectorAll( 'noscript' ) );
-
-		noscripts.forEach( function( noscript ) {
-			if ( ! noscript.firstChild ) {
-				return;
-			}
-			let firstChildData = formatting.decodeEntities( noscript.firstChild.data );
-			let match = firstChildData.match( '^<a href="http:\/\/polldaddy.com\/poll\/([0-9]+)' );
-			if ( match ) {
-				let p = document.createElement( 'p' );
-				p.innerHTML = '<a rel="external" target="_blank" href="http://polldaddy.com/poll/' + match[1] + '">' + i18n.translate( 'Take our poll' ) + '</a>';
-				noscript.parentNode.replaceChild( p, noscript );
-			}
-		} );
-
-		callback();
-	}
-
+	removeStyles,
+	safeContentImages,
+	makeEmbedsSecure,
+	wordCountAndReadingTime,
+	detectEmbeds,
+	disableAutoPlayOnMedia,
+	disableAutoPlayOnEmbeds,
+	detectPolls
 };
 
 module.exports = normalizePost;

--- a/client/lib/post-normalizer/rule-content-detect-embeds.js
+++ b/client/lib/post-normalizer/rule-content-detect-embeds.js
@@ -1,0 +1,128 @@
+/**
+ * External Dependencies
+ */
+import endsWith from 'lodash/endsWith';
+import filter from 'lodash/filter';
+import forEach from 'lodash/forEach';
+import forOwn from 'lodash/forOwn';
+import map from 'lodash/map';
+import some from 'lodash/some';
+import toArray from 'lodash/toArray';
+import url from 'url';
+
+/**
+ * Internal Dependencies
+ */
+
+export default function detectEmbeds( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+
+	let embeds = toArray( dom.querySelectorAll( 'iframe' ) );
+
+	const iframeWhitelist = [
+		'youtube.com',
+		'youtube-nocookie.com',
+		'videopress.com',
+		'vimeo.com',
+		'cloudup.com',
+		'soundcloud.com',
+		'8tracks.com',
+		'spotify.com',
+		'me.sh',
+		'bandcamp.com'
+	];
+
+	// hosts that we trust that don't work in a sandboxed iframe
+	const iframeNoSandbox = [
+		'spotify.com'
+	];
+
+	embeds = filter( embeds, function( iframe ) {
+		const iframeSrc = iframe.src && url.parse( iframe.src ).hostname.toLowerCase();
+		return some( iframeWhitelist, function( accepted ) {
+			return endsWith( '.' + iframeSrc, '.' + accepted );
+		} );
+	} );
+
+	const content_embeds = map( embeds, function( iframe ) {
+		var node = iframe,
+			embedType = null,
+			aspectRatio,
+			width, height,
+			matches;
+
+		const iframeHost = iframe.src && url.parse( iframe.src ).hostname.toLowerCase();
+		const trustedHost = some( iframeNoSandbox, function( accepted ) {
+			return endsWith( '.' + iframeHost, '.' + accepted );
+		} );
+
+		if ( trustedHost ) {
+			iframe.removeAttribute( 'sandbox' );
+		} else {
+			// we allow featured iframes to use a free-er sandbox
+			iframe.setAttribute( 'sandbox', 'allow-same-origin allow-scripts allow-popups' );
+		}
+
+		if ( iframe.width && iframe.height ) {
+			width = Number( iframe.width );
+			height = Number( iframe.height );
+			if ( ! isNaN( width ) && ! isNaN( height ) ) {
+				aspectRatio = width / height;
+			}
+			if ( isNaN( width ) ) {
+				width = iframe.width;
+			}
+			if ( isNaN( height ) ) {
+				height = iframe.height;
+			}
+		}
+
+		const embedUrl = iframe.getAttribute( 'data-wpcom-embed-url' );
+
+		do {
+			if ( ! node.className ) {
+				continue;
+			}
+			matches = node.className.match( /\bembed-([-a-zA-Z0-9_]+)\b/ );
+			if ( matches ) {
+				embedType = matches[ 1 ];
+				break;
+			}
+		} while ( ( node = node.parentNode ) );
+
+		return {
+			type: embedType,
+			src: iframe.src,
+			embedUrl,
+			iframe: iframe.outerHTML,
+			aspectRatio: aspectRatio,
+			width: width,
+			height: height
+		};
+	} );
+
+	const funnyEmbedSelectors = {
+		'blockquote[class^="instagram-"]': 'instagram',
+		'blockquote[class^="twitter-"]': 'twitter',
+		'fb\\\:post': 'facebook',
+		'[class^="fb-"]': 'facebook'
+	};
+
+	forOwn( funnyEmbedSelectors, function( type, selector ) {
+		const funnyEmbeds = toArray( dom.querySelectorAll( selector ) );
+		forEach( funnyEmbeds, function( node ) {
+			content_embeds.push( {
+				type: 'special-' + type,
+				content: node.outerHTML
+			} );
+		} );
+	} );
+
+	if ( content_embeds.length ) {
+		post.content_embeds = content_embeds;
+	}
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-content-detect-polls.js
+++ b/client/lib/post-normalizer/rule-content-detect-polls.js
@@ -1,0 +1,35 @@
+/**
+ * External Dependencies
+ */
+import forEach from 'lodash/forEach';
+
+/**
+ * Internal Dependencies
+ */
+import { decodeEntities } from 'lib/formatting';
+import i18n from 'lib/mixins/i18n';
+
+export default function detectPolls( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+
+	// Polldaddy embed markup isn't very helpfully structured, but we can look for the noscript tag,
+	// which contains the information we need, and replace it with a paragraph.
+	let noscripts = dom.querySelectorAll( 'noscript' );
+
+	forEach( noscripts, noscript => {
+		if ( ! noscript.firstChild ) {
+			return;
+		}
+		let firstChildData = decodeEntities( noscript.firstChild.data );
+		let match = firstChildData.match( '^<a href="http:\/\/polldaddy.com\/poll\/([0-9]+)' );
+		if ( match ) {
+			let p = document.createElement( 'p' );
+			p.innerHTML = '<a rel="external" target="_blank" href="http://polldaddy.com/poll/' + match[1] + '">' + i18n.translate( 'Take our poll' ) + '</a>';
+			noscript.parentNode.replaceChild( p, noscript );
+		}
+	} );
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-content-disable-autoplay.js
+++ b/client/lib/post-normalizer/rule-content-disable-autoplay.js
@@ -1,0 +1,52 @@
+/**
+ * External Dependencies
+ */
+import forEach from 'lodash/forEach';
+import url from 'url';
+
+/**
+ * Internal Dependencies
+ */
+
+function stripAutoPlays( query ) {
+	const keys = Object.keys( query ).filter( function( k ) {
+		return /^auto_?play$/i.test( k );
+	} );
+	forEach( keys, key => {
+		const val = query[ key ].toLowerCase();
+		if ( val === '1' ) {
+			query[ key ] = '0';
+		} else if ( val === 'true' ) {
+			query[ key ] = 'false';
+		}
+	} );
+	return query;
+}
+
+export function disableAutoPlayOnMedia( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+	forEach(
+		dom.querySelectorAll( 'audio, video' ),
+		el => el.autoplay = false
+	);
+	return post;
+}
+
+export function disableAutoPlayOnEmbeds( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+
+	forEach( dom.querySelectorAll( 'iframe' ), embed => {
+		const srcUrl = url.parse( embed.src, true, true );
+		if ( srcUrl.query ) {
+			srcUrl.query = stripAutoPlays( srcUrl.query );
+			srcUrl.search = null;
+			embed.src = url.format( srcUrl );
+		}
+	} );
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-content-make-embeds-secure.js
+++ b/client/lib/post-normalizer/rule-content-make-embeds-secure.js
@@ -1,0 +1,42 @@
+/**
+ * External Dependencies
+ */
+import forEach from 'lodash/forEach';
+import startsWith from 'lodash/startsWith';
+
+/**
+ * Internal Dependencies
+ */
+
+export default function makeEmbedsSecure( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+
+	let iframes = dom.querySelectorAll( 'iframe' );
+
+	const badFrames = [];
+
+	forEach( iframes, function( iframe ) {
+		iframe.setAttribute( 'sandbox', '' );
+		if ( ! startsWith( iframe.src, 'http' ) ) {
+			badFrames.push( iframe );
+		} else {
+			iframe.src = iframe.src.replace( /^http:/, 'https:' );
+		}
+	} );
+
+	forEach( badFrames, function( frame ) {
+		frame.parentNode.removeChild( frame );
+	} );
+
+	if ( post.is_external || post.is_jetpack ) {
+		let embeds = dom.querySelectorAll( 'embed,object' );
+
+		forEach( embeds, function( embed ) {
+			embed.parentNode.removeChild( embed );
+		} );
+	}
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-content-remove-styles.js
+++ b/client/lib/post-normalizer/rule-content-remove-styles.js
@@ -1,0 +1,32 @@
+/**
+ * External Dependencies
+ */
+import forEach from 'lodash/forEach';
+
+/**
+ * Internal Dependencies
+ */
+
+export default function removeContentStyles( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+
+	// if there are any specials in the post, skip it
+	if ( dom.querySelector( '.gallery, .tiled-gallery, blockquote[class^="instagram-"], blockquote[class^="twitter-"]' ) ) {
+		return post;
+	}
+
+	// remove most style attributes
+	let styled = dom.querySelectorAll( '[style]' );
+	forEach( styled, function( element ) {
+		element.removeAttribute( 'style' );
+	} );
+
+	// remove all style elements
+	forEach( dom.querySelectorAll( 'style' ), function( element ) {
+		element.parentNode && element.parentNode.removeChild( element );
+	} );
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-content-safe-images.js
+++ b/client/lib/post-normalizer/rule-content-safe-images.js
@@ -1,0 +1,145 @@
+/**
+ * External Dependencies
+ */
+import filter from 'lodash/filter';
+import forEach from 'lodash/forEach';
+import every from 'lodash/every';
+import some from 'lodash/some';
+import startsWith from 'lodash/startsWith';
+import toArray from 'lodash/toArray';
+import url from 'url';
+import srcset from 'srcset';
+
+/**
+ * Internal Dependencies
+ */
+import safeImageURL from 'lib/safe-image-url';
+import { maxWidthPhotonishURL } from './utils';
+
+const TRANSPARENT_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+function removeUnsafeAttributes( node ) {
+	if ( ! node || ! node.hasAttributes() ) {
+		return;
+	}
+
+	// Have to toArray this because attributes is a live
+	// NodeMap and would node removals would invalidate
+	// the current index as we walked it.
+	forEach( toArray( node.attributes ), function( attr ) {
+		if ( startsWith( attr.name, 'on' ) ) {
+			node.removeAttribute( attr.name );
+		}
+	} );
+}
+
+const bannedUrlParts = [
+	'feeds.feedburner.com',
+	'feeds.wordpress.com/',
+	'.feedsportal.com',
+	'wp-includes',
+	'wp-content/themes',
+	'wp-content/plugins',
+	'stats.wordpress.com',
+	'pixel.wp.com'
+];
+
+function imageShouldBeRemovedFromContent( imageUrl ) {
+	return some( bannedUrlParts, function( part ) {
+		return imageUrl && imageUrl.toLowerCase().indexOf( part ) !== -1;
+	} );
+}
+
+const excludedContentImageUrlParts = [ 'gravatar.com' ];
+
+function isCandidateForContentImage( imageUrl ) {
+	return ! imageShouldBeRemovedFromContent( imageUrl ) && every( excludedContentImageUrlParts, function( part ) {
+		return imageUrl && imageUrl.toLowerCase().indexOf( part ) === -1;
+	} );
+}
+
+export default function( maxWidth ) {
+	return function safeContentImages( post, dom ) {
+		var content_images = [],
+			images;
+
+		if ( ! dom ) {
+			throw new Error( 'this transform must be used as part of withContentDOM' );
+		}
+		images = dom.querySelectorAll( 'img[src]' );
+
+		// push everything, including tracking pixels, over to a safe URL
+		forEach( images, function( image ) {
+			let imgSource = image.getAttribute( 'src' ),
+				parsedImgSrc = url.parse( imgSource, false, true ),
+				hostName = parsedImgSrc.hostname;
+
+			let safeSource;
+			// if imgSource is relative, prepend post domain so it isn't relative to calypso
+			if ( ! hostName ) {
+				imgSource = url.resolve( post.URL, imgSource );
+				parsedImgSrc = url.parse( imgSource, false, true );
+			}
+
+			safeSource = safeImageURL( imgSource );
+			if ( ! safeSource && parsedImgSrc.search ) {
+				// we can't make externals with a querystring safe.
+				// try stripping it and retry
+				parsedImgSrc.search = null;
+				parsedImgSrc.query = null;
+				safeSource = safeImageURL( url.format( parsedImgSrc ) );
+			}
+
+			removeUnsafeAttributes( image );
+
+			if ( ! safeSource || imageShouldBeRemovedFromContent( imgSource ) ) {
+				image.parentNode.removeChild( image );
+				// fun fact: removing the node from the DOM will not prevent it from loading. You actually have to
+				// change out the src to change what loads. The following is a 1x1 transparent gif as a data URL
+				image.setAttribute( 'src', TRANSPARENT_GIF );
+				image.removeAttribute( 'srcset' );
+				return;
+			}
+
+			if ( maxWidth ) {
+				safeSource = maxWidthPhotonishURL( safeSource, maxWidth );
+			}
+
+			image.setAttribute( 'src', safeSource );
+
+			if ( image.hasAttribute( 'srcset' ) ) {
+				const imgSrcSet = srcset.parse( image.getAttribute( 'srcset' ) ).map( imgSrc => {
+					if ( ! url.parse( imgSrc.url, false, true ).hostname ) {
+						imgSrc.url = url.resolve( post.URL, imgSrc.url );
+					}
+					imgSrc.url = safeImageURL( imgSrc.url );
+					return imgSrc;
+				} ).filter( imgSrc => imgSrc.url );
+				image.setAttribute( 'srcset', srcset.stringify( imgSrcSet ) );
+			}
+
+			if ( isCandidateForContentImage( imgSource ) ) {
+				content_images.push( {
+					src: safeSource,
+					original_src: imgSource,
+					width: image.width,
+					height: image.height
+				} );
+			}
+		} );
+
+		// grab all of the non-tracking pixels and push them into content_images
+		content_images = filter( content_images, function( image ) {
+			if ( ! image.src ) return false;
+			const edgeLength = image.height + image.width;
+			// if the image size isn't set (0) or is greater than 2, keep it
+			return edgeLength === 0 || edgeLength > 2;
+		} );
+
+		if ( content_images.length ) {
+			post.content_images = content_images;
+		}
+
+		return post;
+	};
+}

--- a/client/lib/post-normalizer/rule-content-word-count.js
+++ b/client/lib/post-normalizer/rule-content-word-count.js
@@ -1,0 +1,26 @@
+/**
+ * External Dependencies
+ */
+ import trim from 'lodash/trim';
+
+/**
+ * Internal Dependencies
+ */
+
+const READING_WORDS_PER_SECOND = 250 / 60; // Longreads says that people can read 250 words per minute. We want the rate in words per second.
+
+export default function wordCountAndReadingTime( post, dom ) {
+	if ( ! dom ) {
+		throw new Error( 'this transform must be used as part of withContentDOM' );
+	}
+
+	let textContent = trim( dom.textContent );
+
+	post.word_count = ( textContent.replace( /['";:,.?¿\-!¡]+/g, '' ).match( /\S+/g ) || [] ).length;
+
+	if ( post.word_count > 0 ) {
+		post.reading_time = Math.ceil( post.word_count / READING_WORDS_PER_SECOND ); // in seconds
+	}
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-create-better-excerpt.js
+++ b/client/lib/post-normalizer/rule-create-better-excerpt.js
@@ -1,0 +1,58 @@
+/**
+ * External Dependencies
+ */
+import forEach from 'lodash/forEach';
+import striptags from 'striptags';
+import trim from 'lodash/trim';
+
+/**
+ * Internal Dependencies
+ */
+
+export default function createBetterExcerpt( post ) {
+	if ( ! post || ! post.content ) {
+		return post;
+	}
+
+	function removeElement( element ) {
+		element.parentNode && element.parentNode.removeChild( element );
+	}
+
+	let betterExcerpt = striptags( post.content, [ 'p', 'br' ] );
+
+	// Spin up a new DOM for the linebreak markup
+	const dom = document.createElement( 'div' );
+	dom.id = '__better_excerpt__';
+	dom.innerHTML = betterExcerpt;
+
+	// Ditch any photo captions with the wp-caption-text class
+	forEach( dom.querySelectorAll( '.wp-caption-text' ), removeElement );
+
+	// Strip any empty p and br elements from the beginning of the content
+	forEach( dom.querySelectorAll( 'p,br' ), function( element ) {
+		// is this element non-empty? bail on our iteration.
+		if ( element.childNodes.length > 0 && trim( element.textContent ).length > 0 ) {
+			return false;
+		}
+		element.parentNode && element.parentNode.removeChild( element );
+	} );
+
+	// now strip any p's that are empty
+	forEach( dom.querySelectorAll( 'p' ), function( element ) {
+		if ( trim( element.textContent ).length === 0 ) {
+			element.parentNode && element.parentNode.removeChild( element );
+		}
+	} );
+
+	// now limit it to the first three elements
+	forEach( dom.querySelectorAll( '#__better_excerpt__ > p, #__better_excerpt__ > br' ), function( element, index ) {
+		if ( index >= 3 ) {
+			element.parentNode && element.parentNode.removeChild( element );
+		}
+	} );
+
+	post.better_excerpt = trim( dom.innerHTML );
+	dom.innerHTML = '';
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-decode-entities.js
+++ b/client/lib/post-normalizer/rule-decode-entities.js
@@ -1,0 +1,43 @@
+/**
+ * External Dependencies
+ */
+
+import forEach from 'lodash/forEach';
+import forOwn from 'lodash/forOwn';
+
+/**
+ * Internal Dependencies
+ */
+
+import { decodeEntities as decode } from 'lib/formatting';
+import safeImageURL from 'lib/safe-image-url';
+
+export default function decodeEntities( post ) {
+	forEach( [ 'excerpt', 'title', 'site_name' ], function( prop ) {
+		if ( post[ prop ] ) {
+			post[ prop ] = decode( post[ prop ] );
+		}
+	} );
+
+	if ( post.parent && post.parent.title ) {
+		post.parent.title = decode( post.parent.title );
+	}
+
+	if ( post.author ) {
+		if ( post.author.name ) {
+			post.author.name = decode( post.author.name );
+		}
+		if ( post.author.avatar_URL ) {
+			post.author.avatar_URL = safeImageURL( post.author.avatar_URL );
+		}
+	}
+
+	if ( post.tags ) {
+		// tags is an object
+		forOwn( post.tags, function( tag ) {
+			tag.name = decode( tag.name );
+		} );
+	}
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-first-pass-canonical-image.js
+++ b/client/lib/post-normalizer/rule-first-pass-canonical-image.js
@@ -1,0 +1,34 @@
+/**
+ * External Dependencies
+ */
+import assign from 'lodash/assign';
+import filter from 'lodash/filter';
+import head from 'lodash/head';
+import startsWith from 'lodash/startsWith';
+
+/**
+ * Internal Dependencies
+ */
+import { imageSizeFromAttachments } from './utils';
+
+export default function firstPassCanonicalImage( post ) {
+	if ( post.featured_image ) {
+		post.canonical_image = assign( {
+			uri: post.featured_image,
+			type: 'image'
+		}, imageSizeFromAttachments( post.featured_image ) );
+	} else {
+		let candidate = head( filter( post.attachments, function( attachment ) {
+			return startsWith( attachment.mime_type, 'image/' );
+		} ) );
+
+		if ( candidate ) {
+			post.canonical_image = {
+				uri: candidate.URL,
+				width: candidate.width,
+				height: candidate.height,
+				type: 'image'
+			};
+		}
+	}
+}

--- a/client/lib/post-normalizer/rule-keep-valid-images.js
+++ b/client/lib/post-normalizer/rule-keep-valid-images.js
@@ -1,0 +1,27 @@
+/**
+ * External Dependencies
+ */
+import filter from 'lodash/filter';
+
+/**
+ * Internal Dependencies
+ */
+
+ function imageHasMinWidthAndHeight( width, height ) {
+	return function( image ) {
+		return image.naturalWidth >= width && image.naturalHeight >= height;
+	};
+}
+
+export default function keepValidImages( minWidth, minHeight ) {
+	return function keepValidImagesForWidthAndHeight( post ) {
+		var imageFilter = imageHasMinWidthAndHeight( minWidth, minHeight );
+		if ( post.images ) {
+			post.images = filter( post.images, imageFilter );
+		}
+		if ( post.content_images ) {
+			post.content_images = filter( post.content_images, imageFilter );
+		}
+		return post;
+	};
+}

--- a/client/lib/post-normalizer/rule-make-site-id-safe-for-api.js
+++ b/client/lib/post-normalizer/rule-make-site-id-safe-for-api.js
@@ -1,0 +1,7 @@
+export default function makeSiteIDSafeForAPI( post ) {
+	if ( post.site_id ) {
+		post.normalized_site_id = ( '' + post.site_id ).replace( /::/g, '/' );
+	}
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-pick-canonical-image.js
+++ b/client/lib/post-normalizer/rule-pick-canonical-image.js
@@ -1,0 +1,53 @@
+/**
+ * External Dependencies
+ */
+import filter from 'lodash/filter';
+import debugFactory from 'debug';
+
+/**
+ * Internal Dependencies
+ */
+
+const debug = debugFactory( 'calypso:post-normalizer:pick-canonical-image' );
+
+function candidateForCanonicalImage( image ) {
+	if ( ! image ) {
+		return false;
+	}
+
+	if ( image.naturalWidth < 350 ) {
+		debug( ( image && image.src ), ': not wide enough' );
+		return false;
+	}
+
+	if ( ( image.naturalWidth * image.naturalHeight ) < 30000 ) {
+		debug( ( image && image.src ), ': not enough area' );
+		return false;
+	}
+	return true;
+}
+
+export default function pickCanonicalImage( post ) {
+	var canonicalImage;
+	if ( post.images ) {
+		canonicalImage = filter( post.images, candidateForCanonicalImage )[ 0 ];
+		if ( canonicalImage ) {
+			canonicalImage = {
+				uri: canonicalImage.src,
+				width: canonicalImage.naturalWidth,
+				height: canonicalImage.naturalHeight
+			};
+		}
+	} else if ( post.featured_image ) {
+		canonicalImage = {
+			uri: post.featured_image,
+			width: 0,
+			height: 0
+		};
+	}
+
+	if ( canonicalImage ) {
+		post.canonical_image = canonicalImage;
+	}
+	return post;
+}

--- a/client/lib/post-normalizer/rule-pick-primary-tag.js
+++ b/client/lib/post-normalizer/rule-pick-primary-tag.js
@@ -1,0 +1,22 @@
+/**
+ * External Dependencies
+ */
+import maxBy from 'lodash/maxBy';
+import values from 'lodash/values';
+
+/**
+ * Internal Dependencies
+ */
+
+export default function pickPrimaryTag( post ) {
+	// if we hand max an invalid or empty array, it returns -Infinity
+	const primary_tag = maxBy( values( post.tags ), function( tag ) {
+		return tag.post_count;
+	} );
+
+	if ( primary_tag !== undefined ) {
+		post.primary_tag = primary_tag;
+	}
+
+	return post;
+}

--- a/client/lib/post-normalizer/rule-prevent-widows.js
+++ b/client/lib/post-normalizer/rule-prevent-widows.js
@@ -1,0 +1,18 @@
+/**
+ * External Dependencies
+ */
+import forEach from 'lodash/forEach';
+
+/**
+ * Internal Dependencies
+ */
+import formatting from 'lib/formatting';
+
+export default function preventWidows( post ) {
+	forEach( [ 'title', 'excerpt' ], function( prop ) {
+		if ( post[ prop ] ) {
+			post[ prop ] = formatting.preventWidows( post[ prop ], 2 );
+		}
+	} );
+	return post;
+}

--- a/client/lib/post-normalizer/rule-safe-image-properties.js
+++ b/client/lib/post-normalizer/rule-safe-image-properties.js
@@ -1,0 +1,32 @@
+/**
+ * External Dependencies
+ */
+import forOwn from 'lodash/forOwn';
+import startsWith from 'lodash/startsWith';
+
+/**
+ * Internal Dependencies
+ */
+import { makeImageURLSafe } from './utils';
+
+export default function safeImagePropertiesForWidth( maxWidth ) {
+	return function safeImageProperties( post ) {
+		makeImageURLSafe( post.author, 'avatar_URL', maxWidth );
+		makeImageURLSafe( post, 'featured_image', maxWidth, post.URL );
+		if ( post.featured_media && post.featured_media.type === 'image' ) {
+			makeImageURLSafe( post.featured_media, 'uri', maxWidth, post.URL );
+		}
+		if ( post.canonical_image && post.canonical_image.type === 'image' ) {
+			makeImageURLSafe( post.canonical_image, 'uri', maxWidth, post.URL );
+		}
+		if ( post.attachments ) {
+			forOwn( post.attachments, function( attachment ) {
+				if ( startsWith( attachment.mime_type, 'image/' ) ) {
+					makeImageURLSafe( attachment, 'URL', maxWidth, post.URL );
+				}
+			} );
+		}
+
+		return post;
+	};
+}

--- a/client/lib/post-normalizer/rule-strip-html.js
+++ b/client/lib/post-normalizer/rule-strip-html.js
@@ -1,0 +1,22 @@
+/**
+ * External Dependencies
+ */
+import forEach from 'lodash/forEach';
+
+/**
+ * Internal Dependencies
+ */
+import formatting from 'lib/formatting';
+
+export default function stripHtml( post ) {
+	forEach( [ 'excerpt', 'title', 'site_name' ], function( prop ) {
+		if ( post[ prop ] ) {
+			post[ prop ] = formatting.stripHTML( post[ prop ] );
+		}
+	} );
+
+	if ( post.author && post.author.name ) {
+		post.author.name = formatting.stripHTML( post.author.name );
+	}
+	return post;
+}

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -1,0 +1,88 @@
+/**
+ * External Dependencies
+ */
+import filter from 'lodash/filter';
+import flow from 'lodash/flow';
+import forEach from 'lodash/forEach';
+import map from 'lodash/map';
+import pick from 'lodash/pick';
+import pull from 'lodash/pull';
+import uniq from 'lodash/uniq';
+
+/**
+ * Internal Dependencies
+ */
+
+function convertImageToObject( image ) {
+	return pick( image, [ 'src', 'naturalWidth', 'naturalHeight' ] );
+}
+
+function imageForURL( imageUrl ) {
+	var img = new Image();
+	img.src = imageUrl;
+	return img;
+}
+
+function promiseForImage( image ) {
+	if ( image.complete && image.naturalWidth > 0 ) {
+		return Promise.resolve();
+	}
+	return new Promise( ( resolve, reject ) => {
+		image.onload = () => resolve( image );
+		image.onerror = () => reject( image );
+	} );
+}
+
+export default function waitForImagesToLoad( post ) {
+	return new Promise( ( resolve ) => {
+		function acceptLoadedImages( images ) {
+			post.images = map( images, convertImageToObject );
+
+			post.content_images = filter( map( post.content_images, function( image ) {
+				return find( post.images, { src: image.src } );
+			} ), Boolean );
+
+			resolve( post );
+		}
+
+		let imagesToCheck = [];
+
+		if ( post.featured_image ) {
+			imagesToCheck.push( post.featured_image );
+		}
+
+		forEach( post.content_images, function( image ) {
+			imagesToCheck.push( image.src );
+		} );
+
+		if ( imagesToCheck.length === 0 ) {
+			resolve( post );
+			return;
+		}
+
+		// dedupe the set of images
+		imagesToCheck = uniq( imagesToCheck );
+
+		// convert to image objects to start the load process
+		let promises = map( imagesToCheck, flow( imageForURL, promiseForImage ) );
+
+		const imagesLoaded = [];
+
+		forEach( promises, promise => {
+			promise.then( image => {
+				// keep track of what loaded successfully
+				imagesLoaded.push( image );
+			} ).catch( () => {
+				// ignore what did not, but return the promise chain to success
+				return null;
+			} ).then( () => {
+				// check to see if all of the promises have settled
+				// if so, accept what loaded and resolve the main promise
+				promises = pull( promises, promise );
+				if ( promises.length === 0 ) {
+					acceptLoadedImages( imagesLoaded );
+				}
+			} );
+		} );
+	} );
+}

--- a/client/lib/post-normalizer/rule-wait-for-images-to-load.js
+++ b/client/lib/post-normalizer/rule-wait-for-images-to-load.js
@@ -2,6 +2,7 @@
  * External Dependencies
  */
 import filter from 'lodash/filter';
+import find from 'lodash/find';
 import flow from 'lodash/flow';
 import forEach from 'lodash/forEach';
 import map from 'lodash/map';

--- a/client/lib/post-normalizer/rule-with-content-dom.js
+++ b/client/lib/post-normalizer/rule-with-content-dom.js
@@ -1,0 +1,19 @@
+import reduce from 'lodash/reduce';
+
+export default function createDomTransformRunner( transforms ) {
+	return function withContentDOM( post ) {
+		if ( ! post || ! post.content || ! transforms ) {
+			return post;
+		}
+
+		// spin up the DOM
+		const dom = document.createElement( 'div' );
+		dom.innerHTML = post.content;
+		post = reduce( transforms, ( memo, transform ) => {
+			return transform( memo, dom );
+		}, post );
+		post.content = dom.innerHTML;
+		dom.innerHTML = '';
+		return post;
+	};
+}

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -236,7 +236,7 @@ describe( 'index', function() {
 				assert.strictEqual( normalized.author.avatar_URL, 'http://example.com/me.jpg-SAFE?w=200&quality=80&strip=info' );
 				assert.strictEqual( normalized.featured_image, 'http://foo.bar/-SAFE?w=200&quality=80&strip=info' );
 				assert.strictEqual( normalized.featured_media.uri, 'http://example.com/media.jpg-SAFE?w=200&quality=80&strip=info' );
-				assert.strictEqual( normalized.attachments['1234'].URL, 'http://example.com/media.jpg-SAFE?w=200&quality=80&strip=info' )
+				assert.strictEqual( normalized.attachments['1234'].URL, 'http://example.com/media.jpg-SAFE?w=200&quality=80&strip=info' );
 				assert.strictEqual( normalized.attachments['3456'].URL, 'http://example.com/media.jpg' );
 				done( err );
 			} );
@@ -308,7 +308,7 @@ describe( 'index', function() {
 					assert.deepEqual( normalized, { content: '<video></video>' } );
 					done( err );
 				}
-			)
+			);
 		} );
 
 		it( 'should strip autoplay attributes from audio', function( done ) {
@@ -321,7 +321,7 @@ describe( 'index', function() {
 					assert.deepEqual( normalized, { content: '<audio></audio>' } );
 					done( err );
 				}
-			)
+			);
 		} );
 	} );
 
@@ -340,29 +340,18 @@ describe( 'index', function() {
 		} );
 
 		it( 'should provide a __contentDOM property to transforms and remove it after', function( done ) {
-			function detectTimeTransform( post, callback ) {
-				assert.ok( post.__contentDOM );
-				assert.ok( post.__contentDOM.querySelectorAll );
-				assert.equal( post.__contentDOM.querySelectorAll( 'time' ).length, 1 );
-				callback();
+			function detectTimeTransform( post, dom ) {
+				assert.ok( dom );
+				assert.ok( dom.querySelectorAll );
+				assert.equal( dom.querySelectorAll( 'time' ).length, 1 );
+				return post;
 			}
 			normalizer(
 				{
 					content: '<time>now</time>'
 				},
 				[ normalizer.withContentDOM( [ detectTimeTransform ] ) ], function( err, normalized ) {
-					assert( ! normalized.__contentDOM );
-					done( err );
-				}
-			);
-		} );
-
-		it( 'should support async transforms', function( done ) {
-			normalizer(
-				{
-					content: '<span>hi</span>'
-				},
-				[ normalizer.withContentDOM( [ asyncTransform, asyncTransform, asyncTransform ] ) ], function( err ) {
+					assert.ok( normalized );
 					done( err );
 				}
 			);

--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -1,0 +1,77 @@
+/**
+ * External Dependencies
+ */
+import find from 'lodash/find';
+import forEach from 'lodash/forEach';
+import url from 'url';
+
+/**
+ * Internal Dependencies
+ */
+import safeImageURL from 'lib/safe-image-url';
+
+const IMAGE_SCALE_FACTOR = ( typeof window !== 'undefined' && window.devicePixelRatio && window.devicePixelRatio > 1 ) ? 2 : 1;
+
+const DEFAULT_PHOTON_QUALITY = 80; // 80 was chosen after some heuristic testing as the best blend of size and quality
+
+export function imageSizeFromAttachments( post, imageUrl ) {
+	if ( ! post.attachments ) {
+		return;
+	}
+
+	const found = find( post.attachments, function( attachment ) {
+		return attachment.URL === imageUrl;
+	} );
+
+	if ( found ) {
+		return {
+			width: found.width,
+			height: found.height
+		};
+	}
+}
+
+export function maxWidthPhotonishURL( imageURL, width ) {
+	if ( ! imageURL ) {
+		return imageURL;
+	}
+
+	let parsedURL = url.parse( imageURL, true, true ), // true, true means allow protocol-less hosts and parse the querystring
+		isGravatar, sizeParam;
+
+	if ( ! parsedURL.host ) {
+		return imageURL;
+	}
+
+	isGravatar = parsedURL.host.indexOf( 'gravatar.com' ) !== -1;
+
+	delete parsedURL.search;
+	// strip other sizing params
+	forEach( [ 'h', 'crop', 'resize', 'fit' ], function( param ) {
+		delete parsedURL.query[ param ];
+	} );
+
+	sizeParam = isGravatar ? 's' : 'w';
+	parsedURL.query[ sizeParam ] = width * IMAGE_SCALE_FACTOR;
+
+	if ( ! isGravatar ) {
+		// gravatar doesn't support these, only photon / files.wordpress
+		parsedURL.query.quality = DEFAULT_PHOTON_QUALITY;
+		parsedURL.query.strip = 'info'; // strip all exif data, leave ICC intact
+	}
+
+	return url.format( parsedURL );
+}
+
+export function makeImageURLSafe( object, propName, maxWidth, baseURL ) {
+	if ( object && object[ propName ] ) {
+		if ( baseURL && ! url.parse( object[ propName ], true, true ).hostname ) {
+			object[ propName ] = url.resolve( baseURL, object[ propName ] );
+		}
+		object[ propName ] = safeImageURL( object[ propName ] );
+
+		if ( maxWidth ) {
+			object[ propName ] = maxWidthPhotonishURL( object[ propName ], maxWidth );
+		}
+	}
+}


### PR DESCRIPTION
And make the sync rules truly sync, wrapping them in the main post normalizer.

This really just moves all of the post normalizer rules out of the one massive file into little files. This helps scoping quite a bit and makes it clearer what each rule does and what constants it depends on.

I also took the opportunity to make all of the sync rules look and feel like sync functions. No longer do they take a callback, which implies async behavior, and invoke is synchronously. There is a new wrapper that converts the sync variants to look like the old async-ish version so the refactoring doesn't impact users of the post normalizer. 

To test, 
1. Run the test suite. Yay tests!
2. Try using the Reader. Posts should categorize based on content, like they do now. Posts without a featued image spec'd should get one when a good candidate is found
3. Try using My Posts. Same basic set of criteria.

Stuff for another PR
- [ ] Rework lib/feed-post-store/* to use the rules directly and avoid using postNormalizer and async
- [ ] Rework lib/posts to use the rules directly
- [ ] Find anywhere else that's using post norm and rework it
- [ ] Kill post norm and the async dependency