### PR TITLE
Reader: Fix uncaught error in prev/nextItem selection handling

### DIFF
--- a/client/reader/following-stream/index.jsx
+++ b/client/reader/following-stream/index.jsx
@@ -233,12 +233,16 @@ module.exports = React.createClass( {
 		return !! window.location.pathname.match( /^\/read\/(blogs|feeds)\/([0-9]+)\/posts\/([0-9]+)$/i );
 	},
 
+	getVisibleItemIndexes: function() {
+		return this._list && this._list.getVisibleItemIndexes( { offsetTop: HEADER_OFFSET_TOP } );
+	},
+
 	selectNextItem: function() {
-		var visibleIndexes = this._list.getVisibleItemIndexes( { offsetTop: HEADER_OFFSET_TOP } ),
+		var visibleIndexes = this.getVisibleItemIndexes(),
 			visibleIndex,
 			index,
 			i;
-		if ( visibleIndexes.length > 0 ) {
+		if ( visibleIndexes && visibleIndexes.length > 0 ) {
 			index = visibleIndexes[ 0 ].index;
 			for ( i = 0; i < visibleIndexes.length; i++ ) {
 				visibleIndex = visibleIndexes[ i ];
@@ -256,11 +260,11 @@ module.exports = React.createClass( {
 	},
 
 	selectPrevItem: function() {
-		var visibleIndexes = this._list.getVisibleItemIndexes( { offsetTop: HEADER_OFFSET_TOP } ),
+		var visibleIndexes = this.getVisibleItemIndexes(),
 			visibleIndex,
 			index,
 			i;
-		if ( visibleIndexes.length > 0 ) {
+		if ( visibleIndexes && visibleIndexes.length > 0 ) {
 			index = visibleIndexes[ 0 ].index;
 			for ( i = 0; i < visibleIndexes.length; i++ ) {
 				visibleIndex = visibleIndexes[ i ];


### PR DESCRIPTION
This error happened when you pressed <kbd>j</kbd> or <kbd>k</kbd> on an empty list like this one:

<img width="400" alt="screen shot 2016-05-26 at 13 02 43" src="https://cloud.githubusercontent.com/assets/156676/15572987/5a7e6108-2344-11e6-8f59-734d0e90e8f7.png">

Keyboard shortcut handler was calling `this._list.getVisibleItemIndexes()`, without testing if `this._list` is null.