### PR TITLE
Themes: Fix theme sheets for IE/Edge

### DIFF
--- a/client/state/themes/theme-details/selectors.js
+++ b/client/state/themes/theme-details/selectors.js
@@ -12,14 +12,7 @@ export function getThemeDetails( state, id ) {
 // Convert price to format used by v1.2 themes API to fit with existing components.
 // TODO (seear): remove when v1.2 theme details endpoint is added
 function formatPrice( price ) {
-	if ( price.value === 0 ) {
-		// Free themes have plaintext string
-		return price.display;
-	}
-	// Premium themes have markup in price.display, so create our own plaintext
-	return price.value.toLocaleString( 'default', {
-		style: 'currency',
-		currency: price.currency,
-		minimumFractionDigits: 0,
-	} );
+	// premium theme price.display example: "<abbr title="United States Dollars">$</abbr>65"
+	const priceMatcher = /^<[^>]*>([^<]*)<[^>]*>(\d*)$/;
+	return price.display.replace( priceMatcher, '$1$2' );
 }

--- a/client/state/themes/theme-details/test/selectors.js
+++ b/client/state/themes/theme-details/test/selectors.js
@@ -11,19 +11,43 @@ import { getThemeDetails } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( '#getThemeDetails()', () => {
-		it( 'should return details for a theme given its ID', () => {
-			const details = getThemeDetails( {
-				themes: {
-					themeDetails: Map( {
-						mood: Map( {
-							name: 'Mood',
-							author: 'Automattic'
-						} )
-					} )
-				}
-			}, 'mood' );
 
-			expect( details ).to.eql( { name: 'Mood', author: 'Automattic' } );
+		const themes = {
+			themes: {
+				themeDetails: Map( {
+					mood: Map( {
+						name: 'Mood',
+						author: 'Automattic',
+						price: {
+							value: 65,
+							currency: 'USD',
+							display: '<abbr title=\"United States Dollars\">$</abbr>65'
+						},
+					} ),
+					twentysixteen: Map( {
+						name: 'Twenty Sixteen',
+						author: 'Automattic',
+						price: {
+							value: 0,
+							currency: 'USD',
+							display: 'Free'
+						},
+					} ),
+				} )
+			}
+		};
+
+		it( 'should return details for a theme given its ID', () => {
+			const details = getThemeDetails( themes, 'mood' );
+			expect( details ).to.eql( { name: 'Mood', author: 'Automattic', price: '$65' } );
+		} );
+
+		it( 'should format the price as plaintext', () => {
+			const mood = getThemeDetails( themes, 'mood' );
+			expect( mood.price ).to.eql( '$65' );
+
+			const twentysixteen = getThemeDetails( themes, 'twentysixteen' );
+			expect( twentysixteen.price ).to.eql( 'Free' );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #5495

Use of 'default' locale was causing an error in IE/Edge. Also, the `soLocaleString()` option `style: 'currency'` is not supported in most browsers, leading to a missing currency symbol.

Remove the markup from the API result using a regex instead of `toLocaleString()`.

![screen shot 2016-05-26 at 13 12 16](https://cloud.githubusercontent.com/assets/7767559/15574131/94bdb37e-2343-11e6-915c-a0e311543249.png)
