### PR TITLE
Reader Topics: add /topic paths to reader in dev and wpcalypso

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -107,6 +107,16 @@ const ReaderSidebar = React.createClass( {
 	openExpandableMenuForCurrentTagOrList() {
 		const pathParts = this.props.path.split( '/' );
 
+		if ( config.isEnabled( 'reader/topics' ) ) {
+			if ( startsWith( this.props.path, '/topic/' ) ) {
+				const tagSlug = pathParts[2];
+				if ( tagSlug ) {
+					// Don't open the sidebar for topics
+					this.setState( { currentTag: tagSlug } );
+				}
+			}
+		}
+
 		if ( startsWith( this.props.path, '/tag/' ) ) {
 			const tagSlug = pathParts[2];
 			if ( tagSlug ) {

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -39,6 +39,9 @@ function getLocation() {
 	if ( path.indexOf( '/tag/' ) === 0 ) {
 		return 'topic_page';
 	}
+	if ( path.indexOf( '/topic/' ) === 0 ) {
+		return 'topic_page';
+	}
 	if ( path.match( /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i ) ) {
 		return 'single_post';
 	}

--- a/client/reader/tag-stream/controller.js
+++ b/client/reader/tag-stream/controller.js
@@ -16,16 +16,31 @@ const analyticsPageTitle = 'Reader';
 
 export default {
 	tagListing( context ) {
-		var TagStream = require( 'reader/tag-stream/main' ),
-			basePath = '/tag/:slug',
-			fullAnalyticsPageTitle = analyticsPageTitle + ' > Tag > ' + context.params.tag,
-			tagSlug = trim( context.params.tag )
-				.toLowerCase()
-				.replace( /\s+/g, '-' )
-				.replace( /-{2,}/g, '-' ),
-			encodedTag = encodeURIComponent( tagSlug ).toLowerCase(),
-			tagStore = feedStreamFactory( 'tag:' + tagSlug ),
-			mcKey = 'topic';
+		var config = require( 'config' );
+
+		if ( config.isEnabled( 'reader/topics' ) ) {
+			var TagStream = require( 'reader/tag-stream/main' ),
+				basePath = '/topic/:slug',
+				fullAnalyticsPageTitle = analyticsPageTitle + ' > Tag > ' + context.params.tag,
+				tagSlug = trim( context.params.tag )
+					.toLowerCase()
+					.replace( /\s+/g, '-' )
+					.replace( /-{2,}/g, '-' ),
+				encodedTag = encodeURIComponent( tagSlug ).toLowerCase(),
+				tagStore = feedStreamFactory( 'tag:' + tagSlug ),
+				mcKey = 'topic';
+		} else {
+			var TagStream = require( 'reader/tag-stream/main' ),
+				basePath = '/tag/:slug',
+				fullAnalyticsPageTitle = analyticsPageTitle + ' > Tag > ' + context.params.tag,
+				tagSlug = trim( context.params.tag )
+					.toLowerCase()
+					.replace( /\s+/g, '-' )
+					.replace( /-{2,}/g, '-' ),
+				encodedTag = encodeURIComponent( tagSlug ).toLowerCase(),
+				tagStore = feedStreamFactory( 'tag:' + tagSlug ),
+				mcKey = 'topic';
+		}
 
 		ensureStoreLoading( tagStore, context );
 

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -10,6 +10,8 @@ import controller from './controller';
 import readerController from 'reader/controller';
 
 export default function() {
+	var config = require( 'config' );
+
 	page( '/tag/*', readerController.loadSubscriptions, readerController.initAbTests );
 	page( '/tag/:tag',
 		readerController.updateLastRoute,
@@ -17,6 +19,16 @@ export default function() {
 		readerController.sidebar,
 		controller.tagListing
 	);
+
+	if ( config.isEnabled( 'reader/topics' ) ) {
+		page( '/topic/*', readerController.loadSubscriptions, readerController.initAbTests );
+		page( '/topic/:tag',
+			readerController.updateLastRoute,
+			readerController.removePost,
+			readerController.sidebar,
+			controller.tagListing
+		);
+	}
 
 	page( '/tags',
 		readerController.loadSubscriptions,

--- a/client/sections.js
+++ b/client/sections.js
@@ -247,7 +247,7 @@ if ( config.isEnabled( 'reader' ) ) {
 
 	sections.push( {
 		name: 'reader-tags',
-		paths: [ '/tags', '/tag' ],
+		paths: [ '/tags', '/tag', '/topic' ],
 		module: 'reader/tag-stream',
 		secondary: true,
 		group: 'reader'

--- a/config/development.json
+++ b/config/development.json
@@ -107,6 +107,7 @@
 		"reader/recommendations/posts": true,
 		"reader/search": true,
 		"reader/start": true,
+		"reader/topics": true,
 		"reader/tags-with-elasticsearch": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,6 +82,7 @@
 		"reader/full-errors": true,
 		"reader/recommendations/posts": true,
 		"reader/search": true,
+		"reader/topics": true,
 		"reader/tags-with-elasticsearch": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,


### PR DESCRIPTION
- new routes so there is a sandbox for playing with topics (saved searches) to replace tags
- enables experimenting with new streams that combine algorithm streams with time streams

Simple test: http://calypso.localhost:3000/topic/wordpress

cc @blowery 
