### PR TITLE
Reader: Add Go to Top keyboard shortcut

### DIFF
--- a/client/lib/keyboard-shortcuts/key-bindings.js
+++ b/client/lib/keyboard-shortcuts/key-bindings.js
@@ -47,6 +47,14 @@ KeyBindings.prototype.get = function() {
 					keys: [ 'enter' ],
 					text: i18n.translate( 'Open selection' )
 				}
+			},
+			{
+				eventName: 'go-to-top',
+				keys: [ '.' ],
+				description: {
+					keys: [ '.' ],
+					text: i18n.translate( 'Go to top' )
+				},
 			}
 		],
 

--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -139,6 +139,7 @@ module.exports = React.createClass( {
 		KeyboardShortcuts.on( 'move-selection-up', this.selectPrevItem );
 		KeyboardShortcuts.on( 'open-selection', this.showSelectedPost );
 		KeyboardShortcuts.on( 'like-selection', this.toggleLikeOnSelectedPost );
+		KeyboardShortcuts.on( 'go-to-top', this.goToTop );
 		window.addEventListener( 'popstate', this._popstate );
 		if ( 'scrollRestoration' in history ) {
 			history.scrollRestoration = 'manual';
@@ -153,6 +154,7 @@ module.exports = React.createClass( {
 		KeyboardShortcuts.off( 'move-selection-up', this.selectPrevItem );
 		KeyboardShortcuts.off( 'open-selection', this.showSelectedPost );
 		KeyboardShortcuts.off( 'like-selection', this.toggleLikeOnSelectedPost );
+		KeyboardShortcuts.off( 'go-to-top', this.goToTop );
 		window.removeEventListener( 'popstate', this._popstate );
 		if ( 'scrollRestoration' in history ) {
 			history.scrollRestoration = 'auto';
@@ -233,6 +235,14 @@ module.exports = React.createClass( {
 		return !! window.location.pathname.match( /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i );
 	},
 
+	goToTop: function() {
+		if ( this.state.updateCount && this.state.updateCount > 0 ) {
+			this.showUpdates();
+		} else {
+			FeedStreamStoreActions.selectItem( this.props.store.id, 0 );
+		}
+	},
+
 	getVisibleItemIndexes: function() {
 		return this._list && this._list.getVisibleItemIndexes( { offsetTop: HEADER_OFFSET_TOP } );
 	},
@@ -291,7 +301,7 @@ module.exports = React.createClass( {
 		FeedStreamStoreActions.fetchNextPage( this.props.store.id );
 	},
 
-	handleUpdateClick: function() {
+	showUpdates: function() {
 		this.props.onUpdatesShown();
 		FeedStreamStoreActions.showUpdates( this.props.store.id );
 		if ( this._list ) {
@@ -438,7 +448,7 @@ module.exports = React.createClass( {
 					<h1>{ this.props.listName }</h1>
 				</MobileBackToSidebar>
 
-				<UpdateNotice count={ this.state.updateCount } onClick={ this.handleUpdateClick } />
+				<UpdateNotice count={ this.state.updateCount } onClick={ this.showUpdates } />
 				{ this.props.children }
 				{ body }
 			</Main>


### PR DESCRIPTION
This adds a new keyboard shortcut <kbd>.</kbd> (dot) that moves you to the top of articles in Reader. The difference between this and native <kbd>Home</kbd> is that this shortcut also shows new content, if available. 

Until now there was no keyboard-only way to access newly loaded articles:

<img width="149" alt="screen shot 2016-05-26 at 12 45 11" src="https://cloud.githubusercontent.com/assets/156676/15572267/cca4c5ce-233f-11e6-9b71-7d5d6eb935e2.png">

This new behavior is exactly what Twitter uses on their timeline. They similarly have a notification when there are new posts available and <kbd>.</kbd> is the way to show it. If there are no new tweets, it just scrolls to the top to stay consistent.

One thing that I'm not 100% sure about is the title of shortcut in the help modal. I called it "Go to top". Twitter calls that shortcut "Load new Tweets", but if we call it the same way ("Load new Posts"), it might indicate that by pressing that key, we will try to fetch new data from server, which is not what we do. We just show them, so I consider "Go to top" to be a better fit.