### PR TITLE
Reader comments: Fix "view earlier comments" does not load all top-level comments

### DIFF
--- a/client/reader/comments/post-comment-list.jsx
+++ b/client/reader/comments/post-comment-list.jsx
@@ -152,10 +152,7 @@ class PostCommentList extends React.Component {
 		const siteId = this.props.post.site_ID;
 		const postId = this.props.post.ID;
 
-		let amountOfCommentsToTake = Math.min(
-			this.state.amountOfCommentsToTake + this.props.pageSize,
-			this.props.commentsTree.get( 'children' ).size
-		);
+		const amountOfCommentsToTake = this.state.amountOfCommentsToTake + this.props.pageSize;
 
 		this.setState( {
 			amountOfCommentsToTake

--- a/client/reader/comments/post-comment-list.jsx
+++ b/client/reader/comments/post-comment-list.jsx
@@ -131,7 +131,7 @@ class PostCommentList extends React.Component {
 
 	/***
 	 * Gets comments for display
-	 * @param {Array<Number>} commentIds The top level commentIds to take from
+	 * @param {Immutable.List<Number>} commentIds The top level commentIds to take from
 	 * @param {Number} take How many top level comments to take
 	 * @returns {Object} that has the displayed comments + total displayed count including children
 	 */

--- a/client/reader/comments/post-comment-list.jsx
+++ b/client/reader/comments/post-comment-list.jsx
@@ -129,24 +129,22 @@ class PostCommentList extends React.Component {
 		return commentIds.reduce( ( prevSum, commentId ) => prevSum + this.getCommentsCount( this.props.commentsTree.getIn( [ commentId, 'children' ] ) ) + 1, 0 );
 	}
 
+	/***
+	 * Gets comments for display
+	 * @param {Array<Number>} commentIds The top level commentIds to take from
+	 * @param {Number} take How many top level comments to take
+	 * @returns {Object} that has the displayed comments + total displayed count including children
+	 */
 	getDisplayedComments( commentIds, take ) {
 		if ( ! commentIds ) {
 			return null;
 		}
 
-		let foundComments = 0;
-
-		const displayedComments = commentIds.takeWhile( ( val ) => {
-			const keepGoing = foundComments < take;
-			if ( keepGoing ) {
-				foundComments += this.getCommentsCount( [ val ] );
-			}
-			return keepGoing;
-		} );
+		const displayedComments = commentIds.take( take );
 
 		return {
 			displayedComments: displayedComments,
-			displayedCommentsCount: foundComments
+			displayedCommentsCount: this.getCommentsCount( displayedComments )
 		};
 	}
 


### PR DESCRIPTION
That fixes #5587 

`getDisplayedComments` method should only count top level comments as the taken ones, not count comments with children

We also shouldn't rely on previous comments count since we requesting a fetch.