### PR TITLE
DesignPreview: Enable preview-layout in wpcalypso and horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -70,6 +70,8 @@
 		"phone_signup": false,
 		"post-editor/insert-menu": true,
 		"press-this": true,
+		"preview-layout": true,
+		"preview-endpoint": false,
 		"reader": true,
 		"resume-editing": true,
 		"rubberband-scroll-disable": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -79,6 +79,8 @@
 		"phone_signup": true,
 		"post-editor/insert-menu": true,
 		"press-this": true,
+		"preview-layout": true,
+		"preview-endpoint": false,
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/recommendations/posts": true,


### PR DESCRIPTION
For wpcalypso/horizon envs only:

- Will enable current-site card opening a preview, instead of a tab
- Will enable preview portion of `main` guided tour
- Does NOT enable preview endpoint