### PR TITLE
Support User: Focus password input after unsuccessful login request

### DIFF
--- a/client/support/support-user/login-dialog.jsx
+++ b/client/support/support-user/login-dialog.jsx
@@ -23,7 +23,7 @@ const SupportUserLoginDialog = React.createClass( {
 		return {
 			supportUser: '',
 			supportPassword: ''
-		}
+		};
 	},
 
 	onSubmit() {
@@ -56,6 +56,12 @@ const SupportUserLoginDialog = React.createClass( {
 				return this.onEnterKey( event );
 			case 'Escape':
 				return this.onEscapeKey( event );
+		}
+	},
+
+	componentDidUpdate( prevProps ) {
+		if ( ! this.props.isBusy && prevProps.isBusy ) {
+			setTimeout( () => this.supportPasswordInput.focus(), 0 );
 		}
 	},
 


### PR DESCRIPTION
Support user login form was optimized for keyboard access, except for the situation when you enter an incorrect password. In that case, form fields would stop being `disabled`, but none of them has focus, so you cannot continue just by keyboard anymore.

I do not have a support account, so I didn't test the case when you enter the correct password. Please test that while reviewing.

This PR joins the effort of #3201 to make the form accessible by keyboard only.