### PR TITLE
Google Apps: Fix italicize issue on "billed yearly" text

### DIFF
--- a/client/my-sites/upgrades/domain-management/email/add-google-apps-card.jsx
+++ b/client/my-sites/upgrades/domain-management/email/add-google-apps-card.jsx
@@ -61,8 +61,9 @@ const AddGoogleAppsCard = React.createClass( {
 									}
 								)
 							}
-							<em> | </em>
 						</h4>
+
+						<span className="add-google-apps-card__price-separator"> | </span>
 
 						<h5 className="add-google-apps-card__billing-period">
 							{ this.translate( 'Billed yearly — get 2 months free!' ) }

--- a/client/my-sites/upgrades/domain-management/style.scss
+++ b/client/my-sites/upgrades/domain-management/style.scss
@@ -494,11 +494,11 @@ input[type=radio].domain-management-list-item__radio {
 
 .add-google-apps-card__price {
 	clear: both;
-	font-style: italic;
 	margin: 0;
 
 	.add-google-apps-card__price-per-user {
 		display: inline-block;
+		font-style: italic;
 
 		strong {
 			color: darken($gray, 15%);
@@ -506,23 +506,23 @@ input[type=radio].domain-management-list-item__radio {
 			font-weight: 600;
 		}
 
-		span, em {
+		span {
 			color: $gray;
 			font-size: 12px;
 			font-weight: normal;
 		}
+	}
 
-		em {
-			@include breakpoint( "<660px" ) {
-				display: none;
-			}
-		}
+	.add-google-apps-card__price-separator {
+		color: $gray;
+		font-size: 12px;
 	}
 
 	.add-google-apps-card__billing-period {
 		color: lighten( $gray, 10% );
 		display: inline-block;
 		font-size: 11px;
+		font-style: italic;
 		text-transform: uppercase;
 	}
 }


### PR DESCRIPTION
This is a small PR to address a styling issue mentioned in #5523. Previously, the separator between the price and the "Billed yearly" text was italicized. This PR introduces a class for the separator and moves the `font-style: italicized;` declaration to specific components that need to be italicized (as opposed to keeping a higher level italicize declaration and contradicting later on).

I also removed the breakpoint declaration after a bit of testing. With the breakpoint declaration, the price and billing period text run together on small screens, which didn't seem optimal. It's easy to reintroduce if necessary (comparison screenshots below).

**To test:**
1. Checkout this branch
2. Visit http://calypso.localhost:3000/domains/manage/domain/email/domain for your specific domain/site

**Screenshot:**
<img width="763" alt="update" src="https://cloud.githubusercontent.com/assets/7240478/15552383/ee2acec2-226e-11e6-8b7c-72fc4d366ce1.png">

**Mobile appearance:**
<img width="973" alt="screen shot 2016-05-25 at 11 49 43" src="https://cloud.githubusercontent.com/assets/7240478/15552393/f605368c-226e-11e6-9831-da8091b74f35.png">

cc @breezyskies if you want to take a look