### PR TITLE
Adding gutter note styles for The Daily Post

### DIFF
--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -324,7 +324,7 @@
 }
 
 // Discover-Specific Full Post View Styles
-.blog-53424024 .reader__full-post-content {
+.reader__full-post.blog-53424024 .reader__full-post-content {
 
 	.intro {
 		font-size: 20px;

--- a/client/reader/full-post/_style.scss
+++ b/client/reader/full-post/_style.scss
@@ -424,6 +424,46 @@
 	}
 }
 
+// Daily Post-Specific Full Post View Styles
+.reader__full-post.blog-489937 .reader__full-post-content {
+
+	blockquote.left,
+	blockquote.alignleft,
+	blockquote.align-left,
+	blockquote.left-align {
+		margin: 0;
+		padding: 0;
+		border: none;
+		background: none;
+		font-size: 13px;
+		width: 175px;
+
+		@media ( min-width: 1132px ) {
+			position: absolute;
+			left: -( 175px + 32px );
+			margin-left: 0;
+		}
+
+		@media ( max-width: 1132px ) {
+			background: lighten( $gray, 30 );
+			margin: 0 0 24px 0;
+			padding: 16px;
+			width: calc( 100% - 32px );
+		}
+
+		@include breakpoint( "<480px" ) {
+			margin: 0 0 24px 0;
+			background: lighten( $gray, 30 );
+			padding: 16px;
+
+			img {
+				display: block;
+				margin-bottom: 8px;
+			}
+		}
+	}
+}
+
 .detail-page__backdrop {
 	padding: 1px; // this fixes a strange rendering bug at the bottom of the full post card in safari and chrome -shaun
 	z-index: z-index( 'root', '.detail-page__backdrop' ); // above the masterbar


### PR DESCRIPTION
On [The Daily Post](https://dailypost.wordpress.com), including a `blockquote` within a post, paired with a `leftalign`, `left-align`, `alignleft`, `align-left` class will put that text off to the left like so:

<img width="1077" alt="screen shot 2016-05-25 at 11 14 28 am" src="https://cloud.githubusercontent.com/assets/1202812/15545783/91dd067e-226b-11e6-804d-197b3acb17bc.png">

This PR brings a similar treatment for the Daily Post's full screen posts in the Reader:

<img width="1147" alt="screen shot 2016-05-25 at 11 17 54 am" src="https://cloud.githubusercontent.com/assets/1202812/15545785/9550a98c-226b-11e6-8c90-5484ccad7cbe.png">

These styles mirror the `sidenote` [styles used for Discover posts](https://github.com/Automattic/wp-calypso/pull/2729), but are a little simpler:

- We don't need right-aligned blocks of text, since those aren't used on the Daily Post.
- On smaller screens, we don't need to float these to the right or left at all — they can be full-width.


**To test:**

Visit The Daily Post's blog page, and open a post. Most posts have at least one of these gutter notes. 

http://calypso.localhost:3000/read/blogs/489937

cc @blowery