### PR TITLE
Site Settings SEO: Don't allow HTML tags in the meta description field

### DIFF
--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -36,7 +36,8 @@ const serviceIds = {
 	yandex: 'yandex-verification'
 };
 
-// Matches any open or closed html tag
+// Basic matching for HTML tags
+// Not perfect but meets the needs of this component well
 const anyHtmlTag = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
 
 function getGeneralTabUrl( slug ) {
@@ -101,18 +102,14 @@ export const SeoForm = React.createClass( {
 	},
 
 	handleMetaChange( event ) {
-		const metaContent = event.target.value;
+		const seoMetaDescription = event.target.value;
+		// Don't allow html tags in the input field
+		const hasHtmlTagError = anyHtmlTag.test( seoMetaDescription );
 
-		// Don't allow HTML tags in the input field
-		if ( anyHtmlTag.test( metaContent ) ) {
-			this.setState( { hasHtmlTagError: true } );
-			return;
-		}
-
-		this.setState( {
-			seoMetaDescription: metaContent,
-			hasHtmlTagError: false
-		} );
+		this.setState( Object.assign(
+			{ hasHtmlTagError },
+			! hasHtmlTagError && { seoMetaDescription }
+		) );
 	},
 
 	handleVerificationCodeChange( event, serviceName ) {

--- a/client/my-sites/site-settings/form-seo.jsx
+++ b/client/my-sites/site-settings/form-seo.jsx
@@ -36,6 +36,9 @@ const serviceIds = {
 	yandex: 'yandex-verification'
 };
 
+// Matches any open or closed html tag
+const anyHtmlTag = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
+
 function getGeneralTabUrl( slug ) {
 	return `/settings/general/${ slug }`;
 }
@@ -98,7 +101,18 @@ export const SeoForm = React.createClass( {
 	},
 
 	handleMetaChange( event ) {
-		this.setState( { seoMetaDescription: get( event, 'target.value', '' ) } );
+		const metaContent = event.target.value;
+
+		// Don't allow HTML tags in the input field
+		if ( anyHtmlTag.test( metaContent ) ) {
+			this.setState( { hasHtmlTagError: true } );
+			return;
+		}
+
+		this.setState( {
+			seoMetaDescription: metaContent,
+			hasHtmlTagError: false
+		} );
 	},
 
 	handleVerificationCodeChange( event, serviceName ) {
@@ -187,12 +201,12 @@ export const SeoForm = React.createClass( {
 			seoMetaDescription,
 			verificationServicesCodes,
 			showPasteError = false,
+			hasHtmlTagError = false,
 			invalidCodes = []
 		} = this.state;
 
 		const isSitePrivate = parseInt( blog_public, 10 ) !== 1;
 		const isDisabled = isSitePrivate || isSubmittingForm;
-		const hasMetaError = seoMetaDescription && seoMetaDescription.length > 160;
 
 		const sitemapUrl = `https://${ slug }/sitemap.xml`;
 		const generalTabUrl = getGeneralTabUrl( slug );
@@ -269,8 +283,8 @@ export const SeoForm = React.createClass( {
 									maxLength="160"
 									acceptableLength={ 159 }
 									onChange={ this.handleMetaChange } />
-								{ hasMetaError &&
-									<FormInputValidation isError={ true } text={ this.translate( 'Description can\'t be longer than 160 characters.' ) } />
+								{ hasHtmlTagError &&
+									<FormInputValidation isError={ true } text={ this.translate( 'HTML tags are not allowed.' ) } />
 								}
 								<FormSettingExplanation>
 									{ this.translate( 'Craft a description of your site in 160 characters or less. This description can be used in search engine results for your site\'s Front Page.' ) }


### PR DESCRIPTION
Adds a regexp that checks for html tags in the meta description field. If a tag is found, the content is not saved and an error message is displayed.

Also removes the length check on the textarea, since we switched to using a `CountedTextarea` which enforces that.

cc @dmsnell, mind taking a look?

<img width="689" alt="screen shot 2016-05-25 at 11 35 01 am" src="https://cloud.githubusercontent.com/assets/789137/15551958/2d89bb3e-226d-11e6-919a-1b6a2efab629.png">
