### PR TITLE
Editor: Display warning when post type not supported by site

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -322,6 +322,7 @@
 @import 'post-editor/editor-permalink/style';
 @import 'post-editor/editor-post-formats/style';
 @import 'post-editor/editor-post-type/style';
+@import 'post-editor/editor-post-type-unsupported/style';
 @import 'post-editor/editor-revisions/style';
 @import 'post-editor/editor-sharing/style';
 @import 'post-editor/editor-sidebar/style';

--- a/client/post-editor/editor-post-type-unsupported/index.jsx
+++ b/client/post-editor/editor-post-type-unsupported/index.jsx
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import includes from 'lodash/includes';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getEditorPostId, getEditorNewPostPath } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors';
+import { getPostTypes, getPostType } from 'state/post-types/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import Button from 'components/button';
+import Dialog from 'components/dialog';
+
+/**
+ * Constants
+ */
+
+/**
+ * Post types which can be configured in the Writing Site Settings for a site,
+ * regardless of whether the current theme supports it.
+ *
+ * @type {Array}
+ */
+const CONFIGURABLE_TYPES = [ 'jetpack-portfolio', 'jetpack-testimonial' ];
+
+function EditorPostTypeUnsupported( { translate, types, type, typeObject, writePostPath, siteSlug } ) {
+	// Don't display if:
+	//  1. Types don't exist (haven't yet been loaded for site)
+	//  2. The type value has been unset from the edited post (navigating away)
+	//  3. Type object provided (indicates that type indeed exists)
+	if ( ! types || ! type || typeObject ) {
+		// [TODO]: React 15 supports returning `null` from function components
+		return <noscript />;
+	}
+
+	const buttons = [
+		<Button href={ `/posts/${ siteSlug }` }>
+			{ translate( 'Back to My Sites' ) }
+		</Button>
+	];
+
+	const isConfigurableType = includes( CONFIGURABLE_TYPES, type );
+	let helpText;
+	if ( isConfigurableType ) {
+		// For configurable post types (those supported on WordPress.com,
+		// direct user to enable them through their site settings)
+		switch ( type ) {
+			case 'jetpack-portfolio':
+				helpText = translate( 'Portfolios are not enabled. Open your site settings to activate them.' );
+				break;
+
+			case 'jetpack-testimonial':
+				helpText = translate( 'Testimonials are not enabled. Open your site settings to activate them.' );
+				break;
+		}
+
+		buttons.push(
+			<Button href={ `/settings/writing/${ siteSlug }` } primary>
+				{ translate( 'Site Settings' ) }
+			</Button>
+		);
+	} else {
+		// In all other cases, the path contains a non-existent and unknown
+		// post type, so fall back to a generic error message.
+		helpText = translate( 'To use this post type, please check that your theme and site support it.' );
+
+		buttons.push(
+			<Button href={ writePostPath } primary>
+				{ translate( 'Write a Blog Post' ) }
+			</Button>
+		);
+	}
+
+	return (
+		<Dialog
+			isVisible
+			buttons={ buttons }
+			className="editor-post-type-unsupported">
+			<h1>{ translate( 'This post type is not supported' ) }</h1>
+			<p>{ helpText }</p>
+			<p>
+				{ translate( 'For more information, visit our {{supportLink}}support page on custom content types{{/supportLink}}.', {
+					components: {
+						supportLink: <a href="https://support.wordpress.com/custom-post-types/" />
+					}
+				} ) }
+			</p>
+		</Dialog>
+	);
+}
+
+EditorPostTypeUnsupported.propTypes = {
+	translate: PropTypes.func,
+	types: PropTypes.object,
+	type: PropTypes.string,
+	typeObject: PropTypes.object,
+	writePostPath: PropTypes.string,
+	siteSlug: PropTypes.string
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const type = getEditedPostValue( state, siteId, getEditorPostId( state ), 'type' );
+
+	return {
+		type,
+		types: getPostTypes( state, siteId ),
+		typeObject: getPostType( state, siteId, type ),
+		writePostPath: getEditorNewPostPath( state, siteId ),
+		siteSlug: getSiteSlug( state, siteId )
+	};
+} )( localize( EditorPostTypeUnsupported ) );

--- a/client/post-editor/editor-post-type-unsupported/style.scss
+++ b/client/post-editor/editor-post-type-unsupported/style.scss
@@ -1,0 +1,3 @@
+.editor-post-type-unsupported {
+	max-width: 400px;
+}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -51,6 +51,7 @@ import { toggleEditorDraftsVisible, setEditorPostId } from 'state/ui/editor/acti
 import { receivePost, editPost, resetPostEdits } from 'state/posts/actions';
 import EditorSidebarHeader from 'post-editor/editor-sidebar/header';
 import EditorDocumentHead from 'post-editor/editor-document-head';
+import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
 
 const messages = {
 	post: {
@@ -290,6 +291,7 @@ const PostEditor = React.createClass( {
 		return (
 			<div className="post-editor">
 				<EditorDocumentHead />
+				<EditorPostTypeUnsupported />
 				<div className="post-editor__inner">
 					<div className="post-editor__content">
 						<EditorMobileNavigation site={ site } onClose={ this.onClose } />

--- a/client/state/ui/editor/selectors.js
+++ b/client/state/ui/editor/selectors.js
@@ -40,17 +40,14 @@ export function isEditorDraftsVisible( state ) {
 }
 
 /**
- * Returns the editor URL path for the given site ID, post ID pair.
+ * Returns the editor new post URL path for the given site ID and type.
  *
  * @param  {Object} state       Global state tree
  * @param  {Number} siteId      Site ID
- * @param  {Number} postId      Post ID
- * @param  {String} defaultType Fallback post type if post not found
+ * @param  {Number} type        Post type
  * @return {String}             Editor URL path
  */
-export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
-	const type = get( getEditedPost( state, siteId, postId ), 'type', defaultType );
-
+export function getEditorNewPostPath( state, siteId, type = 'post' ) {
 	let path;
 	switch ( type ) {
 		case 'post': path = '/post'; break;
@@ -64,6 +61,22 @@ export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
 	} else {
 		path += `/${ siteId }`;
 	}
+
+	return path;
+}
+
+/**
+ * Returns the editor URL path for the given site ID, post ID pair.
+ *
+ * @param  {Object} state       Global state tree
+ * @param  {Number} siteId      Site ID
+ * @param  {Number} postId      Post ID
+ * @param  {String} defaultType Fallback post type if post not found
+ * @return {String}             Editor URL path
+ */
+export function getEditorPath( state, siteId, postId, defaultType = 'post' ) {
+	const type = get( getEditedPost( state, siteId, postId ), 'type', defaultType );
+	let path = getEditorNewPostPath( state, siteId, type );
 
 	if ( postId ) {
 		path += `/${ postId }`;

--- a/client/state/ui/editor/test/selectors.js
+++ b/client/state/ui/editor/test/selectors.js
@@ -6,7 +6,13 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { getEditorPostId, isEditorNewPost, isEditorDraftsVisible, getEditorPath } from '../selectors';
+import {
+	getEditorPostId,
+	isEditorNewPost,
+	isEditorDraftsVisible,
+	getEditorNewPostPath,
+	getEditorPath
+} from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#getEditorPostId()', () => {
@@ -60,6 +66,63 @@ describe( 'selectors', () => {
 			} );
 
 			expect( showDrafts ).to.be.true;
+		} );
+	} );
+
+	describe( 'getEditorNewPostPath()', () => {
+		it( 'should return the post path with the site ID if site unknown', () => {
+			const path = getEditorNewPostPath( {
+				sites: {
+					items: {}
+				}
+			}, 2916284 );
+
+			expect( path ).to.equal( '/post/2916284' );
+		} );
+
+		it( 'should prefix the post route for post types', () => {
+			const path = getEditorNewPostPath( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				}
+			}, 2916284, 'post' );
+
+			expect( path ).to.equal( '/post/example.wordpress.com' );
+		} );
+
+		it( 'should prefix the page route for page types', () => {
+			const path = getEditorNewPostPath( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				}
+			}, 2916284, 'page' );
+
+			expect( path ).to.equal( '/page/example.wordpress.com' );
+		} );
+
+		it( 'should prefix the type route for custom post types', () => {
+			const path = getEditorNewPostPath( {
+				sites: {
+					items: {
+						2916284: {
+							ID: 2916284,
+							URL: 'https://example.wordpress.com'
+						}
+					}
+				}
+			}, 2916284, 'jetpack-portfolio' );
+
+			expect( path ).to.equal( '/edit/jetpack-portfolio/example.wordpress.com' );
 		} );
 	} );
 


### PR DESCRIPTION
Related: #5398 

This pull request seeks to display a warning in the post editor when attempting to edit a post type which is not supported by the site.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15563321/8475a6f2-22d5-11e6-8a4b-dd06ceea9f4a.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15830586/30a9ea36-2be7-11e6-9115-834bcc4b406f.png)

__Testing instructions:__

Ensure there are no regressions or warnings when attempting to edit an existing post type, particularly posts or pages.

Verify that when attempting to edit a post type which does not exist for the site, the warning is shown, e.g. [`/edit/xyz`](http://calypso.localhost:3000/edit/xyz) or [`/edit/jetpack-portfolio`](http://calypso.localhost:3000/edit/xyz) when portfolios are not enabled.