### PR TITLE
Editor: Improve routing for users without site access

### DIFF
--- a/client/lib/menu-data/menu-data.js
+++ b/client/lib/menu-data/menu-data.js
@@ -401,7 +401,7 @@ MenuData.prototype.interceptLoadForHomepageLink = function( menu ) {
 
 MenuData.prototype.createNewPagePromise = ( menuItem, siteID ) => new Promise(
 	( resolve, reject ) => {
-		postEditStore.startEditingNew( { ID: siteID } );
+		postEditStore.startEditingNew( siteID );
 		postEditStore.saveEdited(
 			{
 				title: menuItem.name,

--- a/client/lib/posts/actions.js
+++ b/client/lib/posts/actions.js
@@ -103,16 +103,16 @@ PostActions = {
 	/**
 	 * Start keeping track of edits to a new post
 	 *
-	 * @param {Number|String} site - site identifier
-	 * @param {Object} options - edit options
+	 * @param {Number} siteId  Site ID
+	 * @param {Object} options Edit options
 	 */
-	startEditingNew: function( site, options ) {
+	startEditingNew: function( siteId, options ) {
 		var args;
 		options = options || {};
 
 		args = {
 			type: 'DRAFT_NEW_POST',
-			siteId: site.ID,
+			siteId: siteId,
 			postType: options.type || 'post',
 			title: options.title,
 			content: options.content,
@@ -124,28 +124,28 @@ PostActions = {
 	/**
 	 * Load an existing post and keep track of edits to it
 	 *
-	 * @param {object} site to load post from
-	 * @param {number} postId ID of post to load
+	 * @param {Number} siteId Site ID to load post from
+	 * @param {Number} postId Post ID to load
 	 */
-	startEditingExisting: function( site, postId ) {
+	startEditingExisting: function( siteId, postId ) {
 		var currentPost = PostEditStore.get(),
 			postHandle;
 
-		if ( ! site.ID ) {
+		if ( ! siteId ) {
 			return;
 		}
 
-		if ( currentPost && currentPost.site_ID === site.ID && currentPost.ID === postId ) {
+		if ( currentPost && currentPost.site_ID === siteId && currentPost.ID === postId ) {
 			return; // already editing same post
 		}
 
 		Dispatcher.handleViewAction( {
 			type: 'START_EDITING_POST',
-			siteId: site.ID,
+			siteId: siteId,
 			postId: postId
 		} );
 
-		postHandle = wpcom.site( site.ID ).post( postId );
+		postHandle = wpcom.site( siteId ).post( postId );
 
 		postHandle.get( { context: 'edit', meta: 'autosave' }, function( error, data ) {
 			Dispatcher.handleServerAction( {

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -110,11 +110,9 @@ module.exports = {
 		const postType = determinePostType( context );
 		const postID = getPostID( context );
 
-		function startEditing() {
-			const site = sites.getSite( route.getSiteFragment( context.path ) );
-
+		function startEditing( siteId ) {
 			context.store.dispatch( setEditorPostId( postID ) );
-			context.store.dispatch( editPost( { type: postType }, site.ID, postID ) );
+			context.store.dispatch( editPost( { type: postType }, siteId, postID ) );
 
 			if ( maybeRedirect( context ) ) {
 				return;
@@ -132,7 +130,7 @@ module.exports = {
 			// in the view components
 			if ( postID ) {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-				actions.startEditingExisting( site.ID, postID );
+				actions.startEditingExisting( siteId, postID );
 				analytics.pageView.record( '/' + postType + '/:blogid/:postid', gaTitle + ' > Edit' );
 			} else {
 				let postOptions = { type: postType };
@@ -148,28 +146,30 @@ module.exports = {
 				}
 
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-				actions.startEditingNew( site.ID, postOptions );
+				actions.startEditingNew( siteId, postOptions );
 				analytics.pageView.record( '/' + postType, gaTitle + ' > New' );
 			}
 		}
 
-		if ( sites.initialized ) {
-			startEditing();
-		} else {
-			// The site selection flow in the siteSelection route middleware
-			// will cause the change handler here to be invoked before site is
-			// set in Redux store. To account for this, we continue to check
-			// state for site ID to have been set.
-			function startEditingOnSitesInitialized() {
-				if ( getSelectedSiteId( context.store.getState() ) ) {
-					startEditing();
-				} else {
-					sites.once( 'change', startEditingOnSitesInitialized );
-				}
-			}
+		// Before starting to edit, we want to be sure that we have a valid
+		// selected site to work with. Therefore, we wait on the following
+		// conditions:
+		//  - Sites have not yet been initialized (no localStorage available)
+		//  - Sites are initialized, but the site ID is unknown, so we wait for
+		//    the sites list to be refreshed (for example, if the user does not
+		//    have permission to view the site)
+		//  - Sites are initialized _and_ fetched, but the selected site has
+		//    not yet been selected, so is not available in global state yet
+		function startEditingOnSiteSelected() {
+			const siteId = getSelectedSiteId( context.store.getState() );
 
-			sites.once( 'change', startEditingOnSitesInitialized );
+			if ( siteId ) {
+				startEditing( siteId );
+			} else {
+				sites.once( 'change', startEditingOnSiteSelected );
+			}
 		}
+		startEditingOnSiteSelected();
 
 		renderEditor( context, postType );
 	},

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -132,7 +132,7 @@ module.exports = {
 			// in the view components
 			if ( postID ) {
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-				actions.startEditingExisting( site, postID );
+				actions.startEditingExisting( site.ID, postID );
 				analytics.pageView.record( '/' + postType + '/:blogid/:postid', gaTitle + ' > Edit' );
 			} else {
 				let postOptions = { type: postType };
@@ -148,7 +148,7 @@ module.exports = {
 				}
 
 				// TODO: REDUX - remove flux actions when whole post-editor is reduxified
-				actions.startEditingNew( site, postOptions );
+				actions.startEditingNew( site.ID, postOptions );
 				analytics.pageView.record( '/' + postType, gaTitle + ' > New' );
 			}
 		}


### PR DESCRIPTION
Related: #5398, #5571

This pull request seeks to resolve an issue where an error and some improper redirecting can occur when attempting to visit the editor on a site for which the user does not belong.

Previously, if sites had been initialized, but the user did not belong to the site, an error would be logged to  the console ([attempting to access property ID of `undefined`](https://github.com/Automattic/wp-calypso/blob/3685a1e2e389412b70b351488c3cf04c06d1a9dc/client/post-editor/controller.js#L121)).

The primary change here is in the logic for waiting to call `startEditing`, as we cannot assume that `sites.initialized` implies that a site is selected ([given the logic flow of the sites controller](https://github.com/Automattic/wp-calypso/blob/3685a1e2e389412b70b351488c3cf04c06d1a9dc/client/my-sites/controller.js#L171-L190)).

__Testing instructions:__

Verify that there are no regressions in editing a new or existing post for a site to which the user belongs.

Ensure that, when trying to navigate to the editor on a site for which your user does not belong, the following takes place:
- If sites are not initialized, wait until initialization (from `localStorage` or network request)
- If sites are initialized but user does not belong, wait for sites network request to finish
- If, after all of the above, the user does not have permission to view the site, you are navigated to the all sites route (or to the editor for your primary site if a single site user)