### PR TITLE
Plans: check that sites has loaded on the example page

### DIFF
--- a/client/my-sites/domain-tip/docs/example.jsx
+++ b/client/my-sites/domain-tip/docs/example.jsx
@@ -11,7 +11,6 @@ import DomainTip from '../index';
 import sitesList from 'lib/sites-list';
 
 const sites = sitesList();
-const siteId = sites.getPrimary().ID;
 
 export default React.createClass( {
 
@@ -20,6 +19,8 @@ export default React.createClass( {
 	mixins: [ PureRenderMixin ],
 
 	render() {
+		const primarySite = sites.initialized && sites.getPrimary();
+		const siteId = primarySite ? primarySite.ID : 0;
 		return (
 			<div className="design-assets__group">
 				<h2>

--- a/client/my-sites/plan-storage/docs/example.jsx
+++ b/client/my-sites/plan-storage/docs/example.jsx
@@ -15,7 +15,7 @@ const sites = sitesList();
 
 export default React.createClass( {
 
-	displayName: 'PlanStorageExample',
+	displayName: 'PlanStorage',
 
 	mixins: [ PureRenderMixin ],
 
@@ -38,13 +38,15 @@ export default React.createClass( {
 				max_storage_bytes: 3221225472
 			}
 		};
+		const primarySite = sites.initialized && sites.getPrimary();
+		const siteId = primarySite ? primarySite.ID : 0;
 		return (
 			<div className="design-assets__group">
 				<h2>
 					<a href="/devdocs/app-components/plan-storage">Plan Storage</a>
 				</h2>
 				<div style={ { marginBottom: 16 } }>
-					<PlanStorage siteId={ sites.getPrimary().ID } />
+					<PlanStorage siteId={ siteId } />
 				</div>
 				<div style={ { marginBottom: 16 } }>
 					<PlanStorageButton


### PR DESCRIPTION
This fixes a js error where we try and fetch a primary site before checking if sites has initialized yet. This can sometimes cause the devdocs page to not load.

cc @hoverduck @rralian 