### PR TITLE
Plans: update domains credit notice to friendlier copy

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -62,7 +62,7 @@ const SiteNotice = React.createClass( {
 			const eventProperties = { cta_name: 'current_site_domain_notice' };
 			return (
 				<Notice isCompact status="is-success" icon="info-outline">
-					{ this.translate( 'Unused domain credit' ) }
+					{ this.translate( 'Free domain available' ) }
 					<NoticeAction
 						onClick={ this.props.clickClaimDomainNotice }
 						href={ `/domains/add/${ this.props.site.slug }` }

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -71,8 +71,9 @@
 
 .current-site .notice.is-compact {
 	display: flex;
-	margin: 0 -8px;
+	margin: 0;
 	padding: 0 0 0 4px;
+	border-radius: 0;
 
 	@include breakpoint( "<660px" ) {
 		padding: 0 24px;

--- a/client/my-sites/upgrades/domain-management/list/index.jsx
+++ b/client/my-sites/upgrades/domain-management/list/index.jsx
@@ -69,7 +69,7 @@ export const List = React.createClass( {
 				<Notice
 					status="is-info"
 					showDismiss={ false }
-					text={ this.translate( 'You have an unused domain credit!' ) }
+					text={ this.translate( 'Free domain available' ) }
 					icon="globe">
 					<NoticeAction onClick={ this.props.clickClaimDomainNotice } href={ `/domains/add/${ this.props.selectedSite.slug }` }>
 						{ this.translate( 'Claim Free Domain' ) }


### PR DESCRIPTION
As a follow up to https://github.com/Automattic/wp-calypso/pull/4929#issuecomment-218554906 This PR updates the domain notices to include friendlier copy. This also fixes an unintentional horizontal scrollbar ( which is better viewed in a windows env ). The text placement is slightly altered.

<img width="976" alt="copy" src="https://cloud.githubusercontent.com/assets/1270189/15584933/ae82e200-2331-11e6-8459-ad278e060946.png">

## Testing Instructions
- Upgrade a free site to premium or business
- Navigate to http://calypso.localhost:3000/domains and select your upgraded site
- Set the testing variant to: `localStorage.setItem('ABTests','{"domainCreditsInfoNotice_20160420":"showNotice"}')`
- Your upgraded site should see the notice, and other sites should not

cc @umurkontaci @aduth @mtias @drw158 @rralian 
