### PR TITLE
Plans: replace domain upgrade nudge with domain tip

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -17,8 +17,7 @@ import StatsModule from '../stats-module';
 import statsStrings from '../stats-strings';
 import MostPopular from 'my-sites/stats/most-popular';
 import LatestPostSummary from '../post-performance';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
-import { FEATURE_CUSTOM_DOMAIN } from 'lib/plans/constants';
+import DomainTip from 'my-sites/domain-tip';
 
 export default React.createClass( {
 	displayName: 'StatsInsights',
@@ -85,12 +84,7 @@ export default React.createClass( {
 					/>
 					<AllTime allTimeList={ allTimeList } />
 					<MostPopular insightsList={ insightsList } />
-					<UpgradeNudge
-						title={ this.translate( 'Get a free Custom Domain' ) }
-						message={ this.translate( 'Custom domains are free when you upgrade to a Premium or Business plan.' ) }
-						feature={ FEATURE_CUSTOM_DOMAIN }
-						event="stats_insights_domain"
-					/>
+					<DomainTip siteId={ site.ID } />
 					<div className="stats-nonperiodic has-recent">
 						<div className="module-list">
 							<div className="module-column">


### PR DESCRIPTION
This PR replaces a domain upgrade nudge with a domain tip in the stats page:
![domain-tip](https://cloud.githubusercontent.com/assets/1270189/15557366/606bd1bc-2287-11e6-9f5f-b1a2ed4807a5.png)

## Testing Instructions:
- Enable nudges, and domains with plans only: `localStorage.setItem('ABTests','{"domainsWithPlansOnly_20160517":"plansOnly", "nudges_20160519":"showAll"}')`
- Navigate to http://calypso.localhost:3000/stats/insights and select a site with a free plan

cc @rralian @retrofox @drw158 @mtias 