### PR TITLE
Reader: Apply site icon styles specific to start card

### DIFF
--- a/client/reader/start/style.scss
+++ b/client/reader/start/style.scss
@@ -49,10 +49,6 @@
 	}
 }
 
-.site-icon {
-	border: 4px solid $white;
-}
-
 .reader-start-card {
 	box-sizing: border-box;
 	flex: calc( 100% );
@@ -100,6 +96,7 @@
 
   		.site-icon {
   			margin: auto;
+			border: 4px solid $white;
   		}
   	}
 


### PR DESCRIPTION
Regression introduced in #5264
Blocks #5555

This pull request seeks to resolve an issue where `.site-icon` styles intended for the Reader `<StartCard />` component are applied globally, resulting in an incorrect display appearance for the "Resume editing" button.

Before|After
---|---
![Before](https://cloud.githubusercontent.com/assets/1779930/15563471/dab72530-22d6-11e6-935f-f95732c6a0dd.png)|![After](https://cloud.githubusercontent.com/assets/1779930/15563469/cb80e236-22d6-11e6-86d9-1dbdf28a48d8.png)

__Testing instructions:__

Repeat testing instructions for #5264

Repeat testing instructions for #4388, verifying that the display of the "Resume editing" button matches that shown in the "After" screenshot above

/cc @mtias @bluefuton @jancavan @blowery 