### PR TITLE
Framwork: update wpcom dependency to `4.9.13`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -305,7 +305,7 @@
       "version": "3.1.3"
     },
     "binary-extensions": {
-      "version": "1.4.0"
+      "version": "1.4.1"
     },
     "bl": {
       "version": "1.1.2",
@@ -668,7 +668,7 @@
       "version": "0.3.1"
     },
     "cssstyle": {
-      "version": "0.2.34"
+      "version": "0.2.36"
     },
     "d": {
       "version": "0.1.1"
@@ -2175,7 +2175,7 @@
       "version": "1.0.0"
     },
     "node-fetch": {
-      "version": "1.5.2"
+      "version": "1.5.3"
     },
     "node-gyp": {
       "version": "3.3.1",
@@ -2666,7 +2666,7 @@
       "version": "1.0.0"
     },
     "regenerate": {
-      "version": "1.2.1"
+      "version": "1.3.0"
     },
     "regenerator": {
       "version": "0.8.34"
@@ -2757,7 +2757,7 @@
       }
     },
     "rocambole-linebreak": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "semver": {
           "version": "4.3.6"
@@ -3437,7 +3437,7 @@
       "version": "1.2.0"
     },
     "wpcom": {
-      "version": "4.9.12",
+      "version": "4.9.13",
       "dependencies": {
         "babel": {
           "version": "5.8.38"

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "walk": "2.3.4",
     "webpack": "1.12.15",
     "webpack-dev-middleware": "1.2.0",
-    "wpcom": "4.9.12",
+    "wpcom": "4.9.13",
     "wpcom-proxy-request": "1.0.5",
     "wpcom-xhr-request": "0.5.0",
     "xgettext-js": "0.3.0"


### PR DESCRIPTION
This PR updates wpcom.js to `4.9.13`. The change log is here: https://github.com/Automattic/wpcom.js/blob/master/History.md#4913--2016-05-25

### Testing
1) clean the node dependencies
2) install them again
3) everything should be ok

Also you can see the new methods from the console:

```es6
wpcom
.site( 'planbusinesssite.wordpress.com' )
.adCreditVouchers()
.get( 'google-ad-credits' )
  .then( data => console.log( data ) )
  .catch( err => console.error( 'Error: ', err ) );
```

```es6
wpcom
.marketing()
.survey( 'retrofox-survey', 482340 )
.addResponses( {
  one: 'One response',
  two: 'Two response'
} )
.submit()
  .then( res => console.log( res ) )
  .catch( err => console.error( error ) );
```