### PR TITLE
Theme Showcase: custom responsive breakpoint for theme sheets

### DIFF
--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -1,5 +1,3 @@
-$theme-sheet-custom-breakpoint: 900px;
-
 .themes-thanks-modal  {
 	width: 300px;
 	padding: 1.5em;
@@ -105,7 +103,7 @@ $theme-sheet-custom-breakpoint: 900px;
 	display: flex;
 	flex-direction: row;
 
-	@media ( max-width: $theme-sheet-custom-breakpoint ) {
+	@include breakpoint( "<960px" ) {
 		flex-direction: column-reverse;
 	}
 }
@@ -116,7 +114,7 @@ $theme-sheet-custom-breakpoint: 900px;
 	width: 50%;
 	flex-direction: column;
 
-	@media ( max-width: $theme-sheet-custom-breakpoint ) {
+	@include breakpoint( "<960px" ) {
 		width: 100%;
 	}
 }
@@ -124,7 +122,7 @@ $theme-sheet-custom-breakpoint: 900px;
 .themes__sheet-action-bar {
 	height: 50px;
 
-	@media ( max-width: $theme-sheet-custom-breakpoint ) {
+	@include breakpoint( "<960px" ) {
 		&.card {
 			margin: 0 0 1px 0;
 		}
@@ -137,7 +135,7 @@ $theme-sheet-custom-breakpoint: 900px;
 		right: 50%;
 	margin-right: 20px;
 
-	@media ( max-width: $theme-sheet-custom-breakpoint ) {
+	@include breakpoint( "<960px" ) {
 		margin-right: 0;
 		position: absolute;
 			top: 5px;
@@ -169,7 +167,7 @@ $theme-sheet-custom-breakpoint: 900px;
 	// also x-browser issues, so it's smaller than 4:3 proper
 	min-height: 36.15vw; // 36.75vw would be correct, but Safari is slightly off
 
-	@media ( max-width: $theme-sheet-custom-breakpoint ) {
+	@include breakpoint( "<960px" ) {
 		position: relative;
 		top: 0;
 		width: 100%;
@@ -240,7 +238,7 @@ $theme-sheet-custom-breakpoint: 900px;
 		margin-bottom: 0;
 	}
 
-	@media ( max-width: $theme-sheet-custom-breakpoint ) {
+	@include breakpoint( "<960px" ) {
 		flex-wrap: wrap;
 	}
 
@@ -252,7 +250,7 @@ $theme-sheet-custom-breakpoint: 900px;
 	.button {
 		flex: 0 0 auto;
 
-		@media ( max-width: $theme-sheet-custom-breakpoint ) {
+		@include breakpoint( "<960px" ) {
 			flex: 1 1 100%;
 			margin-top: 20px;
 			text-align: center;

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -1,3 +1,5 @@
+$theme-sheet-custom-breakpoint: 900px;
+
 .themes-thanks-modal  {
 	width: 300px;
 	padding: 1.5em;
@@ -103,27 +105,18 @@
 	display: flex;
 	flex-direction: row;
 
-	@include breakpoint( "<660px" ) {
+	@media ( max-width: $theme-sheet-custom-breakpoint ) {
 		flex-direction: column-reverse;
 	}
 }
 
-.themes__sheet-column-left {
-	display: flex;
-	width: 50%;
-	flex-direction: column;
-
-	@include breakpoint( "<660px" ) {
-		width: 100%;
-	}
-}
-
+.themes__sheet-column-left,
 .themes__sheet-column-right {
 	display: flex;
 	width: 50%;
 	flex-direction: column;
 
-	@include breakpoint( "<660px" ) {
+	@media ( max-width: $theme-sheet-custom-breakpoint ) {
 		width: 100%;
 	}
 }
@@ -131,7 +124,7 @@
 .themes__sheet-action-bar {
 	height: 50px;
 
-	@include breakpoint( "<660px" ) {
+	@media ( max-width: $theme-sheet-custom-breakpoint ) {
 		&.card {
 			margin: 0 0 1px 0;
 		}
@@ -144,7 +137,7 @@
 		right: 50%;
 	margin-right: 20px;
 
-	@include breakpoint( "<660px" ) {
+	@media ( max-width: $theme-sheet-custom-breakpoint ) {
 		margin-right: 0;
 		position: absolute;
 			top: 5px;
@@ -176,7 +169,7 @@
 	// also x-browser issues, so it's smaller than 4:3 proper
 	min-height: 36.15vw; // 36.75vw would be correct, but Safari is slightly off
 
-	@include breakpoint( "<660px" ) {
+	@media ( max-width: $theme-sheet-custom-breakpoint ) {
 		position: relative;
 		top: 0;
 		width: 100%;
@@ -247,7 +240,7 @@
 		margin-bottom: 0;
 	}
 
-	@include breakpoint( "<660px" ) {
+	@media ( max-width: $theme-sheet-custom-breakpoint ) {
 		flex-wrap: wrap;
 	}
 
@@ -259,7 +252,7 @@
 	.button {
 		flex: 0 0 auto;
 
-		@include breakpoint( "<660px" ) {
+		@media ( max-width: $theme-sheet-custom-breakpoint ) {
 			flex: 1 1 100%;
 			margin-top: 20px;
 			text-align: center;


### PR DESCRIPTION
This PR addressed some concerns about too narrow columns. See #5472.

The breakpoint is moved now to `900px`. The reason for `900px` instead of the suggested `1024px` is because 1024px is the size of portrait tablets, so makes sense there to still use the two columns view.

Screenshot, `900px`, partially scrolled:

![screen shot 2016-05-25 at 19 25 46](https://cloud.githubusercontent.com/assets/4389/15551605/b0d730ca-22ae-11e6-8f38-3c72d7a02479.png)

/cc @kathrynwp to see if this works. :) 