### PR TITLE
Framework: add `<QuerySiteVouchers />` component

### DIFF
--- a/client/components/data/query-site-vouchers/index.jsx
+++ b/client/components/data/query-site-vouchers/index.jsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isRequestingSiteVouchers } from 'state/sites/vouchers/selectors';
+import { requestSiteVouchers as requestVouchers } from 'state/sites/vouchers/actions';
+
+class QuerySiteVouchers extends Component {
+
+	constructor( props ) {
+		super( props );
+		this.requestVouchers = this.requestVouchers.bind( this );
+	}
+
+	componentWillMount() {
+		this.requestVouchers();
+	}
+
+	componentWillReceiveProps( nextProps ) {
+		if ( nextProps.requestingSiteVouchers ||
+			! nextProps.siteId ||
+			( this.props.siteId === nextProps.siteId ) ) {
+			return;
+		}
+		this.requestVouchers( nextProps );
+	}
+
+	requestVouchers( props = this.props ) {
+		if ( ! props.requestingSiteVouchers && props.siteId ) {
+			props.requestVouchers( props.siteId );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+QuerySiteVouchers.propTypes = {
+	siteId: PropTypes.number,
+	requestingVouchers: PropTypes.bool,
+	requestVouchers: PropTypes.func
+};
+
+QuerySiteVouchers.defaultProps = {
+	requestVouchers: () => {}
+};
+
+export default connect(
+	( state, ownProps ) => {
+		return {
+			requestingSiteVouchers: isRequestingSiteVouchers( state, ownProps.siteId )
+		};
+	},
+	{ requestVouchers }
+)( QuerySiteVouchers );

--- a/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/upgrades/checkout-thank-you/business-plan-details.jsx
@@ -11,12 +11,15 @@ import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import i18n from 'lib/mixins/i18n';
 import { isBusiness } from 'lib/products-values';
 import PurchaseDetail from 'components/purchase-detail';
+import QuerySiteVouchers from 'components/data/query-site-vouchers';
 
 const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature } ) => {
 	const plan = find( sitePlans.data, isBusiness );
 
 	return (
 		<div>
+			<QuerySiteVouchers siteId={ selectedSite.ID } />
+
 			{ plan.hasDomainCredit && <CustomDomainPurchaseDetail selectedSite={ selectedSite } /> }
 
 			{ ! selectedFeature &&


### PR DESCRIPTION
* Implement `<QuerySiteVouchers />` query component and thus use it in business details block.

### Testing

Since the component is being used in business detail block we can see how to data is propagated to state tree going to http://calypso.localhost:3000/plans/my-plan/<my-business-testing-blog> page.

You should see something like the following:

![image](https://cloud.githubusercontent.com/assets/77539/15588483/8e0b536c-2364-11e6-93fa-37e0eb790be3.png)

![image](https://cloud.githubusercontent.com/assets/77539/15588330/b69fa932-2363-11e6-955c-f21403f82b5c.png)