### PR TITLE
Editor: Fix stats exception when setting an excerpt

### DIFF
--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -29,7 +29,7 @@ import PageOrder from 'post-editor/editor-page-order';
 import PostMetadata from 'lib/post-metadata';
 import TrackInputChanges from 'components/track-input-changes';
 import actions from 'lib/posts/actions';
-import stats from 'lib/posts/stats';
+import { recordStat, recordEvent } from 'lib/posts/stats';
 import siteUtils from 'lib/site/utils';
 import QueryPostTypes from 'components/data/query-post-types';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -105,8 +105,8 @@ const EditorDrawer = React.createClass( {
 	},
 
 	recordExcerptChangeStats: function() {
-		stats.recordStat( 'excerpt_changed' );
-		stats.recordEvent( 'Changed Excerpt' );
+		recordStat( 'excerpt_changed' );
+		recordEvent( 'Changed Excerpt' );
 	},
 
 	renderTaxonomies: function() {


### PR DESCRIPTION
Currently when setting an excerpt in the editor sidebar, an exception is thrown:

>  Cannot read property 'recordStat' of undefined

This branch fixes the exception by properly importing the post stats utility methods.

__To Test__
- Open a post in the editor
- Expand More Options in the sidebar, and add an excerpt
- Click outside of the excerpt field, note no exceptions are thrown