### PR TITLE
Implemented Escape key handling to SitePicker

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -197,7 +197,7 @@ const Search = React.createClass( {
 			ReactDom.findDOMNode( this.refs.openIcon ).focus();
 		}
 
-		this.props.onSearchClose();
+		this.props.onSearchClose( event );
 
 		analytics.ga.recordEvent( this.props.analyticsGroup, 'Clicked Close Search' );
 	},
@@ -218,6 +218,9 @@ const Search = React.createClass( {
 	},
 
 	keyDown: function( event ) {
+		if ( event.key === 'Escape' && event.target.value === '' ) {
+			this.closeSearch( event );
+		}
 		this.props.onKeyDown( event );
 	},
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -305,6 +305,7 @@ export default React.createClass( {
 						onSearch={ this.onSearch }
 						autoFocus={ this.props.autoFocus }
 						disabled={ ! this.props.sites.initialized }
+						onSearchClose={ this.props.onClose }
 					/>
 					<div className="site-selector__sites" ref="selector">
 						{ this.renderAllSites() }

--- a/client/my-sites/picker/picker.jsx
+++ b/client/my-sites/picker/picker.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-var ReactDom = require( 'react-dom' ),
-	React = require( 'react' ),
+var React = require( 'react' ),
 	wrapWithClickOutside = require( 'react-click-outside' ),
-	noop = require( 'lodash/noop' );
+	noop = require( 'lodash/noop' ),
+	closeOnEsc = require( 'lib/mixins/close-on-esc' );
 
 /**
  * Internal dependencies
@@ -14,6 +14,8 @@ var SiteSelector = require( 'components/site-selector' ),
 
 const SitePicker = React.createClass( {
 	displayName: 'SitePicker',
+
+	mixins: [ closeOnEsc( 'closePicker' ) ],
 
 	propTypes: {
 		onClose: React.PropTypes.func,
@@ -53,8 +55,7 @@ const SitePicker = React.createClass( {
 	},
 
 	onClose: function( event ) {
-		this.props.layoutFocus && this.props.layoutFocus.setNext( 'sidebar' );
-		this.scrollToTop();
+		this.closePicker();
 		this.props.onClose( event );
 	},
 
@@ -63,11 +64,15 @@ const SitePicker = React.createClass( {
 		window.scrollTo( 0, 0 );
 	},
 
-	handleClickOutside: function() {
+	closePicker: function() {
 		if ( this.props.layoutFocus && this.props.layoutFocus.getCurrent() === 'sites' ) {
-			this.props.layoutFocus && this.props.layoutFocus.set( 'sidebar' );
+			this.props.layoutFocus.set( 'sidebar' );
 			this.scrollToTop();
 		}
+	},
+
+	handleClickOutside: function() {
+		this.closePicker();
 	},
 
 	render: function() {


### PR DESCRIPTION
This fixes #58. 

Scenario | After Pressing Escape
-------- | ------
Search unavailable (user has less than 6 sites) | Immediately close picker
Search available, but not focused | Immediately close picker
Search available, focused, empty | Immediately close picker
Search available, focused, non-empty | Noop

For the last scenario, input should be cleared after pressing Escape. It works correctly in Chrome, but doesn't in Firefox. If there is not already, I will create an issue for that, but it shouldn't delay merging this as it is out of the scope of this PR.

This component is used on various places, I tested few of them like Left Sidebar Site Picker or Popover under "New Post" button.