### PR TITLE
Signup: Do not check domain availability for WordPress.com addresses

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -274,7 +274,7 @@ const RegisterDomainStep = React.createClass( {
 		async.parallel(
 			[
 				callback => {
-					if ( ! domain.match( /.{3,}\..{2,}/ ) ) {
+					if ( !domain.match( /.{3,}\..{2,}/ ) || domain.match( /\.wordpress\.com$/ ) ) {
 						return callback();
 					}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -83,7 +83,8 @@ const RegisterDomainStep = React.createClass( {
 		selectedSite: React.PropTypes.oneOfType( [ React.PropTypes.object, React.PropTypes.bool ] ),
 		basePath: React.PropTypes.string.isRequired,
 		suggestion: React.PropTypes.string,
-		withPlansOnly: React.PropTypes.bool
+		withPlansOnly: React.PropTypes.bool,
+		isSignupStep: React.PropTypes.bool
 	},
 
 	getDefaultProps: function() {
@@ -274,14 +275,10 @@ const RegisterDomainStep = React.createClass( {
 		async.parallel(
 			[
 				callback => {
-					if ( !domain.match( /.{3,}\..{2,}/ ) ) {
+					if ( ! domain.match( /.{3,}\..{2,}/ ) ) {
 						return callback();
 					}
 
-					/**
-					 * Do not fire the domain availability check for .wordpress.com
-					 * addresses only during signup. It should run in every other case.
-					 */
 					if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
 						return callback();
 					}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -274,7 +274,15 @@ const RegisterDomainStep = React.createClass( {
 		async.parallel(
 			[
 				callback => {
-					if ( !domain.match( /.{3,}\..{2,}/ ) || domain.match( /\.wordpress\.com$/ ) ) {
+					if ( !domain.match( /.{3,}\..{2,}/ ) ) {
+						return callback();
+					}
+
+					/**
+					 * Do not fire the domain availability check for .wordpress.com
+					 * addresses only during signup. It should run in every other case.
+					 */
+					if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
 						return callback();
 					}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -203,6 +203,7 @@ module.exports = React.createClass( {
 				analyticsSection="signup"
 				withPlansOnly={ isPlansOnlyTest }
 				includeWordPressDotCom
+				isSignupStep
 				showExampleSuggestions />
 		);
 	},


### PR DESCRIPTION
This is a fix for #5461.

On the domains step during signup, if you type an address that looks like a domain, but ends in `.wordpress.com`, a domain availability call was made, which spawned an unnecessary error message, which didn't bring anything but confusion to the user.

Now the extra call is skipped and the error message is not shown.

To test:

* Start the signup process
* Reach domain steps
* Type an address that ends in `.wordpress.com`, e.g. `nonexistingtestdomainforme.wordpress.com`
* No extra error should be shown, saying that mapping is now allowed for WordPress.com subdomains

cc @michaeldcain @coreh @lancewillett 