### PR TITLE
Sites: open Site Icon link correctly in Jetpack Customizer

### DIFF
--- a/client/my-sites/site/index.jsx
+++ b/client/my-sites/site/index.jsx
@@ -163,7 +163,7 @@ export default React.createClass( {
 			return <SiteIcon site={ this.props.site } />;
 		}
 
-		let url = getCustomizeUrl( null, this.props.site );
+		let url = getCustomizeUrl( null, this.props.site ) + '&autofocus[section]=title_tagline';
 
 		if ( ! this.props.site.jetpack && this.props.site.options ) {
 			url = this.props.site.options.admin_url + 'options-general.php';


### PR DESCRIPTION
Fixes #4608 

To test:

1. Open Calypso and go to My Sites
2. Pick a Jetpack site, click the ... menu next to the site name
3. Click "Edit Icon" which should open a new tab.
4. Ensure the resulting wp-admin view of your Jetpack site is open to Customizer, and the Site Identity section is open

<img width="1392" alt="screen shot 2016-05-26 at 13 53 09" src="https://cloud.githubusercontent.com/assets/66797/15589866/8d170886-2349-11e6-87e5-5cef5a6405e5.png">

<img width="1392" alt="screen shot 2016-05-26 at 13 53 12" src="https://cloud.githubusercontent.com/assets/66797/15589872/903c570a-2349-11e6-8dbc-458f17e4cc38.png">
